### PR TITLE
Set AUTH_PORT=8080 in Docker Compose auth containers

### DIFF
--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -92,6 +92,7 @@ services:
         NPM_TOKEN: ${NPM_TOKEN:-}
     profiles: [ci]
     environment:
+      - AUTH_PORT=8080
       - NODE_ENV=test
       - DB_HOST=ci-db
       - DB_PORT=5432
@@ -247,6 +248,7 @@ services:
         NPM_TOKEN: ${NPM_TOKEN:-}
     profiles: [e2e]
     environment:
+      - AUTH_PORT=8080
       - DB_HOST=e2e-db
       - DB_PORT=5432
       - DB_USERNAME=${DB_USERNAME:-e2euser}


### PR DESCRIPTION
## Summary

- Added `AUTH_PORT=8080` to the CI auth and E2E auth container environments in `dev_env/docker-compose.yml`.
- After #411 changed the auth service default from 8080 to 8082, these containers would bind to the wrong internal port, breaking port mappings and healthchecks.

## Test plan

- [ ] `npm run ci:testmock` passes (CI auth container starts and becomes healthy)
- [ ] E2E tests pass with `docker compose --profile e2e up`

Closes #413