### PR TITLE
album_plays materialized view + scheduled refresh

### DIFF
--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -18,6 +18,7 @@ import { internal_route } from './routes/internal.route.js';
 import { proxy_route } from './routes/proxy.route.js';
 import { playlist_route } from './routes/playlist.route.js';
 import { startPlaylistProxy, stopPlaylistProxy } from './services/playlist-proxy.service.js';
+import { startAlbumPlaysRefresh, stopAlbumPlaysRefresh } from './services/album-plays-refresh.service.js';
 import { setupCdcWebSocket, shutdownCdcWebSocket } from './services/cdc/index.js';
 import { activeShow } from './middleware/checkActiveShow.js';
 import errorHandler from './middleware/errorHandler.js';
@@ -109,6 +110,7 @@ app.use(errorHandler);
 const server = app.listen(port, () => {
   console.log(`listening on port: ${port}!`);
   startPlaylistProxy();
+  startAlbumPlaysRefresh();
   void setupCdcWebSocket(server);
 });
 
@@ -130,6 +132,7 @@ memoryLogTimer.unref();
 function shutdown(signal: string): void {
   console.log(`[shutdown] Received ${signal}, shutting down...`);
   stopPlaylistProxy();
+  stopAlbumPlaysRefresh();
   void shutdownCdcWebSocket();
   server.close(() => {
     closeDatabaseConnection()

--- a/apps/backend/services/album-plays-refresh.service.ts
+++ b/apps/backend/services/album-plays-refresh.service.ts
@@ -1,0 +1,110 @@
+/**
+ * Periodic refresh of the `album_plays` materialized view.
+ *
+ * The MV is the play-weight signal feeding the catalog search ranker (Epic
+ * A). It is created and indexed by migration 0059 and re-derived from
+ * `flowsheet` here on a recurring timer. Last-run timestamps are recorded
+ * in the existing `cronjob_runs` table under the job name
+ * `album-plays-refresh`, mirroring the pattern used by the ETL jobs.
+ *
+ * REFRESH MATERIALIZED VIEW CONCURRENTLY needs the unique index on
+ * `album_id` (also created by 0059) and lets concurrent reads keep using
+ * the previous snapshot while the new one is built. Measured refresh on
+ * the staging clone (2.6M flowsheet rows) is ~98ms.
+ *
+ * Cadence is configurable via `ALBUM_PLAYS_REFRESH_INTERVAL_MS` (default 1
+ * hour). Running more frequently is safe but unnecessary — search ranking
+ * is robust to a slightly stale signal, and the MV is cheap to refresh.
+ *
+ * Exported API:
+ *   startAlbumPlaysRefresh()  — schedule the recurring refresh (call at
+ *                               startup)
+ *   stopAlbumPlaysRefresh()   — cancel the timer (call on shutdown)
+ *   refreshAlbumPlays()       — run one refresh and record last-run; useful
+ *                               for the start-immediate option in tests
+ *                               and for ad-hoc invocation
+ */
+import { sql } from 'drizzle-orm';
+import { db, cronjob_runs, album_plays } from '@wxyc/database';
+
+const JOB_NAME = 'album-plays-refresh';
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+let stopped = false;
+
+/**
+ * Run a single REFRESH MATERIALIZED VIEW CONCURRENTLY pass and record the
+ * completion timestamp in `cronjob_runs`. Safe to call from anywhere; the
+ * caller is responsible for catching errors if it cares about them.
+ */
+export async function refreshAlbumPlays(): Promise<void> {
+  await db.execute(sql`REFRESH MATERIALIZED VIEW CONCURRENTLY ${album_plays}`);
+  const now = new Date();
+  await db
+    .insert(cronjob_runs)
+    .values({ job_name: JOB_NAME, last_run: now })
+    .onConflictDoUpdate({
+      target: cronjob_runs.job_name,
+      set: { last_run: now },
+    });
+}
+
+/**
+ * Schedule the recurring refresh. The first refresh fires after one
+ * interval — the MV is populated at creation time by the migration, so
+ * there is no cold-start gap that requires firing immediately.
+ *
+ * Self-rescheduling via setTimeout (not setInterval) so a slow refresh
+ * cannot stack overlapping runs. If a refresh fails, the error is logged
+ * and the next tick is scheduled normally — transient REFRESH failures
+ * (e.g. another concurrent refresh, lock contention) recover on the next
+ * cycle without operator action.
+ */
+export function startAlbumPlaysRefresh(intervalMs: number = readIntervalFromEnv()): void {
+  if (timer !== null) return;
+  stopped = false;
+  scheduleNext(intervalMs);
+}
+
+/**
+ * Cancel any pending refresh. Idempotent and safe to call when not running.
+ */
+export function stopAlbumPlaysRefresh(): void {
+  stopped = true;
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}
+
+function scheduleNext(intervalMs: number): void {
+  timer = setTimeout(() => {
+    timer = null;
+    void runOneRefreshAndReschedule(intervalMs);
+  }, intervalMs);
+  timer.unref?.();
+}
+
+async function runOneRefreshAndReschedule(intervalMs: number): Promise<void> {
+  try {
+    await refreshAlbumPlays();
+  } catch (err) {
+    console.error('[album-plays-refresh] refresh failed:', err);
+  }
+  if (!stopped) scheduleNext(intervalMs);
+}
+
+function readIntervalFromEnv(): number {
+  const raw = process.env.ALBUM_PLAYS_REFRESH_INTERVAL_MS;
+  if (!raw) return DEFAULT_INTERVAL_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_INTERVAL_MS;
+}
+
+// Exposed for unit tests.
+export const __TEST_ONLY__ = {
+  JOB_NAME,
+  DEFAULT_INTERVAL_MS,
+  hasPendingTimer: (): boolean => timer !== null,
+};

--- a/shared/database/src/migrations/0059_album-plays-materialized-view.sql
+++ b/shared/database/src/migrations/0059_album-plays-materialized-view.sql
@@ -1,0 +1,34 @@
+-- Materialized view that aggregates `flowsheet` track entries into per-album
+-- play counts. Used by the new tsvector-based catalog search ranker
+-- (`Both` mode) as the play-weight signal that nudges canonical answers to
+-- the top of result lists.
+--
+-- The MV exists because the alternatives are worse:
+--   * Reading `count(*)` over `flowsheet` at query time would push every
+--     `/library` search through a full aggregation of 2.6M rows.
+--   * Storing a play counter on `library` and incrementing on insert would
+--     drift from the source of truth (flowsheet rows can be edited or
+--     deleted, ETLs reload, etc.).
+-- A materialized view re-derived from flowsheet on a schedule keeps the
+-- read path O(1) and the value reproducible.
+--
+-- Refresh is owned by `apps/backend/services/album-plays-refresh.service.ts`
+-- and tracked in the existing `cronjob_runs` table under job_name
+-- 'album-plays-refresh'. Measured refresh on the staging clone (2.6M
+-- flowsheet rows) is ~98ms, so a 1-hour cadence is comfortably idle.
+--
+-- The unique index on `album_id` is required by `REFRESH MATERIALIZED VIEW
+-- CONCURRENTLY` — without it Postgres would block reads during refresh,
+-- which defeats the purpose of an incremental signal for an interactive
+-- search endpoint.
+
+CREATE MATERIALIZED VIEW "wxyc_schema"."album_plays" AS
+SELECT
+    "album_id",
+    count(*)::int AS "plays"
+FROM "wxyc_schema"."flowsheet"
+WHERE "entry_type" = 'track' AND "album_id" IS NOT NULL
+GROUP BY "album_id";
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX "album_plays_album_id_idx" ON "wxyc_schema"."album_plays" ("album_id");

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1778164800000,
       "tag": "0058_library-artist-name-and-search-doc",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1778251200000,
+      "tag": "0059_album-plays-materialized-view",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -652,6 +652,19 @@ export type LibraryArtistViewEntry = {
   bandcamp_id: string | null;
 };
 
+// Per-album play count, aggregated from `flowsheet` track entries. The MV is
+// created and indexed by migration 0059, refreshed periodically by
+// `apps/backend/services/album-plays-refresh.service.ts`. Declared with
+// `.existing()` because we own the SQL via the migration; this entry exists
+// so drizzle-kit drift detection treats the MV as known and so the search
+// service can reference its columns through Drizzle.
+export const album_plays = wxyc_schema
+  .materializedView('album_plays', {
+    album_id: integer('album_id').notNull(),
+    plays: integer('plays').notNull(),
+  })
+  .existing();
+
 export const rotation_library_view = wxyc_schema.view('rotation_library_view').as((qb) => {
   return qb
     .select({

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -93,6 +93,10 @@ export const rotation = {
 export const library_artist_view = {
   on_streaming: 'on_streaming',
 };
+export const album_plays = {
+  album_id: 'album_id',
+  plays: 'plays',
+};
 export const flowsheet = {
   id: 'id',
   show_id: 'show_id',

--- a/tests/unit/database/schema.album-plays.test.ts
+++ b/tests/unit/database/schema.album-plays.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Schema-source assertions for the `album_plays` materialized view created
+ * by migration 0059.
+ *
+ * The MV is the play-weight signal feeding the new tsvector ranker (Epic
+ * A). Its shape is locked in three places: the migration SQL (what runs),
+ * the schema declaration (drift detection + Drizzle access), and the
+ * refresh service (consumer). Drift between any two would silently degrade
+ * search ranking — by design, since `ts_rank * ln(plays + 1)` keeps
+ * returning rows even with stale or missing play counts.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const migrationsDir = path.resolve(__dirname, '../../../shared/database/src/migrations');
+const migrationPath = path.join(migrationsDir, '0059_album-plays-materialized-view.sql');
+const journalPath = path.join(migrationsDir, 'meta/_journal.json');
+const schemaPath = path.resolve(__dirname, '../../../shared/database/src/schema.ts');
+const refreshServicePath = path.resolve(__dirname, '../../../apps/backend/services/album-plays-refresh.service.ts');
+
+describe('schema: album_plays materialized view (migration 0059)', () => {
+  it('migration 0059 exists', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  it('migration creates a MATERIALIZED VIEW named album_plays in wxyc_schema', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(/CREATE\s+MATERIALIZED\s+VIEW\s+"wxyc_schema"\."album_plays"/i);
+  });
+
+  it('aggregates from flowsheet, filtered to track entries with a non-null album_id', () => {
+    // Filter is load-bearing: flowsheet has non-track rows (talkset,
+    // breakpoint, …) that have no album, and track rows with a NULL
+    // album_id (the search-only-by-text linkage gap that Epic B is
+    // closing). Both must be excluded so the count reflects "tracks the
+    // station has actually played from a known album".
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(/FROM\s+"wxyc_schema"\."flowsheet"/i);
+    expect(sql).toMatch(/"entry_type"\s*=\s*'track'/i);
+    expect(sql).toMatch(/"album_id"\s+IS\s+NOT\s+NULL/i);
+    expect(sql).toMatch(/GROUP\s+BY\s+"album_id"/i);
+  });
+
+  it('exposes album_id and an int plays column', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(/count\(\*\)::int\s+AS\s+"plays"/i);
+  });
+
+  it('creates a UNIQUE index on album_id (required for REFRESH CONCURRENTLY)', () => {
+    // The index name is asserted because the schema declaration and any
+    // future migration that touches the MV both need to agree on it. The
+    // UNIQUE-ness is what `REFRESH MATERIALIZED VIEW CONCURRENTLY`
+    // requires — without it the refresh would block reads, which is the
+    // whole reason the MV exists in front of the search path.
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(
+      /CREATE\s+UNIQUE\s+INDEX\s+"album_plays_album_id_idx"\s+ON\s+"wxyc_schema"\."album_plays"\s*\(\s*"album_id"\s*\)/i
+    );
+  });
+
+  it('journal includes the 0059 entry', () => {
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
+    const has59 = journal.entries.some((e: { tag: string }) => e.tag === '0059_album-plays-materialized-view');
+    expect(has59).toBe(true);
+  });
+
+  it('schema.ts declares the materialized view so drizzle-kit drift detection sees it', () => {
+    const schemaSource = fs.readFileSync(schemaPath, 'utf-8');
+    expect(schemaSource).toMatch(/wxyc_schema\s*\.\s*materializedView\(\s*'album_plays'/);
+    // Both columns must be declared so consumer queries can reference
+    // them through Drizzle.
+    expect(schemaSource).toMatch(/album_id:\s*integer\(\s*'album_id'\s*\)/);
+    expect(schemaSource).toMatch(/plays:\s*integer\(\s*'plays'\s*\)/);
+    // .existing() so drizzle-kit treats the MV as managed externally
+    // (we own the SQL via the migration).
+    expect(schemaSource).toMatch(/\.existing\(\)/);
+  });
+
+  it('refresh service references the schema-declared view (not a hand-rolled string)', () => {
+    // Catch the failure mode where someone refactors the service to
+    // build the qualified name itself — then a schema rename breaks
+    // refreshes silently in environments where WXYC_SCHEMA_NAME is
+    // overridden (test isolation).
+    const serviceSource = fs.readFileSync(refreshServicePath, 'utf-8');
+    expect(serviceSource).toMatch(/REFRESH\s+MATERIALIZED\s+VIEW\s+CONCURRENTLY/i);
+    expect(serviceSource).toMatch(/album_plays/);
+  });
+});

--- a/tests/unit/services/album-plays-refresh.service.test.ts
+++ b/tests/unit/services/album-plays-refresh.service.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the album_plays MV refresh service.
+ *
+ * The DB is mocked via `tests/mocks/database.mock.ts`. Tests verify:
+ *   1. `refreshAlbumPlays` issues the REFRESH and records last-run.
+ *   2. `startAlbumPlaysRefresh` schedules a recurring timer.
+ *   3. `stopAlbumPlaysRefresh` cancels the timer.
+ *   4. A failed refresh does not stop the schedule.
+ */
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+// drizzle-orm: only `sql` is referenced by the service. We need the tag
+// function to be callable but we don't inspect the result.
+jest.mock('drizzle-orm', () => ({
+  sql: Object.assign(
+    jest.fn((..._args: unknown[]) => ({ __sql: true })),
+    { raw: jest.fn() }
+  ),
+}));
+
+// Suppress error logging from the deliberate failure test.
+jest.spyOn(console, 'error').mockImplementation(() => {});
+
+import {
+  refreshAlbumPlays,
+  startAlbumPlaysRefresh,
+  stopAlbumPlaysRefresh,
+  __TEST_ONLY__,
+} from '../../../apps/backend/services/album-plays-refresh.service';
+import { db } from '../../../tests/mocks/database.mock';
+
+type MockedFn = jest.Mock<(...args: unknown[]) => unknown>;
+
+const insertMock = db.insert as unknown as MockedFn;
+const executeMock = db.execute as unknown as MockedFn;
+const valuesMock = db._chain.values as unknown as MockedFn;
+const onConflictMock = db._chain.onConflictDoUpdate as unknown as MockedFn;
+
+describe('album-plays-refresh.service', () => {
+  beforeEach(() => {
+    insertMock.mockClear();
+    executeMock.mockClear();
+    valuesMock.mockClear();
+    onConflictMock.mockClear();
+    executeMock.mockResolvedValue([]);
+    onConflictMock.mockResolvedValue(undefined);
+    stopAlbumPlaysRefresh();
+  });
+
+  afterEach(() => {
+    stopAlbumPlaysRefresh();
+  });
+
+  describe('refreshAlbumPlays', () => {
+    test('issues REFRESH MATERIALIZED VIEW CONCURRENTLY and upserts cronjob_runs', async () => {
+      await refreshAlbumPlays();
+
+      expect(executeMock).toHaveBeenCalledTimes(1);
+      expect(insertMock).toHaveBeenCalledTimes(1);
+      // Upsert into cronjob_runs with the canonical job name. Both the
+      // job-name string and the upsert shape are part of the contract
+      // shared with `getLastRunTimestamp`.
+      const valuesArg = valuesMock.mock.calls[0]?.[0] as { job_name: string; last_run: Date };
+      expect(valuesArg.job_name).toBe('album-plays-refresh');
+      expect(valuesArg.last_run).toBeInstanceOf(Date);
+      expect(onConflictMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('propagates errors from the REFRESH so callers can decide what to do', async () => {
+      executeMock.mockRejectedValueOnce(new Error('boom'));
+      await expect(refreshAlbumPlays()).rejects.toThrow('boom');
+      // Last-run is intentionally NOT recorded on failure — operators
+      // looking at cronjob_runs should see the last *successful* run,
+      // matching the ETL pattern.
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('startAlbumPlaysRefresh / stopAlbumPlaysRefresh', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
+
+    test('schedules the first refresh one interval out (no immediate fire)', () => {
+      startAlbumPlaysRefresh(60_000);
+      expect(__TEST_ONLY__.hasPendingTimer()).toBe(true);
+      // No refresh has happened yet — the migration populates the MV at
+      // creation time, so no cold-start fire is needed.
+      expect(executeMock).not.toHaveBeenCalled();
+    });
+
+    test('start is idempotent — calling twice does not stack timers', () => {
+      startAlbumPlaysRefresh(60_000);
+      startAlbumPlaysRefresh(60_000);
+      // Second call is a no-op while a timer is already pending.
+      expect(__TEST_ONLY__.hasPendingTimer()).toBe(true);
+    });
+
+    test('stopAlbumPlaysRefresh cancels the pending timer', () => {
+      startAlbumPlaysRefresh(60_000);
+      stopAlbumPlaysRefresh();
+      expect(__TEST_ONLY__.hasPendingTimer()).toBe(false);
+    });
+
+    test('refresh fires after the interval and self-reschedules', async () => {
+      startAlbumPlaysRefresh(60_000);
+
+      // advanceTimersByTimeAsync drains both timers and the awaited
+      // microtasks inside the timer callback before resolving — needed
+      // because the callback awaits db.execute and the cronjob upsert
+      // before reaching scheduleNext().
+      await jest.advanceTimersByTimeAsync(60_000);
+
+      expect(executeMock).toHaveBeenCalledTimes(1);
+      expect(__TEST_ONLY__.hasPendingTimer()).toBe(true);
+    });
+
+    test('a failing refresh does not stop the schedule', async () => {
+      executeMock.mockRejectedValueOnce(new Error('lock contention'));
+      startAlbumPlaysRefresh(60_000);
+
+      await jest.advanceTimersByTimeAsync(60_000);
+
+      // Next tick is still queued — transient failures (e.g. another
+      // concurrent refresh, lock contention) recover automatically.
+      expect(__TEST_ONLY__.hasPendingTimer()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds migration 0059 creating the `album_plays` materialized view and the unique index on `album_id` required by `REFRESH MATERIALIZED VIEW CONCURRENTLY`. The MV aggregates per-album play counts from `flowsheet` track entries with a non-null `album_id` — the play-weight signal for the new tsvector-based catalog search ranker (Epic A).
- Declares the MV in `shared/database/src/schema.ts` so drizzle-kit drift detection treats it as known and so consumers can reference its columns through Drizzle.
- Adds `apps/backend/services/album-plays-refresh.service.ts`, started by the backend on boot. Self-rescheduling `setTimeout` runs `REFRESH MATERIALIZED VIEW CONCURRENTLY album_plays` on a configurable cadence (`ALBUM_PLAYS_REFRESH_INTERVAL_MS`, default 1 hour) and records each successful completion in the existing `cronjob_runs` table under job name `album-plays-refresh`. Failures are logged and the next tick is scheduled normally.

Reading from the MV in the search service is intentionally out of scope — that lands in A.5.

## Test plan

- [x] `npm run test:unit` — all 1107 tests pass; new coverage:
  - `tests/unit/database/schema.album-plays.test.ts` — migration SQL contents, journal entry, schema declaration, and consumer reference
  - `tests/unit/services/album-plays-refresh.service.test.ts` — refresh executes the REFRESH + cronjob upsert; start/stop is idempotent; failures don't stop the schedule
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`

Closes #489