### PR TITLE
Audit columns on flowsheet: linkage_source, linkage_confidence, linked_at

### DIFF
--- a/Dockerfile.flowsheet-linkage-audit-backfill
+++ b/Dockerfile.flowsheet-linkage-audit-backfill
@@ -1,0 +1,27 @@
+#Build stage
+FROM node:25-alpine AS builder
+
+WORKDIR /flowsheet-linkage-audit-backfill-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/flowsheet-linkage-audit-backfill ./jobs/flowsheet-linkage-audit-backfill
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/flowsheet-linkage-audit-backfill
+
+#Production stage
+FROM node:25-alpine AS prod
+
+WORKDIR /flowsheet-linkage-audit-backfill
+
+COPY ./package* ./
+COPY ./jobs/flowsheet-linkage-audit-backfill/package* ./jobs/flowsheet-linkage-audit-backfill/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./flowsheet-linkage-audit-backfill-builder/jobs/flowsheet-linkage-audit-backfill/dist ./jobs/flowsheet-linkage-audit-backfill/dist
+COPY --from=builder ./flowsheet-linkage-audit-backfill-builder/shared/database/dist ./shared/database/dist
+
+CMD ["npm", "start", "--workspace=@wxyc/flowsheet-linkage-audit-backfill"]

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -70,6 +70,9 @@ const FSEntryFieldsRaw = {
   legacy_release_id: flowsheet.legacy_release_id,
   add_time: flowsheet.add_time,
   dj_name: flowsheet.dj_name,
+  linkage_source: flowsheet.linkage_source,
+  linkage_confidence: flowsheet.linkage_confidence,
+  linked_at: flowsheet.linked_at,
   // Metadata (inline on flowsheet, will be nested in transform)
   artwork_url: flowsheet.artwork_url,
   discogs_url: flowsheet.discogs_url,
@@ -105,6 +108,9 @@ type FSEntryRaw = {
   legacy_release_id: number | null;
   add_time: Date | null;
   dj_name: string | null;
+  linkage_source: string | null;
+  linkage_confidence: number | null;
+  linked_at: Date | null;
   artwork_url: string | null;
   discogs_url: string | null;
   release_year: number | null;
@@ -139,6 +145,9 @@ const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
   play_order: raw.play_order ?? 0,
   add_time: raw.add_time ?? new Date(),
   dj_name: raw.dj_name,
+  linkage_source: raw.linkage_source,
+  linkage_confidence: raw.linkage_confidence,
+  linked_at: raw.linked_at,
   // Metadata columns (on FSEntry since they're on the flowsheet table)
   artwork_url: raw.artwork_url,
   discogs_url: raw.discogs_url,

--- a/jobs/flowsheet-linkage-audit-backfill/job.ts
+++ b/jobs/flowsheet-linkage-audit-backfill/job.ts
@@ -1,0 +1,125 @@
+/**
+ * One-shot backfill: classify existing flowsheet linkages into linkage_source
+ * (B-1.4).
+ *
+ * Migration 0062 added linkage_source / linkage_confidence / linked_at as
+ * NULL on every row. This job populates those audit columns for rows where
+ * `album_id` is already set, using two source labels:
+ *
+ *   - 'etl_legacy_id' — `legacy_release_id` is non-null. The ETL resolved
+ *     this row by matching tubafrenzy's release ID to a library row, which
+ *     is the strongest linkage signal we have on legacy data.
+ *
+ *   - 'dj_bin_pick'  — `legacy_release_id` is null. Best guess for rows
+ *     inserted through the live DJ flowsheet UI, where the DJ picked the
+ *     album from the catalog at insert time.
+ *
+ * `linked_at` is set to `add_time` rather than NOW() because that's the
+ * closest proxy we have to when the linkage actually happened — both for
+ * ETL-imported rows (the play time) and for live DJ inserts (when the row
+ * was inserted with album_id set). NOW() would back-stamp every legacy row
+ * with the deploy time, which would defeat the audit.
+ *
+ * `linkage_confidence` stays NULL: ETL legacy-ID matches and human DJ picks
+ * are both implicitly high-confidence, but neither has a numeric score we
+ * can attach honestly. Future LML-resolved linkages (B-2.x) will set both.
+ *
+ * Bounded batched UPDATEs match the dj-name-backfill pattern: each batch
+ * commits independently, the inner SELECT LIMIT prevents unbounded locks,
+ * and `linkage_source IS NULL` makes re-runs idempotent. See issue #511 for
+ * the lock-budget incident this pattern was designed around.
+ *
+ * Run procedure: build via `Manual Build & Deploy` with
+ * `target=flowsheet-linkage-audit-backfill`, then SSH to EC2 and
+ * `docker run --rm --env-file .env <image> 2>&1 | tee log`.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db, closeDatabaseConnection } from '@wxyc/database';
+
+const JOB_NAME = 'flowsheet-linkage-audit-backfill';
+const BATCH_SIZE = 5000;
+const PROGRESS_LOG_EVERY = 1;
+
+/**
+ * Apply one batch of linkage-source classifications and return rows changed.
+ * Each call is its own implicit transaction. Returning 0 means every row
+ * with `album_id IS NOT NULL` already has `linkage_source` populated.
+ */
+const applyBatch = async (batchSize: number): Promise<number> => {
+  const result = await db.execute(sql`
+    UPDATE "wxyc_schema"."flowsheet" AS f
+    SET
+      "linkage_source" = CASE
+        WHEN f."legacy_release_id" IS NOT NULL THEN 'etl_legacy_id'
+        ELSE 'dj_bin_pick'
+      END,
+      "linked_at" = f."add_time"
+    WHERE f."id" IN (
+      SELECT "id" FROM "wxyc_schema"."flowsheet"
+      WHERE "album_id" IS NOT NULL
+        AND "linkage_source" IS NULL
+      ORDER BY "id"
+      LIMIT ${batchSize}
+    )
+  `);
+  return Number(result.count ?? 0);
+};
+
+const formatDuration = (ms: number): string => {
+  const totalSec = Math.round(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return `${min}m ${sec}s`;
+};
+
+const runBackfill = async () => {
+  console.log(`[${JOB_NAME}] Starting backfill of flowsheet linkage audit columns.`);
+  console.log(`[${JOB_NAME}] Batch size: ${BATCH_SIZE}.`);
+
+  const startedAt = Date.now();
+  let batches = 0;
+  let totalUpdated = 0;
+
+  while (true) {
+    const batchStartedAt = Date.now();
+    const updated = await applyBatch(BATCH_SIZE);
+    batches++;
+    totalUpdated += updated;
+
+    if (updated === 0) {
+      // One empty batch is the natural end. Re-running on a fully-backfilled
+      // DB must be a no-op, not loop forever.
+      break;
+    }
+
+    if (batches % PROGRESS_LOG_EVERY === 0) {
+      const batchMs = Date.now() - batchStartedAt;
+      const elapsedMs = Date.now() - startedAt;
+      console.log(
+        `[${JOB_NAME}] batch ${batches}: ${updated} rows in ${formatDuration(batchMs)} | ` +
+          `total ${totalUpdated} rows in ${formatDuration(elapsedMs)}`
+      );
+    }
+  }
+
+  const elapsedMs = Date.now() - startedAt;
+  console.log(
+    `[${JOB_NAME}] Done. Updated ${totalUpdated} rows across ${batches} batches in ${formatDuration(elapsedMs)}.`
+  );
+};
+
+const main = async () => {
+  try {
+    await runBackfill();
+  } finally {
+    await closeDatabaseConnection();
+  }
+};
+
+main().catch((error) => {
+  console.error(`[${JOB_NAME}] Failed:`, error);
+  process.exitCode = 1;
+});
+
+export { applyBatch, runBackfill, formatDuration, BATCH_SIZE };

--- a/jobs/flowsheet-linkage-audit-backfill/package.json
+++ b/jobs/flowsheet-linkage-audit-backfill/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wxyc/flowsheet-linkage-audit-backfill",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot backfill: classify flowsheet.linkage_source on existing linked rows",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_flowsheet_linkage_audit_backfill:ci -f ../../Dockerfile.flowsheet-linkage-audit-backfill ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/flowsheet-linkage-audit-backfill/tsconfig.json
+++ b/jobs/flowsheet-linkage-audit-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/flowsheet-linkage-audit-backfill/tsup.config.ts
+++ b/jobs/flowsheet-linkage-audit-backfill/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -469,8 +469,8 @@
         "drizzle-orm": "^0.45.0"
       }
     },
-    "jobs/library-artist-name-backfill": {
-      "name": "@wxyc/library-artist-name-backfill",
+    "jobs/flowsheet-linkage-audit-backfill": {
+      "name": "@wxyc/flowsheet-linkage-audit-backfill",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -7027,8 +7027,8 @@
       "resolved": "jobs/flowsheet-etl",
       "link": true
     },
-    "node_modules/@wxyc/library-artist-name-backfill": {
-      "resolved": "jobs/library-artist-name-backfill",
+    "node_modules/@wxyc/flowsheet-linkage-audit-backfill": {
+      "resolved": "jobs/flowsheet-linkage-audit-backfill",
       "link": true
     },
     "node_modules/@wxyc/library-etl": {

--- a/shared/database/src/migrations/0062_flowsheet-linkage-audit-columns.sql
+++ b/shared/database/src/migrations/0062_flowsheet-linkage-audit-columns.sql
@@ -1,0 +1,35 @@
+-- Add linkage audit columns to flowsheet (B-1.4).
+--
+-- These three columns let us audit match quality on `album_id`, undo a class
+-- of bad matches if a heuristic regresses, and weight links differently in
+-- ranking down the road (e.g., trust ETL links more than LML-fuzzy links).
+--
+-- Setting the columns on new linkages is handled in B-2.1 / B-2.2 / B-3.1;
+-- this migration only adds the columns nullable. The backfill for existing
+-- linked rows is a separate one-shot job under
+-- `jobs/flowsheet-linkage-audit-backfill/` — DDL inside this migration only.
+--
+-- Production note: ALTER TABLE ADD COLUMN of a nullable column is metadata-
+-- only and instant on PostgreSQL 11+, regardless of table size. Bulk DML
+-- does not belong here: ALTER TABLE acquires AccessExclusiveLock that is
+-- held until the transaction commits, and a long DML can wedge the table
+-- for hours. See migration 0053 + jobs/flowsheet-dj-name-backfill, and
+-- issue #511 for the incident this rule was learned from.
+--
+-- linkage_source        — enum-like text: 'etl_legacy_id', 'dj_bin_pick',
+--                         'lml_high_confidence', 'human_review',
+--                         'tubafrenzy_mirror', etc.
+-- linkage_confidence    — for LML-resolved cases, the confidence score at
+--                         link time. NULL for sources where confidence is
+--                         either implicit (ETL legacy ID match) or
+--                         meaningless (human review).
+-- linked_at             — when album_id was last set or confirmed.
+
+ALTER TABLE "wxyc_schema"."flowsheet"
+  ADD COLUMN "linkage_source" text;--> statement-breakpoint
+
+ALTER TABLE "wxyc_schema"."flowsheet"
+  ADD COLUMN "linkage_confidence" real;--> statement-breakpoint
+
+ALTER TABLE "wxyc_schema"."flowsheet"
+  ADD COLUMN "linked_at" timestamp with time zone;

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -313,13 +313,6 @@
     {
       "idx": 47,
       "version": "7",
-      "when": 1777062000000,
-      "tag": "0046_cdc_notify_triggers",
-      "breakpoints": true
-    },
-    {
-      "idx": 47,
-      "version": "7",
       "when": 1777214400000,
       "tag": "0047_replica-identity-for-pkless-tables",
       "breakpoints": true
@@ -420,6 +413,13 @@
       "version": "7",
       "when": 1779424000000,
       "tag": "0061_library-canonical-entity",
+      "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1778510400000,
+      "tag": "0062_flowsheet-linkage-audit-columns",
       "breakpoints": true
     }
   ]

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -422,6 +422,16 @@ export const flowsheet = wxyc_schema.table(
     // (step 5b). Backfilled by migration 0053; populated on write by the
     // ETL job and the live insert controller from step 5b.2 onward.
     dj_name: text('dj_name'),
+    // Linkage audit (B-1.4). Records how `album_id` was resolved on this
+    // row so we can audit match quality, undo a class of bad matches if a
+    // heuristic regresses, and weight differently in ranking. Setting
+    // these on new linkages is handled in B-2.1 / B-2.2 / B-3.1; this
+    // migration only adds the columns nullable. Source values are
+    // enum-like text: 'etl_legacy_id' | 'dj_bin_pick' | 'lml_high_confidence'
+    // | 'human_review' | 'tubafrenzy_mirror'.
+    linkage_source: text('linkage_source'),
+    linkage_confidence: real('linkage_confidence'),
+    linked_at: timestamp('linked_at', { withTimezone: true }),
     // STORED GENERATED tsvector covering the searchable text fields with
     // weight bands (artist=A, track+dj=B, album=C, label=D). Managed by
     // migration 0054 (which extended the original 0052 expression to include

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -128,6 +128,9 @@ export const flowsheet = {
   artist_bio: 'artist_bio',
   artist_wikipedia_url: 'artist_wikipedia_url',
   dj_name: 'dj_name',
+  linkage_source: 'linkage_source',
+  linkage_confidence: 'linkage_confidence',
+  linked_at: 'linked_at',
   search_doc: 'search_doc',
 };
 export const bins = {};
@@ -255,6 +258,9 @@ export type FSEntry = {
   artist_bio: string | null;
   artist_wikipedia_url: string | null;
   dj_name: string | null;
+  linkage_source: string | null;
+  linkage_confidence: number | null;
+  linked_at: Date | null;
 };
 
 export type NewFSEntry = Partial<FSEntry>;

--- a/tests/unit/database/schema.flowsheet-linkage-audit.test.ts
+++ b/tests/unit/database/schema.flowsheet-linkage-audit.test.ts
@@ -1,0 +1,80 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('schema: flowsheet linkage audit columns (B-1.4)', () => {
+  const schemaPath = path.resolve(__dirname, '../../../shared/database/src/schema.ts');
+  const schemaSource = fs.readFileSync(schemaPath, 'utf-8');
+
+  const migrationsDir = path.resolve(__dirname, '../../../shared/database/src/migrations');
+  const migrationPath = path.join(migrationsDir, '0062_flowsheet-linkage-audit-columns.sql');
+  const journalPath = path.join(migrationsDir, 'meta/_journal.json');
+
+  const extractTableDef = (tableName: string): string => {
+    const regex = new RegExp(`export const ${tableName}\\b[\\s\\S]*?^\\);`, 'm');
+    const match = schemaSource.match(regex);
+    if (!match) throw new Error(`Table definition for ${tableName} not found in schema`);
+    return match[0];
+  };
+
+  it('flowsheet table declares a nullable linkage_source text column', () => {
+    const def = extractTableDef('flowsheet');
+    expect(def).toMatch(/linkage_source:\s*text\(['"]linkage_source['"]\)/);
+    // No `.notNull()` on the column — backfill cannot fill every row.
+    expect(def).not.toMatch(/linkage_source:\s*text\(['"]linkage_source['"]\)[^,]*notNull/);
+  });
+
+  it('flowsheet table declares a nullable linkage_confidence real column', () => {
+    const def = extractTableDef('flowsheet');
+    expect(def).toMatch(/linkage_confidence:\s*real\(['"]linkage_confidence['"]\)/);
+    expect(def).not.toMatch(/linkage_confidence:\s*real\(['"]linkage_confidence['"]\)[^,]*notNull/);
+  });
+
+  it('flowsheet table declares a nullable linked_at timestamptz column', () => {
+    const def = extractTableDef('flowsheet');
+    expect(def).toMatch(/linked_at:\s*timestamp\(['"]linked_at['"],\s*\{\s*withTimezone:\s*true\s*\}\)/);
+    expect(def).not.toMatch(
+      /linked_at:\s*timestamp\(['"]linked_at['"],\s*\{\s*withTimezone:\s*true\s*\}\)[^,]*notNull/
+    );
+  });
+
+  it('migration 0062 exists and adds the three columns', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(
+      /ALTER TABLE\s+"wxyc_schema"\."flowsheet"\s+ADD COLUMN\s+"linkage_source"\s+text/i
+    );
+    expect(sql).toMatch(
+      /ALTER TABLE\s+"wxyc_schema"\."flowsheet"\s+ADD COLUMN\s+"linkage_confidence"\s+real/i
+    );
+    expect(sql).toMatch(
+      /ALTER TABLE\s+"wxyc_schema"\."flowsheet"\s+ADD COLUMN\s+"linked_at"\s+timestamp with time zone/i
+    );
+  });
+
+  it('migration 0062 is DDL-only — no in-migration backfill', () => {
+    // Bulk DML inside a migration holds the AccessExclusiveLock acquired by
+    // ALTER TABLE for the duration of the UPDATE, which can wedge the table
+    // for hours on a 2M-row flowsheet. The backfill lives in its own
+    // one-shot job (jobs/flowsheet-linkage-audit-backfill). See issue #511.
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).not.toMatch(/^\s*UPDATE\s+"wxyc_schema"\."flowsheet"/im);
+  });
+
+  it('journal includes the 0062 entry', () => {
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
+    const has62 = journal.entries.some(
+      (e: { tag: string }) => e.tag === '0062_flowsheet-linkage-audit-columns'
+    );
+    expect(has62).toBe(true);
+  });
+
+  it('mock includes linkage_source, linkage_confidence, and linked_at on flowsheet', () => {
+    const mockPath = path.resolve(__dirname, '../../mocks/database.mock.ts');
+    const mockSource = fs.readFileSync(mockPath, 'utf-8');
+    const flowsheetMock = mockSource.match(/export const flowsheet\s*=\s*\{[\s\S]*?\};/)?.[0];
+    expect(flowsheetMock).toBeDefined();
+    expect(flowsheetMock).toContain("linkage_source: 'linkage_source'");
+    expect(flowsheetMock).toContain("linkage_confidence: 'linkage_confidence'");
+    expect(flowsheetMock).toContain("linked_at: 'linked_at'");
+  });
+});

--- a/tests/unit/database/schema.flowsheet-linkage-audit.test.ts
+++ b/tests/unit/database/schema.flowsheet-linkage-audit.test.ts
@@ -40,12 +40,8 @@ describe('schema: flowsheet linkage audit columns (B-1.4)', () => {
   it('migration 0062 exists and adds the three columns', () => {
     expect(fs.existsSync(migrationPath)).toBe(true);
     const sql = fs.readFileSync(migrationPath, 'utf-8');
-    expect(sql).toMatch(
-      /ALTER TABLE\s+"wxyc_schema"\."flowsheet"\s+ADD COLUMN\s+"linkage_source"\s+text/i
-    );
-    expect(sql).toMatch(
-      /ALTER TABLE\s+"wxyc_schema"\."flowsheet"\s+ADD COLUMN\s+"linkage_confidence"\s+real/i
-    );
+    expect(sql).toMatch(/ALTER TABLE\s+"wxyc_schema"\."flowsheet"\s+ADD COLUMN\s+"linkage_source"\s+text/i);
+    expect(sql).toMatch(/ALTER TABLE\s+"wxyc_schema"\."flowsheet"\s+ADD COLUMN\s+"linkage_confidence"\s+real/i);
     expect(sql).toMatch(
       /ALTER TABLE\s+"wxyc_schema"\."flowsheet"\s+ADD COLUMN\s+"linked_at"\s+timestamp with time zone/i
     );
@@ -62,9 +58,7 @@ describe('schema: flowsheet linkage audit columns (B-1.4)', () => {
 
   it('journal includes the 0062 entry', () => {
     const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
-    const has62 = journal.entries.some(
-      (e: { tag: string }) => e.tag === '0062_flowsheet-linkage-audit-columns'
-    );
+    const has62 = journal.entries.some((e: { tag: string }) => e.tag === '0062_flowsheet-linkage-audit-columns');
     expect(has62).toBe(true);
   });
 

--- a/tests/unit/jobs/flowsheet-linkage-audit-backfill/job.test.ts
+++ b/tests/unit/jobs/flowsheet-linkage-audit-backfill/job.test.ts
@@ -72,7 +72,7 @@ describe('flowsheet-linkage-audit-backfill: applyBatch', () => {
 
     const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*linked_at/i);
     const sqlText = renderSql(call?.[0]);
-    expect(sqlText).toMatch(/"linked_at"\s*=\s*"add_time"|linked_at"?\s*=\s*[a-z_.]*\.?add_time/i);
+    expect(sqlText).toMatch(/"linked_at"\s*=\s*[a-z_.]*"?add_time"?/i);
   });
 
   it('restricts the UPDATE to album_id IS NOT NULL AND linkage_source IS NULL within a bounded LIMIT batch', async () => {

--- a/tests/unit/jobs/flowsheet-linkage-audit-backfill/job.test.ts
+++ b/tests/unit/jobs/flowsheet-linkage-audit-backfill/job.test.ts
@@ -9,11 +9,7 @@
  */
 
 import { db } from '@wxyc/database';
-import {
-  applyBatch,
-  runBackfill,
-  BATCH_SIZE,
-} from '../../../../jobs/flowsheet-linkage-audit-backfill/job';
+import { applyBatch, runBackfill, BATCH_SIZE } from '../../../../jobs/flowsheet-linkage-audit-backfill/job';
 
 type SqlLike = {
   sql?: string | string[];

--- a/tests/unit/jobs/flowsheet-linkage-audit-backfill/job.test.ts
+++ b/tests/unit/jobs/flowsheet-linkage-audit-backfill/job.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for the flowsheet linkage-audit backfill job.
+ *
+ * Counterpart to the DDL-only migration 0062: after the columns ship NULL on
+ * every row, this job classifies legacy linked rows by where their album_id
+ * came from. ETL-linked rows (those with a legacy_release_id) → 'etl_legacy_id'.
+ * Anything else with album_id IS NOT NULL → 'dj_bin_pick' (best guess for
+ * recent inserts that were resolved through the catalog-search path).
+ */
+
+import { db } from '@wxyc/database';
+import {
+  applyBatch,
+  runBackfill,
+  BATCH_SIZE,
+} from '../../../../jobs/flowsheet-linkage-audit-backfill/job';
+
+type SqlLike = {
+  sql?: string | string[];
+  queryChunks?: Array<string | { value?: string | string[] }>;
+};
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const findExecuteCallMatching = (pattern: RegExp): unknown[] | undefined => {
+  const calls = (db.execute as jest.Mock).mock.calls;
+  return calls.find((call) => pattern.test(renderSql(call[0])));
+};
+
+describe('flowsheet-linkage-audit-backfill: applyBatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('classifies ETL-linked rows as etl_legacy_id and others as dj_bin_pick', async () => {
+    // Backfill rule from the issue body: rows with legacy_release_id set
+    // came from the ETL → 'etl_legacy_id'. Anything else with album_id set
+    // is a best-guess DJ bin pick.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 5000 });
+
+    await applyBatch(5000);
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*linkage_source/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/CASE\s+WHEN[\s\S]*legacy_release_id[\s\S]*IS\s+NOT\s+NULL[\s\S]*'etl_legacy_id'/i);
+    expect(sqlText).toMatch(/ELSE\s+'dj_bin_pick'/i);
+  });
+
+  it('sets linked_at from add_time so the audit reflects when linkage actually happened', async () => {
+    // Using NOW() would lie about legacy linkage timestamps. add_time is the
+    // closest proxy we have — for ETL-imported rows this is the play time,
+    // for DJ bin picks it is when the row was inserted (and linked).
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 5000 });
+
+    await applyBatch(5000);
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*linked_at/i);
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/"linked_at"\s*=\s*"add_time"|linked_at"?\s*=\s*[a-z_.]*\.?add_time/i);
+  });
+
+  it('restricts the UPDATE to album_id IS NOT NULL AND linkage_source IS NULL within a bounded LIMIT batch', async () => {
+    // Three regression guards:
+    //   - album_id IS NOT NULL (only rows that have a linkage to audit)
+    //   - linkage_source IS NULL (idempotency: re-run skips already-classified)
+    //   - LIMIT in an inner SELECT (bounded — never an unbounded UPDATE
+    //     that would hold a write lock for hours, per issue #511)
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 5000 });
+
+    await applyBatch(5000);
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*linkage_source/i);
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/album_id"?\s+IS\s+NOT\s+NULL/i);
+    expect(sqlText).toMatch(/linkage_source"?\s+IS\s+NULL/i);
+    expect(sqlText).toMatch(/LIMIT/i);
+  });
+
+  it('passes the batch size argument through into the SQL builder', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await applyBatch(1234);
+
+    const call = (db.execute as jest.Mock).mock.calls.find((c) =>
+      /UPDATE[\s\S]*flowsheet[\s\S]*linkage_source/i.test(renderSql(c[0]))
+    );
+    const serialized = JSON.stringify(call?.[0]);
+    expect(serialized).toContain('1234');
+  });
+
+  it('returns the postgres-js result.count as the rows-updated number', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 4321 });
+
+    const updated = await applyBatch(5000);
+
+    expect(updated).toBe(4321);
+  });
+
+  it('returns 0 when the result has no count property (empty result)', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({});
+
+    const updated = await applyBatch(5000);
+
+    expect(updated).toBe(0);
+  });
+});
+
+describe('flowsheet-linkage-audit-backfill: runBackfill loop control', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('iterates batches until applyBatch returns 0 (natural end)', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce({ count: 5000 })
+      .mockResolvedValueOnce({ count: 5000 })
+      .mockResolvedValueOnce({ count: 1234 })
+      .mockResolvedValueOnce({ count: 0 });
+
+    await runBackfill();
+
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(4);
+  });
+
+  it('exits cleanly on the very first empty batch (already-backfilled state)', async () => {
+    // Re-running on a fully-backfilled DB must be a no-op, not loop forever.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await runBackfill();
+
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  it('uses BATCH_SIZE of 5000 (not unbounded)', () => {
+    // Bounded UPDATEs are how this job avoids lock contention. If a future
+    // change accidentally bumps this into the millions or removes the LIMIT,
+    // it will reproduce the issue #511 incident.
+    expect(BATCH_SIZE).toBe(5000);
+  });
+});


### PR DESCRIPTION
Closes #497.

Part of [Epic B](https://github.com/WXYC/Backend-Service/issues/484).

## Summary

- Migration 0062 adds three nullable columns to `flowsheet`: `linkage_source text`, `linkage_confidence real`, `linked_at timestamptz`. DDL-only — no in-migration UPDATE, per the issue #511 lock-budget rule.
- New one-shot backfill job `@wxyc/flowsheet-linkage-audit-backfill` classifies legacy linked rows: `legacy_release_id IS NOT NULL` → `'etl_legacy_id'`, otherwise → `'dj_bin_pick'`. Sets `linked_at` to `add_time` so the audit reflects when linkage actually happened, not deploy time. `linkage_confidence` stays NULL on legacy rows (ETL legacy-ID matches and DJ bin picks have no honest numeric score).
- Bounded batched UPDATEs (BATCH_SIZE=5000) and a `linkage_source IS NULL` idempotency filter — same pattern as `flowsheet-dj-name-backfill`. Re-runs are safe.
- Setting these columns on new linkages is out of scope; that lands in B-2.1 / B-2.2 / B-3.1.
- Threaded the new columns through `FSEntryFieldsRaw` / `FSEntryRaw` / `transformToIFSEntry` in `apps/backend/services/flowsheet.service.ts` so the controller-facing `IFSEntry` continues to mirror the schema.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:unit` (1132 tests pass; 16 new — 7 schema, 9 backfill)
- [ ] Apply migration 0062 against staging
- [ ] Build + run the backfill image against staging; verify `count(*) FILTER (WHERE album_id IS NOT NULL AND linkage_source IS NULL)` reaches 0