### PR TITLE
Library schema: denormalize artist_name + add search_doc tsvector

### DIFF
--- a/shared/database/src/migrations/0058_library-artist-name-and-search-doc.sql
+++ b/shared/database/src/migrations/0058_library-artist-name-and-search-doc.sql
@@ -1,0 +1,40 @@
+-- Denormalize artist_name onto library and add a STORED tsvector search_doc
+-- (Epic A.1). The cross-table OR predicate in the existing catalog search
+-- path prevents the planner from using either trigram GIN index, leading to
+-- 100-200ms median per query. With both searchable columns living on the
+-- same table, the new search_doc index can power a sub-1ms tsvector path
+-- (see Epic A #483 for the full plan).
+--
+-- Order of operations across Epic A:
+--   A.1 (this migration): add artist_name + search_doc + indexes (nullable).
+--   A.2 (backfill job):   populate library.artist_name from the artists join.
+--   A.3 (live writes):    addAlbum writes artist_name; cascade on artists UPDATE.
+--   A.4 (parallel):       album_plays materialized view + scheduled refresh.
+--   A.5 (service):        route Both-mode search through tsvector + plays.
+--
+-- Production note: ALTER TABLE ADD COLUMN of a nullable column is
+-- metadata-only and instant. The STORED generated column is computed for
+-- every row when added (an ACCESS EXCLUSIVE lock is held for the duration
+-- of the rewrite); on the 64K-row library this is fast — well under the
+-- lock-budget that wedged migration 0053 (see issue #511). search_doc will
+-- be NULL-equivalent (an empty tsvector with album_title weight) until A.2
+-- populates artist_name; A.5 won't read this index until then.
+--
+-- The backfill (A.2) lives in jobs/<name>-backfill and runs as a separate
+-- one-shot deploy. This migration is DDL-only — no in-migration UPDATE.
+
+ALTER TABLE "wxyc_schema"."library"
+  ADD COLUMN "artist_name" varchar(128);--> statement-breakpoint
+
+ALTER TABLE "wxyc_schema"."library"
+  ADD COLUMN "search_doc" tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('simple', coalesce("artist_name", '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce("album_title", '')), 'B')
+  ) STORED;--> statement-breakpoint
+
+CREATE INDEX "library_search_doc_idx"
+  ON "wxyc_schema"."library" USING gin ("search_doc");--> statement-breakpoint
+
+CREATE INDEX "library_artist_name_trgm_idx"
+  ON "wxyc_schema"."library" USING gin ("artist_name" gin_trgm_ops);

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1778078400000,
       "tag": "0057_flowsheet-artwork-lookup-partial-idx",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1778164800000,
+      "tag": "0058_library-artist-name-and-search-doc",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -287,6 +287,17 @@ export const library = wxyc_schema.table(
     date_found: timestamp('date_found', { withTimezone: true }),
     on_streaming: boolean('on_streaming'),
     artwork_url: varchar('artwork_url', { length: 512 }),
+    // Denormalized from artists.artist_name (Epic A.1). Nullable until A.2
+    // backfills it from the artists join; A.3 keeps it current on insert and
+    // cascades on artists UPDATE. A.5 reads it via search_doc.
+    artist_name: varchar('artist_name', { length: 128 }),
+    // STORED GENERATED tsvector covering the searchable text fields with
+    // weight bands (artist=A, album=B). NULL for rows where artist_name has
+    // not been backfilled yet — A.2 populates legacy rows, A.3 keeps live
+    // writes current. Read by the new tsvector search path in A.5.
+    search_doc: tsvector('search_doc').generatedAlwaysAs(
+      sql`setweight(to_tsvector('simple', coalesce("artist_name", '')), 'A') || setweight(to_tsvector('simple', coalesce("album_title", '')), 'B')`
+    ),
   },
   (table) => {
     return {
@@ -296,6 +307,11 @@ export const library = wxyc_schema.table(
       artistIdIdx: index('artist_id_idx').on(table.artist_id),
       legacyReleaseIdIdx: uniqueIndex('library_legacy_release_id_idx').on(table.legacy_release_id),
       albumArtistTrgmIdx: index('album_artist_trgm_idx').using(`gin`, sql`${table.album_artist} gin_trgm_ops`),
+      libraryArtistNameTrgmIdx: index('library_artist_name_trgm_idx').using(
+        `gin`,
+        sql`${table.artist_name} gin_trgm_ops`
+      ),
+      librarySearchDocIdx: index('library_search_doc_idx').using('gin', sql`${table.search_doc}`),
     };
   }
 );

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -72,6 +72,8 @@ export const library = {
   legacy_release_id: 'legacy_release_id',
   on_streaming: 'on_streaming',
   artwork_url: 'artwork_url',
+  artist_name: 'artist_name',
+  search_doc: 'search_doc',
 };
 export const artists = {};
 export const genres = {};

--- a/tests/unit/database/schema.library-artist-name-search-doc.test.ts
+++ b/tests/unit/database/schema.library-artist-name-search-doc.test.ts
@@ -1,0 +1,88 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('schema: library.artist_name + library.search_doc denormalization (A.1)', () => {
+  const schemaPath = path.resolve(__dirname, '../../../shared/database/src/schema.ts');
+  const schemaSource = fs.readFileSync(schemaPath, 'utf-8');
+
+  const migrationsDir = path.resolve(__dirname, '../../../shared/database/src/migrations');
+  const migrationPath = path.join(migrationsDir, '0058_library-artist-name-and-search-doc.sql');
+  const journalPath = path.join(migrationsDir, 'meta/_journal.json');
+
+  const extractTableDef = (tableName: string): string => {
+    const regex = new RegExp(`export const ${tableName}\\b[\\s\\S]*?^\\);`, 'm');
+    const match = schemaSource.match(regex);
+    if (!match) throw new Error(`Table definition for ${tableName} not found in schema`);
+    return match[0];
+  };
+
+  it('library table declares an artist_name column (nullable)', () => {
+    const def = extractTableDef('library');
+    expect(def).toMatch(/artist_name:\s*varchar\(['"]artist_name['"]/);
+    // Nullable initially — A.2 backfills, A.3 keeps it current.
+    expect(def).not.toMatch(/artist_name:\s*varchar\([^)]*\)\.notNull\(\)/);
+  });
+
+  it('library table declares a STORED search_doc tsvector column', () => {
+    const def = extractTableDef('library');
+    expect(def).toMatch(/search_doc:\s*tsvector\(['"]search_doc['"]\)/);
+    expect(def).toMatch(/generatedAlwaysAs/);
+    // Weight bands: artist=A, album=B
+    expect(def).toMatch(
+      /setweight\(\s*to_tsvector\(\s*'simple'\s*,\s*coalesce\(\s*"artist_name"\s*,\s*''\s*\)\s*\)\s*,\s*'A'\s*\)/
+    );
+    expect(def).toMatch(
+      /setweight\(\s*to_tsvector\(\s*'simple'\s*,\s*coalesce\(\s*"album_title"\s*,\s*''\s*\)\s*\)\s*,\s*'B'\s*\)/
+    );
+  });
+
+  it('library table declares a GIN index on search_doc', () => {
+    const def = extractTableDef('library');
+    expect(def).toMatch(/library_search_doc_idx[\s\S]*?gin/);
+  });
+
+  it('library table declares a trigram index on artist_name', () => {
+    const def = extractTableDef('library');
+    expect(def).toMatch(/library_artist_name_trgm_idx[\s\S]*?gin[\s\S]*?artist_name[\s\S]*?gin_trgm_ops/);
+  });
+
+  it('migration 0058 exists and adds artist_name + search_doc columns', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(/ALTER TABLE\s+"wxyc_schema"\."library"\s+ADD COLUMN\s+"artist_name"\s+varchar/i);
+    expect(sql).toMatch(/ADD COLUMN\s+"search_doc"\s+tsvector\s+GENERATED ALWAYS AS/i);
+    expect(sql).toMatch(/STORED/);
+  });
+
+  it('migration 0058 creates the GIN index on search_doc and the trigram index on artist_name', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(/CREATE INDEX[^;]*"library_search_doc_idx"[\s\S]*?USING gin\s*\(\s*"search_doc"\s*\)/i);
+    expect(sql).toMatch(
+      /CREATE INDEX[^;]*"library_artist_name_trgm_idx"[\s\S]*?USING gin\s*\(\s*"artist_name"\s+gin_trgm_ops\s*\)/i
+    );
+  });
+
+  it('migration 0058 is DDL-only — no in-migration backfill', () => {
+    // Adding nullable columns is metadata-only, but a backfill UPDATE inside
+    // the same transaction would hold AccessExclusiveLock and could wedge the
+    // table. Backfill belongs in jobs/<name>-backfill (A.2). See issue #511
+    // for the incident pattern this rule encodes.
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).not.toMatch(/^\s*UPDATE\s+"wxyc_schema"\."library"/im);
+  });
+
+  it('journal includes the 0058 entry', () => {
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
+    const has58 = journal.entries.some((e: { tag: string }) => e.tag === '0058_library-artist-name-and-search-doc');
+    expect(has58).toBe(true);
+  });
+
+  it('mock includes artist_name and search_doc on library', () => {
+    const mockPath = path.resolve(__dirname, '../../mocks/database.mock.ts');
+    const mockSource = fs.readFileSync(mockPath, 'utf-8');
+    const libraryMock = mockSource.match(/export const library\s*=\s*\{[\s\S]*?\};/)?.[0];
+    expect(libraryMock).toBeDefined();
+    expect(libraryMock).toContain("artist_name: 'artist_name'");
+    expect(libraryMock).toContain("search_doc: 'search_doc'");
+  });
+});


### PR DESCRIPTION
Closes #486. Part of [Epic A #483](https://github.com/WXYC/Backend-Service/issues/483).

## Summary

- Adds nullable `library.artist_name varchar(128)` and a STORED generated `library.search_doc tsvector` with weight bands (artist=A, album=B).
- Adds a GIN index on `search_doc` and a trigram GIN index on `library.artist_name` (separate from the existing `artist_name_trgm_idx` on `artists.artist_name`).
- Migration `0058_library-artist-name-and-search-doc.sql` is DDL-only — backfill is A.2's job, mirroring the lock-budget pattern from `0053 + jobs/flowsheet-dj-name-backfill` (issue #511).

## Why

`EXPLAIN ANALYZE` on the current catalog search shows the trigram GIN indexes are never touched because the OR predicate spans `artists` and `library` and is evaluated as a join filter post merge-join. Putting both searchable columns on the same table is the precondition for the new tsvector path.

## Order of operations

| Step | Status |
|---|---|
| A.1 schema (this PR) | here |
| A.2 backfill `library.artist_name` from the join | next |
| A.3 live writes + cascade on `artists` UPDATE | parallel with A.2 |
| A.4 `album_plays` MV (independent) | parallel |
| A.5 service rewrite reads `search_doc` | after A.2 + A.3 + A.4 |

`search_doc` is NULL-equivalent (an empty tsvector with album_title weight) for every existing row until A.2 ships. A.5 won't read the index before that.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:unit` (1101 passing, including 9 new schema-source assertions in `tests/unit/database/schema.library-artist-name-search-doc.test.ts` mirroring the `0053` pattern)
- [ ] Drizzle generate diff verified against schema after merge (sanity check, no new migration produced)