### PR TITLE
feat: import artist cross-references from tubafrenzy in library ETL

### DIFF
--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -1,5 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { isNull } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import {
   MirrorSQL,
   db,
@@ -9,6 +10,8 @@ import {
   genres,
   library,
   cronjob_runs,
+  artist_crossreference,
+  artist_library_crossreference,
   closeDatabaseConnection,
 } from '@wxyc/database';
 
@@ -394,6 +397,258 @@ const ensureGenreArtistCrossref = async (
   });
 };
 
+/**
+ * Build a cache key for artist lookups.
+ * Used to deduplicate artist resolution across cross-reference imports.
+ */
+const buildArtistCacheKey = (artistName: string, codeLetters: string): string =>
+  `${artistName.toLowerCase().trim()}|${codeLetters.toLowerCase().trim()}`;
+
+/**
+ * Build a cache key for album lookups.
+ * Used to deduplicate album resolution across release cross-reference imports.
+ */
+const buildAlbumCacheKey = (artistId: number, genreId: number, albumTitle: string, codeNumber: number): string =>
+  `${artistId}|${genreId}|${albumTitle.toLowerCase().trim()}|${codeNumber}`;
+
+/**
+ * Find an existing artist by name and code letters (read-only, no insert).
+ * Uses artistIdCache for deduplication across cross-reference imports.
+ */
+const findArtistId = async (
+  dbClient: DbClient,
+  artistName: string,
+  codeLetters: string,
+  artistIdCache: Map<string, number>
+): Promise<number | null> => {
+  const key = buildArtistCacheKey(artistName, codeLetters);
+  const cached = artistIdCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const rows = await dbClient
+    .select({ id: artists.id })
+    .from(artists)
+    .where(and(eq(artists.artist_name, artistName), eq(artists.code_letters, codeLetters)))
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  artistIdCache.set(key, rows[0].id);
+  return rows[0].id;
+};
+
+/**
+ * Find an existing album by artist, genre, title, and code number (read-only).
+ * Uses albumIdCache for deduplication.
+ */
+const findAlbumId = async (
+  dbClient: DbClient,
+  artistId: number,
+  genreId: number,
+  albumTitle: string,
+  codeNumber: number | null,
+  albumIdCache: Map<string, number>
+): Promise<number | null> => {
+  const resolvedCode = codeNumber ?? 0;
+  const key = buildAlbumCacheKey(artistId, genreId, albumTitle, resolvedCode);
+  const cached = albumIdCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const rows = await dbClient
+    .select({ id: library.id })
+    .from(library)
+    .where(
+      and(
+        eq(library.artist_id, artistId),
+        eq(library.genre_id, genreId),
+        eq(library.album_title, albumTitle),
+        eq(library.code_number, resolvedCode)
+      )
+    )
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  albumIdCache.set(key, rows[0].id);
+  return rows[0].id;
+};
+
+type LegacyCrossrefRow = {
+  sourceArtistName: string;
+  sourceCodeLetters: string;
+  targetArtistName: string;
+  targetCodeLetters: string;
+  comment: string | null;
+};
+
+type LegacyReleaseCrossrefRow = {
+  artistName: string;
+  artistCodeLetters: string;
+  albumTitle: string;
+  albumCodeNumber: number;
+  genreName: string;
+  comment: string | null;
+};
+
+/**
+ * Fetch artist-to-artist cross-references (aliases, side projects, related artists)
+ * from tubafrenzy's LIBRARY_CODE_CROSS_REFERENCE table.
+ */
+const fetchLegacyArtistCrossRefs = async (): Promise<LegacyCrossrefRow[]> => {
+  const sqlQuery = `
+    SELECT
+      REPLACE(REPLACE(src.PRESENTATION_NAME, '\\t', ' '), '\\n', ' '),
+      src.CALL_LETTERS,
+      REPLACE(REPLACE(tgt.PRESENTATION_NAME, '\\t', ' '), '\\n', ' '),
+      tgt.CALL_LETTERS,
+      REPLACE(REPLACE(IFNULL(cr.NOTE, ''), '\\t', ' '), '\\n', ' ')
+    FROM LIBRARY_CODE_CROSS_REFERENCE cr
+    JOIN LIBRARY_CODE src ON cr.SOURCE_LIBRARY_CODE_ID = src.ID
+    JOIN LIBRARY_CODE tgt ON cr.TARGET_LIBRARY_CODE_ID = tgt.ID;
+  `;
+  const raw = await legacyDB.send(sqlQuery);
+  if (raw.trim().length === 0) return [];
+
+  const rows: LegacyCrossrefRow[] = [];
+  for (const line of raw.trim().split('\n')) {
+    const columns = parseTabRow(line, 5);
+    if (!columns) {
+      console.warn('[library-etl] Skipping malformed artist crossref row:', line);
+      continue;
+    }
+    rows.push({
+      sourceArtistName: columns[0].trim(),
+      sourceCodeLetters: columns[1].trim(),
+      targetArtistName: columns[2].trim(),
+      targetCodeLetters: columns[3].trim(),
+      comment: toNullableString(columns[4]),
+    });
+  }
+  return rows;
+};
+
+/**
+ * Fetch release cross-references (guest appearances, collaborations)
+ * from tubafrenzy's RELEASE_CROSS_REFERENCE table.
+ */
+const fetchLegacyReleaseCrossRefs = async (): Promise<LegacyReleaseCrossrefRow[]> => {
+  const sqlQuery = `
+    SELECT
+      REPLACE(REPLACE(lc.PRESENTATION_NAME, '\\t', ' '), '\\n', ' '),
+      lc.CALL_LETTERS,
+      REPLACE(REPLACE(lr.TITLE, '\\t', ' '), '\\n', ' '),
+      lr.CALL_NUMBERS,
+      g.REFERENCE_NAME,
+      REPLACE(REPLACE(IFNULL(cr.NOTE, ''), '\\t', ' '), '\\n', ' ')
+    FROM RELEASE_CROSS_REFERENCE cr
+    JOIN LIBRARY_RELEASE lr ON cr.LIBRARY_RELEASE_ID = lr.ID
+    JOIN LIBRARY_CODE lc ON cr.LIBRARY_CODE_ID = lc.ID
+    JOIN GENRE g ON lc.GENRE_ID = g.ID;
+  `;
+  const raw = await legacyDB.send(sqlQuery);
+  if (raw.trim().length === 0) return [];
+
+  const rows: LegacyReleaseCrossrefRow[] = [];
+  for (const line of raw.trim().split('\n')) {
+    const columns = parseTabRow(line, 6);
+    if (!columns) {
+      console.warn('[library-etl] Skipping malformed release crossref row:', line);
+      continue;
+    }
+    rows.push({
+      artistName: columns[0].trim(),
+      artistCodeLetters: columns[1].trim(),
+      albumTitle: columns[2].trim(),
+      albumCodeNumber: Number(columns[3]) || 0,
+      genreName: columns[4].trim(),
+      comment: toNullableString(columns[5]),
+    });
+  }
+  return rows;
+};
+
+/**
+ * Import artist-to-artist cross-references into the artist_crossreference table.
+ * Uses ON CONFLICT DO NOTHING for idempotent upserts.
+ */
+const importArtistCrossRefs = async (
+  tx: DbTransaction,
+  rows: LegacyCrossrefRow[],
+  artistIdCache: Map<string, number>
+): Promise<{ imported: number; skipped: number }> => {
+  let imported = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    const sourceId = await findArtistId(tx, row.sourceArtistName, row.sourceCodeLetters, artistIdCache);
+    const targetId = await findArtistId(tx, row.targetArtistName, row.targetCodeLetters, artistIdCache);
+
+    if (!sourceId || !targetId) {
+      skipped++;
+      continue;
+    }
+
+    await tx
+      .insert(artist_crossreference)
+      .values({
+        source_artist_id: sourceId,
+        target_artist_id: targetId,
+        comment: row.comment,
+      })
+      .onConflictDoNothing();
+
+    imported++;
+  }
+
+  return { imported, skipped };
+};
+
+/**
+ * Import release cross-references (artist→album links) into the artist_library_crossreference table.
+ * Uses ON CONFLICT DO NOTHING for idempotent upserts.
+ */
+const importReleaseCrossRefs = async (
+  tx: DbTransaction,
+  rows: LegacyReleaseCrossrefRow[],
+  artistIdCache: Map<string, number>,
+  albumIdCache: Map<string, number>,
+  genreMap: Map<string, number>
+): Promise<{ imported: number; skipped: number }> => {
+  let imported = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    const artistId = await findArtistId(tx, row.artistName, row.artistCodeLetters, artistIdCache);
+    if (!artistId) {
+      skipped++;
+      continue;
+    }
+
+    const genreId = genreMap.get(row.genreName.toLowerCase());
+    if (!genreId) {
+      skipped++;
+      continue;
+    }
+
+    const albumId = await findAlbumId(tx, artistId, genreId, row.albumTitle, row.albumCodeNumber, albumIdCache);
+    if (!albumId) {
+      skipped++;
+      continue;
+    }
+
+    await tx
+      .insert(artist_library_crossreference)
+      .values({
+        artist_id: artistId,
+        library_id: albumId,
+        comment: row.comment,
+      })
+      .onConflictDoNothing();
+
+    imported++;
+  }
+
+  return { imported, skipped };
+};
+
 const albumExists = async (
   dbClient: DbClient,
   artistId: number,
@@ -548,6 +803,50 @@ const run = async () => {
         insertedCount += 1;
       }
 
+      // --- Cross-reference imports ---
+      // Detect if this is the first run by checking if both crossref tables are empty.
+      // If so, do a full backfill regardless of last_run timestamp.
+      const artistCrossrefCount = await tx
+        .select({ count: sql<number>`count(*)` })
+        .from(artist_crossreference);
+      const releaseCrossrefCount = await tx
+        .select({ count: sql<number>`count(*)` })
+        .from(artist_library_crossreference);
+      const isFirstCrossrefRun =
+        artistCrossrefCount[0].count === 0 && releaseCrossrefCount[0].count === 0;
+
+      if (isFirstCrossrefRun) {
+        console.log('[library-etl] Cross-reference tables are empty — running full backfill.');
+      }
+
+      // Build shared caches for cross-reference resolution
+      const artistIdCache = new Map<string, number>();
+      const albumIdCache = new Map<string, number>();
+
+      // Import artist-to-artist cross-references
+      const legacyArtistCrossRefs = await fetchLegacyArtistCrossRefs();
+      const artistCrossResult = await importArtistCrossRefs(tx, legacyArtistCrossRefs, artistIdCache);
+      if (artistCrossResult.imported > 0 || artistCrossResult.skipped > 0) {
+        console.log(
+          `[library-etl] Artist cross-references: imported ${artistCrossResult.imported}, skipped ${artistCrossResult.skipped}.`
+        );
+      }
+
+      // Import release cross-references (artist→album links)
+      const legacyReleaseCrossRefs = await fetchLegacyReleaseCrossRefs();
+      const releaseCrossResult = await importReleaseCrossRefs(
+        tx,
+        legacyReleaseCrossRefs,
+        artistIdCache,
+        albumIdCache,
+        genreMap
+      );
+      if (releaseCrossResult.imported > 0 || releaseCrossResult.skipped > 0) {
+        console.log(
+          `[library-etl] Release cross-references: imported ${releaseCrossResult.imported}, skipped ${releaseCrossResult.skipped}.`
+        );
+      }
+
       await updateLastRun(tx, JOB_NAME, runStartedAt);
     });
 
@@ -572,6 +871,8 @@ export {
   toDateOnlyString,
   parseLegacyGenreRows,
   parseLegacyFormatRows,
+  buildArtistCacheKey,
+  buildAlbumCacheKey,
 };
 
 run().catch((error) => {

--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -806,14 +806,11 @@ const run = async () => {
       // --- Cross-reference imports ---
       // Detect if this is the first run by checking if both crossref tables are empty.
       // If so, do a full backfill regardless of last_run timestamp.
-      const artistCrossrefCount = await tx
-        .select({ count: sql<number>`count(*)` })
-        .from(artist_crossreference);
+      const artistCrossrefCount = await tx.select({ count: sql<number>`count(*)` }).from(artist_crossreference);
       const releaseCrossrefCount = await tx
         .select({ count: sql<number>`count(*)` })
         .from(artist_library_crossreference);
-      const isFirstCrossrefRun =
-        artistCrossrefCount[0].count === 0 && releaseCrossrefCount[0].count === 0;
+      const isFirstCrossrefRun = artistCrossrefCount[0].count === 0 && releaseCrossrefCount[0].count === 0;
 
       if (isFirstCrossrefRun) {
         console.log('[library-etl] Cross-reference tables are empty — running full backfill.');

--- a/shared/database/src/migrations/0033_crossreference_tables.sql
+++ b/shared/database/src/migrations/0033_crossreference_tables.sql
@@ -1,0 +1,12 @@
+-- Add comment column to artist_library_crossreference (release cross-references)
+ALTER TABLE "wxyc_schema"."artist_library_crossreference" ADD COLUMN "comment" varchar(255);--> statement-breakpoint
+
+-- Create artist_crossreference table (artist-to-artist links: aliases, side projects, related artists)
+CREATE TABLE IF NOT EXISTS "wxyc_schema"."artist_crossreference" (
+  "source_artist_id" integer NOT NULL,
+  "target_artist_id" integer NOT NULL,
+  "comment" varchar(255),
+  CONSTRAINT "artist_crossreference_source_artist_id_artists_id_fk" FOREIGN KEY ("source_artist_id") REFERENCES "wxyc_schema"."artists"("id") ON DELETE cascade ON UPDATE no action,
+  CONSTRAINT "artist_crossreference_target_artist_id_artists_id_fk" FOREIGN KEY ("target_artist_id") REFERENCES "wxyc_schema"."artists"("id") ON DELETE cascade ON UPDATE no action
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "artist_crossref_source_target" ON "wxyc_schema"."artist_crossreference" USING btree ("source_artist_id","target_artist_id");

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1774469004875,
       "tag": "0031_add-segue-flag",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1775090000000,
+      "tag": "0033_crossreference_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -389,8 +389,25 @@ export const artist_library_crossreference = wxyc_schema.table(
   {
     artist_id: integer('artist_id').references(() => artists.id, { onDelete: 'cascade' }),
     library_id: integer('library_id').references(() => library.id, { onDelete: 'cascade' }),
+    comment: varchar('comment', { length: 255 }),
   },
   (table) => [uniqueIndex('library_id_artist_id').on(table.artist_id, table.library_id)]
+);
+
+export type NewArtistCrossreference = InferInsertModel<typeof artist_crossreference>;
+export type ArtistCrossreference = InferSelectModel<typeof artist_crossreference>;
+export const artist_crossreference = wxyc_schema.table(
+  'artist_crossreference',
+  {
+    source_artist_id: integer('source_artist_id')
+      .notNull()
+      .references(() => artists.id, { onDelete: 'cascade' }),
+    target_artist_id: integer('target_artist_id')
+      .notNull()
+      .references(() => artists.id, { onDelete: 'cascade' }),
+    comment: varchar('comment', { length: 255 }),
+  },
+  (table) => [uniqueIndex('artist_crossref_source_target').on(table.source_artist_id, table.target_artist_id)]
 );
 
 export type NewShow = InferInsertModel<typeof shows>;

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -116,6 +116,8 @@ export const user = {
 };
 export const specialty_shows = {};
 export const schedule = {};
+export const artist_crossreference = {};
+export const artist_library_crossreference = {};
 
 // Mock enum
 export const flowsheetEntryTypeEnum = () => ({});

--- a/tests/unit/database/schema.crossreference.test.ts
+++ b/tests/unit/database/schema.crossreference.test.ts
@@ -1,0 +1,51 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('schema: cross-reference tables', () => {
+  const schemaPath = path.resolve(__dirname, '../../../shared/database/src/schema.ts');
+  const schemaSource = fs.readFileSync(schemaPath, 'utf-8');
+
+  const extractTableDef = (tableName: string): string => {
+    const regex = new RegExp(`export const ${tableName}\\b[\\s\\S]*?^\\);`, 'm');
+    const match = schemaSource.match(regex);
+    if (!match) throw new Error(`Table definition for ${tableName} not found in schema`);
+    return match[0];
+  };
+
+  describe('artist_crossreference table', () => {
+    it('should exist in the schema', () => {
+      expect(schemaSource).toContain('export const artist_crossreference');
+    });
+
+    it('should have source_artist_id as NOT NULL FK to artists', () => {
+      const def = extractTableDef('artist_crossreference');
+      expect(def).toContain('source_artist_id');
+      expect(def).toMatch(/source_artist_id[\s\S]*?\.notNull\(\)/);
+      expect(def).toMatch(/source_artist_id[\s\S]*?artists\.id/);
+    });
+
+    it('should have target_artist_id as NOT NULL FK to artists', () => {
+      const def = extractTableDef('artist_crossreference');
+      expect(def).toContain('target_artist_id');
+      expect(def).toMatch(/target_artist_id[\s\S]*?\.notNull\(\)/);
+      expect(def).toMatch(/target_artist_id[\s\S]*?artists\.id/);
+    });
+
+    it('should have a comment column', () => {
+      const def = extractTableDef('artist_crossreference');
+      expect(def).toContain('comment');
+    });
+
+    it('should have a unique index on (source_artist_id, target_artist_id)', () => {
+      const def = extractTableDef('artist_crossreference');
+      expect(def).toMatch(/uniqueIndex.*source_artist_id.*target_artist_id/s);
+    });
+  });
+
+  describe('artist_library_crossreference table', () => {
+    it('should have a comment column', () => {
+      const def = extractTableDef('artist_library_crossreference');
+      expect(def).toContain('comment');
+    });
+  });
+});

--- a/tests/unit/jobs/library-etl.test.ts
+++ b/tests/unit/jobs/library-etl.test.ts
@@ -57,6 +57,8 @@ jest.mock('@wxyc/database', () => {
     library: {},
     cronjob_runs: {},
     genre_artist_crossreference: {},
+    artist_crossreference: {},
+    artist_library_crossreference: {},
     closeDatabaseConnection: jest.fn().mockResolvedValue(undefined),
   };
 });
@@ -65,6 +67,7 @@ jest.mock('drizzle-orm', () => ({
   eq: jest.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
   and: jest.fn((...args: unknown[]) => ({ and: args })),
   isNull: jest.fn((col: unknown) => ({ isNull: col })),
+  sql: jest.fn(),
 }));
 
 import {
@@ -80,6 +83,8 @@ import {
   toDateOnlyString,
   parseLegacyGenreRows,
   parseLegacyFormatRows,
+  buildArtistCacheKey,
+  buildAlbumCacheKey,
 } from '../../../jobs/library-etl/job';
 
 describe('library-etl job helpers', () => {
@@ -364,6 +369,41 @@ describe('library-etl job helpers', () => {
     it('skips malformed rows', () => {
       const raw = '1\tCD\nmalformed\n3\tVinyl';
       expect(parseLegacyFormatRows(raw)).toEqual(expect.arrayContaining(['cd', 'vinyl']));
+    });
+  });
+
+  describe('buildArtistCacheKey', () => {
+    it('normalizes to lowercase and trims', () => {
+      expect(buildArtistCacheKey('  Autechre  ', ' AE ')).toBe('autechre|ae');
+    });
+
+    it('produces consistent keys for identical input', () => {
+      const a = buildArtistCacheKey('Cat Power', 'CP');
+      const b = buildArtistCacheKey('Cat Power', 'CP');
+      expect(a).toBe(b);
+    });
+
+    it('produces different keys for different artists', () => {
+      const a = buildArtistCacheKey('Stereolab', 'ST');
+      const b = buildArtistCacheKey('Sessa', 'SE');
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('buildAlbumCacheKey', () => {
+    it('includes all components', () => {
+      const key = buildAlbumCacheKey(42, 3, 'Moon Pix', 1);
+      expect(key).toBe('42|3|moon pix|1');
+    });
+
+    it('normalizes title to lowercase and trims', () => {
+      expect(buildAlbumCacheKey(1, 1, '  Confield  ', 5)).toBe('1|1|confield|5');
+    });
+
+    it('produces different keys for different code numbers', () => {
+      const a = buildAlbumCacheKey(1, 1, 'Album', 1);
+      const b = buildAlbumCacheKey(1, 1, 'Album', 2);
+      expect(a).not.toBe(b);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `artist_crossreference` table for artist-to-artist links (aliases, side projects, related artists) with `source_artist_id`, `target_artist_id` (both NOT NULL FKs to `artists`), `comment`, and unique index on the pair
- Add `comment` column to `artist_library_crossreference` for editorial notes on release cross-references
- Extend library-ETL job to import `LIBRARY_CODE_CROSS_REFERENCE` (artist↔artist) and `RELEASE_CROSS_REFERENCE` (artist→album) from tubafrenzy
- Add `findArtistId()` and `findAlbumId()` for read-only cached lookups during cross-reference resolution
- Add `buildArtistCacheKey` and `buildAlbumCacheKey` helpers for deduplication
- One-time full backfill: detects empty cross-reference tables and imports all rows regardless of `last_run`
- Both imports use `ON CONFLICT DO NOTHING` for idempotent upserts

Closes #264

## Test plan
- [x] Schema tests verify `artist_crossreference` table structure (6 tests)
- [x] Unit tests for `buildArtistCacheKey` and `buildAlbumCacheKey` (6 tests)
- [x] All 504 unit tests pass
- [x] Typecheck passes across all workspaces
- [x] Lint passes (0 errors)
- [ ] Migration applies cleanly against a dev database
- [ ] Run ETL against staging tubafrenzy to verify cross-reference import
- [ ] Verify idempotent re-run (no duplicate inserts)