### PR TITLE
Restore anonymous_devices migration and fix db:stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:e2e": "jest --config jest.e2e.config.json",
     "test:all": "npm run test:unit && npm run test:integration",
     "db:start": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile dev up -d; docker attach wxyc-db-init",
-    "db:stop": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile dev down db -v --remove-orphans",
+    "db:stop": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile dev down -v --remove-orphans",
     "ci:build": "npm run docker:build --workspace=apps/**",
     "ci:env": "./scripts/ci-env.sh",
     "ci:env:full": "./scripts/ci-env.sh --full",

--- a/shared/database/src/migrations/0024_anonymous_devices.sql
+++ b/shared/database/src/migrations/0024_anonymous_devices.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "anonymous_devices" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"device_id" varchar(255) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"blocked" boolean DEFAULT false NOT NULL,
+	"blocked_at" timestamp with time zone,
+	"blocked_reason" text,
+	"request_count" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "anonymous_devices_device_id_unique" UNIQUE("device_id")
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "anonymous_devices_device_id_key" ON "anonymous_devices" USING btree ("device_id");

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -160,151 +160,158 @@
       "idx": 25,
       "version": "7",
       "when": 1769067600001,
-      "tag": "0025_rate_limiting_tables",
+      "tag": "0024_anonymous_devices",
       "breakpoints": true
     },
     {
       "idx": 26,
+      "version": "7",
+      "when": 1769067600002,
+      "tag": "0025_rate_limiting_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
       "version": "7",
       "when": 1771099200000,
       "tag": "0026_rename_play_freq_to_rotation_bin",
       "breakpoints": true
     },
     {
-      "idx": 27,
+      "idx": 28,
       "version": "7",
       "when": 1771099200001,
       "tag": "0026_capabilities_column",
       "breakpoints": true
     },
     {
-      "idx": 28,
+      "idx": 29,
       "version": "7",
       "when": 1772298699137,
       "tag": "0027_cron_job_tracking",
       "breakpoints": true
     },
     {
-      "idx": 29,
+      "idx": 30,
       "version": "7",
       "when": 1772298699138,
       "tag": "0028_drop_genre_from_artist_table",
       "breakpoints": true
     },
     {
-      "idx": 30,
+      "idx": 31,
       "version": "7",
       "when": 1772298699139,
       "tag": "0029_add_artists_alphabetical_name",
       "breakpoints": true
     },
     {
-      "idx": 31,
+      "idx": 32,
       "version": "7",
       "when": 1773965212606,
       "tag": "0030_labels_table",
       "breakpoints": true
     },
     {
-      "idx": 32,
+      "idx": 33,
       "version": "7",
       "when": 1774469004875,
       "tag": "0031_add-segue-flag",
       "breakpoints": true
     },
     {
-      "idx": 33,
+      "idx": 34,
       "version": "7",
       "when": 1775084400000,
       "tag": "0032_audit_f19_f20",
       "breakpoints": true
     },
     {
-      "idx": 34,
+      "idx": 35,
       "version": "7",
       "when": 1775090000000,
       "tag": "0033_crossreference_tables",
       "breakpoints": true
     },
     {
-      "idx": 35,
+      "idx": 36,
       "version": "7",
       "when": 1775095000000,
       "tag": "0034_legacy_id_columns",
       "breakpoints": true
     },
     {
-      "idx": 36,
+      "idx": 37,
       "version": "7",
       "when": 1775523600000,
       "tag": "0035_inline_flowsheet_metadata",
       "breakpoints": true
     },
     {
-      "idx": 37,
+      "idx": 38,
       "version": "7",
       "when": 1776224209937,
       "tag": "0037_etl-schema-sync",
       "breakpoints": true
     },
     {
-      "idx": 38,
+      "idx": 39,
       "version": "7",
       "when": 1776394873403,
       "tag": "0038_etl-legacy-columns",
       "breakpoints": true
     },
     {
-      "idx": 39,
+      "idx": 40,
       "version": "7",
       "when": 1776565622430,
       "tag": "0039_add_on_streaming",
       "breakpoints": true
     },
     {
-      "idx": 40,
+      "idx": 41,
       "version": "7",
       "when": 1776698270591,
       "tag": "0040_add_album_artist",
       "breakpoints": true
     },
     {
-      "idx": 41,
+      "idx": 42,
       "version": "7",
       "when": 1776825600000,
       "tag": "0041_rotation_etl_support",
       "breakpoints": true
     },
     {
-      "idx": 42,
+      "idx": 43,
       "version": "7",
       "when": 1776825600001,
       "tag": "0042_flowsheet-suggest-indexes",
       "breakpoints": true
     },
     {
-      "idx": 43,
+      "idx": 44,
       "version": "7",
       "when": 1776825600002,
       "tag": "0043_add-has-completed-onboarding",
       "breakpoints": true
     },
     {
-      "idx": 44,
+      "idx": 45,
       "version": "7",
       "when": 1776927425413,
       "tag": "0044_add_plays_to_library_artist_view",
       "breakpoints": true
     },
     {
-      "idx": 45,
+      "idx": 46,
       "version": "7",
       "when": 1776950835732,
       "tag": "0045_add-library-artwork-url",
       "breakpoints": true
     },
     {
-      "idx": 46,
+      "idx": 47,
       "version": "7",
       "when": 1777062000000,
       "tag": "0046_cdc_notify_triggers",


### PR DESCRIPTION
## Summary

- Restore `0024_anonymous_devices.sql` and add its journal entry. The file was erroneously deleted as an "orphan" in 4d80a98 but is required by the CDC triggers in migration 0046, which reference `public.anonymous_devices`. Without this migration, fresh databases fail to initialize.
- Fix `db:stop` to tear down all containers (`down -v`) instead of just the db service (`down db -v`), which left the `wxyc-db-init` container orphaned with a stale Docker network reference, causing `db:start` to fail on the next run.

## Test plan

- [ ] Run `npm run db:stop && npm run db:start` — verify all 45 migrations apply and seeding completes
- [ ] Run `npm run db:stop && npm run db:start` a second time — verify no stale network error
- [ ] Run `node scripts/validate-migrations.mjs` — verify journal validation passes