### PR TITLE
Add flowsheet.dj_name backfill job (one-shot)

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -413,13 +413,26 @@ jobs:
         run: |
           TARGET_APP=${{ matrix.target }}
           if [ -f "jobs/$TARGET_APP/package.json" ]; then
-            TARGET_TYPE="job"
-            CRON_SCHEDULE=$(yq -r '.["cron-schedule"]' jobs/$TARGET_APP/package.json)
-            if [ -z "$CRON_SCHEDULE" ] || [ "$CRON_SCHEDULE" = "null" ]; then
-              echo "Missing cron-schedule in jobs/$TARGET_APP/package.json" >&2
+            # job-type defaults to "cron" for backward compatibility with the
+            # existing flowsheet/library/rotation/artist-identity ETLs. Set
+            # "one-shot" in package.json for backfills that the build pushes
+            # to ECR but does NOT register in the crontab — those are invoked
+            # manually via `docker run` during a maintenance window.
+            JOB_TYPE=$(yq -r '.["job-type"] // "cron"' jobs/$TARGET_APP/package.json)
+            if [ "$JOB_TYPE" = "one-shot" ]; then
+              TARGET_TYPE="one-shot-job"
+            elif [ "$JOB_TYPE" = "cron" ]; then
+              TARGET_TYPE="job"
+              CRON_SCHEDULE=$(yq -r '.["cron-schedule"]' jobs/$TARGET_APP/package.json)
+              if [ -z "$CRON_SCHEDULE" ] || [ "$CRON_SCHEDULE" = "null" ]; then
+                echo "Missing cron-schedule in jobs/$TARGET_APP/package.json (job-type=cron)" >&2
+                exit 1
+              fi
+              echo "cron_schedule=$CRON_SCHEDULE" >> $GITHUB_OUTPUT
+            else
+              echo "Unknown job-type '$JOB_TYPE' in jobs/$TARGET_APP/package.json (expected 'cron' or 'one-shot')" >&2
               exit 1
             fi
-            echo "cron_schedule=$CRON_SCHEDULE" >> $GITHUB_OUTPUT
           else
             TARGET_TYPE="app"
             PUBLISH_PORT=$(yq .publishPort apps/$TARGET_APP/package.json)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,17 +6,18 @@ API and authentication service for WXYC applications. Provides endpoints for the
 
 ### Monorepo Layout
 
-npm workspaces with four packages:
+npm workspaces:
 
-| Package                     | Path                        | Purpose                                                |
-| --------------------------- | --------------------------- | ------------------------------------------------------ |
-| `@wxyc/backend`             | `apps/backend/`             | Express API server (port 8080)                         |
-| `@wxyc/auth-service`        | `apps/auth/`                | better-auth server (port 8082)                         |
-| `@wxyc/database`            | `shared/database/`          | Drizzle ORM schema, client, migrations, ETL utilities  |
-| `@wxyc/authentication`      | `shared/authentication/`    | Auth middleware, roles, JWT verification               |
-| `@wxyc/flowsheet-etl`       | `jobs/flowsheet-etl/`       | Flowsheet ETL: sync from tubafrenzy                    |
-| `@wxyc/rotation-etl`        | `jobs/rotation-etl/`        | Rotation ETL: sync from tubafrenzy                     |
-| `@wxyc/artist-identity-etl` | `jobs/artist-identity-etl/` | Artist identity ETL: sync from LML's `entity.identity` |
+| Package                            | Path                               | Purpose                                                                                   |
+| ---------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| `@wxyc/backend`                    | `apps/backend/`                    | Express API server (port 8080)                                                            |
+| `@wxyc/auth-service`               | `apps/auth/`                       | better-auth server (port 8082)                                                            |
+| `@wxyc/database`                   | `shared/database/`                 | Drizzle ORM schema, client, migrations, ETL utilities                                     |
+| `@wxyc/authentication`             | `shared/authentication/`           | Auth middleware, roles, JWT verification                                                  |
+| `@wxyc/flowsheet-etl`              | `jobs/flowsheet-etl/`              | Flowsheet ETL: sync from tubafrenzy                                                       |
+| `@wxyc/rotation-etl`               | `jobs/rotation-etl/`               | Rotation ETL: sync from tubafrenzy                                                        |
+| `@wxyc/artist-identity-etl`        | `jobs/artist-identity-etl/`        | Artist identity ETL: sync from LML's `entity.identity`                                    |
+| `@wxyc/flowsheet-dj-name-backfill` | `jobs/flowsheet-dj-name-backfill/` | One-shot backfill: populate `flowsheet.dj_name` on legacy track rows after migration 0053 |
 
 ### API Server (`apps/backend`)
 
@@ -83,6 +84,8 @@ npm run drizzle:generate   # Generate SQL migration from schema changes
 npm run drizzle:migrate    # Apply migrations to database
 npm run drizzle:drop       # Delete a migration file
 ```
+
+**Migrations are DDL-only.** Bulk DML (rewrites of more than ~10k rows) does not belong inside a migration file because the DDL portion takes an `AccessExclusiveLock` that is held until the transaction commits, and a long DML can wedge the table for hours. Put the rewrite in a one-shot backfill job under `jobs/<name>-backfill/` (declared with `"job-type": "one-shot"` in `package.json`). The build pipeline pushes the image to ECR; a human invokes it via `docker run --rm --env-file .env <image>` during a low-traffic window. If a downstream migration depends on the backfill having run, gate it with a `DO $$ ... RAISE EXCEPTION ... END $$;` precondition guard at the top of the file. See `0053_flowsheet-dj-name-column.sql` + `jobs/flowsheet-dj-name-backfill/` + `0054_flowsheet-search-doc-with-dj-name.sql` for the canonical pattern, and issue #511 for the incident this rule was learned from.
 
 ### Authentication (`shared/authentication`)
 

--- a/Dockerfile.flowsheet-dj-name-backfill
+++ b/Dockerfile.flowsheet-dj-name-backfill
@@ -1,0 +1,27 @@
+#Build stage
+FROM node:25-alpine AS builder
+
+WORKDIR /flowsheet-dj-name-backfill-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/flowsheet-dj-name-backfill ./jobs/flowsheet-dj-name-backfill
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/flowsheet-dj-name-backfill
+
+#Production stage
+FROM node:25-alpine AS prod
+
+WORKDIR /flowsheet-dj-name-backfill
+
+COPY ./package* ./
+COPY ./jobs/flowsheet-dj-name-backfill/package* ./jobs/flowsheet-dj-name-backfill/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./flowsheet-dj-name-backfill-builder/jobs/flowsheet-dj-name-backfill/dist ./jobs/flowsheet-dj-name-backfill/dist
+COPY --from=builder ./flowsheet-dj-name-backfill-builder/shared/database/dist ./shared/database/dist
+
+CMD ["npm", "start", "--workspace=@wxyc/flowsheet-dj-name-backfill"]

--- a/jobs/flowsheet-dj-name-backfill/job.ts
+++ b/jobs/flowsheet-dj-name-backfill/job.ts
@@ -1,0 +1,145 @@
+/**
+ * One-shot backfill: populate flowsheet.dj_name on legacy track rows.
+ *
+ * Splits the large UPDATE that was originally embedded in migration 0053 into
+ * batched, individually-committed UPDATEs so a long run cannot hold an
+ * AccessExclusiveLock or wedge concurrent reads. Each batch is bounded by
+ * `BATCH_SIZE`, ordered by `id`, and naturally restartable via the
+ * `dj_name IS NULL` filter (re-running picks up exactly the rows the previous
+ * run did not finish).
+ *
+ * The COALESCE order matches the search service's DJ_NAME_EXPR and the live
+ * insert path, so every row carries the same resolved name regardless of
+ * which subsystem populated it.
+ *
+ * Track-only filter: matches the precondition guard in migration 0054, which
+ * only requires dj_name on track rows. Non-track entries (talkset, breakpoint,
+ * show_start, etc.) keep dj_name NULL — search never reads them.
+ *
+ * Run procedure: see Backend-Service/CLAUDE.md and issue #511. Build via
+ * `Manual Build & Deploy` with `target=flowsheet-dj-name-backfill`, then SSH
+ * to EC2 and `docker run --rm --env-file .env <image> 2>&1 | tee log`.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db, closeDatabaseConnection } from '@wxyc/database';
+
+const JOB_NAME = 'flowsheet-dj-name-backfill';
+const BATCH_SIZE = 5000;
+const PROGRESS_LOG_EVERY = 1; // every batch; the operation is rare enough that verbose is fine
+
+/**
+ * Apply one batch of dj_name updates and return the number of rows changed.
+ * Each call is its own implicit transaction (postgres-js commits per execute
+ * unless wrapped in db.transaction). Returning 0 means we have backfilled
+ * every track row reachable through a `shows` join.
+ */
+const applyBatch = async (batchSize: number): Promise<number> => {
+  const result = await db.execute(sql`
+    UPDATE "wxyc_schema"."flowsheet" AS f
+    SET "dj_name" = COALESCE(u."dj_name", s."legacy_dj_name", u."name")
+    FROM "wxyc_schema"."shows" AS s
+    LEFT JOIN "auth_user" AS u ON u."id" = s."primary_dj_id"
+    WHERE f."show_id" = s."id"
+      AND f."entry_type" = 'track'
+      AND f."dj_name" IS NULL
+      AND f."id" IN (
+        SELECT "id" FROM "wxyc_schema"."flowsheet"
+        WHERE "entry_type" = 'track'
+          AND "dj_name" IS NULL
+        ORDER BY "id"
+        LIMIT ${batchSize}
+      )
+  `);
+  return Number(result.count ?? 0);
+};
+
+/**
+ * Format a millisecond duration as `Xm Ys` for human-readable progress logs.
+ */
+const formatDuration = (ms: number): string => {
+  const totalSec = Math.round(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}m ${sec}s`;
+};
+
+const runBackfill = async () => {
+  console.log(`[${JOB_NAME}] Starting backfill of flowsheet.dj_name (track rows).`);
+  console.log(`[${JOB_NAME}] Batch size: ${BATCH_SIZE}.`);
+
+  const startedAt = Date.now();
+  let batches = 0;
+  let totalUpdated = 0;
+  let consecutiveEmpty = 0;
+
+  while (true) {
+    const batchStartedAt = Date.now();
+    const updated = await applyBatch(BATCH_SIZE);
+    batches++;
+    totalUpdated += updated;
+
+    if (updated === 0) {
+      // One empty batch is the natural end. Log and break. We do not retry on
+      // empty because that would loop forever in a fully-backfilled state.
+      consecutiveEmpty++;
+      if (consecutiveEmpty >= 1) {
+        break;
+      }
+    } else {
+      consecutiveEmpty = 0;
+    }
+
+    if (batches % PROGRESS_LOG_EVERY === 0) {
+      const batchMs = Date.now() - batchStartedAt;
+      const elapsedMs = Date.now() - startedAt;
+      console.log(
+        `[${JOB_NAME}] batch ${batches}: ${updated} rows in ${formatDuration(batchMs)} | ` +
+          `total ${totalUpdated} rows in ${formatDuration(elapsedMs)}`
+      );
+    }
+  }
+
+  const elapsedMs = Date.now() - startedAt;
+  console.log(
+    `[${JOB_NAME}] Done. Updated ${totalUpdated} rows across ${batches} batches in ${formatDuration(elapsedMs)}.`
+  );
+};
+
+/**
+ * Verify the backfill is complete: 0 track rows with NULL dj_name. Run as a
+ * post-flight check so a deploy that follows can apply migration 0054 without
+ * tripping its precondition guard. Logs the count and (only) raises if any
+ * remain — typical operator-friendly output even on success.
+ */
+const verifyComplete = async () => {
+  const result = await db.execute(
+    sql`SELECT count(*)::int AS missing FROM "wxyc_schema"."flowsheet" WHERE entry_type = 'track' AND dj_name IS NULL`
+  );
+  const missing = Number((result as unknown as Array<{ missing: number }>)[0]?.missing ?? 0);
+  if (missing > 0) {
+    throw new Error(
+      `[${JOB_NAME}] Verification failed: ${missing} track row(s) still have dj_name IS NULL. ` +
+        `Re-run the backfill — it is idempotent and will pick up the remaining rows.`
+    );
+  }
+  console.log(`[${JOB_NAME}] Verification passed: 0 track rows with dj_name IS NULL.`);
+};
+
+const main = async () => {
+  try {
+    await runBackfill();
+    await verifyComplete();
+  } finally {
+    await closeDatabaseConnection();
+  }
+};
+
+main().catch((error) => {
+  console.error(`[${JOB_NAME}] Failed:`, error);
+  process.exitCode = 1;
+});
+
+// Exports for unit tests. Production entry point is the `main()` invocation
+// above; tests reach into the individual primitives.
+export { applyBatch, runBackfill, verifyComplete, formatDuration, BATCH_SIZE };

--- a/jobs/flowsheet-dj-name-backfill/package.json
+++ b/jobs/flowsheet-dj-name-backfill/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wxyc/flowsheet-dj-name-backfill",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot backfill: populate flowsheet.dj_name on legacy track rows",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_flowsheet_dj_name_backfill:ci -f ../../Dockerfile.flowsheet-dj-name-backfill ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/flowsheet-dj-name-backfill/tsconfig.json
+++ b/jobs/flowsheet-dj-name-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/flowsheet-dj-name-backfill/tsup.config.ts
+++ b/jobs/flowsheet-dj-name-backfill/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -441,6 +441,20 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/flowsheet-dj-name-backfill": {
+      "name": "@wxyc/flowsheet-dj-name-backfill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/flowsheet-etl": {
       "name": "@wxyc/flowsheet-etl",
       "version": "1.0.0",
@@ -6989,6 +7003,10 @@
     },
     "node_modules/@wxyc/database": {
       "resolved": "shared/database",
+      "link": true
+    },
+    "node_modules/@wxyc/flowsheet-dj-name-backfill": {
+      "resolved": "jobs/flowsheet-dj-name-backfill",
       "link": true
     },
     "node_modules/@wxyc/flowsheet-etl": {

--- a/tests/unit/jobs/flowsheet-dj-name-backfill/job.test.ts
+++ b/tests/unit/jobs/flowsheet-dj-name-backfill/job.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for the flowsheet.dj_name backfill job.
+ *
+ * The backfill is the runtime counterpart to the DDL-only migration 0053:
+ * after the column is added (NULL on every row), this job populates legacy
+ * track rows in batched UPDATEs that each commit independently. The 0054
+ * migration cannot apply until this backfill is verified complete.
+ */
+
+import { db } from '@wxyc/database';
+import {
+  applyBatch,
+  runBackfill,
+  verifyComplete,
+  formatDuration,
+  BATCH_SIZE,
+} from '../../../../jobs/flowsheet-dj-name-backfill/job';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const findExecuteCallMatching = (pattern: RegExp): unknown[] | undefined => {
+  const calls = (db.execute as jest.Mock).mock.calls;
+  return calls.find((call) => pattern.test(renderSql(call[0])));
+};
+
+describe('flowsheet-dj-name-backfill: applyBatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds an UPDATE that COALESCEs auth_user.dj_name → shows.legacy_dj_name → auth_user.name', async () => {
+    // Match the same precedence the search service and live insert path use.
+    // Drift here would silently change which name appears for legacy rows.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 5000 });
+
+    await applyBatch(5000);
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*dj_name[\s\S]*COALESCE/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/COALESCE\(\s*u\."dj_name",\s*s\."legacy_dj_name",\s*u\."name"\s*\)/);
+  });
+
+  it('restricts the UPDATE to track rows with NULL dj_name within a bounded batch', async () => {
+    // Three regression guards in one test:
+    //   - entry_type = 'track' filter (matches 0054's precondition guard)
+    //   - dj_name IS NULL (idempotency: re-run skips already-backfilled rows)
+    //   - LIMIT in an inner SELECT (bounded batch — never an unbounded UPDATE)
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 5000 });
+
+    await applyBatch(5000);
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*dj_name/i);
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/entry_type"?\s*=\s*'track'/i);
+    expect(sqlText).toMatch(/dj_name"?\s+IS\s+NULL/i);
+    expect(sqlText).toMatch(/LIMIT/i);
+  });
+
+  it('passes the batch size argument through into the SQL builder', async () => {
+    // Looser assertion than reaching into Drizzle's queryChunks shape (which
+    // varies between Drizzle versions). The point of the test is that the
+    // function actually uses its argument; serializing the SQL and JSON-
+    // stringifying the parameter object catches the value either as a
+    // bound parameter or an inlined literal.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await applyBatch(1234);
+
+    const call = (db.execute as jest.Mock).mock.calls.find((c) =>
+      /UPDATE[\s\S]*flowsheet[\s\S]*dj_name/i.test(renderSql(c[0]))
+    );
+    const serialized = JSON.stringify(call?.[0]);
+    expect(serialized).toContain('1234');
+  });
+
+  it('returns the postgres-js result.count as the rows-updated number', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 4321 });
+
+    const updated = await applyBatch(5000);
+
+    expect(updated).toBe(4321);
+  });
+
+  it('returns 0 when the result has no count property (empty result)', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({});
+
+    const updated = await applyBatch(5000);
+
+    expect(updated).toBe(0);
+  });
+});
+
+describe('flowsheet-dj-name-backfill: runBackfill loop control', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('iterates batches until applyBatch returns 0 (natural end)', async () => {
+    // Three non-empty batches, then one empty batch terminates the loop.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce({ count: 5000 })
+      .mockResolvedValueOnce({ count: 5000 })
+      .mockResolvedValueOnce({ count: 1234 })
+      .mockResolvedValueOnce({ count: 0 });
+
+    await runBackfill();
+
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(4);
+  });
+
+  it('exits cleanly on the very first empty batch (already-backfilled state)', async () => {
+    // Re-running on a fully-backfilled DB must be a no-op, not loop forever.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await runBackfill();
+
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  it('uses BATCH_SIZE of 5000 (not unbounded)', () => {
+    // The whole point of the rewrite is bounded UPDATEs. If a future change
+    // accidentally bumps the batch size into the millions or removes the LIMIT,
+    // this test catches it.
+    expect(BATCH_SIZE).toBe(5000);
+  });
+});
+
+describe('flowsheet-dj-name-backfill: verifyComplete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('passes when zero track rows have NULL dj_name', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ missing: 0 }]);
+
+    await expect(verifyComplete()).resolves.toBeUndefined();
+  });
+
+  it('throws with a remediation hint when track rows still have NULL dj_name', async () => {
+    // mockResolvedValue (not Once) so both rejection assertions get the
+    // same response — the second await re-invokes verifyComplete.
+    (db.execute as jest.Mock).mockResolvedValue([{ missing: 137 }]);
+
+    await expect(verifyComplete()).rejects.toThrow(/137 track row\(s\)/);
+    await expect(verifyComplete()).rejects.toThrow(/idempotent/i);
+  });
+});
+
+describe('flowsheet-dj-name-backfill: formatDuration', () => {
+  it('formats sub-minute durations as "0m Xs"', () => {
+    expect(formatDuration(0)).toBe('0m 0s');
+    expect(formatDuration(1500)).toBe('0m 2s');
+    expect(formatDuration(45_000)).toBe('0m 45s');
+  });
+
+  it('formats multi-minute durations as "Xm Ys"', () => {
+    expect(formatDuration(60_000)).toBe('1m 0s');
+    expect(formatDuration(125_000)).toBe('2m 5s');
+    expect(formatDuration(3_600_000)).toBe('60m 0s');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `@wxyc/flowsheet-dj-name-backfill` at `jobs/flowsheet-dj-name-backfill/` — runtime counterpart to migration 0053. Populates `flowsheet.dj_name` on legacy track rows in batched UPDATEs of 5000, each its own transaction. Idempotent via `WHERE dj_name IS NULL`; restartable.
- Adds `Dockerfile.flowsheet-dj-name-backfill` matching the existing ETL Dockerfile pattern.
- Teaches the deploy workflow about a new `job-type` field in `package.json`. Default `cron` (no behavior change for flowsheet-etl, library-etl, rotation-etl, artist-identity-etl). New value `one-shot` builds + pushes the image to ECR but skips the cron-install and post-deploy confirmation steps — the operator invokes manually.
- Documents the migration-vs-backfill rule in `Backend-Service/CLAUDE.md` so the lesson from #511 is durable.

## Why

Companion to PR #515. With migration 0053 reduced to DDL-only, `dj_name` ends up NULL on every legacy row. Migration 0054 has a precondition guard that fails the deploy until backfill runs. This PR is what runs.

## Sequencing (after this PR merges)

This PR's CI must merge first, then the auto-deploy will:
1. **Build** — pushes `flowsheet-dj-name-backfill:vX.Y.Z` to ECR.
2. **Migrate** — 0053 already applied (column exists); 0054 still fails its guard. Migrate step exits non-zero. *Expected.* Build artifacts are in ECR regardless.

Then a human, during a low-traffic window:

```bash
ssh wxyc-ec2
aws ecr get-login-password --region us-east-1 \
  | docker login --username AWS --password-stdin 203767826763.dkr.ecr.us-east-1.amazonaws.com
docker pull 203767826763.dkr.ecr.us-east-1.amazonaws.com/flowsheet-dj-name-backfill:latest
docker run --rm --env-file .env \
  203767826763.dkr.ecr.us-east-1.amazonaws.com/flowsheet-dj-name-backfill:latest \
  2>&1 | tee /tmp/backfill-$(date +%s).log
```

Expected runtime: ~2.6M track rows ÷ 5000 batch = ~520 batches. With JOIN cost + commit overhead, estimate 30-60 min. The job verifies completion at the end (`verifyComplete()`) and exits non-zero if any track row still has `dj_name IS NULL`.

After verification passes, a tiny follow-up PR strips the precondition guard from `0054_flowsheet-search-doc-with-dj-name.sql`. The next deploy applies 0054 + 0055.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (257 pre-existing warnings)
- [x] `npm run format:check` — clean
- [x] `npm run lint:migrations` — passes (1 historical allowlisted warning)
- [x] `npm run test:unit` — 1077 / 1077 passing, stable across 3 consecutive full runs
- [x] 12 new unit tests covering: COALESCE precedence, batch boundedness (entry_type filter, NULL filter, LIMIT), batch-size argument flow, rowCount unwrapping, default to 0 on empty result, loop termination on empty batch, no-op on already-backfilled DB, BATCH_SIZE pinned to 5000, verifyComplete pass/fail, formatDuration formatting
- [x] `@wxyc/flowsheet-dj-name-backfill` and `@wxyc/database` build cleanly via tsup
- [ ] Post-merge: confirm new image lands in ECR (`flowsheet-dj-name-backfill` repository)
- [ ] Post-merge: run the backfill manually per the procedure above; verify `verifyComplete` passes
- [ ] Post-merge follow-up PR: strip the 0054 guard

Refs #511.