### PR TITLE
Fix slow playlist search with missing indexes and single-pass query

### DIFF
--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -19,6 +19,7 @@ type SearchResultRow = {
   record_label: string | null;
   show_id: number | null;
   dj_name: string | null;
+  total: number;
 };
 
 export type SearchResult = {
@@ -68,7 +69,7 @@ export async function searchFlowsheet(params: SearchParams): Promise<{ results: 
 
   const fullWhere = whereClause ? sql`${baseFrom} AND ${whereClause}` : baseFrom;
 
-  const dataQuery = sql`
+  const query = sql`
     SELECT
       ${flowsheet.id},
       ${flowsheet.add_time} AS play_date,
@@ -77,21 +78,18 @@ export async function searchFlowsheet(params: SearchParams): Promise<{ results: 
       ${flowsheet.album_title},
       ${flowsheet.record_label},
       ${flowsheet.show_id},
-      ${DJ_NAME_EXPR} AS dj_name
+      ${DJ_NAME_EXPR} AS dj_name,
+      COUNT(*)::int OVER() AS total
     ${fullWhere}
     ORDER BY ${sortExpr} ${orderDirection}
     LIMIT ${limit} OFFSET ${offset}
   `;
 
-  const countQuery = sql`
-    SELECT COUNT(*)::int AS total
-    ${fullWhere}
-  `;
+  const rows = await db.execute(query);
 
-  const [rows, countRows] = await Promise.all([db.execute(dataQuery), db.execute(countQuery)]);
-
-  const results = (rows as unknown as SearchResultRow[]).map(transformRow);
-  const total = (countRows as unknown as Array<{ total: number }>)[0]?.total ?? 0;
+  const typedRows = rows as unknown as SearchResultRow[];
+  const results = typedRows.map(transformRow);
+  const total = typedRows[0]?.total ?? 0;
 
   return { results, total };
 }

--- a/shared/database/src/migrations/0049_flowsheet-search-indexes.sql
+++ b/shared/database/src/migrations/0049_flowsheet-search-indexes.sql
@@ -1,0 +1,6 @@
+-- Flowsheet search indexes: support playlist archive search on album_title and record_label.
+-- Complements the existing GIN trigram indexes on artist_name and track_title (0042),
+-- so that "all fields" ILIKE searches can use BitmapOr across all four columns.
+
+CREATE INDEX "flowsheet_album_title_trgm_idx" ON "wxyc_schema"."flowsheet" USING gin ("album_title" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "flowsheet_record_label_trgm_idx" ON "wxyc_schema"."flowsheet" USING gin ("record_label" gin_trgm_ops);

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1777300800000,
       "tag": "0048_fix-fk-on-delete-set-null",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1777387200000,
+      "tag": "0049_flowsheet-search-indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -372,6 +372,8 @@ export const flowsheet = wxyc_schema.table(
     index('flowsheet_legacy_release_id_idx').on(table.legacy_release_id),
     index('flowsheet_artist_name_trgm_idx').using('gin', sql`${table.artist_name} gin_trgm_ops`),
     index('flowsheet_track_title_trgm_idx').using('gin', sql`${table.track_title} gin_trgm_ops`),
+    index('flowsheet_album_title_trgm_idx').using('gin', sql`${table.album_title} gin_trgm_ops`),
+    index('flowsheet_record_label_trgm_idx').using('gin', sql`${table.record_label} gin_trgm_ops`),
   ]
 );
 

--- a/tests/unit/services/search.service.test.ts
+++ b/tests/unit/services/search.service.test.ts
@@ -15,25 +15,24 @@ const makeRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
   record_label: 'Warp',
   show_id: 100,
   dj_name: 'DJ Test',
+  total: 1,
   ...overrides,
 });
 
 describe('searchFlowsheet', () => {
   it('returns paginated results for a simple query', async () => {
-    const rows = [makeRow(), makeRow({ id: 2, artist_name: 'Autolux' })];
-    (db.execute as jest.Mock)
-      .mockResolvedValueOnce(rows) // data query
-      .mockResolvedValueOnce([{ total: 2 }]); // count query
+    const rows = [makeRow({ total: 2 }), makeRow({ id: 2, artist_name: 'Autolux', total: 2 })];
+    (db.execute as jest.Mock).mockResolvedValueOnce(rows);
 
     const result = await searchFlowsheet({ q: 'aut', page: 0, limit: 50, sort: 'date', order: 'desc' });
 
     expect(result.results).toHaveLength(2);
     expect(result.total).toBe(2);
-    expect(db.execute).toHaveBeenCalledTimes(2);
+    expect(db.execute).toHaveBeenCalledTimes(1);
   });
 
   it('returns empty results when no matches', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0 }]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
 
     const result = await searchFlowsheet({ q: 'nonexistent', page: 0, limit: 50, sort: 'date', order: 'desc' });
 
@@ -42,18 +41,17 @@ describe('searchFlowsheet', () => {
   });
 
   it('calculates correct offset from page and limit', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow()]).mockResolvedValueOnce([{ total: 100 }]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow({ total: 100 })]);
 
     const result = await searchFlowsheet({ q: 'autechre', page: 2, limit: 10, sort: 'date', order: 'desc' });
 
     expect(result.results).toHaveLength(1);
     expect(result.total).toBe(100);
-    // Verify db.execute was called (offset = 2 * 10 = 20)
-    expect(db.execute).toHaveBeenCalledTimes(2);
+    expect(db.execute).toHaveBeenCalledTimes(1);
   });
 
   it('handles field-prefixed queries', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow()]).mockResolvedValueOnce([{ total: 1 }]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow()]);
 
     const result = await searchFlowsheet({
       q: 'artist:autechre',
@@ -69,9 +67,7 @@ describe('searchFlowsheet', () => {
 
   it('formats play_date as ISO string', async () => {
     const date = new Date('2024-06-15T14:30:00Z');
-    (db.execute as jest.Mock)
-      .mockResolvedValueOnce([makeRow({ play_date: date })])
-      .mockResolvedValueOnce([{ total: 1 }]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow({ play_date: date })]);
 
     const result = await searchFlowsheet({ q: 'autechre', page: 0, limit: 50, sort: 'date', order: 'desc' });
 
@@ -79,7 +75,7 @@ describe('searchFlowsheet', () => {
   });
 
   it('coerces null dj_name to empty string', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow({ dj_name: null })]).mockResolvedValueOnce([{ total: 1 }]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow({ dj_name: null })]);
 
     const result = await searchFlowsheet({ q: 'autechre', page: 0, limit: 50, sort: 'date', order: 'desc' });
 
@@ -87,16 +83,14 @@ describe('searchFlowsheet', () => {
   });
 
   it('coerces null text fields to empty strings', async () => {
-    (db.execute as jest.Mock)
-      .mockResolvedValueOnce([
-        makeRow({
-          artist_name: null,
-          track_title: null,
-          album_title: null,
-          record_label: null,
-        }),
-      ])
-      .mockResolvedValueOnce([{ total: 1 }]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([
+      makeRow({
+        artist_name: null,
+        track_title: null,
+        album_title: null,
+        record_label: null,
+      }),
+    ]);
 
     const result = await searchFlowsheet({ q: 'test', page: 0, limit: 50, sort: 'date', order: 'desc' });
 


### PR DESCRIPTION
## Summary

- Add GIN trigram indexes on `album_title` and `record_label` in the flowsheet table — bare queries (e.g., `?q=autechre`) OR across all four text columns, but only `artist_name` and `track_title` had trigram indexes, forcing a sequential scan on the other two
- Combine the data and count queries into a single pass using `COUNT(*) OVER()` window function, eliminating the duplicate scan

Before: `?q=autechre` ~11s, `?q=artist:autechre` ~0.3s
Expected after: both under 1s

## Test plan

- [x] All 43 search tests pass (updated to expect single `db.execute` call)
- [x] Full unit test suite passes (913/913)
- [x] Typecheck, lint, formatting, migration validation all pass
- [ ] Verify `?q=autechre` responds in under 1s after deploy