### PR TITLE
fix: use req.ip instead of 'unknown' as rate limit fallback key

### DIFF
--- a/apps/backend/middleware/rateLimiting.ts
+++ b/apps/backend/middleware/rateLimiting.ts
@@ -80,8 +80,7 @@ export const songRequestRateLimit = shouldEnableRateLimiting
         if (req.user?.id) {
           return req.user.id;
         }
-        // Fall back to 'unknown' - this shouldn't happen since auth middleware runs first
-        return 'unknown';
+        return req.ip || 'unknown';
       },
       handler: (_req: Request, res: Response) => {
         res.status(429).json({

--- a/tests/unit/middleware/rateLimiting.test.ts
+++ b/tests/unit/middleware/rateLimiting.test.ts
@@ -1,0 +1,68 @@
+import { Request } from 'express';
+
+let capturedConfigs: Record<string, unknown>[] = [];
+
+jest.mock('express-rate-limit', () => {
+  const { MemoryStore } = jest.requireActual<typeof import('express-rate-limit')>('express-rate-limit');
+  const mockRateLimit = (config: Record<string, unknown>) => {
+    capturedConfigs.push(config);
+    return (_req: unknown, _res: unknown, next: () => void) => next();
+  };
+  mockRateLimit.MemoryStore = MemoryStore;
+  return { __esModule: true, default: mockRateLimit, MemoryStore };
+});
+
+describe('songRequestRateLimit keyGenerator', () => {
+  let keyGenerator: (req: Request) => string;
+
+  beforeAll(async () => {
+    capturedConfigs = [];
+    // Force rate limiting to be active so the config is captured
+    process.env.TEST_RATE_LIMITING = 'true';
+    // Re-import after mock is in place
+    jest.resetModules();
+
+    // Re-apply the mock after resetModules
+    jest.mock('express-rate-limit', () => {
+      const { MemoryStore } = jest.requireActual<typeof import('express-rate-limit')>('express-rate-limit');
+      const mockRateLimit = (config: Record<string, unknown>) => {
+        capturedConfigs.push(config);
+        return (_req: unknown, _res: unknown, next: () => void) => next();
+      };
+      mockRateLimit.MemoryStore = MemoryStore;
+      return { __esModule: true, default: mockRateLimit, MemoryStore };
+    });
+
+    await import('../../../apps/backend/middleware/rateLimiting');
+
+    const songRequestConfig = capturedConfigs.find(
+      (c) => typeof c.keyGenerator === 'function'
+    );
+    expect(songRequestConfig).toBeDefined();
+    keyGenerator = songRequestConfig!.keyGenerator as (req: Request) => string;
+  });
+
+  afterAll(() => {
+    delete process.env.TEST_RATE_LIMITING;
+  });
+
+  it('returns user ID when req.user.id is set', () => {
+    const req = { user: { id: 'user-123' }, ip: '10.0.0.1' } as unknown as Request;
+    expect(keyGenerator(req)).toBe('user-123');
+  });
+
+  it('returns req.ip when req.user is undefined', () => {
+    const req = { user: undefined, ip: '192.168.1.42' } as unknown as Request;
+    expect(keyGenerator(req)).toBe('192.168.1.42');
+  });
+
+  it('returns req.ip when req.user.id is missing', () => {
+    const req = { user: {}, ip: '10.0.0.5' } as unknown as Request;
+    expect(keyGenerator(req)).toBe('10.0.0.5');
+  });
+
+  it('returns "unknown" only when both req.user.id and req.ip are unavailable', () => {
+    const req = { user: undefined, ip: undefined } as unknown as Request;
+    expect(keyGenerator(req)).toBe('unknown');
+  });
+});

--- a/tests/unit/middleware/rateLimiting.test.ts
+++ b/tests/unit/middleware/rateLimiting.test.ts
@@ -35,11 +35,9 @@ describe('songRequestRateLimit keyGenerator', () => {
 
     await import('../../../apps/backend/middleware/rateLimiting');
 
-    const songRequestConfig = capturedConfigs.find(
-      (c) => typeof c.keyGenerator === 'function'
-    );
+    const songRequestConfig = capturedConfigs.find((c) => typeof c.keyGenerator === 'function');
     expect(songRequestConfig).toBeDefined();
-    keyGenerator = songRequestConfig!.keyGenerator as (req: Request) => string;
+    keyGenerator = songRequestConfig.keyGenerator as (req: Request) => string;
   });
 
   afterAll(() => {


### PR DESCRIPTION
## Summary
- **Bug**: The `songRequestRateLimit` keyGenerator fell back to the string `'unknown'` when `req.user.id` was not set, causing all unauthenticated requests to share a single rate limit bucket.
- **Fix**: Changed the fallback to `req.ip || 'unknown'` so unauthenticated requests are rate-limited per client IP.
- **Tests**: Added unit tests that mock `express-rate-limit` to extract and verify the `keyGenerator` logic for authenticated, unauthenticated, and edge-case scenarios.

## Test plan
- [x] Unit test fails before fix (returns `'unknown'` instead of `req.ip`)
- [x] Unit test passes after fix (4/4 tests green)
- [ ] CI passes


Made with [Cursor](https://cursor.com)