### PR TITLE
Fix double /api/v1 prefix in LML client URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ SPOTIFY_CLIENT_SECRET=your_spotify_client_secret
 LASTFM_API_KEY=your_lastfm_api_key
 
 ### Library Metadata Lookup (LML) Service
-LIBRARY_METADATA_URL=http://localhost:8001/api/v1
+LIBRARY_METADATA_URL=http://localhost:8001
 
 ### iOS App Configuration (served via GET /config)
 POSTHOG_API_KEY=your_posthog_api_key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:
 
 ### Metadata Services
 
-- `LIBRARY_METADATA_URL` -- library-metadata-lookup base URL (e.g. `http://localhost:8001/api/v1`). Required for proxy endpoints.
+- `LIBRARY_METADATA_URL` -- library-metadata-lookup base URL (e.g. `http://localhost:8001`). Required for proxy endpoints. Do not include the `/api/v1` path prefix; the LML client adds it automatically.
 - `DISCOGS_API_KEY`, `DISCOGS_API_SECRET`
 - `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`
 

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -103,7 +103,7 @@ function getBaseUrl(): string {
   if (!url) {
     throw new LmlClientError('LIBRARY_METADATA_URL is not configured', 503);
   }
-  return url.replace(/\/$/, '');
+  return url.replace(/\/api\/v1\/?$/, '').replace(/\/$/, '');
 }
 
 async function lmlFetch(path: string, init?: RequestInit): Promise<Response> {

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -163,5 +163,20 @@ describe('lml.client', () => {
 
       expect(mockFetch).toHaveBeenCalledWith('http://lml.test:8000/api/v1/discogs/search', expect.anything());
     });
+
+    it('does not double the /api/v1 prefix when LIBRARY_METADATA_URL already includes it', async () => {
+      process.env.LIBRARY_METADATA_URL = 'http://lml.test:8000/api/v1';
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], total: 0, cached: false }),
+      } as unknown as globalThis.Response);
+
+      await searchDiscogs('Autechre');
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain('/api/v1/api/v1');
+      expect(calledUrl).toBe('http://lml.test:8000/api/v1/discogs/search');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fix `getBaseUrl()` in the LML client to strip a trailing `/api/v1` from `LIBRARY_METADATA_URL`, preventing a doubled path prefix that caused all LML requests to 404
- Correct `.env.example` and documentation to show the proper base URL format
- Add regression test that verifies the URL is constructed correctly even when the env var includes `/api/v1`

**Note:** This branch is based on `feature/metadata-proxy-266` (the LML proxy routing work). It should be merged after that branch lands.

Closes #270

## Test plan

- [ ] Existing LML client unit tests pass
- [ ] New regression test verifies no doubled `/api/v1` prefix when env var includes it
- [ ] Verify production `LIBRARY_METADATA_URL` env var is updated to exclude `/api/v1`