### PR TITLE
Feature/playlist endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 tests/report
+coverage
 dist
 .env
 .DS_STORE

--- a/src/controllers/flowsheet.controller.ts
+++ b/src/controllers/flowsheet.controller.ts
@@ -355,3 +355,20 @@ export const changeOrder: RequestHandler<object, unknown, { entry_id: number; ne
     }
   }
 };
+
+export const getPlaylist: RequestHandler<object, unknown, object, { show_id: string }> = async (req, res, next) => {
+  const showId = parseInt(req.query.show_id);
+  if (isNaN(showId)) {
+    console.error('Bad Request, Missing Playlist Identifier: show_id');
+    res.status(400).send('Bad Request, Missing Playlist Identifier: show_id');
+  } else {
+    try {
+      const playlist = await flowsheet_service.getPlaylist(showId);
+      res.status(200).json(playlist);
+    } catch (e) {
+      console.error('Error: Failed to retrieve playlist');
+      console.error(e);
+      next(e);
+    }
+  }
+};

--- a/src/db/migrations/0000_rare_prima.sql
+++ b/src/db/migrations/0000_rare_prima.sql
@@ -130,8 +130,6 @@ CREATE TABLE IF NOT EXISTS "wxyc_schema"."specialty_shows" (
 	"last_modified" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "artist_name_trgm_idx" ON "wxyc_schema"."artists" USING gin ("artist_name" gin_trgm_ops);--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "title_trgm_idx" ON "wxyc_schema"."library" USING gin ("album_title" gin_trgm_ops);--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "genre_id_idx" ON "wxyc_schema"."library" ("genre_id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "format_id_idx" ON "wxyc_schema"."library" ("format_id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "artist_id_idx" ON "wxyc_schema"."library" ("artist_id");--> statement-breakpoint

--- a/src/db/migrations/0018_curvy_carnage.sql
+++ b/src/db/migrations/0018_curvy_carnage.sql
@@ -1,4 +1,2 @@
-DROP INDEX IF EXISTS "artist_name_trgm_idx";--> statement-breakpoint
-DROP INDEX IF EXISTS "title_trgm_idx";--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "artist_name_trgm_idx" ON "wxyc_schema"."artists" USING gin ("artist_name" gin_trgm_ops);--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "title_trgm_idx" ON "wxyc_schema"."library" USING gin ("album_title" gin_trgm_ops);

--- a/src/routes/djs.route.ts
+++ b/src/routes/djs.route.ts
@@ -19,5 +19,3 @@ dj_route.delete('/bin', cognitoMiddleware(), djsController.deleteFromBin);
 dj_route.get('/bin', cognitoMiddleware(), djsController.getBin);
 
 dj_route.get('/playlists', cognitoMiddleware(), djsController.getPlaylistsForDJ);
-
-dj_route.get('/playlist', cognitoMiddleware(), djsController.getPlaylist);

--- a/src/routes/flowsheet.route.ts
+++ b/src/routes/flowsheet.route.ts
@@ -23,3 +23,5 @@ flowsheet_route.get('/djs-on-air', flowsheetController.getDJList);
 flowsheet_route.get('/on-air', flowsheetController.getOnAir);
 
 flowsheet_route.patch('/play-order', flowsheetController.changeOrder);
+
+flowsheet_route.get('/playlist', flowsheetController.getPlaylist);

--- a/tests/utils/flowsheet_util.js
+++ b/tests/utils/flowsheet_util.js
@@ -15,7 +15,7 @@ exports.join_show = async (dj_id, access_token) => {
     }),
   });
 
-  return res.ok;
+  return res;
 };
 
 exports.leave_show = async (dj_id, access_token) => {
@@ -30,5 +30,5 @@ exports.leave_show = async (dj_id, access_token) => {
     }),
   });
 
-  return res.ok;
+  return res;
 };


### PR DESCRIPTION
- Move playlist route form `/djs/playlist` to `/flowsheet/playlist` as that makes more semantic sense. `/djs/playlists` will still exist to get the show ids a dj has been a part of, but to get the expanded playlist view of a full show you will hit /flowsheet/playlist and provide the `show_id` as a query param.
- Add integration/unit tests for this endpoint.
- Remove duplicate index out of migration file causing warning in `ci:test` and regular migration.
- Add `coverage` dir to `.gitignore`