### PR TITLE
Set per-connection statement_timeout on every postgres-js client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,8 @@ Connects to tubafrenzy's CDC WebSocket and verifies changes land in Backend-Serv
 - `DB_PORT` (default 5432)
 - `CI_DB_PORT` (default 5433)
 - `WXYC_SCHEMA_NAME` (default `wxyc_schema`)
+- `DB_STATEMENT_TIMEOUT_MS` (default `5000` / 5s) -- Server-enforced per-statement timeout on every postgres-js connection. Backend and auth inherit the default — any HTTP-handler query that runs longer than 5s is by definition an orphan (Express's request timeout has already fired). ETLs override to `300000` (5min) in their Dockerfiles because their bulk passes can legitimately take tens of seconds. Backfills override similarly. Set `0` to disable (use only for unit-test fixtures).
+- `DB_APPLICATION_NAME` (default `wxyc-backend`) -- Sets `application_name` on the postgres connection so `pg_stat_activity` makes the source obvious during incident triage. Each Dockerfile overrides this with its own service name (`wxyc-backend`, `wxyc-auth`, `wxyc-flowsheet-etl`, etc.).
 
 ### better-auth
 

--- a/Dockerfile.artist-identity-etl
+++ b/Dockerfile.artist-identity-etl
@@ -24,4 +24,8 @@ RUN npm install --omit=dev
 COPY --from=builder ./artist-identity-etl-builder/jobs/artist-identity-etl/dist ./jobs/artist-identity-etl/dist
 COPY --from=builder ./artist-identity-etl-builder/shared/database/dist ./shared/database/dist
 
+# Override the @wxyc/database default of 5s. See shared/database/src/client.ts.
+ENV DB_STATEMENT_TIMEOUT_MS=300000
+ENV DB_APPLICATION_NAME=wxyc-artist-identity-etl
+
 CMD ["npm", "start", "--workspace=@wxyc/artist-identity-etl"]

--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -30,4 +30,10 @@ COPY --from=builder ./auth-builder/apps/auth/dist ./apps/auth/dist
 COPY --from=builder ./auth-builder/shared/database/dist ./shared/database/dist
 COPY --from=builder ./auth-builder/shared/authentication/dist ./shared/authentication/dist
 
+# Inherit the @wxyc/database 5s default. Auth handlers finish in
+# milliseconds (better-auth's queries are JWKS lookups, session reads,
+# permission checks). Anything over 5s is an orphan. See
+# shared/database/src/client.ts.
+ENV DB_APPLICATION_NAME=wxyc-auth
+
 CMD ["npm", "start", "--workspace=@wxyc/auth-service"]

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -30,4 +30,11 @@ COPY --from=builder ./builder/apps/backend/dist ./apps/backend/dist
 COPY --from=builder ./builder/shared/database/dist ./shared/database/dist
 COPY --from=builder ./builder/shared/authentication/dist ./shared/authentication/dist
 
+# Inherit the @wxyc/database 5s default. Backend HTTP handlers always finish
+# in milliseconds; anything longer than 5s is an orphan from a request that
+# already timed out at the Express layer (see shared/database/src/client.ts).
+# Set the application_name explicitly so pg_stat_activity makes the source
+# obvious during incident triage.
+ENV DB_APPLICATION_NAME=wxyc-backend
+
 CMD ["npm", "start", "--workspace=@wxyc/backend"]

--- a/Dockerfile.flowsheet-etl
+++ b/Dockerfile.flowsheet-etl
@@ -24,4 +24,11 @@ RUN npm install --omit=dev
 COPY --from=builder ./flowsheet-etl-builder/jobs/flowsheet-etl/dist ./jobs/flowsheet-etl/dist
 COPY --from=builder ./flowsheet-etl-builder/shared/database/dist ./shared/database/dist
 
+# Override the @wxyc/database default of 5s. ETL UPDATE/SELECT batches can
+# legitimately take tens of seconds on the 2.6M-row flowsheet table. The
+# 5min cap still keeps a runaway query from wedging the cron tick. See
+# shared/database/src/client.ts for the rationale.
+ENV DB_STATEMENT_TIMEOUT_MS=300000
+ENV DB_APPLICATION_NAME=wxyc-flowsheet-etl
+
 CMD ["npm", "start", "--workspace=@wxyc/flowsheet-etl"]

--- a/Dockerfile.library-etl
+++ b/Dockerfile.library-etl
@@ -24,4 +24,11 @@ RUN npm install --omit=dev
 COPY --from=builder ./library-etl-builder/jobs/library-etl/dist ./jobs/library-etl/dist
 COPY --from=builder ./library-etl-builder/shared/database/dist ./shared/database/dist
 
+# Override the @wxyc/database default of 5s. Bulk ETL queries (legacy joins,
+# album/release reconciliation passes) can run tens of seconds on a fresh
+# library cache. Without this override the cron tick would 5s-timeout. See
+# shared/database/src/client.ts for the rationale.
+ENV DB_STATEMENT_TIMEOUT_MS=300000
+ENV DB_APPLICATION_NAME=wxyc-library-etl
+
 CMD ["npm", "start", "--workspace=@wxyc/library-etl"]

--- a/Dockerfile.rotation-etl
+++ b/Dockerfile.rotation-etl
@@ -24,4 +24,8 @@ RUN npm install --omit=dev
 COPY --from=builder ./rotation-etl-builder/jobs/rotation-etl/dist ./jobs/rotation-etl/dist
 COPY --from=builder ./rotation-etl-builder/shared/database/dist ./shared/database/dist
 
+# Override the @wxyc/database default of 5s. See shared/database/src/client.ts.
+ENV DB_STATEMENT_TIMEOUT_MS=300000
+ENV DB_APPLICATION_NAME=wxyc-rotation-etl
+
 CMD ["npm", "start", "--workspace=@wxyc/rotation-etl"]

--- a/shared/database/src/client.ts
+++ b/shared/database/src/client.ts
@@ -10,13 +10,63 @@ if (missingVars.length > 0) {
   throw new Error(`Missing required database environment variables: ${missingVars.join(', ')}`);
 }
 
+/**
+ * Resolve the per-connection `statement_timeout` (in ms) for this process.
+ *
+ * Three classes of caller:
+ *   - HTTP request handlers (apps/backend, apps/auth) — every query should
+ *     finish within seconds. Express's own request timeout is 30s. A query
+ *     longer than that is always an orphan (the HTTP response went out long
+ *     ago). The default 5s catches that aggressively.
+ *   - Migrations (db-migrate image) — DDL is normally instant but ALTER
+ *     against contended tables can need a few seconds. Set
+ *     `DB_STATEMENT_TIMEOUT_MS=300000` (5 min) in the migrate container.
+ *   - One-shot backfills (jobs/<x>-backfill/) — bounded batches, but each
+ *     batch can be 30-60s on a hot table. Set
+ *     `DB_STATEMENT_TIMEOUT_MS=300000` or higher in the backfill container.
+ *
+ * Setting `0` disables the timeout (postgres-js default behaviour). Use that
+ * only for unit-test fixtures or one-off scripts.
+ *
+ * Reason this lives at connection level: HTTP request abort does not
+ * propagate to postgres-js, so a 504 returned to the client leaves the SQL
+ * running. Without a server-side cap, a backend with a few sluggish
+ * endpoints will accumulate orphans until the connection pool is exhausted
+ * — exactly the wedge from incident #511.
+ */
+/**
+ * Pure helper for resolving the `statement_timeout` from environment input.
+ * Exported so unit tests can validate parsing behaviour without dragging in
+ * the real postgres-js connection.
+ */
+export const resolveStatementTimeoutMs = (raw: string | undefined = process.env.DB_STATEMENT_TIMEOUT_MS): number => {
+  if (raw === undefined) return 5000;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(
+      `Invalid DB_STATEMENT_TIMEOUT_MS=${JSON.stringify(raw)}; must be a non-negative integer (ms). Use 0 to disable.`
+    );
+  }
+  return parsed;
+};
+
+const statementTimeoutMs = resolveStatementTimeoutMs();
+
 const queryClient = postgres({
   host: process.env.DB_HOST,
   port: process.env.DB_PORT != null ? Number(process.env.DB_PORT) : 5432,
   database: process.env.DB_NAME,
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
+  connection: {
+    application_name: process.env.DB_APPLICATION_NAME ?? 'wxyc-backend',
+    // Server-enforced per-statement timeout. postgres-js issues this as
+    // `SET statement_timeout = '<n>ms'` after each session is established.
+    statement_timeout: statementTimeoutMs,
+  },
 });
+
+console.log(`[database] statement_timeout=${statementTimeoutMs}ms${statementTimeoutMs === 0 ? ' (disabled)' : ''}`);
 
 export const db = drizzle(queryClient, { schema });
 

--- a/tests/unit/database/client.statement-timeout.test.ts
+++ b/tests/unit/database/client.statement-timeout.test.ts
@@ -55,8 +55,7 @@ const loadResolver = (): ((raw?: string) => number) => {
     // jest.requireActual rather than the bare require keyword (which
     // @typescript-eslint/no-require-imports forbids) preserves the same
     // resolution semantics while staying within the lint rules.
-    const mod: { resolveStatementTimeoutMs: (raw?: string) => number } =
-      jest.requireActual(clientSourcePath);
+    const mod: { resolveStatementTimeoutMs: (raw?: string) => number } = jest.requireActual(clientSourcePath);
     return mod.resolveStatementTimeoutMs;
   } finally {
     logSpy.mockRestore();

--- a/tests/unit/database/client.statement-timeout.test.ts
+++ b/tests/unit/database/client.statement-timeout.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for `shared/database/src/client.ts` — verify the postgres-js
+ * client is configured with a server-side `statement_timeout` to prevent
+ * orphan-query accumulation when an HTTP request handler times out
+ * (incident #511).
+ *
+ * Two-pronged strategy:
+ *   1. Test the pure `resolveStatementTimeoutMs` helper for parsing edge
+ *      cases. The helper is exported specifically so tests can reach it
+ *      without going through the moduleNameMapper that maps
+ *      `@wxyc/database` and `**\/shared/database/src/client` to the in-memory
+ *      mock.
+ *   2. Source-grep client.ts to assert the postgres() call passes
+ *      `connection.statement_timeout` and `connection.application_name`
+ *      derived from the helper. Catches refactors that reshape the call.
+ */
+
+// Stub out the heavy module-level work in client.ts (postgres-js connection
+// + drizzle schema introspection) so requiring the real file via its
+// absolute .ts path is side-effect-free.
+jest.mock('postgres', () => jest.fn(() => ({ end: jest.fn().mockResolvedValue(undefined) })));
+jest.mock('drizzle-orm/postgres-js', () => ({ drizzle: jest.fn(() => ({})) }));
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const clientSourcePath = path.resolve(__dirname, '../../../shared/database/src/client.ts');
+const clientSource = fs.readFileSync(clientSourcePath, 'utf-8');
+
+/**
+ * Reach into the helper without going through moduleNameMapper. Resolving
+ * the file by absolute path with the .ts extension bypasses both the
+ * `^@wxyc/database$` and `**\/shared/database/src/client(.js)?$` regex
+ * mappings (the latter does not match `.ts`).
+ */
+const loadResolver = (): ((raw?: string) => number) => {
+  // Bare `require` re-runs the module top-level once per resolved path, but
+  // this module's only top-level effect is the env-var validation block.
+  // That block reads `DB_HOST` etc. at import time, so we provide minimal
+  // values to satisfy it. The validation has already passed by the time
+  // resolveStatementTimeoutMs is called, so we then clear DB_HOST again to
+  // avoid leaking into other tests that depend on its absence.
+  const prev = { ...process.env };
+  process.env.DB_HOST = process.env.DB_HOST ?? 'localhost';
+  process.env.DB_NAME = process.env.DB_NAME ?? 'wxyc_db';
+  process.env.DB_USERNAME = process.env.DB_USERNAME ?? 'wxyc_admin';
+  process.env.DB_PASSWORD = process.env.DB_PASSWORD ?? 'pw';
+
+  // Silence the bootstrap log line.
+  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+  try {
+    // ts-jest resolves .ts files; this absolute path doesn't match the
+    // moduleNameMapper regex above, so we get the real module. Using
+    // jest.requireActual rather than the bare require keyword (which
+    // @typescript-eslint/no-require-imports forbids) preserves the same
+    // resolution semantics while staying within the lint rules.
+    const mod: { resolveStatementTimeoutMs: (raw?: string) => number } =
+      jest.requireActual(clientSourcePath);
+    return mod.resolveStatementTimeoutMs;
+  } finally {
+    logSpy.mockRestore();
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in prev)) delete process.env[k];
+    });
+    Object.assign(process.env, prev);
+  }
+};
+
+describe('resolveStatementTimeoutMs', () => {
+  let resolveStatementTimeoutMs: (raw?: string) => number;
+
+  beforeAll(() => {
+    resolveStatementTimeoutMs = loadResolver();
+  });
+
+  it('defaults to 5000ms when the env var is unset', () => {
+    // 5s catches the orphan-query class without affecting normal endpoints,
+    // which finish in milliseconds. Migrations and backfills opt into a
+    // longer timeout via DB_STATEMENT_TIMEOUT_MS.
+    expect(resolveStatementTimeoutMs(undefined)).toBe(5000);
+  });
+
+  it('parses a custom millisecond value', () => {
+    // Migrations set 5min so DDL on contended tables can wait for the lock.
+    expect(resolveStatementTimeoutMs('300000')).toBe(300000);
+  });
+
+  it('treats "0" as disabled (no server-side timeout)', () => {
+    // Escape hatch for unit-test fixtures and one-off scripts where any
+    // server-side timeout would mask test failures.
+    expect(resolveStatementTimeoutMs('0')).toBe(0);
+  });
+
+  it('throws on negative values', () => {
+    expect(() => resolveStatementTimeoutMs('-1')).toThrow(/DB_STATEMENT_TIMEOUT_MS=.*must be a non-negative integer/);
+  });
+
+  it('throws on non-numeric values', () => {
+    expect(() => resolveStatementTimeoutMs('soon')).toThrow(/DB_STATEMENT_TIMEOUT_MS=.*must be a non-negative integer/);
+  });
+
+  it('throws on NaN', () => {
+    expect(() => resolveStatementTimeoutMs('NaN')).toThrow(/DB_STATEMENT_TIMEOUT_MS=.*must be a non-negative integer/);
+  });
+});
+
+describe('client.ts: postgres() call shape', () => {
+  it('passes connection.statement_timeout sourced from the helper', () => {
+    // Source-grep guard: catches refactors that reshape the postgres() call
+    // and accidentally drop the timeout. The exact value is the helper's
+    // responsibility (covered above) — this test just verifies the wiring.
+    expect(clientSource).toMatch(
+      /postgres\(\{[\s\S]*connection:\s*\{[\s\S]*statement_timeout:\s*statementTimeoutMs[\s\S]*\}/
+    );
+  });
+
+  it('passes connection.application_name with a wxyc-* default', () => {
+    // pg_stat_activity's application_name column is the only fast way to
+    // tell at incident time which subsystem is holding a runaway query.
+    // Default + override pattern lets backfills and migrations identify
+    // themselves without code changes.
+    expect(clientSource).toMatch(/application_name:\s*process\.env\.DB_APPLICATION_NAME\s*\?\?\s*'wxyc-/);
+  });
+
+  it('logs the resolved timeout at startup so operators can verify config', () => {
+    // Prevents silent misconfiguration: if a deploy ships without the var,
+    // the log line surfaces the actual default (5000ms) on the first run
+    // rather than waiting for an orphan to accumulate.
+    expect(clientSource).toMatch(/console\.log\([\s\S]*statement_timeout=\$\{statementTimeoutMs\}/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `connection.statement_timeout` to the postgres-js client in `shared/database/src/client.ts`, configurable via `DB_STATEMENT_TIMEOUT_MS` with a 5s default.
- Add `connection.application_name` so `pg_stat_activity` makes the source obvious during incident triage.
- Per-service overrides in Dockerfiles: backend/auth inherit the 5s default; ETLs set 5min; new application_name on each.
- 9 unit tests covering the parsing helper (default, custom, zero, negative, non-numeric, NaN) plus source-grep guards on the postgres() call shape.

## Why

The wedge in #511 had a hidden multiplier: HTTP requests time out at Express (`server.setTimeout(30000)`) but postgres-js does not propagate that abort to PostgreSQL. The query keeps grinding until it finally returns to a client socket that has long since closed. Each slow-path endpoint hit leaves a fresh orphan SELECT in `pg_stat_activity`. The orphans accumulate, hold `AccessShareLock`s, and block DDL waiting on `AccessExclusiveLock`. During triage today we watched migrations sit in lock-wait queues for hours behind these orphans.

This is layer 1 of the structural fix. Layer 2 (partial functional index for the artwork lookup) lands separately. Layer 3 (extract album_metadata into its own table) is filed as a follow-up issue.

## Service config

| Service | `DB_STATEMENT_TIMEOUT_MS` | `DB_APPLICATION_NAME` |
| --- | --- | --- |
| `backend` | 5000 (default) | `wxyc-backend` |
| `auth` | 5000 (default) | `wxyc-auth` |
| `flowsheet-etl` | 300000 (5min) | `wxyc-flowsheet-etl` |
| `rotation-etl` | 300000 (5min) | `wxyc-rotation-etl` |
| `library-etl` | 300000 (5min) | `wxyc-library-etl` |
| `artist-identity-etl` | 300000 (5min) | `wxyc-artist-identity-etl` |
| `db-migrate` | not affected | unchanged |
| backfill jobs | (set in PR #522) | (set in PR #522) |

ETLs get 5min because their bulk passes can legitimately run tens of seconds (joins against the legacy library, count queries on the 2.6M-row flowsheet table during incremental sync). 5s would break them. 5min still keeps a runaway from wedging the cron tick.

`db-migrate` (`Dockerfile.migrate` + `dev_env/init-db.mjs`) uses a separate postgres connection that does not go through this client, so it inherits PostgreSQL's default unlimited statement_timeout — correct for DDL that legitimately needs to wait for `AccessExclusiveLock`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (259 pre-existing warnings)
- [x] `npm run format:check` — clean
- [x] `npm run lint:migrations` — passes (1 historical allowlisted warning)
- [x] `npm run test:unit` — 1074 / 1074 passing, stable across 3 runs
- [x] 9 new tests in `tests/unit/database/client.statement-timeout.test.ts`
- [ ] Post-merge: confirm `pg_stat_activity` shows `application_name` matching each service after deploy
- [ ] Post-merge: confirm orphan-query class no longer accumulates by checking `pg_stat_activity` for queries older than `DB_STATEMENT_TIMEOUT_MS`

## Risks

- **Behaviour change for existing services.** ETLs may have queries that legitimately take >5s; without the explicit 5min override they would break. The Dockerfile changes are tied to this PR specifically to prevent that. If a future ETL is added without setting `DB_STATEMENT_TIMEOUT_MS`, it gets the 5s default — that's a feature (forces explicit consideration) but worth flagging in code review.
- **5min may be too tight for the library ETL during a fresh bootstrap.** If observed, bump that single Dockerfile to 600000 (10min) without changing the rest.
- **The 5s default deliberately bites endpoints that currently issue full table scans** (the `count(*)` query on `/flowsheet` listed in #511). Those endpoints will now return errors after 5s instead of silently hanging. That's better than the alternative (orphan accumulation), but is a user-visible behaviour change. PR-4 (partial index) makes the artwork query fast enough that the 5s cap never trips for it. The `count(*)` on `/flowsheet` should switch to cursor pagination in a follow-up — tracking via #511's plan.

Refs #511.