### PR TITLE
Add flowsheet webhook receiver for tubafrenzy sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Express 5 application with these route groups:
 | `/schedule`     | Schedule management                               |
 | `/events`       | SSE for real-time updates                         |
 | `/healthcheck`  | Health check                                      |
-| `/internal`     | Internal endpoints (ETL sync notifications)       |
+| `/internal`     | Internal endpoints (ETL notifications, tubafrenzy webhook) |
 
 Code is organized as controllers (HTTP handling) -> services (business logic) -> database (Drizzle queries).
 
@@ -282,7 +282,7 @@ The flowsheet ETL supports two run modes: one-shot (`npm start`) for cron invoca
 
 - `ETL_POLL_INTERVAL_MS` -- Poll interval in milliseconds (default `30000`)
 - `BACKEND_SERVICE_URL` -- Backend-Service URL for SSE notifications (default `http://localhost:8080`)
-- `ETL_NOTIFY_KEY` -- Shared secret for the internal notification endpoint (required in production)
+- `ETL_NOTIFY_KEY` -- Shared secret for internal endpoints: ETL sync notification and tubafrenzy webhook (required in production)
 
 ## Relationship to Other Repos
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,18 +19,18 @@ npm workspaces with four packages:
 
 Express 5 application with these route groups:
 
-| Route           | Purpose                                           |
-| --------------- | ------------------------------------------------- |
-| `/config`       | Public app bootstrap configuration                |
-| `/proxy`        | iOS proxy endpoints (anonymous auth + rate limit) |
-| `/library`      | Music library catalog                             |
-| `/flowsheet`    | V1 flowsheet (legacy)                             |
-| `/v2/flowsheet` | V2 flowsheet (uses `@wxyc/shared` DTOs)           |
-| `/djs`          | DJ profiles and management                        |
-| `/request`      | Song request line                                 |
-| `/schedule`     | Schedule management                               |
-| `/events`       | SSE for real-time updates                         |
-| `/healthcheck`  | Health check                                      |
+| Route           | Purpose                                                    |
+| --------------- | ---------------------------------------------------------- |
+| `/config`       | Public app bootstrap configuration                         |
+| `/proxy`        | iOS proxy endpoints (anonymous auth + rate limit)          |
+| `/library`      | Music library catalog                                      |
+| `/flowsheet`    | V1 flowsheet (legacy)                                      |
+| `/v2/flowsheet` | V2 flowsheet (uses `@wxyc/shared` DTOs)                    |
+| `/djs`          | DJ profiles and management                                 |
+| `/request`      | Song request line                                          |
+| `/schedule`     | Schedule management                                        |
+| `/events`       | SSE for real-time updates                                  |
+| `/healthcheck`  | Health check                                               |
 | `/internal`     | Internal endpoints (ETL notifications, tubafrenzy webhook) |
 
 Code is organized as controllers (HTTP handling) -> services (business logic) -> database (Drizzle queries).

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -1,9 +1,21 @@
 import { Router } from 'express';
+import { eq, sql } from 'drizzle-orm';
+import { db, flowsheet, shows } from '@wxyc/database';
 import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
+import { updateLastModified } from '../services/flowsheet.service.js';
+import { mapProdEntryType, truncate } from '../utils/flowsheet-transform.js';
 
 const ETL_NOTIFY_KEY = process.env.ETL_NOTIFY_KEY ?? '';
 
 export const internal_route = Router();
+
+/**
+ * Authenticate internal requests via a shared secret in the X-Internal-Key header.
+ * Used by the ETL and tubafrenzy webhook.
+ */
+function authenticateInternal(key: string | undefined): boolean {
+  return !!ETL_NOTIFY_KEY && key === ETL_NOTIFY_KEY;
+}
 
 /**
  * POST /internal/flowsheet-sync-notify
@@ -11,12 +23,9 @@ export const internal_route = Router();
  * Called by the flowsheet ETL after importing new or updated entries from
  * tubafrenzy. Broadcasts a refetch event to all SSE clients subscribed to
  * the liveFs topic so dj-site UIs stay in sync.
- *
- * Authenticated via a shared secret in the X-Internal-Key header.
  */
 internal_route.post('/flowsheet-sync-notify', (req, res) => {
-  const key = req.get('X-Internal-Key');
-  if (!ETL_NOTIFY_KEY || key !== ETL_NOTIFY_KEY) {
+  if (!authenticateInternal(req.get('X-Internal-Key'))) {
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
@@ -27,4 +36,104 @@ internal_route.post('/flowsheet-sync-notify', (req, res) => {
   });
 
   res.json({ ok: true });
+});
+
+/**
+ * Look up a show by legacy_show_id, creating a stub if it doesn't exist.
+ * Uses onConflictDoNothing + re-select for concurrent-insert safety.
+ */
+async function resolveShowId(legacyShowId: number): Promise<number | null> {
+  if (!legacyShowId) return null;
+
+  const existing = await db.select({ id: shows.id }).from(shows).where(eq(shows.legacy_show_id, legacyShowId)).limit(1);
+  if (existing.length > 0) return existing[0].id;
+
+  // Create a stub show — the ETL will fill in details (end_time, show_name) later.
+  await db.insert(shows).values({ legacy_show_id: legacyShowId, start_time: new Date() }).onConflictDoNothing();
+
+  const [row] = await db.select({ id: shows.id }).from(shows).where(eq(shows.legacy_show_id, legacyShowId)).limit(1);
+  return row?.id ?? null;
+}
+
+const VALID_ACTIONS = new Set(['create', 'update', 'delete']);
+
+/**
+ * POST /internal/flowsheet-webhook
+ *
+ * Receives flowsheet entry events from tubafrenzy. Called by tubafrenzy's
+ * WebhookFlowsheetEntryListener when entries are created, updated, or deleted.
+ *
+ * Payload:
+ *   { action: "create"|"update", entry: { id, radioShowId, flowsheetEntryType, ... } }
+ *   { action: "delete", entryId: number }
+ */
+internal_route.post('/flowsheet-webhook', async (req, res) => {
+  if (!authenticateInternal(req.get('X-Internal-Key'))) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const { action, entry, entryId } = req.body ?? {};
+
+  if (!action || !VALID_ACTIONS.has(action)) {
+    res.status(400).json({ error: 'Missing or invalid action. Expected: create, update, or delete.' });
+    return;
+  }
+
+  try {
+    if (action === 'delete') {
+      if (typeof entryId !== 'number') {
+        res.status(400).json({ error: 'Missing entryId for delete action.' });
+        return;
+      }
+      await db.delete(flowsheet).where(eq(flowsheet.legacy_entry_id, entryId));
+    } else {
+      // create or update — both use upsert
+      if (!entry || typeof entry.id !== 'number') {
+        res.status(400).json({ error: 'Missing entry.id for create/update action.' });
+        return;
+      }
+
+      const entryType = mapProdEntryType(entry.flowsheetEntryType ?? 0);
+      const showId = await resolveShowId(entry.radioShowId);
+
+      await db
+        .insert(flowsheet)
+        .values({
+          legacy_entry_id: entry.id,
+          show_id: showId,
+          entry_type: entryType,
+          artist_name: truncate(entry.artistName, 128),
+          album_title: truncate(entry.releaseTitle, 128),
+          track_title: truncate(entry.songTitle, 128),
+          record_label: truncate(entry.labelName, 128),
+          request_flag: !!entry.requestFlag,
+          segue: false,
+          play_order: entry.sequenceWithinShow ?? 0,
+          add_time: entry.startTime ? new Date(entry.startTime) : new Date(),
+        })
+        .onConflictDoUpdate({
+          target: flowsheet.legacy_entry_id,
+          set: {
+            artist_name: sql`excluded.artist_name`,
+            album_title: sql`excluded.album_title`,
+            track_title: sql`excluded.track_title`,
+            record_label: sql`excluded.record_label`,
+            request_flag: sql`excluded.request_flag`,
+            entry_type: sql`excluded.entry_type`,
+          },
+        });
+    }
+
+    updateLastModified();
+    serverEventsMgr.broadcast(Topics.liveFs, {
+      type: FsEvents.refetch,
+      payload: { source: 'webhook' },
+    });
+
+    res.json({ ok: true });
+  } catch (e) {
+    console.error('[webhook] Flowsheet webhook error:', e);
+    res.status(500).json({ error: 'Internal server error' });
+  }
 });

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -37,7 +37,7 @@ const nextPlayOrder = async (): Promise<number> => {
 export const getLastModifiedAt = (): Date => lastModifiedAt;
 
 /** Update the last modified timestamp (call after any write operation) */
-const updateLastModified = () => {
+export const updateLastModified = () => {
   // Truncate to seconds for HTTP Date header compatibility (avoids millisecond precision issues)
   const now = new Date();
   now.setMilliseconds(0);

--- a/apps/backend/utils/flowsheet-transform.ts
+++ b/apps/backend/utils/flowsheet-transform.ts
@@ -1,0 +1,55 @@
+/**
+ * Flowsheet entry type mapping and text utilities for the webhook receiver.
+ *
+ * Copied from jobs/flowsheet-etl/transform.ts — keep synchronized if
+ * entry type codes or truncation rules change.
+ */
+
+type BackendEntryType =
+  | 'track'
+  | 'show_start'
+  | 'show_end'
+  | 'breakpoint'
+  | 'talkset'
+  | 'dj_join'
+  | 'dj_leave'
+  | 'message';
+
+/**
+ * FLOWSHEET_ENTRY_TYPE_CODE_ID codes (production FLOWSHEET_ENTRY_PROD table):
+ *   0 = OTHER (non-rotation track)
+ *   1-4 = HEAVY/MEDIUM/LIGHT/SINGLES (rotation tracks)
+ *   5 = NEW (new vinyl, not yet in rotation)
+ *   6 = LIBRARY (existing library release)
+ *   7 = TALKSET
+ *   8 = HOURLY_BREAK
+ *   9 = START_OF_SHOW
+ *   10 = END_OF_SHOW
+ */
+const PROD_ENTRY_TYPE_MAP: Record<number, BackendEntryType> = {
+  0: 'track',
+  1: 'track',
+  2: 'track',
+  3: 'track',
+  4: 'track',
+  5: 'track',
+  6: 'track',
+  7: 'talkset',
+  8: 'breakpoint',
+  9: 'show_start',
+  10: 'show_end',
+};
+
+export const mapProdEntryType = (typeCode: number): BackendEntryType => {
+  return PROD_ENTRY_TYPE_MAP[typeCode] ?? 'message';
+};
+
+/**
+ * Truncate a string to a max length, returning null if empty.
+ * Matches the VARCHAR(128) / VARCHAR(250) limits in the schema.
+ */
+export const truncate = (value: string | null | undefined, maxLength: number): string | null => {
+  if (!value || value.trim().length === 0) return null;
+  const trimmed = value.trim();
+  return trimmed.length <= maxLength ? trimmed : trimmed.slice(0, maxLength);
+};

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -1,8 +1,7 @@
 /**
- * Unit tests for the internal SSE notification endpoint.
- *
- * POST /internal/flowsheet-sync-notify triggers a refetch broadcast
- * to connected dj-site clients when the ETL imports new entries.
+ * Unit tests for internal endpoints:
+ * - POST /internal/flowsheet-sync-notify (ETL SSE notification)
+ * - POST /internal/flowsheet-webhook (tubafrenzy webhook receiver)
  */
 
 const mockBroadcast = jest.fn();
@@ -13,6 +12,12 @@ jest.mock('../../../apps/backend/utils/serverEvents', () => ({
   serverEventsMgr: { broadcast: mockBroadcast },
 }));
 
+const mockUpdateLastModified = jest.fn();
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  updateLastModified: mockUpdateLastModified,
+}));
+
+import { db } from '@wxyc/database';
 import express from 'express';
 import request from 'supertest';
 
@@ -21,9 +26,18 @@ process.env.ETL_NOTIFY_KEY = 'test-secret-key';
 
 import { internal_route } from '../../../apps/backend/routes/internal.route';
 
+// Make the DB mock chain's terminal methods resolve to arrays (needed by webhook handler)
+const mockDb = db as unknown as Record<string, jest.Mock>;
+const mockChain = mockDb.select();
+(mockChain as Record<string, jest.Mock>).limit = jest.fn().mockResolvedValue([]);
+(mockChain as Record<string, jest.Mock>).onConflictDoNothing = jest.fn().mockResolvedValue(undefined);
+(mockChain as Record<string, jest.Mock>).onConflictDoUpdate = jest.fn().mockResolvedValue(undefined);
+
 const app = express();
 app.use(express.json());
 app.use('/internal', internal_route);
+
+// ---- flowsheet-sync-notify (existing) ----
 
 describe('POST /internal/flowsheet-sync-notify', () => {
   beforeEach(() => {
@@ -53,6 +67,132 @@ describe('POST /internal/flowsheet-sync-notify', () => {
     expect(mockBroadcast).toHaveBeenCalledWith('live-fs-topic', {
       type: 'refetch',
       payload: { source: 'etl' },
+    });
+  });
+});
+
+// ---- flowsheet-webhook (new) ----
+
+describe('POST /internal/flowsheet-webhook', () => {
+  const validEntry = {
+    id: 2002,
+    radioShowId: 1001,
+    flowsheetEntryType: 6,
+    artistName: 'Autechre',
+    songTitle: 'VI Scose Poise',
+    releaseTitle: 'Confield',
+    labelName: 'Warp',
+    startTime: 1706799600000,
+    requestFlag: false,
+    sequenceWithinShow: 2,
+    libraryReleaseId: 101,
+    rotationReleaseId: 0,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // -- Auth --
+
+  it('returns 401 without X-Internal-Key header', async () => {
+    const res = await request(app).post('/internal/flowsheet-webhook').send({ action: 'create', entry: validEntry });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with wrong key', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'wrong-key')
+      .send({ action: 'create', entry: validEntry });
+
+    expect(res.status).toBe(401);
+  });
+
+  // -- Validation --
+
+  it('returns 400 for missing action field', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ entry: validEntry });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/action/i);
+  });
+
+  it('returns 400 for invalid action', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'purge', entry: validEntry });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for create with missing entry.id', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, id: undefined } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for delete with missing entryId', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'delete' });
+
+    expect(res.status).toBe(400);
+  });
+
+  // -- Create --
+
+  it('returns 200 for valid create and broadcasts refetch', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(mockUpdateLastModified).toHaveBeenCalled();
+    expect(mockBroadcast).toHaveBeenCalledWith('live-fs-topic', {
+      type: 'refetch',
+      payload: { source: 'webhook' },
+    });
+  });
+
+  // -- Update --
+
+  it('returns 200 for valid update', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', entry: validEntry });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(mockUpdateLastModified).toHaveBeenCalled();
+  });
+
+  // -- Delete --
+
+  it('returns 200 for valid delete', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'delete', entryId: 2002 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(mockUpdateLastModified).toHaveBeenCalled();
+    expect(mockBroadcast).toHaveBeenCalledWith('live-fs-topic', {
+      type: 'refetch',
+      payload: { source: 'webhook' },
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `POST /internal/flowsheet-webhook` endpoint that receives create/update/delete events from tubafrenzy
- Upserts entries using `legacy_entry_id` for idempotency and loop prevention
- Auto-creates show stubs when entries reference unknown shows
- Broadcasts SSE refetch to connected dj-site clients after each write

Closes #324

## Changes

- `apps/backend/routes/internal.route.ts` — new webhook endpoint with input validation, auth, upsert/delete logic
- `apps/backend/utils/flowsheet-transform.ts` — shared `mapProdEntryType` and `truncate` utilities (copied from ETL)
- `apps/backend/services/flowsheet.service.ts` — export `updateLastModified` for webhook use
- `tests/unit/routes/internal.route.test.ts` — 9 new tests (auth, validation, create, update, delete)
- `CLAUDE.md` — document `/internal` route and `ETL_NOTIFY_KEY` dual use

## Test plan

- [ ] 12 unit tests pass (3 existing sync-notify + 9 new webhook)
- [ ] 695 total unit tests pass (1 pre-existing cookie-config failure)
- [ ] Manual: POST to `/internal/flowsheet-webhook` with valid payload, verify entry appears in DB
- [ ] Manual: POST duplicate create, verify idempotent (no error, no duplicate)
- [ ] Lint, format, typecheck clean