### PR TITLE
Recover broken-FK flowsheet entries (~292K, 15%)

### DIFF
--- a/Dockerfile.broken-fk-recovery
+++ b/Dockerfile.broken-fk-recovery
@@ -1,0 +1,27 @@
+#Build stage
+FROM node:25-alpine AS builder
+
+WORKDIR /broken-fk-recovery-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/broken-fk-recovery ./jobs/broken-fk-recovery
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/broken-fk-recovery
+
+#Production stage
+FROM node:25-alpine AS prod
+
+WORKDIR /broken-fk-recovery
+
+COPY ./package* ./
+COPY ./jobs/broken-fk-recovery/package* ./jobs/broken-fk-recovery/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./broken-fk-recovery-builder/jobs/broken-fk-recovery/dist ./jobs/broken-fk-recovery/dist
+COPY --from=builder ./broken-fk-recovery-builder/shared/database/dist ./shared/database/dist
+
+CMD ["npm", "start", "--workspace=@wxyc/broken-fk-recovery"]

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -34,7 +34,7 @@ export interface IFSEntryMetadata {
 // search_doc is a STORED GENERATED tsvector used only by the search hot path
 // (apps/backend/services/search.service.ts); the controller layer never reads
 // or constructs it, so it is excluded from the application-facing entry type.
-export interface IFSEntry extends Omit<FSEntry, 'search_doc'> {
+export interface IFSEntry extends Omit<FSEntry, 'search_doc' | 'legacy_link_attempted_at'> {
   label_id: number | null;
   rotation_bin: string | null;
   on_streaming: boolean | null;

--- a/jobs/broken-fk-recovery/job.ts
+++ b/jobs/broken-fk-recovery/job.ts
@@ -1,0 +1,175 @@
+/**
+ * One-shot job: recover broken-FK flowsheet entries (B-0.5).
+ *
+ * Of the 1.18M unlinked flowsheet rows, 292K (15%) have a non-null
+ * legacy_release_id whose value isn't in library.legacy_release_id. Some
+ * fraction of those land after subsequent library imports — re-running the
+ * existing legacy-FK resolver picks them up without LML. The residual is
+ * the genuinely-unrecoverable bucket that B-2.2 will hand to LML.
+ *
+ * Phases:
+ *   1. reresolveAlbumIds — re-runs the same UPDATE the flowsheet ETL ships,
+ *      idempotent over album_id IS NULL.
+ *   2. classifyUnresolvable — counts the residual split by missing vs.
+ *      collision vs. other, single round-trip via FILTER aggregates.
+ *   3. markUnresolvable — stamps legacy_link_attempted_at = now() so B-2.2
+ *      can join (legacy_release_id IS NULL OR legacy_link_attempted_at IS
+ *      NOT NULL) to find both broken-FK and never-had-FK buckets in one
+ *      predicate.
+ *
+ * The classification report is printed to stdout. The operator pastes it as
+ * a comment on issue #493 (per the issue's acceptance criteria).
+ *
+ * Run procedure: build via `Manual Build & Deploy` with
+ * `target=broken-fk-recovery`, then SSH to EC2 and
+ * `docker run --rm --env-file .env <image> 2>&1 | tee log`.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db, closeDatabaseConnection } from '@wxyc/database';
+
+const JOB_NAME = 'broken-fk-recovery';
+
+export type ClassificationCounts = {
+  missing: number;
+  collision: number;
+  other: number;
+  total: number;
+};
+
+/**
+ * Re-run the legacy-FK album_id resolver against any flowsheet rows that
+ * still have album_id IS NULL but a non-null legacy_release_id. Mirrors the
+ * resolver in jobs/flowsheet-etl/job.ts — duplicated rather than imported
+ * because the ETL package is a separate workspace and importing across job
+ * packages would couple their build graphs.
+ */
+export const reresolveAlbumIds = async (): Promise<number> => {
+  const result = await db.execute(sql`
+    UPDATE "wxyc_schema"."flowsheet" AS f
+    SET "album_id" = l."id"
+    FROM "wxyc_schema"."library" AS l
+    WHERE f."legacy_release_id" = l."legacy_release_id"
+      AND f."legacy_release_id" IS NOT NULL
+      AND f."album_id" IS NULL
+  `);
+  const resolved = Number(result.count ?? 0);
+  console.log(`[${JOB_NAME}] Re-resolved album_id for ${resolved} flowsheet rows.`);
+  return resolved;
+};
+
+/**
+ * Classify the residual broken-FK rows into missing / collision / other in
+ * a single round-trip. Postgres-js returns COUNT() as a string in some
+ * driver configurations, so coerce every column to Number defensively.
+ *
+ * "missing" — flowsheet's legacy_release_id has zero matching library rows
+ * (the typical post-deletion case).
+ * "collision" — legacy_release_id matches multiple library rows. Structurally
+ * impossible while library_legacy_release_id_idx is unique, but the SQL
+ * carries the case forward in case a future migration relaxes that.
+ * "other" — anything else (e.g. legacy_release_id IS 0 / sentinel data
+ * the ETL didn't fully normalize).
+ */
+export const classifyUnresolvable = async (): Promise<ClassificationCounts> => {
+  const rows = (await db.execute(sql`
+    WITH unresolved AS (
+      SELECT f."id", f."legacy_release_id"
+      FROM "wxyc_schema"."flowsheet" AS f
+      WHERE f."album_id" IS NULL
+        AND f."legacy_release_id" IS NOT NULL
+    ),
+    counts AS (
+      SELECT
+        u."id",
+        u."legacy_release_id",
+        (SELECT COUNT(*) FROM "wxyc_schema"."library" AS l
+          WHERE l."legacy_release_id" = u."legacy_release_id") AS lib_match_count
+      FROM unresolved u
+    )
+    SELECT
+      COUNT(*) FILTER (WHERE "lib_match_count" = 0 AND "legacy_release_id" > 0) AS "missing",
+      COUNT(*) FILTER (WHERE "lib_match_count" > 1) AS "collision",
+      COUNT(*) FILTER (WHERE "lib_match_count" = 0 AND ("legacy_release_id" <= 0)) AS "other",
+      COUNT(*) AS "total"
+    FROM counts
+  `)) as unknown as Array<{
+    missing: number | string;
+    collision: number | string;
+    other: number | string;
+    total: number | string;
+  }>;
+  const row = rows[0];
+  if (!row) return { missing: 0, collision: 0, other: 0, total: 0 };
+  return {
+    missing: Number(row.missing ?? 0),
+    collision: Number(row.collision ?? 0),
+    other: Number(row.other ?? 0),
+    total: Number(row.total ?? 0),
+  };
+};
+
+/**
+ * Stamp legacy_link_attempted_at = now() on the broken-FK residual.
+ *
+ * Idempotent: the `legacy_link_attempted_at IS NULL` filter means a second
+ * run skips rows already stamped, preserving the original "first attempted
+ * at" timestamp. That matters for any future audit trying to reconstruct
+ * when a row first fell off the legacy-FK path.
+ */
+export const markUnresolvable = async (): Promise<number> => {
+  const result = await db.execute(sql`
+    UPDATE "wxyc_schema"."flowsheet" AS f
+    SET "legacy_link_attempted_at" = now()
+    WHERE f."album_id" IS NULL
+      AND f."legacy_release_id" IS NOT NULL
+      AND f."legacy_link_attempted_at" IS NULL
+  `);
+  const stamped = Number(result.count ?? 0);
+  console.log(`[${JOB_NAME}] Stamped legacy_link_attempted_at on ${stamped} unresolvable rows.`);
+  return stamped;
+};
+
+/**
+ * Produce a comment-friendly report of the classification. The operator
+ * pastes this onto issue #493 per the acceptance criteria.
+ */
+export const formatReport = (counts: ClassificationCounts): string => {
+  const fmt = (n: number) => n.toLocaleString('en-US');
+  return [
+    `Broken-FK recovery classification:`,
+    `  missing   (no library row): ${fmt(counts.missing)}`,
+    `  collision (multiple library rows): ${fmt(counts.collision)}`,
+    `  other     (sentinel / non-positive legacy_release_id): ${fmt(counts.other)}`,
+    `  total     residual: ${fmt(counts.total)}`,
+  ].join('\n');
+};
+
+export const runRecovery = async (): Promise<{
+  resolved: number;
+  marked: number;
+  counts: ClassificationCounts;
+}> => {
+  console.log(`[${JOB_NAME}] Starting broken-FK recovery.`);
+  const resolved = await reresolveAlbumIds();
+  const counts = await classifyUnresolvable();
+  console.log(formatReport(counts));
+  const marked = await markUnresolvable();
+  console.log(`[${JOB_NAME}] Done. Resolved ${resolved}; marked ${marked} as legacy-FK unresolvable.`);
+  return { resolved, marked, counts };
+};
+
+const main = async () => {
+  try {
+    await runRecovery();
+  } finally {
+    await closeDatabaseConnection();
+  }
+};
+
+if (process.env.NODE_ENV !== 'test') {
+  main().catch((error) => {
+    console.error(`[${JOB_NAME}] Failed:`, error);
+    process.exitCode = 1;
+  });
+}

--- a/jobs/broken-fk-recovery/package.json
+++ b/jobs/broken-fk-recovery/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wxyc/broken-fk-recovery",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot job: recover broken-FK flowsheet entries (B-0.5)",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_broken_fk_recovery:ci -f ../../Dockerfile.broken-fk-recovery ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/broken-fk-recovery/tsconfig.json
+++ b/jobs/broken-fk-recovery/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/broken-fk-recovery/tsup.config.ts
+++ b/jobs/broken-fk-recovery/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -441,6 +441,20 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/broken-fk-recovery": {
+      "name": "@wxyc/broken-fk-recovery",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/flowsheet-dj-name-backfill": {
       "name": "@wxyc/flowsheet-dj-name-backfill",
       "version": "1.0.0",
@@ -7013,6 +7027,10 @@
     },
     "node_modules/@wxyc/backend": {
       "resolved": "apps/backend",
+      "link": true
+    },
+    "node_modules/@wxyc/broken-fk-recovery": {
+      "resolved": "jobs/broken-fk-recovery",
       "link": true
     },
     "node_modules/@wxyc/database": {

--- a/shared/database/src/migrations/0063_flowsheet-legacy-link-attempted-at.sql
+++ b/shared/database/src/migrations/0063_flowsheet-legacy-link-attempted-at.sql
@@ -1,0 +1,25 @@
+-- B-0.5 marker column: stamp rows where the legacy_release_id → library.id
+-- FK resolver ran but could not link.
+--
+-- Background: 292K of 1.18M unlinked flowsheet rows have a non-null
+-- legacy_release_id whose value isn't present in library.legacy_release_id
+-- (rows deleted or rewritten in tubafrenzy after the ETL ran). Re-running the
+-- resolver picks up some on every cron tick — but the residual is permanent
+-- and has to fall through to LML in B-2.2.
+--
+-- B-2.2's backfill needs a single predicate to grab both the 889K
+-- never-had-legacy-id rows and the broken-FK residual. With this column the
+-- query is:
+--   WHERE album_id IS NULL
+--     AND (legacy_release_id IS NULL OR legacy_link_attempted_at IS NOT NULL)
+--
+-- The B-0.5 recovery job (jobs/broken-fk-recovery) runs as a one-shot deploy
+-- after this DDL ships. It re-runs the legacy-FK resolver, then UPDATEs
+-- legacy_link_attempted_at = now() on the rows that still didn't link.
+--
+-- DDL-only — no in-migration UPDATE. ALTER TABLE ADD COLUMN of a nullable
+-- column is metadata-only and instant on PostgreSQL 11+, regardless of
+-- table size. Same hard-won pattern as 0053 (see issue #511).
+
+ALTER TABLE "wxyc_schema"."flowsheet"
+  ADD COLUMN "legacy_link_attempted_at" timestamp with time zone;

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1778510400000,
       "tag": "0062_flowsheet-linkage-audit-columns",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1778596800000,
+      "tag": "0063_flowsheet-legacy-link-attempted-at",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -432,6 +432,13 @@ export const flowsheet = wxyc_schema.table(
     linkage_source: text('linkage_source'),
     linkage_confidence: real('linkage_confidence'),
     linked_at: timestamp('linked_at', { withTimezone: true }),
+    // B-0.5 marker: timestamp set when the legacy_release_id → library.id
+    // resolver ran for this row and could not link. Lets B-2.2's LML
+    // backfill find the broken-FK residual alongside the rows that never
+    // had a legacy_release_id at all. NULL means "either already linked,
+    // or the FK resolver hasn't run yet". See migration 0063 +
+    // jobs/broken-fk-recovery for the population pass.
+    legacy_link_attempted_at: timestamp('legacy_link_attempted_at', { withTimezone: true }),
     // STORED GENERATED tsvector covering the searchable text fields with
     // weight bands (artist=A, track+dj=B, album=C, label=D). Managed by
     // migration 0054 (which extended the original 0052 expression to include

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -105,6 +105,8 @@ export const flowsheet = {
   show_id: 'show_id',
   album_id: 'album_id',
   legacy_entry_id: 'legacy_entry_id',
+  legacy_release_id: 'legacy_release_id',
+  legacy_link_attempted_at: 'legacy_link_attempted_at',
   entry_type: 'entry_type',
   track_title: 'track_title',
   album_title: 'album_title',

--- a/tests/unit/database/schema.flowsheet-legacy-link-attempted-at.test.ts
+++ b/tests/unit/database/schema.flowsheet-legacy-link-attempted-at.test.ts
@@ -1,0 +1,61 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('schema: flowsheet.legacy_link_attempted_at marker (B-0.5)', () => {
+  const schemaPath = path.resolve(__dirname, '../../../shared/database/src/schema.ts');
+  const schemaSource = fs.readFileSync(schemaPath, 'utf-8');
+
+  const migrationsDir = path.resolve(__dirname, '../../../shared/database/src/migrations');
+  const migrationPath = path.join(migrationsDir, '0063_flowsheet-legacy-link-attempted-at.sql');
+  const journalPath = path.join(migrationsDir, 'meta/_journal.json');
+
+  const extractTableDef = (tableName: string): string => {
+    const regex = new RegExp(`export const ${tableName}\\b[\\s\\S]*?^\\);`, 'm');
+    const match = schemaSource.match(regex);
+    if (!match) throw new Error(`Table definition for ${tableName} not found in schema`);
+    return match[0];
+  };
+
+  it('flowsheet table declares a legacy_link_attempted_at column', () => {
+    // The column marks rows where the legacy_release_id → library.id FK
+    // resolver ran and could not link. B-2.2's LML backfill picks these up
+    // alongside the 889K rows that never had a legacy_release_id at all.
+    const def = extractTableDef('flowsheet');
+    expect(def).toMatch(/legacy_link_attempted_at:\s*timestamp\(\s*['"]legacy_link_attempted_at['"][\s\S]*?withTimezone:\s*true/);
+  });
+
+  it('migration 0063 exists and adds the nullable timestamptz column', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).toMatch(
+      /ALTER TABLE\s+"wxyc_schema"\."flowsheet"\s+ADD COLUMN\s+"legacy_link_attempted_at"\s+timestamp\s+with\s+time\s+zone/i
+    );
+  });
+
+  it('migration 0063 is DDL-only — no in-migration UPDATE', () => {
+    // The marking pass lives in jobs/broken-fk-recovery, run as a one-shot
+    // deploy after this DDL ships. Same pattern as 0053+dj-name-backfill.
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+    expect(sql).not.toMatch(/^\s*UPDATE\s+"wxyc_schema"\."flowsheet"/im);
+  });
+
+  it('journal includes the 0063 entry', () => {
+    const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
+    const has63 = journal.entries.some(
+      (e: { tag: string }) => e.tag === '0063_flowsheet-legacy-link-attempted-at'
+    );
+    expect(has63).toBe(true);
+  });
+
+  it('mock includes legacy_release_id and legacy_link_attempted_at on flowsheet', () => {
+    // The recovery job reads legacy_release_id and writes legacy_link_attempted_at;
+    // both must be addressable through the mocked schema or a unit test that
+    // references them via Drizzle's column proxy will throw.
+    const mockPath = path.resolve(__dirname, '../../mocks/database.mock.ts');
+    const mockSource = fs.readFileSync(mockPath, 'utf-8');
+    const flowsheetMock = mockSource.match(/export const flowsheet\s*=\s*\{[\s\S]*?\};/)?.[0];
+    expect(flowsheetMock).toBeDefined();
+    expect(flowsheetMock).toContain("legacy_release_id: 'legacy_release_id'");
+    expect(flowsheetMock).toContain("legacy_link_attempted_at: 'legacy_link_attempted_at'");
+  });
+});

--- a/tests/unit/database/schema.flowsheet-legacy-link-attempted-at.test.ts
+++ b/tests/unit/database/schema.flowsheet-legacy-link-attempted-at.test.ts
@@ -21,7 +21,9 @@ describe('schema: flowsheet.legacy_link_attempted_at marker (B-0.5)', () => {
     // resolver ran and could not link. B-2.2's LML backfill picks these up
     // alongside the 889K rows that never had a legacy_release_id at all.
     const def = extractTableDef('flowsheet');
-    expect(def).toMatch(/legacy_link_attempted_at:\s*timestamp\(\s*['"]legacy_link_attempted_at['"][\s\S]*?withTimezone:\s*true/);
+    expect(def).toMatch(
+      /legacy_link_attempted_at:\s*timestamp\(\s*['"]legacy_link_attempted_at['"][\s\S]*?withTimezone:\s*true/
+    );
   });
 
   it('migration 0063 exists and adds the nullable timestamptz column', () => {
@@ -41,9 +43,7 @@ describe('schema: flowsheet.legacy_link_attempted_at marker (B-0.5)', () => {
 
   it('journal includes the 0063 entry', () => {
     const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
-    const has63 = journal.entries.some(
-      (e: { tag: string }) => e.tag === '0063_flowsheet-legacy-link-attempted-at'
-    );
+    const has63 = journal.entries.some((e: { tag: string }) => e.tag === '0063_flowsheet-legacy-link-attempted-at');
     expect(has63).toBe(true);
   });
 

--- a/tests/unit/jobs/broken-fk-recovery/job.test.ts
+++ b/tests/unit/jobs/broken-fk-recovery/job.test.ts
@@ -106,9 +106,7 @@ describe('broken-fk-recovery: classifyUnresolvable', () => {
   it('returns counts split by missing / collision / other', async () => {
     // Single round-trip: a CASE/FILTER aggregate beats issuing one COUNT
     // per category against a 1.18M-row table.
-    (db.execute as jest.Mock).mockResolvedValueOnce([
-      { missing: 290000, collision: 0, other: 2226, total: 292226 },
-    ]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ missing: 290000, collision: 0, other: 2226, total: 292226 }]);
 
     const counts = await classifyUnresolvable();
 
@@ -116,9 +114,7 @@ describe('broken-fk-recovery: classifyUnresolvable', () => {
   });
 
   it('coerces row counts to numbers (postgres-js returns bigint as string for COUNT)', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([
-      { missing: '5', collision: '0', other: '2', total: '7' },
-    ]);
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ missing: '5', collision: '0', other: '2', total: '7' }]);
 
     const counts = await classifyUnresolvable();
 

--- a/tests/unit/jobs/broken-fk-recovery/job.test.ts
+++ b/tests/unit/jobs/broken-fk-recovery/job.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for the B-0.5 broken-FK flowsheet recovery job.
+ *
+ * The job:
+ *   1. Re-runs the legacy_release_id → library.id FK resolver to catch
+ *      post-ETL library imports that weren't reconciled at the time.
+ *   2. Classifies the residual (missing / collision / other).
+ *   3. Stamps legacy_link_attempted_at = now() on the residual so B-2.2's
+ *      LML backfill can pick them up alongside the never-had-legacy-id
+ *      rows.
+ *
+ * Tests don't reach the database — they verify that the right shape of
+ * SQL is built for each phase, the orchestrator calls phases in order,
+ * and the report formatter produces a comment-friendly string.
+ */
+
+import { db } from '@wxyc/database';
+import {
+  reresolveAlbumIds,
+  classifyUnresolvable,
+  markUnresolvable,
+  runRecovery,
+  formatReport,
+} from '../../../../jobs/broken-fk-recovery/job';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const findExecuteCallMatching = (pattern: RegExp): unknown[] | undefined => {
+  const calls = (db.execute as jest.Mock).mock.calls;
+  return calls.find((call) => pattern.test(renderSql(call[0])));
+};
+
+describe('broken-fk-recovery: reresolveAlbumIds', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('issues an UPDATE that joins flowsheet to library on legacy_release_id', async () => {
+    // Mirrors the resolver in jobs/flowsheet-etl/job.ts. Re-running it is
+    // the easy-win first pass in B-0.5: any library rows that landed after
+    // the original ETL get linked here without LML.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await reresolveAlbumIds();
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*album_id[\s\S]*FROM[\s\S]*library/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/legacy_release_id/i);
+  });
+
+  it('only touches rows where album_id IS NULL and legacy_release_id IS NOT NULL', async () => {
+    // Idempotency guard: re-running must not stomp existing links and must
+    // not consider rows with no FK to resolve.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await reresolveAlbumIds();
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i);
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/album_id"?\s+IS\s+NULL/i);
+    expect(sqlText).toMatch(/legacy_release_id"?\s+IS\s+NOT\s+NULL/i);
+  });
+
+  it('returns the rows-resolved count from postgres-js result.count', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 137 });
+
+    const resolved = await reresolveAlbumIds();
+
+    expect(resolved).toBe(137);
+  });
+});
+
+describe('broken-fk-recovery: classifyUnresolvable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns counts split by missing / collision / other', async () => {
+    // Single round-trip: a CASE/FILTER aggregate beats issuing one COUNT
+    // per category against a 1.18M-row table.
+    (db.execute as jest.Mock).mockResolvedValueOnce([
+      { missing: 290000, collision: 0, other: 2226, total: 292226 },
+    ]);
+
+    const counts = await classifyUnresolvable();
+
+    expect(counts).toEqual({ missing: 290000, collision: 0, other: 2226, total: 292226 });
+  });
+
+  it('coerces row counts to numbers (postgres-js returns bigint as string for COUNT)', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([
+      { missing: '5', collision: '0', other: '2', total: '7' },
+    ]);
+
+    const counts = await classifyUnresolvable();
+
+    expect(counts.missing).toBe(5);
+    expect(counts.collision).toBe(0);
+    expect(counts.other).toBe(2);
+    expect(counts.total).toBe(7);
+  });
+
+  it('treats missing as: no library row shares the flowsheet legacy_release_id', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ missing: 0, collision: 0, other: 0, total: 0 }]);
+
+    await classifyUnresolvable();
+
+    const call = findExecuteCallMatching(/missing/i);
+    const sqlText = renderSql(call?.[0]);
+    // The classification SQL must distinguish missing from collision via
+    // a count of matching library rows (0 = missing, >1 = collision).
+    expect(sqlText).toMatch(/library/i);
+    expect(sqlText).toMatch(/legacy_release_id/i);
+  });
+
+  it('returns zeros when the residual is empty (already-recovered state)', async () => {
+    // Re-running on a fully-recovered DB must report all zeros, not crash.
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    const counts = await classifyUnresolvable();
+
+    expect(counts).toEqual({ missing: 0, collision: 0, other: 0, total: 0 });
+  });
+});
+
+describe('broken-fk-recovery: markUnresolvable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('stamps legacy_link_attempted_at = now() on the broken-FK residual', async () => {
+    // The marker is what B-2.2's LML backfill keys off of to find these
+    // rows alongside the never-had-legacy-id rows.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 292226 });
+
+    await markUnresolvable();
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*legacy_link_attempted_at/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/legacy_link_attempted_at"?\s*=\s*now\(\)/i);
+  });
+
+  it('only marks rows where album_id IS NULL and legacy_release_id IS NOT NULL', async () => {
+    // Don't stamp rows that were just resolved on the re-run, and don't
+    // stamp the never-had-legacy-id 889K bucket — those are categorically
+    // distinct and B-2.2's predicate already covers them.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await markUnresolvable();
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*legacy_link_attempted_at/i);
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/album_id"?\s+IS\s+NULL/i);
+    expect(sqlText).toMatch(/legacy_release_id"?\s+IS\s+NOT\s+NULL/i);
+  });
+
+  it('only stamps rows that have not been stamped before (idempotency)', async () => {
+    // Re-running the job after a partial run must skip rows already
+    // stamped — otherwise the timestamp would slide forward on every run
+    // and lose the "first attempted at" signal.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await markUnresolvable();
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*legacy_link_attempted_at/i);
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/legacy_link_attempted_at"?\s+IS\s+NULL/i);
+  });
+
+  it('returns the rows-stamped count from postgres-js result.count', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 292226 });
+
+    const stamped = await markUnresolvable();
+
+    expect(stamped).toBe(292226);
+  });
+});
+
+describe('broken-fk-recovery: runRecovery orchestration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('runs phases in order: reresolve → classify → mark', async () => {
+    // Order matters: classify must read the post-resolver state (so the
+    // "newly recovered" rows aren't reported as broken), and mark must
+    // run after classify (so the report reflects the residual that's
+    // actually being marked).
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce({ count: 5 }) // reresolve
+      .mockResolvedValueOnce([{ missing: 100, collision: 0, other: 0, total: 100 }]) // classify
+      .mockResolvedValueOnce({ count: 100 }); // mark
+
+    const result = await runRecovery();
+
+    expect(result.resolved).toBe(5);
+    expect(result.counts).toEqual({ missing: 100, collision: 0, other: 0, total: 100 });
+    expect(result.marked).toBe(100);
+
+    const callOrder = (db.execute as jest.Mock).mock.calls.map((c) => renderSql(c[0]));
+    expect(callOrder[0]).toMatch(/UPDATE[\s\S]*flowsheet[\s\S]*album_id[\s\S]*FROM[\s\S]*library/i);
+    expect(callOrder[1]).toMatch(/missing/i);
+    expect(callOrder[2]).toMatch(/UPDATE[\s\S]*flowsheet[\s\S]*legacy_link_attempted_at/i);
+  });
+});
+
+describe('broken-fk-recovery: formatReport', () => {
+  it('renders a comment-friendly breakdown including all three categories', () => {
+    // The operator pastes this output as a comment on the issue. Whatever
+    // shape future-us picks, the three categories from the issue's
+    // acceptance criteria all need to be visible.
+    const report = formatReport({ missing: 290000, collision: 0, other: 2226, total: 292226 });
+    expect(report).toMatch(/missing[\s\S]*290,?000/i);
+    expect(report).toMatch(/collision[\s\S]*0\b/i);
+    expect(report).toMatch(/other[\s\S]*2,?226/i);
+    expect(report).toMatch(/total[\s\S]*292,?226/i);
+  });
+
+  it('handles the all-zeros case (already recovered)', () => {
+    const report = formatReport({ missing: 0, collision: 0, other: 0, total: 0 });
+    expect(report).toMatch(/0/);
+    expect(report).not.toContain('NaN');
+    expect(report).not.toContain('undefined');
+  });
+});


### PR DESCRIPTION
Closes #493. Part of [Epic B](https://github.com/WXYC/Backend-Service/issues/484).

## Scope

For the ~292K flowsheet `track` rows where `legacy_release_id IS NOT NULL AND album_id IS NULL`:

1. Re-run the existing legacy-FK resolver to catch any post-ETL library imports that weren't reconciled at the time.
2. Classify the residual into missing / collision / other in a single round-trip.
3. Stamp `legacy_link_attempted_at = now()` on the residual so [B-2.2](https://github.com/WXYC/Backend-Service/issues/499)'s LML backfill can find both the broken-FK rows and the never-had-legacy-id 889K rows in one predicate.

## Changes

- Migration `0063_flowsheet-legacy-link-attempted-at.sql` adds a nullable `timestamptz` marker column. DDL-only — same hard-won pattern as 0053 (issue #511).
- `jobs/broken-fk-recovery/` — new one-shot job (`reresolveAlbumIds` → `classifyUnresolvable` → `markUnresolvable`) plus a comment-friendly `formatReport` helper.
- Excludes `legacy_link_attempted_at` from the API-facing `IFSEntry` interface (mirrors the existing `search_doc` exclusion) since it is internal recovery state.
- Drizzle journal updated; mock updated; Dockerfile + workspace lockfile entries added.

B-2.2's predicate after this lands:

```sql
WHERE album_id IS NULL
  AND (legacy_release_id IS NULL OR legacy_link_attempted_at IS NOT NULL)
```

## Test plan

- [x] `npm run test:unit` — 1135 tests pass (15 new, covering each phase's SQL shape, the orchestrator's call order, and `formatReport`)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [ ] Build the Docker image: `Manual Build & Deploy` with `target=broken-fk-recovery`, then on EC2 `docker run --rm --env-file .env <image> 2>&1 | tee log` against the production-clone first to capture the actual classification counts and post them to #493.

## Out of scope

- LML reconciliation — that's [B-2.2](https://github.com/WXYC/Backend-Service/issues/499).
- Canonical-entity work — independent of this PR (parallel with [B-1.1](https://github.com/WXYC/Backend-Service/issues/494)).