### PR TITLE
fix: sync crossref comment updates instead of dropping them

### DIFF
--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -631,7 +631,10 @@ const importArtistCrossRefs = async (
         target_artist_id: targetId,
         comment: row.comment,
       })
-      .onConflictDoNothing();
+      .onConflictDoUpdate({
+        target: [artist_crossreference.source_artist_id, artist_crossreference.target_artist_id],
+        set: { comment: sql`excluded.comment` },
+      });
 
     imported++;
   }
@@ -767,7 +770,10 @@ const importReleaseCrossRefs = async (
         library_id: albumId,
         comment: row.comment,
       })
-      .onConflictDoNothing();
+      .onConflictDoUpdate({
+        target: [artist_library_crossreference.artist_id, artist_library_crossreference.library_id],
+        set: { comment: sql`excluded.comment` },
+      });
 
     imported++;
   }


### PR DESCRIPTION
## Summary

- `artist_crossreference` and `artist_library_crossreference` imports used `onConflictDoNothing`, silently discarding comment edits from tubafrenzy
- Replaced with `onConflictDoUpdate` targeting the `comment` column so edits propagate

Closes #375

## Test plan

- [ ] Verify crossref imports still work for new entries (inserts)
- [ ] Verify updated comments in tubafrenzy propagate on re-import