### PR TITLE
Fix playlist proxy to use flowsheet table instead of deleted album_metadata

### DIFF
--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -3,7 +3,7 @@
  *
  * Subscribes to tubafrenzy's SSE stream at /playlists/recentStream, maintains
  * an in-memory copy of the current playlist, and enriches playcuts with
- * artwork URLs from the album_metadata table. Client requests are served
+ * artwork URLs from the flowsheet table. Client requests are served
  * instantly from memory via getRecentEntries().
  *
  * Exported API:
@@ -19,12 +19,19 @@
  *   resetState()              — clear in-memory store (tests only)
  */
 import { EventSource } from 'eventsource';
-import { db, album_metadata } from '@wxyc/database';
-import { inArray } from 'drizzle-orm';
-import { generateAlbumCacheKey } from './metadata/metadata.cache.js';
+import { db, flowsheet } from '@wxyc/database';
+import { sql, inArray, isNotNull } from 'drizzle-orm';
 
 const TUBAFRENZY_URL = process.env.TUBAFRENZY_URL ?? 'https://www.wxyc.info';
 const MAX_ENTRIES = 200;
+
+/** Compute a normalized lookup key from artist and album for matching against flowsheet rows. */
+function lookupKey(artist: string, album: string): string {
+  return `${artist.toLowerCase().trim()}-${album.toLowerCase().trim()}`;
+}
+
+/** SQL expression that computes the same lookup key from flowsheet columns. */
+const flowsheetLookupKey = sql<string>`lower(trim(${flowsheet.artist_name})) || '-' || lower(trim(coalesce(${flowsheet.album_title}, '')))`;
 
 // --- Types ---
 
@@ -288,36 +295,37 @@ export function processDeletedEvent(data: string): void {
 // --- Enrichment ---
 
 /**
- * Batch-enrich all playcut entries with artwork URLs from album_metadata.
+ * Batch-enrich all playcut entries with artwork URLs from the flowsheet table.
  */
 async function enrichPlaycuts(): Promise<void> {
   const playcutEntries = entries.filter((e) => e.entryType === 'playcut' && e.playcut);
   if (playcutEntries.length === 0) return;
 
-  const cacheKeyToIds = new Map<string, number[]>();
+  const keyToIds = new Map<string, number[]>();
   for (const entry of playcutEntries) {
-    const key = generateAlbumCacheKey(entry.playcut!.artistName, entry.playcut!.releaseTitle);
-    const ids = cacheKeyToIds.get(key) ?? [];
+    const key = lookupKey(entry.playcut!.artistName, entry.playcut!.releaseTitle);
+    const ids = keyToIds.get(key) ?? [];
     ids.push(entry.id);
-    cacheKeyToIds.set(key, ids);
+    keyToIds.set(key, ids);
   }
 
-  const cacheKeys = [...cacheKeyToIds.keys()];
+  const keys = [...keyToIds.keys()];
 
   try {
     const rows = await db
       .select({
-        cache_key: album_metadata.cache_key,
-        artwork_url: album_metadata.artwork_url,
+        key: flowsheetLookupKey,
+        artwork_url: flowsheet.artwork_url,
       })
-      .from(album_metadata)
-      .where(inArray(album_metadata.cache_key, cacheKeys));
+      .from(flowsheet)
+      .where(inArray(flowsheetLookupKey, keys))
+      .groupBy(flowsheetLookupKey, flowsheet.artwork_url);
 
     // Build new map and only swap on success — preserves existing artwork on DB failure
     const newMap = new Map<number, string>();
     for (const row of rows) {
-      if (row.cache_key && row.artwork_url) {
-        const entryIds = cacheKeyToIds.get(row.cache_key);
+      if (row.key && row.artwork_url) {
+        const entryIds = keyToIds.get(row.key);
         if (entryIds) {
           for (const id of entryIds) {
             newMap.set(id, row.artwork_url);
@@ -334,21 +342,19 @@ async function enrichPlaycuts(): Promise<void> {
 }
 
 /**
- * Enrich a single playcut entry with artwork from album_metadata.
+ * Enrich a single playcut entry with artwork from the flowsheet table.
  */
 async function enrichSinglePlaycut(entry: TubafrenzyEntry): Promise<void> {
   if (!entry.playcut) return;
 
-  const cacheKey = generateAlbumCacheKey(entry.playcut.artistName, entry.playcut.releaseTitle);
+  const key = lookupKey(entry.playcut.artistName, entry.playcut.releaseTitle);
 
   try {
     const rows = await db
-      .select({
-        cache_key: album_metadata.cache_key,
-        artwork_url: album_metadata.artwork_url,
-      })
-      .from(album_metadata)
-      .where(inArray(album_metadata.cache_key, [cacheKey]));
+      .select({ artwork_url: flowsheet.artwork_url })
+      .from(flowsheet)
+      .where(inArray(flowsheetLookupKey, [key]))
+      .limit(1);
 
     if (rows.length > 0 && rows[0].artwork_url) {
       artworkMap.set(entry.id, rows[0].artwork_url);

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the playlist proxy service.
  *
  * Tests SSE event parsing, in-memory store management, and artwork
- * enrichment from album_metadata. The EventSource connection is mocked;
+ * enrichment from the flowsheet table. The EventSource connection is mocked;
  * only the pure logic is exercised here.
  */
 import { jest } from '@jest/globals';
@@ -13,31 +13,41 @@ import { jest } from '@jest/globals';
 const mockSelect = jest.fn();
 const mockFrom = jest.fn();
 const mockWhere = jest.fn();
+const mockGroupBy = jest.fn();
+const mockLimit = jest.fn();
 
 const mockDbChain = {
   select: mockSelect,
   from: mockFrom,
   where: mockWhere,
+  groupBy: mockGroupBy,
+  limit: mockLimit,
 };
 mockSelect.mockReturnValue(mockDbChain);
 mockFrom.mockReturnValue(mockDbChain);
-mockWhere.mockResolvedValue([]);
+mockWhere.mockReturnValue(mockDbChain);
+mockGroupBy.mockResolvedValue([]);
+mockLimit.mockResolvedValue([]);
 
 jest.mock('@wxyc/database', () => ({
   db: {
     select: (...args: unknown[]) => mockSelect(...args),
     from: (...args: unknown[]) => mockFrom(...args),
     where: (...args: unknown[]) => mockWhere(...args),
+    groupBy: (...args: unknown[]) => mockGroupBy(...args),
+    limit: (...args: unknown[]) => mockLimit(...args),
   },
-  album_metadata: {
-    cache_key: 'cache_key',
+  flowsheet: {
+    artist_name: 'artist_name',
+    album_title: 'album_title',
     artwork_url: 'artwork_url',
   },
 }));
 
 jest.mock('drizzle-orm', () => ({
-  eq: jest.fn(),
+  sql: Object.assign(jest.fn(), { raw: jest.fn() }),
   inArray: jest.fn(),
+  isNotNull: jest.fn(),
 }));
 
 // Mock EventSource — we do not want to open real SSE connections in tests.
@@ -136,7 +146,9 @@ describe('playlist-proxy.service', () => {
     // Reset the db chain mocks
     mockSelect.mockReturnValue(mockDbChain);
     mockFrom.mockReturnValue(mockDbChain);
-    mockWhere.mockResolvedValue([]);
+    mockWhere.mockReturnValue(mockDbChain);
+    mockGroupBy.mockResolvedValue([]); // batch enrichment default
+    mockLimit.mockResolvedValue([]); // single enrichment default
   });
 
   describe('isConnected', () => {
@@ -218,8 +230,8 @@ describe('playlist-proxy.service', () => {
     });
 
     it('enriches playcuts with artwork from DB', async () => {
-      mockWhere.mockResolvedValue([
-        { cache_key: 'nina simone-best of', artwork_url: 'https://i.discogs.com/nina.jpg' },
+      mockGroupBy.mockResolvedValue([
+        { key: 'nina simone-best of', artwork_url: 'https://i.discogs.com/nina.jpg' },
       ]);
 
       await processInitEvent(JSON.stringify([ninaSimoneEntry]));
@@ -229,7 +241,7 @@ describe('playlist-proxy.service', () => {
     });
 
     it('handles entries with no metadata match (artworkURL omitted)', async () => {
-      mockWhere.mockResolvedValue([]);
+      mockGroupBy.mockResolvedValue([]);
 
       await processInitEvent(JSON.stringify([ninaSimoneEntry]));
 
@@ -239,14 +251,14 @@ describe('playlist-proxy.service', () => {
 
     it('preserves existing artwork when DB fails on re-init', async () => {
       // First init succeeds with artwork
-      mockWhere.mockResolvedValue([
-        { cache_key: 'nina simone-best of', artwork_url: 'https://i.discogs.com/nina.jpg' },
+      mockGroupBy.mockResolvedValue([
+        { key: 'nina simone-best of', artwork_url: 'https://i.discogs.com/nina.jpg' },
       ]);
       await processInitEvent(JSON.stringify([ninaSimoneEntry]));
       expect(getRecentEntries(50).playcuts[0].artworkURL).toBe('https://i.discogs.com/nina.jpg');
 
       // Second init: DB fails — existing artwork should be preserved
-      mockWhere.mockRejectedValue(new Error('DB connection lost'));
+      mockGroupBy.mockRejectedValue(new Error('DB connection lost'));
       await processInitEvent(JSON.stringify([ninaSimoneEntry]));
 
       const result = getRecentEntries(50);
@@ -299,7 +311,7 @@ describe('playlist-proxy.service', () => {
     it('enriches newly created playcuts with artwork', async () => {
       await processInitEvent(JSON.stringify([talksetEntry]));
 
-      mockWhere.mockResolvedValue([{ cache_key: 'juana molina-doga', artwork_url: 'https://i.discogs.com/juana.jpg' }]);
+      mockLimit.mockResolvedValue([{ artwork_url: 'https://i.discogs.com/juana.jpg' }]);
 
       await processCreatedEvent(JSON.stringify(juanaMolinaEntry));
 
@@ -359,8 +371,8 @@ describe('playlist-proxy.service', () => {
     it('enriches updated playcuts with artwork', async () => {
       await processInitEvent(JSON.stringify([ninaSimoneEntry]));
 
-      mockWhere.mockResolvedValue([
-        { cache_key: 'nina simone-best of', artwork_url: 'https://i.discogs.com/updated.jpg' },
+      mockLimit.mockResolvedValue([
+        { artwork_url: 'https://i.discogs.com/updated.jpg' },
       ]);
 
       await processUpdatedEvent(JSON.stringify(ninaSimoneEntry));


### PR DESCRIPTION
## Summary

- Rewrite playlist proxy enrichment to query the `flowsheet` table's inline `artwork_url` instead of the deleted `album_metadata` table
- Uses the same normalized key-based matching pattern but queries flowsheet directly
- Required because #305 removes the `album_metadata` table

Depends on #305 (must merge first).

## Test plan

- [ ] `npm run test:unit` — playlist proxy tests pass (22 tests, verified locally)
- [ ] CI passes after #305 merges