### PR TITLE
Fix metadata JOIN for non-library flowsheet entries

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1,4 +1,4 @@
-import { sql, desc, eq, and, lte, gte, inArray } from 'drizzle-orm';
+import { sql, desc, eq, and, or, lte, gte, inArray } from 'drizzle-orm';
 import WxycError from '../utils/error.js';
 import {
   db,
@@ -40,6 +40,38 @@ const updateLastModified = () => {
     lastModifiedAt = now;
   }
 };
+
+/**
+ * SQL expression that computes an album cache key from flowsheet artist_name and album_title.
+ * Must mirror generateAlbumCacheKey() in metadata.cache.ts:
+ *   `${artistName.toLowerCase().trim()}-${(albumTitle || '').toLowerCase().trim()}`
+ */
+const computedAlbumCacheKey = sql<string>`substring(lower(trim(${flowsheet.artist_name})) || '-' || lower(trim(coalesce(${flowsheet.album_title}, ''))), 1, 512)`;
+
+/**
+ * SQL expression that computes an artist cache key from flowsheet artist_name.
+ * Must mirror generateArtistCacheKey() in metadata.cache.ts:
+ *   `artistName.toLowerCase().trim()`
+ */
+const computedArtistCacheKey = sql<string>`substring(lower(trim(${flowsheet.artist_name})), 1, 256)`;
+
+/**
+ * Join condition for album_metadata: match on album_id when present,
+ * fall back to cache_key for non-library entries (where album_id is NULL).
+ */
+const albumMetadataJoinCondition = or(
+  eq(album_metadata.album_id, flowsheet.album_id),
+  and(sql`${flowsheet.album_id} is null`, eq(album_metadata.cache_key, computedAlbumCacheKey))
+);
+
+/**
+ * Join condition for artist_metadata: match on artist_id via the library table
+ * when album_id is present, fall back to cache_key for non-library entries.
+ */
+const artistMetadataJoinCondition = or(
+  eq(artist_metadata.artist_id, library.artist_id),
+  and(sql`${flowsheet.album_id} is null`, eq(artist_metadata.cache_key, computedArtistCacheKey))
+);
 
 // SQL query fields (flat structure from database)
 const FSEntryFieldsRaw = {
@@ -144,9 +176,9 @@ export const getEntriesByPage = async (offset: number, limit: number): Promise<I
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
-    .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
+    .leftJoin(album_metadata, albumMetadataJoinCondition)
     .leftJoin(library, eq(library.id, flowsheet.album_id))
-    .leftJoin(artist_metadata, eq(artist_metadata.artist_id, library.artist_id))
+    .leftJoin(artist_metadata, artistMetadataJoinCondition)
     .orderBy(desc(flowsheet.play_order))
     .offset(offset)
     .limit(limit);
@@ -158,9 +190,9 @@ export const getEntriesByRange = async (startId: number, endId: number): Promise
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
-    .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
+    .leftJoin(album_metadata, albumMetadataJoinCondition)
     .leftJoin(library, eq(library.id, flowsheet.album_id))
-    .leftJoin(artist_metadata, eq(artist_metadata.artist_id, library.artist_id))
+    .leftJoin(artist_metadata, artistMetadataJoinCondition)
     .where(and(gte(flowsheet.id, startId), lte(flowsheet.id, endId)))
     .orderBy(desc(flowsheet.play_order));
 
@@ -175,9 +207,9 @@ export const getEntriesByShow = async (...show_ids: number[]): Promise<IFSEntry[
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
-    .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
+    .leftJoin(album_metadata, albumMetadataJoinCondition)
     .leftJoin(library, eq(library.id, flowsheet.album_id))
-    .leftJoin(artist_metadata, eq(artist_metadata.artist_id, library.artist_id))
+    .leftJoin(artist_metadata, artistMetadataJoinCondition)
     .where(inArray(flowsheet.show_id, show_ids))
     .orderBy(desc(flowsheet.play_order));
 

--- a/tests/unit/authentication/shared-type-compatibility.test.ts
+++ b/tests/unit/authentication/shared-type-compatibility.test.ts
@@ -17,16 +17,15 @@ describe('shared type compatibility', () => {
       expect(Authorization.DJ).toBe(1);
       expect(Authorization.MD).toBe(2);
       expect(Authorization.SM).toBe(3);
-      expect(Authorization.ADMIN).toBe(4);
     });
   });
 
   describe('normalizeRole consistency with roleToAuthorization', () => {
-    it('admin normalizes to stationManager, consistent with shared ADMIN >= SM', () => {
+    it('admin normalizes to stationManager, consistent with shared SM mapping', () => {
       expect(normalizeRole('admin')).toBe('stationManager');
-      // Shared maps "admin" to ADMIN (4), which is >= SM (3).
+      // Shared maps "admin" to SM (3) — the highest station role.
       // Both grant full access; the normalization is a backend-specific concern.
-      expect(roleToAuthorization('admin')).toBe(Authorization.ADMIN);
+      expect(roleToAuthorization('admin')).toBe(Authorization.SM);
     });
 
     it.each(['member', 'dj', 'musicDirector', 'stationManager'] as const)(

--- a/tests/unit/controllers/events.controller.test.ts
+++ b/tests/unit/controllers/events.controller.test.ts
@@ -19,7 +19,7 @@ jest.mock('../../../apps/backend/utils/serverEvents', () => {
   };
 });
 
-import { registerEventClient } from '../../../apps/backend/controllers/events.conroller';
+import { registerEventClient } from '../../../apps/backend/controllers/events.controller';
 import { serverEventsMgr, Topics } from '../../../apps/backend/utils/serverEvents';
 
 describe('events controller', () => {


### PR DESCRIPTION
## Summary

- Fix flowsheet queries to return cached metadata for non-library tracks by adding `cache_key` fallback JOIN conditions
- Fix `Authorization.ADMIN` test assertion to match actual `@wxyc/shared` enum values (`admin` maps to `SM`, not a separate `ADMIN` level)
- Fix typo in events controller test import (`events.conroller` → `events.controller`)

Closes #276

## Details

The `album_metadata` and `artist_metadata` tables store entries two ways: by `album_id` (for library tracks) or by `cache_key` (for non-library tracks). The flowsheet queries only joined on `album_id`, so metadata for non-library tracks was always null — even when it existed in the database.

The fix adds `OR` conditions to the LEFT JOINs that compute the `cache_key` from `flowsheet.artist_name` and `flowsheet.album_title` using the same formula as `generateAlbumCacheKey()` in `metadata.cache.ts`.

## Test plan

- [x] `npm run typecheck` passes
- [x] All 413 unit tests pass (was 411 with 2 pre-existing failures)
- [x] Lint passes (0 errors)
- [ ] Integration tests pass with Docker DB (`npm run ci:testmock`)
- [ ] Verify on staging: add a non-library track, confirm metadata fields are populated in GET response