### PR TITLE
Resync package-lock.json for @wxyc/library-artist-name-backfill workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -497,6 +497,20 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/library-artist-name-backfill": {
+      "name": "@wxyc/library-artist-name-backfill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/library-etl": {
       "name": "@wxyc/library-etl",
       "version": "1.0.0",
@@ -7047,6 +7061,10 @@
     },
     "node_modules/@wxyc/flowsheet-linkage-audit-backfill": {
       "resolved": "jobs/flowsheet-linkage-audit-backfill",
+      "link": true
+    },
+    "node_modules/@wxyc/library-artist-name-backfill": {
+      "resolved": "jobs/library-artist-name-backfill",
       "link": true
     },
     "node_modules/@wxyc/library-etl": {


### PR DESCRIPTION
## Summary

Re-runs \`npm install\` to sync \`package-lock.json\` with the \`@wxyc/library-artist-name-backfill\` workspace added in 1db8f50.

## Why

The lockfile drift is blocking every \`Auto Build & Deploy\` run on main. The \`setup\` step does \`npm ci\` which fails:

\`\`\`
npm error Missing: @wxyc/library-artist-name-backfill@1.0.0 from lock file
\`\`\`

That cascades to all downstream jobs being skipped — no new images get built, no deploys happen.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run test:unit\` — same pass/fail count as origin/main; this PR doesn't introduce new failures

Note: \`npm run lint:migrations\` and the \`tests/unit/scripts/validate-migrations.test.ts\` suite are failing on origin/main due to unrelated journal drift (idx 61's \`when\` timestamp is out of order, and \`0046_cdc_notify_triggers.sql\` exists as an orphan file). Both predate this PR. They should be addressed separately.

Refs #511.