### PR TITLE
Fix paginated flowsheet ordering after ETL import

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -169,7 +169,7 @@ export const getEntriesByPage = async (offset: number, limit: number): Promise<I
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
-    .orderBy(desc(flowsheet.play_order))
+    .orderBy(desc(flowsheet.id))
     .offset(offset)
     .limit(limit);
   return raw.map(transformToIFSEntry);

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -781,20 +781,10 @@ describe('Paginated ordering with ETL-imported entries', () => {
   });
 
   test('newest entry appears first even when older entry has higher play_order', async () => {
-    // First, create a fresh entry via the API
-    await fls_util.join_show(global.primary_dj_id, global.access_token);
-    const addRes = await request
-      .post('/flowsheet')
-      .set('Authorization', global.access_token)
-      .send({
-        album_id: 1,
-        track_title: 'Carry the Zero',
-      })
-      .expect(201);
-
-    // Now insert a stale ETL-imported entry directly into the DB with a very high
-    // play_order but old timestamp — simulating the October 2025 show 72945 that
-    // blocked production by sorting above all recent entries
+    // Insert a stale ETL-imported entry first — it gets a lower id, simulating
+    // old data imported by the ETL before the current show exists. It has a very
+    // high play_order (from a long old show), which under the old ORDER BY
+    // play_order DESC would sort above all recent entries.
     const schema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
     const result = await sql.unsafe(`
       INSERT INTO ${schema}.flowsheet
@@ -804,6 +794,18 @@ describe('Paginated ordering with ETL-imported entries', () => {
       RETURNING id
     `);
     staleEntryId = result[0].id;
+
+    // Now create a fresh entry via the API — this gets a higher id but lower
+    // play_order, matching the production scenario
+    await fls_util.join_show(global.primary_dj_id, global.access_token);
+    const addRes = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: 1,
+        track_title: 'Carry the Zero',
+      })
+      .expect(201);
 
     // The paginated endpoint should return the fresh entry first, not the stale one
     const res = await request.get('/flowsheet').query({ limit: 1 }).expect(200);

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -753,6 +753,66 @@ describe('Retrieve Playlist Object', () => {
   });
 });
 
+describe('Paginated ordering with ETL-imported entries', () => {
+  const postgres = require('postgres');
+  let sql;
+  let staleEntryId;
+
+  beforeAll(() => {
+    sql = postgres({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+      database: process.env.DB_NAME || 'wxyc_db',
+      user: process.env.DB_USERNAME || 'test-user',
+      password: process.env.DB_PASSWORD || 'test-pw',
+    });
+  });
+
+  afterAll(async () => {
+    if (staleEntryId) {
+      const schema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+      await sql.unsafe(`DELETE FROM ${schema}.flowsheet WHERE id = ${staleEntryId}`);
+    }
+    await sql.end();
+  });
+
+  afterEach(async () => {
+    await fls_util.leave_show(global.primary_dj_id, global.access_token);
+  });
+
+  test('newest entry appears first even when older entry has higher play_order', async () => {
+    // First, create a fresh entry via the API
+    await fls_util.join_show(global.primary_dj_id, global.access_token);
+    const addRes = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: 1,
+        track_title: 'Carry the Zero',
+      })
+      .expect(201);
+
+    // Now insert a stale ETL-imported entry directly into the DB with a very high
+    // play_order but old timestamp — simulating the October 2025 show 72945 that
+    // blocked production by sorting above all recent entries
+    const schema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+    const result = await sql.unsafe(`
+      INSERT INTO ${schema}.flowsheet
+        (play_order, entry_type, artist_name, album_title, track_title, record_label, add_time, request_flag, segue)
+      VALUES
+        (99999, 'track', 'Stale Artist', 'Stale Album', 'Stale Track', 'Stale Label', '2020-01-01T00:00:00Z', false, false)
+      RETURNING id
+    `);
+    staleEntryId = result[0].id;
+
+    // The paginated endpoint should return the fresh entry first, not the stale one
+    const res = await request.get('/flowsheet').query({ limit: 1 }).expect(200);
+
+    expect(res.body.entries[0].artist_name).not.toBe('Stale Artist');
+    expect(res.body.entries[0].id).toBe(addRes.body.id);
+  });
+});
+
 describe('V1 API - entry_type field', () => {
   beforeEach(async () => {
     await fls_util.join_show(global.primary_dj_id, global.access_token);


### PR DESCRIPTION
## Summary

- Changes `getEntriesByPage` to order by `id DESC` instead of `play_order DESC`
- Adds integration test reproducing the issue (stale entry with high play_order sorting above recent entries)

Closes #329

## Context

After the ETL bulk load imported 2.6M entries from tubafrenzy, the paginated `GET /flowsheet` endpoint returned entries from an October 2025 show (play_order 464) above today's entries (play_order 1-5). The `play_order` column is per-show and not globally meaningful. Ordering by `id` preserves insertion order (chronological) while show-scoped queries continue using `play_order` for DJ reordering.

## Test plan

- [ ] Integration test: "newest entry appears first even when older entry has higher play_order"
- [ ] Unit tests pass (695/696, 1 pre-existing cookie-config failure)
- [ ] Manual: `GET /flowsheet?limit=5` returns most recent entries, not October 2025 data
- [ ] dj.wxyc.org displays current show entries after deploy

Note: Integration test suite has a pre-existing failure unrelated to this change (Start Show returns 500). The new test is structurally correct and will pass once the CI infra issue is resolved.