### PR TITLE
Fix: add missing Dockerfile.flowsheet-etl blocking all deploys

### DIFF
--- a/Dockerfile.flowsheet-etl
+++ b/Dockerfile.flowsheet-etl
@@ -1,0 +1,27 @@
+#Build stage
+FROM node:25-alpine AS builder
+
+WORKDIR /flowsheet-etl-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/flowsheet-etl ./jobs/flowsheet-etl
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/flowsheet-etl
+
+#Production stage
+FROM node:25-alpine AS prod
+
+WORKDIR /flowsheet-etl
+
+COPY ./package* ./
+COPY ./jobs/flowsheet-etl/package* ./jobs/flowsheet-etl/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./flowsheet-etl-builder/jobs/flowsheet-etl/dist ./jobs/flowsheet-etl/dist
+COPY --from=builder ./flowsheet-etl-builder/shared/database/dist ./shared/database/dist
+
+CMD ["npm", "start", "--workspace=@wxyc/flowsheet-etl"]


### PR DESCRIPTION
## Summary

- Adds `Dockerfile.flowsheet-etl` based on the existing `Dockerfile.library-etl` pattern
- Adds an "ensure ECR repository exists" step to the build job so new targets don't fail on first deploy

The `jobs/flowsheet-etl/` package was added to main on April 1 without its Dockerfile. Turborepo detects it as an affected target, the deploy matrix tries `docker build -f Dockerfile.flowsheet-etl`, and the missing file fails the entire pipeline — **blocking all deploys (backend, auth, everything) since April 2.**

The build job also assumed ECR repositories already existed, so even with the Dockerfile, the push would fail for any new target. The migrate job already had an auto-create step; the build job now uses the same pattern.

Closes #310

## Test plan

- [ ] CI passes
- [ ] Auto Build & Deploy workflow succeeds after merge