### PR TITLE
Bugfix/workflow type error

### DIFF
--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -9,4 +9,4 @@ jobs:
   trigger-build-and-deploy:
     uses: ./.github/workflows/deploy.yml
     with:
-      dry-run: false
+      dry-run: 'false'

--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -1,4 +1,4 @@
-name: Auto Deploy
+name: Auto Build & Deploy
 
 on:
   push:

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -1,4 +1,4 @@
-name: Manual Deploy
+name: Manual Build & Deploy
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy
+name: Build & Deploy Base Workflow
 
 on:
   workflow_call:


### PR DESCRIPTION
-Pass proper dry-run input type from auto deploy workflow.
-Rename workflows to be more descriptive.