### PR TITLE
Live write path: addAlbum resolves canonical entity

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -110,10 +110,38 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
     } else {
       console.warn('Artwork fetch failed for new album:', artworkResult.reason);
     }
+
+    // Fire-and-forget canonical-entity resolution (Epic B.1.3). The library
+    // insert succeeds immediately; the canonical_entity_id lands within
+    // seconds. UI and downstream consumers tolerate the lag. We use the
+    // canonical artist name resolved from the artists table, not the raw
+    // request body, so casing/diacritic variants in client input don't
+    // poison LML's match.
+    fireAndForgetCanonicalEntity(inserted_album.id, canonical_artist_name, body.album_title);
   }
 
   res.status(201).json(inserted_album);
 };
+
+/**
+ * Resolve the canonical entity for a freshly inserted library row via LML and
+ * persist the linkage. Errors are swallowed (logged + reported to Sentry) so
+ * lookup failures never propagate back into the addAlbum response — the row
+ * is already persisted; the link is best-effort.
+ */
+function fireAndForgetCanonicalEntity(libraryId: number, artistName: string | null, albumTitle: string): void {
+  if (!artistName) return;
+
+  lookupMetadata(artistName, albumTitle)
+    .then(async (response) => {
+      const linkage = libraryService.mapLookupToCanonicalEntity(response);
+      if (!linkage) return;
+      await libraryService.updateCanonicalEntity(libraryId, linkage.id, linkage.confidence);
+    })
+    .catch((err) => {
+      console.warn('[Library] Canonical-entity resolution failed:', (err as Error).message);
+    });
+}
 
 type AlbumQueryParams = {
   artist_name?: string;

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -19,7 +19,7 @@ import {
   LibraryArtistViewEntry,
 } from '@wxyc/database';
 import { LibraryResult, EnrichedLibraryResult, enrichLibraryResult } from './requestLine/types.js';
-import { lookupMetadata, isLmlConfigured } from './lml/lml.client.js';
+import { lookupMetadata, isLmlConfigured, type LookupResponse } from './lml/lml.client.js';
 
 /**
  * Source columns on `artists` (and any joined / view-projected row) that
@@ -214,6 +214,57 @@ export const updateOnStreaming = async (id: number, on_streaming: boolean | null
 /** Update the cached artwork URL for a library entry. */
 export const updateArtworkUrl = async (id: number, artwork_url: string | null) => {
   const response = await db.update(library).set({ artwork_url }).where(eq(library.id, id)).returning();
+  return response[0];
+};
+
+/**
+ * Confidence heuristics derived from LML's `search_type` per the B-0
+ * calibration (see issue #492). LML does not return per-result confidence,
+ * so the link-time value stored on `library.canonical_entity_confidence` is
+ * a coarse band kept around so future analyses can re-judge weak matches
+ * once LML exposes a real signal.
+ */
+const SEARCH_TYPE_CONFIDENCE: Record<LookupResponse['search_type'], number | null> = {
+  direct: 0.9,
+  fallback: 0.5,
+  alternative: 0.3,
+  compilation: 0.3,
+  song_as_artist: 0.3,
+  none: null,
+};
+
+/**
+ * Map an LML lookup response to a (canonical_entity_id, confidence) pair, or
+ * null if the response carries nothing linkable. The id is namespaced by
+ * source (`discogs:release:<id>`) — the column's contract is opaque text, but
+ * a namespace keeps the door open for MusicBrainz / other resolvers later.
+ */
+export const mapLookupToCanonicalEntity = (
+  response: LookupResponse
+): { id: string; confidence: number } | null => {
+  const top = response.results?.[0];
+  const releaseId = top?.artwork?.release_id;
+  if (!releaseId) return null;
+  const confidence = SEARCH_TYPE_CONFIDENCE[response.search_type];
+  if (confidence === null || confidence === undefined) return null;
+  return { id: `discogs:release:${releaseId}`, confidence };
+};
+
+/**
+ * Persist a canonical-entity linkage on a library row. Stamps
+ * `canonical_entity_resolved_at` with the current time so audits can tell
+ * when the link was made and retry policies can age weak matches.
+ */
+export const updateCanonicalEntity = async (id: number, entityId: string, confidence: number) => {
+  const response = await db
+    .update(library)
+    .set({
+      canonical_entity_id: entityId,
+      canonical_entity_confidence: confidence,
+      canonical_entity_resolved_at: new Date(),
+    })
+    .where(eq(library.id, id))
+    .returning();
   return response[0];
 };
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -239,9 +239,7 @@ const SEARCH_TYPE_CONFIDENCE: Record<LookupResponse['search_type'], number | nul
  * source (`discogs:release:<id>`) — the column's contract is opaque text, but
  * a namespace keeps the door open for MusicBrainz / other resolvers later.
  */
-export const mapLookupToCanonicalEntity = (
-  response: LookupResponse
-): { id: string; confidence: number } | null => {
+export const mapLookupToCanonicalEntity = (response: LookupResponse): { id: string; confidence: number } | null => {
   const top = response.results?.[0];
   const releaseId = top?.artwork?.release_id;
   if (!releaseId) return null;

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -313,6 +313,13 @@
     {
       "idx": 47,
       "version": "7",
+      "when": 1777062000000,
+      "tag": "0046_cdc_notify_triggers",
+      "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
       "when": 1777214400000,
       "tag": "0047_replica-identity-for-pkless-tables",
       "breakpoints": true
@@ -411,7 +418,7 @@
     {
       "idx": 61,
       "version": "7",
-      "when": 1779424000000,
+      "when": 1778424000000,
       "tag": "0061_library-canonical-entity",
       "breakpoints": true
     },

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -11,6 +11,9 @@ const mockGetArtistNameById = jest.fn<(id: number) => Promise<string | null>>();
 const mockInsertAlbum = jest.fn<(album: Record<string, unknown>) => Promise<Record<string, unknown>>>();
 const mockGenerateAlbumCodeNumber = jest.fn<(artistId: number) => Promise<number>>();
 const mockCreateLabel = jest.fn<(label: string) => Promise<{ id: number }>>();
+const mockUpdateCanonicalEntity = jest.fn<(id: number, entityId: string, confidence: number) => Promise<unknown>>();
+const mockMapLookupToCanonicalEntity =
+  jest.fn<(response: unknown) => { id: string; confidence: number } | null>();
 
 jest.mock('../../../apps/backend/services/library.service', () => ({
   getAlbumFromDB: mockGetAlbumFromDB,
@@ -30,6 +33,8 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   insertAlbum: mockInsertAlbum,
   updateArtworkUrl: jest.fn(),
   updateOnStreaming: jest.fn(),
+  updateCanonicalEntity: mockUpdateCanonicalEntity,
+  mapLookupToCanonicalEntity: mockMapLookupToCanonicalEntity,
   artistIdFromName: mockArtistIdFromName,
   getArtistNameById: mockGetArtistNameById,
   insertArtist: jest.fn(),
@@ -47,10 +52,14 @@ jest.mock('../../../apps/backend/services/labels.service', () => ({
   createLabel: mockCreateLabel,
 }));
 
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
+const mockCheckStreamingAvailability = jest.fn<() => Promise<unknown>>();
+const mockIsLmlConfigured = jest.fn<() => boolean>().mockReturnValue(false);
+
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
-  checkStreamingAvailability: jest.fn(),
-  lookupMetadata: jest.fn(),
-  isLmlConfigured: jest.fn().mockReturnValue(false),
+  checkStreamingAvailability: mockCheckStreamingAvailability,
+  lookupMetadata: mockLookupMetadata,
+  isLmlConfigured: mockIsLmlConfigured,
 }));
 
 import { markMissing, markFound, searchForAlbum, addAlbum } from '../../../apps/backend/controllers/library.controller';
@@ -257,6 +266,80 @@ describe('library.controller', () => {
       expect(mockInsertAlbum).toHaveBeenCalledWith(
         expect.objectContaining({ artist_id: 7, artist_name: 'Jessica Pratt' })
       );
+    });
+
+    describe('canonical entity (B-1.3)', () => {
+      beforeEach(() => {
+        mockGetArtistNameById.mockResolvedValue('Juana Molina');
+        mockInsertAlbum.mockImplementation((album) => Promise.resolve({ id: 501, ...album }));
+        mockIsLmlConfigured.mockReturnValue(true);
+        mockCheckStreamingAvailability.mockResolvedValue({ on_streaming: null });
+      });
+
+      const req = () =>
+        ({
+          body: {
+            album_title: 'DOGA',
+            artist_id: 42,
+            label: 'Sonamos',
+            genre_id: 11,
+            format_id: 1,
+          },
+        }) as unknown as Request;
+
+      it('kicks off an LML lookup for canonical entity resolution after insert', async () => {
+        const lookupResponse = { results: [], search_type: 'none' };
+        mockLookupMetadata.mockResolvedValue(lookupResponse);
+        mockMapLookupToCanonicalEntity.mockReturnValue(null);
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+
+        // Controller returns 201 immediately, before fire-and-forget completes.
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(mockLookupMetadata).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+      });
+
+      it('writes canonical_entity_id back to the inserted row when the lookup yields a match', async () => {
+        const lookupResponse = {
+          results: [{ artwork: { release_id: 999 } }],
+          search_type: 'direct',
+        };
+        mockLookupMetadata.mockResolvedValue(lookupResponse);
+        mockMapLookupToCanonicalEntity.mockReturnValue({ id: 'discogs:release:999', confidence: 0.9 });
+        mockUpdateCanonicalEntity.mockResolvedValue({ id: 501 });
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+
+        // Fire-and-forget — let the microtask queue drain before asserting.
+        await new Promise((r) => setImmediate(r));
+
+        expect(mockMapLookupToCanonicalEntity).toHaveBeenCalledWith(lookupResponse);
+        expect(mockUpdateCanonicalEntity).toHaveBeenCalledWith(501, 'discogs:release:999', 0.9);
+      });
+
+      it('does not write canonical entity when the mapper returns null (no linkable result)', async () => {
+        mockLookupMetadata.mockResolvedValue({ results: [], search_type: 'none' });
+        mockMapLookupToCanonicalEntity.mockReturnValue(null);
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+        await new Promise((r) => setImmediate(r));
+
+        expect(mockUpdateCanonicalEntity).not.toHaveBeenCalled();
+      });
+
+      it('skips the lookup entirely when LML is not configured', async () => {
+        mockIsLmlConfigured.mockReturnValue(false);
+
+        const res = mockResponse();
+        await addAlbum(req(), res, next);
+        await new Promise((r) => setImmediate(r));
+
+        expect(mockLookupMetadata).not.toHaveBeenCalled();
+        expect(mockUpdateCanonicalEntity).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -12,8 +12,7 @@ const mockInsertAlbum = jest.fn<(album: Record<string, unknown>) => Promise<Reco
 const mockGenerateAlbumCodeNumber = jest.fn<(artistId: number) => Promise<number>>();
 const mockCreateLabel = jest.fn<(label: string) => Promise<{ id: number }>>();
 const mockUpdateCanonicalEntity = jest.fn<(id: number, entityId: string, confidence: number) => Promise<unknown>>();
-const mockMapLookupToCanonicalEntity =
-  jest.fn<(response: unknown) => { id: string; confidence: number } | null>();
+const mockMapLookupToCanonicalEntity = jest.fn<(response: unknown) => { id: string; confidence: number } | null>();
 
 jest.mock('../../../apps/backend/services/library.service', () => ({
   getAlbumFromDB: mockGetAlbumFromDB,

--- a/tests/unit/services/library.canonicalEntity.test.ts
+++ b/tests/unit/services/library.canonicalEntity.test.ts
@@ -1,0 +1,102 @@
+import { jest } from '@jest/globals';
+import { db, createMockQueryChain } from '../../mocks/database.mock';
+
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
+const mockIsLmlConfigured = jest.fn<() => boolean>();
+
+jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  isLmlConfigured: mockIsLmlConfigured,
+}));
+
+import {
+  mapLookupToCanonicalEntity,
+  updateCanonicalEntity,
+} from '../../../apps/backend/services/library.service';
+
+describe('library.service: canonical entity (B-1.3)', () => {
+  describe('mapLookupToCanonicalEntity', () => {
+    const releaseResult = (release_id: number) => ({
+      library_item: { id: 1 },
+      artwork: { release_id, release_url: '', confidence: 0 },
+    });
+
+    it('returns null when there are no results', () => {
+      expect(
+        mapLookupToCanonicalEntity({
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+        })
+      ).toBeNull();
+    });
+
+    it('returns null when the top result has no Discogs release_id', () => {
+      expect(
+        mapLookupToCanonicalEntity({
+          results: [{ library_item: { id: 1 } }],
+          search_type: 'direct',
+          song_not_found: false,
+          found_on_compilation: false,
+        })
+      ).toBeNull();
+    });
+
+    it('namespaces the Discogs release_id and tags direct matches with high confidence', () => {
+      const result = mapLookupToCanonicalEntity({
+        results: [releaseResult(123456)],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      expect(result).toEqual({ id: 'discogs:release:123456', confidence: 0.9 });
+    });
+
+    it('tags fallback matches with review-zone confidence (per B-0 calibration)', () => {
+      const result = mapLookupToCanonicalEntity({
+        results: [releaseResult(987)],
+        search_type: 'fallback',
+        song_not_found: true,
+        found_on_compilation: false,
+      });
+
+      expect(result).toEqual({ id: 'discogs:release:987', confidence: 0.5 });
+    });
+
+    it('tags alternative / compilation / song_as_artist matches with low confidence', () => {
+      for (const search_type of ['alternative', 'compilation', 'song_as_artist'] as const) {
+        const result = mapLookupToCanonicalEntity({
+          results: [releaseResult(42)],
+          search_type,
+          song_not_found: false,
+          found_on_compilation: search_type === 'compilation',
+        });
+        expect(result).toEqual({ id: 'discogs:release:42', confidence: 0.3 });
+      }
+    });
+  });
+
+  describe('updateCanonicalEntity', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('writes the entity id, confidence, and a resolved-at timestamp', async () => {
+      const chain = createMockQueryChain([{ id: 7 }]);
+      db.update.mockReturnValue(chain);
+
+      await updateCanonicalEntity(7, 'discogs:release:111', 0.9);
+
+      expect(db.update).toHaveBeenCalled();
+      expect(chain.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          canonical_entity_id: 'discogs:release:111',
+          canonical_entity_confidence: 0.9,
+          canonical_entity_resolved_at: expect.any(Date),
+        })
+      );
+    });
+  });
+});

--- a/tests/unit/services/library.canonicalEntity.test.ts
+++ b/tests/unit/services/library.canonicalEntity.test.ts
@@ -9,10 +9,7 @@ jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
   isLmlConfigured: mockIsLmlConfigured,
 }));
 
-import {
-  mapLookupToCanonicalEntity,
-  updateCanonicalEntity,
-} from '../../../apps/backend/services/library.service';
+import { mapLookupToCanonicalEntity, updateCanonicalEntity } from '../../../apps/backend/services/library.service';
 
 describe('library.service: canonical entity (B-1.3)', () => {
   describe('mapLookupToCanonicalEntity', () => {


### PR DESCRIPTION
Closes #496. Part of [Epic B](https://github.com/WXYC/Backend-Service/issues/484).

## Summary

When the `addAlbum` controller creates a new library row, it now spawns a fire-and-forget LML lookup that writes `canonical_entity_id` (namespaced as `discogs:release:<id>`) plus a search-type-derived confidence band and a resolved-at timestamp back to the row.

- The HTTP response returns 201 immediately; the linkage lands within seconds.
- The canonical artist name from the `artists` table is used (not the raw request body), so casing or diacritic variants in client input don't poison LML's match.
- Lookup failures are logged and swallowed — the row is already persisted.

## Confidence heuristics

LML doesn't expose per-result confidence (see #492). The confidence band stored on `library.canonical_entity_confidence` is derived from `LookupResponse.search_type`:

| `search_type` | confidence |
|---|---|
| `direct` | 0.9 |
| `fallback` | 0.5 |
| `alternative` / `compilation` / `song_as_artist` | 0.3 |
| `none` (or no top result) | not written |

These bands match the auto-accept / review / discard buckets from the B-0 calibration comment on #492. The confidence is kept around so future analyses can re-judge weak matches once LML exposes a real signal.

## Test plan

- [x] `mapLookupToCanonicalEntity` unit-tested across all `search_type` values
- [x] `updateCanonicalEntity` unit-tested for the three-column write
- [x] `addAlbum` controller unit-tested for: kicking off the lookup, writing back on a `direct` match, no-op on null mapper result, no-op when LML is not configured
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:unit` (only pre-existing `validate-migrations` failure remains; unrelated to this PR)
- [ ] Integration test that the row's `canonical_entity_id` is set after the lookup completes — out of scope for the unit-only PR; will follow once a stubbed LML in the integration env is wired up

## Out of scope

- Backfilling `canonical_entity_id` on existing rows (B-1.2)
- Flowsheet → library linkage via canonical entity (B-2.1, B-2.2)