### PR TITLE
Pass NPM_TOKEN as build arg in Docker Compose CI and E2E services

### DIFF
--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -88,6 +88,8 @@ services:
     build:
       context: '../'
       dockerfile: Dockerfile.auth
+      args:
+        NPM_TOKEN: ${NPM_TOKEN:-}
     profiles: [ci]
     environment:
       - DB_HOST=ci-db
@@ -126,6 +128,8 @@ services:
     build:
       context: '../'
       dockerfile: Dockerfile.backend
+      args:
+        NPM_TOKEN: ${NPM_TOKEN:-}
     profiles: [ci]
     environment:
       - DB_HOST=ci-db
@@ -221,6 +225,8 @@ services:
     build:
       context: '../'
       dockerfile: Dockerfile.auth
+      args:
+        NPM_TOKEN: ${NPM_TOKEN:-}
     profiles: [e2e]
     environment:
       - DB_HOST=e2e-db
@@ -257,6 +263,8 @@ services:
     build:
       context: '../'
       dockerfile: Dockerfile.backend
+      args:
+        NPM_TOKEN: ${NPM_TOKEN:-}
     profiles: [e2e]
     environment:
       - DB_HOST=e2e-db


### PR DESCRIPTION
## Summary

Add `NPM_TOKEN` build arg to all Docker Compose service definitions that build from `Dockerfile.backend` or `Dockerfile.auth`. These Dockerfiles declare `ARG NPM_TOKEN` for GitHub Packages auth during `npm install`, but the docker-compose build configs were missing the corresponding `args`, causing 401 errors.

Affects CI (`ci-auth`, `ci-backend`) and E2E (`e2e-auth`, `e2e-backend`) profiles.

## Related

- dj-site PR #291: passes `NPM_TOKEN` env var to the Docker Compose step in the E2E workflow
- Backend-Service deploy-base.yml: already fixed in commit 14ed704

## Test plan

- [ ] CI profile services build successfully with NPM_TOKEN
- [ ] E2E profile services build successfully with NPM_TOKEN
- [ ] dj-site E2E tests pass