### PR TITLE
Library schema: canonical_entity_id + index

### DIFF
--- a/shared/database/src/migrations/0061_library-canonical-entity.sql
+++ b/shared/database/src/migrations/0061_library-canonical-entity.sql
@@ -1,0 +1,44 @@
+-- Add reconciled canonical-entity linkage columns to library (Epic B.1).
+-- B-0 (issue #492) confirmed LML doesn't expose per-result confidence, so the
+-- value stored here is heuristic-derived (search_type=direct => high; fallback
+-- => low) at link time and kept around for retroactive re-judging once LML
+-- exposes a real signal.
+--
+-- Column choices:
+--   canonical_entity_id          TEXT  — opaque identifier (Discogs/MusicBrainz/
+--                                        LML id, optionally namespaced). The
+--                                        scheme is the resolver's contract, not
+--                                        this column's; TEXT keeps us flexible
+--                                        if the source-of-truth shifts.
+--   canonical_entity_confidence  REAL  — confidence at link time, in [0, 1].
+--   canonical_entity_resolved_at TIMESTAMPTZ — when the linkage was set, for
+--                                        audit + retry policy.
+--
+-- Index: B-tree on canonical_entity_id supports the flowsheet → library join
+-- via canonical entity (B-2). Default B-tree (not GIN/hash) — we want range
+-- and equality lookups, the column is short text, and the cardinality is at
+-- most one row per ~64K library entries.
+--
+-- Order across Epic B:
+--   B-1.1 (this migration): add nullable columns + index.
+--   B-1.2 (backfill job):   populate from LML for existing rows.
+--   B-1.3 (live writes):    addAlbum writes the linkage on insert.
+--   B-1.4 (flowsheet):      add audit columns on the flowsheet side.
+--
+-- Production note: ALTER TABLE ADD COLUMN of nullable columns is metadata-
+-- only, so this DDL is fast even on the full library. CREATE INDEX takes a
+-- ShareLock that blocks writes; on ~64K rows this completes in well under a
+-- second. No CONCURRENTLY needed (and CONCURRENTLY can't run inside a
+-- migration transaction anyway).
+
+ALTER TABLE "wxyc_schema"."library"
+  ADD COLUMN "canonical_entity_id" text;--> statement-breakpoint
+
+ALTER TABLE "wxyc_schema"."library"
+  ADD COLUMN "canonical_entity_confidence" real;--> statement-breakpoint
+
+ALTER TABLE "wxyc_schema"."library"
+  ADD COLUMN "canonical_entity_resolved_at" timestamp with time zone;--> statement-breakpoint
+
+CREATE INDEX "library_canonical_entity_id_idx"
+  ON "wxyc_schema"."library" ("canonical_entity_id");

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1778337600000,
       "tag": "0060_library-artist-name-cascade-trigger",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1779424000000,
+      "tag": "0061_library-canonical-entity",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -16,6 +16,7 @@ import {
   date,
   uniqueIndex,
   customType,
+  real,
 } from 'drizzle-orm/pg-core';
 
 // PostgreSQL tsvector. Drizzle has no first-class tsvector type, but we only
@@ -291,6 +292,17 @@ export const library = wxyc_schema.table(
     // backfills it from the artists join; A.3 keeps it current on insert and
     // cascades on artists UPDATE. A.5 reads it via search_doc.
     artist_name: varchar('artist_name', { length: 128 }),
+    // Reconciled canonical entity for the album, derived via LML lookup
+    // (Epic B.1). Nullable until B-1.2 backfills it; B-1.3 keeps it current
+    // on insert. The identifier is opaque text (e.g. a Discogs/MusicBrainz
+    // release id, optionally namespaced) — schemes are decided per-source by
+    // the resolver, not the column. Confidence is captured at link time so
+    // retroactive analyses can re-judge weak matches; resolved_at supports
+    // audit + retry policy. The B-tree index supports flowsheet → library
+    // joins via canonical entity in B-2.
+    canonical_entity_id: text('canonical_entity_id'),
+    canonical_entity_confidence: real('canonical_entity_confidence'),
+    canonical_entity_resolved_at: timestamp('canonical_entity_resolved_at', { withTimezone: true }),
     // STORED GENERATED tsvector covering the searchable text fields with
     // weight bands (artist=A, album=B). NULL for rows where artist_name has
     // not been backfilled yet — A.2 populates legacy rows, A.3 keeps live
@@ -312,6 +324,7 @@ export const library = wxyc_schema.table(
         sql`${table.artist_name} gin_trgm_ops`
       ),
       librarySearchDocIdx: index('library_search_doc_idx').using('gin', sql`${table.search_doc}`),
+      libraryCanonicalEntityIdIdx: index('library_canonical_entity_id_idx').on(table.canonical_entity_id),
     };
   }
 );

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -74,6 +74,9 @@ export const library = {
   artwork_url: 'artwork_url',
   artist_name: 'artist_name',
   search_doc: 'search_doc',
+  canonical_entity_id: 'canonical_entity_id',
+  canonical_entity_confidence: 'canonical_entity_confidence',
+  canonical_entity_resolved_at: 'canonical_entity_resolved_at',
 };
 export const artists = {};
 export const genres = {};

--- a/tests/unit/database/schema.library-canonical-entity.test.ts
+++ b/tests/unit/database/schema.library-canonical-entity.test.ts
@@ -1,0 +1,90 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('schema: library canonical_entity_id columns + index (B-1.1)', () => {
+  const schemaPath = path.resolve(__dirname, '../../../shared/database/src/schema.ts');
+  const schemaSource = fs.readFileSync(schemaPath, 'utf-8');
+
+  const migrationsDir = path.resolve(__dirname, '../../../shared/database/src/migrations');
+  const migrationPath = path.join(migrationsDir, '0061_library-canonical-entity.sql');
+  const journalPath = path.join(migrationsDir, 'meta/_journal.json');
+
+  const extractTableDef = (tableName: string): string => {
+    const regex = new RegExp(`export const ${tableName}\\b[\\s\\S]*?^\\);`, 'm');
+    const match = schemaSource.match(regex);
+    if (!match) throw new Error(`Table definition for ${tableName} not found in schema`);
+    return match[0];
+  };
+
+  it('library table declares a nullable canonical_entity_id text column', () => {
+    const def = extractTableDef('library');
+    expect(def).toMatch(/canonical_entity_id:\s*text\(['"]canonical_entity_id['"]\)/);
+    // Nullable — populated by B-1.2 backfill and B-1.3 live writes.
+    expect(def).not.toMatch(/canonical_entity_id:\s*text\([^)]*\)\.notNull\(\)/);
+  });
+
+  it('library table declares a nullable canonical_entity_confidence real column', () => {
+    const def = extractTableDef('library');
+    expect(def).toMatch(/canonical_entity_confidence:\s*real\(['"]canonical_entity_confidence['"]\)/);
+    expect(def).not.toMatch(/canonical_entity_confidence:\s*real\([^)]*\)\.notNull\(\)/);
+  });
+
+  it('library table declares a nullable canonical_entity_resolved_at timestamptz column', () => {
+    const def = extractTableDef('library');
+    expect(def).toMatch(
+      /canonical_entity_resolved_at:\s*timestamp\(\s*['"]canonical_entity_resolved_at['"][\s\S]*?withTimezone:\s*true/
+    );
+    expect(def).not.toMatch(/canonical_entity_resolved_at:[\s\S]*?\.notNull\(\)/);
+  });
+
+  it('library table declares a B-tree index on canonical_entity_id', () => {
+    const def = extractTableDef('library');
+    expect(def).toMatch(/library_canonical_entity_id_idx[\s\S]*?canonical_entity_id/);
+    // No `using('gin', ...)` for this index — it's a default B-tree.
+    const idxBlock = def.match(/library_canonical_entity_id_idx[\s\S]{0,200}/)?.[0] ?? '';
+    expect(idxBlock).not.toMatch(/using\(\s*['"]gin['"]/);
+  });
+
+  it('migration 0061 exists and adds the three canonical_entity columns', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(/ALTER TABLE\s+"wxyc_schema"\."library"\s+ADD COLUMN\s+"canonical_entity_id"\s+text/i);
+    expect(sql).toMatch(/ADD COLUMN\s+"canonical_entity_confidence"\s+real/i);
+    expect(sql).toMatch(/ADD COLUMN\s+"canonical_entity_resolved_at"\s+timestamp\s+with\s+time\s+zone/i);
+  });
+
+  it('migration 0061 creates a B-tree index on canonical_entity_id', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    // Default B-tree index — no USING clause expected.
+    expect(sql).toMatch(
+      /CREATE INDEX[^;]*"library_canonical_entity_id_idx"[\s\S]*?ON\s+"wxyc_schema"\."library"\s*\(\s*"canonical_entity_id"\s*\)/i
+    );
+    const idxStatement = sql.match(/CREATE INDEX[^;]*"library_canonical_entity_id_idx"[^;]*/i)?.[0] ?? '';
+    expect(idxStatement).not.toMatch(/USING\s+gin/i);
+    expect(idxStatement).not.toMatch(/USING\s+hash/i);
+  });
+
+  it('migration 0061 is DDL-only — no in-migration backfill', () => {
+    // Adding nullable columns is metadata-only. A backfill UPDATE inside the
+    // same transaction would hold AccessExclusiveLock and could wedge the
+    // table; backfill belongs in B-1.2 (jobs/<name>-backfill).
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).not.toMatch(/^\s*UPDATE\s+"wxyc_schema"\."library"/im);
+  });
+
+  it('journal includes the 0061 entry', () => {
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
+    const has61 = journal.entries.some((e: { tag: string }) => e.tag === '0061_library-canonical-entity');
+    expect(has61).toBe(true);
+  });
+
+  it('mock includes the canonical_entity columns on library', () => {
+    const mockPath = path.resolve(__dirname, '../../mocks/database.mock.ts');
+    const mockSource = fs.readFileSync(mockPath, 'utf-8');
+    const libraryMock = mockSource.match(/export const library\s*=\s*\{[\s\S]*?\};/)?.[0];
+    expect(libraryMock).toBeDefined();
+    expect(libraryMock).toContain("canonical_entity_id: 'canonical_entity_id'");
+    expect(libraryMock).toContain("canonical_entity_confidence: 'canonical_entity_confidence'");
+    expect(libraryMock).toContain("canonical_entity_resolved_at: 'canonical_entity_resolved_at'");
+  });
+});


### PR DESCRIPTION
Closes #494.

## Summary

Adds three nullable columns to `library` plus a B-tree index — the schema substrate B-1.2 (backfill) and B-1.3 (live writes) will populate.

- `canonical_entity_id text` — opaque identifier; the resolver decides the namespace (Discogs / MusicBrainz / LML id), this column doesn't constrain it.
- `canonical_entity_confidence real` — heuristic confidence at link time. B-0 (#492) found that LML doesn't expose a per-result confidence score, so this captures whatever signal we derive (`search_type=direct` ≈ high; `fallback` ≈ low) and lets us re-judge weak matches retroactively once LML offers a real score.
- `canonical_entity_resolved_at timestamptz` — when the linkage was set; supports audit + retry policy.
- `library_canonical_entity_id_idx` — default B-tree, supports the flowsheet → library join via canonical entity that B-2 will issue.

Migration `0061_library-canonical-entity` is DDL-only. Adding nullable columns is metadata-only and the B-tree CREATE INDEX completes well under a second on the ~64K-row library.

## Out of scope

- Backfilling values (B-1.2).
- Live writes from `addAlbum` (B-1.3).
- Flowsheet-side audit columns (B-1.4).

## Test plan

- [x] `npm run test:unit` — 9 new schema-source assertions for the columns, the index, the migration text, the journal entry, and the database mock. Pre-existing `http.mirror.test.ts` was flaky on first run, passed on rerun; unrelated to this change.
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`