### PR TITLE
fix: copy lockfile into Docker builder stage and use npm ci

### DIFF
--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -3,12 +3,12 @@ FROM node:22-alpine AS builder
 
 WORKDIR /auth-builder
 
-COPY ./package.json ./
+COPY ./package.json ./package-lock.json ./
 COPY ./tsconfig.base.json ./
 COPY ./shared ./shared
 COPY ./apps/auth ./apps/auth
 
-RUN npm install && npm run build --workspace=@wxyc/database --workspace=shared/** --workspace=@wxyc/auth-service
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=shared/** --workspace=@wxyc/auth-service
 
 #Production stage
 FROM node:22-alpine AS prod

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -3,12 +3,12 @@ FROM node:22-alpine AS builder
 
 WORKDIR /builder
 
-COPY ./package.json ./
+COPY ./package.json ./package-lock.json ./
 COPY ./tsconfig.base.json ./
 COPY ./shared ./shared
 COPY ./apps/backend ./apps/backend
 
-RUN npm install && npm run build --workspace=@wxyc/database --workspace=shared/** --workspace=@wxyc/backend
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=shared/** --workspace=@wxyc/backend
 
 #Production stage
 FROM node:22-alpine AS prod


### PR DESCRIPTION
## Summary
- The builder stages in `Dockerfile.backend` and `Dockerfile.auth` only copied `package.json`, not `package-lock.json`
- This caused `npm install` to resolve caret ranges to latest compatible versions instead of locked versions
- `better-auth` resolved to 1.5.1 (which has breaking type changes in `Auth`) instead of the locked 1.4.9, failing integration tests on every open PR
- Fix: copy `package-lock.json` into the builder stage and switch from `npm install` to `npm ci` for deterministic builds

## Test plan
- [x] Verified the change is limited to Dockerfile COPY and RUN lines
- [ ] CI integration tests should pass (this is the fix for the current failures on PRs #150, #163, #172, #174, #182, #183)