### PR TITLE
Fix: Automatically assign show_id to flowsheet entries

### DIFF
--- a/src/controllers/flowsheet.controller.ts
+++ b/src/controllers/flowsheet.controller.ts
@@ -110,6 +110,7 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
               track_title: body.track_title,
               rotation_id: body.rotation_id,
               request_flag: body.request_flag,
+              show_id: latestShow.id,
             };
 
             const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
@@ -125,6 +126,7 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
           } else {
             const fsEntry: NewFSEntry = {
               ...body,
+              show_id: latestShow.id,
             };
 
             const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
@@ -143,6 +145,7 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
         album_title: '',
         track_title: '',
         message: body.message,
+        show_id: latestShow.id,
       };
       try {
         const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);


### PR DESCRIPTION
During testing I realized it doesn't make sense to be passing a show_id to the flowsheet endpoint for each request. Here I just append any flowsheet add request with the current show's flowsheet show id.
I'll need to add some checks to make sure the dj making this request is a member of the show_djs for this show, but for now this will do.