### PR TITLE
Replay flowsheet.search_doc rewrite (0054 skipped by drizzle cursor)

### DIFF
--- a/shared/database/src/migrations/0065_replay-flowsheet-search-doc-with-dj-name.sql
+++ b/shared/database/src/migrations/0065_replay-flowsheet-search-doc-with-dj-name.sql
@@ -1,0 +1,59 @@
+-- 0065: Replay 0054's flowsheet.search_doc rewrite (the dj_name version).
+--
+-- 0054 was one of five migrations drizzle silently skipped over in
+-- production after 0061 was originally committed with a far-future `when`
+-- and jumped the migrator's "latest applied created_at" cursor. Four of
+-- the five (0055/0056/0062/0063) have since been reapplied: their SQL
+-- was hand-applied to prod and matching hashes inserted into
+-- drizzle.__drizzle_migrations, then commit 82a0263 re-timestamped the
+-- journal so 0061-0063 are properly monotonic again.
+--
+-- 0054 was deliberately left for a real migration to handle because it is
+-- the one expensive change in the set: redefining the search_doc generated
+-- column requires DROP COLUMN + ADD COLUMN, which evaluates the new
+-- expression for every flowsheet row (~2.6M live rows on prod). The
+-- AccessExclusiveLock that ALTER TABLE holds for the duration of that
+-- rewrite is the rule CLAUDE.md spells out as "migrations are DDL-only,
+-- no bulk DML"; we are knowingly making an exception because Postgres
+-- has no way to redefine a generated column's expression in place. Apply
+-- during a low-traffic window.
+--
+-- Idempotent against any partial-apply state:
+--   - DROP COLUMN IF EXISTS handles search_doc never having been created
+--     (or having been created with a different definition).
+--   - ADD COLUMN can be unconditional because the previous statement
+--     guarantees the column does not exist at this point.
+--   - CREATE INDEX IF NOT EXISTS handles the case where the index was
+--     already built by a successful local apply of 0054.
+--   - DROP INDEX IF EXISTS handles the case where 0051's per-table
+--     trigram indexes were already cleaned up.
+--
+-- statement_timeout=10min puts a hard cap on the rewrite. If it fails
+-- under contention it surfaces a clear error in CI/migrate logs (the
+-- behaviour we built into 0056 in #524) instead of timing out the
+-- GitHub Actions runner silently.
+
+SET LOCAL lock_timeout = '30s';--> statement-breakpoint
+SET LOCAL statement_timeout = '10min';--> statement-breakpoint
+
+ALTER TABLE "wxyc_schema"."flowsheet" DROP COLUMN IF EXISTS "search_doc";--> statement-breakpoint
+
+ALTER TABLE "wxyc_schema"."flowsheet"
+  ADD COLUMN "search_doc" tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('simple', coalesce("artist_name", '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce("track_title", '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce("dj_name", '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce("album_title", '')), 'C') ||
+    setweight(to_tsvector('simple', coalesce("record_label", '')), 'D')
+  ) STORED;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "flowsheet_search_doc_idx"
+  ON "wxyc_schema"."flowsheet" USING gin ("search_doc");--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "flowsheet_dj_name_trgm_idx"
+  ON "wxyc_schema"."flowsheet" USING gin ("dj_name" gin_trgm_ops);--> statement-breakpoint
+
+DROP INDEX IF EXISTS "auth_user_dj_name_trgm_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "auth_user_name_trgm_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "wxyc_schema"."shows_legacy_dj_name_trgm_idx";

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1779683200000,
       "tag": "0064_propagate-v012-mojibake",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1779683200001,
+      "tag": "0065_replay-flowsheet-search-doc-with-dj-name",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Production is missing 0054's effect: \`flowsheet.search_doc\` is still defined without \`dj_name\` in its tsvector expression. Verified directly:

\`\`\`sql
SELECT generation_expression LIKE '%dj_name%' AS has_dj_name
FROM information_schema.columns
WHERE table_schema='wxyc_schema' AND table_name='flowsheet' AND column_name='search_doc';
-- → NO
\`\`\`

This is the last residue of the cursor-skip incident (#550). The other four skipped migrations (0055/0056/0062/0063) were reapplied by hand, with matching hashes inserted into \`drizzle.__drizzle_migrations\`, and commit \`82a0263\` re-timestamped 0061-0063 so the journal is properly monotonic again.

0054 was deliberately left for a real migration to handle because it is the one expensive change in the set — redefining a \`STORED\` generated column requires \`DROP COLUMN\` + \`ADD COLUMN\`, which re-evaluates the tsvector expression for every flowsheet row (~2.6M rows on prod) under an \`AccessExclusiveLock\`. CLAUDE.md's "DDL-only" rule applies; the exception here is unavoidable because Postgres has no in-place way to redefine a generated column's expression.

## What this PR adds

A single migration: \`shared/database/src/migrations/0065_replay-flowsheet-search-doc-with-dj-name.sql\`

- DROP COLUMN IF EXISTS \`flowsheet.search_doc\` → idempotent against any prior definition.
- ADD COLUMN \`search_doc\` GENERATED ALWAYS AS (artist_name A, track_title B, **dj_name B**, album_title C, record_label D) STORED.
- CREATE INDEX IF NOT EXISTS \`flowsheet_search_doc_idx\` (GIN over search_doc) + \`flowsheet_dj_name_trgm_idx\` (GIN trigram over dj_name).
- DROP INDEX IF EXISTS the three obsolete per-table trigram indexes from 0051 (\`auth_user_dj_name_trgm_idx\`, \`auth_user_name_trgm_idx\`, \`shows_legacy_dj_name_trgm_idx\`).
- Wrapped in \`SET LOCAL lock_timeout = '30s'\` + \`SET LOCAL statement_timeout = '10min'\` so a stuck rewrite surfaces a clear error in the migrate-job logs (the behaviour we built into 0056 in #524) instead of silently timing out the GHA runner.
- Journal entry at \`when=1779683200001\` (cursor + 1ms above main's latest 0064_propagate-v012-mojibake).

Closes #550. Unblocks #517, #518, #519, #520, #521, #523, and the WXYC/wxyc-shared#82 epic.

## What this PR no longer does (and why)

The previous version of this PR consolidated five skipped migrations (0054, 0055, 0056, 0062, 0063), extended the validator with two new allowlists, and renumbered the journal. Since then, parallel commits to main have addressed everything except 0054:

- \`82a0263 Fix migration journal: restore 0046 entry and reorder 0061 timestamp\` — kills the cursor-skip bug at the root by re-timestamping 0061-0063 so they are properly monotonic.
- \`51a0126 Repair pre-existing migration journal validator failures\` — adds \`KNOWN_ORPHAN_TAGS = {0046_cdc_notify_triggers}\` to the validator, covering the orphan allowlist I had drafted.
- 0055/0056/0062/0063 SQL was hand-applied to prod with hashes inserted, and 0062/0063 SQL files have since landed in main with corrected timestamps.

So the only piece still missing in prod is 0054. Reducing the PR to one migration is the smallest correct delta.

## Test plan

- [x] \`scripts/validate-migrations.mjs\` passes (1 pre-existing allowlisted warning, 0 errors).
- [x] \`tests/unit/scripts/validate-migrations.test.ts\` — 8 tests pass.
- [x] \`npm run typecheck\` clean.
- [x] \`npm run lint\` clean (0 errors, only pre-existing warnings).
- [x] **Local end-to-end:** \`npm run db:start\` then \`npm run drizzle:migrate\` against a freshly seeded local DB applies 0065 cleanly. The resulting \`flowsheet.search_doc\` generation expression includes \`dj_name\`; both required GIN indexes exist; the three obsolete trigram indexes from 0051 are absent. A re-run of \`drizzle:migrate\` is a no-op (no duplicate row at \`created_at=1779683200001\`).
- [ ] CI integration tests pass.
- [ ] After merge, watch \`Auto Build & Deploy\` for the merge commit; \`migrate\` runs 0065 within the 10-minute statement_timeout window, then \`deploy\` runs.
- [ ] After 0065 lands in prod, verify \`generation_expression LIKE '%dj_name%'\` is true for \`wxyc_schema.flowsheet.search_doc\`.

## Operational notes for the merge

The 0065 rewrite holds \`AccessExclusiveLock\` on \`wxyc_schema.flowsheet\` for the duration of the table rewrite. With ~2.6M rows on prod, expect:

- ~30s–2min lock window (varies with I/O contention; the autovacuum issues from #525 have since cleared).
- During that window, all flowsheet writes (DJ entry adds, request-line, legacy-mirror queue) block. The legacy mirror's bounded retry buffer should absorb it; the request-line will queue.
- DJ-name search is currently broken (the v1 search service falls back to a no-match for legacy rows because their search_doc has no dj_name term). 0065 fixes the search_doc shape but legacy rows still need dj_name backfilled by \`jobs/flowsheet-dj-name-backfill\` to actually match.

Apply during a low-traffic window (e.g., outside the 7-9pm DJ-show peak).