### PR TITLE
fix: prevent auth server crash-loop when createDefaultUser fails

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -280,8 +280,8 @@ const createDefaultUser = async () => {
 
     console.log('Default user created successfully with admin role.');
   } catch (error) {
-    console.error('Error creating default user!');
-    throw error;
+    console.error('[DEFAULT USER] Error creating default user:', error);
+    Sentry.captureException(error, { level: 'warning', tags: { subsystem: 'default-user' } });
   }
 };
 


### PR DESCRIPTION
## Summary

- `createDefaultUser()` threw on error, crashing the auth server before it could start listening. In production the default user already exists, so this function failing should not be fatal.
- Logs the actual error (previously swallowed) and reports to Sentry instead of rethrowing, matching the existing `syncAdminRoles()` pattern.

Closes #358

## Test plan

- [ ] Deploy to EC2 with `NODE_ENV=production` and verify the auth server starts without crash-looping
- [ ] Verify `__Secure-` cookies have the `Secure` flag set (new sign-ins work in the browser)
- [ ] Verify test endpoints (`/auth/test/*`) are disabled in production mode
- [ ] Confirm Sentry receives the `default-user` tagged event if `createDefaultUser` fails