### PR TITLE
Fix express-rate-limit IPv6 validation crash

### DIFF
--- a/apps/backend/middleware/rateLimiting.ts
+++ b/apps/backend/middleware/rateLimiting.ts
@@ -81,11 +81,11 @@ export const songRequestRateLimit = shouldEnableRateLimiting
       legacyHeaders: false,
       store: songRequestStore,
       keyGenerator: (req: Request) => {
-        // Use user ID if available (set by requirePermissions middleware)
+        // Use user ID (set by requirePermissions middleware, which runs before this)
         if (req.auth?.id) {
           return req.auth.id;
         }
-        return req.ip || 'unknown';
+        return 'unknown';
       },
       handler: (_req: Request, res: Response) => {
         res.status(429).json({
@@ -93,7 +93,6 @@ export const songRequestRateLimit = shouldEnableRateLimiting
           retryAfter: Math.ceil(REQUEST_WINDOW_MS / 1000),
         });
       },
-      // Skip validation for keyGenerator since we primarily use user ID, not IP
       validate: { xForwardedForHeader: false, keyGeneratorIpFallback: false } as Partial<Options['validate']>,
     })
   : passThrough;

--- a/tests/unit/middleware/rateLimiting.test.ts
+++ b/tests/unit/middleware/rateLimiting.test.ts
@@ -49,18 +49,13 @@ describe('songRequestRateLimit keyGenerator', () => {
     expect(keyGenerator(req)).toBe('user-123');
   });
 
-  it('returns req.ip when req.auth is undefined', () => {
+  it('returns "unknown" when req.auth is undefined', () => {
     const req = { auth: undefined, ip: '192.168.1.42' } as unknown as Request;
-    expect(keyGenerator(req)).toBe('192.168.1.42');
+    expect(keyGenerator(req)).toBe('unknown');
   });
 
-  it('returns req.ip when req.auth.id is missing', () => {
+  it('returns "unknown" when req.auth.id is missing', () => {
     const req = { auth: {}, ip: '10.0.0.5' } as unknown as Request;
-    expect(keyGenerator(req)).toBe('10.0.0.5');
-  });
-
-  it('returns "unknown" only when both req.auth.id and req.ip are unavailable', () => {
-    const req = { auth: undefined, ip: undefined } as unknown as Request;
     expect(keyGenerator(req)).toBe('unknown');
   });
 });


### PR DESCRIPTION
## Summary

- Remove unreachable `req.ip` fallback from `songRequestRateLimit` keyGenerator that triggered `ERR_ERL_KEY_GEN_IPV6` in express-rate-limit 8.x
- `requirePermissions` middleware always runs first, so `req.auth.id` is always set; changed fallback to `'unknown'` to match `proxyRateLimit`'s pattern
- Updated unit tests to reflect new behavior

Closes #428

## Test plan

- [x] `rateLimiting.test.ts` updated and passing
- [x] Typecheck, lint, format all pass
- [ ] Server starts without `ERR_ERL_KEY_GEN_IPV6` crash
- [ ] Song request rate limiting still works with authenticated users