### PR TITLE
Add tsvector hybrid search path (step 4)

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -31,7 +31,10 @@ export interface IFSEntryMetadata {
   artist_wikipedia_url: string | null;
 }
 
-export interface IFSEntry extends FSEntry {
+// search_doc is a STORED GENERATED tsvector used only by the search hot path
+// (apps/backend/services/search.service.ts); the controller layer never reads
+// or constructs it, so it is excluded from the application-facing entry type.
+export interface IFSEntry extends Omit<FSEntry, 'search_doc'> {
   label_id: number | null;
   rotation_bin: string | null;
   on_streaming: boolean | null;

--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -174,10 +174,30 @@ function buildColumnMatch(column: string, value: string, exact: boolean): SQL {
   return sql`${col} ILIKE ${'%' + value + '%'}`;
 }
 
+/**
+ * Decide whether an `all`-field bare-term query should use the tsvector path
+ * or fall back to the trigram ILIKE path. Tsvector handles whole-word and
+ * prefix matching cleanly via `websearch_to_tsquery`, but it tokenizes — so
+ * pure-punctuation strings (`!!!`, `$$$`) and single-character fragments are
+ * better served by trigram, which can match arbitrary substrings.
+ */
+export function shouldUseTsvector(value: string): boolean {
+  if (value.length < 3) return false;
+  return /[a-zA-Z0-9]/.test(value);
+}
+
 function buildAllFieldMatch(value: string, exact: boolean): SQL {
   if (exact) {
     return sql`(${flowsheet.artist_name} = ${value} OR ${flowsheet.track_title} = ${value} OR ${flowsheet.album_title} = ${value} OR ${flowsheet.record_label} = ${value})`;
   }
+  if (shouldUseTsvector(value)) {
+    // Tsvector path: tokenized whole-word / prefix matching across all four
+    // weighted fields via the GIN index on flowsheet.search_doc. websearch_
+    // to_tsquery handles natural query input (quoted phrases, OR, etc.).
+    return sql`${flowsheet.search_doc} @@ websearch_to_tsquery('simple', ${value})`;
+  }
+  // Trigram fallback: short queries, pure-punctuation strings, and any other
+  // input that the tsvector path would tokenize away.
   const pattern = '%' + value + '%';
   return sql`(${flowsheet.artist_name} ILIKE ${pattern} OR ${flowsheet.track_title} ILIKE ${pattern} OR ${flowsheet.album_title} ILIKE ${pattern} OR ${flowsheet.record_label} ILIKE ${pattern})`;
 }

--- a/shared/database/src/migrations/0052_flowsheet-tsvector-search.sql
+++ b/shared/database/src/migrations/0052_flowsheet-tsvector-search.sql
@@ -1,0 +1,22 @@
+-- Flowsheet hybrid search: generated tsvector covering the four text fields
+-- with weight bands (artist=A, track=B, album=C, label=D), backed by a GIN
+-- index. The search service routes 'all'-field queries between this tsvector
+-- path and the existing trigram path based on query shape; field-prefixed
+-- queries (artist:, song:, album:, label:) keep using trigram.
+--
+-- Uses the 'simple' text search config — music titles are full of proper
+-- nouns, foreign words, and stylized spellings that English stemming
+-- distorts; 'simple' tokenizes on word boundaries without stemming or
+-- stop-word removal.
+
+ALTER TABLE "wxyc_schema"."flowsheet"
+  ADD COLUMN "search_doc" tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('simple', coalesce("artist_name", '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce("track_title", '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce("album_title", '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce("record_label", '')), 'D')
+  ) STORED;--> statement-breakpoint
+
+CREATE INDEX "flowsheet_search_doc_idx"
+  ON "wxyc_schema"."flowsheet" USING gin ("search_doc");

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1777560000000,
       "tag": "0051_dj-name-search-indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1777646400000,
+      "tag": "0052_flowsheet-tsvector-search",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -15,7 +15,19 @@ import {
   pgEnum,
   date,
   uniqueIndex,
+  customType,
 } from 'drizzle-orm/pg-core';
+
+// PostgreSQL tsvector. Drizzle has no first-class tsvector type, but we only
+// reference these columns from raw SQL fragments (WHERE search_doc @@ ...),
+// so the in-TS data type does not matter — what matters is the dataType()
+// returned to drizzle-kit so generated migrations / schema diffs use the
+// right SQL type name.
+const tsvector = customType<{ data: string; driverData: string }>({
+  dataType() {
+    return 'tsvector';
+  },
+});
 
 // Schema name is configurable for parallel test isolation (each Jest worker gets its own schema)
 const WXYC_SCHEMA_NAME = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
@@ -368,6 +380,13 @@ export const flowsheet = wxyc_schema.table(
     soundcloud_url: varchar('soundcloud_url', { length: 512 }),
     artist_bio: text('artist_bio'),
     artist_wikipedia_url: varchar('artist_wikipedia_url', { length: 512 }),
+    // STORED GENERATED tsvector covering the four text fields with weight
+    // bands (artist=A, track=B, album=C, label=D). Managed by migration
+    // 0052; declared here so drizzle-kit drift detection treats it as
+    // present rather than proposing to add it.
+    search_doc: tsvector('search_doc').generatedAlwaysAs(
+      sql`setweight(to_tsvector('simple', coalesce("artist_name", '')), 'A') || setweight(to_tsvector('simple', coalesce("track_title", '')), 'B') || setweight(to_tsvector('simple', coalesce("album_title", '')), 'C') || setweight(to_tsvector('simple', coalesce("record_label", '')), 'D')`
+    ),
   },
   (table) => [
     uniqueIndex('flowsheet_legacy_entry_id_idx').on(table.legacy_entry_id),
@@ -379,6 +398,7 @@ export const flowsheet = wxyc_schema.table(
     index('flowsheet_track_add_time_idx')
       .on(sql`${table.add_time} DESC`)
       .where(sql`${table.entry_type} = 'track'`),
+    index('flowsheet_search_doc_idx').using('gin', sql`${table.search_doc}`),
   ]
 );
 

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -118,6 +118,7 @@ export const flowsheet = {
   soundcloud_url: 'soundcloud_url',
   artist_bio: 'artist_bio',
   artist_wikipedia_url: 'artist_wikipedia_url',
+  search_doc: 'search_doc',
 };
 export const bins = {};
 export const shows = {};

--- a/tests/unit/services/search.service.test.ts
+++ b/tests/unit/services/search.service.test.ts
@@ -4,7 +4,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-import { searchFlowsheet } from '../../../apps/backend/services/search.service';
+import { searchFlowsheet, shouldUseTsvector } from '../../../apps/backend/services/search.service';
 
 const makeRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
   id: 1,
@@ -152,5 +152,38 @@ describe('searchFlowsheet', () => {
     expect(result.results[0].track_title).toBe('');
     expect(result.results[0].album_title).toBe('');
     expect(result.results[0].record_label).toBe('');
+  });
+});
+
+describe('shouldUseTsvector', () => {
+  describe('routes to tsvector for well-tokenized queries', () => {
+    it.each([
+      ['autechre'],
+      ['the'],
+      ['Sigur Rós'],
+      ['Belle & Sebastian'],
+      ['Godspeed You! Black Emperor'],
+      ['M.A.N.D.Y.'],
+      ['a&b'],
+      ['123'],
+      ['Mac DeMarco'],
+      ['Jessica Pratt'],
+    ])('uses tsvector for %j', (value) => {
+      expect(shouldUseTsvector(value)).toBe(true);
+    });
+  });
+
+  describe('falls back to trigram for unsuitable queries', () => {
+    it.each([
+      ['', 'empty'],
+      ['a', 'single character'],
+      ['au', 'two characters (under tsvector min)'],
+      ['!!!', 'pure punctuation'],
+      ['$$$', 'pure punctuation'],
+      ['...', 'pure punctuation'],
+      ['   ', 'whitespace only'],
+    ])('uses trigram for %j (%s)', (value) => {
+      expect(shouldUseTsvector(value)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a STORED GENERATED `tsvector` column on `flowsheet` covering the four text fields with weight bands (artist=A, track=B, album=C, label=D), backed by a GIN index. Migration `0052_flowsheet-tsvector-search.sql`.
- Routes all-field bare-term queries through a new `shouldUseTsvector(value)` helper: tokenized matching via `websearch_to_tsquery('simple', value)` for well-formed input; trigram fallback for short queries, pure-punctuation, and empty.
- Field-prefixed queries (`artist:`, `song:`, `album:`, `label:`, `dj:`) and quoted exact matches keep their existing per-column trigram paths.
- Uses the `'simple'` text search config — no stemming or stop-word removal, since music titles need stylized spellings preserved.
- Declares `search_doc` in `schema.ts` via `customType` + `.generatedAlwaysAs(...)` so drizzle-kit drift detection is happy. `IFSEntry` Omits it so no controller/service has to construct it.

Implements step 4 from `docs/playlist-search/README.md`.

## Production deployment note

`ALTER TABLE ... ADD COLUMN ... GENERATED ALWAYS AS ... STORED` rewrites every existing row to compute the initial tsvector value. Against the empty CI DB this is instant; in production it will hold an `ACCESS EXCLUSIVE` lock while the rewrite runs. Apply during a low-traffic window. (Flowsheet rowcount × ~four short text fields per row is the rewrite cost; should be on the order of seconds-to-minutes, not hours.)

## Test plan

- [x] `shouldUseTsvector` unit tests cover the well-tokenized cases (autechre, Sigur Rós, Belle & Sebastian, Godspeed You! Black Emperor, M.A.N.D.Y., dotted initialisms, ampersands) and the trigram-fallback cases (empty, single char, sub-min length, pure punctuation, whitespace-only)
- [x] Existing search service / parser / controller tests still pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (warnings unchanged from main)
- [x] `npx prettier --check` clean on touched files
- [ ] CI integration tests verify the migration applies cleanly
- [ ] After deploy: hit `/flowsheet/search?q=love` against staging, confirm sub-second response (this is the previously slow-path popular-term query that motivated step 4)

Closes #470