### PR TITLE
Refactor: remove controller try/catch boilerplate

### DIFF
--- a/apps/backend/controllers/djs.controller.ts
+++ b/apps/backend/controllers/djs.controller.ts
@@ -10,7 +10,7 @@ export type binBody = {
   track_title?: string;
 };
 
-export const addToBin: RequestHandler<object, unknown, binBody> = async (req, res, next) => {
+export const addToBin: RequestHandler<object, unknown, binBody> = async (req, res) => {
   if (req.body.album_id === undefined) {
     throw new WxycError('Bad Request, Missing album identifier: album_id', 400);
   }
@@ -20,14 +20,8 @@ export const addToBin: RequestHandler<object, unknown, binBody> = async (req, re
     album_id: req.body.album_id,
     track_title: req.body.track_title === undefined ? null : req.body.track_title,
   };
-  try {
-    const added_bin_item = await DJService.addToBin(bin_entry);
-    res.status(201).json(added_bin_item);
-  } catch (e) {
-    console.error('Server error: Failed to insert into bin');
-    console.error(e);
-    next(e);
-  }
+  const added_bin_item = await DJService.addToBin(bin_entry);
+  res.status(201).json(added_bin_item);
 };
 
 export type binQuery = {
@@ -37,57 +31,34 @@ export type binQuery = {
   track_title?: string;
 };
 
-export const deleteFromBin: RequestHandler<object, unknown, unknown, binQuery> = async (req, res, next) => {
+export const deleteFromBin: RequestHandler<object, unknown, unknown, binQuery> = async (req, res) => {
   if (req.query.album_id === undefined) {
     throw new WxycError('Bad Request, Missing Bin Entry Identifier: album_id', 400);
   }
 
-  try {
-    const removed_bin_item = await DJService.removeFromBin(parseInt(req.query.album_id), req.auth!.id!);
-    res.status(200).json(removed_bin_item);
-  } catch (e) {
-    console.error(e);
-    next(e);
-  }
+  const removed_bin_item = await DJService.removeFromBin(parseInt(req.query.album_id), req.auth!.id!);
+  res.status(200).json(removed_bin_item);
 };
 
-export const getBin: RequestHandler = async (req, res, next) => {
-  try {
-    const dj_bin = await DJService.getBinFromDB(req.auth!.id!);
-    res.status(200).json(dj_bin);
-  } catch (e) {
-    console.error("Error: Failed to retrieve dj's bin");
-    console.error(e);
-    next(e);
-  }
+export const getBin: RequestHandler = async (req, res) => {
+  const dj_bin = await DJService.getBinFromDB(req.auth!.id!);
+  res.status(200).json(dj_bin);
 };
 
-export const getPlaylistsForDJ: RequestHandler<object, unknown, object, { dj_id: string }> = async (req, res, next) => {
+export const getPlaylistsForDJ: RequestHandler<object, unknown, object, { dj_id: string }> = async (req, res) => {
   if (req.query.dj_id === undefined) {
     throw new WxycError('Bad Request, Missing DJ Identifier: dj_id', 400);
   }
 
-  try {
-    const playlists = await DJService.getPlaylistsForDJ(req.query.dj_id);
-    res.status(200).json(playlists);
-  } catch (e) {
-    console.error('Error: Failed to retrieve playlists');
-    console.error(e);
-    next(e);
-  }
+  const playlists = await DJService.getPlaylistsForDJ(req.query.dj_id);
+  res.status(200).json(playlists);
 };
 
-export const getPlaylist: RequestHandler<object, unknown, object, { playlist_id: string }> = async (req, res, next) => {
+export const getPlaylist: RequestHandler<object, unknown, object, { playlist_id: string }> = async (req, res) => {
   if (req.query.playlist_id === undefined) {
     throw new WxycError('Bad Request, Missing Playlist Identifier: playlist_id', 400);
   }
 
-  try {
-    const playlist = await DJService.getPlaylist(parseInt(req.query.playlist_id));
-    res.status(200).json(playlist);
-  } catch (e) {
-    console.error('Error: Failed to retrieve playlist');
-    console.error(e);
-    next(e);
-  }
+  const playlist = await DJService.getPlaylist(parseInt(req.query.playlist_id));
+  res.status(200).json(playlist);
 };

--- a/apps/backend/controllers/events.controller.ts
+++ b/apps/backend/controllers/events.controller.ts
@@ -1,5 +1,6 @@
 import { Request, RequestHandler } from 'express';
 import { serverEventsMgr, TestEvents, Topics, type EventData } from '../utils/serverEvents';
+import WxycError from '../utils/error.js';
 
 // Role constants for event authorization
 const ROLE_DJ = 'dj';
@@ -41,27 +42,18 @@ type subReqBody = {
   topics: string[];
 };
 
-export const subscribeToTopic: RequestHandler<object, unknown, subReqBody> = (req, res, next) => {
+export const subscribeToTopic: RequestHandler<object, unknown, subReqBody> = (req, res) => {
   const { client_id, topics } = req.body;
 
   if (!client_id || !topics) {
-    return res.status(400).json({
-      message: 'Bad Request: client_id or topics missing from request body',
-    });
+    throw new WxycError('Bad Request: client_id or topics missing from request body', 400);
   }
 
-  try {
-    const subbedTopics = serverEventsMgr.subscribe(topics, client_id);
-
-    res.status(200).json({ message: 'successfully subscribed', topics: subbedTopics });
-  } catch (e) {
-    console.error('Failed to subscribe to event: ', e);
-
-    return next(e);
-  }
+  const subbedTopics = serverEventsMgr.subscribe(topics, client_id);
+  res.status(200).json({ message: 'successfully subscribed', topics: subbedTopics });
 };
 
-export const testTrigger: RequestHandler = (req, res, next) => {
+export const testTrigger: RequestHandler = (req, res) => {
   const data: EventData = {
     type: TestEvents.test,
     payload: {
@@ -70,13 +62,7 @@ export const testTrigger: RequestHandler = (req, res, next) => {
     timestamp: new Date(),
   };
 
-  try {
-    serverEventsMgr.broadcast(Topics.test, data);
-  } catch (e) {
-    console.error('Failed to broadcast event: ', e);
-
-    return next(e);
-  }
+  serverEventsMgr.broadcast(Topics.test, data);
 
   res.status(200).json({
     message: 'event triggered',

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -82,111 +82,71 @@ function fireAndForgetMetadata(completedEntry: FSEntry, artistId?: number): void
 
 const MAX_ITEMS = 200;
 const DELETION_OFFSET = 10; //This offsets the ID's not representing the actual number of tracks due to deletions
-export const getEntries: RequestHandler<object, unknown, object, QueryParams> = async (req, res, next) => {
+export const getEntries: RequestHandler<object, unknown, object, QueryParams> = async (req, res) => {
   const { query } = req;
 
   const page = parseInt(query.page ?? '0');
   const limit = parseInt(query.limit ?? '30');
 
   if (query.shows_limit !== undefined) {
-    try {
-      const numberOfShows = parseInt(query.shows_limit);
-      if (isNaN(numberOfShows) || numberOfShows < 1) {
-        res.status(400).json({
-          message: 'shows_limit must be a positive number',
-        });
-        return;
-      }
-      const recentShows = await flowsheet_service.getNShows(numberOfShows, page);
-      const entries = await flowsheet_service.getEntriesByShow(...recentShows.map((show) => show.id));
-
-      if (entries.length) {
-        res.status(200).json(entries.map(flowsheet_service.transformToV2));
-      } else {
-        res.status(404).json({
-          message: 'No Tracks found',
-        });
-      }
-      return;
-    } catch (e) {
-      console.error('Failed to retrieve tracks from previous shows');
-      console.error(`Error: ${e}`);
-      next(e);
-      return;
+    const numberOfShows = parseInt(query.shows_limit);
+    if (isNaN(numberOfShows) || numberOfShows < 1) {
+      throw new WxycError('shows_limit must be a positive number', 400);
     }
+    const recentShows = await flowsheet_service.getNShows(numberOfShows, page);
+    const entries = await flowsheet_service.getEntriesByShow(...recentShows.map((show) => show.id));
+
+    if (entries.length) {
+      res.status(200).json(entries.map(flowsheet_service.transformToV2));
+    } else {
+      res.status(404).json({
+        message: 'No Tracks found',
+      });
+    }
+    return;
   }
 
   if (query.start_id !== undefined && query.end_id !== undefined) {
     if (parseInt(query.end_id) - parseInt(query.start_id) - DELETION_OFFSET > MAX_ITEMS) {
-      res.status(400).json({ message: 'Requested too many entries' });
-      return;
+      throw new WxycError('Requested too many entries', 400);
     }
-    try {
-      const entries = await flowsheet_service.getEntriesByRange(parseInt(query.start_id), parseInt(query.end_id));
-      if (entries.length) {
-        res.status(200).json(entries.map(flowsheet_service.transformToV2));
-      } else {
-        res.status(404).json({ message: 'No Tracks found' });
-      }
-    } catch (e) {
-      console.error('Failed to retrieve tracks');
-      console.error(`Error: ${e}`);
-      next(e);
+    const entries = await flowsheet_service.getEntriesByRange(parseInt(query.start_id), parseInt(query.end_id));
+    if (entries.length) {
+      res.status(200).json(entries.map(flowsheet_service.transformToV2));
+    } else {
+      res.status(404).json({ message: 'No Tracks found' });
     }
     return;
   }
 
   // Default: paginated entries with discriminated union format
-  if (isNaN(limit) || limit < 1) {
-    res.status(400).json({ message: 'limit must be a positive number' });
-    return;
-  }
+  if (isNaN(limit) || limit < 1) throw new WxycError('limit must be a positive number', 400);
+  if (limit > MAX_ITEMS) throw new WxycError('Requested too many entries', 400);
+  if (isNaN(page) || page < 0) throw new WxycError('page must be a non-negative number', 400);
 
-  if (limit > MAX_ITEMS) {
-    res.status(400).json({ message: 'Requested too many entries' });
-    return;
-  }
+  const offset = page * limit;
+  const [entries, total] = await Promise.all([
+    flowsheet_service.getEntriesByPage(offset, limit),
+    flowsheet_service.getEntryCount(),
+  ]);
 
-  if (isNaN(page) || page < 0) {
-    res.status(400).json({ message: 'page must be a non-negative number' });
-    return;
-  }
+  const totalPages = Math.ceil(total / limit);
 
-  try {
-    const offset = page * limit;
-    const [entries, total] = await Promise.all([
-      flowsheet_service.getEntriesByPage(offset, limit),
-      flowsheet_service.getEntryCount(),
-    ]);
-
-    const totalPages = Math.ceil(total / limit);
-
-    res.status(200).json({
-      entries: entries.map(flowsheet_service.transformToV2),
-      total,
-      page,
-      limit,
-      totalPages,
-    });
-  } catch (e) {
-    console.error('Failed to retrieve tracks');
-    console.error(`Error: ${e}`);
-    next(e);
-  }
+  res.status(200).json({
+    entries: entries.map(flowsheet_service.transformToV2),
+    total,
+    page,
+    limit,
+    totalPages,
+  });
 };
 
-export const getLatest: RequestHandler = async (req, res, next) => {
-  try {
-    const entries = await flowsheet_service.getEntriesByPage(0, 1);
-    if (entries.length) {
-      res.status(200).json(flowsheet_service.transformToV2(entries[0]));
-    } else {
-      res.status(204).end();
-    }
-  } catch (e) {
-    console.error('Error: Failed to retrieve track');
-    console.error(`Error: ${e}`);
-    next(e);
+export const getLatest: RequestHandler = async (req, res) => {
+  const entries = await flowsheet_service.getEntriesByPage(0, 1);
+  if (entries.length) {
+    res.status(200).json(flowsheet_service.transformToV2(entries[0]));
+  } else {
+    res.status(204).end();
   }
 };
 
@@ -216,17 +176,9 @@ export type FSEntryRequestBody = {
 
 // either an id is provided (meaning it came from the user's bin or was fuzzy found)
 // or it's not provided in which case whe just throw the data provided into the table w/ album_id = NULL
-export const addEntry: RequestHandler = async (req: Request<object, object, FSEntryRequestBody>, res, next) => {
+export const addEntry: RequestHandler = async (req: Request<object, object, FSEntryRequestBody>, res) => {
   const { body } = req;
-  let latestShow;
-  try {
-    latestShow = await flowsheet_service.getLatestShow();
-  } catch (e) {
-    console.error('Error: Failed to retrieve most recent show ');
-    console.error(e);
-    next(e);
-    return;
-  }
+  const latestShow = await flowsheet_service.getLatestShow();
   if (latestShow?.end_time !== null) {
     throw new WxycError('Bad Request, There are no active shows', 400);
   }
@@ -241,14 +193,8 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
       message: body.message,
       show_id: latestShow.id,
     };
-    try {
-      const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
-      res.status(201).json(completedEntry);
-    } catch (e) {
-      console.error('Error: Failed to add message to flowsheet');
-      console.error(e);
-      next(e);
-    }
+    const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
+    res.status(201).json(completedEntry);
     return;
   }
 
@@ -257,61 +203,49 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
     throw new WxycError('Bad Request, Missing query parameter: track_title', 400);
   }
 
-  try {
-    if (body.album_id !== undefined) {
-      //backfill album info from library before adding to flowsheet
-      const albumInfo = await flowsheet_service.getAlbumFromDB(body.album_id);
+  if (body.album_id !== undefined) {
+    //backfill album info from library before adding to flowsheet
+    const albumInfo = await flowsheet_service.getAlbumFromDB(body.album_id);
 
-      if (body.record_label !== undefined) {
-        albumInfo.record_label = body.record_label;
-      }
-
-      const fsEntry: NewFSEntry = {
-        album_id: body.album_id,
-        ...albumInfo,
-        track_title: body.track_title,
-        rotation_id: body.rotation_id,
-        request_flag: body.request_flag,
-        segue: body.segue ?? false,
-        show_id: latestShow.id,
-      };
-
-      const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
-      fireAndForgetMetadata(completedEntry, albumInfo.artist_id ?? undefined);
-      res.status(201).json(completedEntry);
-    } else if (body.album_title === undefined || body.artist_name === undefined || body.track_title === undefined) {
-      throw new WxycError('Bad Request, Missing Flowsheet Parameters: album_title, artist_name, track_title', 400);
-    } else {
-      const fsEntry: NewFSEntry = {
-        ...body,
-        show_id: latestShow.id,
-      };
-
-      const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
-      fireAndForgetMetadata(completedEntry);
-      res.status(201).json(completedEntry);
+    if (body.record_label !== undefined) {
+      albumInfo.record_label = body.record_label;
     }
-  } catch (e) {
-    console.error('Error: Failed to add track to flowsheet');
-    console.error(e);
-    next(e);
+
+    const fsEntry: NewFSEntry = {
+      album_id: body.album_id,
+      ...albumInfo,
+      track_title: body.track_title,
+      rotation_id: body.rotation_id,
+      request_flag: body.request_flag,
+      segue: body.segue ?? false,
+      show_id: latestShow.id,
+    };
+
+    const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
+    fireAndForgetMetadata(completedEntry, albumInfo.artist_id ?? undefined);
+    res.status(201).json(completedEntry);
+  } else if (body.album_title === undefined || body.artist_name === undefined || body.track_title === undefined) {
+    throw new WxycError('Bad Request, Missing Flowsheet Parameters: album_title, artist_name, track_title', 400);
+  } else {
+    const fsEntry: NewFSEntry = {
+      ...body,
+      show_id: latestShow.id,
+    };
+
+    const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
+    fireAndForgetMetadata(completedEntry);
+    res.status(201).json(completedEntry);
   }
 };
 
-export const deleteEntry: RequestHandler<object, unknown, { entry_id: number }> = async (req, res, next) => {
+export const deleteEntry: RequestHandler<object, unknown, { entry_id: number }> = async (req, res) => {
   const { entry_id } = req.body;
   if (entry_id === undefined) {
     throw new WxycError('Bad Request, Missing entry identifier: entry_id', 400);
   }
 
-  try {
-    const removedEntry: FSEntry = await flowsheet_service.removeTrack(entry_id);
-    res.status(200).json(removedEntry);
-  } catch (e) {
-    console.error('Error: Failed to remove entry');
-    console.error(e);
-    next(e);
-  }
+  const removedEntry: FSEntry = await flowsheet_service.removeTrack(entry_id);
+  res.status(200).json(removedEntry);
 };
 
 export type UpdateRequestBody = {
@@ -327,22 +261,15 @@ export type UpdateRequestBody = {
 
 export const updateEntry: RequestHandler<object, unknown, { entry_id: number; data: UpdateRequestBody }> = async (
   req,
-  res,
-  next
+  res
 ) => {
   const { entry_id, data } = req.body;
   if (entry_id === undefined) {
     throw new WxycError('Bad Request, Missing entry identifier: entry_id', 400);
   }
 
-  try {
-    const updatedEntry: FSEntry = await flowsheet_service.updateEntry(entry_id, data);
-    res.status(200).json(updatedEntry);
-  } catch (e) {
-    console.error('Error: Failed to update entry');
-    console.error(e);
-    next(e);
-  }
+  const updatedEntry: FSEntry = await flowsheet_service.updateEntry(entry_id, data);
+  res.status(200).json(updatedEntry);
 };
 
 export type JoinRequestBody = {
@@ -352,86 +279,56 @@ export type JoinRequestBody = {
 };
 
 //POST
-export const joinShow: RequestHandler = async (req: Request<object, object, JoinRequestBody>, res, next) => {
+export const joinShow: RequestHandler = async (req: Request<object, object, JoinRequestBody>, res) => {
   const current_show = await flowsheet_service.getLatestShow();
   if (req.body.dj_id === undefined) {
     throw new WxycError('Bad Request, Must include a dj_id to join show', 400);
   }
 
   if (current_show?.end_time !== null) {
-    try {
-      const show_session: Show = await flowsheet_service.startShow(
-        req.body.dj_id,
-        req.body.show_name,
-        req.body.specialty_id
-      );
+    const show_session: Show = await flowsheet_service.startShow(
+      req.body.dj_id,
+      req.body.show_name,
+      req.body.specialty_id
+    );
 
-      res.status(200).json(show_session);
-    } catch (e) {
-      console.error('Error: Failed to start show');
-      console.error(e);
-      next(e);
-    }
+    res.status(200).json(show_session);
   } else {
-    try {
-      const show_dj_instance: ShowDJ = await flowsheet_service.addDJToShow(req.body.dj_id, current_show);
-      res.status(200).json(show_dj_instance);
-    } catch (e) {
-      console.error('Error: Failed to join show');
-      console.error(e);
-      next(e);
-    }
+    const show_dj_instance: ShowDJ = await flowsheet_service.addDJToShow(req.body.dj_id, current_show);
+    res.status(200).json(show_dj_instance);
   }
 };
 
 //TODO consume JWT and ensure that jwt.dj_id = current_show.dj_id
-export const leaveShow: RequestHandler<object, unknown, { dj_id: string }> = async (req, res, next) => {
+export const leaveShow: RequestHandler<object, unknown, { dj_id: string }> = async (req, res) => {
   const currentShow = await flowsheet_service.getLatestShow();
   if (currentShow?.end_time !== null) {
-    res.status(400).json({ message: 'Bad Request: No active show session found.' });
+    throw new WxycError('Bad Request: No active show session found.', 400);
+  }
+
+  // Show membership is verified by showMemberMiddleware on the route
+  if (req.body.dj_id === currentShow.primary_dj_id) {
+    const finalizedShow: Show = await flowsheet_service.endShow(currentShow);
+    res.status(200).json(finalizedShow);
   } else {
-    try {
-      // Show membership is verified by showMemberMiddleware on the route
-      if (req.body.dj_id === currentShow.primary_dj_id) {
-        const finalizedShow: Show = await flowsheet_service.endShow(currentShow);
-        res.status(200).json(finalizedShow);
-      } else {
-        const showDJ: ShowDJ = await flowsheet_service.leaveShow(req.body.dj_id, currentShow);
-        res.status(200).json(showDJ);
-      }
-    } catch (e) {
-      console.error('Error: Failed to leave show');
-      console.error(e);
-      next(e);
-    }
+    const showDJ: ShowDJ = await flowsheet_service.leaveShow(req.body.dj_id, currentShow);
+    res.status(200).json(showDJ);
   }
 };
 
-export const getDJList: RequestHandler = async (req, res, next) => {
-  try {
-    const currentDJs = await flowsheet_service.getDJsInCurrentShow();
-    const cleanDJList = currentDJs.map((dj) => {
-      return { id: dj.id, dj_name: dj.djName || dj.name };
-    });
-    res.status(200).json(cleanDJList);
-  } catch (e) {
-    console.error('Error: Failed to retrieve current DJs');
-    console.error(e);
-    next(e);
-  }
+export const getDJList: RequestHandler = async (req, res) => {
+  const currentDJs = await flowsheet_service.getDJsInCurrentShow();
+  const cleanDJList = currentDJs.map((dj) => {
+    return { id: dj.id, dj_name: dj.djName || dj.name };
+  });
+  res.status(200).json(cleanDJList);
 };
 
-export const getOnAir: RequestHandler = async (req, res, next) => {
+export const getOnAir: RequestHandler = async (req, res) => {
   const { dj_id } = req.query;
 
-  try {
-    const isActive = await flowsheet_service.getOnAirStatusForDJ(dj_id as string);
-    res.status(200).json({ id: dj_id, is_live: isActive });
-  } catch (e) {
-    console.error('Error: Failed to retrieve current show');
-    console.error(e);
-    next(e);
-  }
+  const isActive = await flowsheet_service.getOnAirStatusForDJ(dj_id as string);
+  res.status(200).json({ id: dj_id, is_live: isActive });
 };
 
 // Accepts a request body with entry_id and new_position, where
@@ -442,25 +339,20 @@ const orderMutex = new Mutex();
 
 export const changeOrder: RequestHandler<object, unknown, { entry_id: number; new_position: number }> = async (
   req,
-  res,
-  next
+  res
 ) => {
   const { entry_id, new_position } = req.body;
 
   if (entry_id === undefined || new_position === undefined) {
-    res.status(400).json({ message: 'Bad Request: entry_id and new_position are required' });
-  } else {
-    const release = await orderMutex.acquire();
-    try {
-      const updatedEntry = await flowsheet_service.changeOrder(entry_id, new_position);
-      res.status(200).json(updatedEntry);
-    } catch (e) {
-      console.error('Error: Failed to change order');
-      console.error(e);
-      next(e);
-    } finally {
-      release();
-    }
+    throw new WxycError('Bad Request: entry_id and new_position are required', 400);
+  }
+
+  const release = await orderMutex.acquire();
+  try {
+    const updatedEntry = await flowsheet_service.changeOrder(entry_id, new_position);
+    res.status(200).json(updatedEntry);
+  } finally {
+    release();
   }
 };
 
@@ -473,27 +365,18 @@ export interface ShowInfo extends ShowMetadata {
   entries: FSEntry[];
 }
 
-export const getShowInfo: RequestHandler<object, unknown, object, { show_id: string }> = async (req, res, next) => {
+export const getShowInfo: RequestHandler<object, unknown, object, { show_id: string }> = async (req, res) => {
   const showId = parseInt(req.query.show_id);
 
-  if (isNaN(showId)) {
-    res.status(400).json({ message: 'Missing or invalid show_id parameter' });
-    return;
-  }
+  if (isNaN(showId)) throw new WxycError('Missing or invalid show_id parameter', 400);
 
-  try {
-    const [showMetadata, entries] = await Promise.all([
-      flowsheet_service.getShowMetadata(showId),
-      flowsheet_service.getEntriesByShow(showId),
-    ]);
+  const [showMetadata, entries] = await Promise.all([
+    flowsheet_service.getShowMetadata(showId),
+    flowsheet_service.getEntriesByShow(showId),
+  ]);
 
-    res.status(200).json({
-      ...showMetadata,
-      entries: entries.map(flowsheet_service.transformToV2),
-    });
-  } catch (e) {
-    console.error('Error: Failed to retrieve playlist');
-    console.error(e);
-    next(e);
-  }
+  res.status(200).json({
+    ...showMetadata,
+    entries: entries.map(flowsheet_service.transformToV2),
+  });
 };

--- a/apps/backend/controllers/labels.controller.ts
+++ b/apps/backend/controllers/labels.controller.ts
@@ -1,75 +1,45 @@
 import { Request, RequestHandler } from 'express';
 import * as labelsService from '../services/labels.service.js';
+import WxycError from '../utils/error.js';
 
 type CreateLabelRequest = {
   label_name: string;
   parent_label_id?: number;
 };
 
-export const getLabels: RequestHandler = async (req, res, next) => {
-  try {
-    const labels = await labelsService.getAllLabels();
-    res.status(200).json(labels);
-  } catch (e) {
-    console.error('Error retrieving labels');
-    console.error(e);
-    next(e);
-  }
+export const getLabels: RequestHandler = async (req, res) => {
+  const labels = await labelsService.getAllLabels();
+  res.status(200).json(labels);
 };
 
-export const getLabel: RequestHandler<object, unknown, unknown, { id: string }> = async (req, res, next) => {
+export const getLabel: RequestHandler<object, unknown, unknown, { id: string }> = async (req, res) => {
   const id = parseInt(req.query.id);
-  if (isNaN(id)) {
-    res.status(400).json({ message: 'Missing or invalid label id' });
+  if (isNaN(id)) throw new WxycError('Missing or invalid label id', 400);
+
+  const label = await labelsService.getLabelById(id);
+  if (label) {
+    res.status(200).json(label);
   } else {
-    try {
-      const label = await labelsService.getLabelById(id);
-      if (label) {
-        res.status(200).json(label);
-      } else {
-        res.status(404).json({ message: 'Label not found' });
-      }
-    } catch (e) {
-      console.error('Error retrieving label');
-      console.error(e);
-      next(e);
-    }
+    res.status(404).json({ message: 'Label not found' });
   }
 };
 
-export const createLabel: RequestHandler = async (req: Request<object, object, CreateLabelRequest>, res, next) => {
+export const createLabel: RequestHandler = async (req: Request<object, object, CreateLabelRequest>, res) => {
   const { body } = req;
-  if (!body.label_name) {
-    res.status(400).json({ message: 'Missing required parameter: label_name' });
-  } else {
-    try {
-      const label = await labelsService.createLabel(body.label_name, body.parent_label_id);
-      res.status(200).json(label);
-    } catch (e) {
-      console.error('Error creating label');
-      console.error(e);
-      next(e);
-    }
-  }
+  if (!body.label_name) throw new WxycError('Missing required parameter: label_name', 400);
+
+  const label = await labelsService.createLabel(body.label_name, body.parent_label_id);
+  res.status(200).json(label);
 };
 
 export const searchLabelsEndpoint: RequestHandler<object, unknown, unknown, { q: string; limit?: string }> = async (
   req,
-  res,
-  next
+  res
 ) => {
   const query = req.query.q;
-  if (!query) {
-    res.status(400).json({ message: 'Missing required query parameter: q' });
-  } else {
-    try {
-      const limit = req.query.limit ? parseInt(req.query.limit) : undefined;
-      const labels = await labelsService.searchLabels(query, limit);
-      res.status(200).json(labels);
-    } catch (e) {
-      console.error('Error searching labels');
-      console.error(e);
-      next(e);
-    }
-  }
+  if (!query) throw new WxycError('Missing required query parameter: q', 400);
+
+  const limit = req.query.limit ? parseInt(req.query.limit) : undefined;
+  const labels = await labelsService.searchLabels(query, limit);
+  res.status(200).json(labels);
 };

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -28,7 +28,7 @@ type NewAlbumRequest = {
 
 //Check if artist exists.
 //Add new album to library
-export const addAlbum: RequestHandler = async (req: Request<object, object, NewAlbumRequest>, res, next) => {
+export const addAlbum: RequestHandler = async (req: Request<object, object, NewAlbumRequest>, res) => {
   const { body } = req;
   if (
     body.album_title === undefined ||
@@ -42,13 +42,7 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
 
   let artist_id = body.artist_id;
   if (artist_id === undefined && body.artist_name !== undefined) {
-    try {
-      artist_id = await libraryService.artistIdFromName(body.artist_name, body.genre_id);
-    } catch (e) {
-      console.error('Error: Failed to get artist_id from name');
-      console.error(e);
-      next(e);
-    }
+    artist_id = await libraryService.artistIdFromName(body.artist_name, body.genre_id);
   }
   if (!artist_id) {
     throw new WxycError(
@@ -57,70 +51,64 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
     );
   }
 
-  try {
-    // Resolve label string to label_id via upsert
-    let label_id = body.label_id;
-    if (label_id === undefined && body.label) {
-      const resolvedLabel = await labelsService.createLabel(body.label);
-      label_id = resolvedLabel.id;
-    }
-
-    const new_album: NewAlbum = {
-      artist_id: artist_id,
-      genre_id: body.genre_id,
-      format_id: body.format_id,
-      album_title: body.album_title,
-      label: body.label,
-      label_id: label_id,
-      code_number: await libraryService.generateAlbumCodeNumber(artist_id),
-      alternate_artist_name: body.alternate_artist_name,
-      disc_quantity: body.disc_quantity,
-    };
-
-    let inserted_album: Album = await libraryService.insertAlbum(new_album);
-
-    // Enrich with LML metadata (streaming + artwork) — don't fail the insert
-    if (isLmlConfigured()) {
-      const artistName = body.alternate_artist_name || body.artist_name || '';
-      const [streamingResult, artworkResult] = await Promise.allSettled([
-        checkStreamingAvailability(artistName, body.album_title),
-        searchDiscogs(artistName, body.album_title),
-      ]);
-
-      if (streamingResult.status === 'fulfilled' && streamingResult.value.on_streaming !== null) {
-        try {
-          inserted_album = await libraryService.updateOnStreaming(
-            inserted_album.id,
-            streamingResult.value.on_streaming
-          );
-        } catch (e) {
-          console.warn('Failed to persist streaming status:', (e as Error).message);
-        }
-      } else if (streamingResult.status === 'rejected') {
-        console.warn('Streaming check failed for new album:', streamingResult.reason);
-      }
-
-      if (artworkResult.status === 'fulfilled') {
-        const top = artworkResult.value.results[0];
-        if (top?.artwork_url && !top.artwork_url.includes('spacer.gif')) {
-          try {
-            await libraryService.updateArtworkUrl(inserted_album.id, top.artwork_url);
-            (inserted_album as Record<string, unknown>).artwork_url = top.artwork_url;
-          } catch (e) {
-            console.warn('Failed to persist artwork URL:', (e as Error).message);
-          }
-        }
-      } else {
-        console.warn('Artwork fetch failed for new album:', artworkResult.reason);
-      }
-    }
-
-    res.status(201).json(inserted_album);
-  } catch (e) {
-    console.error('Error: Could not insert new album');
-    console.error(e);
-    next(e);
+  // Resolve label string to label_id via upsert
+  let label_id = body.label_id;
+  if (label_id === undefined && body.label) {
+    const resolvedLabel = await labelsService.createLabel(body.label);
+    label_id = resolvedLabel.id;
   }
+
+  const new_album: NewAlbum = {
+    artist_id: artist_id,
+    genre_id: body.genre_id,
+    format_id: body.format_id,
+    album_title: body.album_title,
+    label: body.label,
+    label_id: label_id,
+    code_number: await libraryService.generateAlbumCodeNumber(artist_id),
+    alternate_artist_name: body.alternate_artist_name,
+    disc_quantity: body.disc_quantity,
+  };
+
+  let inserted_album: Album = await libraryService.insertAlbum(new_album);
+
+  // Enrich with LML metadata (streaming + artwork) -- don't fail the insert
+  if (isLmlConfigured()) {
+    const artistName = body.alternate_artist_name || body.artist_name || '';
+    const [streamingResult, artworkResult] = await Promise.allSettled([
+      checkStreamingAvailability(artistName, body.album_title),
+      searchDiscogs(artistName, body.album_title),
+    ]);
+
+    if (streamingResult.status === 'fulfilled' && streamingResult.value.on_streaming !== null) {
+      try {
+        inserted_album = await libraryService.updateOnStreaming(
+          inserted_album.id,
+          streamingResult.value.on_streaming
+        );
+      } catch (e) {
+        console.warn('Failed to persist streaming status:', (e as Error).message);
+      }
+    } else if (streamingResult.status === 'rejected') {
+      console.warn('Streaming check failed for new album:', streamingResult.reason);
+    }
+
+    if (artworkResult.status === 'fulfilled') {
+      const top = artworkResult.value.results[0];
+      if (top?.artwork_url && !top.artwork_url.includes('spacer.gif')) {
+        try {
+          await libraryService.updateArtworkUrl(inserted_album.id, top.artwork_url);
+          (inserted_album as Record<string, unknown>).artwork_url = top.artwork_url;
+        } catch (e) {
+          console.warn('Failed to persist artwork URL:', (e as Error).message);
+        }
+      }
+    } else {
+      console.warn('Artwork fetch failed for new album:', artworkResult.reason);
+    }
+  }
+
+  res.status(201).json(inserted_album);
 };
 
 type AlbumQueryParams = {
@@ -136,8 +124,7 @@ type AlbumQueryParams = {
 
 export const searchForAlbum: RequestHandler = async (
   req: Request<object, object, object, AlbumQueryParams>,
-  res,
-  next
+  res
 ) => {
   const { query } = req;
   if (
@@ -158,20 +145,14 @@ export const searchForAlbum: RequestHandler = async (
 
   const onStreaming = query.on_streaming === 'true' ? true : query.on_streaming === 'false' ? false : undefined;
 
-  try {
-    const response = await libraryService.fuzzySearchLibrary(
-      query.artist_name,
-      query.album_title,
-      query.n,
-      onStreaming
-    );
-    const enriched = await libraryService.enrichWithArtwork(response as Array<Record<string, unknown>>);
-    res.status(200).json(enriched);
-  } catch (e) {
-    console.error("Error: Couldn't get album");
-    console.error(e);
-    next(e);
-  }
+  const response = await libraryService.fuzzySearchLibrary(
+    query.artist_name,
+    query.album_title,
+    query.n,
+    onStreaming
+  );
+  const enriched = await libraryService.enrichWithArtwork(response as Array<Record<string, unknown>>);
+  res.status(200).json(enriched);
 };
 
 type NewArtistRequest = {
@@ -182,7 +163,7 @@ type NewArtistRequest = {
   code_number: number;
 };
 
-export const addArtist: RequestHandler = async (req: Request<object, object, NewArtistRequest>, res, next) => {
+export const addArtist: RequestHandler = async (req: Request<object, object, NewArtistRequest>, res) => {
   const { body } = req;
   if (
     body.artist_name === undefined ||
@@ -193,34 +174,28 @@ export const addArtist: RequestHandler = async (req: Request<object, object, New
     throw new WxycError('Missing Request Parameters: artist_name, code_letters, genre_id, or code_number', 400);
   }
 
-  try {
-    const existingArtist = await libraryService.getArtistByCode(body.code_letters, body.genre_id, body.code_number);
-    if (existingArtist) {
-      res.status(409).json({
-        message: 'Artist code already exists for that genre and code letters.',
-        artist: existingArtist,
-      });
-      return;
-    }
-
-    const new_artist: NewArtist = {
-      artist_name: body.artist_name,
-      alphabetical_name: body.alphabetical_name ?? body.artist_name,
-      code_letters: body.code_letters,
-    };
-
-    const response: Artist = await libraryService.insertArtist(new_artist);
-    await libraryService.insertArtistGenreCrossreference(response.id, body.genre_id, body.code_number);
-    res.status(201).json({
-      ...response,
-      code_number: body.code_number,
-      genre_id: body.genre_id,
+  const existingArtist = await libraryService.getArtistByCode(body.code_letters, body.genre_id, body.code_number);
+  if (existingArtist) {
+    res.status(409).json({
+      message: 'Artist code already exists for that genre and code letters.',
+      artist: existingArtist,
     });
-  } catch (e) {
-    console.error('Error: Failed to add new artist');
-    console.error(e);
-    next(e);
+    return;
   }
+
+  const new_artist: NewArtist = {
+    artist_name: body.artist_name,
+    alphabetical_name: body.alphabetical_name ?? body.artist_name,
+    code_letters: body.code_letters,
+  };
+
+  const response: Artist = await libraryService.insertArtist(new_artist);
+  await libraryService.insertArtistGenreCrossreference(response.id, body.genre_id, body.code_number);
+  res.status(201).json({
+    ...response,
+    code_number: body.code_number,
+    genre_id: body.genre_id,
+  });
 };
 
 type ArtistNumberPeekQuery = {
@@ -230,8 +205,7 @@ type ArtistNumberPeekQuery = {
 
 export const peekArtistNumber: RequestHandler = async (
   req: Request<object, object, object, ArtistNumberPeekQuery>,
-  res,
-  next
+  res
 ) => {
   const { query } = req;
   if (!query.code_letters || !query.genre_id) {
@@ -243,40 +217,23 @@ export const peekArtistNumber: RequestHandler = async (
     throw new WxycError('Invalid genre_id', 400);
   }
 
-  try {
-    const nextCode = await libraryService.generateArtistNumber(query.code_letters, genreId);
-    res.status(200).json({ next_code_number: nextCode });
-  } catch (e) {
-    console.error('Error: Failed to generate artist number');
-    console.error(e);
-    next(e);
-  }
+  const nextCode = await libraryService.generateArtistNumber(query.code_letters, genreId);
+  res.status(200).json({ next_code_number: nextCode });
 };
 
-export const getRotation: RequestHandler = async (req, res, next) => {
-  try {
-    const rotation = await libraryService.getRotationFromDB();
-    res.status(200).json(rotation);
-  } catch (e) {
-    console.error('Error retrieving rotation form DB');
-    console.error(e);
-    next(e);
-  }
+export const getRotation: RequestHandler = async (req, res) => {
+  const rotation = await libraryService.getRotationFromDB();
+  res.status(200).json(rotation);
 };
 
 export type RotationAddRequest = Omit<NewRotationRelease, 'id'>;
-export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = async (req, res, next) => {
+export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = async (req, res) => {
   if (req.body.album_id === undefined || req.body.rotation_bin === undefined) {
     throw new WxycError('Missing Parameters: album_id or rotation_bin', 400);
   }
 
-  try {
-    const rotationRelease: RotationRelease = await libraryService.addToRotation(req.body);
-    res.status(201).json(rotationRelease);
-  } catch (e) {
-    console.error(e);
-    next(e);
-  }
+  const rotationRelease: RotationRelease = await libraryService.addToRotation(req.body);
+  res.status(201).json(rotationRelease);
 };
 
 export type KillRotationRelease = {
@@ -284,7 +241,7 @@ export type KillRotationRelease = {
   kill_date?: string; //Accepts ISO8601 formatted dates YYYY-MM-DD
 };
 
-export const killRotation: RequestHandler<object, unknown, KillRotationRelease> = async (req, res, next) => {
+export const killRotation: RequestHandler<object, unknown, KillRotationRelease> = async (req, res) => {
   const { body } = req;
 
   if (body.rotation_id === undefined) {
@@ -294,49 +251,31 @@ export const killRotation: RequestHandler<object, unknown, KillRotationRelease> 
     throw new WxycError('Bad Request, Incorrect Date Format: kill_date should be of form YYYY-MM-DD', 400);
   }
 
-  try {
-    const updatedRotation: RotationRelease = await libraryService.killRotationInDB(body.rotation_id, body.kill_date);
-    if (updatedRotation !== undefined) {
-      res.status(200).json(updatedRotation);
-    } else {
-      throw new WxycError('Rotation entry not found', 400);
-    }
-  } catch (e) {
-    console.error('Failed to update rotation kill_date');
-    console.error(e);
-    next(e);
+  const updatedRotation: RotationRelease = await libraryService.killRotationInDB(body.rotation_id, body.kill_date);
+  if (updatedRotation !== undefined) {
+    res.status(200).json(updatedRotation);
+  } else {
+    throw new WxycError('Rotation entry not found', 400);
   }
 };
 
-export const getFormats: RequestHandler = async (req, res, next) => {
-  try {
-    const formats = await libraryService.getFormatsFromDB();
-    res.status(200).json(formats);
-  } catch (e) {
-    console.error('Error retrieving formats from DB');
-    console.error(e);
-    next(e);
-  }
+export const getFormats: RequestHandler = async (req, res) => {
+  const formats = await libraryService.getFormatsFromDB();
+  res.status(200).json(formats);
 };
 
-export const addFormat: RequestHandler = async (req, res, next) => {
+export const addFormat: RequestHandler = async (req, res) => {
   const { body } = req;
   if (body.name === undefined) {
     throw new WxycError('Bad Request, Missing Parameter: name', 400);
   }
 
-  try {
-    const newFormat: NewAlbumFormat = {
-      format_name: body.name,
-    };
+  const newFormat: NewAlbumFormat = {
+    format_name: body.name,
+  };
 
-    const insertion = await libraryService.insertFormat(newFormat);
-    res.status(201).json(insertion);
-  } catch (e) {
-    console.error('Failed to add new format');
-    console.error(e);
-    next(e);
-  }
+  const insertion = await libraryService.insertFormat(newFormat);
+  res.status(201).json(insertion);
 };
 
 export const getGenres: RequestHandler = async (req, res) => {
@@ -344,45 +283,33 @@ export const getGenres: RequestHandler = async (req, res) => {
   res.status(200).json(genres);
 };
 
-export const addGenre: RequestHandler = async (req, res, next) => {
+export const addGenre: RequestHandler = async (req, res) => {
   const { body } = req;
   if (body.name === undefined || body.description === undefined) {
     throw new WxycError('Bad Request, Parameters name and description are required.', 400);
   }
 
-  try {
-    const newGenre: NewGenre = {
-      genre_name: body.name,
-      description: body.description,
-      plays: 0,
-      add_date: new Date().toISOString(),
-      last_modified: new Date(),
-    };
+  const newGenre: NewGenre = {
+    genre_name: body.name,
+    description: body.description,
+    plays: 0,
+    add_date: new Date().toISOString(),
+    last_modified: new Date(),
+  };
 
-    const insertion = await libraryService.insertGenre(newGenre);
+  const insertion = await libraryService.insertGenre(newGenre);
 
-    res.status(201).json(insertion);
-  } catch (e) {
-    console.error('Failed to add new genre');
-    console.error(e);
-    next(e);
-  }
+  res.status(201).json(insertion);
 };
 
-export const getAlbum: RequestHandler<object, unknown, unknown, { album_id: string }> = async (req, res, next) => {
+export const getAlbum: RequestHandler<object, unknown, unknown, { album_id: string }> = async (req, res) => {
   const { query } = req;
   if (query.album_id === undefined) {
     throw new WxycError('Bad Request, missing album identifier: album_id', 400);
   }
 
-  try {
-    const album = await libraryService.getAlbumFromDB(parseInt(query.album_id));
-    res.status(200).json(album);
-  } catch (e) {
-    console.error('Failed to retrieve album');
-    console.error(e);
-    next(e);
-  }
+  const album = await libraryService.getAlbumFromDB(parseInt(query.album_id));
+  res.status(200).json(album);
 };
 
 const parseAlbumId = (rawId: string): number => {
@@ -393,40 +320,22 @@ const parseAlbumId = (rawId: string): number => {
   return albumId;
 };
 
-export const markMissing: RequestHandler<{ id: string }> = async (req, res, next) => {
+export const markMissing: RequestHandler<{ id: string }> = async (req, res) => {
   const albumId = parseAlbumId(req.params.id);
 
-  try {
-    const result = await libraryService.markAlbumMissing(albumId);
-    if (!result) {
-      throw new WxycError('Album not found', 404);
-    }
+  const result = await libraryService.markAlbumMissing(albumId);
+  if (!result) throw new WxycError('Album not found', 404);
 
-    const album = await libraryService.getAlbumFromDB(albumId);
-    res.status(200).json(album);
-  } catch (e) {
-    if (e instanceof WxycError) throw e;
-    console.error('Failed to mark album as missing');
-    console.error(e);
-    next(e);
-  }
+  const album = await libraryService.getAlbumFromDB(albumId);
+  res.status(200).json(album);
 };
 
-export const markFound: RequestHandler<{ id: string }> = async (req, res, next) => {
+export const markFound: RequestHandler<{ id: string }> = async (req, res) => {
   const albumId = parseAlbumId(req.params.id);
 
-  try {
-    const result = await libraryService.markAlbumFound(albumId);
-    if (!result) {
-      throw new WxycError('Album not found', 404);
-    }
+  const result = await libraryService.markAlbumFound(albumId);
+  if (!result) throw new WxycError('Album not found', 404);
 
-    const album = await libraryService.getAlbumFromDB(albumId);
-    res.status(200).json(album);
-  } catch (e) {
-    if (e instanceof WxycError) throw e;
-    console.error('Failed to mark album as found');
-    console.error(e);
-    next(e);
-  }
+  const album = await libraryService.getAlbumFromDB(albumId);
+  res.status(200).json(album);
 };

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -82,10 +82,7 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
 
     if (streamingResult.status === 'fulfilled' && streamingResult.value.on_streaming !== null) {
       try {
-        inserted_album = await libraryService.updateOnStreaming(
-          inserted_album.id,
-          streamingResult.value.on_streaming
-        );
+        inserted_album = await libraryService.updateOnStreaming(inserted_album.id, streamingResult.value.on_streaming);
       } catch (e) {
         console.warn('Failed to persist streaming status:', (e as Error).message);
       }
@@ -122,10 +119,7 @@ type AlbumQueryParams = {
   on_streaming?: string;
 };
 
-export const searchForAlbum: RequestHandler = async (
-  req: Request<object, object, object, AlbumQueryParams>,
-  res
-) => {
+export const searchForAlbum: RequestHandler = async (req: Request<object, object, object, AlbumQueryParams>, res) => {
   const { query } = req;
   if (
     query.artist_name === undefined &&
@@ -145,12 +139,7 @@ export const searchForAlbum: RequestHandler = async (
 
   const onStreaming = query.on_streaming === 'true' ? true : query.on_streaming === 'false' ? false : undefined;
 
-  const response = await libraryService.fuzzySearchLibrary(
-    query.artist_name,
-    query.album_title,
-    query.n,
-    onStreaming
-  );
+  const response = await libraryService.fuzzySearchLibrary(query.artist_name, query.album_title, query.n, onStreaming);
   const enriched = await libraryService.enrichWithArtwork(response as Array<Record<string, unknown>>);
   res.status(200).json(enriched);
 };

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -18,9 +18,9 @@ import {
   getArtistDetails,
   resolveEntity as lmlResolveEntity,
   searchLibrary,
-  LmlClientError,
 } from '../services/lml/lml.client.js';
 import { LRUCache } from 'lru-cache';
+import WxycError from '../utils/error.js';
 
 /** Spotify OAuth2 token response. */
 interface SpotifyTokenResponse {
@@ -101,13 +101,10 @@ function artworkCacheKey(artistName: string, releaseTitle?: string): string {
  * Returns 200 with image bytes and Content-Type if SFW artwork is found.
  * Returns 404 if no artwork found or if artwork is NSFW.
  */
-export const searchArtwork: RequestHandler<object, unknown, unknown, ArtworkSearchQuery> = async (req, res, next) => {
+export const searchArtwork: RequestHandler<object, unknown, unknown, ArtworkSearchQuery> = async (req, res) => {
   const { artistName, releaseTitle } = req.query;
 
-  if (!artistName) {
-    res.status(400).json({ message: 'artistName query parameter is required' });
-    return;
-  }
+  if (!artistName) throw new WxycError('artistName query parameter is required', 400);
 
   const cacheKey = artworkCacheKey(artistName, releaseTitle);
 
@@ -126,50 +123,45 @@ export const searchArtwork: RequestHandler<object, unknown, unknown, ArtworkSear
     return;
   }
 
-  try {
-    const finder = getArtworkFinder();
-    const result = await finder.find({
-      artist: artistName,
-      album: releaseTitle || undefined,
-    });
+  const finder = getArtworkFinder();
+  const result = await finder.find({
+    artist: artistName,
+    album: releaseTitle || undefined,
+  });
 
-    if (!result.artworkUrl) {
-      negativeCache.set(cacheKey, true);
-      res.status(404).json({ message: 'No artwork found' });
-      return;
-    }
-
-    // Download the image
-    const imageResponse = await fetch(result.artworkUrl);
-    if (!imageResponse.ok) {
-      console.warn(`[ProxyController] Failed to download artwork from ${result.artworkUrl}: ${imageResponse.status}`);
-      negativeCache.set(cacheKey, true);
-      res.status(404).json({ message: 'Failed to fetch artwork image' });
-      return;
-    }
-
-    const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
-    const contentType = imageResponse.headers.get('content-type') || 'image/jpeg';
-
-    // Run NSFW classification
-    const nsfwResult = await classifyNSFW(imageBuffer);
-    if (nsfwResult === 'nsfw') {
-      console.log(`[ProxyController] NSFW artwork blocked for ${artistName} - ${releaseTitle || '(no album)'}`);
-      negativeCache.set(cacheKey, true);
-      res.status(404).json({ message: 'No artwork available' });
-      return;
-    }
-
-    // Cache and return the SFW image
-    artworkCache.set(cacheKey, { contentType, data: imageBuffer });
-
-    res.set('Content-Type', contentType);
-    res.set('Cache-Control', 'private, max-age=600');
-    res.status(200).send(imageBuffer);
-  } catch (e) {
-    console.error('[ProxyController] searchArtwork error:', e);
-    next(e);
+  if (!result.artworkUrl) {
+    negativeCache.set(cacheKey, true);
+    res.status(404).json({ message: 'No artwork found' });
+    return;
   }
+
+  // Download the image
+  const imageResponse = await fetch(result.artworkUrl);
+  if (!imageResponse.ok) {
+    console.warn(`[ProxyController] Failed to download artwork from ${result.artworkUrl}: ${imageResponse.status}`);
+    negativeCache.set(cacheKey, true);
+    res.status(404).json({ message: 'Failed to fetch artwork image' });
+    return;
+  }
+
+  const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+  const contentType = imageResponse.headers.get('content-type') || 'image/jpeg';
+
+  // Run NSFW classification
+  const nsfwResult = await classifyNSFW(imageBuffer);
+  if (nsfwResult === 'nsfw') {
+    console.log(`[ProxyController] NSFW artwork blocked for ${artistName} - ${releaseTitle || '(no album)'}`);
+    negativeCache.set(cacheKey, true);
+    res.status(404).json({ message: 'No artwork available' });
+    return;
+  }
+
+  // Cache and return the SFW image
+  artworkCache.set(cacheKey, { contentType, data: imageBuffer });
+
+  res.set('Content-Type', contentType);
+  res.set('Cache-Control', 'private, max-age=600');
+  res.status(200).send(imageBuffer);
 };
 
 /**
@@ -179,84 +171,72 @@ export const searchArtwork: RequestHandler<object, unknown, unknown, ArtworkSear
  * enriched streaming URLs (Spotify, Apple Music, YouTube Music, Bandcamp,
  * SoundCloud), so no direct calls to those APIs are needed.
  */
-export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMetadataQuery> = async (
-  req,
-  res,
-  next
-) => {
+export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMetadataQuery> = async (req, res) => {
   const { artistName, releaseTitle, trackTitle } = req.query;
 
-  if (!artistName) {
-    res.status(400).json({ message: 'artistName query parameter is required' });
-    return;
-  }
+  if (!artistName) throw new WxycError('artistName query parameter is required', 400);
 
+  const metadata: Record<string, unknown> = {};
+  const searchTerm = releaseTitle || trackTitle || '';
+
+  let lmlResults;
   try {
-    const metadata: Record<string, unknown> = {};
-    const searchTerm = releaseTitle || trackTitle || '';
-
-    let lmlResults;
-    try {
-      lmlResults = await searchDiscogs(artistName, searchTerm || undefined);
-    } catch (searchError) {
-      console.warn('[ProxyController] LML search failed:', searchError);
-    }
-
-    if (lmlResults && lmlResults.results.length > 0) {
-      const topResult = lmlResults.results[0];
-      metadata.discogsReleaseId = topResult.release_id;
-      metadata.discogsUrl = topResult.release_url;
-      metadata.artworkUrl = topResult.artwork_url || undefined;
-
-      // Artist bio and Wikipedia from LML search result
-      if (topResult.artist_bio) metadata.artistBio = topResult.artist_bio;
-      if (topResult.wikipedia_url) metadata.artistWikipediaUrl = topResult.wikipedia_url;
-
-      // Streaming URLs from LML enrichment
-      if (topResult.spotify_url) metadata.spotifyUrl = topResult.spotify_url;
-      if (topResult.apple_music_url) metadata.appleMusicUrl = topResult.apple_music_url;
-      if (topResult.youtube_music_url) metadata.youtubeMusicUrl = topResult.youtube_music_url;
-      if (topResult.bandcamp_url) metadata.bandcampUrl = topResult.bandcamp_url;
-      if (topResult.soundcloud_url) metadata.soundcloudUrl = topResult.soundcloud_url;
-
-      // Fetch enriched release details
-      try {
-        const release = await getRelease(topResult.release_id);
-        metadata.releaseYear = release.year ?? undefined;
-        metadata.genres = release.genres.length > 0 ? release.genres : undefined;
-        metadata.styles = release.styles.length > 0 ? release.styles : undefined;
-        metadata.label = release.label ?? undefined;
-        metadata.discogsArtistId = release.artist_id ?? null;
-        metadata.fullReleaseDate = release.released ?? undefined;
-        if (release.tracklist.length > 0) {
-          metadata.tracklist = release.tracklist.map((t) => ({
-            position: t.position,
-            title: t.title,
-            duration: t.duration ?? undefined,
-          }));
-        }
-        // Prefer release artwork over search artwork
-        if (release.artwork_url) {
-          metadata.artworkUrl = release.artwork_url;
-        }
-      } catch (releaseError) {
-        console.warn('[ProxyController] Failed to fetch release details from LML:', releaseError);
-      }
-    }
-
-    // Fallback: construct search URLs for services without LML-provided URLs
-    const query = searchTerm ? `${artistName} ${searchTerm}` : artistName;
-    const encodedQuery = encodeURIComponent(query);
-    if (!metadata.youtubeMusicUrl) metadata.youtubeMusicUrl = `https://music.youtube.com/search?q=${encodedQuery}`;
-    if (!metadata.bandcampUrl) metadata.bandcampUrl = `https://bandcamp.com/search?q=${encodedQuery}`;
-    if (!metadata.soundcloudUrl) metadata.soundcloudUrl = `https://soundcloud.com/search?q=${encodedQuery}`;
-
-    res.set('Cache-Control', 'private, max-age=600');
-    res.status(200).json(metadata);
-  } catch (e) {
-    console.error('[ProxyController] getAlbumMetadata error:', e);
-    next(e);
+    lmlResults = await searchDiscogs(artistName, searchTerm || undefined);
+  } catch (searchError) {
+    console.warn('[ProxyController] LML search failed:', searchError);
   }
+
+  if (lmlResults && lmlResults.results.length > 0) {
+    const topResult = lmlResults.results[0];
+    metadata.discogsReleaseId = topResult.release_id;
+    metadata.discogsUrl = topResult.release_url;
+    metadata.artworkUrl = topResult.artwork_url || undefined;
+
+    // Artist bio and Wikipedia from LML search result
+    if (topResult.artist_bio) metadata.artistBio = topResult.artist_bio;
+    if (topResult.wikipedia_url) metadata.artistWikipediaUrl = topResult.wikipedia_url;
+
+    // Streaming URLs from LML enrichment
+    if (topResult.spotify_url) metadata.spotifyUrl = topResult.spotify_url;
+    if (topResult.apple_music_url) metadata.appleMusicUrl = topResult.apple_music_url;
+    if (topResult.youtube_music_url) metadata.youtubeMusicUrl = topResult.youtube_music_url;
+    if (topResult.bandcamp_url) metadata.bandcampUrl = topResult.bandcamp_url;
+    if (topResult.soundcloud_url) metadata.soundcloudUrl = topResult.soundcloud_url;
+
+    // Fetch enriched release details
+    try {
+      const release = await getRelease(topResult.release_id);
+      metadata.releaseYear = release.year ?? undefined;
+      metadata.genres = release.genres.length > 0 ? release.genres : undefined;
+      metadata.styles = release.styles.length > 0 ? release.styles : undefined;
+      metadata.label = release.label ?? undefined;
+      metadata.discogsArtistId = release.artist_id ?? null;
+      metadata.fullReleaseDate = release.released ?? undefined;
+      if (release.tracklist.length > 0) {
+        metadata.tracklist = release.tracklist.map((t) => ({
+          position: t.position,
+          title: t.title,
+          duration: t.duration ?? undefined,
+        }));
+      }
+      // Prefer release artwork over search artwork
+      if (release.artwork_url) {
+        metadata.artworkUrl = release.artwork_url;
+      }
+    } catch (releaseError) {
+      console.warn('[ProxyController] Failed to fetch release details from LML:', releaseError);
+    }
+  }
+
+  // Fallback: construct search URLs for services without LML-provided URLs
+  const query = searchTerm ? `${artistName} ${searchTerm}` : artistName;
+  const encodedQuery = encodeURIComponent(query);
+  if (!metadata.youtubeMusicUrl) metadata.youtubeMusicUrl = `https://music.youtube.com/search?q=${encodedQuery}`;
+  if (!metadata.bandcampUrl) metadata.bandcampUrl = `https://bandcamp.com/search?q=${encodedQuery}`;
+  if (!metadata.soundcloudUrl) metadata.soundcloudUrl = `https://soundcloud.com/search?q=${encodedQuery}`;
+
+  res.set('Cache-Control', 'private, max-age=600');
+  res.status(200).json(metadata);
 };
 
 /**
@@ -266,45 +246,26 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
  * Bio is available as both raw Discogs markup (`bio`) and pre-parsed structured
  * tokens (`bioTokens`) for direct rendering by clients.
  */
-export const getArtistMetadata: RequestHandler<object, unknown, unknown, ArtistMetadataQuery> = async (
-  req,
-  res,
-  next
-) => {
+export const getArtistMetadata: RequestHandler<object, unknown, unknown, ArtistMetadataQuery> = async (req, res) => {
   const { artistId } = req.query;
 
-  if (!artistId) {
-    res.status(400).json({ message: 'artistId query parameter is required' });
-    return;
-  }
+  if (!artistId) throw new WxycError('artistId query parameter is required', 400);
 
   const id = parseInt(artistId, 10);
-  if (isNaN(id)) {
-    res.status(400).json({ message: 'artistId must be an integer' });
-    return;
-  }
+  if (isNaN(id)) throw new WxycError('artistId must be an integer', 400);
 
-  try {
-    const artist = await getArtistDetails(id);
+  const artist = await getArtistDetails(id);
 
-    const wikipediaUrl = artist.urls.find((url) => url.includes('wikipedia.org')) ?? null;
+  const wikipediaUrl = artist.urls.find((url) => url.includes('wikipedia.org')) ?? null;
 
-    res.set('Cache-Control', 'private, max-age=3600');
-    res.status(200).json({
-      discogsArtistId: artist.artist_id,
-      bio: artist.profile ?? null,
-      bioTokens: artist.profile_tokens ?? null,
-      wikipediaUrl,
-      imageUrl: artist.image_url ?? null,
-    });
-  } catch (e) {
-    if (e instanceof LmlClientError) {
-      res.status(e.statusCode).json({ message: e.message });
-      return;
-    }
-    console.error('[ProxyController] getArtistMetadata error:', e);
-    next(e);
-  }
+  res.set('Cache-Control', 'private, max-age=3600');
+  res.status(200).json({
+    discogsArtistId: artist.artist_id,
+    bio: artist.profile ?? null,
+    bioTokens: artist.profile_tokens ?? null,
+    wikipediaUrl,
+    imageUrl: artist.image_url ?? null,
+  });
 };
 
 /**
@@ -313,39 +274,23 @@ export const getArtistMetadata: RequestHandler<object, unknown, unknown, ArtistM
  * Resolves a Discogs entity (artist, release, master) by type and ID via LML.
  * Returns the entity's name and basic info.
  */
-export const resolveEntity: RequestHandler<object, unknown, unknown, EntityResolveQuery> = async (req, res, next) => {
+export const resolveEntity: RequestHandler<object, unknown, unknown, EntityResolveQuery> = async (req, res) => {
   const { type, id } = req.query;
 
-  if (!type || !id) {
-    res.status(400).json({ message: 'type and id query parameters are required' });
-    return;
-  }
+  if (!type || !id) throw new WxycError('type and id query parameters are required', 400);
 
   const validTypes = ['artist', 'release', 'master'] as const;
   if (!validTypes.includes(type as (typeof validTypes)[number])) {
-    res.status(400).json({ message: `type must be one of: ${validTypes.join(', ')}` });
-    return;
+    throw new WxycError(`type must be one of: ${validTypes.join(', ')}`, 400);
   }
 
   const entityId = parseInt(id, 10);
-  if (isNaN(entityId)) {
-    res.status(400).json({ message: 'id must be an integer' });
-    return;
-  }
+  if (isNaN(entityId)) throw new WxycError('id must be an integer', 400);
 
-  try {
-    const result = await lmlResolveEntity(type as 'artist' | 'release' | 'master', entityId);
+  const result = await lmlResolveEntity(type as 'artist' | 'release' | 'master', entityId);
 
-    res.set('Cache-Control', 'private, max-age=86400');
-    res.status(200).json({ name: result.name, type: result.type, id: result.id });
-  } catch (e) {
-    if (e instanceof LmlClientError) {
-      res.status(e.statusCode).json({ message: e.message });
-      return;
-    }
-    console.error('[ProxyController] resolveEntity error:', e);
-    next(e);
-  }
+  res.set('Cache-Control', 'private, max-age=86400');
+  res.status(200).json({ name: result.name, type: result.type, id: result.id });
 };
 
 /**
@@ -353,75 +298,67 @@ export const resolveEntity: RequestHandler<object, unknown, unknown, EntityResol
  *
  * Fetches Spotify track metadata using backend credentials.
  */
-export const getSpotifyTrack: RequestHandler<SpotifyTrackParams> = async (req, res, next) => {
+export const getSpotifyTrack: RequestHandler<SpotifyTrackParams> = async (req, res) => {
   const { id } = req.params;
 
-  if (!id) {
-    res.status(400).json({ message: 'Track ID is required' });
+  if (!id) throw new WxycError('Track ID is required', 400);
+
+  // Use the SpotifyProvider's internal auth to call the Spotify API
+  const spotifyClientId = process.env.SPOTIFY_CLIENT_ID;
+  const spotifyClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+
+  if (!spotifyClientId || !spotifyClientSecret) {
+    res.status(503).json({ message: 'Spotify integration not configured' });
     return;
   }
 
-  try {
-    // Use the SpotifyProvider's internal auth to call the Spotify API
-    const spotifyClientId = process.env.SPOTIFY_CLIENT_ID;
-    const spotifyClientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+  // Get or refresh Spotify access token
+  const tokenResponse = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${spotifyClientId}:${spotifyClientSecret}`).toString('base64')}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'grant_type=client_credentials',
+  });
 
-    if (!spotifyClientId || !spotifyClientSecret) {
-      res.status(503).json({ message: 'Spotify integration not configured' });
-      return;
-    }
-
-    // Get or refresh Spotify access token
-    const tokenResponse = await fetch('https://accounts.spotify.com/api/token', {
-      method: 'POST',
-      headers: {
-        Authorization: `Basic ${Buffer.from(`${spotifyClientId}:${spotifyClientSecret}`).toString('base64')}`,
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: 'grant_type=client_credentials',
-    });
-
-    if (!tokenResponse.ok) {
-      console.error(`[ProxyController] Spotify auth failed: ${tokenResponse.status}`);
-      res.status(502).json({ message: 'Spotify authentication failed' });
-      return;
-    }
-
-    const tokenData: SpotifyTokenResponse = (await tokenResponse.json()) as SpotifyTokenResponse;
-
-    const trackResponse = await fetch(`https://api.spotify.com/v1/tracks/${encodeURIComponent(id)}`, {
-      headers: {
-        Authorization: `Bearer ${tokenData.access_token}`,
-      },
-    });
-
-    if (!trackResponse.ok) {
-      if (trackResponse.status === 404) {
-        res.status(404).json({ message: 'Track not found' });
-        return;
-      }
-      console.error(`[ProxyController] Spotify track fetch failed: ${trackResponse.status}`);
-      res.status(502).json({ message: 'Failed to fetch track from Spotify' });
-      return;
-    }
-
-    const track: SpotifyTrackApiResponse = (await trackResponse.json()) as SpotifyTrackApiResponse;
-
-    res.set('Cache-Control', 'private, max-age=600');
-    res.status(200).json({
-      title: track.name,
-      artist: track.artists?.[0]?.name || '',
-      album: track.album?.name || '',
-      artworkUrl: track.album?.images?.[0]?.url || null,
-    });
-  } catch (e) {
-    console.error('[ProxyController] getSpotifyTrack error:', e);
-    next(e);
+  if (!tokenResponse.ok) {
+    console.error(`[ProxyController] Spotify auth failed: ${tokenResponse.status}`);
+    res.status(502).json({ message: 'Spotify authentication failed' });
+    return;
   }
+
+  const tokenData: SpotifyTokenResponse = (await tokenResponse.json()) as SpotifyTokenResponse;
+
+  const trackResponse = await fetch(`https://api.spotify.com/v1/tracks/${encodeURIComponent(id)}`, {
+    headers: {
+      Authorization: `Bearer ${tokenData.access_token}`,
+    },
+  });
+
+  if (!trackResponse.ok) {
+    if (trackResponse.status === 404) {
+      res.status(404).json({ message: 'Track not found' });
+      return;
+    }
+    console.error(`[ProxyController] Spotify track fetch failed: ${trackResponse.status}`);
+    res.status(502).json({ message: 'Failed to fetch track from Spotify' });
+    return;
+  }
+
+  const track: SpotifyTrackApiResponse = (await trackResponse.json()) as SpotifyTrackApiResponse;
+
+  res.set('Cache-Control', 'private, max-age=600');
+  res.status(200).json({
+    title: track.name,
+    artist: track.artists?.[0]?.name || '',
+    album: track.album?.name || '',
+    artworkUrl: track.album?.images?.[0]?.url || null,
+  });
 };
 
 /**
- * GET /proxy/library/search — Search the WXYC library catalog via LML.
+ * GET /proxy/library/search -- Search the WXYC library catalog via LML.
  *
  * Proxies to LML's GET /api/v1/library/search, providing auth, rate limiting,
  * and activity tracking. Used by dj-site for flowsheet autocomplete.
@@ -435,30 +372,18 @@ type LibrarySearchQuery = {
   limit?: string;
 };
 
-export const librarySearch: RequestHandler<object, unknown, unknown, LibrarySearchQuery> = async (req, res, next) => {
+export const librarySearch: RequestHandler<object, unknown, unknown, LibrarySearchQuery> = async (req, res) => {
   const { artist, title, q, limit } = req.query;
 
-  if (!artist && !title && !q) {
-    res.status(400).json({ message: 'At least one of artist, title, or q is required' });
-    return;
-  }
+  if (!artist && !title && !q) throw new WxycError('At least one of artist, title, or q is required', 400);
 
-  try {
-    const results = await searchLibrary({
-      artist,
-      title,
-      q,
-      limit: limit ? parseInt(limit, 10) : undefined,
-    });
+  const results = await searchLibrary({
+    artist,
+    title,
+    q,
+    limit: limit ? parseInt(limit, 10) : undefined,
+  });
 
-    res.set('Cache-Control', 'private, max-age=60');
-    res.status(200).json(results);
-  } catch (e) {
-    if (e instanceof LmlClientError) {
-      res.status(e.statusCode).json({ message: e.message });
-      return;
-    }
-    console.error('[ProxyController] librarySearch error:', e);
-    next(e);
-  }
+  res.set('Cache-Control', 'private, max-age=60');
+  res.status(200).json(results);
 };

--- a/apps/backend/controllers/requestLine.controller.ts
+++ b/apps/backend/controllers/requestLine.controller.ts
@@ -2,6 +2,7 @@ import { RequestHandler } from 'express';
 import { processRequest, parseOnly, getConfig, isParsingEnabled } from '../services/requestLine/index.js';
 import { postTextToSlack } from '../services/slack/index.js';
 import { searchLibrary } from '../services/library.service.js';
+import WxycError from '../utils/error.js';
 
 export type RequestLineBody = {
   message: string;
@@ -62,52 +63,12 @@ export const submitRequestLine: RequestHandler<object, unknown, RequestLineBody>
     timestamp: new Date().toISOString(),
   });
 
-  // Validate message is present (handle empty body case)
-  if (!req.body || req.body.message === undefined) {
-    const errorMsg = 'Bad Request: Missing request line message';
-    console.log(`[${logId}] ${errorMsg}`);
-
-    const responseTime = Date.now() - startTime;
-    console.log(`[${logId}] Request completed:`, {
-      statusCode: 400,
-      responseTime: `${responseTime}ms`,
-      error: errorMsg,
-    });
-
-    res.status(400).json({ message: errorMsg });
-    return;
-  }
-
-  // Validate message length (after trim)
+  // Validate message
+  if (!req.body?.message) throw new WxycError('Missing request line message', 400);
   const trimmedMessage = req.body.message.trim();
-  if (trimmedMessage.length < MESSAGE_MIN_LENGTH) {
-    const errorMsg = 'Bad Request: Message cannot be empty';
-    console.log(`[${logId}] ${errorMsg}`);
-
-    const responseTime = Date.now() - startTime;
-    console.log(`[${logId}] Request completed:`, {
-      statusCode: 400,
-      responseTime: `${responseTime}ms`,
-      error: errorMsg,
-    });
-
-    res.status(400).json({ message: errorMsg });
-    return;
-  }
-
+  if (trimmedMessage.length < MESSAGE_MIN_LENGTH) throw new WxycError('Message cannot be empty', 400);
   if (trimmedMessage.length > MESSAGE_MAX_LENGTH) {
-    const errorMsg = `Bad Request: Message exceeds maximum length of ${MESSAGE_MAX_LENGTH} characters`;
-    console.log(`[${logId}] ${errorMsg}`);
-
-    const responseTime = Date.now() - startTime;
-    console.log(`[${logId}] Request completed:`, {
-      statusCode: 400,
-      responseTime: `${responseTime}ms`,
-      error: errorMsg,
-    });
-
-    res.status(400).json({ message: errorMsg });
-    return;
+    throw new WxycError(`Message exceeds maximum length of ${MESSAGE_MAX_LENGTH} characters`, 400);
   }
 
   try {

--- a/apps/backend/controllers/requestLine.controller.ts
+++ b/apps/backend/controllers/requestLine.controller.ts
@@ -64,7 +64,7 @@ export const submitRequestLine: RequestHandler<object, unknown, RequestLineBody>
   });
 
   // Validate message
-  if (!req.body?.message) throw new WxycError('Missing request line message', 400);
+  if (!req.body || req.body.message === undefined) throw new WxycError('Missing request line message', 400);
   const trimmedMessage = req.body.message.trim();
   if (trimmedMessage.length < MESSAGE_MIN_LENGTH) throw new WxycError('Message cannot be empty', 400);
   if (trimmedMessage.length > MESSAGE_MAX_LENGTH) {

--- a/apps/backend/controllers/schedule.controller.ts
+++ b/apps/backend/controllers/schedule.controller.ts
@@ -2,27 +2,15 @@ import { Request, RequestHandler } from 'express';
 import * as ScheduleService from '../services/schedule.service.js';
 import { NewShift } from '@wxyc/database';
 
-export const getSchedule: RequestHandler<object, unknown, object, object> = async (req, res, next) => {
-  try {
-    const schedule = await ScheduleService.getSchedule();
-    res.status(200).json(schedule);
-  } catch (e) {
-    console.error('Error getting schedule');
-    console.error(e);
-    next(e);
-  }
+export const getSchedule: RequestHandler<object, unknown, object, object> = async (req, res) => {
+  const schedule = await ScheduleService.getSchedule();
+  res.status(200).json(schedule);
 };
 
-export const addToSchedule: RequestHandler = async (req: Request<object, object, NewShift>, res, next) => {
+export const addToSchedule: RequestHandler = async (req: Request<object, object, NewShift>, res) => {
   const { body } = req;
-  try {
-    const response = await ScheduleService.addToSchedule(body);
-    res.status(201).json(response);
-  } catch (e) {
-    console.error('Error adding to schedule');
-    console.error(e);
-    next(e);
-  }
+  const response = await ScheduleService.addToSchedule(body);
+  res.status(201).json(response);
 };
 
 /* TODO: stubbed out schedule controller logic

--- a/apps/backend/controllers/suggest.controller.ts
+++ b/apps/backend/controllers/suggest.controller.ts
@@ -1,25 +1,17 @@
 import { RequestHandler } from 'express';
 import * as suggestService from '../services/suggest.service.js';
+import WxycError from '../utils/error.js';
 
 export const suggestArtistsEndpoint: RequestHandler<object, unknown, unknown, { q: string; limit?: string }> = async (
   req,
-  res,
-  next
+  res
 ) => {
   const query = req.query.q;
-  if (!query) {
-    res.status(400).json({ message: 'Missing required query parameter: q' });
-  } else {
-    try {
-      const limit = req.query.limit ? parseInt(req.query.limit) : undefined;
-      const artists = await suggestService.suggestArtists(query, limit);
-      res.status(200).json(artists);
-    } catch (e) {
-      console.error('Error suggesting artists');
-      console.error(e);
-      next(e);
-    }
-  }
+  if (!query) throw new WxycError('Missing required query parameter: q', 400);
+
+  const limit = req.query.limit ? parseInt(req.query.limit) : undefined;
+  const artists = await suggestService.suggestArtists(query, limit);
+  res.status(200).json(artists);
 };
 
 export const suggestTracksEndpoint: RequestHandler<
@@ -27,24 +19,15 @@ export const suggestTracksEndpoint: RequestHandler<
   unknown,
   unknown,
   { q: string; artist: string; limit?: string }
-> = async (req, res, next) => {
+> = async (req, res) => {
   const query = req.query.q;
   const artist = req.query.artist;
-  if (!query) {
-    res.status(400).json({ message: 'Missing required query parameter: q' });
-  } else if (!artist) {
-    res.status(400).json({ message: 'Missing required query parameter: artist' });
-  } else {
-    try {
-      const limit = req.query.limit ? parseInt(req.query.limit) : undefined;
-      const tracks = await suggestService.suggestTracks(query, artist, limit);
-      res.status(200).json(tracks);
-    } catch (e) {
-      console.error('Error suggesting tracks');
-      console.error(e);
-      next(e);
-    }
-  }
+  if (!query) throw new WxycError('Missing required query parameter: q', 400);
+  if (!artist) throw new WxycError('Missing required query parameter: artist', 400);
+
+  const limit = req.query.limit ? parseInt(req.query.limit) : undefined;
+  const tracks = await suggestService.suggestTracks(query, artist, limit);
+  res.status(200).json(tracks);
 };
 
 export const getTrackDetailsEndpoint: RequestHandler<
@@ -52,21 +35,12 @@ export const getTrackDetailsEndpoint: RequestHandler<
   unknown,
   unknown,
   { artist: string; track: string }
-> = async (req, res, next) => {
+> = async (req, res) => {
   const artist = req.query.artist;
   const track = req.query.track;
-  if (!artist) {
-    res.status(400).json({ message: 'Missing required query parameter: artist' });
-  } else if (!track) {
-    res.status(400).json({ message: 'Missing required query parameter: track' });
-  } else {
-    try {
-      const details = await suggestService.getTrackDetails(artist, track);
-      res.status(200).json(details);
-    } catch (e) {
-      console.error('Error getting track details');
-      console.error(e);
-      next(e);
-    }
-  }
+  if (!artist) throw new WxycError('Missing required query parameter: artist', 400);
+  if (!track) throw new WxycError('Missing required query parameter: track', 400);
+
+  const details = await suggestService.getTrackDetails(artist, track);
+  res.status(200).json(details);
 };

--- a/apps/backend/middleware/errorHandler.ts
+++ b/apps/backend/middleware/errorHandler.ts
@@ -1,5 +1,10 @@
 import WxycError from '../utils/error.js';
+import { LmlClientError } from '../services/lml/lml.client.js';
 import { Request, Response, NextFunction } from 'express';
+
+function hasStatusCode(error: Error): error is WxycError | LmlClientError {
+  return error instanceof WxycError || error instanceof LmlClientError;
+}
 
 function errorHandler(err: any, req: Request, res: Response, next: NextFunction) {
   // prettier-ignore
@@ -7,8 +12,8 @@ function errorHandler(err: any, req: Request, res: Response, next: NextFunction)
     ? err
     : new Error(String(err));
 
-  if (error instanceof WxycError) {
-    console.error(`[${req.method} ${req.url}] WxycError ${error.statusCode}: ${error.message}`);
+  if (hasStatusCode(error)) {
+    console.error(`[${req.method} ${req.url}] ${error.name} ${error.statusCode}: ${error.message}`);
     res.status(error.statusCode).json({ message: error.message });
   } else {
     console.error(`[${req.method} ${req.url}] Unhandled error:`, error);

--- a/tests/unit/controllers/flowsheet.addEntry.test.ts
+++ b/tests/unit/controllers/flowsheet.addEntry.test.ts
@@ -22,13 +22,11 @@ describe('addEntry', () => {
   const res = { status: mockStatus, send: mockSend, json: mockJson } as any;
   const next = jest.fn();
 
-  it('should call next with the error when getLatestShow throws', async () => {
+  it('should reject with the error when getLatestShow throws', async () => {
     const dbError = new Error('DB connection failed');
     (flowsheet_service.getLatestShow as jest.Mock).mockRejectedValue(dbError);
 
-    await addEntry(req, res, next);
-
-    expect(next).toHaveBeenCalledWith(dbError);
+    await expect(addEntry(req, res, next)).rejects.toThrow(dbError);
     expect(mockStatus).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -32,6 +32,7 @@ jest.mock('../../../apps/backend/services/metadata/index', () => ({
 }));
 
 import { getEntries, getLatest, getShowInfo, addEntry } from '../../../apps/backend/controllers/flowsheet.controller';
+import WxycError from '../../../apps/backend/utils/error';
 
 // Helper to create mock Express req/res/next
 const createMockReq = (query: Record<string, string> = {}): Partial<Request> => ({
@@ -143,14 +144,11 @@ describe('flowsheet.controller', () => {
         ['abc', 'limit must be a positive number'],
         ['0', 'limit must be a positive number'],
         ['-1', 'limit must be a positive number'],
-      ])('rejects limit=%s with 400', async (limit, expectedMessage) => {
+      ])('rejects limit=%s with WxycError', async (limit, expectedMessage) => {
         const req = createMockReq({ limit });
         const res = createMockRes();
 
-        await getEntries(req as Request, res as Response, mockNext);
-
-        expect(res.status).toHaveBeenCalledWith(400);
-        expect(res.json).toHaveBeenCalledWith({ message: expectedMessage });
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(expectedMessage);
         expect(mockGetEntriesByPage).not.toHaveBeenCalled();
       });
 
@@ -158,10 +156,9 @@ describe('flowsheet.controller', () => {
         const req = createMockReq({ limit: '201' });
         const res = createMockRes();
 
-        await getEntries(req as Request, res as Response, mockNext);
-
-        expect(res.status).toHaveBeenCalledWith(400);
-        expect(res.json).toHaveBeenCalledWith({ message: 'Requested too many entries' });
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(
+          'Requested too many entries'
+        );
       });
 
       it('accepts limit=200 (exactly MAX_ITEMS)', async () => {
@@ -180,14 +177,11 @@ describe('flowsheet.controller', () => {
       it.each([
         ['abc', 'page must be a non-negative number'],
         ['-1', 'page must be a non-negative number'],
-      ])('rejects page=%s with 400', async (page, expectedMessage) => {
+      ])('rejects page=%s with WxycError', async (page, expectedMessage) => {
         const req = createMockReq({ page });
         const res = createMockRes();
 
-        await getEntries(req as Request, res as Response, mockNext);
-
-        expect(res.status).toHaveBeenCalledWith(400);
-        expect(res.json).toHaveBeenCalledWith({ message: expectedMessage });
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(expectedMessage);
         expect(mockGetEntriesByPage).not.toHaveBeenCalled();
       });
 
@@ -204,16 +198,14 @@ describe('flowsheet.controller', () => {
       });
     });
 
-    it('calls next with error on service failure', async () => {
+    it('rejects with error on service failure', async () => {
       const error = new Error('DB connection failed');
       mockGetEntriesByPage.mockRejectedValue(error);
 
       const req = createMockReq();
       const res = createMockRes();
 
-      await getEntries(req as Request, res as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalledWith(error);
+      await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(error);
     });
   });
 
@@ -247,16 +239,14 @@ describe('flowsheet.controller', () => {
       expect(mockTransformToV2).not.toHaveBeenCalled();
     });
 
-    it('calls next with error on service failure', async () => {
+    it('rejects with error on service failure', async () => {
       const error = new Error('DB timeout');
       mockGetEntriesByPage.mockRejectedValue(error);
 
       const req = createMockReq();
       const res = createMockRes();
 
-      await getLatest(req as Request, res as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalledWith(error);
+      await expect(getLatest(req as Request, res as Response, mockNext)).rejects.toThrow(error);
     });
   });
 
@@ -307,29 +297,26 @@ describe('flowsheet.controller', () => {
       expect(mockGetEntriesByShow).toHaveBeenCalledWith(1);
     });
 
-    it.each([['abc'], [undefined]])('returns 400 for invalid show_id=%s', async (show_id) => {
+    it.each([['abc'], [undefined]])('throws WxycError for invalid show_id=%s', async (show_id) => {
       const query = show_id !== undefined ? { show_id } : {};
       const req = createMockReq(query as Record<string, string>);
       const res = createMockRes();
 
-      await getShowInfo(req as Request, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({ message: 'Missing or invalid show_id parameter' });
+      await expect(getShowInfo(req as Request, res as Response, mockNext)).rejects.toThrow(
+        'Missing or invalid show_id parameter'
+      );
       expect(mockGetShowMetadata).not.toHaveBeenCalled();
       expect(mockGetEntriesByShow).not.toHaveBeenCalled();
     });
 
-    it('calls next with error on service failure', async () => {
+    it('rejects with error on service failure', async () => {
       const error = new Error('Show not found');
       mockGetShowMetadata.mockRejectedValue(error);
 
       const req = createMockReq({ show_id: '1' });
       const res = createMockRes();
 
-      await getShowInfo(req as Request, res as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalledWith(error);
+      await expect(getShowInfo(req as Request, res as Response, mockNext)).rejects.toThrow(error);
     });
   });
 

--- a/tests/unit/controllers/flowsheet.leaveShow.test.ts
+++ b/tests/unit/controllers/flowsheet.leaveShow.test.ts
@@ -17,6 +17,7 @@ jest.mock('async-mutex', () => ({
 }));
 
 import { leaveShow } from '../../../apps/backend/controllers/flowsheet.controller';
+import WxycError from '../../../apps/backend/utils/error';
 import type { Request, Response, NextFunction } from 'express';
 
 function createMockRes() {
@@ -31,7 +32,7 @@ function createMockRes() {
 }
 
 describe('leaveShow', () => {
-  it('returns 400 when no active show session exists (end_time is set)', async () => {
+  it('throws WxycError 400 when no active show session exists (end_time is set)', async () => {
     mockGetLatestShow.mockResolvedValue({
       id: 1,
       primary_dj_id: 'dj-1',
@@ -40,14 +41,10 @@ describe('leaveShow', () => {
     });
 
     const req = { body: { dj_id: 'dj-1' } } as Request;
-    const { res, statusMock, jsonMock } = createMockRes();
+    const { res } = createMockRes();
     const next = jest.fn() as unknown as NextFunction;
 
-    await leaveShow(req, res, next);
-
-    expect(statusMock).toHaveBeenCalledWith(400);
-    expect(jsonMock).toHaveBeenCalledWith({
-      message: 'Bad Request: No active show session found.',
-    });
+    await expect(leaveShow(req, res, next)).rejects.toThrow(WxycError);
+    await expect(leaveShow(req, res, next)).rejects.toThrow('Bad Request: No active show session found.');
   });
 });

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -182,18 +182,16 @@ describe('library.controller', () => {
       expect(res.json).toHaveBeenCalledWith(enrichedResults);
     });
 
-    it('returns results even if enrichment throws', async () => {
+    it('rejects when enrichment throws', async () => {
       const searchResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
       mockFuzzySearchLibrary.mockResolvedValue(searchResults);
-      mockEnrichWithArtwork.mockRejectedValue(new Error('enrichment failed'));
+      const enrichError = new Error('enrichment failed');
+      mockEnrichWithArtwork.mockRejectedValue(enrichError);
 
       const req = { query: { artist_name: 'Autechre' } } as unknown as Request;
       const res = mockResponse();
 
-      await searchForAlbum(req, res, next);
-
-      // Error should be passed to next()
-      expect(next).toHaveBeenCalled();
+      await expect(searchForAlbum(req, res, next)).rejects.toThrow(enrichError);
     });
   });
 });

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -100,14 +100,13 @@ describe('proxy.controller', () => {
   // --- searchArtwork ---
 
   describe('searchArtwork', () => {
-    it('returns 400 when artistName is missing', async () => {
+    it('throws WxycError 400 when artistName is missing', async () => {
       const req = { query: {} } as unknown as Request;
       const res = createMockRes();
 
-      await searchArtwork(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({ message: 'artistName query parameter is required' });
+      await expect(searchArtwork(req, res as Response, mockNext)).rejects.toThrow(
+        'artistName query parameter is required'
+      );
     });
 
     it('returns SFW image bytes with content type and cache header', async () => {
@@ -187,29 +186,27 @@ describe('proxy.controller', () => {
       expect(res.status).toHaveBeenCalledWith(404);
     });
 
-    it('calls next on error', async () => {
+    it('rejects with error on service failure', async () => {
       const error = new Error('Service failure');
       mockFind.mockRejectedValue(error);
 
       const req = { query: { artistName: 'Test' } } as unknown as Request;
       const res = createMockRes();
 
-      await searchArtwork(req, res as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalledWith(error);
+      await expect(searchArtwork(req, res as Response, mockNext)).rejects.toThrow(error);
     });
   });
 
   // --- getAlbumMetadata ---
 
   describe('getAlbumMetadata', () => {
-    it('returns 400 when artistName is missing', async () => {
+    it('throws WxycError 400 when artistName is missing', async () => {
       const req = { query: {} } as unknown as Request;
       const res = createMockRes();
 
-      await getAlbumMetadata(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(400);
+      await expect(getAlbumMetadata(req, res as Response, mockNext)).rejects.toThrow(
+        'artistName query parameter is required'
+      );
     });
 
     it('returns merged metadata from LML search + release details', async () => {
@@ -379,24 +376,20 @@ describe('proxy.controller', () => {
   // --- getArtistMetadata ---
 
   describe('getArtistMetadata', () => {
-    it('returns 400 when artistId is missing', async () => {
+    it('throws WxycError 400 when artistId is missing', async () => {
       const req = { query: {} } as unknown as Request;
       const res = createMockRes();
 
-      await getArtistMetadata(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({ message: 'artistId query parameter is required' });
+      await expect(getArtistMetadata(req, res as Response, mockNext)).rejects.toThrow(
+        'artistId query parameter is required'
+      );
     });
 
-    it('returns 400 when artistId is not a number', async () => {
+    it('throws WxycError 400 when artistId is not a number', async () => {
       const req = { query: { artistId: 'abc' } } as unknown as Request;
       const res = createMockRes();
 
-      await getArtistMetadata(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({ message: 'artistId must be an integer' });
+      await expect(getArtistMetadata(req, res as Response, mockNext)).rejects.toThrow('artistId must be an integer');
     });
 
     it('returns artist metadata with raw bio, bioTokens, imageUrl, and cache header', async () => {
@@ -499,63 +492,51 @@ describe('proxy.controller', () => {
       expect(result.imageUrl).toBeNull();
     });
 
-    it('returns 404 when LML returns 404', async () => {
+    it('rejects with LmlClientError when LML returns 404', async () => {
       const { LmlClientError } = await import('../../../apps/backend/services/lml/lml.client');
       mockGetArtistDetails.mockRejectedValue(new LmlClientError('Not found', 404));
 
       const req = { query: { artistId: '99999' } } as unknown as Request;
       const res = createMockRes();
 
-      await getArtistMetadata(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(404);
+      await expect(getArtistMetadata(req, res as Response, mockNext)).rejects.toThrow('Not found');
     });
 
-    it('returns 502 when LML is unreachable', async () => {
+    it('rejects with LmlClientError when LML is unreachable', async () => {
       const { LmlClientError } = await import('../../../apps/backend/services/lml/lml.client');
       mockGetArtistDetails.mockRejectedValue(new LmlClientError('Connection refused', 502));
 
       const req = { query: { artistId: '3840' } } as unknown as Request;
       const res = createMockRes();
 
-      await getArtistMetadata(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(502);
+      await expect(getArtistMetadata(req, res as Response, mockNext)).rejects.toThrow('Connection refused');
     });
   });
 
   // --- resolveEntity ---
 
   describe('resolveEntity', () => {
-    it('returns 400 when type or id is missing', async () => {
+    it('throws WxycError 400 when type or id is missing', async () => {
       const req = { query: { type: 'artist' } } as unknown as Request;
       const res = createMockRes();
 
-      await resolveEntity(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-    });
-
-    it('returns 400 for invalid type', async () => {
-      const req = { query: { type: 'label', id: '1' } } as unknown as Request;
-      const res = createMockRes();
-
-      await resolveEntity(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({ message: expect.stringContaining('artist, release, master') })
+      await expect(resolveEntity(req, res as Response, mockNext)).rejects.toThrow(
+        'type and id query parameters are required'
       );
     });
 
-    it('returns 400 when id is not a number', async () => {
+    it('throws WxycError 400 for invalid type', async () => {
+      const req = { query: { type: 'label', id: '1' } } as unknown as Request;
+      const res = createMockRes();
+
+      await expect(resolveEntity(req, res as Response, mockNext)).rejects.toThrow('type must be one of');
+    });
+
+    it('throws WxycError 400 when id is not a number', async () => {
       const req = { query: { type: 'artist', id: 'abc' } } as unknown as Request;
       const res = createMockRes();
 
-      await resolveEntity(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({ message: 'id must be an integer' });
+      await expect(resolveEntity(req, res as Response, mockNext)).rejects.toThrow('id must be an integer');
     });
 
     it('resolves an artist by ID via LML', async () => {
@@ -596,28 +577,24 @@ describe('proxy.controller', () => {
       expect(res.json).toHaveBeenCalledWith({ name: 'Confield', type: 'master', id: 44444 });
     });
 
-    it('returns 404 when LML returns not found', async () => {
+    it('rejects with LmlClientError when LML returns not found', async () => {
       const { LmlClientError } = await import('../../../apps/backend/services/lml/lml.client');
       mockResolveEntity.mockRejectedValue(new LmlClientError('Not found', 404));
 
       const req = { query: { type: 'artist', id: '99999' } } as unknown as Request;
       const res = createMockRes();
 
-      await resolveEntity(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(404);
+      await expect(resolveEntity(req, res as Response, mockNext)).rejects.toThrow('Not found');
     });
 
-    it('returns 504 when LML times out', async () => {
+    it('rejects with LmlClientError when LML times out', async () => {
       const { LmlClientError } = await import('../../../apps/backend/services/lml/lml.client');
       mockResolveEntity.mockRejectedValue(new LmlClientError('LML request timed out', 504));
 
       const req = { query: { type: 'artist', id: '3840' } } as unknown as Request;
       const res = createMockRes();
 
-      await resolveEntity(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(504);
+      await expect(resolveEntity(req, res as Response, mockNext)).rejects.toThrow('LML request timed out');
     });
   });
 
@@ -636,13 +613,11 @@ describe('proxy.controller', () => {
       process.env = originalEnv;
     });
 
-    it('returns 400 when track ID is missing', async () => {
+    it('throws WxycError 400 when track ID is missing', async () => {
       const req = { params: {} } as unknown as Request;
       const res = createMockRes();
 
-      await getSpotifyTrack(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(400);
+      await expect(getSpotifyTrack(req, res as Response, mockNext)).rejects.toThrow('Track ID is required');
     });
 
     it('returns 503 when Spotify credentials are not configured', async () => {
@@ -728,14 +703,13 @@ describe('proxy.controller', () => {
   });
 
   describe('librarySearch', () => {
-    it('returns 400 when no search params provided', async () => {
+    it('throws WxycError 400 when no search params provided', async () => {
       const req = { query: {} } as unknown as Request;
       const res = createMockRes();
 
-      await librarySearch(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('artist') }));
+      await expect(librarySearch(req, res as Response, mockNext)).rejects.toThrow(
+        'At least one of artist, title, or q is required'
+      );
     });
 
     it('forwards artist and title to LML searchLibrary', async () => {
@@ -772,26 +746,21 @@ describe('proxy.controller', () => {
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
-    it('maps LmlClientError to the correct status code', async () => {
+    it('rejects with LmlClientError (handled by errorHandler)', async () => {
       mockSearchLibrary.mockRejectedValue(new MockLmlClientError('LML not configured', 503));
       const req = { query: { artist: 'Stereolab' } } as unknown as Request;
       const res = createMockRes();
 
-      await librarySearch(req, res as Response, mockNext);
-
-      expect(res.status).toHaveBeenCalledWith(503);
-      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ message: 'LML not configured' }));
+      await expect(librarySearch(req, res as Response, mockNext)).rejects.toThrow('LML not configured');
     });
 
-    it('passes unexpected errors to next()', async () => {
+    it('rejects with unexpected errors (handled by errorHandler)', async () => {
       const error = new Error('unexpected');
       mockSearchLibrary.mockRejectedValue(error);
       const req = { query: { artist: 'Stereolab' } } as unknown as Request;
       const res = createMockRes();
 
-      await librarySearch(req, res as Response, mockNext);
-
-      expect(mockNext).toHaveBeenCalledWith(error);
+      await expect(librarySearch(req, res as Response, mockNext)).rejects.toThrow(error);
     });
   });
 });

--- a/tests/unit/controllers/suggest.controller.test.ts
+++ b/tests/unit/controllers/suggest.controller.test.ts
@@ -99,17 +99,13 @@ describe('suggest.controller', () => {
     it('throws WxycError 400 when artist parameter is missing', async () => {
       const { req, res, next } = mockReqResNext({ track: 'VI Scose Poise' });
 
-      await expect(getTrackDetailsEndpoint(req, res, next)).rejects.toThrow(
-        'Missing required query parameter: artist'
-      );
+      await expect(getTrackDetailsEndpoint(req, res, next)).rejects.toThrow('Missing required query parameter: artist');
     });
 
     it('throws WxycError 400 when track parameter is missing', async () => {
       const { req, res, next } = mockReqResNext({ artist: 'Autechre' });
 
-      await expect(getTrackDetailsEndpoint(req, res, next)).rejects.toThrow(
-        'Missing required query parameter: track'
-      );
+      await expect(getTrackDetailsEndpoint(req, res, next)).rejects.toThrow('Missing required query parameter: track');
     });
 
     it('returns 200 with track details', async () => {

--- a/tests/unit/controllers/suggest.controller.test.ts
+++ b/tests/unit/controllers/suggest.controller.test.ts
@@ -8,6 +8,7 @@ import {
   suggestTracksEndpoint,
   getTrackDetailsEndpoint,
 } from '../../../apps/backend/controllers/suggest.controller';
+import WxycError from '../../../apps/backend/utils/error';
 
 function mockReqResNext(query: Record<string, string> = {}) {
   const req = { query } as unknown as Request;
@@ -27,13 +28,11 @@ describe('suggest.controller', () => {
   });
 
   describe('suggestArtistsEndpoint', () => {
-    it('returns 400 when q parameter is missing', async () => {
-      const { req, res, next, statusMock, jsonMock } = mockReqResNext({});
+    it('throws WxycError 400 when q parameter is missing', async () => {
+      const { req, res, next } = mockReqResNext({});
 
-      await suggestArtistsEndpoint(req, res, next);
-
-      expect(statusMock).toHaveBeenCalledWith(400);
-      expect(jsonMock).toHaveBeenCalledWith({ message: 'Missing required query parameter: q' });
+      await expect(suggestArtistsEndpoint(req, res, next)).rejects.toThrow(WxycError);
+      await expect(suggestArtistsEndpoint(req, res, next)).rejects.toThrow('Missing required query parameter: q');
     });
 
     it('returns 200 with artist names', async () => {
@@ -59,35 +58,27 @@ describe('suggest.controller', () => {
       expect(suggestService.suggestArtists).toHaveBeenCalledWith('Aut', 1);
     });
 
-    it('calls next on service error', async () => {
+    it('rejects with the service error', async () => {
       const error = new Error('DB error');
       (suggestService.suggestArtists as jest.Mock).mockRejectedValue(error);
 
       const { req, res, next } = mockReqResNext({ q: 'Aut' });
 
-      await suggestArtistsEndpoint(req, res, next);
-
-      expect(next).toHaveBeenCalledWith(error);
+      await expect(suggestArtistsEndpoint(req, res, next)).rejects.toThrow(error);
     });
   });
 
   describe('suggestTracksEndpoint', () => {
-    it('returns 400 when q parameter is missing', async () => {
-      const { req, res, next, statusMock, jsonMock } = mockReqResNext({ artist: 'Autechre' });
+    it('throws WxycError 400 when q parameter is missing', async () => {
+      const { req, res, next } = mockReqResNext({ artist: 'Autechre' });
 
-      await suggestTracksEndpoint(req, res, next);
-
-      expect(statusMock).toHaveBeenCalledWith(400);
-      expect(jsonMock).toHaveBeenCalledWith({ message: 'Missing required query parameter: q' });
+      await expect(suggestTracksEndpoint(req, res, next)).rejects.toThrow('Missing required query parameter: q');
     });
 
-    it('returns 400 when artist parameter is missing', async () => {
-      const { req, res, next, statusMock, jsonMock } = mockReqResNext({ q: 'VI' });
+    it('throws WxycError 400 when artist parameter is missing', async () => {
+      const { req, res, next } = mockReqResNext({ q: 'VI' });
 
-      await suggestTracksEndpoint(req, res, next);
-
-      expect(statusMock).toHaveBeenCalledWith(400);
-      expect(jsonMock).toHaveBeenCalledWith({ message: 'Missing required query parameter: artist' });
+      await expect(suggestTracksEndpoint(req, res, next)).rejects.toThrow('Missing required query parameter: artist');
     });
 
     it('returns 200 with track results', async () => {
@@ -105,22 +96,20 @@ describe('suggest.controller', () => {
   });
 
   describe('getTrackDetailsEndpoint', () => {
-    it('returns 400 when artist parameter is missing', async () => {
-      const { req, res, next, statusMock, jsonMock } = mockReqResNext({ track: 'VI Scose Poise' });
+    it('throws WxycError 400 when artist parameter is missing', async () => {
+      const { req, res, next } = mockReqResNext({ track: 'VI Scose Poise' });
 
-      await getTrackDetailsEndpoint(req, res, next);
-
-      expect(statusMock).toHaveBeenCalledWith(400);
-      expect(jsonMock).toHaveBeenCalledWith({ message: 'Missing required query parameter: artist' });
+      await expect(getTrackDetailsEndpoint(req, res, next)).rejects.toThrow(
+        'Missing required query parameter: artist'
+      );
     });
 
-    it('returns 400 when track parameter is missing', async () => {
-      const { req, res, next, statusMock, jsonMock } = mockReqResNext({ artist: 'Autechre' });
+    it('throws WxycError 400 when track parameter is missing', async () => {
+      const { req, res, next } = mockReqResNext({ artist: 'Autechre' });
 
-      await getTrackDetailsEndpoint(req, res, next);
-
-      expect(statusMock).toHaveBeenCalledWith(400);
-      expect(jsonMock).toHaveBeenCalledWith({ message: 'Missing required query parameter: track' });
+      await expect(getTrackDetailsEndpoint(req, res, next)).rejects.toThrow(
+        'Missing required query parameter: track'
+      );
     });
 
     it('returns 200 with track details', async () => {

--- a/tests/unit/middleware/errorHandler.test.ts
+++ b/tests/unit/middleware/errorHandler.test.ts
@@ -1,5 +1,6 @@
 import errorHandler from '../../../apps/backend/middleware/errorHandler';
 import WxycError from '../../../apps/backend/utils/error';
+import { LmlClientError } from '../../../apps/backend/services/lml/lml.client';
 import { Request, Response, NextFunction } from 'express';
 
 function mockResponse() {
@@ -43,6 +44,16 @@ describe('errorHandler middleware', () => {
 
     expect(statusMock).toHaveBeenCalledWith(500);
     expect(jsonMock).toHaveBeenCalledWith({ message: 'Internal server error' });
+  });
+
+  it('returns { message } with correct status for LmlClientError', () => {
+    const { res, statusMock, jsonMock } = mockResponse();
+    const error = new LmlClientError('LML request timed out', 504);
+
+    errorHandler(error, mockReq, res, mockNext);
+
+    expect(statusMock).toHaveBeenCalledWith(504);
+    expect(jsonMock).toHaveBeenCalledWith({ message: 'LML request timed out' });
   });
 
   it('logs non-WxycError errors to console', () => {


### PR DESCRIPTION
## Summary

- Remove ~480 lines of redundant try/catch + `console.error` + `next(e)` boilerplate across all 9 controllers, relying on Express 5's native async error forwarding to `errorHandler` middleware
- Converge validation on `throw new WxycError(...)` instead of a mix of `res.status(400).json()` and `throw`
- Extend `errorHandler` to handle `LmlClientError` alongside `WxycError`, eliminating per-handler catch branches in proxy controller
- Fix `addAlbum` error flow where `next(e)` was called without returning

Closes #440

## Test plan

- [x] `npm run typecheck` -- passes
- [x] `npm run lint` -- 0 errors
- [x] `npm run format:check` -- passes
- [x] `npm run test:unit` -- 866/867 passing (1 pre-existing failure: `shared-type-compatibility` missing `@wxyc/shared`)
- [ ] CI passes