### PR TITLE
Add REPLICA IDENTITY to tables without primary keys

### DIFF
--- a/shared/database/src/migrations/0047_replica-identity-for-pkless-tables.sql
+++ b/shared/database/src/migrations/0047_replica-identity-for-pkless-tables.sql
@@ -1,0 +1,15 @@
+-- Tables without a primary key need explicit REPLICA IDENTITY when a
+-- FOR ALL TABLES publication exists (wxyc_cdc).  Without it, PostgreSQL
+-- rejects DELETE and UPDATE operations with:
+--   "cannot delete from table … because it does not have a replica identity
+--    and publishes deletes"
+--
+-- Use the existing unique index where available; fall back to FULL.
+
+ALTER TABLE wxyc_schema.show_djs REPLICA IDENTITY USING INDEX show_djs_show_id_dj_id_unique;
+--> statement-breakpoint
+ALTER TABLE wxyc_schema.artist_library_crossreference REPLICA IDENTITY FULL;
+--> statement-breakpoint
+ALTER TABLE wxyc_schema.genre_artist_crossreference REPLICA IDENTITY USING INDEX artist_genre_key;
+--> statement-breakpoint
+ALTER TABLE wxyc_schema.artist_crossreference REPLICA IDENTITY USING INDEX artist_crossref_source_target;

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1777062000000,
       "tag": "0046_cdc_notify_triggers",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1777214400000,
+      "tag": "0047_replica-identity-for-pkless-tables",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add migration 0047 that sets REPLICA IDENTITY on four tables lacking primary keys (`show_djs`, `artist_library_crossreference`, `genre_artist_crossreference`, `artist_crossreference`)
- These tables caused 500 errors on DELETE operations due to the `wxyc_cdc` publication requiring replica identity for change tracking

Closes #426

## Test plan

- [x] Migration applied to production successfully
- [x] User deletion from admin roster verified working
- [ ] CI passes