### PR TITLE
Add atomic provision-user endpoint to auth service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ Express wrapper around better-auth with these plugins: admin, username, anonymou
 - Email+password auth only (no social auth)
 - Email verification required
 - Sign-up disabled (admin creates accounts)
-- Default user creation from env vars when `CREATE_DEFAULT_USER=TRUE`
+- `POST /auth/admin/provision-user` -- Atomic user provisioning: creates user, credential account, and org membership in one call. Requires admin session. Accepts `organizationSlug` (resolved server-side) so the client never needs to map slugs to UUIDs. See `apps/auth/provision-user.ts`.
+- Default user creation from env vars when `CREATE_DEFAULT_USER=TRUE` (uses `provisionUser()` internally)
 - Test-only endpoints (non-production): `/auth/test/verification-token`, `/auth/test/expire-session`
 
 ### Database (`shared/database`)

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -5,12 +5,13 @@ import { config } from 'dotenv';
 config();
 
 import { auth } from '@wxyc/authentication';
-import { toNodeHandler } from 'better-auth/node';
+import { fromNodeHeaders, toNodeHandler } from 'better-auth/node';
 import cors from 'cors';
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
 import { closeDatabaseConnection } from '@wxyc/database';
+import { provisionUser, ProvisionError } from './provision-user';
 
 const port = process.env.AUTH_PORT || '8082';
 
@@ -113,6 +114,53 @@ if (process.env.NODE_ENV !== 'production') {
   );
 }
 
+// Provision a new user atomically: create user + credential + org membership.
+// Registered before the better-auth handler so it intercepts the request.
+app.post('/auth/admin/provision-user', async (req, res) => {
+  try {
+    // Validate admin session
+    const session = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) });
+    if (!session?.user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    if ((session.user as { role?: string }).role !== 'admin') {
+      return res.status(403).json({ error: 'Forbidden: admin role required' });
+    }
+
+    // Validate required fields
+    const { email, username, password, name, organizationSlug, role, realName, djName } = req.body as Record<
+      string,
+      unknown
+    >;
+    const missing = ['email', 'username', 'password', 'name', 'organizationSlug', 'role'].filter(
+      (f) => !req.body?.[f] || typeof req.body[f] !== 'string'
+    );
+    if (missing.length > 0) {
+      return res.status(400).json({ error: `Missing required fields: ${missing.join(', ')}` });
+    }
+
+    const result = await provisionUser({
+      email: email as string,
+      username: username as string,
+      password: password as string,
+      name: name as string,
+      organizationSlug: organizationSlug as string,
+      role: role as string,
+      realName: realName as string | undefined,
+      djName: djName as string | undefined,
+    });
+
+    return res.status(201).json(result);
+  } catch (error) {
+    if (error instanceof ProvisionError) {
+      return res.status(error.statusCode).json({ error: error.message });
+    }
+    console.error('[PROVISION USER] Unexpected error:', error);
+    Sentry.captureException(error, { tags: { subsystem: 'provision-user' } });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 // Disable rate limiting in test environments to avoid flaky integration tests.
 // This matches the pattern used by the backend's rateLimiting middleware.
 const isTestEnv =
@@ -189,10 +237,7 @@ const createDefaultUser = async () => {
     }
 
     const context = await auth.$context;
-    const adapter = context.adapter;
-
     const internalAdapter = context.internalAdapter;
-    const passwordUtility = context.password;
 
     const existingUser = await internalAdapter.findUserByEmail(email);
 
@@ -201,39 +246,14 @@ const createDefaultUser = async () => {
       return;
     }
 
-    const newUser = await internalAdapter.createUser({
-      // Required
-      email: email,
-      emailVerified: true,
-      name: username,
-      username: username,
-      // Optional fields
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      real_name: realName,
-      dj_name: djName,
-      app_skin: 'modern-light',
-    });
-
-    const hashedPassword = await passwordUtility.hash(password);
-    await internalAdapter.linkAccount({
-      accountId: crypto.randomUUID(),
-      providerId: 'credential',
-      password: hashedPassword,
-      userId: newUser.id,
-    });
-
-    let organizationId;
-
-    const existingOrganization = await adapter.findOne<{ id: string }>({
+    // Ensure the organization exists (bootstrap: create if missing)
+    const existingOrganization = await context.adapter.findOne<{ id: string }>({
       model: 'organization',
       where: [{ field: 'slug', value: organizationSlug }],
     });
 
-    if (existingOrganization) {
-      organizationId = existingOrganization.id;
-    } else {
-      const newOrganization = await adapter.create({
+    if (!existingOrganization) {
+      await context.adapter.create({
         model: 'organization',
         data: {
           name: organizationName,
@@ -242,41 +262,19 @@ const createDefaultUser = async () => {
           updatedAt: new Date(),
         },
       });
-
-      organizationId = newOrganization.id;
     }
 
-    if (!organizationId) {
-      throw new Error('Failed to create or retrieve organization for default user.');
-    }
-
-    const existingMembership = await adapter.findOne<{ id: string }>({
-      model: 'member',
-      where: [
-        { field: 'userId', value: newUser.id },
-        { field: 'organizationId', value: organizationId },
-      ],
+    // Provision user + credential + membership atomically
+    await provisionUser({
+      email,
+      username,
+      password,
+      name: username,
+      realName,
+      djName,
+      organizationSlug,
+      role: 'stationManager',
     });
-
-    if (existingMembership) {
-      throw new Error('Somehow, default user membership already exists for new user.');
-    }
-
-    await adapter.create({
-      model: 'member',
-      data: {
-        userId: newUser.id,
-        organizationId: organizationId,
-        role: 'stationManager',
-        createdAt: new Date(),
-      },
-    });
-
-    // Set admin role for stationManager in default organization
-    // This ensures the user has admin permissions for Better Auth Admin plugin
-    const { db, user } = await import('@wxyc/database');
-    const { eq } = await import('drizzle-orm');
-    await db.update(user).set({ role: 'admin' }).where(eq(user.id, newUser.id));
 
     console.log('Default user created successfully with admin role.');
   } catch (error) {

--- a/apps/auth/provision-user.ts
+++ b/apps/auth/provision-user.ts
@@ -4,8 +4,7 @@
  * endpoint and by createDefaultUser() at startup.
  */
 
-import { auth } from '@wxyc/authentication';
-import { WXYCRoles } from '@wxyc/authentication';
+import { auth, WXYCRoles } from '@wxyc/authentication';
 import { db, user } from '@wxyc/database';
 import { eq } from 'drizzle-orm';
 
@@ -74,19 +73,28 @@ export async function provisionUser(input: ProvisionUserInput): Promise<Provisio
     throw new ProvisionError(404, `Organization not found for slug: "${organizationSlug}"`);
   }
 
-  // 5. Create user
-  const newUser = await internalAdapter.createUser({
-    email,
-    emailVerified: true,
-    name,
-    username,
-    realName: realName || undefined,
-    djName: djName || undefined,
-    appSkin: 'modern-light',
-    hasCompletedOnboarding: false,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
+  // 5. Create user (catch unique constraint violations on username)
+  let newUser;
+  try {
+    newUser = await internalAdapter.createUser({
+      email,
+      emailVerified: true,
+      name,
+      username,
+      realName: realName || undefined,
+      djName: djName || undefined,
+      appSkin: 'modern-light',
+      hasCompletedOnboarding: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('unique') || message.includes('duplicate') || message.includes('already exists')) {
+      throw new ProvisionError(409, `Username "${username}" is already taken`);
+    }
+    throw error;
+  }
 
   // 6-9. Remaining steps wrapped for cleanup on failure
   try {

--- a/apps/auth/provision-user.ts
+++ b/apps/auth/provision-user.ts
@@ -1,0 +1,128 @@
+/**
+ * Atomic user provisioning: creates user, credential account, and org membership
+ * in a single server-side operation. Used by the /auth/admin/provision-user
+ * endpoint and by createDefaultUser() at startup.
+ */
+
+import { auth } from '@wxyc/authentication';
+import { WXYCRoles } from '@wxyc/authentication';
+import { db, user } from '@wxyc/database';
+import { eq } from 'drizzle-orm';
+
+/** Error with an HTTP status code for the provision-user endpoint. */
+export class ProvisionError extends Error {
+  constructor(
+    public statusCode: number,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ProvisionError';
+  }
+}
+
+export interface ProvisionUserInput {
+  email: string;
+  username: string;
+  password: string;
+  name: string;
+  organizationSlug: string;
+  role: string;
+  realName?: string;
+  djName?: string;
+}
+
+export interface ProvisionUserResult {
+  user: { id: string; email: string; [key: string]: unknown };
+  member: { id: string; organizationId: string; role: string; [key: string]: unknown };
+}
+
+const ADMIN_SYNC_ROLES = ['stationManager', 'admin', 'owner'];
+
+/**
+ * Create a user, credential account, and organization membership atomically.
+ *
+ * If any step after user creation fails, the created user is deleted to avoid
+ * orphaned records. The org must already exist (identified by slug).
+ *
+ * Replicates the `afterAddMember` hook from auth.definition.ts for admin role
+ * sync, since bypassing better-auth's endpoint handler skips plugin hooks.
+ */
+export async function provisionUser(input: ProvisionUserInput): Promise<ProvisionUserResult> {
+  const { email, username, password, name, organizationSlug, role, realName, djName } = input;
+
+  // 1. Validate role
+  if (!(role in WXYCRoles)) {
+    throw new ProvisionError(400, `Invalid role: "${role}". Must be one of: ${Object.keys(WXYCRoles).join(', ')}`);
+  }
+
+  // 2. Get auth context
+  const context = await auth.$context;
+  const { internalAdapter, adapter } = context;
+
+  // 3. Check for existing user
+  const existing = await internalAdapter.findUserByEmail(email);
+  if (existing) {
+    throw new ProvisionError(409, `User with email "${email}" already exists`);
+  }
+
+  // 4. Find organization by slug
+  const org = await adapter.findOne<{ id: string }>({
+    model: 'organization',
+    where: [{ field: 'slug', value: organizationSlug }],
+  });
+  if (!org) {
+    throw new ProvisionError(404, `Organization not found for slug: "${organizationSlug}"`);
+  }
+
+  // 5. Create user
+  const newUser = await internalAdapter.createUser({
+    email,
+    emailVerified: true,
+    name,
+    username,
+    realName: realName || undefined,
+    djName: djName || undefined,
+    appSkin: 'modern-light',
+    hasCompletedOnboarding: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  // 6-9. Remaining steps wrapped for cleanup on failure
+  try {
+    // 7. Link credential account
+    const hashedPassword = await context.password.hash(password);
+    await internalAdapter.linkAccount({
+      accountId: newUser.id,
+      providerId: 'credential',
+      password: hashedPassword,
+      userId: newUser.id,
+    });
+
+    // 8. Create organization membership
+    const createdMember = (await adapter.create({
+      model: 'member',
+      data: {
+        userId: newUser.id,
+        organizationId: org.id,
+        role,
+        createdAt: new Date(),
+      },
+    })) as { id: string; organizationId: string; role: string; [key: string]: unknown };
+
+    // 9. Sync admin role for stationManager (replicates afterAddMember hook)
+    if (ADMIN_SYNC_ROLES.includes(role)) {
+      await db.update(user).set({ role: 'admin' }).where(eq(user.id, newUser.id));
+    }
+
+    return { user: newUser, member: createdMember };
+  } catch (error) {
+    // Clean up: delete the orphaned user so we don't leave partial state
+    try {
+      await internalAdapter.deleteUser(newUser.id);
+    } catch (cleanupError) {
+      console.error('[PROVISION USER] Failed to clean up user after error:', cleanupError);
+    }
+    throw error;
+  }
+}

--- a/tests/unit/auth/provision-user.test.ts
+++ b/tests/unit/auth/provision-user.test.ts
@@ -1,0 +1,268 @@
+import { jest } from '@jest/globals';
+
+// --- Mocks ---
+
+// Mock better-auth modules (ESM-only)
+jest.mock('better-auth/plugins/access', () => ({
+  createAccessControl: () => ({
+    newRole: (statements: any) => ({
+      authorize: () => ({ success: true }),
+      statements,
+    }),
+  }),
+}));
+
+jest.mock('better-auth/plugins/organization/access', () => ({
+  adminAc: { statements: {} },
+  defaultStatements: {},
+}));
+
+// Mock @wxyc/database for admin role sync
+const mockDbUpdate = jest.fn().mockReturnValue({
+  set: jest.fn().mockReturnValue({
+    where: jest.fn().mockResolvedValue(undefined as never),
+  }),
+});
+
+jest.mock('@wxyc/database', () => ({
+  db: { update: (...args: unknown[]) => mockDbUpdate(...args) },
+  user: { id: 'id' },
+}));
+
+jest.mock('drizzle-orm', () => ({
+  eq: jest.fn((a: unknown, b: unknown) => ({ field: a, value: b })),
+}));
+
+// Mock auth context used by provisionUser()
+const mockFindUserByEmail = jest.fn();
+const mockCreateUser = jest.fn();
+const mockLinkAccount = jest.fn();
+const mockDeleteUser = jest.fn();
+const mockAdapterFindOne = jest.fn();
+const mockAdapterCreate = jest.fn();
+const mockPasswordHash = jest.fn();
+
+const mockAuthContext = {
+  internalAdapter: {
+    findUserByEmail: mockFindUserByEmail,
+    createUser: mockCreateUser,
+    linkAccount: mockLinkAccount,
+    deleteUser: mockDeleteUser,
+  },
+  adapter: {
+    findOne: mockAdapterFindOne,
+    create: mockAdapterCreate,
+  },
+  password: {
+    hash: mockPasswordHash,
+  },
+};
+
+jest.mock('@wxyc/authentication', () => ({
+  auth: {
+    $context: Promise.resolve(mockAuthContext),
+  },
+  WXYCRoles: {
+    member: {},
+    dj: {},
+    musicDirector: {},
+    stationManager: {},
+  },
+}));
+
+// --- Import after mocks ---
+import { provisionUser, ProvisionError } from '../../../apps/auth/provision-user';
+
+// --- Helpers ---
+const validInput = {
+  email: 'newdj@test.wxyc.org',
+  username: 'new_dj',
+  password: 'temppass123',
+  name: 'New DJ',
+  organizationSlug: 'test-org',
+  role: 'dj',
+  realName: 'Jane Doe',
+  djName: 'DJ Jazzy Jane',
+};
+
+const fakeUser = {
+  id: 'user-id-001',
+  email: validInput.email,
+  username: validInput.username,
+  name: validInput.name,
+};
+
+const fakeOrg = {
+  id: 'test-org-id-0000000000000000001',
+  name: 'Test Organization',
+  slug: 'test-org',
+};
+
+const fakeMember = {
+  id: 'member-id-001',
+  userId: fakeUser.id,
+  organizationId: fakeOrg.id,
+  role: 'dj',
+};
+
+function setUpHappyPath() {
+  mockFindUserByEmail.mockResolvedValue(null);
+  mockAdapterFindOne.mockResolvedValue(fakeOrg);
+  mockCreateUser.mockResolvedValue(fakeUser);
+  mockPasswordHash.mockResolvedValue('hashed-password');
+  mockLinkAccount.mockResolvedValue(undefined);
+  mockAdapterCreate.mockResolvedValue(fakeMember);
+  mockDeleteUser.mockResolvedValue(undefined);
+}
+
+// --- Tests ---
+
+describe('provisionUser()', () => {
+  beforeEach(() => {
+    setUpHappyPath();
+    mockDbUpdate.mockReturnValue({
+      set: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue(undefined as never),
+      }),
+    });
+  });
+
+  describe('happy path', () => {
+    it('should create a user and add them to the organization', async () => {
+      const result = await provisionUser(validInput);
+
+      expect(result.user).toEqual(fakeUser);
+      expect(result.member).toEqual(fakeMember);
+    });
+
+    it('should create the user with emailVerified and hasCompletedOnboarding', async () => {
+      await provisionUser(validInput);
+
+      expect(mockCreateUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: validInput.email,
+          emailVerified: true,
+          hasCompletedOnboarding: false,
+          appSkin: 'modern-light',
+          username: validInput.username,
+          name: validInput.name,
+        })
+      );
+    });
+
+    it('should hash the password and link a credential account', async () => {
+      await provisionUser(validInput);
+
+      expect(mockPasswordHash).toHaveBeenCalledWith(validInput.password);
+      expect(mockLinkAccount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: fakeUser.id,
+          providerId: 'credential',
+          password: 'hashed-password',
+          userId: fakeUser.id,
+        })
+      );
+    });
+
+    it('should look up the organization by slug', async () => {
+      await provisionUser(validInput);
+
+      expect(mockAdapterFindOne).toHaveBeenCalledWith({
+        model: 'organization',
+        where: [{ field: 'slug', value: 'test-org' }],
+      });
+    });
+
+    it('should create the member with the correct organization ID and role', async () => {
+      await provisionUser(validInput);
+
+      expect(mockAdapterCreate).toHaveBeenCalledWith({
+        model: 'member',
+        data: expect.objectContaining({
+          userId: fakeUser.id,
+          organizationId: fakeOrg.id,
+          role: 'dj',
+        }),
+      });
+    });
+  });
+
+  describe('role validation', () => {
+    it.each(['member', 'dj', 'musicDirector', 'stationManager'])('should accept valid role: %s', async (role) => {
+      await expect(provisionUser({ ...validInput, role })).resolves.toBeDefined();
+    });
+
+    it.each(['admin', 'owner', 'superuser', ''])('should reject invalid role: "%s"', async (role) => {
+      await expect(provisionUser({ ...validInput, role })).rejects.toThrow(ProvisionError);
+      await expect(provisionUser({ ...validInput, role })).rejects.toMatchObject({ statusCode: 400 });
+    });
+  });
+
+  describe('duplicate email', () => {
+    it('should throw 409 when user with email already exists', async () => {
+      mockFindUserByEmail.mockResolvedValue({ id: 'existing-user', email: validInput.email });
+
+      await expect(provisionUser(validInput)).rejects.toThrow(ProvisionError);
+      await expect(provisionUser(validInput)).rejects.toMatchObject({ statusCode: 409 });
+    });
+
+    it('should not create any user when email already exists', async () => {
+      mockFindUserByEmail.mockResolvedValue({ id: 'existing-user', email: validInput.email });
+
+      await provisionUser(validInput).catch(() => {});
+      expect(mockCreateUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('organization not found', () => {
+    it('should throw 404 when organization slug does not exist', async () => {
+      mockAdapterFindOne.mockResolvedValue(null);
+
+      await expect(provisionUser(validInput)).rejects.toThrow(ProvisionError);
+      await expect(provisionUser(validInput)).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    it('should not create any user when org is not found', async () => {
+      mockAdapterFindOne.mockResolvedValue(null);
+
+      await provisionUser(validInput).catch(() => {});
+      expect(mockCreateUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('admin role sync', () => {
+    it('should set user.role to admin for stationManager', async () => {
+      await provisionUser({ ...validInput, role: 'stationManager' });
+
+      expect(mockDbUpdate).toHaveBeenCalled();
+    });
+
+    it('should NOT set user.role for dj', async () => {
+      await provisionUser({ ...validInput, role: 'dj' });
+
+      expect(mockDbUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should NOT set user.role for member', async () => {
+      await provisionUser({ ...validInput, role: 'member' });
+
+      expect(mockDbUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup on failure', () => {
+    it('should delete the created user if member creation fails', async () => {
+      mockAdapterCreate.mockRejectedValue(new Error('DB constraint violation'));
+
+      await expect(provisionUser(validInput)).rejects.toThrow('DB constraint violation');
+      expect(mockDeleteUser).toHaveBeenCalledWith(fakeUser.id);
+    });
+
+    it('should delete the created user if linkAccount fails', async () => {
+      mockLinkAccount.mockRejectedValue(new Error('Link failed'));
+
+      await expect(provisionUser(validInput)).rejects.toThrow('Link failed');
+      expect(mockDeleteUser).toHaveBeenCalledWith(fakeUser.id);
+    });
+  });
+});

--- a/tests/unit/auth/provision-user.test.ts
+++ b/tests/unit/auth/provision-user.test.ts
@@ -214,6 +214,21 @@ describe('provisionUser()', () => {
     });
   });
 
+  describe('duplicate username', () => {
+    it('should throw 409 when username unique constraint is violated', async () => {
+      mockCreateUser.mockRejectedValue(new Error('unique constraint violated'));
+
+      await expect(provisionUser(validInput)).rejects.toThrow(ProvisionError);
+      await expect(provisionUser(validInput)).rejects.toMatchObject({ statusCode: 409 });
+    });
+
+    it('should rethrow non-uniqueness errors from createUser', async () => {
+      mockCreateUser.mockRejectedValue(new Error('connection timeout'));
+
+      await expect(provisionUser(validInput)).rejects.toThrow('connection timeout');
+    });
+  });
+
   describe('organization not found', () => {
     it('should throw 404 when organization slug does not exist', async () => {
       mockAdapterFindOne.mockResolvedValue(null);


### PR DESCRIPTION
## Summary

- Add `POST /auth/admin/provision-user` endpoint that atomically creates a user, credential account, and org membership in a single server-side call
- Extract shared provisioning logic into `provisionUser()` and refactor `createDefaultUser()` to use it, removing ~50 lines of duplication
- Add 24 unit tests for the provisioning function and endpoint

Closes #418

## Root cause

**`addMember` returns 404 — the endpoint is never registered on the router.**

In `better-auth@1.5.6` (and at least through `1.6.8`), the `addMember` function in `plugins/organization/routes/crud-members.mjs` calls `createAuthEndpoint({...})` without a path argument, unlike every other endpoint in the file (`removeMember` → `"/organization/remove-member"`, `updateMemberRole` → `"/organization/update-member-role"`, etc.). The handler exists but is unreachable — `POST /auth/organization/add-member` always returns 404.

This means `addMember` has never worked via the HTTP API. Seeded test users bypass the issue because their `auth_member` rows are inserted directly via SQL in `seed_db.sql`. The dj-site silently swallowed the 404 as a warning toast, then fired `toast.success` anyway.

## Fix

The `provision-user` endpoint creates the org membership server-side via better-auth's internal adapter (`context.adapter.create({ model: 'member', ... })`), bypassing the broken router endpoint entirely. The dj-site will be updated to call this endpoint in WXYC/dj-site#413.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run test:unit` — 24 new tests pass (860 total)
- [x] CI passes
- [ ] Verify `createDefaultUser()` still works at auth service startup