### PR TITLE
Migrate show mirror from SQL to HTTP, pass radioShowID on entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Key middleware:
 - `anonymousAuth` -- Validates better-auth session
 - `rateLimiting` -- Rate limits on registration and song requests
 - `errorHandler` -- Centralized error handling returning standardized responses
-- Legacy mirror middleware -- Compatibility layer for old frontend
+- Legacy mirror middleware -- Syncs flowsheet data to tubafrenzy. Show lifecycle (`startShow`, `endShow`) and entry CRUD (`addEntry`, `updateEntry`) use HTTP REST calls to tubafrenzy's mirror API. `deleteEntry` uses raw SQL via SSH. Show IDs are cached in-memory (`showIdMap`) and persisted to `shows.legacy_show_id` for restart resilience. Every entry mirror call includes `radioShowID` when available (cache → DB fallback → omit for auto-resolution).
 
 Server timeout is 5 seconds globally; SSE routes have no timeout.
 

--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -75,10 +75,7 @@ const startShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
     if (entryId != null) {
       cacheEntryId(announcementEntry[0].play_order, entryId);
       try {
-        await db
-          .update(flowsheet)
-          .set({ legacy_entry_id: entryId })
-          .where(eq(flowsheet.id, announcementEntry[0].id));
+        await db.update(flowsheet).set({ legacy_entry_id: entryId }).where(eq(flowsheet.id, announcementEntry[0].id));
       } catch (e) {
         console.error('[mirror] Failed to persist legacy_entry_id for announcement:', e);
       }
@@ -110,10 +107,7 @@ export const endShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
     if (entryId != null) {
       cacheEntryId(announcementEntry[0].play_order, entryId);
       try {
-        await db
-          .update(flowsheet)
-          .set({ legacy_entry_id: entryId })
-          .where(eq(flowsheet.id, announcementEntry[0].id));
+        await db.update(flowsheet).set({ legacy_entry_id: entryId }).where(eq(flowsheet.id, announcementEntry[0].id));
       } catch (e) {
         console.error('[mirror] Failed to persist legacy_entry_id for announcement:', e);
       }

--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -1,16 +1,21 @@
 import { QueryParams } from '../../controllers/flowsheet.controller';
 import { db } from '@wxyc/database';
-import { user, flowsheet, FSEntry, Show } from '@wxyc/database';
+import { user, flowsheet, shows, FSEntry, Show } from '@wxyc/database';
 import { asc, desc, eq } from 'drizzle-orm';
 import { Request } from 'express';
 import { createBackendMirrorMiddleware, createHttpMirrorMiddleware } from './mirror.middleware.js';
 import { safeSql, safeSqlNum, toMs } from './utilities.mirror.js';
 import {
   mirrorCreateEntry,
+  mirrorCreateShow,
+  mirrorSignoffShow,
   mirrorUpdateEntry,
   cacheEntryId,
+  cacheShowId,
   getCachedEntryId,
+  getCachedShowId,
   mapEntryToTubafrenzy,
+  mapShowToTubafrenzy,
   mapUpdateToTubafrenzy,
 } from './http.mirror.js';
 
@@ -27,15 +32,9 @@ const getEntries = createBackendMirrorMiddleware<any>(async (req, data) => {
   return [`SELECT * FROM ${FLOWSHEET_ENTRY_TABLE} LIMIT ${limit} OFFSET ${offset};`];
 });
 
-const startShow = createBackendMirrorMiddleware<Show>(async (req, show) => {
-  const nowMs = Date.now();
-  const statements: string[] = [];
-
-  const startMs = toMs(show.start_time ?? req.body?.start_time ?? nowMs);
-  const djId = show.primary_dj_id ?? req.body?.dj_id;
-
-  if (!djId) return statements; // no DJ, nothing to do
-  if (!show) return statements; // no show, nothing to do
+const startShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
+  const djId = show.primary_dj_id;
+  if (!djId || !show) return;
 
   const dj = (
     await db
@@ -45,40 +44,24 @@ const startShow = createBackendMirrorMiddleware<Show>(async (req, show) => {
       .limit(1)
   )?.[0];
 
-  if (!dj) return statements; // DJ not found
+  if (!dj) return;
 
-  const showName = show.show_name ?? req.body?.show_name ?? '';
-  const specialtyId = Number.isFinite(Number(show.specialty_id ?? req.body?.specialty_id))
-    ? Number(show.specialty_id ?? req.body?.specialty_id)
-    : 0;
-  const startingHour = Math.floor(startMs / 3_600_000) * 3_600_000;
-  const workingHour = startingHour; // Initially same as starting hour, updates as show progresses
-  const timeCreated = startMs;
-  const timeModified = startMs;
+  // 1. Create show in tubafrenzy via REST API
+  const body = mapShowToTubafrenzy(show, dj);
+  const tubafrenzyShowId = await mirrorCreateShow(body);
 
-  // NOTE: Legacy table has no AUTO_INCREMENT; we allocate ID as MAX(ID)+1.
-  statements.push(
-    `SET @NEW_RS_ID := (SELECT IFNULL(MAX(ID), 0) + 1 FROM ${RADIO_SHOW_TABLE});`,
-    `INSERT INTO ${RADIO_SHOW_TABLE}
-        (ID, STARTING_RADIO_HOUR, DJ_NAME, DJ_ID, DJ_HANDLE, SHOW_NAME, SPECIALTY_SHOW_ID,
-         WORKING_HOUR, SIGNON_TIME, SIGNOFF_TIME, TIME_LAST_MODIFIED, TIME_CREATED, MODLOCK, SHOW_ID)
-       VALUES
-        (@NEW_RS_ID,
-         ${safeSqlNum(startingHour)},         -- STARTING_RADIO_HOUR (hour bucket)
-         ${safeSql(dj.realName || dj.name)},            -- DJ_NAME (real name)
-         0,                                   -- DJ_ID (always 0 in legacy system)
-         ${safeSql(dj.djName || dj.name)},              -- DJ_HANDLE (DJ name/handle)
-         ${safeSql(showName)},                -- SHOW_NAME
-         ${safeSqlNum(specialtyId)},          -- SPECIALTY_SHOW_ID (0 if not specialty)
-         ${safeSqlNum(workingHour)},          -- WORKING_HOUR (current working hour bucket)
-         ${safeSqlNum(startMs)},              -- SIGNON_TIME (actual sign-on timestamp)
-         0,                                   -- SIGNOFF_TIME (0 for active shows, set to timestamp on end)
-         ${safeSqlNum(timeModified)},         -- TIME_LAST_MODIFIED
-         ${safeSqlNum(timeCreated)},          -- TIME_CREATED
-         0,                                   -- MODLOCK (0 for active, 1 when completed)
-         @NEW_RS_ID);` // SHOW_ID (same as ID)
-  );
+  if (tubafrenzyShowId != null) {
+    // Cache for subsequent addEntry calls in this process lifetime
+    cacheShowId(show.id, tubafrenzyShowId);
+    // Persist for ETL dedup and restart resilience
+    try {
+      await db.update(shows).set({ legacy_show_id: tubafrenzyShowId }).where(eq(shows.id, show.id));
+    } catch (e) {
+      console.error('[mirror] Failed to persist legacy_show_id:', e);
+    }
+  }
 
+  // 2. Mirror the show_start announcement entry
   const announcementEntry = await db
     .select()
     .from(flowsheet)
@@ -86,29 +69,34 @@ const startShow = createBackendMirrorMiddleware<Show>(async (req, show) => {
     .orderBy(desc(flowsheet.play_order))
     .limit(1);
 
-  if (announcementEntry && announcementEntry.length > 0) {
-    statements.push(...(await getAddEntrySQL(req, announcementEntry[0])));
+  if (announcementEntry?.[0]) {
+    const entryBody = mapEntryToTubafrenzy(announcementEntry[0], tubafrenzyShowId);
+    const entryId = await mirrorCreateEntry(entryBody);
+    if (entryId != null) {
+      cacheEntryId(announcementEntry[0].play_order, entryId);
+      try {
+        await db
+          .update(flowsheet)
+          .set({ legacy_entry_id: entryId })
+          .where(eq(flowsheet.id, announcementEntry[0].id));
+      } catch (e) {
+        console.error('[mirror] Failed to persist legacy_entry_id for announcement:', e);
+      }
+    }
   }
-
-  return statements;
 });
 
-export const endShow = createBackendMirrorMiddleware<Show>(async (req, show) => {
+export const endShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
   const endMs = toMs(show.end_time ?? Date.now());
-  const statements: string[] = [];
 
-  // Update the most recent active show (SIGNOFF_TIME = 0, MODLOCK = 0)
-  statements.push(
-    `UPDATE ${RADIO_SHOW_TABLE}
-       SET SIGNOFF_TIME = ${safeSqlNum(endMs)},
-           TIME_LAST_MODIFIED = ${safeSqlNum(endMs)},
-           MODLOCK = 1
-     WHERE SIGNOFF_TIME = 0
-       AND MODLOCK = 0
-     ORDER BY STARTING_RADIO_HOUR DESC
-     LIMIT 1;`
-  );
+  // Resolve tubafrenzy show ID: in-memory cache → persisted legacy_show_id
+  const tubafrenzyShowId = getCachedShowId(show.id) ?? show.legacy_show_id;
 
+  if (tubafrenzyShowId != null) {
+    await mirrorSignoffShow(tubafrenzyShowId, endMs);
+  }
+
+  // Mirror the show_end announcement entry
   const announcementEntry = await db
     .select()
     .from(flowsheet)
@@ -116,11 +104,21 @@ export const endShow = createBackendMirrorMiddleware<Show>(async (req, show) => 
     .orderBy(desc(flowsheet.play_order))
     .limit(1);
 
-  if (announcementEntry && announcementEntry.length > 0) {
-    statements.push(...(await getAddEntrySQL(req, announcementEntry[0])));
+  if (announcementEntry?.[0]) {
+    const entryBody = mapEntryToTubafrenzy(announcementEntry[0], tubafrenzyShowId);
+    const entryId = await mirrorCreateEntry(entryBody);
+    if (entryId != null) {
+      cacheEntryId(announcementEntry[0].play_order, entryId);
+      try {
+        await db
+          .update(flowsheet)
+          .set({ legacy_entry_id: entryId })
+          .where(eq(flowsheet.id, announcementEntry[0].id));
+      } catch (e) {
+        console.error('[mirror] Failed to persist legacy_entry_id for announcement:', e);
+      }
+    }
   }
-
-  return statements;
 });
 
 const getAddEntrySQL = async (req: Request, entry: FSEntry) => {
@@ -289,7 +287,22 @@ export const addEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) 
   // Loop guard: entry imported from tubafrenzy by ETL — don't mirror back
   if (entry.legacy_entry_id != null) return;
 
-  const body = mapEntryToTubafrenzy(entry);
+  // Resolve tubafrenzy show ID: (1) in-memory cache, (2) DB, (3) null (auto-resolve)
+  let radioShowID: number | null | undefined = entry.show_id != null ? getCachedShowId(entry.show_id) : undefined;
+  if (radioShowID == null && entry.show_id != null) {
+    try {
+      const showRow = await db
+        .select({ legacy_show_id: shows.legacy_show_id })
+        .from(shows)
+        .where(eq(shows.id, entry.show_id as number))
+        .limit(1);
+      radioShowID = showRow?.[0]?.legacy_show_id ?? null;
+    } catch {
+      // DB lookup failed; fall back to tubafrenzy auto-resolution
+    }
+  }
+
+  const body = mapEntryToTubafrenzy(entry, radioShowID);
   const tubafrenzyId = await mirrorCreateEntry(body);
   if (tubafrenzyId != null) {
     cacheEntryId(entry.play_order, tubafrenzyId);

--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -291,6 +291,9 @@ export const addEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) 
         .where(eq(shows.id, entry.show_id as number))
         .limit(1);
       radioShowID = showRow?.[0]?.legacy_show_id ?? null;
+      if (radioShowID != null) {
+        cacheShowId(entry.show_id as number, radioShowID);
+      }
     } catch {
       // DB lookup failed; fall back to tubafrenzy auto-resolution
     }

--- a/apps/backend/middleware/legacy/http.mirror.ts
+++ b/apps/backend/middleware/legacy/http.mirror.ts
@@ -1,16 +1,22 @@
 /**
  * HTTP client for the tubafrenzy mirror API.
  *
- * Replaces raw SQL for addEntry/updateEntry mirror operations.
- * Calls POST/PATCH on tubafrenzy's /playlists/api/flowsheetEntry endpoint,
- * which goes through FlowsheetEntryService so listeners (cache, SSE, Lucene) fire.
+ * Mirrors flowsheet entries and radio shows to tubafrenzy via REST endpoints:
+ * - POST/PATCH /playlists/api/flowsheetEntry — entry CRUD
+ * - POST /playlists/api/radioShow — show creation
+ * - POST /playlists/api/radioShow/signoff — show sign-off
  */
+
+import * as Sentry from '@sentry/node';
 
 const TUBAFRENZY_URL = process.env.TUBAFRENZY_URL ?? 'https://www.wxyc.info';
 const MIRROR_API_KEY = process.env.MIRROR_API_KEY ?? '';
 
 /** In-memory map: Backend-Service play_order → tubafrenzy entry ID */
 const entryIdMap = new Map<number, number>();
+
+/** In-memory map: Backend-Service show ID → tubafrenzy show ID */
+const showIdMap = new Map<number, number>();
 
 interface MirrorEntry {
   entry_type: string;
@@ -91,10 +97,10 @@ export function clearEntryIdMap(): void {
 
 /**
  * Maps a Backend-Service FSEntry to the tubafrenzy POST JSON body.
- * radioShowID is omitted — tubafrenzy auto-resolves from the current show.
+ * When radioShowID is provided, it's included so tubafrenzy doesn't auto-resolve.
  * nowPlayingFlag is always 0 (dropped — nothing in tubafrenzy reads it).
  */
-export function mapEntryToTubafrenzy(entry: MirrorEntry): Record<string, unknown> {
+export function mapEntryToTubafrenzy(entry: MirrorEntry, radioShowID?: number | null): Record<string, unknown> {
   const startMs = entry.add_time ? new Date(entry.add_time as any).getTime() : Date.now();
   const radioHour = Math.floor(startMs / 3_600_000) * 3_600_000;
 
@@ -137,6 +143,7 @@ export function mapEntryToTubafrenzy(entry: MirrorEntry): Record<string, unknown
     }
 
     return {
+      ...(radioShowID != null ? { radioShowID } : {}),
       radioHour,
       flowsheetEntryType,
       artistName: message,
@@ -153,6 +160,7 @@ export function mapEntryToTubafrenzy(entry: MirrorEntry): Record<string, unknown
   }
 
   return {
+    ...(radioShowID != null ? { radioShowID } : {}),
     radioHour,
     flowsheetEntryType,
     artistName: entry.artist_name ?? '',
@@ -189,6 +197,116 @@ export function mapUpdateToTubafrenzy(entry: MirrorEntry): Record<string, unknow
     libraryReleaseID: entry.album_id ?? 0,
     rotationReleaseID: entry.rotation_id ?? 0,
     flowsheetEntryType,
+  };
+}
+
+// ── Show mirror functions ──────────────────────────────────────────────
+
+/**
+ * POST a new radio show to tubafrenzy. Retries up to 5 times with exponential
+ * backoff (base 500ms, max 8s) because a failed show creation cascades: every
+ * subsequent entry will lack a radioShowID. Returns the tubafrenzy show ID, or
+ * null after all retries fail.
+ */
+export async function mirrorCreateShow(body: Record<string, unknown>): Promise<number | null> {
+  const MAX_ATTEMPTS = 5;
+  const BASE_BACKOFF_MS = 500;
+  const MAX_BACKOFF_MS = 8_000;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const response = await fetch(`${TUBAFRENZY_URL}/playlists/api/radioShow`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${MIRROR_API_KEY}`,
+        },
+        body: JSON.stringify(body),
+      });
+      if (response.ok) {
+        const json = await response.json();
+        return json.id ?? null;
+      }
+      const text = await response.text();
+      console.error(`[mirror] POST radioShow failed (attempt ${attempt}/${MAX_ATTEMPTS}): ${response.status} ${text}`);
+    } catch (e) {
+      console.error(`[mirror] POST radioShow error (attempt ${attempt}/${MAX_ATTEMPTS}):`, e);
+    }
+
+    if (attempt < MAX_ATTEMPTS) {
+      const delay = Math.min(BASE_BACKOFF_MS * Math.pow(2, attempt - 1), MAX_BACKOFF_MS);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  Sentry.captureMessage('Mirror: show creation failed after all retries', {
+    level: 'error',
+    tags: { subsystem: 'legacy-mirror' },
+    extra: { body },
+  });
+  return null;
+}
+
+/**
+ * POST a show signoff to tubafrenzy. Fire-and-forget (single attempt).
+ * Signoff failure doesn't cascade — the show already exists in tubafrenzy.
+ */
+export async function mirrorSignoffShow(radioShowId: number, signoffTime: number): Promise<void> {
+  try {
+    const response = await fetch(`${TUBAFRENZY_URL}/playlists/api/radioShow/signoff`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${MIRROR_API_KEY}`,
+      },
+      body: JSON.stringify({ radioShowId, signoffTime }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      console.error(`[mirror] POST radioShow/signoff failed: ${response.status} ${text}`);
+    }
+  } catch (e) {
+    console.error('[mirror] POST radioShow/signoff error:', e);
+  }
+}
+
+export function cacheShowId(backendShowId: number, tubafrenzyShowId: number): void {
+  showIdMap.set(backendShowId, tubafrenzyShowId);
+}
+
+export function getCachedShowId(backendShowId: number): number | undefined {
+  return showIdMap.get(backendShowId);
+}
+
+export function clearShowIdMap(): void {
+  showIdMap.clear();
+}
+
+interface MirrorShow {
+  id: number;
+  show_name?: string | null;
+  specialty_id?: number | null;
+  start_time?: Date | string | number | null;
+}
+
+interface MirrorDJ {
+  realName?: string | null;
+  djName?: string | null;
+  name: string;
+}
+
+/**
+ * Maps a Backend-Service Show + user to the tubafrenzy radioShow POST body.
+ */
+export function mapShowToTubafrenzy(show: MirrorShow, dj: MirrorDJ): Record<string, unknown> {
+  const startMs = show.start_time ? new Date(show.start_time as any).getTime() : Date.now();
+  return {
+    djName: dj.realName || dj.name,
+    djHandle: dj.djName || dj.name,
+    djId: 0,
+    showName: show.show_name ?? '',
+    specialtyShowId: show.specialty_id ?? 0,
+    signonTime: startMs,
   };
 }
 

--- a/dev_env/mock-api-server/src/routes/tubafrenzy.ts
+++ b/dev_env/mock-api-server/src/routes/tubafrenzy.ts
@@ -42,4 +42,15 @@ router.patch('/playlists/api/flowsheetEntry', (req: Request, res: Response) => {
   res.status(200).json(req.body);
 });
 
+/** POST /playlists/api/radioShow — create a mirror radio show */
+router.post('/playlists/api/radioShow', (req: Request, res: Response) => {
+  const id = nextId++;
+  res.status(201).json({ id, ...req.body });
+});
+
+/** POST /playlists/api/radioShow/signoff — sign off a mirror radio show */
+router.post('/playlists/api/radioShow/signoff', (req: Request, res: Response) => {
+  res.status(200).json({ ...req.body, modlock: 1 });
+});
+
 export default router;

--- a/tests/integration/mirror-http.spec.js
+++ b/tests/integration/mirror-http.spec.js
@@ -53,10 +53,12 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
     await new Promise((r) => setTimeout(r, 300));
 
     const tubafrenzyRequests = await getMockRequests('tubafrenzy');
-    const postCalls = tubafrenzyRequests.filter((r) => r.method === 'POST');
-    expect(postCalls.length).toBeGreaterThanOrEqual(1);
+    const entryPosts = tubafrenzyRequests.filter(
+      (r) => r.method === 'POST' && r.path.includes('/api/flowsheetEntry')
+    );
+    expect(entryPosts.length).toBeGreaterThanOrEqual(1);
 
-    const body = postCalls[0].body;
+    const body = entryPosts[entryPosts.length - 1].body;
     expect(body.artistName).toBe('Autechre');
     expect(body.songTitle).toBe('VI Scose Poise');
     expect(body.releaseTitle).toBe('Confield');
@@ -78,11 +80,13 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
     await new Promise((r) => setTimeout(r, 300));
 
     const tubafrenzyRequests = await getMockRequests('tubafrenzy');
-    const postCalls = tubafrenzyRequests.filter((r) => r.method === 'POST');
-    expect(postCalls.length).toBeGreaterThanOrEqual(1);
+    const entryPosts = tubafrenzyRequests.filter(
+      (r) => r.method === 'POST' && r.path.includes('/api/flowsheetEntry')
+    );
+    expect(entryPosts.length).toBeGreaterThanOrEqual(1);
 
     // Non-library, non-rotation track should be type 0
-    expect(postCalls[0].body.flowsheetEntryType).toBe(0);
+    expect(entryPosts[entryPosts.length - 1].body.flowsheetEntryType).toBe(0);
   });
 
   test('mirror failure does not block primary response', async () => {

--- a/tests/integration/mirror-http.spec.js
+++ b/tests/integration/mirror-http.spec.js
@@ -53,9 +53,7 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
     await new Promise((r) => setTimeout(r, 300));
 
     const tubafrenzyRequests = await getMockRequests('tubafrenzy');
-    const entryPosts = tubafrenzyRequests.filter(
-      (r) => r.method === 'POST' && r.path.includes('/api/flowsheetEntry')
-    );
+    const entryPosts = tubafrenzyRequests.filter((r) => r.method === 'POST' && r.path.includes('/api/flowsheetEntry'));
     expect(entryPosts.length).toBeGreaterThanOrEqual(1);
 
     const body = entryPosts[entryPosts.length - 1].body;
@@ -80,9 +78,7 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
     await new Promise((r) => setTimeout(r, 300));
 
     const tubafrenzyRequests = await getMockRequests('tubafrenzy');
-    const entryPosts = tubafrenzyRequests.filter(
-      (r) => r.method === 'POST' && r.path.includes('/api/flowsheetEntry')
-    );
+    const entryPosts = tubafrenzyRequests.filter((r) => r.method === 'POST' && r.path.includes('/api/flowsheetEntry'));
     expect(entryPosts.length).toBeGreaterThanOrEqual(1);
 
     // Non-library, non-rotation track should be type 0

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -17,11 +17,18 @@ import {
   clearEntryIdMap,
   mapEntryToTubafrenzy,
   mapUpdateToTubafrenzy,
+  mirrorCreateShow,
+  mirrorSignoffShow,
+  cacheShowId,
+  getCachedShowId,
+  clearShowIdMap,
+  mapShowToTubafrenzy,
 } from '../../../../apps/backend/middleware/legacy/http.mirror';
 
 beforeEach(() => {
   mockFetch.mockReset();
   clearEntryIdMap();
+  clearShowIdMap();
 });
 
 describe('http.mirror', () => {
@@ -180,8 +187,18 @@ describe('http.mirror', () => {
       expect(result.nowPlayingFlag).toBe(0);
     });
 
-    it('does not include radioShowID (auto-resolved by tubafrenzy)', () => {
+    it('does not include radioShowID when not provided', () => {
       const result = mapEntryToTubafrenzy(baseTrack);
+      expect(result).not.toHaveProperty('radioShowID');
+    });
+
+    it('includes radioShowID when provided', () => {
+      const result = mapEntryToTubafrenzy(baseTrack, 171500);
+      expect(result.radioShowID).toBe(171500);
+    });
+
+    it('does not include radioShowID when null', () => {
+      const result = mapEntryToTubafrenzy(baseTrack, null);
       expect(result).not.toHaveProperty('radioShowID');
     });
 
@@ -480,6 +497,156 @@ describe('http.mirror', () => {
       expect(result.libraryReleaseID).toBe(0);
       expect(result.rotationReleaseID).toBe(0);
       expect(result.flowsheetEntryType).toBe(0);
+    });
+  });
+
+  describe('mirrorCreateShow', () => {
+    it('POSTs to the tubafrenzy radioShow API', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 171500 }),
+      });
+
+      const body = { djName: 'Kate Bailey', djHandle: 'DJ Catalyst', signonTime: 1773792000000 };
+      const result = await mirrorCreateShow(body);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/playlists/api/radioShow');
+      expect(options.method).toBe('POST');
+      expect(JSON.parse(options.body)).toEqual(body);
+      expect(result).toBe(171500);
+    });
+
+    it('retries on failure up to 5 times', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500, text: () => Promise.resolve('error') })
+        .mockResolvedValueOnce({ ok: false, status: 500, text: () => Promise.resolve('error') })
+        .mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: 171500 }) });
+
+      const result = await mirrorCreateShow({ djName: 'Test' });
+      expect(result).toBe(171500);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns null after all retries fail', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('error'),
+      });
+
+      const result = await mirrorCreateShow({ djName: 'Test' });
+      expect(result).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(5);
+    });
+
+    it('returns null on network error without throwing', async () => {
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const result = await mirrorCreateShow({ djName: 'Test' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('mirrorSignoffShow', () => {
+    it('POSTs to the signoff endpoint', async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+      await mirrorSignoffShow(171500, 1773799200000);
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/playlists/api/radioShow/signoff');
+      expect(options.method).toBe('POST');
+      const parsed = JSON.parse(options.body);
+      expect(parsed.radioShowId).toBe(171500);
+      expect(parsed.signoffTime).toBe(1773799200000);
+    });
+
+    it('does not throw on HTTP error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 409,
+        text: () => Promise.resolve('already signed off'),
+      });
+
+      await expect(mirrorSignoffShow(171500, 1773799200000)).resolves.toBeUndefined();
+    });
+
+    it('does not throw on network error', async () => {
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(mirrorSignoffShow(171500, 1773799200000)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('showIdMap', () => {
+    it('stores and retrieves show IDs by backend show ID', () => {
+      cacheShowId(100, 171500);
+      expect(getCachedShowId(100)).toBe(171500);
+    });
+
+    it('returns undefined for unknown backend show ID', () => {
+      expect(getCachedShowId(999)).toBeUndefined();
+    });
+
+    it('overwrites existing entries', () => {
+      cacheShowId(100, 171500);
+      cacheShowId(100, 171501);
+      expect(getCachedShowId(100)).toBe(171501);
+    });
+
+    it('clearShowIdMap removes all entries', () => {
+      cacheShowId(100, 171500);
+      cacheShowId(101, 171501);
+      clearShowIdMap();
+      expect(getCachedShowId(100)).toBeUndefined();
+      expect(getCachedShowId(101)).toBeUndefined();
+    });
+  });
+
+  describe('mapShowToTubafrenzy', () => {
+    it('maps show and DJ to tubafrenzy JSON', () => {
+      const show = {
+        id: 100,
+        show_name: 'Friday Night Jazz',
+        specialty_id: 5,
+        start_time: new Date('2024-02-01T12:00:00Z'),
+      };
+      const dj = {
+        realName: 'Kate Bailey',
+        djName: 'DJ Catalyst',
+        name: 'kate',
+      };
+
+      const result = mapShowToTubafrenzy(show as any, dj as any);
+
+      expect(result.djName).toBe('Kate Bailey');
+      expect(result.djHandle).toBe('DJ Catalyst');
+      expect(result.showName).toBe('Friday Night Jazz');
+      expect(result.specialtyShowId).toBe(5);
+      expect(result.signonTime).toBe(new Date('2024-02-01T12:00:00Z').getTime());
+    });
+
+    it('falls back to name when realName/djName are null', () => {
+      const show = { id: 100, start_time: new Date() };
+      const dj = { realName: null, djName: null, name: 'kate' };
+
+      const result = mapShowToTubafrenzy(show as any, dj as any);
+
+      expect(result.djName).toBe('kate');
+      expect(result.djHandle).toBe('kate');
+    });
+
+    it('defaults optional fields', () => {
+      const show = { id: 100, start_time: new Date() };
+      const dj = { name: 'kate' };
+
+      const result = mapShowToTubafrenzy(show as any, dj as any);
+
+      expect(result.showName).toBe('');
+      expect(result.specialtyShowId).toBe(0);
+      expect(result.djId).toBe(0);
     });
   });
 });

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -12,7 +12,9 @@
 const mockMirrorCreateEntry = jest.fn();
 const mockMirrorUpdateEntry = jest.fn();
 const mockCacheEntryId = jest.fn();
+const mockCacheShowId = jest.fn();
 const mockGetCachedEntryId = jest.fn();
+const mockGetCachedShowId = jest.fn().mockReturnValue(undefined);
 const mockMapEntryToTubafrenzy = jest.fn().mockReturnValue({ artistName: 'test' });
 const mockMapUpdateToTubafrenzy = jest.fn().mockReturnValue({ artistName: 'test' });
 
@@ -22,9 +24,9 @@ jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
   mirrorSignoffShow: jest.fn(),
   mirrorUpdateEntry: mockMirrorUpdateEntry,
   cacheEntryId: mockCacheEntryId,
-  cacheShowId: jest.fn(),
+  cacheShowId: mockCacheShowId,
   getCachedEntryId: mockGetCachedEntryId,
-  getCachedShowId: jest.fn().mockReturnValue(undefined),
+  getCachedShowId: mockGetCachedShowId,
   clearEntryIdMap: jest.fn(),
   clearShowIdMap: jest.fn(),
   mapEntryToTubafrenzy: mockMapEntryToTubafrenzy,
@@ -197,6 +199,30 @@ describe('mirror loop prevention', () => {
       void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
         expect(mockCacheEntryId).not.toHaveBeenCalled();
         expect(mockDbUpdate).not.toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('back-fills show ID cache after DB fallback lookup', (done) => {
+      mockMirrorCreateEntry.mockResolvedValue(99);
+      mockGetCachedShowId.mockReturnValue(undefined);
+      mockSelectLimitResult = [{ legacy_show_id: 171500 }];
+
+      void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
+        expect(mockCacheShowId).toHaveBeenCalledWith(100, 171500);
+        expect(mockMapEntryToTubafrenzy).toHaveBeenCalledWith(expect.anything(), 171500);
+        done();
+      });
+    });
+
+    it('does not back-fill show ID cache when DB returns null', (done) => {
+      mockMirrorCreateEntry.mockResolvedValue(99);
+      mockGetCachedShowId.mockReturnValue(undefined);
+      mockSelectLimitResult = [{ legacy_show_id: null }];
+
+      void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
+        expect(mockCacheShowId).not.toHaveBeenCalled();
+        expect(mockMapEntryToTubafrenzy).toHaveBeenCalledWith(expect.anything(), null);
         done();
       });
     });

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -18,11 +18,17 @@ const mockMapUpdateToTubafrenzy = jest.fn().mockReturnValue({ artistName: 'test'
 
 jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
   mirrorCreateEntry: mockMirrorCreateEntry,
+  mirrorCreateShow: jest.fn(),
+  mirrorSignoffShow: jest.fn(),
   mirrorUpdateEntry: mockMirrorUpdateEntry,
   cacheEntryId: mockCacheEntryId,
+  cacheShowId: jest.fn(),
   getCachedEntryId: mockGetCachedEntryId,
+  getCachedShowId: jest.fn().mockReturnValue(undefined),
   clearEntryIdMap: jest.fn(),
+  clearShowIdMap: jest.fn(),
   mapEntryToTubafrenzy: mockMapEntryToTubafrenzy,
+  mapShowToTubafrenzy: jest.fn(),
   mapUpdateToTubafrenzy: mockMapUpdateToTubafrenzy,
 }));
 
@@ -47,7 +53,8 @@ jest.mock('@wxyc/database', () => ({
     update: mockDbUpdate,
   },
   user: {},
-  flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id' },
+  flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id', show_id: 'show_id' },
+  shows: { id: 'id', legacy_show_id: 'legacy_show_id' },
 }));
 
 jest.mock('drizzle-orm', () => ({

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -38,18 +38,23 @@ const mockDbUpdate = jest.fn().mockReturnValue({
   }),
 });
 
+// Configurable per-test: default resolves to [] (no results)
+let mockSelectLimitResult: unknown[] = [];
+
+const mockDbSelect = jest.fn().mockReturnValue({
+  from: jest.fn().mockReturnValue({
+    where: jest.fn().mockReturnValue({
+      orderBy: jest.fn().mockReturnValue({
+        limit: jest.fn().mockImplementation(() => Promise.resolve(mockSelectLimitResult)),
+      }),
+      limit: jest.fn().mockImplementation(() => Promise.resolve(mockSelectLimitResult)),
+    }),
+  }),
+});
+
 jest.mock('@wxyc/database', () => ({
   db: {
-    select: jest.fn().mockReturnValue({
-      from: jest.fn().mockReturnValue({
-        where: jest.fn().mockReturnValue({
-          orderBy: jest.fn().mockReturnValue({
-            limit: jest.fn().mockResolvedValue([]),
-          }),
-          limit: jest.fn().mockResolvedValue([]),
-        }),
-      }),
-    }),
+    select: mockDbSelect,
     update: mockDbUpdate,
   },
   user: {},
@@ -137,6 +142,7 @@ describe('mirror loop prevention', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetCachedEntryId.mockReturnValue(undefined);
+    mockSelectLimitResult = [];
   });
 
   const baseEntry = {


### PR DESCRIPTION
## Summary

- Rewrite `startShow` and `endShow` mirrors from SSH/SQL (`createBackendMirrorMiddleware`) to HTTP REST (`createHttpMirrorMiddleware`), calling tubafrenzy's new `/api/radioShow` endpoint
- Pass explicit `radioShowID` on every `addEntry` mirror call, eliminating the race condition where tubafrenzy auto-resolved to the wrong show
- Show ID resolution: in-memory cache → `shows.legacy_show_id` from DB → null (graceful degradation)
- `mirrorCreateShow` retries up to 5 times with exponential backoff (base 500ms, max 8s)

Closes #359
Depends on WXYC/tubafrenzy#445 (deploy tubafrenzy first)

## Test plan

- [x] 63 http.mirror unit tests: `mirrorCreateShow` (retry logic, success, failure), `mirrorSignoffShow`, `showIdMap` cache, `mapShowToTubafrenzy`, `mapEntryToTubafrenzy` with `radioShowID`
- [x] Loop prevention tests updated for new exports
- [x] Full unit suite: 797 tests passing, zero regressions
- [x] TypeScript typecheck clean (only pre-existing proxy warnings)
- [ ] Deploy to staging after tubafrenzy, run full show lifecycle (start → add tracks → end → check radioWeek)