### PR TITLE
Fix critical memory leaks causing EC2 crashes

### DIFF
--- a/.github/actions/deploy-service/action.yml
+++ b/.github/actions/deploy-service/action.yml
@@ -71,7 +71,19 @@ runs:
           docker ps -a --filter "publish=$PUBLISH_PORT" --format "{{.ID}}" | xargs -r docker rm 
 
           echo "Starting new Docker container..."
-          docker run -d --name $TARGET_APP -p $PUBLISH_PORT:8080 --restart unless-stopped --env-file .env -e SENTRY_RELEASE=$TARGET_APP@$DEPLOY_TAG ${{ inputs.aws_ecr_uri }}/$TARGET_APP:$DEPLOY_TAG
+          docker run -d --name $TARGET_APP \
+            -p $PUBLISH_PORT:8080 \
+            --restart unless-stopped \
+            --memory=450m \
+            --env-file .env \
+            -e SENTRY_RELEASE=$TARGET_APP@$DEPLOY_TAG \
+            -e NODE_OPTIONS="--max-old-space-size=384" \
+            --health-cmd="wget -qO- http://localhost:8080/healthcheck || exit 1" \
+            --health-interval=30s \
+            --health-timeout=10s \
+            --health-retries=3 \
+            --health-start-period=30s \
+            ${{ inputs.aws_ecr_uri }}/$TARGET_APP:$DEPLOY_TAG
 
           echo "Cleaning up old Docker images..."
           docker images --format '{{.Repository}} {{.Tag}}' | \

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -10,6 +10,7 @@ import cors from 'cors';
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
+import { closeDatabaseConnection } from '@wxyc/database';
 
 const port = process.env.AUTH_PORT || '8080';
 
@@ -334,9 +335,23 @@ void (async () => {
   await createDefaultUser();
   await syncAdminRoles();
 
-  app.listen(parseInt(port), () => {
+  const server = app.listen(parseInt(port), () => {
     console.log(`listening on port: ${port}! (auth service)`);
   });
+
+  function shutdown(signal: string): void {
+    console.log(`[auth-shutdown] Received ${signal}, shutting down...`);
+    server.close(() => {
+      closeDatabaseConnection()
+        .then(() => process.exit(0))
+        .catch(() => process.exit(1));
+    });
+    setTimeout(() => server.closeAllConnections(), 5_000).unref();
+    setTimeout(() => process.exit(1), 10_000).unref();
+  }
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
 })();
 
 export default app;

--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -16,11 +16,12 @@ import { request_line_route } from './routes/requestLine.route.js';
 import { config_route } from './routes/config.route.js';
 import { proxy_route } from './routes/proxy.route.js';
 import { playlist_route } from './routes/playlist.route.js';
-import { startPlaylistProxy } from './services/playlist-proxy.service.js';
+import { startPlaylistProxy, stopPlaylistProxy } from './services/playlist-proxy.service.js';
 import { activeShow } from './middleware/checkActiveShow.js';
 import errorHandler from './middleware/errorHandler.js';
 import { requestIdMiddleware } from './middleware/requestId.js';
 import { requirePermissions } from '@wxyc/authentication';
+import { closeDatabaseConnection } from '@wxyc/database';
 
 const port = process.env.PORT || 8080;
 const app = express();
@@ -100,3 +101,35 @@ const server = app.listen(port, () => {
 });
 
 server.setTimeout(30000);
+
+// --- Memory monitoring ---
+
+const MEMORY_LOG_INTERVAL = 5 * 60 * 1000; // 5 minutes
+const memoryLogTimer = setInterval(() => {
+  const usage = process.memoryUsage();
+  console.log(
+    `[memory] rss=${(usage.rss / 1024 / 1024).toFixed(1)}MB heap=${(usage.heapUsed / 1024 / 1024).toFixed(1)}/${(usage.heapTotal / 1024 / 1024).toFixed(1)}MB`
+  );
+}, MEMORY_LOG_INTERVAL);
+memoryLogTimer.unref();
+
+// --- Graceful shutdown ---
+
+function shutdown(signal: string): void {
+  console.log(`[shutdown] Received ${signal}, shutting down...`);
+  stopPlaylistProxy();
+  server.close(() => {
+    closeDatabaseConnection()
+      .then(() => process.exit(0))
+      .catch(() => process.exit(1));
+  });
+  // Force-close lingering connections (SSE clients, slow requests)
+  setTimeout(() => {
+    console.warn('[shutdown] Force closing remaining connections');
+    server.closeAllConnections();
+  }, 5_000).unref();
+  setTimeout(() => process.exit(1), 10_000).unref();
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -72,7 +72,9 @@ interface CachedArtwork {
 }
 
 const artworkCache = new LRUCache<string, CachedArtwork>({
-  max: 500,
+  max: 200,
+  maxSize: 20 * 1024 * 1024, // 20MB total
+  sizeCalculation: (value) => value.data.byteLength,
   ttl: 1000 * 60 * 60, // 1 hour for positive results
 });
 

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -8,6 +8,7 @@
  *
  * Exported API:
  *   startPlaylistProxy() — open the SSE connection (call once at startup)
+ *   stopPlaylistProxy()  — close the SSE connection and cancel pending reconnects
  *   getRecentEntries(n)  — current enriched playlist, sliced to n entries
  *   isConnected()        — true once the init event has been processed
  *
@@ -170,18 +171,43 @@ export function resetState(): void {
   connected = false;
 }
 
+/**
+ * Close the SSE connection, cancel pending reconnects, and stop heartbeat monitoring.
+ */
+export function stopPlaylistProxy(): void {
+  console.log('[playlist-proxy] Stopping proxy...');
+  connected = false;
+  if (currentEventSource) {
+    currentEventSource.close();
+    currentEventSource = null;
+  }
+  clearHeartbeatTimer();
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+}
+
 // --- SSE connection ---
 
 let reconnectDelay = 1000;
 const MAX_RECONNECT_DELAY = 30000;
 let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
 const HEARTBEAT_TIMEOUT = 60000;
+let currentEventSource: EventSource | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 function connectSSE(): void {
   const url = `${TUBAFRENZY_URL}/playlists/recentStream`;
   console.log(`[playlist-proxy] Connecting to SSE: ${url}`);
 
+  if (currentEventSource) {
+    currentEventSource.close();
+    currentEventSource = null;
+  }
+
   const es = new EventSource(url);
+  currentEventSource = es;
 
   es.addEventListener('init', (event: MessageEvent) => {
     reconnectDelay = 1000; // reset backoff on successful connection
@@ -212,7 +238,10 @@ function connectSSE(): void {
     console.error(`[playlist-proxy] SSE error, reconnecting in ${reconnectDelay}ms`);
     clearHeartbeatTimer();
     es.close();
-    setTimeout(() => connectSSE(), reconnectDelay);
+    currentEventSource = null;
+    reconnectTimer = setTimeout(() => {
+      if (connected) connectSSE();
+    }, reconnectDelay);
     reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY);
   });
 }
@@ -222,7 +251,8 @@ function resetHeartbeatTimer(es: EventSource): void {
   heartbeatTimer = setTimeout(() => {
     console.warn('[playlist-proxy] Heartbeat timeout, reconnecting');
     es.close();
-    connectSSE();
+    currentEventSource = null;
+    if (connected) connectSSE();
   }, HEARTBEAT_TIMEOUT);
 }
 


### PR DESCRIPTION
## Summary

- Fix EventSource reconnection leak in playlist proxy by tracking the instance globally and closing before reconnect
- Cap artwork proxy LRUCache at 20MB total (was unbounded, up to ~250MB)
- Add SIGTERM/SIGINT graceful shutdown handlers to both backend and auth services
- Add Docker memory limits (450MB), V8 heap cap (384MB), and healthcheck to deploy action
- Add periodic memory usage logging for trend monitoring

Closes #319

## Test plan

- [x] All 653 unit tests pass (1 pre-existing failure in `cookie-config.test.ts` unrelated)
- [ ] After deploying, verify memory limits: `docker stats --no-stream`
- [ ] After deploying, verify healthcheck: `docker inspect backend --format '{{json .State.Health}}'`
- [ ] Monitor `[memory]` log lines for heap growth trends over 24 hours