### PR TITLE
Fix welcome email missing password reset token

### DIFF
--- a/apps/auth/provision-user.ts
+++ b/apps/auth/provision-user.ts
@@ -4,7 +4,7 @@
  * endpoint and by createDefaultUser() at startup.
  */
 
-import { auth, WXYCRoles, sendAccountSetupEmail } from '@wxyc/authentication';
+import { auth, WXYCRoles } from '@wxyc/authentication';
 import { db, user } from '@wxyc/database';
 import { eq } from 'drizzle-orm';
 
@@ -123,10 +123,15 @@ export async function provisionUser(input: ProvisionUserInput): Promise<Provisio
       await db.update(user).set({ role: 'admin' }).where(eq(user.id, newUser.id));
     }
 
-    // 10. Send welcome email (fire-and-forget so provisioning isn't blocked by SES)
+    // 10. Trigger password reset flow to send welcome email with a tokenized setup URL.
+    // The sendResetPassword hook in auth.definition.ts detects hasCompletedOnboarding === false
+    // and sends the accountSetup email template instead of a plain password reset.
     const frontendUrl = process.env.FRONTEND_SOURCE || 'http://localhost:3000';
-    sendAccountSetupEmail({ to: email, setupUrl: `${frontendUrl}/login` }).catch((error) => {
-      console.error('[PROVISION USER] Failed to send welcome email:', error);
+    auth.api.requestPasswordReset({
+      body: { email, redirectTo: `${frontendUrl}/login` },
+      headers: new Headers({ origin: frontendUrl }),
+    }).catch((error: unknown) => {
+      console.error('[PROVISION USER] Failed to trigger setup email:', error);
     });
 
     return { user: newUser, member: createdMember };

--- a/apps/auth/provision-user.ts
+++ b/apps/auth/provision-user.ts
@@ -127,12 +127,14 @@ export async function provisionUser(input: ProvisionUserInput): Promise<Provisio
     // The sendResetPassword hook in auth.definition.ts detects hasCompletedOnboarding === false
     // and sends the accountSetup email template instead of a plain password reset.
     const frontendUrl = process.env.FRONTEND_SOURCE || 'http://localhost:3000';
-    auth.api.requestPasswordReset({
-      body: { email, redirectTo: `${frontendUrl}/login` },
-      headers: new Headers({ origin: frontendUrl }),
-    }).catch((error: unknown) => {
-      console.error('[PROVISION USER] Failed to trigger setup email:', error);
-    });
+    auth.api
+      .requestPasswordReset({
+        body: { email, redirectTo: `${frontendUrl}/login` },
+        headers: new Headers({ origin: frontendUrl }),
+      })
+      .catch((error: unknown) => {
+        console.error('[PROVISION USER] Failed to trigger setup email:', error);
+      });
 
     return { user: newUser, member: createdMember };
   } catch (error) {

--- a/scripts/resend-setup-emails.ts
+++ b/scripts/resend-setup-emails.ts
@@ -1,0 +1,85 @@
+/**
+ * Resend account setup emails to users who haven't completed onboarding.
+ *
+ * Queries all users with hasCompletedOnboarding === false and triggers
+ * better-auth's password reset flow for each, which sends the accountSetup
+ * email template with a tokenized URL.
+ *
+ * Usage:
+ *   npx tsx scripts/resend-setup-emails.ts [--dry-run]
+ *
+ * Requires:
+ *   - Database connection (DB_HOST, DB_NAME, etc.)
+ *   - Auth server running (BETTER_AUTH_URL)
+ *   - SES configured (AWS_ACCESS_KEY_ID, etc.)
+ *   - FRONTEND_SOURCE set to the frontend URL
+ */
+
+import { config } from 'dotenv';
+config();
+
+import { db, user } from '@wxyc/database';
+import { auth } from '@wxyc/authentication';
+import { eq } from 'drizzle-orm';
+
+const dryRun = process.argv.includes('--dry-run');
+const DELAY_MS = 500; // Avoid SES rate limiting
+
+async function main() {
+  console.log(dryRun ? '🔍 DRY RUN — no emails will be sent\n' : '📧 Sending setup emails...\n');
+
+  const incompleteUsers = await db
+    .select({ id: user.id, email: user.email, name: user.name })
+    .from(user)
+    .where(eq(user.hasCompletedOnboarding, false));
+
+  if (incompleteUsers.length === 0) {
+    console.log('No users with incomplete onboarding found.');
+    process.exit(0);
+  }
+
+  console.log(`Found ${incompleteUsers.length} user(s) with incomplete onboarding:\n`);
+
+  for (const u of incompleteUsers) {
+    console.log(`  ${u.email} (${u.name || 'no name'})`);
+  }
+
+  if (dryRun) {
+    console.log('\nDry run complete. Run without --dry-run to send emails.');
+    process.exit(0);
+  }
+
+  console.log('');
+
+  const frontendUrl = process.env.FRONTEND_SOURCE || 'http://localhost:3000';
+  let sent = 0;
+  let failed = 0;
+
+  for (const u of incompleteUsers) {
+    try {
+      await auth.api.requestPasswordReset({
+        body: { email: u.email, redirectTo: `${frontendUrl}/login` },
+        headers: new Headers({ origin: frontendUrl }),
+      });
+      sent++;
+      console.log(`  ✅ ${u.email}`);
+    } catch (error) {
+      failed++;
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`  ❌ ${u.email}: ${message}`);
+    }
+
+    // Pace requests to avoid SES throttling
+    if (sent + failed < incompleteUsers.length) {
+      await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+    }
+  }
+
+  console.log(`\nDone. Sent: ${sent}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/tests/unit/auth/provision-user.test.ts
+++ b/tests/unit/auth/provision-user.test.ts
@@ -58,9 +58,14 @@ const mockAuthContext = {
   },
 };
 
+const mockRequestPasswordReset = jest.fn().mockResolvedValue({ status: true } as never);
+
 jest.mock('@wxyc/authentication', () => ({
   auth: {
     $context: Promise.resolve(mockAuthContext),
+    api: {
+      requestPasswordReset: (...args: unknown[]) => mockRequestPasswordReset(...args),
+    },
   },
   WXYCRoles: {
     member: {},
@@ -68,12 +73,10 @@ jest.mock('@wxyc/authentication', () => ({
     musicDirector: {},
     stationManager: {},
   },
-  sendAccountSetupEmail: jest.fn().mockResolvedValue(undefined),
 }));
 
 // --- Import after mocks ---
 import { provisionUser, ProvisionError } from '../../../apps/auth/provision-user';
-import { sendAccountSetupEmail } from '@wxyc/authentication';
 
 // --- Helpers ---
 const validInput = {
@@ -268,33 +271,33 @@ describe('provisionUser()', () => {
   });
 
   describe('welcome email', () => {
-    it('should send account setup email after successful provisioning', async () => {
+    it('should trigger password reset flow after successful provisioning', async () => {
       await provisionUser(validInput);
 
-      expect(sendAccountSetupEmail).toHaveBeenCalledWith({
-        to: validInput.email,
-        setupUrl: expect.stringContaining('/login'),
+      expect(mockRequestPasswordReset).toHaveBeenCalledWith({
+        body: { email: validInput.email, redirectTo: expect.stringContaining('/login') },
+        headers: expect.any(Headers),
       });
     });
 
-    it('should not send email if user creation fails', async () => {
+    it('should not trigger password reset if user creation fails', async () => {
       mockCreateUser.mockRejectedValue(new Error('unique constraint violated'));
 
       await provisionUser(validInput).catch(() => {});
 
-      expect(sendAccountSetupEmail).not.toHaveBeenCalled();
+      expect(mockRequestPasswordReset).not.toHaveBeenCalled();
     });
 
-    it('should not send email if member creation fails', async () => {
+    it('should not trigger password reset if member creation fails', async () => {
       mockAdapterCreate.mockRejectedValue(new Error('DB constraint violation'));
 
       await provisionUser(validInput).catch(() => {});
 
-      expect(sendAccountSetupEmail).not.toHaveBeenCalled();
+      expect(mockRequestPasswordReset).not.toHaveBeenCalled();
     });
 
-    it('should not block provisioning if email send fails', async () => {
-      (sendAccountSetupEmail as jest.Mock).mockRejectedValue(new Error('SES error'));
+    it('should not block provisioning if password reset trigger fails', async () => {
+      mockRequestPasswordReset.mockRejectedValue(new Error('SES error'));
 
       const result = await provisionUser(validInput);
 


### PR DESCRIPTION
## Summary

- Replace direct `sendAccountSetupEmail()` call in `provisionUser()` with `auth.api.requestPasswordReset()`, which generates a verification token and routes through the existing `sendResetPassword` hook
- The hook detects `hasCompletedOnboarding === false` and sends the `accountSetup` email template with a working tokenized URL
- Add `scripts/resend-setup-emails.ts` for bulk-resending setup emails to users who haven't completed onboarding

Closes #458

## Test plan

- [x] Unit tests updated and passing (28/28)
- [x] Typecheck clean
- [x] Lint clean
- [x] Manually verified: triggered `requestPasswordReset` for a test account and confirmed the email contains a tokenized URL that works end-to-end