### PR TITLE
Prevent show overlaps in flowsheet ETL

### DIFF
--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -300,6 +300,24 @@ export const runIncremental = async (): Promise<SyncResult> => {
     showsImported++;
   }
 
+  // Clamp show end_times to prevent overlaps: if a show's end_time exceeds the
+  // next show's start_time, truncate it. This handles cases where the ETL or
+  // webhook stamped incorrect times during outage recovery.
+  if (showsImported > 0) {
+    await db.execute(sql`
+      UPDATE wxyc_schema.shows s
+      SET end_time = next.start_time
+      FROM (
+        SELECT id, LEAD(start_time) OVER (ORDER BY start_time) AS next_start
+        FROM wxyc_schema.shows
+      ) next
+      WHERE s.id = next.id
+        AND s.end_time IS NOT NULL
+        AND next.next_start IS NOT NULL
+        AND s.end_time > next.next_start
+    `);
+  }
+
   // Build show mapping
   const showRows = await db.select({ id: shows.id, legacyId: shows.legacy_show_id }).from(shows);
   const showIdMap = new Map<number, number>();
@@ -361,6 +379,9 @@ export const runIncremental = async (): Promise<SyncResult> => {
           request_flag: sql`excluded.request_flag`,
           segue: sql`excluded.segue`,
           entry_type: sql`excluded.entry_type`,
+          add_time: sql`excluded.add_time`,
+          show_id: sql`excluded.show_id`,
+          play_order: sql`excluded.play_order`,
         },
       });
 

--- a/tests/unit/jobs/flowsheet-etl/job.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.test.ts
@@ -110,6 +110,33 @@ describe('runIncremental', () => {
     expect(result.entriesUpdated).toBe(0);
   });
 
+  it('clamps overlapping show end_times after importing shows', async () => {
+    mockFetchLegacyShows.mockResolvedValue([makeShow()]);
+    mockFetchLegacyEntries.mockResolvedValue([]);
+
+    await runIncremental();
+
+    // db.execute is called for the overlap clamping query when shows are imported
+    const executeCalls = (db.execute as jest.Mock).mock.calls;
+    expect(executeCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('skips overlap clamping when no shows are imported', async () => {
+    mockFetchLegacyShows.mockResolvedValue([]);
+    mockFetchLegacyEntries.mockResolvedValue([]);
+
+    // Reset chain.then for the show map + existing IDs queries
+    chain.then
+      .mockReset()
+      .mockImplementationOnce((resolve: (v: unknown) => void) => resolve([]))
+      .mockImplementationOnce((resolve: (v: unknown) => void) => resolve([]));
+
+    await runIncremental();
+
+    // db.execute should NOT be called for overlap clamping
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
+  });
+
   it('distinguishes inserts from updates in return counts', async () => {
     mockFetchLegacyShows.mockResolvedValue([makeShow()]);
     mockFetchLegacyEntries.mockResolvedValue([


### PR DESCRIPTION
## Summary

- Add `add_time`, `show_id`, `play_order` to the ETL entry upsert's conflict update clause so re-synced entries get correct tubafrenzy timestamps
- Clamp show `end_time` to not exceed the next show's `start_time` after every incremental sync
- Add unit tests for overlap clamping (runs when shows imported, skipped otherwise)

Closes #447

## Test plan

- [x] Existing ETL unit tests pass (3/3)
- [x] New overlap clamping tests pass (2/2)
- [ ] CI passes
- [ ] Verify on staging: overlapping shows are corrected after ETL sync

## Context

During the 2026-04-24 RDS outage, the ETL re-synced entries with stale `add_time` values and created overlapping shows, causing duplicate "ended the set" entries and misordered flowsheet display.