### PR TITLE
fix: re-sync compilation track artists on every ETL run

### DIFF
--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -1009,15 +1009,12 @@ const run = async () => {
       }
 
       // Import compilation track artists (V/A releases)
-      const ctaCount = await tx.select({ count: sql<number>`count(*)::int` }).from(compilation_track_artist);
-      if (ctaCount[0].count === 0) {
-        const legacyCTA = await fetchLegacyCompilationTracks();
-        if (legacyCTA.length > 0) {
-          const ctaResult = await importCompilationTracks(tx, legacyCTA);
-          console.log(
-            `[library-etl] Compilation track artists: imported ${ctaResult.imported}, skipped ${ctaResult.skipped}.`
-          );
-        }
+      const legacyCTA = await fetchLegacyCompilationTracks();
+      if (legacyCTA.length > 0) {
+        const ctaResult = await importCompilationTracks(tx, legacyCTA);
+        console.log(
+          `[library-etl] Compilation track artists: imported ${ctaResult.imported}, skipped ${ctaResult.skipped}.`
+        );
       }
 
       await updateLastRun(tx, JOB_NAME, runStartedAt);


### PR DESCRIPTION
## Summary

- The compilation track artist import was guarded by a `count === 0` check, making it a one-time backfill that never picked up new V/A tracks added to tubafrenzy after the first run
- Removed the guard; the existing `onConflictDoNothing` on the insert already handles idempotency

Closes #377

## Test plan

- [ ] Verify existing compilation track data is not duplicated on re-run (onConflictDoNothing)
- [ ] Add a new compilation track in tubafrenzy and verify it appears after ETL run