### PR TITLE
Fix: scope auth rate limiting to mutation endpoints only

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -120,7 +120,9 @@ const isTestEnv =
 if (isTestEnv) {
   app.use('/auth', toNodeHandler(auth));
 } else {
-  const authRateLimit = rateLimit({
+  // Strict limit for auth mutations vulnerable to brute-force attacks.
+  // These are the only endpoints that need tight rate limiting.
+  const authMutationRateLimit = rateLimit({
     windowMs: 15 * 60 * 1000,
     limit: 10,
     standardHeaders: 'draft-7',
@@ -128,7 +130,18 @@ if (isTestEnv) {
     message: { error: 'Too many requests, please try again later.' },
   });
 
-  app.use('/auth', authRateLimit, toNodeHandler(auth));
+  const rateLimitedPaths = [
+    '/auth/sign-in',
+    '/auth/sign-up',
+    '/auth/email-otp/send-verification-otp',
+    '/auth/forget-password',
+  ];
+
+  for (const path of rateLimitedPaths) {
+    app.use(path, authMutationRateLimit);
+  }
+
+  app.use('/auth', toNodeHandler(auth));
 }
 
 //endpoint for healthchecks

--- a/apps/backend/middleware/errorHandler.ts
+++ b/apps/backend/middleware/errorHandler.ts
@@ -3,14 +3,15 @@ import { Request, Response, NextFunction } from 'express';
 
 function errorHandler(err: any, req: Request, res: Response, next: NextFunction) {
   // prettier-ignore
-  const error = err instanceof Error 
-    ? err 
+  const error = err instanceof Error
+    ? err
     : new Error(String(err));
 
   if (error instanceof WxycError) {
+    console.error(`[${req.method} ${req.url}] WxycError ${error.statusCode}: ${error.message}`);
     res.status(error.statusCode).json({ message: error.message });
   } else {
-    console.error('Unhandled error:', error);
+    console.error(`[${req.method} ${req.url}] Unhandled error:`, error);
     res.status(500).json({ message: 'Internal server error' });
   }
 }

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -108,7 +108,7 @@ export const auth = betterAuth({
   advanced: {
     defaultCookieAttributes: {
       sameSite: (process.env.COOKIE_SAME_SITE as 'lax' | 'strict' | 'none') || 'lax',
-      secure: true,
+      secure: process.env.NODE_ENV === 'production',
     },
   },
 
@@ -125,31 +125,30 @@ export const auth = betterAuth({
       // Custom payload to include organization member role and capabilities
       jwt: {
         definePayload: async ({ user }) => {
-          // Query organization membership to get member role
-          if (user?.id) {
-            const memberRecord = await db
-              .select({ role: member.role })
-              .from(member)
-              .where(sql`${member.userId} = ${user.id}` as any)
-              .limit(1);
-
-            if (memberRecord.length > 0) {
-              // Cast user to access capabilities field
-              const userWithCapabilities = user as typeof user & {
-                capabilities?: string[] | null;
-              };
-              return {
-                ...user,
-                role: memberRecord[0].role, // Use organization member role instead of default user role
-                capabilities: userWithCapabilities.capabilities ?? [], // Include capabilities in JWT
-              };
-            }
-          }
-          // Fallback to default user data if no organization membership found
-          // Still include capabilities even without organization membership
           const userWithCapabilities = user as typeof user & {
             capabilities?: string[] | null;
           };
+          // Query organization membership to get member role
+          if (user?.id) {
+            try {
+              const memberRecord = await db
+                .select({ role: member.role })
+                .from(member)
+                .where(eq(member.userId, user.id))
+                .limit(1);
+
+              if (memberRecord.length > 0) {
+                return {
+                  ...user,
+                  role: memberRecord[0].role,
+                  capabilities: userWithCapabilities.capabilities ?? [],
+                };
+              }
+            } catch (error) {
+              console.error('[JWT] Failed to fetch member role:', error);
+            }
+          }
+          // Fallback: no organization membership or query failed
           return {
             ...user,
             capabilities: userWithCapabilities?.capabilities ?? [],

--- a/tests/unit/auth/rate-limiting.test.ts
+++ b/tests/unit/auth/rate-limiting.test.ts
@@ -12,10 +12,13 @@ describe('Auth service rate limiting', () => {
     expect(authAppSource).toMatch(/rateLimit\s*\(/);
   });
 
-  it('applies rate limiting to the auth handler in production', () => {
-    // The rate limiter is applied conditionally: skipped in test env, active otherwise.
-    // Verify the production branch wires authRateLimit before toNodeHandler(auth).
-    expect(authAppSource).toMatch(/authRateLimit,\s*toNodeHandler\s*\(\s*auth\s*\)/);
+  it('applies rate limiting to sensitive auth endpoints in production', () => {
+    // The rate limiter targets specific mutation paths, not all /auth routes.
+    expect(authAppSource).toMatch(/authMutationRateLimit/);
+    expect(authAppSource).toMatch(/\/auth\/sign-in/);
+    expect(authAppSource).toMatch(/\/auth\/sign-up/);
+    expect(authAppSource).toMatch(/\/auth\/email-otp\/send-verification-otp/);
+    expect(authAppSource).toMatch(/\/auth\/forget-password/);
   });
 
   it('disables rate limiting in test environments', () => {

--- a/tests/unit/middleware/errorHandler.test.ts
+++ b/tests/unit/middleware/errorHandler.test.ts
@@ -12,7 +12,7 @@ function mockResponse() {
   return { res, statusMock, jsonMock };
 }
 
-const mockReq = {} as Request;
+const mockReq = { method: 'GET', url: '/flowsheet/latest' } as Request;
 const mockNext = jest.fn() as NextFunction;
 
 describe('errorHandler middleware', () => {
@@ -52,7 +52,7 @@ describe('errorHandler middleware', () => {
 
     errorHandler(error, mockReq, res, mockNext);
 
-    expect(consoleSpy).toHaveBeenCalledWith('Unhandled error:', error);
+    expect(consoleSpy).toHaveBeenCalledWith('[GET /flowsheet/latest] Unhandled error:', error);
     consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- Replaces blanket rate limit on all `/auth/*` routes with targeted limits on sign-in, sign-up, OTP send, and password reset endpoints only
- Read-only endpoints (get-session, JWKS, token, healthcheck) are no longer rate-limited
- Disables secure cookie flag in local dev so session cookies work over plain HTTP
- Hardens JWT payload with error handling and type-safe queries
- Updates unit test assertions to verify the new targeted paths

Closes #310

## Context

The auth service applies a blanket rate limit of 10 requests per 15 minutes to all `/auth/*` routes. better-auth's `useSession()` hook fires `GET /auth/get-session` on page load and tab focus, consuming the budget before the DJ ever submits the login form. The first sign-in attempt returns 429.

## Test plan

- [ ] Unit tests pass (`npm run test:unit`)
- [ ] Verify first login attempt succeeds without 429