### PR TITLE
Add trailing whitespace check for .env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+### Backend Service Port
+PORT=8080
+CI_PORT=8081
+AUTH_PORT=8082
+
+### Better Auth Configuration
+BETTER_AUTH_URL=http://localhost:8082/auth
+BETTER_AUTH_JWKS_URL=http://localhost:8082/auth/jwks
+BETTER_AUTH_ISSUER=http://localhost:8082
+BETTER_AUTH_AUDIENCE=http://localhost:8082
+
+### DB Info
+DB_HOST=your-db-host.example.com
+DB_NAME=wxyc_db
+DB_USERNAME=your_db_username
+DB_PASSWORD=your_db_password
+DB_PORT=5432
+CI_DB_PORT=5433
+
+### Cognito Auth Info for Starting Backend Service Auth
+COGNITO_USERPOOL_ID=your_userpool_id
+DJ_APP_CLIENT_ID=your_client_id
+
+### Testing Env Variables
+TEST_HOST=http://localhost
+AUTH_BYPASS=true
+AUTH_USERNAME=test_user
+AUTH_PASSWORD=your_test_password
+
+### Slack Song Request Webhook
+SLACK_WXYC_REQUESTS_APP_ID=your_app_id
+SLACK_WXYC_REQUESTS_CLIENT_ID=your_client_id
+SLACK_WXYC_REQUESTS_CLIENT_SECRET=your_client_secret
+SLACK_WXYC_REQUESTS_SIGNING_SECRET=your_signing_secret
+SLACK_WXYC_REQUESTS_WEBHOOK=https://hooks.slack.com/services/your/webhook/url
+
+### Metadata Service - External API Keys
+DISCOGS_API_KEY=your_discogs_api_key
+DISCOGS_API_SECRET=your_discogs_api_secret
+SPOTIFY_CLIENT_ID=your_spotify_client_id
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
+
+### Metadata Cache Configuration
+METADATA_ALBUM_CACHE_MAX_SIZE=1000
+METADATA_ARTIST_CACHE_MAX_SIZE=500
+METADATA_ROTATION_PRIORITY=2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install Dependencies
         run: npm install --only=dev
 
+      - name: Lint .env file
+        run: npm run lint:env
+
       - name: Set Up Test Environment
         run: touch .env && npm run ci:env
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "All necessary app services for the WXYC flowsheet backend",
   "scripts": {
+    "lint:env": "node scripts/lint-env.js",
     "build": "npm run build --workspace=@wxyc/database --workspace=shared/** --workspace=apps/**",
     "dev": "dotenvx run -f .env -- concurrently \"npm:dev:auth\" \"npm:dev:backend\"",
     "dev:backend": "npm run dev --workspace=@wxyc/backend",

--- a/scripts/lint-env.js
+++ b/scripts/lint-env.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const filesToCheck = ['.env', '.env.example'];
+
+let hasErrors = false;
+let checkedAny = false;
+
+filesToCheck.forEach((filename) => {
+  const filePath = path.join(rootDir, filename);
+
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  checkedAny = true;
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split('\n');
+  const violations = [];
+
+  lines.forEach((line, index) => {
+    if (/\s$/.test(line)) {
+      violations.push({
+        line: index + 1,
+        content: line,
+      });
+    }
+  });
+
+  if (violations.length > 0) {
+    hasErrors = true;
+    console.error(`Error: ${filename} contains trailing whitespace:\n`);
+    violations.forEach(({ line, content }) => {
+      const visualized = content.replace(/\s+$/, (match) => '·'.repeat(match.length));
+      console.error(`  Line ${line}: ${visualized}`);
+    });
+    console.error('');
+  } else {
+    console.log(`${filename} OK`);
+  }
+});
+
+if (!checkedAny) {
+  console.log('No .env files found, skipping check');
+  process.exit(0);
+}
+
+if (hasErrors) {
+  console.error('Remove trailing whitespace from the above lines.');
+  process.exit(1);
+}
+
+console.log('All env files passed trailing whitespace check');
+process.exit(0);


### PR DESCRIPTION
## Summary
- Adds a cross-platform Node.js script (`scripts/lint-env.js`) that checks `.env` and `.env.example` for trailing whitespace
- Adds `npm run lint:env` script for local development
- Adds lint step to CI workflow (runs before tests)
- Adds `.env.example` template for new developers

## Test plan
- [x] Verified script catches trailing whitespace (shows line numbers and visualizes with `·`)
- [x] Verified script passes when no trailing whitespace exists
- [x] Verified script works on macOS (Darwin)
- [x] CI workflow runs lint step before tests