### PR TITLE
Add cursor pagination to /flowsheet/search (step 3)

### DIFF
--- a/apps/backend/controllers/search.controller.ts
+++ b/apps/backend/controllers/search.controller.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express';
 import * as searchService from '../services/search.service.js';
+import { parseCursor } from '../services/search.service.js';
 import type { SearchParams } from '../services/search.service.js';
 
 type SearchQueryParams = {
@@ -8,6 +9,7 @@ type SearchQueryParams = {
   limit?: string;
   sort?: string;
   order?: string;
+  cursor?: string;
 };
 
 const VALID_SORTS: SearchParams['sort'][] = ['date', 'artist', 'song', 'dj'];
@@ -49,11 +51,32 @@ export const searchFlowsheetEndpoint: RequestHandler<object, unknown, unknown, S
     VALID_ORDERS.includes(req.query.order as SearchParams['order']) ? req.query.order : 'desc'
   ) as SearchParams['order'];
 
+  // Cursor is optional. If present it must round-trip through parseCursor;
+  // a malformed token is a 400 rather than silently falling back to offset
+  // (clients that ask for cursor mode should know it failed).
+  const cursor = req.query.cursor;
+  if (cursor !== undefined && parseCursor(cursor) === null) {
+    res.status(400).json({ message: 'Invalid cursor token' });
+    return;
+  }
+
   try {
-    const { results, total } = await searchService.searchFlowsheet({ q, page, limit, sort, order });
+    const { results, total, nextCursor } = await searchService.searchFlowsheet({
+      q,
+      page,
+      limit,
+      sort,
+      order,
+      cursor,
+    });
     const totalPages = Math.ceil(total / limit);
 
-    res.status(200).json({ results, total, page, totalPages });
+    // totalPages stays in the response for backward compat with offset-mode
+    // clients during the dj-site cursor migration. nextCursor is included
+    // only when the service produced one (cursor mode + full page).
+    const body: Record<string, unknown> = { results, total, page, totalPages };
+    if (nextCursor !== undefined) body.nextCursor = nextCursor;
+    res.status(200).json(body);
   } catch (e) {
     console.error('Error searching flowsheet');
     console.error(e);

--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -8,7 +8,34 @@ export type SearchParams = {
   limit: number;
   sort: 'date' | 'artist' | 'song' | 'dj';
   order: 'asc' | 'desc';
+  /**
+   * Opaque cursor token from a previous response's `nextCursor`. When provided
+   * with `sort: 'date'`, replaces offset pagination with a `WHERE add_time` /
+   * `id` predicate so each page costs O(limit) instead of O(page * limit).
+   * Ignored for non-date sorts (no compound index supports them).
+   */
+  cursor?: string;
 };
+
+export type Cursor = { addTime: string; id: number };
+
+/** Encode a cursor for the next page. Format: `${ISO timestamp}_${id}`. */
+export function encodeCursor(addTime: string, id: number): string {
+  return `${addTime}_${id}`;
+}
+
+/** Parse a cursor token, or return null if malformed. */
+export function parseCursor(cursor: string): Cursor | null {
+  const lastUnderscore = cursor.lastIndexOf('_');
+  if (lastUnderscore <= 0) return null;
+  const addTime = cursor.slice(0, lastUnderscore);
+  const idStr = cursor.slice(lastUnderscore + 1);
+  if (!addTime || !idStr) return null;
+  const id = Number(idStr);
+  if (!Number.isInteger(id) || id <= 0) return null;
+  if (Number.isNaN(Date.parse(addTime))) return null;
+  return { addTime, id };
+}
 
 type SearchResultRow = {
   id: number;
@@ -52,14 +79,22 @@ const COLUMN_MAP: Record<string, SQL> = {
 };
 
 /** Search historical flowsheet entries with filtering, sorting, and pagination. */
-export async function searchFlowsheet(params: SearchParams): Promise<{ results: SearchResult[]; total: number }> {
-  const { q, page, limit, sort, order } = params;
-  const offset = page * limit;
+export async function searchFlowsheet(
+  params: SearchParams
+): Promise<{ results: SearchResult[]; total: number; nextCursor?: string }> {
+  const { q, page, limit, sort, order, cursor } = params;
   const conditions = parseSearchQuery(q);
 
   const whereClause = buildWhereClause(conditions);
   const orderDirection = order === 'asc' ? sql`ASC` : sql`DESC`;
   const sortExpr = SORT_MAP[sort];
+
+  // Cursor pagination is only meaningful for date sort. Other sorts fall back
+  // to offset because their sort columns are not unique and there is no
+  // compound index to support a (sort_col, id) cursor predicate.
+  const parsedCursor = cursor !== undefined && sort === 'date' ? parseCursor(cursor) : null;
+  const useCursor = parsedCursor !== null;
+  const offset = useCursor ? 0 : page * limit;
 
   const baseFrom = sql`
     FROM ${flowsheet}
@@ -68,12 +103,26 @@ export async function searchFlowsheet(params: SearchParams): Promise<{ results: 
     WHERE ${flowsheet.entry_type} = 'track'
   `;
 
-  const fullWhere = whereClause ? sql`${baseFrom} AND ${whereClause}` : baseFrom;
+  let fullWhere = whereClause ? sql`${baseFrom} AND ${whereClause}` : baseFrom;
+  if (parsedCursor) {
+    // Compound (add_time, id) cursor handles ties when multiple rows share an
+    // add_time — common for batch-imported legacy entries that all carry the
+    // same import timestamp.
+    const cmp = order === 'asc' ? sql`>` : sql`<`;
+    fullWhere = sql`${fullWhere} AND (${flowsheet.add_time}, ${flowsheet.id}) ${cmp} (${parsedCursor.addTime}::timestamptz, ${parsedCursor.id})`;
+  }
+
+  // In cursor mode, add id as a tiebreaker so the ORDER BY matches the
+  // cursor predicate's compound key — required for stable pagination.
+  const orderByClause = useCursor
+    ? sql`${sortExpr} ${orderDirection}, ${flowsheet.id} ${orderDirection}`
+    : sql`${sortExpr} ${orderDirection}`;
 
   // Run data and count in parallel. A combined `COUNT(*) OVER()` window query
   // forces Postgres to materialize the full match set before LIMIT can apply,
   // which defeats short-circuiting on the data side. Two queries let the data
   // query stop at LIMIT rows via index, while the count runs concurrently.
+  const limitClause = useCursor ? sql`LIMIT ${limit}` : sql`LIMIT ${limit} OFFSET ${offset}`;
   const dataQuery = sql`
     SELECT
       ${flowsheet.id},
@@ -85,8 +134,8 @@ export async function searchFlowsheet(params: SearchParams): Promise<{ results: 
       ${flowsheet.show_id},
       ${DJ_NAME_EXPR} AS dj_name
     ${fullWhere}
-    ORDER BY ${sortExpr} ${orderDirection}
-    LIMIT ${limit} OFFSET ${offset}
+    ORDER BY ${orderByClause}
+    ${limitClause}
   `;
 
   const countQuery = sql`SELECT COUNT(*)::int AS total ${fullWhere}`;
@@ -96,7 +145,14 @@ export async function searchFlowsheet(params: SearchParams): Promise<{ results: 
   const results = (dataRows as unknown as SearchResultRow[]).map(transformRow);
   const total = (countRows as unknown as CountRow[])[0]?.total ?? 0;
 
-  return { results, total };
+  // nextCursor only when cursor mode is active AND we got a full page —
+  // a short page means there are no more rows.
+  const nextCursor =
+    useCursor && results.length === limit
+      ? encodeCursor(results[results.length - 1].play_date, results[results.length - 1].id)
+      : undefined;
+
+  return nextCursor !== undefined ? { results, total, nextCursor } : { results, total };
 }
 
 function transformRow(row: SearchResultRow): SearchResult {

--- a/docs/playlist-search/README.md
+++ b/docs/playlist-search/README.md
@@ -89,11 +89,15 @@ Lets the planner satisfy `ORDER BY add_time DESC LIMIT 50` directly from the ind
 
 ### 3. Cursor-based pagination
 
-The frontend already uses infinite scroll, so `OFFSET` is doing extra work for no benefit — its cost grows linearly with page depth because Postgres still has to scan and discard the skipped rows. Replacing it with a cursor (`WHERE add_time < $cursor`) makes every page O(limit) regardless of depth and pairs cleanly with the new `add_time` index.
+The frontend already uses infinite scroll, so `OFFSET` is doing extra work for no benefit — its cost grows linearly with page depth because Postgres still has to scan and discard the skipped rows. Replacing it with a cursor (`WHERE (add_time, id) < (cursor_time, cursor_id)`) makes every page O(limit) regardless of depth and pairs cleanly with the new `add_time` index.
 
-This also removes the need for a precise `total` for paging UI; the response can return `nextCursor` instead of `totalPages`.
+The cursor is **compound** `(add_time, id)` rather than `add_time` alone because the legacy ETL backfilled many rows with batch-import timestamps that share the same `add_time` value to the microsecond — a single-column cursor would silently drop those rows on page boundaries. The compound form orders by `(add_time, id)` and uses row-value comparison `(add_time, id) < (cursor_time, cursor_id)` to break ties on `id`.
 
-**Compatibility plan.** The dj-site `useLazySearchPlaylistsQuery` is the only known consumer and currently reads `totalPages`. To avoid a breaking change, the response should return both `nextCursor` and (when the count is computed) `totalPages` for one release; once dj-site is migrated, `totalPages` and the `page`/`offset` query parameters can be removed in a follow-up. New consumers should be guided to the cursor form from the start.
+**Sort coverage.** Cursor pagination only applies to `sort=date`. Other sorts (`artist`, `song`, `dj`) keep using offset because their sort columns are not unique and there is no compound index supporting a `(sort_col, id)` cursor. This matches usage: the default Previous Sets view and the empty-`q` recent-tracks path both use date sort.
+
+**Compatibility plan.** The dj-site `useLazySearchPlaylistsQuery` is the only known consumer and currently reads `totalPages`. The response returns both `nextCursor` (when cursor mode is active) and `totalPages` (always) so dj-site can migrate when convenient. Once dj-site is migrated, `totalPages` and the `page` query parameter can be removed in a follow-up. New consumers should be guided to the cursor form from the start.
+
+A malformed cursor returns `400`. Encoding format is `${ISO_timestamp}_${id}` — opaque to clients in spirit, debuggable in practice.
 
 ### 4. Generated `tsvector` column with hybrid trigram fallback
 

--- a/tests/unit/controllers/search.controller.test.ts
+++ b/tests/unit/controllers/search.controller.test.ts
@@ -2,9 +2,16 @@ import { Request, Response } from 'express';
 
 const searchFlowsheet = jest.fn();
 
-jest.mock('../../../apps/backend/services/search.service', () => ({
-  searchFlowsheet: (...args: unknown[]) => searchFlowsheet(...args),
-}));
+jest.mock('../../../apps/backend/services/search.service', () => {
+  // Use the real parseCursor implementation so the controller's validation
+  // exercises actual codec semantics rather than a hand-mocked allow-list.
+  const actual = jest.requireActual('../../../apps/backend/services/search.service');
+  return {
+    searchFlowsheet: (...args: unknown[]) => searchFlowsheet(...args),
+    parseCursor: actual.parseCursor,
+    encodeCursor: actual.encodeCursor,
+  };
+});
 
 import { searchFlowsheetEndpoint } from '../../../apps/backend/controllers/search.controller';
 
@@ -147,6 +154,65 @@ describe('searchFlowsheetEndpoint', () => {
       await run();
 
       expect(res._body).toEqual({ results: [], total: 0, page: 0, totalPages: 0 });
+    });
+
+    it('includes nextCursor when the service returns one', async () => {
+      searchFlowsheet.mockResolvedValueOnce({
+        results: ['a'],
+        total: 1000,
+        nextCursor: '2024-06-15T14:30:00.000Z_42',
+      });
+      const { res, run } = invoke({ cursor: '2024-06-16T00:00:00.000Z_99' });
+
+      await run();
+
+      expect(res._body).toMatchObject({
+        results: ['a'],
+        total: 1000,
+        nextCursor: '2024-06-15T14:30:00.000Z_42',
+      });
+    });
+
+    it('omits nextCursor when the service does not return one', async () => {
+      searchFlowsheet.mockResolvedValueOnce({ results: ['a'], total: 1 });
+      const { res, run } = invoke({});
+
+      await run();
+
+      expect(res._body).not.toHaveProperty('nextCursor');
+    });
+  });
+
+  describe('cursor parameter', () => {
+    it('forwards a valid cursor to the service', async () => {
+      const { run } = invoke({ cursor: '2024-06-15T14:30:00.000Z_42' });
+
+      await run();
+
+      expect(searchFlowsheet).toHaveBeenCalledWith(expect.objectContaining({ cursor: '2024-06-15T14:30:00.000Z_42' }));
+    });
+
+    it('passes cursor as undefined when not provided', async () => {
+      const { run } = invoke({});
+
+      await run();
+
+      expect(searchFlowsheet).toHaveBeenCalledWith(expect.objectContaining({ cursor: undefined }));
+    });
+
+    it.each([
+      ['no-underscore'],
+      ['_42'],
+      ['2024-06-15T14:30:00.000Z_'],
+      ['2024-06-15T14:30:00.000Z_abc'],
+      ['not-a-date_42'],
+    ])('returns 400 for malformed cursor %j', async (cursor) => {
+      const { res, run } = invoke({ cursor });
+
+      await run();
+
+      expect(res._status).toBe(400);
+      expect(searchFlowsheet).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/services/search.service.test.ts
+++ b/tests/unit/services/search.service.test.ts
@@ -4,7 +4,12 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-import { searchFlowsheet, shouldUseTsvector } from '../../../apps/backend/services/search.service';
+import {
+  searchFlowsheet,
+  shouldUseTsvector,
+  parseCursor,
+  encodeCursor,
+} from '../../../apps/backend/services/search.service';
 
 const makeRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
   id: 1,
@@ -185,5 +190,132 @@ describe('shouldUseTsvector', () => {
     ])('uses trigram for %j (%s)', (value) => {
       expect(shouldUseTsvector(value)).toBe(false);
     });
+  });
+});
+
+describe('cursor codec', () => {
+  describe('parseCursor', () => {
+    it('parses a valid cursor', () => {
+      expect(parseCursor('2024-06-15T14:30:00.000Z_12345')).toEqual({
+        addTime: '2024-06-15T14:30:00.000Z',
+        id: 12345,
+      });
+    });
+
+    it('handles cursors that contain underscores in the timestamp segment', () => {
+      // ISO timestamps do not contain underscores, but underscores at the
+      // end of the timestamp would still split correctly because we use the
+      // last underscore as the separator.
+      expect(parseCursor('2024-06-15T14:30:00.000Z_999')).toEqual({
+        addTime: '2024-06-15T14:30:00.000Z',
+        id: 999,
+      });
+    });
+
+    it.each([
+      ['', 'empty string'],
+      ['no-underscore', 'no separator'],
+      ['_42', 'empty addTime'],
+      ['2024-06-15T14:30:00.000Z_', 'empty id'],
+      ['2024-06-15T14:30:00.000Z_abc', 'non-numeric id'],
+      ['not-a-date_42', 'unparseable date'],
+    ])('returns null for %j (%s)', (cursor) => {
+      expect(parseCursor(cursor)).toBeNull();
+    });
+  });
+
+  describe('encodeCursor', () => {
+    it('round-trips with parseCursor', () => {
+      const cursor = encodeCursor('2024-06-15T14:30:00.000Z', 12345);
+      expect(parseCursor(cursor)).toEqual({
+        addTime: '2024-06-15T14:30:00.000Z',
+        id: 12345,
+      });
+    });
+  });
+});
+
+describe('searchFlowsheet cursor pagination', () => {
+  it('returns nextCursor when results fill the page and cursor mode is active', async () => {
+    const rows = Array.from({ length: 50 }, (_, i) => ({
+      ...makeRow({ id: 100 - i, play_date: new Date(`2024-06-15T${String(i % 24).padStart(2, '0')}:00:00Z`) }),
+    }));
+    mockDataAndCount(rows, 1000);
+
+    const result = await searchFlowsheet({
+      q: '',
+      page: 0,
+      limit: 50,
+      sort: 'date',
+      order: 'desc',
+      cursor: '2024-06-16T00:00:00.000Z_999',
+    });
+
+    expect(result.results).toHaveLength(50);
+    const lastRow = result.results[49];
+    expect(result.nextCursor).toBe(encodeCursor(lastRow.play_date, lastRow.id));
+  });
+
+  it('omits nextCursor when fewer rows are returned than requested', async () => {
+    const rows = [makeRow({ id: 1 })];
+    mockDataAndCount(rows, 1);
+
+    const result = await searchFlowsheet({
+      q: '',
+      page: 0,
+      limit: 50,
+      sort: 'date',
+      order: 'desc',
+      cursor: '2024-06-16T00:00:00.000Z_999',
+    });
+
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  it('omits nextCursor when cursor is not provided (offset mode)', async () => {
+    const rows = Array.from({ length: 50 }, (_, i) => makeRow({ id: i + 1 }));
+    mockDataAndCount(rows, 1000);
+
+    const result = await searchFlowsheet({
+      q: '',
+      page: 0,
+      limit: 50,
+      sort: 'date',
+      order: 'desc',
+    });
+
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  it('omits nextCursor when sort is not date even if cursor is provided', async () => {
+    const rows = Array.from({ length: 50 }, (_, i) => makeRow({ id: i + 1 }));
+    mockDataAndCount(rows, 1000);
+
+    const result = await searchFlowsheet({
+      q: '',
+      page: 0,
+      limit: 50,
+      sort: 'artist',
+      order: 'asc',
+      cursor: '2024-06-16T00:00:00.000Z_999',
+    });
+
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  it('still returns total even in cursor mode (for backward-compat display)', async () => {
+    const rows = [makeRow()];
+    mockDataAndCount(rows, 7);
+
+    const result = await searchFlowsheet({
+      q: '',
+      page: 0,
+      limit: 50,
+      sort: 'date',
+      order: 'desc',
+      cursor: '2024-06-16T00:00:00.000Z_999',
+    });
+
+    expect(result.total).toBe(7);
   });
 });


### PR DESCRIPTION
## Summary

- Adds an optional `cursor` query parameter to `GET /flowsheet/search`. When provided with `sort=date`, the WHERE switches from `OFFSET` to a row-value comparison `(add_time, id) < (cursor_time, cursor_id)` (or `>` for asc) so each page costs O(limit) regardless of depth.
- Cursor is **compound** `(add_time, id)` rather than `add_time` alone — the legacy ETL backfilled many rows with batch-import timestamps that share the same `add_time` to the microsecond, and a single-column cursor would silently drop those rows on page boundaries.
- Other sorts (`artist`, `song`, `dj`) ignore cursor and continue using offset because their sort columns are not unique and no compound index supports a `(sort_col, id)` cursor.
- `nextCursor` returned only when cursor mode is active **and** the page came back full. `totalPages` stays in the response always — both shapes coexist for the dj-site backward-compat window.
- Encoding format is `${ISO_timestamp}_${id}`. Malformed cursor → `400`.

Implements step 3 from `docs/playlist-search/README.md`.

## Test plan

- [x] `parseCursor` / `encodeCursor` codec tests including round-trip and a comprehensive set of malformed-cursor cases
- [x] Service tests cover: `nextCursor` on full page, omission on short page, omission in offset mode, omission when sort is not date, total still returned in cursor mode
- [x] Controller tests cover: forwarding a valid cursor, undefined-when-missing, 400 on malformed cursor, response shape with and without `nextCursor`
- [x] Existing offset-based tests still pass — backward compat verified by the unchanged tests
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (warnings unchanged from main)
- [x] `npx prettier --check` clean on touched files
- [ ] CI integration tests verify nothing regresses against a real DB

Closes #472