### PR TITLE
fix: add unique constraint on show_djs (show_id, dj_id)

### DIFF
--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -394,15 +394,19 @@ export const shows = wxyc_schema.table('shows', {
 
 export type NewShowDJ = InferInsertModel<typeof show_djs>;
 export type ShowDJ = InferSelectModel<typeof show_djs>;
-export const show_djs = wxyc_schema.table('show_djs', {
-  show_id: integer('show_id')
-    .references(() => shows.id)
-    .notNull(),
-  dj_id: varchar('dj_id', { length: 255 })
-    .references(() => user.id, { onDelete: 'cascade' })
-    .notNull(),
-  active: boolean('active').default(true),
-});
+export const show_djs = wxyc_schema.table(
+  'show_djs',
+  {
+    show_id: integer('show_id')
+      .references(() => shows.id)
+      .notNull(),
+    dj_id: varchar('dj_id', { length: 255 })
+      .references(() => user.id, { onDelete: 'cascade' })
+      .notNull(),
+    active: boolean('active').default(true),
+  },
+  (table) => [uniqueIndex('show_djs_show_id_dj_id_unique').on(table.show_id, table.dj_id)]
+);
 
 //create entry w/ ID 0 for regular shows
 export type NewSpecialtyShow = InferInsertModel<typeof specialty_shows>;

--- a/tests/__mocks__/drizzle-orm.ts
+++ b/tests/__mocks__/drizzle-orm.ts
@@ -1,5 +1,7 @@
 // Mock drizzle-orm for unit tests
 export const eq = jest.fn((a, b) => ({ eq: [a, b] }));
+export const and = jest.fn((...conditions: unknown[]) => ({ and: conditions }));
+export const or = jest.fn((...conditions: unknown[]) => ({ or: conditions }));
 export const sql = Object.assign(
   jest.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
     sql: strings,

--- a/tests/unit/database/schema.show-djs.test.ts
+++ b/tests/unit/database/schema.show-djs.test.ts
@@ -1,0 +1,17 @@
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { show_djs } from '../../../shared/database/src/schema';
+
+describe('show_djs schema', () => {
+  it('has a unique index on (show_id, dj_id)', () => {
+    const config = getTableConfig(show_djs);
+    const uniqueIndexes = config.indexes.filter((idx) => idx.config.unique);
+
+    const showDjIndex = uniqueIndexes.find((idx) =>
+      idx.config.columns.length === 2 &&
+      idx.config.columns.some((col) => 'name' in col && col.name === 'show_id') &&
+      idx.config.columns.some((col) => 'name' in col && col.name === 'dj_id')
+    );
+
+    expect(showDjIndex).toBeDefined();
+  });
+});

--- a/tests/unit/database/schema.show-djs.test.ts
+++ b/tests/unit/database/schema.show-djs.test.ts
@@ -6,10 +6,11 @@ describe('show_djs schema', () => {
     const config = getTableConfig(show_djs);
     const uniqueIndexes = config.indexes.filter((idx) => idx.config.unique);
 
-    const showDjIndex = uniqueIndexes.find((idx) =>
-      idx.config.columns.length === 2 &&
-      idx.config.columns.some((col) => 'name' in col && col.name === 'show_id') &&
-      idx.config.columns.some((col) => 'name' in col && col.name === 'dj_id')
+    const showDjIndex = uniqueIndexes.find(
+      (idx) =>
+        idx.config.columns.length === 2 &&
+        idx.config.columns.some((col) => 'name' in col && col.name === 'show_id') &&
+        idx.config.columns.some((col) => 'name' in col && col.name === 'dj_id')
     );
 
     expect(showDjIndex).toBeDefined();


### PR DESCRIPTION
## Summary
- Adds a composite `uniqueIndex` on `(show_id, dj_id)` to the `show_djs` junction table to prevent duplicate DJ-show pairings
- Adds a schema assertion unit test that verifies the unique index exists

## Test plan
- [x] New unit test `schema.show-djs.test.ts` fails before the fix and passes after
- [x] Existing unit tests pass (`npm run test:unit`)
- [x] Integration tests pass against a running database

Closes #21

Made with [Cursor](https://cursor.com)

> **Note:** This fix is consolidated in #199 (coordinated schema migration batch). Consider closing in favor of #199.