### PR TITLE
Fix flowsheet ETL show_id FK violation and timezone handling

### DIFF
--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -68,7 +68,7 @@ const runBulkLoad = async (dumpPath: string) => {
   let entryCount = 0;
   const pendingEntries: Array<{
     legacy_entry_id: number;
-    show_id: number;
+    show_id: number | null;
     entry_type: string;
     artist_name: string | null;
     album_title: string | null;
@@ -126,7 +126,7 @@ const runBulkLoad = async (dumpPath: string) => {
 
       pendingEntries.push({
         legacy_entry_id: entry.legacy_entry_id,
-        show_id: backendShowId ?? 0,
+        show_id: backendShowId ?? null,
         entry_type: entry.entry_type,
         artist_name: entry.artist_name,
         album_title: entry.album_title,

--- a/jobs/flowsheet-etl/transform.ts
+++ b/jobs/flowsheet-etl/transform.ts
@@ -43,14 +43,45 @@ export const mapEntryType = (legacyType: number): BackendEntryType => {
 };
 
 /**
+ * Resolve the UTC offset for America/New_York at a given instant.
+ * Returns a string like "-05:00" (EST) or "-04:00" (EDT).
+ */
+const easternOffsetAt = (probeUtc: Date): string => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    timeZoneName: 'shortOffset',
+  }).formatToParts(probeUtc);
+  const tz = parts.find((p) => p.type === 'timeZoneName')?.value ?? 'GMT-5';
+  // tz is "GMT-5" or "GMT-4"; normalize to "-05:00" / "-04:00"
+  const hours = parseInt(tz.replace('GMT', ''), 10);
+  const sign = hours <= 0 ? '-' : '+';
+  return `${sign}${String(Math.abs(hours)).padStart(2, '0')}:00`;
+};
+
+/**
  * Convert a MySQL DATETIME string (e.g. '2023-10-15 14:30:00') to a JS Date.
- * tubafrenzy stores times in America/New_York.
+ * tubafrenzy stores times as America/New_York wall-clock values with no
+ * offset, so we determine whether EST or EDT applies for the given date and
+ * append the correct offset before parsing.
  * Returns null if the input is null, empty, or unparseable.
  */
 export const parseMySQLDatetime = (datetime: string | null): Date | null => {
   if (!datetime || datetime.trim().length === 0 || datetime === 'NULL') return null;
-  const date = new Date(datetime.trim().replace(' ', 'T') + '-04:00');
-  return Number.isNaN(date.getTime()) ? null : date;
+  const isoString = datetime.trim().replace(' ', 'T');
+  // First pass: treat the wall-clock time as UTC to probe the Eastern offset
+  const probeUtc = new Date(isoString + 'Z');
+  if (Number.isNaN(probeUtc.getTime())) return null;
+  const offset1 = easternOffsetAt(probeUtc);
+  const date1 = new Date(isoString + offset1);
+  // Second pass: the first result is the true UTC instant (within 1 hour);
+  // re-probe to handle the edge case near DST transitions where the UTC
+  // probe date falls on the wrong side of the boundary.
+  const offset2 = easternOffsetAt(date1);
+  if (offset2 !== offset1) {
+    const date2 = new Date(isoString + offset2);
+    return Number.isNaN(date2.getTime()) ? null : date2;
+  }
+  return Number.isNaN(date1.getTime()) ? null : date1;
 };
 
 /**

--- a/tests/unit/jobs/flowsheet-etl/transform.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/transform.test.ts
@@ -33,6 +33,39 @@ describe('flowsheet-etl transform', () => {
       expect(result?.toISOString()).toContain('2023-10-15');
     });
 
+    it('applies EDT offset (-04:00) for summer dates', () => {
+      // July 4 is always EDT (UTC-4)
+      const result = parseMySQLDatetime('2023-07-04 12:00:00');
+      expect(result).toBeInstanceOf(Date);
+      // 12:00 EDT = 16:00 UTC
+      expect(result?.toISOString()).toBe('2023-07-04T16:00:00.000Z');
+    });
+
+    it('applies EST offset (-05:00) for winter dates', () => {
+      // January 15 is always EST (UTC-5)
+      const result = parseMySQLDatetime('2023-01-15 12:00:00');
+      expect(result).toBeInstanceOf(Date);
+      // 12:00 EST = 17:00 UTC
+      expect(result?.toISOString()).toBe('2023-01-15T17:00:00.000Z');
+    });
+
+    it('handles the spring-forward DST transition date', () => {
+      // March 12, 2023: clocks spring forward at 2:00 AM ET
+      // 1:00 AM is still EST (UTC-5)
+      const beforeSpring = parseMySQLDatetime('2023-03-12 01:00:00');
+      expect(beforeSpring?.toISOString()).toBe('2023-03-12T06:00:00.000Z');
+      // 3:00 AM is EDT (UTC-4)
+      const afterSpring = parseMySQLDatetime('2023-03-12 03:00:00');
+      expect(afterSpring?.toISOString()).toBe('2023-03-12T07:00:00.000Z');
+    });
+
+    it('handles the fall-back DST transition date', () => {
+      // November 5, 2023: clocks fall back at 2:00 AM ET
+      // 12:00 PM is EST (UTC-5) after the transition
+      const result = parseMySQLDatetime('2023-11-05 12:00:00');
+      expect(result?.toISOString()).toBe('2023-11-05T17:00:00.000Z');
+    });
+
     it('returns null for null input', () => {
       expect(parseMySQLDatetime(null)).toBeNull();
     });


### PR DESCRIPTION
## Summary

- Change `show_id: backendShowId ?? 0` to `?? null` in bulk load path (FK violation fix)
- Replace hardcoded `-04:00` EDT offset with dynamic EST/EDT resolution using `Intl.DateTimeFormat`
- Add tests for summer (EDT), winter (EST), spring-forward, and fall-back DST transitions

Closes #295

## Test plan

- [x] Unit test: July date uses EDT offset (UTC-4)
- [x] Unit test: January date uses EST offset (UTC-5)
- [x] Unit test: Spring-forward transition date (March 12, 2023)
- [x] Unit test: Fall-back transition date (November 5, 2023)
- [x] Full ETL test suite passes (56 tests)