### PR TITLE
fix: rename album_title query param to album_name to match API spec

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -79,7 +79,7 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
 
 type AlbumQueryParams = {
   artist_name?: string;
-  album_title?: string;
+  album_name?: string;
   code_letters?: string;
   code_artist_number?: string;
   code_number?: number;
@@ -95,12 +95,12 @@ export const searchForAlbum: RequestHandler = async (
   const { query } = req;
   if (
     query.artist_name === undefined &&
-    query.album_title === undefined &&
+    query.album_name === undefined &&
     (query.code_letters === undefined || query.code_artist_number === undefined)
   ) {
     res.status(400);
     res.send(
-      'Missing query parameter. Query must include: artist_name, album_title, or code_letters, code_artist_number, and code_number'
+      'Missing query parameter. Query must include: artist_name, album_name, or code_letters, code_artist_number, and code_number'
     );
   } else if (query.code_letters !== undefined && query.code_artist_number !== undefined) {
     //quickly look up albums by that artist
@@ -108,7 +108,7 @@ export const searchForAlbum: RequestHandler = async (
     res.send('TODO: Library Code Lookup');
   } else {
     try {
-      const response = await libraryService.fuzzySearchLibrary(query.artist_name, query.album_title, query.n);
+      const response = await libraryService.fuzzySearchLibrary(query.artist_name, query.album_name, query.n);
       res.status(200).json(response);
     } catch (e) {
       console.error("Error: Couldn't get album");

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -34,7 +34,7 @@ describe('Library Catalog', () => {
     });
 
     test('searches by album title', async () => {
-      const res = await auth.get('/library').query({ album_title: 'Keep it Like a Secret' }).expect(200);
+      const res = await auth.get('/library').query({ album_name: 'Keep it Like a Secret' }).expect(200);
 
       expectArray(res);
       expect(res.body.length).toBeGreaterThan(0);
@@ -43,7 +43,7 @@ describe('Library Catalog', () => {
     test('searches by both artist and album', async () => {
       const res = await auth
         .get('/library')
-        .query({ artist_name: 'Built to Spill', album_title: 'Keep it' })
+        .query({ artist_name: 'Built to Spill', album_name: 'Keep it' })
         .expect(200);
 
       expectArray(res);

--- a/tests/utils/library_util.js
+++ b/tests/utils/library_util.js
@@ -164,7 +164,7 @@ exports.getAlbumInfo = async (album_id, access_token) => {
  *
  * @param {object} searchParams - Search parameters
  * @param {string} [searchParams.artist_name] - Artist name
- * @param {string} [searchParams.album_title] - Album title
+ * @param {string} [searchParams.album_name] - Album name
  * @param {number} [searchParams.n] - Number of results
  * @param {string} access_token - Authorization token
  * @returns {Promise<object>} Search results
@@ -172,7 +172,7 @@ exports.getAlbumInfo = async (album_id, access_token) => {
 exports.searchLibrary = async (searchParams, access_token) => {
   const params = new URLSearchParams();
   if (searchParams.artist_name) params.append('artist_name', searchParams.artist_name);
-  if (searchParams.album_title) params.append('album_title', searchParams.album_title);
+  if (searchParams.album_name) params.append('album_name', searchParams.album_name);
   if (searchParams.n) params.append('n', searchParams.n.toString());
 
   const res = await fetch(`${url}/library?${params.toString()}`, {


### PR DESCRIPTION
## Summary

- Rename `album_title` to `album_name` in `AlbumQueryParams` for `GET /library` to match `CatalogSearchParams` in `api.yaml` and the dj-site frontend
- Update integration tests and test utility to use the corrected parameter name

The frontend sends `album_name` but the backend expected `album_title`, so album searches were silently ignored — only artist name matching worked.

Closes #233

## Test plan

- [ ] `GET /library?album_name=Confield` returns Autechre's "Confield"
- [ ] `GET /library?artist_name=Built+to+Spill&album_name=Keep+it` returns matching results
- [ ] `GET /library` with no params still returns 400
- [ ] Integration tests pass (`searches by album title`, `searches by both artist and album`)