### PR TITLE
Library backfill: resolve canonical entity per row via LML

### DIFF
--- a/Dockerfile.library-canonical-entity-backfill
+++ b/Dockerfile.library-canonical-entity-backfill
@@ -1,0 +1,27 @@
+#Build stage
+FROM node:25-alpine AS builder
+
+WORKDIR /library-canonical-entity-backfill-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/library-canonical-entity-backfill ./jobs/library-canonical-entity-backfill
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/library-canonical-entity-backfill
+
+#Production stage
+FROM node:25-alpine AS prod
+
+WORKDIR /library-canonical-entity-backfill
+
+COPY ./package* ./
+COPY ./jobs/library-canonical-entity-backfill/package* ./jobs/library-canonical-entity-backfill/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./library-canonical-entity-backfill-builder/jobs/library-canonical-entity-backfill/dist ./jobs/library-canonical-entity-backfill/dist
+COPY --from=builder ./library-canonical-entity-backfill-builder/shared/database/dist ./shared/database/dist
+
+CMD ["npm", "start", "--workspace=@wxyc/library-canonical-entity-backfill"]

--- a/jobs/library-canonical-entity-backfill/job.ts
+++ b/jobs/library-canonical-entity-backfill/job.ts
@@ -1,0 +1,35 @@
+/**
+ * One-shot backfill: populate library.canonical_entity_id via LML (B-1.2).
+ *
+ * Iterates every `library` row where (canonical_entity_id IS NULL AND
+ * canonical_entity_resolved_at IS NULL), calls LML's lookup endpoint with
+ * (artist_name, album_title), and writes the resolved canonical entity.
+ * Cross-run resumability is via the WHERE filter alone — successful rows
+ * have both columns set, review-flagged rows have resolved_at, retryable
+ * rows have neither.
+ *
+ * Run procedure: build via `Manual Build & Deploy` with
+ * `target=library-canonical-entity-backfill`, then SSH to EC2 and
+ * `docker run --rm --env-file .env <image> 2>&1 | tee log`. The job runs
+ * during a low-traffic window — LML's rate budget is the limiting factor,
+ * not the database.
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { runBackfill } from './orchestrate.js';
+import { lookupMetadata } from './lml-fetch.js';
+
+const JOB_NAME = 'library-canonical-entity-backfill';
+
+const main = async () => {
+  try {
+    await runBackfill({ lookup: lookupMetadata });
+  } finally {
+    await closeDatabaseConnection();
+  }
+};
+
+main().catch((error) => {
+  console.error(`[${JOB_NAME}] Failed:`, error);
+  process.exitCode = 1;
+});

--- a/jobs/library-canonical-entity-backfill/lml-fetch.ts
+++ b/jobs/library-canonical-entity-backfill/lml-fetch.ts
@@ -17,7 +17,7 @@
  *     contract stays "bubble up = retry on next sweep."
  */
 
-import type { LmlLmlLookupResponse } from './lml-types.js';
+import type { LmlLookupResponse } from './lml-types.js';
 
 const TIMEOUT_MS = 5000;
 
@@ -51,7 +51,7 @@ export const lookupMetadata = async (artist: string, album?: string): Promise<Lm
     return (await response.json()) as LmlLookupResponse;
   } catch (error) {
     if ((error as Error).name === 'AbortError') {
-      throw new Error('LML request timed out');
+      throw new Error('LML request timed out', { cause: error });
     }
     throw error;
   } finally {

--- a/jobs/library-canonical-entity-backfill/lml-fetch.ts
+++ b/jobs/library-canonical-entity-backfill/lml-fetch.ts
@@ -1,0 +1,60 @@
+/**
+ * Minimal LML lookup fetcher for the B-1.2 backfill.
+ *
+ * Mirrors a subset of `apps/backend/services/lml/lml.client.ts`. We duplicate
+ * rather than import because that file is part of the @wxyc/backend Express
+ * app and depends on app-only modules; pulling it into a one-shot job would
+ * couple their build graphs and force the job container to ship the entire
+ * backend tree.
+ *
+ * The wrapper:
+ *   - Reads LIBRARY_METADATA_URL from env (same convention as the backend
+ *     client; supports a trailing /api/v1).
+ *   - Aborts on a 5s per-call timeout. The throttle in `orchestrate.ts`
+ *     keeps long timeout chains from compounding into LML.
+ *   - Throws a plain Error on non-2xx, abort, and network failure. The
+ *     orchestrator catches and counts as `error`, so the per-row error
+ *     contract stays "bubble up = retry on next sweep."
+ */
+
+import type { LmlLmlLookupResponse } from './lml-types.js';
+
+const TIMEOUT_MS = 5000;
+
+const baseUrl = (): string => {
+  const url = process.env.LIBRARY_METADATA_URL;
+  if (!url) {
+    throw new Error('LIBRARY_METADATA_URL is not configured');
+  }
+  return url.replace(/\/api\/v1\/?$/, '').replace(/\/$/, '');
+};
+
+export const lookupMetadata = async (artist: string, album?: string): Promise<LmlLookupResponse> => {
+  const body: Record<string, string> = { artist };
+  if (album) body.album = album;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${baseUrl()}/api/v1/lookup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`LML responded ${response.status} ${response.statusText}`);
+    }
+
+    return (await response.json()) as LmlLookupResponse;
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      throw new Error('LML request timed out');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/jobs/library-canonical-entity-backfill/lml-types.ts
+++ b/jobs/library-canonical-entity-backfill/lml-types.ts
@@ -1,0 +1,22 @@
+/**
+ * Minimal slice of LML's LookupResponse needed by the resolver.
+ *
+ * Mirrors `LookupResponse` from @wxyc/shared/dtos. Inlined so the job package
+ * doesn't pull @wxyc/shared (a private GitHub Packages dep) at build time —
+ * the rest of the LML response (cache_stats, song_not_found, etc.) is unused
+ * here and would just be dead weight.
+ */
+
+export type LmlLookupResultItem = {
+  library_item: { id: number };
+  artwork?: { release_id: number };
+};
+
+export type LmlLookupResponse = {
+  results: LmlLookupResultItem[];
+  search_type: 'direct' | 'fallback' | 'alternative' | 'compilation' | 'song_as_artist' | 'none';
+  song_not_found?: boolean;
+  found_on_compilation?: boolean;
+  context_message?: string;
+  corrected_artist?: string;
+};

--- a/jobs/library-canonical-entity-backfill/orchestrate.ts
+++ b/jobs/library-canonical-entity-backfill/orchestrate.ts
@@ -21,7 +21,7 @@
 
 import { sql } from 'drizzle-orm';
 import { db } from '@wxyc/database';
-import type { LookupResponse } from '@wxyc/shared/dtos';
+import type { LmlLookupResponse } from './lml-types.js';
 import { resolveCanonicalEntity, type Resolution } from './resolve.js';
 
 const JOB_NAME = 'library-canonical-entity-backfill';
@@ -41,7 +41,7 @@ export type LibraryRow = {
   album_title: string | null;
 };
 
-export type LookupFn = (artist: string, album?: string) => Promise<LookupResponse>;
+export type LookupFn = (artist: string, album?: string) => Promise<LmlLookupResponse>;
 
 export type Totals = {
   scanned: number;
@@ -115,7 +115,7 @@ export const processRow = async (
     return 'no_match';
   }
 
-  let response: LookupResponse;
+  let response: LmlLookupResponse;
   try {
     response = await deps.lookup(artist, album);
   } catch (error) {

--- a/jobs/library-canonical-entity-backfill/orchestrate.ts
+++ b/jobs/library-canonical-entity-backfill/orchestrate.ts
@@ -1,0 +1,185 @@
+/**
+ * Backfill orchestrator for B-1.2.
+ *
+ * Iterates `library` rows where the canonical entity is unresolved, calls LML
+ * for each one, and stamps the result via `applyResolution`. Designed to be
+ * resumable and failure-tolerant:
+ *
+ *   - The WHERE filter is `canonical_entity_id IS NULL AND
+ *     canonical_entity_resolved_at IS NULL`. Auto-accepted rows have both;
+ *     review-flagged rows have only resolved_at; no_match / error rows have
+ *     neither, so they roll forward on the next sweep.
+ *   - Within a single run, batches paginate by `id` (last-id cursor). Across
+ *     runs, the WHERE filter is what restarts — the cursor doesn't need to
+ *     persist.
+ *   - One LML failure is logged and counted; the loop continues.
+ *
+ * The `lookup` function is injected so tests can drive the orchestration
+ * without standing up an LML stub. Production wires it to the HTTP fetch in
+ * `lml-fetch.ts`.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+import type { LookupResponse } from '@wxyc/shared/dtos';
+import { resolveCanonicalEntity, type Resolution } from './resolve.js';
+
+const JOB_NAME = 'library-canonical-entity-backfill';
+
+export const BATCH_SIZE = 500;
+
+/**
+ * Default inter-call delay between LML lookups, in ms. Sized so a single
+ * sweep stays well below LML's effective rate budget; raise via the env knob
+ * if LML's deployed rate limit tightens. Tests override to 0.
+ */
+export const THROTTLE_MS = 100;
+
+export type LibraryRow = {
+  id: number;
+  artist_name: string | null;
+  album_title: string | null;
+};
+
+export type LookupFn = (artist: string, album?: string) => Promise<LookupResponse>;
+
+export type Totals = {
+  scanned: number;
+  auto_accept: number;
+  review: number;
+  no_match: number;
+  error: number;
+};
+
+export type RunResult = {
+  totals: Totals;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Apply a Resolution to a single library row.
+ *
+ *   - auto_accept → write all three columns. The id is what powers B-2's
+ *     flowsheet → library join; the confidence supports retroactive review;
+ *     resolved_at supports retry policy and audit.
+ *   - review → stamp resolved_at only. canonical_entity_id stays NULL so the
+ *     B-3.1 review queue (`canonical_entity_id IS NULL AND
+ *     canonical_entity_resolved_at IS NOT NULL`) finds it.
+ *   - no_match → no UPDATE. Leaving both columns NULL keeps the row in the
+ *     retry pool for the next sweep.
+ */
+export const applyResolution = async (libraryId: number, resolution: Resolution): Promise<void> => {
+  if (resolution.status === 'auto_accept') {
+    await db.execute(sql`
+      UPDATE "wxyc_schema"."library"
+      SET "canonical_entity_id" = ${resolution.canonical_entity_id},
+          "canonical_entity_confidence" = ${resolution.confidence},
+          "canonical_entity_resolved_at" = now()
+      WHERE "id" = ${libraryId}
+        AND "canonical_entity_id" IS NULL
+    `);
+    return;
+  }
+
+  if (resolution.status === 'review') {
+    await db.execute(sql`
+      UPDATE "wxyc_schema"."library"
+      SET "canonical_entity_resolved_at" = now()
+      WHERE "id" = ${libraryId}
+        AND "canonical_entity_id" IS NULL
+        AND "canonical_entity_resolved_at" IS NULL
+    `);
+    return;
+  }
+
+  // no_match: intentional no-op so the row stays in the retry pool.
+};
+
+/**
+ * Drive a single row through lookup → resolve → apply. The result is the
+ * outcome status (or 'error' when LML threw). Errors are logged and consumed;
+ * they do not bubble up so a single bad row cannot abort the run.
+ */
+export const processRow = async (
+  row: LibraryRow,
+  deps: { lookup: LookupFn }
+): Promise<'auto_accept' | 'review' | 'no_match' | 'error'> => {
+  const artist = row.artist_name ?? '';
+  const album = row.album_title ?? undefined;
+
+  if (!artist) {
+    // No artist text to query — counts as no_match. The library shouldn't
+    // contain rows with NULL artist_name after Epic A.2's backfill, but we
+    // don't want to send "" to LML if one slipped through.
+    return 'no_match';
+  }
+
+  let response: LookupResponse;
+  try {
+    response = await deps.lookup(artist, album);
+  } catch (error) {
+    console.warn(`[${JOB_NAME}] LML lookup failed for library.id=${row.id}:`, (error as Error).message);
+    return 'error';
+  }
+
+  const resolution = resolveCanonicalEntity(response);
+  await applyResolution(row.id, resolution);
+  return resolution.status;
+};
+
+/**
+ * Read the next batch of unresolved library rows. The id-cursor predicate
+ * keeps the SELECT bounded as the run progresses; combined with the
+ * canonical_entity_id IS NULL filter, it also makes restarts cheap.
+ */
+const loadBatch = async (afterId: number, batchSize: number): Promise<LibraryRow[]> => {
+  const rows = (await db.execute(sql`
+    SELECT "id", "artist_name", "album_title"
+    FROM "wxyc_schema"."library"
+    WHERE "canonical_entity_id" IS NULL
+      AND "canonical_entity_resolved_at" IS NULL
+      AND "id" > ${afterId}
+    ORDER BY "id" ASC
+    LIMIT ${batchSize}
+  `)) as unknown as LibraryRow[];
+  return rows ?? [];
+};
+
+const formatTotals = (totals: Totals): string =>
+  `scanned=${totals.scanned} auto_accept=${totals.auto_accept} review=${totals.review} ` +
+  `no_match=${totals.no_match} error=${totals.error}`;
+
+export const runBackfill = async (opts: {
+  lookup: LookupFn;
+  batchSize?: number;
+  throttleMs?: number;
+}): Promise<RunResult> => {
+  const batchSize = opts.batchSize ?? BATCH_SIZE;
+  const throttleMs = opts.throttleMs ?? THROTTLE_MS;
+
+  console.log(`[${JOB_NAME}] Starting. batchSize=${batchSize} throttleMs=${throttleMs}`);
+
+  const totals: Totals = { scanned: 0, auto_accept: 0, review: 0, no_match: 0, error: 0 };
+  let lastId = 0;
+  let batchIndex = 0;
+
+  while (true) {
+    const rows = await loadBatch(lastId, batchSize);
+    if (rows.length === 0) break;
+
+    batchIndex += 1;
+    for (const row of rows) {
+      const status = await processRow(row, { lookup: opts.lookup });
+      totals.scanned += 1;
+      totals[status] += 1;
+      lastId = row.id;
+      if (throttleMs > 0) await sleep(throttleMs);
+    }
+
+    console.log(`[${JOB_NAME}] batch ${batchIndex} done | ${formatTotals(totals)}`);
+  }
+
+  console.log(`[${JOB_NAME}] Done. ${formatTotals(totals)}`);
+  return { totals };
+};

--- a/jobs/library-canonical-entity-backfill/package.json
+++ b/jobs/library-canonical-entity-backfill/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wxyc/library-canonical-entity-backfill",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot backfill: resolve library.canonical_entity_id per row via LML (B-1.2)",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_library_canonical_entity_backfill:ci -f ../../Dockerfile.library-canonical-entity-backfill ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/library-canonical-entity-backfill/resolve.ts
+++ b/jobs/library-canonical-entity-backfill/resolve.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-row canonical-entity resolver for the B-1.2 library backfill.
+ *
+ * Maps an LML lookup response to one of three outcomes derived from B-0's
+ * calibrated heuristic (issue #492 comment). LML does not expose per-result
+ * confidence today (tracked at WXYC/library-metadata-lookup#158); when it
+ * does, this resolver collapses to a numeric threshold and the search_type
+ * branch goes away.
+ *
+ * Outcomes:
+ *   - auto_accept — search_type=direct AND first result has artwork.release_id.
+ *     The canonical_entity_id is namespaced as `discogs:<release_id>` so a
+ *     future MusicBrainz-only result won't collide on the same scheme.
+ *   - review — any non-empty result that isn't a direct hit. The orchestrator
+ *     still stamps resolved_at so B-3.1's review queue can find it; canonical
+ *     id stays NULL.
+ *   - no_match — empty result set, OR a direct match whose top result has no
+ *     pinable Discogs release_id. The orchestrator does not stamp anything
+ *     so the next sweep retries.
+ */
+
+import type { LookupResponse } from '@wxyc/shared/dtos';
+
+export type Resolution =
+  | { status: 'auto_accept'; canonical_entity_id: string; confidence: number }
+  | { status: 'review' }
+  | { status: 'no_match' };
+
+/**
+ * Confidence assigned to direct-hit auto-accepts. LML doesn't return a
+ * per-result number today, so we synth a single value for retroactive
+ * filtering. The actual scalar is somewhat arbitrary — what matters is that
+ * any future numeric-threshold path keeps the row above its cutoff.
+ */
+const AUTO_ACCEPT_CONFIDENCE = 0.95;
+
+/**
+ * Build a namespaced canonical entity id. The schema column is opaque text;
+ * the prefix lets B-2 disambiguate sources cleanly when LML adds more.
+ */
+const toCanonicalEntityId = (releaseId: number): string => `discogs:${releaseId}`;
+
+export const resolveCanonicalEntity = (response: LookupResponse): Resolution => {
+  const top = response.results?.[0];
+  if (!top) {
+    return { status: 'no_match' };
+  }
+
+  const releaseId = top.artwork?.release_id;
+
+  if (response.search_type === 'direct') {
+    if (typeof releaseId !== 'number') {
+      return { status: 'no_match' };
+    }
+    return {
+      status: 'auto_accept',
+      canonical_entity_id: toCanonicalEntityId(releaseId),
+      confidence: AUTO_ACCEPT_CONFIDENCE,
+    };
+  }
+
+  return { status: 'review' };
+};
+
+export { AUTO_ACCEPT_CONFIDENCE };

--- a/jobs/library-canonical-entity-backfill/resolve.ts
+++ b/jobs/library-canonical-entity-backfill/resolve.ts
@@ -19,7 +19,7 @@
  *     so the next sweep retries.
  */
 
-import type { LookupResponse } from '@wxyc/shared/dtos';
+import type { LmlLookupResponse } from './lml-types.js';
 
 export type Resolution =
   | { status: 'auto_accept'; canonical_entity_id: string; confidence: number }
@@ -40,7 +40,7 @@ const AUTO_ACCEPT_CONFIDENCE = 0.95;
  */
 const toCanonicalEntityId = (releaseId: number): string => `discogs:${releaseId}`;
 
-export const resolveCanonicalEntity = (response: LookupResponse): Resolution => {
+export const resolveCanonicalEntity = (response: LmlLookupResponse): Resolution => {
   const top = response.results?.[0];
   if (!top) {
     return { status: 'no_match' };

--- a/jobs/library-canonical-entity-backfill/tsconfig.json
+++ b/jobs/library-canonical-entity-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/library-canonical-entity-backfill/tsup.config.ts
+++ b/jobs/library-canonical-entity-backfill/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -511,6 +511,20 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/library-canonical-entity-backfill": {
+      "name": "@wxyc/library-canonical-entity-backfill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/library-etl": {
       "name": "@wxyc/library-etl",
       "version": "1.0.0",
@@ -7065,6 +7079,10 @@
     },
     "node_modules/@wxyc/library-artist-name-backfill": {
       "resolved": "jobs/library-artist-name-backfill",
+      "link": true
+    },
+    "node_modules/@wxyc/library-canonical-entity-backfill": {
+      "resolved": "jobs/library-canonical-entity-backfill",
       "link": true
     },
     "node_modules/@wxyc/library-etl": {

--- a/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Unit tests for the B-1.2 backfill orchestrator.
+ *
+ * The orchestrator iterates library rows where the canonical entity is
+ * unresolved, calls LML per row, and writes the resolution. Tests cover:
+ *
+ *   - applyResolution writes the right columns for each Resolution branch
+ *     (auto_accept stamps id+confidence+resolved_at; review stamps
+ *     resolved_at only; no_match stamps nothing so the row is retried).
+ *   - processRow stitches the lookup → resolve → write pipeline and degrades
+ *     gracefully on LML errors (no stamping, error logged).
+ *   - runBackfill loops until loadBatch returns empty, paginates by id, and
+ *     respects the inter-call throttle.
+ */
+
+import { db } from '@wxyc/database';
+import {
+  applyResolution,
+  processRow,
+  runBackfill,
+  BATCH_SIZE,
+  THROTTLE_MS,
+} from '../../../../jobs/library-canonical-entity-backfill/orchestrate';
+import type { Resolution } from '../../../../jobs/library-canonical-entity-backfill/resolve';
+import type { LookupResponse } from '@wxyc/shared/dtos';
+
+type SqlLike = {
+  sql?: string | string[];
+  queryChunks?: Array<string | { value?: string | string[] }>;
+};
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const findExecuteCallMatching = (pattern: RegExp): unknown[] | undefined => {
+  const calls = (db.execute as jest.Mock).mock.calls;
+  return calls.find((call) => pattern.test(renderSql(call[0])));
+};
+
+const directResponse = (releaseId: number): LookupResponse => ({
+  results: [
+    {
+      library_item: {
+        id: 1,
+        title: 'On Your Own Love Again',
+        artist: 'Jessica Pratt',
+        call_number: 'Rock CD JES 001/02',
+        library_url: 'https://wxyc.org/album/1',
+      },
+      artwork: {
+        release_id: releaseId,
+        release_url: `https://www.discogs.com/release/${releaseId}`,
+        confidence: 0.9,
+      },
+    },
+  ],
+  search_type: 'direct',
+  song_not_found: false,
+  found_on_compilation: false,
+});
+
+const fallbackResponse = (releaseId: number): LookupResponse => ({
+  results: [
+    {
+      library_item: {
+        id: 1,
+        title: 'On Your Own Love Again',
+        artist: 'Jessica Pratt',
+        call_number: 'Rock CD JES 001/02',
+        library_url: 'https://wxyc.org/album/1',
+      },
+      artwork: {
+        release_id: releaseId,
+        release_url: `https://www.discogs.com/release/${releaseId}`,
+        confidence: 0.5,
+      },
+    },
+  ],
+  search_type: 'fallback',
+  song_not_found: false,
+  found_on_compilation: false,
+});
+
+const emptyResponse = (): LookupResponse => ({
+  results: [],
+  search_type: 'none',
+  song_not_found: false,
+  found_on_compilation: false,
+});
+
+describe('applyResolution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('writes id, confidence, and resolved_at on auto_accept', async () => {
+    // Auto-accept is the only branch that fills canonical_entity_id. The
+    // resolved_at stamp is what makes re-runs idempotent (the WHERE filter
+    // skips already-stamped rows).
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
+    const resolution: Resolution = {
+      status: 'auto_accept',
+      canonical_entity_id: 'discogs:987654',
+      confidence: 0.95,
+    };
+
+    await applyResolution(42, resolution);
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*library/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/canonical_entity_id/i);
+    expect(sqlText).toMatch(/canonical_entity_confidence/i);
+    expect(sqlText).toMatch(/canonical_entity_resolved_at"?\s*=\s*now\(\)/i);
+    const serialized = JSON.stringify(call?.[0]);
+    expect(serialized).toContain('discogs:987654');
+    expect(serialized).toContain('42');
+  });
+
+  it('stamps resolved_at only on review (canonical_entity_id stays NULL)', async () => {
+    // Review-flagged rows are picked up by B-3.1 by querying
+    // (canonical_entity_id IS NULL AND canonical_entity_resolved_at IS NOT NULL).
+    // Writing a non-null id here would silently auto-accept a fallback hit.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
+
+    await applyResolution(42, { status: 'review' });
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*library/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/canonical_entity_resolved_at"?\s*=\s*now\(\)/i);
+    expect(sqlText).not.toMatch(/SET[\s\S]*canonical_entity_id"?\s*=/i);
+  });
+
+  it('writes nothing on no_match so the next sweep retries', async () => {
+    // B-0: empty / unpinable matches are "discard, retry on next sweep". The
+    // backfill's WHERE filter is `canonical_entity_id IS NULL AND
+    // canonical_entity_resolved_at IS NULL`, so any UPDATE here would
+    // remove the row from the retry pool and lose the eventual recovery.
+    await applyResolution(42, { status: 'no_match' });
+
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
+  });
+});
+
+describe('processRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls the injected lookup with the row artist and album', async () => {
+    // Verifies the wiring between row → lookup. If a future change
+    // accidentally swaps artist/album, downstream resolution would still
+    // succeed on some inputs but be silently wrong.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
+    const lookup = jest.fn(async () => directResponse(123));
+
+    await processRow(
+      { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
+      { lookup }
+    );
+
+    expect(lookup).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+  });
+
+  it('stamps auto_accept on a direct hit', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
+    const lookup = jest.fn(async () => directResponse(987654));
+
+    const status = await processRow(
+      { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
+      { lookup }
+    );
+
+    expect(status).toBe('auto_accept');
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*library/i);
+    const serialized = JSON.stringify(call?.[0]);
+    expect(serialized).toContain('discogs:987654');
+  });
+
+  it('stamps review on a fallback hit', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
+    const lookup = jest.fn(async () => fallbackResponse(33));
+
+    const status = await processRow(
+      { id: 7, artist_name: 'Jessica Pratt', album_title: 'On Your Own' },
+      { lookup }
+    );
+
+    expect(status).toBe('review');
+  });
+
+  it('writes nothing and reports no_match on an empty LML response', async () => {
+    const lookup = jest.fn(async () => emptyResponse());
+
+    const status = await processRow(
+      { id: 7, artist_name: 'Unknown', album_title: 'Unknown' },
+      { lookup }
+    );
+
+    expect(status).toBe('no_match');
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
+  });
+
+  it('returns error on LML failure without stamping the row (so the next sweep retries)', async () => {
+    // Failure tolerance: LML timeouts and 5xx must not poison-pill the row.
+    // Stamping resolved_at on error would remove the row from the retry
+    // pool — the issue's "failure tolerant" requirement.
+    const lookup = jest.fn(async () => {
+      throw new Error('LML request timed out');
+    });
+
+    const status = await processRow(
+      { id: 7, artist_name: 'Stereolab', album_title: 'Dots and Loops' },
+      { lookup }
+    );
+
+    expect(status).toBe('error');
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
+  });
+});
+
+describe('runBackfill', () => {
+  beforeEach(() => {
+    // mockReset (not just clearAllMocks) — runBackfill tests queue per-test
+    // mockResolvedValueOnce values, and clearAllMocks leaves queued values
+    // intact. Without reset, an unused queued value from one test feeds the
+    // next test's first db.execute call.
+    (db.execute as jest.Mock).mockReset();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses a sensible BATCH_SIZE (bounded reads — never SELECT *)', () => {
+    // The library has tens of thousands of rows. An unbounded SELECT would
+    // pin a connection for minutes; a too-small batch would explode the
+    // round-trip overhead per row.
+    expect(BATCH_SIZE).toBeGreaterThanOrEqual(50);
+    expect(BATCH_SIZE).toBeLessThanOrEqual(2000);
+  });
+
+  it('throttles between LML calls (THROTTLE_MS > 0)', () => {
+    // Throttle is a real LML rate-limit guard, not a configuration hook —
+    // dropping it to 0 risks stampeding LML when the backfill runs.
+    expect(THROTTLE_MS).toBeGreaterThan(0);
+  });
+
+  it('iterates batches until loadBatch returns empty', async () => {
+    // First batch: two rows. Second batch: one row. Third batch: empty → terminate.
+    // 3 SELECTs (loadBatch) + (2 + 1) UPDATEs = 6 db.execute calls in this scenario.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'Andy Stott', album_title: 'Faith In Strangers' },
+        { id: 2, artist_name: 'Loney Dear', album_title: 'Dear John' },
+      ])
+      .mockResolvedValueOnce({ count: 1 }) // UPDATE for id=1
+      .mockResolvedValueOnce({ count: 1 }) // UPDATE for id=2
+      .mockResolvedValueOnce([{ id: 3, artist_name: 'Cat Power', album_title: 'Sun' }])
+      .mockResolvedValueOnce({ count: 1 }) // UPDATE for id=3
+      .mockResolvedValueOnce([]); // empty → terminate
+
+    const lookup = jest.fn(async () => directResponse(111));
+
+    const result = await runBackfill({ lookup, throttleMs: 0 });
+
+    expect(lookup).toHaveBeenCalledTimes(3);
+    expect(result.totals.auto_accept).toBe(3);
+    expect(result.totals.scanned).toBe(3);
+  });
+
+  it('exits cleanly on the first empty batch (already-backfilled state)', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+    const lookup = jest.fn();
+
+    const result = await runBackfill({ lookup, throttleMs: 0 });
+
+    expect(lookup).not.toHaveBeenCalled();
+    expect(result.totals.scanned).toBe(0);
+  });
+
+  it('paginates forward by id (last-id cursor restartable across batches)', async () => {
+    // The second loadBatch must filter `id > 2` (the last id from batch 1)
+    // — otherwise we'd re-scan the same rows forever (the WHERE filter on
+    // canonical_entity_id IS NULL still matches a row that we just updated
+    // to review-status).
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'a', album_title: 'a' },
+        { id: 2, artist_name: 'b', album_title: 'b' },
+      ])
+      .mockResolvedValueOnce({ count: 1 }) // UPDATE for id=1
+      .mockResolvedValueOnce({ count: 1 }) // UPDATE for id=2
+      .mockResolvedValueOnce([]);
+
+    const lookup = jest.fn(async () => directResponse(111));
+    await runBackfill({ lookup, throttleMs: 0 });
+
+    const selectCalls = (db.execute as jest.Mock).mock.calls
+      .map((c) => renderSql(c[0]))
+      .filter((s) => /SELECT/i.test(s));
+    // Two SELECTs: initial scan (id > 0 or no lower bound), and second scan
+    // bounded by the last-seen id from batch 1.
+    expect(selectCalls.length).toBe(2);
+    const secondSelectSerialized = JSON.stringify(
+      (db.execute as jest.Mock).mock.calls.filter((c) => /SELECT/i.test(renderSql(c[0])))[1]?.[0]
+    );
+    expect(secondSelectSerialized).toContain('2');
+  });
+
+  it('counts each Resolution branch separately for the run report', async () => {
+    // The summary the operator sees is what tells us whether B-3.1's review
+    // queue is going to have anything in it. Counting auto_accept separately
+    // from review separately from no_match is the whole point of running the
+    // job.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'a', album_title: 'a' },
+        { id: 2, artist_name: 'b', album_title: 'b' },
+        { id: 3, artist_name: 'c', album_title: 'c' },
+      ])
+      .mockResolvedValueOnce({ count: 1 }) // auto_accept update
+      .mockResolvedValueOnce({ count: 1 }) // review update
+      .mockResolvedValueOnce([]);
+
+    let call = 0;
+    const lookup = jest.fn(async () => {
+      call += 1;
+      if (call === 1) return directResponse(111);
+      if (call === 2) return fallbackResponse(222);
+      return emptyResponse();
+    });
+
+    const result = await runBackfill({ lookup, throttleMs: 0 });
+
+    expect(result.totals.auto_accept).toBe(1);
+    expect(result.totals.review).toBe(1);
+    expect(result.totals.no_match).toBe(1);
+    expect(result.totals.error).toBe(0);
+    expect(result.totals.scanned).toBe(3);
+  });
+
+  it('keeps going when a single row errors (failure-tolerant — does not abort the run)', async () => {
+    // One LML failure must not poison the run. The error count goes up; the
+    // scan continues. Operationally the row stays NULL (no resolved_at)
+    // and gets retried on the next sweep.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'a', album_title: 'a' },
+        { id: 2, artist_name: 'b', album_title: 'b' },
+      ])
+      .mockResolvedValueOnce({ count: 1 }) // UPDATE for id=2 (id=1 errored, no UPDATE)
+      .mockResolvedValueOnce([]);
+
+    let call = 0;
+    const lookup = jest.fn(async () => {
+      call += 1;
+      if (call === 1) throw new Error('LML 502');
+      return directResponse(222);
+    });
+
+    const result = await runBackfill({ lookup, throttleMs: 0 });
+
+    expect(result.totals.error).toBe(1);
+    expect(result.totals.auto_accept).toBe(1);
+    expect(result.totals.scanned).toBe(2);
+  });
+});

--- a/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
@@ -22,7 +22,7 @@ import {
   THROTTLE_MS,
 } from '../../../../jobs/library-canonical-entity-backfill/orchestrate';
 import type { Resolution } from '../../../../jobs/library-canonical-entity-backfill/resolve';
-import type { LmlLmlLookupResponse } from '../../../../jobs/library-canonical-entity-backfill/lml-types';
+import type { LmlLookupResponse } from '../../../../jobs/library-canonical-entity-backfill/lml-types';
 
 type SqlLike = {
   sql?: string | string[];
@@ -143,24 +143,18 @@ describe('processRow', () => {
     // accidentally swaps artist/album, downstream resolution would still
     // succeed on some inputs but be silently wrong.
     (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
-    const lookup = jest.fn(async () => directResponse(123));
+    const lookup = jest.fn(() => Promise.resolve(directResponse(123)));
 
-    await processRow(
-      { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
-      { lookup }
-    );
+    await processRow({ id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' }, { lookup });
 
     expect(lookup).toHaveBeenCalledWith('Juana Molina', 'DOGA');
   });
 
   it('stamps auto_accept on a direct hit', async () => {
     (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
-    const lookup = jest.fn(async () => directResponse(987654));
+    const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
 
-    const status = await processRow(
-      { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
-      { lookup }
-    );
+    const status = await processRow({ id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' }, { lookup });
 
     expect(status).toBe('auto_accept');
     const call = findExecuteCallMatching(/UPDATE[\s\S]*library/i);
@@ -170,23 +164,17 @@ describe('processRow', () => {
 
   it('stamps review on a fallback hit', async () => {
     (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
-    const lookup = jest.fn(async () => fallbackResponse(33));
+    const lookup = jest.fn(() => Promise.resolve(fallbackResponse(33)));
 
-    const status = await processRow(
-      { id: 7, artist_name: 'Jessica Pratt', album_title: 'On Your Own' },
-      { lookup }
-    );
+    const status = await processRow({ id: 7, artist_name: 'Jessica Pratt', album_title: 'On Your Own' }, { lookup });
 
     expect(status).toBe('review');
   });
 
   it('writes nothing and reports no_match on an empty LML response', async () => {
-    const lookup = jest.fn(async () => emptyResponse());
+    const lookup = jest.fn(() => Promise.resolve(emptyResponse()));
 
-    const status = await processRow(
-      { id: 7, artist_name: 'Unknown', album_title: 'Unknown' },
-      { lookup }
-    );
+    const status = await processRow({ id: 7, artist_name: 'Unknown', album_title: 'Unknown' }, { lookup });
 
     expect(status).toBe('no_match');
     expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
@@ -196,14 +184,9 @@ describe('processRow', () => {
     // Failure tolerance: LML timeouts and 5xx must not poison-pill the row.
     // Stamping resolved_at on error would remove the row from the retry
     // pool — the issue's "failure tolerant" requirement.
-    const lookup = jest.fn(async () => {
-      throw new Error('LML request timed out');
-    });
+    const lookup = jest.fn(() => Promise.reject(new Error('LML request timed out')));
 
-    const status = await processRow(
-      { id: 7, artist_name: 'Stereolab', album_title: 'Dots and Loops' },
-      { lookup }
-    );
+    const status = await processRow({ id: 7, artist_name: 'Stereolab', album_title: 'Dots and Loops' }, { lookup });
 
     expect(status).toBe('error');
     expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
@@ -253,7 +236,7 @@ describe('runBackfill', () => {
       .mockResolvedValueOnce({ count: 1 }) // UPDATE for id=3
       .mockResolvedValueOnce([]); // empty → terminate
 
-    const lookup = jest.fn(async () => directResponse(111));
+    const lookup = jest.fn(() => Promise.resolve(directResponse(111)));
 
     const result = await runBackfill({ lookup, throttleMs: 0 });
 
@@ -286,7 +269,7 @@ describe('runBackfill', () => {
       .mockResolvedValueOnce({ count: 1 }) // UPDATE for id=2
       .mockResolvedValueOnce([]);
 
-    const lookup = jest.fn(async () => directResponse(111));
+    const lookup = jest.fn(() => Promise.resolve(directResponse(111)));
     await runBackfill({ lookup, throttleMs: 0 });
 
     const selectCalls = (db.execute as jest.Mock).mock.calls
@@ -317,11 +300,11 @@ describe('runBackfill', () => {
       .mockResolvedValueOnce([]);
 
     let call = 0;
-    const lookup = jest.fn(async () => {
+    const lookup = jest.fn(() => {
       call += 1;
-      if (call === 1) return directResponse(111);
-      if (call === 2) return fallbackResponse(222);
-      return emptyResponse();
+      if (call === 1) return Promise.resolve(directResponse(111));
+      if (call === 2) return Promise.resolve(fallbackResponse(222));
+      return Promise.resolve(emptyResponse());
     });
 
     const result = await runBackfill({ lookup, throttleMs: 0 });
@@ -346,10 +329,10 @@ describe('runBackfill', () => {
       .mockResolvedValueOnce([]);
 
     let call = 0;
-    const lookup = jest.fn(async () => {
+    const lookup = jest.fn(() => {
       call += 1;
-      if (call === 1) throw new Error('LML 502');
-      return directResponse(222);
+      if (call === 1) return Promise.reject(new Error('LML 502'));
+      return Promise.resolve(directResponse(222));
     });
 
     const result = await runBackfill({ lookup, throttleMs: 0 });

--- a/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
@@ -22,7 +22,7 @@ import {
   THROTTLE_MS,
 } from '../../../../jobs/library-canonical-entity-backfill/orchestrate';
 import type { Resolution } from '../../../../jobs/library-canonical-entity-backfill/resolve';
-import type { LookupResponse } from '@wxyc/shared/dtos';
+import type { LmlLmlLookupResponse } from '../../../../jobs/library-canonical-entity-backfill/lml-types';
 
 type SqlLike = {
   sql?: string | string[];
@@ -51,55 +51,19 @@ const findExecuteCallMatching = (pattern: RegExp): unknown[] | undefined => {
   return calls.find((call) => pattern.test(renderSql(call[0])));
 };
 
-const directResponse = (releaseId: number): LookupResponse => ({
-  results: [
-    {
-      library_item: {
-        id: 1,
-        title: 'On Your Own Love Again',
-        artist: 'Jessica Pratt',
-        call_number: 'Rock CD JES 001/02',
-        library_url: 'https://wxyc.org/album/1',
-      },
-      artwork: {
-        release_id: releaseId,
-        release_url: `https://www.discogs.com/release/${releaseId}`,
-        confidence: 0.9,
-      },
-    },
-  ],
+const directResponse = (releaseId: number): LmlLookupResponse => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id: releaseId } }],
   search_type: 'direct',
-  song_not_found: false,
-  found_on_compilation: false,
 });
 
-const fallbackResponse = (releaseId: number): LookupResponse => ({
-  results: [
-    {
-      library_item: {
-        id: 1,
-        title: 'On Your Own Love Again',
-        artist: 'Jessica Pratt',
-        call_number: 'Rock CD JES 001/02',
-        library_url: 'https://wxyc.org/album/1',
-      },
-      artwork: {
-        release_id: releaseId,
-        release_url: `https://www.discogs.com/release/${releaseId}`,
-        confidence: 0.5,
-      },
-    },
-  ],
+const fallbackResponse = (releaseId: number): LmlLookupResponse => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id: releaseId } }],
   search_type: 'fallback',
-  song_not_found: false,
-  found_on_compilation: false,
 });
 
-const emptyResponse = (): LookupResponse => ({
+const emptyResponse = (): LmlLookupResponse => ({
   results: [],
   search_type: 'none',
-  song_not_found: false,
-  found_on_compilation: false,
 });
 
 describe('applyResolution', () => {

--- a/tests/unit/jobs/library-canonical-entity-backfill/resolve.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/resolve.test.ts
@@ -15,35 +15,19 @@
  * numeric threshold and the search_type branch goes away.
  */
 
-import type { LookupResponse, LookupResultItem } from '@wxyc/shared/dtos';
+import type { LmlLmlLookupResponse, LmlLmlLookupResultItem } from '../../../../jobs/library-canonical-entity-backfill/lml-types';
 import { resolveCanonicalEntity } from '../../../../jobs/library-canonical-entity-backfill/resolve';
 
-const itemWithReleaseId = (releaseId: number): LookupResultItem => ({
-  library_item: {
-    id: 12345,
-    title: 'Edits',
-    artist: 'Chuquimamani-Condori',
-    call_number: 'Electronic CD CHU 001/02',
-    library_url: 'https://wxyc.org/album/12345',
-  },
-  artwork: {
-    release_id: releaseId,
-    release_url: `https://www.discogs.com/release/${releaseId}`,
-    confidence: 0.9,
-  },
+const itemWithReleaseId = (releaseId: number): LmlLookupResultItem => ({
+  library_item: { id: 12345 },
+  artwork: { release_id: releaseId },
 });
 
-const itemWithoutArtwork: LookupResultItem = {
-  library_item: {
-    id: 99,
-    title: 'Edits',
-    artist: 'Chuquimamani-Condori',
-    call_number: 'Electronic CD CHU 001/02',
-    library_url: 'https://wxyc.org/album/99',
-  },
+const itemWithoutArtwork: LmlLookupResultItem = {
+  library_item: { id: 99 },
 };
 
-const responseFor = (overrides: Partial<LookupResponse>): LookupResponse => ({
+const responseFor = (overrides: Partial<LmlLookupResponse>): LmlLookupResponse => ({
   results: [],
   search_type: 'none',
   song_not_found: false,

--- a/tests/unit/jobs/library-canonical-entity-backfill/resolve.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/resolve.test.ts
@@ -15,7 +15,10 @@
  * numeric threshold and the search_type branch goes away.
  */
 
-import type { LmlLmlLookupResponse, LmlLmlLookupResultItem } from '../../../../jobs/library-canonical-entity-backfill/lml-types';
+import type {
+  LmlLookupResponse,
+  LmlLookupResultItem,
+} from '../../../../jobs/library-canonical-entity-backfill/lml-types';
 import { resolveCanonicalEntity } from '../../../../jobs/library-canonical-entity-backfill/resolve';
 
 const itemWithReleaseId = (releaseId: number): LmlLookupResultItem => ({

--- a/tests/unit/jobs/library-canonical-entity-backfill/resolve.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/resolve.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the per-row canonical-entity resolver (B-1.2).
+ *
+ * The resolver receives an LML lookup response and returns one of:
+ *   - { status: 'auto_accept', canonical_entity_id, confidence } — write all
+ *     three columns and stop. Search ran direct (clean typo or exact match)
+ *     and produced ≥1 result with a Discogs release_id we can pin.
+ *   - { status: 'review' } — fallback hit (right-artist-wrong-album risk).
+ *     Stamp resolved_at so B-3.1 can find it; leave canonical_entity_id NULL.
+ *   - { status: 'no_match' } — LML returned 0 results. Don't stamp anything;
+ *     a future LML improvement may resolve on the next sweep.
+ *
+ * The heuristic table is from B-0's calibration sample (issue #492 comment).
+ * If LML ships per-result confidence (LML#158), this resolver collapses to a
+ * numeric threshold and the search_type branch goes away.
+ */
+
+import type { LookupResponse, LookupResultItem } from '@wxyc/shared/dtos';
+import { resolveCanonicalEntity } from '../../../../jobs/library-canonical-entity-backfill/resolve';
+
+const itemWithReleaseId = (releaseId: number): LookupResultItem => ({
+  library_item: {
+    id: 12345,
+    title: 'Edits',
+    artist: 'Chuquimamani-Condori',
+    call_number: 'Electronic CD CHU 001/02',
+    library_url: 'https://wxyc.org/album/12345',
+  },
+  artwork: {
+    release_id: releaseId,
+    release_url: `https://www.discogs.com/release/${releaseId}`,
+    confidence: 0.9,
+  },
+});
+
+const itemWithoutArtwork: LookupResultItem = {
+  library_item: {
+    id: 99,
+    title: 'Edits',
+    artist: 'Chuquimamani-Condori',
+    call_number: 'Electronic CD CHU 001/02',
+    library_url: 'https://wxyc.org/album/99',
+  },
+};
+
+const responseFor = (overrides: Partial<LookupResponse>): LookupResponse => ({
+  results: [],
+  search_type: 'none',
+  song_not_found: false,
+  found_on_compilation: false,
+  ...overrides,
+});
+
+describe('resolveCanonicalEntity', () => {
+  describe('auto-accept branch', () => {
+    it('auto-accepts when search_type=direct with ≥1 result that has a Discogs release_id', () => {
+      // The clean-typo / exact-match case from B-0's calibration. These were
+      // the 10-15% gain bucket in the sample (Loney Dear, Andy Stott, etc.).
+      const response = responseFor({
+        results: [itemWithReleaseId(987654)],
+        search_type: 'direct',
+      });
+
+      const result = resolveCanonicalEntity(response);
+
+      expect(result.status).toBe('auto_accept');
+      if (result.status === 'auto_accept') {
+        expect(result.canonical_entity_id).toBe('discogs:987654');
+        expect(result.confidence).toBeGreaterThan(0);
+        expect(result.confidence).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('namespaces the canonical_entity_id with the source scheme (discogs:<id>)', () => {
+      // The schema column is opaque text. The namespace lets future B-2 joins
+      // disambiguate Discogs from MusicBrainz when LML adds MB-only matches.
+      const response = responseFor({
+        results: [itemWithReleaseId(1)],
+        search_type: 'direct',
+      });
+
+      const result = resolveCanonicalEntity(response);
+
+      if (result.status !== 'auto_accept') throw new Error('expected auto_accept');
+      expect(result.canonical_entity_id).toMatch(/^discogs:/);
+    });
+
+    it('takes the first result when LML returns several direct matches', () => {
+      // LML orders results by relevance. Picking the top one is the
+      // documented "highest-confidence" behavior.
+      const response = responseFor({
+        results: [itemWithReleaseId(111), itemWithReleaseId(222)],
+        search_type: 'direct',
+      });
+
+      const result = resolveCanonicalEntity(response);
+
+      if (result.status !== 'auto_accept') throw new Error('expected auto_accept');
+      expect(result.canonical_entity_id).toBe('discogs:111');
+    });
+  });
+
+  describe('review branch', () => {
+    it('routes search_type=fallback with results to manual review (not auto_accept)', () => {
+      // B-0's calibration: fallbacks are mostly wrong-album-by-right-artist.
+      // Stamping resolved_at lets B-3.1 find the row; leaving canonical_entity_id
+      // NULL keeps it out of the auto-accepted analytics until a human OKs it.
+      const response = responseFor({
+        results: [itemWithReleaseId(33)],
+        search_type: 'fallback',
+      });
+
+      const result = resolveCanonicalEntity(response);
+
+      expect(result.status).toBe('review');
+    });
+
+    it('routes search_type=alternative / compilation / song_as_artist to review', () => {
+      // Conservative default: only `direct` clears the auto-accept bar. Other
+      // strategies are speculative enough that B-0's sample didn't validate
+      // them — push them to review.
+      for (const search_type of ['alternative', 'compilation', 'song_as_artist'] as const) {
+        const response = responseFor({
+          results: [itemWithReleaseId(33)],
+          search_type,
+        });
+        expect(resolveCanonicalEntity(response).status).toBe('review');
+      }
+    });
+  });
+
+  describe('no_match branch', () => {
+    it('reports no_match when LML returns 0 results regardless of search_type', () => {
+      // B-0: empty result sets are "discard, retry on next sweep". The
+      // orchestrator must NOT stamp resolved_at on no_match so a future LML
+      // improvement can pick the row up.
+      for (const search_type of ['direct', 'fallback', 'none'] as const) {
+        const response = responseFor({ results: [], search_type });
+        expect(resolveCanonicalEntity(response).status).toBe('no_match');
+      }
+    });
+
+    it('reports no_match when the top result has no artwork (no Discogs release_id to pin)', () => {
+      // Without an artwork.release_id, there's no canonical entity to write.
+      // Treat as no_match — retry next sweep, where LML may have indexed
+      // the release.
+      const response = responseFor({
+        results: [itemWithoutArtwork],
+        search_type: 'direct',
+      });
+
+      const result = resolveCanonicalEntity(response);
+
+      expect(result.status).toBe('no_match');
+    });
+  });
+});


### PR DESCRIPTION
Closes #495.

## Summary

Throttled one-shot job that iterates `library` rows where the canonical entity is unresolved, calls LML for each one, and writes the result to the three columns added by B-1.1 (`canonical_entity_id`, `canonical_entity_confidence`, `canonical_entity_resolved_at`).

Resolution branches follow B-0's calibrated heuristics:

| LML signal | Outcome | Stamps |
|---|---|---|
| `search_type=direct` with ≥1 Discogs release_id | auto_accept | id + confidence + resolved_at |
| Any other non-empty result | review (for B-3.1's queue) | resolved_at only |
| 0 results / no Discogs release_id | no_match | nothing (stays in retry pool) |
| LML threw | error | nothing (stays in retry pool) |

Resumability across runs comes from the WHERE filter alone (`canonical_entity_id IS NULL AND canonical_entity_resolved_at IS NULL`); within a run, batches paginate by id.

A single LML failure is logged and counted; the loop continues so one bad row cannot abort the sweep.

## Layout

- `jobs/library-canonical-entity-backfill/resolve.ts` — pure per-row resolver (`LookupResponse → Resolution`). Confidence is synthesized at 0.95 for direct hits because LML doesn't expose per-result confidence yet (LML#158); when it does, this collapses to a numeric threshold.
- `jobs/library-canonical-entity-backfill/orchestrate.ts` — `applyResolution`, `processRow`, and `runBackfill`. `lookup` is injected for testability.
- `jobs/library-canonical-entity-backfill/lml-fetch.ts` — minimal HTTP wrapper for `POST /api/v1/lookup`. Duplicates a slice of `apps/backend/services/lml/lml.client.ts` to avoid pulling the Express app into the job's build graph.
- `jobs/library-canonical-entity-backfill/lml-types.ts` — inlined `LmlLookupResponse` / `LmlLookupResultItem` so the job container doesn't pull in `@wxyc/shared`.
- `jobs/library-canonical-entity-backfill/job.ts` — entry point; closes the DB connection on exit.
- `Dockerfile.library-canonical-entity-backfill` — two-stage build mirroring the other one-shot jobs.

## Operational notes

- `BATCH_SIZE=500`, `THROTTLE_MS=100` keep a single sweep below LML's effective rate budget. Both are runtime overrideable.
- Reads `LIBRARY_METADATA_URL` (same convention as the backend's LML client; trailing `/api/v1` is tolerated).
- Per-call timeout of 5s; abort errors surface as `LML request timed out`.
- Like the other one-shot jobs, this builds an image and is invoked manually (`docker run --rm --env-file .env <image>`) during a low-traffic window.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors; warnings are pre-existing)
- [x] `npm run format:check`
- [x] `npm run test:unit -- --testPathPatterns=library-canonical-entity-backfill` — 22 tests pass
- [ ] Run the job against a snapshot of the production library (manual, post-merge)