### PR TITLE
Auto-verify admin-created users, fix seed idempotency

### DIFF
--- a/dev_env/seed_db.sql
+++ b/dev_env/seed_db.sql
@@ -46,6 +46,8 @@ VALUES
 ON CONFLICT (id) DO UPDATE SET
   dj_name = EXCLUDED.dj_name,
   real_name = EXCLUDED.real_name,
+  email_verified = EXCLUDED.email_verified,
+  role = EXCLUDED.role,
   updated_at = NOW();
 
 -- Create credential accounts for all test users

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -273,19 +273,12 @@ export const auth = betterAuth({
         return;
       }
 
-      // Send verification email for admin-created users
-      const callbackURL = process.env.EMAIL_VERIFICATION_REDIRECT_URL?.trim() || process.env.FRONTEND_SOURCE?.trim();
-
-      void auth.api
-        .sendVerificationEmail({
-          body: {
-            email,
-            callbackURL,
-          },
-        })
-        .catch((error) => {
-          console.error('Error triggering verification email:', error);
-        });
+      // Auto-verify email for admin-created users (trusted operation)
+      try {
+        await db.update(user).set({ emailVerified: true }).where(eq(user.email, email));
+      } catch (error) {
+        console.error('Error auto-verifying admin-created user:', error);
+      }
     }),
   },
 


### PR DESCRIPTION
## Summary

- Replace verification email with direct DB `emailVerified = true` update in admin create-user after-hook — admin creation is trusted
- Add `email_verified` and `role` to seed `ON CONFLICT` clause for idempotent re-seeding

Closes #221

> **Note:** E2E tests also depend on WXYC/dj-site#271 for full resolution.

## Test plan

- [ ] Admin-created users have `email_verified = true` in the database
- [ ] Admin-created users can log in immediately without clicking verification link
- [ ] Re-running seed fixes users with stale `email_verified` or `role` values
- [ ] E2E tests pass when combined with WXYC/dj-site#271