### PR TITLE
Build internal workspace dists before lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "All necessary app services for the WXYC flowsheet backend",
   "packageManager": "npm@11.11.0",
   "scripts": {
-    "typecheck": "npm run build --workspace=@wxyc/database --workspace=@wxyc/authentication && npm run typecheck --workspace=@wxyc/database --workspace=shared/** --workspace=apps/**",
-    "lint": "eslint --cache --cache-strategy content --cache-location .cache/eslint/ .",
-    "lint:fix": "eslint --cache --cache-strategy content --cache-location .cache/eslint/ . --fix",
+    "typecheck": "npm run lint:prebuild && npm run typecheck --workspace=@wxyc/database --workspace=shared/** --workspace=apps/**",
+    "lint:prebuild": "npm run build --workspace=@wxyc/database --workspace=@wxyc/authentication",
+    "lint": "npm run lint:prebuild && eslint --cache --cache-strategy content --cache-location .cache/eslint/ .",
+    "lint:fix": "npm run lint:prebuild && eslint --cache --cache-strategy content --cache-location .cache/eslint/ . --fix",
     "lint:env": "node scripts/lint-env.js",
     "format": "prettier --cache --cache-location .cache/prettier/ --write .",
     "format:check": "prettier --cache --cache-location .cache/prettier/ --check .",


### PR DESCRIPTION
Closes #536.

## Summary
- Adds `lint:prebuild` script that builds `@wxyc/database` and `@wxyc/authentication` workspace dists, and chains it into `lint`, `lint:fix`, and `typecheck`.
- Eliminates the 924 ESLint errors that appear on a fresh checkout when those dists are missing -- the `recommendedTypeChecked` rule set was correctly flagging cascading `any` resolutions caused by the missing `dist/` outputs.
- Pre-push hook (`typecheck && lint`) now exits 0 without `--no-verify`.

## Why this is the right fix

The 924 errors are entirely a build-ordering symptom. `eslint.config.mjs` already classifies these unsafe-* rules as `warn` for `apps/**` and `shared/**` (the team's stated "warn tier for gradual cleanup"). The errors only surfaced for `jobs/**` and a handful of `no-redundant-type-constituents` reports because both depend on workspace types that resolved to `any` when their `dist/` was missing. Building the dists first makes the type-checked lint accurate; no rule changes, no code changes, no warning-count changes.

## Verification

From a fully-cleaned worktree:

```sh
npm run clean
rm -rf .cache/eslint
npm run lint   # 0 errors, 267 warnings, exit 0
```

- Pre-push hook: PASS (this PR was pushed without `--no-verify`).
- `npm run test:unit`: 1092/1092 pass.
- `npm run typecheck`: PASS (and is now slightly DRYer: it calls `lint:prebuild` instead of duplicating the `--workspace=@wxyc/database --workspace=@wxyc/authentication` build invocation).

## Test plan

- [ ] CI passes.
- [ ] Confirm a fresh clone + `npm install` + `npm run lint` exits 0.
- [ ] Confirm a `git push` from a clean tree completes without `--no-verify`.

## Follow-ups (out of scope)

The 267 remaining warnings are mostly `security/detect-non-literal-fs-filename` and `security/detect-object-injection` in tests, plus a handful of `@typescript-eslint/no-unused-vars` and `restrict-template-expressions`. They are intentionally left as warnings per the gradual-cleanup tier in `eslint.config.mjs` and can be addressed in a separate PR if desired.