### PR TITLE
Change flowsheet default limit to 30, add previous_shows filter

### DIFF
--- a/dev_env/seed_db.sql
+++ b/dev_env/seed_db.sql
@@ -33,6 +33,6 @@ INSERT INTO wxyc_schema.library(
 
 INSERT INTO wxyc_schema.library(
     artist_id, genre_id, format_id, album_title, code_number) 
-    VALUES (3, 1, 2, 'I love you Jennifer B', 1);
+    VALUES (3, 1, 2, 'I Love You Jennifer B', 1);
 
 INSERT INTO wxyc_schema.rotation(album_id, play_freq) VALUES (1, 'L')

--- a/src/controllers/flowsheet.controller.ts
+++ b/src/controllers/flowsheet.controller.ts
@@ -18,7 +18,7 @@ const DELETION_OFFSET = 10; //This offsets the ID's not representing the actual 
 export const getEntries: RequestHandler<object, unknown, object, QueryParams> = async (req, res, next) => {
   const { query } = req;
   const page = parseInt(query.page ?? '0');
-  const limit = parseInt(query.limit ?? '5');
+  const limit = parseInt(query.limit ?? '30');
   const offset = page * limit;
 
   if (

--- a/src/controllers/flowsheet.controller.ts
+++ b/src/controllers/flowsheet.controller.ts
@@ -7,7 +7,7 @@ type QueryParams = {
   limit?: string;
   start_id?: string;
   end_id?: string;
-  previous_shows?: string;
+  shows_limit?: string;
 };
 
 export interface IFSEntry extends FSEntry {
@@ -18,23 +18,27 @@ const MAX_ITEMS = 200;
 const DELETION_OFFSET = 10; //This offsets the ID's not representing the actual number of tracks due to deletions
 export const getEntries: RequestHandler<object, unknown, object, QueryParams> = async (req, res, next) => {
   const { query } = req;
-  
-  if (query.previous_shows !== undefined) {
+
+  const page = parseInt(query.page ?? '0');
+  const limit = parseInt(query.limit ?? '30');
+  const offset = page * limit;
+
+  if (query.shows_limit !== undefined) {
     try {
-      const numberOfShows = parseInt(query.previous_shows);
+      const numberOfShows = parseInt(query.shows_limit);
       if (isNaN(numberOfShows) || numberOfShows < 1) {
         res.status(400).json({
-          status: 400,
-          message: 'previous_shows must be a positive number',
+          message: 'shows_limit must be a positive number',
         });
         return;
       }
-      const entries = await flowsheet_service.getEntriesFromPreviousShows(numberOfShows);
+      const recentShows = await flowsheet_service.getNShows(numberOfShows, page);
+      const entries = await flowsheet_service.getEntriesByShow(...recentShows.map((show) => show.id));
+
       if (entries.length) {
         res.status(200).json(entries);
       } else {
         res.status(404).json({
-          status: 404,
           message: 'No Tracks found',
         });
       }
@@ -47,17 +51,16 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
     }
   }
 
-  const page = parseInt(query.page ?? '0');
-  const limit = parseInt(query.limit ?? '30');
-  const offset = page * limit;
-
   if (
     parseInt(query.end_id ?? '0') - parseInt(query.start_id ?? '0') - DELETION_OFFSET > MAX_ITEMS ||
     limit > MAX_ITEMS
   ) {
     res.status(400).json({
-      status: 400,
       message: 'Requested too many entries',
+    });
+  } else if (isNaN(limit) || limit < 1) {
+    res.status(400).json({
+      message: 'limit must be a positive number',
     });
   } else {
     try {
@@ -70,7 +73,6 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
       } else {
         console.error('No Tracks found');
         res.status(404).json({
-          status: 404,
           message: 'No Tracks found',
         });
       }

--- a/src/services/flowsheet.service.ts
+++ b/src/services/flowsheet.service.ts
@@ -19,22 +19,24 @@ import {
 import { IFSEntry, UpdateRequestBody } from '../controllers/flowsheet.controller';
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
 
+const FSEntryFields = {
+  id: flowsheet.id,
+  show_id: flowsheet.show_id,
+  album_id: flowsheet.album_id,
+  artist_name: flowsheet.artist_name,
+  album_title: flowsheet.album_title,
+  track_title: flowsheet.track_title,
+  record_label: flowsheet.record_label,
+  rotation_id: flowsheet.rotation_id,
+  rotation_play_freq: rotation.play_freq,
+  request_flag: flowsheet.request_flag,
+  message: flowsheet.message,
+  play_order: flowsheet.play_order,
+};
+
 export const getEntriesByPage = async (offset: number, limit: number) => {
   const response: IFSEntry[] = await db
-    .select({
-      id: flowsheet.id,
-      show_id: flowsheet.show_id,
-      album_id: flowsheet.album_id,
-      artist_name: flowsheet.artist_name,
-      album_title: flowsheet.album_title,
-      track_title: flowsheet.track_title,
-      record_label: flowsheet.record_label,
-      rotation_id: flowsheet.rotation_id,
-      rotation_play_freq: rotation.play_freq,
-      request_flag: flowsheet.request_flag,
-      message: flowsheet.message,
-      play_order: flowsheet.play_order,
-    })
+    .select(FSEntryFields)
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
     .orderBy(desc(flowsheet.play_order))
@@ -46,23 +48,24 @@ export const getEntriesByPage = async (offset: number, limit: number) => {
 
 export const getEntriesByRange = async (startId: number, endId: number) => {
   const response: IFSEntry[] = await db
-    .select({
-      id: flowsheet.id,
-      show_id: flowsheet.show_id,
-      album_id: flowsheet.album_id,
-      artist_name: flowsheet.artist_name,
-      album_title: flowsheet.album_title,
-      track_title: flowsheet.track_title,
-      record_label: flowsheet.record_label,
-      rotation_id: flowsheet.rotation_id,
-      rotation_play_freq: rotation.play_freq,
-      request_flag: flowsheet.request_flag,
-      message: flowsheet.message,
-      play_order: flowsheet.play_order,
-    })
+    .select(FSEntryFields)
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
     .where(and(gte(flowsheet.id, startId), lte(flowsheet.id, endId)))
+    .orderBy(desc(flowsheet.play_order));
+
+  return response;
+};
+
+export const getEntriesByShow = async (...show_ids: number[]) => {
+  if (show_ids.length === 0) return [];
+
+  // Get all entries from these shows
+  const response: IFSEntry[] = await db
+    .select(FSEntryFields)
+    .from(flowsheet)
+    .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
+    .where(inArray(flowsheet.show_id, show_ids))
     .orderBy(desc(flowsheet.play_order));
 
   return response;
@@ -324,9 +327,17 @@ const createLeaveNotification = async (dj_id: number, show_id: number): Promise<
   return notification[0];
 };
 
+export const getNShows = async (numberOfShows: number = 1, page: number = 0): Promise<Show[]> => {
+  return await db
+    .select()
+    .from(shows)
+    .orderBy(desc(shows.id))
+    .offset(page * numberOfShows)
+    .limit(numberOfShows);
+};
+
 export const getLatestShow = async (): Promise<Show> => {
-  const latest_show = (await db.select().from(shows).orderBy(desc(shows.id)).limit(1))[0];
-  return latest_show;
+  return (await getNShows(1))[0];
 };
 
 export const getOnAirStatusForDJ = async (dj_id: number): Promise<boolean> => {
@@ -421,40 +432,4 @@ export const changeOrder = async (entry_id: number, position_new: number): Promi
   const response = await db.select().from(flowsheet).where(eq(flowsheet.play_order, position_new)).limit(1);
 
   return response[0];
-};
-
-export const getEntriesFromPreviousShows = async (numberOfShows: number) => {
-  // Get the most recent N+1 shows (including current show)
-  const recentShows = await db
-    .select()
-    .from(shows)
-    .orderBy(desc(shows.id))
-    .limit(numberOfShows + 1);
-
-  if (recentShows.length === 0) {
-    return [];
-  }
-
-  // Get all entries from these shows
-  const response: IFSEntry[] = await db
-    .select({
-      id: flowsheet.id,
-      show_id: flowsheet.show_id,
-      album_id: flowsheet.album_id,
-      artist_name: flowsheet.artist_name,
-      album_title: flowsheet.album_title,
-      track_title: flowsheet.track_title,
-      record_label: flowsheet.record_label,
-      rotation_id: flowsheet.rotation_id,
-      rotation_play_freq: rotation.play_freq,
-      request_flag: flowsheet.request_flag,
-      message: flowsheet.message,
-      play_order: flowsheet.play_order,
-    })
-    .from(flowsheet)
-    .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
-    .where(inArray(flowsheet.show_id, recentShows.map(show => show.id)))
-    .orderBy(desc(flowsheet.play_order));
-
-  return response;
 };

--- a/tests/specs/flowsheet.spec.js
+++ b/tests/specs/flowsheet.spec.js
@@ -2,7 +2,6 @@ require('dotenv').config({ path: '../../.env' });
 const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
 const { after } = require('node:test');
 const fls_util = require('../utils/flowsheet_util');
-const { db } = require('../../src/db/drizzle_client');
 
 /*
  * Start Show (Primary dj hits /flowsheet/join)
@@ -415,10 +414,8 @@ describe('Retrieve Flowsheet Entries', () => {
   });
 
   test('Get entries from previous show when none exist', async () => {
-    // End current show and clear database
+    // End current show
     await fls_util.leave_show(global.primary_dj_id, global.access_token);
-    await db.delete(flowsheet);
-    await db.delete(shows);
 
     // Start new show
     await fls_util.join_show(global.primary_dj_id, global.access_token);


### PR DESCRIPTION
This changes the default number of returned items in the flowsheet from 5 to 30.

I also added a new param `?previous_shows` which takes a number `2` and returns all entries from the current show + the last 2 shows.

Didn't bother testing locally... lemme know if you see anything amiss.