### PR TITLE
Expand album info response and add mark missing/found endpoints

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -345,3 +345,49 @@ export const getAlbum: RequestHandler<object, unknown, unknown, { album_id: stri
     next(e);
   }
 };
+
+const parseAlbumId = (rawId: string): number => {
+  const albumId = Number(rawId);
+  if (!Number.isInteger(albumId) || albumId <= 0) {
+    throw new WxycError('Invalid album ID', 400);
+  }
+  return albumId;
+};
+
+export const markMissing: RequestHandler<{ id: string }> = async (req, res, next) => {
+  const albumId = parseAlbumId(req.params.id);
+
+  try {
+    const result = await libraryService.markAlbumMissing(albumId);
+    if (!result) {
+      throw new WxycError('Album not found', 404);
+    }
+
+    const album = await libraryService.getAlbumFromDB(albumId);
+    res.status(200).json(album);
+  } catch (e) {
+    if (e instanceof WxycError) throw e;
+    console.error('Failed to mark album as missing');
+    console.error(e);
+    next(e);
+  }
+};
+
+export const markFound: RequestHandler<{ id: string }> = async (req, res, next) => {
+  const albumId = parseAlbumId(req.params.id);
+
+  try {
+    const result = await libraryService.markAlbumFound(albumId);
+    if (!result) {
+      throw new WxycError('Album not found', 404);
+    }
+
+    const album = await libraryService.getAlbumFromDB(albumId);
+    res.status(200).json(album);
+  } catch (e) {
+    if (e instanceof WxycError) throw e;
+    console.error('Failed to mark album as found');
+    console.error(e);
+    next(e);
+  }
+};

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -207,6 +207,10 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
       metadata.discogsUrl = topResult.release_url;
       metadata.artworkUrl = topResult.artwork_url || undefined;
 
+      // Artist bio and Wikipedia from LML search result
+      if (topResult.artist_bio) metadata.artistBio = topResult.artist_bio;
+      if (topResult.wikipedia_url) metadata.artistWikipediaUrl = topResult.wikipedia_url;
+
       // Streaming URLs from LML enrichment
       if (topResult.spotify_url) metadata.spotifyUrl = topResult.spotify_url;
       if (topResult.apple_music_url) metadata.appleMusicUrl = topResult.apple_music_url;
@@ -221,7 +225,7 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
         metadata.genres = release.genres.length > 0 ? release.genres : undefined;
         metadata.styles = release.styles.length > 0 ? release.styles : undefined;
         metadata.label = release.label ?? undefined;
-        metadata.discogsArtistId = release.artist_id ?? undefined;
+        metadata.discogsArtistId = release.artist_id ?? null;
         metadata.fullReleaseDate = release.released ?? undefined;
         if (release.tracklist.length > 0) {
           metadata.tracklist = release.tracklist.map((t) => ({

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -33,3 +33,7 @@ library_route.get('/genres', requirePermissions({ catalog: ['read'] }), libraryC
 library_route.post('/genres', requirePermissions({ catalog: ['write'] }), libraryController.addGenre);
 
 library_route.get('/info', requirePermissions({ catalog: ['read'] }), libraryController.getAlbum);
+
+library_route.patch('/:id/missing', requirePermissions({ catalog: ['write'] }), libraryController.markMissing);
+
+library_route.patch('/:id/found', requirePermissions({ catalog: ['write'] }), libraryController.markFound);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -263,9 +263,16 @@ export const getAlbumFromDB = async (album_id: number) => {
       plays: library.plays,
       add_date: library.add_date,
       last_modified: library.last_modified,
+      format_name: format.format_name,
+      genre_name: genres.genre_name,
+      date_lost: library.date_lost,
+      date_found: library.date_found,
+      on_streaming: library.on_streaming,
     })
     .from(library)
     .innerJoin(artists, eq(artists.id, library.artist_id))
+    .innerJoin(format, eq(format.id, library.format_id))
+    .innerJoin(genres, eq(genres.id, library.genre_id))
     .innerJoin(
       genre_artist_crossreference,
       and(
@@ -277,6 +284,24 @@ export const getAlbumFromDB = async (album_id: number) => {
     .limit(1);
 
   return album[0];
+};
+
+export const markAlbumMissing = async (album_id: number) => {
+  const result = await db
+    .update(library)
+    .set({ date_lost: sql`NOW()`, date_found: null, last_modified: sql`NOW()` })
+    .where(eq(library.id, album_id))
+    .returning({ id: library.id });
+  return result[0];
+};
+
+export const markAlbumFound = async (album_id: number) => {
+  const result = await db
+    .update(library)
+    .set({ date_found: sql`NOW()`, last_modified: sql`NOW()` })
+    .where(eq(library.id, album_id))
+    .returning({ id: library.id });
+  return result[0];
 };
 
 export const getGenresFromDB = async () => {

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -146,6 +146,11 @@ export const schedule = {};
 export const artist_crossreference = {};
 export const artist_library_crossreference = {};
 export const compilation_track_artist = {};
+export const genre_artist_crossreference = {
+  artist_id: 'artist_id',
+  genre_id: 'genre_id',
+  artist_genre_code: 'artist_genre_code',
+};
 
 // Pure ETL utility functions (copied from etl-utils.ts to avoid importing the real DB client)
 export const epochMsToDate = (epochMs: number | null): Date | null => {

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -1,0 +1,155 @@
+import { jest } from '@jest/globals';
+import type { Request, Response, NextFunction } from 'express';
+
+const mockGetAlbumFromDB = jest.fn<() => Promise<Record<string, unknown> | undefined>>();
+const mockMarkAlbumMissing = jest.fn<() => Promise<{ id: number } | undefined>>();
+const mockMarkAlbumFound = jest.fn<() => Promise<{ id: number } | undefined>>();
+
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  getAlbumFromDB: mockGetAlbumFromDB,
+  markAlbumMissing: mockMarkAlbumMissing,
+  markAlbumFound: mockMarkAlbumFound,
+  // Stub out other exports that may be referenced at import time
+  getFormatsFromDB: jest.fn(),
+  getRotationFromDB: jest.fn(),
+  addToRotation: jest.fn(),
+  killRotationInDB: jest.fn(),
+  insertAlbum: jest.fn(),
+  fuzzySearchLibrary: jest.fn(),
+  artistIdFromName: jest.fn(),
+  insertArtist: jest.fn(),
+  insertArtistGenreCrossreference: jest.fn(),
+  getArtistByCode: jest.fn(),
+  generateAlbumCodeNumber: jest.fn(),
+  generateArtistNumber: jest.fn(),
+  getGenresFromDB: jest.fn(),
+  insertGenre: jest.fn(),
+  insertFormat: jest.fn(),
+  isISODate: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/labels.service', () => ({
+  createLabel: jest.fn(),
+}));
+
+import { markMissing, markFound } from '../../../apps/backend/controllers/library.controller';
+
+function mockResponse(): Response {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res) as unknown as Response['status'];
+  res.json = jest.fn().mockReturnValue(res) as unknown as Response['json'];
+  return res;
+}
+
+const fullAlbum = {
+  id: 42,
+  code_letters: 'AU',
+  code_artist_number: 1,
+  code_number: 3,
+  artist_name: 'Autechre',
+  alphabetical_name: 'Autechre',
+  album_title: 'Confield',
+  record_label: 'Warp',
+  label_id: 10,
+  plays: 5,
+  add_date: new Date('2024-01-15'),
+  last_modified: new Date('2024-03-01'),
+  format_name: 'CD',
+  genre_name: 'Electronic',
+  date_lost: new Date('2026-04-22'),
+  date_found: null,
+  on_streaming: true,
+};
+
+describe('library.controller', () => {
+  let next: NextFunction;
+
+  beforeEach(() => {
+    next = jest.fn() as unknown as NextFunction;
+  });
+
+  describe('markMissing', () => {
+    it('returns 400 for non-numeric id parameter', async () => {
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(markMissing(req, res, next)).rejects.toThrow('Invalid album ID');
+    });
+
+    it('returns 400 for non-positive id parameter', async () => {
+      const req = { params: { id: '0' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(markMissing(req, res, next)).rejects.toThrow('Invalid album ID');
+    });
+
+    it('returns 400 for negative id parameter', async () => {
+      const req = { params: { id: '-5' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(markMissing(req, res, next)).rejects.toThrow('Invalid album ID');
+    });
+
+    it('returns 404 when album not found', async () => {
+      mockMarkAlbumMissing.mockResolvedValue(undefined);
+      const req = { params: { id: '999' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(markMissing(req, res, next)).rejects.toThrow('Album not found');
+    });
+
+    it('returns 200 with full album on success', async () => {
+      mockMarkAlbumMissing.mockResolvedValue({ id: 42 });
+      mockGetAlbumFromDB.mockResolvedValue(fullAlbum);
+      const req = { params: { id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await markMissing(req, res, next);
+
+      expect(mockMarkAlbumMissing).toHaveBeenCalledWith(42);
+      expect(mockGetAlbumFromDB).toHaveBeenCalledWith(42);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(fullAlbum);
+    });
+  });
+
+  describe('markFound', () => {
+    it('returns 400 for non-numeric id parameter', async () => {
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(markFound(req, res, next)).rejects.toThrow('Invalid album ID');
+    });
+
+    it('returns 400 for non-positive id parameter', async () => {
+      const req = { params: { id: '0' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(markFound(req, res, next)).rejects.toThrow('Invalid album ID');
+    });
+
+    it('returns 404 when album not found', async () => {
+      mockMarkAlbumFound.mockResolvedValue(undefined);
+      const req = { params: { id: '999' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(markFound(req, res, next)).rejects.toThrow('Album not found');
+    });
+
+    it('returns 200 with full album on success', async () => {
+      mockMarkAlbumFound.mockResolvedValue({ id: 42 });
+      mockGetAlbumFromDB.mockResolvedValue({ ...fullAlbum, date_lost: null, date_found: new Date('2026-04-22') });
+      const req = { params: { id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await markFound(req, res, next);
+
+      expect(mockMarkAlbumFound).toHaveBeenCalledWith(42);
+      expect(mockGetAlbumFromDB).toHaveBeenCalledWith(42);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 42, date_found: expect.any(Date) })
+      );
+    });
+  });
+});

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -147,9 +147,7 @@ describe('library.controller', () => {
       expect(mockMarkAlbumFound).toHaveBeenCalledWith(42);
       expect(mockGetAlbumFromDB).toHaveBeenCalledWith(42);
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 42, date_found: expect.any(Date) })
-      );
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ id: 42, date_found: expect.any(Date) }));
     });
   });
 });

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -1,57 +1,12 @@
-// Mock dependencies before importing the service
-jest.mock('@wxyc/database', () => {
-  const chain: Record<string, jest.Mock> = {};
-  const chainMethods = [
-    'select',
-    'from',
-    'where',
-    'innerJoin',
-    'leftJoin',
-    'orderBy',
-    'limit',
-    'insert',
-    'values',
-    'update',
-    'set',
-    'delete',
-    'offset',
-  ];
-  chainMethods.forEach((method) => {
-    chain[method] = jest.fn().mockReturnValue(chain);
-  });
-  chain.returning = jest.fn().mockResolvedValue([]);
-  chain.execute = jest.fn().mockResolvedValue([]);
+import { db, createMockQueryChain } from '../../mocks/database.mock';
 
-  return {
-    db: {
-      select: chain.select,
-      insert: chain.insert,
-      update: chain.update,
-      delete: chain.delete,
-      execute: chain.execute,
-      _chain: chain,
-    },
-    library: { on_streaming: 'on_streaming' },
-    artists: {},
-    genres: {},
-    format: {},
-    rotation: {},
-    library_artist_view: { on_streaming: 'on_streaming' },
-  };
-});
-
-jest.mock('drizzle-orm', () => ({
-  eq: jest.fn((a, b) => ({ eq: [a, b] })),
-  and: jest.fn((...args: unknown[]) => ({ and: args })),
-  sql: Object.assign(
-    jest.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: strings, values })),
-    { raw: jest.fn((s: string) => ({ raw: s })) }
-  ),
-  desc: jest.fn((col) => ({ desc: col })),
-}));
-
-import { isISODate, fuzzySearchLibrary } from '../../../apps/backend/services/library.service';
-import { db } from '@wxyc/database';
+import {
+  isISODate,
+  fuzzySearchLibrary,
+  getAlbumFromDB,
+  markAlbumMissing,
+  markAlbumFound,
+} from '../../../apps/backend/services/library.service';
 
 describe('library.service', () => {
   describe('fuzzySearchLibrary', () => {
@@ -111,6 +66,99 @@ describe('library.service', () => {
       expect(isISODate('2024-02-29')).toBe(true); // leap year
       expect(isISODate('2024-02-30')).toBe(true); // invalid day but correct format
       expect(isISODate('2024-13-01')).toBe(true); // invalid month but correct format
+    });
+  });
+
+  describe('getAlbumFromDB', () => {
+    it('returns album with format_name, genre_name, date_lost, date_found, and on_streaming', async () => {
+      const mockAlbum = {
+        id: 42,
+        code_letters: 'AU',
+        code_artist_number: 1,
+        code_number: 3,
+        artist_name: 'Autechre',
+        alphabetical_name: 'Autechre',
+        album_title: 'Confield',
+        record_label: 'Warp',
+        label_id: 10,
+        plays: 5,
+        add_date: new Date('2024-01-15'),
+        last_modified: new Date('2024-03-01'),
+        format_name: 'CD',
+        genre_name: 'Electronic',
+        date_lost: null,
+        date_found: null,
+        on_streaming: true,
+      };
+      const chain = createMockQueryChain([mockAlbum]);
+      (db.select as jest.Mock).mockReturnValue(chain);
+      chain.limit = jest.fn().mockResolvedValue([mockAlbum]);
+
+      const result = await getAlbumFromDB(42);
+
+      expect(result).toEqual(mockAlbum);
+      expect(result).toHaveProperty('format_name', 'CD');
+      expect(result).toHaveProperty('genre_name', 'Electronic');
+      expect(result).toHaveProperty('date_lost', null);
+      expect(result).toHaveProperty('date_found', null);
+      expect(result).toHaveProperty('on_streaming', true);
+      expect(db.select).toHaveBeenCalled();
+    });
+
+    it('returns undefined when album not found', async () => {
+      const chain = createMockQueryChain([]);
+      (db.select as jest.Mock).mockReturnValue(chain);
+      chain.limit = jest.fn().mockResolvedValue([]);
+
+      const result = await getAlbumFromDB(999);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('markAlbumMissing', () => {
+    it('issues UPDATE and returns the updated row ID', async () => {
+      const chain = createMockQueryChain([{ id: 42 }]);
+      (db.update as jest.Mock).mockReturnValue(chain);
+      chain.returning = jest.fn().mockResolvedValue([{ id: 42 }]);
+
+      const result = await markAlbumMissing(42);
+
+      expect(result).toEqual({ id: 42 });
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it('returns undefined when album does not exist', async () => {
+      const chain = createMockQueryChain([]);
+      (db.update as jest.Mock).mockReturnValue(chain);
+      chain.returning = jest.fn().mockResolvedValue([]);
+
+      const result = await markAlbumMissing(999);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('markAlbumFound', () => {
+    it('issues UPDATE and returns the updated row ID', async () => {
+      const chain = createMockQueryChain([{ id: 42 }]);
+      (db.update as jest.Mock).mockReturnValue(chain);
+      chain.returning = jest.fn().mockResolvedValue([{ id: 42 }]);
+
+      const result = await markAlbumFound(42);
+
+      expect(result).toEqual({ id: 42 });
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it('returns undefined when album does not exist', async () => {
+      const chain = createMockQueryChain([]);
+      (db.update as jest.Mock).mockReturnValue(chain);
+      chain.returning = jest.fn().mockResolvedValue([]);
+
+      const result = await markAlbumFound(999);
+
+      expect(result).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Expand `getAlbumFromDB` to join `format` and `genres` tables and select `format_name`, `genre_name`, `date_lost`, `date_found`, `on_streaming`
- Add `PATCH /library/:id/missing` and `PATCH /library/:id/found` endpoints with `catalog: ['write']` permissions
- Add service functions, controller handlers, routes, and unit tests

Closes #381

## Test plan
- [x] Unit tests for expanded `getAlbumFromDB` response (new fields present)
- [x] Unit tests for `markAlbumMissing` and `markAlbumFound` service functions
- [x] Controller tests for validation (400), not found (404), and success (200)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test:unit` — 814 tests pass