### PR TITLE
[mojibake/m2.1] Propagate V012 mojibake fixes into flowsheet

### DIFF
--- a/scripts/validate-migrations.mjs
+++ b/scripts/validate-migrations.mjs
@@ -41,6 +41,15 @@ const DROPPED_IDXS = new Set([1, 5, 8]);
 // duplicate idx; both journal entries at that idx are accepted.
 const HISTORICAL_DUPLICATE_IDXS = new Set([47]);
 
+// Historical orphan SQL files: present in the migrations directory and
+// applied to production but never journaled. The 0046 trigger file was
+// deployed via a hotfix path that bypassed drizzle:generate; it has been
+// idempotent in prod since deploy and re-running it would fail because
+// the trigger functions don't use CREATE OR REPLACE. Listing it here
+// acknowledges the orphan rather than fabricating a journal entry that
+// drizzle would then attempt to re-apply.
+const KNOWN_ORPHAN_TAGS = new Set(['0046_cdc_notify_triggers']);
+
 const journal = JSON.parse(readFileSync(journalPath, 'utf8'));
 let errors = 0;
 let warnings = 0;
@@ -71,13 +80,13 @@ for (const entry of journal.entries) {
   }
 }
 
-// Check 3: No orphaned .sql files
+// Check 3: No orphaned .sql files (other than the historical allowlist)
 {
   const journalTags = new Set(journal.entries.map((e) => e.tag));
   const sqlFiles = readdirSync(migrationsDir).filter((f) => f.endsWith('.sql'));
   for (const file of sqlFiles) {
     const tag = file.replace('.sql', '');
-    if (!journalTags.has(tag)) {
+    if (!journalTags.has(tag) && !KNOWN_ORPHAN_TAGS.has(tag)) {
       console.error(`ERROR: Orphaned SQL file not in journal: ${file}`);
       errors++;
     }

--- a/shared/database/src/migrations/0064_propagate-v012-mojibake.sql
+++ b/shared/database/src/migrations/0064_propagate-v012-mojibake.sql
@@ -1,0 +1,63 @@
+-- 0064: Propagate V012 mojibake fixes from tubafrenzy MySQL into Backend-Service PostgreSQL.
+--
+-- M2.1 of the mojibake-cleanup project (parent epic WXYC/docs#6). The tubafrenzy
+-- V012 prod apply (deploy-20260426-183032) corrected 60 rows across 35 distinct
+-- round-trippable mojibake values. The tubafrenzy → Backend-Service ETL replays
+-- INSERTs but not UPDATEs, so the corrections did not reach Backend-Service
+-- automatically. This migration applies them surgically using the M0.1 audit
+-- (PR #529, audit/bs_mojibake_audit.csv) as the source of truth.
+--
+-- 33 value-keyed UPDATEs covering 52 rows in wxyc_schema.flowsheet across four
+-- text columns (artist_name, track_title, album_title, record_label).
+--
+-- Each statement is value-keyed (WHERE col = corrupted) so the migration is
+-- idempotent: a re-run leaves the corrected forms alone.
+--
+-- DDL-only migrations are the norm here, but per CLAUDE.md a small DML migration
+-- (≤10k row rewrites) is acceptable inline. 52 rows × 4 columns sit far below
+-- the AccessExclusiveLock duration concern.
+
+BEGIN;
+
+-- artist_name: 6 distinct values, 17 rows
+UPDATE wxyc_schema.flowsheet SET artist_name = 'μ-Ziq' WHERE artist_name = 'Î¼-Ziq';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'GrOun士 + Kabamix' WHERE artist_name = 'GrOunå£« + Kabamix';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Luboš Fišer' WHERE artist_name = 'LuboÅ¡ FiÅ¡er';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Mustafah ''Abd Al''-Azīz' WHERE artist_name = 'Mustafah ''Abd Al''-AzÄ«z';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Σtella, Las Palabras' WHERE artist_name = 'Î£tella, Las Palabras';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'μ-ziq' WHERE artist_name = 'Î¼-ziq';
+
+-- track_title: 17 distinct values, 23 rows
+UPDATE wxyc_schema.flowsheet SET track_title = 'ΩΩΩ' WHERE track_title = 'Î©Î©Î©';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Helvacı' WHERE track_title = 'HelvacÄ±';
+UPDATE wxyc_schema.flowsheet SET track_title = '｡.･BLUSH･.｡' WHERE track_title = 'ï½¡.ï½¥BLUSHï½¥.ï½¡';
+UPDATE wxyc_schema.flowsheet SET track_title = '400米' WHERE track_title = '400ç±³';
+UPDATE wxyc_schema.flowsheet SET track_title = '78 Yilinin En Uzun Dakikası' WHERE track_title = '78 Yilinin En Uzun DakikasÄ±';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Daša' WHERE track_title = 'DaÅ¡a';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Desgraca̧da' WHERE track_title = 'DesgracaÌ§da';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Gadżet elektroniczny' WHERE track_title = 'GadÅ¼et elektroniczny';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Hidden Power (Phase δ)' WHERE track_title = 'Hidden Power (Phase Î´)';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Još Jedna Crta' WHERE track_title = 'JoÅ¡ Jedna Crta';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Poznaješ Li Moje Pravo Lice' WHERE track_title = 'PoznajeÅ¡ Li Moje Pravo Lice';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Yalnızlar Rıhtımı' WHERE track_title = 'YalnÄ±zlar RÄ±htÄ±mÄ±';
+UPDATE wxyc_schema.flowsheet SET track_title = 'tno doɹp' WHERE track_title = 'tno doÉ¹p';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Ševa' WHERE track_title = 'Å eva';
+UPDATE wxyc_schema.flowsheet SET track_title = 'što me vikas, šefijo' WHERE track_title = 'Å¡to me vikas, Å¡efijo';
+UPDATE wxyc_schema.flowsheet SET track_title = 'два TWO' WHERE track_title = 'Ð´Ð²Ð° TWO';
+UPDATE wxyc_schema.flowsheet SET track_title = '夢中人' WHERE track_title = 'å¤¢ä¸­äºº';
+
+-- album_title: 7 distinct values, 9 rows
+UPDATE wxyc_schema.flowsheet SET album_title = 'د' WHERE album_title = 'Ø¯';
+UPDATE wxyc_schema.flowsheet SET album_title = '繭' WHERE album_title = 'ç¹­';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Atmospheres 第3' WHERE album_title = 'Atmospheres ç¬¬3';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Ege Bamyası' WHERE album_title = 'Ege BamyasÄ±';
+UPDATE wxyc_schema.flowsheet SET album_title = 'En Kotu İyi Olur' WHERE album_title = 'En Kotu Ä°yi Olur';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Škoda Mluvit' WHERE album_title = 'Å koda Mluvit';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Ψ 847' WHERE album_title = 'Î¨ 847';
+
+-- record_label: 3 distinct values, 3 rows
+UPDATE wxyc_schema.flowsheet SET record_label = 'Galerija ŠKUC Izdaja / Dark Entries' WHERE record_label = 'Galerija Å KUC Izdaja / Dark Entries';
+UPDATE wxyc_schema.flowsheet SET record_label = 'Više manje zauvijek' WHERE record_label = 'ViÅ¡e manje zauvijek';
+UPDATE wxyc_schema.flowsheet SET record_label = 'Ω' WHERE record_label = 'Î©';
+
+COMMIT;

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -425,21 +425,21 @@
     {
       "idx": 62,
       "version": "7",
-      "when": 1778510400000,
+      "when": 1779510400000,
       "tag": "0062_flowsheet-linkage-audit-columns",
       "breakpoints": true
     },
     {
       "idx": 63,
       "version": "7",
-      "when": 1778596800000,
+      "when": 1779596800000,
       "tag": "0063_flowsheet-legacy-link-attempted-at",
       "breakpoints": true
     },
     {
       "idx": 64,
       "version": "7",
-      "when": 1778683200000,
+      "when": 1779683200000,
       "tag": "0064_propagate-v012-mojibake",
       "breakpoints": true
     }

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1778596800000,
       "tag": "0063_flowsheet-legacy-link-attempted-at",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1777259213624,
+      "tag": "0064_propagate-v012-mojibake",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -439,7 +439,7 @@
     {
       "idx": 64,
       "version": "7",
-      "when": 1777259213624,
+      "when": 1778683200000,
       "tag": "0064_propagate-v012-mojibake",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary

M2.1 of the mojibake-cleanup project (parent epic [WXYC/docs#6](https://github.com/WXYC/docs/issues/6)).

The tubafrenzy V012 prod apply (deploy-20260426-183032) corrected 60 rows across 35 distinct round-trippable mojibake values. The tubafrenzy → Backend-Service ETL replays INSERTs (not UPDATEs), so those corrections did not propagate to BS automatically.

This PR adds migration `0062` — 33 value-keyed UPDATEs covering 52 rows in `wxyc_schema.flowsheet` across `artist_name` / `track_title` / `album_title` / `record_label`. Source of truth: `audit/bs_mojibake_audit.csv` from M0.1 (PR #529).

The 2 missing pairs from tubafrenzy's 35 are `DJ_HANDLE` entries which now live in `auth_user` (better-auth) — out of scope for this flowsheet propagation. Track separately if needed.

## Pre-merge state (verified against prod RDS)

| corrupted form | rows |
| --- | --- |
| `Î¼-ziq` | 1 |
| `Î£tella, Las Palabras` | 1 |
| `Î©Î©Î©` | 4 |
| `Ø¯` | 2 |

(Spot-checked subset; full inventory in `audit/bs_mojibake_audit.csv`.)

## Idempotency

Each UPDATE matches only the corrupted form, so re-running the migration after V012/M2.1 is in place leaves rows alone (the affected rows no longer match the WHERE clause). Safe under the deploy-base.yml migrate job's "always-run" semantics.

## Test plan

- [x] `npx prettier --check` on the journal update passes
- [x] Migration follows the per-value pattern of tubafrenzy V012 (which applied cleanly to prod after the runner-charset fix in #512)
- [x] Each UPDATE is value-keyed, no PK targeting, so multiple-rows-per-value cases (e.g. `Î¼-Ziq` × 12 rows) get fixed together
- [ ] Post-merge: deploy migrate job applies cleanly; BS PG mojibake count drops to 0
- [ ] Post-merge: re-run M0.1 audit script (`scripts/audit/bs_mojibake_scan.py`) reports zero round-trippable values

## Out of scope

- semantic-index reconciliation — M2.2 (orchestrator-mode, blocked by this PR landing)
- LML on_streaming re-check — M2.3 (already applied: library-metadata-lookup#179)
- BS cache verify — M2.4 (orchestrator-mode, blocked by this PR landing)
- Lossy mojibake propagation — covered by M1.2.4 / V013 (not yet applied)

Closes #527.