### PR TITLE
Fix FK constraints to use ON DELETE SET NULL

### DIFF
--- a/shared/database/src/migrations/0048_fix-fk-on-delete-set-null.sql
+++ b/shared/database/src/migrations/0048_fix-fk-on-delete-set-null.sql
@@ -1,0 +1,14 @@
+-- Fix FK constraints that were created with ON DELETE NO ACTION in migration 0021
+-- but should be ON DELETE SET NULL to match the Drizzle schema.
+
+ALTER TABLE wxyc_schema.schedule DROP CONSTRAINT schedule_assigned_dj_id_auth_user_id_fk;
+ALTER TABLE wxyc_schema.schedule ADD CONSTRAINT schedule_assigned_dj_id_auth_user_id_fk FOREIGN KEY (assigned_dj_id) REFERENCES public.auth_user(id) ON DELETE SET NULL;
+
+ALTER TABLE wxyc_schema.schedule DROP CONSTRAINT schedule_assigned_dj_id2_auth_user_id_fk;
+ALTER TABLE wxyc_schema.schedule ADD CONSTRAINT schedule_assigned_dj_id2_auth_user_id_fk FOREIGN KEY (assigned_dj_id2) REFERENCES public.auth_user(id) ON DELETE SET NULL;
+
+ALTER TABLE wxyc_schema.shift_covers DROP CONSTRAINT shift_covers_cover_dj_id_auth_user_id_fk;
+ALTER TABLE wxyc_schema.shift_covers ADD CONSTRAINT shift_covers_cover_dj_id_auth_user_id_fk FOREIGN KEY (cover_dj_id) REFERENCES public.auth_user(id) ON DELETE SET NULL;
+
+ALTER TABLE wxyc_schema.shows DROP CONSTRAINT shows_primary_dj_id_auth_user_id_fk;
+ALTER TABLE wxyc_schema.shows ADD CONSTRAINT shows_primary_dj_id_auth_user_id_fk FOREIGN KEY (primary_dj_id) REFERENCES public.auth_user(id) ON DELETE SET NULL;

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1777214400000,
       "tag": "0047_replica-identity-for-pkless-tables",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1777300800000,
+      "tag": "0048_fix-fk-on-delete-set-null",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds migration `0048_fix-fk-on-delete-set-null.sql` to drop and recreate four FK constraints that reference `auth_user.id` with `ON DELETE SET NULL`, matching the Drizzle schema
- Affected tables: `schedule` (2 columns), `shift_covers`, `shows`

Closes #433

## Test plan

- [ ] Run `npm run lint:migrations` — passes
- [ ] Apply migration against a dev database with existing schedule/show data
- [ ] Verify deleting a user with schedule assignments sets the FK columns to NULL instead of failing