### PR TITLE
fix: ensure db-init seed data persists

### DIFF
--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -12,6 +12,12 @@ services:
       - '${DB_PORT:-5432}:5432'
     volumes:
       - pg-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${DB_USERNAME} -d ${DB_NAME} || pg_isready']
+      interval: 2s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
 
   # Database Initialization (migrations + seeding)
   db-init:
@@ -22,7 +28,8 @@ services:
       dockerfile: dev_env/Dockerfile.init
     container_name: wxyc-db-init
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - DB_HOST=db # Differentiates between db containers with internal network hostname
       - DB_PORT=5432
@@ -65,7 +72,8 @@ services:
       dockerfile: dev_env/Dockerfile.init
     container_name: wxyc-ci-db-init
     depends_on:
-      - ci-db
+      ci-db:
+        condition: service_healthy
     environment:
       - DB_HOST=ci-db # Differentiates between db containers with internal network hostname
       - DB_PORT=5432

--- a/dev_env/init-db.mjs
+++ b/dev_env/init-db.mjs
@@ -39,8 +39,6 @@ const dbConfig = {
 
 const sql = postgres(dbConfig);
 
-const bold = 'font-weight: strong;';
-
 console.log(styleText(['bold'], `🔧 Database Init Script Starting...`));
 console.log(`   Host: ${dbConfig.host}:${dbConfig.port}`);
 console.log(`   Database: ${dbConfig.database}\n`);
@@ -194,23 +192,58 @@ async function isDatabaseSeeded() {
 }
 
 /**
- * Seed the database
+ * Seed the database inside an explicit transaction.
+ *
+ * The seed file contains many statements. Running them via sql.unsafe() in
+ * the simple query protocol means each statement auto-commits independently.
+ * If an intermediate statement fails, the postgres library may not surface the
+ * error, leaving the database partially seeded while the script reports success.
+ *
+ * Wrapping in sql.begin() ensures atomicity: either every statement commits
+ * or the entire batch rolls back, and any error is properly propagated.
  */
 async function seedDatabase() {
   console.log(styleText(['bold'], '🌱 Seeding database...\n'));
 
-  try {
-    const seedSQL = readFileSync(join(__dirname, './seed_db.sql'), 'utf8');
+  const seedSQL = readFileSync(join(__dirname, './seed_db.sql'), 'utf8');
 
-    // Execute the seed SQL
-    await sql.unsafe(seedSQL);
-    await sql.end();
+  await sql.begin(async (tx) => {
+    await tx.unsafe(seedSQL);
+  });
 
-    console.log('Database seeded successfully!\n');
-  } catch (error) {
-    await sql.end();
-    console.error('Seeding failed:', error.message);
-    throw error;
+  console.log('Database seeded successfully!\n');
+}
+
+/**
+ * Verify that critical seed data was persisted.
+ *
+ * Catches silent failures where the seed appears to succeed but no rows
+ * were actually committed (the original bug reported in #408).
+ */
+async function verifySeedData() {
+  console.log(styleText(['bold'], '🔍 Verifying seed data...\n'));
+
+  const counts = await sql`
+    SELECT
+      (SELECT COUNT(*) FROM auth_user) AS users,
+      (SELECT COUNT(*) FROM auth_account) AS accounts,
+      (SELECT COUNT(*) FROM auth_member) AS members,
+      (SELECT COUNT(*) FROM wxyc_schema.genres) AS genres,
+      (SELECT COUNT(*) FROM wxyc_schema.artists) AS artists
+  `;
+
+  const { users, accounts, members, genres, artists } = counts[0];
+  console.log(`   auth_user:    ${users} rows`);
+  console.log(`   auth_account: ${accounts} rows`);
+  console.log(`   auth_member:  ${members} rows`);
+  console.log(`   genres:       ${genres} rows`);
+  console.log(`   artists:      ${artists} rows\n`);
+
+  if (parseInt(users) === 0 || parseInt(genres) === 0) {
+    throw new Error(
+      'Seed verification failed: critical tables are empty after seeding. ' +
+        'The seed SQL may have been silently rolled back.'
+    );
   }
 }
 
@@ -243,15 +276,16 @@ async function main() {
         console.log('Database already contains data, skipping seed.\n');
       } else {
         await seedDatabase();
+        await verifySeedData();
       }
     }
 
     console.log(styleText(['bold'], '💾 Database initialization complete!'));
-    sql.end();
+    await sql.end();
     process.exit(0);
   } catch (error) {
     console.error('\nDatabase initialization failed:', error);
-    sql.end();
+    await sql.end();
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

Fixes #408 — the Docker db-init container reported "Database seeded successfully!" but seed data wasn't persisting.

Three root causes addressed:

- **No explicit transaction for seeding.** `sql.unsafe(seedSQL)` sends the entire seed file as a single simple-query-protocol message. Each statement auto-commits independently, and if an intermediate statement fails, the `postgres` library may not surface the error — leaving the database empty while the script logs success. Now uses `sql.begin()` to make seeding atomic.
- **Missing healthcheck on dev PostgreSQL.** The `db` service (dev profile) was the only PostgreSQL service without a healthcheck. `db-init` started before PostgreSQL was fully ready, relying solely on `SELECT 1` retries. Added a healthcheck matching the e2e/ci/etl profiles, and `db-init` + `ci-db-init` now use `condition: service_healthy`.
- **Premature connection close.** `sql.end()` was called inside `seedDatabase()` then called again (unawaited) in `main()` before `process.exit(0)`. Moved cleanup to `main()` only, with proper `await`.

Also adds `verifySeedData()` — a post-seed check that queries `auth_user`, `auth_account`, `auth_member`, `genres`, and `artists` counts and fails loudly if critical tables are empty.

## Test plan

- [ ] Delete dev volume (`docker volume rm dev_env_pg-data`), run `npm run db:start`, verify `auth_user` and `wxyc_schema.artists` are populated
- [ ] Run `npm run ci:testmock` to verify CI profile still works
- [ ] Verify E2E profile is unaffected (no changes to e2e services)