### PR TITLE
Add DB check to healthcheck endpoint

### DIFF
--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -23,7 +23,8 @@ import { activeShow } from './middleware/checkActiveShow.js';
 import errorHandler from './middleware/errorHandler.js';
 import { requestIdMiddleware } from './middleware/requestId.js';
 import { requirePermissions } from '@wxyc/authentication';
-import { closeDatabaseConnection } from '@wxyc/database';
+import { closeDatabaseConnection, db } from '@wxyc/database';
+import { sql } from 'drizzle-orm';
 
 const port = process.env.PORT || 8080;
 const app = express();
@@ -91,7 +92,12 @@ app.get('/testAuth', requirePermissions({ flowsheet: ['read'] }), async (req, re
 
 //endpoint for healthchecks
 app.get('/healthcheck', async (req, res) => {
-  res.json({ message: 'Healthy!' });
+  try {
+    await db.execute(sql`SELECT 1`);
+    res.json({ message: 'Healthy!' });
+  } catch {
+    res.status(503).json({ message: 'Database unreachable' });
+  }
 });
 
 // Internal endpoints (ETL sync notifications, key-authenticated)


### PR DESCRIPTION
## Summary

- Add a `SELECT 1` query to `/healthcheck` so it returns 503 when the database is unreachable
- Previously the endpoint always returned 200, masking the 2026-04-24 RDS outage from uptime monitors

Closes #444

## Test plan

- [ ] Verify `/healthcheck` returns 200 with a running database
- [ ] Verify `/healthcheck` returns 503 when the database is down (stop Docker DB, hit endpoint)
- [ ] Confirm no regression in existing health monitoring