### PR TITLE
fix: add authentication to POST /schedule endpoint

### DIFF
--- a/apps/backend/routes/schedule.route.ts
+++ b/apps/backend/routes/schedule.route.ts
@@ -1,3 +1,4 @@
+import { requirePermissions } from '@wxyc/authentication';
 import { Router } from 'express';
 import * as scheduleController from '../controllers/schedule.controller.js';
 
@@ -5,7 +6,7 @@ export const schedule_route = Router();
 
 schedule_route.get('/', scheduleController.getSchedule);
 
-schedule_route.post('/', scheduleController.addToSchedule);
+schedule_route.post('/', requirePermissions({ flowsheet: ['write'] }), scheduleController.addToSchedule);
 
 /*
 schedule_route.delete('/', scheduleController.removeFromSchedule);

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/node": "^24.12.0",
         "@types/pg": "^8.20.0",
         "@types/ssh2": "^1.15.5",
+        "@types/supertest": "^6.0.3",
         "@types/swagger-ui-express": "^4.1.8",
         "concurrently": "^9.2.1",
         "drizzle-kit": "^0.31.10",
@@ -6302,6 +6303,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -6598,6 +6606,13 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mysql": {
       "version": "2.15.27",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
@@ -6726,6 +6741,30 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/swagger-ui-express": {
       "version": "4.1.8",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/node": "^24.12.0",
     "@types/pg": "^8.20.0",
     "@types/ssh2": "^1.15.5",
+    "@types/supertest": "^6.0.3",
     "@types/swagger-ui-express": "^4.1.8",
     "concurrently": "^9.2.1",
     "drizzle-kit": "^0.31.10",

--- a/tests/mocks/authentication.mock.ts
+++ b/tests/mocks/authentication.mock.ts
@@ -1,3 +1,5 @@
+import { Request, Response, NextFunction } from 'express';
+
 /**
  * Minimal mock for @wxyc/authentication workspace package.
  * Tests that need auth should provide their own jest.mock() factory.
@@ -8,4 +10,12 @@ export const auth = {
   },
 };
 
-export const requirePermissions = () => (_req: unknown, _res: unknown, next: () => void) => next();
+export function requirePermissions(_required: Record<string, string[]>) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ error: 'Unauthorized: Missing Authorization header.' });
+    }
+    return next();
+  };
+}

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -115,6 +115,7 @@ export const user = {
   capabilities: 'capabilities',
 };
 export const specialty_shows = {};
+export const schedule = {};
 
 // Mock enum
 export const flowsheetEntryTypeEnum = () => ({});
@@ -166,6 +167,7 @@ export type Show = Record<string, unknown>;
 export type ShowDJ = Record<string, unknown>;
 export type User = Record<string, unknown>;
 
+
 export type BinEntry = {
   id: number;
   dj_id: string;
@@ -173,3 +175,4 @@ export type BinEntry = {
   track_title: string | null;
 };
 export type NewBinEntry = Omit<BinEntry, 'id'>;
+export type NewShift = Record<string, unknown>;

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -167,7 +167,6 @@ export type Show = Record<string, unknown>;
 export type ShowDJ = Record<string, unknown>;
 export type User = Record<string, unknown>;
 
-
 export type BinEntry = {
   id: number;
   dj_id: string;

--- a/tests/unit/routes/schedule.route.test.ts
+++ b/tests/unit/routes/schedule.route.test.ts
@@ -1,0 +1,19 @@
+import express from 'express';
+import request from 'supertest';
+import { schedule_route } from '../../../apps/backend/routes/schedule.route';
+
+const app = express();
+app.use(express.json());
+app.use('/schedule', schedule_route);
+
+describe('schedule route', () => {
+  it('POST /schedule requires authentication', async () => {
+    const response = await request(app).post('/schedule').send({});
+    expect(response.status).toBe(401);
+  });
+
+  it('GET /schedule is publicly accessible', async () => {
+    const response = await request(app).get('/schedule');
+    expect(response.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- **Bug**: `POST /schedule` had no authentication middleware, allowing anonymous users to insert arbitrary schedule entries
- **Fix**: Added `requirePermissions({ flowsheet: ['write'] })` middleware to the POST route, matching the pattern used by flowsheet and other write endpoints
- **Test**: Added unit test verifying POST /schedule returns 401 without auth and GET /schedule remains publicly accessible
- **Infrastructure**: Added `@wxyc/authentication` mock and `schedule`/`NewShift` exports to the database mock for unit testing routes that use auth middleware

## Test plan
- [x] New unit test fails before fix (POST returns 200)
- [x] New unit test passes after fix (POST returns 401)
- [x] All 122 existing unit tests continue to pass
- [ ] Integration test: POST /schedule without auth header returns 401
- [ ] Integration test: POST /schedule with valid DJ+ token succeeds

Made with [Cursor](https://cursor.com)