### PR TITLE
fix: propagate database errors in addEntry instead of swallowing

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -178,6 +178,8 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
   } catch (e) {
     console.error('Error: Failed to retrieve most recent show ');
     console.error(e);
+    next(e);
+    return;
   }
   if (latestShow?.end_time !== null) {
     throw new WxycError('Bad Request, There are no active shows', 400);

--- a/tests/unit/controllers/flowsheet.addEntry.test.ts
+++ b/tests/unit/controllers/flowsheet.addEntry.test.ts
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getLatestShow: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/metadata/index', () => ({
+  fetchAndCacheMetadata: jest.fn(),
+}));
+
+import { addEntry } from '../../../apps/backend/controllers/flowsheet.controller';
+import * as flowsheet_service from '../../../apps/backend/services/flowsheet.service';
+
+describe('addEntry', () => {
+  const mockStatus = jest.fn().mockReturnThis();
+  const mockSend = jest.fn();
+  const mockJson = jest.fn();
+
+  const req = { body: { track_title: 'Test', artist_name: 'Artist', album_title: 'Album', record_label: 'Label' } } as any;
+  const res = { status: mockStatus, send: mockSend, json: mockJson } as any;
+  const next = jest.fn();
+
+  it('should call next with the error when getLatestShow throws', async () => {
+    const dbError = new Error('DB connection failed');
+    (flowsheet_service.getLatestShow as jest.Mock).mockRejectedValue(dbError);
+
+    await addEntry(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(dbError);
+    expect(mockStatus).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/controllers/flowsheet.addEntry.test.ts
+++ b/tests/unit/controllers/flowsheet.addEntry.test.ts
@@ -16,7 +16,9 @@ describe('addEntry', () => {
   const mockSend = jest.fn();
   const mockJson = jest.fn();
 
-  const req = { body: { track_title: 'Test', artist_name: 'Artist', album_title: 'Album', record_label: 'Label' } } as any;
+  const req = {
+    body: { track_title: 'Test', artist_name: 'Artist', album_title: 'Album', record_label: 'Label' },
+  } as any;
   const res = { status: mockStatus, send: mockSend, json: mockJson } as any;
   const next = jest.fn();
 


### PR DESCRIPTION
## Summary
- addEntry's catch block for getLatestShow() only logged the error without calling next(e)
- Execution fell through and sent a misleading 400 'no active shows' instead of a 500

## Test plan
- [x] Unit test: mock getLatestShow to throw, assert next(e) is called

Made with [Cursor](https://cursor.com)