### PR TITLE
Filter playlist-proxy artwork queries on artwork_url IS NOT NULL

### DIFF
--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -21,7 +21,7 @@
  */
 import { EventSource } from 'eventsource';
 import { db, flowsheet } from '@wxyc/database';
-import { sql, inArray } from 'drizzle-orm';
+import { sql, inArray, and, isNotNull } from 'drizzle-orm';
 
 const TUBAFRENZY_URL = process.env.TUBAFRENZY_URL ?? 'https://www.wxyc.info';
 const MAX_ENTRIES = 200;
@@ -331,7 +331,15 @@ async function enrichPlaycuts(): Promise<void> {
         artwork_url: flowsheet.artwork_url,
       })
       .from(flowsheet)
-      .where(inArray(flowsheetLookupKey, keys))
+      // The `artwork_url IS NOT NULL` filter is required for the planner to
+      // use the partial index `flowsheet_artwork_lookup_idx` (migration 0057).
+      // Without it, the predicate doesn't match the index's WHERE clause and
+      // PG falls back to a sequential scan of every flowsheet row — on a
+      // 2.6M-row table that runs minutes per call and accumulates orphan
+      // queries. The post-query JS filter (`if (row.key && row.artwork_url)`)
+      // already excludes NULL rows, so this is semantically a no-op; it just
+      // pushes the filter to PG so the index can fire. See incident #511.
+      .where(and(inArray(flowsheetLookupKey, keys), isNotNull(flowsheet.artwork_url)))
       .groupBy(flowsheetLookupKey, flowsheet.artwork_url);
 
     // Build new map and only swap on success — preserves existing artwork on DB failure
@@ -366,7 +374,8 @@ async function enrichSinglePlaycut(entry: TubafrenzyEntry): Promise<void> {
     const rows = await db
       .select({ artwork_url: flowsheet.artwork_url })
       .from(flowsheet)
-      .where(inArray(flowsheetLookupKey, [key]))
+      // Same partial-index alignment as enrichPlaycuts — see comment there.
+      .where(and(inArray(flowsheetLookupKey, [key]), isNotNull(flowsheet.artwork_url)))
       .limit(1);
 
     if (rows.length > 0 && rows[0].artwork_url) {

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -48,6 +48,7 @@ jest.mock('drizzle-orm', () => ({
   sql: Object.assign(jest.fn(), { raw: jest.fn() }),
   inArray: jest.fn(),
   isNotNull: jest.fn(),
+  and: jest.fn(),
 }));
 
 // Mock EventSource — we do not want to open real SSE connections in tests.
@@ -396,6 +397,46 @@ describe('playlist-proxy.service', () => {
       expect(result.playcuts).toEqual([]);
       expect(result.talksets).toEqual([]);
       expect(result.breakpoints).toEqual([]);
+    });
+  });
+
+  describe('artwork query: partial-index alignment (regression for #511)', () => {
+    // The partial functional index `flowsheet_artwork_lookup_idx` (migration
+    // 0057) only covers rows where `artwork_url IS NOT NULL`. Without that
+    // filter on the query side, the planner falls back to a sequential scan
+    // of every flowsheet row — which times out at the 5s server-side
+    // statement_timeout and accumulates orphan queries (incident #511).
+    //
+    // Source-grep over the deployed file is the right shape because the
+    // bug is a *missing* clause in the SQL builder. A behavioural test
+    // wouldn't catch a future regression where someone adds a new query
+    // path without the filter; the source-grep does.
+    const fs = jest.requireActual<typeof import('fs')>('fs');
+    const path = jest.requireActual<typeof import('path')>('path');
+
+    const proxySource = fs.readFileSync(
+      path.resolve(__dirname, '../../../apps/backend/services/playlist-proxy.service.ts'),
+      'utf-8'
+    );
+
+    it('imports `and` and `isNotNull` from drizzle-orm', () => {
+      expect(proxySource).toMatch(/from\s+'drizzle-orm'/);
+      expect(proxySource).toMatch(/\band\b/);
+      expect(proxySource).toMatch(/\bisNotNull\b/);
+    });
+
+    it('every flowsheet artwork SELECT filters on isNotNull(flowsheet.artwork_url)', () => {
+      // Find every WHERE that targets the flowsheetLookupKey-on-flowsheet
+      // pattern. Each must be combined with isNotNull(flowsheet.artwork_url).
+      // Two call sites exist today (enrichPlaycuts, enrichSinglePlaycut);
+      // any future addition should match the same shape so the partial
+      // index continues to fire.
+      const whereCalls = proxySource.match(/\.where\([\s\S]*?\)\s*(?:\.|;)/g) ?? [];
+      const artworkWhereCalls = whereCalls.filter((w) => /flowsheetLookupKey/.test(w));
+      expect(artworkWhereCalls.length).toBeGreaterThanOrEqual(2);
+      for (const call of artworkWhereCalls) {
+        expect(call).toMatch(/isNotNull\s*\(\s*flowsheet\.artwork_url\s*\)/);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds `isNotNull(flowsheet.artwork_url)` to the WHERE clause of both artwork lookup queries in `apps/backend/services/playlist-proxy.service.ts` (`enrichPlaycuts` and `enrichSinglePlaycut`). Activates the partial functional index from migration 0057.

## Why

Migration 0057 (PR #531) created a partial index `flowsheet_artwork_lookup_idx` ... `WHERE artwork_url IS NOT NULL`. The consumer queries in playlist-proxy didn't include the matching predicate, so the planner couldn't safely use the partial index — fell back to a 2.6M-row sequential scan, the same query shape that wedged production for hours during incident #511.

After PR #530's `statement_timeout=5000ms` reached production, the seq scans now get cancelled at 5s, but every tubafrenzy SSE event still throws `canceling statement due to statement timeout` and artwork enrichment fails for every new playcut.

This PR adds the missing predicate so the partial index can fire. EXPLAIN before vs after:

```
-- Before
Seq Scan on flowsheet  (cost=0.00..6980717.65 rows=1877234 width=4)
  Filter: ((dj_name IS NULL) AND (entry_type = 'track'::flowsheet_entry_type))

-- After  
Index Scan using flowsheet_artwork_lookup_idx on flowsheet  (cost=0.28..32.40 rows=7 width=186)
  Index Cond: ((lower(trim(artist_name)) || '-' || ...) = $1)
```

The post-query JS filter (`if (row.key && row.artwork_url)`) already excluded NULL rows, so the SQL change is semantically a no-op — just pushes the filter to PG.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (283 pre-existing warnings)
- [x] `npm run format:check` — clean
- [x] `npm run lint:migrations` — passes
- [x] `npm run test:unit` — 1132 / 1132 passing
- [x] New regression test in `playlist-proxy.service.test.ts` source-greps the deployed file: enforces `and`/`isNotNull` imports + that every `flowsheetLookupKey`-targeting WHERE includes `isNotNull(flowsheet.artwork_url)`. Catches future regressions where someone adds a third query path without the filter.
- [x] Verified manually in production: `EXPLAIN` against `flowsheet_artwork_lookup_idx` switches from Seq Scan to Index Scan when the filter is present.

## Deployment

The partial index was created manually via `CREATE INDEX CONCURRENTLY` in production during incident response, and migration 0057 was marked applied in `drizzle.__drizzle_migrations`. So the index is already live; this PR's code just lets the existing query plan use it.

After merge: backend image builds. Manual swap on EC2 (the regular deploy chain is still gated on migration 0054 applying — separate work). Or wait for the deploy chain to unblock and let the new image roll out normally.

Refs #511.