### PR TITLE
Add E2E tests for metadata proxy flow

### DIFF
--- a/jest.e2e.config.json
+++ b/jest.e2e.config.json
@@ -1,0 +1,15 @@
+{
+  "preset": "ts-jest",
+  "testEnvironment": "node",
+  "testMatch": ["<rootDir>/tests/e2e/**/*.test.ts", "<rootDir>/tests/e2e/**/*.spec.js"],
+  "transform": {
+    "^.+\\.[jt]sx?$": ["ts-jest", { "tsconfig": "<rootDir>/tests/tsconfig.json" }]
+  },
+  "transformIgnorePatterns": ["node_modules/(?!(jose|drizzle-orm|@wxyc/shared)/)"],
+  "moduleNameMapper": {
+    "^(\\.{1,2}/.*)\\.(js)$": "$1"
+  },
+  "testTimeout": 30000,
+  "verbose": true,
+  "forceExit": true
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:unit:watch": "jest --config jest.unit.config.ts --watch",
     "test:integration": "dotenvx run -f .env -- jest --config jest.config.json --runInBand",
     "test:integration:parallel": "dotenvx run -f .env -- jest --config jest.parallel.config.json",
+    "test:e2e": "jest --config jest.e2e.config.json",
     "test:all": "npm run test:unit && npm run test:integration",
     "db:start": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile dev up -d; docker attach wxyc-db-init",
     "db:stop": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile dev down db -v --remove-orphans",

--- a/tests/e2e/lml-connectivity.test.ts
+++ b/tests/e2e/lml-connectivity.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Layer 2: LML Client Connectivity Tests
+ *
+ * Tests that directly import and call lml.client.ts functions against a running
+ * library-metadata-lookup instance. No Express middleware involved.
+ *
+ * Prerequisites:
+ * - A running LML instance (default: http://localhost:8000)
+ * - Set LIBRARY_METADATA_URL env var if not using the default
+ *
+ * Run:
+ *   LIBRARY_METADATA_URL=http://localhost:8000 npx jest --config jest.e2e.config.ts tests/e2e/lml-connectivity.test.ts
+ */
+
+import {
+  searchDiscogs,
+  getRelease,
+  getArtistDetails,
+  resolveEntity,
+  LmlClientError,
+} from '../../apps/backend/services/lml/lml.client';
+
+const LML_BASE_URL = process.env.LIBRARY_METADATA_URL || 'http://localhost:8000';
+
+let lmlReachable = false;
+
+beforeAll(async () => {
+  // Ensure the env var is set so the client can find the service
+  if (!process.env.LIBRARY_METADATA_URL) {
+    process.env.LIBRARY_METADATA_URL = LML_BASE_URL;
+  }
+
+  // Probe the health endpoint to determine if LML is available.
+  // LML returns 503 when the library DB is missing but Discogs endpoints
+  // still work, so any HTTP response means the service is reachable.
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    const response = await fetch(`${LML_BASE_URL}/health`, { signal: controller.signal });
+    clearTimeout(timeout);
+    lmlReachable = response.status > 0;
+  } catch {
+    lmlReachable = false;
+  }
+});
+
+function skipIfUnreachable() {
+  if (!lmlReachable) {
+    console.warn(`Skipping test: LML is not reachable at ${LML_BASE_URL}`);
+  }
+}
+
+describe('LML Client Connectivity', () => {
+  describe('Health Check', () => {
+    test('LML service is reachable', async () => {
+      const response = await fetch(`${LML_BASE_URL}/health`);
+      // 200 = healthy/degraded, 503 = unhealthy (e.g., library DB missing).
+      // Either means the service is running; Discogs endpoints work regardless.
+      expect([200, 503]).toContain(response.status);
+      const body = (await response.json()) as { status: string };
+      expect(['healthy', 'degraded', 'unhealthy']).toContain(body.status);
+    });
+  });
+
+  describe('Search', () => {
+    beforeEach(() => skipIfUnreachable());
+
+    test('returns results for known artist and album', async () => {
+      if (!lmlReachable) return;
+
+      const response = await searchDiscogs('Stereolab', 'Dots and Loops');
+      expect(response.results.length).toBeGreaterThan(0);
+      expect(typeof response.results[0].release_id).toBe('number');
+      expect(response.results[0].release_url).toMatch(/^https?:\/\//);
+    });
+
+    test('returns empty results for nonexistent artist', async () => {
+      if (!lmlReachable) return;
+
+      const response = await searchDiscogs('xyznonexistent12345', 'nothing');
+      expect(response.results).toHaveLength(0);
+    });
+  });
+
+  describe('Release', () => {
+    beforeEach(() => skipIfUnreachable());
+
+    test('returns metadata for known release ID', async () => {
+      if (!lmlReachable) return;
+
+      // Dots and Loops by Stereolab (Discogs release 90416)
+      const release = await getRelease(90416);
+      expect(release.title).toContain('Dots');
+      expect(release.tracklist.length).toBeGreaterThan(0);
+      expect(release.release_url).toContain('90416');
+    });
+  });
+
+  describe('Artist', () => {
+    beforeEach(() => skipIfUnreachable());
+
+    test('returns details for known artist ID', async () => {
+      if (!lmlReachable) return;
+
+      // Stereolab (Discogs artist 388)
+      const artist = await getArtistDetails(388);
+      expect(artist.name).toBe('Stereolab');
+      expect(artist.artist_id).toBe(388);
+      expect(typeof artist.profile).toBe('string');
+    });
+
+    test('throws for nonexistent artist', async () => {
+      if (!lmlReachable) return;
+
+      await expect(getArtistDetails(999999999)).rejects.toThrow(LmlClientError);
+      await expect(getArtistDetails(999999999)).rejects.toMatchObject({
+        statusCode: expect.any(Number),
+      });
+    });
+  });
+
+  describe('Entity Resolution', () => {
+    beforeEach(() => skipIfUnreachable());
+
+    test('resolves artist entity', async () => {
+      if (!lmlReachable) return;
+
+      const entity = await resolveEntity('artist', 388);
+      expect(entity.name).toBe('Stereolab');
+      expect(entity.type).toBe('artist');
+      expect(entity.id).toBe(388);
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('throws LmlClientError with 502 when LML is unreachable', async () => {
+      const original = process.env.LIBRARY_METADATA_URL;
+      process.env.LIBRARY_METADATA_URL = 'http://localhost:59999';
+      try {
+        await expect(searchDiscogs('test')).rejects.toThrow(LmlClientError);
+        await expect(searchDiscogs('test')).rejects.toMatchObject({
+          statusCode: 502,
+        });
+      } finally {
+        process.env.LIBRARY_METADATA_URL = original;
+      }
+    });
+
+    test('throws LmlClientError with 503 when LIBRARY_METADATA_URL is unset', async () => {
+      const original = process.env.LIBRARY_METADATA_URL;
+      delete process.env.LIBRARY_METADATA_URL;
+      try {
+        await expect(searchDiscogs('test')).rejects.toThrow(LmlClientError);
+        await expect(searchDiscogs('test')).rejects.toMatchObject({
+          statusCode: 503,
+        });
+      } finally {
+        process.env.LIBRARY_METADATA_URL = original;
+      }
+    });
+  });
+});

--- a/tests/e2e/metadata-proxy.spec.js
+++ b/tests/e2e/metadata-proxy.spec.js
@@ -1,0 +1,193 @@
+/**
+ * Layer 3: Metadata Proxy E2E Tests
+ *
+ * Full E2E tests hitting Backend-Service Express endpoints via supertest.
+ * Requires a running Backend-Service (with LML configured) and a running
+ * better-auth service (for anonymous auth session).
+ *
+ * Prerequisites:
+ * - Running Backend-Service (default: http://localhost:8080)
+ * - Running better-auth service (default: http://localhost:8082/auth)
+ * - Running LML service (LIBRARY_METADATA_URL configured in backend)
+ *
+ * Proxy endpoints require anonymous auth (better-auth session). The tests
+ * obtain a session token via the anonymous sign-in endpoint before running.
+ *
+ * Run:
+ *   npx jest --config jest.e2e.config.ts tests/e2e/metadata-proxy.spec.js
+ */
+
+const request = require('supertest');
+
+const baseUrl = `${process.env.TEST_HOST || 'http://localhost'}:${process.env.PORT || 8080}`;
+const BETTER_AUTH_URL = process.env.BETTER_AUTH_URL || 'http://localhost:8082/auth';
+
+let authToken = null;
+let servicesReachable = false;
+
+/**
+ * Obtain an anonymous session token from better-auth.
+ * Returns the bearer token string or null if auth is unavailable.
+ */
+async function getAnonymousToken() {
+  try {
+    const response = await fetch(`${BETTER_AUTH_URL}/sign-in/anonymous`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!response.ok) return null;
+
+    const token = response.headers.get('set-auth-token');
+    if (token) return token;
+
+    const body = await response.json();
+    return body.token || null;
+  } catch {
+    return null;
+  }
+}
+
+beforeAll(async () => {
+  // Check if Backend-Service is reachable
+  try {
+    const healthRes = await fetch(`${baseUrl}/healthcheck`);
+    if (!healthRes.ok) {
+      console.warn(`Backend-Service healthcheck failed at ${baseUrl}/healthcheck`);
+      return;
+    }
+  } catch {
+    console.warn(`Backend-Service is not reachable at ${baseUrl}`);
+    return;
+  }
+
+  // Obtain anonymous auth token
+  authToken = await getAnonymousToken();
+  if (!authToken) {
+    console.warn(
+      `Could not obtain anonymous auth token from ${BETTER_AUTH_URL}. Proxy tests that require auth will be skipped.`
+    );
+  }
+
+  servicesReachable = true;
+});
+
+function skipIfUnavailable() {
+  if (!servicesReachable) {
+    console.warn('Skipping test: Backend-Service or auth service is not reachable');
+  }
+}
+
+/**
+ * Helper that attaches the anonymous auth token to a supertest request.
+ * Proxy endpoints require a valid better-auth session.
+ */
+function withAuth(req) {
+  if (authToken) {
+    return req.set('Authorization', `Bearer ${authToken}`);
+  }
+  return req;
+}
+
+describe('Metadata Proxy E2E', () => {
+  describe('GET /proxy/metadata/album', () => {
+    beforeEach(() => skipIfUnavailable());
+
+    test('returns Discogs metadata for known artist and album', async () => {
+      if (!servicesReachable || !authToken) return;
+
+      const res = await withAuth(
+        request(baseUrl).get('/proxy/metadata/album').query({ artistName: 'Stereolab', releaseTitle: 'Dots and Loops' })
+      ).expect(200);
+
+      expect(res.body.discogsReleaseId).toBeDefined();
+      expect(typeof res.body.discogsReleaseId).toBe('number');
+      expect(res.body.discogsUrl).toMatch(/discogs\.com/);
+    });
+
+    test('returns enriched fields from LML release details', async () => {
+      if (!servicesReachable || !authToken) return;
+
+      const res = await withAuth(
+        request(baseUrl).get('/proxy/metadata/album').query({ artistName: 'Stereolab', releaseTitle: 'Dots and Loops' })
+      ).expect(200);
+
+      expect(res.body.releaseYear).toBeDefined();
+      expect(typeof res.body.releaseYear).toBe('number');
+      expect(Array.isArray(res.body.genres)).toBe(true);
+      expect(res.body.genres.length).toBeGreaterThan(0);
+    });
+
+    test('returns search URLs even for unknown artists', async () => {
+      if (!servicesReachable || !authToken) return;
+
+      const res = await withAuth(
+        request(baseUrl).get('/proxy/metadata/album').query({ artistName: 'xyznonexistent12345' })
+      ).expect(200);
+
+      expect(res.body.youtubeMusicUrl).toBeDefined();
+      expect(res.body.bandcampUrl).toBeDefined();
+      expect(res.body.discogsReleaseId).toBeUndefined();
+    });
+
+    test('returns 400 without artistName', async () => {
+      if (!servicesReachable || !authToken) return;
+
+      await withAuth(request(baseUrl).get('/proxy/metadata/album')).expect(400);
+    });
+  });
+
+  describe('GET /proxy/metadata/artist', () => {
+    beforeEach(() => skipIfUnavailable());
+
+    test('returns artist bio for known Discogs ID', async () => {
+      if (!servicesReachable || !authToken) return;
+
+      const res = await withAuth(request(baseUrl).get('/proxy/metadata/artist').query({ artistId: '388' })).expect(200);
+
+      expect(res.body.discogsArtistId).toBe(388);
+      expect(typeof res.body.bio).toBe('string');
+      expect(res.body.bio.length).toBeGreaterThan(0);
+    });
+
+    test('returns 400 without artistId', async () => {
+      if (!servicesReachable || !authToken) return;
+
+      await withAuth(request(baseUrl).get('/proxy/metadata/artist')).expect(400);
+    });
+
+    test('returns 400 for non-numeric artistId', async () => {
+      if (!servicesReachable || !authToken) return;
+
+      await withAuth(request(baseUrl).get('/proxy/metadata/artist').query({ artistId: 'abc' })).expect(400);
+    });
+  });
+
+  describe('GET /proxy/entity/resolve', () => {
+    beforeEach(() => skipIfUnavailable());
+
+    test('resolves artist entity', async () => {
+      if (!servicesReachable || !authToken) return;
+
+      const res = await withAuth(
+        request(baseUrl).get('/proxy/entity/resolve').query({ type: 'artist', id: '388' })
+      ).expect(200);
+
+      expect(res.body.name).toBe('Stereolab');
+      expect(res.body.type).toBe('artist');
+      expect(res.body.id).toBe(388);
+    });
+
+    test('returns 400 for missing params', async () => {
+      if (!servicesReachable || !authToken) return;
+
+      await withAuth(request(baseUrl).get('/proxy/entity/resolve').query({ type: 'artist' })).expect(400);
+    });
+
+    test('returns 400 for invalid entity type', async () => {
+      if (!servicesReachable || !authToken) return;
+
+      await withAuth(request(baseUrl).get('/proxy/entity/resolve').query({ type: 'invalid', id: '388' })).expect(400);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add Layer 2 (LML client connectivity) and Layer 3 (proxy endpoint) E2E tests
- Add `jest.e2e.config.json` and `test:e2e` npm script
- Tests gracefully skip when services are not running

Closes #272

## Test plan

- [ ] Layer 2 tests pass with LML running: `LIBRARY_METADATA_URL=http://localhost:8001 npm run test:e2e -- tests/e2e/lml-connectivity.test.ts`
- [ ] Layer 3 tests pass with full stack: `npm run test:e2e -- tests/e2e/metadata-proxy.spec.js`
- [ ] Tests skip gracefully when services are unavailable