### PR TITLE
ci: fix Docker builder-stage layer caching

### DIFF
--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -3,12 +3,20 @@ FROM node:22-alpine AS builder
 
 WORKDIR /auth-builder
 
-COPY ./package.json ./
+# Copy package manifests first for better layer caching
+COPY ./package.json ./package-lock.json ./
+COPY ./apps/auth/package.json ./apps/auth/
+COPY ./shared/database/package.json ./shared/database/
+COPY ./shared/authentication/package.json ./shared/authentication/
+
+RUN npm ci
+
+# Copy source code and build (this layer invalidates on code changes)
 COPY ./tsconfig.base.json ./
 COPY ./shared ./shared
 COPY ./apps/auth ./apps/auth
 
-RUN npm install && npm run build --workspace=@wxyc/database --workspace=shared/** --workspace=@wxyc/auth-service
+RUN npm run build --workspace=@wxyc/database --workspace=shared/** --workspace=@wxyc/auth-service
 
 #Production stage
 FROM node:22-alpine AS prod

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -3,12 +3,20 @@ FROM node:22-alpine AS builder
 
 WORKDIR /builder
 
-COPY ./package.json ./
+# Copy package manifests first for better layer caching
+COPY ./package.json ./package-lock.json ./
+COPY ./apps/backend/package.json ./apps/backend/
+COPY ./shared/database/package.json ./shared/database/
+COPY ./shared/authentication/package.json ./shared/authentication/
+
+RUN npm ci
+
+# Copy source code and build (this layer invalidates on code changes)
 COPY ./tsconfig.base.json ./
 COPY ./shared ./shared
 COPY ./apps/backend ./apps/backend
 
-RUN npm install && npm run build --workspace=@wxyc/database --workspace=shared/** --workspace=@wxyc/backend
+RUN npm run build --workspace=@wxyc/database --workspace=shared/** --workspace=@wxyc/backend
 
 #Production stage
 FROM node:22-alpine AS prod


### PR DESCRIPTION
## Summary
- Restructure builder stages in `Dockerfile.backend` and `Dockerfile.auth` to copy package manifests before source code
- Replace `npm install` with `npm ci` for deterministic, faster dependency resolution
- Add `package-lock.json` to builder stage (was missing, causing non-deterministic installs)

This enables Docker layer caching for the `npm ci` step: when only source code changes (the common case), the dependency layer is reused instead of rebuilt.

## Estimated savings
~1-2 minutes when code changes but dependencies don't (most CI runs)

## Test plan
- [ ] CI Docker build steps show cache hits for the `npm ci` layer when only source changed
- [ ] Docker images build and run correctly (integration tests pass)
- [ ] Local Docker builds still work