### PR TITLE
Fix: handle missing shows gracefully instead of crashing

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -135,7 +135,7 @@ export const getLatest: RequestHandler = async (req, res, next) => {
     if (entries.length) {
       res.status(200).json(flowsheet_service.transformToV2(entries[0]));
     } else {
-      res.status(404).json({ message: 'No entries found' });
+      res.status(200).json(null);
     }
   } catch (e) {
     console.error('Error: Failed to retrieve track');

--- a/apps/backend/middleware/checkActiveShow.ts
+++ b/apps/backend/middleware/checkActiveShow.ts
@@ -3,7 +3,7 @@ import { getLatestShow } from '../services/flowsheet.service.js';
 
 export const activeShow: RequestHandler = async (req, res, next) => {
   const latestShow = await getLatestShow();
-  if (latestShow.end_time !== null) {
+  if (!latestShow || latestShow.end_time !== null) {
     res.status(400).json({ message: 'Bad Request: No active show' });
   } else {
     next();

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -413,7 +413,8 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
 
   await db.update(shows).set({ end_time: new Date() }).where(eq(shows.id, currentShow.id));
 
-  return await getLatestShow();
+  // We just ended this show, so a latest show always exists here
+  return (await getLatestShow())!;
 };
 
 export const leaveShow = async (dj_id: string, currentShow: Show): Promise<ShowDJ> => {
@@ -467,28 +468,23 @@ export const getNShows = async (numberOfShows: number = 1, page: number = 0): Pr
     .limit(numberOfShows);
 };
 
-export const getLatestShow = async (): Promise<Show> => {
+export const getLatestShow = async (): Promise<Show | undefined> => {
   return (await getNShows(1))[0];
 };
 
 export const getOnAirStatusForDJ = async (dj_id: string): Promise<boolean> => {
   const latest_show = await getLatestShow();
-
-  //Avoid a round trip to db with this check
-  if (latest_show.end_time !== null) {
+  if (!latest_show || latest_show.end_time !== null) {
     return false;
   }
 
   const show_djs = await getDJsInShow(latest_show.id, true);
-
   return show_djs.some((dj) => dj.id == dj_id);
 };
 
 export const getDJsInCurrentShow = async (): Promise<User[]> => {
   const current_show = await getLatestShow();
-
-  //Avoid a round trip to db with this check
-  if (current_show.end_time !== null) {
+  if (!current_show || current_show.end_time !== null) {
     return [];
   }
 

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -228,7 +228,7 @@ describe('flowsheet.controller', () => {
       expect(res.json).toHaveBeenCalledWith({ ...entry, v2: true });
     });
 
-    it('returns 404 when no entries exist', async () => {
+    it('returns 200 with null when no entries exist', async () => {
       mockGetEntriesByPage.mockResolvedValue([]);
 
       const req = createMockReq();
@@ -236,8 +236,8 @@ describe('flowsheet.controller', () => {
 
       await getLatest(req as Request, res as Response, mockNext);
 
-      expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.json).toHaveBeenCalledWith({ message: 'No entries found' });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(null);
       expect(mockTransformToV2).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/services/flowsheet.service.test.ts
+++ b/tests/unit/services/flowsheet.service.test.ts
@@ -1,4 +1,9 @@
-import { transformToV2 } from '../../../apps/backend/services/flowsheet.service';
+import {
+  transformToV2,
+  getDJsInCurrentShow,
+  getOnAirStatusForDJ,
+  getLatestShow,
+} from '../../../apps/backend/services/flowsheet.service';
 import { IFSEntry, IFSEntryMetadata } from '../../../apps/backend/controllers/flowsheet.controller';
 
 const nullMetadata: IFSEntryMetadata = {
@@ -446,6 +451,25 @@ describe('flowsheet.service', () => {
 
         expect(result.dj_name).toBe("DJ O'Brien & The Crew");
       });
+    });
+  });
+
+  describe('no-show edge cases', () => {
+    // The mock DB returns [] by default, so getLatestShow() returns undefined
+
+    it('getLatestShow returns undefined when no shows exist', async () => {
+      const result = await getLatestShow();
+      expect(result).toBeUndefined();
+    });
+
+    it('getDJsInCurrentShow returns empty array when no shows exist', async () => {
+      const result = await getDJsInCurrentShow();
+      expect(result).toEqual([]);
+    });
+
+    it('getOnAirStatusForDJ returns false when no shows exist', async () => {
+      const result = await getOnAirStatusForDJ('some-dj-id');
+      expect(result).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- `getLatestShow()` now returns `Show | undefined` instead of assuming shows always exist
- `getDJsInCurrentShow()` returns `[]` instead of crashing when no shows exist
- `getOnAirStatusForDJ()` returns `false` instead of crashing
- `activeShow` middleware returns 400 "No active show" instead of crashing
- `GET /flowsheet/latest` returns `200 null` instead of `404` when flowsheet is empty

## Test plan

- [x] 3 new unit tests for no-show edge cases (getLatestShow, getDJsInCurrentShow, getOnAirStatusForDJ)
- [x] Updated existing test: `getLatest` now expects 200 null instead of 404
- [x] `npm run typecheck` clean
- [x] 320/320 tests pass

Closes #255