### PR TITLE
Add change-email OTP test and document ETL env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,18 @@ GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:
 - `SLACK_WXYC_REQUESTS_CLIENT_SECRET`, `SLACK_WXYC_REQUESTS_SIGNING_SECRET`
 - `SLACK_WXYC_REQUESTS_WEBHOOK`
 
+### ETL Jobs
+
+The library ETL (`scripts/run-library-etl.sh`) syncs the music library from the legacy MySQL database into PostgreSQL. It requires the standard database variables above plus these for SSH tunneling to the legacy server:
+
+- `SSH_HOST` -- Hostname of the legacy server
+- `SSH_USERNAME` -- SSH login username
+- `SSH_PASSWORD` -- SSH login password
+- `REMOTE_DB_HOST` -- MySQL host on the legacy server (typically `localhost` from inside the tunnel)
+- `REMOTE_DB_USER` -- MySQL username
+- `REMOTE_DB_PASSWORD` -- MySQL password
+- `REMOTE_DB_NAME` -- MySQL database name
+
 ## Relationship to Other Repos
 
 - **[dj-site](https://github.com/WXYC/dj-site)** -- React frontend that consumes this API

--- a/tests/unit/authentication/email-otp.test.ts
+++ b/tests/unit/authentication/email-otp.test.ts
@@ -98,6 +98,11 @@ describe('Email OTP', () => {
         expectedSubject: 'Your WXYC password reset code',
         expectedIntro: 'Use this code to reset your password.',
       },
+      {
+        type: 'change-email' as const,
+        expectedSubject: 'Your WXYC email change code',
+        expectedIntro: 'Use this code to confirm your email change.',
+      },
     ])(
       'should send $type OTP email with correct subject and content',
       async ({ type, expectedSubject, expectedIntro }) => {


### PR DESCRIPTION
## Summary

- Add `change-email` to the parameterized OTP email test cases (was handled in code but untested)
- Document ETL SSH/MySQL environment variables in CLAUDE.md

Closes #297

## Test plan

- [x] OTP email test suite passes with 10 tests (was 9)
- [x] Full unit test suite passes