### PR TITLE
fix: always use dj.wxyc.org for email links

### DIFF
--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -23,25 +23,7 @@ import {
 import { eq, sql } from 'drizzle-orm';
 import { WXYCRoles } from './auth.roles';
 import { sendResetPasswordEmail, sendVerificationEmailMessage } from './email';
-
-/**
- * Rewrites a URL to use the frontend host and protocol while preserving path and query params.
- * This allows email links to point to the frontend domain while keeping all Better Auth parameters intact.
- */
-export const rewriteUrlForFrontend = (url: string): string => {
-  try {
-    const parsed = new URL(url);
-    const frontend = new URL(
-      process.env.FRONTEND_SOURCE || 'http://localhost:3000'
-    );
-    parsed.host = frontend.host;
-    parsed.protocol = frontend.protocol;
-    return parsed.toString();
-  } catch {
-    // If URL parsing fails, return original URL
-    return url;
-  }
-};
+import { rewriteUrlForFrontend } from './url-rewrite';
 
 const buildResetUrl = (url: string, redirectTo?: string) => {
   const rewrittenUrl = rewriteUrlForFrontend(url);

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -28,7 +28,7 @@ import { sendResetPasswordEmail, sendVerificationEmailMessage } from './email';
  * Rewrites a URL to use the frontend host and protocol while preserving path and query params.
  * This allows email links to point to the frontend domain while keeping all Better Auth parameters intact.
  */
-const rewriteUrlForFrontend = (url: string): string => {
+export const rewriteUrlForFrontend = (url: string): string => {
   try {
     const parsed = new URL(url);
     const frontend = new URL(

--- a/shared/authentication/src/url-rewrite.ts
+++ b/shared/authentication/src/url-rewrite.ts
@@ -1,0 +1,18 @@
+/**
+ * Rewrites a URL to use the frontend host and protocol while preserving path and query params.
+ * This allows email links to point to the frontend domain while keeping all Better Auth parameters intact.
+ */
+export const rewriteUrlForFrontend = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    const frontend = new URL(
+      process.env.FRONTEND_SOURCE || 'http://localhost:3000'
+    );
+    parsed.host = frontend.host;
+    parsed.protocol = frontend.protocol;
+    return parsed.toString();
+  } catch {
+    // If URL parsing fails, return original URL
+    return url;
+  }
+};

--- a/tests/unit/authentication/url-rewrite.test.ts
+++ b/tests/unit/authentication/url-rewrite.test.ts
@@ -1,0 +1,75 @@
+import { rewriteUrlForFrontend } from '../../../shared/authentication/src/auth.definition';
+
+describe('rewriteUrlForFrontend', () => {
+  const originalEnv = process.env.FRONTEND_SOURCE;
+
+  afterEach(() => {
+    if (originalEnv) {
+      process.env.FRONTEND_SOURCE = originalEnv;
+    } else {
+      delete process.env.FRONTEND_SOURCE;
+    }
+  });
+
+  it('replaces host and protocol while preserving path and query params', () => {
+    process.env.FRONTEND_SOURCE = 'https://dj.wxyc.org';
+    const input =
+      'https://api.wxyc.org/auth/verify-email?token=abc123&callbackURL=%2Fonboarding';
+    const result = rewriteUrlForFrontend(input);
+
+    expect(result).toBe(
+      'https://dj.wxyc.org/auth/verify-email?token=abc123&callbackURL=%2Fonboarding'
+    );
+  });
+
+  it('handles URLs without query params', () => {
+    process.env.FRONTEND_SOURCE = 'https://dj.wxyc.org';
+    const input = 'https://api.wxyc.org/auth/reset-password/token123';
+    const result = rewriteUrlForFrontend(input);
+
+    expect(result).toBe('https://dj.wxyc.org/auth/reset-password/token123');
+  });
+
+  it('preserves complex query parameters', () => {
+    process.env.FRONTEND_SOURCE = 'https://dj.wxyc.org';
+    const input =
+      'https://api.wxyc.org/auth/verify-email?token=xyz&callbackURL=%2Fdashboard&redirectTo=%2Fhome';
+    const result = rewriteUrlForFrontend(input);
+
+    expect(result).toBe(
+      'https://dj.wxyc.org/auth/verify-email?token=xyz&callbackURL=%2Fdashboard&redirectTo=%2Fhome'
+    );
+  });
+
+  it('handles invalid URLs gracefully by returning original', () => {
+    process.env.FRONTEND_SOURCE = 'https://dj.wxyc.org';
+    const input = 'not-a-valid-url';
+    const result = rewriteUrlForFrontend(input);
+
+    expect(result).toBe('not-a-valid-url');
+  });
+
+  it('uses default localhost when FRONTEND_SOURCE is not set', () => {
+    delete process.env.FRONTEND_SOURCE;
+    const input = 'https://api.wxyc.org/auth/verify-email?token=test';
+    const result = rewriteUrlForFrontend(input);
+
+    expect(result).toBe('http://localhost:3000/auth/verify-email?token=test');
+  });
+
+  it('handles different protocols correctly', () => {
+    process.env.FRONTEND_SOURCE = 'http://localhost:3000';
+    const input = 'https://api.wxyc.org/auth/verify-email';
+    const result = rewriteUrlForFrontend(input);
+
+    expect(result).toBe('http://localhost:3000/auth/verify-email');
+  });
+
+  it('preserves port numbers in frontend URL', () => {
+    process.env.FRONTEND_SOURCE = 'http://localhost:8080';
+    const input = 'https://api.wxyc.org/auth/verify-email';
+    const result = rewriteUrlForFrontend(input);
+
+    expect(result).toBe('http://localhost:8080/auth/verify-email');
+  });
+});

--- a/tests/unit/authentication/url-rewrite.test.ts
+++ b/tests/unit/authentication/url-rewrite.test.ts
@@ -1,4 +1,4 @@
-import { rewriteUrlForFrontend } from '../../../shared/authentication/src/auth.definition';
+import { rewriteUrlForFrontend } from '../../../shared/authentication/src/url-rewrite';
 
 describe('rewriteUrlForFrontend', () => {
   const originalEnv = process.env.FRONTEND_SOURCE;


### PR DESCRIPTION
**This is absolutely critical for getting login flow working**

Rewrites email verification and password reset URLs to use the frontend domain instead of the backend API domain, while preserving path and query parameters.

#### What Changed
- Added `rewriteUrlForFrontend` helper that replaces only the host and protocol, leaving path and query params intact
- Applied URL rewriting to verification email links
- Applied URL rewriting to password reset email links (via `buildResetUrl`)

#### Why
Email links now point to `dj.wxyc.org` instead of `api.wxyc.org`, so users land on the frontend. The `callbackURL` query parameter remains a relative path (e.g., `/onboarding`) that the frontend resolves correctly. This removes the need for frontend URL sanitization helpers.