### PR TITLE
Proxy controller: use LML streaming URLs instead of direct API calls

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -2,16 +2,14 @@
  * Proxy controller - thin HTTP layer over existing services.
  *
  * Four of the five handlers route through library-metadata-lookup (LML) for
- * Discogs data: searchArtwork, getAlbumMetadata, getArtistMetadata, and
- * resolveEntity. The Spotify track handler calls the Spotify API directly.
+ * Discogs data and enriched streaming URLs: searchArtwork, getAlbumMetadata,
+ * getArtistMetadata, and resolveEntity. The Spotify track handler calls the
+ * Spotify API directly (track-by-ID, a different use case from search).
  *
  * All handlers require `requireAnonymousAuth` + `proxyRateLimit` middleware
  * applied at the route level.
  */
 import { RequestHandler } from 'express';
-import { SpotifyProvider } from '../services/metadata/providers/spotify.provider.js';
-import { AppleMusicProvider } from '../services/metadata/providers/apple.provider.js';
-import { SearchUrlProvider } from '../services/metadata/providers/search-urls.provider.js';
 import { getArtworkFinder } from '../services/artwork/finder.js';
 import { classify as classifyNSFW } from '../services/artwork/nsfw.js';
 import {
@@ -21,8 +19,14 @@ import {
   resolveEntity as lmlResolveEntity,
   LmlClientError,
 } from '../services/lml/lml.client.js';
-import { SpotifyTokenResponse } from '../services/metadata/metadata.types.js';
 import { LRUCache } from 'lru-cache';
+
+/** Spotify OAuth2 token response. */
+interface SpotifyTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+}
 
 interface SpotifyTrackApiResponse {
   name: string;
@@ -32,11 +36,6 @@ interface SpotifyTrackApiResponse {
     images?: Array<{ url: string }>;
   };
 }
-
-// Reuse the existing singleton provider instances (non-Discogs)
-const spotify = new SpotifyProvider();
-const appleMusic = new AppleMusicProvider();
-const searchUrls = new SearchUrlProvider();
 
 // --- Query parameter types ---
 
@@ -173,8 +172,9 @@ export const searchArtwork: RequestHandler<object, unknown, unknown, ArtworkSear
 /**
  * GET /proxy/metadata/album
  *
- * Fetches album metadata from LML (Discogs search + release details), Spotify,
- * Apple Music, and search URL providers in parallel.
+ * Fetches album metadata from LML. The LML search response already includes
+ * enriched streaming URLs (Spotify, Apple Music, YouTube Music, Bandcamp,
+ * SoundCloud), so no direct calls to those APIs are needed.
  */
 export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMetadataQuery> = async (
   req,
@@ -189,22 +189,28 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   }
 
   try {
+    const metadata: Record<string, unknown> = {};
     const searchTerm = releaseTitle || trackTitle || '';
 
-    const [lmlSearchResult, spotifyUrl, appleMusicUrl] = await Promise.allSettled([
-      searchDiscogs(artistName, searchTerm || undefined),
-      spotify.getSpotifyUrl(artistName, releaseTitle, trackTitle),
-      appleMusic.getAppleMusicUrl(artistName, releaseTitle, trackTitle),
-    ]);
+    let lmlResults;
+    try {
+      lmlResults = await searchDiscogs(artistName, searchTerm || undefined);
+    } catch (searchError) {
+      console.warn('[ProxyController] LML search failed:', searchError);
+    }
 
-    const metadata: Record<string, unknown> = {};
-
-    // Extract Discogs data from LML search + release
-    if (lmlSearchResult.status === 'fulfilled' && lmlSearchResult.value.results.length > 0) {
-      const topResult = lmlSearchResult.value.results[0];
+    if (lmlResults && lmlResults.results.length > 0) {
+      const topResult = lmlResults.results[0];
       metadata.discogsReleaseId = topResult.release_id;
       metadata.discogsUrl = topResult.release_url;
       metadata.artworkUrl = topResult.artwork_url || undefined;
+
+      // Streaming URLs from LML enrichment
+      if (topResult.spotify_url) metadata.spotifyUrl = topResult.spotify_url;
+      if (topResult.apple_music_url) metadata.appleMusicUrl = topResult.apple_music_url;
+      if (topResult.youtube_music_url) metadata.youtubeMusicUrl = topResult.youtube_music_url;
+      if (topResult.bandcamp_url) metadata.bandcampUrl = topResult.bandcamp_url;
+      if (topResult.soundcloud_url) metadata.soundcloudUrl = topResult.soundcloud_url;
 
       // Fetch enriched release details
       try {
@@ -231,18 +237,12 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
       }
     }
 
-    if (spotifyUrl.status === 'fulfilled' && spotifyUrl.value) {
-      metadata.spotifyUrl = spotifyUrl.value;
-    }
-
-    if (appleMusicUrl.status === 'fulfilled' && appleMusicUrl.value) {
-      metadata.appleMusicUrl = appleMusicUrl.value;
-    }
-
-    const urls = searchUrls.getAllSearchUrls(artistName, releaseTitle, trackTitle);
-    metadata.youtubeMusicUrl = urls.youtubeMusicUrl;
-    metadata.bandcampUrl = urls.bandcampUrl;
-    metadata.soundcloudUrl = urls.soundcloudUrl;
+    // Fallback: construct search URLs for services without LML-provided URLs
+    const query = searchTerm ? `${artistName} ${searchTerm}` : artistName;
+    const encodedQuery = encodeURIComponent(query);
+    if (!metadata.youtubeMusicUrl) metadata.youtubeMusicUrl = `https://music.youtube.com/search?q=${encodedQuery}`;
+    if (!metadata.bandcampUrl) metadata.bandcampUrl = `https://bandcamp.com/search?q=${encodedQuery}`;
+    if (!metadata.soundcloudUrl) metadata.soundcloudUrl = `https://soundcloud.com/search?q=${encodedQuery}`;
 
     res.set('Cache-Control', 'private, max-age=600');
     res.status(200).json(metadata);

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -46,30 +46,12 @@ jest.mock('../../../apps/backend/services/artwork/finder', () => ({
   getArtworkFinder: () => ({ find: mockFind }),
 }));
 
-// Spotify and Apple Music providers (still used by getAlbumMetadata)
-const mockGetSpotifyUrl = jest.fn<() => Promise<string | null>>();
-
-jest.mock('../../../apps/backend/services/metadata/providers/spotify.provider', () => ({
-  SpotifyProvider: jest.fn().mockImplementation(() => ({
-    getSpotifyUrl: mockGetSpotifyUrl,
-  })),
-}));
-
-const mockGetAppleMusicUrl = jest.fn<() => Promise<string | null>>();
-
-jest.mock('../../../apps/backend/services/metadata/providers/apple.provider', () => ({
-  AppleMusicProvider: jest.fn().mockImplementation(() => ({
-    getAppleMusicUrl: mockGetAppleMusicUrl,
-  })),
-}));
-
-jest.mock('../../../apps/backend/services/metadata/providers/search-urls.provider', () => ({
-  SearchUrlProvider: jest.fn().mockImplementation(() => ({
-    getAllSearchUrls: (artist: string, _album?: string, _track?: string) => ({
-      youtubeMusicUrl: `https://music.youtube.com/search?q=${encodeURIComponent(artist)}`,
-      bandcampUrl: `https://bandcamp.com/search?q=${encodeURIComponent(artist)}`,
-      soundcloudUrl: `https://soundcloud.com/search?q=${encodeURIComponent(artist)}`,
-    }),
+// LRU cache mock (proxy controller uses it for artwork caching)
+jest.mock('lru-cache', () => ({
+  LRUCache: jest.fn().mockImplementation(() => ({
+    get: jest.fn(),
+    set: jest.fn(),
+    has: jest.fn().mockReturnValue(false),
   })),
 }));
 
@@ -225,7 +207,7 @@ describe('proxy.controller', () => {
       expect(res.status).toHaveBeenCalledWith(400);
     });
 
-    it('returns merged metadata from LML search + release + other providers', async () => {
+    it('returns merged metadata from LML search + release details', async () => {
       mockSearchDiscogs.mockResolvedValue({
         results: [
           {
@@ -235,6 +217,14 @@ describe('proxy.controller', () => {
             album: 'Confield',
             artist: 'Autechre',
             confidence: 0.95,
+            release_year: null,
+            artist_bio: null,
+            wikipedia_url: null,
+            spotify_url: 'https://open.spotify.com/album/abc',
+            apple_music_url: 'https://music.apple.com/album/xyz',
+            youtube_music_url: 'https://music.youtube.com/search?q=Autechre+Confield',
+            bandcamp_url: 'https://bandcamp.com/search?q=Autechre+Confield',
+            soundcloud_url: 'https://soundcloud.com/search?q=Autechre+Confield',
           },
         ],
         total: 1,
@@ -261,9 +251,6 @@ describe('proxy.controller', () => {
         artists: [{ artist_id: 3840, name: 'Autechre', join: '', role: null }],
       });
 
-      mockGetSpotifyUrl.mockResolvedValue('https://open.spotify.com/album/abc');
-      mockGetAppleMusicUrl.mockResolvedValue('https://music.apple.com/album/xyz');
-
       const req = {
         query: { artistName: 'Autechre', releaseTitle: 'Confield' },
       } as unknown as Request;
@@ -286,28 +273,32 @@ describe('proxy.controller', () => {
         { position: '1', title: 'VI Scose Poise', duration: '6:45' },
         { position: '2', title: 'Cfern', duration: '7:01' },
       ]);
+      // Streaming URLs from LML search results
       expect(result.spotifyUrl).toBe('https://open.spotify.com/album/abc');
       expect(result.appleMusicUrl).toBe('https://music.apple.com/album/xyz');
-      expect(result.youtubeMusicUrl).toContain('music.youtube.com');
-      expect(result.bandcampUrl).toContain('bandcamp.com');
-      expect(result.soundcloudUrl).toContain('soundcloud.com');
+      expect(result.youtubeMusicUrl).toBe('https://music.youtube.com/search?q=Autechre+Confield');
+      expect(result.bandcampUrl).toBe('https://bandcamp.com/search?q=Autechre+Confield');
+      expect(result.soundcloudUrl).toBe('https://soundcloud.com/search?q=Autechre+Confield');
       expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=600');
     });
 
-    it('returns partial metadata when LML search fails but other providers succeed', async () => {
+    it('returns fallback search URLs when LML search fails', async () => {
       mockSearchDiscogs.mockRejectedValue(new Error('LML down'));
-      mockGetSpotifyUrl.mockResolvedValue('https://open.spotify.com/track/abc');
-      mockGetAppleMusicUrl.mockResolvedValue(null);
 
-      const req = { query: { artistName: 'Test Artist' } } as unknown as Request;
+      const req = { query: { artistName: 'Test Artist', releaseTitle: 'Test Album' } } as unknown as Request;
       const res = createMockRes();
 
       await getAlbumMetadata(req, res as Response, mockNext);
 
       expect(res.status).toHaveBeenCalledWith(200);
       const result = (res.json as jest.Mock).mock.calls[0][0];
-      expect(result.spotifyUrl).toBe('https://open.spotify.com/track/abc');
       expect(result.discogsReleaseId).toBeUndefined();
+      expect(result.spotifyUrl).toBeUndefined();
+      expect(result.appleMusicUrl).toBeUndefined();
+      // Search URLs are always constructed as fallback
+      expect(result.youtubeMusicUrl).toContain('music.youtube.com');
+      expect(result.bandcampUrl).toContain('bandcamp.com');
+      expect(result.soundcloudUrl).toContain('soundcloud.com');
     });
 
     it('returns search-only metadata when release fetch fails', async () => {
@@ -320,6 +311,14 @@ describe('proxy.controller', () => {
             album: 'Moon Pix',
             artist: 'Cat Power',
             confidence: 0.9,
+            release_year: null,
+            artist_bio: null,
+            wikipedia_url: null,
+            spotify_url: 'https://open.spotify.com/album/moonpix',
+            apple_music_url: null,
+            youtube_music_url: null,
+            bandcamp_url: null,
+            soundcloud_url: null,
           },
         ],
         total: 1,
@@ -327,8 +326,6 @@ describe('proxy.controller', () => {
       });
 
       mockGetRelease.mockRejectedValue(new Error('Release fetch failed'));
-      mockGetSpotifyUrl.mockResolvedValue(null);
-      mockGetAppleMusicUrl.mockResolvedValue(null);
 
       const req = {
         query: { artistName: 'Cat Power', releaseTitle: 'Moon Pix' },
@@ -341,20 +338,19 @@ describe('proxy.controller', () => {
       const result = (res.json as jest.Mock).mock.calls[0][0];
       expect(result.discogsReleaseId).toBe(99999);
       expect(result.artworkUrl).toBe('https://i.discogs.com/art.jpg');
+      // Streaming URLs from search result still present
+      expect(result.spotifyUrl).toBe('https://open.spotify.com/album/moonpix');
       // No enriched fields since release fetch failed
       expect(result.genres).toBeUndefined();
       expect(result.tracklist).toBeUndefined();
     });
 
-    it('returns metadata when LML search returns empty results', async () => {
+    it('returns fallback search URLs when LML search returns empty results', async () => {
       mockSearchDiscogs.mockResolvedValue({
         results: [],
         total: 0,
         cached: false,
       });
-
-      mockGetSpotifyUrl.mockResolvedValue('https://open.spotify.com/track/xyz');
-      mockGetAppleMusicUrl.mockResolvedValue(null);
 
       const req = { query: { artistName: 'Obscure Artist', releaseTitle: 'Unknown Album' } } as unknown as Request;
       const res = createMockRes();
@@ -364,7 +360,13 @@ describe('proxy.controller', () => {
       expect(res.status).toHaveBeenCalledWith(200);
       const result = (res.json as jest.Mock).mock.calls[0][0];
       expect(result.discogsReleaseId).toBeUndefined();
-      expect(result.spotifyUrl).toBe('https://open.spotify.com/track/xyz');
+      expect(result.spotifyUrl).toBeUndefined();
+      expect(result.appleMusicUrl).toBeUndefined();
+      // Search URLs are constructed as fallback
+      expect(result.youtubeMusicUrl).toContain('music.youtube.com');
+      expect(result.youtubeMusicUrl).toContain('Obscure%20Artist');
+      expect(result.bandcampUrl).toContain('bandcamp.com');
+      expect(result.soundcloudUrl).toContain('soundcloud.com');
       expect(mockGetRelease).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary

- Remove direct `SpotifyProvider`, `AppleMusicProvider`, and `SearchUrlProvider` calls from the proxy controller's `getAlbumMetadata` handler
- Extract streaming URLs (Spotify, Apple Music, YouTube Music, Bandcamp, SoundCloud) from LML search results, which already include them
- Construct fallback search URLs inline when LML returns no results
- Move `SpotifyTokenResponse` interface inline into the controller (only remaining consumer)
- Update unit tests to verify streaming URLs come from LML results

Closes #286

## Test plan

- [x] All 29 proxy controller unit tests pass
- [x] Full unit test suite passes (392/394 — 2 pre-existing failures in `shared-type-compatibility.test.ts`)
- [ ] Integration tests with running LML service
- [ ] Manual: verify `/proxy/metadata/album` returns streaming URLs from LML

## What stays unchanged

- `getSpotifyTrack` — still calls Spotify directly (track-by-ID, not search)
- `searchArtwork`, `getArtistMetadata`, `resolveEntity` — no changes