### PR TITLE
Fix genre ID mismatch between seed files and production

### DIFF
--- a/dev_env/etl-seed-pg.sql
+++ b/dev_env/etl-seed-pg.sql
@@ -2,11 +2,14 @@
 -- Only provides genres and formats (required by the library ETL to map releases).
 -- All other data (artists, albums, flowsheet) should be created by the ETL itself.
 
-INSERT INTO wxyc_schema.genres(genre_name) VALUES
-  ('Rock'), ('Hiphop'), ('Electronic'), ('Jazz'), ('Reggae'),
-  ('Classical'), ('Latin'), ('Blues'), ('Soundtracks'), ('Spoken'),
-  ('Comedy'), ('Africa'), ('Asia'), ('OCS'), ('Xmas')
-ON CONFLICT DO NOTHING;
+-- Genre IDs must match production (alphabetical assignment from the initial ETL sync).
+-- Using explicit IDs ensures compatibility with pg_dump snapshots and crossreference data.
+INSERT INTO wxyc_schema.genres(id, genre_name) VALUES
+  (1, 'Africa'), (2, 'Asia'), (3, 'Blues'), (4, 'Classical'), (5, 'Comedy'),
+  (6, 'Hiphop'), (7, 'Jazz'), (8, 'Latin'), (9, 'OCS'), (10, 'Reggae'),
+  (11, 'Rock'), (12, 'Soundtracks'), (13, 'Spoken'), (14, 'Xmas'), (15, 'Electronic')
+ON CONFLICT (id) DO NOTHING;
+SELECT setval('wxyc_schema.genres_id_seq', 15, true);
 
 INSERT INTO wxyc_schema.format(format_name) VALUES
   ('cd'), ('vinyl'), ('vinyl 12"'), ('vinyl 7"'), ('vinyl 10"'), ('cdr')

--- a/dev_env/seed_db.sql
+++ b/dev_env/seed_db.sql
@@ -104,11 +104,14 @@ ON CONFLICT (id) DO NOTHING;
 -- Genres and media formats matching the legacy tubafrenzy database.
 -- The library ETL job looks up genres/formats by name and skips releases
 -- where the genre or format is missing, so all legacy values must be seeded.
-INSERT INTO wxyc_schema.genres(genre_name) VALUES
-  ('Rock'), ('Hiphop'), ('Electronic'), ('Jazz'), ('Reggae'),
-  ('Classical'), ('Latin'), ('Blues'), ('Soundtracks'), ('Spoken'),
-  ('Comedy'), ('Africa'), ('Asia'), ('OCS'), ('Xmas')
-ON CONFLICT DO NOTHING;
+-- Genre IDs must match production (alphabetical assignment from the initial ETL sync).
+-- Using explicit IDs ensures compatibility with pg_dump snapshots and crossreference data.
+INSERT INTO wxyc_schema.genres(id, genre_name) VALUES
+  (1, 'Africa'), (2, 'Asia'), (3, 'Blues'), (4, 'Classical'), (5, 'Comedy'),
+  (6, 'Hiphop'), (7, 'Jazz'), (8, 'Latin'), (9, 'OCS'), (10, 'Reggae'),
+  (11, 'Rock'), (12, 'Soundtracks'), (13, 'Spoken'), (14, 'Xmas'), (15, 'Electronic')
+ON CONFLICT (id) DO NOTHING;
+SELECT setval('wxyc_schema.genres_id_seq', 15, true);
 
 INSERT INTO wxyc_schema.format(format_name) VALUES
   ('cd'), ('vinyl'), ('vinyl 12"'), ('vinyl 7"'), ('vinyl 10"'), ('cdr')
@@ -124,23 +127,23 @@ INSERT INTO wxyc_schema.artists(artist_name, alphabetical_name, code_letters)
 	VALUES ('Jockstrap', 'Jockstrap', 'JO');
 
 INSERT INTO wxyc_schema.genre_artist_crossreference(artist_id, genre_id, artist_genre_code)
-	VALUES (1, 1, 60);
+	VALUES (1, 11, 60);
 INSERT INTO wxyc_schema.genre_artist_crossreference(artist_id, genre_id, artist_genre_code)
-	VALUES (2, 2, 35);
+	VALUES (2, 6, 35);
 INSERT INTO wxyc_schema.genre_artist_crossreference(artist_id, genre_id, artist_genre_code)
-	VALUES (3, 1, 108);
+	VALUES (3, 11, 108);
 
 INSERT INTO wxyc_schema.library(
-    artist_id, genre_id, format_id, album_title, code_number) 
-    VALUES (1, 1, 1, 'Keep it Like a Secret', 8);
+    artist_id, genre_id, format_id, album_title, code_number)
+    VALUES (1, 11, 1, 'Keep it Like a Secret', 8);
 
 INSERT INTO wxyc_schema.library(
-    artist_id, genre_id, format_id, album_title, code_number) 
-    VALUES (2, 2, 1, 'Crush', 1);
+    artist_id, genre_id, format_id, album_title, code_number)
+    VALUES (2, 6, 1, 'Crush', 1);
 
 INSERT INTO wxyc_schema.library(
-    artist_id, genre_id, format_id, album_title, code_number) 
-    VALUES (3, 1, 2, 'I Love You Jennifer B', 1);
+    artist_id, genre_id, format_id, album_title, code_number)
+    VALUES (3, 11, 2, 'I Love You Jennifer B', 1);
 
 -- Additional artists for parallel test isolation (metadata.spec.js uses albums 4-6)
 INSERT INTO wxyc_schema.artists(artist_name, alphabetical_name, code_letters)
@@ -153,24 +156,24 @@ INSERT INTO wxyc_schema.artists(artist_name, alphabetical_name, code_letters)
 	VALUES ('Bjork', 'Bjork', 'BJ');
 
 INSERT INTO wxyc_schema.genre_artist_crossreference(artist_id, genre_id, artist_genre_code)
-	VALUES (4, 1, 42);
+	VALUES (4, 11, 42);
 INSERT INTO wxyc_schema.genre_artist_crossreference(artist_id, genre_id, artist_genre_code)
-	VALUES (5, 2, 15);
+	VALUES (5, 6, 15);
 INSERT INTO wxyc_schema.genre_artist_crossreference(artist_id, genre_id, artist_genre_code)
-	VALUES (6, 1, 22);
+	VALUES (6, 11, 22);
 
 -- Additional albums for parallel test isolation (IDs 4, 5, 6 for metadata.spec.js)
 INSERT INTO wxyc_schema.library(
     artist_id, genre_id, format_id, album_title, code_number)
-    VALUES (4, 1, 1, 'Illinois', 1);
+    VALUES (4, 11, 1, 'Illinois', 1);
 
 INSERT INTO wxyc_schema.library(
     artist_id, genre_id, format_id, album_title, code_number)
-    VALUES (5, 2, 1, 'To Pimp a Butterfly', 1);
+    VALUES (5, 6, 1, 'To Pimp a Butterfly', 1);
 
 INSERT INTO wxyc_schema.library(
     artist_id, genre_id, format_id, album_title, code_number)
-    VALUES (6, 1, 2, 'Homogenic', 1);
+    VALUES (6, 11, 2, 'Homogenic', 1);
 
 INSERT INTO wxyc_schema.rotation(album_id, rotation_bin) VALUES (1, 'L');
 

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -84,7 +84,7 @@ describe('Library Catalog', () => {
           album_title: `Test Album ${Date.now()}`,
           artist_name: 'Built to Spill',
           label: 'Test Label',
-          genre_id: 1,
+          genre_id: 11,
           format_id: 1,
         })
         .expect(201);
@@ -99,7 +99,7 @@ describe('Library Catalog', () => {
         .send({
           artist_id: 1,
           label: 'Test Label',
-          genre_id: 1,
+          genre_id: 11,
           format_id: 1,
         })
         .expect(400);
@@ -113,7 +113,7 @@ describe('Library Catalog', () => {
         .send({
           album_title: 'Test Album',
           artist_id: 1,
-          genre_id: 1,
+          genre_id: 11,
           format_id: 1,
         })
         .expect(400);
@@ -142,7 +142,7 @@ describe('Library Catalog', () => {
           album_title: 'Test Album',
           artist_id: 1,
           label: 'Test Label',
-          genre_id: 1,
+          genre_id: 11,
         })
         .expect(400);
 
@@ -155,7 +155,7 @@ describe('Library Catalog', () => {
         .send({
           album_title: 'Test Album',
           label: 'Test Label',
-          genre_id: 1,
+          genre_id: 11,
           format_id: 1,
         })
         .expect(400);
@@ -320,7 +320,7 @@ describe('Library Artists', () => {
         .send({
           artist_name: `Test Artist ${uniqueSuffix}`,
           code_letters: uniqueSuffix,
-          genre_id: 1,
+          genre_id: 11,
           code_number: 1,
         })
         .expect(201);
@@ -336,7 +336,7 @@ describe('Library Artists', () => {
         .post('/library/artists')
         .send({
           code_letters: 'TS',
-          genre_id: 1,
+          genre_id: 11,
           code_number: 1,
         })
         .expect(400);
@@ -349,7 +349,7 @@ describe('Library Artists', () => {
         .post('/library/artists')
         .send({
           artist_name: 'Test Artist',
-          genre_id: 1,
+          genre_id: 11,
           code_number: 1,
         })
         .expect(400);
@@ -376,7 +376,7 @@ describe('Library Artists', () => {
         .send({
           artist_name: 'Test Artist',
           code_letters: 'TS',
-          genre_id: 1,
+          genre_id: 11,
         })
         .expect(400);
 
@@ -391,7 +391,7 @@ describe('Library Artists', () => {
           artist_name: `The Band ${uniqueSuffix}`,
           alphabetical_name: `Band ${uniqueSuffix}, The`,
           code_letters: uniqueSuffix,
-          genre_id: 1,
+          genre_id: 11,
           code_number: 1,
         })
         .expect(201);
@@ -409,7 +409,7 @@ describe('Library Artists Peek Code', () => {
   });
 
   test('peeks next code_artist_number', async () => {
-    const res = await auth.get('/library/artists/peek-code').query({ code_letters: 'BU', genre_id: 1 }).expect(200);
+    const res = await auth.get('/library/artists/peek-code').query({ code_letters: 'BU', genre_id: 11 }).expect(200);
 
     // BU is the code for Built to Spill and has artist_genre_code 60
     expect(res.body.next_code_number).toBe(61);


### PR DESCRIPTION
## Summary

- Assign explicit genre IDs in seed files (`seed_db.sql`, `etl-seed-pg.sql`) matching production's alphabetical ordering (Africa=1, Asia=2, ..., Rock=11, ..., Electronic=15)
- Update all test data (crossreferences, library entries) and integration tests to use the correct genre IDs
- Add `setval` call to position the IDENTITY sequence correctly after seeding
- Use `ON CONFLICT (id) DO NOTHING` so explicit IDs properly trigger the conflict clause

Previously, genres were inserted without explicit IDs, so PostgreSQL auto-assigned them in insertion order (Rock=1, Hiphop=2, Electronic=3, ...). Production's genres were created in alphabetical order by the initial ETL sync. This caused `genre_artist_crossreference` data from `pg_dump` snapshots to map to wrong genres (e.g. Autechre displaying as "Xmas" instead of "Electronic").

Closes #354

## Test plan

- [ ] Verify `npm run test:unit` passes (755 tests, no regressions)
- [ ] Verify integration tests pass against seeded database with new genre IDs
- [ ] Load `prod-snapshot.sql` into a fresh dev database and confirm genre codes display correctly for library entries