### PR TITLE
fix: update artist_genre_code when source value changes

### DIFF
--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -416,12 +416,20 @@ const ensureGenreArtistCrossref = async (
   artistGenreCode: number
 ) => {
   const existing = await dbClient
-    .select({ artist_id: genre_artist_crossreference.artist_id })
+    .select({ artist_id: genre_artist_crossreference.artist_id, artist_genre_code: genre_artist_crossreference.artist_genre_code })
     .from(genre_artist_crossreference)
     .where(and(eq(genre_artist_crossreference.artist_id, artistId), eq(genre_artist_crossreference.genre_id, genreId)))
     .limit(1);
 
-  if (existing.length) return;
+  if (existing.length) {
+    if (existing[0].artist_genre_code !== artistGenreCode) {
+      await dbClient
+        .update(genre_artist_crossreference)
+        .set({ artist_genre_code: artistGenreCode })
+        .where(and(eq(genre_artist_crossreference.artist_id, artistId), eq(genre_artist_crossreference.genre_id, genreId)));
+    }
+    return;
+  }
 
   await dbClient.insert(genre_artist_crossreference).values({
     artist_id: artistId,

--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -415,27 +415,13 @@ const ensureGenreArtistCrossref = async (
   genreId: number,
   artistGenreCode: number
 ) => {
-  const existing = await dbClient
-    .select({ artist_id: genre_artist_crossreference.artist_id, artist_genre_code: genre_artist_crossreference.artist_genre_code })
-    .from(genre_artist_crossreference)
-    .where(and(eq(genre_artist_crossreference.artist_id, artistId), eq(genre_artist_crossreference.genre_id, genreId)))
-    .limit(1);
-
-  if (existing.length) {
-    if (existing[0].artist_genre_code !== artistGenreCode) {
-      await dbClient
-        .update(genre_artist_crossreference)
-        .set({ artist_genre_code: artistGenreCode })
-        .where(and(eq(genre_artist_crossreference.artist_id, artistId), eq(genre_artist_crossreference.genre_id, genreId)));
-    }
-    return;
-  }
-
-  await dbClient.insert(genre_artist_crossreference).values({
-    artist_id: artistId,
-    genre_id: genreId,
-    artist_genre_code: artistGenreCode,
-  });
+  await dbClient
+    .insert(genre_artist_crossreference)
+    .values({ artist_id: artistId, genre_id: genreId, artist_genre_code: artistGenreCode })
+    .onConflictDoUpdate({
+      target: [genre_artist_crossreference.artist_id, genre_artist_crossreference.genre_id],
+      set: { artist_genre_code: artistGenreCode },
+    });
 };
 
 /**


### PR DESCRIPTION
## Summary

- `ensureGenreArtistCrossref` previously returned early when a row existed for an `(artist_id, genre_id)` pair, never updating `artist_genre_code` even if the source value differed
- Now compares the stored code with the incoming value and updates when they differ
- Fixes stale codes persisting permanently (e.g. Autechre displaying as AU 0 instead of AU 3)

Closes #373

## Test plan

- [ ] Run library ETL against an artist with a known stale `artist_genre_code` and verify it gets corrected
- [ ] Verify no regressions: artists with correct codes are not modified (no unnecessary UPDATEs)