### PR TITLE
fix: default cookie sameSite to 'lax' instead of 'none'

### DIFF
--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -99,7 +99,7 @@ export const auth = betterAuth({
   // Subdomain-friendly cookie setting (recommended over cross-site cookies)
   advanced: {
     defaultCookieAttributes: {
-      sameSite: 'none',
+      sameSite: (process.env.COOKIE_SAME_SITE as 'lax' | 'strict' | 'none') || 'lax',
       secure: true,
     },
   },

--- a/tests/unit/authentication/cookie-config.test.ts
+++ b/tests/unit/authentication/cookie-config.test.ts
@@ -1,0 +1,25 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('auth.definition.ts cookie configuration', () => {
+  const authDefPath = path.resolve(
+    __dirname,
+    '../../../shared/authentication/src/auth.definition.ts'
+  );
+  let source: string;
+
+  beforeAll(() => {
+    source = fs.readFileSync(authDefPath, 'utf-8');
+  });
+
+  it('should not use sameSite: none (weakens CSRF protection)', () => {
+    const hardcodedNone = /sameSite:\s*['"]none['"]/;
+    expect(source).not.toMatch(hardcodedNone);
+
+    expect(source).toMatch(/sameSite:/);
+  });
+
+  it('should set secure: true on cookies', () => {
+    expect(source).toMatch(/secure:\s*true/);
+  });
+});

--- a/tests/unit/authentication/cookie-config.test.ts
+++ b/tests/unit/authentication/cookie-config.test.ts
@@ -2,10 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 describe('auth.definition.ts cookie configuration', () => {
-  const authDefPath = path.resolve(
-    __dirname,
-    '../../../shared/authentication/src/auth.definition.ts'
-  );
+  const authDefPath = path.resolve(__dirname, '../../../shared/authentication/src/auth.definition.ts');
   let source: string;
 
   beforeAll(() => {


### PR DESCRIPTION
## Summary
- **Bug**: `sameSite: 'none'` in `shared/authentication/src/auth.definition.ts` sends cookies on all cross-site requests, weakening CSRF protection.
- **Fix**: Default `sameSite` to `'lax'` while allowing override via `COOKIE_SAME_SITE` env var for deployments that need cross-origin cookie behavior.
- **Test**: Added source-reading unit test that asserts `sameSite` is never hardcoded to `'none'`.

Closes #31

## Test plan
- [x] Unit test fails with the old `sameSite: 'none'` value
- [x] Unit test passes after fix (defaults to `'lax'`)
- [ ] Verify auth flows work in staging with default `lax` setting
- [ ] Verify `COOKIE_SAME_SITE=none` env override works for cross-origin deployments

Made with [Cursor](https://cursor.com)