### PR TITLE
fix: surface drizzle-kit migration errors in init script

### DIFF
--- a/dev_env/init-db.mjs
+++ b/dev_env/init-db.mjs
@@ -105,6 +105,8 @@ async function runMigrations() {
     console.log('\nMigrations completed successfully!\n');
   } catch (error) {
     console.error('Migration failed:', error.message);
+    if (error.stdout) console.error('stdout:', error.stdout);
+    if (error.stderr) console.error('stderr:', error.stderr);
     throw error;
   }
 }


### PR DESCRIPTION
## Summary

- Log `error.stdout` and `error.stderr` when `drizzle-kit migrate` fails in the DB init container, so migration errors are diagnosable without manually running drizzle-kit inside the container

Previously the catch block only logged `error.message` which is the generic "Command failed: npm run drizzle:migrate" string. The actual error (e.g., a missing table reference) was in `error.stdout`/`error.stderr` and silently dropped.

## Test plan

- [ ] Run `docker compose -f dev_env/docker-compose.yml --env-file .env --profile dev down -v && docker compose ... up -d` — migrations succeed, logs look normal
- [ ] Introduce a deliberate SQL error in a migration, rebuild init image, verify error is visible in container logs