### PR TITLE
fix: fall back to TIME_CREATED in flowsheet ETL incremental sync

### DIFF
--- a/jobs/flowsheet-etl/fetch-legacy.ts
+++ b/jobs/flowsheet-etl/fetch-legacy.ts
@@ -32,6 +32,7 @@ export type LegacyEntryRow = {
   requestFlag: number;
   playOrder: number;
   startTime: number;
+  timeCreated: number;
   timeLastModified: number;
   legacyReleaseId: number | null;
   segueFlag: number;
@@ -83,10 +84,10 @@ export const fetchLegacyShows = async (sinceMs: number | null): Promise<LegacySh
  * Parse tab-separated entry rows. Column positions:
  *   0: ID, 1: RADIO_SHOW_ID, 2: ENTRY_TYPE_CODE, 3: ARTIST_NAME,
  *   4: RELEASE_TITLE, 5: SONG_TITLE, 6: LABEL_NAME, 7: REQUEST_FLAG,
- *   8: SEQUENCE_WITHIN_SHOW, 9: START_TIME, 10: TIME_LAST_MODIFIED,
- *   11: LIBRARY_RELEASE_ID [, 12: SEGUE_FLAG — optional]
+ *   8: SEQUENCE_WITHIN_SHOW, 9: START_TIME, 10: TIME_CREATED,
+ *   11: TIME_LAST_MODIFIED, 12: LIBRARY_RELEASE_ID [, 13: SEGUE_FLAG — optional]
  *
- * columnCount: 12 (without SEGUE_FLAG) or 13 (with)
+ * columnCount: 13 (without SEGUE_FLAG) or 14 (with)
  */
 export const parseEntryRows = (raw: string, columnCount: number): LegacyEntryRow[] => {
   if (raw.trim().length === 0) return [];
@@ -98,7 +99,7 @@ export const parseEntryRows = (raw: string, columnCount: number): LegacyEntryRow
       console.warn('[flowsheet-etl] Skipping malformed entry row:', line);
       continue;
     }
-    const rawReleaseId = Number(cols[11]) || 0;
+    const rawReleaseId = Number(cols[12]) || 0;
     rows.push({
       id: Number(cols[0]),
       showId: Number(cols[1]),
@@ -110,9 +111,10 @@ export const parseEntryRows = (raw: string, columnCount: number): LegacyEntryRow
       requestFlag: Number(cols[7]) || 0,
       playOrder: Number(cols[8]) || 0,
       startTime: Number(cols[9]),
-      timeLastModified: Number(cols[10]) || 0,
+      timeCreated: Number(cols[10]) || 0,
+      timeLastModified: Number(cols[11]) || 0,
       legacyReleaseId: rawReleaseId === 0 ? null : rawReleaseId,
-      segueFlag: columnCount >= 13 ? Number(cols[12]) || 0 : 0,
+      segueFlag: columnCount >= 14 ? Number(cols[13]) || 0 : 0,
     });
   }
   return rows;
@@ -129,22 +131,26 @@ const BASE_ENTRY_COLUMNS = `
       fe.REQUEST_FLAG,
       fe.SEQUENCE_WITHIN_SHOW,
       fe.START_TIME,
+      fe.TIME_CREATED,
       fe.TIME_LAST_MODIFIED,
       fe.LIBRARY_RELEASE_ID`;
 
 export const fetchLegacyEntries = async (sinceMs: number | null): Promise<LegacyEntryRow[]> => {
-  const filter = sinceMs != null ? `WHERE fe.START_TIME > ${sinceMs} OR fe.TIME_LAST_MODIFIED > ${sinceMs}` : '';
+  const filter =
+    sinceMs != null
+      ? `WHERE fe.START_TIME > ${sinceMs} OR fe.TIME_CREATED > ${sinceMs} OR fe.TIME_LAST_MODIFIED > ${sinceMs}`
+      : '';
 
   // Try with SEGUE_FLAG first; fall back without it if the column doesn't exist
   try {
     const queryWithSegue = `SELECT ${BASE_ENTRY_COLUMNS}, fe.SEGUE_FLAG FROM FLOWSHEET_ENTRY_PROD fe ${filter} ORDER BY fe.ID ASC;`;
     const raw = await legacyDB.send(queryWithSegue);
-    return parseEntryRows(raw, 13);
+    return parseEntryRows(raw, 14);
   } catch {
     console.warn('[flowsheet-etl] SEGUE_FLAG not available, defaulting to 0.');
     const queryWithout = `SELECT ${BASE_ENTRY_COLUMNS} FROM FLOWSHEET_ENTRY_PROD fe ${filter} ORDER BY fe.ID ASC;`;
     const raw = await legacyDB.send(queryWithout);
-    return parseEntryRows(raw, 12);
+    return parseEntryRows(raw, 13);
   }
 };
 

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -327,7 +327,7 @@ const runIncremental = async (): Promise<SyncResult> => {
   let entriesImported = 0;
   let entriesUpdated = 0;
   for (const entry of legacyEntries) {
-    const addTime = epochMsToDate(entry.startTime);
+    const addTime = resolveEntryTimestamp(entry.startTime, entry.timeCreated, entry.timeLastModified);
     if (!addTime) continue;
 
     const backendShowId = showIdMap.get(entry.showId);

--- a/tests/unit/jobs/flowsheet-etl/fetch-legacy.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/fetch-legacy.test.ts
@@ -2,7 +2,8 @@
  * Unit tests for flowsheet ETL fetch-legacy parsing functions.
  *
  * Tests the tab-separated row parsing for entries and shows, including
- * the TIME_LAST_MODIFIED column used for update detection.
+ * the TIME_CREATED and TIME_LAST_MODIFIED columns used for timestamp
+ * resolution and update detection.
  */
 
 jest.mock('@wxyc/database', () => ({
@@ -51,11 +52,12 @@ describe('fetch-legacy parsing', () => {
   });
 
   describe('parseEntryRows', () => {
-    // Columns: ID, SHOW_ID, TYPE, ARTIST, ALBUM, TRACK, LABEL, REQ, SEQ, START, TLM, LIBRARY_RELEASE_ID [, SEGUE_FLAG]
+    // Columns: ID, SHOW_ID, TYPE, ARTIST, ALBUM, TRACK, LABEL, REQ, SEQ, START, TIME_CREATED, TLM, LIBRARY_RELEASE_ID [, SEGUE_FLAG]
 
-    it('parses 12-column format (without SEGUE_FLAG)', () => {
-      const raw = '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t0\t1\t1706799600000\t1706799700000\t101';
-      const rows = parseEntryRows(raw, 12);
+    it('parses 13-column format (without SEGUE_FLAG)', () => {
+      const raw =
+        '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t0\t1\t1706799600000\t1706799650000\t1706799700000\t101';
+      const rows = parseEntryRows(raw, 13);
 
       expect(rows).toHaveLength(1);
       expect(rows[0]).toEqual({
@@ -69,40 +71,43 @@ describe('fetch-legacy parsing', () => {
         requestFlag: 0,
         playOrder: 1,
         startTime: 1706799600000,
+        timeCreated: 1706799650000,
         timeLastModified: 1706799700000,
         legacyReleaseId: 101,
         segueFlag: 0,
       });
     });
 
-    it('parses 13-column format (with SEGUE_FLAG)', () => {
-      const raw = '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t1\t1\t1706799600000\t1706799700000\t101\t1';
-      const rows = parseEntryRows(raw, 13);
+    it('parses 14-column format (with SEGUE_FLAG)', () => {
+      const raw =
+        '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t1\t1\t1706799600000\t1706799650000\t1706799700000\t101\t1';
+      const rows = parseEntryRows(raw, 14);
 
       expect(rows).toHaveLength(1);
       expect(rows[0].requestFlag).toBe(1);
+      expect(rows[0].timeCreated).toBe(1706799650000);
       expect(rows[0].timeLastModified).toBe(1706799700000);
       expect(rows[0].legacyReleaseId).toBe(101);
       expect(rows[0].segueFlag).toBe(1);
     });
 
-    it('defaults segueFlag to 0 in 12-column format', () => {
-      const raw = '100\t200\t0\tArtist\tAlbum\tTrack\tLabel\t0\t1\t1000\t2000\t42';
-      const rows = parseEntryRows(raw, 12);
+    it('defaults segueFlag to 0 in 13-column format', () => {
+      const raw = '100\t200\t0\tArtist\tAlbum\tTrack\tLabel\t0\t1\t1000\t1500\t2000\t42';
+      const rows = parseEntryRows(raw, 13);
 
       expect(rows[0].segueFlag).toBe(0);
     });
 
     it('sets legacyReleaseId to null when value is 0', () => {
-      const raw = '100\t200\t7\tTALKSET\t\t\t\t0\t5\t1000\t2000\t0';
-      const rows = parseEntryRows(raw, 12);
+      const raw = '100\t200\t7\tTALKSET\t\t\t\t0\t5\t1000\t1500\t2000\t0';
+      const rows = parseEntryRows(raw, 13);
 
       expect(rows[0].legacyReleaseId).toBeNull();
     });
 
     it('handles NULL/empty text fields', () => {
-      const raw = '100\t200\t7\tNULL\t\t\t\t0\t5\t1000\t2000\t0';
-      const rows = parseEntryRows(raw, 12);
+      const raw = '100\t200\t7\tNULL\t\t\t\t0\t5\t1000\t1500\t2000\t0';
+      const rows = parseEntryRows(raw, 13);
 
       expect(rows[0].artistName).toBeNull();
       expect(rows[0].albumTitle).toBeNull();
@@ -114,7 +119,7 @@ describe('fetch-legacy parsing', () => {
       const raw = '100\t200\t0\tArtist';
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      const rows = parseEntryRows(raw, 12);
+      const rows = parseEntryRows(raw, 13);
 
       expect(rows).toHaveLength(0);
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('malformed'), expect.any(String));
@@ -122,23 +127,33 @@ describe('fetch-legacy parsing', () => {
     });
 
     it('returns empty array for empty input', () => {
-      expect(parseEntryRows('', 12)).toEqual([]);
-      expect(parseEntryRows('   ', 12)).toEqual([]);
+      expect(parseEntryRows('', 13)).toEqual([]);
+      expect(parseEntryRows('   ', 13)).toEqual([]);
     });
 
     it('parses multiple rows', () => {
       const raw = [
-        '1\t100\t0\tArtist1\tAlbum1\tTrack1\tLabel1\t0\t1\t1000\t2000\t101',
-        '2\t100\t0\tArtist2\tAlbum2\tTrack2\tLabel2\t1\t2\t3000\t4000\t102',
+        '1\t100\t0\tArtist1\tAlbum1\tTrack1\tLabel1\t0\t1\t1000\t1500\t2000\t101',
+        '2\t100\t0\tArtist2\tAlbum2\tTrack2\tLabel2\t1\t2\t3000\t3500\t4000\t102',
       ].join('\n');
-      const rows = parseEntryRows(raw, 12);
+      const rows = parseEntryRows(raw, 13);
 
       expect(rows).toHaveLength(2);
       expect(rows[0].id).toBe(1);
       expect(rows[0].legacyReleaseId).toBe(101);
       expect(rows[1].id).toBe(2);
       expect(rows[1].legacyReleaseId).toBe(102);
+      expect(rows[1].timeCreated).toBe(3500);
       expect(rows[1].timeLastModified).toBe(4000);
+    });
+
+    it('preserves timeCreated when START_TIME is 0', () => {
+      const raw = '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t0\t1\t0\t1706799650000\t1706799700000\t101';
+      const rows = parseEntryRows(raw, 13);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].startTime).toBe(0);
+      expect(rows[0].timeCreated).toBe(1706799650000);
     });
   });
 


### PR DESCRIPTION
## Summary

- The incremental sync used only `START_TIME` to resolve entry timestamps. Most track entries in tubafrenzy have `START_TIME = 0`, so `epochMsToDate(0)` returned null and tracks were silently skipped — only show_start/show_end entries survived.
- Apply the same `resolveEntryTimestamp` fallback (START_TIME → TIME_CREATED → TIME_LAST_MODIFIED) that the bulk load mode already uses.
- Add `fe.TIME_CREATED` to the SQL SELECT, WHERE clause, and `LegacyEntryRow` type.

## Test plan

- [x] Unit tests updated: all 755 pass across 70 suites
- [x] Typecheck, lint, format all pass
- [ ] After deploy, verify incremental sync imports track entries (not just show boundaries)
- [ ] Verify dj-site flowsheet shows tracks between set start/end entries

Closes #351