### PR TITLE
Fix column reference in ETL overlap clamping query

### DIFF
--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -306,7 +306,7 @@ export const runIncremental = async (): Promise<SyncResult> => {
   if (showsImported > 0) {
     await db.execute(sql`
       UPDATE wxyc_schema.shows s
-      SET end_time = next.start_time
+      SET end_time = next.next_start
       FROM (
         SELECT id, LEAD(start_time) OVER (ORDER BY start_time) AS next_start
         FROM wxyc_schema.shows


### PR DESCRIPTION
## Summary

- Fix `next.start_time` → `next.next_start` in the show overlap clamping SQL from #448
- The SET clause referenced the wrong column alias, causing `errorMissingColumn` at runtime

## Test plan

- [x] ETL unit tests pass (5/5)
- [ ] CI passes
- [ ] flowsheet-etl-cron runs without error on EC2