### PR TITLE
Add Dependabot config, update @wxyc/shared to ^0.4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      better-auth:
+        patterns:
+          - "better-auth"
+          - "@better-auth/*"
+      wxyc-shared:
+        patterns:
+          - "@wxyc/shared"
+      dev-dependencies:
+        dependency-type: "development"
+        exclude-patterns:
+          - "better-auth"
+          - "@better-auth/*"
+          - "@wxyc/shared"
+      production-dependencies:
+        dependency-type: "production"
+        exclude-patterns:
+          - "better-auth"
+          - "@better-auth/*"
+          - "@wxyc/shared"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,41 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: 'weekly'
+      day: 'monday'
     groups:
       better-auth:
         patterns:
-          - "better-auth"
-          - "@better-auth/*"
+          - 'better-auth'
+          - '@better-auth/*'
+      drizzle:
+        patterns:
+          - 'drizzle-orm'
+          - 'drizzle-kit'
       wxyc-shared:
         patterns:
-          - "@wxyc/shared"
+          - '@wxyc/shared'
       dev-dependencies:
-        dependency-type: "development"
+        dependency-type: 'development'
         exclude-patterns:
-          - "better-auth"
-          - "@better-auth/*"
-          - "@wxyc/shared"
+          - 'better-auth'
+          - '@better-auth/*'
+          - 'drizzle-orm'
+          - 'drizzle-kit'
+          - '@wxyc/shared'
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: 'production'
         exclude-patterns:
-          - "better-auth"
-          - "@better-auth/*"
-          - "@wxyc/shared"
+          - 'better-auth'
+          - '@better-auth/*'
+          - 'drizzle-orm'
+          - 'drizzle-kit'
+          - '@wxyc/shared'
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: 'weekly'
+      day: 'monday'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1815,41 +1815,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@better-auth/core": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.9.tgz",
-      "integrity": "sha512-JT2q4NDkQzN22KclUEoZ7qU6tl9HUTfK1ctg2oWlT87SEagkwJcnrUwS9VznL+u9ziOIfY27P0f7/jSnmvLcoQ==",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "zod": "^4.1.12"
-      },
-      "peerDependencies": {
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21",
-        "better-call": "1.1.7",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5",
-        "nanostores": "^1.0.1"
-      }
-    },
-    "node_modules/@better-auth/telemetry": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.9.tgz",
-      "integrity": "sha512-Tthy1/Gmx+pYlbvRQPBTKfVei8+pJwvH1NZp+5SbhwA6K2EXIaoonx/K6N/AXYs2aKUpyR4/gzqDesDjL7zd6A==",
-      "dependencies": {
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21"
-      },
-      "peerDependencies": {
-        "@better-auth/core": "1.4.9"
-      }
-    },
-    "node_modules/@better-auth/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT"
-    },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
@@ -7366,19 +7331,6 @@
       "resolved": "jobs/rotation-etl",
       "link": true
     },
-    "node_modules/@wxyc/shared": {
-      "version": "0.3.2",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.3.2/675cda0ccd36e71a269a8cf2bf9900f7166e8e99",
-      "integrity": "sha512-KkmjaY47kdYjrU35HtZafk3vpFzHvUGNefu4j+S9kTK5x1RtxzQ7RQJrGzSQN1+ASmFKCESp0cOJgffBhDN1dg==",
-      "license": "MIT",
-      "dependencies": {
-        "better-auth": "^1.4.9",
-        "date-fns": "^4.1.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0 || ^6.0.0"
-      }
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -7791,146 +7743,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/better-auth": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.9.tgz",
-      "integrity": "sha512-usSdjuyTzZwIvM8fjF8YGhPncxV3MAg3dHUO9uPUnf0yklXUSYISiH1+imk6/Z+UBqsscyyPRnbIyjyK97p7YA==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/core": "1.4.9",
-        "@better-auth/telemetry": "1.4.9",
-        "@better-auth/utils": "0.3.0",
-        "@better-fetch/fetch": "1.1.21",
-        "@noble/ciphers": "^2.0.0",
-        "@noble/hashes": "^2.0.0",
-        "better-call": "1.1.7",
-        "defu": "^6.1.4",
-        "jose": "^6.1.0",
-        "kysely": "^0.28.5",
-        "nanostores": "^1.0.1",
-        "zod": "^4.1.12"
-      },
-      "peerDependencies": {
-        "@lynx-js/react": "*",
-        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "@sveltejs/kit": "^2.0.0",
-        "@tanstack/react-start": "^1.0.0",
-        "better-sqlite3": "^12.0.0",
-        "drizzle-kit": ">=0.31.4",
-        "drizzle-orm": ">=0.41.0",
-        "mongodb": "^6.0.0 || ^7.0.0",
-        "mysql2": "^3.0.0",
-        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
-        "pg": "^8.0.0",
-        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
-        "solid-js": "^1.0.0",
-        "svelte": "^4.0.0 || ^5.0.0",
-        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
-        "vue": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@lynx-js/react": {
-          "optional": true
-        },
-        "@prisma/client": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "@tanstack/react-start": {
-          "optional": true
-        },
-        "better-sqlite3": {
-          "optional": true
-        },
-        "drizzle-kit": {
-          "optional": true
-        },
-        "drizzle-orm": {
-          "optional": true
-        },
-        "mongodb": {
-          "optional": true
-        },
-        "mysql2": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "pg": {
-          "optional": true
-        },
-        "prisma": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "solid-js": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vitest": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/better-auth/node_modules/@noble/ciphers": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.1.1.tgz",
-      "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/better-auth/node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/better-call": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.7.tgz",
-      "integrity": "sha512-6gaJe1bBIEgVebQu/7q9saahVzvBsGaByEnE8aDVncZEDiJO7sdNB28ot9I6iXSbR25egGmmZ6aIURXyQHRraQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@better-auth/utils": "^0.3.0",
-        "@better-fetch/fetch": "^1.1.4",
-        "rou3": "^0.7.10",
-        "set-cookie-parser": "^2.7.1"
-      },
-      "peerDependencies": {
-        "zod": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/binary-extensions": {
@@ -13092,12 +12904,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -15733,7 +15539,7 @@
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1014.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^0.3.2",
+        "@wxyc/shared": "^0.4.0",
         "better-auth": "^1.5.6",
         "drizzle-orm": "^0.41.0",
         "postgres": "^3.4.8"
@@ -15853,6 +15659,19 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "shared/authentication/node_modules/@wxyc/shared": {
+      "version": "0.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.4.0/88a8a2128fc917acd3d0882094e4a7f1a1a8a566",
+      "integrity": "sha512-5HIyILNJXVpE/wkdBDWEAvFUA5sbhK2z+l6fUZxprRSE6O7oB5JuV/4IoXnpKV+9lZJB0TMruwKvgMMHpG6SUA==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "better-auth": "^1.5.0",
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "shared/authentication/node_modules/better-auth": {

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1014.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^0.3.2",
+    "@wxyc/shared": "^0.4.0",
     "better-auth": "^1.5.6",
     "drizzle-orm": "^0.41.0",
     "postgres": "^3.4.8"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` with weekly update schedule and dedicated groups for `better-auth`, `drizzle-orm`, and `@wxyc/shared`
- Update `@wxyc/shared` from `^0.3.2` to `^0.4.0` in `shared/authentication/package.json`

Closes #362

## Context

Part 2 of the dependency sync strategy. Depends on WXYC/wxyc-shared#47 being merged and `v0.4.0` tagged/published before the `@wxyc/shared` version can resolve. The Dependabot config takes effect immediately on merge.

### Dependabot groups

| Group | Packages | Purpose |
|-------|----------|---------|
| `better-auth` | `better-auth`, `@better-auth/*` | Coordinated auth library updates |
| `drizzle` | `drizzle-orm`, `drizzle-kit` | Coordinated ORM updates (may involve migrations) |
| `wxyc-shared` | `@wxyc/shared` | Shared package updates |
| `dev-dependencies` | All other dev deps | Grouped dev dependency updates |
| `production-dependencies` | All other prod deps | Grouped production updates |

## Test plan

- [x] `npm run lint` passes (no new errors)
- [x] Dependabot YAML is valid
- [ ] CI passes
- [ ] After WXYC/wxyc-shared#47 merges: `npm install` resolves `@wxyc/shared@^0.4.0`, run `npm run ci:testmock`
- [ ] After merge: verify Dependabot appears in repo Settings > Code security