### PR TITLE
Fix Unicode garbling in MirrorSQL ETL commands

### DIFF
--- a/shared/database/src/legacy/sql.mirror.ts
+++ b/shared/database/src/legacy/sql.mirror.ts
@@ -78,6 +78,7 @@ export class MirrorSQL {
               --protocol=TCP \\
               --connect-timeout=10 \\
               --skip-ssl \\
+              --default-character-set=utf8 \\
               --batch --raw --silent <<'__SQL__'
 ${sql}
 __SQL__
@@ -89,7 +90,7 @@ __SQL__
     const password = process.env.REMOTE_DB_PASSWORD || '';
     const database = process.env.REMOTE_DB_NAME || 'wxycmusic';
 
-    const command = `docker exec -i ${container} mysql -u${user} -p${password} ${database} --batch --raw --silent`;
+    const command = `docker exec -i ${container} mysql -u${user} -p${password} ${database} --default-character-set=utf8 --batch --raw --silent`;
 
     try {
       const stdout = execSync(command, { encoding: 'utf8', input: sql, maxBuffer: 50 * 1024 * 1024 });


### PR DESCRIPTION
## Summary

- Add `--default-character-set=utf8` to the `mysql` CLI invocations in `MirrorSQL.makeSqlCommand()` (SSH mode) and `MirrorSQL.sendLocal()` (Docker mode)
- Without this flag, the `mysql` CLI defaults to `latin1` for the client connection charset, causing MySQL to perform a server-side conversion that replaces characters outside the latin1 range (em-dashes, en-dashes, CJK, etc.) with replacement characters (`�`)

Closes #454

## Test plan

- [ ] Deploy and re-run flowsheet ETL and library ETL (after resetting `last_run` timestamps per the issue) to overwrite garbled values
- [ ] Verify that entry #5198493's `album_title` reads `Music from the Caucasus — The Archive of ORED Recordings, 2013–2023` (with proper em-dash and en-dash)
- [ ] Spot-check other entries with non-latin1 characters (curly quotes, CJK, Arabic)