### PR TITLE
ci: skip redundant Docker builds in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,7 +369,7 @@ jobs:
         if: env.RUN_TESTS == 'true'
         run: |
           touch .env
-          npm run ci:env
+          ./scripts/ci-env.sh --skip-build
 
       - name: Run Integration Tests
         if: env.RUN_TESTS == 'true'

--- a/scripts/ci-env.sh
+++ b/scripts/ci-env.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # CI Environment Setup Script
-# Usage: ./scripts/ci-env.sh [--full]
+# Usage: ./scripts/ci-env.sh [--full] [--skip-build]
 #
 # Options:
-#   --full    Enable rate limiting and create default admin user for full test suite
+#   --full         Enable rate limiting and create default admin user for full test suite
+#   --skip-build   Skip Docker image builds (use when images are already built, e.g. in CI)
 
 set -e
 
@@ -12,17 +13,26 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 # Parse arguments
 FULL_MODE=false
+SKIP_BUILD=false
 for arg in "$@"; do
   case $arg in
     --full)
       FULL_MODE=true
       shift
       ;;
+    --skip-build)
+      SKIP_BUILD=true
+      shift
+      ;;
   esac
 done
 
-# Build the Docker images
-npm run ci:build
+# Build the Docker images (unless --skip-build is set, e.g. when CI has already built them)
+if [ "$SKIP_BUILD" = true ]; then
+  echo "Skipping Docker image builds (--skip-build)"
+else
+  npm run ci:build
+fi
 
 # Set up compose command with environment
 COMPOSE_CMD="docker compose -f $PROJECT_ROOT/dev_env/docker-compose.yml --env-file $PROJECT_ROOT/.env --profile ci"


### PR DESCRIPTION
## Summary
- Add `--skip-build` flag to `scripts/ci-env.sh` to skip `npm run ci:build` when Docker images are already built
- Pass `--skip-build` from the workflow's "Set Up Test Environment" step, since `docker/build-push-action` already builds and tags the images
- Local `npm run ci:testmock` continues to work unchanged (no flag passed)

## Estimated savings
~1-2 minutes per integration test run (eliminates redundant Docker image rebuilds)

## Test plan
- [ ] CI integration tests pass with `--skip-build` (no Docker build output in "Set Up Test Environment" step)
- [ ] Local `npm run ci:testmock` still builds images and runs tests correctly