### PR TITLE
HOTFIX: Strip 0054 precondition guard to unblock deploy chain

### DIFF
--- a/shared/database/src/migrations/0054_flowsheet-search-doc-with-dj-name.sql
+++ b/shared/database/src/migrations/0054_flowsheet-search-doc-with-dj-name.sql
@@ -1,22 +1,23 @@
--- Precondition: backfill must have populated dj_name on every track row.
---
--- 0054's DROP+ADD of search_doc rebuilds the tsvector for every flowsheet row.
--- If dj_name is NULL on any track row (because the backfill hasn't run yet),
--- the new search_doc has no dj-name terms for those rows — search would
--- silently lose dj-name matching for legacy entries until the next full row
--- rewrite. Block the migration loudly so the operator runs the backfill
--- (jobs/backfills/flowsheet-dj-name-backfill) first. See issue #511.
-DO $$
-BEGIN
-  IF (
-    SELECT count(*) FROM "wxyc_schema"."flowsheet"
-    WHERE entry_type = 'track' AND dj_name IS NULL
-  ) > 0 THEN
-    RAISE EXCEPTION 'flowsheet.dj_name backfill incomplete; run jobs/backfills/flowsheet-dj-name-backfill before applying 0054';
-  END IF;
-END $$;--> statement-breakpoint
-
 -- Switch search reads to flowsheet.dj_name (step 5b.3).
+--
+-- The original version of this migration carried a precondition guard
+-- (DO $$ ... RAISE EXCEPTION when any track row has dj_name IS NULL) so
+-- it would refuse to run before the dj_name backfill completed. The guard
+-- was correct in spirit but blocked the deploy chain when the backfill
+-- itself ran into the bloated-table I/O problem from incident #511 — see
+-- the back-and-forth in #511 for the operational dead-end.
+--
+-- Removing the guard makes 0054 apply unconditionally. Legacy track rows
+-- that still have dj_name IS NULL get an empty dj-name term in the new
+-- search_doc tsvector, so search just doesn't match dj-name queries for
+-- those rows. The search service in apps/backend uses
+-- COALESCE(flowsheet.dj_name, 'Unknown DJ') for display, so users see
+-- "Unknown DJ" rather than a NULL or crash.
+--
+-- The backfill (jobs/flowsheet-dj-name-backfill) still needs to run; once
+-- it does, the dj_name UPDATE recomputes the search_doc generated column
+-- (dj_name is in the expression) and dj-name search becomes correct for
+-- legacy rows. Run during a low-traffic window after this deploys.
 --
 -- Now that 5b.1 backfilled and 5b.2 keeps flowsheet.dj_name current on every
 -- insert, the search service can read the column directly. This migration:

--- a/tests/unit/database/schema.flowsheet-search-doc-with-dj-name.test.ts
+++ b/tests/unit/database/schema.flowsheet-search-doc-with-dj-name.test.ts
@@ -62,16 +62,24 @@ describe('schema: search_doc augmented with dj_name + dropped trgm indexes (step
     expect(has54).toBe(true);
   });
 
-  it('migration 0054 has a precondition guard requiring the dj_name backfill', () => {
-    // 0054's DROP+ADD of search_doc rebuilds the tsvector for every flowsheet
-    // row. If dj_name is NULL (because the backfill has not run yet), the new
-    // search_doc has no dj-name terms — search would silently lose dj-name
-    // matching until the next full row rewrite. Block the migration if any
-    // track row still has dj_name IS NULL.
+  it('migration 0054 applies unconditionally — no precondition guard', () => {
+    // Originally 0054 had a precondition block that aborted the migration if
+    // any track row still had dj_name IS NULL (i.e. the backfill hadn't run
+    // yet). That block was removed in the hotfix that unblocked production
+    // after the backfill stalled on the bloated table. Legacy rows with NULL
+    // dj_name get an empty dj-name term in the rebuilt search_doc tsvector —
+    // search just doesn't match dj-name queries for those rows until the
+    // backfill eventually runs and the generated search_doc recomputes. The
+    // search service uses COALESCE(flowsheet.dj_name, 'Unknown DJ') for
+    // display so users see "Unknown DJ" rather than a NULL or crash. See
+    // issue #511.
+    //
+    // Strip everything that looks like a SQL line comment ('-- …') before
+    // matching, so explanatory comments in the migration file (which may
+    // mention historical keywords) don't mask the assertion.
     const sql = fs.readFileSync(migrationPath, 'utf-8');
-    expect(sql).toMatch(/RAISE\s+EXCEPTION/i);
-    expect(sql).toMatch(/dj_name\s+IS\s+NULL/i);
-    expect(sql).toMatch(/entry_type\s*=\s*'track'/i);
-    expect(sql).toMatch(/flowsheet-dj-name-backfill/);
+    const sqlNoComments = sql.replace(/--[^\n]*/g, '');
+    expect(sqlNoComments).not.toMatch(/RAISE\s+EXCEPTION/i);
+    expect(sqlNoComments).not.toMatch(/DO\s+\$\$/i);
   });
 });


### PR DESCRIPTION
## Summary

Removes the `DO $$ ... RAISE EXCEPTION` precondition block from `shared/database/src/migrations/0054_flowsheet-search-doc-with-dj-name.sql`. Migration 0054 now applies unconditionally.

## Why now

The deploy chain has been blocked since the incident #511 unwind because:

1. The backfill that the guard required (1.96M-row UPDATE on a bloated 2.6GB table) stalled. Batched UPDATEs hit `statement_timeout`. The all-in-one UPDATE was running for 1+ hour with an estimated 2-4 hours total — generating ~490 MB/min of disk reads and starving `/flowsheet` traffic. **Users are currently getting 502 on /flowsheet.**
2. With 0054 unapplied, the deploy step is skipped on every Auto Build & Deploy run.
3. PR #530's per-connection `statement_timeout` (the actual structural fix for the orphan-pool wedge) cannot reach production until the deploy step runs.

Stripping the guard breaks the deadlock. The guard is reapplied as a constraint at *runtime*, not migration-time: the search service's projection in `apps/backend/services/search.service.ts` already does `COALESCE(flowsheet.dj_name, 'Unknown DJ')` (added in PR #515), so legacy rows with NULL `dj_name` show "Unknown DJ" in search results rather than NULL or crashing. Search just doesn't match dj-name queries for legacy rows until the backfill runs — same as today's behavior, since search currently reads via the join path.

## Why it's safe

- `flowsheet.search_doc` is a `GENERATED ALWAYS AS (... coalesce(dj_name, '') ...) STORED` column. When the backfill eventually populates `dj_name` for a row, PG recomputes `search_doc` for that row (because `dj_name` is an input) and writes the updated tsvector. So dj-name search becomes correct for legacy rows automatically as the backfill runs — no second migration needed.
- The DROP+ADD of `search_doc` in 0054 takes `AccessExclusiveLock` on `flowsheet` for the rewrite. PR #530's `statement_timeout` doesn't yet apply to migrations (drizzle-kit's connection inherits role-level), so this could compete with backend SELECTs. But the same risk existed before this change — stripping the guard doesn't change the lock window. (Plan: monitor deploy and cancel if it looks wedged.)
- PR #524's `CREATE OR REPLACE VIEW` fix for migration 0056 is on main and will apply right after 0054, removing the next blocker.

## What still needs to happen after this lands

1. Backfill `flowsheet.dj_name` for the ~1.96M legacy track rows. Image is in ECR. Run during a low-traffic window with `docker run --rm --env-file .env -e DB_STATEMENT_TIMEOUT_MS=300000 <image>` from EC2.
2. Revert the role-level `ALTER ROLE wxyc_admin SET statement_timeout = '30s'` set during incident response, since PR #530's per-connection setting will take over once it deploys.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (267 pre-existing warnings)
- [x] `npm run format:check` — clean
- [x] `npm run lint:migrations` — passes
- [x] `npm run test:unit` — 1092 / 1092 passing. The `migration 0054 ...` test was flipped to assert the guard is *absent* (and uses comment-stripping so the explanatory comment in the SQL doesn't trip the regex).
- [ ] Post-merge: confirm `Auto Build & Deploy` migrate step applies 0054, 0055, 0056 (with PR #524's fix), 0057 in order. Deploy step runs.
- [ ] Post-merge: confirm `pg_stat_activity` shows backend connections with `application_name = 'wxyc-backend'` and the `statement_timeout = 5s` taking effect (verifies PR #530 deployed).
- [ ] Post-merge: run the backfill manually.
- [ ] Post-merge: revert the role-level statement_timeout: `ALTER ROLE wxyc_admin RESET statement_timeout`.

Refs #511.