### PR TITLE
Enable OIDC provider for Wiki.js authentication

### DIFF
--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -8,6 +8,7 @@ import {
   bearer,
   emailOTP,
   jwt,
+  oidcProvider,
   organization as organizationPlugin,
   username,
 } from 'better-auth/plugins';
@@ -157,6 +158,39 @@ export const auth = betterAuth({
             capabilities: userWithCapabilities?.capabilities ?? [],
           };
         },
+      },
+    }),
+    oidcProvider({
+      loginPage: '/sign-in',
+      allowDynamicClientRegistration: false,
+      requirePKCE: true,
+      trustedClients: [
+        {
+          clientId: process.env.WIKIJS_OIDC_CLIENT_ID!,
+          clientSecret: process.env.WIKIJS_OIDC_CLIENT_SECRET!,
+          redirectUrls: [`${process.env.WIKIJS_URL}/login/oidc/callback`],
+          name: 'Wiki.js',
+          type: 'web' as const,
+          disabled: false,
+          icon: undefined,
+          metadata: null,
+          skipConsent: true,
+        },
+      ],
+      getAdditionalUserInfoClaim: async (userRecord) => {
+        try {
+          const memberRecord = await db
+            .select({ role: member.role })
+            .from(member)
+            .where(eq(member.userId, userRecord.id))
+            .limit(1);
+          return {
+            role: memberRecord[0]?.role ?? 'member',
+            capabilities: (userRecord as typeof userRecord & { capabilities?: string[] }).capabilities ?? [],
+          };
+        } catch {
+          return { role: 'member', capabilities: [] };
+        }
       },
     }),
     organizationPlugin({


### PR DESCRIPTION
## Summary

- Enables the better-auth `oidcProvider` plugin in the auth service
- Registers Wiki.js as a trusted OIDC client (in-code, no dynamic registration)
- Adds `getAdditionalUserInfoClaim` hook to include `role` and `capabilities` in the OIDC userinfo response, so Wiki.js can map WXYC roles to internal groups for per-page permissions

## Context

Wiki.js is deployed at wiki.wxyc.org but can't use JWT/JWKS verification directly like our own services — it's a third-party app that needs a standard OIDC flow. The better-auth OIDC provider plugin exposes standard endpoints (`/.well-known/openid-configuration`, `/oauth2/authorize`, `/oauth2/token`, `/oauth2/userinfo`) that Wiki.js authenticates against. This maintains the single-identity principle from the unified auth system.

## Configuration

Requires three new env vars on the auth container:

```
WIKIJS_OIDC_CLIENT_ID=wikijs
WIKIJS_OIDC_CLIENT_SECRET=<secret>
WIKIJS_URL=https://wiki.wxyc.org
```

The plugin creates three internal tables (`oauth_application`, `oauth_access_token`, `oauth_consent`) via better-auth's schema system on first startup.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:unit` passes (701 tests)
- [ ] Verify `/.well-known/openid-configuration` returns OIDC metadata after deploy
- [ ] Configure Wiki.js OIDC strategy and test end-to-end login