### PR TITLE
Add streaming check on library album insert

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@wxyc/database';
 import * as libraryService from '../services/library.service.js';
 import * as labelsService from '../services/labels.service.js';
+import { checkStreamingAvailability, isLmlConfigured } from '../services/lml/lml.client.js';
 import WxycError from '../utils/error.js';
 
 type NewAlbumRequest = {
@@ -76,7 +77,21 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
       disc_quantity: body.disc_quantity,
     };
 
-    const inserted_album: Album = await libraryService.insertAlbum(new_album);
+    let inserted_album: Album = await libraryService.insertAlbum(new_album);
+
+    // Check streaming availability asynchronously — don't fail the insert
+    if (isLmlConfigured()) {
+      try {
+        const artistName = body.alternate_artist_name || body.artist_name || '';
+        const result = await checkStreamingAvailability(artistName, body.album_title);
+        if (result.on_streaming !== null) {
+          inserted_album = await libraryService.updateOnStreaming(inserted_album.id, result.on_streaming);
+        }
+      } catch (e) {
+        console.warn('Streaming check failed for new album, leaving on_streaming as null:', (e as Error).message);
+      }
+    }
+
     res.status(201).json(inserted_album);
   } catch (e) {
     console.error('Error: Could not insert new album');

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -110,11 +110,7 @@ export const insertAlbum = async (newAlbum: NewAlbum) => {
 };
 
 export const updateOnStreaming = async (id: number, on_streaming: boolean | null) => {
-  const response = await db
-    .update(library)
-    .set({ on_streaming })
-    .where(eq(library.id, id))
-    .returning();
+  const response = await db.update(library).set({ on_streaming }).where(eq(library.id, id)).returning();
   return response[0];
 };
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -109,6 +109,15 @@ export const insertAlbum = async (newAlbum: NewAlbum) => {
   return response[0];
 };
 
+export const updateOnStreaming = async (id: number, on_streaming: boolean | null) => {
+  const response = await db
+    .update(library)
+    .set({ on_streaming })
+    .where(eq(library.id, id))
+    .returning();
+  return response[0];
+};
+
 //based on artist name and album title, retrieve n best matches from db
 //let's build the query using drizzle's sql object
 export const fuzzySearchLibrary = async (artist_name?: string, album_title?: string, n = 5, on_streaming?: boolean) => {

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -300,10 +300,7 @@ export interface LmlStreamingCheckResponse {
  * @param title - Album title
  * @returns Streaming availability result with per-source URLs
  */
-export async function checkStreamingAvailability(
-  artist: string,
-  title: string
-): Promise<LmlStreamingCheckResponse> {
+export async function checkStreamingAvailability(artist: string, title: string): Promise<LmlStreamingCheckResponse> {
   const response = await lmlFetch('/api/v1/streaming-check', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -275,6 +275,37 @@ export async function validateTrackOnRelease(releaseId: number, track: string, a
   return false;
 }
 
+/** Response from LML's streaming-check endpoint. */
+export interface LmlStreamingCheckResponse {
+  on_streaming: boolean | null;
+  sources: {
+    spotify?: { url: string; confidence: number } | null;
+    deezer?: { url: string; confidence: number } | null;
+    apple_music?: { url: string; confidence: number } | null;
+    bandcamp?: { url: string; confidence: number } | null;
+  };
+}
+
+/**
+ * Check streaming availability for an artist+title pair.
+ *
+ * @param artist - Artist name
+ * @param title - Album title
+ * @returns Streaming availability result with per-source URLs
+ */
+export async function checkStreamingAvailability(
+  artist: string,
+  title: string
+): Promise<LmlStreamingCheckResponse> {
+  const response = await lmlFetch('/api/v1/streaming-check', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ artist, title }),
+  });
+
+  return (await response.json()) as LmlStreamingCheckResponse;
+}
+
 /**
  * Check whether the LML service is configured.
  */

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -12,6 +12,7 @@ import {
   getArtistDetails,
   resolveEntity,
   LmlClientError,
+  checkStreamingAvailability,
 } from '../../../apps/backend/services/lml/lml.client';
 
 describe('lml.client', () => {
@@ -177,6 +178,64 @@ describe('lml.client', () => {
       const calledUrl = mockFetch.mock.calls[0][0] as string;
       expect(calledUrl).not.toContain('/api/v1/api/v1');
       expect(calledUrl).toBe('http://lml.test:8000/api/v1/discogs/search');
+    });
+  });
+
+  describe('checkStreamingAvailability', () => {
+    it('sends POST to /api/v1/streaming-check with artist and title', async () => {
+      const mockResponse = {
+        on_streaming: true,
+        sources: {
+          spotify: { url: 'https://open.spotify.com/album/abc', confidence: 95.0 },
+          deezer: null,
+          apple_music: null,
+          bandcamp: null,
+        },
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as unknown as globalThis.Response);
+
+      const result = await checkStreamingAvailability('Stereolab', 'Aluminum Tunes');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://lml.test:8000/api/v1/streaming-check',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ artist: 'Stereolab', title: 'Aluminum Tunes' }),
+        })
+      );
+      expect(result.on_streaming).toBe(true);
+      expect(result.sources.spotify?.url).toBe('https://open.spotify.com/album/abc');
+    });
+
+    it('returns on_streaming=false when not found', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            on_streaming: false,
+            sources: { spotify: null, deezer: null, apple_music: null, bandcamp: null },
+          }),
+      } as unknown as globalThis.Response);
+
+      const result = await checkStreamingAvailability('Chuquimamani-Condori', 'Edits');
+
+      expect(result.on_streaming).toBe(false);
+    });
+
+    it('throws LmlClientError on non-2xx response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      } as unknown as globalThis.Response);
+
+      await expect(checkStreamingAvailability('Stereolab', 'Aluminum Tunes')).rejects.toThrow(
+        LmlClientError
+      );
     });
   });
 });

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -233,9 +233,7 @@ describe('lml.client', () => {
         statusText: 'Internal Server Error',
       } as unknown as globalThis.Response);
 
-      await expect(checkStreamingAvailability('Stereolab', 'Aluminum Tunes')).rejects.toThrow(
-        LmlClientError
-      );
+      await expect(checkStreamingAvailability('Stereolab', 'Aluminum Tunes')).rejects.toThrow(LmlClientError);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `checkStreamingAvailability()` to the LML client (`lml.client.ts`)
- Add `updateOnStreaming()` to the library service for writing the `on_streaming` column
- After `POST /library` inserts a new album, call LML's streaming-check endpoint and update `on_streaming`
- Graceful degradation: if LML is not configured or the check fails, `on_streaming` stays null

Closes #398

## Test plan

- [x] 3 new LML client unit tests (success, not-found, error)
- [x] Typecheck passes
- [x] Lint passes (0 errors)
- [x] Unit tests pass (818/818, 1 pre-existing skip)
- [ ] CI passes

🔗 Depends on WXYC/library-metadata-lookup#135