### PR TITLE
fix: add BETTER_AUTH_SECRET to CI integration test env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,6 +247,7 @@ jobs:
       BETTER_AUTH_JWKS_URL: http://localhost:8083/auth/jwks
       BETTER_AUTH_ISSUER: http://localhost:8083
       BETTER_AUTH_AUDIENCE: http://localhost:8083
+      BETTER_AUTH_SECRET: ci-test-secret-key-for-jwt-signing
     steps:
       - name: Skip notification
         if: env.RUN_TESTS != 'true'


### PR DESCRIPTION
## Summary

- Adds `BETTER_AUTH_SECRET` to the Integration-Tests job env in `.github/workflows/test.yml` so the auth service can sign JWTs during CI runs.

The auth service needs this secret to encrypt/decrypt the JWKS private key in the database. Without it, `/auth/token` fails, `get_access_token()` returns undefined, and all authenticated integration tests break.

Integration tests have not run successfully since the better-auth migration (March 6).

Closes #389

## Test plan

- [ ] CI integration tests pass on this PR (flowsheet, library, djs, events, schedule, metadata specs)