### PR TITLE
test: add integration tests for DJ, Library, and Schedule endpoints

### DIFF
--- a/tests/integration/djs.spec.js
+++ b/tests/integration/djs.spec.js
@@ -1,0 +1,177 @@
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const fls_util = require('../utils/flowsheet_util');
+const { createAuthRequest, expectErrorContains, expectFields, expectArray } = require('../utils/test_helpers');
+
+/**
+ * DJ Endpoints Integration Tests
+ *
+ * Tests for:
+ * - GET /djs/bin - Retrieve DJ's bin
+ * - POST /djs/bin - Add entry to bin
+ * - DELETE /djs/bin - Remove entry from bin
+ * - GET /djs/playlists - Get playlists for a DJ
+ */
+
+describe('DJ Bin', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  describe('GET /djs/bin', () => {
+    test('returns array for DJ', async () => {
+      const res = await auth.get('/djs/bin').query({ dj_id: global.primary_dj_id }).expect(200);
+
+      expectArray(res);
+    });
+
+    test('returns 400 when dj_id is missing', async () => {
+      const res = await auth.get('/djs/bin').expect(400);
+
+      expectErrorContains(res, 'Missing DJ Identifier');
+    });
+
+    test('returns empty array for DJ with no bin entries', async () => {
+      const res = await auth.get('/djs/bin').query({ dj_id: global.secondary_dj_id }).expect(200);
+
+      expectArray(res);
+    });
+  });
+
+  describe('POST /djs/bin', () => {
+    afterEach(async () => {
+      // Clean up any bin entries created during tests
+      await auth.delete('/djs/bin').query({ dj_id: global.primary_dj_id, album_id: 1 });
+    });
+
+    test('adds entry to bin successfully', async () => {
+      const res = await auth
+        .post('/djs/bin')
+        .send({
+          dj_id: global.primary_dj_id,
+          album_id: 1,
+        })
+        .expect(200);
+
+      expectFields(res.body, 'album_id', 'dj_id');
+      expect(res.body.album_id).toBe(1);
+      expect(res.body.dj_id).toBe(global.primary_dj_id);
+    });
+
+    test('adds entry with track title to bin', async () => {
+      const res = await auth
+        .post('/djs/bin')
+        .send({
+          dj_id: global.primary_dj_id,
+          album_id: 1,
+          track_title: 'Carry the Zero',
+        })
+        .expect(200);
+
+      expectFields(res.body, 'album_id', 'track_title');
+      expect(res.body.album_id).toBe(1);
+      expect(res.body.track_title).toBe('Carry the Zero');
+    });
+
+    test('returns 400 when album_id is missing', async () => {
+      const res = await auth
+        .post('/djs/bin')
+        .send({
+          dj_id: global.primary_dj_id,
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing');
+    });
+
+    test('returns 400 when dj_id is missing', async () => {
+      const res = await auth
+        .post('/djs/bin')
+        .send({
+          album_id: 1,
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing');
+    });
+  });
+
+  describe('DELETE /djs/bin', () => {
+    beforeEach(async () => {
+      // Set up a bin entry to delete
+      await auth.post('/djs/bin').send({
+        dj_id: global.primary_dj_id,
+        album_id: 2,
+      });
+    });
+
+    test('removes entry from bin successfully', async () => {
+      const res = await auth
+        .delete('/djs/bin')
+        .query({ dj_id: global.primary_dj_id, album_id: 2 })
+        .expect(200);
+
+      expect(res.body).toBeDefined();
+
+      // Verify it was removed
+      const binRes = await auth.get('/djs/bin').query({ dj_id: global.primary_dj_id }).expect(200);
+
+      const entry = binRes.body.find((e) => e.album_id === 2);
+      expect(entry).toBeUndefined();
+    });
+
+    test('returns 400 when album_id is missing', async () => {
+      const res = await auth.delete('/djs/bin').query({ dj_id: global.primary_dj_id }).expect(400);
+
+      expectErrorContains(res, 'Missing');
+    });
+
+    test('returns 400 when dj_id is missing', async () => {
+      const res = await auth.delete('/djs/bin').query({ album_id: 2 }).expect(400);
+
+      expectErrorContains(res, 'Missing');
+    });
+  });
+});
+
+describe('DJ Playlists', () => {
+  let auth;
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    // Create a show to ensure DJ has at least one playlist
+    await fls_util.join_show(global.primary_dj_id, global.access_token);
+    await fls_util.leave_show(global.primary_dj_id, global.access_token);
+  });
+
+  describe('GET /djs/playlists', () => {
+    test('returns playlists for DJ with shows', async () => {
+      const res = await auth.get('/djs/playlists').query({ dj_id: global.primary_dj_id }).expect(200);
+
+      expectArray(res);
+      expect(res.body.length).toBeGreaterThan(0);
+    });
+
+    test('returns empty array for DJ without shows', async () => {
+      const res = await auth.get('/djs/playlists').query({ dj_id: 'nonexistent-dj-id-12345' }).expect(200);
+
+      expectArray(res);
+      expect(res.body.length).toBe(0);
+    });
+
+    test('returns 400 when dj_id is missing', async () => {
+      const res = await auth.get('/djs/playlists').expect(400);
+
+      expectErrorContains(res, 'Missing DJ Identifier');
+    });
+
+    test('playlist contains expected fields', async () => {
+      const res = await auth.get('/djs/playlists').query({ dj_id: global.primary_dj_id }).expect(200);
+
+      if (res.body.length > 0) {
+        expectFields(res.body[0], 'show', 'date', 'djs', 'preview');
+      }
+    });
+  });
+});

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -1,0 +1,521 @@
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest, expectErrorContains, expectFields, expectArray } = require('../utils/test_helpers');
+
+/**
+ * Library Endpoints Integration Tests
+ *
+ * Tests for:
+ * - GET /library - Fuzzy search for albums
+ * - POST /library - Add album to library
+ * - GET /library/rotation - Get active rotations
+ * - POST /library/rotation - Add album to rotation
+ * - PATCH /library/rotation - Kill rotation entry
+ * - POST /library/artists - Add artist
+ * - GET /library/formats - Get all formats
+ * - POST /library/formats - Add format
+ * - GET /library/genres - Get all genres
+ * - POST /library/genres - Add genre
+ * - GET /library/info - Get album info
+ */
+
+describe('Library Catalog', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  describe('GET /library (Fuzzy Search)', () => {
+    test('searches by artist name', async () => {
+      const res = await auth.get('/library').query({ artist_name: 'Built to Spill' }).expect(200);
+
+      expectArray(res);
+      expect(res.body.length).toBeGreaterThan(0);
+    });
+
+    test('searches by album title', async () => {
+      const res = await auth.get('/library').query({ album_title: 'Keep it Like a Secret' }).expect(200);
+
+      expectArray(res);
+      expect(res.body.length).toBeGreaterThan(0);
+    });
+
+    test('searches by both artist and album', async () => {
+      const res = await auth.get('/library').query({ artist_name: 'Built to Spill', album_title: 'Keep it' }).expect(200);
+
+      expectArray(res);
+    });
+
+    test('limits results with n parameter', async () => {
+      const res = await auth.get('/library').query({ artist_name: 'a', n: 3 }).expect(200);
+
+      expectArray(res);
+      expect(res.body.length).toBeLessThanOrEqual(3);
+    });
+
+    test('returns 400 when no search parameters provided', async () => {
+      const res = await auth.get('/library').expect(400);
+
+      expectErrorContains(res, 'Missing query parameter');
+    });
+
+    test('returns empty array when no results found', async () => {
+      const res = await auth.get('/library').query({ artist_name: 'xyznonexistentartist123' }).expect(200);
+
+      expectArray(res);
+      expect(res.body.length).toBe(0);
+    });
+
+    test('code lookup returns 501 (not implemented)', async () => {
+      const res = await auth.get('/library').query({ code_letters: 'BUI', code_artist_number: '1' }).expect(501);
+
+      expectErrorContains(res, 'TODO');
+    });
+  });
+
+  describe('POST /library (Add Album)', () => {
+    test('adds album with existing artist_name', async () => {
+      const res = await auth
+        .post('/library')
+        .send({
+          album_title: `Test Album ${Date.now()}`,
+          artist_name: 'Built to Spill',
+          label: 'Test Label',
+          genre_id: 1,
+          format_id: 1,
+        })
+        .expect(200);
+
+      expectFields(res.body, 'id', 'album_title');
+      expect(res.body.album_title).toContain('Test Album');
+    });
+
+    test('returns 400 when album_title is missing', async () => {
+      const res = await auth
+        .post('/library')
+        .send({
+          artist_id: 1,
+          label: 'Test Label',
+          genre_id: 1,
+          format_id: 1,
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Parameters');
+    });
+
+    test('returns 400 when label is missing', async () => {
+      const res = await auth
+        .post('/library')
+        .send({
+          album_title: 'Test Album',
+          artist_id: 1,
+          genre_id: 1,
+          format_id: 1,
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Parameters');
+    });
+
+    test('returns 400 when genre_id is missing', async () => {
+      const res = await auth
+        .post('/library')
+        .send({
+          album_title: 'Test Album',
+          artist_id: 1,
+          label: 'Test Label',
+          format_id: 1,
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Parameters');
+    });
+
+    test('returns 400 when format_id is missing', async () => {
+      const res = await auth
+        .post('/library')
+        .send({
+          album_title: 'Test Album',
+          artist_id: 1,
+          label: 'Test Label',
+          genre_id: 1,
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Parameters');
+    });
+
+    test('returns 400 when neither artist_id nor artist_name provided', async () => {
+      const res = await auth
+        .post('/library')
+        .send({
+          album_title: 'Test Album',
+          label: 'Test Label',
+          genre_id: 1,
+          format_id: 1,
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Parameters');
+    });
+  });
+});
+
+describe('Library Rotation', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  describe('GET /library/rotation', () => {
+    test('returns rotation as an array', async () => {
+      const res = await auth.get('/library/rotation').expect(200);
+
+      expectArray(res);
+    });
+
+    test('rotation entries have expected fields', async () => {
+      const res = await auth.get('/library/rotation').expect(200);
+
+      if (res.body.length > 0) {
+        expectFields(res.body[0], 'id', 'artist_name', 'album_title', 'play_freq', 'rotation_id');
+      }
+    });
+  });
+
+  describe('POST /library/rotation', () => {
+    test('adds album to rotation', async () => {
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          album_id: 2,
+          play_freq: 'M',
+        })
+        .expect(200);
+
+      expectFields(res.body, 'id', 'album_id', 'play_freq');
+      expect(res.body.album_id).toBe(2);
+      expect(res.body.play_freq).toBe('M');
+
+      // Clean up
+      if (res.body.id) {
+        await auth.patch('/library/rotation').send({ rotation_id: res.body.id });
+      }
+    });
+
+    test('returns 400 when album_id is missing', async () => {
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          play_freq: 'M',
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Parameters');
+    });
+
+    test('returns 400 when play_freq is missing', async () => {
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          album_id: 2,
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Parameters');
+    });
+  });
+
+  describe('PATCH /library/rotation (Kill Rotation)', () => {
+    let testRotationId;
+
+    beforeEach(async () => {
+      const res = await auth.post('/library/rotation').send({
+        album_id: 3,
+        play_freq: 'L',
+      });
+
+      if (res.body && res.body.id) {
+        testRotationId = res.body.id;
+      }
+    });
+
+    test('kills rotation with default date', async () => {
+      if (!testRotationId) {
+        console.log('Skipping test - no rotation ID available');
+        return;
+      }
+
+      const res = await auth.patch('/library/rotation').send({ rotation_id: testRotationId }).expect(200);
+
+      expectFields(res.body, 'id', 'kill_date');
+      expect(res.body.id).toBe(testRotationId);
+    });
+
+    test('kills rotation with specific date', async () => {
+      const createRes = await auth.post('/library/rotation').send({
+        album_id: 3,
+        play_freq: 'H',
+      });
+
+      if (createRes.body && createRes.body.id) {
+        const killDate = '2025-12-31';
+        const res = await auth
+          .patch('/library/rotation')
+          .send({
+            rotation_id: createRes.body.id,
+            kill_date: killDate,
+          })
+          .expect(200);
+
+        expect(res.body.kill_date).toBe(killDate);
+      }
+    });
+
+    test('returns 400 when rotation_id is missing', async () => {
+      const res = await auth.patch('/library/rotation').send({}).expect(400);
+
+      expectErrorContains(res, 'Missing Parameter');
+    });
+
+    test('returns 400 with invalid date format', async () => {
+      const res = await auth
+        .patch('/library/rotation')
+        .send({
+          rotation_id: 1,
+          kill_date: '12/31/2025',
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Incorrect Date Format');
+    });
+  });
+});
+
+describe('Library Artists', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  describe('POST /library/artists', () => {
+    test('adds new artist', async () => {
+      const uniqueSuffix = Date.now().toString(36).toUpperCase().slice(-2);
+      const res = await auth
+        .post('/library/artists')
+        .send({
+          artist_name: `Test Artist ${uniqueSuffix}`,
+          code_letters: uniqueSuffix,
+          genre_id: 1,
+        })
+        .expect(200);
+
+      expectFields(res.body, 'id', 'artist_name', 'code_letters', 'code_artist_number');
+      expect(res.body.artist_name).toContain('Test Artist');
+      expect(res.body.code_letters).toBe(uniqueSuffix);
+    });
+
+    test('generates incremented code_artist_number', async () => {
+      const uniqueCode = Date.now().toString(36).toUpperCase().slice(-2);
+
+      const res1 = await auth.post('/library/artists').send({
+        artist_name: `Test Artist A ${uniqueCode}`,
+        code_letters: uniqueCode,
+        genre_id: 1,
+      });
+
+      const res2 = await auth.post('/library/artists').send({
+        artist_name: `Test Artist B ${uniqueCode}`,
+        code_letters: uniqueCode,
+        genre_id: 1,
+      });
+
+      if (res1.body.code_artist_number && res2.body.code_artist_number) {
+        expect(res2.body.code_artist_number).toBeGreaterThan(res1.body.code_artist_number);
+      }
+    });
+
+    test('returns 400 when artist_name is missing', async () => {
+      const res = await auth
+        .post('/library/artists')
+        .send({
+          code_letters: 'TS',
+          genre_id: 1,
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Request Parameters');
+    });
+
+    test('returns 400 when code_letters is missing', async () => {
+      const res = await auth
+        .post('/library/artists')
+        .send({
+          artist_name: 'Test Artist',
+          genre_id: 1,
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Request Parameters');
+    });
+
+    test('returns 400 when genre_id is missing', async () => {
+      const res = await auth
+        .post('/library/artists')
+        .send({
+          artist_name: 'Test Artist',
+          code_letters: 'TS',
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'Missing Request Parameters');
+    });
+  });
+});
+
+describe('Library Formats', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  describe('GET /library/formats', () => {
+    test('returns formats as an array', async () => {
+      const res = await auth.get('/library/formats').expect(200);
+
+      expectArray(res);
+      expect(res.body.length).toBeGreaterThan(0);
+    });
+
+    test('formats have expected fields', async () => {
+      const res = await auth.get('/library/formats').expect(200);
+
+      if (res.body.length > 0) {
+        expectFields(res.body[0], 'id', 'format_name');
+      }
+    });
+  });
+
+  describe('POST /library/formats', () => {
+    test('adds new format', async () => {
+      const uniqueSuffix = Date.now();
+      const res = await auth
+        .post('/library/formats')
+        .send({
+          name: `Test Format ${uniqueSuffix}`,
+        })
+        .expect(200);
+
+      expectFields(res.body, 'id', 'format_name');
+      expect(res.body.format_name).toContain('Test Format');
+    });
+
+    test('returns 400 when name is missing', async () => {
+      const res = await auth.post('/library/formats').send({}).expect(400);
+
+      expectErrorContains(res, 'Missing Parameter');
+    });
+  });
+});
+
+describe('Library Genres', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  describe('GET /library/genres', () => {
+    test('returns genres as an array', async () => {
+      const res = await auth.get('/library/genres').expect(200);
+
+      expectArray(res);
+      expect(res.body.length).toBeGreaterThan(0);
+    });
+
+    test('genres have expected fields', async () => {
+      const res = await auth.get('/library/genres').expect(200);
+
+      if (res.body.length > 0) {
+        expectFields(res.body[0], 'id', 'genre_name');
+      }
+    });
+  });
+
+  describe('POST /library/genres', () => {
+    test('adds new genre', async () => {
+      const uniqueSuffix = Date.now();
+      const res = await auth
+        .post('/library/genres')
+        .send({
+          name: `Test Genre ${uniqueSuffix}`,
+          description: 'A test genre for integration testing',
+        })
+        .expect(200);
+
+      expectFields(res.body, 'id', 'genre_name');
+      expect(res.body.genre_name).toContain('Test Genre');
+    });
+
+    test('returns 400 when name is missing', async () => {
+      const res = await auth
+        .post('/library/genres')
+        .send({
+          description: 'Test description',
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'name and description are required');
+    });
+
+    test('returns 400 when description is missing', async () => {
+      const res = await auth
+        .post('/library/genres')
+        .send({
+          name: 'Test Genre',
+        })
+        .expect(400);
+
+      expectErrorContains(res, 'name and description are required');
+    });
+  });
+});
+
+describe('Library Album Info', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  describe('GET /library/info', () => {
+    test('returns album info for valid album_id', async () => {
+      const res = await auth.get('/library/info').query({ album_id: 1 }).expect(200);
+
+      expectFields(res.body, 'id', 'artist_name', 'album_title');
+      expect(res.body.id).toBe(1);
+    });
+
+    test('returns album with all expected fields', async () => {
+      const res = await auth.get('/library/info').query({ album_id: 1 }).expect(200);
+
+      expectFields(res.body, 'id', 'artist_name', 'album_title', 'code_letters', 'code_number', 'plays');
+    });
+
+    test('returns 400 when album_id is missing', async () => {
+      const res = await auth.get('/library/info').expect(400);
+
+      expectErrorContains(res, 'missing album identifier');
+    });
+
+    test('returns undefined/empty for non-existent album_id', async () => {
+      const res = await auth.get('/library/info').query({ album_id: 999999 }).expect(200);
+
+      expect(res.body).toBeFalsy();
+    });
+  });
+});

--- a/tests/integration/schedule.spec.js
+++ b/tests/integration/schedule.spec.js
@@ -1,0 +1,150 @@
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { expectFields, expectArray } = require('../utils/test_helpers');
+
+/**
+ * Schedule Endpoints Integration Tests
+ *
+ * Tests for:
+ * - GET /schedule - Retrieve full schedule
+ * - POST /schedule - Add shift to schedule
+ *
+ * Note: Schedule endpoints don't require authentication
+ */
+
+describe('Schedule', () => {
+  const createdScheduleIds = [];
+
+  afterAll(async () => {
+    // Note: Cleanup would require a DELETE endpoint (currently commented out in route)
+  });
+
+  describe('GET /schedule', () => {
+    test('returns schedule as an array', async () => {
+      const res = await request.get('/schedule').expect(200);
+
+      expectArray(res);
+    });
+
+    test('schedule entries have expected fields', async () => {
+      const res = await request.get('/schedule').expect(200);
+
+      if (res.body.length > 0) {
+        expectFields(res.body[0], 'id', 'day', 'start_time', 'show_duration');
+      }
+    });
+
+    test('day field contains valid values (0-6)', async () => {
+      const res = await request.get('/schedule').expect(200);
+
+      res.body.forEach((shift) => {
+        expect(shift.day).toBeGreaterThanOrEqual(0);
+        expect(shift.day).toBeLessThanOrEqual(6);
+      });
+    });
+  });
+
+  describe('POST /schedule', () => {
+    test('adds shift to schedule successfully', async () => {
+      const newShift = {
+        day: 0,
+        start_time: '14:00:00',
+        show_duration: 8,
+      };
+
+      const res = await request.post('/schedule').send(newShift).expect(200);
+
+      expectFields(res.body, 'id', 'day', 'start_time', 'show_duration');
+      expect(res.body.day).toBe(0);
+      expect(res.body.start_time).toBe('14:00:00');
+      expect(res.body.show_duration).toBe(8);
+
+      if (res.body.id) {
+        createdScheduleIds.push(res.body.id);
+      }
+    });
+
+    test('adds shift with specialty_id', async () => {
+      const newShift = {
+        day: 2,
+        start_time: '20:00:00',
+        show_duration: 4,
+        specialty_id: null,
+      };
+
+      const res = await request.post('/schedule').send(newShift).expect(200);
+
+      expect(res.body.day).toBe(2);
+
+      if (res.body.id) {
+        createdScheduleIds.push(res.body.id);
+      }
+    });
+
+    test('adds shift on different days of the week', async () => {
+      const days = [
+        { day: 1, name: 'Tuesday' },
+        { day: 3, name: 'Thursday' },
+        { day: 4, name: 'Friday' },
+        { day: 5, name: 'Saturday' },
+        { day: 6, name: 'Sunday' },
+      ];
+
+      for (const { day } of days) {
+        const newShift = {
+          day,
+          start_time: '10:00:00',
+          show_duration: 4,
+        };
+
+        const res = await request.post('/schedule').send(newShift).expect(200);
+
+        expect(res.body.day).toBe(day);
+
+        if (res.body.id) {
+          createdScheduleIds.push(res.body.id);
+        }
+      }
+    });
+
+    test('handles various time formats', async () => {
+      const newShift = {
+        day: 0,
+        start_time: '08:30:00',
+        show_duration: 2,
+      };
+
+      const res = await request.post('/schedule').send(newShift).expect(200);
+
+      expect(res.body.start_time).toBe('08:30:00');
+
+      if (res.body.id) {
+        createdScheduleIds.push(res.body.id);
+      }
+    });
+
+    test('schedule is updated after adding shift', async () => {
+      const initialRes = await request.get('/schedule').expect(200);
+      const initialCount = initialRes.body.length;
+
+      const newShift = {
+        day: 6,
+        start_time: '23:00:00',
+        show_duration: 4,
+      };
+
+      const postRes = await request.post('/schedule').send(newShift).expect(200);
+
+      if (postRes.body.id) {
+        createdScheduleIds.push(postRes.body.id);
+      }
+
+      const finalRes = await request.get('/schedule').expect(200);
+
+      expect(finalRes.body.length).toBe(initialCount + 1);
+
+      const addedShift = finalRes.body.find((s) => s.id === postRes.body.id);
+      expect(addedShift).toBeDefined();
+      expect(addedShift.day).toBe(6);
+    });
+  });
+});

--- a/tests/utils/library_util.js
+++ b/tests/utils/library_util.js
@@ -1,0 +1,187 @@
+/**
+ * Library test utilities
+ * Helper functions for library-related integration tests
+ */
+
+const url = `${process.env.TEST_HOST}:${process.env.PORT}`;
+
+/**
+ * Creates a new artist in the library.
+ *
+ * @param {object} artistData - Artist data
+ * @param {string} artistData.artist_name - Artist name
+ * @param {string} artistData.code_letters - Artist code letters (e.g., 'BUI')
+ * @param {number} artistData.genre_id - Genre ID
+ * @param {string} access_token - Authorization token
+ * @returns {Promise<object>} Created artist
+ */
+exports.createArtist = async (artistData, access_token) => {
+  const res = await fetch(`${url}/library/artists`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: access_token,
+    },
+    body: JSON.stringify(artistData),
+  });
+
+  return res;
+};
+
+/**
+ * Creates a new album in the library.
+ *
+ * @param {object} albumData - Album data
+ * @param {string} albumData.album_title - Album title
+ * @param {number} [albumData.artist_id] - Artist ID
+ * @param {string} [albumData.artist_name] - Artist name (if artist_id not provided)
+ * @param {string} albumData.label - Record label
+ * @param {number} albumData.genre_id - Genre ID
+ * @param {number} albumData.format_id - Format ID
+ * @param {string} access_token - Authorization token
+ * @returns {Promise<object>} Created album
+ */
+exports.createAlbum = async (albumData, access_token) => {
+  const res = await fetch(`${url}/library`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: access_token,
+    },
+    body: JSON.stringify(albumData),
+  });
+
+  return res;
+};
+
+/**
+ * Creates a new format in the library.
+ *
+ * @param {object} formatData - Format data
+ * @param {string} formatData.name - Format name
+ * @param {string} access_token - Authorization token
+ * @returns {Promise<object>} Created format
+ */
+exports.createFormat = async (formatData, access_token) => {
+  const res = await fetch(`${url}/library/formats`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: access_token,
+    },
+    body: JSON.stringify(formatData),
+  });
+
+  return res;
+};
+
+/**
+ * Creates a new genre in the library.
+ *
+ * @param {object} genreData - Genre data
+ * @param {string} genreData.name - Genre name
+ * @param {string} genreData.description - Genre description
+ * @param {string} access_token - Authorization token
+ * @returns {Promise<object>} Created genre
+ */
+exports.createGenre = async (genreData, access_token) => {
+  const res = await fetch(`${url}/library/genres`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: access_token,
+    },
+    body: JSON.stringify(genreData),
+  });
+
+  return res;
+};
+
+/**
+ * Adds an album to rotation.
+ *
+ * @param {object} rotationData - Rotation data
+ * @param {number} rotationData.album_id - Album ID
+ * @param {string} rotationData.play_freq - Play frequency (S, L, M, H)
+ * @param {string} access_token - Authorization token
+ * @returns {Promise<object>} Created rotation entry
+ */
+exports.addToRotation = async (rotationData, access_token) => {
+  const res = await fetch(`${url}/library/rotation`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: access_token,
+    },
+    body: JSON.stringify(rotationData),
+  });
+
+  return res;
+};
+
+/**
+ * Kills a rotation entry.
+ *
+ * @param {object} killData - Kill data
+ * @param {number} killData.rotation_id - Rotation ID
+ * @param {string} [killData.kill_date] - Kill date (YYYY-MM-DD format)
+ * @param {string} access_token - Authorization token
+ * @returns {Promise<object>} Updated rotation entry
+ */
+exports.killRotation = async (killData, access_token) => {
+  const res = await fetch(`${url}/library/rotation`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: access_token,
+    },
+    body: JSON.stringify(killData),
+  });
+
+  return res;
+};
+
+/**
+ * Gets album info by ID.
+ *
+ * @param {number} album_id - Album ID
+ * @param {string} access_token - Authorization token
+ * @returns {Promise<object>} Album info
+ */
+exports.getAlbumInfo = async (album_id, access_token) => {
+  const res = await fetch(`${url}/library/info?album_id=${album_id}`, {
+    method: 'GET',
+    headers: {
+      Authorization: access_token,
+    },
+  });
+
+  return res;
+};
+
+/**
+ * Searches the library with DJ auth.
+ *
+ * @param {object} searchParams - Search parameters
+ * @param {string} [searchParams.artist_name] - Artist name
+ * @param {string} [searchParams.album_title] - Album title
+ * @param {number} [searchParams.n] - Number of results
+ * @param {string} access_token - Authorization token
+ * @returns {Promise<object>} Search results
+ */
+exports.searchLibrary = async (searchParams, access_token) => {
+  const params = new URLSearchParams();
+  if (searchParams.artist_name) params.append('artist_name', searchParams.artist_name);
+  if (searchParams.album_title) params.append('album_title', searchParams.album_title);
+  if (searchParams.n) params.append('n', searchParams.n.toString());
+
+  const res = await fetch(`${url}/library?${params.toString()}`, {
+    method: 'GET',
+    headers: {
+      Authorization: access_token,
+    },
+  });
+
+  return res;
+};
+

--- a/tests/utils/test_helpers.js
+++ b/tests/utils/test_helpers.js
@@ -1,0 +1,74 @@
+/**
+ * Shared test helper utilities for integration tests
+ *
+ * Provides:
+ * - Authenticated request helpers
+ * - Error response assertions
+ * - Field validation helpers
+ */
+
+/**
+ * Creates an authenticated request wrapper that automatically sets the Authorization header.
+ *
+ * @param {object} baseRequest - The supertest request object
+ * @param {string} token - The authorization token
+ * @returns {object} Object with HTTP method helpers
+ *
+ * @example
+ * const auth = createAuthRequest(request, global.access_token);
+ * const res = await auth.get('/djs/bin').query({ dj_id: 123 });
+ */
+const createAuthRequest = (baseRequest, token) => ({
+  get: (path) => baseRequest.get(path).set('Authorization', token),
+  post: (path) => baseRequest.post(path).set('Authorization', token),
+  put: (path) => baseRequest.put(path).set('Authorization', token),
+  patch: (path) => baseRequest.patch(path).set('Authorization', token),
+  delete: (path) => baseRequest.delete(path).set('Authorization', token),
+});
+
+/**
+ * Asserts that an error response contains the expected message.
+ * Handles both res.body.message and res.text formats.
+ *
+ * @param {object} res - The supertest response object
+ * @param {string} messageContains - String that should be in the error message (case-insensitive)
+ *
+ * @example
+ * expectErrorContains(res, 'missing');
+ */
+const expectErrorContains = (res, messageContains) => {
+  const message = res.body?.message || res.text || '';
+  expect(message.toLowerCase()).toContain(messageContains.toLowerCase());
+};
+
+/**
+ * Asserts that an object has all the specified properties.
+ *
+ * @param {object} obj - The object to check
+ * @param {...string} fields - The field names that should exist
+ *
+ * @example
+ * expectFields(res.body, 'id', 'artist_name', 'album_title');
+ */
+const expectFields = (obj, ...fields) => {
+  fields.forEach((field) => expect(obj).toHaveProperty(field));
+};
+
+/**
+ * Asserts that a response body is an array.
+ *
+ * @param {object} res - The supertest response object
+ *
+ * @example
+ * expectArray(res);
+ */
+const expectArray = (res) => {
+  expect(Array.isArray(res.body)).toBe(true);
+};
+
+module.exports = {
+  createAuthRequest,
+  expectErrorContains,
+  expectFields,
+  expectArray,
+};


### PR DESCRIPTION
## Summary
- Add integration tests for DJ endpoints
- Add integration tests for Library endpoints
- Add integration tests for Schedule endpoints
- Add shared test utilities

## Test plan
- [ ] Run `npm run test:integration` to verify tests pass

Generated with [Claude Code](https://claude.com/claude-code)