### PR TITLE
fix: remove heartbeat timer causing OOM via EventSource leak

### DIFF
--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -8,6 +8,7 @@
  *
  * Exported API:
  *   startPlaylistProxy() — open the SSE connection (call once at startup)
+ *   stopPlaylistProxy()  — close the SSE connection and cancel pending reconnects
  *   getRecentEntries(n)  — current enriched playlist, sliced to n entries
  *   isConnected()        — true once the init event has been processed
  *
@@ -20,7 +21,7 @@
  */
 import { EventSource } from 'eventsource';
 import { db, flowsheet } from '@wxyc/database';
-import { sql, inArray, isNotNull } from 'drizzle-orm';
+import { sql, inArray } from 'drizzle-orm';
 
 const TUBAFRENZY_URL = process.env.TUBAFRENZY_URL ?? 'https://www.wxyc.info';
 const MAX_ENTRIES = 200;
@@ -162,75 +163,87 @@ export function startPlaylistProxy(): void {
 }
 
 /**
- * Clear all in-memory state. For tests only.
+ * Close the SSE connection, cancel pending reconnects, and clear state.
  */
-export function resetState(): void {
-  entries = [];
-  artworkMap = new Map();
+export function stopPlaylistProxy(): void {
+  if (currentEventSource) {
+    currentEventSource.close();
+    currentEventSource = null;
+  }
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
   connected = false;
 }
 
+/**
+ * Clear all in-memory state. For tests only.
+ */
+export function resetState(): void {
+  stopPlaylistProxy();
+  entries = [];
+  artworkMap = new Map();
+}
+
 // --- SSE connection ---
+//
+// Reconnection relies on two mechanisms:
+//   1. The `eventsource` package detects TCP-level disconnections and
+//      emits an `error` event, which triggers reconnection with backoff.
+//   2. Tubafrenzy sends `:heartbeat` SSE comments every 30 seconds,
+//      keeping the TCP connection alive so idle timeouts don't fire.
+//
+// There is intentionally no application-level heartbeat timer here.
+// SSE comments are invisible to addEventListener (per the spec), so any
+// timer that resets only on named events will misfire on an idle-but-alive
+// connection, causing unnecessary reconnects and EventSource leaks.
 
 let reconnectDelay = 1000;
 const MAX_RECONNECT_DELAY = 30000;
-let heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
-const HEARTBEAT_TIMEOUT = 60000;
+let currentEventSource: EventSource | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 function connectSSE(): void {
   const url = `${TUBAFRENZY_URL}/playlists/recentStream`;
   console.log(`[playlist-proxy] Connecting to SSE: ${url}`);
 
+  if (currentEventSource) {
+    currentEventSource.close();
+    currentEventSource = null;
+  }
+
   const es = new EventSource(url);
+  currentEventSource = es;
 
   es.addEventListener('init', (event: MessageEvent) => {
-    reconnectDelay = 1000; // reset backoff on successful connection
-    resetHeartbeatTimer(es);
+    reconnectDelay = 1000;
     processInitEvent(event.data).catch((err) => console.error('[playlist-proxy] Error processing init event:', err));
   });
 
   es.addEventListener('created', (event: MessageEvent) => {
-    resetHeartbeatTimer(es);
     processCreatedEvent(event.data).catch((err) =>
       console.error('[playlist-proxy] Error processing created event:', err)
     );
   });
 
   es.addEventListener('updated', (event: MessageEvent) => {
-    resetHeartbeatTimer(es);
     processUpdatedEvent(event.data).catch((err) =>
       console.error('[playlist-proxy] Error processing updated event:', err)
     );
   });
 
   es.addEventListener('deleted', (event: MessageEvent) => {
-    resetHeartbeatTimer(es);
     processDeletedEvent(event.data);
   });
 
   es.addEventListener('error', () => {
     console.error(`[playlist-proxy] SSE error, reconnecting in ${reconnectDelay}ms`);
-    clearHeartbeatTimer();
     es.close();
-    setTimeout(() => connectSSE(), reconnectDelay);
+    if (currentEventSource === es) currentEventSource = null;
+    reconnectTimer = setTimeout(() => connectSSE(), reconnectDelay);
     reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY);
   });
-}
-
-function resetHeartbeatTimer(es: EventSource): void {
-  clearHeartbeatTimer();
-  heartbeatTimer = setTimeout(() => {
-    console.warn('[playlist-proxy] Heartbeat timeout, reconnecting');
-    es.close();
-    connectSSE();
-  }, HEARTBEAT_TIMEOUT);
-}
-
-function clearHeartbeatTimer(): void {
-  if (heartbeatTimer) {
-    clearTimeout(heartbeatTimer);
-    heartbeatTimer = null;
-  }
 }
 
 // --- Event processing (exported for testability) ---

--- a/tests/unit/services/playlist-proxy.connection.test.ts
+++ b/tests/unit/services/playlist-proxy.connection.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for playlist proxy SSE connection lifecycle.
+ *
+ * These tests verify that the proxy manages its EventSource connection
+ * correctly — specifically that it does not tear down healthy connections
+ * due to an overly aggressive heartbeat timeout.
+ *
+ * Background: tubafrenzy sends `:heartbeat` SSE comments every 30 seconds.
+ * The EventSource API silently consumes SSE comments without dispatching
+ * events, so any application-level heartbeat timer that resets only on
+ * named events (init, created, updated, deleted) will never see the
+ * heartbeat comments and will conclude the connection is dead.
+ */
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+// --- Mock EventSource that tracks instances and captures listeners ---
+
+type EventHandler = (event: { data: string }) => void;
+
+interface MockES {
+  url: string;
+  listeners: Map<string, EventHandler[]>;
+  addEventListener: jest.Mock;
+  close: jest.Mock;
+  readyState: number;
+}
+
+const instances: MockES[] = [];
+
+jest.mock('eventsource', () => ({
+  EventSource: jest.fn().mockImplementation((url: string) => {
+    const listeners = new Map<string, EventHandler[]>();
+    const instance: MockES = {
+      url,
+      listeners,
+      addEventListener: jest.fn((type: string, fn: EventHandler) => {
+        if (!listeners.has(type)) listeners.set(type, []);
+        listeners.get(type)?.push(fn);
+      }),
+      close: jest.fn(),
+      readyState: 1,
+    };
+    instances.push(instance);
+    return instance;
+  }),
+}));
+
+// drizzle-orm mock (needed by enrichPlaycuts)
+jest.mock('drizzle-orm', () => ({
+  sql: Object.assign(jest.fn(), { raw: jest.fn() }),
+  inArray: jest.fn(),
+  isNotNull: jest.fn(),
+}));
+
+// Suppress console output
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'error').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+// Import after mocks are in place. @wxyc/database is mapped to the
+// shared mock by jest.unit.config.ts moduleNameMapper.
+import { startPlaylistProxy, resetState } from '../../../apps/backend/services/playlist-proxy.service';
+
+/** Fire a named event on a mock EventSource instance. */
+function fireEvent(es: MockES, type: string, data: unknown = {}): void {
+  const handlers = es.listeners.get(type) ?? [];
+  const event: { data: string } = { data: typeof data === 'string' ? data : JSON.stringify(data) };
+  for (const handler of handlers) handler(event);
+}
+
+describe('playlist-proxy SSE connection stability', () => {
+  beforeEach(() => {
+    instances.length = 0;
+    resetState();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('does not reconnect when the connection is healthy and has no errors', () => {
+    // Tubafrenzy sends :heartbeat SSE comments every 30 seconds.
+    // The proxy's heartbeat timer (60 s) should not fire when the
+    // underlying connection is still alive. Today it does, because
+    // SSE comments are invisible to addEventListener — only named
+    // events (init, created, …) reset the timer.
+
+    startPlaylistProxy();
+    expect(instances).toHaveLength(1);
+
+    // Server delivers the init payload — connection is established.
+    fireEvent(instances[0], 'init', []);
+
+    // Advance well past the 60-second heartbeat timeout.
+    // No errors have occurred; the connection is perfectly healthy.
+    jest.advanceTimersByTime(90_000);
+
+    // A healthy, error-free connection should not be torn down.
+    expect(instances).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Remove the 60-second heartbeat timer from the playlist proxy SSE connection. Tubafrenzy sends `:heartbeat` SSE comments every 30s, but the EventSource API silently consumes comments without dispatching events, so the timer always fired — reconnecting every 60 seconds and leaking EventSource objects until the instance OOM'd.
- Track `currentEventSource` so error-driven reconnects close the previous connection.
- Add `stopPlaylistProxy()` for graceful shutdown.

Closes #331

## Test plan

- [x] New unit test: healthy connection is not torn down after 90s of no named events
- [x] All 22 existing playlist proxy tests pass
- [x] Full unit suite: 696/697 pass (1 pre-existing failure in `cookie-config.test.ts`)
- [x] Lint and format checks pass
- [ ] Deploy to EC2 and monitor `docker stats` memory over several hours