### PR TITLE
Library backfill: populate library.artist_name from artists join

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,16 +8,17 @@ API and authentication service for WXYC applications. Provides endpoints for the
 
 npm workspaces:
 
-| Package                            | Path                               | Purpose                                                                                   |
-| ---------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------- |
-| `@wxyc/backend`                    | `apps/backend/`                    | Express API server (port 8080)                                                            |
-| `@wxyc/auth-service`               | `apps/auth/`                       | better-auth server (port 8082)                                                            |
-| `@wxyc/database`                   | `shared/database/`                 | Drizzle ORM schema, client, migrations, ETL utilities                                     |
-| `@wxyc/authentication`             | `shared/authentication/`           | Auth middleware, roles, JWT verification                                                  |
-| `@wxyc/flowsheet-etl`              | `jobs/flowsheet-etl/`              | Flowsheet ETL: sync from tubafrenzy                                                       |
-| `@wxyc/rotation-etl`               | `jobs/rotation-etl/`               | Rotation ETL: sync from tubafrenzy                                                        |
-| `@wxyc/artist-identity-etl`        | `jobs/artist-identity-etl/`        | Artist identity ETL: sync from LML's `entity.identity`                                    |
-| `@wxyc/flowsheet-dj-name-backfill` | `jobs/flowsheet-dj-name-backfill/` | One-shot backfill: populate `flowsheet.dj_name` on legacy track rows after migration 0053 |
+| Package                              | Path                                 | Purpose                                                                                                   |
+| ------------------------------------ | ------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `@wxyc/backend`                      | `apps/backend/`                      | Express API server (port 8080)                                                                            |
+| `@wxyc/auth-service`                 | `apps/auth/`                         | better-auth server (port 8082)                                                                            |
+| `@wxyc/database`                     | `shared/database/`                   | Drizzle ORM schema, client, migrations, ETL utilities                                                     |
+| `@wxyc/authentication`               | `shared/authentication/`             | Auth middleware, roles, JWT verification                                                                  |
+| `@wxyc/flowsheet-etl`                | `jobs/flowsheet-etl/`                | Flowsheet ETL: sync from tubafrenzy                                                                       |
+| `@wxyc/rotation-etl`                 | `jobs/rotation-etl/`                 | Rotation ETL: sync from tubafrenzy                                                                        |
+| `@wxyc/artist-identity-etl`          | `jobs/artist-identity-etl/`          | Artist identity ETL: sync from LML's `entity.identity`                                                    |
+| `@wxyc/flowsheet-dj-name-backfill`   | `jobs/flowsheet-dj-name-backfill/`   | One-shot backfill: populate `flowsheet.dj_name` on legacy track rows after migration 0053                 |
+| `@wxyc/library-artist-name-backfill` | `jobs/library-artist-name-backfill/` | One-shot backfill: populate `library.artist_name` from the `artists` join after migration 0058 (Epic A.2) |
 
 ### API Server (`apps/backend`)
 

--- a/Dockerfile.library-artist-name-backfill
+++ b/Dockerfile.library-artist-name-backfill
@@ -1,0 +1,27 @@
+#Build stage
+FROM node:25-alpine AS builder
+
+WORKDIR /library-artist-name-backfill-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/library-artist-name-backfill ./jobs/library-artist-name-backfill
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/library-artist-name-backfill
+
+#Production stage
+FROM node:25-alpine AS prod
+
+WORKDIR /library-artist-name-backfill
+
+COPY ./package* ./
+COPY ./jobs/library-artist-name-backfill/package* ./jobs/library-artist-name-backfill/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./library-artist-name-backfill-builder/jobs/library-artist-name-backfill/dist ./jobs/library-artist-name-backfill/dist
+COPY --from=builder ./library-artist-name-backfill-builder/shared/database/dist ./shared/database/dist
+
+CMD ["npm", "start", "--workspace=@wxyc/library-artist-name-backfill"]

--- a/jobs/library-artist-name-backfill/job.ts
+++ b/jobs/library-artist-name-backfill/job.ts
@@ -1,0 +1,140 @@
+/**
+ * One-shot backfill: populate library.artist_name from the artists join (Epic A.2).
+ *
+ * Migration 0058 (Epic A.1) added library.artist_name as a nullable column and
+ * the STORED `search_doc` tsvector that depends on it. Until artist_name is
+ * populated, search_doc reflects only album_title — the new tsvector search
+ * path (A.5) cannot match by artist for legacy rows. This job populates every
+ * library row from the existing artist_id FK in batched, individually-committed
+ * UPDATEs so a long run cannot hold an AccessExclusiveLock or wedge concurrent
+ * reads. Each batch is bounded by `BATCH_SIZE`, ordered by `id`, and naturally
+ * restartable via the `artist_name IS NULL` filter (re-running picks up exactly
+ * the rows the previous run did not finish).
+ *
+ * The NULL guard also makes this safe to interleave with A.3's live-write
+ * path: if A.3 has already written artist_name on an insert, this job leaves
+ * it untouched.
+ *
+ * Run procedure: see Backend-Service/CLAUDE.md and issue #511. Build via
+ * `Manual Build & Deploy` with `target=library-artist-name-backfill`, then SSH
+ * to EC2 and `docker run --rm --env-file .env <image> 2>&1 | tee log`.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db, closeDatabaseConnection } from '@wxyc/database';
+
+const JOB_NAME = 'library-artist-name-backfill';
+const BATCH_SIZE = 5000;
+const PROGRESS_LOG_EVERY = 1; // every batch; the operation is rare enough that verbose is fine
+
+/**
+ * Apply one batch of artist_name updates and return the number of rows changed.
+ * Each call is its own implicit transaction (postgres-js commits per execute
+ * unless wrapped in db.transaction). Returning 0 means we have backfilled
+ * every library row reachable through an `artists` join.
+ */
+const applyBatch = async (batchSize: number): Promise<number> => {
+  const result = await db.execute(sql`
+    UPDATE "wxyc_schema"."library" AS l
+    SET "artist_name" = a."artist_name"
+    FROM "wxyc_schema"."artists" AS a
+    WHERE a."id" = l."artist_id"
+      AND l."artist_name" IS NULL
+      AND l."id" IN (
+        SELECT "id" FROM "wxyc_schema"."library"
+        WHERE "artist_name" IS NULL
+        ORDER BY "id"
+        LIMIT ${batchSize}
+      )
+  `);
+  return Number(result.count ?? 0);
+};
+
+/**
+ * Format a millisecond duration as `Xm Ys` for human-readable progress logs.
+ */
+const formatDuration = (ms: number): string => {
+  const totalSec = Math.round(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}m ${sec}s`;
+};
+
+const runBackfill = async () => {
+  console.log(`[${JOB_NAME}] Starting backfill of library.artist_name.`);
+  console.log(`[${JOB_NAME}] Batch size: ${BATCH_SIZE}.`);
+
+  const startedAt = Date.now();
+  let batches = 0;
+  let totalUpdated = 0;
+  let consecutiveEmpty = 0;
+
+  while (true) {
+    const batchStartedAt = Date.now();
+    const updated = await applyBatch(BATCH_SIZE);
+    batches++;
+    totalUpdated += updated;
+
+    if (updated === 0) {
+      // One empty batch is the natural end. Log and break. We do not retry on
+      // empty because that would loop forever in a fully-backfilled state.
+      consecutiveEmpty++;
+      if (consecutiveEmpty >= 1) {
+        break;
+      }
+    } else {
+      consecutiveEmpty = 0;
+    }
+
+    if (batches % PROGRESS_LOG_EVERY === 0) {
+      const batchMs = Date.now() - batchStartedAt;
+      const elapsedMs = Date.now() - startedAt;
+      console.log(
+        `[${JOB_NAME}] batch ${batches}: ${updated} rows in ${formatDuration(batchMs)} | ` +
+          `total ${totalUpdated} rows in ${formatDuration(elapsedMs)}`
+      );
+    }
+  }
+
+  const elapsedMs = Date.now() - startedAt;
+  console.log(
+    `[${JOB_NAME}] Done. Updated ${totalUpdated} rows across ${batches} batches in ${formatDuration(elapsedMs)}.`
+  );
+};
+
+/**
+ * Verify the backfill is complete: 0 library rows with NULL artist_name. Logs
+ * the count and (only) raises if any remain — operator-friendly output even on
+ * success.
+ */
+const verifyComplete = async () => {
+  const result = await db.execute(
+    sql`SELECT count(*)::int AS missing FROM "wxyc_schema"."library" WHERE artist_name IS NULL`
+  );
+  const missing = Number((result as unknown as Array<{ missing: number }>)[0]?.missing ?? 0);
+  if (missing > 0) {
+    throw new Error(
+      `[${JOB_NAME}] Verification failed: ${missing} library row(s) still have artist_name IS NULL. ` +
+        `Re-run the backfill — it is idempotent and will pick up the remaining rows.`
+    );
+  }
+  console.log(`[${JOB_NAME}] Verification passed: 0 library rows with artist_name IS NULL.`);
+};
+
+const main = async () => {
+  try {
+    await runBackfill();
+    await verifyComplete();
+  } finally {
+    await closeDatabaseConnection();
+  }
+};
+
+main().catch((error) => {
+  console.error(`[${JOB_NAME}] Failed:`, error);
+  process.exitCode = 1;
+});
+
+// Exports for unit tests. Production entry point is the `main()` invocation
+// above; tests reach into the individual primitives.
+export { applyBatch, runBackfill, verifyComplete, formatDuration, BATCH_SIZE };

--- a/jobs/library-artist-name-backfill/package.json
+++ b/jobs/library-artist-name-backfill/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wxyc/library-artist-name-backfill",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot backfill: populate library.artist_name from the artists join (Epic A.2)",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_library_artist_name_backfill:ci -f ../../Dockerfile.library-artist-name-backfill ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/library-artist-name-backfill/tsconfig.json
+++ b/jobs/library-artist-name-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/library-artist-name-backfill/tsup.config.ts
+++ b/jobs/library-artist-name-backfill/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -469,6 +469,20 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/library-artist-name-backfill": {
+      "name": "@wxyc/library-artist-name-backfill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/library-etl": {
       "name": "@wxyc/library-etl",
       "version": "1.0.0",
@@ -7011,6 +7025,10 @@
     },
     "node_modules/@wxyc/flowsheet-etl": {
       "resolved": "jobs/flowsheet-etl",
+      "link": true
+    },
+    "node_modules/@wxyc/library-artist-name-backfill": {
+      "resolved": "jobs/library-artist-name-backfill",
       "link": true
     },
     "node_modules/@wxyc/library-etl": {

--- a/tests/unit/jobs/library-artist-name-backfill/job.test.ts
+++ b/tests/unit/jobs/library-artist-name-backfill/job.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the library.artist_name backfill job (Epic A.2).
+ *
+ * The backfill is the runtime counterpart to migration 0058 (Epic A.1):
+ * after the column is added (NULL on every row), this job populates legacy
+ * library rows by joining against `artists` in batched UPDATEs that each
+ * commit independently. Once `artist_name` is populated, the STORED
+ * `search_doc` tsvector becomes meaningful for those rows and the new
+ * tsvector search path (A.5) starts returning matches.
+ */
+
+import { db } from '@wxyc/database';
+import {
+  applyBatch,
+  runBackfill,
+  verifyComplete,
+  formatDuration,
+  BATCH_SIZE,
+} from '../../../../jobs/library-artist-name-backfill/job';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const findExecuteCallMatching = (pattern: RegExp): unknown[] | undefined => {
+  const calls = (db.execute as jest.Mock).mock.calls;
+  return calls.find((call) => pattern.test(renderSql(call[0])));
+};
+
+describe('library-artist-name-backfill: applyBatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds an UPDATE that sets library.artist_name from the artists join', async () => {
+    // The whole point of A.2 is to denormalize artists.artist_name onto
+    // library.artist_name. Drift here would either copy the wrong column
+    // or skip the join entirely.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 5000 });
+
+    await applyBatch(5000);
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*library[\s\S]*artist_name/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/SET\s+"?artist_name"?\s*=\s*a\."artist_name"/i);
+    expect(sqlText).toMatch(/FROM[\s\S]*"?artists"?\s+AS\s+a/i);
+    expect(sqlText).toMatch(/a\."id"\s*=\s*l\."artist_id"/i);
+  });
+
+  it('restricts the UPDATE to NULL artist_name rows within a bounded batch', async () => {
+    // Three regression guards in one test:
+    //   - artist_name IS NULL on the outer UPDATE (don't overwrite live writes from A.3)
+    //   - LIMIT in an inner SELECT (bounded batch — never an unbounded UPDATE)
+    //   - artist_name IS NULL also on the inner SELECT (idempotent re-runs)
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 5000 });
+
+    await applyBatch(5000);
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*library[\s\S]*artist_name/i);
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/artist_name"?\s+IS\s+NULL/i);
+    expect(sqlText).toMatch(/LIMIT/i);
+    // Inner SELECT for the bounded batch — there should be a SELECT inside the UPDATE.
+    expect(sqlText).toMatch(/IN\s*\(\s*SELECT/i);
+  });
+
+  it('passes the batch size argument through into the SQL builder', async () => {
+    // Looser assertion than reaching into Drizzle's queryChunks shape (which
+    // varies between Drizzle versions). The point of the test is that the
+    // function actually uses its argument; serializing the SQL and JSON-
+    // stringifying the parameter object catches the value either as a
+    // bound parameter or an inlined literal.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await applyBatch(1234);
+
+    const call = (db.execute as jest.Mock).mock.calls.find((c) =>
+      /UPDATE[\s\S]*library[\s\S]*artist_name/i.test(renderSql(c[0]))
+    );
+    const serialized = JSON.stringify(call?.[0]);
+    expect(serialized).toContain('1234');
+  });
+
+  it('returns the postgres-js result.count as the rows-updated number', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 4321 });
+
+    const updated = await applyBatch(5000);
+
+    expect(updated).toBe(4321);
+  });
+
+  it('returns 0 when the result has no count property (empty result)', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({});
+
+    const updated = await applyBatch(5000);
+
+    expect(updated).toBe(0);
+  });
+});
+
+describe('library-artist-name-backfill: runBackfill loop control', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('iterates batches until applyBatch returns 0 (natural end)', async () => {
+    // Three non-empty batches, then one empty batch terminates the loop.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce({ count: 5000 })
+      .mockResolvedValueOnce({ count: 5000 })
+      .mockResolvedValueOnce({ count: 1234 })
+      .mockResolvedValueOnce({ count: 0 });
+
+    await runBackfill();
+
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(4);
+  });
+
+  it('exits cleanly on the very first empty batch (already-backfilled state)', async () => {
+    // Re-running on a fully-backfilled DB must be a no-op, not loop forever.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await runBackfill();
+
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  it('uses BATCH_SIZE of 5000 (not unbounded)', () => {
+    // Bounded UPDATEs are the whole point. If a future change accidentally bumps
+    // the batch size into the millions or removes the LIMIT, this test catches it.
+    expect(BATCH_SIZE).toBe(5000);
+  });
+});
+
+describe('library-artist-name-backfill: verifyComplete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('passes when zero library rows have NULL artist_name', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ missing: 0 }]);
+
+    await expect(verifyComplete()).resolves.toBeUndefined();
+  });
+
+  it('throws with a remediation hint when library rows still have NULL artist_name', async () => {
+    // mockResolvedValue (not Once) so both rejection assertions get the
+    // same response — the second await re-invokes verifyComplete.
+    (db.execute as jest.Mock).mockResolvedValue([{ missing: 137 }]);
+
+    await expect(verifyComplete()).rejects.toThrow(/137 library row\(s\)/);
+    await expect(verifyComplete()).rejects.toThrow(/idempotent/i);
+  });
+});
+
+describe('library-artist-name-backfill: formatDuration', () => {
+  it('formats sub-minute durations as "0m Xs"', () => {
+    expect(formatDuration(0)).toBe('0m 0s');
+    expect(formatDuration(1500)).toBe('0m 2s');
+    expect(formatDuration(45_000)).toBe('0m 45s');
+  });
+
+  it('formats multi-minute durations as "Xm Ys"', () => {
+    expect(formatDuration(60_000)).toBe('1m 0s');
+    expect(formatDuration(125_000)).toBe('2m 5s');
+    expect(formatDuration(3_600_000)).toBe('60m 0s');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the `@wxyc/library-artist-name-backfill` one-shot job that populates `library.artist_name` from the `artists` join, batching 5000 rows at a time with the canonical inner-`SELECT … LIMIT` pattern. Each batch commits independently so a long run cannot wedge the table.
- Idempotent via the `artist_name IS NULL` filter; safe to interleave with A.3's live-write path. `verifyComplete` post-flight raises if any row remains, so re-running closes any partial run.
- Mirrors the structure of `jobs/flowsheet-dj-name-backfill/` end-to-end (job module, package.json with `job-type: one-shot`, tsup config, Dockerfile, ECR-driven manual deploy via `target=library-artist-name-backfill`).
- Once this lands, the STORED `search_doc` tsvector added in A.1 (#486) becomes meaningful for legacy rows and the new search path (A.5) starts returning artist matches.

Run procedure: `Manual Build & Deploy` workflow with `target=library-artist-name-backfill`, then SSH to EC2 and `docker run --rm --env-file .env <image>` during a low-traffic window. The 64K-row library finishes in well under a second per batch.

Closes #487.

## Test plan

- [x] `npm run test:unit` — 1128/1128 pass, 12 new tests for `applyBatch`, `runBackfill`, `verifyComplete`, `formatDuration`, `BATCH_SIZE` constant
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run build --workspace=@wxyc/library-artist-name-backfill` — builds via tsup
- [ ] On staging: run the image against the production clone, confirm `verifyComplete` reports 0 NULL rows and `search_doc` is non-empty for sampled rows