### PR TITLE
Validate Drizzle metadata: conflict markers, prevId chain, duplicate idxs

### DIFF
--- a/scripts/validate-migrations.mjs
+++ b/scripts/validate-migrations.mjs
@@ -1,42 +1,65 @@
 #!/usr/bin/env node
 
 /**
- * Validates migration journal integrity. Run as a CI check to prevent
- * out-of-order timestamps from being merged — Drizzle silently skips
- * migrations whose "when" timestamp is earlier than the most recently
- * applied migration's created_at.
+ * Validates Drizzle migration metadata. Run as a CI check to prevent
+ * journal corruption (out-of-order timestamps, conflict markers, broken
+ * prevId chain, duplicate idxs) from being merged.
+ *
+ * Drizzle silently skips migrations whose "when" timestamp is earlier than
+ * the most recently applied migration's created_at, and `drizzle-kit generate`
+ * uses `lastEntry.idx + 1` for the next migration's idx -- so a duplicate idx
+ * cascades into ambiguous bookkeeping.
  *
  * Checks:
  * 1. All "when" timestamps are strictly monotonically increasing
  * 2. Every journal entry has a corresponding .sql file
  * 3. No orphaned .sql files exist without a journal entry
+ * 4. Every meta/*.json file parses (catches conflict markers)
+ * 5. No duplicate idxs in journal (with HISTORICAL_DUPLICATE_IDXS allowlist)
+ * 6. The latest snapshot's prevId chain is reachable back to the genesis
+ *    snapshot (allowing breaks at known-dropped historical idxs)
  *
- * See: https://github.com/WXYC/Backend-Service/issues/400
+ * See: WXYC/Backend-Service#400 (timestamp ordering),
+ *      WXYC/Backend-Service#505 (metadata repair),
+ *      WXYC/wxyc-shared#82 (Phase 4 epic).
  */
 
-import { readFileSync, readdirSync } from 'fs';
-import { existsSync } from 'fs';
+import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join } from 'path';
 
 const journalPath = 'shared/database/src/migrations/meta/_journal.json';
 const migrationsDir = 'shared/database/src/migrations';
+const metaDir = join(migrationsDir, 'meta');
+
+// Idx values that drop targets left behind. Keeping the journal/snapshot
+// state read-only means these break the prevId chain by design; the
+// validator skips them rather than failing.
+const DROPPED_IDXS = new Set([1, 5, 8]);
+
+// Historical duplicate idxs that predate this validator. Tracked as an
+// allowlist so future PRs can't introduce new ones. Each entry is a
+// duplicate idx; both journal entries at that idx are accepted.
+const HISTORICAL_DUPLICATE_IDXS = new Set([47]);
 
 const journal = JSON.parse(readFileSync(journalPath, 'utf8'));
 let errors = 0;
+let warnings = 0;
 
 // Check 1: Monotonically increasing timestamps
-let prevWhen = 0;
-let prevTag = '';
-for (const entry of journal.entries) {
-  if (entry.when <= prevWhen) {
-    console.error(
-      `ERROR: Out-of-order timestamp at idx ${entry.idx} (${entry.tag}):\n` +
-        `  when=${entry.when} must be > previous when=${prevWhen} (${prevTag})\n`
-    );
-    errors++;
+{
+  let prevWhen = 0;
+  let prevTag = '';
+  for (const entry of journal.entries) {
+    if (entry.when <= prevWhen) {
+      console.error(
+        `ERROR: Out-of-order timestamp at idx ${entry.idx} (${entry.tag}):\n` +
+          `  when=${entry.when} must be > previous when=${prevWhen} (${prevTag})\n`
+      );
+      errors++;
+    }
+    prevWhen = entry.when;
+    prevTag = entry.tag;
   }
-  prevWhen = entry.when;
-  prevTag = entry.tag;
 }
 
 // Check 2: Every journal entry has a .sql file
@@ -49,19 +72,123 @@ for (const entry of journal.entries) {
 }
 
 // Check 3: No orphaned .sql files
-const journalTags = new Set(journal.entries.map((e) => e.tag));
-const sqlFiles = readdirSync(migrationsDir).filter((f) => f.endsWith('.sql'));
-for (const file of sqlFiles) {
-  const tag = file.replace('.sql', '');
-  if (!journalTags.has(tag)) {
-    console.error(`ERROR: Orphaned SQL file not in journal: ${file}`);
+{
+  const journalTags = new Set(journal.entries.map((e) => e.tag));
+  const sqlFiles = readdirSync(migrationsDir).filter((f) => f.endsWith('.sql'));
+  for (const file of sqlFiles) {
+    const tag = file.replace('.sql', '');
+    if (!journalTags.has(tag)) {
+      console.error(`ERROR: Orphaned SQL file not in journal: ${file}`);
+      errors++;
+    }
+  }
+}
+
+// Check 4: Every meta/*.json file parses (catches merge-conflict markers)
+const snapshotsById = new Map();
+const metaFiles = readdirSync(metaDir).filter((f) => f.endsWith('.json') && f !== '_journal.json');
+for (const file of metaFiles) {
+  const path = join(metaDir, file);
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (e) {
+    console.error(`ERROR: Cannot read ${path}: ${e.message}`);
+    errors++;
+    continue;
+  }
+  if (raw.includes('<<<<<<<') || raw.includes('>>>>>>>')) {
+    console.error(`ERROR: Conflict markers in ${path}`);
+    errors++;
+    continue;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed.id) {
+      snapshotsById.set(parsed.id, { file, prevId: parsed.prevId });
+    }
+  } catch (e) {
+    console.error(`ERROR: Invalid JSON in ${path}: ${e.message}`);
     errors++;
   }
 }
 
+// Check 5: No new duplicate idxs (allowlist historical ones)
+{
+  const idxCounts = new Map();
+  for (const entry of journal.entries) {
+    idxCounts.set(entry.idx, (idxCounts.get(entry.idx) || 0) + 1);
+  }
+  for (const [idx, count] of idxCounts) {
+    if (count > 1 && !HISTORICAL_DUPLICATE_IDXS.has(idx)) {
+      const dups = journal.entries.filter((e) => e.idx === idx).map((e) => e.tag);
+      console.error(`ERROR: Duplicate idx ${idx} in journal: ${dups.join(', ')}`);
+      errors++;
+    } else if (count > 1) {
+      const dups = journal.entries.filter((e) => e.idx === idx).map((e) => e.tag);
+      console.warn(`WARN:  Historical duplicate idx ${idx} (allowlisted): ${dups.join(', ')}`);
+      warnings++;
+    }
+  }
+}
+
+// Check 6: prevId chain from latest snapshot back to genesis. Walk only the
+// latest entry's chain (not every snapshot file) so we don't fail on
+// intentionally-dropped or missing intermediate snapshots.
+//
+// We pick the latest snapshot by alphabetical filename (Drizzle's own
+// behaviour in `prepareOutFolder`) so the chain we walk matches what
+// `drizzle-kit generate` will diff against on the next migration.
+if (metaFiles.length > 0) {
+  const latestFile = [...metaFiles].sort().pop();
+  const latestRaw = readFileSync(join(metaDir, latestFile), 'utf8');
+  let latest;
+  try {
+    latest = JSON.parse(latestRaw);
+  } catch {
+    latest = null;
+  }
+  if (latest) {
+    const visited = new Set();
+    let cursor = latest;
+    let cursorFile = latestFile;
+    while (cursor && cursor.prevId && cursor.prevId !== '00000000-0000-0000-0000-000000000000') {
+      if (visited.has(cursor.id)) {
+        console.error(`ERROR: Cycle detected in prevId chain at ${cursorFile} (id=${cursor.id})`);
+        errors++;
+        break;
+      }
+      visited.add(cursor.id);
+      const next = snapshotsById.get(cursor.prevId);
+      if (!next) {
+        // Look up the matching journal entry to decide if this is a
+        // known-dropped break or a real chain corruption.
+        const cursorEntry = journal.entries.find(
+          (e) =>
+            `${e.idx.toString().padStart(4, '0')}_snapshot.json` === cursorFile ||
+            `${e.tag.split('_')[0]}_snapshot.json` === cursorFile
+        );
+        const expectedPrevIdx = cursorEntry ? cursorEntry.idx - 1 : null;
+        if (expectedPrevIdx !== null && DROPPED_IDXS.has(expectedPrevIdx)) {
+          // Expected break -- skipped/dropped historical idx. Stop walking.
+          break;
+        }
+        console.error(
+          `ERROR: prevId ${cursor.prevId} from ${cursorFile} not found in any snapshot ` +
+            `(missing intermediate snapshot or broken chain)`
+        );
+        errors++;
+        break;
+      }
+      cursor = JSON.parse(readFileSync(join(metaDir, next.file), 'utf8'));
+      cursorFile = next.file;
+    }
+  }
+}
+
 if (errors > 0) {
-  console.error(`\nMigration validation failed with ${errors} error(s).`);
+  console.error(`\nMigration validation failed with ${errors} error(s) and ${warnings} warning(s).`);
   process.exit(1);
 } else {
-  console.log(`Migration journal validation passed (${journal.entries.length} entries).`);
+  console.log(`Migration journal validation passed (${journal.entries.length} entries, ${warnings} warning(s)).`);
 }

--- a/tests/unit/scripts/validate-migrations.test.ts
+++ b/tests/unit/scripts/validate-migrations.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Spawns scripts/validate-migrations.mjs against a temp copy of the
+ * migrations directory so each scenario runs in isolation. The validator
+ * is a CI gate, so the cases here mirror the regressions it has to catch.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { spawnSync } from 'child_process';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const validatorPath = path.join(repoRoot, 'scripts/validate-migrations.mjs');
+const sourceMigrationsDir = path.join(repoRoot, 'shared/database/src/migrations');
+
+function run(workdir: string): { status: number; stdout: string; stderr: string } {
+  const result = spawnSync('node', [validatorPath], { cwd: workdir, encoding: 'utf8' });
+  return { status: result.status ?? -1, stdout: result.stdout, stderr: result.stderr };
+}
+
+function setUpFixture(): string {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'validate-migrations-'));
+  const targetDir = path.join(tmpRoot, 'shared/database/src/migrations');
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.cpSync(sourceMigrationsDir, targetDir, { recursive: true });
+  return tmpRoot;
+}
+
+function readJournal(workdir: string): {
+  entries: Array<{ idx: number; tag: string; when: number; version: string; breakpoints: boolean }>;
+} {
+  const journalPath = path.join(workdir, 'shared/database/src/migrations/meta/_journal.json');
+  return JSON.parse(fs.readFileSync(journalPath, 'utf8'));
+}
+
+function writeJournal(workdir: string, journal: object): void {
+  const journalPath = path.join(workdir, 'shared/database/src/migrations/meta/_journal.json');
+  fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2));
+}
+
+describe('validate-migrations.mjs', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = setUpFixture();
+  });
+
+  afterEach(() => {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  });
+
+  test('passes on the current repo state', () => {
+    const { status, stdout } = run(workdir);
+    expect(status).toBe(0);
+    expect(stdout).toContain('validation passed');
+  });
+
+  test('flags out-of-order timestamps', () => {
+    const journal = readJournal(workdir);
+    journal.entries[journal.entries.length - 1].when = 0;
+    writeJournal(workdir, journal);
+
+    const { status, stderr } = run(workdir);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/Out-of-order timestamp/);
+  });
+
+  test('flags conflict markers in snapshot files', () => {
+    const snapshotPath = path.join(workdir, 'shared/database/src/migrations/meta/0055_snapshot.json');
+    const raw = fs.readFileSync(snapshotPath, 'utf8');
+    fs.writeFileSync(snapshotPath, '<<<<<<< HEAD\n' + raw + '\n>>>>>>> branch');
+
+    const { status, stderr } = run(workdir);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/Conflict markers/);
+  });
+
+  test('flags non-allowlisted duplicate idxs', () => {
+    const journal = readJournal(workdir);
+    // Duplicate idx 50 (not in HISTORICAL_DUPLICATE_IDXS allowlist)
+    journal.entries.push({
+      idx: 50,
+      version: '7',
+      when: Date.now(),
+      tag: '0050_flowsheet-track-add-time-idx',
+      breakpoints: true,
+    });
+    writeJournal(workdir, journal);
+
+    const { status, stderr } = run(workdir);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/Duplicate idx 50/);
+  });
+
+  test('flags missing SQL files for journal entries', () => {
+    const journal = readJournal(workdir);
+    journal.entries.push({
+      idx: 100,
+      version: '7',
+      when: Date.now(),
+      tag: 'nonexistent_tag',
+      breakpoints: true,
+    });
+    writeJournal(workdir, journal);
+
+    const { status, stderr } = run(workdir);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/Missing SQL file/);
+  });
+
+  test('flags orphaned SQL files not in the journal', () => {
+    const orphanPath = path.join(workdir, 'shared/database/src/migrations/9999_orphan.sql');
+    fs.writeFileSync(orphanPath, '-- orphan\n');
+
+    const { status, stderr } = run(workdir);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/Orphaned SQL file/);
+  });
+
+  test('warns on the historical idx 47 duplicate but does not fail', () => {
+    const { status, stdout, stderr } = run(workdir);
+    expect(status).toBe(0);
+    // Warnings go to stderr (console.warn), summary goes to stdout
+    expect(stderr + stdout).toMatch(/Historical duplicate idx 47/);
+  });
+
+  test('flags a broken prevId chain (not a dropped-idx break)', () => {
+    // The latest snapshot's prevId points at 0046's id. Replace 0055's
+    // prevId with a UUID that doesn't exist in any snapshot.
+    const latestPath = path.join(workdir, 'shared/database/src/migrations/meta/0055_snapshot.json');
+    const snap = JSON.parse(fs.readFileSync(latestPath, 'utf8'));
+    snap.prevId = '00000000-1111-2222-3333-444444444444';
+    fs.writeFileSync(latestPath, JSON.stringify(snap, null, 2));
+
+    const { status, stderr } = run(workdir);
+    expect(status).toBe(1);
+    expect(stderr).toMatch(/prevId .* not found in any snapshot/);
+  });
+});


### PR DESCRIPTION
## Summary

The original `scripts/validate-migrations.mjs` only checked timestamps, SQL files, and orphans. It missed the failure modes that PR #482 had to hand-patch around when generating the 0055 migration: literal merge-conflict markers in `meta/0045_snapshot.json` and `meta/0046_snapshot.json` (committed in 09a6f96), an `idx: 47` duplicated in the journal, and a broken `prevId` chain at the 0044→0045 boundary. The current state passes, but only because #482 fixed those three by hand.

This PR extends the validator with three new checks so the next regression is caught before it reaches `main`, and locks the behaviour in with unit tests.

### Checks added

- **Conflict markers / JSON parse**: every `meta/*.json` is scanned for `<<<<<<<` / `>>>>>>>` and parsed. A bad JSON parse is an error.
- **Duplicate idxs**: journal idxs must be unique, with an explicit `HISTORICAL_DUPLICATE_IDXS = {47}` allowlist for the predating bug so future PRs are blocked but CI doesn't break on the existing state.
- **prevId chain**: the latest snapshot's `prevId` chain is walked back to genesis. Breaks at `DROPPED_IDXS = {1, 5, 8}` (entries removed via `drizzle-kit drop`) are tolerated; any other dangling `prevId` is an error.

### Cut-over rationale

Per the issue's recommended approach, the missing 0036, 0041, 0047-0054 snapshot files are **not** reconstructed. `drizzle-kit` reads `meta/*.json` alphabetically and only diffs against the latest snapshot for forward generation (verified: `drizzle-kit generate` reports "No schema changes, nothing to migrate"), so the gap doesn't affect new migrations. The validator's chain walk reaches genesis through existing snapshots without traversing the missing ones.

### Verification

- `npm run lint:migrations` passes with one allowlisted warning for the historical idx 47 duplicate.
- `npm run typecheck`, `npm run lint`, `npm run format:check` all pass.
- `npm run test:unit`: 1050 tests pass, including 8 new tests in `tests/unit/scripts/validate-migrations.test.ts` covering each check.
- `drizzle-kit generate` against current `schema.ts` still reports clean (so 0055_snapshot.json correctly reflects current state).

## Test plan

- [ ] CI green
- [ ] Reviewer confirms the allowlist for idx 47 makes sense (vs. the alternative of renumbering 9 journal entries and renaming the latest snapshot file)

Closes #505