### PR TITLE
fix: ETL bulk load timestamp fallback for START_TIME=0 entries

### DIFF
--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -153,9 +153,9 @@ const runBulkLoad = async (dumpPath: string) => {
 
     for (const tuple of parsed.tuples) {
       const addTime = resolveEntryTimestamp(
-        Number(tuple[10]) || 0,   // START_TIME
-        Number(tuple[17]) || 0,   // TIME_CREATED
-        Number(tuple[16]) || 0,   // TIME_LAST_MODIFIED
+        Number(tuple[10]) || 0, // START_TIME
+        Number(tuple[17]) || 0, // TIME_CREATED
+        Number(tuple[16]) || 0 // TIME_LAST_MODIFIED
       );
       if (!addTime) continue;
       const entryId = Number(tuple[0]);

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -16,7 +16,7 @@ import { readFileSync } from 'fs';
 import { eq, sql } from 'drizzle-orm';
 import { db, shows, flowsheet, cronjob_runs, closeDatabaseConnection } from '@wxyc/database';
 import { parseInsertLine } from './parse-dump.js';
-import { mapProdEntryType, epochMsToDate, parseShowEntryDJName, truncate } from './transform.js';
+import { mapProdEntryType, epochMsToDate, resolveEntryTimestamp, parseShowEntryDJName, truncate } from './transform.js';
 import { fetchLegacyShows, fetchLegacyEntries, closeLegacyConnection } from './fetch-legacy.js';
 
 const JOB_NAME = 'flowsheet-etl';
@@ -67,7 +67,7 @@ const resetSequences = async () => {
 const resolveArtistName = (rawArtistName: string | null, entryType: string): string | null => {
   if (!rawArtistName) return null;
   if (entryType === 'show_start' || entryType === 'show_end') {
-    return parseShowEntryDJName(rawArtistName) ?? truncate(rawArtistName, 128);
+    return truncate(parseShowEntryDJName(rawArtistName), 128) ?? truncate(rawArtistName, 128);
   }
   return truncate(rawArtistName, 128);
 };
@@ -152,7 +152,11 @@ const runBulkLoad = async (dumpPath: string) => {
     if (!parsed || parsed.table !== 'FLOWSHEET_ENTRY_PROD') continue;
 
     for (const tuple of parsed.tuples) {
-      const addTime = epochMsToDate(Number(tuple[10]) || 0);
+      const addTime = resolveEntryTimestamp(
+        Number(tuple[10]) || 0,   // START_TIME
+        Number(tuple[17]) || 0,   // TIME_CREATED
+        Number(tuple[16]) || 0,   // TIME_LAST_MODIFIED
+      );
       if (!addTime) continue;
       const entryId = Number(tuple[0]);
       const showId = Number(tuple[12]);

--- a/jobs/flowsheet-etl/transform.ts
+++ b/jobs/flowsheet-etl/transform.ts
@@ -131,7 +131,7 @@ export const epochMsToDate = (epochMs: number | null): Date | null => {
 export const resolveEntryTimestamp = (
   startTime: number | null,
   timeCreated: number | null,
-  timeLastModified: number | null,
+  timeLastModified: number | null
 ): Date | null => {
   return epochMsToDate(startTime) ?? epochMsToDate(timeCreated) ?? epochMsToDate(timeLastModified);
 };

--- a/jobs/flowsheet-etl/transform.ts
+++ b/jobs/flowsheet-etl/transform.ts
@@ -124,6 +124,19 @@ export const epochMsToDate = (epochMs: number | null): Date | null => {
 };
 
 /**
+ * Resolve the best available timestamp for a FLOWSHEET_ENTRY_PROD row.
+ * Prefers START_TIME (epoch ms), falls back to TIME_CREATED, then TIME_LAST_MODIFIED.
+ * Most track entries have START_TIME = 0, so the fallback is essential.
+ */
+export const resolveEntryTimestamp = (
+  startTime: number | null,
+  timeCreated: number | null,
+  timeLastModified: number | null,
+): Date | null => {
+  return epochMsToDate(startTime) ?? epochMsToDate(timeCreated) ?? epochMsToDate(timeLastModified);
+};
+
+/**
  * Extract the DJ name from a START/END OF SHOW message in FLOWSHEET_ENTRY_PROD.
  * These entries store structured text in the ARTIST_NAME column:
  *   "START OF SHOW: DJ Bluejay SIGNED ON at 12:03 PM (4/4/26)"

--- a/tests/unit/jobs/flowsheet-etl/transform.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/transform.test.ts
@@ -2,6 +2,7 @@ import {
   mapEntryType,
   mapProdEntryType,
   epochMsToDate,
+  resolveEntryTimestamp,
   parseShowEntryDJName,
   parseMySQLDatetime,
   truncate,
@@ -69,6 +70,40 @@ describe('flowsheet-etl transform', () => {
 
     it('returns null for NaN', () => {
       expect(epochMsToDate(NaN)).toBeNull();
+    });
+  });
+
+  describe('resolveEntryTimestamp', () => {
+    const VALID_MS = 1099537681134; // 2004-11-04T02:08:01.134Z
+    const CREATED_MS = 1099537727355;
+    const MODIFIED_MS = 1099537978522;
+
+    it('prefers START_TIME when available', () => {
+      const result = resolveEntryTimestamp(VALID_MS, CREATED_MS, MODIFIED_MS);
+      expect(result?.getTime()).toBe(VALID_MS);
+    });
+
+    it('falls back to TIME_CREATED when START_TIME is 0', () => {
+      const result = resolveEntryTimestamp(0, CREATED_MS, MODIFIED_MS);
+      expect(result?.getTime()).toBe(CREATED_MS);
+    });
+
+    it('falls back to TIME_CREATED when START_TIME is null', () => {
+      const result = resolveEntryTimestamp(null, CREATED_MS, MODIFIED_MS);
+      expect(result?.getTime()).toBe(CREATED_MS);
+    });
+
+    it('falls back to TIME_LAST_MODIFIED when both are 0', () => {
+      const result = resolveEntryTimestamp(0, 0, MODIFIED_MS);
+      expect(result?.getTime()).toBe(MODIFIED_MS);
+    });
+
+    it('returns null when all timestamps are 0', () => {
+      expect(resolveEntryTimestamp(0, 0, 0)).toBeNull();
+    });
+
+    it('returns null when all timestamps are null', () => {
+      expect(resolveEntryTimestamp(null, null, null)).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `resolveEntryTimestamp` that falls back from `START_TIME` to `TIME_CREATED` to `TIME_LAST_MODIFIED`, fixing the bulk load which was skipping ~94% of entries (~2.45M of ~2.6M) because most tracks have `START_TIME=0`
- Truncate DJ names returned by `parseShowEntryDJName` to 128 chars to prevent `varchar(128)` overflow errors during insert
- Add 6 unit tests covering all fallback scenarios for `resolveEntryTimestamp`

Closes #318

## Test plan

- [ ] Verify `resolveEntryTimestamp` unit tests pass (`npm test -- --testPathPattern transform.test`)
- [ ] Run full ETL bulk load against a staging database and confirm entry count is close to 2.6M
- [ ] Confirm no `value too long for type character varying(128)` errors during import