### PR TITLE
hardening: Docker memory limits, graceful shutdown, heap monitoring

### DIFF
--- a/.github/actions/deploy-service/action.yml
+++ b/.github/actions/deploy-service/action.yml
@@ -71,7 +71,19 @@ runs:
           docker ps -a --filter "publish=$PUBLISH_PORT" --format "{{.ID}}" | xargs -r docker rm 
 
           echo "Starting new Docker container..."
-          docker run -d --name $TARGET_APP -p $PUBLISH_PORT:8080 --restart unless-stopped --env-file .env -e SENTRY_RELEASE=$TARGET_APP@$DEPLOY_TAG ${{ inputs.aws_ecr_uri }}/$TARGET_APP:$DEPLOY_TAG
+          docker run -d --name $TARGET_APP \
+            -p $PUBLISH_PORT:8080 \
+            --restart unless-stopped \
+            --memory=450m \
+            --env-file .env \
+            -e SENTRY_RELEASE=$TARGET_APP@$DEPLOY_TAG \
+            -e NODE_OPTIONS="--max-old-space-size=384" \
+            --health-cmd="wget -qO- http://localhost:8080/healthcheck || exit 1" \
+            --health-interval=30s \
+            --health-timeout=10s \
+            --health-retries=3 \
+            --health-start-period=30s \
+            ${{ inputs.aws_ecr_uri }}/$TARGET_APP:$DEPLOY_TAG
 
           echo "Cleaning up old Docker images..."
           docker images --format '{{.Repository}} {{.Tag}}' | \

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -10,6 +10,7 @@ import cors from 'cors';
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
+import { closeDatabaseConnection } from '@wxyc/database';
 
 const port = process.env.AUTH_PORT || '8080';
 
@@ -334,9 +335,23 @@ void (async () => {
   await createDefaultUser();
   await syncAdminRoles();
 
-  app.listen(parseInt(port), () => {
+  const server = app.listen(parseInt(port), () => {
     console.log(`listening on port: ${port}! (auth service)`);
   });
+
+  function shutdown(signal: string): void {
+    console.log(`[auth-shutdown] Received ${signal}, shutting down...`);
+    server.close(() => {
+      closeDatabaseConnection()
+        .then(() => process.exit(0))
+        .catch(() => process.exit(1));
+    });
+    setTimeout(() => server.closeAllConnections(), 5_000).unref();
+    setTimeout(() => process.exit(1), 10_000).unref();
+  }
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
 })();
 
 export default app;

--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -17,11 +17,12 @@ import { config_route } from './routes/config.route.js';
 import { internal_route } from './routes/internal.route.js';
 import { proxy_route } from './routes/proxy.route.js';
 import { playlist_route } from './routes/playlist.route.js';
-import { startPlaylistProxy } from './services/playlist-proxy.service.js';
+import { startPlaylistProxy, stopPlaylistProxy } from './services/playlist-proxy.service.js';
 import { activeShow } from './middleware/checkActiveShow.js';
 import errorHandler from './middleware/errorHandler.js';
 import { requestIdMiddleware } from './middleware/requestId.js';
 import { requirePermissions } from '@wxyc/authentication';
+import { closeDatabaseConnection } from '@wxyc/database';
 
 const port = process.env.PORT || 8080;
 const app = express();
@@ -104,3 +105,34 @@ const server = app.listen(port, () => {
 });
 
 server.setTimeout(30000);
+
+// --- Memory monitoring ---
+
+const MEMORY_LOG_INTERVAL = 5 * 60 * 1000; // 5 minutes
+const memoryLogTimer = setInterval(() => {
+  const usage = process.memoryUsage();
+  console.log(
+    `[memory] rss=${(usage.rss / 1024 / 1024).toFixed(1)}MB heap=${(usage.heapUsed / 1024 / 1024).toFixed(1)}/${(usage.heapTotal / 1024 / 1024).toFixed(1)}MB`
+  );
+}, MEMORY_LOG_INTERVAL);
+memoryLogTimer.unref();
+
+// --- Graceful shutdown ---
+
+function shutdown(signal: string): void {
+  console.log(`[shutdown] Received ${signal}, shutting down...`);
+  stopPlaylistProxy();
+  server.close(() => {
+    closeDatabaseConnection()
+      .then(() => process.exit(0))
+      .catch(() => process.exit(1));
+  });
+  setTimeout(() => {
+    console.warn('[shutdown] Force closing remaining connections');
+    server.closeAllConnections();
+  }, 5_000).unref();
+  setTimeout(() => process.exit(1), 10_000).unref();
+}
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -72,7 +72,9 @@ interface CachedArtwork {
 }
 
 const artworkCache = new LRUCache<string, CachedArtwork>({
-  max: 500,
+  max: 200,
+  maxSize: 20 * 1024 * 1024, // 20 MB total
+  sizeCalculation: (value) => value.data.byteLength,
   ttl: 1000 * 60 * 60, // 1 hour for positive results
 });
 


### PR DESCRIPTION
## Summary

- Add Docker `--memory=450m` and `--max-old-space-size=384` so a memory leak crashes the container (auto-restarted) instead of the entire EC2 instance
- Add Docker healthcheck via `/healthcheck` endpoint with 3 retries
- Add SIGTERM/SIGINT graceful shutdown to both backend and auth services (stop playlist proxy, drain HTTP server, close DB connections)
- Add periodic heap usage logging every 5 minutes (`[memory] rss=... heap=...`)
- Cap artwork proxy LRU cache at 20 MB total (was unbounded by byte size)

Follow-up to #332. Incorporates the non-overlapping changes from #321 (now closed).

## Test plan

- [x] 700 unit tests pass (1 pre-existing failure in `cookie-config.test.ts`)
- [x] Format check passes
- [ ] After deploy, verify memory limits: `docker stats --no-stream`
- [ ] After deploy, verify healthcheck: `docker inspect backend --format '{{json .State.Health}}'`
- [ ] Monitor `[memory]` log lines for heap trends over 24 hours