### PR TITLE
fix: return 404 in changeOrder when entry doesn't exist

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -20,7 +20,6 @@ import {
   artist_metadata,
 } from '@wxyc/database';
 import { IFSEntry, ShowInfo, ShowMetadata, UpdateRequestBody } from '../controllers/flowsheet.controller.js';
-import WxycError from '../utils/error.js';
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
 
 // Track when the flowsheet was last modified for conditional responses (304 Not Modified)

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -20,6 +20,7 @@ import {
   artist_metadata,
 } from '@wxyc/database';
 import { IFSEntry, ShowInfo, ShowMetadata, UpdateRequestBody } from '../controllers/flowsheet.controller.js';
+import WxycError from '../utils/error.js';
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
 
 // Track when the flowsheet was last modified for conditional responses (304 Not Modified)
@@ -535,15 +536,19 @@ export const getAlbumFromDB = async (album_id: number) => {
 export const changeOrder = async (entry_id: number, position_new: number): Promise<FSEntry> => {
   await db.transaction(
     async (trx) => {
-      const position_old = (
-        await trx
-          .select({
-            play_order: flowsheet.play_order,
-          })
-          .from(flowsheet)
-          .where(eq(flowsheet.id, entry_id))
-          .limit(1)
-      )[0].play_order;
+      const result = await trx
+        .select({
+          play_order: flowsheet.play_order,
+        })
+        .from(flowsheet)
+        .where(eq(flowsheet.id, entry_id))
+        .limit(1);
+
+      if (result.length === 0) {
+        throw new WxycError(`Flowsheet entry ${entry_id} not found`, 404);
+      }
+
+      const position_old = result[0].play_order;
 
       if (position_new < position_old) {
         await trx

--- a/tests/unit/services/flowsheet.changeOrder.test.ts
+++ b/tests/unit/services/flowsheet.changeOrder.test.ts
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+import { db } from '@wxyc/database';
+import { createMockQueryChain } from '../../mocks/database.mock';
+import WxycError from '../../../apps/backend/utils/error';
+
+describe('flowsheet.service', () => {
+  describe('changeOrder', () => {
+    it('throws WxycError with 404 when entry does not exist', async () => {
+      const emptyChain = createMockQueryChain([]);
+      // Make the chain thenable so `await trx.select().from().where().limit()` resolves
+      (emptyChain as any).then = (resolve: (v: unknown) => void) => resolve([]);
+
+      const mockTrx = {
+        select: jest.fn().mockReturnValue(emptyChain),
+        update: jest.fn().mockReturnValue(emptyChain),
+      };
+
+      (db as any).transaction = jest.fn().mockImplementation(async (cb: Function) => {
+        return cb(mockTrx);
+      });
+
+      const { changeOrder } = await import('../../../apps/backend/services/flowsheet.service');
+
+      await expect(changeOrder(999999, 1)).rejects.toThrow(WxycError);
+      await expect(changeOrder(999999, 1)).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+});

--- a/tests/unit/services/flowsheet.changeOrder.test.ts
+++ b/tests/unit/services/flowsheet.changeOrder.test.ts
@@ -15,7 +15,7 @@ describe('flowsheet.service', () => {
         update: jest.fn().mockReturnValue(emptyChain),
       };
 
-      (db as any).transaction = jest.fn().mockImplementation(async (cb: Function) => {
+      (db as any).transaction = jest.fn().mockImplementation(async (cb: (trx: typeof mockTrx) => Promise<void>) => {
         return cb(mockTrx);
       });
 


### PR DESCRIPTION
## Summary
- `changeOrder` crashed with `TypeError: Cannot read properties of undefined (reading 'play_order')` when called with a non-existent `entry_id`, because the query result was accessed at `[0]` without checking for an empty array.
- Now checks if the select query returns no rows and throws `WxycError(404)` for a clean error response.
- Added unit test covering the missing-entry case.

## Test plan
- [x] Unit test: `flowsheet.changeOrder.test.ts` — mocks `db.transaction` with a trx returning empty array, asserts `WxycError` with `statusCode: 404`
- [x] Full unit suite passes (121 tests)

Made with [Cursor](https://cursor.com)