### PR TITLE
Add POST /auth/test/confirm-user test endpoint

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -108,9 +108,29 @@ if (process.env.NODE_ENV !== 'production') {
     }
   });
 
+  // Confirm a user (mark onboarding as complete) for testing
+  app.post('/auth/test/confirm-user', async (req, res) => {
+    try {
+      const { userId } = req.body as { userId?: string };
+      if (!userId) {
+        return res.status(400).json({ error: 'userId is required' });
+      }
+
+      const { db, user } = await import('@wxyc/database');
+      const { eq } = await import('drizzle-orm');
+
+      await db.update(user).set({ hasCompletedOnboarding: true }).where(eq(user.id, userId));
+
+      return res.json({ success: true });
+    } catch (error) {
+      console.error('[TEST ENDPOINTS] Failed to confirm user:', error);
+      return res.status(500).json({ error: 'Failed to confirm user' });
+    }
+  });
+
   // Report session
   console.log(
-    '[TEST ENDPOINTS] Test helper endpoints enabled (/auth/test/verification-token, /auth/test/expire-session)'
+    '[TEST ENDPOINTS] Test helper endpoints enabled (/auth/test/verification-token, /auth/test/expire-session, /auth/test/confirm-user)'
   );
 }
 


### PR DESCRIPTION
Closes #416

## Summary

- Add `POST /auth/test/confirm-user` test endpoint gated by `NODE_ENV !== 'production'`
- Sets `hasCompletedOnboarding=true` on the `auth_user` record for a given `userId`
- Follows the pattern of existing `/auth/test/verification-token` and `/auth/test/expire-session` endpoints

## Test plan

- [ ] Verify endpoint returns `{ success: true }` when called with valid `userId`
- [ ] Verify endpoint returns 400 when `userId` is missing
- [ ] Verify endpoint is not available in production (`NODE_ENV=production`)
- [ ] Verify console.log lists all three test endpoints on startup