### PR TITLE
fix: return 410 Gone instead of 301 for deprecated registerDevice

### DIFF
--- a/apps/backend/controllers/requestLine.controller.ts
+++ b/apps/backend/controllers/requestLine.controller.ts
@@ -41,7 +41,7 @@ export const registerDevice: RequestHandler<object, unknown, RegisterDeviceBody>
     timestamp: new Date().toISOString(),
   });
 
-  res.status(301).json({
+  res.status(410).json({
     message: 'This endpoint is deprecated. Use POST /auth/sign-in/anonymous for registration.',
     endpoint: `${authUrl}/sign-in/anonymous`,
   });

--- a/tests/integration/requestLine.spec.js
+++ b/tests/integration/requestLine.spec.js
@@ -10,10 +10,10 @@ const getTestToken = async () => {
 
 describe('Request Line Endpoint', () => {
   describe('Device Registration (Legacy Endpoint)', () => {
-    it('should return 301 redirect for legacy registration endpoint', async () => {
+    it('should return 410 Gone for legacy registration endpoint', async () => {
       const response = await request.post('/request/register').send({ deviceId: 'test-uuid' });
 
-      expect(response.status).toBe(301);
+      expect(response.status).toBe(410);
       expect(response.body.message).toMatch(/deprecated/i);
       expect(response.body.endpoint).toMatch(/sign-in\/anonymous/);
     });

--- a/tests/unit/controllers/requestLine.registerDevice.test.ts
+++ b/tests/unit/controllers/requestLine.registerDevice.test.ts
@@ -1,0 +1,83 @@
+import { registerDevice } from '../../../apps/backend/controllers/requestLine.controller';
+import type { Request, Response } from 'express';
+
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return {
+    method: 'POST',
+    originalUrl: '/request/register',
+    ip: '127.0.0.1',
+    get: jest.fn().mockReturnValue('test-agent'),
+    body: { deviceId: 'some-device-id' },
+    ...overrides,
+  } as unknown as Request;
+}
+
+function mockRes(): Response & { _status: number; _json: unknown } {
+  const res = {
+    _status: 0,
+    _json: undefined as unknown,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(body: unknown) {
+      res._json = body;
+      return res;
+    },
+  };
+  return res as unknown as Response & { _status: number; _json: unknown };
+}
+
+describe('registerDevice', () => {
+  const originalEnv = process.env.BETTER_AUTH_URL;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.BETTER_AUTH_URL = originalEnv;
+    } else {
+      delete process.env.BETTER_AUTH_URL;
+    }
+  });
+
+  it('returns 410 Gone for the deprecated endpoint', async () => {
+    process.env.BETTER_AUTH_URL = 'https://api.wxyc.org/auth';
+
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await registerDevice(req, res as unknown as Response, next);
+
+    expect(res._status).toBe(410);
+  });
+
+  it('includes deprecation message and replacement endpoint', async () => {
+    process.env.BETTER_AUTH_URL = 'https://api.wxyc.org/auth';
+
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await registerDevice(req, res as unknown as Response, next);
+
+    expect(res._json).toEqual({
+      message: 'This endpoint is deprecated. Use POST /auth/sign-in/anonymous for registration.',
+      endpoint: 'https://api.wxyc.org/auth/sign-in/anonymous',
+    });
+  });
+
+  it('falls back to localhost auth URL when BETTER_AUTH_URL is unset', async () => {
+    delete process.env.BETTER_AUTH_URL;
+
+    const req = mockReq();
+    const res = mockRes();
+    const next = jest.fn();
+
+    await registerDevice(req, res as unknown as Response, next);
+
+    expect(res._status).toBe(410);
+    expect((res._json as { endpoint: string }).endpoint).toBe(
+      'http://localhost:8082/auth/sign-in/anonymous'
+    );
+  });
+});

--- a/tests/unit/controllers/requestLine.registerDevice.test.ts
+++ b/tests/unit/controllers/requestLine.registerDevice.test.ts
@@ -76,8 +76,6 @@ describe('registerDevice', () => {
     await registerDevice(req, res as unknown as Response, next);
 
     expect(res._status).toBe(410);
-    expect((res._json as { endpoint: string }).endpoint).toBe(
-      'http://localhost:8082/auth/sign-in/anonymous'
-    );
+    expect((res._json as { endpoint: string }).endpoint).toBe('http://localhost:8082/auth/sign-in/anonymous');
   });
 });


### PR DESCRIPTION
## Summary
- The deprecated `registerDevice` endpoint (`POST /request/register`) was returning HTTP 301 (Moved Permanently), which is a redirect status — browsers follow the `Location` header rather than reading the JSON body.
- Changed to HTTP 410 (Gone) to correctly signal the endpoint is retired.
- Added unit tests for the handler covering status code, response body, and env fallback.

## Test plan
- [x] Unit test asserts response status is 410 (verified it fails with 301 before the fix)
- [x] Unit test asserts the deprecation JSON body with correct replacement endpoint
- [x] Unit test verifies fallback to `localhost:8082` when `BETTER_AUTH_URL` is unset

Fixes #27

Made with [Cursor](https://cursor.com)