### PR TITLE
feat: library ETL runner script and auto-sync genres/formats

### DIFF
--- a/jest.unit.config.ts
+++ b/jest.unit.config.ts
@@ -28,6 +28,7 @@ const config: Config = {
     '^(\\.{1,2}/.*)\\.(js)$': '$1',
   },
   collectCoverageFrom: ['apps/backend/**/*.ts', 'jobs/**/*.ts', '!**/*.d.ts', '!**/dist/**'],
+  modulePathIgnorePatterns: ['<rootDir>/.claude/worktrees'],
   clearMocks: true,
 };
 

--- a/jobs/library-etl/README.md
+++ b/jobs/library-etl/README.md
@@ -1,0 +1,137 @@
+# Library ETL Job
+
+Incremental synchronization of the music library from the legacy tubafrenzy MySQL database to PostgreSQL. The job connects to the remote MySQL server over SSH, fetches releases modified since the last run, normalizes the data, and inserts new artists and albums into the PostgreSQL database via Drizzle ORM.
+
+## How It Works
+
+1. Reads the last successful run timestamp from the `cronjob_runs` table.
+2. SSH-tunnels into the legacy server and queries `LIBRARY_RELEASE` joined with `LIBRARY_CODE`, `GENRE`, and `FORMAT` for all releases modified since that timestamp. On the first run (no prior timestamp), all releases are fetched.
+3. Parses the tab-delimited MySQL output into structured rows.
+4. Within a single database transaction:
+   - Syncs genres and formats from the legacy database into PostgreSQL (insert-only — existing records are unchanged).
+   - Normalizes artist names (e.g., "Various Artists" variants are collapsed, "The Beatles" becomes "Beatles, The" for alphabetical sorting).
+   - Normalizes code letters (2-3 character uppercase identifiers; `Z-*` codes map to `V/A`).
+   - Parses format strings into canonical names (`cd`, `cdr`, `vinyl`, `vinyl 7"`, `vinyl 10"`, `vinyl 12"`) and disc quantities.
+   - Inserts or looks up artists (with an in-memory cache to avoid redundant queries).
+   - Ensures `genre_artist_crossreference` entries exist.
+   - Inserts new albums into the `library` table, skipping duplicates.
+5. Updates the `cronjob_runs` timestamp on success.
+
+Rows with `db_only` genre, missing genre/format mappings, empty artist names, or empty album titles are skipped with a warning.
+
+## Environment Variables
+
+The job requires two sets of credentials: one for the SSH tunnel to the legacy server, and one for the target PostgreSQL database.
+
+### SSH Tunnel (legacy server access)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SSH_HOST` | Yes | — | Hostname of the legacy server |
+| `SSH_PORT` | No | `22` | SSH port |
+| `SSH_USERNAME` | Yes | — | SSH login username |
+| `SSH_PASSWORD` | Yes | — | SSH login password |
+
+### Remote MySQL (queried over SSH)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `REMOTE_DB_HOST` | Yes | — | MySQL host (as seen from the SSH server) |
+| `REMOTE_DB_PORT` | No | `3306` | MySQL port |
+| `REMOTE_DB_USER` | Yes | — | MySQL username |
+| `REMOTE_DB_PASSWORD` | Yes | — | MySQL password |
+| `REMOTE_DB_NAME` | Yes | — | MySQL database name |
+
+### Target PostgreSQL (Drizzle ORM)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DB_HOST` | Yes | — | PostgreSQL host |
+| `DB_PORT` | No | `5432` | PostgreSQL port |
+| `DB_NAME` | Yes | — | PostgreSQL database name |
+| `DB_USERNAME` | Yes | — | PostgreSQL username |
+| `DB_PASSWORD` | Yes | — | PostgreSQL password |
+| `WXYC_SCHEMA_NAME` | No | `wxyc_schema` | PostgreSQL schema name |
+
+## Prerequisites
+
+- Node.js 22+
+- Docker (for local development database; the runner script starts Docker and the database container automatically if needed)
+- Network access to the legacy SSH server
+- A running PostgreSQL database with migrations applied. For local development, the runner script (`npm run etl:library`) handles this automatically — it starts Docker, launches the database container, and runs Drizzle migrations. If the database container already exists with stale settings, remove the volume first: `docker compose -f dev_env/docker-compose.yml --profile dev down -v`. The job automatically syncs genres and formats from the legacy database on each run, so no manual seeding is required.
+
+## Building
+
+From the repo root:
+
+```bash
+npm run build --workspace=@wxyc/library-etl
+```
+
+Or from within `jobs/library-etl/`:
+
+```bash
+npm run build
+```
+
+This compiles `job.ts` with tsup (esbuild) into `dist/job.js`.
+
+## Running
+
+### Locally
+
+The runner script validates your environment, checks database connectivity, builds if needed, and runs the job with clear error messages if anything is wrong:
+
+```bash
+npm run etl:library
+```
+
+This is the recommended way to run the job locally. It handles `.env` loading via `dotenvx` automatically.
+
+### Development (watch mode)
+
+Rebuilds and re-runs the job on every file change:
+
+```bash
+npm run dev --workspace=@wxyc/library-etl
+```
+
+### Docker
+
+Build and run the production container:
+
+```bash
+# Build (from repo root)
+npm run docker:build --workspace=@wxyc/library-etl
+
+# Run
+docker run --env-file .env wxyc_library_etl:ci
+```
+
+### Scheduled Execution
+
+The job is designed to run every 30 minutes (see `cron-schedule` in `package.json`). In production, an external scheduler (e.g., Kubernetes CronJob, AWS ECS Scheduled Task, or cron) should invoke:
+
+```
+npm start --workspace=@wxyc/library-etl
+```
+
+The job is safe to run on a schedule because it is incremental (only processes releases modified since the last run) and idempotent (duplicate albums are detected and skipped).
+
+## Testing
+
+Unit tests for the parsing and normalization functions:
+
+```bash
+npm run test:unit -- --testPathPatterns=library-etl
+```
+
+## Troubleshooting
+
+| Symptom | Likely Cause |
+|---------|-------------|
+| `Error executing remote SQL command over SSH` | SSH credentials are wrong, the legacy server is unreachable, or MySQL credentials are invalid. Check `SSH_HOST`, `SSH_USERNAME`, `SSH_PASSWORD`, and the `REMOTE_DB_*` variables. |
+| `Missing genre "X" for release Y` | The legacy database has a referential integrity issue — a release references a genre that doesn't exist in the legacy `GENRE` table. This is a data quality issue in tubafrenzy, not a configuration problem. |
+| `Missing format "X" for release Y` | The legacy format string could not be parsed into a canonical format name (e.g., unsupported media type like cassette). |
+| `No new legacy releases found` | Normal when nothing has changed since the last run. |
+| Job runs but inserts nothing | Check the `cronjob_runs` table — the `last_run` timestamp may already be ahead of all legacy data. To force a full re-sync, delete the row: `DELETE FROM cronjob_runs WHERE job_name = 'library-etl';` |

--- a/jobs/library-etl/README.md
+++ b/jobs/library-etl/README.md
@@ -25,33 +25,33 @@ The job requires two sets of credentials: one for the SSH tunnel to the legacy s
 
 ### SSH Tunnel (legacy server access)
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `SSH_HOST` | Yes | — | Hostname of the legacy server |
-| `SSH_PORT` | No | `22` | SSH port |
-| `SSH_USERNAME` | Yes | — | SSH login username |
-| `SSH_PASSWORD` | Yes | — | SSH login password |
+| Variable       | Required | Default | Description                   |
+| -------------- | -------- | ------- | ----------------------------- |
+| `SSH_HOST`     | Yes      | —       | Hostname of the legacy server |
+| `SSH_PORT`     | No       | `22`    | SSH port                      |
+| `SSH_USERNAME` | Yes      | —       | SSH login username            |
+| `SSH_PASSWORD` | Yes      | —       | SSH login password            |
 
 ### Remote MySQL (queried over SSH)
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `REMOTE_DB_HOST` | Yes | — | MySQL host (as seen from the SSH server) |
-| `REMOTE_DB_PORT` | No | `3306` | MySQL port |
-| `REMOTE_DB_USER` | Yes | — | MySQL username |
-| `REMOTE_DB_PASSWORD` | Yes | — | MySQL password |
-| `REMOTE_DB_NAME` | Yes | — | MySQL database name |
+| Variable             | Required | Default | Description                              |
+| -------------------- | -------- | ------- | ---------------------------------------- |
+| `REMOTE_DB_HOST`     | Yes      | —       | MySQL host (as seen from the SSH server) |
+| `REMOTE_DB_PORT`     | No       | `3306`  | MySQL port                               |
+| `REMOTE_DB_USER`     | Yes      | —       | MySQL username                           |
+| `REMOTE_DB_PASSWORD` | Yes      | —       | MySQL password                           |
+| `REMOTE_DB_NAME`     | Yes      | —       | MySQL database name                      |
 
 ### Target PostgreSQL (Drizzle ORM)
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `DB_HOST` | Yes | — | PostgreSQL host |
-| `DB_PORT` | No | `5432` | PostgreSQL port |
-| `DB_NAME` | Yes | — | PostgreSQL database name |
-| `DB_USERNAME` | Yes | — | PostgreSQL username |
-| `DB_PASSWORD` | Yes | — | PostgreSQL password |
-| `WXYC_SCHEMA_NAME` | No | `wxyc_schema` | PostgreSQL schema name |
+| Variable           | Required | Default       | Description              |
+| ------------------ | -------- | ------------- | ------------------------ |
+| `DB_HOST`          | Yes      | —             | PostgreSQL host          |
+| `DB_PORT`          | No       | `5432`        | PostgreSQL port          |
+| `DB_NAME`          | Yes      | —             | PostgreSQL database name |
+| `DB_USERNAME`      | Yes      | —             | PostgreSQL username      |
+| `DB_PASSWORD`      | Yes      | —             | PostgreSQL password      |
+| `WXYC_SCHEMA_NAME` | No       | `wxyc_schema` | PostgreSQL schema name   |
 
 ## Prerequisites
 
@@ -128,10 +128,10 @@ npm run test:unit -- --testPathPatterns=library-etl
 
 ## Troubleshooting
 
-| Symptom | Likely Cause |
-|---------|-------------|
-| `Error executing remote SQL command over SSH` | SSH credentials are wrong, the legacy server is unreachable, or MySQL credentials are invalid. Check `SSH_HOST`, `SSH_USERNAME`, `SSH_PASSWORD`, and the `REMOTE_DB_*` variables. |
-| `Missing genre "X" for release Y` | The legacy database has a referential integrity issue — a release references a genre that doesn't exist in the legacy `GENRE` table. This is a data quality issue in tubafrenzy, not a configuration problem. |
-| `Missing format "X" for release Y` | The legacy format string could not be parsed into a canonical format name (e.g., unsupported media type like cassette). |
-| `No new legacy releases found` | Normal when nothing has changed since the last run. |
-| Job runs but inserts nothing | Check the `cronjob_runs` table — the `last_run` timestamp may already be ahead of all legacy data. To force a full re-sync, delete the row: `DELETE FROM cronjob_runs WHERE job_name = 'library-etl';` |
+| Symptom                                       | Likely Cause                                                                                                                                                                                                  |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Error executing remote SQL command over SSH` | SSH credentials are wrong, the legacy server is unreachable, or MySQL credentials are invalid. Check `SSH_HOST`, `SSH_USERNAME`, `SSH_PASSWORD`, and the `REMOTE_DB_*` variables.                             |
+| `Missing genre "X" for release Y`             | The legacy database has a referential integrity issue — a release references a genre that doesn't exist in the legacy `GENRE` table. This is a data quality issue in tubafrenzy, not a configuration problem. |
+| `Missing format "X" for release Y`            | The legacy format string could not be parsed into a canonical format name (e.g., unsupported media type like cassette).                                                                                       |
+| `No new legacy releases found`                | Normal when nothing has changed since the last run.                                                                                                                                                           |
+| Job runs but inserts nothing                  | Check the `cronjob_runs` table — the `last_run` timestamp may already be ahead of all legacy data. To force a full re-sync, delete the row: `DELETE FROM cronjob_runs WHERE job_name = 'library-etl';`        |

--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -441,7 +441,9 @@ const run = async () => {
       const genresInserted = await syncGenres(tx, legacyGenreNames);
       const formatsInserted = await syncFormats(tx, canonicalFormatNames);
       if (genresInserted > 0 || formatsInserted > 0) {
-        console.log(`[library-etl] Synced ${genresInserted} new genre(s), ${formatsInserted} new format(s) from legacy database.`);
+        console.log(
+          `[library-etl] Synced ${genresInserted} new genre(s), ${formatsInserted} new format(s) from legacy database.`
+        );
       }
 
       const genreRows = await tx.select().from(genres);

--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -140,6 +140,50 @@ const toDateOnlyString = (value: number | null) => {
   return date.toISOString().slice(0, 10);
 };
 
+/**
+ * Parse tab-delimited output from `SELECT ID, REFERENCE_NAME FROM GENRE`.
+ * Filters out `db_only` and rows with empty names.
+ */
+const parseLegacyGenreRows = (raw: string): string[] => {
+  if (raw.trim().length === 0) return [];
+  const results: string[] = [];
+  for (const line of raw.trim().split('\n')) {
+    const columns = parseTabRow(line, 2);
+    if (!columns) {
+      console.warn('[library-etl] Skipping malformed legacy genre row:', line);
+      continue;
+    }
+    const name = columns[1].trim();
+    if (name.length === 0) continue;
+    if (isDbOnlyGenre(name)) continue;
+    results.push(name);
+  }
+  return results;
+};
+
+/**
+ * Parse tab-delimited output from `SELECT ID, REFERENCE_NAME FROM FORMAT`.
+ * Normalizes each to a canonical format name via `parseFormatAndDiscs` and deduplicates.
+ */
+const parseLegacyFormatRows = (raw: string): string[] => {
+  if (raw.trim().length === 0) return [];
+  const seen = new Set<string>();
+  const results: string[] = [];
+  for (const line of raw.trim().split('\n')) {
+    const columns = parseTabRow(line, 2);
+    if (!columns) {
+      console.warn('[library-etl] Skipping malformed legacy format row:', line);
+      continue;
+    }
+    const parsed = parseFormatAndDiscs(columns[1]);
+    if (!parsed) continue;
+    if (seen.has(parsed.formatName)) continue;
+    seen.add(parsed.formatName);
+    results.push(parsed.formatName);
+  }
+  return results;
+};
+
 type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 type DbClient = typeof db | DbTransaction;
 
@@ -152,6 +196,50 @@ const getLastRunTimestamp = async (jobName: string): Promise<number | null> => {
 
   const lastRun = response[0]?.lastRun ?? null;
   return lastRun ? lastRun.getTime() : null;
+};
+
+const fetchLegacyGenres = async () => {
+  const raw = await legacyDB.send('SELECT ID, REFERENCE_NAME FROM GENRE;');
+  return parseLegacyGenreRows(raw);
+};
+
+const fetchLegacyFormats = async () => {
+  const raw = await legacyDB.send('SELECT ID, REFERENCE_NAME FROM FORMAT;');
+  return parseLegacyFormatRows(raw);
+};
+
+/**
+ * Insert genres that don't already exist in PostgreSQL.
+ * Existing records are unchanged (insert-only, no updates).
+ */
+const syncGenres = async (tx: DbTransaction, legacyGenreNames: string[]) => {
+  const existingRows = await tx.select().from(genres);
+  const existingNames = new Set(existingRows.map((r) => r.genre_name.toLowerCase()));
+  let inserted = 0;
+  for (const name of legacyGenreNames) {
+    if (existingNames.has(name.toLowerCase())) continue;
+    await tx.insert(genres).values({ genre_name: name });
+    existingNames.add(name.toLowerCase());
+    inserted++;
+  }
+  return inserted;
+};
+
+/**
+ * Insert formats that don't already exist in PostgreSQL.
+ * Existing records are unchanged (insert-only, no updates).
+ */
+const syncFormats = async (tx: DbTransaction, canonicalFormatNames: string[]) => {
+  const existingRows = await tx.select().from(format);
+  const existingNames = new Set(existingRows.map((r) => r.format_name.toLowerCase()));
+  let inserted = 0;
+  for (const name of canonicalFormatNames) {
+    if (existingNames.has(name.toLowerCase())) continue;
+    await tx.insert(format).values({ format_name: name });
+    existingNames.add(name.toLowerCase());
+    inserted++;
+  }
+  return inserted;
 };
 
 const updateLastRun = async (dbClient: DbClient, jobName: string, lastRun: Date) => {
@@ -347,6 +435,15 @@ const run = async () => {
     let skippedCount = 0;
 
     await db.transaction(async (tx) => {
+      // Sync genres and formats from legacy database before processing releases
+      const legacyGenreNames = await fetchLegacyGenres();
+      const canonicalFormatNames = await fetchLegacyFormats();
+      const genresInserted = await syncGenres(tx, legacyGenreNames);
+      const formatsInserted = await syncFormats(tx, canonicalFormatNames);
+      if (genresInserted > 0 || formatsInserted > 0) {
+        console.log(`[library-etl] Synced ${genresInserted} new genre(s), ${formatsInserted} new format(s) from legacy database.`);
+      }
+
       const genreRows = await tx.select().from(genres);
       const genreMap = new Map(genreRows.map((genre) => [genre.genre_name.toLowerCase(), genre.id]));
 
@@ -471,6 +568,8 @@ export {
   parseFormatAndDiscs,
   toDateOrUndefined,
   toDateOnlyString,
+  parseLegacyGenreRows,
+  parseLegacyFormatRows,
 };
 
 run().catch((error) => {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "e2e:env": "npm run docker:build --workspace=apps/** && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up -d e2e-db && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up e2e-db-init && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up -d e2e-auth e2e-backend",
     "e2e:setup-users": "E2E_DB_PORT=${E2E_DB_PORT:-5434} DB_PORT=${E2E_DB_PORT:-5434} npm run setup:e2e-users",
     "e2e:clean": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e down -v",
+    "etl:library": "./scripts/run-library-etl.sh",
     "drizzle:generate": "read -p \"Enter migration name (optional): \" MIGRATION_NAME && dotenvx run -f .env -- drizzle-kit generate --config 'drizzle.config.ts' --name \"$MIGRATION_NAME\"",
     "drizzle:migrate": "dotenvx run -f .env -- drizzle-kit migrate --config 'drizzle.config.ts'",
     "drizzle:drop": "dotenvx run -f .env -- drizzle-kit drop --out ./shared/database/src/migrations",

--- a/scripts/run-library-etl.sh
+++ b/scripts/run-library-etl.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Library ETL Runner Script
+# Usage: ./scripts/run-library-etl.sh
+#
+# Validates the environment, ensures the database is reachable,
+# builds the job if needed, and runs it.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+JOB_DIR="$PROJECT_ROOT/jobs/library-etl"
+
+# ── Helper ──────────────────────────────────────────────────────────
+
+fail() {
+  echo "❌ $1" >&2
+  exit 1
+}
+
+info() {
+  echo "── $1"
+}
+
+# ── 1. Check .env ───────────────────────────────────────────────────
+
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ ! -f "$ENV_FILE" ]; then
+  fail ".env file not found at $ENV_FILE. Copy .env.example and fill in your values."
+fi
+
+# Parse a var from .env (handles simple KEY=value lines; dotenvx handles the real loading)
+parse_env_var() {
+  grep -E "^$1=" "$ENV_FILE" | head -1 | cut -d= -f2-
+}
+
+DOTENVX="npx dotenvx run --quiet -f $ENV_FILE --"
+
+# ── 2. Validate required env vars ──────────────────────────────────
+
+MISSING=()
+for var in DB_HOST DB_NAME DB_USERNAME; do
+  val="$(parse_env_var "$var")"
+  if [ -z "$val" ]; then
+    MISSING+=("$var")
+  fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  fail "Missing required environment variables in .env: ${MISSING[*]}"
+fi
+
+DB_HOST="$(parse_env_var DB_HOST)"
+DB_PORT="$(parse_env_var DB_PORT)"
+DB_PORT="${DB_PORT:-5432}"
+DB_NAME="$(parse_env_var DB_NAME)"
+
+info "Target database: $DB_HOST:$DB_PORT/$DB_NAME"
+
+# ── 3. Check SSH vars (legacy server access) ───────────────────────
+
+SSH_MISSING=()
+for var in SSH_HOST SSH_USERNAME SSH_PASSWORD REMOTE_DB_HOST REMOTE_DB_USER REMOTE_DB_PASSWORD REMOTE_DB_NAME; do
+  val="$(parse_env_var "$var")"
+  if [ -z "$val" ]; then
+    SSH_MISSING+=("$var")
+  fi
+done
+
+if [ ${#SSH_MISSING[@]} -gt 0 ]; then
+  echo "⚠️  Missing legacy server variables in .env: ${SSH_MISSING[*]}"
+  echo "   The job will fail when it tries to connect to the legacy MySQL database."
+  echo ""
+fi
+
+# ── 4. Check Docker + database container ────────────────────────────
+
+if [ "$DB_HOST" = "localhost" ] || [ "$DB_HOST" = "127.0.0.1" ]; then
+  if ! docker info &>/dev/null 2>&1; then
+    info "Docker is not running. Starting Docker Desktop..."
+    open -a Docker
+    # Wait for the daemon to become responsive
+    DOCKER_RETRIES=30
+    for i in $(seq 1 $DOCKER_RETRIES); do
+      if docker info &>/dev/null 2>&1; then
+        break
+      fi
+      if [ "$i" -eq "$DOCKER_RETRIES" ]; then
+        fail "Docker did not start after ${DOCKER_RETRIES}s. Start Docker Desktop manually and try again."
+      fi
+      printf "   Waiting for Docker daemon... (%d/%d)\r" "$i" "$DOCKER_RETRIES"
+      sleep 1
+    done
+    echo ""
+    info "Docker is running"
+  fi
+
+  if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q 'dev_env-db-1'; then
+    info "Database container is not running. Starting it..."
+    npm run db:start
+  fi
+
+  info "Docker database container is running"
+fi
+
+# ── 5. Verify database connectivity ────────────────────────────────
+
+# Use a lightweight Node check so we don't need psql installed
+DB_USERNAME="$(parse_env_var DB_USERNAME)"
+DB_PASSWORD="$(parse_env_var DB_PASSWORD)"
+
+DB_CHECK=$(DB_HOST="$DB_HOST" DB_PORT="$DB_PORT" DB_NAME="$DB_NAME" \
+  DB_USERNAME="$DB_USERNAME" DB_PASSWORD="$DB_PASSWORD" \
+  node --input-type=module -e '
+import postgres from "postgres";
+const sql = postgres({
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT || 5432),
+  database: process.env.DB_NAME,
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  connect_timeout: 5,
+  max: 1,
+});
+try {
+  await sql`SELECT 1`;
+  console.log("ok");
+  await sql.end();
+} catch (e) {
+  console.error(e.message);
+  await sql.end();
+  process.exit(1);
+}
+' 2>&1) || true
+
+if [ "$DB_CHECK" != "ok" ]; then
+  echo ""
+  echo "❌ Cannot connect to database at $DB_HOST:$DB_PORT/$DB_NAME"
+  echo "   Error: $DB_CHECK"
+  echo ""
+  if [ "$DB_HOST" = "localhost" ] || [ "$DB_HOST" = "127.0.0.1" ]; then
+    echo "   The Docker container is running but the database may not exist."
+    echo "   Try removing the volume and reinitializing:"
+    echo ""
+    echo "     docker compose -f dev_env/docker-compose.yml --profile dev down -v"
+    echo "     npm run db:start"
+  fi
+  exit 1
+fi
+
+info "Database connection verified"
+
+# ── 6. Build if needed ──────────────────────────────────────────────
+
+if [ ! -f "$JOB_DIR/dist/job.js" ]; then
+  info "Building library-etl job..."
+  npm run build --workspace=@wxyc/library-etl
+else
+  # Rebuild if source is newer than the built output
+  if [ "$JOB_DIR/job.ts" -nt "$JOB_DIR/dist/job.js" ]; then
+    info "Source changed, rebuilding..."
+    npm run build --workspace=@wxyc/library-etl
+  fi
+fi
+
+# ── 7. Run ──────────────────────────────────────────────────────────
+
+info "Running library-etl job..."
+echo ""
+$DOTENVX npm start --workspace=@wxyc/library-etl

--- a/shared/database/src/client.ts
+++ b/shared/database/src/client.ts
@@ -4,7 +4,7 @@ import * as schema from './schema';
 
 // Validate required environment variables
 const requiredEnvVars = ['DB_HOST', 'DB_NAME', 'DB_USERNAME', 'DB_PASSWORD'];
-const missingVars = requiredEnvVars.filter((v) => !process.env[v]);
+const missingVars = requiredEnvVars.filter((v) => process.env[v] === undefined);
 if (missingVars.length > 0) {
   console.error('[ERROR] Missing required database environment variables:', missingVars.join(', '));
   throw new Error(`Missing required database environment variables: ${missingVars.join(', ')}`);

--- a/tests/unit/jobs/library-etl.test.ts
+++ b/tests/unit/jobs/library-etl.test.ts
@@ -78,6 +78,8 @@ import {
   parseFormatAndDiscs,
   toDateOrUndefined,
   toDateOnlyString,
+  parseLegacyGenreRows,
+  parseLegacyFormatRows,
 } from '../../../jobs/library-etl/job';
 
 describe('library-etl job helpers', () => {
@@ -304,6 +306,64 @@ describe('library-etl job helpers', () => {
 
     it('returns undefined for invalid timestamp', () => {
       expect(toDateOnlyString(Number.NaN)).toBeUndefined();
+    });
+  });
+
+  describe('parseLegacyGenreRows', () => {
+    it('parses tab-delimited genre rows into names', () => {
+      const raw = '1\tRock\n2\tJazz\n3\tElectronic';
+      expect(parseLegacyGenreRows(raw)).toEqual(['Rock', 'Jazz', 'Electronic']);
+    });
+
+    it('filters out db_only (case insensitive)', () => {
+      const raw = '1\tRock\n2\tdb_only\n3\tDB_ONLY\n4\tJazz';
+      expect(parseLegacyGenreRows(raw)).toEqual(['Rock', 'Jazz']);
+    });
+
+    it('skips malformed rows', () => {
+      const raw = '1\tRock\nmalformed\n3\tJazz';
+      expect(parseLegacyGenreRows(raw)).toEqual(['Rock', 'Jazz']);
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(parseLegacyGenreRows('')).toEqual([]);
+    });
+
+    it('trims whitespace from genre names', () => {
+      const raw = '1\t  Rock  \n2\t Jazz ';
+      expect(parseLegacyGenreRows(raw)).toEqual(['Rock', 'Jazz']);
+    });
+
+    it('skips rows with empty genre name', () => {
+      const raw = '1\tRock\n2\t\n3\t   \n4\tJazz';
+      expect(parseLegacyGenreRows(raw)).toEqual(['Rock', 'Jazz']);
+    });
+  });
+
+  describe('parseLegacyFormatRows', () => {
+    it('normalizes raw format names to canonical set', () => {
+      const raw = '1\tCD\n2\tVinyl 12"\n3\tCDR';
+      expect(parseLegacyFormatRows(raw)).toEqual(expect.arrayContaining(['cd', 'vinyl 12"', 'cdr']));
+    });
+
+    it('deduplicates canonical names', () => {
+      const raw = '1\tCD\n2\tCD x 2\n3\tCD box';
+      const result = parseLegacyFormatRows(raw);
+      expect(result.filter((f) => f === 'cd')).toHaveLength(1);
+    });
+
+    it('skips unsupported formats', () => {
+      const raw = '1\tCD\n2\tcassette\n3\tdigital';
+      expect(parseLegacyFormatRows(raw)).toEqual(['cd']);
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(parseLegacyFormatRows('')).toEqual([]);
+    });
+
+    it('skips malformed rows', () => {
+      const raw = '1\tCD\nmalformed\n3\tVinyl';
+      expect(parseLegacyFormatRows(raw)).toEqual(expect.arrayContaining(['cd', 'vinyl']));
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add a runner script (`npm run etl:library`) that validates the environment, starts Docker and the database container if needed, checks connectivity, and runs the ETL job with clear error messages at each step
- Auto-sync genres and formats from the legacy MySQL database before processing releases, eliminating the dependency on pre-seeded data
- Fix database client env validation to accept empty `DB_PASSWORD` (common for local Docker databases)
- Add documentation for setting up and running the ETL job

Closes #259

## Test plan

- [ ] `npm run test:unit -- --testPathPatterns=library-etl` — 50 tests pass (39 existing + 11 new)
- [ ] `npm run etl:library` with Docker stopped — script starts Docker and the database automatically
- [ ] `npm run etl:library` with database container stopped — script runs `npm run db:start`
- [ ] `npm run etl:library` with missing `.env` vars — clear error message listing the missing vars
- [ ] `npm run etl:library` against real legacy dataset — genres/formats synced, zero missing genre/format warnings
- [ ] Verify `npm run etl:library` is idempotent (second run skips already-inserted data)