### PR TITLE
fix: Add comprehensive Sentry logging for flowsheet mirror behavior

### DIFF
--- a/apps/backend/middleware/legacy/commandqueue.mirror.ts
+++ b/apps/backend/middleware/legacy/commandqueue.mirror.ts
@@ -5,6 +5,18 @@ import { EventEmitter } from 'node:events';
 import path from 'path';
 import { MirrorSQL } from '@wxyc/database';
 import { cryptoRandomId, expBackoffMs } from './utilities.mirror';
+import {
+  addMirrorBreadcrumb,
+  buildMirrorCommandSummary,
+  captureMirrorException,
+  getMirrorRingIndex,
+  hashSha256Hex,
+  summarizeSql,
+  type MirrorCommandSummary,
+  type MirrorLogContext,
+  type MirrorCommandStatus,
+  truncateForMirrorPayload,
+} from './mirror.logging';
 
 const CommandQueueEvents = {
   enqueued: 'enqueued',
@@ -18,11 +30,15 @@ const CommandQueueEvents = {
 export interface MirrorCommand {
   id: string;
   sql: string;
+  sqlLength: number;
+  sqlHash: string;
+  statementsCount: number;
   enqueuedAt: number;
   attempts: number;
   lastResult?: string;
   lastError?: string;
   status: 'pending' | 'in_progress' | 'in_progress_retrying' | 'completed' | 'failed';
+  context?: MirrorLogContext;
 }
 
 export interface MirrorQueueOptions {
@@ -34,11 +50,13 @@ export interface MirrorQueueOptions {
 }
 
 export interface FatalInfo {
-  failedCommand: MirrorCommand;
-  pendingQueue: MirrorCommand[];
+  failedCommand: MirrorCommandSummary;
+  pendingQueue: MirrorCommandSummary[];
+  pendingQueueDepth: number;
   reason: string;
   timestamp: string;
   logFile: string;
+  ringIndex: number;
 }
 
 export class MirrorCommandQueue extends EventEmitter {
@@ -59,16 +77,66 @@ export class MirrorCommandQueue extends EventEmitter {
     return this._instance;
   }
 
-  private static createTrigger = (eventType: keyof typeof MirrorEvents) => (cmd: MirrorCommand) => {
-    const data: EventData = {
-      type: eventType,
-      payload: cmd,
-      timestamp: new Date(),
-    };
+  private static createTrigger =
+    (eventType: keyof typeof MirrorEvents) =>
+    (payload: MirrorCommand | { cmd: MirrorCommand; error: Error; attempt: number } | FatalInfo) => {
+      const data: EventData = {
+        type: eventType,
+        payload,
+        timestamp: new Date(),
+      };
 
-    serverEventsMgr.broadcast('mirror', data);
-    console.table(cmd);
-  };
+      serverEventsMgr.broadcast('mirror', data);
+
+      // Best-effort breadcrumbs for debugging; don't let this crash the queue.
+      try {
+        if ('cmd' in payload) {
+          const ctx = payload.cmd.context ?? {};
+          addMirrorBreadcrumb(
+            'Mirror sync: retry/failure attempt',
+            {
+              eventType,
+              mirror_cmd_id: payload.cmd.id,
+              attempt: payload.attempt,
+              last_error: truncateForMirrorPayload(payload.error?.message, 256),
+            },
+            ctx,
+            payload.attempt >= 2 ? 'warning' : 'info'
+          );
+          return;
+        }
+
+        if ('id' in payload && 'status' in payload) {
+          const ctx = payload.context ?? {};
+          addMirrorBreadcrumb(
+            `Mirror sync: ${eventType}`,
+            {
+              eventType,
+              mirror_cmd_id: payload.id,
+              status: payload.status,
+              attempt: payload.attempts,
+            },
+            ctx,
+            eventType === 'syncError' ? 'error' : 'info'
+          );
+          return;
+        }
+
+        // FatalInfo
+        addMirrorBreadcrumb(
+          `Mirror sync: ${eventType}`,
+          {
+            eventType,
+            ringFile: payload.logFile,
+            reason: truncateForMirrorPayload(payload.reason, 256),
+          },
+          payload.failedCommand.context,
+          'error'
+        );
+      } catch {
+        // ignore
+      }
+    };
 
   private readonly options: Required<MirrorQueueOptions>;
   private readonly queue: MirrorCommand[] = [];
@@ -87,17 +155,22 @@ export class MirrorCommandQueue extends EventEmitter {
     };
   }
 
-  enqueue(sqls: string[]): MirrorCommand | null {
+  enqueue(sqls: string[], context?: MirrorLogContext): MirrorCommand | null {
     if (!this.alive) return null;
     let sql = sqls.map((s) => (s.trim().endsWith(';') ? s.trim() : s.trim() + ';')).join('\n');
     sql = `START TRANSACTION;\n${sql}\nCOMMIT;`;
 
+    const sqlSummary = summarizeSql(sql);
     const cmd: MirrorCommand = {
       id: cryptoRandomId(),
       sql,
+      sqlLength: sqlSummary.sqlLength,
+      sqlHash: sqlSummary.sqlHash ?? hashSha256Hex(sql),
+      statementsCount: sqls.length,
       enqueuedAt: Date.now(),
       attempts: 0,
       status: 'pending',
+      context,
     };
 
     this.queue.push(cmd);
@@ -165,12 +238,42 @@ export class MirrorCommandQueue extends EventEmitter {
       return;
     }
 
+    // Secondary reports: first failure (or configurable attempt) to disk; bounded ring-buffer.
+    try {
+      const secondaryAttempt = parseInt(process.env.MIRROR_SECONDARY_REPORT_ON_ATTEMPT ?? '1', 10);
+      const maxSecondaryReports = parseInt(process.env.MIRROR_SECONDARY_REPORTS_MAX ?? '10', 10);
+      const secondaryIntervalMs = parseInt(process.env.MIRROR_SECONDARY_REPORTS_INTERVAL_MS ?? String(10 * 60 * 1000), 10);
+      if (cmd.attempts === secondaryAttempt && maxSecondaryReports > 0) {
+        void this.persistSecondaryReport({
+          cmd,
+          err,
+          attempt: cmd.attempts,
+          maxSecondaryReports,
+          secondaryIntervalMs,
+        });
+      }
+    } catch {
+      // ignore
+    }
+
     cmd.status = 'in_progress_retrying';
     const delay = expBackoffMs(
       cmd.attempts,
       this.options.baseBackoffMs,
       this.options.maxBackoffMs,
       this.options.jitterMs
+    );
+
+    addMirrorBreadcrumb(
+      'Mirror sync: retry scheduled',
+      {
+        mirror_cmd_id: cmd.id,
+        attempt: cmd.attempts,
+        delay_ms: delay,
+        last_error: truncateForMirrorPayload(cmd.lastError, 256),
+      },
+      cmd.context,
+      'warning'
     );
 
     setTimeout(() => {
@@ -188,33 +291,130 @@ export class MirrorCommandQueue extends EventEmitter {
     this.fatalEmitted = true;
     this.alive = false;
 
+    const ctx: MirrorLogContext = {
+      ...(failedCommand.context ?? {}),
+      operation: failedCommand.context?.operation ?? 'mirror.fatal',
+      mirrorCmdId: failedCommand.id,
+      attempt: failedCommand.attempts,
+      maxAttempts: this.options.maxAttempts,
+    };
+
+    captureMirrorException(new Error(failedCommand.lastError ?? reason), ctx, {
+      reason,
+      mirror_cmd_id: failedCommand.id,
+      sqlLength: failedCommand.sqlLength,
+      sqlHash: failedCommand.sqlHash,
+      statementsCount: failedCommand.statementsCount,
+    });
+
     const info = await this.persistQueue(reason, failedCommand);
     this.emit(CommandQueueEvents.fatal, info);
   }
 
-  private async persistQueue(reason: string, failedCommand?: MirrorCommand) {
+  private async persistSecondaryReport(params: {
+    cmd: MirrorCommand;
+    err: Error;
+    attempt: number;
+    maxSecondaryReports: number;
+    secondaryIntervalMs: number;
+  }) {
+    const nowMs = Date.now();
     await promises.mkdir(this.options.logFile, { recursive: true });
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const logFile = path.join(this.options.logFile, `queue-fatal-${timestamp}.json`);
+    const ringIndex = getMirrorRingIndex(nowMs, params.secondaryIntervalMs, params.maxSecondaryReports);
+    const logFile = path.join(this.options.logFile, `queue-secondary-ring-${ringIndex}.json`);
 
-    const info: FatalInfo = {
-      failedCommand: failedCommand ?? {
-        id: 'n/a',
-        sql: 'n/a',
-        status: 'failed',
-        enqueuedAt: 0,
-        attempts: 0,
-        lastResult: 'n/a',
-        lastError: 'n/a',
-      },
-      pendingQueue: [...this.queue],
-      reason,
-      timestamp: new Date().toISOString(),
+    const payload = {
+      reportType: 'secondary',
+      ringIndex,
+      timestamp: new Date(nowMs).toISOString(),
       logFile,
+      attempt: params.attempt,
+      reason: 'Mirror failedAttempt; retry scheduled',
+      cmd: buildMirrorCommandSummary(params.cmd),
+      error: truncateForMirrorPayload(params.err?.message ?? String(params.err), 2048),
     };
 
-    const payload = JSON.stringify(info, null, 2);
-    await promises.writeFile(logFile, payload, 'utf8');
+    // Keep disk report bounded: ensure we never write huge JSON strings.
+    // If too large, write a smaller summary payload.
+    const maxJsonBytes = parseInt(process.env.MIRROR_REPORT_MAX_BYTES ?? String(64 * 1024), 10);
+    const fullJson = JSON.stringify(payload);
+    let boundedJson = fullJson;
+
+    if (fullJson.length > maxJsonBytes) {
+      boundedJson = JSON.stringify({
+        reportType: 'secondary',
+        ringIndex,
+        timestamp: payload.timestamp,
+        logFile: payload.logFile,
+        attempt: payload.attempt,
+        reason: payload.reason,
+        // Strip context to keep the report small.
+        cmd: { ...payload.cmd, context: undefined },
+        error: payload.error,
+        truncated: true,
+        jsonBytes: fullJson.length,
+      });
+    }
+
+    await promises.writeFile(logFile, boundedJson, 'utf8');
+    addMirrorBreadcrumb('Mirror sync: secondary report persisted', { ringIndex, logFile }, params.cmd.context, 'info');
+  }
+
+  private async persistQueue(reason: string, failedCommand?: MirrorCommand) {
+    await promises.mkdir(this.options.logFile, { recursive: true });
+
+    const nowMs = Date.now();
+    const maxFatalReports = parseInt(process.env.MIRROR_FATAL_REPORTS_MAX ?? '10', 10);
+    const fatalIntervalMs = parseInt(process.env.MIRROR_FATAL_REPORTS_INTERVAL_MS ?? String(15 * 60 * 1000), 10);
+    const ringIndex = getMirrorRingIndex(nowMs, fatalIntervalMs, maxFatalReports);
+    const logFile = path.join(this.options.logFile, `queue-fatal-ring-${ringIndex}.json`);
+
+    const failedCmdSummary = failedCommand
+      ? buildMirrorCommandSummary(failedCommand)
+      : ({
+          id: 'n/a',
+          enqueuedAt: 0,
+          attempts: 0,
+          status: 'failed',
+          lastError: 'n/a',
+          sqlLength: 0,
+          sqlHash: 'n/a',
+          statementsCount: 0,
+        } satisfies MirrorCommandSummary);
+
+    const maxPendingSummaries = parseInt(process.env.MIRROR_PENDING_QUEUE_SUMMARIES_MAX ?? '20', 10);
+    const pendingQueue = this.queue.slice(0, maxPendingSummaries).map((c) => buildMirrorCommandSummary(c));
+
+    const info: FatalInfo = {
+      failedCommand: failedCmdSummary,
+      pendingQueue,
+      pendingQueueDepth: this.queue.length,
+      reason: truncateForMirrorPayload(reason, 2048) ?? reason,
+      timestamp: new Date(nowMs).toISOString(),
+      logFile,
+      ringIndex,
+    };
+
+    const maxJsonBytes = parseInt(process.env.MIRROR_REPORT_MAX_BYTES ?? String(64 * 1024), 10);
+
+    const fullJson = JSON.stringify(info);
+    let boundedJson = fullJson;
+
+    if (fullJson.length > maxJsonBytes) {
+      boundedJson = JSON.stringify({
+        reportType: 'fatal',
+        ringIndex,
+        timestamp: info.timestamp,
+        logFile: info.logFile,
+        reason: info.reason,
+        failedCommand: { ...info.failedCommand, context: undefined },
+        pendingQueueDepth: info.pendingQueueDepth,
+        truncated: true,
+        jsonBytes: fullJson.length,
+      });
+    }
+
+    await promises.writeFile(logFile, boundedJson, 'utf8');
     this.emit(CommandQueueEvents.persisted, info);
     return info;
   }

--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -17,7 +17,16 @@ import {
 const FLOWSHEET_ENTRY_TABLE = 'FLOWSHEET_ENTRY_PROD';
 const RADIO_SHOW_TABLE = 'FLOWSHEET_RADIO_SHOW_PROD';
 
-const getEntries = createBackendMirrorMiddleware<any>('flowsheet.getEntries', async (req, data) => {
+const MirrorOps = {
+  getEntries: 'flowsheet.getEntries',
+  startShow: 'flowsheet.startShow',
+  endShow: 'flowsheet.endShow',
+  addEntry: 'flowsheet.addEntry',
+  updateEntry: 'flowsheet.updateEntry',
+  deleteEntry: 'flowsheet.deleteEntry',
+} as const;
+
+const getEntries = createBackendMirrorMiddleware<any>(MirrorOps.getEntries, async (req, data) => {
   const query = req.query as QueryParams;
 
   const page = parseInt(query.page ?? '0');
@@ -27,7 +36,7 @@ const getEntries = createBackendMirrorMiddleware<any>('flowsheet.getEntries', as
   return [`SELECT * FROM ${FLOWSHEET_ENTRY_TABLE} LIMIT ${limit} OFFSET ${offset};`];
 });
 
-const startShow = createBackendMirrorMiddleware<Show>('flowsheet.startShow', async (req, show) => {
+const startShow = createBackendMirrorMiddleware<Show>(MirrorOps.startShow, async (req, show) => {
   const nowMs = Date.now();
   const statements: string[] = [];
 
@@ -93,7 +102,7 @@ const startShow = createBackendMirrorMiddleware<Show>('flowsheet.startShow', asy
   return statements;
 });
 
-export const endShow = createBackendMirrorMiddleware<Show>('flowsheet.endShow', async (req, show) => {
+export const endShow = createBackendMirrorMiddleware<Show>(MirrorOps.endShow, async (req, show) => {
   const endMs = toMs(show.end_time ?? Date.now());
   const statements: string[] = [];
 
@@ -283,7 +292,7 @@ const getAddEntrySQL = async (req: Request, entry: FSEntry) => {
   return statements;
 };
 
-export const addEntry = createHttpMirrorMiddleware<FSEntry>('flowsheet.addEntry', async (_req, entry) => {
+export const addEntry = createHttpMirrorMiddleware<FSEntry>(MirrorOps.addEntry, async (_req, entry) => {
   const body = mapEntryToTubafrenzy(entry);
   const tubafrenzyId = await mirrorCreateEntry(body);
   if (tubafrenzyId != null) {
@@ -291,7 +300,7 @@ export const addEntry = createHttpMirrorMiddleware<FSEntry>('flowsheet.addEntry'
   }
 });
 
-export const updateEntry = createHttpMirrorMiddleware<FSEntry>('flowsheet.updateEntry', async (_req, entry) => {
+export const updateEntry = createHttpMirrorMiddleware<FSEntry>(MirrorOps.updateEntry, async (_req, entry) => {
   // Message-only rows aren't updateable
   if (entry?.message && entry.message.trim() !== '') return;
 
@@ -305,7 +314,7 @@ export const updateEntry = createHttpMirrorMiddleware<FSEntry>('flowsheet.update
   await mirrorUpdateEntry(tubafrenzyId, body);
 });
 
-export const deleteEntry = createBackendMirrorMiddleware<FSEntry>('flowsheet.deleteEntry', async (req, removed) => {
+export const deleteEntry = createBackendMirrorMiddleware<FSEntry>(MirrorOps.deleteEntry, async (req, removed) => {
   const statements: string[] = [];
 
   // Resolve the RADIO_SHOW_ID first

--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -17,7 +17,7 @@ import {
 const FLOWSHEET_ENTRY_TABLE = 'FLOWSHEET_ENTRY_PROD';
 const RADIO_SHOW_TABLE = 'FLOWSHEET_RADIO_SHOW_PROD';
 
-const getEntries = createBackendMirrorMiddleware<any>(async (req, data) => {
+const getEntries = createBackendMirrorMiddleware<any>('flowsheet.getEntries', async (req, data) => {
   const query = req.query as QueryParams;
 
   const page = parseInt(query.page ?? '0');
@@ -27,7 +27,7 @@ const getEntries = createBackendMirrorMiddleware<any>(async (req, data) => {
   return [`SELECT * FROM ${FLOWSHEET_ENTRY_TABLE} LIMIT ${limit} OFFSET ${offset};`];
 });
 
-const startShow = createBackendMirrorMiddleware<Show>(async (req, show) => {
+const startShow = createBackendMirrorMiddleware<Show>('flowsheet.startShow', async (req, show) => {
   const nowMs = Date.now();
   const statements: string[] = [];
 
@@ -93,7 +93,7 @@ const startShow = createBackendMirrorMiddleware<Show>(async (req, show) => {
   return statements;
 });
 
-export const endShow = createBackendMirrorMiddleware<Show>(async (req, show) => {
+export const endShow = createBackendMirrorMiddleware<Show>('flowsheet.endShow', async (req, show) => {
   const endMs = toMs(show.end_time ?? Date.now());
   const statements: string[] = [];
 
@@ -283,7 +283,7 @@ const getAddEntrySQL = async (req: Request, entry: FSEntry) => {
   return statements;
 };
 
-export const addEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) => {
+export const addEntry = createHttpMirrorMiddleware<FSEntry>('flowsheet.addEntry', async (_req, entry) => {
   const body = mapEntryToTubafrenzy(entry);
   const tubafrenzyId = await mirrorCreateEntry(body);
   if (tubafrenzyId != null) {
@@ -291,7 +291,7 @@ export const addEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) 
   }
 });
 
-export const updateEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) => {
+export const updateEntry = createHttpMirrorMiddleware<FSEntry>('flowsheet.updateEntry', async (_req, entry) => {
   // Message-only rows aren't updateable
   if (entry?.message && entry.message.trim() !== '') return;
 
@@ -305,7 +305,7 @@ export const updateEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entr
   await mirrorUpdateEntry(tubafrenzyId, body);
 });
 
-export const deleteEntry = createBackendMirrorMiddleware<FSEntry>(async (req, removed) => {
+export const deleteEntry = createBackendMirrorMiddleware<FSEntry>('flowsheet.deleteEntry', async (req, removed) => {
   const statements: string[] = [];
 
   // Resolve the RADIO_SHOW_ID first

--- a/apps/backend/middleware/legacy/mirror.logging.ts
+++ b/apps/backend/middleware/legacy/mirror.logging.ts
@@ -1,0 +1,159 @@
+import * as Sentry from '@sentry/node';
+import crypto from 'crypto';
+
+export type MirrorLogContext = {
+  requestId?: string;
+  operation?: string;
+  showId?: string | number;
+  djId?: string;
+  route?: string;
+  method?: string;
+  httpStatus?: number;
+  mirrorCmdId?: string;
+  attempt?: number;
+  maxAttempts?: number;
+  mirrorFeatureEnabled?: boolean;
+};
+
+export type MirrorCommandSummary = {
+  id: string;
+  enqueuedAt: number;
+  attempts: number;
+  status: MirrorCommandStatus;
+  lastError?: string;
+  sqlLength: number;
+  sqlHash: string;
+  statementsCount: number;
+  // Not persisted to disk; safe for in-memory context only.
+  context?: MirrorLogContext;
+};
+
+export type MirrorCommandStatus = 'pending' | 'in_progress' | 'in_progress_retrying' | 'completed' | 'failed';
+
+const MAX_STRING_LEN_DEFAULT = 1024;
+const MAX_SQL_PREVIEW_LEN = 256;
+const MAX_TAG_VALUE_LEN = 64;
+
+function truncateString(input: unknown, maxLen: number): string | undefined {
+  if (input === undefined || input === null) return undefined;
+  const s = typeof input === 'string' ? input : String(input);
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen);
+}
+
+export function hashSha256Hex(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+export function summarizeSql(sql: string) {
+  return {
+    sqlLength: sql.length,
+    sqlHash: hashSha256Hex(sql),
+    sqlPreview: truncateString(sql, MAX_SQL_PREVIEW_LEN),
+  };
+}
+
+export function getMirrorRingIndex(nowMs: number, intervalMs: number, maxReports: number): number {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) intervalMs = 1;
+  if (!Number.isFinite(maxReports) || maxReports <= 0) maxReports = 1;
+  const bucket = Math.floor(nowMs / intervalMs);
+  return ((bucket % maxReports) + maxReports) % maxReports;
+}
+
+export function addMirrorBreadcrumb(
+  message: string,
+  data?: Record<string, unknown>,
+  context?: MirrorLogContext,
+  level: 'info' | 'warning' | 'error' | 'debug' = 'info'
+) {
+  // Best-effort: breadcrumbs aren't guaranteed to persist across async boundaries,
+  // but they will show up when a scope is still active.
+  try {
+    const breadcrumbData: Record<string, unknown> = {
+      ...data,
+      ...(context?.mirrorCmdId ? { mirror_cmd_id: context.mirrorCmdId } : {}),
+    };
+    Sentry.addBreadcrumb({
+      category: 'mirror',
+      message: truncateString(message, 200) ?? message,
+      level,
+      data: breadcrumbData,
+    });
+  } catch {
+    // Never let logging break mirror execution.
+  }
+}
+
+export function captureMirrorException(
+  error: unknown,
+  context: MirrorLogContext,
+  extra?: Record<string, unknown>
+) {
+  const err = error instanceof Error ? error : new Error(String(error));
+  try {
+    Sentry.withScope((scope) => {
+      // Keep tags bounded; avoid unbounded payload in tags.
+      const tags: Record<string, string> = {};
+      if (context.requestId) tags.request_id = truncateString(context.requestId, MAX_TAG_VALUE_LEN) ?? context.requestId;
+      if (context.operation) tags.mirror_operation = truncateString(context.operation, MAX_TAG_VALUE_LEN) ?? context.operation;
+      if (context.mirrorCmdId) tags.mirror_cmd_id = truncateString(context.mirrorCmdId, MAX_TAG_VALUE_LEN) ?? context.mirrorCmdId;
+      if (context.showId !== undefined) tags.show_id = truncateString(String(context.showId), MAX_TAG_VALUE_LEN) ?? String(context.showId);
+      if (context.djId) tags.dj_id = truncateString(context.djId, MAX_TAG_VALUE_LEN) ?? context.djId;
+      if (context.route) tags.route = truncateString(context.route, MAX_TAG_VALUE_LEN) ?? context.route;
+      if (context.method) tags.method = truncateString(context.method, MAX_TAG_VALUE_LEN) ?? context.method;
+      if (context.httpStatus !== undefined) tags.http_status = String(context.httpStatus);
+      if (context.attempt !== undefined) tags.attempt = String(context.attempt);
+      if (context.maxAttempts !== undefined) tags.max_attempts = String(context.maxAttempts);
+      if (context.mirrorFeatureEnabled !== undefined) tags.mirror_feature_enabled = String(context.mirrorFeatureEnabled);
+
+      scope.setTags(tags);
+
+      // Avoid huge extras. Truncate common large fields defensively.
+      const safeExtra: Record<string, unknown> = {};
+      if (extra) {
+        for (const [k, v] of Object.entries(extra)) {
+          if (typeof v === 'string') {
+            safeExtra[k] = truncateString(v, MAX_STRING_LEN_DEFAULT) ?? v;
+          } else {
+            safeExtra[k] = v;
+          }
+        }
+      }
+
+      scope.setExtra('mirror', safeExtra);
+      scope.setExtra('error_message', truncateString(err.message, MAX_STRING_LEN_DEFAULT) ?? err.message);
+      Sentry.captureException(err);
+    });
+  } catch {
+    // Never let logging break mirror execution.
+  }
+}
+
+export function truncateForMirrorPayload(input: unknown, maxLen = MAX_STRING_LEN_DEFAULT): string | undefined {
+  return truncateString(input, maxLen);
+}
+
+export function buildMirrorCommandSummary(cmd: {
+  id: string;
+  enqueuedAt: number;
+  attempts: number;
+  status: MirrorCommandStatus;
+  lastError?: string;
+  sqlLength: number;
+  sqlHash: string;
+  statementsCount: number;
+  context?: MirrorLogContext;
+}): MirrorCommandSummary {
+  return {
+    id: cmd.id,
+    enqueuedAt: cmd.enqueuedAt,
+    attempts: cmd.attempts,
+    status: cmd.status,
+    lastError: truncateString(cmd.lastError, MAX_STRING_LEN_DEFAULT),
+    sqlLength: cmd.sqlLength,
+    sqlHash: cmd.sqlHash,
+    statementsCount: cmd.statementsCount,
+    context: cmd.context,
+  };
+}
+

--- a/apps/backend/middleware/legacy/mirror.middleware.ts
+++ b/apps/backend/middleware/legacy/mirror.middleware.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import { MirrorCommandQueue } from './commandqueue.mirror';
 import { getPostHogClient } from '../../utils/posthog.js';
+import { addMirrorBreadcrumb, captureMirrorException, hashSha256Hex, type MirrorLogContext } from './mirror.logging';
 
 /**
  * Check the PostHog `backend-mirror` feature flag. If PostHog is not
@@ -17,7 +18,7 @@ async function isMirrorEnabled(req: Request): Promise<boolean> {
 }
 
 export const createBackendMirrorMiddleware =
-  <T>(createCommand: (req: Request, data: T) => Promise<string[]>) =>
+  <T>(operation: string, createCommand: (req: Request, data: T) => Promise<string[]>) =>
   async (req: Request, res: Response, next: NextFunction) => {
     tapJsonResponse(res);
 
@@ -25,23 +26,58 @@ export const createBackendMirrorMiddleware =
     res.once('finish', () => {
       void (async () => {
         try {
-          console.log('Response finished, checking for mirror work...');
           const ok = res.statusCode >= 200 && res.statusCode < 305;
           const data = (res.locals as any).mirrorData as T | undefined;
 
-          console.log('Response status:', res.statusCode, 'ok?', ok);
+          const requestId = (res.getHeader('X-Request-Id') ?? req.get('X-Request-Id'))?.toString();
+          const ctx = buildMirrorContext({ operation, req, res, data, requestId });
 
-          if (!ok || data == null) return;
+          if (!ok) {
+            addMirrorBreadcrumb('Mirror skipped: non-success http status', { http_status: res.statusCode }, ctx, 'debug');
+            return;
+          }
+
+          if (data == null) {
+            addMirrorBreadcrumb('Mirror skipped: missing mirrorData', { http_status: res.statusCode }, ctx, 'debug');
+            return;
+          }
 
           const mirrorOn = await isMirrorEnabled(req);
-          if (!mirrorOn) return;
+          ctx.mirrorFeatureEnabled = mirrorOn;
+          const distinctId = (req as any).user?.id ?? req.ip ?? 'anonymous';
+          const distinctIdHash = distinctId ? hashSha256Hex(String(distinctId)) : undefined;
 
-          console.log('Enqueuing mirror work...');
+          if (!mirrorOn) {
+            addMirrorBreadcrumb(
+              'Mirror skipped: backend-mirror flag disabled',
+              { mirror_feature_enabled: mirrorOn, posthog_distinct_id_hash: distinctIdHash },
+              ctx,
+              'info'
+            );
+            return;
+          }
 
+          addMirrorBreadcrumb('Mirror enqueue: generating SQL', { http_status: res.statusCode }, ctx, 'info');
           const queue = MirrorCommandQueue.instance();
-          queue.enqueue(await createCommand(req, data));
+          const sqls = await createCommand(req, data);
+          const cmd = queue.enqueue(sqls, ctx);
+          if (cmd) {
+            ctx.mirrorCmdId = cmd.id;
+            addMirrorBreadcrumb(
+              'Mirror enqueue: queued command',
+              { mirror_cmd_id: cmd.id, statementsCount: cmd.statementsCount },
+              cmd.context ?? ctx,
+              'info'
+            );
+          } else {
+            addMirrorBreadcrumb('Mirror enqueue: queue is dead; command not enqueued', { mirror_cmd_id: 'unknown' }, ctx, 'warning');
+          }
         } catch (e) {
-          console.error('Error in mirror middleware:', e);
+          captureMirrorException(e, {
+            operation,
+            requestId: (res.getHeader('X-Request-Id') ?? req.get('X-Request-Id'))?.toString(),
+            httpStatus: res.statusCode,
+          });
         }
       })();
     });
@@ -55,7 +91,7 @@ export const createBackendMirrorMiddleware =
  * HTTP calls instead of returning SQL strings for the command queue.
  */
 export const createHttpMirrorMiddleware =
-  <T>(execute: (req: Request, data: T) => Promise<void>) =>
+  <T>(operation: string, execute: (req: Request, data: T) => Promise<void>) =>
   async (req: Request, res: Response, next: NextFunction) => {
     tapJsonResponse(res);
 
@@ -65,14 +101,35 @@ export const createHttpMirrorMiddleware =
           const ok = res.statusCode >= 200 && res.statusCode < 305;
           const data = (res.locals as any).mirrorData as T | undefined;
 
-          if (!ok || data == null) return;
+          const requestId = (res.getHeader('X-Request-Id') ?? req.get('X-Request-Id'))?.toString();
+          const ctx = buildMirrorContext({ operation, req, res, data, requestId });
+
+          if (!ok) {
+            addMirrorBreadcrumb('HTTP mirror skipped: non-success http status', { http_status: res.statusCode }, ctx, 'debug');
+            return;
+          }
+
+          if (data == null) {
+            addMirrorBreadcrumb('HTTP mirror skipped: missing mirrorData', { http_status: res.statusCode }, ctx, 'debug');
+            return;
+          }
 
           const mirrorOn = await isMirrorEnabled(req);
-          if (!mirrorOn) return;
+          ctx.mirrorFeatureEnabled = mirrorOn;
 
+          if (!mirrorOn) {
+            addMirrorBreadcrumb('HTTP mirror skipped: backend-mirror flag disabled', { mirror_feature_enabled: mirrorOn }, ctx, 'info');
+            return;
+          }
+
+          addMirrorBreadcrumb('HTTP mirror: executing callback', {}, ctx, 'info');
           await execute(req, data);
         } catch (e) {
-          console.error('Error in HTTP mirror middleware:', e);
+          captureMirrorException(e, {
+            operation,
+            requestId: (res.getHeader('X-Request-Id') ?? req.get('X-Request-Id'))?.toString(),
+            httpStatus: res.statusCode,
+          });
         }
       })();
     });
@@ -105,4 +162,44 @@ function tapJsonResponse(res: Response) {
     (res.locals as any).mirrorData = captured;
     return origSend(body);
   }) as any;
+}
+
+function buildMirrorContext<T>(params: {
+  operation: string;
+  req: Request;
+  res: Response;
+  data: T | undefined;
+  requestId?: string;
+}): MirrorLogContext {
+  const { operation, req, res, data, requestId } = params;
+
+  const route = (req.route?.path ?? req.path ?? req.originalUrl)?.toString();
+  const method = req.method;
+
+  let showId: string | number | undefined;
+  let djId: string | undefined;
+
+  if (data && typeof data === 'object') {
+    const anyData = data as any;
+
+    // Show-like objects
+    if (anyData?.primary_dj_id && anyData?.id !== undefined) {
+      showId = anyData.id;
+      djId = String(anyData.primary_dj_id);
+    }
+
+    // FSEntry-like objects
+    if (anyData?.show_id != null) showId = anyData.show_id;
+    if (anyData?.dj_id) djId = String(anyData.dj_id);
+  }
+
+  return {
+    operation,
+    requestId,
+    showId,
+    djId,
+    route,
+    method,
+    httpStatus: res.statusCode,
+  };
 }

--- a/tests/unit/middleware/legacy/commandqueue.mirror.test.ts
+++ b/tests/unit/middleware/legacy/commandqueue.mirror.test.ts
@@ -1,0 +1,194 @@
+const mockSend = jest.fn();
+const mockBroadcast = jest.fn();
+const mockMkdir = jest.fn().mockResolvedValue(undefined);
+const mockWriteFile = jest.fn().mockResolvedValue(undefined);
+const mockAddMirrorBreadcrumb = jest.fn();
+const mockCaptureMirrorException = jest.fn();
+
+jest.mock('@wxyc/database', () => ({
+  MirrorSQL: {
+    instance: jest.fn(() => ({
+      send: mockSend,
+    })),
+  },
+}));
+
+jest.mock('fs', () => ({
+  promises: {
+    mkdir: mockMkdir,
+    writeFile: mockWriteFile,
+  },
+}));
+
+jest.mock('../../../../apps/backend/utils/serverEvents', () => ({
+  MirrorEvents: {
+    syncStarted: 'sync-started',
+    syncProgress: 'sync-progress',
+    syncComplete: 'sync-complete',
+    syncRetry: 'sync-retry',
+    syncError: 'sync-error',
+  },
+  serverEventsMgr: {
+    broadcast: mockBroadcast,
+  },
+}));
+
+jest.mock('../../../../apps/backend/middleware/legacy/mirror.logging', () => ({
+  addMirrorBreadcrumb: mockAddMirrorBreadcrumb,
+  captureMirrorException: mockCaptureMirrorException,
+  getMirrorRingIndex: (nowMs: number, intervalMs: number, maxReports: number) => {
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) intervalMs = 1;
+    if (!Number.isFinite(maxReports) || maxReports <= 0) maxReports = 1;
+    const bucket = Math.floor(nowMs / intervalMs);
+    return ((bucket % maxReports) + maxReports) % maxReports;
+  },
+  summarizeSql: (sql: string) => ({
+    sqlLength: sql.length,
+    sqlHash: `hash_${sql.length}`,
+    sqlPreview: sql.slice(0, 256),
+  }),
+  hashSha256Hex: (input: string) => `hash_${input.length}`,
+  truncateForMirrorPayload: (input: unknown, maxLen = 1024) => {
+    if (input === undefined || input === null) return undefined;
+    const s = String(input);
+    return s.length <= maxLen ? s : s.slice(0, maxLen);
+  },
+  buildMirrorCommandSummary: (cmd: any) => ({
+    id: cmd.id,
+    enqueuedAt: cmd.enqueuedAt,
+    attempts: cmd.attempts,
+    status: cmd.status,
+    lastError: cmd.lastError ? String(cmd.lastError).slice(0, 1024) : undefined,
+    sqlLength: cmd.sqlLength,
+    sqlHash: cmd.sqlHash,
+    statementsCount: cmd.statementsCount,
+    context: cmd.context,
+  }),
+}));
+
+import { MirrorCommandQueue } from '../../../../apps/backend/middleware/legacy/commandqueue.mirror';
+
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('commandqueue.mirror', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (MirrorCommandQueue as any)._instance = null;
+    delete process.env.MIRROR_SECONDARY_REPORT_ON_ATTEMPT;
+    delete process.env.MIRROR_SECONDARY_REPORTS_MAX;
+    delete process.env.MIRROR_SECONDARY_REPORTS_INTERVAL_MS;
+    delete process.env.MIRROR_FATAL_REPORTS_MAX;
+    delete process.env.MIRROR_FATAL_REPORTS_INTERVAL_MS;
+    delete process.env.MIRROR_PENDING_QUEUE_SUMMARIES_MAX;
+    delete process.env.MIRROR_REPORT_MAX_BYTES;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('processes happy-path command and captures SQL summary metadata', async () => {
+    mockSend.mockResolvedValueOnce('ok');
+    const queue = MirrorCommandQueue.instance({
+      baseBackoffMs: 1,
+      maxBackoffMs: 1,
+      jitterMs: 0,
+      logFile: '/tmp/mirror-logs-test',
+    });
+
+    const cmd = queue.enqueue(['SELECT 1'], { operation: 'flowsheet.addEntry', requestId: 'req-1' });
+    await flush();
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(cmd).not.toBeNull();
+    expect(cmd?.sqlLength).toBeGreaterThan(0);
+    expect(cmd?.sqlHash).toBeDefined();
+    expect(cmd?.statementsCount).toBe(1);
+    expect(cmd?.status).toBe('completed');
+    expect(mockCaptureMirrorException).not.toHaveBeenCalled();
+  });
+
+  it('retries after failure and writes secondary ring report deterministically', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-03-19T00:00:05.000Z'));
+
+    process.env.MIRROR_SECONDARY_REPORT_ON_ATTEMPT = '1';
+    process.env.MIRROR_SECONDARY_REPORTS_MAX = '10';
+    process.env.MIRROR_SECONDARY_REPORTS_INTERVAL_MS = '10000';
+
+    mockSend.mockRejectedValueOnce(new Error('boom-1')).mockResolvedValueOnce('ok');
+
+    const queue = MirrorCommandQueue.instance({
+      baseBackoffMs: 1,
+      maxBackoffMs: 1,
+      jitterMs: 0,
+      logFile: '/tmp/mirror-logs-test',
+    });
+
+    queue.enqueue(['SELECT 1'], { operation: 'flowsheet.updateEntry', requestId: 'req-2' });
+    await flush();
+    jest.advanceTimersByTime(5);
+    await flush();
+
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining('queue-secondary-ring-0.json'),
+      expect.any(String),
+      'utf8'
+    );
+    expect(mockAddMirrorBreadcrumb).toHaveBeenCalled();
+  });
+
+  it('captures fatal to sentry and writes bounded fatal ring payload without raw SQL', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-03-19T00:00:25.000Z')); // bucket index 2 for 10s interval
+
+    process.env.MIRROR_FATAL_REPORTS_MAX = '10';
+    process.env.MIRROR_FATAL_REPORTS_INTERVAL_MS = '10000';
+    process.env.MIRROR_REPORT_MAX_BYTES = '220';
+
+    mockSend.mockRejectedValueOnce(new Error('fatal-db-down'));
+
+    const queue = MirrorCommandQueue.instance({
+      maxAttempts: 1,
+      baseBackoffMs: 1,
+      maxBackoffMs: 1,
+      jitterMs: 0,
+      logFile: '/tmp/mirror-logs-test',
+    });
+
+    queue.enqueue(["SELECT * FROM BIG_TABLE WHERE payload = '" + 'x'.repeat(5000) + "'"], {
+      operation: 'flowsheet.deleteEntry',
+      requestId: 'req-3',
+    });
+    await flush();
+
+    expect(mockCaptureMirrorException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        operation: 'flowsheet.deleteEntry',
+        attempt: 1,
+        maxAttempts: 1,
+      }),
+      expect.objectContaining({
+        statementsCount: 1,
+      })
+    );
+
+    expect(mockWriteFile).toHaveBeenCalledWith(expect.stringContaining('queue-fatal-ring-2.json'), expect.any(String), 'utf8');
+    const payload = mockWriteFile.mock.calls[mockWriteFile.mock.calls.length - 1][1] as string;
+    expect(payload).not.toContain('START TRANSACTION;');
+    expect(payload).not.toContain('BIG_TABLE');
+
+    const parsed = JSON.parse(payload);
+    const failedCmd = parsed.failedCommand ?? {};
+    expect(failedCmd.sqlLength ?? parsed.failedCommand?.sqlLength).toBeDefined();
+    expect(failedCmd.sqlHash ?? parsed.failedCommand?.sqlHash).toBeDefined();
+    expect(failedCmd.statementsCount ?? parsed.failedCommand?.statementsCount).toBeDefined();
+    expect(failedCmd.sql).toBeUndefined();
+  });
+});
+

--- a/tests/unit/middleware/legacy/commandqueue.mirror.test.ts
+++ b/tests/unit/middleware/legacy/commandqueue.mirror.test.ts
@@ -50,8 +50,14 @@ jest.mock('../../../../apps/backend/middleware/legacy/mirror.logging', () => ({
   hashSha256Hex: (input: string) => `hash_${input.length}`,
   truncateForMirrorPayload: (input: unknown, maxLen = 1024) => {
     if (input === undefined || input === null) return undefined;
-    const s = String(input);
-    return s.length <= maxLen ? s : s.slice(0, maxLen);
+    if (typeof input === 'string') {
+      return input.length <= maxLen ? input : input.slice(0, maxLen);
+    }
+    if (typeof input === 'number' || typeof input === 'boolean' || typeof input === 'bigint') {
+      const s = String(input);
+      return s.length <= maxLen ? s : s.slice(0, maxLen);
+    }
+    return undefined;
   },
   buildMirrorCommandSummary: (cmd: any) => ({
     id: cmd.id,

--- a/tests/unit/middleware/legacy/mirror.logging.test.ts
+++ b/tests/unit/middleware/legacy/mirror.logging.test.ts
@@ -1,0 +1,88 @@
+jest.mock('@sentry/node', () => ({
+  addBreadcrumb: jest.fn(),
+  captureException: jest.fn(),
+  withScope: (fn: (scope: { setTags: jest.Mock; setExtra: jest.Mock }) => void) =>
+    fn({
+      setTags: jest.fn(),
+      setExtra: jest.fn(),
+    }),
+}));
+
+import { buildMirrorCommandSummary, getMirrorRingIndex, hashSha256Hex, summarizeSql, truncateForMirrorPayload } from '../../../../apps/backend/middleware/legacy/mirror.logging';
+
+describe('mirror.logging', () => {
+  describe('getMirrorRingIndex', () => {
+    it('returns 0 for first bucket', () => {
+      expect(getMirrorRingIndex(0, 1000, 10)).toBe(0);
+      expect(getMirrorRingIndex(999, 1000, 10)).toBe(0);
+    });
+
+    it('increments bucket index after interval', () => {
+      expect(getMirrorRingIndex(1000, 1000, 10)).toBe(1);
+      expect(getMirrorRingIndex(1999, 1000, 10)).toBe(1);
+      expect(getMirrorRingIndex(2000, 1000, 10)).toBe(2);
+    });
+
+    it('wraps around using modulo maxReports', () => {
+      const intervalMs = 1000;
+      const maxReports = 10;
+      expect(getMirrorRingIndex(10_000, intervalMs, maxReports)).toBe(0); // bucket=10 -> 10%10
+      expect(getMirrorRingIndex(10_001, intervalMs, maxReports)).toBe(0); // still bucket=10
+    });
+
+    it('is deterministic under fake timers', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-03-19T00:00:05.000Z'));
+      const nowMs = Date.now();
+      // interval=10s buckets => 5s -> bucket0 => index0
+      expect(getMirrorRingIndex(nowMs, 10_000, 10)).toBe(0);
+      jest.useRealTimers();
+    });
+  });
+
+  describe('summarizeSql and hash helpers', () => {
+    it('summarizeSql returns sqlLength and stable sqlHash', () => {
+      const sql = 'SELECT 1;';
+      const summary = summarizeSql(sql);
+      expect(summary.sqlLength).toBe(sql.length);
+      expect(summary.sqlHash).toBe(hashSha256Hex(sql));
+    });
+  });
+
+  describe('truncateForMirrorPayload', () => {
+    it('truncates long strings', () => {
+      const s = 'a'.repeat(2000);
+      const out = truncateForMirrorPayload(s, 10);
+      expect(out).toHaveLength(10);
+    });
+  });
+
+  describe('buildMirrorCommandSummary', () => {
+    it('omits full SQL and truncates lastError', () => {
+      const cmd = {
+        id: 'cmd-1',
+        enqueuedAt: 1,
+        attempts: 2,
+        status: 'failed' as const,
+        lastError: 'b'.repeat(5000),
+        sqlLength: 1234,
+        sqlHash: 'hash-1',
+        statementsCount: 3,
+        context: {
+          operation: 'flowsheet.addEntry',
+          requestId: 'req-1',
+          showId: 123,
+        },
+      };
+
+      const summary = buildMirrorCommandSummary(cmd);
+      expect(summary).toHaveProperty('sqlLength', 1234);
+      expect(summary).toHaveProperty('sqlHash', 'hash-1');
+      expect(summary).toHaveProperty('statementsCount', 3);
+      expect((summary as any).sql).toBeUndefined();
+      expect(summary.lastError).toBeDefined();
+      expect(summary.lastError!.length).toBeLessThanOrEqual(1024);
+    });
+  });
+});
+

--- a/tests/unit/middleware/legacy/mirror.logging.test.ts
+++ b/tests/unit/middleware/legacy/mirror.logging.test.ts
@@ -182,9 +182,11 @@ describe('mirror.logging', () => {
       expect(summary).toHaveProperty('sqlLength', 1234);
       expect(summary).toHaveProperty('sqlHash', 'hash-1');
       expect(summary).toHaveProperty('statementsCount', 3);
-      expect((summary as any).sql).toBeUndefined();
+      expect(summary).not.toHaveProperty('sql');
       expect(summary.lastError).toBeDefined();
-      expect(summary.lastError!.length).toBeLessThanOrEqual(1024);
+      if (summary.lastError !== undefined) {
+        expect(summary.lastError.length).toBeLessThanOrEqual(1024);
+      }
     });
   });
 });

--- a/tests/unit/middleware/legacy/mirror.logging.test.ts
+++ b/tests/unit/middleware/legacy/mirror.logging.test.ts
@@ -1,16 +1,35 @@
-jest.mock('@sentry/node', () => ({
-  addBreadcrumb: jest.fn(),
-  captureException: jest.fn(),
-  withScope: (fn: (scope: { setTags: jest.Mock; setExtra: jest.Mock }) => void) =>
-    fn({
-      setTags: jest.fn(),
-      setExtra: jest.fn(),
-    }),
-}));
+const mockAddBreadcrumb = jest.fn();
+const mockCaptureException = jest.fn();
+const mockSetTags = jest.fn();
+const mockSetExtra = jest.fn();
+const mockWithScope = jest.fn((fn: (scope: { setTags: jest.Mock; setExtra: jest.Mock }) => void) =>
+  fn({
+    setTags: mockSetTags,
+    setExtra: mockSetExtra,
+  })
+);
 
-import { buildMirrorCommandSummary, getMirrorRingIndex, hashSha256Hex, summarizeSql, truncateForMirrorPayload } from '../../../../apps/backend/middleware/legacy/mirror.logging';
+jest.mock('@sentry/node', () => ({
+  addBreadcrumb: mockAddBreadcrumb,
+  captureException: mockCaptureException,
+  withScope: mockWithScope,
+}), { virtual: true });
+
+import {
+  addMirrorBreadcrumb,
+  buildMirrorCommandSummary,
+  captureMirrorException,
+  getMirrorRingIndex,
+  hashSha256Hex,
+  summarizeSql,
+  truncateForMirrorPayload,
+} from '../../../../apps/backend/middleware/legacy/mirror.logging';
 
 describe('mirror.logging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('getMirrorRingIndex', () => {
     it('returns 0 for first bucket', () => {
       expect(getMirrorRingIndex(0, 1000, 10)).toBe(0);
@@ -38,6 +57,11 @@ describe('mirror.logging', () => {
       expect(getMirrorRingIndex(nowMs, 10_000, 10)).toBe(0);
       jest.useRealTimers();
     });
+
+    it('falls back to safe defaults for invalid inputs', () => {
+      expect(getMirrorRingIndex(1000, 0, 0)).toBe(0);
+      expect(getMirrorRingIndex(1000, -10, -2)).toBe(0);
+    });
   });
 
   describe('summarizeSql and hash helpers', () => {
@@ -54,6 +78,85 @@ describe('mirror.logging', () => {
       const s = 'a'.repeat(2000);
       const out = truncateForMirrorPayload(s, 10);
       expect(out).toHaveLength(10);
+    });
+  });
+
+  describe('addMirrorBreadcrumb', () => {
+    it('emits mirror breadcrumb with mirror_cmd_id from context', () => {
+      addMirrorBreadcrumb(
+        'Mirror enqueue',
+        { statementsCount: 2 },
+        { mirrorCmdId: 'cmd-123', operation: 'flowsheet.addEntry' },
+        'info'
+      );
+      expect(mockAddBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'mirror',
+          message: 'Mirror enqueue',
+          level: 'info',
+          data: expect.objectContaining({
+            statementsCount: 2,
+            mirror_cmd_id: 'cmd-123',
+          }),
+        })
+      );
+    });
+
+    it('swallows sentry breadcrumb exceptions', () => {
+      mockAddBreadcrumb.mockImplementationOnce(() => {
+        throw new Error('sentry down');
+      });
+      expect(() => addMirrorBreadcrumb('x', {}, { mirrorCmdId: 'cmd-1' })).not.toThrow();
+    });
+  });
+
+  describe('captureMirrorException', () => {
+    it('sets expected sentry tags and extras', () => {
+      captureMirrorException(
+        new Error('boom'),
+        {
+          requestId: 'req-1',
+          operation: 'flowsheet.addEntry',
+          mirrorCmdId: 'cmd-1',
+          showId: 42,
+          djId: 'dj-1',
+          route: '/flowsheet',
+          method: 'POST',
+          httpStatus: 200,
+          attempt: 2,
+          maxAttempts: 5,
+          mirrorFeatureEnabled: true,
+        },
+        {
+          sql_preview: 'SELECT * FROM t',
+        }
+      );
+
+      expect(mockWithScope).toHaveBeenCalled();
+      expect(mockSetTags).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request_id: 'req-1',
+          mirror_operation: 'flowsheet.addEntry',
+          mirror_cmd_id: 'cmd-1',
+          show_id: '42',
+          dj_id: 'dj-1',
+          route: '/flowsheet',
+          method: 'POST',
+          http_status: '200',
+          attempt: '2',
+          max_attempts: '5',
+          mirror_feature_enabled: 'true',
+        })
+      );
+      expect(mockSetExtra).toHaveBeenCalledWith('mirror', expect.objectContaining({ sql_preview: 'SELECT * FROM t' }));
+      expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('swallows sentry scope exceptions', () => {
+      mockWithScope.mockImplementationOnce(() => {
+        throw new Error('scope fail');
+      });
+      expect(() => captureMirrorException(new Error('boom'), { operation: 'flowsheet.addEntry' })).not.toThrow();
     });
   });
 

--- a/tests/unit/middleware/legacy/mirror.posthog.test.ts
+++ b/tests/unit/middleware/legacy/mirror.posthog.test.ts
@@ -4,25 +4,28 @@ const mockPostHogInstance = {
 };
 
 const mockGetPostHogClient = jest.fn(() => mockPostHogInstance);
+const mockEnqueue = jest.fn();
+const mockAddBreadcrumb = jest.fn();
+const mockCaptureException = jest.fn();
 
 jest.mock('../../../../apps/backend/utils/posthog', () => ({
   getPostHogClient: mockGetPostHogClient,
 }));
 
 jest.mock('@sentry/node', () => ({
-  addBreadcrumb: jest.fn(),
-  captureException: jest.fn(),
+  addBreadcrumb: mockAddBreadcrumb,
+  captureException: mockCaptureException,
   withScope: (fn: (scope: { setTags: jest.Mock; setExtra: jest.Mock }) => void) =>
     fn({
       setTags: jest.fn(),
       setExtra: jest.fn(),
     }),
-}));
+}), { virtual: true });
 
 jest.mock('../../../../apps/backend/middleware/legacy/commandqueue.mirror', () => ({
   MirrorCommandQueue: {
     instance: jest.fn(() => ({
-      enqueue: jest.fn(),
+      enqueue: mockEnqueue,
     })),
   },
 }));
@@ -32,12 +35,18 @@ import { Request, Response } from 'express';
 import { EventEmitter } from 'events';
 
 function createMockReqRes() {
-  const req = { user: { id: 'user-1' }, ip: '127.0.0.1' } as unknown as Request;
+  const req = {
+    user: { id: 'user-1' },
+    ip: '127.0.0.1',
+    method: 'POST',
+    path: '/flowsheet',
+    get: jest.fn((k: string) => (k.toLowerCase() === 'x-request-id' ? 'req-1' : undefined)),
+  } as unknown as Request;
 
   const res = new EventEmitter() as Response & EventEmitter;
   res.statusCode = 200;
   (res as any).locals = {};
-  res.getHeader = jest.fn().mockReturnValue('application/json');
+  res.getHeader = jest.fn((k: string) => (k.toLowerCase() === 'content-type' ? 'application/json' : undefined)) as any;
   const origSend = jest.fn().mockReturnThis();
   res.send = origSend;
 
@@ -49,9 +58,13 @@ describe('PostHog client usage', () => {
 
   beforeEach(() => {
     process.env.POSTHOG_API_KEY = 'test-key';
+    mockEnqueue.mockReset();
+    mockEnqueue.mockReturnValue({ id: 'cmd-1', statementsCount: 1, context: { operation: 'flowsheet.test' } });
     mockGetPostHogClient.mockClear();
     mockPostHogInstance.isFeatureEnabled.mockClear();
     mockPostHogInstance.shutdown.mockClear();
+    mockAddBreadcrumb.mockClear();
+    mockCaptureException.mockClear();
   });
 
   afterEach(() => {
@@ -87,5 +100,104 @@ describe('PostHog client usage', () => {
     // getPostHogClient is called per-request, but it returns the same singleton
     expect(mockGetPostHogClient).toHaveBeenCalled();
     expect(mockPostHogInstance.isFeatureEnabled).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips when response status is not successful', async () => {
+    const createCommand = jest.fn().mockResolvedValue(['SQL1']);
+    const middleware = createBackendMirrorMiddleware('flowsheet.test', createCommand);
+    const { req, res } = createMockReqRes();
+    res.statusCode = 500;
+
+    await middleware(req, res, jest.fn());
+    res.send(JSON.stringify({ ok: true }));
+    res.emit('finish');
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mockPostHogInstance.isFeatureEnabled).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(createCommand).not.toHaveBeenCalled();
+  });
+
+  it('skips when mirrorData is missing', async () => {
+    const createCommand = jest.fn().mockResolvedValue(['SQL1']);
+    const middleware = createBackendMirrorMiddleware('flowsheet.test', createCommand);
+    const { req, res } = createMockReqRes();
+
+    await middleware(req, res, jest.fn());
+    // no send => no mirrorData capture
+    res.emit('finish');
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mockPostHogInstance.isFeatureEnabled).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips enqueue when feature flag is disabled', async () => {
+    mockPostHogInstance.isFeatureEnabled.mockResolvedValueOnce(false);
+    const createCommand = jest.fn().mockResolvedValue(['SQL1']);
+    const middleware = createBackendMirrorMiddleware('flowsheet.test', createCommand);
+    const { req, res } = createMockReqRes();
+
+    await middleware(req, res, jest.fn());
+    res.send(JSON.stringify({ ok: true, show_id: 10 }));
+    res.emit('finish');
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mockPostHogInstance.isFeatureEnabled).toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    expect(createCommand).not.toHaveBeenCalled();
+  });
+
+  it('enqueues with context when feature flag is enabled', async () => {
+    const createCommand = jest.fn().mockResolvedValue(['SQL1']);
+    const middleware = createBackendMirrorMiddleware('flowsheet.test', createCommand);
+    const { req, res } = createMockReqRes();
+
+    await middleware(req, res, jest.fn());
+    res.send(JSON.stringify({ show_id: 55, dj_id: 'dj-22' }));
+    res.emit('finish');
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      ['SQL1'],
+      expect.objectContaining({
+        operation: 'flowsheet.test',
+        requestId: 'req-1',
+        showId: 55,
+        djId: 'dj-22',
+      })
+    );
+  });
+
+  it('captures exception when createCommand throws', async () => {
+    const createCommand = jest.fn().mockRejectedValue(new Error('create fail'));
+    const middleware = createBackendMirrorMiddleware('flowsheet.test', createCommand);
+    const { req, res } = createMockReqRes();
+
+    await middleware(req, res, jest.fn());
+    res.send(JSON.stringify({ ok: true }));
+    res.emit('finish');
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('logs warning path when queue is dead (enqueue returns null)', async () => {
+    mockEnqueue.mockReturnValueOnce(null);
+    const createCommand = jest.fn().mockResolvedValue(['SQL1']);
+    const middleware = createBackendMirrorMiddleware('flowsheet.test', createCommand);
+    const { req, res } = createMockReqRes();
+
+    await middleware(req, res, jest.fn());
+    res.send(JSON.stringify({ ok: true }));
+    res.emit('finish');
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mockAddBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'mirror',
+        level: 'warning',
+      })
+    );
   });
 });

--- a/tests/unit/middleware/legacy/mirror.posthog.test.ts
+++ b/tests/unit/middleware/legacy/mirror.posthog.test.ts
@@ -9,6 +9,16 @@ jest.mock('../../../../apps/backend/utils/posthog', () => ({
   getPostHogClient: mockGetPostHogClient,
 }));
 
+jest.mock('@sentry/node', () => ({
+  addBreadcrumb: jest.fn(),
+  captureException: jest.fn(),
+  withScope: (fn: (scope: { setTags: jest.Mock; setExtra: jest.Mock }) => void) =>
+    fn({
+      setTags: jest.fn(),
+      setExtra: jest.fn(),
+    }),
+}));
+
 jest.mock('../../../../apps/backend/middleware/legacy/commandqueue.mirror', () => ({
   MirrorCommandQueue: {
     instance: jest.fn(() => ({
@@ -54,7 +64,7 @@ describe('PostHog client usage', () => {
 
   it('uses the shared PostHog singleton from utils/posthog', async () => {
     const createCommand = jest.fn().mockResolvedValue(['SQL1']);
-    const middleware = createBackendMirrorMiddleware(createCommand);
+    const middleware = createBackendMirrorMiddleware('flowsheet.test', createCommand);
 
     const { req: req1, res: res1 } = createMockReqRes();
     const { req: req2, res: res2 } = createMockReqRes();


### PR DESCRIPTION
## Summary
This PR hardens legacy flowsheet mirror observability by introducing structured mirror logging, Sentry integration, request-level correlation context, and bounded EC2-safe report persistence.

### Why

Before this work, mirror failures were hard to debug: logs were sparse, the queue detached from the original HTTP request, and fatal dumps could grow large on disk. Mirror runs against legacy SQL over SSH, so when something breaks we need clear signals (what operation, which request, what step failed, retries vs. final failure) without filling the instance with huge files.

### What we changed (implementation)

- **One place for mirror telemetry** – Helper code centralizes Sentry breadcrumbs, exception capture, truncation, and SQL “fingerprints” (length + hash) so behavior stays consistent.
- **Tie logs to the HTTP request** – Middleware passes context into the queue: operation name, correlation id, show/DJ when available, route/method/status. That survives after the response finishes.
- **Explicit branches, not guesswork** – We log when mirror work is skipped (bad status, no body to mirror, PostHog flag off) vs. when work is queued vs. when the queue is dead.
- **Queue lifecycle is visible** – Enqueue, start, success, failed attempt, planned retry, and fatal each emit breadcrumbs; fatals also send a Sentry error with attempt counts.
- **Disk reports are safe on EC2** – Secondary and fatal reports use rotating filenames and capped JSON; if a payload would be huge, we write a smaller summary instead. We do not persist full raw SQL in those files.

### Tests

We added focused unit tests so we can trust the above: Sentry helper behavior (tags, breadcrumbs, no crash if Sentry acts up), middleware paths (skip vs. enqueue vs. errors vs. dead queue), and queue behavior (success, retry, fatal, ring file names, size cap, SQL summary without leaking the full statement). Tests mock I/O and Sentry so they stay fast and deterministic.

### Ops / rollout notes

- Sentry and `X-Request-Id` behavior are unchanged at the app level; mirror events now show up with richer tags and breadcrumbs.
- Optional env vars tune report rotation and max JSON size for secondary/fatal files; defaults aim for a small, fixed footprint on disk.
- No change required for clients unless you were parsing mirror SSE payloads specifically for raw SQL (reports on disk intentionally avoid full SQL).