### PR TITLE
Fix COUNT(*) OVER() cast syntax causing 500

### DIFF
--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -79,7 +79,7 @@ export async function searchFlowsheet(params: SearchParams): Promise<{ results: 
       ${flowsheet.record_label},
       ${flowsheet.show_id},
       ${DJ_NAME_EXPR} AS dj_name,
-      COUNT(*)::int OVER() AS total
+      (COUNT(*) OVER())::int AS total
     ${fullWhere}
     ORDER BY ${sortExpr} ${orderDirection}
     LIMIT ${limit} OFFSET ${offset}


### PR DESCRIPTION
## Summary

One-line fix: `COUNT(*)::int OVER()` is invalid SQL — PostgreSQL parses the `::int` cast before `OVER()`, making it `(COUNT(*)::int) OVER()` which fails. Wrapping correctly: `(COUNT(*) OVER())::int`.

This was introduced in #446 when converting from two separate queries to a single window function pass.

## Test plan

- [x] All search tests pass
- [ ] Verify `GET /flowsheet/search?q=autechre` returns 200 after deploy