### PR TITLE
fix: enable trust proxy for correct client IP resolution

### DIFF
--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -18,6 +18,8 @@ import { requirePermissions } from '@wxyc/authentication';
 const port = process.env.PORT || 8080;
 const app = express();
 
+app.set('trust proxy', true);
+
 //Interpret parse json into js objects
 app.use(express.json());
 

--- a/tests/unit/config/trust-proxy.test.ts
+++ b/tests/unit/config/trust-proxy.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('Express trust proxy configuration', () => {
+  const appSource = readFileSync(resolve(__dirname, '../../../apps/backend/app.ts'), 'utf-8');
+
+  it('should enable trust proxy so req.ip reflects the real client IP behind a reverse proxy', () => {
+    expect(appSource).toMatch(/app\.set\(\s*['"]trust proxy['"]/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `app.set('trust proxy', true)` to `apps/backend/app.ts` so that `req.ip` returns the real client IP instead of the load balancer's IP when running behind a reverse proxy.
- Adds a unit test (`tests/unit/config/trust-proxy.test.ts`) that reads the app source and asserts the trust proxy setting is present.

Closes #24

## Test plan
- [x] New unit test fails without the fix and passes with it
- [ ] Verify `req.ip` returns the correct client IP in staging behind the ALB/reverse proxy
- [ ] Confirm IP-based rate limiting works correctly with real client IPs


Made with [Cursor](https://cursor.com)