### PR TITLE
Expose nested reconciled_identity on artist responses

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -181,7 +181,7 @@ export const addArtist: RequestHandler = async (req: Request<object, object, New
   const response: Artist = await libraryService.insertArtist(new_artist);
   await libraryService.insertArtistGenreCrossreference(response.id, body.genre_id, body.code_number);
   res.status(201).json({
-    ...response,
+    ...libraryService.serializeArtist(response),
     code_number: body.code_number,
     genre_id: body.genre_id,
   });

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1,7 +1,9 @@
 import { and, asc, desc, eq, ilike, or, sql } from 'drizzle-orm';
+import type { ReconciledIdentity } from '@wxyc/shared/dtos';
 import { RotationAddRequest } from '../controllers/library.controller.js';
 import { db } from '@wxyc/database';
 import {
+  Artist,
   NewAlbum,
   NewAlbumFormat,
   NewArtist,
@@ -19,6 +21,68 @@ import {
 import { LibraryResult, EnrichedLibraryResult, enrichLibraryResult } from './requestLine/types.js';
 import { extractSignificantWords } from './requestLine/matching/index.js';
 import { lookupMetadata, isLmlConfigured } from './lml/lml.client.js';
+
+/**
+ * Source columns on `artists` that comprise a ReconciledIdentity. Kept in
+ * sync with the @wxyc/shared schema; if a new external-ID field appears on
+ * the shared type, add it here too.
+ */
+const RECONCILED_IDENTITY_KEYS = [
+  'discogs_artist_id',
+  'musicbrainz_artist_id',
+  'wikidata_qid',
+  'spotify_artist_id',
+  'apple_music_artist_id',
+  'bandcamp_id',
+] as const;
+
+/**
+ * Build a shared `ReconciledIdentity` from an artist row, or null when none of
+ * the six external-ID fields are populated. Matching the semantic-index
+ * pattern lets consumers distinguish "no IDs resolved yet" from "resolved with
+ * some null IDs."
+ */
+export function toReconciledIdentity(artist: Artist): ReconciledIdentity | null {
+  const identity: ReconciledIdentity = {
+    discogs_artist_id: artist.discogs_artist_id,
+    musicbrainz_artist_id: artist.musicbrainz_artist_id,
+    wikidata_qid: artist.wikidata_qid,
+    spotify_artist_id: artist.spotify_artist_id,
+    apple_music_artist_id: artist.apple_music_artist_id,
+    bandcamp_id: artist.bandcamp_id,
+  };
+  if (RECONCILED_IDENTITY_KEYS.every((key) => identity[key] === null)) {
+    return null;
+  }
+  return identity;
+}
+
+/**
+ * Wire-format for an artist response. Replaces the six flat external-ID
+ * columns with a nested `reconciled_identity` object that conforms to the
+ * shared @wxyc/shared schema.
+ */
+export type ArtistResponse = Omit<Artist, (typeof RECONCILED_IDENTITY_KEYS)[number]> & {
+  reconciled_identity: ReconciledIdentity | null;
+};
+
+/**
+ * Convert a Drizzle `artists` row to the public-facing artist response.
+ * Strips the six flat external-ID columns and replaces them with a nested
+ * `reconciled_identity` object.
+ */
+export function serializeArtist(artist: Artist): ArtistResponse {
+  const {
+    discogs_artist_id: _discogs,
+    musicbrainz_artist_id: _mb,
+    wikidata_qid: _qid,
+    spotify_artist_id: _spotify,
+    apple_music_artist_id: _apple,
+    bandcamp_id: _bandcamp,
+    ...rest
+  } = artist;
+  return { ...rest, reconciled_identity: toReconciledIdentity(artist) };
+}
 
 export const getFormatsFromDB = async () => {
   const formats = await db

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -329,6 +329,12 @@ describe('Library Artists', () => {
       expect(res.body.artist_name).toContain('Test Artist');
       expect(res.body.alphabetical_name).toBeDefined();
       expect(res.body.code_letters).toBe(uniqueSuffix);
+      // A freshly inserted artist has no resolved external IDs, so the
+      // nested ReconciledIdentity is null. The flat external-ID columns are
+      // not exposed on the wire — they're only accessible via the nested form.
+      expect(res.body.reconciled_identity).toBeNull();
+      expect(res.body).not.toHaveProperty('discogs_artist_id');
+      expect(res.body).not.toHaveProperty('musicbrainz_artist_id');
     });
 
     test('returns 400 when artist_name is missing', async () => {

--- a/tests/unit/services/library.reconciledIdentity.test.ts
+++ b/tests/unit/services/library.reconciledIdentity.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the artist response serializer that attaches a nested
+ * `reconciled_identity` field conforming to the @wxyc/shared schema.
+ */
+
+// The service module imports drizzle and DB internals at top level. None of
+// our tests touch the DB; mock the @wxyc/database package surface so the
+// import chain doesn't require live SQL clients.
+jest.mock('@wxyc/database', () => ({
+  db: {},
+  artists: {},
+  genre_artist_crossreference: {},
+  format: {},
+  genres: {},
+  library: {},
+  library_artist_view: {},
+  rotation: {},
+}));
+
+jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
+  lookupMetadata: jest.fn(),
+  isLmlConfigured: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../../../apps/backend/services/requestLine/types', () => ({
+  enrichLibraryResult: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/requestLine/matching/index', () => ({
+  extractSignificantWords: jest.fn(),
+}));
+
+import type { Artist } from '@wxyc/database';
+import { serializeArtist, toReconciledIdentity } from '../../../apps/backend/services/library.service';
+
+function makeArtist(overrides: Partial<Artist> = {}): Artist {
+  return {
+    id: 1,
+    artist_name: 'Stereolab',
+    alphabetical_name: 'Stereolab',
+    code_letters: 'S',
+    add_date: '2026-01-01',
+    last_modified: new Date('2026-01-01T00:00:00Z'),
+    discogs_artist_id: null,
+    musicbrainz_artist_id: null,
+    wikidata_qid: null,
+    spotify_artist_id: null,
+    apple_music_artist_id: null,
+    bandcamp_id: null,
+    ...overrides,
+  };
+}
+
+describe('toReconciledIdentity', () => {
+  test('returns null when all six external-ID fields are null', () => {
+    expect(toReconciledIdentity(makeArtist())).toBeNull();
+  });
+
+  test('returns a populated object when at least one ID is set', () => {
+    const identity = toReconciledIdentity(
+      makeArtist({
+        discogs_artist_id: 388,
+        wikidata_qid: 'Q650826',
+      })
+    );
+
+    expect(identity).not.toBeNull();
+    expect(identity!.discogs_artist_id).toBe(388);
+    expect(identity!.wikidata_qid).toBe('Q650826');
+    // Unset fields are explicitly null on the nested object so consumers can
+    // rely on key presence.
+    expect(identity!.musicbrainz_artist_id).toBeNull();
+    expect(identity!.spotify_artist_id).toBeNull();
+    expect(identity!.apple_music_artist_id).toBeNull();
+    expect(identity!.bandcamp_id).toBeNull();
+  });
+
+  test('returns all six fields when fully reconciled', () => {
+    const identity = toReconciledIdentity(
+      makeArtist({
+        discogs_artist_id: 388,
+        musicbrainz_artist_id: '4ab1437f-2cb7-46c1-a55e-7d5b0a2b4d5c',
+        wikidata_qid: 'Q650826',
+        spotify_artist_id: '4uSftVc3FPWe6RJuMZNEe9',
+        apple_music_artist_id: '88495919',
+        bandcamp_id: 'stereolab',
+      })
+    );
+
+    expect(identity).toEqual({
+      discogs_artist_id: 388,
+      musicbrainz_artist_id: '4ab1437f-2cb7-46c1-a55e-7d5b0a2b4d5c',
+      wikidata_qid: 'Q650826',
+      spotify_artist_id: '4uSftVc3FPWe6RJuMZNEe9',
+      apple_music_artist_id: '88495919',
+      bandcamp_id: 'stereolab',
+    });
+  });
+});
+
+describe('serializeArtist', () => {
+  test('strips the six flat external-ID columns from the wire shape', () => {
+    const wire = serializeArtist(
+      makeArtist({
+        discogs_artist_id: 388,
+        spotify_artist_id: '4uSftVc3FPWe6RJuMZNEe9',
+      })
+    );
+
+    expect(wire).not.toHaveProperty('discogs_artist_id');
+    expect(wire).not.toHaveProperty('musicbrainz_artist_id');
+    expect(wire).not.toHaveProperty('wikidata_qid');
+    expect(wire).not.toHaveProperty('spotify_artist_id');
+    expect(wire).not.toHaveProperty('apple_music_artist_id');
+    expect(wire).not.toHaveProperty('bandcamp_id');
+  });
+
+  test('preserves the non-identity columns from the row', () => {
+    const wire = serializeArtist(
+      makeArtist({
+        id: 42,
+        artist_name: 'Juana Molina',
+        alphabetical_name: 'Molina, Juana',
+        code_letters: 'MO',
+      })
+    );
+
+    expect(wire.id).toBe(42);
+    expect(wire.artist_name).toBe('Juana Molina');
+    expect(wire.alphabetical_name).toBe('Molina, Juana');
+    expect(wire.code_letters).toBe('MO');
+  });
+
+  test('attaches a populated reconciled_identity when at least one ID is set', () => {
+    const wire = serializeArtist(makeArtist({ bandcamp_id: 'juanamolina' }));
+
+    expect(wire.reconciled_identity).toEqual({
+      discogs_artist_id: null,
+      musicbrainz_artist_id: null,
+      wikidata_qid: null,
+      spotify_artist_id: null,
+      apple_music_artist_id: null,
+      bandcamp_id: 'juanamolina',
+    });
+  });
+
+  test('attaches reconciled_identity=null for an unreconciled artist', () => {
+    const wire = serializeArtist(makeArtist());
+
+    expect(wire.reconciled_identity).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a nested `reconciled_identity` field to the `POST /library/artists` response that conforms to the `@wxyc/shared` `ReconciledIdentity` schema (6 external IDs across Discogs/MusicBrainz/Wikidata/Spotify/Apple Music/Bandcamp). Replaces the flat external-ID columns on the wire — no consumer depends on them yet, so going nested-only matches the shared schema directly.

This is **PR 3 of 3** for #317. Predecessors: #481 (cleanup + dependency bump) and #482 (schema migration).

## Implementation

Two helpers in `apps/backend/services/library.service.ts`:

- `toReconciledIdentity(artist)` — pulls the 6 columns into a `ReconciledIdentity`, returns `null` when none are populated. The "all-null returns null" rule lets consumers distinguish "unresolved" from "resolved with some null IDs," matching the semantic-index pattern.
- `serializeArtist(artist)` — strips the 6 flat columns from the row and attaches `reconciled_identity`, producing the public-facing wire shape.

## Scope note

Wire change applies **only to `POST /library/artists`** for now. The view-based read endpoints (`fuzzySearchLibrary`, `searchLibrary`, `getAlbumFromDB`, `getRotationFromDB`) don't expose the new columns at all today: they read `library_artist_view` which doesn't project them. Extending the view to include the 6 columns is a separate concern with its own migration risk (`CREATE OR REPLACE VIEW`) and is out of scope here. Worth a follow-up issue once a consumer actually needs reconciled identity on the read path.

Closes #317. Part of [Shared Types Consolidation](https://github.com/orgs/WXYC/projects/16).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (after cache invalidation)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 1018 passed (added 7 new unit tests in `library.reconciledIdentity.test.ts`)
- [x] Integration test (`tests/integration/library.spec.js`) — asserts `reconciled_identity` is null on a freshly inserted artist and that the flat columns are absent from the wire