### PR TITLE
Fix library codes showing 0 in card catalog search

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, sql } from 'drizzle-orm';
 import { RotationAddRequest } from '../controllers/library.controller.js';
 import { db } from '@wxyc/database';
 import {
@@ -159,48 +159,23 @@ export async function enrichWithArtwork(
   return results;
 }
 
-//based on artist name and album title, retrieve n best matches from db
-//let's build the query using drizzle's sql object
 export const fuzzySearchLibrary = async (artist_name?: string, album_title?: string, n = 5, on_streaming?: boolean) => {
-  const streamingFilter =
-    on_streaming !== undefined ? sql` AND ${library_artist_view.on_streaming} = ${on_streaming}` : sql``;
+  const similarityCondition = sql`(${library_artist_view.artist_name} % ${artist_name || null} OR ${library_artist_view.album_title} % ${album_title || null})`;
 
-  const query = sql`SELECT *,
-                    ${library_artist_view.artist_name} <-> ${artist_name || null} AS artist_dist,
-                    ${library_artist_view.album_title} <-> ${album_title || null} AS album_dist
-                      FROM ${library_artist_view}
-                      WHERE (${library_artist_view.artist_name} % ${artist_name || null} OR
-                            ${library_artist_view.album_title} % ${album_title || null})${streamingFilter}
-                      ORDER BY artist_dist asc, album_dist asc
-                      LIMIT ${n}`;
+  const streamingCondition =
+    on_streaming !== undefined ? eq(library_artist_view.on_streaming, on_streaming) : undefined;
 
-  const response = await db.execute(query);
-  return response;
+  const results = await db
+    .select()
+    .from(library_artist_view)
+    .where(streamingCondition ? and(similarityCondition, streamingCondition) : similarityCondition)
+    .orderBy(
+      asc(sql`${library_artist_view.artist_name} <-> ${artist_name || null}`),
+      asc(sql`${library_artist_view.album_title} <-> ${album_title || null}`)
+    )
+    .limit(n);
 
-  // trying to get something like this working, but having type issues using orderBy method with 2 computed columns
-  // maybe at some point for more type safety 🤷
-
-  // const query1 = db
-  //   .select({
-  //     library_id: library_artist_view.library_id,
-  //     album_title: library_artist_view.album_title,
-  //     artist_name: library_artist_view.artist_name,
-  //     artist_similarity: sql`similarity(${library_artist_view.artist_name}, ${artist_name || ''})`,
-  //     album_similarity: sql`similarity(${library_artist_view.album_title}, ${album_title || ''})`,
-  //   })
-  //   .from(library_artist_view)
-  //   .where(
-  //     sql`${library_artist_view.album_title} % ${album_title} OR ${library_artist_view.artist_name} % ${artist_name}`
-  //   )
-  //   .orderBy(
-  //     ({ album_similarity }) =>
-  //       desc(
-  //         album_similarity
-  //       ) /*, ({ artist_similarity, album_similarity }) => {desc(artist_similarity), desc(album_similarity)}*/
-  //   )
-  //   .limit(n)
-  //   .toSQL();
-  // console.log(query1);
+  return results;
 };
 
 export const artistIdFromName = async (artist_name: string, genre_id: number): Promise<number> => {

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -21,31 +21,50 @@ import {
 
 describe('library.service', () => {
   describe('fuzzySearchLibrary', () => {
+    const mockViewRow = {
+      id: 1,
+      code_letters: 'AU',
+      code_artist_number: 3,
+      code_number: 2,
+      artist_name: 'Autechre',
+      alphabetical_name: 'Autechre',
+      album_title: 'Confield',
+      format_name: 'cd',
+      genre_name: 'Electronic',
+      rotation_bin: null,
+      add_date: new Date('2024-01-15'),
+      label: 'Warp',
+      label_id: null,
+      on_streaming: true,
+      album_artist: null,
+      plays: 5,
+      artwork_url: null,
+    };
+
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
-    it('passes through results when no on_streaming filter is provided', async () => {
-      const mockResults = [
-        { id: 1, artist_name: 'Autechre', album_title: 'Confield', on_streaming: true },
-        { id: 2, artist_name: 'Autechre', album_title: 'LP5', on_streaming: false },
-      ];
-      db.execute.mockResolvedValueOnce(mockResults);
+    it('returns results with code_artist_number mapped from the view', async () => {
+      const chain = createMockQueryChain([mockViewRow]);
+      db.select.mockReturnValue(chain);
+      chain.limit = jest.fn().mockResolvedValue([mockViewRow]);
 
       const results = await fuzzySearchLibrary('Autechre', undefined, 5);
 
-      expect(results).toEqual(mockResults);
-      expect(db.execute).toHaveBeenCalled();
+      expect(results).toHaveLength(1);
+      expect(results[0]).toHaveProperty('code_artist_number', 3);
     });
 
-    it('calls db.execute when on_streaming filter is provided', async () => {
-      const mockResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', on_streaming: true }];
-      db.execute.mockResolvedValueOnce(mockResults);
+    it('applies on_streaming filter when provided', async () => {
+      const chain = createMockQueryChain([mockViewRow]);
+      db.select.mockReturnValue(chain);
+      chain.limit = jest.fn().mockResolvedValue([mockViewRow]);
 
       const results = await fuzzySearchLibrary('Autechre', undefined, 5, true);
 
-      expect(results).toEqual(mockResults);
-      expect(db.execute).toHaveBeenCalled();
+      expect(results).toHaveLength(1);
+      expect(results[0]).toHaveProperty('on_streaming', true);
     });
   });
 


### PR DESCRIPTION
## Summary

- The `library_artist_view` PostgreSQL view was missing the `AS code_artist_number` alias on the `artist_genre_code` column. `fuzzySearchLibrary` used raw SQL (`db.execute` with `SELECT *`), so results had the PostgreSQL column name `artist_genre_code` instead of `code_artist_number`. The frontend's `convertToAlbumEntry` read `code_artist_number`, got `undefined`, and fell back to `?? 0`.
- Added migration `0048` to recreate the view with the proper alias.
- Rewrote `fuzzySearchLibrary` to use Drizzle's query builder (`db.select().from()`) instead of raw SQL, preventing this class of column name mismatch.
- The remaining raw SQL search functions (`searchLibrary`, `searchByArtist`, `searchAlbumsByTitle`) are tracked in #436.

## Test plan

- [x] Unit test verifies `fuzzySearchLibrary` returns results with `code_artist_number` field
- [ ] Deploy to staging and verify Autechre shows `AU 3/*` instead of `AU 0/*` in the card catalog