### PR TITLE
Fix backend crash: add ws to workspace dependencies

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -40,6 +40,7 @@
     "sharp": "^0.34.5",
     "ssh2": "^1.17.0",
     "swagger-ui-express": "^5.0.1",
+    "ws": "^8.20.0",
     "yaml": "^2.8.2"
   },
   "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -385,6 +385,7 @@
         "sharp": "^0.34.5",
         "ssh2": "^1.17.0",
         "swagger-ui-express": "^5.0.1",
+        "ws": "^8.20.0",
         "yaml": "^2.8.2"
       },
       "peerDependencies": {
@@ -15529,7 +15530,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary

- The `ws` package was in the root `package.json` but missing from `apps/backend/package.json`
- The Docker production stage installs per-workspace dependencies (`npm install --omit=dev` with workspace package.json files), so `ws` was absent at runtime
- The backend container crash-loops on startup with `ERR_MODULE_NOT_FOUND: Cannot find package 'ws'`
- This was introduced by the CDC WebSocket feature (commit a61d2d5) and the tsup external marking (commit cafec43)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (warnings only, no errors)
- [x] `npm run format:check` passes
- [ ] Auto Build & Deploy succeeds and backend container starts