### PR TITLE
Add on_streaming to flowsheet entries and exclusive filter to library search

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -34,6 +34,7 @@ export interface IFSEntryMetadata {
 export interface IFSEntry extends FSEntry {
   label_id: number | null;
   rotation_bin: string | null;
+  on_streaming: boolean | null;
   metadata: IFSEntryMetadata;
 }
 

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -93,6 +93,7 @@ type AlbumQueryParams = {
   code_number?: number;
   n?: number;
   page?: number;
+  on_streaming?: string;
 };
 
 export const searchForAlbum: RequestHandler = async (
@@ -117,8 +118,10 @@ export const searchForAlbum: RequestHandler = async (
     throw new WxycError('TODO: Library Code Lookup', 501);
   }
 
+  const onStreaming = query.on_streaming === 'true' ? true : query.on_streaming === 'false' ? false : undefined;
+
   try {
-    const response = await libraryService.fuzzySearchLibrary(query.artist_name, query.album_title, query.n);
+    const response = await libraryService.fuzzySearchLibrary(query.artist_name, query.album_title, query.n, onStreaming);
     res.status(200).json(response);
   } catch (e) {
     console.error("Error: Couldn't get album");

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -121,7 +121,12 @@ export const searchForAlbum: RequestHandler = async (
   const onStreaming = query.on_streaming === 'true' ? true : query.on_streaming === 'false' ? false : undefined;
 
   try {
-    const response = await libraryService.fuzzySearchLibrary(query.artist_name, query.album_title, query.n, onStreaming);
+    const response = await libraryService.fuzzySearchLibrary(
+      query.artist_name,
+      query.album_title,
+      query.n,
+      onStreaming
+    );
     res.status(200).json(response);
   } catch (e) {
     console.error("Error: Couldn't get album");

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -80,6 +80,7 @@ const FSEntryFieldsRaw = {
   soundcloud_url: flowsheet.soundcloud_url,
   artist_bio: flowsheet.artist_bio,
   artist_wikipedia_url: flowsheet.artist_wikipedia_url,
+  on_streaming: library.on_streaming,
 };
 
 // Raw result type from SQL query
@@ -112,6 +113,7 @@ type FSEntryRaw = {
   soundcloud_url: string | null;
   artist_bio: string | null;
   artist_wikipedia_url: string | null;
+  on_streaming: boolean | null;
 };
 
 /** Transform flat SQL result to nested IFSEntry structure */
@@ -145,6 +147,7 @@ const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
   soundcloud_url: raw.soundcloud_url,
   artist_bio: raw.artist_bio,
   artist_wikipedia_url: raw.artist_wikipedia_url,
+  on_streaming: raw.on_streaming ?? null,
   // Nested metadata view (used by transformToV2)
   metadata: {
     artwork_url: raw.artwork_url,
@@ -172,6 +175,7 @@ export const getEntriesByPage = async (offset: number, limit: number): Promise<I
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
+    .leftJoin(library, eq(library.id, flowsheet.album_id))
     .orderBy(desc(flowsheet.id))
     .offset(offset)
     .limit(limit);
@@ -183,6 +187,7 @@ export const getEntriesByRange = async (startId: number, endId: number): Promise
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
+    .leftJoin(library, eq(library.id, flowsheet.album_id))
     .where(and(gte(flowsheet.id, startId), lte(flowsheet.id, endId)))
     .orderBy(desc(flowsheet.play_order));
 
@@ -196,6 +201,7 @@ export const getEntriesByShow = async (...show_ids: number[]): Promise<IFSEntry[
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
+    .leftJoin(library, eq(library.id, flowsheet.album_id))
     .where(inArray(flowsheet.show_id, show_ids))
     .orderBy(desc(flowsheet.play_order));
 
@@ -666,6 +672,7 @@ export const transformToV2 = (entry: IFSEntry): Record<string, unknown> => {
         soundcloud_url: entry.metadata?.soundcloud_url ?? null,
         artist_bio: entry.metadata?.artist_bio ?? null,
         artist_wikipedia_url: entry.metadata?.artist_wikipedia_url ?? null,
+        on_streaming: entry.on_streaming ?? null,
       };
 
     case 'show_start':

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -111,13 +111,17 @@ export const insertAlbum = async (newAlbum: NewAlbum) => {
 
 //based on artist name and album title, retrieve n best matches from db
 //let's build the query using drizzle's sql object
-export const fuzzySearchLibrary = async (artist_name?: string, album_title?: string, n = 5) => {
+export const fuzzySearchLibrary = async (artist_name?: string, album_title?: string, n = 5, on_streaming?: boolean) => {
+  const streamingFilter = on_streaming !== undefined
+    ? sql` AND ${library_artist_view.on_streaming} = ${on_streaming}`
+    : sql``;
+
   const query = sql`SELECT *,
                     ${library_artist_view.artist_name} <-> ${artist_name || null} AS artist_dist,
                     ${library_artist_view.album_title} <-> ${album_title || null} AS album_dist
                       FROM ${library_artist_view}
-                      WHERE ${library_artist_view.artist_name} % ${artist_name || null} OR
-                            ${library_artist_view.album_title} % ${album_title || null}
+                      WHERE (${library_artist_view.artist_name} % ${artist_name || null} OR
+                            ${library_artist_view.album_title} % ${album_title || null})${streamingFilter}
                       ORDER BY artist_dist asc, album_dist asc
                       LIMIT ${n}`;
 
@@ -331,7 +335,8 @@ export async function searchLibrary(
   query?: string,
   artist?: string,
   title?: string,
-  limit = 5
+  limit = 5,
+  on_streaming?: boolean
 ): Promise<EnrichedLibraryResult[]> {
   let results: LibraryArtistViewEntry[] = [];
 
@@ -375,7 +380,7 @@ export async function searchLibrary(
     }
   } else if (artist || title) {
     // Filtered search by artist and/or title
-    const response = await fuzzySearchLibrary(artist, title, limit);
+    const response = await fuzzySearchLibrary(artist, title, limit, on_streaming);
     results = response as unknown as LibraryArtistViewEntry[];
   }
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -112,9 +112,8 @@ export const insertAlbum = async (newAlbum: NewAlbum) => {
 //based on artist name and album title, retrieve n best matches from db
 //let's build the query using drizzle's sql object
 export const fuzzySearchLibrary = async (artist_name?: string, album_title?: string, n = 5, on_streaming?: boolean) => {
-  const streamingFilter = on_streaming !== undefined
-    ? sql` AND ${library_artist_view.on_streaming} = ${on_streaming}`
-    : sql``;
+  const streamingFilter =
+    on_streaming !== undefined ? sql` AND ${library_artist_view.on_streaming} = ${on_streaming}` : sql``;
 
   const query = sql`SELECT *,
                     ${library_artist_view.artist_name} <-> ${artist_name || null} AS artist_dist,

--- a/shared/database/src/types/flowsheet.types.ts
+++ b/shared/database/src/types/flowsheet.types.ts
@@ -53,6 +53,7 @@ export interface TrackEntryV2 extends BaseEntry {
   soundcloud_url: string | null;
   artist_bio: string | null;
   artist_wikipedia_url: string | null;
+  on_streaming?: boolean | null;
 }
 
 /** Show start event - when a show begins */

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -70,6 +70,7 @@ export const labels = {};
 export const library = {
   id: 'id',
   legacy_release_id: 'legacy_release_id',
+  on_streaming: 'on_streaming',
 };
 export const artists = {};
 export const genres = {};
@@ -86,7 +87,9 @@ export const rotation = {
   album_title: 'album_title',
   record_label: 'record_label',
 };
-export const library_artist_view = {};
+export const library_artist_view = {
+  on_streaming: 'on_streaming',
+};
 export const flowsheet = {
   id: 'id',
   show_id: 'show_id',

--- a/tests/unit/services/flowsheet.service.test.ts
+++ b/tests/unit/services/flowsheet.service.test.ts
@@ -39,6 +39,7 @@ const createBaseEntry = (overrides: Partial<IFSEntry & { metadata?: Partial<IFSE
     message: null,
     add_time: new Date('2024-01-15T12:00:00Z'),
     rotation_bin: null,
+    on_streaming: null,
     metadata: {
       ...nullMetadata,
       ...metadataOverrides,
@@ -136,6 +137,36 @@ describe('flowsheet.service', () => {
         const result = transformToV2(entry);
 
         expect(result.label_id).toBe(42);
+      });
+
+      it.each([
+        { value: true, description: 'true' },
+        { value: false, description: 'false' },
+        { value: null, description: 'null' },
+      ])('includes on_streaming as $description for track entries', ({ value }) => {
+        const entry = createBaseEntry({
+          entry_type: 'track',
+          artist_name: 'Autechre',
+          album_title: 'Confield',
+          on_streaming: value,
+        });
+
+        const result = transformToV2(entry);
+
+        expect(result.on_streaming).toBe(value);
+      });
+
+      it('defaults on_streaming to null when entry has no album_id', () => {
+        const entry = createBaseEntry({
+          entry_type: 'track',
+          album_id: null,
+          artist_name: 'Autechre',
+          album_title: 'Confield',
+        });
+
+        const result = transformToV2(entry);
+
+        expect(result.on_streaming).toBeNull();
       });
 
       it('excludes message field from track entries', () => {

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -1,7 +1,21 @@
 // Mock dependencies before importing the service
 jest.mock('@wxyc/database', () => {
   const chain: Record<string, jest.Mock> = {};
-  const chainMethods = ['select', 'from', 'where', 'innerJoin', 'leftJoin', 'orderBy', 'limit', 'insert', 'values', 'update', 'set', 'delete', 'offset'];
+  const chainMethods = [
+    'select',
+    'from',
+    'where',
+    'innerJoin',
+    'leftJoin',
+    'orderBy',
+    'limit',
+    'insert',
+    'values',
+    'update',
+    'set',
+    'delete',
+    'offset',
+  ];
   chainMethods.forEach((method) => {
     chain[method] = jest.fn().mockReturnValue(chain);
   });
@@ -59,9 +73,7 @@ describe('library.service', () => {
     });
 
     it('calls db.execute when on_streaming filter is provided', async () => {
-      const mockResults = [
-        { id: 1, artist_name: 'Autechre', album_title: 'Confield', on_streaming: true },
-      ];
+      const mockResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', on_streaming: true }];
       (db.execute as jest.Mock).mockResolvedValueOnce(mockResults);
 
       const results = await fuzzySearchLibrary('Autechre', undefined, 5, true);

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -1,21 +1,34 @@
 // Mock dependencies before importing the service
-jest.mock('@wxyc/database', () => ({
-  db: {
-    select: jest.fn().mockReturnThis(),
-    insert: jest.fn().mockReturnThis(),
-    update: jest.fn().mockReturnThis(),
-    delete: jest.fn().mockReturnThis(),
-  },
-  library: {},
-  artists: {},
-  genres: {},
-  format: {},
-  rotation: {},
-  library_artist_view: {},
-}));
+jest.mock('@wxyc/database', () => {
+  const chain: Record<string, jest.Mock> = {};
+  const chainMethods = ['select', 'from', 'where', 'innerJoin', 'leftJoin', 'orderBy', 'limit', 'insert', 'values', 'update', 'set', 'delete', 'offset'];
+  chainMethods.forEach((method) => {
+    chain[method] = jest.fn().mockReturnValue(chain);
+  });
+  chain.returning = jest.fn().mockResolvedValue([]);
+  chain.execute = jest.fn().mockResolvedValue([]);
+
+  return {
+    db: {
+      select: chain.select,
+      insert: chain.insert,
+      update: chain.update,
+      delete: chain.delete,
+      execute: chain.execute,
+      _chain: chain,
+    },
+    library: { on_streaming: 'on_streaming' },
+    artists: {},
+    genres: {},
+    format: {},
+    rotation: {},
+    library_artist_view: { on_streaming: 'on_streaming' },
+  };
+});
 
 jest.mock('drizzle-orm', () => ({
   eq: jest.fn((a, b) => ({ eq: [a, b] })),
+  and: jest.fn((...args: unknown[]) => ({ and: args })),
   sql: Object.assign(
     jest.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: strings, values })),
     { raw: jest.fn((s: string) => ({ raw: s })) }
@@ -23,9 +36,41 @@ jest.mock('drizzle-orm', () => ({
   desc: jest.fn((col) => ({ desc: col })),
 }));
 
-import { isISODate } from '../../../apps/backend/services/library.service';
+import { isISODate, fuzzySearchLibrary } from '../../../apps/backend/services/library.service';
+import { db } from '@wxyc/database';
 
 describe('library.service', () => {
+  describe('fuzzySearchLibrary', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('passes through results when no on_streaming filter is provided', async () => {
+      const mockResults = [
+        { id: 1, artist_name: 'Autechre', album_title: 'Confield', on_streaming: true },
+        { id: 2, artist_name: 'Autechre', album_title: 'LP5', on_streaming: false },
+      ];
+      (db.execute as jest.Mock).mockResolvedValueOnce(mockResults);
+
+      const results = await fuzzySearchLibrary('Autechre', undefined, 5);
+
+      expect(results).toEqual(mockResults);
+      expect(db.execute).toHaveBeenCalled();
+    });
+
+    it('calls db.execute when on_streaming filter is provided', async () => {
+      const mockResults = [
+        { id: 1, artist_name: 'Autechre', album_title: 'Confield', on_streaming: true },
+      ];
+      (db.execute as jest.Mock).mockResolvedValueOnce(mockResults);
+
+      const results = await fuzzySearchLibrary('Autechre', undefined, 5, true);
+
+      expect(results).toEqual(mockResults);
+      expect(db.execute).toHaveBeenCalled();
+    });
+  });
+
   describe('isISODate', () => {
     it('returns true for valid ISO date format YYYY-MM-DD', () => {
       expect(isISODate('2024-01-15')).toBe(true);


### PR DESCRIPTION
## Summary

- Flowsheet queries now LEFT JOIN the `library` table to include `on_streaming` in V2 track entry responses
- `GET /library` accepts optional `on_streaming` query parameter for filtering by streaming availability
- Updated `TrackEntryV2` type, `IFSEntry` interface, flowsheet transforms, and database mocks

Closes #385

Depends on WXYC/wxyc-shared#55

## Test plan

- [x] All 277 unit tests pass (including new flowsheet and library filter tests)
- [x] Typecheck passes
- [ ] Verify `/v2/flowsheet` response includes `on_streaming` on track entries
- [ ] Verify `GET /library?on_streaming=false` returns only exclusive albums