### PR TITLE
Index DJ name search (step 5a)

### DIFF
--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -183,10 +183,16 @@ function buildAllFieldMatch(value: string, exact: boolean): SQL {
 }
 
 function buildDjNameMatch(value: string, exact: boolean): SQL {
+  // OR-decompose across the three underlying columns instead of filtering on
+  // the COALESCE expression. Postgres does not push ILIKE predicates through
+  // COALESCE to use the per-column trigram indexes; the OR form lets the
+  // planner BitmapOr across user.dj_name, user.name, and shows.legacy_dj_name.
+  // Display still uses COALESCE (DJ_NAME_EXPR) for the priority-ordered name.
   if (exact) {
-    return sql`${DJ_NAME_EXPR} = ${value}`;
+    return sql`(${user.djName} = ${value} OR ${user.name} = ${value} OR ${shows.legacy_dj_name} = ${value})`;
   }
-  return sql`${DJ_NAME_EXPR} ILIKE ${'%' + value + '%'}`;
+  const pattern = '%' + value + '%';
+  return sql`(${user.djName} ILIKE ${pattern} OR ${user.name} ILIKE ${pattern} OR ${shows.legacy_dj_name} ILIKE ${pattern})`;
 }
 
 function buildDateMatch(value: string): SQL {

--- a/docs/playlist-search/README.md
+++ b/docs/playlist-search/README.md
@@ -126,20 +126,22 @@ When this lands, the test suite should cover music titles with stylized punctuat
 
 ### 5a. Index DJ name search (independent quick win)
 
-DJ filter and sort hit a `COALESCE(user.dj_name, shows.legacy_dj_name, user.name)` expression with no supporting index. The cheapest mitigation, runnable immediately and not blocked on anything else, is a functional GIN trigram index on the expression:
+DJ filter and sort hit a `COALESCE(user.dj_name, shows.legacy_dj_name, user.name)` expression with no supporting index. The cheapest mitigation, runnable immediately and not blocked on anything else, is twofold:
+
+**Service change:** OR-decompose the WHERE filter across the three underlying columns instead of filtering on the COALESCE result. Postgres does not push ILIKE predicates through `COALESCE` to use per-column indexes, so a `COALESCE(...) ILIKE '%x%'` predicate stays unindexed regardless of what indexes exist on the inputs. Rewriting the filter as `(a ILIKE '%x%' OR b ILIKE '%x%' OR c ILIKE '%x%')` lets the planner BitmapOr across the three columns. Display still uses the COALESCE expression so the priority-ordered name shows in results; only the filter changes shape.
+
+**Schema change:** plain GIN trigram indexes on the three filtered columns:
 
 ```sql
-CREATE INDEX shows_dj_name_trgm_idx
-  ON wxyc_schema.shows USING gin (
-    (COALESCE(legacy_dj_name, '')) gin_trgm_ops
-  );
-CREATE INDEX user_dj_name_trgm_idx
-  ON wxyc_schema."user" USING gin (
-    (COALESCE(dj_name, name, '')) gin_trgm_ops
-  );
+CREATE INDEX auth_user_dj_name_trgm_idx
+  ON wxyc_schema.auth_user USING gin (dj_name gin_trgm_ops);
+CREATE INDEX auth_user_name_trgm_idx
+  ON wxyc_schema.auth_user USING gin (name gin_trgm_ops);
+CREATE INDEX shows_legacy_dj_name_trgm_idx
+  ON wxyc_schema.shows USING gin (legacy_dj_name gin_trgm_ops);
 ```
 
-(Postgres requires the indexed expression to come from a single table, so the `COALESCE` is split across the two underlying tables and the planner combines them via the join.)
+The OR semantics are also a UX upgrade: a search for `dj:jake` now matches if the DJ's preferred name OR display name OR legacy show name contains `jake`, instead of only matching against whichever name the COALESCE happened to surface.
 
 ### 5b. Denormalize `dj_name` onto flowsheet (paired with step 4)
 

--- a/shared/database/src/migrations/0051_dj-name-search-indexes.sql
+++ b/shared/database/src/migrations/0051_dj-name-search-indexes.sql
@@ -1,0 +1,16 @@
+-- DJ-name search indexes: support `dj:` filter and dj-name `all` matches.
+-- Adds GIN trigram indexes on the three columns the search service ORs
+-- together when filtering by DJ name, so the planner can BitmapOr across
+-- them instead of falling back to a sequential scan over the join.
+--
+-- The COALESCE expression in the SELECT (DJ_NAME_EXPR) is unchanged — it
+-- still produces the priority-ordered display name. Only the WHERE clause
+-- filter is OR-decomposed across the underlying columns; see
+-- apps/backend/services/search.service.ts buildDjNameMatch.
+
+CREATE INDEX "auth_user_dj_name_trgm_idx"
+  ON "wxyc_schema"."auth_user" USING gin ("dj_name" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "auth_user_name_trgm_idx"
+  ON "wxyc_schema"."auth_user" USING gin ("name" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX "shows_legacy_dj_name_trgm_idx"
+  ON "wxyc_schema"."shows" USING gin ("legacy_dj_name" gin_trgm_ops);

--- a/shared/database/src/migrations/0051_dj-name-search-indexes.sql
+++ b/shared/database/src/migrations/0051_dj-name-search-indexes.sql
@@ -9,8 +9,8 @@
 -- apps/backend/services/search.service.ts buildDjNameMatch.
 
 CREATE INDEX "auth_user_dj_name_trgm_idx"
-  ON "wxyc_schema"."auth_user" USING gin ("dj_name" gin_trgm_ops);--> statement-breakpoint
+  ON "auth_user" USING gin ("dj_name" gin_trgm_ops);--> statement-breakpoint
 CREATE INDEX "auth_user_name_trgm_idx"
-  ON "wxyc_schema"."auth_user" USING gin ("name" gin_trgm_ops);--> statement-breakpoint
+  ON "auth_user" USING gin ("name" gin_trgm_ops);--> statement-breakpoint
 CREATE INDEX "shows_legacy_dj_name_trgm_idx"
   ON "wxyc_schema"."shows" USING gin ("legacy_dj_name" gin_trgm_ops);

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1777473600000,
       "tag": "0050_flowsheet-track-add-time-idx",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1777560000000,
+      "tag": "0051_dj-name-search-indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -48,6 +48,8 @@ export const user = pgTable(
   (table) => [
     uniqueIndex('auth_user_email_key').on(table.email),
     uniqueIndex('auth_user_username_key').on(table.username),
+    index('auth_user_dj_name_trgm_idx').using('gin', sql`${table.djName} gin_trgm_ops`),
+    index('auth_user_name_trgm_idx').using('gin', sql`${table.name} gin_trgm_ops`),
   ]
 );
 
@@ -489,7 +491,10 @@ export const shows = wxyc_schema.table(
     start_time: timestamp('start_time', { withTimezone: true }).defaultNow().notNull(),
     end_time: timestamp('end_time', { withTimezone: true }),
   },
-  (table) => [uniqueIndex('shows_legacy_show_id_idx').on(table.legacy_show_id)]
+  (table) => [
+    uniqueIndex('shows_legacy_show_id_idx').on(table.legacy_show_id),
+    index('shows_legacy_dj_name_trgm_idx').using('gin', sql`${table.legacy_dj_name} gin_trgm_ops`),
+  ]
 );
 
 export type NewShowDJ = InferInsertModel<typeof show_djs>;

--- a/tests/unit/services/search.service.test.ts
+++ b/tests/unit/services/search.service.test.ts
@@ -86,6 +86,36 @@ describe('searchFlowsheet', () => {
     expect(result.results[0].artist_name).toBe('Autechre');
   });
 
+  it('handles a dj-name filter without errors', async () => {
+    mockDataAndCount([makeRow({ dj_name: 'jake' })], 1);
+
+    const result = await searchFlowsheet({
+      q: 'dj:jake',
+      page: 0,
+      limit: 50,
+      sort: 'date',
+      order: 'desc',
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].dj_name).toBe('jake');
+  });
+
+  it('handles a dj-name filter with exact match without errors', async () => {
+    mockDataAndCount([makeRow({ dj_name: 'jake' })], 1);
+
+    const result = await searchFlowsheet({
+      q: 'dj:"jake"',
+      page: 0,
+      limit: 50,
+      sort: 'date',
+      order: 'desc',
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].dj_name).toBe('jake');
+  });
+
   it('formats play_date as ISO string', async () => {
     const date = new Date('2024-06-15T14:30:00Z');
     mockDataAndCount([makeRow({ play_date: date })], 1);


### PR DESCRIPTION
## Summary

- OR-decomposes the DJ-name WHERE filter across `user.dj_name`, `user.name`, and `shows.legacy_dj_name` so the planner can BitmapOr against per-column indexes. Postgres does not push ILIKE predicates through COALESCE, so the previous COALESCE-on-WHERE form bypassed indexes regardless of what was on the inputs.
- Adds migration `0051_dj-name-search-indexes.sql` with three GIN trigram indexes on those three columns.
- Display still uses the COALESCE expression so the priority-ordered name appears in result rows; only the filter changes shape.
- Corrects the design doc step 5a section, which originally proposed functional COALESCE indexes that would not have helped.
- UX side effect: `dj:jake` now matches if any of the DJ's known names contains "jake", not just whichever the COALESCE surfaced.

Implements step 5a from `docs/playlist-search/README.md`.

## Test plan

- [x] Existing search service / parser / controller tests still pass
- [x] Added two unit tests covering substring and exact-match `dj:` filters
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (warnings unchanged from main)
- [x] `npx prettier --check` clean on touched files
- [ ] CI integration tests verify the migration applies cleanly

Closes #468