### PR TITLE
Bidirectional continuous flowsheet sync with tubafrenzy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Express 5 application with these route groups:
 | `/schedule`     | Schedule management                               |
 | `/events`       | SSE for real-time updates                         |
 | `/healthcheck`  | Health check                                      |
+| `/internal`     | Internal endpoints (ETL sync notifications)       |
 
 Code is organized as controllers (HTTP handling) -> services (business logic) -> database (Drizzle queries).
 
@@ -267,7 +268,7 @@ GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:
 
 ### ETL Jobs
 
-The library ETL (`scripts/run-library-etl.sh`) syncs the music library from the legacy MySQL database into PostgreSQL. It requires the standard database variables above plus these for SSH tunneling to the legacy server:
+The library ETL (`scripts/run-library-etl.sh`) syncs the music library from the legacy MySQL database into PostgreSQL. The flowsheet ETL (`jobs/flowsheet-etl/`) syncs flowsheet entries and shows from tubafrenzy. Both require the standard database variables above plus these for SSH tunneling to the legacy server:
 
 - `SSH_HOST` -- Hostname of the legacy server
 - `SSH_USERNAME` -- SSH login username
@@ -276,6 +277,12 @@ The library ETL (`scripts/run-library-etl.sh`) syncs the music library from the 
 - `REMOTE_DB_USER` -- MySQL username
 - `REMOTE_DB_PASSWORD` -- MySQL password
 - `REMOTE_DB_NAME` -- MySQL database name
+
+The flowsheet ETL supports two run modes: one-shot (`npm start`) for cron invocation, and continuous polling (`npm run start:poll` or `node dist/job.js --poll`) for real-time sync. In polling mode, it queries tubafrenzy every `ETL_POLL_INTERVAL_MS` (default 30 seconds) for new or modified entries and upserts them into PostgreSQL. After importing changes, it notifies the Backend-Service via `POST /internal/flowsheet-sync-notify` so connected dj-site clients receive an SSE refetch event.
+
+- `ETL_POLL_INTERVAL_MS` -- Poll interval in milliseconds (default `30000`)
+- `BACKEND_SERVICE_URL` -- Backend-Service URL for SSE notifications (default `http://localhost:8080`)
+- `ETL_NOTIFY_KEY` -- Shared secret for the internal notification endpoint (required in production)
 
 ## Relationship to Other Repos
 

--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -14,6 +14,7 @@ import { schedule_route } from './routes/schedule.route.js';
 import { events_route } from './routes/events.route.js';
 import { request_line_route } from './routes/requestLine.route.js';
 import { config_route } from './routes/config.route.js';
+import { internal_route } from './routes/internal.route.js';
 import { proxy_route } from './routes/proxy.route.js';
 import { playlist_route } from './routes/playlist.route.js';
 import { startPlaylistProxy } from './services/playlist-proxy.service.js';
@@ -38,7 +39,7 @@ app.use(
   cors({
     origin: process.env.FRONTEND_SOURCE || '*',
     methods: ['GET', 'POST', 'DELETE', 'PATCH'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-Id'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-Id', 'X-Internal-Key'],
     exposedHeaders: ['X-Request-Id'],
     credentials: true,
   })
@@ -90,6 +91,9 @@ app.get('/testAuth', requirePermissions({ flowsheet: ['read'] }), async (req, re
 app.get('/healthcheck', async (req, res) => {
   res.json({ message: 'Healthy!' });
 });
+
+// Internal endpoints (ETL sync notifications, key-authenticated)
+app.use('/internal', internal_route);
 
 Sentry.setupExpressErrorHandler(app);
 app.use(errorHandler);

--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -286,10 +286,19 @@ const getAddEntrySQL = async (req: Request, entry: FSEntry) => {
 };
 
 export const addEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) => {
+  // Loop guard: entry imported from tubafrenzy by ETL — don't mirror back
+  if (entry.legacy_entry_id != null) return;
+
   const body = mapEntryToTubafrenzy(entry);
   const tubafrenzyId = await mirrorCreateEntry(body);
   if (tubafrenzyId != null) {
     cacheEntryId(entry.play_order, tubafrenzyId);
+    // Persist the mapping so the ETL can deduplicate
+    try {
+      await db.update(flowsheet).set({ legacy_entry_id: tubafrenzyId }).where(eq(flowsheet.id, entry.id));
+    } catch (e) {
+      console.error('[mirror] Failed to persist legacy_entry_id:', e);
+    }
   }
 });
 
@@ -297,9 +306,16 @@ export const updateEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entr
   // Message-only rows aren't updateable
   if (entry?.message && entry.message.trim() !== '') return;
 
-  const tubafrenzyId = getCachedEntryId(entry.play_order);
+  const cachedId = getCachedEntryId(entry.play_order);
+
+  // Loop guard: entry has a legacy ID but we didn't cache it this lifecycle —
+  // it was imported by the ETL, not created by our mirror. Don't mirror back.
+  if (cachedId == null && entry.legacy_entry_id != null) return;
+
+  // Use cache (fast path) or fall back to persisted legacy_entry_id (after restart)
+  const tubafrenzyId = cachedId ?? entry.legacy_entry_id;
   if (tubafrenzyId == null) {
-    console.warn('[mirror] No cached tubafrenzy ID for play_order', entry.play_order);
+    console.warn('[mirror] No tubafrenzy ID for play_order', entry.play_order);
     return;
   }
 

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
+
+const ETL_NOTIFY_KEY = process.env.ETL_NOTIFY_KEY ?? '';
+
+export const internal_route = Router();
+
+/**
+ * POST /internal/flowsheet-sync-notify
+ *
+ * Called by the flowsheet ETL after importing new or updated entries from
+ * tubafrenzy. Broadcasts a refetch event to all SSE clients subscribed to
+ * the liveFs topic so dj-site UIs stay in sync.
+ *
+ * Authenticated via a shared secret in the X-Internal-Key header.
+ */
+internal_route.post('/flowsheet-sync-notify', (req, res) => {
+  const key = req.get('X-Internal-Key');
+  if (!ETL_NOTIFY_KEY || key !== ETL_NOTIFY_KEY) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  serverEventsMgr.broadcast(Topics.liveFs, {
+    type: FsEvents.refetch,
+    payload: { source: 'etl' },
+  });
+
+  res.json({ ok: true });
+});

--- a/jobs/flowsheet-etl/fetch-legacy.ts
+++ b/jobs/flowsheet-etl/fetch-legacy.ts
@@ -13,6 +13,7 @@ export type LegacyShowRow = {
   startTime: number;
   endTime: number | null;
   showName: string | null;
+  timeLastModified: number;
 };
 
 export type LegacyEntryRow = {
@@ -26,37 +27,26 @@ export type LegacyEntryRow = {
   requestFlag: number;
   playOrder: number;
   startTime: number;
+  timeLastModified: number;
   segueFlag: number;
 };
 
-const parseTabRow = (line: string, columnCount: number) => {
+export const parseTabRow = (line: string, columnCount: number) => {
   const columns = line.split('\t');
   return columns.length === columnCount ? columns : null;
 };
 
-const toNullable = (value: string): string | null => {
+export const toNullable = (value: string): string | null => {
   const trimmed = value.trim();
   return trimmed.length === 0 || trimmed === 'NULL' ? null : trimmed;
 };
 
-export const fetchLegacyShows = async (sinceMs: number | null): Promise<LegacyShowRow[]> => {
-  const filter = sinceMs != null ? `WHERE rs.SIGNON_TIME > ${sinceMs}` : '';
-  const query = `
-    SELECT
-      rs.ID,
-      rs.SIGNON_TIME,
-      rs.SIGNOFF_TIME,
-      rs.SHOW_NAME
-    FROM FLOWSHEET_RADIO_SHOW_PROD rs
-    ${filter}
-    ORDER BY rs.ID ASC;
-  `;
-  const raw = await legacyDB.send(query);
+export const parseShowRows = (raw: string): LegacyShowRow[] => {
   if (raw.trim().length === 0) return [];
 
   const rows: LegacyShowRow[] = [];
   for (const line of raw.trim().split('\n')) {
-    const cols = parseTabRow(line, 4);
+    const cols = parseTabRow(line, 5);
     if (!cols) continue;
     const startTime = Number(cols[1]);
     if (!Number.isFinite(startTime) || startTime === 0) continue;
@@ -65,12 +55,39 @@ export const fetchLegacyShows = async (sinceMs: number | null): Promise<LegacySh
       startTime,
       endTime: Number(cols[2]) || null,
       showName: toNullable(cols[3]),
+      timeLastModified: Number(cols[4]) || 0,
     });
   }
   return rows;
 };
 
-const parseEntryRows = (raw: string, columnCount: number): LegacyEntryRow[] => {
+export const fetchLegacyShows = async (sinceMs: number | null): Promise<LegacyShowRow[]> => {
+  const filter = sinceMs != null ? `WHERE rs.SIGNON_TIME > ${sinceMs} OR rs.TIME_LAST_MODIFIED > ${sinceMs}` : '';
+  const query = `
+    SELECT
+      rs.ID,
+      rs.SIGNON_TIME,
+      rs.SIGNOFF_TIME,
+      rs.SHOW_NAME,
+      rs.TIME_LAST_MODIFIED
+    FROM FLOWSHEET_RADIO_SHOW_PROD rs
+    ${filter}
+    ORDER BY rs.ID ASC;
+  `;
+  const raw = await legacyDB.send(query);
+  return parseShowRows(raw);
+};
+
+/**
+ * Parse tab-separated entry rows. Column positions:
+ *   0: ID, 1: RADIO_SHOW_ID, 2: ENTRY_TYPE_CODE, 3: ARTIST_NAME,
+ *   4: RELEASE_TITLE, 5: SONG_TITLE, 6: LABEL_NAME, 7: REQUEST_FLAG,
+ *   8: SEQUENCE_WITHIN_SHOW, 9: START_TIME, 10: TIME_LAST_MODIFIED
+ *   [11: SEGUE_FLAG — optional]
+ *
+ * columnCount: 11 (without SEGUE_FLAG) or 12 (with)
+ */
+export const parseEntryRows = (raw: string, columnCount: number): LegacyEntryRow[] => {
   if (raw.trim().length === 0) return [];
 
   const rows: LegacyEntryRow[] = [];
@@ -91,7 +108,8 @@ const parseEntryRows = (raw: string, columnCount: number): LegacyEntryRow[] => {
       requestFlag: Number(cols[7]) || 0,
       playOrder: Number(cols[8]) || 0,
       startTime: Number(cols[9]),
-      segueFlag: columnCount >= 11 ? Number(cols[10]) || 0 : 0,
+      timeLastModified: Number(cols[10]) || 0,
+      segueFlag: columnCount >= 12 ? Number(cols[11]) || 0 : 0,
     });
   }
   return rows;
@@ -107,21 +125,22 @@ const BASE_ENTRY_COLUMNS = `
       REPLACE(REPLACE(IFNULL(fe.LABEL_NAME, ''), '\\t', ' '), '\\n', ' '),
       fe.REQUEST_FLAG,
       fe.SEQUENCE_WITHIN_SHOW,
-      fe.START_TIME`;
+      fe.START_TIME,
+      fe.TIME_LAST_MODIFIED`;
 
 export const fetchLegacyEntries = async (sinceMs: number | null): Promise<LegacyEntryRow[]> => {
-  const filter = sinceMs != null ? `WHERE fe.START_TIME > ${sinceMs}` : '';
+  const filter = sinceMs != null ? `WHERE fe.START_TIME > ${sinceMs} OR fe.TIME_LAST_MODIFIED > ${sinceMs}` : '';
 
   // Try with SEGUE_FLAG first; fall back without it if the column doesn't exist
   try {
     const queryWithSegue = `SELECT ${BASE_ENTRY_COLUMNS}, fe.SEGUE_FLAG FROM FLOWSHEET_ENTRY_PROD fe ${filter} ORDER BY fe.ID ASC;`;
     const raw = await legacyDB.send(queryWithSegue);
-    return parseEntryRows(raw, 11);
+    return parseEntryRows(raw, 12);
   } catch {
     console.warn('[flowsheet-etl] SEGUE_FLAG not available, defaulting to 0.');
     const queryWithout = `SELECT ${BASE_ENTRY_COLUMNS} FROM FLOWSHEET_ENTRY_PROD fe ${filter} ORDER BY fe.ID ASC;`;
     const raw = await legacyDB.send(queryWithout);
-    return parseEntryRows(raw, 10);
+    return parseEntryRows(raw, 11);
   }
 };
 

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -9,11 +9,12 @@
  *
  * Usage:
  *   node dist/job.js /path/to/dump.sql [--force]   # bulk load
- *   node dist/job.js                                # incremental sync
+ *   node dist/job.js                                # one-shot incremental sync
+ *   node dist/job.js --poll                         # continuous polling loop
  */
 
 import { readFileSync } from 'fs';
-import { eq, sql } from 'drizzle-orm';
+import { eq, isNotNull, sql } from 'drizzle-orm';
 import { db, shows, flowsheet, cronjob_runs, closeDatabaseConnection } from '@wxyc/database';
 import { parseInsertLine } from './parse-dump.js';
 import { mapProdEntryType, epochMsToDate, resolveEntryTimestamp, parseShowEntryDJName, truncate } from './transform.js';
@@ -204,7 +205,9 @@ const runBulkLoad = async (dumpPath: string) => {
 
 // ---- Incremental Sync Mode ----
 
-const runIncremental = async () => {
+type SyncResult = { showsImported: number; entriesImported: number; entriesUpdated: number };
+
+const runIncremental = async (): Promise<SyncResult> => {
   const runStartedAt = new Date();
   const lastRunMs = await getLastRunTimestamp();
 
@@ -237,9 +240,17 @@ const runIncremental = async () => {
     }
   }
 
-  // Sync entries
+  // Collect existing legacy IDs to distinguish inserts from updates
+  const existingIds = new Set(
+    (
+      await db.select({ lid: flowsheet.legacy_entry_id }).from(flowsheet).where(isNotNull(flowsheet.legacy_entry_id))
+    ).map((r) => r.lid)
+  );
+
+  // Sync entries (upsert: insert new, update display fields on conflict)
   const legacyEntries = await fetchLegacyEntries(lastRunMs);
   let entriesImported = 0;
+  let entriesUpdated = 0;
   for (const entry of legacyEntries) {
     const addTime = epochMsToDate(entry.startTime);
     if (!addTime) continue;
@@ -263,21 +274,94 @@ const runIncremental = async () => {
         play_order: entry.playOrder,
         add_time: addTime,
       })
-      .onConflictDoNothing();
-    entriesImported++;
+      .onConflictDoUpdate({
+        target: flowsheet.legacy_entry_id,
+        set: {
+          artist_name: sql`excluded.artist_name`,
+          album_title: sql`excluded.album_title`,
+          track_title: sql`excluded.track_title`,
+          record_label: sql`excluded.record_label`,
+          request_flag: sql`excluded.request_flag`,
+          segue: sql`excluded.segue`,
+          entry_type: sql`excluded.entry_type`,
+        },
+      });
+
+    if (existingIds.has(entry.id)) {
+      entriesUpdated++;
+    } else {
+      entriesImported++;
+    }
   }
 
   await updateLastRun(runStartedAt);
-  console.log(`[flowsheet-etl] Incremental sync: ${showsImported} shows, ${entriesImported} entries.`);
+  const parts = [`${showsImported} shows`, `${entriesImported} new entries`];
+  if (entriesUpdated > 0) parts.push(`${entriesUpdated} updated entries`);
+  console.log(`[flowsheet-etl] Incremental sync: ${parts.join(', ')}.`);
+
+  return { showsImported, entriesImported, entriesUpdated };
+};
+
+// ---- SSE Notification ----
+
+const notifyBackendService = async () => {
+  const url = process.env.BACKEND_SERVICE_URL ?? 'http://localhost:8080';
+  const key = process.env.ETL_NOTIFY_KEY ?? '';
+  try {
+    await fetch(`${url}/internal/flowsheet-sync-notify`, {
+      method: 'POST',
+      headers: { 'X-Internal-Key': key },
+    });
+  } catch (e) {
+    console.warn('[flowsheet-etl] Failed to notify backend:', e);
+  }
+};
+
+// ---- Continuous Polling Mode ----
+
+const runPollingLoop = async () => {
+  const intervalMs = Number(process.env.ETL_POLL_INTERVAL_MS) || 30_000;
+  let running = true;
+  let sleepResolve: (() => void) | null = null;
+
+  const shutdown = () => {
+    running = false;
+    sleepResolve?.();
+  };
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+
+  console.log(`[flowsheet-etl] Polling every ${intervalMs}ms. PID ${process.pid}`);
+
+  while (running) {
+    try {
+      const result = await runIncremental();
+      if (result.entriesImported > 0 || result.entriesUpdated > 0) {
+        await notifyBackendService();
+      }
+    } catch (e) {
+      console.error('[flowsheet-etl] Poll error:', e);
+    }
+    if (!running) break;
+    await new Promise<void>((resolve) => {
+      sleepResolve = resolve;
+      setTimeout(resolve, intervalMs);
+    });
+  }
+
+  console.log('[flowsheet-etl] Shutting down.');
 };
 
 // ---- Main ----
 
 const run = async () => {
   try {
-    const dumpPath = process.argv[2];
-    if (dumpPath && !dumpPath.startsWith('--')) {
+    const args = process.argv.slice(2);
+    const dumpPath = args.find((a) => !a.startsWith('--'));
+    if (dumpPath) {
       await runBulkLoad(dumpPath);
+    } else if (args.includes('--poll')) {
+      await runPollingLoop();
     } else {
       await runIncremental();
     }

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -14,7 +14,7 @@
  */
 
 import { readFileSync } from 'fs';
-import { eq, isNotNull, sql } from 'drizzle-orm';
+import { eq, inArray, sql } from 'drizzle-orm';
 import { db, shows, flowsheet, cronjob_runs, closeDatabaseConnection } from '@wxyc/database';
 import { parseInsertLine } from './parse-dump.js';
 import { mapProdEntryType, epochMsToDate, resolveEntryTimestamp, parseShowEntryDJName, truncate } from './transform.js';
@@ -227,7 +227,13 @@ const runIncremental = async (): Promise<SyncResult> => {
         end_time: endTime,
         show_name: truncate(show.showName, 128),
       })
-      .onConflictDoNothing();
+      .onConflictDoUpdate({
+        target: shows.legacy_show_id,
+        set: {
+          end_time: sql`excluded.end_time`,
+          show_name: sql`excluded.show_name`,
+        },
+      });
     showsImported++;
   }
 
@@ -240,15 +246,21 @@ const runIncremental = async (): Promise<SyncResult> => {
     }
   }
 
-  // Collect existing legacy IDs to distinguish inserts from updates
-  const existingIds = new Set(
-    (
-      await db.select({ lid: flowsheet.legacy_entry_id }).from(flowsheet).where(isNotNull(flowsheet.legacy_entry_id))
-    ).map((r) => r.lid)
-  );
-
   // Sync entries (upsert: insert new, update display fields on conflict)
   const legacyEntries = await fetchLegacyEntries(lastRunMs);
+
+  // Collect existing legacy IDs (scoped to this batch) to distinguish inserts from updates
+  const batchIds = legacyEntries.map((e) => e.id).filter((id) => Number.isFinite(id));
+  const existingIds = new Set(
+    batchIds.length > 0
+      ? (
+          await db
+            .select({ lid: flowsheet.legacy_entry_id })
+            .from(flowsheet)
+            .where(inArray(flowsheet.legacy_entry_id, batchIds))
+        ).map((r) => r.lid)
+      : []
+  );
   let entriesImported = 0;
   let entriesUpdated = 0;
   for (const entry of legacyEntries) {
@@ -308,10 +320,13 @@ const notifyBackendService = async () => {
   const url = process.env.BACKEND_SERVICE_URL ?? 'http://localhost:8080';
   const key = process.env.ETL_NOTIFY_KEY ?? '';
   try {
-    await fetch(`${url}/internal/flowsheet-sync-notify`, {
+    const response = await fetch(`${url}/internal/flowsheet-sync-notify`, {
       method: 'POST',
       headers: { 'X-Internal-Key': key },
     });
+    if (!response.ok) {
+      console.warn(`[flowsheet-etl] Backend notify returned ${response.status}`);
+    }
   } catch (e) {
     console.warn('[flowsheet-etl] Failed to notify backend:', e);
   }

--- a/jobs/flowsheet-etl/package.json
+++ b/jobs/flowsheet-etl/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/job.js",
   "scripts": {
     "start": "node dist/job.js",
+    "start:poll": "node dist/job.js --poll",
     "build": "tsup --minify",
     "clean": "rm -rf dist",
     "docker:build": "docker build -t wxyc_flowsheet_etl:ci -f ../../Dockerfile.flowsheet-etl ../../",

--- a/tests/e2e/etl.test.ts
+++ b/tests/e2e/etl.test.ts
@@ -36,12 +36,14 @@ const etlEnv = {
   REMOTE_DB_NAME: 'wxycmusic',
 };
 
-const runETL = (jobPath: string, jobName: string) => {
-  // Clear last_run to force a full import
-  execSync(
-    `psql "postgres://etluser:etltest@localhost:${PG_PORT}/etldb" -c "DELETE FROM ${SCHEMA}.cronjob_runs WHERE job_name = '${jobName}'"`,
-    { stdio: 'pipe' }
-  );
+const runETL = (jobPath: string, jobName: string, { resetLastRun = true } = {}) => {
+  if (resetLastRun) {
+    // Clear last_run to force a full import
+    execSync(
+      `psql "postgres://etluser:etltest@localhost:${PG_PORT}/etldb" -c "DELETE FROM ${SCHEMA}.cronjob_runs WHERE job_name = '${jobName}'"`,
+      { stdio: 'pipe' }
+    );
+  }
   execSync(`npx tsx ${jobPath}`, {
     env: etlEnv,
     cwd: process.cwd(),
@@ -232,5 +234,70 @@ describe('Flowsheet ETL', () => {
     const rows = await pg`SELECT last_run FROM ${pg(SCHEMA)}.cronjob_runs WHERE job_name = 'flowsheet-etl'`;
     expect(rows.length).toBe(1);
     expect(rows[0].last_run).toBeInstanceOf(Date);
+  });
+});
+
+// ---- Flowsheet ETL: Incremental Sync (bidirectional) ----
+
+describe('Flowsheet ETL incremental sync', () => {
+  const MYSQL_CONTAINER = 'dev_env-etl-mysql-1';
+  const MYSQL_CMD = `docker exec -i ${MYSQL_CONTAINER} mysql -uetluser -petltest wxycmusic --batch --raw --silent`;
+
+  const runMySQL = (sql: string) => {
+    execSync(MYSQL_CMD, { encoding: 'utf8', input: sql, stdio: 'pipe' });
+  };
+
+  it('imports a new entry added to tubafrenzy after the initial sync', async () => {
+    const newStartTime = Date.now();
+    runMySQL(`
+      INSERT INTO FLOWSHEET_ENTRY_PROD
+        (ID, ARTIST_NAME, ARTIST_ID, SONG_TITLE, RELEASE_TITLE, RELEASE_FORMAT_ID,
+         LIBRARY_RELEASE_ID, ROTATION_RELEASE_ID, LABEL_NAME, RADIO_HOUR,
+         START_TIME, STOP_TIME, RADIO_SHOW_ID, SEQUENCE_WITHIN_SHOW,
+         NOW_PLAYING_FLAG, FLOWSHEET_ENTRY_TYPE_CODE_ID,
+         TIME_LAST_MODIFIED, TIME_CREATED, REQUEST_FLAG, GLOBAL_ORDER_ID,
+         BMI_COMPOSER, SEGUE_FLAG)
+      VALUES
+        (3001, 'Sessa', 0, 'Pequena Vertigem', 'Pequena Vertigem de Amor', 0,
+         0, 0, 'Mexican Summer', ${Math.floor(newStartTime / 3600000) * 3600000},
+         ${newStartTime}, 0, 1002, 3, 0, 0,
+         ${newStartTime}, ${newStartTime}, 0, 1002003,
+         '', 0);
+    `);
+
+    runETL('jobs/flowsheet-etl/job.ts', 'flowsheet-etl', { resetLastRun: false });
+
+    const rows =
+      await pg`SELECT artist_name, track_title, album_title, record_label, legacy_entry_id FROM ${pg(SCHEMA)}.flowsheet WHERE legacy_entry_id = 3001`;
+    expect(rows.length).toBe(1);
+    expect(rows[0].artist_name).toBe('Sessa');
+    expect(rows[0].track_title).toBe('Pequena Vertigem');
+    expect(rows[0].album_title).toBe('Pequena Vertigem de Amor');
+    expect(rows[0].record_label).toBe('Mexican Summer');
+  });
+
+  it('propagates edits from tubafrenzy to Backend-Service on re-sync', async () => {
+    const now = Date.now();
+    runMySQL(`
+      UPDATE FLOWSHEET_ENTRY_PROD
+      SET ARTIST_NAME = 'Sessa (updated)',
+          SONG_TITLE = 'Pequena Vertigem (live)',
+          TIME_LAST_MODIFIED = ${now}
+      WHERE ID = 3001;
+    `);
+
+    runETL('jobs/flowsheet-etl/job.ts', 'flowsheet-etl', { resetLastRun: false });
+
+    const rows = await pg`SELECT artist_name, track_title FROM ${pg(SCHEMA)}.flowsheet WHERE legacy_entry_id = 3001`;
+    expect(rows.length).toBe(1);
+    expect(rows[0].artist_name).toBe('Sessa (updated)');
+    expect(rows[0].track_title).toBe('Pequena Vertigem (live)');
+  });
+
+  it('does not duplicate entries on repeated syncs', async () => {
+    runETL('jobs/flowsheet-etl/job.ts', 'flowsheet-etl', { resetLastRun: false });
+
+    const rows = await pg`SELECT COUNT(*)::int AS count FROM ${pg(SCHEMA)}.flowsheet WHERE legacy_entry_id = 3001`;
+    expect(rows[0].count).toBe(1);
   });
 });

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -77,6 +77,7 @@ export const flowsheet = {
   id: 'id',
   show_id: 'show_id',
   album_id: 'album_id',
+  legacy_entry_id: 'legacy_entry_id',
   entry_type: 'entry_type',
   track_title: 'track_title',
   album_title: 'album_title',
@@ -86,6 +87,7 @@ export const flowsheet = {
   rotation_id: 'rotation_id',
   play_order: 'play_order',
   request_flag: 'request_flag',
+  segue: 'segue',
   message: 'message',
   add_time: 'add_time',
   artwork_url: 'artwork_url',
@@ -155,6 +157,7 @@ export type FSEntry = {
   show_id: number | null;
   album_id: number | null;
   rotation_id: number | null;
+  legacy_entry_id: number | null;
   entry_type: string;
   track_title: string | null;
   album_title: string | null;
@@ -163,6 +166,7 @@ export type FSEntry = {
   label_id: number | null;
   play_order: number;
   request_flag: boolean;
+  segue: boolean;
   message: string | null;
   add_time: Date;
   artwork_url: string | null;

--- a/tests/unit/jobs/flowsheet-etl/fetch-legacy.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/fetch-legacy.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for flowsheet ETL fetch-legacy parsing functions.
+ *
+ * Tests the tab-separated row parsing for entries and shows, including
+ * the TIME_LAST_MODIFIED column used for update detection.
+ */
+
+jest.mock('@wxyc/database', () => ({
+  MirrorSQL: {
+    instance: jest.fn().mockReturnValue({
+      send: jest.fn(),
+      close: jest.fn(),
+    }),
+  },
+}));
+
+import { parseTabRow, toNullable, parseEntryRows, parseShowRows } from '../../../../jobs/flowsheet-etl/fetch-legacy';
+
+describe('fetch-legacy parsing', () => {
+  describe('parseTabRow', () => {
+    it('returns columns when count matches', () => {
+      expect(parseTabRow('a\tb\tc', 3)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns null when count does not match', () => {
+      expect(parseTabRow('a\tb', 3)).toBeNull();
+    });
+  });
+
+  describe('toNullable', () => {
+    it('returns trimmed string for non-empty values', () => {
+      expect(toNullable(' Autechre ')).toBe('Autechre');
+    });
+
+    it('returns null for empty strings', () => {
+      expect(toNullable('')).toBeNull();
+      expect(toNullable('   ')).toBeNull();
+    });
+
+    it('returns null for NULL string', () => {
+      expect(toNullable('NULL')).toBeNull();
+    });
+  });
+
+  describe('parseEntryRows', () => {
+    it('parses 11-column format (without SEGUE_FLAG)', () => {
+      // Columns: ID, SHOW_ID, TYPE, ARTIST, ALBUM, TRACK, LABEL, REQ, SEQ, START, TLM
+      const raw = '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t0\t1\t1706799600000\t1706799700000';
+      const rows = parseEntryRows(raw, 11);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toEqual({
+        id: 100,
+        showId: 200,
+        entryTypeCode: 0,
+        artistName: 'Autechre',
+        albumTitle: 'Confield',
+        trackTitle: 'VI Scose Poise',
+        label: 'Warp',
+        requestFlag: 0,
+        playOrder: 1,
+        startTime: 1706799600000,
+        timeLastModified: 1706799700000,
+        segueFlag: 0,
+      });
+    });
+
+    it('parses 12-column format (with SEGUE_FLAG)', () => {
+      const raw = '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t1\t1\t1706799600000\t1706799700000\t1';
+      const rows = parseEntryRows(raw, 12);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].requestFlag).toBe(1);
+      expect(rows[0].timeLastModified).toBe(1706799700000);
+      expect(rows[0].segueFlag).toBe(1);
+    });
+
+    it('defaults segueFlag to 0 in 11-column format', () => {
+      const raw = '100\t200\t0\tArtist\tAlbum\tTrack\tLabel\t0\t1\t1000\t2000';
+      const rows = parseEntryRows(raw, 11);
+
+      expect(rows[0].segueFlag).toBe(0);
+    });
+
+    it('handles NULL/empty text fields', () => {
+      const raw = '100\t200\t7\tNULL\t\t\t\t0\t5\t1000\t2000';
+      const rows = parseEntryRows(raw, 11);
+
+      expect(rows[0].artistName).toBeNull();
+      expect(rows[0].albumTitle).toBeNull();
+      expect(rows[0].trackTitle).toBeNull();
+      expect(rows[0].label).toBeNull();
+    });
+
+    it('skips malformed rows with wrong column count', () => {
+      const raw = '100\t200\t0\tArtist';
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      const rows = parseEntryRows(raw, 11);
+
+      expect(rows).toHaveLength(0);
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('malformed'), expect.any(String));
+      consoleSpy.mockRestore();
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(parseEntryRows('', 11)).toEqual([]);
+      expect(parseEntryRows('   ', 11)).toEqual([]);
+    });
+
+    it('parses multiple rows', () => {
+      const raw = [
+        '1\t100\t0\tArtist1\tAlbum1\tTrack1\tLabel1\t0\t1\t1000\t2000',
+        '2\t100\t0\tArtist2\tAlbum2\tTrack2\tLabel2\t1\t2\t3000\t4000',
+      ].join('\n');
+      const rows = parseEntryRows(raw, 11);
+
+      expect(rows).toHaveLength(2);
+      expect(rows[0].id).toBe(1);
+      expect(rows[1].id).toBe(2);
+      expect(rows[1].timeLastModified).toBe(4000);
+    });
+  });
+
+  describe('parseShowRows', () => {
+    it('parses 5-column format with TIME_LAST_MODIFIED', () => {
+      const raw = '1\t1706799600000\t1706803200000\tThe Morning Show\t1706799700000';
+      const rows = parseShowRows(raw);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toEqual({
+        id: 1,
+        startTime: 1706799600000,
+        endTime: 1706803200000,
+        showName: 'The Morning Show',
+        timeLastModified: 1706799700000,
+      });
+    });
+
+    it('skips rows with invalid startTime', () => {
+      const raw = '1\t0\t0\tBad Show\t0';
+      const rows = parseShowRows(raw);
+
+      expect(rows).toHaveLength(0);
+    });
+
+    it('handles null endTime and showName', () => {
+      const raw = '1\t1706799600000\t0\tNULL\t0';
+      const rows = parseShowRows(raw);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].endTime).toBeNull();
+      expect(rows[0].showName).toBeNull();
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(parseShowRows('')).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -106,7 +106,7 @@ function createMockReq() {
 async function runMiddleware(
   middleware: (req: any, res: any, next: any) => Promise<void> | void,
   entry: Record<string, unknown>,
-  statusCode = 201,
+  statusCode = 201
 ) {
   const req = createMockReq();
   const res = createMockRes(statusCode, entry);

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -72,9 +72,10 @@ import { EventEmitter } from 'events';
 // Helper: create mock Express response that simulates the middleware lifecycle
 function createMockRes(statusCode: number, body: Record<string, unknown>) {
   const emitter = new EventEmitter();
+  const locals: Record<string, unknown> = {};
   const res = {
     statusCode,
-    locals: {} as Record<string, unknown>,
+    locals,
     getHeader: jest.fn().mockReturnValue('application/json'),
     send: jest.fn(),
     once: emitter.once.bind(emitter),
@@ -85,7 +86,7 @@ function createMockRes(statusCode: number, body: Record<string, unknown>) {
 
   // After send is called, emit 'finish' to trigger mirror logic
   res.send.mockImplementation((data: unknown) => {
-    (res.locals as Record<string, unknown>).mirrorData = typeof data === 'string' ? JSON.parse(data) : data;
+    locals.mirrorData = typeof data === 'string' ? JSON.parse(data) : data;
     // Simulate Express: emit finish after send
     setTimeout(() => emitter.emit('finish'), 0);
     return res;
@@ -103,7 +104,7 @@ function createMockReq() {
 
 // Helper: call middleware and wait for the async finish handler
 async function runMiddleware(
-  middleware: (req: any, res: any, next: any) => void,
+  middleware: (req: any, res: any, next: any) => Promise<void> | void,
   entry: Record<string, unknown>,
   statusCode = 201,
 ) {
@@ -111,7 +112,8 @@ async function runMiddleware(
   const res = createMockRes(statusCode, entry);
   const next = jest.fn();
 
-  await middleware(req, res, next);
+  // Middleware may or may not return a promise
+  void middleware(req, res, next);
   expect(next).toHaveBeenCalled();
 
   // Trigger send (which populates mirrorData and emits finish)
@@ -135,7 +137,7 @@ describe('mirror loop prevention', () => {
     show_id: 100,
     album_id: null,
     rotation_id: null,
-    legacy_entry_id: null,
+    legacy_entry_id: null as number | null,
     entry_type: 'track',
     track_title: 'VI Scose Poise',
     album_title: 'Confield',
@@ -144,87 +146,92 @@ describe('mirror loop prevention', () => {
     play_order: 1,
     request_flag: false,
     segue: false,
-    message: null,
+    message: null as string | null,
     add_time: new Date('2024-02-01T12:00:00Z').toISOString(),
   };
 
   describe('addEntry', () => {
-    it('mirrors normally when legacy_entry_id is null', async () => {
+    it('mirrors normally when legacy_entry_id is null', (done) => {
       mockMirrorCreateEntry.mockResolvedValue(99);
 
-      await runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null });
-
-      expect(mockMapEntryToTubafrenzy).toHaveBeenCalled();
-      expect(mockMirrorCreateEntry).toHaveBeenCalled();
+      void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
+        expect(mockMapEntryToTubafrenzy).toHaveBeenCalled();
+        expect(mockMirrorCreateEntry).toHaveBeenCalled();
+        done();
+      });
     });
 
-    it('skips mirroring when legacy_entry_id is non-null (ETL-imported)', async () => {
-      await runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: 12345 });
-
-      expect(mockMirrorCreateEntry).not.toHaveBeenCalled();
+    it('skips mirroring when legacy_entry_id is non-null (ETL-imported)', (done) => {
+      void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: 12345 }).then(() => {
+        expect(mockMirrorCreateEntry).not.toHaveBeenCalled();
+        done();
+      });
     });
 
-    it('persists tubafrenzy ID to legacy_entry_id after successful POST', async () => {
+    it('persists tubafrenzy ID to legacy_entry_id after successful POST', (done) => {
       mockMirrorCreateEntry.mockResolvedValue(99);
 
-      await runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null });
-
-      expect(mockCacheEntryId).toHaveBeenCalledWith(1, 99);
-      expect(mockDbUpdate).toHaveBeenCalled();
+      void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
+        expect(mockCacheEntryId).toHaveBeenCalledWith(1, 99);
+        expect(mockDbUpdate).toHaveBeenCalled();
+        done();
+      });
     });
 
-    it('does not persist legacy_entry_id when POST fails', async () => {
+    it('does not persist legacy_entry_id when POST fails', (done) => {
       mockMirrorCreateEntry.mockResolvedValue(null);
 
-      await runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null });
-
-      expect(mockCacheEntryId).not.toHaveBeenCalled();
-      expect(mockDbUpdate).not.toHaveBeenCalled();
+      void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
+        expect(mockCacheEntryId).not.toHaveBeenCalled();
+        expect(mockDbUpdate).not.toHaveBeenCalled();
+        done();
+      });
     });
   });
 
   describe('updateEntry', () => {
-    it('skips mirroring when legacy_entry_id is set but not in cache (ETL-imported)', async () => {
+    it('skips mirroring when legacy_entry_id is set but not in cache (ETL-imported)', (done) => {
       mockGetCachedEntryId.mockReturnValue(undefined);
 
-      await runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: 12345 });
-
-      expect(mockMirrorUpdateEntry).not.toHaveBeenCalled();
+      void runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: 12345 }).then(() => {
+        expect(mockMirrorUpdateEntry).not.toHaveBeenCalled();
+        done();
+      });
     });
 
-    it('mirrors when cached ID exists (we created it this lifecycle)', async () => {
+    it('mirrors when cached ID exists (we created it this lifecycle)', (done) => {
       mockGetCachedEntryId.mockReturnValue(99);
 
-      await runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: null });
-
-      expect(mockMapUpdateToTubafrenzy).toHaveBeenCalled();
-      expect(mockMirrorUpdateEntry).toHaveBeenCalledWith(99, expect.any(Object));
+      void runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
+        expect(mockMapUpdateToTubafrenzy).toHaveBeenCalled();
+        expect(mockMirrorUpdateEntry).toHaveBeenCalledWith(99, expect.any(Object));
+        done();
+      });
     });
 
-    it('skips message-only entries', async () => {
+    it('skips message-only entries', (done) => {
       mockGetCachedEntryId.mockReturnValue(99);
 
-      await runMiddleware(flowsheetMirror.updateEntry, {
+      void runMiddleware(flowsheetMirror.updateEntry, {
         ...baseEntry,
         message: 'This is a message',
         legacy_entry_id: null,
+      }).then(() => {
+        expect(mockMirrorUpdateEntry).not.toHaveBeenCalled();
+        done();
       });
-
-      expect(mockMirrorUpdateEntry).not.toHaveBeenCalled();
     });
 
-    it('logs warning when no tubafrenzy ID available at all', async () => {
+    it('logs warning when no tubafrenzy ID available at all', (done) => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
       mockGetCachedEntryId.mockReturnValue(undefined);
 
-      await runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: null });
-
-      expect(mockMirrorUpdateEntry).not.toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[mirror]'),
-        expect.anything(),
-      );
-      consoleSpy.mockRestore();
+      void runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
+        expect(mockMirrorUpdateEntry).not.toHaveBeenCalled();
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[mirror]'), expect.anything());
+        consoleSpy.mockRestore();
+        done();
+      });
     });
   });
 });

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for bidirectional sync loop prevention in the flowsheet mirror.
+ *
+ * Verifies that:
+ * - addEntry skips mirroring when legacy_entry_id is non-null (ETL-imported)
+ * - addEntry persists the tubafrenzy ID to legacy_entry_id after POST
+ * - updateEntry skips mirroring for ETL-imported entries (not in cache)
+ */
+
+// --- Mocks ---
+
+const mockMirrorCreateEntry = jest.fn();
+const mockMirrorUpdateEntry = jest.fn();
+const mockCacheEntryId = jest.fn();
+const mockGetCachedEntryId = jest.fn();
+const mockMapEntryToTubafrenzy = jest.fn().mockReturnValue({ artistName: 'test' });
+const mockMapUpdateToTubafrenzy = jest.fn().mockReturnValue({ artistName: 'test' });
+
+jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
+  mirrorCreateEntry: mockMirrorCreateEntry,
+  mirrorUpdateEntry: mockMirrorUpdateEntry,
+  cacheEntryId: mockCacheEntryId,
+  getCachedEntryId: mockGetCachedEntryId,
+  clearEntryIdMap: jest.fn(),
+  mapEntryToTubafrenzy: mockMapEntryToTubafrenzy,
+  mapUpdateToTubafrenzy: mockMapUpdateToTubafrenzy,
+}));
+
+const mockDbUpdate = jest.fn().mockReturnValue({
+  set: jest.fn().mockReturnValue({
+    where: jest.fn().mockResolvedValue(undefined),
+  }),
+});
+
+jest.mock('@wxyc/database', () => ({
+  db: {
+    select: jest.fn().mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          orderBy: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue([]),
+          }),
+          limit: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+    }),
+    update: mockDbUpdate,
+  },
+  user: {},
+  flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id' },
+}));
+
+jest.mock('drizzle-orm', () => ({
+  eq: jest.fn((...args: unknown[]) => args),
+  desc: jest.fn(),
+  asc: jest.fn(),
+}));
+
+jest.mock('posthog-node', () => ({
+  PostHog: jest.fn().mockImplementation(() => ({
+    isFeatureEnabled: jest.fn().mockResolvedValue(true),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
+
+import { EventEmitter } from 'events';
+
+// Helper: create mock Express response that simulates the middleware lifecycle
+function createMockRes(statusCode: number, body: Record<string, unknown>) {
+  const emitter = new EventEmitter();
+  const res = {
+    statusCode,
+    locals: {} as Record<string, unknown>,
+    getHeader: jest.fn().mockReturnValue('application/json'),
+    send: jest.fn(),
+    once: emitter.once.bind(emitter),
+    on: emitter.on.bind(emitter),
+    emit: emitter.emit.bind(emitter),
+    _body: body,
+  };
+
+  // After send is called, emit 'finish' to trigger mirror logic
+  res.send.mockImplementation((data: unknown) => {
+    (res.locals as Record<string, unknown>).mirrorData = typeof data === 'string' ? JSON.parse(data) : data;
+    // Simulate Express: emit finish after send
+    setTimeout(() => emitter.emit('finish'), 0);
+    return res;
+  });
+
+  return res;
+}
+
+function createMockReq() {
+  return {
+    ip: '127.0.0.1',
+    user: { id: 'test-user' },
+  };
+}
+
+// Helper: call middleware and wait for the async finish handler
+async function runMiddleware(
+  middleware: (req: any, res: any, next: any) => void,
+  entry: Record<string, unknown>,
+  statusCode = 201,
+) {
+  const req = createMockReq();
+  const res = createMockRes(statusCode, entry);
+  const next = jest.fn();
+
+  await middleware(req, res, next);
+  expect(next).toHaveBeenCalled();
+
+  // Trigger send (which populates mirrorData and emits finish)
+  res.send(JSON.stringify(entry));
+
+  // Wait for async finish handler to complete
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+// Import the middleware AFTER all mocks are set up
+import { flowsheetMirror } from '../../../../apps/backend/middleware/legacy/flowsheet.mirror';
+
+describe('mirror loop prevention', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCachedEntryId.mockReturnValue(undefined);
+  });
+
+  const baseEntry = {
+    id: 42,
+    show_id: 100,
+    album_id: null,
+    rotation_id: null,
+    legacy_entry_id: null,
+    entry_type: 'track',
+    track_title: 'VI Scose Poise',
+    album_title: 'Confield',
+    artist_name: 'Autechre',
+    record_label: 'Warp',
+    play_order: 1,
+    request_flag: false,
+    segue: false,
+    message: null,
+    add_time: new Date('2024-02-01T12:00:00Z').toISOString(),
+  };
+
+  describe('addEntry', () => {
+    it('mirrors normally when legacy_entry_id is null', async () => {
+      mockMirrorCreateEntry.mockResolvedValue(99);
+
+      await runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null });
+
+      expect(mockMapEntryToTubafrenzy).toHaveBeenCalled();
+      expect(mockMirrorCreateEntry).toHaveBeenCalled();
+    });
+
+    it('skips mirroring when legacy_entry_id is non-null (ETL-imported)', async () => {
+      await runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: 12345 });
+
+      expect(mockMirrorCreateEntry).not.toHaveBeenCalled();
+    });
+
+    it('persists tubafrenzy ID to legacy_entry_id after successful POST', async () => {
+      mockMirrorCreateEntry.mockResolvedValue(99);
+
+      await runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null });
+
+      expect(mockCacheEntryId).toHaveBeenCalledWith(1, 99);
+      expect(mockDbUpdate).toHaveBeenCalled();
+    });
+
+    it('does not persist legacy_entry_id when POST fails', async () => {
+      mockMirrorCreateEntry.mockResolvedValue(null);
+
+      await runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null });
+
+      expect(mockCacheEntryId).not.toHaveBeenCalled();
+      expect(mockDbUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateEntry', () => {
+    it('skips mirroring when legacy_entry_id is set but not in cache (ETL-imported)', async () => {
+      mockGetCachedEntryId.mockReturnValue(undefined);
+
+      await runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: 12345 });
+
+      expect(mockMirrorUpdateEntry).not.toHaveBeenCalled();
+    });
+
+    it('mirrors when cached ID exists (we created it this lifecycle)', async () => {
+      mockGetCachedEntryId.mockReturnValue(99);
+
+      await runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: null });
+
+      expect(mockMapUpdateToTubafrenzy).toHaveBeenCalled();
+      expect(mockMirrorUpdateEntry).toHaveBeenCalledWith(99, expect.any(Object));
+    });
+
+    it('skips message-only entries', async () => {
+      mockGetCachedEntryId.mockReturnValue(99);
+
+      await runMiddleware(flowsheetMirror.updateEntry, {
+        ...baseEntry,
+        message: 'This is a message',
+        legacy_entry_id: null,
+      });
+
+      expect(mockMirrorUpdateEntry).not.toHaveBeenCalled();
+    });
+
+    it('logs warning when no tubafrenzy ID available at all', async () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      mockGetCachedEntryId.mockReturnValue(undefined);
+
+      await runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: null });
+
+      expect(mockMirrorUpdateEntry).not.toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[mirror]'),
+        expect.anything(),
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for the internal SSE notification endpoint.
+ *
+ * POST /internal/flowsheet-sync-notify triggers a refetch broadcast
+ * to connected dj-site clients when the ETL imports new entries.
+ */
+
+const mockBroadcast = jest.fn();
+
+jest.mock('../../../apps/backend/utils/serverEvents', () => ({
+  Topics: { liveFs: 'live-fs-topic' },
+  FsEvents: { refetch: 'refetch' },
+  serverEventsMgr: { broadcast: mockBroadcast },
+}));
+
+import express from 'express';
+import request from 'supertest';
+
+// Set the key before importing the route
+process.env.ETL_NOTIFY_KEY = 'test-secret-key';
+
+import { internal_route } from '../../../apps/backend/routes/internal.route';
+
+const app = express();
+app.use(express.json());
+app.use('/internal', internal_route);
+
+describe('POST /internal/flowsheet-sync-notify', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 without X-Internal-Key header', async () => {
+    const res = await request(app).post('/internal/flowsheet-sync-notify');
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Unauthorized');
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 with wrong key', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-sync-notify')
+      .set('X-Internal-Key', 'wrong-key');
+
+    expect(res.status).toBe(401);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with correct key and broadcasts refetch', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-sync-notify')
+      .set('X-Internal-Key', 'test-secret-key');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(mockBroadcast).toHaveBeenCalledWith('live-fs-topic', {
+      type: 'refetch',
+      payload: { source: 'etl' },
+    });
+  });
+});

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -39,18 +39,14 @@ describe('POST /internal/flowsheet-sync-notify', () => {
   });
 
   it('returns 401 with wrong key', async () => {
-    const res = await request(app)
-      .post('/internal/flowsheet-sync-notify')
-      .set('X-Internal-Key', 'wrong-key');
+    const res = await request(app).post('/internal/flowsheet-sync-notify').set('X-Internal-Key', 'wrong-key');
 
     expect(res.status).toBe(401);
     expect(mockBroadcast).not.toHaveBeenCalled();
   });
 
   it('returns 200 with correct key and broadcasts refetch', async () => {
-    const res = await request(app)
-      .post('/internal/flowsheet-sync-notify')
-      .set('X-Internal-Key', 'test-secret-key');
+    const res = await request(app).post('/internal/flowsheet-sync-notify').set('X-Internal-Key', 'test-secret-key');
 
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);


### PR DESCRIPTION
## Summary

- Adds reverse-direction sync: entries created/edited in tubafrenzy now appear in Backend-Service within ~30 seconds via continuous ETL polling
- Prevents infinite sync loops using `legacy_entry_id` as the deduplication key in both directions
- Adds `POST /internal/flowsheet-sync-notify` endpoint so the ETL can trigger SSE refetch events for connected dj-site clients

Closes #322

## Changes

**Mirror loop prevention** (`flowsheet.mirror.ts`):
- `addEntry` skips mirroring when `legacy_entry_id` is non-null (ETL-imported); persists tubafrenzy ID to `legacy_entry_id` after successful POST
- `updateEntry` uses cache-vs-`legacy_entry_id` distinction to skip ETL-imported entries

**ETL update detection** (`fetch-legacy.ts`):
- Adds `TIME_LAST_MODIFIED` to show and entry queries
- Broadens WHERE filters to catch edits, not just new entries

**ETL upsert** (`job.ts`):
- Changes `onConflictDoNothing` to `onConflictDoUpdate` targeting `legacy_entry_id`
- Only display fields updated on conflict; structural fields preserved

**Continuous polling** (`job.ts`):
- `--poll` flag enters a long-lived loop (default 30s, configurable via `ETL_POLL_INTERVAL_MS`)
- Graceful SIGTERM/SIGINT shutdown
- One-shot mode preserved for cron compatibility

**SSE notification** (`internal.route.ts`, `app.ts`):
- New `POST /internal/flowsheet-sync-notify` endpoint with `X-Internal-Key` auth
- Broadcasts `FsEvents.refetch` on `Topics.liveFs`

## Test plan

- [ ] 27 new unit tests across 3 test files (mirror loop prevention, ETL parsing, internal endpoint)
- [ ] All 680 existing unit tests pass (1 pre-existing failure in cookie-config unrelated)
- [ ] Manual: create entry via dj-site, verify `legacy_entry_id` gets set on the Backend-Service row
- [ ] Manual: create entry in tubafrenzy, verify it appears in Backend-Service within 30s when ETL runs with `--poll`
- [ ] Manual: edit entry in tubafrenzy, verify the edit propagates
- [ ] Manual: verify no duplicate entries after multiple poll cycles