### PR TITLE
Add resolve-organization admin endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Express wrapper around better-auth with these plugins: admin, username, anonymou
 - Email verification required
 - Sign-up disabled (admin creates accounts)
 - `POST /auth/admin/provision-user` -- Atomic user provisioning: creates user, credential account, and org membership in one call. Requires admin session. Accepts `organizationSlug` (resolved server-side) so the client never needs to map slugs to UUIDs. See `apps/auth/provision-user.ts`.
+- `GET /auth/admin/resolve-organization?slug=<slug>` -- Resolves an organization slug to its UUID. Requires admin session. Returns `{ id, slug, name }`. Used by dj-site admin pages to avoid the fragile `getFullOrganization` SDK call which requires `orgSessionMiddleware`. See `apps/auth/resolve-organization.ts`.
 - Default user creation from env vars when `CREATE_DEFAULT_USER=TRUE` (uses `provisionUser()` internally)
 - Test-only endpoints (non-production): `/auth/test/verification-token`, `/auth/test/expire-session`
 

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -12,6 +12,7 @@ import type { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
 import { closeDatabaseConnection } from '@wxyc/database';
 import { provisionUser, ProvisionError } from './provision-user';
+import { resolveOrganization } from './resolve-organization';
 
 const port = process.env.AUTH_PORT || '8082';
 
@@ -133,6 +134,36 @@ if (process.env.NODE_ENV !== 'production') {
     '[TEST ENDPOINTS] Test helper endpoints enabled (/auth/test/verification-token, /auth/test/expire-session, /auth/test/confirm-user)'
   );
 }
+
+// Resolve an organization slug to its UUID.
+// Used by dj-site admin pages to avoid the fragile getFullOrganization SDK call.
+app.get('/auth/admin/resolve-organization', async (req, res) => {
+  try {
+    const session = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) });
+    if (!session?.user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    if ((session.user as { role?: string }).role !== 'admin') {
+      return res.status(403).json({ error: 'Forbidden: admin role required' });
+    }
+
+    const slug = req.query.slug;
+    if (!slug || typeof slug !== 'string') {
+      return res.status(400).json({ error: 'Missing required query parameter: slug' });
+    }
+
+    const org = await resolveOrganization(slug, session);
+    if (!org) {
+      return res.status(404).json({ error: `Organization not found for slug: "${slug}"` });
+    }
+
+    return res.json(org);
+  } catch (error) {
+    console.error('[RESOLVE ORG] Unexpected error:', error);
+    Sentry.captureException(error, { tags: { subsystem: 'resolve-organization' } });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
 
 // Provision a new user atomically: create user + credential + org membership.
 // Registered before the better-auth handler so it intercepts the request.

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -152,7 +152,7 @@ app.get('/auth/admin/resolve-organization', async (req, res) => {
       return res.status(400).json({ error: 'Missing required query parameter: slug' });
     }
 
-    const org = await resolveOrganization(slug, session);
+    const org = await resolveOrganization(slug);
     if (!org) {
       return res.status(404).json({ error: `Organization not found for slug: "${slug}"` });
     }

--- a/apps/auth/resolve-organization.ts
+++ b/apps/auth/resolve-organization.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolve an organization slug to its ID, slug, and name.
+ * Used by the GET /auth/admin/resolve-organization endpoint.
+ */
+
+import { auth } from '@wxyc/authentication';
+
+export interface ResolvedOrganization {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+/**
+ * Look up an organization by slug using the better-auth adapter.
+ * Returns the organization's id, slug, and name, or null if not found.
+ */
+export async function resolveOrganization(
+  slug: string,
+  _session: unknown
+): Promise<ResolvedOrganization | null> {
+  const context = await auth.$context;
+  const { adapter } = context;
+
+  const org = await adapter.findOne<{ id: string; slug: string; name: string }>({
+    model: 'organization',
+    where: [{ field: 'slug', value: slug }],
+  });
+
+  if (!org) {
+    return null;
+  }
+
+  return { id: org.id, slug: org.slug, name: org.name };
+}

--- a/apps/auth/resolve-organization.ts
+++ b/apps/auth/resolve-organization.ts
@@ -15,10 +15,7 @@ export interface ResolvedOrganization {
  * Look up an organization by slug using the better-auth adapter.
  * Returns the organization's id, slug, and name, or null if not found.
  */
-export async function resolveOrganization(
-  slug: string,
-  _session: unknown
-): Promise<ResolvedOrganization | null> {
+export async function resolveOrganization(slug: string, _session: unknown): Promise<ResolvedOrganization | null> {
   const context = await auth.$context;
   const { adapter } = context;
 

--- a/apps/auth/resolve-organization.ts
+++ b/apps/auth/resolve-organization.ts
@@ -15,7 +15,7 @@ export interface ResolvedOrganization {
  * Look up an organization by slug using the better-auth adapter.
  * Returns the organization's id, slug, and name, or null if not found.
  */
-export async function resolveOrganization(slug: string, _session: unknown): Promise<ResolvedOrganization | null> {
+export async function resolveOrganization(slug: string): Promise<ResolvedOrganization | null> {
   const context = await auth.$context;
   const { adapter } = context;
 

--- a/tests/unit/auth/resolve-organization.test.ts
+++ b/tests/unit/auth/resolve-organization.test.ts
@@ -29,7 +29,6 @@ jest.mock('drizzle-orm', () => ({
 
 // Mock auth context
 const mockAdapterFindOne = jest.fn();
-const mockGetSession = jest.fn();
 
 jest.mock('@wxyc/authentication', () => ({
   auth: {
@@ -38,9 +37,6 @@ jest.mock('@wxyc/authentication', () => ({
         findOne: mockAdapterFindOne,
       },
     }),
-    api: {
-      getSession: mockGetSession,
-    },
   },
   WXYCRoles: {
     member: {},
@@ -60,21 +56,6 @@ const MOCK_ORG = {
   name: 'WXYC 89.3 FM',
 };
 
-const ADMIN_SESSION = {
-  user: { id: 'admin-1', role: 'admin', email: 'admin@wxyc.org' },
-  session: { id: 'session-1' },
-};
-
-const NON_ADMIN_SESSION = {
-  user: { id: 'dj-1', role: 'user', email: 'dj@wxyc.org' },
-  session: { id: 'session-2' },
-};
-
-function setUpHappyPath() {
-  mockGetSession.mockResolvedValue(ADMIN_SESSION);
-  mockAdapterFindOne.mockResolvedValue(MOCK_ORG);
-}
-
 // --- Tests ---
 describe('resolveOrganization', () => {
   beforeEach(() => {
@@ -82,10 +63,12 @@ describe('resolveOrganization', () => {
   });
 
   describe('happy path', () => {
-    beforeEach(setUpHappyPath);
+    beforeEach(() => {
+      mockAdapterFindOne.mockResolvedValue(MOCK_ORG);
+    });
 
     it('returns the organization id, slug, and name', async () => {
-      const result = await resolveOrganization('wxyc', ADMIN_SESSION);
+      const result = await resolveOrganization('wxyc');
 
       expect(result).toEqual({
         id: MOCK_ORG.id,
@@ -95,7 +78,7 @@ describe('resolveOrganization', () => {
     });
 
     it('queries the adapter with the slug', async () => {
-      await resolveOrganization('wxyc', ADMIN_SESSION);
+      await resolveOrganization('wxyc');
 
       expect(mockAdapterFindOne).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -108,10 +91,9 @@ describe('resolveOrganization', () => {
 
   describe('organization not found', () => {
     it('returns null when the slug does not match any organization', async () => {
-      mockGetSession.mockResolvedValue(ADMIN_SESSION);
       mockAdapterFindOne.mockResolvedValue(null);
 
-      const result = await resolveOrganization('nonexistent', ADMIN_SESSION);
+      const result = await resolveOrganization('nonexistent');
 
       expect(result).toBeNull();
     });

--- a/tests/unit/auth/resolve-organization.test.ts
+++ b/tests/unit/auth/resolve-organization.test.ts
@@ -1,0 +1,119 @@
+import { jest } from '@jest/globals';
+
+// --- Mocks ---
+
+// Mock better-auth modules (ESM-only)
+jest.mock('better-auth/plugins/access', () => ({
+  createAccessControl: () => ({
+    newRole: (statements: any) => ({
+      authorize: () => ({ success: true }),
+      statements,
+    }),
+  }),
+}));
+
+jest.mock('better-auth/plugins/organization/access', () => ({
+  adminAc: { statements: {} },
+  defaultStatements: {},
+}));
+
+// Mock @wxyc/database (not used by this endpoint, but required by @wxyc/authentication)
+jest.mock('@wxyc/database', () => ({
+  db: {},
+  user: { id: 'id' },
+}));
+
+jest.mock('drizzle-orm', () => ({
+  eq: jest.fn((a: unknown, b: unknown) => ({ field: a, value: b })),
+}));
+
+// Mock auth context
+const mockAdapterFindOne = jest.fn();
+const mockGetSession = jest.fn();
+
+jest.mock('@wxyc/authentication', () => ({
+  auth: {
+    $context: Promise.resolve({
+      adapter: {
+        findOne: mockAdapterFindOne,
+      },
+    }),
+    api: {
+      getSession: mockGetSession,
+    },
+  },
+  WXYCRoles: {
+    member: {},
+    dj: {},
+    musicDirector: {},
+    stationManager: {},
+  },
+}));
+
+// --- Import after mocks ---
+import { resolveOrganization } from '../../../apps/auth/resolve-organization';
+
+// --- Helpers ---
+const MOCK_ORG = {
+  id: 'org-uuid-123',
+  slug: 'wxyc',
+  name: 'WXYC 89.3 FM',
+};
+
+const ADMIN_SESSION = {
+  user: { id: 'admin-1', role: 'admin', email: 'admin@wxyc.org' },
+  session: { id: 'session-1' },
+};
+
+const NON_ADMIN_SESSION = {
+  user: { id: 'dj-1', role: 'user', email: 'dj@wxyc.org' },
+  session: { id: 'session-2' },
+};
+
+function setUpHappyPath() {
+  mockGetSession.mockResolvedValue(ADMIN_SESSION);
+  mockAdapterFindOne.mockResolvedValue(MOCK_ORG);
+}
+
+// --- Tests ---
+describe('resolveOrganization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('happy path', () => {
+    beforeEach(setUpHappyPath);
+
+    it('returns the organization id, slug, and name', async () => {
+      const result = await resolveOrganization('wxyc', ADMIN_SESSION);
+
+      expect(result).toEqual({
+        id: MOCK_ORG.id,
+        slug: MOCK_ORG.slug,
+        name: MOCK_ORG.name,
+      });
+    });
+
+    it('queries the adapter with the slug', async () => {
+      await resolveOrganization('wxyc', ADMIN_SESSION);
+
+      expect(mockAdapterFindOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'organization',
+          where: [{ field: 'slug', value: 'wxyc' }],
+        })
+      );
+    });
+  });
+
+  describe('organization not found', () => {
+    it('returns null when the slug does not match any organization', async () => {
+      mockGetSession.mockResolvedValue(ADMIN_SESSION);
+      mockAdapterFindOne.mockResolvedValue(null);
+
+      const result = await resolveOrganization('nonexistent', ADMIN_SESSION);
+
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `GET /auth/admin/resolve-organization?slug=<slug>` endpoint that resolves an organization slug to its UUID
- Uses the same `adapter.findOne()` pattern as `provision-user`, bypassing `orgSessionMiddleware`
- Requires admin session (same auth check as `provision-user`)

Closes #421

## Context

The dj-site admin pages resolve organization slugs to UUIDs via `authClient.organization.getFullOrganization()`, which requires `orgSessionMiddleware` and silently falls back to returning the raw slug when it fails. This endpoint provides a reliable alternative for admin contexts.

## Test plan

- [x] Unit tests pass: `npx jest --config jest.unit.config.ts resolve-organization`
- [x] Typecheck passes
- [x] Lint passes (no new errors)
- [ ] CI passes