### PR TITLE
fix: guard AUTH_BYPASS from taking effect in production

### DIFF
--- a/shared/authentication/src/auth.middleware.ts
+++ b/shared/authentication/src/auth.middleware.ts
@@ -52,7 +52,7 @@ export type RequiredPermissions = {
 
 export function requirePermissions(required: RequiredPermissions) {
   return async (req: Request, res: Response, next: NextFunction) => {
-    if (process.env.AUTH_BYPASS === 'true') {
+    if (process.env.AUTH_BYPASS === 'true' && process.env.NODE_ENV !== 'production') {
       // In bypass mode, try to decode the JWT (without verification) so that
       // req.auth is populated for controllers that rely on req.auth.id.
       // If the token is not a valid JWT (e.g. integration tests pass a raw

--- a/tests/unit/authentication/auth-bypass.test.ts
+++ b/tests/unit/authentication/auth-bypass.test.ts
@@ -1,0 +1,93 @@
+import { jest } from '@jest/globals';
+import { Request, Response, NextFunction } from 'express';
+
+// Mock better-auth modules to avoid ESM import issues
+jest.mock('better-auth/plugins/access', () => ({
+  createAccessControl: () => ({
+    newRole: (statements: any) => ({
+      authorize: (req: any) => ({ success: true }),
+      statements,
+    }),
+  }),
+}));
+
+jest.mock('better-auth/plugins/organization/access', () => ({
+  adminAc: { statements: {} },
+  defaultStatements: {},
+}));
+
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn().mockReturnValue(jest.fn()),
+  jwtVerify: jest.fn(),
+}));
+
+// Set required env vars before importing the module
+process.env.BETTER_AUTH_JWKS_URL = 'https://auth.example.com/.well-known/jwks.json';
+process.env.BETTER_AUTH_ISSUER = 'https://auth.example.com';
+process.env.BETTER_AUTH_AUDIENCE = 'test-audience';
+
+import { requirePermissions } from '../../../shared/authentication/src/auth.middleware';
+
+describe('AUTH_BYPASS environment variable', () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let mockNext: jest.Mock;
+
+  beforeEach(() => {
+    mockReq = {
+      headers: {},
+    };
+    mockRes = {
+      status: jest.fn().mockReturnThis() as any,
+      json: jest.fn().mockReturnThis() as any,
+    };
+    mockNext = jest.fn();
+  });
+
+  afterEach(() => {
+    delete process.env.AUTH_BYPASS;
+    delete process.env.NODE_ENV;
+  });
+
+  it('should NOT bypass auth in production even when AUTH_BYPASS is true', async () => {
+    process.env.AUTH_BYPASS = 'true';
+    process.env.NODE_ENV = 'production';
+
+    const middleware = requirePermissions({ flowsheet: ['read'] });
+    await middleware(mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+    expect(mockNext).not.toHaveBeenCalled();
+    expect(mockRes.status).toHaveBeenCalledWith(401);
+  });
+
+  it('should allow bypass in non-production when AUTH_BYPASS is true', async () => {
+    process.env.AUTH_BYPASS = 'true';
+    process.env.NODE_ENV = 'test';
+
+    const middleware = requirePermissions({ flowsheet: ['read'] });
+    await middleware(mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+    expect(mockNext).toHaveBeenCalled();
+  });
+
+  it('should allow bypass when NODE_ENV is not set and AUTH_BYPASS is true', async () => {
+    process.env.AUTH_BYPASS = 'true';
+    delete process.env.NODE_ENV;
+
+    const middleware = requirePermissions({ flowsheet: ['read'] });
+    await middleware(mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+    expect(mockNext).toHaveBeenCalled();
+  });
+
+  it('should NOT bypass when AUTH_BYPASS is not set', async () => {
+    delete process.env.AUTH_BYPASS;
+    process.env.NODE_ENV = 'test';
+
+    const middleware = requirePermissions({ flowsheet: ['read'] });
+    await middleware(mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+    expect(mockNext).not.toHaveBeenCalled();
+    expect(mockRes.status).toHaveBeenCalledWith(401);
+  });
+});

--- a/tests/unit/authentication/auth-bypass.test.ts
+++ b/tests/unit/authentication/auth-bypass.test.ts
@@ -5,7 +5,7 @@ import { Request, Response, NextFunction } from 'express';
 jest.mock('better-auth/plugins/access', () => ({
   createAccessControl: () => ({
     newRole: (statements: any) => ({
-      authorize: (req: any) => ({ success: true }),
+      authorize: () => ({ success: true }),
       statements,
     }),
   }),


### PR DESCRIPTION
## Summary
- AUTH_BYPASS=true silently disables all authorization middleware with no environment guard
- Added `NODE_ENV !== 'production'` check so the bypass only works in dev/test
- Added unit tests verifying the guard works correctly in all combinations

## Test plan
- [x] Unit test: AUTH_BYPASS=true + NODE_ENV=production → auth NOT bypassed (401)
- [x] Unit test: AUTH_BYPASS=true + NODE_ENV=test → auth bypassed
- [x] Unit test: AUTH_BYPASS=true + NODE_ENV unset → auth bypassed
- [x] Unit test: AUTH_BYPASS unset → auth NOT bypassed (401)


Made with [Cursor](https://cursor.com)