### PR TITLE
feat(mirror): bound legacy queue disk reports and add Sentry breadcrumbs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,18 @@ Connects to tubafrenzy's CDC WebSocket and verifies changes land in Backend-Serv
 - `SENTRY_DSN` -- Sentry project DSN (required for error reporting). Without this, Sentry silently disables itself.
 - `SENTRY_RELEASE` -- Set automatically by the deploy action to `<app>@<tag>`
 
+### Legacy mirror queue (`apps/backend/middleware/legacy/commandqueue.mirror.ts`)
+
+Bounded ring-buffer reports written under `mirror-logs/`. Reports never include raw SQL — only length, sha256, and statement count.
+
+- `MIRROR_FATAL_REPORTS_MAX` (default `10`) -- Number of ring slots for fatal reports. Total disk = max × `MIRROR_REPORT_MAX_BYTES`.
+- `MIRROR_FATAL_REPORTS_INTERVAL_MS` (default `900000` / 15 min) -- Bucket width for the fatal ring index. Reports in the same bucket overwrite the same slot.
+- `MIRROR_SECONDARY_REPORTS_MAX` (default `10`) -- Same scheme for first-failure secondary reports. Set to `0` to disable secondaries.
+- `MIRROR_SECONDARY_REPORTS_INTERVAL_MS` (default `600000` / 10 min) -- Bucket width for secondary ring.
+- `MIRROR_SECONDARY_REPORT_ON_ATTEMPT` (default `1`) -- Attempt number that triggers a secondary report.
+- `MIRROR_REPORT_MAX_BYTES` (default `65536` / 64 KiB) -- Per-file JSON cap. Oversize payloads are replaced with a `truncated: true` summary.
+- `MIRROR_PENDING_QUEUE_SUMMARIES_MAX` (default `20`) -- Max number of pending-queue summaries embedded in a fatal report.
+
 ### Metadata Services
 
 - `LIBRARY_METADATA_URL` -- library-metadata-lookup base URL (e.g. `http://localhost:8001`). Required for proxy endpoints, metadata enrichment, and track search. All Discogs access is routed through LML. Do not include the `/api/v1` path prefix; the LML client adds it automatically.

--- a/apps/backend/middleware/legacy/commandqueue.mirror.ts
+++ b/apps/backend/middleware/legacy/commandqueue.mirror.ts
@@ -5,6 +5,17 @@ import { EventEmitter } from 'node:events';
 import path from 'path';
 import { MirrorSQL } from '@wxyc/database';
 import { cryptoRandomId, expBackoffMs } from './utilities.mirror';
+import {
+  addMirrorBreadcrumb,
+  buildMirrorCommandSummary,
+  captureMirrorException,
+  getMirrorRingIndex,
+  summarizeSql,
+  truncateForMirrorPayload,
+  type MirrorCommandStatus,
+  type MirrorCommandSummary,
+  type MirrorLogContext,
+} from './mirror.logging';
 
 const CommandQueueEvents = {
   enqueued: 'enqueued',
@@ -18,11 +29,15 @@ const CommandQueueEvents = {
 export interface MirrorCommand {
   id: string;
   sql: string;
+  sqlLength: number;
+  sqlHash: string;
+  statementsCount: number;
   enqueuedAt: number;
   attempts: number;
   lastResult?: string;
   lastError?: string;
-  status: 'pending' | 'in_progress' | 'in_progress_retrying' | 'completed' | 'failed';
+  status: MirrorCommandStatus;
+  context?: MirrorLogContext;
 }
 
 export interface MirrorQueueOptions {
@@ -34,11 +49,40 @@ export interface MirrorQueueOptions {
 }
 
 export interface FatalInfo {
-  failedCommand: MirrorCommand;
-  pendingQueue: MirrorCommand[];
+  failedCommand: MirrorCommandSummary;
+  pendingQueue: MirrorCommandSummary[];
+  pendingQueueDepth: number;
   reason: string;
   timestamp: string;
   logFile: string;
+  ringIndex: number;
+}
+
+/**
+ * Internal payload for `createTrigger`. Tagged so each branch is exhaustive
+ * and survives future field additions; the wire shape sent to SSE consumers
+ * stays the bare `MirrorCommand` / `FatalInfo` for backwards compatibility.
+ */
+type TriggerPayload =
+  | { kind: 'command'; cmd: MirrorCommand }
+  | { kind: 'retry'; cmd: MirrorCommand; error: Error; attempt: number }
+  | { kind: 'fatal'; info: FatalInfo };
+
+const DEFAULTS = {
+  fatalReportsMax: 10,
+  fatalReportsIntervalMs: 15 * 60 * 1000,
+  secondaryReportsMax: 10,
+  secondaryReportsIntervalMs: 10 * 60 * 1000,
+  secondaryReportOnAttempt: 1,
+  reportMaxBytes: 64 * 1024,
+  pendingQueueSummariesMax: 20,
+} as const;
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : fallback;
 }
 
 export class MirrorCommandQueue extends EventEmitter {
@@ -48,27 +92,103 @@ export class MirrorCommandQueue extends EventEmitter {
     if (!this._instance) {
       this._instance = new MirrorCommandQueue(options);
 
-      this._instance.on(CommandQueueEvents.enqueued, this.createTrigger('syncStarted'));
-      this._instance.on(CommandQueueEvents.started, this.createTrigger('syncProgress'));
-      this._instance.on(CommandQueueEvents.succeeded, this.createTrigger('syncComplete'));
-      this._instance.on(CommandQueueEvents.failedAttempt, this.createTrigger('syncRetry'));
-      this._instance.on(CommandQueueEvents.fatal, this.createTrigger('syncError'));
-      this._instance.on(CommandQueueEvents.persisted, this.createTrigger('syncError'));
+      this._instance.on(CommandQueueEvents.enqueued, this.dispatch('syncStarted'));
+      this._instance.on(CommandQueueEvents.started, this.dispatch('syncProgress'));
+      this._instance.on(CommandQueueEvents.succeeded, this.dispatch('syncComplete'));
+      this._instance.on(CommandQueueEvents.failedAttempt, this.dispatch('syncRetry'));
+      this._instance.on(CommandQueueEvents.fatal, this.dispatch('syncError'));
+      this._instance.on(CommandQueueEvents.persisted, this.dispatch('syncError'));
     }
 
     return this._instance;
   }
 
-  private static createTrigger = (eventType: keyof typeof MirrorEvents) => (cmd: MirrorCommand) => {
-    const data: EventData = {
-      type: eventType,
-      payload: cmd,
-      timestamp: new Date(),
+  /**
+   * Builds an EventEmitter listener for a given MirrorEvents type.
+   * Wraps the raw payload (cmd / failedAttempt-tuple / FatalInfo) into a
+   * tagged TriggerPayload for the breadcrumb branch, then broadcasts the
+   * unwrapped, original-shape payload to SSE subscribers.
+   */
+  private static dispatch =
+    (eventType: keyof typeof MirrorEvents) =>
+    (raw: MirrorCommand | { cmd: MirrorCommand; error: Error; attempt: number } | FatalInfo) => {
+      const tagged = MirrorCommandQueue.tagPayload(raw);
+
+      // SSE wire format: keep the prior bare-shape payload to avoid breaking dj-site.
+      const data: EventData = {
+        type: eventType,
+        payload: MirrorCommandQueue.broadcastPayload(tagged),
+        timestamp: new Date(),
+      };
+      serverEventsMgr.broadcast('mirror', data);
+
+      try {
+        switch (tagged.kind) {
+          case 'command':
+            addMirrorBreadcrumb(
+              `Mirror queue: ${eventType}`,
+              {
+                eventType,
+                status: tagged.cmd.status,
+                attempt: tagged.cmd.attempts,
+                sql_length: tagged.cmd.sqlLength,
+                sql_hash: tagged.cmd.sqlHash,
+              },
+              tagged.cmd.context ?? { mirrorCmdId: tagged.cmd.id },
+              eventType === 'syncError' ? 'error' : 'info'
+            );
+            return;
+          case 'retry':
+            addMirrorBreadcrumb(
+              'Mirror queue: failed attempt',
+              {
+                eventType,
+                attempt: tagged.attempt,
+                last_error: truncateForMirrorPayload(tagged.error?.message, 256),
+              },
+              tagged.cmd.context ?? { mirrorCmdId: tagged.cmd.id },
+              tagged.attempt >= 2 ? 'warning' : 'info'
+            );
+            return;
+          case 'fatal':
+            addMirrorBreadcrumb(
+              `Mirror queue: ${eventType}`,
+              {
+                eventType,
+                ring_file: tagged.info.logFile,
+                pending_depth: tagged.info.pendingQueueDepth,
+                reason: truncateForMirrorPayload(tagged.info.reason, 256),
+              },
+              tagged.info.failedCommand.context,
+              'error'
+            );
+            return;
+        }
+      } catch {
+        // Never let observability break the queue.
+      }
     };
 
-    serverEventsMgr.broadcast('mirror', data);
-    console.table(cmd);
-  };
+  private static tagPayload(
+    raw: MirrorCommand | { cmd: MirrorCommand; error: Error; attempt: number } | FatalInfo
+  ): TriggerPayload {
+    if ('failedCommand' in raw) return { kind: 'fatal', info: raw };
+    if ('cmd' in raw && 'error' in raw) return { kind: 'retry', ...raw };
+    return { kind: 'command', cmd: raw };
+  }
+
+  private static broadcastPayload(
+    tagged: TriggerPayload
+  ): MirrorCommand | FatalInfo | { cmd: MirrorCommand; error: Error; attempt: number } {
+    switch (tagged.kind) {
+      case 'command':
+        return tagged.cmd;
+      case 'retry':
+        return { cmd: tagged.cmd, error: tagged.error, attempt: tagged.attempt };
+      case 'fatal':
+        return tagged.info;
+    }
+  }
 
   private readonly options: Required<MirrorQueueOptions>;
   private readonly queue: MirrorCommand[] = [];
@@ -87,17 +207,23 @@ export class MirrorCommandQueue extends EventEmitter {
     };
   }
 
-  enqueue(sqls: string[]): MirrorCommand | null {
+  enqueue(sqls: string[], context?: MirrorLogContext): MirrorCommand | null {
     if (!this.alive) return null;
-    let sql = sqls.map((s) => (s.trim().endsWith(';') ? s.trim() : s.trim() + ';')).join('\n');
-    sql = `START TRANSACTION;\n${sql}\nCOMMIT;`;
+    const joined = sqls.map((s) => (s.trim().endsWith(';') ? s.trim() : s.trim() + ';')).join('\n');
+    const sql = `START TRANSACTION;\n${joined}\nCOMMIT;`;
+    const { sqlLength, sqlHash } = summarizeSql(sql);
 
+    const id = cryptoRandomId();
     const cmd: MirrorCommand = {
-      id: cryptoRandomId(),
+      id,
       sql,
+      sqlLength,
+      sqlHash,
+      statementsCount: sqls.length,
       enqueuedAt: Date.now(),
       attempts: 0,
       status: 'pending',
+      context: context ? { ...context, mirrorCmdId: id } : { mirrorCmdId: id },
     };
 
     this.queue.push(cmd);
@@ -109,6 +235,7 @@ export class MirrorCommandQueue extends EventEmitter {
   isAlive() {
     return this.alive;
   }
+
   isDead() {
     return !this.alive;
   }
@@ -165,12 +292,32 @@ export class MirrorCommandQueue extends EventEmitter {
       return;
     }
 
+    const secondaryAttempt = envInt('MIRROR_SECONDARY_REPORT_ON_ATTEMPT', DEFAULTS.secondaryReportOnAttempt);
+    const maxSecondary = envInt('MIRROR_SECONDARY_REPORTS_MAX', DEFAULTS.secondaryReportsMax);
+    if (cmd.attempts === secondaryAttempt && maxSecondary > 0) {
+      // Best-effort: persistSecondaryReport handles its own errors. Awaiting it
+      // is safe because it never throws — we rely on this so a disk write
+      // failure can never abort the retry/re-queue path below.
+      await this.persistSecondaryReport(cmd, err, maxSecondary);
+    }
+
     cmd.status = 'in_progress_retrying';
     const delay = expBackoffMs(
       cmd.attempts,
       this.options.baseBackoffMs,
       this.options.maxBackoffMs,
       this.options.jitterMs
+    );
+
+    addMirrorBreadcrumb(
+      'Mirror queue: retry scheduled',
+      {
+        attempt: cmd.attempts,
+        delay_ms: delay,
+        last_error: truncateForMirrorPayload(cmd.lastError, 256),
+      },
+      cmd.context,
+      'warning'
     );
 
     setTimeout(() => {
@@ -188,34 +335,136 @@ export class MirrorCommandQueue extends EventEmitter {
     this.fatalEmitted = true;
     this.alive = false;
 
+    const ctx: MirrorLogContext = {
+      ...(failedCommand.context ?? {}),
+      mirrorCmdId: failedCommand.id,
+      attempt: failedCommand.attempts,
+      maxAttempts: this.options.maxAttempts,
+    };
+
+    captureMirrorException(new Error(failedCommand.lastError ?? reason), ctx, {
+      reason,
+      sql_length: failedCommand.sqlLength,
+      sql_hash: failedCommand.sqlHash,
+      statements_count: failedCommand.statementsCount,
+    });
+
     const info = await this.persistQueue(reason, failedCommand);
     this.emit(CommandQueueEvents.fatal, info);
   }
 
-  private async persistQueue(reason: string, failedCommand?: MirrorCommand) {
-    await promises.mkdir(this.options.logFile, { recursive: true });
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const logFile = path.join(this.options.logFile, `queue-fatal-${timestamp}.json`);
+  /**
+   * Best-effort: never throws. A failed disk write degrades observability
+   * (caught and surfaced as a Sentry breadcrumb) but never breaks the retry
+   * loop in `handleFailure`.
+   */
+  private async persistSecondaryReport(cmd: MirrorCommand, err: Error, maxReports: number): Promise<void> {
+    const intervalMs = envInt('MIRROR_SECONDARY_REPORTS_INTERVAL_MS', DEFAULTS.secondaryReportsIntervalMs);
+    const maxBytes = envInt('MIRROR_REPORT_MAX_BYTES', DEFAULTS.reportMaxBytes);
+    const nowMs = Date.now();
+    const ringIndex = getMirrorRingIndex(nowMs, intervalMs, maxReports);
+    const logFile = path.join(this.options.logFile, `queue-secondary-ring-${ringIndex}.json`);
 
-    const info: FatalInfo = {
-      failedCommand: failedCommand ?? {
-        id: 'n/a',
-        sql: 'n/a',
-        status: 'failed',
-        enqueuedAt: 0,
-        attempts: 0,
-        lastResult: 'n/a',
-        lastError: 'n/a',
-      },
-      pendingQueue: [...this.queue],
-      reason,
-      timestamp: new Date().toISOString(),
+    const payload = {
+      reportType: 'secondary' as const,
+      ringIndex,
+      timestamp: new Date(nowMs).toISOString(),
       logFile,
+      attempt: cmd.attempts,
+      reason: 'Mirror failedAttempt; retry scheduled',
+      cmd: buildMirrorCommandSummary(cmd),
+      error: truncateForMirrorPayload(err?.message ?? String(err), 2048),
     };
 
-    const payload = JSON.stringify(info, null, 2);
-    await promises.writeFile(logFile, payload, 'utf8');
+    try {
+      await promises.mkdir(this.options.logFile, { recursive: true });
+      const json = boundedJson(payload, maxBytes, () => ({
+        reportType: 'secondary' as const,
+        ringIndex,
+        timestamp: payload.timestamp,
+        logFile: payload.logFile,
+        attempt: payload.attempt,
+        reason: payload.reason,
+        cmd: { ...payload.cmd, context: undefined },
+        error: payload.error,
+        truncated: true,
+      }));
+      await promises.writeFile(logFile, json, 'utf8');
+      addMirrorBreadcrumb('Mirror queue: secondary report persisted', { ringIndex, logFile }, cmd.context, 'info');
+    } catch (writeErr) {
+      addMirrorBreadcrumb(
+        'Mirror queue: secondary report write failed',
+        { ringIndex, logFile, error: truncateForMirrorPayload((writeErr as Error)?.message ?? String(writeErr), 256) },
+        cmd.context,
+        'warning'
+      );
+    }
+  }
+
+  private async persistQueue(reason: string, failedCommand?: MirrorCommand): Promise<FatalInfo> {
+    const intervalMs = envInt('MIRROR_FATAL_REPORTS_INTERVAL_MS', DEFAULTS.fatalReportsIntervalMs);
+    const maxReports = envInt('MIRROR_FATAL_REPORTS_MAX', DEFAULTS.fatalReportsMax);
+    const maxBytes = envInt('MIRROR_REPORT_MAX_BYTES', DEFAULTS.reportMaxBytes);
+    const maxPendingSummaries = envInt('MIRROR_PENDING_QUEUE_SUMMARIES_MAX', DEFAULTS.pendingQueueSummariesMax);
+
+    const nowMs = Date.now();
+    const ringIndex = getMirrorRingIndex(nowMs, intervalMs, maxReports);
+    const logFile = path.join(this.options.logFile, `queue-fatal-ring-${ringIndex}.json`);
+
+    const failedCmdSummary: MirrorCommandSummary = failedCommand
+      ? buildMirrorCommandSummary(failedCommand)
+      : {
+          id: 'n/a',
+          enqueuedAt: 0,
+          attempts: 0,
+          status: 'failed',
+          lastError: 'n/a',
+          sqlLength: 0,
+          sqlHash: 'n/a',
+          statementsCount: 0,
+        };
+
+    const pendingQueue = this.queue.slice(0, maxPendingSummaries).map(buildMirrorCommandSummary);
+
+    const info: FatalInfo = {
+      failedCommand: failedCmdSummary,
+      pendingQueue,
+      pendingQueueDepth: this.queue.length,
+      reason: truncateForMirrorPayload(reason, 2048) ?? reason,
+      timestamp: new Date(nowMs).toISOString(),
+      logFile,
+      ringIndex,
+    };
+
+    try {
+      await promises.mkdir(this.options.logFile, { recursive: true });
+      const json = boundedJson(info, maxBytes, () => ({
+        reportType: 'fatal' as const,
+        ringIndex,
+        timestamp: info.timestamp,
+        logFile: info.logFile,
+        reason: info.reason,
+        failedCommand: { ...info.failedCommand, context: undefined },
+        pendingQueueDepth: info.pendingQueueDepth,
+        truncated: true,
+      }));
+      await promises.writeFile(logFile, json, 'utf8');
+    } catch (writeErr) {
+      addMirrorBreadcrumb(
+        'Mirror queue: fatal report write failed',
+        { ringIndex, logFile, error: truncateForMirrorPayload((writeErr as Error)?.message ?? String(writeErr), 256) },
+        failedCmdSummary.context,
+        'error'
+      );
+    }
+
     this.emit(CommandQueueEvents.persisted, info);
     return info;
   }
+}
+
+function boundedJson<T>(payload: T, maxBytes: number, summarize: () => unknown): string {
+  const full = JSON.stringify(payload);
+  if (full.length <= maxBytes) return full;
+  return JSON.stringify({ ...(summarize() as Record<string, unknown>), jsonBytes: full.length });
 }

--- a/apps/backend/middleware/legacy/mirror.logging.ts
+++ b/apps/backend/middleware/legacy/mirror.logging.ts
@@ -1,0 +1,132 @@
+import * as Sentry from '@sentry/node';
+import crypto from 'crypto';
+
+export type MirrorLogContext = {
+  requestId?: string;
+  mirrorCmdId?: string;
+  attempt?: number;
+  maxAttempts?: number;
+  extra?: Record<string, unknown>;
+};
+
+export type MirrorCommandStatus = 'pending' | 'in_progress' | 'in_progress_retrying' | 'completed' | 'failed';
+
+export type MirrorCommandSummary = {
+  id: string;
+  enqueuedAt: number;
+  attempts: number;
+  status: MirrorCommandStatus;
+  lastError?: string;
+  sqlLength: number;
+  sqlHash: string;
+  statementsCount: number;
+  context?: MirrorLogContext;
+};
+
+const MAX_STRING_LEN_DEFAULT = 1024;
+const MAX_TAG_VALUE_LEN = 64;
+
+function truncateString(input: unknown, maxLen: number): string | undefined {
+  if (input === undefined || input === null) return undefined;
+  const s = typeof input === 'string' ? input : String(input);
+  return s.length <= maxLen ? s : s.slice(0, maxLen);
+}
+
+export function hashSha256Hex(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+export function summarizeSql(sql: string): { sqlLength: number; sqlHash: string } {
+  return {
+    sqlLength: sql.length,
+    sqlHash: hashSha256Hex(sql),
+  };
+}
+
+export function getMirrorRingIndex(nowMs: number, intervalMs: number, maxReports: number): number {
+  const safeInterval = Number.isFinite(intervalMs) && intervalMs > 0 ? intervalMs : 1;
+  const safeMax = Number.isFinite(maxReports) && maxReports > 0 ? Math.floor(maxReports) : 1;
+  const bucket = Math.floor(nowMs / safeInterval);
+  return ((bucket % safeMax) + safeMax) % safeMax;
+}
+
+export function addMirrorBreadcrumb(
+  message: string,
+  data?: Record<string, unknown>,
+  context?: MirrorLogContext,
+  level: 'info' | 'warning' | 'error' | 'debug' = 'info'
+): void {
+  try {
+    const breadcrumbData: Record<string, unknown> = {
+      ...data,
+      ...(context?.mirrorCmdId ? { mirror_cmd_id: context.mirrorCmdId } : {}),
+      ...(context?.requestId ? { request_id: context.requestId } : {}),
+    };
+    Sentry.addBreadcrumb({
+      category: 'mirror',
+      message: truncateString(message, 200) ?? message,
+      level,
+      data: breadcrumbData,
+    });
+  } catch {
+    // Never let observability break mirror execution.
+  }
+}
+
+export function captureMirrorException(
+  error: unknown,
+  context: MirrorLogContext,
+  extra?: Record<string, unknown>
+): void {
+  const err = error instanceof Error ? error : new Error(String(error));
+  try {
+    Sentry.withScope((scope) => {
+      const tags: Record<string, string> = { subsystem: 'legacy-mirror' };
+      if (context.requestId) tags.request_id = truncateString(context.requestId, MAX_TAG_VALUE_LEN)!;
+      if (context.mirrorCmdId) tags.mirror_cmd_id = truncateString(context.mirrorCmdId, MAX_TAG_VALUE_LEN)!;
+      if (context.attempt !== undefined) tags.attempt = String(context.attempt);
+      if (context.maxAttempts !== undefined) tags.max_attempts = String(context.maxAttempts);
+      scope.setTags(tags);
+
+      const safeExtra: Record<string, unknown> = {};
+      if (extra) {
+        for (const [k, v] of Object.entries(extra)) {
+          safeExtra[k] = typeof v === 'string' ? truncateString(v, MAX_STRING_LEN_DEFAULT) : v;
+        }
+      }
+      scope.setExtra('mirror', safeExtra);
+      scope.setExtra('error_message', truncateString(err.message, MAX_STRING_LEN_DEFAULT));
+      Sentry.captureException(err);
+    });
+  } catch {
+    // Never let observability break mirror execution.
+  }
+}
+
+export function truncateForMirrorPayload(input: unknown, maxLen = MAX_STRING_LEN_DEFAULT): string | undefined {
+  return truncateString(input, maxLen);
+}
+
+export function buildMirrorCommandSummary(cmd: {
+  id: string;
+  enqueuedAt: number;
+  attempts: number;
+  status: MirrorCommandStatus;
+  lastError?: string;
+  sqlLength: number;
+  sqlHash: string;
+  statementsCount: number;
+  context?: MirrorLogContext;
+}): MirrorCommandSummary {
+  return {
+    id: cmd.id,
+    enqueuedAt: cmd.enqueuedAt,
+    attempts: cmd.attempts,
+    status: cmd.status,
+    lastError: truncateString(cmd.lastError, MAX_STRING_LEN_DEFAULT),
+    sqlLength: cmd.sqlLength,
+    sqlHash: cmd.sqlHash,
+    statementsCount: cmd.statementsCount,
+    context: cmd.context,
+  };
+}

--- a/tests/unit/middleware/legacy/commandqueue.mirror.test.ts
+++ b/tests/unit/middleware/legacy/commandqueue.mirror.test.ts
@@ -1,6 +1,5 @@
 import { jest } from '@jest/globals';
 
-// Mock @wxyc/database — MirrorSQL.instance().send()
 const mockSend = jest.fn<() => Promise<string>>();
 jest.mock('@wxyc/database', () => ({
   MirrorSQL: {
@@ -8,9 +7,9 @@ jest.mock('@wxyc/database', () => ({
   },
 }));
 
-// Mock serverEventsMgr.broadcast
+const mockBroadcast = jest.fn();
 jest.mock('../../../../apps/backend/utils/serverEvents', () => ({
-  serverEventsMgr: { broadcast: jest.fn() },
+  serverEventsMgr: { broadcast: (...args: unknown[]) => mockBroadcast(...args) },
   MirrorEvents: {
     syncStarted: 'syncStarted',
     syncProgress: 'syncProgress',
@@ -20,14 +19,12 @@ jest.mock('../../../../apps/backend/utils/serverEvents', () => ({
   },
 }));
 
-// Mock utilities (cryptoRandomId, expBackoffMs)
 let idCounter = 0;
 jest.mock('../../../../apps/backend/middleware/legacy/utilities.mirror', () => ({
   cryptoRandomId: () => `test-id-${idCounter++}`,
-  expBackoffMs: () => 1, // Minimal delay for tests
+  expBackoffMs: () => 1,
 }));
 
-// Mock fs.promises for persistQueue
 const mockMkdir = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
 const mockWriteFile = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
 jest.mock('fs', () => ({
@@ -37,24 +34,42 @@ jest.mock('fs', () => ({
   },
 }));
 
-// Suppress console.table in tests
-jest.spyOn(console, 'table').mockImplementation(() => {});
+const mockAddBreadcrumb = jest.fn();
+const mockCaptureException = jest.fn();
+jest.mock('@sentry/node', () => ({
+  addBreadcrumb: (...args: unknown[]) => mockAddBreadcrumb(...args),
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  withScope: (fn: (scope: unknown) => void) => fn({ setTags: jest.fn(), setExtra: jest.fn() }),
+}));
 
-import { MirrorCommandQueue } from '../../../../apps/backend/middleware/legacy/commandqueue.mirror';
+import {
+  MirrorCommandQueue,
+  type FatalInfo,
+  type MirrorCommand,
+} from '../../../../apps/backend/middleware/legacy/commandqueue.mirror';
+
+const SECONDARY_ENV_VARS = [
+  'MIRROR_SECONDARY_REPORTS_MAX',
+  'MIRROR_SECONDARY_REPORTS_INTERVAL_MS',
+  'MIRROR_SECONDARY_REPORT_ON_ATTEMPT',
+  'MIRROR_FATAL_REPORTS_MAX',
+  'MIRROR_FATAL_REPORTS_INTERVAL_MS',
+  'MIRROR_REPORT_MAX_BYTES',
+  'MIRROR_PENDING_QUEUE_SUMMARIES_MAX',
+];
 
 describe('MirrorCommandQueue', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     idCounter = 0;
-
-    // Reset the singleton so each test gets a fresh queue
-    // Access private static _instance
+    SECONDARY_ENV_VARS.forEach((v) => delete process.env[v]);
     (MirrorCommandQueue as unknown as { _instance: unknown })._instance = null;
   });
 
   afterEach(() => {
     jest.useRealTimers();
+    SECONDARY_ENV_VARS.forEach((v) => delete process.env[v]);
   });
 
   function createQueue(options = {}) {
@@ -68,7 +83,7 @@ describe('MirrorCommandQueue', () => {
     });
   }
 
-  test('enqueue wraps SQL in a transaction and adds to queue', () => {
+  test('enqueue wraps SQL in a transaction and populates fingerprint fields', () => {
     const queue = createQueue();
     const cmd = queue.enqueue(['SELECT 1', 'SELECT 2']);
 
@@ -77,7 +92,9 @@ describe('MirrorCommandQueue', () => {
     expect(cmd?.sql).toContain('SELECT 1;');
     expect(cmd?.sql).toContain('SELECT 2;');
     expect(cmd?.sql).toContain('COMMIT;');
-    // Status may already be 'in_progress' since enqueue() kicks the work loop
+    expect(cmd?.statementsCount).toBe(2);
+    expect(cmd?.sqlLength).toBe(cmd?.sql.length);
+    expect(cmd?.sqlHash).toMatch(/^[a-f0-9]{64}$/);
     expect(['pending', 'in_progress']).toContain(cmd?.status);
   });
 
@@ -88,40 +105,29 @@ describe('MirrorCommandQueue', () => {
     queue.on('succeeded', succeededSpy);
 
     queue.enqueue(['SELECT 1']);
-
-    // Allow the async workLoop to run
     await jest.advanceTimersByTimeAsync(10);
 
     expect(succeededSpy).toHaveBeenCalledTimes(1);
     expect(succeededSpy).toHaveBeenCalledWith(expect.objectContaining({ status: 'completed', attempts: 1 }));
   });
 
-  test('failed command retries up to maxAttempts', async () => {
+  test('failed command retries up to maxAttempts and stops fatal', async () => {
     mockSend
       .mockRejectedValueOnce(new Error('fail 1'))
       .mockRejectedValueOnce(new Error('fail 2'))
       .mockRejectedValueOnce(new Error('fail 3'));
 
     const queue = createQueue({ maxAttempts: 3 });
-    const failedAttemptSpy = jest.fn();
     const fatalSpy = jest.fn();
-    queue.on('failedAttempt', failedAttemptSpy);
     queue.on('fatal', fatalSpy);
 
     queue.enqueue(['SELECT 1']);
 
-    // Process first attempt
-    await jest.advanceTimersByTimeAsync(10);
-    // Process retry after backoff
-    await jest.advanceTimersByTimeAsync(10);
-    await jest.advanceTimersByTimeAsync(10);
-    // Third attempt triggers fatal
-    await jest.advanceTimersByTimeAsync(10);
+    await jest.advanceTimersByTimeAsync(50);
 
     expect(mockSend).toHaveBeenCalledTimes(3);
     expect(fatalSpy).toHaveBeenCalledTimes(1);
     expect(queue.isDead()).toBe(true);
-    expect(queue.isAlive()).toBe(false);
   });
 
   test('dead queue rejects new commands', async () => {
@@ -130,41 +136,162 @@ describe('MirrorCommandQueue', () => {
     const queue = createQueue({ maxAttempts: 1 });
     queue.enqueue(['SELECT 1']);
 
-    // Let the single attempt fail and trigger fatal
     await jest.advanceTimersByTimeAsync(50);
 
     expect(queue.isDead()).toBe(true);
-
-    const cmd = queue.enqueue(['SELECT 2']);
-    expect(cmd).toBeNull();
+    expect(queue.enqueue(['SELECT 2'])).toBeNull();
   });
 
-  test('fatal stop persists queue to disk', async () => {
-    mockSend.mockRejectedValue(new Error('persistent failure'));
+  describe('fatal report on disk', () => {
+    test('uses ring-buffer filename and never serializes raw SQL', async () => {
+      mockSend.mockRejectedValue(new Error('connection refused'));
 
+      const queue = createQueue({ maxAttempts: 1 });
+      // The literal "MIRROR_SQL_SECRET_TOKEN" appears only in the SQL string, not in the
+      // error message or any other field, so any leak into the report can only come from
+      // a code path that serializes raw SQL.
+      queue.enqueue([`UPDATE users SET password = 'MIRROR_SQL_SECRET_TOKEN'`]);
+
+      await jest.advanceTimersByTimeAsync(50);
+
+      expect(mockMkdir).toHaveBeenCalledWith('/tmp/test-mirror-logs', { recursive: true });
+      const fatalCall = mockWriteFile.mock.calls.find((c) => (c[0] as string).includes('queue-fatal-ring-')) as
+        | [string, string]
+        | undefined;
+      expect(fatalCall).toBeDefined();
+
+      const [filePath, content] = fatalCall;
+      expect(filePath).toMatch(/queue-fatal-ring-\d+\.json$/);
+
+      const parsed = JSON.parse(content);
+      expect(parsed.failedCommand).not.toHaveProperty('sql');
+      expect(parsed.failedCommand.sqlLength).toBeGreaterThan(0);
+      expect(parsed.failedCommand.sqlHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(parsed.failedCommand.statementsCount).toBe(1);
+      expect(content).not.toContain('MIRROR_SQL_SECRET_TOKEN');
+      expect(parsed.reason).toContain('maxAttempts=1');
+    });
+
+    test('emits a truncated summary instead of writing past MIRROR_REPORT_MAX_BYTES', async () => {
+      process.env.MIRROR_REPORT_MAX_BYTES = '256';
+      process.env.MIRROR_PENDING_QUEUE_SUMMARIES_MAX = '50';
+      mockSend.mockRejectedValue(new Error('x'.repeat(2048)));
+
+      const queue = createQueue({ maxAttempts: 1 });
+      // Pad pending depth so the JSON exceeds 256 bytes even with hashed SQL.
+      queue.enqueue(['INSERT INTO a VALUES (1)']);
+      for (let i = 0; i < 5; i++) queue.enqueue([`INSERT INTO b VALUES (${i})`]);
+
+      await jest.advanceTimersByTimeAsync(50);
+
+      const fatalCall = mockWriteFile.mock.calls.find((c) => (c[0] as string).includes('queue-fatal-ring-')) as
+        | [string, string]
+        | undefined;
+      expect(fatalCall).toBeDefined();
+      const parsed = JSON.parse(fatalCall[1]);
+      expect(parsed.truncated).toBe(true);
+      expect(parsed.jsonBytes).toBeGreaterThan(256);
+    });
+  });
+
+  describe('secondary report', () => {
+    test('writes queue-secondary-ring-N.json on first failure when enabled', async () => {
+      mockSend.mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce('OK');
+
+      const queue = createQueue({ maxAttempts: 3 });
+      queue.enqueue(['SELECT 1']);
+
+      await jest.advanceTimersByTimeAsync(50);
+
+      const secondaryCall = mockWriteFile.mock.calls.find((c) => (c[0] as string).includes('queue-secondary-ring-')) as
+        | [string, string]
+        | undefined;
+      expect(secondaryCall).toBeDefined();
+      const parsed = JSON.parse(secondaryCall[1]);
+      expect(parsed.reportType).toBe('secondary');
+      expect(parsed.cmd.sqlHash).toMatch(/^[a-f0-9]{64}$/);
+      expect(parsed.cmd).not.toHaveProperty('sql');
+    });
+
+    test('disabled when MIRROR_SECONDARY_REPORTS_MAX=0', async () => {
+      process.env.MIRROR_SECONDARY_REPORTS_MAX = '0';
+      mockSend.mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce('OK');
+
+      const queue = createQueue({ maxAttempts: 3 });
+      queue.enqueue(['SELECT 1']);
+      await jest.advanceTimersByTimeAsync(50);
+
+      const secondaryCalls = mockWriteFile.mock.calls.filter((c) => (c[0] as string).includes('queue-secondary-ring-'));
+      expect(secondaryCalls).toHaveLength(0);
+    });
+
+    test('write failure does not abort the retry loop', async () => {
+      mockSend.mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce('OK');
+      // First write call (the secondary report) rejects; later calls (none expected here) succeed.
+      mockWriteFile.mockRejectedValueOnce(new Error('disk full'));
+
+      const queue = createQueue({ maxAttempts: 3 });
+      const succeededSpy = jest.fn();
+      queue.on('succeeded', succeededSpy);
+
+      queue.enqueue(['SELECT 1']);
+      await jest.advanceTimersByTimeAsync(50);
+
+      expect(succeededSpy).toHaveBeenCalledTimes(1);
+      expect(queue.isAlive()).toBe(true);
+      // A breadcrumb noting the write failure should have been recorded.
+      const breadcrumbMessages = mockAddBreadcrumb.mock.calls.map((c) => (c[0] as { message: string }).message);
+      expect(breadcrumbMessages).toContain('Mirror queue: secondary report write failed');
+    });
+  });
+
+  describe('SSE broadcast wire shape', () => {
+    test('preserves bare MirrorCommand on lifecycle events', async () => {
+      mockSend.mockResolvedValueOnce('OK');
+      const queue = createQueue();
+      queue.enqueue(['SELECT 1']);
+      await jest.advanceTimersByTimeAsync(10);
+
+      // Find the syncComplete broadcast
+      const completeCall = mockBroadcast.mock.calls.find((c) => (c[1] as { type: string }).type === 'syncComplete') as
+        | [string, { type: string; payload: MirrorCommand }]
+        | undefined;
+      expect(completeCall).toBeDefined();
+      const payload = completeCall[1].payload;
+      expect(payload).toHaveProperty('id');
+      expect(payload).toHaveProperty('sql');
+      expect(payload).toHaveProperty('status', 'completed');
+      // Crucially, payload is NOT wrapped in `{ kind: 'command', cmd: ... }`.
+      expect(payload).not.toHaveProperty('kind');
+    });
+
+    test('preserves bare FatalInfo on syncError', async () => {
+      mockSend.mockRejectedValue(new Error('persistent'));
+      const queue = createQueue({ maxAttempts: 1 });
+      queue.enqueue(['SELECT 1']);
+      await jest.advanceTimersByTimeAsync(50);
+
+      const errorCall = mockBroadcast.mock.calls.find(
+        (c) =>
+          (c[1] as { type: string }).type === 'syncError' &&
+          'failedCommand' in ((c[1] as { payload: unknown }).payload as object)
+      ) as [string, { type: string; payload: FatalInfo }] | undefined;
+      expect(errorCall).toBeDefined();
+      const fatal = errorCall[1].payload;
+      expect(fatal).toHaveProperty('failedCommand');
+      expect(fatal).toHaveProperty('pendingQueueDepth');
+      expect(fatal).not.toHaveProperty('kind');
+    });
+  });
+
+  test('Sentry capture on fatal stop includes mirror tags', async () => {
+    mockSend.mockRejectedValue(new Error('persistent failure'));
     const queue = createQueue({ maxAttempts: 1 });
     queue.enqueue(['SELECT 1']);
-
     await jest.advanceTimersByTimeAsync(50);
 
-    expect(mockMkdir).toHaveBeenCalledWith('/tmp/test-mirror-logs', { recursive: true });
-    expect(mockWriteFile).toHaveBeenCalledTimes(1);
-
-    const [filePath, content] = mockWriteFile.mock.calls[0] as [string, string];
-    expect(filePath).toContain('queue-fatal-');
-    const parsed = JSON.parse(content);
-    expect(parsed.reason).toContain('maxAttempts=1');
-    expect(parsed.failedCommand.sql).toContain('SELECT 1');
-  });
-
-  test('getState returns current queue state', () => {
-    const queue = createQueue({ maxAttempts: 5 });
-    const state = queue.getState();
-
-    expect(state.alive).toBe(true);
-    expect(state.working).toBe(false);
-    expect(state.depth).toBe(0);
-    expect(state.maxAttempts).toBe(5);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException.mock.calls[0][0]).toBeInstanceOf(Error);
   });
 
   test('commands drain in FIFO order', async () => {
@@ -177,7 +304,6 @@ describe('MirrorCommandQueue', () => {
     const queue = createQueue();
     queue.enqueue(['FIRST']);
     queue.enqueue(['SECOND']);
-
     await jest.advanceTimersByTimeAsync(50);
 
     expect(sendOrder.length).toBe(2);
@@ -187,20 +313,20 @@ describe('MirrorCommandQueue', () => {
 
   test('successful retry after transient failure', async () => {
     mockSend.mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce('OK');
-
     const queue = createQueue({ maxAttempts: 3 });
     const succeededSpy = jest.fn();
     queue.on('succeeded', succeededSpy);
 
     queue.enqueue(['SELECT 1']);
-
-    // First attempt fails
-    await jest.advanceTimersByTimeAsync(10);
-    // Retry succeeds after backoff
-    await jest.advanceTimersByTimeAsync(10);
+    await jest.advanceTimersByTimeAsync(50);
 
     expect(mockSend).toHaveBeenCalledTimes(2);
     expect(succeededSpy).toHaveBeenCalledTimes(1);
     expect(queue.isAlive()).toBe(true);
+  });
+
+  test('getState returns current queue state', () => {
+    const queue = createQueue({ maxAttempts: 5 });
+    expect(queue.getState()).toEqual({ alive: true, working: false, depth: 0, maxAttempts: 5 });
   });
 });

--- a/tests/unit/middleware/legacy/mirror.logging.test.ts
+++ b/tests/unit/middleware/legacy/mirror.logging.test.ts
@@ -1,0 +1,181 @@
+import { jest } from '@jest/globals';
+
+const mockAddBreadcrumb = jest.fn();
+const mockCaptureException = jest.fn();
+const mockSetTags = jest.fn();
+const mockSetExtra = jest.fn();
+const mockWithScope = jest.fn((fn: (scope: unknown) => void) => fn({ setTags: mockSetTags, setExtra: mockSetExtra }));
+
+jest.mock('@sentry/node', () => ({
+  addBreadcrumb: (...args: unknown[]) => mockAddBreadcrumb(...args),
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  withScope: (fn: (scope: unknown) => void) => mockWithScope(fn),
+}));
+
+import {
+  addMirrorBreadcrumb,
+  buildMirrorCommandSummary,
+  captureMirrorException,
+  getMirrorRingIndex,
+  hashSha256Hex,
+  summarizeSql,
+  truncateForMirrorPayload,
+} from '../../../../apps/backend/middleware/legacy/mirror.logging';
+
+describe('mirror.logging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('summarizeSql', () => {
+    test('returns deterministic length and sha256 hash', () => {
+      const sql = 'INSERT INTO foo VALUES (1);';
+      const summary = summarizeSql(sql);
+
+      expect(summary.sqlLength).toBe(sql.length);
+      expect(summary.sqlHash).toBe(hashSha256Hex(sql));
+      expect(summary.sqlHash).toHaveLength(64);
+    });
+
+    test('does not include a sql preview (no leak surface)', () => {
+      const summary = summarizeSql("INSERT INTO foo VALUES ('secret');");
+      expect(summary).not.toHaveProperty('sqlPreview');
+      expect(JSON.stringify(summary)).not.toContain('secret');
+    });
+
+    test('different SQL strings produce different hashes', () => {
+      expect(summarizeSql('a').sqlHash).not.toBe(summarizeSql('b').sqlHash);
+    });
+  });
+
+  describe('getMirrorRingIndex', () => {
+    test('cycles through buckets', () => {
+      const interval = 1000;
+      const max = 4;
+      expect(getMirrorRingIndex(0, interval, max)).toBe(0);
+      expect(getMirrorRingIndex(1000, interval, max)).toBe(1);
+      expect(getMirrorRingIndex(2000, interval, max)).toBe(2);
+      expect(getMirrorRingIndex(3000, interval, max)).toBe(3);
+      expect(getMirrorRingIndex(4000, interval, max)).toBe(0);
+    });
+
+    test('handles non-positive interval defensively', () => {
+      const idx = getMirrorRingIndex(123, 0, 5);
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(5);
+    });
+
+    test('handles non-positive max defensively (collapses to slot 0)', () => {
+      expect(getMirrorRingIndex(123, 1000, 0)).toBe(0);
+      expect(getMirrorRingIndex(123, 1000, -3)).toBe(0);
+    });
+
+    test('handles non-finite inputs without throwing', () => {
+      expect(() => getMirrorRingIndex(Date.now(), Number.NaN, Number.POSITIVE_INFINITY)).not.toThrow();
+    });
+  });
+
+  describe('addMirrorBreadcrumb', () => {
+    test('forwards category, message, level, and merged data', () => {
+      addMirrorBreadcrumb('hello', { foo: 'bar' }, { mirrorCmdId: 'cmd-1', requestId: 'req-1' });
+
+      expect(mockAddBreadcrumb).toHaveBeenCalledTimes(1);
+      const arg = mockAddBreadcrumb.mock.calls[0][0] as {
+        category: string;
+        message: string;
+        level: string;
+        data: Record<string, unknown>;
+      };
+      expect(arg.category).toBe('mirror');
+      expect(arg.message).toBe('hello');
+      expect(arg.level).toBe('info');
+      expect(arg.data).toMatchObject({ foo: 'bar', mirror_cmd_id: 'cmd-1', request_id: 'req-1' });
+    });
+
+    test('truncates oversize message bodies', () => {
+      addMirrorBreadcrumb('x'.repeat(500));
+      const arg = mockAddBreadcrumb.mock.calls[0][0] as { message: string };
+      expect(arg.message.length).toBeLessThanOrEqual(200);
+    });
+
+    test('never throws when Sentry throws', () => {
+      mockAddBreadcrumb.mockImplementationOnce(() => {
+        throw new Error('sentry exploded');
+      });
+      expect(() => addMirrorBreadcrumb('hello')).not.toThrow();
+    });
+  });
+
+  describe('captureMirrorException', () => {
+    test('sets subsystem tag and forwards the error', () => {
+      const err = new Error('boom');
+      captureMirrorException(err, { mirrorCmdId: 'cmd-1', attempt: 3, maxAttempts: 5 });
+
+      expect(mockWithScope).toHaveBeenCalledTimes(1);
+      expect(mockSetTags).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subsystem: 'legacy-mirror',
+          mirror_cmd_id: 'cmd-1',
+          attempt: '3',
+          max_attempts: '5',
+        })
+      );
+      expect(mockCaptureException).toHaveBeenCalledWith(err);
+    });
+
+    test('wraps non-Error values', () => {
+      captureMirrorException('not an error', { mirrorCmdId: 'cmd-1' });
+      const passed = mockCaptureException.mock.calls[0][0] as Error;
+      expect(passed).toBeInstanceOf(Error);
+      expect(passed.message).toBe('not an error');
+    });
+
+    test('truncates string values in extra payload', () => {
+      captureMirrorException(new Error('boom'), { mirrorCmdId: 'cmd-1' }, { huge: 'x'.repeat(5000) });
+      const extras = mockSetExtra.mock.calls.find((c) => (c[0] as string) === 'mirror') as
+        | [string, { huge: string }]
+        | undefined;
+      expect(extras).toBeDefined();
+      expect(extras[1].huge.length).toBeLessThanOrEqual(1024);
+    });
+
+    test('never throws when Sentry throws', () => {
+      mockWithScope.mockImplementationOnce(() => {
+        throw new Error('sentry exploded');
+      });
+      expect(() => captureMirrorException(new Error('boom'), { mirrorCmdId: 'cmd-1' })).not.toThrow();
+    });
+  });
+
+  describe('buildMirrorCommandSummary', () => {
+    test('passes through fingerprint fields and truncates lastError', () => {
+      const summary = buildMirrorCommandSummary({
+        id: 'cmd-1',
+        enqueuedAt: 1000,
+        attempts: 2,
+        status: 'failed',
+        lastError: 'x'.repeat(5000),
+        sqlLength: 42,
+        sqlHash: 'deadbeef',
+        statementsCount: 3,
+      });
+
+      expect(summary.sqlLength).toBe(42);
+      expect(summary.sqlHash).toBe('deadbeef');
+      expect(summary.statementsCount).toBe(3);
+      expect(summary.lastError.length).toBeLessThanOrEqual(1024);
+    });
+  });
+
+  describe('truncateForMirrorPayload', () => {
+    test('returns undefined for null/undefined inputs', () => {
+      expect(truncateForMirrorPayload(undefined)).toBeUndefined();
+      expect(truncateForMirrorPayload(null)).toBeUndefined();
+    });
+
+    test('respects custom max length', () => {
+      const out = truncateForMirrorPayload('abcdefghij', 4);
+      expect(out).toBe('abcd');
+    });
+  });
+});


### PR DESCRIPTION
Closes #507. Carries forward the high-value pieces of #243 onto current `main`, addresses the unresolved review feedback there, and intentionally drops the operation-tag plumbing that would have required re-applying surgery to the freshly rewritten HTTP mirror handlers.

## Summary

- Bounded ring-buffer fatal reports (`queue-fatal-ring-N.json`) replace the unbounded `queue-fatal-${timestamp}.json` scheme. Disk usage is now capped at `MIRROR_FATAL_REPORTS_MAX × MIRROR_REPORT_MAX_BYTES`.
- Reports never serialize raw SQL — only `sqlLength`, `sqlHash` (SHA-256), and `statementsCount`. Closes a long-standing leak surface.
- Optional secondary reports written on first failure (`queue-secondary-ring-N.json`) for diagnosing transient failures before retries succeed.
- Queue lifecycle Sentry breadcrumbs at every event (enqueued / started / succeeded / failedAttempt / retry-scheduled / fatal). Fatal stops also call `captureMirrorException` with attempt counts and SQL fingerprint.
- All Sentry calls wrapped in try/catch — observability failures cannot break the queue.
- `persistSecondaryReport` is best-effort by design with internal try/catch and a Sentry breadcrumb on write failure. Awaitable safely; cannot abort the retry/re-queue path.
- `createTrigger` payload duck-typing replaced with a tagged discriminated union (`{ kind: 'command' | 'retry' | 'fatal', ... }`). The SSE wire payload stays identical (bare `MirrorCommand` / `FatalInfo`) — dj-site mirror-status consumers unaffected.

## What this does NOT include (vs #243)

- Operation-tag plumbing through `mirror.middleware.ts` and `MirrorLogContext` threading into `enqueue()`. Those touch every handler in the rewritten `flowsheet.mirror.ts` / `http.mirror.ts` plus a half-dozen test files. Revisit if production Sentry reports turn out to lack discriminating tags.

## Test plan

- [x] `npm run typecheck` — passes.
- [x] `npm run lint` — 0 errors, only pre-existing warnings (lint config tightened in `0639c53`; this branch introduces none).
- [x] `npm run format:check` — clean.
- [x] `npm run test:unit` — 1035 tests pass across 85 suites; 166 pass under `--testPathPatterns=middleware/legacy` specifically.
- [ ] CI integration suite (Docker) — run by GitHub Actions; couldn't run `ci:testmock` locally without `NPM_TOKEN` for the GitHub Packages registry.
- [ ] After merge: comment on #243 with link, thank the author, close #243.

## New environment variables

All optional; defaults documented in `CLAUDE.md`. Production deployments do not need to set anything — the defaults bound disk usage to ~1.3 MiB total under the new ring-buffer scheme.

| Var | Default |
| --- | --- |
| `MIRROR_FATAL_REPORTS_MAX` | `10` |
| `MIRROR_FATAL_REPORTS_INTERVAL_MS` | `900000` |
| `MIRROR_SECONDARY_REPORTS_MAX` | `10` |
| `MIRROR_SECONDARY_REPORTS_INTERVAL_MS` | `600000` |
| `MIRROR_SECONDARY_REPORT_ON_ATTEMPT` | `1` |
| `MIRROR_REPORT_MAX_BYTES` | `65536` |
| `MIRROR_PENDING_QUEUE_SUMMARIES_MAX` | `20` |

## Coordination

#243 is the source of the design. Once this merges, #243 will be closed with a comment explaining which pieces survived intact and which were intentionally dropped.