### PR TITLE
Fix ETL parsing MySQL NULL as on_streaming=false

### DIFF
--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -297,7 +297,7 @@ const buildReleaseQuery = (
 };
 
 const parseOnStreaming = (value?: string): boolean | null => {
-  if (value == null || value.trim().length === 0) return null;
+  if (value == null || value.trim().length === 0 || value.trim() === 'NULL') return null;
   return value.trim() === '1';
 };
 

--- a/tests/unit/jobs/library-etl.test.ts
+++ b/tests/unit/jobs/library-etl.test.ts
@@ -490,6 +490,13 @@ describe('library-etl job helpers', () => {
       expect(result[0].release_on_streaming).toBe(false);
     });
 
+    it('parses a 17-column row with on_streaming=null for MySQL NULL literal', () => {
+      const row = [...base13, '0', '0', 'Autechre', 'NULL'].join('\t');
+      const result = parseReleaseRows(row, 17);
+      expect(result).toHaveLength(1);
+      expect(result[0].release_on_streaming).toBeNull();
+    });
+
     it('parses a 17-column row with on_streaming=null for empty value', () => {
       // Use two rows so raw.trim() does not strip trailing tabs from the first row
       const row1 = [...base13, '0', '0', '', ''].join('\t');


### PR DESCRIPTION
## Summary

- Handle MySQL literal `"NULL"` string in `parseOnStreaming` — return `null` instead of `false`
- Without this fix, ~2,975 releases with unknown streaming status were incorrectly classified as WXYC exclusives

Closes #391

## Test plan

- [x] New test: 17-column row with `"NULL"` literal parses as `release_on_streaming: null`
- [x] All 70 ETL unit tests pass
- [x] Full ETL run against local Docker DB verified: 2,979 unknown (up from 4), 3,477 exclusive (down from 6,456)