### PR TITLE
Fix: use rm -f in cron deploy cleanup

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -479,7 +479,7 @@ jobs:
             echo "CRONTAB:"
             crontab -l
 
-            rm crontab.txt
+            rm -f crontab.txt
 
       - name: Confirm server is up
         if: steps.deploy_vars.outputs.target_type == 'app'


### PR DESCRIPTION
## Summary

- Changes `rm crontab.txt` to `rm -f crontab.txt` in the cron deploy step

The cron deploy step runs with `set -e`. When `crontab.txt` doesn't exist at cleanup time, the `rm` fails and kills the job, which cancels all remaining deploy jobs (including auth and backend).

## Test plan

- [ ] Auto Build & Deploy succeeds after merge