### PR TITLE
Replace LML types with generated and add library search proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,42 @@ GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:
 - CI/CD via GitHub Actions (manual trigger: Actions tab -> CI/CD Pipeline -> Run Workflow)
 - Docker images built with multi-stage Dockerfile (`node:25-alpine`), stored in Amazon ECR
 
+## Database Replication (Local Sync)
+
+PostgreSQL logical replication keeps a local database clone in sync with production RDS in real time. Changes stream continuously with guaranteed delivery — the replication slot retains WAL even if the subscriber is offline.
+
+### Setup
+
+```bash
+# One-time: enable rds.logical_replication=1 in the RDS parameter group (requires reboot)
+# Then:
+./scripts/sync/setup-replication.sh    # Opens tunnel, creates publication + subscription
+```
+
+### Daily use
+
+```bash
+./scripts/sync/tunnel.sh               # Open tunnel (must stay open for replication)
+./scripts/sync/tunnel.sh --kill        # Close tunnel
+./scripts/sync/teardown-replication.sh # Remove subscription + close tunnel
+```
+
+### Monitor replication status
+
+```sql
+-- On local database:
+SELECT * FROM pg_stat_subscription;     -- srsubstate = 'r' means ready
+SELECT * FROM pg_subscription;          -- shows connection info
+```
+
+### Prerequisites
+
+- RDS parameter group: `rds.logical_replication = 1` (one-time, requires instance reboot)
+- `rds_replication` role granted to the RDS user
+- SSH access via `ssh wxyc-ec2`
+- Local PostgreSQL running (`npm run db:start`)
+- `psql` installed (`brew install libpq`)
+
 ## Environment Variables
 
 ### Backend Service

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -17,6 +17,7 @@ import {
   getRelease,
   getArtistDetails,
   resolveEntity as lmlResolveEntity,
+  searchLibrary,
   LmlClientError,
 } from '../services/lml/lml.client.js';
 import { LRUCache } from 'lru-cache';
@@ -415,6 +416,49 @@ export const getSpotifyTrack: RequestHandler<SpotifyTrackParams> = async (req, r
     });
   } catch (e) {
     console.error('[ProxyController] getSpotifyTrack error:', e);
+    next(e);
+  }
+};
+
+/**
+ * GET /proxy/library/search — Search the WXYC library catalog via LML.
+ *
+ * Proxies to LML's GET /api/v1/library/search, providing auth, rate limiting,
+ * and activity tracking. Used by dj-site for flowsheet autocomplete.
+ *
+ * Query params: artist, title, q (free text), limit (default 10)
+ */
+type LibrarySearchQuery = {
+  artist?: string;
+  title?: string;
+  q?: string;
+  limit?: string;
+};
+
+export const librarySearch: RequestHandler<object, unknown, unknown, LibrarySearchQuery> = async (req, res, next) => {
+  const { artist, title, q, limit } = req.query;
+
+  if (!artist && !title && !q) {
+    res.status(400).json({ message: 'At least one of artist, title, or q is required' });
+    return;
+  }
+
+  try {
+    const results = await searchLibrary({
+      artist,
+      title,
+      q,
+      limit: limit ? parseInt(limit, 10) : undefined,
+    });
+
+    res.set('Cache-Control', 'private, max-age=60');
+    res.status(200).json(results);
+  } catch (e) {
+    if (e instanceof LmlClientError) {
+      res.status(e.statusCode).json({ message: e.message });
+      return;
+    }
+    console.error('[ProxyController] librarySearch error:', e);
     next(e);
   }
 };

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,6 +20,7 @@
     "@tensorflow/tfjs": "^4.22.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
+    "@wxyc/shared": "^0.5.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.15.0",

--- a/apps/backend/routes/proxy.route.ts
+++ b/apps/backend/routes/proxy.route.ts
@@ -14,3 +14,4 @@ proxy_route.get('/metadata/album', proxyController.getAlbumMetadata);
 proxy_route.get('/metadata/artist', proxyController.getArtistMetadata);
 proxy_route.get('/entity/resolve', proxyController.resolveEntity);
 proxy_route.get('/spotify/track/:id', proxyController.getSpotifyTrack);
+proxy_route.get('/library/search', proxyController.librarySearch);

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -1,113 +1,40 @@
 /**
  * HTTP client for the library-metadata-lookup (LML) service.
  *
- * Thin wrapper around LML's Discogs endpoints. Reads LIBRARY_METADATA_URL from
- * env. All methods throw on non-2xx responses so the proxy controller's
- * try/catch blocks can translate to appropriate HTTP error codes.
+ * Thin wrapper around LML's endpoints. Reads LIBRARY_METADATA_URL from env.
+ * All methods throw on non-2xx responses so the proxy controller's try/catch
+ * blocks can translate to appropriate HTTP error codes.
+ *
+ * Response types are generated from wxyc-shared/api.yaml — see @wxyc/shared/dtos.
  */
 
-/** Search result from LML's Discogs search endpoint. */
-export interface LmlSearchResult {
-  album: string | null;
-  artist: string | null;
-  release_id: number;
-  release_url: string;
-  artwork_url: string | null;
-  confidence: number;
-  release_year: number | null;
-  artist_bio: string | null;
-  wikipedia_url: string | null;
-  spotify_url: string | null;
-  apple_music_url: string | null;
-  youtube_music_url: string | null;
-  bandcamp_url: string | null;
-  soundcloud_url: string | null;
-}
+import type {
+  DiscogsSearchResponse,
+  DiscogsReleaseMetadata,
+  DiscogsArtistDetails,
+  DiscogsTrackReleasesResponse,
+  EntityResolveResponse,
+  LibrarySearchResponse,
+  StreamingCheckResponse,
+} from '@wxyc/shared/dtos';
 
-export interface LmlSearchResponse {
-  results: LmlSearchResult[];
-  total: number;
-  cached: boolean;
-}
-
-/** Track item from LML's release endpoint. */
-export interface LmlTrackItem {
-  position: string;
-  title: string;
-  duration: string | null;
-  artists: string[];
-}
-
-/** Artist credit from LML's release endpoint. */
-export interface LmlArtistCredit {
-  artist_id: number | null;
-  name: string;
-  join: string;
-  role: string | null;
-}
-
-/** Release metadata from LML. */
-export interface LmlReleaseResponse {
-  release_id: number;
-  title: string;
-  artist: string;
-  year: number | null;
-  label: string | null;
-  artist_id: number | null;
-  genres: string[];
-  styles: string[];
-  tracklist: LmlTrackItem[];
-  artwork_url: string | null;
-  release_url: string;
-  cached: boolean;
-  artists: LmlArtistCredit[];
-  released: string | null;
-}
-
-/** A single resolved token from LML's Discogs markup parser. */
-export interface LmlResolvedToken {
-  type: string;
-  [key: string]: unknown;
-}
-
-/** Artist details from LML. */
-export interface LmlArtistDetails {
-  artist_id: number;
-  name: string;
-  profile: string | null;
-  profile_tokens: LmlResolvedToken[] | null;
-  image_url: string | null;
-  name_variations: string[];
-  aliases: Array<{ id: number; name: string }>;
-  members: Array<{ id: number; name: string; active: boolean }>;
-  urls: string[];
-  cached: boolean;
-}
-
-/** Release info from LML's track-releases endpoint. */
-export interface LmlReleaseInfo {
-  album: string;
-  artist: string;
-  release_id: number;
-  release_url: string;
-  is_compilation: boolean;
-}
-
-/** Response from LML's track-releases endpoint. */
-export interface LmlTrackReleasesResponse {
-  track: string;
-  artist: string | null;
-  releases: LmlReleaseInfo[];
-  total: number;
-  cached: boolean;
-}
-
-/** Entity resolution response from LML. */
-export interface LmlEntityResponse {
-  name: string;
-  type: 'artist' | 'release' | 'master';
-  id: number;
-}
+export type {
+  DiscogsSearchResponse,
+  DiscogsEnrichedSearchResult,
+  DiscogsReleaseMetadata,
+  DiscogsTrackItem,
+  DiscogsArtistCredit,
+  DiscogsArtistDetails,
+  DiscogsResolvedToken,
+  DiscogsReleaseInfo,
+  DiscogsTrackReleasesResponse,
+  EntityResolveResponse,
+  LibrarySearchItem,
+  LibrarySearchResponse,
+  StreamingCheckResponse,
+  StreamingSourceMatch,
+  StreamingCheckSources,
+} from '@wxyc/shared/dtos';
 
 class LmlClientError extends Error {
   constructor(
@@ -168,7 +95,7 @@ async function lmlFetch(path: string, init?: RequestInit): Promise<Response> {
  * @param album - Album/release title
  * @returns Search results with enriched metadata
  */
-export async function searchDiscogs(artist: string, album?: string): Promise<LmlSearchResponse> {
+export async function searchDiscogs(artist: string, album?: string): Promise<DiscogsSearchResponse> {
   const body: Record<string, string> = { artist };
   if (album) body.album = album;
 
@@ -178,7 +105,7 @@ export async function searchDiscogs(artist: string, album?: string): Promise<Lml
     body: JSON.stringify(body),
   });
 
-  return (await response.json()) as LmlSearchResponse;
+  return (await response.json()) as DiscogsSearchResponse;
 }
 
 /**
@@ -187,9 +114,9 @@ export async function searchDiscogs(artist: string, album?: string): Promise<Lml
  * @param releaseId - Discogs release ID
  * @returns Release metadata including tracklist, genres, styles
  */
-export async function getRelease(releaseId: number): Promise<LmlReleaseResponse> {
+export async function getRelease(releaseId: number): Promise<DiscogsReleaseMetadata> {
   const response = await lmlFetch(`/api/v1/discogs/release/${releaseId}`);
-  return (await response.json()) as LmlReleaseResponse;
+  return (await response.json()) as DiscogsReleaseMetadata;
 }
 
 /**
@@ -198,9 +125,9 @@ export async function getRelease(releaseId: number): Promise<LmlReleaseResponse>
  * @param artistId - Discogs artist ID
  * @returns Artist details including bio, image, URLs
  */
-export async function getArtistDetails(artistId: number): Promise<LmlArtistDetails> {
+export async function getArtistDetails(artistId: number): Promise<DiscogsArtistDetails> {
   const response = await lmlFetch(`/api/v1/discogs/artist/${artistId}`);
-  return (await response.json()) as LmlArtistDetails;
+  return (await response.json()) as DiscogsArtistDetails;
 }
 
 /**
@@ -210,9 +137,9 @@ export async function getArtistDetails(artistId: number): Promise<LmlArtistDetai
  * @param id - Discogs entity ID
  * @returns Entity name and basic info
  */
-export async function resolveEntity(type: 'artist' | 'release' | 'master', id: number): Promise<LmlEntityResponse> {
+export async function resolveEntity(type: 'artist' | 'release' | 'master', id: number): Promise<EntityResolveResponse> {
   const response = await lmlFetch(`/api/v1/discogs/entity/${type}/${id}`);
-  return (await response.json()) as LmlEntityResponse;
+  return (await response.json()) as EntityResolveResponse;
 }
 
 /**
@@ -227,13 +154,13 @@ export async function searchTrackReleases(
   track: string,
   artist?: string,
   limit = 20
-): Promise<LmlTrackReleasesResponse> {
+): Promise<DiscogsTrackReleasesResponse> {
   const params = new URLSearchParams({ track });
   if (artist) params.set('artist', artist);
   if (limit !== 20) params.set('limit', String(limit));
 
   const response = await lmlFetch(`/api/v1/discogs/track-releases?${params}`);
-  return (await response.json()) as LmlTrackReleasesResponse;
+  return (await response.json()) as DiscogsTrackReleasesResponse;
 }
 
 /**
@@ -282,17 +209,6 @@ export async function validateTrackOnRelease(releaseId: number, track: string, a
   return false;
 }
 
-/** Response from LML's streaming-check endpoint. */
-export interface LmlStreamingCheckResponse {
-  on_streaming: boolean | null;
-  sources: {
-    spotify?: { url: string; confidence: number } | null;
-    deezer?: { url: string; confidence: number } | null;
-    apple_music?: { url: string; confidence: number } | null;
-    bandcamp?: { url: string; confidence: number } | null;
-  };
-}
-
 /**
  * Check streaming availability for an artist+title pair.
  *
@@ -300,14 +216,36 @@ export interface LmlStreamingCheckResponse {
  * @param title - Album title
  * @returns Streaming availability result with per-source URLs
  */
-export async function checkStreamingAvailability(artist: string, title: string): Promise<LmlStreamingCheckResponse> {
+export async function checkStreamingAvailability(artist: string, title: string): Promise<StreamingCheckResponse> {
   const response = await lmlFetch('/api/v1/streaming-check', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ artist, title }),
   });
 
-  return (await response.json()) as LmlStreamingCheckResponse;
+  return (await response.json()) as StreamingCheckResponse;
+}
+
+/**
+ * Search the library catalog via LML.
+ *
+ * @param params - Search parameters (artist, title, q, limit)
+ * @returns Library search results
+ */
+export async function searchLibrary(params: {
+  artist?: string;
+  title?: string;
+  q?: string;
+  limit?: number;
+}): Promise<LibrarySearchResponse> {
+  const searchParams = new URLSearchParams();
+  if (params.artist) searchParams.set('artist', params.artist);
+  if (params.title) searchParams.set('title', params.title);
+  if (params.q) searchParams.set('q', params.q);
+  if (params.limit) searchParams.set('limit', String(params.limit));
+
+  const response = await lmlFetch(`/api/v1/library/search?${searchParams}`);
+  return (await response.json()) as LibrarySearchResponse;
 }
 
 /**

--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -8,7 +8,8 @@
  * URLs are constructed for services where LML returns null.
  */
 import { MetadataRequest, AlbumMetadataResult, ArtistMetadataResult, FlowsheetMetadata } from './metadata.types.js';
-import { searchDiscogs, getRelease, getArtistDetails, LmlSearchResult } from '../lml/lml.client.js';
+import { searchDiscogs, getRelease, getArtistDetails } from '../lml/lml.client.js';
+import type { DiscogsEnrichedSearchResult } from '../lml/lml.client.js';
 import { SearchUrlProvider } from './providers/search-urls.provider.js';
 
 const searchUrls = new SearchUrlProvider();
@@ -77,7 +78,7 @@ export async function fetchMetadata(request: MetadataRequest): Promise<Flowsheet
 async function fetchAlbumMetadata(request: MetadataRequest): Promise<{
   albumMetadata: AlbumMetadataResult | null;
   artistId: number | null;
-  searchResult: LmlSearchResult | null;
+  searchResult: DiscogsEnrichedSearchResult | null;
 }> {
   const { artistName, albumTitle, trackTitle } = request;
   const searchTerm = albumTitle || trackTitle || '';
@@ -147,7 +148,7 @@ async function fetchAlbumMetadata(request: MetadataRequest): Promise<{
 async function fetchArtistMetadata(
   _request: MetadataRequest,
   discogsArtistId: number | null,
-  searchResult: LmlSearchResult | null
+  searchResult: DiscogsEnrichedSearchResult | null
 ): Promise<ArtistMetadataResult | null> {
   // Try fetching full artist details by ID
   if (discogsArtistId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -362,6 +362,7 @@
         "@tensorflow/tfjs": "^4.22.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
+        "@wxyc/shared": "^0.5.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.15.0",
@@ -532,6 +533,19 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "apps/backend/node_modules/@wxyc/shared": {
+      "version": "0.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.5.0/8a21b34be7e3cd90bd0cf9433dd678bef8385842",
+      "integrity": "sha512-n2J9ZO5cgVVp9y803Bsmvq48AfE4sxuxVT1ebel4ELg1vE7x5C38GX/Ek/7I30uaz9NZ+xFHkJLK7+youcDzCA==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "better-auth": "^1.5.0",
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "apps/backend/node_modules/better-auth": {
@@ -15539,7 +15553,7 @@
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1014.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^0.4.0",
+        "@wxyc/shared": "^0.5.0",
         "better-auth": "^1.5.6",
         "drizzle-orm": "^0.41.0",
         "postgres": "^3.4.8"
@@ -15662,9 +15676,9 @@
       }
     },
     "shared/authentication/node_modules/@wxyc/shared": {
-      "version": "0.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.4.0/88a8a2128fc917acd3d0882094e4a7f1a1a8a566",
-      "integrity": "sha512-5HIyILNJXVpE/wkdBDWEAvFUA5sbhK2z+l6fUZxprRSE6O7oB5JuV/4IoXnpKV+9lZJB0TMruwKvgMMHpG6SUA==",
+      "version": "0.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.5.0/8a21b34be7e3cd90bd0cf9433dd678bef8385842",
+      "integrity": "sha512-n2J9ZO5cgVVp9y803Bsmvq48AfE4sxuxVT1ebel4ELg1vE7x5C38GX/Ek/7I30uaz9NZ+xFHkJLK7+youcDzCA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/scripts/sync/setup-replication.sh
+++ b/scripts/sync/setup-replication.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+#
+# Sets up PostgreSQL logical replication from production RDS to a local
+# PostgreSQL instance.
+#
+# This script:
+#   1. Opens an SSH tunnel to RDS (if not already open)
+#   2. Ensures the local database schema exists (via Drizzle migrations)
+#   3. Creates the publication on RDS (if it doesn't exist)
+#   4. Creates a subscription on the local database
+#
+# The subscription copies all existing data (copy_data=true) and then
+# streams ongoing changes in real time. If the tunnel drops, the
+# replication slot retains WAL until the subscriber reconnects.
+#
+# Prerequisites:
+#   - RDS parameter group: rds.logical_replication = 1 (requires instance restart)
+#   - rds_replication role granted to the RDS user
+#   - SSH access via 'ssh wxyc-ec2'
+#   - Local PostgreSQL running (npm run db:start)
+#   - pg_dump / psql installed (brew install libpq)
+#
+# Usage:
+#   ./setup-replication.sh
+#
+# Environment:
+#   TUNNEL_PORT        Local tunnel port (default: 15432)
+#   LOCAL_DB_HOST      Local PostgreSQL host (default: localhost)
+#   LOCAL_DB_PORT      Local PostgreSQL port (default: 5432)
+#   LOCAL_DB_NAME      Local database name (default: wxyc_db)
+#   LOCAL_DB_USER      Local database user (default: postgres)
+#   LOCAL_DB_PASSWORD   Local database password (default: empty)
+#   REMOTE_ENV_PATH    Path to .env on EC2 (default: /home/ec2-user/.env)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TUNNEL_PORT="${TUNNEL_PORT:-15432}"
+LOCAL_DB_HOST="${LOCAL_DB_HOST:-localhost}"
+LOCAL_DB_PORT="${LOCAL_DB_PORT:-5432}"
+LOCAL_DB_NAME="${LOCAL_DB_NAME:-wxyc_db}"
+LOCAL_DB_USER="${LOCAL_DB_USER:-postgres}"
+LOCAL_DB_PASSWORD="${LOCAL_DB_PASSWORD:-}"
+REMOTE_ENV_PATH="${REMOTE_ENV_PATH:-/home/ec2-user/.env}"
+
+# --- Step 1: Ensure tunnel is open ---
+
+if lsof -ti :"$TUNNEL_PORT" -sTCP:LISTEN &>/dev/null; then
+    echo "SSH tunnel already open on port $TUNNEL_PORT."
+else
+    echo "Opening SSH tunnel..."
+    "$SCRIPT_DIR/tunnel.sh"
+fi
+
+# --- Step 2: Read RDS credentials ---
+
+echo "Reading RDS credentials from EC2..."
+ENV_OUTPUT=$(ssh wxyc-ec2 "grep -E '^DB_(HOST|PORT|USERNAME|PASSWORD|NAME)=' '$REMOTE_ENV_PATH'" 2>/dev/null) || true
+
+parse_env_var() {
+    echo "$ENV_OUTPUT" | grep "^$1=" | head -1 | cut -d= -f2-
+}
+
+RDS_HOST=$(parse_env_var DB_HOST)
+RDS_PORT=$(parse_env_var DB_PORT)
+RDS_USER=$(parse_env_var DB_USERNAME)
+RDS_PASS=$(parse_env_var DB_PASSWORD)
+RDS_NAME=$(parse_env_var DB_NAME)
+RDS_PORT="${RDS_PORT:-5432}"
+
+if [ -z "$RDS_HOST" ] || [ -z "$RDS_USER" ] || [ -z "$RDS_PASS" ]; then
+    echo "Error: could not read RDS credentials from EC2"
+    exit 1
+fi
+
+echo "  RDS: $RDS_USER@$RDS_HOST:$RDS_PORT/$RDS_NAME"
+echo "  Local: $LOCAL_DB_USER@$LOCAL_DB_HOST:$LOCAL_DB_PORT/$LOCAL_DB_NAME"
+
+# --- Step 3: Verify wal_level on RDS ---
+
+echo ""
+echo "Checking RDS wal_level..."
+WAL_LEVEL=$(PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -tAc "SHOW wal_level;" 2>/dev/null)
+
+if [ "$WAL_LEVEL" != "logical" ]; then
+    echo ""
+    echo "ERROR: wal_level is '$WAL_LEVEL', needs to be 'logical'."
+    echo ""
+    echo "To fix this in the AWS console:"
+    echo "  1. Go to RDS → Parameter Groups"
+    echo "  2. Create or modify a parameter group for PostgreSQL 14"
+    echo "  3. Set rds.logical_replication = 1"
+    echo "  4. Apply the parameter group to your RDS instance"
+    echo "  5. Reboot the instance"
+    echo ""
+    echo "After the reboot, re-run this script."
+    exit 1
+fi
+
+echo "  wal_level = logical ✓"
+
+# --- Step 4: Create publication on RDS (if it doesn't exist) ---
+
+echo ""
+echo "Creating publication on RDS..."
+PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" <<'SQL'
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'wxyc_cdc') THEN
+        EXECUTE 'CREATE PUBLICATION wxyc_cdc FOR ALL TABLES';
+        RAISE NOTICE 'Publication wxyc_cdc created.';
+    ELSE
+        RAISE NOTICE 'Publication wxyc_cdc already exists.';
+    END IF;
+END $$;
+SQL
+
+# --- Step 5: Ensure local schema exists ---
+
+echo ""
+echo "Ensuring local schema exists (running Drizzle migrations)..."
+cd "$BACKEND_DIR"
+if [ -f "dev_env/init-db.mjs" ]; then
+    DB_HOST="$LOCAL_DB_HOST" DB_PORT="$LOCAL_DB_PORT" DB_NAME="$LOCAL_DB_NAME" \
+    DB_USERNAME="$LOCAL_DB_USER" DB_PASSWORD="$LOCAL_DB_PASSWORD" \
+    SKIP_SEED=true node dev_env/init-db.mjs 2>&1 | tail -5
+else
+    echo "Warning: init-db.mjs not found, assuming schema exists."
+fi
+
+# --- Step 6: Create subscription on local database ---
+
+echo ""
+echo "Creating subscription on local database..."
+
+# Build the connection string for the subscription (points to tunnel, not RDS directly)
+CONN_STRING="host=localhost port=$TUNNEL_PORT dbname=$RDS_NAME user=$RDS_USER password=$RDS_PASS"
+
+PGPASSWORD="$LOCAL_DB_PASSWORD" psql -h "$LOCAL_DB_HOST" -p "$LOCAL_DB_PORT" -U "$LOCAL_DB_USER" -d "$LOCAL_DB_NAME" <<SQL
+DO \$\$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_subscription WHERE subname = 'local_sync') THEN
+        EXECUTE format(
+            'CREATE SUBSCRIPTION local_sync CONNECTION %L PUBLICATION wxyc_cdc WITH (copy_data = true)',
+            '$CONN_STRING'
+        );
+        RAISE NOTICE 'Subscription local_sync created. Initial data copy starting...';
+    ELSE
+        RAISE NOTICE 'Subscription local_sync already exists.';
+    END IF;
+END \$\$;
+SQL
+
+# --- Step 7: Show replication status ---
+
+echo ""
+echo "Replication status:"
+PGPASSWORD="$LOCAL_DB_PASSWORD" psql -h "$LOCAL_DB_HOST" -p "$LOCAL_DB_PORT" -U "$LOCAL_DB_USER" -d "$LOCAL_DB_NAME" -c "
+SELECT subname, subenabled, subconninfo
+FROM pg_subscription
+WHERE subname = 'local_sync';
+"
+
+echo ""
+echo "To monitor initial sync progress:"
+echo "  PGPASSWORD='$LOCAL_DB_PASSWORD' psql -h $LOCAL_DB_HOST -p $LOCAL_DB_PORT -U $LOCAL_DB_USER -d $LOCAL_DB_NAME \\"
+echo "    -c \"SELECT * FROM pg_stat_subscription;\""
+echo ""
+echo "Done. The tunnel must remain open for replication to stream."
+echo "Kill it with: $SCRIPT_DIR/tunnel.sh --kill"

--- a/scripts/sync/teardown-replication.sh
+++ b/scripts/sync/teardown-replication.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Tears down PostgreSQL logical replication: drops the local subscription
+# and kills the SSH tunnel.
+#
+# Usage:
+#   ./teardown-replication.sh
+#
+# Environment:
+#   TUNNEL_PORT        Local tunnel port (default: 15432)
+#   LOCAL_DB_HOST      Local PostgreSQL host (default: localhost)
+#   LOCAL_DB_PORT      Local PostgreSQL port (default: 5432)
+#   LOCAL_DB_NAME      Local database name (default: wxyc_db)
+#   LOCAL_DB_USER      Local database user (default: postgres)
+#   LOCAL_DB_PASSWORD   Local database password (default: empty)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+TUNNEL_PORT="${TUNNEL_PORT:-15432}"
+LOCAL_DB_HOST="${LOCAL_DB_HOST:-localhost}"
+LOCAL_DB_PORT="${LOCAL_DB_PORT:-5432}"
+LOCAL_DB_NAME="${LOCAL_DB_NAME:-wxyc_db}"
+LOCAL_DB_USER="${LOCAL_DB_USER:-postgres}"
+LOCAL_DB_PASSWORD="${LOCAL_DB_PASSWORD:-}"
+
+# --- Drop subscription ---
+
+echo "Dropping subscription..."
+PGPASSWORD="$LOCAL_DB_PASSWORD" psql -h "$LOCAL_DB_HOST" -p "$LOCAL_DB_PORT" -U "$LOCAL_DB_USER" -d "$LOCAL_DB_NAME" -c "
+DROP SUBSCRIPTION IF EXISTS local_sync;
+" 2>&1
+
+echo "Subscription dropped."
+
+# --- Kill tunnel ---
+
+"$SCRIPT_DIR/tunnel.sh" --kill
+
+echo "Teardown complete."

--- a/scripts/sync/tunnel.sh
+++ b/scripts/sync/tunnel.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Opens and maintains an SSH tunnel to the RDS PostgreSQL instance.
+#
+# Uses autossh for automatic reconnection if available, falls back to
+# plain ssh otherwise. The tunnel maps local port 15432 to RDS port 5432
+# through the EC2 bastion host.
+#
+# Usage:
+#   ./tunnel.sh          # Open tunnel in background
+#   ./tunnel.sh --kill   # Kill existing tunnel
+#
+# Requires:
+#   - SSH access via 'ssh wxyc-ec2' (configured in ~/.ssh/config)
+#
+# Environment:
+#   TUNNEL_PORT        Local port (default: 15432)
+#   REMOTE_ENV_PATH    Path to .env on EC2 (default: /home/ec2-user/.env)
+
+set -euo pipefail
+
+TUNNEL_PORT="${TUNNEL_PORT:-15432}"
+REMOTE_ENV_PATH="${REMOTE_ENV_PATH:-/home/ec2-user/.env}"
+
+kill_tunnel() {
+    local pid
+    pid=$(lsof -ti :"$TUNNEL_PORT" -sTCP:LISTEN 2>/dev/null || true)
+    if [ -n "$pid" ]; then
+        echo "Killing tunnel on port $TUNNEL_PORT (PID $pid)..."
+        kill "$pid" 2>/dev/null || true
+        sleep 1
+    else
+        echo "No tunnel running on port $TUNNEL_PORT."
+    fi
+}
+
+if [ "${1:-}" = "--kill" ]; then
+    kill_tunnel
+    exit 0
+fi
+
+# Clean up stale tunnel
+kill_tunnel
+
+# Read RDS host from EC2's .env
+echo "Reading RDS host from EC2..."
+RDS_HOST=$(ssh wxyc-ec2 "grep '^DB_HOST=' '$REMOTE_ENV_PATH'" 2>/dev/null | cut -d= -f2) || true
+if [ -z "$RDS_HOST" ]; then
+    echo "Error: could not read DB_HOST from EC2's .env"
+    exit 1
+fi
+
+echo "Opening tunnel: localhost:$TUNNEL_PORT → $RDS_HOST:5432 (via wxyc-ec2)"
+
+if command -v autossh &>/dev/null; then
+    autossh -M 0 -f -N \
+        -o "ServerAliveInterval=30" \
+        -o "ServerAliveCountMax=3" \
+        -L "$TUNNEL_PORT:$RDS_HOST:5432" \
+        wxyc-ec2
+    echo "Tunnel opened with autossh (auto-reconnect enabled)."
+else
+    ssh -f -N \
+        -o "ServerAliveInterval=30" \
+        -o "ServerAliveCountMax=3" \
+        -L "$TUNNEL_PORT:$RDS_HOST:5432" \
+        wxyc-ec2
+    echo "Tunnel opened with ssh (install autossh for auto-reconnect: brew install autossh)."
+fi
+
+echo "Tunnel PID: $(lsof -ti :"$TUNNEL_PORT" -sTCP:LISTEN 2>/dev/null || echo unknown)"

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1014.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^0.4.0",
+    "@wxyc/shared": "^0.5.0",
     "better-auth": "^1.5.6",
     "drizzle-orm": "^0.41.0",
     "postgres": "^3.4.8"

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -14,20 +14,24 @@ const mockSearchDiscogs = jest.fn<() => Promise<unknown>>();
 const mockGetRelease = jest.fn<() => Promise<unknown>>();
 const mockGetArtistDetails = jest.fn<() => Promise<unknown>>();
 const mockResolveEntity = jest.fn<() => Promise<unknown>>();
+const mockSearchLibrary = jest.fn<() => Promise<unknown>>();
+
+class MockLmlClientError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = 'LmlClientError';
+    this.statusCode = statusCode;
+  }
+}
 
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
   searchDiscogs: mockSearchDiscogs,
   getRelease: mockGetRelease,
   getArtistDetails: mockGetArtistDetails,
   resolveEntity: mockResolveEntity,
-  LmlClientError: class LmlClientError extends Error {
-    statusCode: number;
-    constructor(message: string, statusCode: number) {
-      super(message);
-      this.name = 'LmlClientError';
-      this.statusCode = statusCode;
-    }
-  },
+  searchLibrary: mockSearchLibrary,
+  LmlClientError: MockLmlClientError,
 }));
 
 // Artwork finder mock (still used for Last.fm/iTunes fallback in searchArtwork)
@@ -71,6 +75,7 @@ import {
   getArtistMetadata,
   resolveEntity,
   getSpotifyTrack,
+  librarySearch,
 } from '../../../apps/backend/controllers/proxy.controller';
 
 // --- Helpers ---
@@ -719,6 +724,74 @@ describe('proxy.controller', () => {
       await getSpotifyTrack(req, res as Response, mockNext);
 
       expect(res.status).toHaveBeenCalledWith(502);
+    });
+  });
+
+  describe('librarySearch', () => {
+    it('returns 400 when no search params provided', async () => {
+      const req = { query: {} } as unknown as Request;
+      const res = createMockRes();
+
+      await librarySearch(req, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('artist') }));
+    });
+
+    it('forwards artist and title to LML searchLibrary', async () => {
+      const mockResponse = {
+        results: [{ id: 1, title: 'Aluminum Tunes', artist: 'Stereolab' }],
+        total: 1,
+        query: 'Stereolab',
+      };
+      mockSearchLibrary.mockResolvedValue(mockResponse);
+      const req = { query: { artist: 'Stereolab', title: 'Aluminum Tunes', limit: '5' } } as unknown as Request;
+      const res = createMockRes();
+
+      await librarySearch(req, res as Response, mockNext);
+
+      expect(mockSearchLibrary).toHaveBeenCalledWith({
+        artist: 'Stereolab',
+        title: 'Aluminum Tunes',
+        q: undefined,
+        limit: 5,
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(mockResponse);
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=60');
+    });
+
+    it('forwards q param for free text search', async () => {
+      mockSearchLibrary.mockResolvedValue({ results: [], total: 0, query: null });
+      const req = { query: { q: 'Cat Power' } } as unknown as Request;
+      const res = createMockRes();
+
+      await librarySearch(req, res as Response, mockNext);
+
+      expect(mockSearchLibrary).toHaveBeenCalledWith(expect.objectContaining({ q: 'Cat Power' }));
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('maps LmlClientError to the correct status code', async () => {
+      mockSearchLibrary.mockRejectedValue(new MockLmlClientError('LML not configured', 503));
+      const req = { query: { artist: 'Stereolab' } } as unknown as Request;
+      const res = createMockRes();
+
+      await librarySearch(req, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ message: 'LML not configured' }));
+    });
+
+    it('passes unexpected errors to next()', async () => {
+      const error = new Error('unexpected');
+      mockSearchLibrary.mockRejectedValue(error);
+      const req = { query: { artist: 'Stereolab' } } as unknown as Request;
+      const res = createMockRes();
+
+      await librarySearch(req, res as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(error);
     });
   });
 });

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -13,6 +13,7 @@ import {
   resolveEntity,
   LmlClientError,
   checkStreamingAvailability,
+  searchLibrary,
 } from '../../../apps/backend/services/lml/lml.client';
 
 describe('lml.client', () => {
@@ -234,6 +235,45 @@ describe('lml.client', () => {
       } as unknown as globalThis.Response);
 
       await expect(checkStreamingAvailability('Stereolab', 'Aluminum Tunes')).rejects.toThrow(LmlClientError);
+    });
+  });
+
+  describe('searchLibrary', () => {
+    it('sends GET to /api/v1/library/search with query params', async () => {
+      const mockResponse = {
+        results: [{ id: 1, title: 'Aluminum Tunes', artist: 'Stereolab' }],
+        total: 1,
+        query: 'Stereolab',
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as unknown as globalThis.Response);
+
+      const result = await searchLibrary({ artist: 'Stereolab', limit: 5 });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/library/search?'),
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('artist=Stereolab');
+      expect(calledUrl).toContain('limit=5');
+      expect(result.total).toBe(1);
+    });
+
+    it('omits unset params', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], total: 0, query: null }),
+      } as unknown as globalThis.Response);
+
+      await searchLibrary({ title: 'Moon Pix' });
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('title=Moon+Pix');
+      expect(calledUrl).not.toContain('artist=');
+      expect(calledUrl).not.toContain('limit=');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Replace 10 hand-written `Lml*` interfaces in `lml.client.ts` with generated types from `@wxyc/shared@0.5.0/dtos`
- Add `GET /proxy/library/search` endpoint that proxies to LML's library catalog search
- Add `searchLibrary()` function to the LML client
- Update `metadata.service.ts` to use `DiscogsEnrichedSearchResult` instead of `LmlSearchResult`
- Bump `@wxyc/shared` to `^0.5.0`

Closes #404

## Test plan

- [x] 5 new proxy controller tests (400, success, free text, LML error, unexpected error)
- [x] 2 new LML client tests (searchLibrary with params, omits unset params)
- [x] 826 tests pass (818 existing + 8 new)
- [x] Typecheck passes
- [x] Lint passes (0 errors)
- [x] Format check passes
- [ ] CI passes