### PR TITLE
fix: Add cognito middleware to all securable routes

### DIFF
--- a/src/routes/djs.route.ts
+++ b/src/routes/djs.route.ts
@@ -1,20 +1,21 @@
 import { Router } from 'express';
 import * as djsController from '../controllers/djs.controller';
+import { cognitoMiddleware } from '../middleware/cognito.auth';
 
 export const dj_route = Router();
 
 //secure: mgmt & individual dj
-dj_route.get('/', djsController.getDJInfo);
+dj_route.get('/', cognitoMiddleware, djsController.getDJInfo);
 
 //secure: mgmt
-dj_route.post('/register', djsController.register);
+dj_route.post('/register', cognitoMiddleware('station-management'), djsController.register);
 
-dj_route.post('/bin', djsController.addToBin);
+dj_route.post('/bin', cognitoMiddleware, djsController.addToBin);
 
-dj_route.delete('/bin', djsController.deleteFromBin);
+dj_route.delete('/bin', cognitoMiddleware, djsController.deleteFromBin);
 
-dj_route.get('/bin', djsController.getBin);
+dj_route.get('/bin', cognitoMiddleware, djsController.getBin);
 
-dj_route.get('/playlists', djsController.getPlaylistsForDJ);
+dj_route.get('/playlists', cognitoMiddleware, djsController.getPlaylistsForDJ);
 
-dj_route.get('/playlist', djsController.getPlaylist);
+dj_route.get('/playlist', cognitoMiddleware, djsController.getPlaylist);

--- a/src/routes/flowsheet.route.ts
+++ b/src/routes/flowsheet.route.ts
@@ -6,17 +6,17 @@ export const flowsheet_route = Router();
 
 flowsheet_route.get('/', flowsheetController.getEntries);
 
-flowsheet_route.post('/', cognitoMiddleware(), flowsheetController.addEntry);
+flowsheet_route.post('/', cognitoMiddleware, flowsheetController.addEntry);
 
-flowsheet_route.patch('/', cognitoMiddleware(), flowsheetController.updateEntry);
+flowsheet_route.patch('/', cognitoMiddleware, flowsheetController.updateEntry);
 
-flowsheet_route.delete('/', cognitoMiddleware(), flowsheetController.deleteEntry);
+flowsheet_route.delete('/', cognitoMiddleware, flowsheetController.deleteEntry);
 
 flowsheet_route.get('/latest', flowsheetController.getLatest);
 
-flowsheet_route.post('/join', cognitoMiddleware(), flowsheetController.joinShow);
+flowsheet_route.post('/join', cognitoMiddleware, flowsheetController.joinShow);
 
-flowsheet_route.post('/end', cognitoMiddleware(), flowsheetController.leaveShow);
+flowsheet_route.post('/end', cognitoMiddleware, flowsheetController.leaveShow);
 
 flowsheet_route.get('/djs-on-air', flowsheetController.getDJList);
 

--- a/src/routes/library.route.ts
+++ b/src/routes/library.route.ts
@@ -5,13 +5,13 @@ import { cognitoMiddleware } from '../middleware/cognito.auth';
 export const library_route = Router();
 
 //secure: discuss, should we lock down the catalog?
-library_route.get('/', libraryController.searchForAlbum);
+library_route.get('/', cognitoMiddleware, libraryController.searchForAlbum);
 
 //secure: mgmt
 library_route.post('/', cognitoMiddleware('station-management'), libraryController.addAlbum);
 
 //secure: mgmt
-library_route.get('/rotation', libraryController.getRotation);
+library_route.get('/rotation', cognitoMiddleware, libraryController.getRotation);
 
 library_route.post('/rotation', cognitoMiddleware('station-management'), libraryController.addRotation);
 
@@ -20,12 +20,12 @@ library_route.patch('/rotation', cognitoMiddleware('station-management'), librar
 //secure: mgmt
 library_route.post('/artists', cognitoMiddleware('station-management'), libraryController.addArtist);
 
-library_route.get('/formats', libraryController.getFormats);
+library_route.get('/formats', cognitoMiddleware, libraryController.getFormats);
 
-library_route.post('/formats', libraryController.addFormat);
+library_route.post('/formats', cognitoMiddleware('station-management'), libraryController.addFormat);
 
-library_route.get('/genres', libraryController.getGenres);
+library_route.get('/genres', cognitoMiddleware, libraryController.getGenres);
 
 library_route.post('/genres', cognitoMiddleware('station-management'), libraryController.addGenre);
 
-library_route.get('/info', libraryController.getAlbum);
+library_route.get('/info', cognitoMiddleware, libraryController.getAlbum);


### PR DESCRIPTION
This PR adds cognito middleware, with elevation to station management if necessary, to all routes where it makes sense.

For modifying the underlying library structure (adding items, including genres and formats) or the roster of DJs, station management access is required.

All other items related to modifying the flowsheet or database are secured behind basic account middleware.

Open to the public are the ability to (1) retrieve the current entry, (2) find out what DJ names are on air, (3) retrieve the latest flowsheet information, and (4) retrieve flowsheet entries for the past, provided they aren't tied to a specific DJ's information.