### PR TITLE
Fix: normalize better-auth system roles in requirePermissions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,31 +8,32 @@ API and authentication service for WXYC applications. Provides endpoints for the
 
 npm workspaces with four packages:
 
-| Package | Path | Purpose |
-|---------|------|---------|
-| `@wxyc/backend` | `apps/backend/` | Express API server (port 8080) |
-| `@wxyc/auth-service` | `apps/auth/` | better-auth server (port 8082) |
-| `@wxyc/database` | `shared/database/` | Drizzle ORM schema, client, migrations |
+| Package                | Path                     | Purpose                                  |
+| ---------------------- | ------------------------ | ---------------------------------------- |
+| `@wxyc/backend`        | `apps/backend/`          | Express API server (port 8080)           |
+| `@wxyc/auth-service`   | `apps/auth/`             | better-auth server (port 8082)           |
+| `@wxyc/database`       | `shared/database/`       | Drizzle ORM schema, client, migrations   |
 | `@wxyc/authentication` | `shared/authentication/` | Auth middleware, roles, JWT verification |
 
 ### API Server (`apps/backend`)
 
 Express 5 application with these route groups:
 
-| Route | Purpose |
-|-------|---------|
-| `/library` | Music library catalog |
-| `/flowsheet` | V1 flowsheet (legacy) |
+| Route           | Purpose                                 |
+| --------------- | --------------------------------------- |
+| `/library`      | Music library catalog                   |
+| `/flowsheet`    | V1 flowsheet (legacy)                   |
 | `/v2/flowsheet` | V2 flowsheet (uses `@wxyc/shared` DTOs) |
-| `/djs` | DJ profiles and management |
-| `/request` | Song request line |
-| `/schedule` | Schedule management |
-| `/events` | SSE for real-time updates |
-| `/healthcheck` | Health check |
+| `/djs`          | DJ profiles and management              |
+| `/request`      | Song request line                       |
+| `/schedule`     | Schedule management                     |
+| `/events`       | SSE for real-time updates               |
+| `/healthcheck`  | Health check                            |
 
 Code is organized as controllers (HTTP handling) -> services (business logic) -> database (Drizzle queries).
 
 Key middleware:
+
 - `requirePermissions` -- JWT auth with role-based access control
 - `showMemberMiddleware` -- Validates user is part of the active show
 - `activeShow` -- Checks for an active show
@@ -68,6 +69,7 @@ Schema is in `shared/database/src/schema.ts`. Migrations are in `shared/database
 **Test isolation**: Each Jest worker gets its own PostgreSQL schema via the `WXYC_SCHEMA_NAME` env var (defaults to `wxyc_schema`).
 
 Migration workflow:
+
 ```bash
 npm run drizzle:generate   # Generate SQL migration from schema changes
 npm run drizzle:migrate    # Apply migrations to database
@@ -77,6 +79,7 @@ npm run drizzle:drop       # Delete a migration file
 ### Authentication (`shared/authentication`)
 
 **Key files:**
+
 - `auth.definition.ts` -- better-auth config with plugins and hooks
 - `auth.roles.ts` -- Role definitions and access control rules
 - `auth.middleware.ts` -- JWT verification and permission checking
@@ -87,16 +90,17 @@ npm run drizzle:drop       # Delete a migration file
 
 **Permissions per role:**
 
-| Role | bin | catalog | flowsheet |
-|------|-----|---------|-----------|
-| member | read/write | read | read |
-| dj | read/write | read | read/write |
-| musicDirector | read/write | read/write | read/write |
-| stationManager | all | all | all + admin |
+| Role           | bin        | catalog    | flowsheet   |
+| -------------- | ---------- | ---------- | ----------- |
+| member         | read/write | read       | read        |
+| dj             | read/write | read       | read/write  |
+| musicDirector  | read/write | read/write | read/write  |
+| stationManager | all        | all        | all + admin |
 
 **JWT payload**: `sub` (user ID), `email`, `role` (queried from the organization member table, not `user.role`).
 
 **`requirePermissions` middleware flow:**
+
 1. Extract Bearer token from `Authorization` header
 2. Verify against JWKS endpoint (`BETTER_AUTH_JWKS_URL`)
 3. Check issuer and audience claims
@@ -123,12 +127,14 @@ Stop the database with `npm run db:stop`.
 ### Code Quality
 
 Pre-push hook (husky) runs automatically:
+
 ```bash
 npm run typecheck        # tsc --noEmit across all workspaces
 npm run lint             # ESLint with TypeScript + security rules
 ```
 
 Other quality commands:
+
 ```bash
 npm run format           # Prettier formatting
 npm run format:check     # Verify formatting (used in CI)
@@ -138,6 +144,7 @@ npm run build            # Compile all workspaces
 ### Branching
 
 Feature branches off `main`. Naming conventions:
+
 - `feature/description` or `feature/issue-123`
 - `task/description`
 - `bugfix/description` or `bugfix/issue-123`
@@ -179,6 +186,7 @@ npm run ci:testmock      # Sets up Docker env, runs tests, cleans up
 ```
 
 Or manually:
+
 ```bash
 npm run ci:env           # Start sandboxed Docker environment
 npm run ci:test          # Run tests against CI environment
@@ -205,16 +213,19 @@ GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:
 ## Environment Variables
 
 ### Backend Service
+
 - `PORT` (default 8080)
 - `CI_PORT` (default 8081)
 
 ### Database
+
 - `DB_HOST`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` (required)
 - `DB_PORT` (default 5432)
 - `CI_DB_PORT` (default 5433)
 - `WXYC_SCHEMA_NAME` (default `wxyc_schema`)
 
 ### better-auth
+
 - `BETTER_AUTH_URL` -- e.g. `http://localhost:8082/auth`
 - `BETTER_AUTH_JWKS_URL` -- e.g. `http://localhost:8082/auth/jwks`
 - `BETTER_AUTH_ISSUER` -- e.g. `http://localhost:8082`
@@ -223,20 +234,24 @@ GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:
 - `FRONTEND_SOURCE` -- Frontend origin for CORS and redirects
 
 ### Email (SES)
+
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`
 - `SES_FROM_EMAIL`
 - `PASSWORD_RESET_REDIRECT_URL`, `EMAIL_VERIFICATION_REDIRECT_URL`
 
 ### Testing
+
 - `AUTH_BYPASS` -- Set `true` to skip JWT verification in tests
 - `AUTH_USERNAME`, `AUTH_PASSWORD` -- Test account credentials (when `AUTH_BYPASS=false`)
 - `TEST_HOST` -- Test server host
 
 ### Metadata Services
+
 - `DISCOGS_API_KEY`, `DISCOGS_API_SECRET`
 - `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`
 
 ### Slack
+
 - `SLACK_WXYC_REQUESTS_APP_ID`, `SLACK_WXYC_REQUESTS_CLIENT_ID`
 - `SLACK_WXYC_REQUESTS_CLIENT_SECRET`, `SLACK_WXYC_REQUESTS_SIGNING_SECRET`
 - `SLACK_WXYC_REQUESTS_WEBHOOK`

--- a/jest.unit.config.ts
+++ b/jest.unit.config.ts
@@ -19,6 +19,9 @@ const config: Config = {
     '^@wxyc/database$': '<rootDir>/tests/mocks/database.mock.ts',
     // Mock database client for any path resolving to shared/database/src/client
     '^.*/shared/database/src/client(\\.js)?$': '<rootDir>/tests/mocks/database.mock.ts',
+    // Mock better-auth access control modules (ESM-only, can't be transformed by ts-jest)
+    '^better-auth/plugins/access$': '<rootDir>/tests/mocks/better-auth-access.mock.ts',
+    '^better-auth/plugins/organization/access$': '<rootDir>/tests/mocks/better-auth-org-access.mock.ts',
     // Remove .js extensions from relative imports (ESM compatibility)
     '^(\\.{1,2}/.*)\\.(js)$': '$1',
   },

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -10,7 +10,7 @@ import { rewriteUrlForFrontend } from './url-rewrite';
 
 const buildResetUrl = (url: string, redirectTo?: string) => {
   const rewrittenUrl = rewriteUrlForFrontend(url);
-  
+
   if (!redirectTo) {
     return rewrittenUrl;
   }
@@ -73,7 +73,7 @@ export const auth: Auth = betterAuth({
   emailVerification: {
     sendVerificationEmail: async ({ user, url }, request) => {
       const verificationUrl = rewriteUrlForFrontend(url);
-      
+
       void sendVerificationEmailMessage({
         to: user.email,
         verificationUrl,

--- a/shared/authentication/src/auth.middleware.ts
+++ b/shared/authentication/src/auth.middleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
-import { AccessControlStatement, WXYCRole, WXYCRoles } from './auth.roles';
+import { AccessControlStatement, WXYCRole, WXYCRoles, normalizeRole } from './auth.roles';
 
 // JWT payload structure expected from better-auth JWT plugin
 // When used with organization plugin, tokens include user info and organization role
@@ -93,15 +93,20 @@ export function requirePermissions(required: RequiredPermissions) {
       id: userId,
     } as WXYCAuthJwtPayload;
 
-    // Validate role exists
+    // Normalize and validate role
     if (!payload.role) {
       return res.status(403).json({ error: 'Forbidden: Missing role in token.' });
     }
 
-    const roleImpl = WXYCRoles[payload.role];
-    if (!roleImpl) {
+    const normalizedRole = normalizeRole(payload.role as string);
+    if (!normalizedRole) {
       return res.status(403).json({ error: 'Forbidden: Invalid role.' });
     }
+
+    // Update req.auth with normalized role so downstream sees a valid WXYCRole
+    req.auth = { ...req.auth!, role: normalizedRole };
+
+    const roleImpl = WXYCRoles[normalizedRole];
 
     // Check permissions
     const ok = Object.entries(required).every(([resource, actions]) => {

--- a/shared/authentication/src/auth.roles.ts
+++ b/shared/authentication/src/auth.roles.ts
@@ -45,3 +45,15 @@ export const WXYCRoles = {
 };
 
 export type WXYCRole = keyof typeof WXYCRoles;
+
+/** Maps better-auth system roles to their WXYC equivalent. */
+const systemRoleMap: Record<string, WXYCRole> = {
+  admin: 'stationManager',
+  owner: 'stationManager',
+};
+
+/** Normalizes a role string to a WXYCRole, mapping better-auth system roles. */
+export function normalizeRole(role: string): WXYCRole | undefined {
+  if (role in WXYCRoles) return role as WXYCRole;
+  return systemRoleMap[role];
+}

--- a/shared/authentication/src/url-rewrite.ts
+++ b/shared/authentication/src/url-rewrite.ts
@@ -5,9 +5,7 @@
 export const rewriteUrlForFrontend = (url: string): string => {
   try {
     const parsed = new URL(url);
-    const frontend = new URL(
-      process.env.FRONTEND_SOURCE || 'http://localhost:3000'
-    );
+    const frontend = new URL(process.env.FRONTEND_SOURCE || 'http://localhost:3000');
     parsed.host = frontend.host;
     parsed.protocol = frontend.protocol;
     return parsed.toString();

--- a/tests/mocks/better-auth-access.mock.ts
+++ b/tests/mocks/better-auth-access.mock.ts
@@ -1,0 +1,32 @@
+/**
+ * Minimal mock for better-auth/plugins/access
+ *
+ * Provides createAccessControl and newRole that mimic the real behavior
+ * closely enough to validate role permission definitions.
+ */
+
+type Statement = Record<string, readonly string[]>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function createAccessControl<S extends Statement>(_statements: S) {
+  return {
+    newRole(permissions: Partial<{ [K in keyof S]: readonly string[] }>) {
+      return {
+        authorize(request: Partial<{ [K in keyof S]: string[] }>) {
+          for (const [resource, actions] of Object.entries(request)) {
+            if (!actions || (actions as string[]).length === 0) continue;
+            const allowed = permissions[resource as keyof S];
+            if (!allowed) return { success: false };
+            for (const action of actions as string[]) {
+              if (!(allowed as readonly string[]).includes(action)) {
+                return { success: false };
+              }
+            }
+          }
+          return { success: true };
+        },
+        statements: permissions,
+      };
+    },
+  };
+}

--- a/tests/mocks/better-auth-org-access.mock.ts
+++ b/tests/mocks/better-auth-org-access.mock.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal mock for better-auth/plugins/organization/access
+ *
+ * Provides the same defaultStatements and adminAc values as the real module.
+ */
+
+export const defaultStatements = {
+  organization: ['update', 'delete'],
+  member: ['create', 'update', 'delete'],
+  invitation: ['create', 'cancel'],
+  team: ['create', 'update', 'delete'],
+  ac: ['create', 'read', 'update', 'delete'],
+} as const;
+
+export const adminAc = {
+  statements: {
+    organization: ['update'],
+    invitation: ['create', 'cancel'],
+    member: ['create', 'update', 'delete'],
+    team: ['create', 'update', 'delete'],
+    ac: ['create', 'read', 'update', 'delete'],
+  } as const,
+};

--- a/tests/unit/authentication/auth.middleware.test.ts
+++ b/tests/unit/authentication/auth.middleware.test.ts
@@ -1,0 +1,222 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+// Set required env vars before module load (ts-jest transforms imports to requires,
+// so these execute before the middleware module's top-level code runs)
+process.env.BETTER_AUTH_JWKS_URL = 'https://test.example.com/.well-known/jwks.json';
+process.env.BETTER_AUTH_ISSUER = 'https://test.example.com';
+process.env.BETTER_AUTH_AUDIENCE = 'https://test.example.com';
+
+// Mock jose -- the middleware calls createRemoteJWKSet at module scope
+// and jwtVerify on each request
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn(() => jest.fn()),
+  jwtVerify: jest.fn(),
+}));
+
+import { jwtVerify } from 'jose';
+import { requirePermissions } from '../../../shared/authentication/src/auth.middleware';
+import type { Request, Response, NextFunction } from 'express';
+
+const mockedJwtVerify = jwtVerify as jest.MockedFunction<typeof jwtVerify>;
+
+function createMocks(authHeader?: string) {
+  const req = {
+    headers: authHeader ? { authorization: authHeader } : {},
+  } as unknown as Request;
+
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+
+  const next = jest.fn() as NextFunction;
+
+  return { req, res, next };
+}
+
+function mockJwtPayload(overrides: Record<string, unknown> = {}) {
+  mockedJwtVerify.mockResolvedValue({
+    payload: {
+      sub: 'test-user-id',
+      email: 'test@wxyc.org',
+      role: 'dj',
+      ...overrides,
+    },
+    protectedHeader: { alg: 'RS256' },
+    key: {} as any,
+  } as any);
+}
+
+describe('requirePermissions middleware', () => {
+  const originalAuthBypass = process.env.AUTH_BYPASS;
+
+  beforeEach(() => {
+    delete process.env.AUTH_BYPASS;
+  });
+
+  afterAll(() => {
+    if (originalAuthBypass !== undefined) {
+      process.env.AUTH_BYPASS = originalAuthBypass;
+    } else {
+      delete process.env.AUTH_BYPASS;
+    }
+  });
+
+  describe('AUTH_BYPASS', () => {
+    it('should skip all validation when AUTH_BYPASS is "true"', async () => {
+      process.env.AUTH_BYPASS = 'true';
+      const { req, res, next } = createMocks();
+      const middleware = requirePermissions({ catalog: ['read'] });
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('token validation', () => {
+    it('should return 401 when Authorization header is missing', async () => {
+      const { req, res, next } = createMocks();
+      const middleware = requirePermissions({ catalog: ['read'] });
+
+      await middleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when JWT verification fails', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockedJwtVerify.mockRejectedValue(new Error('invalid signature'));
+      const { req, res, next } = createMocks('Bearer bad-token');
+      const middleware = requirePermissions({ catalog: ['read'] });
+
+      await middleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('role normalization', () => {
+    /**
+     * Regression test for the 403 bug. Before this fix, WXYCRoles did not
+     * include "admin" or "owner". When better-auth assigned one of those
+     * roles to a user's JWT, the middleware returned 403 "Invalid role".
+     *
+     * The fix normalizes system roles to their WXYC equivalents instead of
+     * adding them as separate roles.
+     */
+    it('should normalize "admin" to stationManager and pass through', async () => {
+      mockJwtPayload({ role: 'admin' });
+      const { req, res, next } = createMocks('Bearer valid-token');
+      const middleware = requirePermissions({ catalog: ['read'] });
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(req.auth?.role).toBe('stationManager');
+    });
+
+    it('should normalize "owner" to stationManager and pass through', async () => {
+      mockJwtPayload({ role: 'owner' });
+      const { req, res, next } = createMocks('Bearer valid-token');
+      const middleware = requirePermissions({ catalog: ['read'] });
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+      expect(req.auth?.role).toBe('stationManager');
+    });
+
+    it('should pass through "dj" role unchanged', async () => {
+      mockJwtPayload({ role: 'dj' });
+      const { req, res, next } = createMocks('Bearer valid-token');
+      const middleware = requirePermissions({ flowsheet: ['write'] });
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(req.auth?.role).toBe('dj');
+    });
+
+    it('should return 403 for an unrecognized role', async () => {
+      mockJwtPayload({ role: 'nonexistent_role' });
+      const { req, res, next } = createMocks('Bearer valid-token');
+      const middleware = requirePermissions({ catalog: ['read'] });
+
+      await middleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining('Invalid role') })
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should return 403 when role is missing from token', async () => {
+      mockJwtPayload({ role: undefined });
+      const { req, res, next } = createMocks('Bearer valid-token');
+      const middleware = requirePermissions({ catalog: ['read'] });
+
+      await middleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('permission checks', () => {
+    it.each(['member', 'dj', 'musicDirector', 'stationManager'] as const)(
+      '"%s" should be authorized for catalog:read',
+      async (role) => {
+        mockJwtPayload({ role });
+        const { req, res, next } = createMocks('Bearer valid-token');
+        const middleware = requirePermissions({ catalog: ['read'] });
+
+        await middleware(req, res, next);
+
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should return 403 when role lacks required permission', async () => {
+      mockJwtPayload({ role: 'member' });
+      const { req, res, next } = createMocks('Bearer valid-token');
+      const middleware = requirePermissions({ catalog: ['write'] });
+
+      await middleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('insufficient permissions'),
+        })
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('normalized admin should have stationManager permissions (catalog:write)', async () => {
+      mockJwtPayload({ role: 'admin' });
+      const { req, res, next } = createMocks('Bearer valid-token');
+      const middleware = requirePermissions({ catalog: ['write'] });
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('normalized owner should have stationManager permissions (flowsheet:write)', async () => {
+      mockJwtPayload({ role: 'owner' });
+      const { req, res, next } = createMocks('Bearer valid-token');
+      const middleware = requirePermissions({ flowsheet: ['write'] });
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/authentication/auth.roles.test.ts
+++ b/tests/unit/authentication/auth.roles.test.ts
@@ -1,0 +1,49 @@
+import { WXYCRoles, normalizeRole, type WXYCRole } from '../../../shared/authentication/src/auth.roles';
+
+describe('normalizeRole', () => {
+  it.each(['member', 'dj', 'musicDirector', 'stationManager'] as const)(
+    'should return "%s" as-is (valid WXYC role)',
+    (role) => {
+      expect(normalizeRole(role)).toBe(role);
+    }
+  );
+
+  it('should map "admin" to "stationManager"', () => {
+    expect(normalizeRole('admin')).toBe('stationManager');
+  });
+
+  it('should map "owner" to "stationManager"', () => {
+    expect(normalizeRole('owner')).toBe('stationManager');
+  });
+
+  it('should return undefined for an unrecognized role', () => {
+    expect(normalizeRole('unknown')).toBeUndefined();
+  });
+});
+
+describe('WXYCRoles', () => {
+  const allRoles = Object.keys(WXYCRoles) as WXYCRole[];
+
+  it.each(allRoles)('"%s" should have an authorize function', (role) => {
+    const roleDef = WXYCRoles[role];
+    expect(typeof (roleDef as any).authorize).toBe('function');
+  });
+
+  it.each(allRoles)('"%s" should authorize catalog:read', (role) => {
+    const roleDef = WXYCRoles[role];
+    const result = (roleDef as any).authorize({ catalog: ['read'] });
+    expect(result.success).toBe(true);
+  });
+
+  it('member should NOT authorize catalog:write', () => {
+    const result = (WXYCRoles.member as any).authorize({ catalog: ['write'] });
+    expect(result.success).toBe(false);
+  });
+
+  it('stationManager should authorize catalog:write', () => {
+    const result = (WXYCRoles.stationManager as any).authorize({
+      catalog: ['write'],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/unit/authentication/url-rewrite.test.ts
+++ b/tests/unit/authentication/url-rewrite.test.ts
@@ -13,13 +13,10 @@ describe('rewriteUrlForFrontend', () => {
 
   it('replaces host and protocol while preserving path and query params', () => {
     process.env.FRONTEND_SOURCE = 'https://dj.wxyc.org';
-    const input =
-      'https://api.wxyc.org/auth/verify-email?token=abc123&callbackURL=%2Fonboarding';
+    const input = 'https://api.wxyc.org/auth/verify-email?token=abc123&callbackURL=%2Fonboarding';
     const result = rewriteUrlForFrontend(input);
 
-    expect(result).toBe(
-      'https://dj.wxyc.org/auth/verify-email?token=abc123&callbackURL=%2Fonboarding'
-    );
+    expect(result).toBe('https://dj.wxyc.org/auth/verify-email?token=abc123&callbackURL=%2Fonboarding');
   });
 
   it('handles URLs without query params', () => {
@@ -32,13 +29,10 @@ describe('rewriteUrlForFrontend', () => {
 
   it('preserves complex query parameters', () => {
     process.env.FRONTEND_SOURCE = 'https://dj.wxyc.org';
-    const input =
-      'https://api.wxyc.org/auth/verify-email?token=xyz&callbackURL=%2Fdashboard&redirectTo=%2Fhome';
+    const input = 'https://api.wxyc.org/auth/verify-email?token=xyz&callbackURL=%2Fdashboard&redirectTo=%2Fhome';
     const result = rewriteUrlForFrontend(input);
 
-    expect(result).toBe(
-      'https://dj.wxyc.org/auth/verify-email?token=xyz&callbackURL=%2Fdashboard&redirectTo=%2Fhome'
-    );
+    expect(result).toBe('https://dj.wxyc.org/auth/verify-email?token=xyz&callbackURL=%2Fdashboard&redirectTo=%2Fhome');
   });
 
   it('handles invalid URLs gracefully by returning original', () => {


### PR DESCRIPTION
## Summary

- Map better-auth system roles (`admin`, `owner`) to `stationManager` in the `requirePermissions` middleware instead of adding them as separate roles
- Add `normalizeRole()` function to `auth.roles.ts` for the mapping
- Update `req.auth.role` with the normalized value so downstream code always sees a valid `WXYCRole`
- Add unit tests for `normalizeRole` and middleware role normalization, including regression tests for the 403 bug

Closes #200

## Test plan

- [x] `normalizeRole` returns WXYC roles as-is
- [x] `normalizeRole('admin')` returns `'stationManager'`
- [x] `normalizeRole('owner')` returns `'stationManager'`
- [x] `normalizeRole('unknown')` returns `undefined`
- [x] Middleware passes `admin` JWT through with stationManager permissions
- [x] Middleware passes `owner` JWT through with stationManager permissions
- [x] Middleware sets `req.auth.role` to the normalized value
- [x] Middleware rejects unrecognized roles with 403
- [x] All 152 existing unit tests continue to pass
- [ ] Deploy and verify `https://api.wxyc.org/flowsheet/join` no longer returns 403 for admin users