### PR TITLE
Implement GET /flowsheet/search endpoint

### DIFF
--- a/apps/backend/controllers/search.controller.ts
+++ b/apps/backend/controllers/search.controller.ts
@@ -1,0 +1,63 @@
+import { RequestHandler } from 'express';
+import * as searchService from '../services/search.service.js';
+import type { SearchParams } from '../services/search.service.js';
+
+type SearchQueryParams = {
+  q?: string;
+  page?: string;
+  limit?: string;
+  sort?: string;
+  order?: string;
+};
+
+const VALID_SORTS: SearchParams['sort'][] = ['date', 'artist', 'song', 'dj'];
+const VALID_ORDERS: SearchParams['order'][] = ['asc', 'desc'];
+const MAX_LIMIT = 100;
+
+/** GET /flowsheet/search — search historical playlist entries. */
+export const searchFlowsheetEndpoint: RequestHandler<object, unknown, unknown, SearchQueryParams> = async (
+  req,
+  res,
+  next
+) => {
+  const q = req.query.q;
+  if (!q) {
+    res.status(400).json({ message: 'Missing required query parameter: q' });
+    return;
+  }
+
+  const page = parseInt(req.query.page ?? '0');
+  if (isNaN(page) || page < 0) {
+    res.status(400).json({ message: 'page must be a non-negative number' });
+    return;
+  }
+
+  const limit = parseInt(req.query.limit ?? '50');
+  if (isNaN(limit) || limit < 1) {
+    res.status(400).json({ message: 'limit must be a positive number' });
+    return;
+  }
+  if (limit > MAX_LIMIT) {
+    res.status(400).json({ message: `limit must not exceed ${MAX_LIMIT}` });
+    return;
+  }
+
+  const sort = (VALID_SORTS.includes(req.query.sort as SearchParams['sort'])
+    ? req.query.sort
+    : 'date') as SearchParams['sort'];
+
+  const order = (VALID_ORDERS.includes(req.query.order as SearchParams['order'])
+    ? req.query.order
+    : 'desc') as SearchParams['order'];
+
+  try {
+    const { results, total } = await searchService.searchFlowsheet({ q, page, limit, sort, order });
+    const totalPages = Math.ceil(total / limit);
+
+    res.status(200).json({ results, total, page, totalPages });
+  } catch (e) {
+    console.error('Error searching flowsheet');
+    console.error(e);
+    next(e);
+  }
+};

--- a/apps/backend/controllers/search.controller.ts
+++ b/apps/backend/controllers/search.controller.ts
@@ -42,13 +42,13 @@ export const searchFlowsheetEndpoint: RequestHandler<object, unknown, unknown, S
     return;
   }
 
-  const sort = (VALID_SORTS.includes(req.query.sort as SearchParams['sort'])
-    ? req.query.sort
-    : 'date') as SearchParams['sort'];
+  const sort = (
+    VALID_SORTS.includes(req.query.sort as SearchParams['sort']) ? req.query.sort : 'date'
+  ) as SearchParams['sort'];
 
-  const order = (VALID_ORDERS.includes(req.query.order as SearchParams['order'])
-    ? req.query.order
-    : 'desc') as SearchParams['order'];
+  const order = (
+    VALID_ORDERS.includes(req.query.order as SearchParams['order']) ? req.query.order : 'desc'
+  ) as SearchParams['order'];
 
   try {
     const { results, total } = await searchService.searchFlowsheet({ q, page, limit, sort, order });

--- a/apps/backend/routes/flowsheet.route.ts
+++ b/apps/backend/routes/flowsheet.route.ts
@@ -1,12 +1,16 @@
 import { requirePermissions } from '@wxyc/authentication';
 import { Router } from 'express';
 import * as flowsheetController from '../controllers/flowsheet.controller';
+import * as searchController from '../controllers/search.controller';
 import * as suggestController from '../controllers/suggest.controller';
 import { flowsheetMirror } from '../middleware/legacy/flowsheet.mirror';
 import { conditionalGet } from '../middleware/conditionalGet';
 import { showMemberMiddleware } from '../middleware/checkShowMember';
 
 export const flowsheet_route = Router();
+
+// Public playlist archive search
+flowsheet_route.get('/search', searchController.searchFlowsheetEndpoint);
 
 flowsheet_route.get('/', conditionalGet, flowsheetMirror.getEntries, flowsheetController.getEntries);
 

--- a/apps/backend/services/search-parser.service.ts
+++ b/apps/backend/services/search-parser.service.ts
@@ -1,0 +1,187 @@
+/**
+ * Parses playlist search query strings into structured conditions.
+ *
+ * Supports:
+ * - Simple terms: `autechre` (searches all text fields)
+ * - Field prefixes: `artist:autechre`, `song:poise`, `album:confield`, `label:warp`, `dj:jake`
+ * - Date filters: `date:2024-06-15`, `dateRange:2024-01-01..2024-12-31`
+ * - Boolean operators: `AND`, `OR`, `NOT`
+ * - Exact match: `artist:"Cat Power"` (quoted values)
+ */
+
+export type SearchOperator = 'AND' | 'OR';
+
+export type SearchField =
+  | 'artist_name'
+  | 'track_title'
+  | 'album_title'
+  | 'record_label'
+  | 'dj_name'
+  | 'add_time'
+  | 'add_time_range'
+  | 'all';
+
+export type SearchCondition = {
+  operator: SearchOperator;
+  field: SearchField;
+  value: string;
+  exact: boolean;
+  negated: boolean;
+};
+
+const FIELD_PREFIXES: Record<string, SearchField> = {
+  'artist:': 'artist_name',
+  'song:': 'track_title',
+  'album:': 'album_title',
+  'label:': 'record_label',
+  'dj:': 'dj_name',
+  'date:': 'add_time',
+  'dateRange:': 'add_time_range',
+};
+
+const OPERATORS = ['AND', 'OR', 'NOT'] as const;
+
+/** Parse a search query string into structured conditions. */
+export function parseSearchQuery(q: string): SearchCondition[] {
+  const trimmed = q.trim();
+  if (!trimmed) return [];
+
+  const tokens = tokenize(trimmed);
+  return buildConditions(tokens);
+}
+
+// --- Tokenizer ---
+
+type TokenType = 'OPERATOR' | 'FIELD_PREFIX' | 'QUOTED_VALUE' | 'BARE_VALUE';
+type Token = { type: TokenType; value: string };
+
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+
+  while (i < input.length) {
+    // Skip whitespace
+    if (input[i] === ' ') {
+      i++;
+      continue;
+    }
+
+    // Check for operators (AND, OR, NOT) — must be followed by space or end-of-string
+    const operatorMatch = tryMatchOperator(input, i);
+    if (operatorMatch) {
+      tokens.push({ type: 'OPERATOR', value: operatorMatch });
+      i += operatorMatch.length;
+      continue;
+    }
+
+    // Check for field prefixes
+    const prefixMatch = tryMatchFieldPrefix(input, i);
+    if (prefixMatch) {
+      tokens.push({ type: 'FIELD_PREFIX', value: prefixMatch });
+      i += prefixMatch.length;
+      continue;
+    }
+
+    // Check for quoted value
+    if (input[i] === '"') {
+      const end = input.indexOf('"', i + 1);
+      if (end === -1) {
+        // Unmatched quote — take rest of string as value
+        tokens.push({ type: 'QUOTED_VALUE', value: input.slice(i + 1) });
+        break;
+      }
+      tokens.push({ type: 'QUOTED_VALUE', value: input.slice(i + 1, end) });
+      i = end + 1;
+      continue;
+    }
+
+    // Bare value — scan to next whitespace
+    const start = i;
+    while (i < input.length && input[i] !== ' ') {
+      i++;
+    }
+    tokens.push({ type: 'BARE_VALUE', value: input.slice(start, i) });
+  }
+
+  return tokens;
+}
+
+function tryMatchOperator(input: string, pos: number): string | null {
+  for (const op of OPERATORS) {
+    if (
+      input.slice(pos, pos + op.length) === op &&
+      (pos + op.length >= input.length || input[pos + op.length] === ' ')
+    ) {
+      return op;
+    }
+  }
+  return null;
+}
+
+function tryMatchFieldPrefix(input: string, pos: number): string | null {
+  for (const prefix of Object.keys(FIELD_PREFIXES)) {
+    if (input.slice(pos, pos + prefix.length) === prefix) {
+      return prefix;
+    }
+  }
+  return null;
+}
+
+// --- Condition builder ---
+
+function buildConditions(tokens: Token[]): SearchCondition[] {
+  const conditions: SearchCondition[] = [];
+  let currentOperator: SearchOperator = 'AND';
+  let negated = false;
+  let currentField: SearchField | null = null;
+  let i = 0;
+
+  while (i < tokens.length) {
+    const token = tokens[i];
+
+    if (token.type === 'OPERATOR') {
+      if (token.value === 'NOT') {
+        negated = true;
+      } else {
+        currentOperator = token.value as SearchOperator;
+      }
+      i++;
+      continue;
+    }
+
+    if (token.type === 'FIELD_PREFIX') {
+      currentField = FIELD_PREFIXES[token.value];
+      i++;
+      continue;
+    }
+
+    if (token.type === 'QUOTED_VALUE' || token.type === 'BARE_VALUE') {
+      const value = token.value;
+      if (!value) {
+        // Empty value (e.g., field prefix with no following value) — skip
+        currentField = null;
+        i++;
+        continue;
+      }
+
+      conditions.push({
+        operator: currentOperator,
+        field: currentField ?? 'all',
+        value,
+        exact: token.type === 'QUOTED_VALUE',
+        negated,
+      });
+
+      // Reset state for next condition
+      currentOperator = 'AND';
+      negated = false;
+      currentField = null;
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return conditions;
+}

--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -80,10 +80,7 @@ export async function searchFlowsheet(params: SearchParams): Promise<{ results: 
     ${fullWhere}
   `;
 
-  const [rows, countRows] = await Promise.all([
-    db.execute(dataQuery),
-    db.execute(countQuery),
-  ]);
+  const [rows, countRows] = await Promise.all([db.execute(dataQuery), db.execute(countQuery)]);
 
   const results = (rows as unknown as SearchResultRow[]).map(transformRow);
   const total = (countRows as unknown as Array<{ total: number }>)[0]?.total ?? 0;

--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -1,0 +1,193 @@
+import { sql, type SQL } from 'drizzle-orm';
+import { db, flowsheet, shows, user } from '@wxyc/database';
+import { parseSearchQuery, type SearchCondition } from './search-parser.service.js';
+
+export type SearchParams = {
+  q: string;
+  page: number;
+  limit: number;
+  sort: 'date' | 'artist' | 'song' | 'dj';
+  order: 'asc' | 'desc';
+};
+
+type SearchResultRow = {
+  id: number;
+  play_date: Date;
+  artist_name: string | null;
+  track_title: string | null;
+  album_title: string | null;
+  record_label: string | null;
+  show_id: number | null;
+  dj_name: string | null;
+};
+
+export type SearchResult = {
+  id: number;
+  play_date: string;
+  artist_name: string;
+  track_title: string;
+  album_title: string;
+  record_label: string;
+  show_id: number;
+  dj_name: string;
+};
+
+const DJ_NAME_EXPR = sql`COALESCE(${user.djName}, ${shows.legacy_dj_name}, ${user.name}, 'Unknown DJ')`;
+
+const SORT_MAP: Record<SearchParams['sort'], SQL> = {
+  date: sql`${flowsheet.add_time}`,
+  artist: sql`${flowsheet.artist_name}`,
+  song: sql`${flowsheet.track_title}`,
+  dj: DJ_NAME_EXPR,
+};
+
+/** Search historical flowsheet entries with filtering, sorting, and pagination. */
+export async function searchFlowsheet(params: SearchParams): Promise<{ results: SearchResult[]; total: number }> {
+  const { q, page, limit, sort, order } = params;
+  const offset = page * limit;
+  const conditions = parseSearchQuery(q);
+
+  const whereClause = buildWhereClause(conditions);
+  const orderDirection = order === 'asc' ? sql`ASC` : sql`DESC`;
+  const sortExpr = SORT_MAP[sort];
+
+  const baseFrom = sql`
+    FROM ${flowsheet} f
+    LEFT JOIN ${shows} s ON s.id = f.show_id
+    LEFT JOIN ${user} u ON u.id = s.primary_dj_id
+    WHERE f.entry_type = 'track'
+  `;
+
+  const fullWhere = whereClause ? sql`${baseFrom} AND ${whereClause}` : baseFrom;
+
+  const dataQuery = sql`
+    SELECT
+      f.id,
+      f.add_time AS play_date,
+      f.artist_name,
+      f.track_title,
+      f.album_title,
+      f.record_label,
+      f.show_id,
+      ${DJ_NAME_EXPR} AS dj_name
+    ${fullWhere}
+    ORDER BY ${sortExpr} ${orderDirection}
+    LIMIT ${limit} OFFSET ${offset}
+  `;
+
+  const countQuery = sql`
+    SELECT COUNT(*)::int AS total
+    ${fullWhere}
+  `;
+
+  const [rows, countRows] = await Promise.all([
+    db.execute(dataQuery),
+    db.execute(countQuery),
+  ]);
+
+  const results = (rows as unknown as SearchResultRow[]).map(transformRow);
+  const total = (countRows as unknown as Array<{ total: number }>)[0]?.total ?? 0;
+
+  return { results, total };
+}
+
+function transformRow(row: SearchResultRow): SearchResult {
+  return {
+    id: row.id,
+    play_date: row.play_date instanceof Date ? row.play_date.toISOString() : String(row.play_date ?? ''),
+    artist_name: row.artist_name ?? '',
+    track_title: row.track_title ?? '',
+    album_title: row.album_title ?? '',
+    record_label: row.record_label ?? '',
+    show_id: row.show_id ?? 0,
+    dj_name: row.dj_name ?? '',
+  };
+}
+
+function buildWhereClause(conditions: SearchCondition[]): SQL | null {
+  if (conditions.length === 0) return null;
+
+  const parts: { operator: 'AND' | 'OR'; fragment: SQL }[] = [];
+
+  for (const condition of conditions) {
+    const fragment = buildConditionFragment(condition);
+    if (fragment) {
+      parts.push({ operator: condition.operator, fragment });
+    }
+  }
+
+  if (parts.length === 0) return null;
+
+  let result = parts[0].fragment;
+  for (let i = 1; i < parts.length; i++) {
+    const { operator, fragment } = parts[i];
+    if (operator === 'OR') {
+      result = sql`${result} OR ${fragment}`;
+    } else {
+      result = sql`${result} AND ${fragment}`;
+    }
+  }
+
+  return sql`(${result})`;
+}
+
+function buildConditionFragment(condition: SearchCondition): SQL | null {
+  const { field, value, exact, negated } = condition;
+
+  let fragment: SQL;
+
+  switch (field) {
+    case 'all':
+      fragment = buildAllFieldMatch(value, exact);
+      break;
+    case 'dj_name':
+      fragment = buildDjNameMatch(value, exact);
+      break;
+    case 'add_time':
+      fragment = buildDateMatch(value);
+      break;
+    case 'add_time_range':
+      fragment = buildDateRangeMatch(value);
+      break;
+    default:
+      fragment = buildColumnMatch(field, value, exact);
+      break;
+  }
+
+  return negated ? sql`NOT (${fragment})` : fragment;
+}
+
+function buildColumnMatch(column: string, value: string, exact: boolean): SQL {
+  const col = sql.raw(`f.${column}`);
+  if (exact) {
+    return sql`${col} = ${value}`;
+  }
+  return sql`${col} ILIKE ${'%' + value + '%'}`;
+}
+
+function buildAllFieldMatch(value: string, exact: boolean): SQL {
+  if (exact) {
+    return sql`(f.artist_name = ${value} OR f.track_title = ${value} OR f.album_title = ${value} OR f.record_label = ${value})`;
+  }
+  const pattern = '%' + value + '%';
+  return sql`(f.artist_name ILIKE ${pattern} OR f.track_title ILIKE ${pattern} OR f.album_title ILIKE ${pattern} OR f.record_label ILIKE ${pattern})`;
+}
+
+function buildDjNameMatch(value: string, exact: boolean): SQL {
+  if (exact) {
+    return sql`${DJ_NAME_EXPR} = ${value}`;
+  }
+  return sql`${DJ_NAME_EXPR} ILIKE ${'%' + value + '%'}`;
+}
+
+function buildDateMatch(value: string): SQL {
+  return sql`f.add_time >= ${value}::date AND f.add_time < (${value}::date + interval '1 day')`;
+}
+
+function buildDateRangeMatch(value: string): SQL {
+  const [start, end] = value.split('..');
+  if (!start || !end) {
+    return buildDateMatch(value);
+  }
+  return sql`f.add_time >= ${start}::date AND f.add_time < (${end}::date + interval '1 day')`;
+}

--- a/tests/unit/services/search-query-parser.test.ts
+++ b/tests/unit/services/search-query-parser.test.ts
@@ -5,9 +5,7 @@ describe('parseSearchQuery', () => {
     it('parses a bare term as all-field search', () => {
       const result = parseSearchQuery('autechre');
 
-      expect(result).toEqual([
-        { operator: 'AND', field: 'all', value: 'autechre', exact: false, negated: false },
-      ]);
+      expect(result).toEqual([{ operator: 'AND', field: 'all', value: 'autechre', exact: false, negated: false }]);
     });
 
     it('parses multiple bare terms as separate AND conditions', () => {
@@ -93,9 +91,7 @@ describe('parseSearchQuery', () => {
     it('parses bare quoted value as all-field exact match', () => {
       const result = parseSearchQuery('"Juana Molina"');
 
-      expect(result).toEqual([
-        { operator: 'AND', field: 'all', value: 'Juana Molina', exact: true, negated: false },
-      ]);
+      expect(result).toEqual([{ operator: 'AND', field: 'all', value: 'Juana Molina', exact: true, negated: false }]);
     });
 
     it('handles unmatched quote by treating rest of string as value', () => {

--- a/tests/unit/services/search-query-parser.test.ts
+++ b/tests/unit/services/search-query-parser.test.ts
@@ -1,0 +1,172 @@
+import { parseSearchQuery } from '../../../apps/backend/services/search-parser.service';
+
+describe('parseSearchQuery', () => {
+  describe('simple terms', () => {
+    it('parses a bare term as all-field search', () => {
+      const result = parseSearchQuery('autechre');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'all', value: 'autechre', exact: false, negated: false },
+      ]);
+    });
+
+    it('parses multiple bare terms as separate AND conditions', () => {
+      const result = parseSearchQuery('autechre confield');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'all', value: 'autechre', exact: false, negated: false },
+        { operator: 'AND', field: 'all', value: 'confield', exact: false, negated: false },
+      ]);
+    });
+  });
+
+  describe('field prefixes', () => {
+    it.each([
+      ['artist:autechre', 'artist_name', 'autechre'],
+      ['song:poise', 'track_title', 'poise'],
+      ['album:confield', 'album_title', 'confield'],
+      ['label:warp', 'record_label', 'warp'],
+      ['dj:jake', 'dj_name', 'jake'],
+    ])('parses %s as field=%s value=%s', (input, expectedField, expectedValue) => {
+      const result = parseSearchQuery(input);
+
+      expect(result).toEqual([
+        { operator: 'AND', field: expectedField, value: expectedValue, exact: false, negated: false },
+      ]);
+    });
+  });
+
+  describe('operators', () => {
+    it('parses AND between two field terms', () => {
+      const result = parseSearchQuery('artist:autechre AND album:confield');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: false },
+        { operator: 'AND', field: 'album_title', value: 'confield', exact: false, negated: false },
+      ]);
+    });
+
+    it('parses OR between two field terms', () => {
+      const result = parseSearchQuery('artist:autechre OR artist:stereolab');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: false },
+        { operator: 'OR', field: 'artist_name', value: 'stereolab', exact: false, negated: false },
+      ]);
+    });
+
+    it('parses NOT as negation on the following condition', () => {
+      const result = parseSearchQuery('NOT artist:autechre');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: true },
+      ]);
+    });
+
+    it('parses operator + NOT combination', () => {
+      const result = parseSearchQuery('artist:stereolab AND NOT artist:autechre');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'stereolab', exact: false, negated: false },
+        { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: true },
+      ]);
+    });
+  });
+
+  describe('exact match (quoted values)', () => {
+    it('parses quoted value as exact match', () => {
+      const result = parseSearchQuery('artist:"Autechre"');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'Autechre', exact: true, negated: false },
+      ]);
+    });
+
+    it('parses quoted value with spaces', () => {
+      const result = parseSearchQuery('artist:"Cat Power"');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'Cat Power', exact: true, negated: false },
+      ]);
+    });
+
+    it('parses bare quoted value as all-field exact match', () => {
+      const result = parseSearchQuery('"Juana Molina"');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'all', value: 'Juana Molina', exact: true, negated: false },
+      ]);
+    });
+
+    it('handles unmatched quote by treating rest of string as value', () => {
+      const result = parseSearchQuery('artist:"Autechre');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'Autechre', exact: true, negated: false },
+      ]);
+    });
+  });
+
+  describe('date and dateRange', () => {
+    it('parses date prefix', () => {
+      const result = parseSearchQuery('date:2024-06-15');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'add_time', value: '2024-06-15', exact: false, negated: false },
+      ]);
+    });
+
+    it('parses dateRange prefix with .. separator', () => {
+      const result = parseSearchQuery('dateRange:2024-01-01..2024-12-31');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'add_time_range', value: '2024-01-01..2024-12-31', exact: false, negated: false },
+      ]);
+    });
+  });
+
+  describe('complex queries', () => {
+    it('parses mixed field and operator query', () => {
+      const result = parseSearchQuery('artist:autechre AND song:poise AND NOT label:warp');
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toMatchObject({ field: 'artist_name', value: 'autechre', negated: false });
+      expect(result[1]).toMatchObject({ field: 'track_title', value: 'poise', operator: 'AND' });
+      expect(result[2]).toMatchObject({ field: 'record_label', value: 'warp', negated: true });
+    });
+
+    it('parses field prefix with simple query and OR', () => {
+      const result = parseSearchQuery('artist:autechre OR artist:"Cat Power"');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: false },
+        { operator: 'OR', field: 'artist_name', value: 'Cat Power', exact: true, negated: false },
+      ]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array for empty string', () => {
+      expect(parseSearchQuery('')).toEqual([]);
+    });
+
+    it('returns empty array for whitespace-only string', () => {
+      expect(parseSearchQuery('   ')).toEqual([]);
+    });
+
+    it('ignores field prefix with no value', () => {
+      const result = parseSearchQuery('artist:');
+
+      expect(result).toEqual([]);
+    });
+
+    it('handles multiple spaces between tokens', () => {
+      const result = parseSearchQuery('artist:autechre   AND   album:confield');
+
+      expect(result).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: false },
+        { operator: 'AND', field: 'album_title', value: 'confield', exact: false, negated: false },
+      ]);
+    });
+  });
+});

--- a/tests/unit/services/search.service.test.ts
+++ b/tests/unit/services/search.service.test.ts
@@ -33,9 +33,7 @@ describe('searchFlowsheet', () => {
   });
 
   it('returns empty results when no matches', async () => {
-    (db.execute as jest.Mock)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ total: 0 }]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0 }]);
 
     const result = await searchFlowsheet({ q: 'nonexistent', page: 0, limit: 50, sort: 'date', order: 'desc' });
 
@@ -44,9 +42,7 @@ describe('searchFlowsheet', () => {
   });
 
   it('calculates correct offset from page and limit', async () => {
-    (db.execute as jest.Mock)
-      .mockResolvedValueOnce([makeRow()])
-      .mockResolvedValueOnce([{ total: 100 }]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow()]).mockResolvedValueOnce([{ total: 100 }]);
 
     const result = await searchFlowsheet({ q: 'autechre', page: 2, limit: 10, sort: 'date', order: 'desc' });
 
@@ -57,9 +53,7 @@ describe('searchFlowsheet', () => {
   });
 
   it('handles field-prefixed queries', async () => {
-    (db.execute as jest.Mock)
-      .mockResolvedValueOnce([makeRow()])
-      .mockResolvedValueOnce([{ total: 1 }]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow()]).mockResolvedValueOnce([{ total: 1 }]);
 
     const result = await searchFlowsheet({
       q: 'artist:autechre',
@@ -85,9 +79,7 @@ describe('searchFlowsheet', () => {
   });
 
   it('coerces null dj_name to empty string', async () => {
-    (db.execute as jest.Mock)
-      .mockResolvedValueOnce([makeRow({ dj_name: null })])
-      .mockResolvedValueOnce([{ total: 1 }]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow({ dj_name: null })]).mockResolvedValueOnce([{ total: 1 }]);
 
     const result = await searchFlowsheet({ q: 'autechre', page: 0, limit: 50, sort: 'date', order: 'desc' });
 

--- a/tests/unit/services/search.service.test.ts
+++ b/tests/unit/services/search.service.test.ts
@@ -1,0 +1,116 @@
+import { db } from '../../mocks/database.mock';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+import { searchFlowsheet } from '../../../apps/backend/services/search.service';
+
+const makeRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 1,
+  play_date: new Date('2024-06-15T14:30:00Z'),
+  artist_name: 'Autechre',
+  track_title: 'VI Scose Poise',
+  album_title: 'Confield',
+  record_label: 'Warp',
+  show_id: 100,
+  dj_name: 'DJ Test',
+  ...overrides,
+});
+
+describe('searchFlowsheet', () => {
+  it('returns paginated results for a simple query', async () => {
+    const rows = [makeRow(), makeRow({ id: 2, artist_name: 'Autolux' })];
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce(rows) // data query
+      .mockResolvedValueOnce([{ total: 2 }]); // count query
+
+    const result = await searchFlowsheet({ q: 'aut', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    expect(result.results).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(db.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns empty results when no matches', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ total: 0 }]);
+
+    const result = await searchFlowsheet({ q: 'nonexistent', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    expect(result.results).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it('calculates correct offset from page and limit', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([makeRow()])
+      .mockResolvedValueOnce([{ total: 100 }]);
+
+    const result = await searchFlowsheet({ q: 'autechre', page: 2, limit: 10, sort: 'date', order: 'desc' });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.total).toBe(100);
+    // Verify db.execute was called (offset = 2 * 10 = 20)
+    expect(db.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles field-prefixed queries', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([makeRow()])
+      .mockResolvedValueOnce([{ total: 1 }]);
+
+    const result = await searchFlowsheet({
+      q: 'artist:autechre',
+      page: 0,
+      limit: 50,
+      sort: 'date',
+      order: 'desc',
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].artist_name).toBe('Autechre');
+  });
+
+  it('formats play_date as ISO string', async () => {
+    const date = new Date('2024-06-15T14:30:00Z');
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([makeRow({ play_date: date })])
+      .mockResolvedValueOnce([{ total: 1 }]);
+
+    const result = await searchFlowsheet({ q: 'autechre', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    expect(result.results[0].play_date).toBe(date.toISOString());
+  });
+
+  it('coerces null dj_name to empty string', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([makeRow({ dj_name: null })])
+      .mockResolvedValueOnce([{ total: 1 }]);
+
+    const result = await searchFlowsheet({ q: 'autechre', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    expect(result.results[0].dj_name).toBe('');
+  });
+
+  it('coerces null text fields to empty strings', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        makeRow({
+          artist_name: null,
+          track_title: null,
+          album_title: null,
+          record_label: null,
+        }),
+      ])
+      .mockResolvedValueOnce([{ total: 1 }]);
+
+    const result = await searchFlowsheet({ q: 'test', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    expect(result.results[0].artist_name).toBe('');
+    expect(result.results[0].track_title).toBe('');
+    expect(result.results[0].album_title).toBe('');
+    expect(result.results[0].record_label).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `GET /flowsheet/search` endpoint for the dj-site Previous Sets page, which was returning 404 because the backend endpoint hadn't been implemented yet
- Query parser supports field prefixes (`artist:`, `song:`, `album:`, `label:`, `dj:`, `date:`, `dateRange:`), boolean operators (`AND`, `OR`, `NOT`), and exact phrase matching
- DJ names resolved via LEFT JOIN through shows/user tables with COALESCE fallback for legacy entries
- Public endpoint (no auth) per the OpenAPI spec, reuses existing pg_trgm GIN indexes

Closes #435

## Test plan

- [x] 23 parser unit tests covering all query forms (simple, field-prefixed, operators, quoted, dates, edge cases)
- [x] 7 service unit tests covering pagination, null coercion, field prefixes
- [x] Full unit test suite passes (896/896)
- [x] Typecheck passes across all workspaces
- [x] Lint passes (0 errors)
- [ ] Manual test: start Backend-Service, curl `GET /flowsheet/search?q=autechre`
- [ ] Manual test: open dj-site `/dashboard/playlists`, verify search works end-to-end