### PR TITLE
fix: return 400 instead of 404 in leaveShow when no active show

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -361,7 +361,7 @@ export const joinShow: RequestHandler = async (req: Request<object, object, Join
 export const leaveShow: RequestHandler<object, unknown, { dj_id: string }> = async (req, res, next) => {
   const currentShow = await flowsheet_service.getLatestShow();
   if (currentShow?.end_time !== null) {
-    res.status(404).json({ message: 'Bad Request: No active show session found.' });
+    res.status(400).json({ message: 'Bad Request: No active show session found.' });
   } else {
     try {
       // Show membership is verified by showMemberMiddleware on the route

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -84,7 +84,7 @@ describe('End Show', () => {
       .send({
         dj_id: global.secondary_dj_id,
       })
-      .expect(404);
+      .expect(400);
     expect(res.body.message).toBeDefined();
   });
 });
@@ -139,7 +139,7 @@ describe('Leave Show', () => {
       .send({
         dj_id: global.secondary_dj_id,
       })
-      .expect(404);
+      .expect(400);
     expect(res.body.message).toBeDefined();
   });
 });

--- a/tests/unit/controllers/flowsheet.leaveShow.test.ts
+++ b/tests/unit/controllers/flowsheet.leaveShow.test.ts
@@ -1,0 +1,49 @@
+import { jest } from '@jest/globals';
+
+const mockGetLatestShow = jest.fn();
+
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getLatestShow: mockGetLatestShow,
+}));
+
+jest.mock('../../../apps/backend/services/metadata/index', () => ({
+  fetchAndCacheMetadata: jest.fn(),
+}));
+
+jest.mock('async-mutex', () => ({
+  Mutex: jest.fn().mockImplementation(() => ({
+    acquire: jest.fn().mockResolvedValue(jest.fn()),
+  })),
+}));
+
+import { leaveShow } from '../../../apps/backend/controllers/flowsheet.controller';
+import type { Request, Response, NextFunction } from 'express';
+
+function createMockRes() {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res) as unknown as Response['status'];
+  res.json = jest.fn().mockReturnValue(res) as unknown as Response['json'];
+  return res as Response;
+}
+
+describe('leaveShow', () => {
+  it('returns 400 when no active show session exists (end_time is set)', async () => {
+    mockGetLatestShow.mockResolvedValue({
+      id: 1,
+      primary_dj_id: 'dj-1',
+      start_time: new Date('2025-01-01'),
+      end_time: new Date('2025-01-01T02:00:00'),
+    });
+
+    const req = { body: { dj_id: 'dj-1' } } as Request;
+    const res = createMockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await leaveShow(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Bad Request: No active show session found.',
+    });
+  });
+});

--- a/tests/unit/controllers/flowsheet.leaveShow.test.ts
+++ b/tests/unit/controllers/flowsheet.leaveShow.test.ts
@@ -20,10 +20,14 @@ import { leaveShow } from '../../../apps/backend/controllers/flowsheet.controlle
 import type { Request, Response, NextFunction } from 'express';
 
 function createMockRes() {
+  const statusMock = jest.fn();
+  const jsonMock = jest.fn();
   const res: Partial<Response> = {};
-  res.status = jest.fn().mockReturnValue(res) as unknown as Response['status'];
-  res.json = jest.fn().mockReturnValue(res) as unknown as Response['json'];
-  return res as Response;
+  statusMock.mockReturnValue(res);
+  jsonMock.mockReturnValue(res);
+  res.status = statusMock as unknown as Response['status'];
+  res.json = jsonMock as unknown as Response['json'];
+  return { res: res as Response, statusMock, jsonMock };
 }
 
 describe('leaveShow', () => {
@@ -36,13 +40,13 @@ describe('leaveShow', () => {
     });
 
     const req = { body: { dj_id: 'dj-1' } } as Request;
-    const res = createMockRes();
+    const { res, statusMock, jsonMock } = createMockRes();
     const next = jest.fn() as unknown as NextFunction;
 
     await leaveShow(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(jsonMock).toHaveBeenCalledWith({
       message: 'Bad Request: No active show session found.',
     });
   });


### PR DESCRIPTION
## Summary
- Fixed `leaveShow` returning HTTP 404 when no active show session exists. The response message said "Bad Request" but the status code was 404 (Not Found), which is semantically incorrect. Changed to 400 (Bad Request) to match the message.
- Added unit test covering the `leaveShow` no-active-show branch to prevent regression.

Fixes #28

## Test plan
- [x] New unit test `flowsheet.leaveShow.test.ts` asserts 400 status when `getLatestShow` returns a show with `end_time` set
- [x] Test fails against the old code (404), passes against the fix (400)
- [x] Existing unit test suite still passes (`npm run test:unit`)

Made with [Cursor](https://cursor.com)