### PR TITLE
Live write paths: addAlbum writes artist_name; artist rename cascades

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -51,6 +51,12 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
     );
   }
 
+  // Denormalize the canonical artist_name onto library (Epic A.3). We always
+  // re-fetch from `artists` rather than trusting body.artist_name so the
+  // library row stays consistent with the FK target even when the client
+  // sent a casing variant. Renames cascade via the trigger added in 0060.
+  const canonical_artist_name = await libraryService.getArtistNameById(artist_id);
+
   // Resolve label string to label_id via upsert
   let label_id = body.label_id;
   if (label_id === undefined && body.label) {
@@ -60,6 +66,7 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
 
   const new_album: NewAlbum = {
     artist_id: artist_id,
+    artist_name: canonical_artist_name,
     genre_id: body.genre_id,
     format_id: body.format_id,
     album_title: body.album_title,

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -295,6 +295,21 @@ export function serializeLibraryArtistViewEntry(row: LibraryArtistViewEntry): Li
   return serializeReconciledIdentity(row);
 }
 
+/**
+ * Look up the canonical `artist_name` for an `artists.id`. Used by addAlbum
+ * (A.3) to denormalize the canonical name onto the library row so client-
+ * supplied casing variants ("jessica pratt") never get persisted to library
+ * out of sync with the `artists` row.
+ */
+export const getArtistNameById = async (artist_id: number): Promise<string | null> => {
+  const response = await db
+    .select({ artist_name: artists.artist_name })
+    .from(artists)
+    .where(eq(artists.id, artist_id))
+    .limit(1);
+  return response[0]?.artist_name ?? null;
+};
+
 export const artistIdFromName = async (artist_name: string, genre_id: number): Promise<number> => {
   const response = await db
     .select({ id: artists.id })

--- a/shared/database/src/migrations/0060_library-artist-name-cascade-trigger.sql
+++ b/shared/database/src/migrations/0060_library-artist-name-cascade-trigger.sql
@@ -1,0 +1,30 @@
+-- Cascade `artists.artist_name` updates onto the denormalized
+-- `library.artist_name` column added in 0058 (Epic A.3).
+--
+-- Synchronous trigger: chosen over an application-side rename path because
+-- the artists row is the source of truth, and a forgotten call site would
+-- silently drift the search_doc tsvector (whose A-weighted artist_name
+-- powers the new catalog search in A.5). Write amplification is modest --
+-- the typical artist has fewer than 10 library rows -- and an
+-- ACCESS EXCLUSIVE lock is never held since the trigger only updates rows
+-- already covered by the originating UPDATE's row-level locks.
+--
+-- The WHEN guard keeps the trigger inert for UPDATEs that don't touch
+-- artist_name (e.g. the artist-identity ETL writing reconciled-identity
+-- columns), avoiding redundant library writes and pg_notify CDC fanout.
+
+CREATE OR REPLACE FUNCTION wxyc_schema.cascade_library_artist_name() RETURNS trigger AS $$
+BEGIN
+  UPDATE wxyc_schema.library
+     SET artist_name = NEW.artist_name
+   WHERE artist_id = NEW.id
+     AND artist_name IS DISTINCT FROM NEW.artist_name;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+CREATE TRIGGER cascade_library_artist_name
+AFTER UPDATE OF artist_name ON wxyc_schema.artists
+FOR EACH ROW
+WHEN (OLD.artist_name IS DISTINCT FROM NEW.artist_name)
+EXECUTE FUNCTION wxyc_schema.cascade_library_artist_name();

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1778251200000,
       "tag": "0059_album-plays-materialized-view",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1778337600000,
+      "tag": "0060_library-artist-name-cascade-trigger",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -439,6 +439,71 @@ describe('Library Artists', () => {
   });
 });
 
+describe('Library artist_name cascade trigger (A.3 / 0060)', () => {
+  const postgres = require('postgres');
+  let sql;
+  let artistId;
+  let albumIds;
+  const schema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+  const originalName = `Cascade Origin ${Date.now()}`;
+  const renamedName = `Cascade Renamed ${Date.now()}`;
+
+  beforeAll(async () => {
+    sql = postgres({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+      database: process.env.DB_NAME || 'wxyc_db',
+      user: process.env.DB_USERNAME || 'test-user',
+      password: process.env.DB_PASSWORD || 'test-pw',
+    });
+
+    // Seed: one artist, two library rows for that artist with the
+    // pre-rename denormalized name.
+    const codeLetters = `Z${Date.now().toString(36).toUpperCase().slice(-2)}`;
+    const artistRes = await sql.unsafe(`
+      INSERT INTO ${schema}.artists (artist_name, alphabetical_name, code_letters)
+      VALUES ('${originalName}', '${originalName}', '${codeLetters}')
+      RETURNING id
+    `);
+    artistId = artistRes[0].id;
+
+    const albumRes = await sql.unsafe(`
+      INSERT INTO ${schema}.library
+        (artist_id, genre_id, format_id, album_title, label, code_number, artist_name)
+      VALUES
+        (${artistId}, 11, 1, 'Cascade Album One', 'Cascade Label', 1, '${originalName}'),
+        (${artistId}, 11, 1, 'Cascade Album Two', 'Cascade Label', 2, '${originalName}')
+      RETURNING id
+    `);
+    albumIds = albumRes.map((r) => r.id);
+  });
+
+  afterAll(async () => {
+    if (albumIds?.length) {
+      await sql.unsafe(`DELETE FROM ${schema}.library WHERE id IN (${albumIds.join(',')})`);
+    }
+    if (artistId) {
+      await sql.unsafe(`DELETE FROM ${schema}.artists WHERE id = ${artistId}`);
+    }
+    await sql.end();
+  });
+
+  test('renaming artists.artist_name updates every library row for that artist', async () => {
+    await sql.unsafe(`
+      UPDATE ${schema}.artists
+         SET artist_name = '${renamedName}'
+       WHERE id = ${artistId}
+    `);
+
+    const rows = await sql.unsafe(
+      `SELECT artist_name FROM ${schema}.library WHERE artist_id = ${artistId} ORDER BY id`
+    );
+
+    expect(rows).toHaveLength(2);
+    rows.forEach((row) => expect(row.artist_name).toBe(renamedName));
+  });
+});
+
 describe('Library Artists Peek Code', () => {
   let auth;
 

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -210,7 +210,7 @@ describe('library.controller', () => {
       jest.clearAllMocks();
       mockGenerateAlbumCodeNumber.mockResolvedValue(1);
       mockCreateLabel.mockResolvedValue({ id: 99 });
-      mockInsertAlbum.mockImplementation(async (album) => ({ id: 1, ...album }));
+      mockInsertAlbum.mockImplementation((album) => Promise.resolve({ id: 1, ...album }));
     });
 
     it('writes the canonical artist_name from the artists table when artist_id is supplied', async () => {

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -6,6 +6,11 @@ const mockMarkAlbumMissing = jest.fn<() => Promise<{ id: number } | undefined>>(
 const mockMarkAlbumFound = jest.fn<() => Promise<{ id: number } | undefined>>();
 const mockFuzzySearchLibrary = jest.fn<() => Promise<unknown[]>>();
 const mockEnrichWithArtwork = jest.fn<(results: unknown[]) => Promise<unknown[]>>();
+const mockArtistIdFromName = jest.fn<(name: string, genreId: number) => Promise<number>>();
+const mockGetArtistNameById = jest.fn<(id: number) => Promise<string | null>>();
+const mockInsertAlbum = jest.fn<(album: Record<string, unknown>) => Promise<Record<string, unknown>>>();
+const mockGenerateAlbumCodeNumber = jest.fn<(artistId: number) => Promise<number>>();
+const mockCreateLabel = jest.fn<(label: string) => Promise<{ id: number }>>();
 
 jest.mock('../../../apps/backend/services/library.service', () => ({
   getAlbumFromDB: mockGetAlbumFromDB,
@@ -22,14 +27,15 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   getRotationFromDB: jest.fn(),
   addToRotation: jest.fn(),
   killRotationInDB: jest.fn(),
-  insertAlbum: jest.fn(),
+  insertAlbum: mockInsertAlbum,
   updateArtworkUrl: jest.fn(),
   updateOnStreaming: jest.fn(),
-  artistIdFromName: jest.fn(),
+  artistIdFromName: mockArtistIdFromName,
+  getArtistNameById: mockGetArtistNameById,
   insertArtist: jest.fn(),
   insertArtistGenreCrossreference: jest.fn(),
   getArtistByCode: jest.fn(),
-  generateAlbumCodeNumber: jest.fn(),
+  generateAlbumCodeNumber: mockGenerateAlbumCodeNumber,
   generateArtistNumber: jest.fn(),
   getGenresFromDB: jest.fn(),
   insertGenre: jest.fn(),
@@ -38,15 +44,16 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
 }));
 
 jest.mock('../../../apps/backend/services/labels.service', () => ({
-  createLabel: jest.fn(),
+  createLabel: mockCreateLabel,
 }));
 
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
   checkStreamingAvailability: jest.fn(),
+  lookupMetadata: jest.fn(),
   isLmlConfigured: jest.fn().mockReturnValue(false),
 }));
 
-import { markMissing, markFound, searchForAlbum } from '../../../apps/backend/controllers/library.controller';
+import { markMissing, markFound, searchForAlbum, addAlbum } from '../../../apps/backend/controllers/library.controller';
 
 function mockResponse(): Response {
   const res = {} as Response;
@@ -195,6 +202,61 @@ describe('library.controller', () => {
       const res = mockResponse();
 
       await expect(searchForAlbum(req, res, next)).rejects.toThrow(enrichError);
+    });
+  });
+
+  describe('addAlbum', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGenerateAlbumCodeNumber.mockResolvedValue(1);
+      mockCreateLabel.mockResolvedValue({ id: 99 });
+      mockInsertAlbum.mockImplementation(async (album) => ({ id: 1, ...album }));
+    });
+
+    it('writes the canonical artist_name from the artists table when artist_id is supplied', async () => {
+      mockGetArtistNameById.mockResolvedValue('Juana Molina');
+
+      const req = {
+        body: {
+          album_title: 'DOGA',
+          artist_id: 42,
+          label: 'Sonamos',
+          genre_id: 11,
+          format_id: 1,
+        },
+      } as unknown as Request;
+      const res = mockResponse();
+
+      await addAlbum(req, res, next);
+
+      expect(mockGetArtistNameById).toHaveBeenCalledWith(42);
+      expect(mockInsertAlbum).toHaveBeenCalledWith(
+        expect.objectContaining({ artist_id: 42, artist_name: 'Juana Molina' })
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('resolves the canonical artist_name even when the request body provides one', async () => {
+      mockArtistIdFromName.mockResolvedValue(7);
+      mockGetArtistNameById.mockResolvedValue('Jessica Pratt');
+
+      const req = {
+        body: {
+          album_title: 'On Your Own Love Again',
+          artist_name: 'jessica pratt',
+          label: 'Drag City',
+          genre_id: 11,
+          format_id: 1,
+        },
+      } as unknown as Request;
+      const res = mockResponse();
+
+      await addAlbum(req, res, next);
+
+      expect(mockGetArtistNameById).toHaveBeenCalledWith(7);
+      expect(mockInsertAlbum).toHaveBeenCalledWith(
+        expect.objectContaining({ artist_id: 7, artist_name: 'Jessica Pratt' })
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #488. Part of [Epic A](https://github.com/WXYC/Backend-Service/issues/483) (catalog search reconciliation). A.1 added the denormalized `library.artist_name` column and the STORED `search_doc` tsvector. A.2 backfilled it for legacy rows. A.3 keeps it current going forward.

- `addAlbum` now resolves the canonical `artist_name` from `artists` (by id, after the existing artist-id-from-name lookup) and writes it onto the `library` row. We always re-fetch from `artists` rather than trusting `body.artist_name`, so the library row matches the FK target even when the client sent a casing variant.
- New service helper `getArtistNameById`.
- Migration `0060_library-artist-name-cascade-trigger.sql`: AFTER UPDATE OF `artist_name` ON `artists` propagates the new value to every library row for that artist. The `WHEN OLD.artist_name IS DISTINCT FROM NEW.artist_name` guard keeps it inert for unrelated UPDATEs (notably the artist-identity ETL writing reconciled-identity columns).

Picked the trigger over an application path per the issue body — the artists row is the source of truth, and a forgotten call site would silently drift the A.5 search index. Modest write amplification (typically <10 albums per artist), no `ACCESS EXCLUSIVE` lock since the trigger only updates rows already covered by the originating UPDATE's row-level locks.

## Test plan

- [x] Unit (`tests/unit/controllers/library.controller.test.ts`): `addAlbum` calls `getArtistNameById(artist_id)` and `insertAlbum` receives `{ artist_id, artist_name }`. Two cases: `artist_id` supplied directly, and `artist_name` supplied (which goes through `artistIdFromName` then back through `getArtistNameById` to canonicalize casing).
- [x] Integration (`tests/integration/library.spec.js`): seed an artist + two library rows with the original name, `UPDATE artists SET artist_name = ...`, assert both library rows pick up the new name.
- [x] `npm run typecheck`, `npm run lint` (no new errors), `npm run format:check`.
- [x] `npm run test:unit -- --testPathPatterns=library.controller` passes.

## Out of scope

- Service reads (A.5).