### PR TITLE
Add flowsheet.dj_name column and backfill (step 5b.1)

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -34,7 +34,12 @@ export interface IFSEntryMetadata {
 // search_doc is a STORED GENERATED tsvector used only by the search hot path
 // (apps/backend/services/search.service.ts); the controller layer never reads
 // or constructs it, so it is excluded from the application-facing entry type.
-export interface IFSEntry extends Omit<FSEntry, 'search_doc'> {
+//
+// dj_name is the denormalized resolved DJ name introduced in step 5b.1. It is
+// backfilled in 0053 but is not yet written on insert (5b.2) nor read by the
+// controller layer; excluding it here keeps the application contract stable
+// until 5b.2 wires the write path.
+export interface IFSEntry extends Omit<FSEntry, 'search_doc' | 'dj_name'> {
   label_id: number | null;
   rotation_bin: string | null;
   on_streaming: boolean | null;

--- a/shared/database/src/migrations/0053_flowsheet-dj-name-column.sql
+++ b/shared/database/src/migrations/0053_flowsheet-dj-name-column.sql
@@ -1,0 +1,30 @@
+-- Denormalize the resolved DJ name onto flowsheet (step 5b.1).
+--
+-- The search hot path currently joins flowsheet -> shows -> auth_user just to
+-- compute COALESCE(auth_user.dj_name, shows.legacy_dj_name, auth_user.name)
+-- for display and for the dj-name search OR-decomposition added in 0051.
+-- Storing the resolved name directly on the flowsheet row removes the join
+-- from the search hot path and lets dj_name fold into the search_doc tsvector
+-- in a follow-up.
+--
+-- Order of operations across the 5b sub-issues:
+--   5b.1 (this migration): add the column nullable + backfill from existing rows.
+--   5b.2: ETL and live insert controller start writing the column on insert.
+--   5b.3: search.service reads dj_name directly; search_doc regenerated to include it;
+--         the trigram indexes from 0051 are dropped.
+--
+-- Production note: ALTER TABLE ... ADD COLUMN of a nullable column is metadata-only
+-- and instant. The backfill UPDATE rewrites every track row but holds row locks,
+-- not a table lock, so concurrent reads keep working. Apply during a low-traffic
+-- window if the table is large enough that the UPDATE takes more than a few seconds.
+
+ALTER TABLE "wxyc_schema"."flowsheet"
+  ADD COLUMN "dj_name" text;--> statement-breakpoint
+
+UPDATE "wxyc_schema"."flowsheet" AS f
+SET "dj_name" = COALESCE(u."dj_name", s."legacy_dj_name", u."name")
+FROM "wxyc_schema"."shows" AS s
+LEFT JOIN "auth_user" AS u ON u."id" = s."primary_dj_id"
+WHERE f."show_id" = s."id"
+  AND f."entry_type" = 'track'
+  AND f."dj_name" IS NULL;

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1777646400000,
       "tag": "0052_flowsheet-tsvector-search",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1777732800000,
+      "tag": "0053_flowsheet-dj-name-column",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -380,6 +380,10 @@ export const flowsheet = wxyc_schema.table(
     soundcloud_url: varchar('soundcloud_url', { length: 512 }),
     artist_bio: text('artist_bio'),
     artist_wikipedia_url: varchar('artist_wikipedia_url', { length: 512 }),
+    // Resolved DJ name denormalized from shows/auth_user at insert time
+    // (step 5b). Backfilled by migration 0053; populated on write by the
+    // ETL job and the live insert controller from step 5b.2 onward.
+    dj_name: text('dj_name'),
     // STORED GENERATED tsvector covering the four text fields with weight
     // bands (artist=A, track=B, album=C, label=D). Managed by migration
     // 0052; declared here so drizzle-kit drift detection treats it as

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -118,6 +118,7 @@ export const flowsheet = {
   soundcloud_url: 'soundcloud_url',
   artist_bio: 'artist_bio',
   artist_wikipedia_url: 'artist_wikipedia_url',
+  dj_name: 'dj_name',
   search_doc: 'search_doc',
 };
 export const bins = {};

--- a/tests/unit/database/schema.flowsheet-dj-name.test.ts
+++ b/tests/unit/database/schema.flowsheet-dj-name.test.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('schema: flowsheet.dj_name denormalization (step 5b.1)', () => {
+  const schemaPath = path.resolve(__dirname, '../../../shared/database/src/schema.ts');
+  const schemaSource = fs.readFileSync(schemaPath, 'utf-8');
+
+  const migrationsDir = path.resolve(__dirname, '../../../shared/database/src/migrations');
+  const migrationPath = path.join(migrationsDir, '0053_flowsheet-dj-name-column.sql');
+  const journalPath = path.join(migrationsDir, 'meta/_journal.json');
+
+  const extractTableDef = (tableName: string): string => {
+    const regex = new RegExp(`export const ${tableName}\\b[\\s\\S]*?^\\);`, 'm');
+    const match = schemaSource.match(regex);
+    if (!match) throw new Error(`Table definition for ${tableName} not found in schema`);
+    return match[0];
+  };
+
+  it('flowsheet table declares a dj_name column', () => {
+    const def = extractTableDef('flowsheet');
+    expect(def).toMatch(/dj_name:\s*text\(['"]dj_name['"]\)/);
+  });
+
+  it('migration 0053 exists and adds the column', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(/ALTER TABLE\s+"wxyc_schema"\."flowsheet"\s+ADD COLUMN\s+"dj_name"\s+text/i);
+  });
+
+  it('migration 0053 backfills dj_name from auth_user.dj_name, shows.legacy_dj_name, auth_user.name', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    // The backfill UPDATE must reference all three source columns in priority
+    // order matching the search service's DJ_NAME_EXPR.
+    expect(sql).toMatch(/UPDATE\s+"wxyc_schema"\."flowsheet"/i);
+    expect(sql).toMatch(/COALESCE\([^)]*dj_name[^)]*legacy_dj_name[^)]*name/i);
+    // Bound the rewrite to the column we actually populate (track entries).
+    expect(sql).toMatch(/entry_type"?\s*=\s*'track'/i);
+  });
+
+  it('journal includes the 0053 entry', () => {
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
+    const has53 = journal.entries.some((e: { tag: string }) => e.tag === '0053_flowsheet-dj-name-column');
+    expect(has53).toBe(true);
+  });
+
+  it('mock includes dj_name on flowsheet', () => {
+    const mockPath = path.resolve(__dirname, '../../mocks/database.mock.ts');
+    const mockSource = fs.readFileSync(mockPath, 'utf-8');
+    const flowsheetMock = mockSource.match(/export const flowsheet\s*=\s*\{[\s\S]*?\};/)?.[0];
+    expect(flowsheetMock).toBeDefined();
+    expect(flowsheetMock).toContain("dj_name: 'dj_name'");
+  });
+});


### PR DESCRIPTION
Implements step 5b.1 from `docs/playlist-search/README.md`. Parent: #474.

## Summary

- New migration `0053_flowsheet-dj-name-column.sql` adds `flowsheet.dj_name text` (nullable) and backfills it from existing `shows`/`auth_user` rows using the same priority the search hot path computes inline today: `COALESCE(auth_user.dj_name, shows.legacy_dj_name, auth_user.name)`.
- `shared/database/src/schema.ts` declares the column.
- `tests/mocks/database.mock.ts` mirrors the column for query-builder unit tests.
- `IFSEntry` excludes `dj_name` alongside `search_doc` so the application contract stays unchanged for this PR. The exclusion relaxes in 5b.2 once the controller / service start writing the column on insert.

This change is purely additive: nothing reads or writes the new column yet. The next two PRs in the 5b sequence (#476, #477) wire the write path and then switch the search service to read from the inline column.

## Production deployment note

`ALTER TABLE ... ADD COLUMN` of a nullable column is metadata-only and instant. The backfill `UPDATE` rewrites every track row but holds row locks rather than a table lock — concurrent reads keep working. Apply during a low-traffic window if the table is large enough that the `UPDATE` takes more than a few seconds.

## Test plan

- [x] `tests/unit/database/schema.flowsheet-dj-name.test.ts` exercises schema declaration, migration SQL shape, and journal entry presence.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` 0 errors (warnings unchanged from main).
- [x] `npm run format:check` clean.
- [x] `npm run test:unit` 980/980 pass (one pre-existing module-resolution failure in `shared-type-compatibility.test.ts` reproduces on main and is unrelated).
- [ ] Integration tests against the dockerized PG via CI — local `npm run ci:testmock` requires `NPM_TOKEN` for `@wxyc/shared` from GitHub Packages.
- [ ] Verify backfill correctness in the staging environment after deploy.

Closes #475