### PR TITLE
Retry LML search with track title when album title returns empty

### DIFF
--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -91,6 +91,15 @@ async function fetchAlbumMetadata(request: MetadataRequest): Promise<{
     // Fall through to construct search URLs
   }
 
+  // Fallback: if album title search returned nothing and we have a track title, retry with it
+  if ((!lmlResults || lmlResults.results.length === 0) && albumTitle && trackTitle) {
+    try {
+      lmlResults = await searchDiscogs(artistName, trackTitle);
+    } catch (error) {
+      console.warn('[MetadataService] LML track title fallback failed:', error);
+    }
+  }
+
   if (!lmlResults || lmlResults.results.length === 0) {
     // No LML results — construct search URLs as bare minimum
     const urls = searchUrls.getAllSearchUrls(artistName, albumTitle, trackTitle);

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -225,4 +225,57 @@ describe('metadata.service', () => {
     // Year from search result, not release
     expect(result?.album?.releaseYear).toBe(2001);
   });
+
+  describe('track title fallback', () => {
+    it('retries with track title when album title search returns empty', async () => {
+      // First call (album title) returns nothing; second call (track title) finds the release
+      mockSearchDiscogs
+        .mockResolvedValueOnce({ results: [], total: 0, cached: false })
+        .mockResolvedValueOnce({ results: [lmlSearchResult], total: 1, cached: false });
+      mockGetRelease.mockResolvedValue(lmlReleaseResponse);
+      mockGetArtistDetails.mockResolvedValue(lmlArtistResponse);
+
+      const result = await fetchMetadata({
+        artistName: 'Cocteau Twins',
+        albumTitle: 'cocteau twins singles collections',
+        trackTitle: 'crushed',
+      });
+
+      expect(mockSearchDiscogs).toHaveBeenCalledTimes(2);
+      expect(mockSearchDiscogs).toHaveBeenNthCalledWith(1, 'Cocteau Twins', 'cocteau twins singles collections');
+      expect(mockSearchDiscogs).toHaveBeenNthCalledWith(2, 'Cocteau Twins', 'crushed');
+      expect(result?.album?.discogsReleaseId).toBe(12345);
+      expect(result?.album?.spotifyUrl).toBe('https://open.spotify.com/album/abc');
+    });
+
+    it('returns search URLs when both album and track title searches return empty', async () => {
+      mockSearchDiscogs.mockResolvedValue({ results: [], total: 0, cached: false });
+
+      const result = await fetchMetadata({
+        artistName: 'Cocteau Twins',
+        albumTitle: 'cocteau twins singles collections',
+        trackTitle: 'crushed',
+      });
+
+      expect(mockSearchDiscogs).toHaveBeenCalledTimes(2);
+      expect(result?.album?.discogsReleaseId).toBeUndefined();
+      expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
+    });
+
+    it('does not retry when album title search returns results', async () => {
+      mockSearchDiscogs.mockResolvedValue({ results: [lmlSearchResult], total: 1, cached: false });
+      mockGetRelease.mockResolvedValue(lmlReleaseResponse);
+      mockGetArtistDetails.mockResolvedValue(lmlArtistResponse);
+
+      const result = await fetchMetadata({
+        artistName: 'Autechre',
+        albumTitle: 'Confield',
+        trackTitle: 'VI Scose Poise',
+      });
+
+      expect(mockSearchDiscogs).toHaveBeenCalledTimes(1);
+      expect(mockSearchDiscogs).toHaveBeenCalledWith('Autechre', 'Confield');
+      expect(result?.album?.discogsReleaseId).toBe(12345);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- When `fetchAlbumMetadata` gets no results from the primary LML search (using album title), it now retries with the track title before falling back to bare search URLs
- Fixes cases like flowsheet entry #5198490 where a misspelled album title ("cocteau twins singles collections" vs "Singles Collection") prevented metadata from being found, even though the track title ("crushed") would have matched

Closes #453

## Test plan

- [x] Album title returns empty, track title retry succeeds — verify `searchDiscogs` called twice, metadata populated
- [x] Both album and track title searches return empty — verify no infinite retry, falls back to search URLs
- [x] Album title returns results on first try — verify no retry (single `searchDiscogs` call)
- [x] All existing tests pass unchanged