### PR TITLE
Fix: seed all legacy genres and formats for ETL

### DIFF
--- a/dev_env/seed_db.sql
+++ b/dev_env/seed_db.sql
@@ -101,12 +101,18 @@ VALUES
   ('test-membership-adminres01', 'test-org-id-0000000000000000001', 'test-adminreset1-id-00000000001', 'dj', NOW())
 ON CONFLICT (id) DO NOTHING;
 
--- Genres, media formats, artists, and albums used in test automation
-INSERT INTO wxyc_schema.genres(genre_name) VALUES ('Rock');
-INSERT INTO wxyc_schema.genres(genre_name) VALUES ('Hiphop');
+-- Genres and media formats matching the legacy tubafrenzy database.
+-- The library ETL job looks up genres/formats by name and skips releases
+-- where the genre or format is missing, so all legacy values must be seeded.
+INSERT INTO wxyc_schema.genres(genre_name) VALUES
+  ('Rock'), ('Hiphop'), ('Electronic'), ('Jazz'), ('Reggae'),
+  ('Classical'), ('Latin'), ('Blues'), ('Soundtracks'), ('Spoken'),
+  ('Comedy'), ('Africa'), ('Asia'), ('OCS'), ('Xmas')
+ON CONFLICT DO NOTHING;
 
-INSERT INTO wxyc_schema.format(format_name) VALUES ('cd');
-INSERT INTO wxyc_schema.format(format_name) VALUES ('vinyl');
+INSERT INTO wxyc_schema.format(format_name) VALUES
+  ('cd'), ('vinyl'), ('vinyl 12"'), ('vinyl 7"'), ('vinyl 10"'), ('cdr')
+ON CONFLICT DO NOTHING;
 
 INSERT INTO wxyc_schema.artists(artist_name, alphabetical_name, code_letters)
 	VALUES ('Built to Spill', 'Built to Spill', 'BU');


### PR DESCRIPTION
## Summary

- Add all 15 legacy genres and 6 normalized format names to the database seed file
- The library ETL job silently skips releases when a genre or format lookup fails, so seeding only Rock/Hiphop/cd/vinyl caused thousands of releases to be dropped during local dev and CI imports

## Test plan

- [x] `npm run test:unit` passes (317/317)
- [ ] `npm run db:start` then run ETL — all genres and formats resolve, no "Missing genre/format" warnings

Closes #253