### PR TITLE
Migrate all callers from searchDiscogs to lookupMetadata

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -11,7 +11,7 @@ import {
 } from '@wxyc/database';
 import * as libraryService from '../services/library.service.js';
 import * as labelsService from '../services/labels.service.js';
-import { checkStreamingAvailability, searchDiscogs, isLmlConfigured } from '../services/lml/lml.client.js';
+import { checkStreamingAvailability, lookupMetadata, isLmlConfigured } from '../services/lml/lml.client.js';
 import WxycError from '../utils/error.js';
 
 type NewAlbumRequest = {
@@ -77,7 +77,7 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
     const artistName = body.alternate_artist_name || body.artist_name || '';
     const [streamingResult, artworkResult] = await Promise.allSettled([
       checkStreamingAvailability(artistName, body.album_title),
-      searchDiscogs(artistName, body.album_title),
+      lookupMetadata(artistName, body.album_title),
     ]);
 
     if (streamingResult.status === 'fulfilled' && streamingResult.value.on_streaming !== null) {
@@ -91,11 +91,11 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
     }
 
     if (artworkResult.status === 'fulfilled') {
-      const top = artworkResult.value.results[0];
-      if (top?.artwork_url && !top.artwork_url.includes('spacer.gif')) {
+      const artworkUrl = artworkResult.value.results?.[0]?.artwork?.artwork_url;
+      if (artworkUrl && !artworkUrl.includes('spacer.gif')) {
         try {
-          await libraryService.updateArtworkUrl(inserted_album.id, top.artwork_url);
-          (inserted_album as Record<string, unknown>).artwork_url = top.artwork_url;
+          await libraryService.updateArtworkUrl(inserted_album.id, artworkUrl);
+          (inserted_album as Record<string, unknown>).artwork_url = artworkUrl;
         } catch (e) {
           console.warn('Failed to persist artwork URL:', (e as Error).message);
         }

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -13,7 +13,7 @@ import { RequestHandler } from 'express';
 import { getArtworkFinder } from '../services/artwork/finder.js';
 import { classify as classifyNSFW } from '../services/artwork/nsfw.js';
 import {
-  searchDiscogs,
+  lookupMetadata,
   getRelease,
   getArtistDetails,
   resolveEntity as lmlResolveEntity,
@@ -179,33 +179,33 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   const metadata: Record<string, unknown> = {};
   const searchTerm = releaseTitle || trackTitle || '';
 
-  let lmlResults;
+  let artwork;
   try {
-    lmlResults = await searchDiscogs(artistName, searchTerm || undefined);
+    const lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle);
+    artwork = lookupResponse.results?.[0]?.artwork;
   } catch (searchError) {
-    console.warn('[ProxyController] LML search failed:', searchError);
+    console.warn('[ProxyController] LML lookup failed:', searchError);
   }
 
-  if (lmlResults && lmlResults.results.length > 0) {
-    const topResult = lmlResults.results[0];
-    metadata.discogsReleaseId = topResult.release_id;
-    metadata.discogsUrl = topResult.release_url;
-    metadata.artworkUrl = topResult.artwork_url || undefined;
+  if (artwork) {
+    metadata.discogsReleaseId = artwork.release_id;
+    metadata.discogsUrl = artwork.release_url;
+    metadata.artworkUrl = artwork.artwork_url || undefined;
 
-    // Artist bio and Wikipedia from LML search result
-    if (topResult.artist_bio) metadata.artistBio = topResult.artist_bio;
-    if (topResult.wikipedia_url) metadata.artistWikipediaUrl = topResult.wikipedia_url;
+    // Artist bio and Wikipedia from lookup result
+    if (artwork.artist_bio) metadata.artistBio = artwork.artist_bio;
+    if (artwork.wikipedia_url) metadata.artistWikipediaUrl = artwork.wikipedia_url;
 
     // Streaming URLs from LML enrichment
-    if (topResult.spotify_url) metadata.spotifyUrl = topResult.spotify_url;
-    if (topResult.apple_music_url) metadata.appleMusicUrl = topResult.apple_music_url;
-    if (topResult.youtube_music_url) metadata.youtubeMusicUrl = topResult.youtube_music_url;
-    if (topResult.bandcamp_url) metadata.bandcampUrl = topResult.bandcamp_url;
-    if (topResult.soundcloud_url) metadata.soundcloudUrl = topResult.soundcloud_url;
+    if (artwork.spotify_url) metadata.spotifyUrl = artwork.spotify_url;
+    if (artwork.apple_music_url) metadata.appleMusicUrl = artwork.apple_music_url;
+    if (artwork.youtube_music_url) metadata.youtubeMusicUrl = artwork.youtube_music_url;
+    if (artwork.bandcamp_url) metadata.bandcampUrl = artwork.bandcamp_url;
+    if (artwork.soundcloud_url) metadata.soundcloudUrl = artwork.soundcloud_url;
 
-    // Fetch enriched release details
+    // Fetch enriched release details (tracklist, genres, styles)
     try {
-      const release = await getRelease(topResult.release_id);
+      const release = await getRelease(artwork.release_id);
       metadata.releaseYear = release.year ?? undefined;
       metadata.genres = release.genres.length > 0 ? release.genres : undefined;
       metadata.styles = release.styles.length > 0 ? release.styles : undefined;
@@ -219,7 +219,7 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
           duration: t.duration ?? undefined,
         }));
       }
-      // Prefer release artwork over search artwork
+      // Prefer release artwork over lookup artwork
       if (release.artwork_url) {
         metadata.artworkUrl = release.artwork_url;
       }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,7 +20,7 @@
     "@tensorflow/tfjs": "^4.22.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^0.5.0",
+    "@wxyc/shared": "^0.6.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.15.0",

--- a/apps/backend/services/artwork/providers/discogs.ts
+++ b/apps/backend/services/artwork/providers/discogs.ts
@@ -6,8 +6,7 @@
 
 import { ArtworkProvider } from './base.js';
 import { ArtworkRequest, ArtworkSearchResult } from '../../requestLine/types.js';
-import { searchDiscogs, searchTrackReleases, validateTrackOnRelease, isLmlConfigured } from '../../lml/lml.client.js';
-import { calculateConfidence } from '../../requestLine/matching/index.js';
+import { lookupMetadata, searchTrackReleases, validateTrackOnRelease, isLmlConfigured } from '../../lml/lml.client.js';
 
 /**
  * Artwork provider backed by LML's Discogs endpoints.
@@ -29,29 +28,28 @@ export class DiscogsProvider implements ArtworkProvider {
       return [];
     }
 
-    let lmlResults;
+    let lookupResponse;
     try {
-      lmlResults = await searchDiscogs(request.artist || '', request.album || request.song || undefined);
+      lookupResponse = await lookupMetadata(request.artist || '', request.album, request.song);
     } catch (error) {
-      console.warn('[DiscogsProvider] LML search failed:', error);
+      console.warn('[DiscogsProvider] LML lookup failed:', error);
       return [];
     }
 
     const results: ArtworkSearchResult[] = [];
-    for (const item of lmlResults.results) {
-      if (!item.artwork_url || item.artwork_url.includes('spacer.gif')) {
+    for (const item of lookupResponse.results ?? []) {
+      const artwork = item.artwork;
+      if (!artwork?.artwork_url || artwork.artwork_url.includes('spacer.gif')) {
         continue;
       }
 
-      const confidence = calculateConfidence(request.artist, request.album, item.artist || '', item.album || '');
-
       results.push({
-        artworkUrl: item.artwork_url,
-        releaseUrl: item.release_url,
-        album: item.album || '',
-        artist: item.artist || '',
+        artworkUrl: artwork.artwork_url,
+        releaseUrl: artwork.release_url,
+        album: artwork.album || '',
+        artist: artwork.artist || '',
         source: this.name,
-        confidence,
+        confidence: artwork.confidence ?? 0,
       });
     }
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -18,7 +18,7 @@ import {
 } from '@wxyc/database';
 import { LibraryResult, EnrichedLibraryResult, enrichLibraryResult } from './requestLine/types.js';
 import { extractSignificantWords } from './requestLine/matching/index.js';
-import { searchDiscogs, isLmlConfigured } from './lml/lml.client.js';
+import { lookupMetadata, isLmlConfigured } from './lml/lml.client.js';
 
 export const getFormatsFromDB = async () => {
   const formats = await db
@@ -142,11 +142,11 @@ export async function enrichWithArtwork(
       const artist = row.artist_name as string;
       const album = row.album_title as string;
       const id = row.id as number;
-      const lmlResult = await searchDiscogs(artist, album);
-      const top = lmlResult.results[0];
-      if (!top?.artwork_url || top.artwork_url.includes('spacer.gif')) return;
-      row.artwork_url = top.artwork_url;
-      await updateArtworkUrl(id, top.artwork_url);
+      const lookupResult = await lookupMetadata(artist, album);
+      const artworkUrl = lookupResult.results?.[0]?.artwork?.artwork_url;
+      if (!artworkUrl || artworkUrl.includes('spacer.gif')) return;
+      row.artwork_url = artworkUrl;
+      await updateArtworkUrl(id, artworkUrl);
     })
   );
 

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -15,12 +15,14 @@ import type {
   DiscogsTrackReleasesResponse,
   EntityResolveResponse,
   LibrarySearchResponse,
+  LookupResponse,
   StreamingCheckResponse,
 } from '@wxyc/shared/dtos';
 
 export type {
   DiscogsSearchResponse,
   DiscogsEnrichedSearchResult,
+  DiscogsMatchResult,
   DiscogsReleaseMetadata,
   DiscogsTrackItem,
   DiscogsArtistCredit,
@@ -31,6 +33,9 @@ export type {
   EntityResolveResponse,
   LibrarySearchItem,
   LibrarySearchResponse,
+  LookupRequest,
+  LookupResponse,
+  LookupResultItem,
   StreamingCheckResponse,
   StreamingSourceMatch,
   StreamingCheckSources,
@@ -106,6 +111,31 @@ export async function searchDiscogs(artist: string, album?: string): Promise<Dis
   });
 
   return (await response.json()) as DiscogsSearchResponse;
+}
+
+/**
+ * Look up a release in the library catalog via LML's full search pipeline.
+ *
+ * Provides artist correction, title normalization, fallback strategies,
+ * artwork, streaming URLs, and artist metadata in a single call.
+ *
+ * @param artist - Artist name
+ * @param album - Album/release title
+ * @param song - Song/track title
+ * @returns Lookup results with library items and enriched artwork metadata
+ */
+export async function lookupMetadata(artist: string, album?: string, song?: string): Promise<LookupResponse> {
+  const body: Record<string, string> = { artist };
+  if (album) body.album = album;
+  if (song) body.song = song;
+
+  const response = await lmlFetch('/api/v1/lookup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  return (await response.json()) as LookupResponse;
 }
 
 /**

--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -2,14 +2,13 @@
  * Metadata Service - Fetches metadata from LML (library-metadata-lookup).
  *
  * Called fire-and-forget on every flowsheet insert. The caller persists the
- * returned metadata directly on the flowsheet row. LML search results include
- * enriched streaming URLs (Spotify, Apple Music, YouTube Music, Bandcamp,
- * SoundCloud), Discogs metadata, artist bio, and Wikipedia URL. Fallback search
- * URLs are constructed for services where LML returns null.
+ * returned metadata directly on the flowsheet row. Uses LML's /lookup endpoint
+ * which provides artist correction, title normalization, fallback strategies,
+ * artwork, streaming URLs, and artist metadata in a single call.
  */
 import { MetadataRequest, AlbumMetadataResult, ArtistMetadataResult, FlowsheetMetadata } from './metadata.types.js';
-import { searchDiscogs, getRelease, getArtistDetails } from '../lml/lml.client.js';
-import type { DiscogsEnrichedSearchResult } from '../lml/lml.client.js';
+import { lookupMetadata } from '../lml/lml.client.js';
+import type { DiscogsMatchResult } from '../lml/lml.client.js';
 import { SearchUrlProvider } from './providers/search-urls.provider.js';
 
 const searchUrls = new SearchUrlProvider();
@@ -49,129 +48,64 @@ export async function fetchMetadata(request: MetadataRequest): Promise<Flowsheet
     return null;
   }
 
+  const { artistName, albumTitle, trackTitle } = request;
   const result: FlowsheetMetadata = {};
 
+  let artwork: DiscogsMatchResult | null = null;
   try {
-    const { albumMetadata, artistId, searchResult } = await fetchAlbumMetadata(request);
-    if (albumMetadata) {
-      result.album = albumMetadata;
-    }
-
-    const artistMetadata = await fetchArtistMetadata(request, artistId, searchResult);
-    if (artistMetadata) {
-      result.artist = artistMetadata;
-    }
-
-    return result;
+    const lookupResponse = await lookupMetadata(artistName, albumTitle, trackTitle);
+    artwork = lookupResponse.results?.[0]?.artwork ?? null;
   } catch (error) {
-    console.error('[MetadataService] fetchMetadata error:', error);
-    return null;
-  }
-}
-
-/**
- * Fetch album metadata from LML.
- *
- * Returns the album metadata result, the Discogs artist ID (if found), and
- * the raw LML search result (for fallback artist bio extraction).
- */
-async function fetchAlbumMetadata(request: MetadataRequest): Promise<{
-  albumMetadata: AlbumMetadataResult | null;
-  artistId: number | null;
-  searchResult: DiscogsEnrichedSearchResult | null;
-}> {
-  const { artistName, albumTitle, trackTitle } = request;
-  const searchTerm = albumTitle || trackTitle || '';
-
-  let lmlResults;
-  try {
-    lmlResults = await searchDiscogs(artistName, searchTerm || undefined);
-  } catch (error) {
-    console.warn('[MetadataService] LML search failed:', error);
-    // Fall through to construct search URLs
+    console.warn('[MetadataService] LML lookup failed:', error);
   }
 
-  if (!lmlResults || lmlResults.results.length === 0) {
-    // No LML results — construct search URLs as bare minimum
-    const urls = searchUrls.getAllSearchUrls(artistName, albumTitle, trackTitle);
-    return {
-      albumMetadata: {
-        youtubeMusicUrl: urls.youtubeMusicUrl,
-        bandcampUrl: urls.bandcampUrl,
-        soundcloudUrl: urls.soundcloudUrl,
-      },
-      artistId: null,
-      searchResult: null,
-    };
+  if (artwork) {
+    result.album = extractAlbumMetadata(artwork);
+    result.artist = extractArtistMetadata(artwork) ?? undefined;
   }
 
-  const topResult = lmlResults.results[0];
-  const metadata: AlbumMetadataResult = {
-    discogsReleaseId: topResult.release_id,
-    discogsUrl: topResult.release_url,
-    artworkUrl: topResult.artwork_url ?? undefined,
-    releaseYear: topResult.release_year ?? undefined,
-    spotifyUrl: topResult.spotify_url ?? undefined,
-    appleMusicUrl: topResult.apple_music_url ?? undefined,
-    youtubeMusicUrl: topResult.youtube_music_url ?? undefined,
-    bandcampUrl: topResult.bandcamp_url ?? undefined,
-    soundcloudUrl: topResult.soundcloud_url ?? undefined,
-  };
-
-  // Fetch release details for artist_id (needed for artist metadata)
-  let artistId: number | null = null;
-  try {
-    const release = await getRelease(topResult.release_id);
-    artistId = release.artist_id ?? null;
-    // Enrich with release-level data
-    if (release.year) metadata.releaseYear = release.year;
-    if (release.artwork_url) metadata.artworkUrl = release.artwork_url;
-  } catch (error) {
-    console.warn('[MetadataService] LML release fetch failed:', error);
-  }
-
-  // Fill missing search URLs
+  // Fill missing search URLs (always available, no API calls)
   const urls = searchUrls.getAllSearchUrls(artistName, albumTitle, trackTitle);
-  if (!metadata.youtubeMusicUrl) metadata.youtubeMusicUrl = urls.youtubeMusicUrl;
-  if (!metadata.bandcampUrl) metadata.bandcampUrl = urls.bandcampUrl;
-  if (!metadata.soundcloudUrl) metadata.soundcloudUrl = urls.soundcloudUrl;
+  if (!result.album) {
+    result.album = {
+      youtubeMusicUrl: urls.youtubeMusicUrl,
+      bandcampUrl: urls.bandcampUrl,
+      soundcloudUrl: urls.soundcloudUrl,
+    };
+  } else {
+    if (!result.album.youtubeMusicUrl) result.album.youtubeMusicUrl = urls.youtubeMusicUrl;
+    if (!result.album.bandcampUrl) result.album.bandcampUrl = urls.bandcampUrl;
+    if (!result.album.soundcloudUrl) result.album.soundcloudUrl = urls.soundcloudUrl;
+  }
 
-  return { albumMetadata: metadata, artistId, searchResult: topResult };
+  return result;
 }
 
 /**
- * Fetch artist metadata from LML.
- *
- * Prefers getArtistDetails by ID (richer data). Falls back to the bio and
- * Wikipedia URL from the LML search result if no artist ID is available.
+ * Extract album metadata from a DiscogsMatchResult.
  */
-async function fetchArtistMetadata(
-  _request: MetadataRequest,
-  discogsArtistId: number | null,
-  searchResult: DiscogsEnrichedSearchResult | null
-): Promise<ArtistMetadataResult | null> {
-  // Try fetching full artist details by ID
-  if (discogsArtistId) {
-    try {
-      const artist = await getArtistDetails(discogsArtistId);
-      const wikipediaUrl = artist.urls.find((url) => url.includes('wikipedia.org')) ?? undefined;
-      const bio = artist.profile ? cleanDiscogsBio(artist.profile) : undefined;
+function extractAlbumMetadata(artwork: DiscogsMatchResult): AlbumMetadataResult {
+  return {
+    discogsReleaseId: artwork.release_id,
+    discogsUrl: artwork.release_url,
+    artworkUrl: artwork.artwork_url ?? undefined,
+    releaseYear: artwork.release_year ?? undefined,
+    spotifyUrl: artwork.spotify_url ?? undefined,
+    appleMusicUrl: artwork.apple_music_url ?? undefined,
+    youtubeMusicUrl: artwork.youtube_music_url ?? undefined,
+    bandcampUrl: artwork.bandcamp_url ?? undefined,
+    soundcloudUrl: artwork.soundcloud_url ?? undefined,
+  };
+}
 
-      return { bio, wikipediaUrl };
-    } catch (error) {
-      console.warn('[MetadataService] LML artist details failed:', error);
-      // Fall through to search result fallback
-    }
+/**
+ * Extract artist metadata from a DiscogsMatchResult.
+ */
+function extractArtistMetadata(artwork: DiscogsMatchResult): ArtistMetadataResult | null {
+  const bio = artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : undefined;
+  const wikipediaUrl = artwork.wikipedia_url ?? undefined;
+  if (bio || wikipediaUrl) {
+    return { bio, wikipediaUrl };
   }
-
-  // Fallback: use bio and Wikipedia URL from the LML search result
-  if (searchResult) {
-    const bio = searchResult.artist_bio ? cleanDiscogsBio(searchResult.artist_bio) : undefined;
-    const wikipediaUrl = searchResult.wikipedia_url ?? undefined;
-    if (bio || wikipediaUrl) {
-      return { bio, wikipediaUrl };
-    }
-  }
-
   return null;
 }

--- a/apps/backend/services/requestLine/requestLine.enhanced.service.ts
+++ b/apps/backend/services/requestLine/requestLine.enhanced.service.ts
@@ -22,7 +22,7 @@ import { getConfig, isParsingEnabled } from './config.js';
 import { parseRequest, isParserAvailable } from '../ai/index.js';
 import { executeSearchPipeline, getSearchTypeFromState } from './search/index.js';
 import { findSimilarArtist } from '../library.service.js';
-import { searchTrackReleases, searchDiscogs, validateTrackOnRelease, isLmlConfigured } from '../lml/lml.client.js';
+import { searchTrackReleases, lookupMetadata, validateTrackOnRelease, isLmlConfigured } from '../lml/lml.client.js';
 import { fetchArtworkForItems } from '../artwork/index.js';
 import {
   buildSlackBlocks,
@@ -227,11 +227,11 @@ export async function processRequest(body: RequestLineRequestBody): Promise<Unif
               }));
             },
             searchReleasesByArtist: async (artist: string, limit = 10) => {
-              const response = await searchDiscogs(artist);
-              return response.results
-                .filter((r) => r.album)
+              const response = await lookupMetadata(artist);
+              return (response.results ?? [])
+                .filter((r) => r.library_item?.title)
                 .slice(0, limit)
-                .map((r) => ({ artist: r.artist ?? '', album: r.album! }));
+                .map((r) => ({ artist: r.library_item.artist ?? '', album: r.library_item.title ?? '' }));
             },
             validateTrackOnRelease,
           }

--- a/dev_env/mock-api-server/src/routes/lml.ts
+++ b/dev_env/mock-api-server/src/routes/lml.ts
@@ -36,6 +36,35 @@ router.use((req: Request, res: Response, next) => {
   next();
 });
 
+/** POST /api/v1/lookup — wraps search fixtures into LookupResponse format. */
+router.post('/api/v1/lookup', (req: Request, res: Response) => {
+  const { artist, album, song } = req.body ?? {};
+  if (!artist) {
+    res.status(400).json({ error: 'artist is required' });
+    return;
+  }
+
+  const key = (artist as string).toLowerCase();
+  const searchData = fixtures.search as Record<string, { results: Array<Record<string, unknown>> }>;
+  const match = searchData[key];
+
+  if (match && match.results.length > 0) {
+    const results = match.results.map((r: Record<string, unknown>, i: number) => ({
+      library_item: {
+        id: i + 1,
+        title: r.album ?? '',
+        artist: r.artist ?? '',
+        call_number: `Mock CD ${i + 1}`,
+        library_url: `https://library.wxyc.org/mock/${i + 1}`,
+      },
+      artwork: r,
+    }));
+    res.json({ results, search_type: 'direct', song_not_found: false, found_on_compilation: false });
+  } else {
+    res.json({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false });
+  }
+});
+
 /** POST /api/v1/discogs/search */
 router.post('/api/v1/discogs/search', (req: Request, res: Response) => {
   const { artist, album } = req.body ?? {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -365,7 +365,7 @@
         "@tensorflow/tfjs": "^4.22.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^0.5.0",
+        "@wxyc/shared": "^0.6.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.15.0",
@@ -540,9 +540,9 @@
       }
     },
     "apps/backend/node_modules/@wxyc/shared": {
-      "version": "0.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.5.0/8a21b34be7e3cd90bd0cf9433dd678bef8385842",
-      "integrity": "sha512-n2J9ZO5cgVVp9y803Bsmvq48AfE4sxuxVT1ebel4ELg1vE7x5C38GX/Ek/7I30uaz9NZ+xFHkJLK7+youcDzCA==",
+      "version": "0.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.6.0/3b475c7508afc37bdf07a76a059744411da8c390",
+      "integrity": "sha512-/IOuWoyspr+VQmvfw7kXS7gwH60O1WZaWW2YU6RHoQcbTYmhBtAMbb+MojoAs55DQIf/AKx2p3PL+dc1Er6Vhg==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -15700,7 +15700,7 @@
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1014.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^0.5.0",
+        "@wxyc/shared": "^0.6.0",
         "better-auth": "^1.5.6",
         "drizzle-orm": "^0.41.0",
         "postgres": "^3.4.8"
@@ -15823,9 +15823,9 @@
       }
     },
     "shared/authentication/node_modules/@wxyc/shared": {
-      "version": "0.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.5.0/8a21b34be7e3cd90bd0cf9433dd678bef8385842",
-      "integrity": "sha512-n2J9ZO5cgVVp9y803Bsmvq48AfE4sxuxVT1ebel4ELg1vE7x5C38GX/Ek/7I30uaz9NZ+xFHkJLK7+youcDzCA==",
+      "version": "0.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.6.0/3b475c7508afc37bdf07a76a059744411da8c390",
+      "integrity": "sha512-/IOuWoyspr+VQmvfw7kXS7gwH60O1WZaWW2YU6RHoQcbTYmhBtAMbb+MojoAs55DQIf/AKx2p3PL+dc1Er6Vhg==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/scripts/backfill-metadata.ts
+++ b/scripts/backfill-metadata.ts
@@ -40,13 +40,7 @@ async function main(): Promise<void> {
       track_title: flowsheet.track_title,
     })
     .from(flowsheet)
-    .where(
-      and(
-        isNull(flowsheet.artwork_url),
-        isNotNull(flowsheet.artist_name),
-        eq(flowsheet.entry_type, 'track')
-      )
-    )
+    .where(and(isNull(flowsheet.artwork_url), isNotNull(flowsheet.artist_name), eq(flowsheet.entry_type, 'track')))
     .orderBy(desc(flowsheet.id))
     .limit(LIMIT);
 

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1014.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^0.5.0",
+    "@wxyc/shared": "^0.6.0",
     "better-auth": "^1.5.6",
     "drizzle-orm": "^0.41.0",
     "postgres": "^3.4.8"

--- a/tests/integration/metadata-lml.spec.js
+++ b/tests/integration/metadata-lml.spec.js
@@ -71,9 +71,9 @@ describe('Metadata via LML (Mock API)', () => {
       await new Promise((r) => setTimeout(r, 300));
 
       const lmlRequests = await getMockRequests('lml');
-      const searchCalls = lmlRequests.filter((r) => r.path === '/api/v1/discogs/search');
-      expect(searchCalls.length).toBeGreaterThanOrEqual(1);
-      expect(searchCalls[0].body.artist).toBe('Autechre');
+      const lookupCalls = lmlRequests.filter((r) => r.path === '/api/v1/lookup');
+      expect(lookupCalls.length).toBeGreaterThanOrEqual(1);
+      expect(lookupCalls[0].body.artist).toBe('Autechre');
     });
 
     test('messages do not trigger LML calls for the message content', async () => {
@@ -91,10 +91,10 @@ describe('Metadata via LML (Mock API)', () => {
       // We can't assert on total count because fire-and-forget from previous
       // tests may still be completing.
       const lmlRequests = await getMockRequests('lml');
-      const searchCalls = lmlRequests.filter(
-        (r) => r.path === '/api/v1/discogs/search' && r.body?.artist === 'Station ID at the top of the hour'
+      const lookupCalls = lmlRequests.filter(
+        (r) => r.path === '/api/v1/lookup' && r.body?.artist === 'Station ID at the top of the hour'
       );
-      expect(searchCalls.length).toBe(0);
+      expect(lookupCalls.length).toBe(0);
     });
   });
 
@@ -183,7 +183,7 @@ describe('Metadata via LML (Mock API)', () => {
       // Wait for any in-flight fire-and-forget to settle, then reset + simulate
       await new Promise((r) => setTimeout(r, 500));
       await resetMockApi();
-      await simulateError('lml', '/api/v1/discogs/search', 500);
+      await simulateError('lml', '/api/v1/lookup', 500);
 
       const addRes = await request
         .post('/flowsheet')
@@ -271,7 +271,7 @@ describe('Proxy endpoints via LML (Mock API)', () => {
     if (!mockApiAvailable || !anonToken) return;
 
     // Permanent error (no count) — affects all subsequent LML search calls
-    await simulateError('lml', '/api/v1/discogs/search', 500);
+    await simulateError('lml', '/api/v1/lookup', 500);
 
     // Make the proxy call immediately before any fire-and-forget can consume the rule
     const res = await request

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -213,7 +213,13 @@ describe('proxy.controller', () => {
       mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            library_item: { id: 1, title: 'Confield', artist: 'Autechre', call_number: 'Electronic CD AUT 1/1', library_url: '' },
+            library_item: {
+              id: 1,
+              title: 'Confield',
+              artist: 'Autechre',
+              call_number: 'Electronic CD AUT 1/1',
+              library_url: '',
+            },
             artwork: {
               release_id: 12345,
               release_url: 'https://www.discogs.com/release/12345',
@@ -308,7 +314,13 @@ describe('proxy.controller', () => {
       mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            library_item: { id: 1, title: 'Moon Pix', artist: 'Cat Power', call_number: 'Rock CD CAT 1/1', library_url: '' },
+            library_item: {
+              id: 1,
+              title: 'Moon Pix',
+              artist: 'Cat Power',
+              call_number: 'Rock CD CAT 1/1',
+              library_url: '',
+            },
             artwork: {
               release_id: 99999,
               release_url: 'https://www.discogs.com/release/99999',

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -10,7 +10,7 @@ import type { Request, Response, NextFunction } from 'express';
 // --- Mocks ---
 
 // LML client mocks (used by searchArtwork, getAlbumMetadata, getArtistMetadata, resolveEntity)
-const mockSearchDiscogs = jest.fn<() => Promise<unknown>>();
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
 const mockGetRelease = jest.fn<() => Promise<unknown>>();
 const mockGetArtistDetails = jest.fn<() => Promise<unknown>>();
 const mockResolveEntity = jest.fn<() => Promise<unknown>>();
@@ -26,7 +26,7 @@ class MockLmlClientError extends Error {
 }
 
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
-  searchDiscogs: mockSearchDiscogs,
+  lookupMetadata: mockLookupMetadata,
   getRelease: mockGetRelease,
   getArtistDetails: mockGetArtistDetails,
   resolveEntity: mockResolveEntity,
@@ -209,28 +209,29 @@ describe('proxy.controller', () => {
       );
     });
 
-    it('returns merged metadata from LML search + release details', async () => {
-      mockSearchDiscogs.mockResolvedValue({
+    it('returns merged metadata from LML lookup + release details', async () => {
+      mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            release_id: 12345,
-            release_url: 'https://www.discogs.com/release/12345',
-            artwork_url: 'https://i.discogs.com/art.jpg',
-            album: 'Confield',
-            artist: 'Autechre',
-            confidence: 0.95,
-            release_year: null,
-            artist_bio: null,
-            wikipedia_url: null,
-            spotify_url: 'https://open.spotify.com/album/abc',
-            apple_music_url: 'https://music.apple.com/album/xyz',
-            youtube_music_url: 'https://music.youtube.com/search?q=Autechre+Confield',
-            bandcamp_url: 'https://bandcamp.com/search?q=Autechre+Confield',
-            soundcloud_url: 'https://soundcloud.com/search?q=Autechre+Confield',
+            library_item: { id: 1, title: 'Confield', artist: 'Autechre', call_number: 'Electronic CD AUT 1/1', library_url: '' },
+            artwork: {
+              release_id: 12345,
+              release_url: 'https://www.discogs.com/release/12345',
+              artwork_url: 'https://i.discogs.com/art.jpg',
+              album: 'Confield',
+              artist: 'Autechre',
+              confidence: 0.95,
+              spotify_url: 'https://open.spotify.com/album/abc',
+              apple_music_url: 'https://music.apple.com/album/xyz',
+              youtube_music_url: 'https://music.youtube.com/search?q=Autechre+Confield',
+              bandcamp_url: 'https://bandcamp.com/search?q=Autechre+Confield',
+              soundcloud_url: 'https://soundcloud.com/search?q=Autechre+Confield',
+            },
           },
         ],
-        total: 1,
-        cached: false,
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
       });
 
       mockGetRelease.mockResolvedValue({
@@ -285,7 +286,7 @@ describe('proxy.controller', () => {
     });
 
     it('returns fallback search URLs when LML search fails', async () => {
-      mockSearchDiscogs.mockRejectedValue(new Error('LML down'));
+      mockLookupMetadata.mockRejectedValue(new Error('LML down'));
 
       const req = { query: { artistName: 'Test Artist', releaseTitle: 'Test Album' } } as unknown as Request;
       const res = createMockRes();
@@ -304,27 +305,28 @@ describe('proxy.controller', () => {
     });
 
     it('returns search-only metadata when release fetch fails', async () => {
-      mockSearchDiscogs.mockResolvedValue({
+      mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            release_id: 99999,
-            release_url: 'https://www.discogs.com/release/99999',
-            artwork_url: 'https://i.discogs.com/art.jpg',
-            album: 'Moon Pix',
-            artist: 'Cat Power',
-            confidence: 0.9,
-            release_year: null,
-            artist_bio: null,
-            wikipedia_url: null,
-            spotify_url: 'https://open.spotify.com/album/moonpix',
-            apple_music_url: null,
-            youtube_music_url: null,
-            bandcamp_url: null,
-            soundcloud_url: null,
+            library_item: { id: 1, title: 'Moon Pix', artist: 'Cat Power', call_number: 'Rock CD CAT 1/1', library_url: '' },
+            artwork: {
+              release_id: 99999,
+              release_url: 'https://www.discogs.com/release/99999',
+              artwork_url: 'https://i.discogs.com/art.jpg',
+              album: 'Moon Pix',
+              artist: 'Cat Power',
+              confidence: 0.9,
+              spotify_url: 'https://open.spotify.com/album/moonpix',
+              apple_music_url: null,
+              youtube_music_url: null,
+              bandcamp_url: null,
+              soundcloud_url: null,
+            },
           },
         ],
-        total: 1,
-        cached: false,
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
       });
 
       mockGetRelease.mockRejectedValue(new Error('Release fetch failed'));
@@ -348,10 +350,11 @@ describe('proxy.controller', () => {
     });
 
     it('returns fallback search URLs when LML search returns empty results', async () => {
-      mockSearchDiscogs.mockResolvedValue({
+      mockLookupMetadata.mockResolvedValue({
         results: [],
-        total: 0,
-        cached: false,
+        search_type: 'none',
+        song_not_found: false,
+        found_on_compilation: false,
       });
 
       const req = { query: { artistName: 'Obscure Artist', releaseTitle: 'Unknown Album' } } as unknown as Request;

--- a/tests/unit/services/artwork.discogs-provider.test.ts
+++ b/tests/unit/services/artwork.discogs-provider.test.ts
@@ -51,7 +51,13 @@ describe('artwork DiscogsProvider', () => {
       mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            library_item: { id: 1, title: 'Confield', artist: 'Autechre', call_number: 'Electronic CD AUT 1/1', library_url: 'https://library.wxyc.org/1' },
+            library_item: {
+              id: 1,
+              title: 'Confield',
+              artist: 'Autechre',
+              call_number: 'Electronic CD AUT 1/1',
+              library_url: 'https://library.wxyc.org/1',
+            },
             artwork: {
               release_id: 12345,
               release_url: 'https://www.discogs.com/release/12345',
@@ -85,12 +91,29 @@ describe('artwork DiscogsProvider', () => {
       mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            library_item: { id: 1, title: 'No Art', artist: 'Artist', call_number: 'Rock CD ART 1/1', library_url: 'https://library.wxyc.org/1' },
+            library_item: {
+              id: 1,
+              title: 'No Art',
+              artist: 'Artist',
+              call_number: 'Rock CD ART 1/1',
+              library_url: 'https://library.wxyc.org/1',
+            },
             artwork: { release_id: 1, release_url: 'https://discogs.com/1', artwork_url: null, confidence: 0 },
           },
           {
-            library_item: { id: 2, title: 'Spacer', artist: 'Artist', call_number: 'Rock CD ART 2/1', library_url: 'https://library.wxyc.org/2' },
-            artwork: { release_id: 2, release_url: 'https://discogs.com/2', artwork_url: 'https://i.discogs.com/spacer.gif', confidence: 0 },
+            library_item: {
+              id: 2,
+              title: 'Spacer',
+              artist: 'Artist',
+              call_number: 'Rock CD ART 2/1',
+              library_url: 'https://library.wxyc.org/2',
+            },
+            artwork: {
+              release_id: 2,
+              release_url: 'https://discogs.com/2',
+              artwork_url: 'https://i.discogs.com/spacer.gif',
+              confidence: 0,
+            },
           },
         ],
         search_type: 'direct',
@@ -112,7 +135,12 @@ describe('artwork DiscogsProvider', () => {
     });
 
     it('uses song when album is not provided', async () => {
-      mockLookupMetadata.mockResolvedValue({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false });
+      mockLookupMetadata.mockResolvedValue({
+        results: [],
+        search_type: 'none',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
 
       await provider.search({ artist: 'Autechre', song: 'VI Scose Poise' });
 

--- a/tests/unit/services/artwork.discogs-provider.test.ts
+++ b/tests/unit/services/artwork.discogs-provider.test.ts
@@ -7,21 +7,16 @@ import { jest } from '@jest/globals';
 
 // --- Mocks ---
 
-const mockSearchDiscogs = jest.fn<() => Promise<unknown>>();
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
 const mockSearchTrackReleases = jest.fn<() => Promise<unknown>>();
 const mockValidateTrackOnRelease = jest.fn<() => Promise<boolean>>();
 const mockIsLmlConfigured = jest.fn<() => boolean>();
 
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
-  searchDiscogs: mockSearchDiscogs,
+  lookupMetadata: mockLookupMetadata,
   searchTrackReleases: mockSearchTrackReleases,
   validateTrackOnRelease: mockValidateTrackOnRelease,
   isLmlConfigured: mockIsLmlConfigured,
-}));
-
-jest.mock('../../../apps/backend/services/requestLine/matching/index', () => ({
-  calculateConfidence: (_reqArtist: string, _reqAlbum: string, resArtist: string, _resAlbum: string) =>
-    resArtist ? 0.85 : 0.5,
 }));
 
 import { DiscogsProvider } from '../../../apps/backend/services/artwork/providers/discogs';
@@ -42,43 +37,39 @@ describe('artwork DiscogsProvider', () => {
       const results = await provider.search({ artist: 'Autechre', album: 'Confield' });
 
       expect(results).toEqual([]);
-      expect(mockSearchDiscogs).not.toHaveBeenCalled();
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
     });
 
     it('returns empty when no searchable fields provided', async () => {
       const results = await provider.search({});
 
       expect(results).toEqual([]);
-      expect(mockSearchDiscogs).not.toHaveBeenCalled();
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
     });
 
     it('searches LML and maps results to ArtworkSearchResult', async () => {
-      mockSearchDiscogs.mockResolvedValue({
+      mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            release_id: 12345,
-            release_url: 'https://www.discogs.com/release/12345',
-            artwork_url: 'https://i.discogs.com/confield.jpg',
-            album: 'Confield',
-            artist: 'Autechre',
-            confidence: 0.95,
-            release_year: 2001,
-            artist_bio: null,
-            wikipedia_url: null,
-            spotify_url: null,
-            apple_music_url: null,
-            youtube_music_url: null,
-            bandcamp_url: null,
-            soundcloud_url: null,
+            library_item: { id: 1, title: 'Confield', artist: 'Autechre', call_number: 'Electronic CD AUT 1/1', library_url: 'https://library.wxyc.org/1' },
+            artwork: {
+              release_id: 12345,
+              release_url: 'https://www.discogs.com/release/12345',
+              artwork_url: 'https://i.discogs.com/confield.jpg',
+              album: 'Confield',
+              artist: 'Autechre',
+              confidence: 0.95,
+            },
           },
         ],
-        total: 1,
-        cached: false,
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
       });
 
       const results = await provider.search({ artist: 'Autechre', album: 'Confield' });
 
-      expect(mockSearchDiscogs).toHaveBeenCalledWith('Autechre', 'Confield');
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined);
       expect(results).toHaveLength(1);
       expect(results[0]).toEqual({
         artworkUrl: 'https://i.discogs.com/confield.jpg',
@@ -86,48 +77,25 @@ describe('artwork DiscogsProvider', () => {
         album: 'Confield',
         artist: 'Autechre',
         source: 'discogs',
-        confidence: 0.85,
+        confidence: 0.95,
       });
     });
 
     it('filters out results without artwork or with spacer.gif', async () => {
-      mockSearchDiscogs.mockResolvedValue({
+      mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            release_id: 1,
-            release_url: 'https://discogs.com/1',
-            artwork_url: null,
-            album: 'No Art',
-            artist: 'Artist',
-            confidence: 0.9,
-            release_year: null,
-            artist_bio: null,
-            wikipedia_url: null,
-            spotify_url: null,
-            apple_music_url: null,
-            youtube_music_url: null,
-            bandcamp_url: null,
-            soundcloud_url: null,
+            library_item: { id: 1, title: 'No Art', artist: 'Artist', call_number: 'Rock CD ART 1/1', library_url: 'https://library.wxyc.org/1' },
+            artwork: { release_id: 1, release_url: 'https://discogs.com/1', artwork_url: null, confidence: 0 },
           },
           {
-            release_id: 2,
-            release_url: 'https://discogs.com/2',
-            artwork_url: 'https://i.discogs.com/spacer.gif',
-            album: 'Spacer',
-            artist: 'Artist',
-            confidence: 0.8,
-            release_year: null,
-            artist_bio: null,
-            wikipedia_url: null,
-            spotify_url: null,
-            apple_music_url: null,
-            youtube_music_url: null,
-            bandcamp_url: null,
-            soundcloud_url: null,
+            library_item: { id: 2, title: 'Spacer', artist: 'Artist', call_number: 'Rock CD ART 2/1', library_url: 'https://library.wxyc.org/2' },
+            artwork: { release_id: 2, release_url: 'https://discogs.com/2', artwork_url: 'https://i.discogs.com/spacer.gif', confidence: 0 },
           },
         ],
-        total: 2,
-        cached: false,
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
       });
 
       const results = await provider.search({ artist: 'Artist', album: 'Album' });
@@ -136,19 +104,19 @@ describe('artwork DiscogsProvider', () => {
     });
 
     it('returns empty on LML error', async () => {
-      mockSearchDiscogs.mockRejectedValue(new Error('LML down'));
+      mockLookupMetadata.mockRejectedValue(new Error('LML down'));
 
       const results = await provider.search({ artist: 'Autechre', album: 'Confield' });
 
       expect(results).toEqual([]);
     });
 
-    it('uses song as search term when album is not provided', async () => {
-      mockSearchDiscogs.mockResolvedValue({ results: [], total: 0, cached: false });
+    it('uses song when album is not provided', async () => {
+      mockLookupMetadata.mockResolvedValue({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false });
 
       await provider.search({ artist: 'Autechre', song: 'VI Scose Poise' });
 
-      expect(mockSearchDiscogs).toHaveBeenCalledWith('Autechre', 'VI Scose Poise');
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', undefined, 'VI Scose Poise');
     });
   });
 

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -1,11 +1,11 @@
 import { jest } from '@jest/globals';
 import { db, createMockQueryChain } from '../../mocks/database.mock';
 
-const mockSearchDiscogs = jest.fn<() => Promise<unknown>>();
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
 const mockIsLmlConfigured = jest.fn<() => boolean>();
 
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
-  searchDiscogs: mockSearchDiscogs,
+  lookupMetadata: mockLookupMetadata,
   isLmlConfigured: mockIsLmlConfigured,
 }));
 
@@ -292,7 +292,7 @@ describe('library.service', () => {
       const enriched = await enrichWithArtwork(results);
 
       expect(enriched).toEqual(results);
-      expect(mockSearchDiscogs).not.toHaveBeenCalled();
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
     });
 
     it('returns results unchanged when all have artwork cached', async () => {
@@ -309,7 +309,7 @@ describe('library.service', () => {
       const enriched = await enrichWithArtwork(results);
 
       expect(enriched).toEqual(results);
-      expect(mockSearchDiscogs).not.toHaveBeenCalled();
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
     });
 
     it('fetches artwork from LML for uncached results and caches to DB', async () => {
@@ -317,19 +317,16 @@ describe('library.service', () => {
       db.update.mockReturnValue(chain);
       chain.returning = jest.fn().mockResolvedValue([{ id: 1 }]);
 
-      mockSearchDiscogs.mockResolvedValue({
+      mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            release_id: 12345,
-            release_url: 'https://www.discogs.com/release/12345',
-            artwork_url: 'https://i.discogs.com/confield.jpg',
-            album: 'Confield',
-            artist: 'Autechre',
-            confidence: 0.95,
+            library_item: { id: 1, title: 'Confield', artist: 'Autechre', call_number: 'Electronic CD AUT 1/1', library_url: '' },
+            artwork: { release_id: 12345, release_url: 'https://www.discogs.com/release/12345', artwork_url: 'https://i.discogs.com/confield.jpg', confidence: 0.95 },
           },
         ],
-        total: 1,
-        cached: false,
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
       });
 
       const results = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
@@ -337,24 +334,21 @@ describe('library.service', () => {
       const enriched = await enrichWithArtwork(results);
 
       expect(enriched[0].artwork_url).toBe('https://i.discogs.com/confield.jpg');
-      expect(mockSearchDiscogs).toHaveBeenCalledWith('Autechre', 'Confield');
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield');
       expect(db.update).toHaveBeenCalled();
     });
 
     it('filters spacer.gif artwork URLs', async () => {
-      mockSearchDiscogs.mockResolvedValue({
+      mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            release_id: 99999,
-            release_url: 'https://www.discogs.com/release/99999',
-            artwork_url: 'https://st.discogs.com/images/spacer.gif',
-            album: 'Unknown',
-            artist: 'Unknown',
-            confidence: 0.5,
+            library_item: { id: 1, title: 'Unknown', artist: 'Unknown', call_number: 'Rock CD UNK 1/1', library_url: '' },
+            artwork: { release_id: 99999, release_url: 'https://www.discogs.com/release/99999', artwork_url: 'https://st.discogs.com/images/spacer.gif', confidence: 0.5 },
           },
         ],
-        total: 1,
-        cached: false,
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
       });
 
       const results = [{ id: 1, artist_name: 'Unknown Artist', album_title: 'Unknown Album', artwork_url: null }];
@@ -366,7 +360,7 @@ describe('library.service', () => {
     });
 
     it('handles LML failure gracefully without throwing', async () => {
-      mockSearchDiscogs.mockRejectedValue(new Error('LML timeout'));
+      mockLookupMetadata.mockRejectedValue(new Error('LML timeout'));
 
       const results = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
 
@@ -381,19 +375,16 @@ describe('library.service', () => {
       db.update.mockReturnValue(chain);
       chain.returning = jest.fn().mockResolvedValue([{ id: 2 }]);
 
-      mockSearchDiscogs.mockResolvedValue({
+      mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            release_id: 67890,
-            release_url: 'https://www.discogs.com/release/67890',
-            artwork_url: 'https://i.discogs.com/lp5.jpg',
-            album: 'LP5',
-            artist: 'Autechre',
-            confidence: 0.9,
+            library_item: { id: 2, title: 'LP5', artist: 'Autechre', call_number: 'Electronic CD AUT 2/1', library_url: '' },
+            artwork: { release_id: 67890, release_url: 'https://www.discogs.com/release/67890', artwork_url: 'https://i.discogs.com/lp5.jpg', confidence: 0.9 },
           },
         ],
-        total: 1,
-        cached: false,
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
       });
 
       const results = [
@@ -408,15 +399,16 @@ describe('library.service', () => {
       // Uncached result enriched
       expect(enriched[1].artwork_url).toBe('https://i.discogs.com/lp5.jpg');
       // Only one LML call (for LP5, not Confield)
-      expect(mockSearchDiscogs).toHaveBeenCalledTimes(1);
-      expect(mockSearchDiscogs).toHaveBeenCalledWith('Autechre', 'LP5');
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'LP5');
     });
 
     it('handles LML returning no results', async () => {
-      mockSearchDiscogs.mockResolvedValue({
+      mockLookupMetadata.mockResolvedValue({
         results: [],
-        total: 0,
-        cached: false,
+        search_type: 'none',
+        song_not_found: false,
+        found_on_compilation: false,
       });
 
       const results = [{ id: 1, artist_name: 'Obscure Artist', album_title: 'Rare Album', artwork_url: null }];

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -320,8 +320,19 @@ describe('library.service', () => {
       mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            library_item: { id: 1, title: 'Confield', artist: 'Autechre', call_number: 'Electronic CD AUT 1/1', library_url: '' },
-            artwork: { release_id: 12345, release_url: 'https://www.discogs.com/release/12345', artwork_url: 'https://i.discogs.com/confield.jpg', confidence: 0.95 },
+            library_item: {
+              id: 1,
+              title: 'Confield',
+              artist: 'Autechre',
+              call_number: 'Electronic CD AUT 1/1',
+              library_url: '',
+            },
+            artwork: {
+              release_id: 12345,
+              release_url: 'https://www.discogs.com/release/12345',
+              artwork_url: 'https://i.discogs.com/confield.jpg',
+              confidence: 0.95,
+            },
           },
         ],
         search_type: 'direct',
@@ -342,8 +353,19 @@ describe('library.service', () => {
       mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            library_item: { id: 1, title: 'Unknown', artist: 'Unknown', call_number: 'Rock CD UNK 1/1', library_url: '' },
-            artwork: { release_id: 99999, release_url: 'https://www.discogs.com/release/99999', artwork_url: 'https://st.discogs.com/images/spacer.gif', confidence: 0.5 },
+            library_item: {
+              id: 1,
+              title: 'Unknown',
+              artist: 'Unknown',
+              call_number: 'Rock CD UNK 1/1',
+              library_url: '',
+            },
+            artwork: {
+              release_id: 99999,
+              release_url: 'https://www.discogs.com/release/99999',
+              artwork_url: 'https://st.discogs.com/images/spacer.gif',
+              confidence: 0.5,
+            },
           },
         ],
         search_type: 'direct',
@@ -378,8 +400,19 @@ describe('library.service', () => {
       mockLookupMetadata.mockResolvedValue({
         results: [
           {
-            library_item: { id: 2, title: 'LP5', artist: 'Autechre', call_number: 'Electronic CD AUT 2/1', library_url: '' },
-            artwork: { release_id: 67890, release_url: 'https://www.discogs.com/release/67890', artwork_url: 'https://i.discogs.com/lp5.jpg', confidence: 0.9 },
+            library_item: {
+              id: 2,
+              title: 'LP5',
+              artist: 'Autechre',
+              call_number: 'Electronic CD AUT 2/1',
+              library_url: '',
+            },
+            artwork: {
+              release_id: 67890,
+              release_url: 'https://www.discogs.com/release/67890',
+              artwork_url: 'https://i.discogs.com/lp5.jpg',
+              confidence: 0.9,
+            },
           },
         ],
         search_type: 'direct',

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -88,7 +88,8 @@ describe('lml.client', () => {
     it('omits album and song when not provided', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
       } as unknown as globalThis.Response);
 
       await lookupMetadata('Autechre');
@@ -104,7 +105,8 @@ describe('lml.client', () => {
     it('does not include raw_message in the request body', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
       } as unknown as globalThis.Response);
 
       await lookupMetadata('Autechre', 'Confield');

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -8,6 +8,7 @@ global.fetch = mockFetch;
 
 import {
   searchDiscogs,
+  lookupMetadata,
   getRelease,
   getArtistDetails,
   resolveEntity,
@@ -61,6 +62,55 @@ describe('lml.client', () => {
           body: JSON.stringify({ artist: 'Autechre' }),
         })
       );
+    });
+  });
+
+  describe('lookupMetadata', () => {
+    it('sends POST to /api/v1/lookup with artist, album, and song', async () => {
+      const mockResponse = { results: [], search_type: 'none', song_not_found: false, found_on_compilation: false };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield', 'VI Scose Poise');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://lml.test:8000/api/v1/lookup',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ artist: 'Autechre', album: 'Confield', song: 'VI Scose Poise' }),
+        })
+      );
+    });
+
+    it('omits album and song when not provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://lml.test:8000/api/v1/lookup',
+        expect.objectContaining({
+          body: JSON.stringify({ artist: 'Autechre' }),
+        })
+      );
+    });
+
+    it('does not include raw_message in the request body', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield');
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody).not.toHaveProperty('raw_message');
     });
   });
 

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -1,21 +1,17 @@
 /**
  * Unit tests for the metadata service.
  *
- * Verifies that fetchMetadata routes through LML and returns metadata
- * for the caller to persist.
+ * Verifies that fetchMetadata routes through LML's /lookup endpoint
+ * and returns metadata for the caller to persist.
  */
 import { jest } from '@jest/globals';
 
 // --- Mocks ---
 
-const mockSearchDiscogs = jest.fn<() => Promise<unknown>>();
-const mockGetRelease = jest.fn<() => Promise<unknown>>();
-const mockGetArtistDetails = jest.fn<() => Promise<unknown>>();
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
 
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
-  searchDiscogs: mockSearchDiscogs,
-  getRelease: mockGetRelease,
-  getArtistDetails: mockGetArtistDetails,
+  lookupMetadata: mockLookupMetadata,
   LmlClientError: class LmlClientError extends Error {
     statusCode: number;
     constructor(message: string, statusCode: number) {
@@ -43,50 +39,44 @@ import { fetchMetadata } from '../../../apps/backend/services/metadata/metadata.
 
 // --- Fixtures ---
 
-const lmlSearchResult = {
-  release_id: 12345,
-  release_url: 'https://www.discogs.com/release/12345',
-  artwork_url: 'https://i.discogs.com/art.jpg',
-  album: 'Confield',
-  artist: 'Autechre',
-  confidence: 0.95,
-  release_year: 2001,
-  artist_bio: '[a=Rob Brown] and [a=Sean Booth] are Autechre.',
-  wikipedia_url: 'https://en.wikipedia.org/wiki/Autechre',
-  spotify_url: 'https://open.spotify.com/album/abc',
-  apple_music_url: 'https://music.apple.com/album/xyz',
-  youtube_music_url: 'https://music.youtube.com/search?q=Autechre+Confield',
-  bandcamp_url: null,
-  soundcloud_url: null,
+const lookupResponseWithResults = {
+  results: [
+    {
+      library_item: {
+        id: 1,
+        title: 'Confield',
+        artist: 'Autechre',
+        call_number: 'Electronic CD AUT 123/1',
+        library_url: 'https://library.wxyc.org/1',
+      },
+      artwork: {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        artwork_url: 'https://i.discogs.com/art.jpg',
+        album: 'Confield',
+        artist: 'Autechre',
+        confidence: 0.95,
+        release_year: 2001,
+        artist_bio: '[a=Rob Brown] and [a=Sean Booth] are Autechre.',
+        wikipedia_url: 'https://en.wikipedia.org/wiki/Autechre',
+        spotify_url: 'https://open.spotify.com/album/abc',
+        apple_music_url: 'https://music.apple.com/album/xyz',
+        youtube_music_url: 'https://music.youtube.com/search?q=Autechre+Confield',
+        bandcamp_url: null,
+        soundcloud_url: null,
+      },
+    },
+  ],
+  search_type: 'direct',
+  song_not_found: false,
+  found_on_compilation: false,
 };
 
-const lmlReleaseResponse = {
-  release_id: 12345,
-  title: 'Confield',
-  artist: 'Autechre',
-  year: 2001,
-  label: 'Warp',
-  artist_id: 3840,
-  genres: ['Electronic'],
-  styles: ['IDM'],
-  tracklist: [],
-  artwork_url: 'https://i.discogs.com/art-release.jpg',
-  release_url: 'https://www.discogs.com/release/12345',
-  released: '2001-04-30',
-  cached: false,
-  artists: [{ artist_id: 3840, name: 'Autechre', join: '', role: null }],
-};
-
-const lmlArtistResponse = {
-  artist_id: 3840,
-  name: 'Autechre',
-  profile: '[a=Rob Brown] and [a=Sean Booth] formed Autechre in [l=Warp Records].',
-  image_url: 'https://i.discogs.com/autechre.jpg',
-  name_variations: [],
-  aliases: [],
-  members: [],
-  urls: ['https://en.wikipedia.org/wiki/Autechre', 'https://autechre.ws'],
-  cached: false,
+const emptyLookupResponse = {
+  results: [],
+  search_type: 'none',
+  song_not_found: false,
+  found_on_compilation: false,
 };
 
 // --- Tests ---
@@ -109,79 +99,96 @@ describe('metadata.service', () => {
     const result = await fetchMetadata({ artistName: 'Autechre' });
 
     expect(result).toBeNull();
-    expect(mockSearchDiscogs).not.toHaveBeenCalled();
+    expect(mockLookupMetadata).not.toHaveBeenCalled();
   });
 
-  it('fetches album and artist metadata via LML and returns it', async () => {
-    mockSearchDiscogs.mockResolvedValue({ results: [lmlSearchResult], total: 1, cached: false });
-    mockGetRelease.mockResolvedValue(lmlReleaseResponse);
-    mockGetArtistDetails.mockResolvedValue(lmlArtistResponse);
+  it('calls lookupMetadata with artist, album, and track', async () => {
+    mockLookupMetadata.mockResolvedValue(lookupResponseWithResults);
+
+    await fetchMetadata({
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+      trackTitle: 'VI Scose Poise',
+    });
+
+    expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', 'VI Scose Poise');
+  });
+
+  it('makes a single LML call instead of three', async () => {
+    mockLookupMetadata.mockResolvedValue(lookupResponseWithResults);
+
+    await fetchMetadata({
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+    });
+
+    expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it('extracts album metadata from lookup response artwork', async () => {
+    mockLookupMetadata.mockResolvedValue(lookupResponseWithResults);
 
     const result = await fetchMetadata({
       artistName: 'Autechre',
       albumTitle: 'Confield',
-      albumId: 42,
-      artistId: 99,
     });
 
-    // Verify LML was called
-    expect(mockSearchDiscogs).toHaveBeenCalledWith('Autechre', 'Confield');
-    expect(mockGetRelease).toHaveBeenCalledWith(12345);
-    expect(mockGetArtistDetails).toHaveBeenCalledWith(3840);
-
-    // Verify album metadata
     expect(result?.album?.discogsReleaseId).toBe(12345);
-    expect(result?.album?.spotifyUrl).toBe('https://open.spotify.com/album/abc');
-    expect(result?.album?.appleMusicUrl).toBe('https://music.apple.com/album/xyz');
-    expect(result?.album?.artworkUrl).toBe('https://i.discogs.com/art-release.jpg'); // release artwork preferred
+    expect(result?.album?.discogsUrl).toBe('https://www.discogs.com/release/12345');
+    expect(result?.album?.artworkUrl).toBe('https://i.discogs.com/art.jpg');
     expect(result?.album?.releaseYear).toBe(2001);
-    // Fallback search URLs filled for missing fields
-    expect(result?.album?.bandcampUrl).toContain('bandcamp.com');
-    expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
-
-    // Verify artist metadata — bio should be cleaned of Discogs markup
-    expect(result?.artist?.bio).toBe('Rob Brown and Sean Booth formed Autechre in Warp Records.');
-    expect(result?.artist?.wikipediaUrl).toBe('https://en.wikipedia.org/wiki/Autechre');
-  });
-
-  it('extracts streaming URLs from LML search results', async () => {
-    mockSearchDiscogs.mockResolvedValue({ results: [lmlSearchResult], total: 1, cached: false });
-    mockGetRelease.mockResolvedValue(lmlReleaseResponse);
-    mockGetArtistDetails.mockResolvedValue(lmlArtistResponse);
-
-    const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
-
     expect(result?.album?.spotifyUrl).toBe('https://open.spotify.com/album/abc');
     expect(result?.album?.appleMusicUrl).toBe('https://music.apple.com/album/xyz');
     expect(result?.album?.youtubeMusicUrl).toBe('https://music.youtube.com/search?q=Autechre+Confield');
   });
 
-  it('uses SearchUrlProvider fallback when LML URLs are null', async () => {
-    const resultNoUrls = {
-      ...lmlSearchResult,
-      spotify_url: null,
-      apple_music_url: null,
-      youtube_music_url: null,
-      bandcamp_url: null,
-      soundcloud_url: null,
-    };
-    mockSearchDiscogs.mockResolvedValue({ results: [resultNoUrls], total: 1, cached: false });
-    mockGetRelease.mockResolvedValue(lmlReleaseResponse);
-    mockGetArtistDetails.mockResolvedValue(lmlArtistResponse);
+  it('extracts artist metadata from lookup response artwork', async () => {
+    mockLookupMetadata.mockResolvedValue(lookupResponseWithResults);
+
+    const result = await fetchMetadata({
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+    });
+
+    expect(result?.artist?.bio).toBe('Rob Brown and Sean Booth are Autechre.');
+    expect(result?.artist?.wikipediaUrl).toBe('https://en.wikipedia.org/wiki/Autechre');
+  });
+
+  it('fills missing streaming URLs with search URL fallbacks', async () => {
+    mockLookupMetadata.mockResolvedValue(lookupResponseWithResults);
+
+    const result = await fetchMetadata({
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+    });
+
+    // bandcamp_url and soundcloud_url are null in the fixture, so fallbacks should fill them
+    expect(result?.album?.bandcampUrl).toContain('bandcamp.com');
+    expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
+  });
+
+  it('uses SearchUrlProvider fallback when all LML URLs are null', async () => {
+    const responseNoUrls = structuredClone(lookupResponseWithResults);
+    const artwork = responseNoUrls.results[0].artwork;
+    artwork.spotify_url = null;
+    artwork.apple_music_url = null;
+    artwork.youtube_music_url = null;
+    artwork.bandcamp_url = null;
+    artwork.soundcloud_url = null;
+    mockLookupMetadata.mockResolvedValue(responseNoUrls);
 
     const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
 
-    // Search URLs constructed as fallback
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
     expect(result?.album?.bandcampUrl).toContain('bandcamp.com');
     expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
-    // API-sourced URLs remain undefined
+    // API-sourced URLs remain undefined (null → undefined)
     expect(result?.album?.spotifyUrl).toBeUndefined();
     expect(result?.album?.appleMusicUrl).toBeUndefined();
   });
 
-  it('returns search URLs when LML search fails', async () => {
-    mockSearchDiscogs.mockRejectedValue(new Error('LML down'));
+  it('returns search URLs when lookup fails', async () => {
+    mockLookupMetadata.mockRejectedValue(new Error('LML down'));
 
     const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
 
@@ -191,8 +198,8 @@ describe('metadata.service', () => {
     expect(result?.artist).toBeUndefined();
   });
 
-  it('returns search URLs when LML search returns empty results', async () => {
-    mockSearchDiscogs.mockResolvedValue({ results: [], total: 0, cached: false });
+  it('returns search URLs when lookup returns empty results', async () => {
+    mockLookupMetadata.mockResolvedValue(emptyLookupResponse);
 
     const result = await fetchMetadata({ artistName: 'Unknown Artist' });
 
@@ -200,29 +207,16 @@ describe('metadata.service', () => {
     expect(result?.album?.discogsReleaseId).toBeUndefined();
   });
 
-  it('falls back to search result bio when artist details fails', async () => {
-    mockSearchDiscogs.mockResolvedValue({ results: [lmlSearchResult], total: 1, cached: false });
-    mockGetRelease.mockResolvedValue(lmlReleaseResponse);
-    mockGetArtistDetails.mockRejectedValue(new Error('Artist fetch failed'));
+  it('returns search URLs when result has no artwork', async () => {
+    const responseNoArtwork = {
+      ...lookupResponseWithResults,
+      results: [{ library_item: lookupResponseWithResults.results[0].library_item, artwork: null }],
+    };
+    mockLookupMetadata.mockResolvedValue(responseNoArtwork);
 
     const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
 
-    // Falls back to search result bio (cleaned of markup)
-    expect(result?.artist?.bio).toBe('Rob Brown and Sean Booth are Autechre.');
-    expect(result?.artist?.wikipediaUrl).toBe('https://en.wikipedia.org/wiki/Autechre');
-  });
-
-  it('handles release fetch failure gracefully', async () => {
-    mockSearchDiscogs.mockResolvedValue({ results: [lmlSearchResult], total: 1, cached: false });
-    mockGetRelease.mockRejectedValue(new Error('Release fetch failed'));
-    // No artist ID available → falls back to search result
-    mockGetArtistDetails.mockRejectedValue(new Error('No ID'));
-
-    const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
-
-    expect(result?.album?.discogsReleaseId).toBe(12345);
-    expect(result?.album?.spotifyUrl).toBe('https://open.spotify.com/album/abc');
-    // Year from search result, not release
-    expect(result?.album?.releaseYear).toBe(2001);
+    expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
+    expect(result?.album?.discogsReleaseId).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Add `lookupMetadata()` to the LML client that calls `POST /api/v1/lookup` with structured fields (artist, album, song). No `raw_message` needed — `@wxyc/shared` 0.6.0 made it optional.
- Migrate all 6 `searchDiscogs()` call sites to `lookupMetadata()`:
  - **metadata.service.ts**: 3 HTTP calls (search + release + artist) reduced to 1 lookup call. The `/lookup` endpoint handles artist correction, fallback strategies, and title normalization, which fixes #453.
  - **proxy.controller.ts**: lookup + release (still needs `getRelease()` for tracklist/genres/styles)
  - **library.service.ts**: artwork enrichment now via lookup
  - **library.controller.ts**: artwork on album insert now via lookup
  - **artwork/providers/discogs.ts**: uses lookup confidence directly instead of local `calculateConfidence()`
  - **requestLine.enhanced.service.ts**: album name resolution from library items instead of raw Discogs results
- Bump `@wxyc/shared` to ^0.6.0 for enriched `DiscogsMatchResult` types

Closes #460
Closes #453

## Test plan

- [x] All unit tests updated and passing (920+ tests)
- [x] TypeScript typecheck passes
- [ ] Staging smoke test: verify flowsheet metadata enrichment works end-to-end
- [ ] Verify dj-site card catalog still loads artwork and streaming links via proxy