### PR TITLE
Add partial functional index for the playlist-proxy artwork lookup

### DIFF
--- a/shared/database/src/migrations/0057_flowsheet-artwork-lookup-partial-idx.sql
+++ b/shared/database/src/migrations/0057_flowsheet-artwork-lookup-partial-idx.sql
@@ -1,0 +1,40 @@
+-- Add a partial functional index to make the playlist-proxy artwork lookup
+-- an index scan instead of a 2.6M-row sequential scan.
+--
+-- The query in `apps/backend/services/playlist-proxy.service.ts` runs every
+-- time tubafrenzy emits a `created`/`updated` SSE event. It computes a
+-- lookup key on the fly:
+--
+--   lower(trim(artist_name)) || '-' || lower(trim(coalesce(album_title, '')))
+--
+-- and asks "has any prior flowsheet row already cached `artwork_url` for
+-- this same artist+album combo?". Without an index, every event scans the
+-- whole flowsheet table — and on a hot table that's 7-15 minutes per scan.
+-- During incident #511 those scans accumulated as orphans (the calling
+-- backend HTTP request had timed out long before the scan finished),
+-- holding AccessShareLock and blocking DDL.
+--
+-- The functional index makes the SQL plan:
+--   Index Scan using flowsheet_artwork_lookup_idx (cost: ms, not minutes)
+--
+-- Partial because only ~5-10% of rows have non-null `artwork_url`. The
+-- query selects `artwork_url` and filters by the lookup key — every other
+-- row would be index dead weight. With the partial predicate the index is
+-- ~10-20MB instead of ~250MB on disk.
+--
+-- Production note: this is a regular CREATE INDEX (not CONCURRENTLY)
+-- because the partial predicate keeps the build small (~200K matching
+-- rows). Build time is seconds. CREATE INDEX takes a `ShareLock` on the
+-- table that briefly blocks writes — INSERTs from the live path queue up
+-- for a few seconds. INSERT throughput is well under the rate that a
+-- few-second pause would cause user-visible problems.
+--
+-- The index is not used by any existing query plan, so it cannot regress
+-- any path. It is consulted only when the playlist-proxy's lookup key
+-- expression appears in a `WHERE` clause — i.e. exclusively the queries
+-- in `playlist-proxy.service.ts:enrichPlaycuts` and `enrichSinglePlaycut`.
+
+CREATE INDEX "flowsheet_artwork_lookup_idx"
+  ON "wxyc_schema"."flowsheet"
+  ((lower(trim("artist_name")) || '-' || lower(trim(coalesce("album_title", '')))))
+  WHERE "artwork_url" IS NOT NULL;

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1777992000000,
       "tag": "0056_project-reconciled-identity-on-library-artist-view",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1778078400000,
+      "tag": "0057_flowsheet-artwork-lookup-partial-idx",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -414,6 +414,14 @@ export const flowsheet = wxyc_schema.table(
       .on(sql`${table.add_time} DESC`)
       .where(sql`${table.entry_type} = 'track'`),
     index('flowsheet_search_doc_idx').using('gin', sql`${table.search_doc}`),
+    // Functional partial index that supports the playlist-proxy artwork
+    // lookup. Mirrors `flowsheetLookupKey` in
+    // apps/backend/services/playlist-proxy.service.ts. Partial because only
+    // ~5-10% of rows have non-null artwork — the others would be index
+    // dead weight.
+    index('flowsheet_artwork_lookup_idx')
+      .on(sql`(lower(trim(${table.artist_name})) || '-' || lower(trim(coalesce(${table.album_title}, ''))))`)
+      .where(sql`${table.artwork_url} IS NOT NULL`),
   ]
 );
 

--- a/tests/unit/database/schema.flowsheet-artwork-lookup-idx.test.ts
+++ b/tests/unit/database/schema.flowsheet-artwork-lookup-idx.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Schema-source assertions for the partial functional index that supports
+ * the playlist-proxy artwork lookup. The index is the only thing standing
+ * between every tubafrenzy SSE event and a 2.6M-row sequential scan, so
+ * drift between the migration SQL, the schema declaration, and the query
+ * code in `playlist-proxy.service.ts` would silently fall back to that
+ * scan without any test failure — exactly the wedge from incident #511.
+ *
+ * The expression `lower(trim(artist_name)) || '-' || lower(trim(coalesce(album_title, '')))`
+ * must appear identically (modulo normalization) in three places:
+ *   1. The migration SQL                       — what runs in production
+ *   2. The Drizzle schema declaration          — drift detection / typing
+ *   3. The query in playlist-proxy.service.ts  — the consumer
+ * If any of the three drifts, the others become dead weight or silently
+ * regress to seq scans.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const migrationsDir = path.resolve(__dirname, '../../../shared/database/src/migrations');
+const migrationPath = path.join(migrationsDir, '0057_flowsheet-artwork-lookup-partial-idx.sql');
+const journalPath = path.join(migrationsDir, 'meta/_journal.json');
+const schemaPath = path.resolve(__dirname, '../../../shared/database/src/schema.ts');
+const proxyServicePath = path.resolve(__dirname, '../../../apps/backend/services/playlist-proxy.service.ts');
+
+describe('schema: flowsheet_artwork_lookup_idx (partial functional index)', () => {
+  it('migration 0057 exists and creates the index with the exact lookup expression', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(/CREATE INDEX\s+"flowsheet_artwork_lookup_idx"/i);
+    // The expression must use lower(trim(artist_name)) || '-' || lower(trim(coalesce(album_title, '')))
+    // — exactly what playlist-proxy.service.ts:flowsheetLookupKey computes.
+    // Whitespace-tolerant regex; column quoting tolerated either way.
+    expect(sql).toMatch(
+      /lower\(\s*trim\(\s*"?artist_name"?\s*\)\s*\)\s*\|\|\s*'-'\s*\|\|\s*lower\(\s*trim\(\s*coalesce\(\s*"?album_title"?\s*,\s*''\s*\)\s*\)\s*\)/i
+    );
+  });
+
+  it('migration 0057 makes the index partial on artwork_url IS NOT NULL', () => {
+    // Critical for size: only ~5-10% of rows have non-null artwork. Without
+    // the partial predicate the index is ~10x larger and contains entries
+    // that the query never reads.
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(/WHERE\s+"?artwork_url"?\s+IS\s+NOT\s+NULL/i);
+  });
+
+  it('migration 0057 does NOT use CREATE INDEX CONCURRENTLY (must run inside the migration txn)', () => {
+    // Drizzle wraps each migration in a transaction. CONCURRENTLY would
+    // raise "CREATE INDEX CONCURRENTLY cannot run inside a transaction
+    // block". Partial index on ~200K rows builds in seconds; the brief
+    // ShareLock on flowsheet is acceptable and keeps the migration shape
+    // simple. Match only at the keyword position (after CREATE [UNIQUE]
+    // INDEX) to avoid tripping on the word in our own explanatory comment.
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).not.toMatch(/CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY/i);
+  });
+
+  it('journal includes the 0057 entry', () => {
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
+    const has57 = journal.entries.some((e: { tag: string }) => e.tag === '0057_flowsheet-artwork-lookup-partial-idx');
+    expect(has57).toBe(true);
+  });
+
+  it('schema.ts declares the index so drizzle-kit drift detection sees it', () => {
+    // If the index lives only in the SQL but not the schema, every future
+    // `drizzle-kit generate` run against this schema would see the index
+    // as drift and try to drop it. Declaring it in schema.ts keeps drift
+    // detection happy.
+    const schemaSource = fs.readFileSync(schemaPath, 'utf-8');
+    expect(schemaSource).toMatch(/index\(\s*'flowsheet_artwork_lookup_idx'\s*\)/);
+    // The schema's expression must mirror the migration's. Loose match for
+    // template-literal whitespace; the structure is what matters.
+    expect(schemaSource).toMatch(
+      /lower\(trim\(\$\{table\.artist_name\}\)\)\s*\|\|\s*'-'\s*\|\|\s*lower\(trim\(coalesce\(\$\{table\.album_title\},\s*''\)\)\)/
+    );
+    expect(schemaSource).toMatch(/\.where\(sql`\$\{table\.artwork_url\} IS NOT NULL`\)/);
+  });
+
+  it('playlist-proxy.service.ts uses the same lookup-key expression', () => {
+    // Fail-fast guard against the consumer drifting away from the indexed
+    // expression. If someone refactors the lookup key (e.g. drops the
+    // coalesce, swaps columns) without updating the index, every SSE event
+    // silently regresses to a seq scan.
+    const proxySource = fs.readFileSync(proxyServicePath, 'utf-8');
+    expect(proxySource).toMatch(
+      /lower\(trim\(\$\{flowsheet\.artist_name\}\)\)\s*\|\|\s*'-'\s*\|\|\s*lower\(trim\(coalesce\(\$\{flowsheet\.album_title\},\s*''\)\)\)/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Migration `0057_flowsheet-artwork-lookup-partial-idx.sql` adds `flowsheet_artwork_lookup_idx` — a partial functional index on `(lower(trim(artist_name)) || '-' || lower(trim(coalesce(album_title, ''))))` `WHERE artwork_url IS NOT NULL`.
- Mirrors the index in the Drizzle schema declaration so drift detection sees it.
- 6 unit tests assert SQL shape, partial predicate, no `CONCURRENTLY` keyword (incompatible with drizzle's tx-wrapping), journal entry, schema mirror, and that `playlist-proxy.service.ts` still uses the indexed expression.

## Why

Every tubafrenzy SSE event hits a SELECT keyed on this derived expression. Without an index it's a 2.6M-row sequential scan — 7 to 15 minutes per query on the bloated table. During incident #511 those scans accumulated as orphans (their parent HTTP request had timed out long before they finished), held `AccessShareLock`, and blocked DDL. This index turns the plan into an Index Scan and removes the entire orphan source.

Layer 2 of the structural fix from #511. Layer 1 (per-connection `statement_timeout`) is in #530. Layer 3 (dedicated `album_metadata` table) is filed as a follow-up.

## Why partial?

Only ~5–10% of rows have non-null `artwork_url` (LML enrichment runs on inserts going forward; legacy rows are mostly NULL). A non-partial index would carry every row but the query selects only `artwork_url IS NOT NULL` rows, so the rest is dead weight — ~10× larger on disk for no benefit.

## Why not CONCURRENTLY?

Drizzle wraps each migration in a transaction and `CREATE INDEX CONCURRENTLY` raises `cannot run inside a transaction block`. The partial predicate keeps the build at ~200K rows, so it finishes in seconds. The brief `ShareLock` on the table queues writes for that window — well below any user-visible threshold. (If profiling later shows this is too disruptive, a CONCURRENTLY one-shot job mirroring `jobs/flowsheet-dj-name-backfill/` is the natural follow-up.)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (265 pre-existing warnings)
- [x] `npm run format:check` — clean
- [x] `npm run lint:migrations` — passes
- [x] `npm run test:unit` — 1071 / 1071, stable across 3 runs
- [x] 6 new tests in `tests/unit/database/schema.flowsheet-artwork-lookup-idx.test.ts`
- [ ] Post-merge: confirm `EXPLAIN SELECT artwork_url FROM flowsheet WHERE lower(trim(artist_name)) || '-' || lower(trim(coalesce(album_title, ''))) = $1` shows `Index Scan using flowsheet_artwork_lookup_idx` instead of `Seq Scan on flowsheet`.
- [ ] Post-merge: confirm orphan-scan accumulation has stopped in `pg_stat_activity` (no queries against this expression older than `DB_STATEMENT_TIMEOUT_MS`).

## Dependencies / sequencing

This migration sits *after* 0056. Per #511's plan, migration 0054 has a precondition guard that keeps it from applying until the `flowsheet-dj-name-backfill` job (PR #522) has run. Drizzle stops on the first failing migration, so 0057 will not apply on a deploy until 0054 is unblocked. Order will be:

1. Backfill job runs (manual, low-traffic window).
2. PR strips the 0054 guard.
3. Next deploy applies 0054, 0055, 0056, 0057 in order.

That's fine for the immediate incident — PR #530's connection-level `statement_timeout` is the layer that actually defangs the orphan-pool problem in flight; this index removes the *source* once it lands.

Refs #511.