### PR TITLE
Fix breakpoint/talkset text lost during tubafrenzy mirror

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -3,7 +3,7 @@ import { eq, sql } from 'drizzle-orm';
 import { db, flowsheet, shows } from '@wxyc/database';
 import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
 import { updateLastModified } from '../services/flowsheet.service.js';
-import { mapProdEntryType, truncate } from '../utils/flowsheet-transform.js';
+import { mapProdEntryType, isMessageEntryType, truncate } from '../utils/flowsheet-transform.js';
 
 const ETL_NOTIFY_KEY = process.env.ETL_NOTIFY_KEY ?? '';
 
@@ -96,6 +96,7 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
 
       const entryType = mapProdEntryType(entry.flowsheetEntryType ?? 0);
       const showId = await resolveShowId(entry.radioShowId);
+      const isMsgType = isMessageEntryType(entryType);
 
       await db
         .insert(flowsheet)
@@ -103,10 +104,11 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
           legacy_entry_id: entry.id,
           show_id: showId,
           entry_type: entryType,
-          artist_name: truncate(entry.artistName, 128),
+          artist_name: isMsgType ? null : truncate(entry.artistName, 128),
           album_title: truncate(entry.releaseTitle, 128),
           track_title: truncate(entry.songTitle, 128),
           record_label: truncate(entry.labelName, 128),
+          message: isMsgType ? truncate(entry.artistName, 250) : null,
           request_flag: !!entry.requestFlag,
           segue: false,
           play_order: entry.sequenceWithinShow ?? 0,
@@ -119,6 +121,7 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
             album_title: sql`excluded.album_title`,
             track_title: sql`excluded.track_title`,
             record_label: sql`excluded.record_label`,
+            message: sql`excluded.message`,
             request_flag: sql`excluded.request_flag`,
             entry_type: sql`excluded.entry_type`,
           },

--- a/apps/backend/utils/flowsheet-transform.ts
+++ b/apps/backend/utils/flowsheet-transform.ts
@@ -44,6 +44,10 @@ export const mapProdEntryType = (typeCode: number): BackendEntryType => {
   return PROD_ENTRY_TYPE_MAP[typeCode] ?? 'message';
 };
 
+/** Entry types whose legacy ARTIST_NAME text is display content, not a real artist. */
+export const isMessageEntryType = (entryType: string): boolean =>
+  entryType === 'breakpoint' || entryType === 'talkset' || entryType === 'message';
+
 /**
  * Truncate a string to a max length, returning null if empty.
  * Matches the VARCHAR(128) / VARCHAR(250) limits in the schema.

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -78,17 +78,31 @@ const resolveAlbumIds = async () => {
   console.log(`[flowsheet-etl] Resolved album_id for flowsheet entries.`);
 };
 
+/** Entry types whose legacy ARTIST_NAME text is display content, not a real artist. */
+const isMessageEntryType = (entryType: string): boolean =>
+  entryType === 'breakpoint' || entryType === 'talkset' || entryType === 'message';
+
 /**
  * Resolve the artist_name for a flowsheet entry. For show_start/show_end entries,
- * parse the DJ name from the structured ARTIST_NAME text. For all other entries,
- * truncate to 128 chars.
+ * parse the DJ name from the structured ARTIST_NAME text. For message-bearing types
+ * (breakpoint, talkset, message), the text belongs in the message field instead.
  */
 const resolveArtistName = (rawArtistName: string | null, entryType: string): string | null => {
   if (!rawArtistName) return null;
+  if (isMessageEntryType(entryType)) return null;
   if (entryType === 'show_start' || entryType === 'show_end') {
     return truncate(parseShowEntryDJName(rawArtistName), 128) ?? truncate(rawArtistName, 128);
   }
   return truncate(rawArtistName, 128);
+};
+
+/**
+ * Resolve the message field for a flowsheet entry. For breakpoint, talkset, and
+ * message entries, the legacy ARTIST_NAME column contains the display text.
+ */
+const resolveMessage = (rawArtistName: string | null, entryType: string): string | null => {
+  if (!rawArtistName || !isMessageEntryType(entryType)) return null;
+  return truncate(rawArtistName, 250);
 };
 
 // ---- Bulk Load Mode ----
@@ -195,7 +209,7 @@ const importEntries = async (dbClient: DbClient, lines: string[], showIdMap: Map
         album_title: truncate(tuple[4] != null ? String(tuple[4]) : null, 128),
         track_title: truncate(tuple[3] != null ? String(tuple[3]) : null, 128),
         record_label: truncate(tuple[8] != null ? String(tuple[8]) : null, 128),
-        message: null,
+        message: resolveMessage(rawArtistName, entryType),
         request_flag: Number(tuple[18]) === 1,
         segue: tuple.length > 21 ? Number(tuple[21]) === 1 : false,
         play_order: Number(tuple[13]) || 0,
@@ -339,7 +353,7 @@ const runIncremental = async (): Promise<SyncResult> => {
         album_title: truncate(entry.albumTitle, 128),
         track_title: truncate(entry.trackTitle, 128),
         record_label: truncate(entry.label, 128),
-        message: null,
+        message: resolveMessage(entry.artistName, entryType),
         request_flag: entry.requestFlag === 1,
         segue: entry.segueFlag === 1,
         play_order: entry.playOrder,
@@ -352,6 +366,7 @@ const runIncremental = async (): Promise<SyncResult> => {
           album_title: sql`excluded.album_title`,
           track_title: sql`excluded.track_title`,
           record_label: sql`excluded.record_label`,
+          message: sql`excluded.message`,
           request_flag: sql`excluded.request_flag`,
           segue: sql`excluded.segue`,
           entry_type: sql`excluded.entry_type`,


### PR DESCRIPTION
## Summary

- Route legacy `ARTIST_NAME` text to the `message` field (instead of `artist_name`) for breakpoint, talkset, and message entry types in the ETL bulk load, ETL incremental sync, and webhook handler
- Include `message` in `onConflictDoUpdate` sets so updates propagate correctly
- Set `artist_name` to `null` for these entry types since they don't have a real artist

## Context

In tubafrenzy's database, breakpoint/talkset display text (e.g., "--- 9:00 PM Breakpoint ---") is stored in the `ARTIST_NAME` column. The mirror was placing this into `artist_name` and hardcoding `message: null`, but dj-site reads `entry.message` for rendering these entry types.

## Test plan

- [x] All 701 unit tests pass
- [x] Typecheck clean
- [ ] After deploy, verify breakpoints/talksets show text in dj-site
- [ ] Run data backfill for existing rows (see #344)

Closes #344