### PR TITLE
Record last_run after ETL bulk load

### DIFF
--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -225,6 +225,8 @@ const runBulkLoad = async (dumpPath: string) => {
   console.log(`[flowsheet-etl] Imported ${entryCount} entries.`);
   await resetSequences();
   await resolveAlbumIds();
+  await updateLastRun(new Date());
+  console.log('[flowsheet-etl] Recorded last_run for future incremental syncs.');
 };
 
 // ---- Incremental Sync Mode ----

--- a/tests/e2e/etl.test.ts
+++ b/tests/e2e/etl.test.ts
@@ -302,6 +302,31 @@ describe('Flowsheet ETL', () => {
 
 // ---- Flowsheet ETL: Incremental Sync (bidirectional) ----
 
+describe('Flowsheet API ordering after ETL import', () => {
+  it('returns newest entries first by id, not by play_order', async () => {
+    // After ETL import, show 1001 has entries with play_order up to 8,
+    // and show 1002 (newer) has entries with play_order 1-2.
+    // ORDER BY id DESC should return show 1002 entries first.
+    const rows = await pg`
+      SELECT id, legacy_entry_id, play_order
+      FROM ${pg(SCHEMA)}.flowsheet
+      WHERE legacy_entry_id IS NOT NULL
+      ORDER BY id DESC
+      LIMIT 3
+    `;
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    // The newest entry (highest legacy_entry_id) should be first
+    expect(rows[0].legacy_entry_id).toBe(2010);
+    // Even though show 1001's entries have higher play_order (up to 8),
+    // they should NOT appear before show 1002's entries
+    const firstPlayOrder = rows[0].play_order;
+    const secondPlayOrder = rows[1].play_order;
+    // show 1002 entry has play_order 2, show 1001's last entry has play_order 8
+    // If sorted by play_order DESC, show 1001 entries would come first (wrong)
+    expect(firstPlayOrder).toBeLessThanOrEqual(secondPlayOrder);
+  });
+});
+
 describe('Flowsheet ETL incremental sync', () => {
   const MYSQL_CONTAINER = 'dev_env-etl-mysql-1';
   const MYSQL_CMD = `docker exec -i ${MYSQL_CONTAINER} mysql -uetluser -petltest wxycmusic --batch --raw --silent`;


### PR DESCRIPTION
## Summary

- Calls `updateLastRun` at the end of `runBulkLoad` so the next incremental sync starts from the correct point

## Context

The bulk load never recorded `last_run` in `cronjob_runs`. After the initial 2.6M-entry bulk import, every 30-minute cron run attempted a full incremental fetch (no `last_run` = no WHERE clause), hanging on the SSH tunnel or OOM-ing. Required manual intervention to set `last_run` via `docker exec`.

## Test plan

- [ ] Unit test: bulk load calls `updateLastRun` (verifiable via E2E test checking `cronjob_runs` after bulk load)
- [ ] After bulk load, `cronjob_runs` has a `flowsheet-etl` row
- [ ] Subsequent incremental run fetches only new entries