### PR TITLE
Fix playlist search slowness: drop COUNT(*) OVER, add add_time partial index

### DIFF
--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -19,8 +19,9 @@ type SearchResultRow = {
   record_label: string | null;
   show_id: number | null;
   dj_name: string | null;
-  total: number;
 };
+
+type CountRow = { total: number };
 
 export type SearchResult = {
   id: number;
@@ -69,7 +70,11 @@ export async function searchFlowsheet(params: SearchParams): Promise<{ results: 
 
   const fullWhere = whereClause ? sql`${baseFrom} AND ${whereClause}` : baseFrom;
 
-  const query = sql`
+  // Run data and count in parallel. A combined `COUNT(*) OVER()` window query
+  // forces Postgres to materialize the full match set before LIMIT can apply,
+  // which defeats short-circuiting on the data side. Two queries let the data
+  // query stop at LIMIT rows via index, while the count runs concurrently.
+  const dataQuery = sql`
     SELECT
       ${flowsheet.id},
       ${flowsheet.add_time} AS play_date,
@@ -78,18 +83,18 @@ export async function searchFlowsheet(params: SearchParams): Promise<{ results: 
       ${flowsheet.album_title},
       ${flowsheet.record_label},
       ${flowsheet.show_id},
-      ${DJ_NAME_EXPR} AS dj_name,
-      (COUNT(*) OVER())::int AS total
+      ${DJ_NAME_EXPR} AS dj_name
     ${fullWhere}
     ORDER BY ${sortExpr} ${orderDirection}
     LIMIT ${limit} OFFSET ${offset}
   `;
 
-  const rows = await db.execute(query);
+  const countQuery = sql`SELECT COUNT(*)::int AS total ${fullWhere}`;
 
-  const typedRows = rows as unknown as SearchResultRow[];
-  const results = typedRows.map(transformRow);
-  const total = typedRows[0]?.total ?? 0;
+  const [dataRows, countRows] = await Promise.all([db.execute(dataQuery), db.execute(countQuery)]);
+
+  const results = (dataRows as unknown as SearchResultRow[]).map(transformRow);
+  const total = (countRows as unknown as CountRow[])[0]?.total ?? 0;
 
   return { results, total };
 }

--- a/docs/playlist-search/README.md
+++ b/docs/playlist-search/README.md
@@ -12,14 +12,14 @@ The search is implemented in `apps/backend/services/search.service.ts`, parsed b
 
 The parser supports a small DSL on top of a single `q` string parameter:
 
-| Form | Example | Behavior |
-|------|---------|----------|
-| Bare term | `autechre` | ILIKE-substring across `artist_name`, `track_title`, `album_title`, `record_label` |
-| Field prefix | `artist:autechre`, `song:poise`, `album:confield`, `label:warp`, `dj:jake` | Restricts to a single column (or DJ name expression) |
-| Date | `date:2024-06-15` | Equality on the calendar day |
-| Date range | `dateRange:2024-01-01..2024-12-31` | Inclusive range on `add_time` |
-| Boolean operators | `artist:juana AND label:sonamos`, `dj:jake OR dj:nora`, `NOT label:warp` | Composes conditions with `AND`, `OR`, `NOT` |
-| Exact match | `artist:"Cat Power"` | Equality instead of substring |
+| Form              | Example                                                                    | Behavior                                                                           |
+| ----------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Bare term         | `autechre`                                                                 | ILIKE-substring across `artist_name`, `track_title`, `album_title`, `record_label` |
+| Field prefix      | `artist:autechre`, `song:poise`, `album:confield`, `label:warp`, `dj:jake` | Restricts to a single column (or DJ name expression)                               |
+| Date              | `date:2024-06-15`                                                          | Equality on the calendar day                                                       |
+| Date range        | `dateRange:2024-01-01..2024-12-31`                                         | Inclusive range on `add_time`                                                      |
+| Boolean operators | `artist:juana AND label:sonamos`, `dj:jake OR dj:nora`, `NOT label:warp`   | Composes conditions with `AND`, `OR`, `NOT`                                        |
+| Exact match       | `artist:"Cat Power"`                                                       | Equality instead of substring                                                      |
 
 The endpoint accepts `page`, `limit` (max 100), `sort` (`date` \| `artist` \| `song` \| `dj`), and `order` (`asc` \| `desc`). Default sort is `date desc`.
 
@@ -27,17 +27,18 @@ The endpoint accepts `page`, `limit` (max 100), `sort` (`date` \| `artist` \| `s
 
 The `wxyc_schema.flowsheet` table holds one row per playlist entry. Search joins to `shows` and `user` only to resolve the displayed DJ name through `COALESCE(user.dj_name, shows.legacy_dj_name, user.name)`.
 
-| Index | Type | Migration | Purpose |
-|-------|------|-----------|---------|
-| `flowsheet_entry_type_idx` | btree on `entry_type` | `0024` | Filters out break / message rows during search (`WHERE entry_type = 'track'`) |
-| `flowsheet_artist_name_trgm_idx` | GIN `gin_trgm_ops` on `artist_name` | `0042` | Substring match on artist (originally added for ghost-text autocomplete) |
-| `flowsheet_track_title_trgm_idx` | GIN `gin_trgm_ops` on `track_title` | `0042` | Substring match on song title |
-| `flowsheet_album_title_trgm_idx` | GIN `gin_trgm_ops` on `album_title` | `0049` | Substring match on album title |
-| `flowsheet_record_label_trgm_idx` | GIN `gin_trgm_ops` on `record_label` | `0049` | Substring match on label |
+| Index                             | Type                                 | Migration | Purpose                                                                       |
+| --------------------------------- | ------------------------------------ | --------- | ----------------------------------------------------------------------------- |
+| `flowsheet_entry_type_idx`        | btree on `entry_type`                | `0024`    | Filters out break / message rows during search (`WHERE entry_type = 'track'`) |
+| `flowsheet_artist_name_trgm_idx`  | GIN `gin_trgm_ops` on `artist_name`  | `0042`    | Substring match on artist (originally added for ghost-text autocomplete)      |
+| `flowsheet_track_title_trgm_idx`  | GIN `gin_trgm_ops` on `track_title`  | `0042`    | Substring match on song title                                                 |
+| `flowsheet_album_title_trgm_idx`  | GIN `gin_trgm_ops` on `album_title`  | `0049`    | Substring match on album title                                                |
+| `flowsheet_record_label_trgm_idx` | GIN `gin_trgm_ops` on `record_label` | `0049`    | Substring match on label                                                      |
 
 Trigram (`pg_trgm`) GIN indexes support `ILIKE '%term%'` queries by indexing every three-character substring. Postgres can `BitmapOr` matches across all four columns when the bare `q` form fans out, which is the path taken when the user types a single unqualified word.
 
 What is **not** indexed:
+
 - `add_time` — the default sort column, used by every query that omits a more specific sort.
 - The DJ-name `COALESCE` expression — `dj:` filters and `sort=dj` both fall back to a sequential scan of the joined rows.
 
@@ -115,6 +116,7 @@ CREATE INDEX flowsheet_search_doc_idx
 Use `'simple'` (no stemming) — music titles are full of proper nouns, foreign words, and stylized spellings that English stemming distorts. Use `websearch_to_tsquery('simple', $1)` to parse user input naturally; it understands quoted phrases and `OR` already.
 
 Keep the trigram indexes. The router logic at the service layer chooses:
+
 - Multi-character word with letters → `tsvector @@ websearch_to_tsquery(...)` (fast, supports relevance ranking via `ts_rank`)
 - Short fragment, internal substring (e.g., `tron` matching `Strontium`), or explicit wildcard → ILIKE on the trigram-indexed columns
 
@@ -152,14 +154,14 @@ Step 5a is worth doing even if 5b is on the roadmap; it costs nothing to keep bo
 
 ## Alternatives Considered
 
-| Option | When it fits | Why we are not taking it |
-|--------|--------------|--------------------------|
-| **Status quo: trigram only** | Substring matching matters more than word-level; small data | Slow for common terms; no relevance; counts always expensive |
-| **`tsvector` only** | Users always search whole words | Loses the substring intent (`tron` does not match `Autechre`); music titles tokenize unpredictably under any stemmer |
-| **Denormalized search table / materialized view** | Joins to `shows`/`user` dominate query cost | Refresh management; the join can be eliminated more cheaply by denormalizing `dj_name` onto `flowsheet` |
-| **SQLite FTS5 ETL** (matches the `library-metadata-lookup` pattern) | Already in the stack; BM25 ranking is desired | Sync lag would block DJs from finding tracks they played within the last few minutes; doubles storage; loses transactional consistency with writes that the legacy flowsheet ETL already complicates |
-| **Meilisearch / Typesense** | Need typo tolerance, faceting, sub-100ms typeahead, public-facing search | Operational burden, RAM-hungry; overkill for an internal DJ tool at our scale |
-| **Elasticsearch / OpenSearch** | Multi-tenant, large-scale, complex relevance tuning | Ops cost dominates value; nothing in the use case justifies it |
+| Option                                                              | When it fits                                                             | Why we are not taking it                                                                                                                                                                             |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status quo: trigram only**                                        | Substring matching matters more than word-level; small data              | Slow for common terms; no relevance; counts always expensive                                                                                                                                         |
+| **`tsvector` only**                                                 | Users always search whole words                                          | Loses the substring intent (`tron` does not match `Autechre`); music titles tokenize unpredictably under any stemmer                                                                                 |
+| **Denormalized search table / materialized view**                   | Joins to `shows`/`user` dominate query cost                              | Refresh management; the join can be eliminated more cheaply by denormalizing `dj_name` onto `flowsheet`                                                                                              |
+| **SQLite FTS5 ETL** (matches the `library-metadata-lookup` pattern) | Already in the stack; BM25 ranking is desired                            | Sync lag would block DJs from finding tracks they played within the last few minutes; doubles storage; loses transactional consistency with writes that the legacy flowsheet ETL already complicates |
+| **Meilisearch / Typesense**                                         | Need typo tolerance, faceting, sub-100ms typeahead, public-facing search | Operational burden, RAM-hungry; overkill for an internal DJ tool at our scale                                                                                                                        |
+| **Elasticsearch / OpenSearch**                                      | Multi-tenant, large-scale, complex relevance tuning                      | Ops cost dominates value; nothing in the use case justifies it                                                                                                                                       |
 
 ## Why Postgres
 
@@ -169,11 +171,11 @@ The library service (`apps/backend/services/library.service.ts`) already uses `p
 
 ## Migration History
 
-| Migration | Purpose |
-|-----------|---------|
-| `0024_flowsheet_entry_type.sql` | Added `entry_type` column and its btree index |
-| `0042_flowsheet-suggest-indexes.sql` | Added GIN trigram indexes on `artist_name` and `track_title` for ghost-text autocomplete |
-| `0049_flowsheet-search-indexes.sql` | Added GIN trigram indexes on `album_title` and `record_label`; combined the data and count queries into a single window-function query (which subsequently regressed performance — see "Current Performance Behavior") |
+| Migration                            | Purpose                                                                                                                                                                                                                |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0024_flowsheet_entry_type.sql`      | Added `entry_type` column and its btree index                                                                                                                                                                          |
+| `0042_flowsheet-suggest-indexes.sql` | Added GIN trigram indexes on `artist_name` and `track_title` for ghost-text autocomplete                                                                                                                               |
+| `0049_flowsheet-search-indexes.sql`  | Added GIN trigram indexes on `album_title` and `record_label`; combined the data and count queries into a single window-function query (which subsequently regressed performance — see "Current Performance Behavior") |
 
 ## Related
 

--- a/shared/database/src/migrations/0050_flowsheet-track-add-time-idx.sql
+++ b/shared/database/src/migrations/0050_flowsheet-track-add-time-idx.sql
@@ -1,0 +1,12 @@
+-- Flowsheet recent-tracks index: support ORDER BY add_time DESC LIMIT N on
+-- track entries. Without it the planner has no index that satisfies the
+-- default sort, so every search query falls back to an in-memory sort over
+-- the trigram bitmap output.
+--
+-- Partial WHERE entry_type = 'track' keeps the index small by excluding
+-- break / message rows that the search filters out anyway, and matches the
+-- exact predicate in apps/backend/services/search.service.ts.
+
+CREATE INDEX "flowsheet_track_add_time_idx"
+  ON "wxyc_schema"."flowsheet" USING btree ("add_time" DESC)
+  WHERE "entry_type" = 'track';

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1777387200000,
       "tag": "0049_flowsheet-search-indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1777473600000,
+      "tag": "0050_flowsheet-track-add-time-idx",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -374,6 +374,9 @@ export const flowsheet = wxyc_schema.table(
     index('flowsheet_track_title_trgm_idx').using('gin', sql`${table.track_title} gin_trgm_ops`),
     index('flowsheet_album_title_trgm_idx').using('gin', sql`${table.album_title} gin_trgm_ops`),
     index('flowsheet_record_label_trgm_idx').using('gin', sql`${table.record_label} gin_trgm_ops`),
+    index('flowsheet_track_add_time_idx')
+      .on(sql`${table.add_time} DESC`)
+      .where(sql`${table.entry_type} = 'track'`),
   ]
 );
 

--- a/tests/unit/services/search.service.test.ts
+++ b/tests/unit/services/search.service.test.ts
@@ -15,24 +15,45 @@ const makeRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
   record_label: 'Warp',
   show_id: 100,
   dj_name: 'DJ Test',
-  total: 1,
   ...overrides,
 });
 
+const mockDataAndCount = (rows: ReturnType<typeof makeRow>[], total: number) => {
+  (db.execute as jest.Mock).mockResolvedValueOnce(rows).mockResolvedValueOnce([{ total }]);
+};
+
 describe('searchFlowsheet', () => {
+  it('issues two parallel queries: data and count', async () => {
+    mockDataAndCount([makeRow()], 1);
+
+    await searchFlowsheet({ q: 'autechre', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    expect(db.execute).toHaveBeenCalledTimes(2);
+  });
+
   it('returns paginated results for a simple query', async () => {
-    const rows = [makeRow({ total: 2 }), makeRow({ id: 2, artist_name: 'Autolux', total: 2 })];
-    (db.execute as jest.Mock).mockResolvedValueOnce(rows);
+    const rows = [makeRow(), makeRow({ id: 2, artist_name: 'Autolux' })];
+    mockDataAndCount(rows, 2);
 
     const result = await searchFlowsheet({ q: 'aut', page: 0, limit: 50, sort: 'date', order: 'desc' });
 
     expect(result.results).toHaveLength(2);
     expect(result.total).toBe(2);
-    expect(db.execute).toHaveBeenCalledTimes(1);
   });
 
-  it('returns empty results when no matches', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+  it('uses the count query result for total, not the data row count', async () => {
+    // Page 0 returns 50 rows but the underlying match set is 100
+    const rows = Array.from({ length: 50 }, (_, i) => makeRow({ id: i + 1 }));
+    mockDataAndCount(rows, 100);
+
+    const result = await searchFlowsheet({ q: 'autechre', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    expect(result.results).toHaveLength(50);
+    expect(result.total).toBe(100);
+  });
+
+  it('returns empty results and zero total when no matches', async () => {
+    mockDataAndCount([], 0);
 
     const result = await searchFlowsheet({ q: 'nonexistent', page: 0, limit: 50, sort: 'date', order: 'desc' });
 
@@ -40,18 +61,18 @@ describe('searchFlowsheet', () => {
     expect(result.total).toBe(0);
   });
 
-  it('calculates correct offset from page and limit', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow({ total: 100 })]);
+  it('reports total from the count query even when the data page is empty', async () => {
+    // User paginated past the end — data query returns nothing but count is real
+    mockDataAndCount([], 100);
 
-    const result = await searchFlowsheet({ q: 'autechre', page: 2, limit: 10, sort: 'date', order: 'desc' });
+    const result = await searchFlowsheet({ q: 'autechre', page: 99, limit: 10, sort: 'date', order: 'desc' });
 
-    expect(result.results).toHaveLength(1);
+    expect(result.results).toEqual([]);
     expect(result.total).toBe(100);
-    expect(db.execute).toHaveBeenCalledTimes(1);
   });
 
   it('handles field-prefixed queries', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow()]);
+    mockDataAndCount([makeRow()], 1);
 
     const result = await searchFlowsheet({
       q: 'artist:autechre',
@@ -67,7 +88,7 @@ describe('searchFlowsheet', () => {
 
   it('formats play_date as ISO string', async () => {
     const date = new Date('2024-06-15T14:30:00Z');
-    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow({ play_date: date })]);
+    mockDataAndCount([makeRow({ play_date: date })], 1);
 
     const result = await searchFlowsheet({ q: 'autechre', page: 0, limit: 50, sort: 'date', order: 'desc' });
 
@@ -75,7 +96,7 @@ describe('searchFlowsheet', () => {
   });
 
   it('coerces null dj_name to empty string', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow({ dj_name: null })]);
+    mockDataAndCount([makeRow({ dj_name: null })], 1);
 
     const result = await searchFlowsheet({ q: 'autechre', page: 0, limit: 50, sort: 'date', order: 'desc' });
 
@@ -83,14 +104,17 @@ describe('searchFlowsheet', () => {
   });
 
   it('coerces null text fields to empty strings', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([
-      makeRow({
-        artist_name: null,
-        track_title: null,
-        album_title: null,
-        record_label: null,
-      }),
-    ]);
+    mockDataAndCount(
+      [
+        makeRow({
+          artist_name: null,
+          track_title: null,
+          album_title: null,
+          record_label: null,
+        }),
+      ],
+      1
+    );
 
     const result = await searchFlowsheet({ q: 'test', page: 0, limit: 50, sort: 'date', order: 'desc' });
 


### PR DESCRIPTION
## Summary

- Reverts the data + count queries to a parallel `Promise.all` so the data query can short-circuit at `LIMIT` rows again instead of materializing the full match set for the `COUNT(*) OVER()` window function.
- Adds a partial btree index `flowsheet_track_add_time_idx` on `(add_time DESC) WHERE entry_type='track'` so the default `ORDER BY add_time DESC` can be satisfied directly from the index instead of falling back to an in-memory sort over the trigram bitmap output.
- Implements steps 1 and 2 from `docs/playlist-search/README.md`.

## Test plan

- [x] Unit tests updated to mock both queries; added explicit count-vs-data-row regression case
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (warnings unchanged from main)
- [x] `npx jest --config jest.unit.config.ts tests/unit/services/search.service.test.ts` all pass
- [ ] Verify migration applies cleanly in CI integration tests
- [ ] After merge, manually time a previously-slow query (`?q=love` or `?q=the`) against staging to confirm the regression is gone

Closes #464