### PR TITLE
Pass through profile_tokens from LML in artist metadata proxy

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -262,7 +262,8 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
  * GET /proxy/metadata/artist
  *
  * Fetches artist metadata (bio, Wikipedia URL, image) from LML by artist ID.
- * Bio is sent as raw Discogs markup — the client handles rendering.
+ * Bio is available as both raw Discogs markup (`bio`) and pre-parsed structured
+ * tokens (`bioTokens`) for direct rendering by clients.
  */
 export const getArtistMetadata: RequestHandler<object, unknown, unknown, ArtistMetadataQuery> = async (
   req,
@@ -291,6 +292,7 @@ export const getArtistMetadata: RequestHandler<object, unknown, unknown, ArtistM
     res.status(200).json({
       discogsArtistId: artist.artist_id,
       bio: artist.profile ?? null,
+      bioTokens: artist.profile_tokens ?? null,
       wikipediaUrl,
       imageUrl: artist.image_url ?? null,
     });

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -64,11 +64,18 @@ export interface LmlReleaseResponse {
   released: string | null;
 }
 
+/** A single resolved token from LML's Discogs markup parser. */
+export interface LmlResolvedToken {
+  type: string;
+  [key: string]: unknown;
+}
+
 /** Artist details from LML. */
 export interface LmlArtistDetails {
   artist_id: number;
   name: string;
   profile: string | null;
+  profile_tokens: LmlResolvedToken[] | null;
   image_url: string | null;
   name_variations: string[];
   aliases: Array<{ id: number; name: string }>;

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -394,11 +394,30 @@ describe('proxy.controller', () => {
       expect(res.json).toHaveBeenCalledWith({ message: 'artistId must be an integer' });
     });
 
-    it('returns artist metadata with raw bio, imageUrl, and cache header', async () => {
+    it('returns artist metadata with raw bio, bioTokens, imageUrl, and cache header', async () => {
+      const profileTokens = [
+        { type: 'plainText', text: 'Autechre is a British electronic music duo consisting of ' },
+        {
+          type: 'artistLink',
+          name: 'Rob Brown',
+          display_name: 'Rob Brown',
+          url: 'https://www.discogs.com/search/?q=Rob%20Brown&type=artist',
+        },
+        { type: 'plainText', text: ' and ' },
+        {
+          type: 'artistLink',
+          name: 'Sean Booth',
+          display_name: 'Sean Booth',
+          url: 'https://www.discogs.com/search/?q=Sean%20Booth&type=artist',
+        },
+        { type: 'plainText', text: '.' },
+      ];
+
       mockGetArtistDetails.mockResolvedValue({
         artist_id: 3840,
         name: 'Autechre',
         profile: 'Autechre is a British electronic music duo consisting of [a=Rob Brown] and [a=Sean Booth].',
+        profile_tokens: profileTokens,
         image_url: 'https://i.discogs.com/autechre.jpg',
         name_variations: [],
         aliases: [],
@@ -421,9 +440,34 @@ describe('proxy.controller', () => {
       expect(result.bio).toBe(
         'Autechre is a British electronic music duo consisting of [a=Rob Brown] and [a=Sean Booth].'
       );
+      expect(result.bioTokens).toEqual(profileTokens);
       expect(result.wikipediaUrl).toBe('https://en.wikipedia.org/wiki/Autechre');
       expect(result.imageUrl).toBe('https://i.discogs.com/autechre.jpg');
       expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=3600');
+    });
+
+    it('returns null bioTokens when LML does not provide profile_tokens', async () => {
+      mockGetArtistDetails.mockResolvedValue({
+        artist_id: 456,
+        name: 'Some Artist',
+        profile: 'Bio text',
+        profile_tokens: null,
+        image_url: null,
+        name_variations: [],
+        aliases: [],
+        members: [],
+        urls: [],
+        cached: false,
+      });
+
+      const req = { query: { artistId: '456' } } as unknown as Request;
+      const res = createMockRes();
+
+      await getArtistMetadata(req, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const result = (res.json as jest.Mock).mock.calls[0][0];
+      expect(result.bioTokens).toBeNull();
     });
 
     it('returns null wikipediaUrl when no Wikipedia link in urls', async () => {


### PR DESCRIPTION
## Summary

- Add `bioTokens` field to `GET /proxy/metadata/artist` response, passing through LML's new `profile_tokens` from the Discogs markup parser (WXYC/library-metadata-lookup#137)
- Add `LmlResolvedToken` type and `profile_tokens` to `LmlArtistDetails` interface
- Add unit tests for bioTokens passthrough and null fallback

Closes #396

## Test plan

- [x] Typecheck passes (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [x] Format passes (`npm run format:check`)
- [x] All 30 proxy controller unit tests pass
- [ ] Verify bioTokens populated in staging via `GET /proxy/metadata/artist?artistId=3840`