### PR TITLE
Send welcome email when provisioning new accounts

### DIFF
--- a/apps/auth/provision-user.ts
+++ b/apps/auth/provision-user.ts
@@ -4,7 +4,7 @@
  * endpoint and by createDefaultUser() at startup.
  */
 
-import { auth, WXYCRoles } from '@wxyc/authentication';
+import { auth, WXYCRoles, sendAccountSetupEmail } from '@wxyc/authentication';
 import { db, user } from '@wxyc/database';
 import { eq } from 'drizzle-orm';
 
@@ -122,6 +122,12 @@ export async function provisionUser(input: ProvisionUserInput): Promise<Provisio
     if (ADMIN_SYNC_ROLES.includes(role)) {
       await db.update(user).set({ role: 'admin' }).where(eq(user.id, newUser.id));
     }
+
+    // 10. Send welcome email (fire-and-forget so provisioning isn't blocked by SES)
+    const frontendUrl = process.env.FRONTEND_SOURCE || 'http://localhost:3000';
+    sendAccountSetupEmail({ to: email, setupUrl: `${frontendUrl}/login` }).catch((error) => {
+      console.error('[PROVISION USER] Failed to send welcome email:', error);
+    });
 
     return { user: newUser, member: createdMember };
   } catch (error) {

--- a/shared/authentication/src/index.ts
+++ b/shared/authentication/src/index.ts
@@ -1,3 +1,4 @@
 export * from './auth.definition';
 export * from './auth.roles';
 export * from './auth.middleware';
+export { sendAccountSetupEmail } from './email';

--- a/tests/unit/auth/provision-user.test.ts
+++ b/tests/unit/auth/provision-user.test.ts
@@ -68,10 +68,12 @@ jest.mock('@wxyc/authentication', () => ({
     musicDirector: {},
     stationManager: {},
   },
+  sendAccountSetupEmail: jest.fn().mockResolvedValue(undefined),
 }));
 
 // --- Import after mocks ---
 import { provisionUser, ProvisionError } from '../../../apps/auth/provision-user';
+import { sendAccountSetupEmail } from '@wxyc/authentication';
 
 // --- Helpers ---
 const validInput = {
@@ -262,6 +264,41 @@ describe('provisionUser()', () => {
       await provisionUser({ ...validInput, role: 'member' });
 
       expect(mockDbUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('welcome email', () => {
+    it('should send account setup email after successful provisioning', async () => {
+      await provisionUser(validInput);
+
+      expect(sendAccountSetupEmail).toHaveBeenCalledWith({
+        to: validInput.email,
+        setupUrl: expect.stringContaining('/login'),
+      });
+    });
+
+    it('should not send email if user creation fails', async () => {
+      mockCreateUser.mockRejectedValue(new Error('unique constraint violated'));
+
+      await provisionUser(validInput).catch(() => {});
+
+      expect(sendAccountSetupEmail).not.toHaveBeenCalled();
+    });
+
+    it('should not send email if member creation fails', async () => {
+      mockAdapterCreate.mockRejectedValue(new Error('DB constraint violation'));
+
+      await provisionUser(validInput).catch(() => {});
+
+      expect(sendAccountSetupEmail).not.toHaveBeenCalled();
+    });
+
+    it('should not block provisioning if email send fails', async () => {
+      (sendAccountSetupEmail as jest.Mock).mockRejectedValue(new Error('SES error'));
+
+      const result = await provisionUser(validInput);
+
+      expect(result.user).toEqual(fakeUser);
     });
   });
 


### PR DESCRIPTION
## Summary

- Wire up `sendAccountSetupEmail` in `provisionUser()` after successful account creation
- Export `sendAccountSetupEmail` from `@wxyc/authentication` package
- Email is fire-and-forget (SES failures don't block provisioning)
- Links to the login page so the new DJ can sign in with the temp password and complete onboarding

Closes #430

## Test plan

- [x] Unit test: email sent after successful provisioning
- [x] Unit test: email NOT sent on creation failure
- [x] Unit test: email NOT sent on member creation failure
- [x] Unit test: SES failure doesn't block provisioning
- [x] All 828 unit tests pass
- [ ] CI passes