### PR TITLE
Feat flowsheet middleware

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,8 @@ import { flowsheet_route } from './routes/flowsheet.route';
 import { library_route } from './routes/library.route';
 import { schedule_route } from './routes/schedule.route';
 import { jwtVerifier, cognitoMiddleware } from './middleware/cognito.auth';
+import { showMemberMiddleware } from './middleware/checkShowMember';
+import { activeShow } from './middleware/checkActiveShow';
 // import errorHandler from './middleware/errorHandler';
 
 const port = process.env.PORT || 8080;
@@ -37,13 +39,10 @@ app.get('/testAuth', cognitoMiddleware(), async (req, res) => {
   res.json({ message: 'Authenticated!' });
 });
 
-// app.get(
-//   '/testErrorHandler',
-//   (req, res, next) => {
-//     next(new Error('Testing Error'));
-//   },
-//   errorHandler
-// );
+//example of how cognito auth middleware can inform further middleware.
+app.get('/testInShow', cognitoMiddleware(), activeShow, showMemberMiddleware, async (req, res) => {
+  res.json({ message: 'Authenticated, active show, & show member' });
+});
 
 //On server startup we pre-fetch all jwt validation keys
 jwtVerifier

--- a/src/middleware/checkActiveShow.ts
+++ b/src/middleware/checkActiveShow.ts
@@ -1,0 +1,11 @@
+import { RequestHandler } from 'express';
+import { getLatestShow } from '../services/flowsheet.service';
+
+export const activeShow: RequestHandler = async (req, res, next) => {
+  const latestShow = await getLatestShow();
+  if (latestShow.end_time !== null) {
+    res.status(400).json({ message: 'Bad Request: No active show' });
+  } else {
+    next();
+  }
+};

--- a/src/middleware/checkShowMember.ts
+++ b/src/middleware/checkShowMember.ts
@@ -1,0 +1,15 @@
+import { RequestHandler } from 'express';
+import { getDJsInCurrentShow } from '../services/flowsheet.service';
+
+export const showMemberMiddleware: RequestHandler = async (req, res, next) => {
+  const show_djs = await getDJsInCurrentShow();
+  const dj_in_show = show_djs.filter((dj) => {
+    return dj.cognito_user_name === res.locals.decodedJWT.username;
+  }).length;
+
+  if (dj_in_show > 0) {
+    next();
+  } else {
+    res.status(400).json({ message: 'Bad Request: DJ not a member of show' });
+  }
+};


### PR DESCRIPTION
### Middleware used to block access to certain controllers based on DJ state

- checkActiveShow.ts contains logic to only continue on to further middleware iff there is a currently active show.
- checkShowMember.ts contains logic to only continue on to further middleware iff the requesting dj is a member of the current show. This function relies on the cognito middlware in order to work as it compares values located in the decoded token (which gets stored in res.locals) against our database.  Because of this it is important that it is always called after cognitoMiddleware() in the chain of middeware. (_sheesh I've typed middleware a lot here_)

I've also included in app.ts a testing endpoint to demonstrate the usage of both of these middleware functions. 