### PR TITLE
ci: enable TypeScript incremental compilation

### DIFF
--- a/shared/authentication/tsconfig.build.json
+++ b/shared/authentication/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": ["./tsconfig.json"],
   "compilerOptions": {
-    "composite": false
+    "composite": false,
+    "incremental": false
   }
 }

--- a/shared/database/tsconfig.build.json
+++ b/shared/database/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": ["./tsconfig.json"],
   "compilerOptions": {
-    "composite": false
+    "composite": false,
+    "incremental": false
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,7 @@
     "alwaysStrict": true,
     "sourceMap": true,
     "declaration": true,
+    "incremental": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- Add `"incremental": true` to `tsconfig.base.json` to generate `.tsbuildinfo` files that speed up subsequent compilations
- Override `incremental` to `false` in `shared/*/tsconfig.build.json` since tsup DTS builds don't support incremental without `tsBuildInfoFile`
- `.tsbuildinfo` files are already in `.gitignore`

## Estimated savings
~5-10 seconds per typecheck locally (negligible in CI without `.tsbuildinfo` caching, but zero cost to enable)

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes (tsup DTS builds succeed with `incremental: false` override)
- [ ] Running `npm run typecheck` twice locally shows faster second run
- [ ] `.tsbuildinfo` files are generated and gitignored