### PR TITLE
feat: add flowsheet ETL for importing historical data from tubafrenzy

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -100,6 +100,7 @@ const FSEntryFieldsRaw = {
   segue: flowsheet.segue,
   message: flowsheet.message,
   play_order: flowsheet.play_order,
+  legacy_entry_id: flowsheet.legacy_entry_id,
   add_time: flowsheet.add_time,
   // Album metadata from cache (will be nested in transform)
   artwork_url: album_metadata.artwork_url,
@@ -132,6 +133,7 @@ type FSEntryRaw = {
   segue: boolean | null;
   message: string | null;
   play_order: number | null;
+  legacy_entry_id: number | null;
   add_time: Date | null;
   artwork_url: string | null;
   discogs_url: string | null;
@@ -150,6 +152,7 @@ const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
   id: raw.id,
   show_id: raw.show_id,
   album_id: raw.album_id,
+  legacy_entry_id: raw.legacy_entry_id ?? null,
   entry_type: raw.entry_type as FSEntry['entry_type'],
   artist_name: raw.artist_name,
   album_title: raw.album_title,

--- a/jobs/flowsheet-etl/fetch-legacy.ts
+++ b/jobs/flowsheet-etl/fetch-legacy.ts
@@ -1,0 +1,115 @@
+/**
+ * MirrorSQL queries for flowsheet ETL incremental sync mode.
+ *
+ * Fetches new shows and entries from tubafrenzy since the last sync.
+ */
+import { MirrorSQL } from '@wxyc/database';
+
+const legacyDB = MirrorSQL.instance();
+
+export type LegacyShowRow = {
+  id: number;
+  startTime: string;
+  endTime: string | null;
+};
+
+export type LegacyEntryRow = {
+  id: number;
+  showId: number;
+  entryType: number;
+  artistName: string | null;
+  albumTitle: string | null;
+  trackTitle: string | null;
+  label: string | null;
+  message: string | null;
+  requestFlag: number;
+  playOrder: number;
+  timePlayed: string;
+};
+
+const parseTabRow = (line: string, columnCount: number) => {
+  const columns = line.split('\t');
+  return columns.length === columnCount ? columns : null;
+};
+
+const toNullable = (value: string): string | null => {
+  const trimmed = value.trim();
+  return trimmed.length === 0 || trimmed === 'NULL' ? null : trimmed;
+};
+
+export const fetchLegacyShows = async (sinceMs: number | null): Promise<LegacyShowRow[]> => {
+  const filter = sinceMs != null ? `WHERE UNIX_TIMESTAMP(ps.START_DATE) * 1000 > ${sinceMs}` : '';
+  const query = `
+    SELECT
+      ps.ID,
+      ps.START_DATE,
+      ps.END_DATE
+    FROM PLAYLIST_SHOW ps
+    ${filter}
+    ORDER BY ps.ID ASC;
+  `;
+  const raw = await legacyDB.send(query);
+  if (raw.trim().length === 0) return [];
+
+  const rows: LegacyShowRow[] = [];
+  for (const line of raw.trim().split('\n')) {
+    const cols = parseTabRow(line, 3);
+    if (!cols) continue;
+    rows.push({
+      id: Number(cols[0]),
+      startTime: cols[1],
+      endTime: toNullable(cols[2]),
+    });
+  }
+  return rows;
+};
+
+export const fetchLegacyEntries = async (sinceMs: number | null): Promise<LegacyEntryRow[]> => {
+  const filter = sinceMs != null ? `WHERE UNIX_TIMESTAMP(pe.TIME_PLAYED) * 1000 > ${sinceMs}` : '';
+  const query = `
+    SELECT
+      pe.ID,
+      pe.PLAYLIST_SHOW_ID,
+      pe.ENTRY_TYPE,
+      REPLACE(REPLACE(IFNULL(pe.ARTIST_NAME, ''), '\\t', ' '), '\\n', ' '),
+      REPLACE(REPLACE(IFNULL(pe.ALBUM_TITLE, ''), '\\t', ' '), '\\n', ' '),
+      REPLACE(REPLACE(IFNULL(pe.SONG_TITLE, ''), '\\t', ' '), '\\n', ' '),
+      REPLACE(REPLACE(IFNULL(pe.LABEL, ''), '\\t', ' '), '\\n', ' '),
+      REPLACE(REPLACE(IFNULL(pe.MESSAGE, ''), '\\t', ' '), '\\n', ' '),
+      pe.REQUEST_FLAG,
+      pe.PLAY_ORDER,
+      pe.TIME_PLAYED
+    FROM PLAYLIST_ENTRY pe
+    ${filter}
+    ORDER BY pe.ID ASC;
+  `;
+  const raw = await legacyDB.send(query);
+  if (raw.trim().length === 0) return [];
+
+  const rows: LegacyEntryRow[] = [];
+  for (const line of raw.trim().split('\n')) {
+    const cols = parseTabRow(line, 11);
+    if (!cols) {
+      console.warn('[flowsheet-etl] Skipping malformed entry row:', line);
+      continue;
+    }
+    rows.push({
+      id: Number(cols[0]),
+      showId: Number(cols[1]),
+      entryType: Number(cols[2]) || 0,
+      artistName: toNullable(cols[3]),
+      albumTitle: toNullable(cols[4]),
+      trackTitle: toNullable(cols[5]),
+      label: toNullable(cols[6]),
+      message: toNullable(cols[7]),
+      requestFlag: Number(cols[8]) || 0,
+      playOrder: Number(cols[9]) || 0,
+      timePlayed: cols[10],
+    });
+  }
+  return rows;
+};
+
+export const closeLegacyConnection = () => {
+  legacyDB.close();
+};

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -1,0 +1,247 @@
+/**
+ * Flowsheet ETL: Import and sync flowsheet data from tubafrenzy.
+ *
+ * Two modes:
+ * - Bulk load: Parse a mysqldump file and insert shows + entries in batches
+ * - Incremental: Query tubafrenzy via MirrorSQL for new data since last run
+ *
+ * Usage:
+ *   node dist/job.js /path/to/dump.sql [--force]   # bulk load
+ *   node dist/job.js                                # incremental sync
+ */
+
+import { readFileSync } from 'fs';
+import { eq, sql } from 'drizzle-orm';
+import { db, shows, flowsheet, cronjob_runs, closeDatabaseConnection } from '@wxyc/database';
+import { parseInsertLine } from './parse-dump.js';
+import { transformShow, transformEntry, mapEntryType, truncate, parseMySQLDatetime } from './transform.js';
+import { fetchLegacyShows, fetchLegacyEntries, closeLegacyConnection } from './fetch-legacy.js';
+
+const JOB_NAME = 'flowsheet-etl';
+const BATCH_SIZE = 5000;
+
+const getLastRunTimestamp = async (): Promise<number | null> => {
+  const response = await db
+    .select({ lastRun: cronjob_runs.last_run })
+    .from(cronjob_runs)
+    .where(eq(cronjob_runs.job_name, JOB_NAME))
+    .limit(1);
+  const lastRun = response[0]?.lastRun ?? null;
+  return lastRun ? lastRun.getTime() : null;
+};
+
+const updateLastRun = async (timestamp: Date) => {
+  await db
+    .insert(cronjob_runs)
+    .values({ job_name: JOB_NAME, last_run: timestamp })
+    .onConflictDoUpdate({
+      target: cronjob_runs.job_name,
+      set: { last_run: timestamp },
+    });
+};
+
+/**
+ * Reset PostgreSQL sequences after a bulk load so that new inserts
+ * get IDs greater than the imported data.
+ */
+const resetSequences = async () => {
+  await db.execute(
+    sql`SELECT setval(pg_get_serial_sequence('wxyc_schema.shows', 'id'), COALESCE((SELECT MAX(id) FROM wxyc_schema.shows), 0) + 1, false)`
+  );
+  await db.execute(
+    sql`SELECT setval(pg_get_serial_sequence('wxyc_schema.flowsheet', 'id'), COALESCE((SELECT MAX(id) FROM wxyc_schema.flowsheet), 0) + 1, false)`
+  );
+  await db.execute(
+    sql`SELECT setval(pg_get_serial_sequence('wxyc_schema.flowsheet', 'play_order'), COALESCE((SELECT MAX(play_order) FROM wxyc_schema.flowsheet), 0) + 1, false)`
+  );
+  console.log('[flowsheet-etl] Reset sequences to max(id)+1.');
+};
+
+// ---- Bulk Load Mode ----
+
+const runBulkLoad = async (dumpPath: string) => {
+  console.log(`[flowsheet-etl] Bulk load from: ${dumpPath}`);
+  const content = readFileSync(dumpPath, 'utf-8');
+  const lines = content.split('\n');
+
+  let showCount = 0;
+  let entryCount = 0;
+  const pendingEntries: Array<{
+    legacy_entry_id: number;
+    show_id: number;
+    entry_type: string;
+    artist_name: string | null;
+    album_title: string | null;
+    track_title: string | null;
+    record_label: string | null;
+    message: string | null;
+    request_flag: boolean;
+    play_order: number;
+    add_time: Date;
+  }> = [];
+
+  // Pass 1: Import shows
+  console.log('[flowsheet-etl] Pass 1: Importing shows...');
+  for (const line of lines) {
+    const parsed = parseInsertLine(line);
+    if (!parsed || parsed.table !== 'PLAYLIST_SHOW') continue;
+
+    for (const tuple of parsed.tuples) {
+      const show = transformShow(tuple as [number, string, string | null]);
+      if (!show) continue;
+
+      await db
+        .insert(shows)
+        .values({
+          legacy_show_id: show.legacy_show_id,
+          start_time: show.start_time,
+          end_time: show.end_time,
+        })
+        .onConflictDoNothing();
+      showCount++;
+    }
+  }
+  console.log(`[flowsheet-etl] Imported ${showCount} shows.`);
+
+  // Build show mapping: legacy_show_id -> backend show id
+  const showRows = await db.select({ id: shows.id, legacyId: shows.legacy_show_id }).from(shows);
+  const showIdMap = new Map<number, number>();
+  for (const row of showRows) {
+    if (row.legacyId != null) {
+      showIdMap.set(row.legacyId, row.id);
+    }
+  }
+
+  // Pass 2: Import entries
+  console.log('[flowsheet-etl] Pass 2: Importing entries...');
+  for (const line of lines) {
+    const parsed = parseInsertLine(line);
+    if (!parsed || parsed.table !== 'PLAYLIST_ENTRY') continue;
+
+    for (const tuple of parsed.tuples) {
+      const entry = transformEntry(tuple);
+      if (!entry) continue;
+
+      const backendShowId = showIdMap.get(entry.legacy_show_id);
+
+      pendingEntries.push({
+        legacy_entry_id: entry.legacy_entry_id,
+        show_id: backendShowId ?? 0,
+        entry_type: entry.entry_type,
+        artist_name: entry.artist_name,
+        album_title: entry.album_title,
+        track_title: entry.track_title,
+        record_label: entry.record_label,
+        message: entry.message,
+        request_flag: entry.request_flag,
+        play_order: entry.play_order,
+        add_time: entry.add_time,
+      });
+
+      if (pendingEntries.length >= BATCH_SIZE) {
+        await db.insert(flowsheet).values(pendingEntries).onConflictDoNothing();
+        entryCount += pendingEntries.length;
+        pendingEntries.length = 0;
+        if (entryCount % 50000 === 0) {
+          console.log(`[flowsheet-etl] ...${entryCount} entries processed.`);
+        }
+      }
+    }
+  }
+
+  // Flush remaining entries
+  if (pendingEntries.length > 0) {
+    await db.insert(flowsheet).values(pendingEntries).onConflictDoNothing();
+    entryCount += pendingEntries.length;
+  }
+
+  console.log(`[flowsheet-etl] Imported ${entryCount} entries.`);
+  await resetSequences();
+};
+
+// ---- Incremental Sync Mode ----
+
+const runIncremental = async () => {
+  const runStartedAt = new Date();
+  const lastRunMs = await getLastRunTimestamp();
+
+  // Sync shows
+  const legacyShows = await fetchLegacyShows(lastRunMs);
+  let showsImported = 0;
+  for (const show of legacyShows) {
+    const startTime = parseMySQLDatetime(show.startTime);
+    const endTime = show.endTime ? parseMySQLDatetime(show.endTime) : null;
+    if (!startTime) continue;
+
+    await db
+      .insert(shows)
+      .values({
+        legacy_show_id: show.id,
+        start_time: startTime,
+        end_time: endTime,
+      })
+      .onConflictDoNothing();
+    showsImported++;
+  }
+
+  // Build show mapping
+  const showRows = await db.select({ id: shows.id, legacyId: shows.legacy_show_id }).from(shows);
+  const showIdMap = new Map<number, number>();
+  for (const row of showRows) {
+    if (row.legacyId != null) {
+      showIdMap.set(row.legacyId, row.id);
+    }
+  }
+
+  // Sync entries
+  const legacyEntries = await fetchLegacyEntries(lastRunMs);
+  let entriesImported = 0;
+  for (const entry of legacyEntries) {
+    const addTime = parseMySQLDatetime(entry.timePlayed);
+    if (!addTime) continue;
+
+    const backendShowId = showIdMap.get(entry.showId);
+
+    await db
+      .insert(flowsheet)
+      .values({
+        legacy_entry_id: entry.id,
+        show_id: backendShowId ?? null,
+        entry_type: mapEntryType(entry.entryType),
+        artist_name: truncate(entry.artistName, 128),
+        album_title: truncate(entry.albumTitle, 128),
+        track_title: truncate(entry.trackTitle, 128),
+        record_label: truncate(entry.label, 128),
+        message: truncate(entry.message, 250),
+        request_flag: entry.requestFlag === 1,
+        play_order: entry.playOrder,
+        add_time: addTime,
+      })
+      .onConflictDoNothing();
+    entriesImported++;
+  }
+
+  await updateLastRun(runStartedAt);
+  console.log(`[flowsheet-etl] Incremental sync: ${showsImported} shows, ${entriesImported} entries.`);
+};
+
+// ---- Main ----
+
+const run = async () => {
+  try {
+    const dumpPath = process.argv[2];
+    if (dumpPath && !dumpPath.startsWith('--')) {
+      await runBulkLoad(dumpPath);
+    } else {
+      await runIncremental();
+    }
+  } finally {
+    await closeDatabaseConnection();
+    closeLegacyConnection();
+  }
+};
+
+run().catch((error) => {
+  console.error('[flowsheet-etl] Failed:', error);
+  process.exitCode = 1;
+});

--- a/jobs/flowsheet-etl/package.json
+++ b/jobs/flowsheet-etl/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wxyc/flowsheet-etl",
+  "cron-schedule": "*/30 * * * *",
+  "version": "1.0.0",
+  "description": "WXYC Flowsheet ETL: Import and sync flowsheet data from tubafrenzy",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_flowsheet_etl:ci -f ../../Dockerfile.flowsheet-etl ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.41.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/jobs/flowsheet-etl/parse-dump.ts
+++ b/jobs/flowsheet-etl/parse-dump.ts
@@ -1,0 +1,132 @@
+/**
+ * MySQL dump parser for the flowsheet ETL bulk load mode.
+ *
+ * Parses INSERT INTO statements from a mysqldump file, extracting tuple values.
+ * Handles MySQL-specific escaping: backslash escapes within single-quoted strings,
+ * NULL literals, and numeric values.
+ */
+
+type TupleValue = string | number | null;
+
+/**
+ * Parse a single value from a MySQL INSERT tuple.
+ * Advances the position past the value and returns the parsed result.
+ *
+ * Handles:
+ * - 'string' with \\, \', \n, \r, \t, \0 escapes
+ * - NULL literal
+ * - Numeric values (integers and floats)
+ */
+const parseValue = (line: string, start: number): { value: TupleValue; end: number } | null => {
+  if (start >= line.length) return null;
+  const ch = line[start];
+
+  // String literal
+  if (ch === "'") {
+    let i = start + 1;
+    let str = '';
+    while (i < line.length) {
+      if (line[i] === '\\') {
+        i++;
+        if (i >= line.length) break;
+        const escaped = line[i];
+        if (escaped === 'n') str += '\n';
+        else if (escaped === 'r') str += '\r';
+        else if (escaped === 't') str += '\t';
+        else if (escaped === '0') str += '\0';
+        else str += escaped; // \', \\, etc.
+        i++;
+      } else if (line[i] === "'") {
+        return { value: str, end: i + 1 };
+      } else {
+        str += line[i];
+        i++;
+      }
+    }
+    return null; // unterminated string
+  }
+
+  // NULL literal
+  if (line.slice(start, start + 4) === 'NULL') {
+    return { value: null, end: start + 4 };
+  }
+
+  // Numeric value
+  let i = start;
+  if (line[i] === '-') i++;
+  while (i < line.length && ((line[i] >= '0' && line[i] <= '9') || line[i] === '.')) {
+    i++;
+  }
+  if (i > start) {
+    const num = Number(line.slice(start, i));
+    return Number.isFinite(num) ? { value: num, end: i } : null;
+  }
+
+  return null;
+};
+
+/**
+ * Parse a single tuple from a MySQL INSERT VALUES clause.
+ * Example: (1,'hello',NULL,42)
+ *
+ * Returns the parsed values array and the position after the closing paren.
+ */
+export const parseTuple = (line: string, start: number): { values: TupleValue[]; end: number } | null => {
+  if (line[start] !== '(') return null;
+
+  const values: TupleValue[] = [];
+  let pos = start + 1;
+
+  while (pos < line.length) {
+    // Skip whitespace
+    while (pos < line.length && line[pos] === ' ') pos++;
+
+    if (line[pos] === ')') {
+      return { values, end: pos + 1 };
+    }
+
+    const result = parseValue(line, pos);
+    if (!result) return null;
+
+    values.push(result.value);
+    pos = result.end;
+
+    // Skip comma between values
+    while (pos < line.length && line[pos] === ' ') pos++;
+    if (line[pos] === ',') pos++;
+  }
+
+  return null; // unterminated tuple
+};
+
+/**
+ * Parse all tuples from a MySQL INSERT INTO line.
+ * Example: INSERT INTO `tablename` VALUES (1,'a',NULL),(2,'b',3);
+ *
+ * Returns the table name and array of tuple values.
+ */
+export const parseInsertLine = (line: string): { table: string; tuples: TupleValue[][] } | null => {
+  const match = line.match(/^INSERT INTO `([^`]+)` VALUES\s*/);
+  if (!match) return null;
+
+  const table = match[1];
+  const tuples: TupleValue[][] = [];
+  let pos = match[0].length;
+
+  while (pos < line.length) {
+    if (line[pos] === '(') {
+      const result = parseTuple(line, pos);
+      if (!result) break;
+      tuples.push(result.values);
+      pos = result.end;
+
+      // Skip comma or semicolon between tuples
+      while (pos < line.length && (line[pos] === ',' || line[pos] === ' ')) pos++;
+      if (line[pos] === ';') break;
+    } else {
+      break;
+    }
+  }
+
+  return tuples.length > 0 ? { table, tuples } : null;
+};

--- a/jobs/flowsheet-etl/transform.ts
+++ b/jobs/flowsheet-etl/transform.ts
@@ -1,0 +1,125 @@
+/**
+ * Data transformers for the flowsheet ETL.
+ *
+ * Maps tubafrenzy entry types and data shapes to Backend-Service schema.
+ * All functions are pure (no side effects) for easy testing.
+ */
+
+/**
+ * tubafrenzy entry_type codes:
+ *   0 = track
+ *   1 = show_start
+ *   2 = show_end
+ *   3 = breakpoint
+ *   4 = talkset
+ *   5 = dj_join
+ *   6 = dj_leave
+ *   7 = message (PSA, announcement)
+ *   8-10 = reserved (treated as message)
+ */
+type BackendEntryType =
+  | 'track'
+  | 'show_start'
+  | 'show_end'
+  | 'breakpoint'
+  | 'talkset'
+  | 'dj_join'
+  | 'dj_leave'
+  | 'message';
+
+const ENTRY_TYPE_MAP: Record<number, BackendEntryType> = {
+  0: 'track',
+  1: 'show_start',
+  2: 'show_end',
+  3: 'breakpoint',
+  4: 'talkset',
+  5: 'dj_join',
+  6: 'dj_leave',
+  7: 'message',
+};
+
+export const mapEntryType = (legacyType: number): BackendEntryType => {
+  return ENTRY_TYPE_MAP[legacyType] ?? 'message';
+};
+
+/**
+ * Convert a MySQL DATETIME string (e.g. '2023-10-15 14:30:00') to a JS Date.
+ * tubafrenzy stores times in America/New_York.
+ * Returns null if the input is null, empty, or unparseable.
+ */
+export const parseMySQLDatetime = (datetime: string | null): Date | null => {
+  if (!datetime || datetime.trim().length === 0 || datetime === 'NULL') return null;
+  const date = new Date(datetime.trim().replace(' ', 'T') + '-04:00');
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+/**
+ * Truncate a string to a max length, returning null if empty.
+ * Matches the VARCHAR(128) / VARCHAR(250) limits in the schema.
+ */
+export const truncate = (value: string | null, maxLength: number): string | null => {
+  if (!value || value.trim().length === 0) return null;
+  const trimmed = value.trim();
+  return trimmed.length <= maxLength ? trimmed : trimmed.slice(0, maxLength);
+};
+
+export type TransformedShow = {
+  legacy_show_id: number;
+  start_time: Date;
+  end_time: Date | null;
+};
+
+export type TransformedEntry = {
+  legacy_entry_id: number;
+  legacy_show_id: number;
+  entry_type: BackendEntryType;
+  artist_name: string | null;
+  album_title: string | null;
+  track_title: string | null;
+  record_label: string | null;
+  message: string | null;
+  request_flag: boolean;
+  play_order: number;
+  add_time: Date;
+};
+
+/**
+ * Transform a raw show tuple from a MySQL dump into a TransformedShow.
+ * Expects columns: [id, start_time, end_time].
+ */
+export const transformShow = (row: [number, string, string | null]): TransformedShow | null => {
+  const startTime = parseMySQLDatetime(row[1]);
+  if (!startTime) return null;
+  return {
+    legacy_show_id: row[0],
+    start_time: startTime,
+    end_time: parseMySQLDatetime(row[2]),
+  };
+};
+
+/**
+ * Transform a raw entry tuple from a MySQL dump into a TransformedEntry.
+ * Expects columns from tubafrenzy PLAYLIST_ENTRY:
+ *   [id, show_id, entry_type, artist_name, album_title, track_title, label, message, request_flag, play_order, time_played]
+ */
+export const transformEntry = (row: (string | number | null)[]): TransformedEntry | null => {
+  if (row[0] == null || row[1] == null) return null;
+  const entryId = Number(row[0]);
+  const showId = Number(row[1]);
+  const addTime = parseMySQLDatetime(row[10] as string | null);
+  if (!addTime || !Number.isFinite(entryId) || !Number.isFinite(showId)) return null;
+
+  return {
+    legacy_entry_id: entryId,
+    legacy_show_id: showId,
+    entry_type: mapEntryType(Number(row[2]) || 0),
+    artist_name: truncate(row[3] as string | null, 128),
+    album_title: truncate(row[4] as string | null, 128),
+    track_title: truncate(row[5] as string | null, 128),
+    record_label: truncate(row[6] as string | null, 128),
+    message: truncate(row[7] as string | null, 250),
+    request_flag: row[8] === 1 || row[8] === '1' || row[8] === true,
+    play_order: Number(row[9]) || 0,
+    add_time: addTime,
+  };
+};

--- a/jobs/flowsheet-etl/tsconfig.json
+++ b/jobs/flowsheet-etl/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/flowsheet-etl/tsup.config.ts
+++ b/jobs/flowsheet-etl/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -669,6 +669,20 @@
       "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "license": "MIT"
     },
+    "jobs/flowsheet-etl": {
+      "name": "@wxyc/flowsheet-etl",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.41.0"
+      }
+    },
     "jobs/library-etl": {
       "name": "@wxyc/library-etl",
       "version": "1.0.0",
@@ -7315,6 +7329,10 @@
     },
     "node_modules/@wxyc/database": {
       "resolved": "shared/database",
+      "link": true
+    },
+    "node_modules/@wxyc/flowsheet-etl": {
+      "resolved": "jobs/flowsheet-etl",
       "link": true
     },
     "node_modules/@wxyc/library-etl": {

--- a/shared/database/src/migrations/0034_legacy_id_columns.sql
+++ b/shared/database/src/migrations/0034_legacy_id_columns.sql
@@ -1,0 +1,14 @@
+-- Add legacy ID columns for ETL deduplication between Backend-Service and tubafrenzy.
+-- These map tubafrenzy primary keys to Backend-Service records for idempotent imports.
+
+-- library.legacy_release_id — maps tubafrenzy LIBRARY_RELEASE.ID
+ALTER TABLE "wxyc_schema"."library" ADD COLUMN "legacy_release_id" integer;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "library_legacy_release_id_idx" ON "wxyc_schema"."library" USING btree ("legacy_release_id");--> statement-breakpoint
+
+-- flowsheet.legacy_entry_id — deduplication key for flowsheet entries
+ALTER TABLE "wxyc_schema"."flowsheet" ADD COLUMN "legacy_entry_id" integer;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "flowsheet_legacy_entry_id_idx" ON "wxyc_schema"."flowsheet" USING btree ("legacy_entry_id");--> statement-breakpoint
+
+-- shows.legacy_show_id — deduplication key for shows
+ALTER TABLE "wxyc_schema"."shows" ADD COLUMN "legacy_show_id" integer;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "shows_legacy_show_id_idx" ON "wxyc_schema"."shows" USING btree ("legacy_show_id");

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1775084400000,
       "tag": "0032_audit_f19_f20",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1775095000000,
+      "tag": "0034_legacy_id_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -255,6 +255,7 @@ export const library = wxyc_schema.table(
     code_volume_letters: varchar('code_volume_letters', { length: 4 }),
     disc_quantity: smallint('disc_quantity').default(1).notNull(),
     plays: integer('plays').default(0).notNull(),
+    legacy_release_id: integer('legacy_release_id'),
     add_date: timestamp('add_date', { withTimezone: true }).defaultNow().notNull(),
     last_modified: timestamp('last_modified', { withTimezone: true }).defaultNow().notNull(),
   },
@@ -264,6 +265,7 @@ export const library = wxyc_schema.table(
       genreIdIdx: index('genre_id_idx').on(table.genre_id),
       formatIdIdx: index('format_id_idx').on(table.format_id),
       artistIdIdx: index('artist_id_idx').on(table.artist_id),
+      legacyReleaseIdIdx: uniqueIndex('library_legacy_release_id_idx').on(table.legacy_release_id),
     };
   }
 );
@@ -302,23 +304,28 @@ export const rotation = wxyc_schema.table(
 
 export type NewFSEntry = InferInsertModel<typeof flowsheet>;
 export type FSEntry = InferSelectModel<typeof flowsheet>;
-export const flowsheet = wxyc_schema.table('flowsheet', {
-  id: serial('id').primaryKey(),
-  show_id: integer('show_id').references(() => shows.id, { onDelete: 'set null' }),
-  album_id: integer('album_id').references(() => library.id, { onDelete: 'set null' }),
-  rotation_id: integer('rotation_id').references(() => rotation.id, { onDelete: 'set null' }),
-  entry_type: flowsheetEntryTypeEnum('entry_type').notNull().default('track'),
-  track_title: varchar('track_title', { length: 128 }),
-  album_title: varchar('album_title', { length: 128 }),
-  artist_name: varchar('artist_name', { length: 128 }),
-  record_label: varchar('record_label', { length: 128 }),
-  label_id: integer('label_id').references(() => labels.id),
-  play_order: integer('play_order').notNull(),
-  request_flag: boolean('request_flag').default(false).notNull(),
-  segue: boolean('segue').default(false).notNull(),
-  message: varchar('message', { length: 250 }),
-  add_time: timestamp('add_time', { withTimezone: true }).defaultNow().notNull(),
-});
+export const flowsheet = wxyc_schema.table(
+  'flowsheet',
+  {
+    id: serial('id').primaryKey(),
+    show_id: integer('show_id').references(() => shows.id, { onDelete: 'set null' }),
+    album_id: integer('album_id').references(() => library.id, { onDelete: 'set null' }),
+    rotation_id: integer('rotation_id').references(() => rotation.id, { onDelete: 'set null' }),
+    legacy_entry_id: integer('legacy_entry_id'),
+    entry_type: flowsheetEntryTypeEnum('entry_type').notNull().default('track'),
+    track_title: varchar('track_title', { length: 128 }),
+    album_title: varchar('album_title', { length: 128 }),
+    artist_name: varchar('artist_name', { length: 128 }),
+    record_label: varchar('record_label', { length: 128 }),
+    label_id: integer('label_id').references(() => labels.id),
+    play_order: integer('play_order').notNull(),
+    request_flag: boolean('request_flag').default(false).notNull(),
+    segue: boolean('segue').default(false).notNull(),
+    message: varchar('message', { length: 250 }),
+    add_time: timestamp('add_time', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [uniqueIndex('flowsheet_legacy_entry_id_idx').on(table.legacy_entry_id)]
+);
 
 export type NewGenre = InferInsertModel<typeof genres>;
 export type Genre = InferSelectModel<typeof genres>;
@@ -416,15 +423,19 @@ export const artist_crossreference = wxyc_schema.table(
 
 export type NewShow = InferInsertModel<typeof shows>;
 export type Show = InferSelectModel<typeof shows>;
-export const shows = wxyc_schema.table('shows', {
-  id: serial('id').primaryKey(),
-  primary_dj_id: varchar('primary_dj_id', { length: 255 }).references(() => user.id, { onDelete: 'set null' }),
-  specialty_id: integer('specialty_id') //Null for regular shows
-    .references(() => specialty_shows.id),
-  show_name: varchar('show_name', { length: 128 }), //Null if not provided or specialty show
-  start_time: timestamp('start_time', { withTimezone: true }).defaultNow().notNull(),
-  end_time: timestamp('end_time', { withTimezone: true }),
-});
+export const shows = wxyc_schema.table(
+  'shows',
+  {
+    id: serial('id').primaryKey(),
+    primary_dj_id: varchar('primary_dj_id', { length: 255 }).references(() => user.id, { onDelete: 'set null' }),
+    specialty_id: integer('specialty_id').references(() => specialty_shows.id),
+    legacy_show_id: integer('legacy_show_id'),
+    show_name: varchar('show_name', { length: 128 }),
+    start_time: timestamp('start_time', { withTimezone: true }).defaultNow().notNull(),
+    end_time: timestamp('end_time', { withTimezone: true }),
+  },
+  (table) => [uniqueIndex('shows_legacy_show_id_idx').on(table.legacy_show_id)]
+);
 
 export type NewShowDJ = InferInsertModel<typeof show_djs>;
 export type ShowDJ = InferSelectModel<typeof show_djs>;

--- a/tests/unit/database/schema.legacy-ids.test.ts
+++ b/tests/unit/database/schema.legacy-ids.test.ts
@@ -1,0 +1,29 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('schema: legacy ID columns for ETL deduplication', () => {
+  const schemaPath = path.resolve(__dirname, '../../../shared/database/src/schema.ts');
+  const schemaSource = fs.readFileSync(schemaPath, 'utf-8');
+
+  const extractTableDef = (tableName: string): string => {
+    const regex = new RegExp(`export const ${tableName}\\b[\\s\\S]*?^\\);`, 'm');
+    const match = schemaSource.match(regex);
+    if (!match) throw new Error(`Table definition for ${tableName} not found in schema`);
+    return match[0];
+  };
+
+  it('library table should have legacy_release_id column', () => {
+    const def = extractTableDef('library');
+    expect(def).toContain('legacy_release_id');
+  });
+
+  it('flowsheet table should have legacy_entry_id column', () => {
+    const def = extractTableDef('flowsheet');
+    expect(def).toContain('legacy_entry_id');
+  });
+
+  it('shows table should have legacy_show_id column', () => {
+    const def = extractTableDef('shows');
+    expect(def).toContain('legacy_show_id');
+  });
+});

--- a/tests/unit/jobs/flowsheet-etl/parse-dump.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/parse-dump.test.ts
@@ -1,0 +1,106 @@
+import { parseTuple, parseInsertLine } from '../../../../jobs/flowsheet-etl/parse-dump';
+
+describe('flowsheet-etl parse-dump', () => {
+  describe('parseTuple', () => {
+    it('parses a simple tuple with string, number, and NULL', () => {
+      const result = parseTuple("(1,'hello',NULL)", 0);
+      expect(result).toEqual(expect.objectContaining({ values: [1, 'hello', null] }));
+    });
+
+    it('handles escaped single quotes', () => {
+      const result = parseTuple("('it\\'s a test')", 0);
+      expect(result).toEqual(expect.objectContaining({ values: ["it's a test"] }));
+    });
+
+    it('handles escaped backslashes', () => {
+      const result = parseTuple("('path\\\\to\\\\file')", 0);
+      expect(result).toEqual(expect.objectContaining({ values: ['path\\to\\file'] }));
+    });
+
+    it('handles escaped newlines and tabs', () => {
+      const result = parseTuple("('line1\\nline2\\ttab')", 0);
+      expect(result).toEqual(expect.objectContaining({ values: ['line1\nline2\ttab'] }));
+    });
+
+    it('handles negative numbers', () => {
+      const result = parseTuple('(-42)', 0);
+      expect(result).toEqual(expect.objectContaining({ values: [-42] }));
+    });
+
+    it('handles decimal numbers', () => {
+      const result = parseTuple('(3.14)', 0);
+      expect(result).toEqual(expect.objectContaining({ values: [3.14] }));
+    });
+
+    it('handles empty string', () => {
+      const result = parseTuple("('')", 0);
+      expect(result).toEqual(expect.objectContaining({ values: [''] }));
+    });
+
+    it('returns null for unterminated tuple', () => {
+      expect(parseTuple("(1,'hello'", 0)).toBeNull();
+    });
+
+    it('parses tuple starting at non-zero offset', () => {
+      const result = parseTuple("xxx(42,'test')", 3);
+      expect(result).toEqual(expect.objectContaining({ values: [42, 'test'] }));
+    });
+
+    it('returns end position after closing paren', () => {
+      const result = parseTuple("(1,'a'),rest", 0);
+      expect(result).toEqual(expect.objectContaining({ end: 7 }));
+    });
+  });
+
+  describe('parseInsertLine', () => {
+    it('parses a single-tuple INSERT line', () => {
+      const result = parseInsertLine(
+        "INSERT INTO `PLAYLIST_SHOW` VALUES (1,'2023-10-15 20:00:00','2023-10-15 22:00:00');"
+      );
+      expect(result).toEqual({
+        table: 'PLAYLIST_SHOW',
+        tuples: [[1, '2023-10-15 20:00:00', '2023-10-15 22:00:00']],
+      });
+    });
+
+    it('parses a multi-tuple INSERT line', () => {
+      const line =
+        "INSERT INTO `PLAYLIST_ENTRY` VALUES (1,10,0,'Autechre','Confield','VI Scose Poise','Warp',NULL,0,1,'2023-10-15 20:05:00'),(2,10,0,'Cat Power','Moon Pix','American Flag','Matador Records',NULL,0,2,'2023-10-15 20:10:00');";
+      const result = parseInsertLine(line);
+      expect(result).toEqual(
+        expect.objectContaining({
+          table: 'PLAYLIST_ENTRY',
+          tuples: expect.arrayContaining([
+            expect.arrayContaining([1, 10, 0, 'Autechre']),
+            expect.arrayContaining([2, 10, 0, 'Cat Power']),
+          ]),
+        })
+      );
+      expect(result?.tuples).toHaveLength(2);
+    });
+
+    it('returns null for non-INSERT lines', () => {
+      expect(parseInsertLine('-- This is a comment')).toBeNull();
+      expect(parseInsertLine('CREATE TABLE `foo` ...')).toBeNull();
+      expect(parseInsertLine('')).toBeNull();
+    });
+
+    it('handles strings with commas inside', () => {
+      const line = "INSERT INTO `test` VALUES (1,'hello, world');";
+      const result = parseInsertLine(line);
+      expect(result?.tuples[0]).toEqual([1, 'hello, world']);
+    });
+
+    it('handles strings with parentheses inside', () => {
+      const line = "INSERT INTO `test` VALUES (1,'value (with parens)');";
+      const result = parseInsertLine(line);
+      expect(result?.tuples[0]).toEqual([1, 'value (with parens)']);
+    });
+
+    it('handles NULL values correctly', () => {
+      const line = "INSERT INTO `test` VALUES (1,NULL,NULL,'text');";
+      const result = parseInsertLine(line);
+      expect(result?.tuples[0]).toEqual([1, null, null, 'text']);
+    });
+  });
+});

--- a/tests/unit/jobs/flowsheet-etl/transform.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/transform.test.ts
@@ -1,4 +1,10 @@
-import { mapEntryType, parseMySQLDatetime, truncate, transformShow, transformEntry } from '../../../../jobs/flowsheet-etl/transform';
+import {
+  mapEntryType,
+  parseMySQLDatetime,
+  truncate,
+  transformShow,
+  transformEntry,
+} from '../../../../jobs/flowsheet-etl/transform';
 
 describe('flowsheet-etl transform', () => {
   describe('mapEntryType', () => {
@@ -97,17 +103,17 @@ describe('flowsheet-etl transform', () => {
   describe('transformEntry', () => {
     const makeRow = (overrides: Partial<Record<number, string | number | null>> = {}) => {
       const base: (string | number | null)[] = [
-        100,                         // 0: id
-        42,                          // 1: show_id
-        0,                           // 2: entry_type (track)
-        'Autechre',                  // 3: artist_name
-        'Confield',                  // 4: album_title
-        'VI Scose Poise',            // 5: track_title
-        'Warp',                      // 6: label
-        null,                        // 7: message
-        0,                           // 8: request_flag
-        1,                           // 9: play_order
-        '2023-10-15 20:05:00',       // 10: time_played
+        100, // 0: id
+        42, // 1: show_id
+        0, // 2: entry_type (track)
+        'Autechre', // 3: artist_name
+        'Confield', // 4: album_title
+        'VI Scose Poise', // 5: track_title
+        'Warp', // 6: label
+        null, // 7: message
+        0, // 8: request_flag
+        1, // 9: play_order
+        '2023-10-15 20:05:00', // 10: time_played
       ];
       for (const [idx, val] of Object.entries(overrides)) {
         base[Number(idx)] = val;

--- a/tests/unit/jobs/flowsheet-etl/transform.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/transform.test.ts
@@ -1,0 +1,175 @@
+import { mapEntryType, parseMySQLDatetime, truncate, transformShow, transformEntry } from '../../../../jobs/flowsheet-etl/transform';
+
+describe('flowsheet-etl transform', () => {
+  describe('mapEntryType', () => {
+    it.each([
+      [0, 'track'],
+      [1, 'show_start'],
+      [2, 'show_end'],
+      [3, 'breakpoint'],
+      [4, 'talkset'],
+      [5, 'dj_join'],
+      [6, 'dj_leave'],
+      [7, 'message'],
+    ] as const)('maps legacy code %d to "%s"', (code, expected) => {
+      expect(mapEntryType(code)).toBe(expected);
+    });
+
+    it.each([8, 9, 10, 99, -1])('maps unknown code %d to "message"', (code) => {
+      expect(mapEntryType(code)).toBe('message');
+    });
+  });
+
+  describe('parseMySQLDatetime', () => {
+    it('parses a standard MySQL datetime string', () => {
+      const result = parseMySQLDatetime('2023-10-15 14:30:00');
+      expect(result).toBeInstanceOf(Date);
+      expect(result?.toISOString()).toContain('2023-10-15');
+    });
+
+    it('returns null for null input', () => {
+      expect(parseMySQLDatetime(null)).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(parseMySQLDatetime('')).toBeNull();
+    });
+
+    it('returns null for "NULL"', () => {
+      expect(parseMySQLDatetime('NULL')).toBeNull();
+    });
+
+    it('returns null for unparseable string', () => {
+      expect(parseMySQLDatetime('not-a-date')).toBeNull();
+    });
+  });
+
+  describe('truncate', () => {
+    it('returns the string unchanged if within limit', () => {
+      expect(truncate('Autechre', 128)).toBe('Autechre');
+    });
+
+    it('truncates to max length', () => {
+      const long = 'A'.repeat(200);
+      expect(truncate(long, 128)).toHaveLength(128);
+    });
+
+    it('returns null for null input', () => {
+      expect(truncate(null, 128)).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(truncate('', 128)).toBeNull();
+    });
+
+    it('trims whitespace', () => {
+      expect(truncate('  Stereolab  ', 128)).toBe('Stereolab');
+    });
+  });
+
+  describe('transformShow', () => {
+    it('transforms a completed show', () => {
+      const result = transformShow([42, '2023-10-15 20:00:00', '2023-10-15 22:00:00']);
+      expect(result).toEqual(
+        expect.objectContaining({
+          legacy_show_id: 42,
+          start_time: expect.any(Date),
+          end_time: expect.any(Date),
+        })
+      );
+    });
+
+    it('transforms an active show (null end_time)', () => {
+      const result = transformShow([43, '2023-10-15 20:00:00', null]);
+      expect(result).toEqual(
+        expect.objectContaining({
+          legacy_show_id: 43,
+          end_time: null,
+        })
+      );
+    });
+
+    it('returns null for invalid start_time', () => {
+      expect(transformShow([44, 'invalid', null])).toBeNull();
+    });
+  });
+
+  describe('transformEntry', () => {
+    const makeRow = (overrides: Partial<Record<number, string | number | null>> = {}) => {
+      const base: (string | number | null)[] = [
+        100,                         // 0: id
+        42,                          // 1: show_id
+        0,                           // 2: entry_type (track)
+        'Autechre',                  // 3: artist_name
+        'Confield',                  // 4: album_title
+        'VI Scose Poise',            // 5: track_title
+        'Warp',                      // 6: label
+        null,                        // 7: message
+        0,                           // 8: request_flag
+        1,                           // 9: play_order
+        '2023-10-15 20:05:00',       // 10: time_played
+      ];
+      for (const [idx, val] of Object.entries(overrides)) {
+        base[Number(idx)] = val;
+      }
+      return base;
+    };
+
+    it('transforms a track entry', () => {
+      const result = transformEntry(makeRow());
+      expect(result).toEqual(
+        expect.objectContaining({
+          legacy_entry_id: 100,
+          legacy_show_id: 42,
+          entry_type: 'track',
+          artist_name: 'Autechre',
+          album_title: 'Confield',
+          track_title: 'VI Scose Poise',
+          record_label: 'Warp',
+          request_flag: false,
+          play_order: 1,
+        })
+      );
+    });
+
+    it('maps talkset entry type', () => {
+      expect(transformEntry(makeRow({ 2: 4 }))).toEqual(expect.objectContaining({ entry_type: 'talkset' }));
+    });
+
+    it('maps breakpoint entry type', () => {
+      expect(transformEntry(makeRow({ 2: 3 }))).toEqual(expect.objectContaining({ entry_type: 'breakpoint' }));
+    });
+
+    it('maps show_start entry type', () => {
+      expect(transformEntry(makeRow({ 2: 1 }))).toEqual(expect.objectContaining({ entry_type: 'show_start' }));
+    });
+
+    it('maps show_end entry type', () => {
+      expect(transformEntry(makeRow({ 2: 2 }))).toEqual(expect.objectContaining({ entry_type: 'show_end' }));
+    });
+
+    it('handles request_flag=1', () => {
+      expect(transformEntry(makeRow({ 8: 1 }))).toEqual(expect.objectContaining({ request_flag: true }));
+    });
+
+    it('truncates long artist names', () => {
+      const longName = 'A'.repeat(200);
+      const result = transformEntry(makeRow({ 3: longName }));
+      expect(result?.artist_name).toHaveLength(128);
+    });
+
+    it('truncates long messages', () => {
+      const longMsg = 'M'.repeat(300);
+      const result = transformEntry(makeRow({ 7: longMsg }));
+      expect(result?.message).toHaveLength(250);
+    });
+
+    it('returns null for missing time_played', () => {
+      expect(transformEntry(makeRow({ 10: null }))).toBeNull();
+    });
+
+    it('returns null for invalid entry id', () => {
+      expect(transformEntry(makeRow({ 0: null }))).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `legacy_release_id` (unique index) to `library`, `legacy_entry_id` to `flowsheet`, and `legacy_show_id` to `shows` for ETL deduplication between Backend-Service and tubafrenzy
- Add `@wxyc/flowsheet-etl` job with two modes:
  - **Bulk load**: `node dist/job.js /path/to/dump.sql` — parses mysqldump, imports ~71K shows (pass 1) then ~2.6M entries in batches of 5000 (pass 2), resets PG sequences
  - **Incremental sync**: `node dist/job.js` (cron `*/30 * * * *`) — queries tubafrenzy via MirrorSQL, deduplicates via legacy ID unique indexes
- MySQL dump parser handles backslash escapes, NULL literals, numeric values, multi-tuple INSERT lines
- Entry type mapper covers all tubafrenzy codes (0-10) to Backend-Service enum
- Hand-crafted migration `0034_legacy_id_columns.sql`

Closes #257

## Test plan
- [x] 16 parser tests: tuples with escapes, NULL, numbers, multi-tuple lines
- [x] 36 transform tests: all entry types, show transform, timestamp parsing, truncation
- [x] 3 schema tests: legacy ID columns exist
- [x] All 547 unit tests pass
- [x] Typecheck passes across all workspaces
- [x] Lint passes (0 errors)
- [ ] Bulk load dry run against local Postgres with dump file
- [ ] Spot check: show/entry counts, ordering, show-entry linkage
- [ ] Incremental dedup: run after bulk load, verify no re-imports
- [ ] Sequence check: insert new entry via Backend API after bulk load