### PR TITLE
fix: remove autoverification from admin create user hook

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -55,7 +55,6 @@ if (process.env.NODE_ENV !== 'production') {
       }
 
       const userId = userResult[0].id;
-
       const tokenPrefix = `${type}:`;
       const result = await db
         .select()

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -311,32 +311,21 @@ export const auth: Auth = betterAuth({
         return;
       }
 
-      // Auto-verify email for admin-created users (admin is a trusted source)
-      // This avoids requiring email verification for accounts created by station managers
-      try {
-        await db
-          .update(user)
-          .set({ emailVerified: true })
-          .where(eq(user.email, email));
-        console.log(`Auto-verified email for admin-created user: ${email}`);
-      } catch (error) {
-        console.error('Error auto-verifying admin-created user email:', error);
-        // Still try to send verification email as fallback
-        const callbackURL =
-          process.env.EMAIL_VERIFICATION_REDIRECT_URL?.trim() ||
-          process.env.FRONTEND_SOURCE?.trim();
+      // Send verification email for admin-created users
+      const callbackURL =
+        process.env.EMAIL_VERIFICATION_REDIRECT_URL?.trim() ||
+        process.env.FRONTEND_SOURCE?.trim();
 
-        void auth.api
-          .sendVerificationEmail({
-            body: {
-              email,
-              callbackURL,
-            },
-          })
-          .catch((verifyError) => {
-            console.error('Error triggering verification email:', verifyError);
-          });
-      }
+      void auth.api
+        .sendVerificationEmail({
+          body: {
+            email,
+            callbackURL,
+          },
+        })
+        .catch((error) => {
+          console.error('Error triggering verification email:', error);
+        });
     }),
   },
 


### PR DESCRIPTION
Removes auto-verification for admin-created users and ensures verification emails are always sent.

## What Changed
Removed auto-verification logic that set emailVerified: true for admin-created users
Hook now always sends verification emails via auth.api.sendVerificationEmail() after user creation
Simplified error handling by removing the try/catch that only sent emails on verification failure

## Why
Admin-created users were being auto-verified, so they never received verification emails. This change ensures all admin-created users receive verification emails and must verify before accessing the system.

## Context
This addresses a mixed-state deployment where old code auto-verified users while new code expected verification emails. The cleanup aligns the hook with the intended behavior: send verification emails for all admin-created users, with no auto-verification.