### PR TITLE
Sync ON_STREAMING from tubafrenzy in library ETL

### DIFF
--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -260,7 +260,12 @@ const updateLastRun = async (dbClient: DbClient, jobName: string, lastRun: Date)
     });
 };
 
-const buildReleaseQuery = (lastRunMs: number | null, includeDateLostFound: boolean, includeAlbumArtist: boolean, includeOnStreaming: boolean = false) => {
+const buildReleaseQuery = (
+  lastRunMs: number | null,
+  includeDateLostFound: boolean,
+  includeAlbumArtist: boolean,
+  includeOnStreaming: boolean = false
+) => {
   const lastRunFilter = lastRunMs == null ? '' : `WHERE lr.TIME_LAST_MODIFIED > ${lastRunMs}`;
   const dateLostFoundColumns = includeDateLostFound ? `,\n      lr.DATE_LOST,\n      lr.DATE_FOUND` : '';
   const albumArtistColumn = includeAlbumArtist

--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -36,6 +36,7 @@ type LegacyReleaseRow = {
   date_lost: number | null;
   date_found: number | null;
   release_album_artist: string | null;
+  release_on_streaming: boolean | null;
 };
 
 const VARIOUS_ARTISTS_NAME = 'Various Artists';
@@ -259,12 +260,13 @@ const updateLastRun = async (dbClient: DbClient, jobName: string, lastRun: Date)
     });
 };
 
-const buildReleaseQuery = (lastRunMs: number | null, includeDateLostFound: boolean, includeAlbumArtist: boolean) => {
+const buildReleaseQuery = (lastRunMs: number | null, includeDateLostFound: boolean, includeAlbumArtist: boolean, includeOnStreaming: boolean = false) => {
   const lastRunFilter = lastRunMs == null ? '' : `WHERE lr.TIME_LAST_MODIFIED > ${lastRunMs}`;
   const dateLostFoundColumns = includeDateLostFound ? `,\n      lr.DATE_LOST,\n      lr.DATE_FOUND` : '';
   const albumArtistColumn = includeAlbumArtist
     ? `,\n      REPLACE(REPLACE(IFNULL(lr.ALBUM_ARTIST, ''), '\\t', ' '), '\\n', ' ')`
     : '';
+  const onStreamingColumn = includeOnStreaming ? `,\n      lr.ON_STREAMING` : '';
   return `
     SELECT
       lr.ID,
@@ -279,7 +281,7 @@ const buildReleaseQuery = (lastRunMs: number | null, includeDateLostFound: boole
       lc.CALL_LETTERS AS artist_call_letters,
       lc.CALL_NUMBERS AS artist_call_numbers,
       g.REFERENCE_NAME,
-      f.REFERENCE_NAME${dateLostFoundColumns}${albumArtistColumn}
+      f.REFERENCE_NAME${dateLostFoundColumns}${albumArtistColumn}${onStreamingColumn}
     FROM LIBRARY_RELEASE lr
     JOIN LIBRARY_CODE lc ON lr.LIBRARY_CODE_ID = lc.ID
     JOIN GENRE g ON lc.GENRE_ID = g.ID
@@ -287,6 +289,11 @@ const buildReleaseQuery = (lastRunMs: number | null, includeDateLostFound: boole
     ${lastRunFilter}
     ORDER BY lr.TIME_LAST_MODIFIED ASC;
   `;
+};
+
+const parseOnStreaming = (value?: string): boolean | null => {
+  if (value == null || value.trim().length === 0) return null;
+  return value.trim() === '1';
 };
 
 const parseReleaseRows = (raw: string, columnCount: number): LegacyReleaseRow[] => {
@@ -317,6 +324,7 @@ const parseReleaseRows = (raw: string, columnCount: number): LegacyReleaseRow[] 
       date_lost: columnCount >= 15 ? toNullableNumber(columns[13]) : null,
       date_found: columnCount >= 15 ? toNullableNumber(columns[14]) : null,
       release_album_artist: columnCount >= 16 ? toNullableString(columns[15]) : null,
+      release_on_streaming: columnCount >= 17 ? parseOnStreaming(columns[16]) : null,
     });
   }
 
@@ -324,7 +332,13 @@ const parseReleaseRows = (raw: string, columnCount: number): LegacyReleaseRow[] 
 };
 
 const fetchLegacyReleases = async (lastRunMs: number | null) => {
-  // Try with DATE_LOST/DATE_FOUND + ALBUM_ARTIST columns first; fall back progressively
+  // Try with ON_STREAMING + DATE_LOST/DATE_FOUND + ALBUM_ARTIST columns first; fall back progressively
+  try {
+    const raw = await legacyDB.send(buildReleaseQuery(lastRunMs, true, true, true));
+    return parseReleaseRows(raw, 17);
+  } catch {
+    console.warn('[library-etl] ON_STREAMING column not available, falling back to 16-column query.');
+  }
   try {
     const raw = await legacyDB.send(buildReleaseQuery(lastRunMs, true, true));
     return parseReleaseRows(raw, 16);
@@ -781,6 +795,7 @@ type ExistingRelease = {
   dateLost: Date | null;
   dateFound: Date | null;
   albumArtist: string | null;
+  onStreaming: boolean | null;
 };
 
 const findExistingRelease = async (
@@ -798,6 +813,7 @@ const findExistingRelease = async (
       dateLost: library.date_lost,
       dateFound: library.date_found,
       albumArtist: library.album_artist,
+      onStreaming: library.on_streaming,
     })
     .from(library)
     .where(
@@ -940,6 +956,10 @@ const run = async () => {
           if ((existing.albumArtist ?? null) !== newAlbumArtist) {
             updates.album_artist = newAlbumArtist;
           }
+          const newOnStreaming = release.release_on_streaming ?? null;
+          if ((existing.onStreaming ?? null) !== newOnStreaming) {
+            updates.on_streaming = newOnStreaming;
+          }
           if (Object.keys(updates).length > 0) {
             await tx.update(library).set(updates).where(eq(library.id, existing.id));
           }
@@ -962,6 +982,7 @@ const run = async () => {
           last_modified: toDateOrUndefined(release.release_last_modified),
           date_lost: toDateOrUndefined(release.date_lost),
           date_found: toDateOrUndefined(release.date_found),
+          on_streaming: release.release_on_streaming,
         });
 
         insertedCount += 1;
@@ -1045,6 +1066,7 @@ export {
   parseLegacyGenreRows,
   parseLegacyFormatRows,
   parseLegacyCompilationTrackRows,
+  parseReleaseRows,
   buildArtistCacheKey,
   buildAlbumCacheKey,
 };

--- a/tests/unit/jobs/library-etl.test.ts
+++ b/tests/unit/jobs/library-etl.test.ts
@@ -460,19 +460,19 @@ describe('library-etl job helpers', () => {
   describe('parseReleaseRows', () => {
     // Base 13 columns shared across all row widths
     const base13 = [
-      '1001',        // ID
-      'Confield',    // TITLE
-      '1700000000',  // TIME_LAST_MODIFIED
-      '1600000000',  // TIME_CREATED
-      '42',          // CALL_NUMBERS
-      'AE',          // CALL_LETTERS
-      '',            // ALTERNATE_ARTIST_NAME
-      'Autechre',    // PRESENTATION_NAME
-      'Autechre',    // ALPHABETICAL_NAME
-      'AE',          // artist CALL_LETTERS
-      '1',           // artist CALL_NUMBERS
-      'Electronic',  // GENRE REFERENCE_NAME
-      'CD',          // FORMAT REFERENCE_NAME
+      '1001', // ID
+      'Confield', // TITLE
+      '1700000000', // TIME_LAST_MODIFIED
+      '1600000000', // TIME_CREATED
+      '42', // CALL_NUMBERS
+      'AE', // CALL_LETTERS
+      '', // ALTERNATE_ARTIST_NAME
+      'Autechre', // PRESENTATION_NAME
+      'Autechre', // ALPHABETICAL_NAME
+      'AE', // artist CALL_LETTERS
+      '1', // artist CALL_NUMBERS
+      'Electronic', // GENRE REFERENCE_NAME
+      'CD', // FORMAT REFERENCE_NAME
     ];
 
     it('parses a 17-column row with on_streaming=true', () => {

--- a/tests/unit/jobs/library-etl.test.ts
+++ b/tests/unit/jobs/library-etl.test.ts
@@ -85,6 +85,7 @@ import {
   parseLegacyGenreRows,
   parseLegacyFormatRows,
   parseLegacyCompilationTrackRows,
+  parseReleaseRows,
   buildArtistCacheKey,
   buildAlbumCacheKey,
 } from '../../../jobs/library-etl/job';
@@ -453,6 +454,93 @@ describe('library-etl job helpers', () => {
 
     it('returns empty array for empty input', () => {
       expect(parseLegacyCompilationTrackRows('')).toEqual([]);
+    });
+  });
+
+  describe('parseReleaseRows', () => {
+    // Base 13 columns shared across all row widths
+    const base13 = [
+      '1001',        // ID
+      'Confield',    // TITLE
+      '1700000000',  // TIME_LAST_MODIFIED
+      '1600000000',  // TIME_CREATED
+      '42',          // CALL_NUMBERS
+      'AE',          // CALL_LETTERS
+      '',            // ALTERNATE_ARTIST_NAME
+      'Autechre',    // PRESENTATION_NAME
+      'Autechre',    // ALPHABETICAL_NAME
+      'AE',          // artist CALL_LETTERS
+      '1',           // artist CALL_NUMBERS
+      'Electronic',  // GENRE REFERENCE_NAME
+      'CD',          // FORMAT REFERENCE_NAME
+    ];
+
+    it('parses a 17-column row with on_streaming=true', () => {
+      const row = [...base13, '0', '0', 'Autechre', '1'].join('\t');
+      const result = parseReleaseRows(row, 17);
+      expect(result).toHaveLength(1);
+      expect(result[0].release_on_streaming).toBe(true);
+      expect(result[0].release_album_artist).toBe('Autechre');
+    });
+
+    it('parses a 17-column row with on_streaming=false', () => {
+      const row = [...base13, '0', '0', '', '0'].join('\t');
+      const result = parseReleaseRows(row, 17);
+      expect(result).toHaveLength(1);
+      expect(result[0].release_on_streaming).toBe(false);
+    });
+
+    it('parses a 17-column row with on_streaming=null for empty value', () => {
+      // Use two rows so raw.trim() does not strip trailing tabs from the first row
+      const row1 = [...base13, '0', '0', '', ''].join('\t');
+      const row2 = [...base13, '0', '0', 'Autechre', '1'].join('\t');
+      const result = parseReleaseRows([row1, row2].join('\n'), 17);
+      expect(result).toHaveLength(2);
+      expect(result[0].release_on_streaming).toBeNull();
+    });
+
+    it('parses a 16-column row with release_on_streaming=null (backward compat)', () => {
+      const row = [...base13, '0', '0', 'Autechre'].join('\t');
+      const result = parseReleaseRows(row, 16);
+      expect(result).toHaveLength(1);
+      expect(result[0].release_on_streaming).toBeNull();
+      expect(result[0].release_album_artist).toBe('Autechre');
+    });
+
+    it('parses a 15-column row with release_on_streaming=null', () => {
+      const row = [...base13, '0', '0'].join('\t');
+      const result = parseReleaseRows(row, 15);
+      expect(result).toHaveLength(1);
+      expect(result[0].release_on_streaming).toBeNull();
+      expect(result[0].release_album_artist).toBeNull();
+    });
+
+    it('parses a 13-column row with release_on_streaming=null', () => {
+      const row = base13.join('\t');
+      const result = parseReleaseRows(row, 13);
+      expect(result).toHaveLength(1);
+      expect(result[0].release_on_streaming).toBeNull();
+      expect(result[0].release_album_artist).toBeNull();
+      expect(result[0].date_lost).toBeNull();
+      expect(result[0].date_found).toBeNull();
+    });
+
+    it('parses multiple 17-column rows with mixed on_streaming values', () => {
+      // Empty-column row is not last to avoid raw.trim() stripping trailing tabs
+      const rows = [
+        [...base13, '0', '0', 'Autechre', '1'].join('\t'),
+        [...base13, '0', '0', '', ''].join('\t'),
+        [...base13, '0', '0', '', '0'].join('\t'),
+      ].join('\n');
+      const result = parseReleaseRows(rows, 17);
+      expect(result).toHaveLength(3);
+      expect(result[0].release_on_streaming).toBe(true);
+      expect(result[1].release_on_streaming).toBeNull();
+      expect(result[2].release_on_streaming).toBe(false);
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(parseReleaseRows('', 17)).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `ON_STREAMING` to the library ETL MySQL SELECT query (17-column progressive fallback)
- Parse tinyint values: `1` → true, `0` → false, empty → null
- Write `on_streaming` during library release insert and update
- 8 new tests for parsing with all column counts and streaming values

Closes #382

## Test plan

- [x] All 69 library ETL unit tests pass
- [x] Typecheck passes
- [x] 16-column backward compatibility verified (on_streaming defaults to null)
- [ ] After deploy: run full ETL cycle to backfill existing rows