### PR TITLE
Add one-time backfill script for legacy_release_id and DJ info

### DIFF
--- a/jobs/flowsheet-etl/backfill-legacy-ids.ts
+++ b/jobs/flowsheet-etl/backfill-legacy-ids.ts
@@ -1,0 +1,230 @@
+/**
+ * One-time backfill: populate legacy_release_id on flowsheet entries and
+ * legacy_dj_name/legacy_dj_id on shows for rows imported before PR #328.
+ *
+ * After updating legacy_release_id, resolves flowsheet.album_id via the
+ * library.legacy_release_id join.
+ *
+ * Usage:
+ *   npx tsx jobs/flowsheet-etl/backfill-legacy-ids.ts [--dry-run]
+ *
+ * Environment: same as the flowsheet ETL (DB_*, LEGACY_DB_DOCKER_CONTAINER or SSH_*).
+ */
+
+import { sql } from 'drizzle-orm';
+import { db, flowsheet, library, shows, closeDatabaseConnection, MirrorSQL } from '@wxyc/database';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const BATCH_SIZE = 5000;
+
+const legacyDB = MirrorSQL.instance();
+
+// ---- Flowsheet: legacy_release_id ----
+
+type ReleaseMapping = { entryId: number; releaseId: number };
+
+const fetchReleaseMappings = async (): Promise<ReleaseMapping[]> => {
+  console.log('[backfill] Fetching LIBRARY_RELEASE_ID mappings from tubafrenzy...');
+  const raw = await legacyDB.send(`
+    SELECT ID, LIBRARY_RELEASE_ID
+    FROM FLOWSHEET_ENTRY_PROD
+    WHERE LIBRARY_RELEASE_ID IS NOT NULL AND LIBRARY_RELEASE_ID != 0;
+  `);
+
+  if (raw.trim().length === 0) return [];
+
+  const mappings: ReleaseMapping[] = [];
+  for (const line of raw.trim().split('\n')) {
+    const [entryIdStr, releaseIdStr] = line.split('\t');
+    const entryId = Number(entryIdStr);
+    const releaseId = Number(releaseIdStr);
+    if (Number.isFinite(entryId) && Number.isFinite(releaseId) && releaseId !== 0) {
+      mappings.push({ entryId, releaseId });
+    }
+  }
+
+  console.log(`[backfill] Found ${mappings.length} entries with LIBRARY_RELEASE_ID.`);
+  return mappings;
+};
+
+const backfillReleaseIds = async (mappings: ReleaseMapping[]): Promise<number> => {
+  let totalUpdated = 0;
+
+  for (let i = 0; i < mappings.length; i += BATCH_SIZE) {
+    const batch = mappings.slice(i, i + BATCH_SIZE);
+
+    // Build VALUES list: (entry_id, release_id), ...
+    const valuesList = batch.map((m) => `(${m.entryId}, ${m.releaseId})`).join(', ');
+
+    if (DRY_RUN) {
+      console.log(
+        `[backfill] [dry-run] Would update ${batch.length} entries (batch ${Math.floor(i / BATCH_SIZE) + 1}).`
+      );
+      totalUpdated += batch.length;
+      continue;
+    }
+
+    const result = await db.execute(
+      sql.raw(`
+      UPDATE ${getSchemaPrefix()}flowsheet f
+      SET legacy_release_id = v.release_id::int
+      FROM (VALUES ${valuesList}) AS v(entry_id, release_id)
+      WHERE f.legacy_entry_id = v.entry_id
+        AND f.legacy_release_id IS NULL
+    `)
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- db.execute returns untyped result
+    const count = Number((result as Record<string, unknown>).count ?? batch.length);
+    totalUpdated += count;
+
+    if ((i / BATCH_SIZE + 1) % 20 === 0) {
+      console.log(`[backfill] ...${totalUpdated} flowsheet entries updated so far.`);
+    }
+  }
+
+  return totalUpdated;
+};
+
+// ---- Shows: legacy_dj_name, legacy_dj_id ----
+
+type DJMapping = { showId: number; djName: string | null; djId: number | null };
+
+const fetchDJMappings = async (): Promise<DJMapping[]> => {
+  console.log('[backfill] Fetching DJ_NAME/DJ_ID mappings from tubafrenzy...');
+  const raw = await legacyDB.send(`
+    SELECT
+      ID,
+      REPLACE(REPLACE(IFNULL(DJ_NAME, ''), '\\t', ' '), '\\n', ' '),
+      DJ_ID
+    FROM FLOWSHEET_RADIO_SHOW_PROD;
+  `);
+
+  if (raw.trim().length === 0) return [];
+
+  const mappings: DJMapping[] = [];
+  for (const line of raw.trim().split('\n')) {
+    const cols = line.split('\t');
+    if (cols.length < 3) continue;
+    const showId = Number(cols[0]);
+    if (!Number.isFinite(showId)) continue;
+    const djName = cols[1].trim().length > 0 && cols[1].trim() !== 'NULL' ? cols[1].trim() : null;
+    const rawDjId = Number(cols[2]);
+    const djId = Number.isFinite(rawDjId) && rawDjId !== 0 ? rawDjId : null;
+    if (djName || djId) {
+      mappings.push({ showId, djName, djId });
+    }
+  }
+
+  console.log(`[backfill] Found ${mappings.length} shows with DJ info.`);
+  return mappings;
+};
+
+const backfillDJInfo = async (mappings: DJMapping[]): Promise<number> => {
+  let totalUpdated = 0;
+
+  for (let i = 0; i < mappings.length; i += BATCH_SIZE) {
+    const batch = mappings.slice(i, i + BATCH_SIZE);
+
+    if (DRY_RUN) {
+      console.log(`[backfill] [dry-run] Would update ${batch.length} shows (batch ${Math.floor(i / BATCH_SIZE) + 1}).`);
+      totalUpdated += batch.length;
+      continue;
+    }
+
+    // Update one at a time — show count is small (71K) and the query needs
+    // to handle nullable strings which are hard to batch via raw VALUES
+    for (const m of batch) {
+      await db
+        .update(shows)
+        .set({
+          legacy_dj_name: m.djName,
+          legacy_dj_id: m.djId,
+        })
+        .where(sql`${shows.legacy_show_id} = ${m.showId} AND ${shows.legacy_dj_name} IS NULL`);
+    }
+
+    totalUpdated += batch.length;
+
+    if ((i / BATCH_SIZE + 1) % 5 === 0) {
+      console.log(`[backfill] ...${totalUpdated} shows updated so far.`);
+    }
+  }
+
+  return totalUpdated;
+};
+
+// ---- Resolve album_id ----
+
+const resolveAlbumIds = async (): Promise<void> => {
+  if (DRY_RUN) {
+    const preview = await db.execute(sql`
+      SELECT COUNT(*)::int AS count
+      FROM ${flowsheet} f
+      JOIN ${library} l ON f.legacy_release_id = l.legacy_release_id
+      WHERE f.legacy_release_id IS NOT NULL AND f.album_id IS NULL
+    `);
+    const rows = preview as Record<string, unknown>[];
+    const count = rows.length > 0 ? (rows[0].count as number) : '?';
+    console.log(`[backfill] [dry-run] Would resolve album_id for ${count} entries.`);
+    return;
+  }
+
+  await db.execute(sql`
+    UPDATE ${flowsheet} f
+    SET album_id = l.id
+    FROM ${library} l
+    WHERE f.legacy_release_id = l.legacy_release_id
+      AND f.legacy_release_id IS NOT NULL
+      AND f.album_id IS NULL
+  `);
+  console.log('[backfill] Resolved album_id via legacy_release_id join.');
+};
+
+// ---- Helpers ----
+
+const getSchemaPrefix = (): string => {
+  const schema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+  return `"${schema}".`;
+};
+
+// ---- Main ----
+
+const main = async () => {
+  if (DRY_RUN) {
+    console.log('[backfill] Running in DRY-RUN mode — no database changes will be made.\n');
+  }
+
+  // 1. Backfill flowsheet.legacy_release_id
+  const releaseMappings = await fetchReleaseMappings();
+  if (releaseMappings.length > 0) {
+    const updated = await backfillReleaseIds(releaseMappings);
+    console.log(`[backfill] Flowsheet legacy_release_id: ${updated} entries updated.`);
+  } else {
+    console.log('[backfill] No release mappings found — skipping flowsheet backfill.');
+  }
+
+  // 2. Resolve album_id from legacy_release_id
+  await resolveAlbumIds();
+
+  // 3. Backfill shows.legacy_dj_name and legacy_dj_id
+  const djMappings = await fetchDJMappings();
+  if (djMappings.length > 0) {
+    const updated = await backfillDJInfo(djMappings);
+    console.log(`[backfill] Shows DJ info: ${updated} shows updated.`);
+  } else {
+    console.log('[backfill] No DJ mappings found — skipping shows backfill.');
+  }
+
+  console.log('\n[backfill] Done.');
+};
+
+main()
+  .catch((err) => {
+    console.error('[backfill] Fatal error:', err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    legacyDB.close();
+    await closeDatabaseConnection();
+  });

--- a/tests/e2e/etl.test.ts
+++ b/tests/e2e/etl.test.ts
@@ -394,3 +394,60 @@ describe('Flowsheet ETL incremental sync', () => {
     expect(rows[0].album_title).toBe('Confield');
   });
 });
+
+// ---- Backfill Script ----
+
+describe('Backfill legacy IDs script', () => {
+  beforeAll(async () => {
+    // NULL out the columns that the backfill script should restore,
+    // simulating entries imported before PR #328
+    await pg`UPDATE ${pg(SCHEMA)}.flowsheet SET legacy_release_id = NULL, album_id = NULL`;
+    await pg`UPDATE ${pg(SCHEMA)}.shows SET legacy_dj_name = NULL, legacy_dj_id = NULL`;
+
+    // Verify they're actually NULL
+    const releaseCheck =
+      await pg`SELECT COUNT(*)::int AS count FROM ${pg(SCHEMA)}.flowsheet WHERE legacy_release_id IS NOT NULL`;
+    expect(releaseCheck[0].count).toBe(0);
+
+    const djCheck = await pg`SELECT COUNT(*)::int AS count FROM ${pg(SCHEMA)}.shows WHERE legacy_dj_name IS NOT NULL`;
+    expect(djCheck[0].count).toBe(0);
+
+    // Run the backfill script
+    execSync('npx tsx jobs/flowsheet-etl/backfill-legacy-ids.ts', {
+      env: etlEnv,
+      cwd: process.cwd(),
+      stdio: 'pipe',
+      timeout: 60000,
+    });
+  });
+
+  it('restores legacy_release_id on flowsheet entries', async () => {
+    const entries =
+      await pg`SELECT legacy_entry_id, legacy_release_id FROM ${pg(SCHEMA)}.flowsheet WHERE legacy_entry_id IN (2002, 2004, 2010)`;
+    const byId = (id: number) => entries.find((e: any) => e.legacy_entry_id === id);
+    expect(byId(2002).legacy_release_id).toBe(101);
+    expect(byId(2004).legacy_release_id).toBeNull(); // talkset
+    expect(byId(2010).legacy_release_id).toBe(105);
+  });
+
+  it('resolves album_id after backfilling legacy_release_id', async () => {
+    const entries = await pg`
+      SELECT f.legacy_entry_id, l.album_title
+      FROM ${pg(SCHEMA)}.flowsheet f
+      LEFT JOIN ${pg(SCHEMA)}.library l ON f.album_id = l.id
+      WHERE f.legacy_entry_id IN (2002, 2003)
+    `;
+    const byId = (id: number) => entries.find((e: any) => e.legacy_entry_id === id);
+    expect(byId(2002).album_title).toBe('Confield');
+    expect(byId(2003).album_title).toBe('Moon Pix');
+  });
+
+  it('restores legacy DJ name and ID on shows', async () => {
+    const rows = await pg`SELECT legacy_show_id, legacy_dj_name, legacy_dj_id FROM ${pg(SCHEMA)}.shows`;
+    const show1001 = rows.find((r: any) => r.legacy_show_id === 1001);
+    const show1002 = rows.find((r: any) => r.legacy_show_id === 1002);
+    expect(show1001.legacy_dj_name).toBe('DJ Bluejay');
+    expect(show1001.legacy_dj_id).toBe(42);
+    expect(show1002.legacy_dj_name).toBe('dj wilde');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `jobs/flowsheet-etl/backfill-legacy-ids.ts` — a one-time script that queries tubafrenzy for `LIBRARY_RELEASE_ID` and `DJ_NAME`/`DJ_ID` mappings, batch-updates PostgreSQL, then resolves `flowsheet.album_id` via the library join
- Supports `--dry-run` for safe preview before production execution
- E2E tests verify the backfill restores NULLed-out columns and resolves album_id

Closes #333

## Context

PR #328 added ETL support for capturing these fields going forward, but the 1.95M flowsheet entries and 71K shows already in production have NULLs. The incremental sync's `onConflictDoUpdate` deliberately excludes `legacy_release_id` (it's immutable per entry), so re-running the ETL won't backfill existing rows. This script fills that gap.

## Test plan

- [x] E2E: NULLs out all backfill columns, runs the script, verifies restoration (3 tests)
- [x] All 32 E2E tests pass
- [x] Lint (0 errors), format check pass
- [x] Pre-push typecheck passes