### PR TITLE
fix: remove redundant .unique() on anonymous_devices.deviceId

### DIFF
--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -584,7 +584,7 @@ export const anonymous_devices = pgTable(
   'anonymous_devices',
   {
     id: serial('id').primaryKey(),
-    deviceId: varchar('device_id', { length: 255 }).notNull().unique(),
+    deviceId: varchar('device_id', { length: 255 }).notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull().defaultNow(),
     blocked: boolean('blocked').notNull().default(false),

--- a/tests/unit/database/schema.anonymous-devices.test.ts
+++ b/tests/unit/database/schema.anonymous-devices.test.ts
@@ -1,0 +1,26 @@
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { anonymous_devices } from '../../../shared/database/src/schema';
+
+describe('anonymous_devices schema', () => {
+  it('should have exactly one uniqueness constraint on device_id', () => {
+    const config = getTableConfig(anonymous_devices);
+    const col = anonymous_devices.deviceId;
+
+    let uniqueCount = 0;
+
+    // .unique() on the column sets isUnique at the column level
+    if (col.isUnique) uniqueCount++;
+
+    // uniqueIndex() in the table's third argument appears in config.indexes
+    const uniqueIndexesOnDeviceId = config.indexes.filter(
+      (idx) =>
+        idx.config.unique &&
+        idx.config.columns.some(
+          (c) => 'name' in c && c.name === 'device_id'
+        )
+    );
+    uniqueCount += uniqueIndexesOnDeviceId.length;
+
+    expect(uniqueCount).toBe(1);
+  });
+});

--- a/tests/unit/database/schema.anonymous-devices.test.ts
+++ b/tests/unit/database/schema.anonymous-devices.test.ts
@@ -13,11 +13,7 @@ describe('anonymous_devices schema', () => {
 
     // uniqueIndex() in the table's third argument appears in config.indexes
     const uniqueIndexesOnDeviceId = config.indexes.filter(
-      (idx) =>
-        idx.config.unique &&
-        idx.config.columns.some(
-          (c) => 'name' in c && c.name === 'device_id'
-        )
+      (idx) => idx.config.unique && idx.config.columns.some((c) => 'name' in c && c.name === 'device_id')
     );
     uniqueCount += uniqueIndexesOnDeviceId.length;
 


### PR DESCRIPTION
## Summary
- The `anonymous_devices` table had both `.unique()` on the `deviceId` column and an explicit `uniqueIndex('anonymous_devices_device_id_key')` in the table's third argument, creating two redundant unique indexes on `device_id`.
- Removed the inline `.unique()` and kept the explicit `uniqueIndex` for naming control.
- Added a schema assertion test that verifies exactly one uniqueness constraint exists on `device_id`.

## Test plan
- [x] New unit test `tests/unit/database/schema.anonymous-devices.test.ts` fails before fix (count = 2) and passes after (count = 1)
- [x] Existing unit tests pass (`npm run test:unit`)
- [x] No migration generated — this is a schema-definition-only change; the database already has the named index

Made with [Cursor](https://cursor.com)

> **Note:** This fix is consolidated in #199 (coordinated schema migration batch). Consider closing in favor of #199.