### PR TITLE
feat: Dependency-aware targets via Turborepo

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -64,8 +64,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-        with:
-          fetch-depth: 2
+
+      - name: Fetch base commit for Turbo diff
+        if: inputs.target == ''
+        run: git fetch origin ${{ github.event.before }} --depth=1
 
       - name: Set up Node.js
         if: inputs.target == ''
@@ -94,9 +96,9 @@ jobs:
             echo "HAS_TARGETS=true" >> $GITHUB_OUTPUT
           else
             echo "Detecting affected app targets (Turborepo)..."
-            export TURBO_SCM_BASE=HEAD^
-            export TURBO_SCM_HEAD=HEAD
-            TARGETS=$(npx turbo ls --affected --output=json | jq -c '[.packages.items[] | select(.path | startswith("apps/")) | .path | split("/")[1]] | unique | sort')
+            export TURBO_SCM_BASE=${{ github.event.before }}
+            export TURBO_SCM_HEAD=${{ github.sha }}
+            TARGETS=$(npx turbo ls --affected --output=json | jq -c '[.packages.items[] | select(.path | (startswith("apps/") or startswith("jobs/"))) | .path | split("/")[1]] | unique | sort')
             if [ "$TARGETS" = "[]" ] || [ -z "$TARGETS" ]; then
               echo "No affected app targets found."
               echo "TARGETS=[]" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -67,25 +67,45 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Set up Node.js
+        if: inputs.target == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Cache node_modules
+        if: inputs.target == ''
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: deploy-node-modules-${{ runner.os }}-node20-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: inputs.target == ''
+        run: npm ci
+
       - name: Detect Build Target
         id: detect_targets
         run: |
           if [ -n "${{ inputs.target }}" ]; then
             echo "Using provided target: ${{ inputs.target }}"
-            TARGETS="${{ inputs.target }}"
-          else
-            echo "Detecting targets from git diff..."
-            TARGETS=$(git diff --name-only HEAD~1..HEAD | awk -F/ '/^(apps|jobs)\//{print $2}' | sort -u)
-          fi
-
-          if [ -z "$TARGETS" ] ; then
-            echo "No targets found. Exiting."
-            echo "TARGETS=[]" >> $GITHUB_OUTPUT
-            echo "HAS_TARGETS=false" >> $GITHUB_OUTPUT
-          else
-            echo "TARGETS=$TARGETS"
-            echo "TARGETS=$(echo "$TARGETS" | jq -R -s -c 'split("\n") | map(select(length > 0))')" >> $GITHUB_OUTPUT
+            TARGETS=$(echo "${{ inputs.target }}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "TARGETS=$TARGETS" >> $GITHUB_OUTPUT
             echo "HAS_TARGETS=true" >> $GITHUB_OUTPUT
+          else
+            echo "Detecting affected app targets (Turborepo)..."
+            export TURBO_SCM_BASE=HEAD^
+            export TURBO_SCM_HEAD=HEAD
+            TARGETS=$(npx turbo ls --affected --output=json | jq -c '[.packages.items[] | select(.path | startswith("apps/")) | .path | split("/")[1]] | unique | sort')
+            if [ "$TARGETS" = "[]" ] || [ -z "$TARGETS" ]; then
+              echo "No affected app targets found."
+              echo "TARGETS=[]" >> $GITHUB_OUTPUT
+              echo "HAS_TARGETS=false" >> $GITHUB_OUTPUT
+            else
+              echo "TARGETS=$TARGETS"
+              echo "TARGETS=$TARGETS" >> $GITHUB_OUTPUT
+              echo "HAS_TARGETS=true" >> $GITHUB_OUTPUT
+            fi
           fi
 
       - name: Generate Unique Build ID

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "ts-node": "^10.9.2",
         "tsup": "^8.4.0",
         "tsx": "^4.21.0",
+        "turbo": "^2.3.0",
         "typescript": "^5.6.2",
         "typescript-eslint": "^8.55.0",
         "wait-on": "^8.0.1"
@@ -12601,6 +12602,108 @@
         "@esbuild/win32-ia32": "0.27.2",
         "@esbuild/win32-x64": "0.27.2"
       }
+    },
+    "node_modules/turbo": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.8.10.tgz",
+      "integrity": "sha512-OxbzDES66+x7nnKGg2MwBA1ypVsZoDTLHpeaP4giyiHSixbsiTaMyeJqbEyvBdp5Cm28fc+8GG6RdQtic0ijwQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "2.8.10",
+        "turbo-darwin-arm64": "2.8.10",
+        "turbo-linux-64": "2.8.10",
+        "turbo-linux-arm64": "2.8.10",
+        "turbo-windows-64": "2.8.10",
+        "turbo-windows-arm64": "2.8.10"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.8.10.tgz",
+      "integrity": "sha512-A03fXh+B7S8mL3PbdhTd+0UsaGrhfyPkODvzBDpKRY7bbeac4MDFpJ7I+Slf2oSkCEeSvHKR7Z4U71uKRUfX7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.8.10.tgz",
+      "integrity": "sha512-sidzowgWL3s5xCHLeqwC9M3s9M0i16W1nuQF3Mc7fPHpZ+YPohvcbVFBB2uoRRHYZg6yBnwD4gyUHKTeXfwtXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.8.10.tgz",
+      "integrity": "sha512-YK9vcpL3TVtqonB021XwgaQhY9hJJbKKUhLv16osxV0HkcQASQWUqR56yMge7puh6nxU67rQlTq1b7ksR1T3KA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.8.10.tgz",
+      "integrity": "sha512-3+j2tL0sG95iBJTm+6J8/45JsETQABPqtFyYjVjBbi6eVGdtNTiBmHNKrbvXRlQ3ZbUG75bKLaSSDHSEEN+btQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.8.10.tgz",
+      "integrity": "sha512-hdeF5qmVY/NFgiucf8FW0CWJWtyT2QPm5mIsX0W1DXAVzqKVXGq+Zf+dg4EUngAFKjDzoBeN6ec2Fhajwfztkw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.8.10.tgz",
+      "integrity": "sha512-QGdr/Q8LWmj+ITMkSvfiz2glf0d7JG0oXVzGL3jxkGqiBI1zXFj20oqVY0qWi+112LO9SVrYdpHS0E/oGFrMbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@wxyc/backend-services",
   "version": "1.0.0",
   "description": "All necessary app services for the WXYC flowsheet backend",
+  "packageManager": "npm@10.9.4",
   "scripts": {
     "typecheck": "npm run build --workspace=@wxyc/database --workspace=@wxyc/authentication && npm run typecheck --workspace=@wxyc/database --workspace=shared/** --workspace=apps/**",
     "lint": "eslint --cache --cache-strategy content --cache-location .cache/eslint/ .",
@@ -71,6 +72,7 @@
     "supertest": "^7.0.0",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
+    "turbo": "^2.3.0",
     "tsup": "^8.4.0",
     "tsx": "^4.21.0",
     "typescript": "^5.6.2",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": { "outputs": ["dist/**"] }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,4 +1,5 @@
 {
+  "globalDependencies": ["tsconfig.base.json"],
   "tasks": {
     "build": { "outputs": ["dist/**"] }
   }


### PR DESCRIPTION
Updates auto-deploy so tags and deploys run for affected apps based on the workspace dependency graph, not only on changes under apps/.

### Problem

“Detect Build Target” only looked at apps/ changes. Edits in shared/ (e.g. shared/database, shared/authentication) did not trigger deploys for backend or auth, even though both depend on those packages.

### Changes

When no target is provided (e.g. push to main), the setup job runs turbo ls --affected (comparing HEAD^ to HEAD) and parses the result to get app names under apps/. Shared-only changes now correctly include both apps in the deploy matrix.

Turbo is used only for affected detection; a minimal root turbo.json and a build task define the graph. Existing npm/Docker builds are unchanged.

- Setup job: for the no-target path, adds Node setup, node_modules cache, and npm ci before turbo ls. Manual deploy (with target set) is unchanged.
- Root package.json: added packageManager: "npm@10.9.4" and turbo as a devDependency so Turbo can resolve workspaces without the package-manager override.
- Manual deploys and the rest of the pipeline (tagging, build, deploy) are unchanged; only how the target list is computed is now dependency-aware.