### PR TITLE
Bump @wxyc/shared to 0.9.0 and remove dead searchDiscogs

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,7 +20,7 @@
     "@tensorflow/tfjs": "^4.22.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^0.6.0",
+    "@wxyc/shared": "^0.9.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.15.2",

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -9,7 +9,6 @@
  */
 
 import type {
-  DiscogsSearchResponse,
   DiscogsReleaseMetadata,
   DiscogsArtistDetails,
   DiscogsTrackReleasesResponse,
@@ -20,8 +19,6 @@ import type {
 } from '@wxyc/shared/dtos';
 
 export type {
-  DiscogsSearchResponse,
-  DiscogsEnrichedSearchResult,
   DiscogsMatchResult,
   DiscogsReleaseMetadata,
   DiscogsTrackItem,
@@ -91,26 +88,6 @@ async function lmlFetch(path: string, init?: RequestInit): Promise<Response> {
   } finally {
     clearTimeout(timeout);
   }
-}
-
-/**
- * Search Discogs via LML.
- *
- * @param artist - Artist name
- * @param album - Album/release title
- * @returns Search results with enriched metadata
- */
-export async function searchDiscogs(artist: string, album?: string): Promise<DiscogsSearchResponse> {
-  const body: Record<string, string> = { artist };
-  if (album) body.album = album;
-
-  const response = await lmlFetch('/api/v1/discogs/search', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-
-  return (await response.json()) as DiscogsSearchResponse;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -232,7 +232,7 @@
         "@tensorflow/tfjs": "^4.22.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^0.6.0",
+        "@wxyc/shared": "^0.9.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.15.2",
@@ -284,9 +284,9 @@
       }
     },
     "apps/backend/node_modules/@wxyc/shared": {
-      "version": "0.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.6.0/3b475c7508afc37bdf07a76a059744411da8c390",
-      "integrity": "sha512-/IOuWoyspr+VQmvfw7kXS7gwH60O1WZaWW2YU6RHoQcbTYmhBtAMbb+MojoAs55DQIf/AKx2p3PL+dc1Er6Vhg==",
+      "version": "0.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.9.0/98b63615b5d760e2d1539d8236b1eda87f0a0da2",
+      "integrity": "sha512-koNAdEYMrZeOGU3Fj1KsApWC7GVL71XO13OOfR3uNEJvGmELEFlWJ/kc48Ju8Zn1aevt4ckT7fYlTHlmB+qRGw==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -15146,7 +15146,7 @@
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1037.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^0.6.0",
+        "@wxyc/shared": "^0.9.0",
         "better-auth": "^1.6.9",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -15182,9 +15182,9 @@
       }
     },
     "shared/authentication/node_modules/@wxyc/shared": {
-      "version": "0.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.6.0/3b475c7508afc37bdf07a76a059744411da8c390",
-      "integrity": "sha512-/IOuWoyspr+VQmvfw7kXS7gwH60O1WZaWW2YU6RHoQcbTYmhBtAMbb+MojoAs55DQIf/AKx2p3PL+dc1Er6Vhg==",
+      "version": "0.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.9.0/98b63615b5d760e2d1539d8236b1eda87f0a0da2",
+      "integrity": "sha512-koNAdEYMrZeOGU3Fj1KsApWC7GVL71XO13OOfR3uNEJvGmELEFlWJ/kc48Ju8Zn1aevt4ckT7fYlTHlmB+qRGw==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1037.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^0.6.0",
+    "@wxyc/shared": "^0.9.0",
     "better-auth": "^1.6.9",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/tests/e2e/lml-connectivity.test.ts
+++ b/tests/e2e/lml-connectivity.test.ts
@@ -13,7 +13,7 @@
  */
 
 import {
-  searchDiscogs,
+  lookupMetadata,
   getRelease,
   getArtistDetails,
   resolveEntity,
@@ -59,26 +59,6 @@ describe('LML Client Connectivity', () => {
       expect([200, 503]).toContain(response.status);
       const body = (await response.json()) as { status: string };
       expect(['healthy', 'degraded', 'unhealthy']).toContain(body.status);
-    });
-  });
-
-  describe('Search', () => {
-    beforeEach(() => skipIfUnreachable());
-
-    test('returns results for known artist and album', async () => {
-      if (!lmlReachable) return;
-
-      const response = await searchDiscogs('Stereolab', 'Dots and Loops');
-      expect(response.results.length).toBeGreaterThan(0);
-      expect(typeof response.results[0].release_id).toBe('number');
-      expect(response.results[0].release_url).toMatch(/^https?:\/\//);
-    });
-
-    test('returns empty results for nonexistent artist', async () => {
-      if (!lmlReachable) return;
-
-      const response = await searchDiscogs('xyznonexistent12345', 'nothing');
-      expect(response.results).toHaveLength(0);
     });
   });
 
@@ -137,8 +117,8 @@ describe('LML Client Connectivity', () => {
       const original = process.env.LIBRARY_METADATA_URL;
       process.env.LIBRARY_METADATA_URL = 'http://localhost:59999';
       try {
-        await expect(searchDiscogs('test')).rejects.toThrow(LmlClientError);
-        await expect(searchDiscogs('test')).rejects.toMatchObject({
+        await expect(lookupMetadata('test')).rejects.toThrow(LmlClientError);
+        await expect(lookupMetadata('test')).rejects.toMatchObject({
           statusCode: 502,
         });
       } finally {
@@ -150,8 +130,8 @@ describe('LML Client Connectivity', () => {
       const original = process.env.LIBRARY_METADATA_URL;
       delete process.env.LIBRARY_METADATA_URL;
       try {
-        await expect(searchDiscogs('test')).rejects.toThrow(LmlClientError);
-        await expect(searchDiscogs('test')).rejects.toMatchObject({
+        await expect(lookupMetadata('test')).rejects.toThrow(LmlClientError);
+        await expect(lookupMetadata('test')).rejects.toMatchObject({
           statusCode: 503,
         });
       } finally {

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -39,7 +39,6 @@ jest.mock('../../../apps/backend/services/labels.service', () => ({
 
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
   checkStreamingAvailability: jest.fn(),
-  searchDiscogs: jest.fn(),
   isLmlConfigured: jest.fn().mockReturnValue(false),
 }));
 

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -7,7 +7,6 @@ const mockFetch = jest.fn<typeof global.fetch>();
 global.fetch = mockFetch;
 
 import {
-  searchDiscogs,
   lookupMetadata,
   getRelease,
   getArtistDetails,
@@ -27,42 +26,6 @@ describe('lml.client', () => {
 
   afterAll(() => {
     process.env = originalEnv;
-  });
-
-  describe('searchDiscogs', () => {
-    it('sends POST to /api/v1/discogs/search with artist and album', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ results: [], total: 0, cached: false }),
-      } as unknown as globalThis.Response);
-
-      await searchDiscogs('Autechre', 'Confield');
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://lml.test:8000/api/v1/discogs/search',
-        expect.objectContaining({
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ artist: 'Autechre', album: 'Confield' }),
-        })
-      );
-    });
-
-    it('omits album when not provided', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ results: [], total: 0, cached: false }),
-      } as unknown as globalThis.Response);
-
-      await searchDiscogs('Autechre');
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://lml.test:8000/api/v1/discogs/search',
-        expect.objectContaining({
-          body: JSON.stringify({ artist: 'Autechre' }),
-        })
-      );
-    });
   });
 
   describe('lookupMetadata', () => {
@@ -173,8 +136,8 @@ describe('lml.client', () => {
     it('throws LmlClientError with 503 when LIBRARY_METADATA_URL is not set', async () => {
       delete process.env.LIBRARY_METADATA_URL;
 
-      await expect(searchDiscogs('Autechre')).rejects.toThrow(LmlClientError);
-      await expect(searchDiscogs('Autechre')).rejects.toMatchObject({ statusCode: 503 });
+      await expect(lookupMetadata('Autechre')).rejects.toThrow(LmlClientError);
+      await expect(lookupMetadata('Autechre')).rejects.toMatchObject({ statusCode: 503 });
     });
 
     it('throws LmlClientError with mapped status on non-2xx response', async () => {
@@ -210,12 +173,12 @@ describe('lml.client', () => {
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ results: [], total: 0, cached: false }),
+        json: () => Promise.resolve({ results: [], search_type: 'none' }),
       } as unknown as globalThis.Response);
 
-      await searchDiscogs('Autechre');
+      await lookupMetadata('Autechre');
 
-      expect(mockFetch).toHaveBeenCalledWith('http://lml.test:8000/api/v1/discogs/search', expect.anything());
+      expect(mockFetch).toHaveBeenCalledWith('http://lml.test:8000/api/v1/lookup', expect.anything());
     });
 
     it('does not double the /api/v1 prefix when LIBRARY_METADATA_URL already includes it', async () => {
@@ -223,14 +186,14 @@ describe('lml.client', () => {
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ results: [], total: 0, cached: false }),
+        json: () => Promise.resolve({ results: [], search_type: 'none' }),
       } as unknown as globalThis.Response);
 
-      await searchDiscogs('Autechre');
+      await lookupMetadata('Autechre');
 
       const calledUrl = mockFetch.mock.calls[0][0] as string;
       expect(calledUrl).not.toContain('/api/v1/api/v1');
-      expect(calledUrl).toBe('http://lml.test:8000/api/v1/discogs/search');
+      expect(calledUrl).toBe('http://lml.test:8000/api/v1/lookup');
     });
   });
 

--- a/tests/unit/services/requestLine.service.test.ts
+++ b/tests/unit/services/requestLine.service.test.ts
@@ -35,7 +35,6 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
 // Mock LML client
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
   searchTrackReleases: jest.fn(),
-  searchDiscogs: jest.fn(),
   validateTrackOnRelease: jest.fn(),
   isLmlConfigured: jest.fn().mockReturnValue(false),
 }));


### PR DESCRIPTION
## Summary

`@wxyc/shared` 0.7.0 removed `DiscogsSearchRequest`, `DiscogsEnrichedSearchResult`, and `DiscogsSearchResponse` along with LML's `/api/v1/discogs/search` endpoint. Backend-Service still imported the first two and exported a `searchDiscogs` function that hit that endpoint, but no production code path called it — only its own unit/e2e tests and two stale `jest.fn()` declarations in unrelated test files.

This PR deletes `searchDiscogs` so the version bump compiles cleanly:

- `apps/backend/services/lml/lml.client.ts` — drop `searchDiscogs`, `DiscogsSearchResponse`, and `DiscogsEnrichedSearchResult`
- `tests/unit/services/lml.client.test.ts` — remove the `searchDiscogs` describe block; reroute the four shared `LmlClientError`/URL-handling tests onto `lookupMetadata`, which exercises the same `lmlFetch` error and prefix logic
- `tests/e2e/lml-connectivity.test.ts` — drop the `Search` describe block; reroute the two error-handling tests onto `lookupMetadata`
- `tests/unit/services/requestLine.service.test.ts` and `tests/unit/controllers/library.controller.test.ts` — remove the now-unused `searchDiscogs` mock declarations

Bumps `@wxyc/shared` from `^0.6.0` to `^0.9.0` in `apps/backend/package.json` and `shared/authentication/package.json`; lockfile resolves to 0.9.0.

This is **PR 1 of 3** preparing the work for #317 (Attach ReconciledIdentity to catalog artist entries):
1. **This PR** — cleanup + dependency bump (no schema, no API surface)
2. Next — schema migration (add 6 nullable columns to `artists`)
3. Last — API exposure (nested `reconciled_identity` on artist responses)

Splitting this way isolates the schema migration to its own PR for surgical review against production replication.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (224 pre-existing warnings, 0 errors)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 1011 passed (was 1013; -2 are the deleted `searchDiscogs` describe-block tests)
- [x] `npm run build` — clean