### PR TITLE
fix: Allow messages to have greater length

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -160,7 +160,7 @@ export const flowsheet = wxyc_schema.table('flowsheet', {
   record_label: varchar('record_label', { length: 128 }),
   play_order: serial('play_order').notNull(),
   request_flag: boolean('request_flag').default(false).notNull(),
-  message: varchar('message', { length: 64 }),
+  message: varchar('message', { length: 250 }),
 });
 
 export type NewGenre = InferModel<typeof genres, 'insert'>;


### PR DESCRIPTION
Right now, messages are limited to 64 characters. While this was sensible on the old database, allowing for more characters to expand the DJ name length and maintain both the datetime and the phrase 'started show' or 'ended show' is vital. This updates the schema to make messages up to 250 characters in length, for safety.