### PR TITLE
Drop explicit BEGIN/COMMIT from migration 0064

### DIFF
--- a/shared/database/src/migrations/0064_propagate-v012-mojibake.sql
+++ b/shared/database/src/migrations/0064_propagate-v012-mojibake.sql
@@ -16,8 +16,11 @@
 -- DDL-only migrations are the norm here, but per CLAUDE.md a small DML migration
 -- (≤10k row rewrites) is acceptable inline. 52 rows × 4 columns sit far below
 -- the AccessExclusiveLock duration concern.
-
-BEGIN;
+--
+-- drizzle-kit wraps every migration in its own transaction, so explicit
+-- BEGIN/COMMIT in the SQL file would either no-op (already inside a
+-- transaction) or, worse, prematurely commit drizzle's outer transaction
+-- and break the migrate run.
 
 -- artist_name: 6 distinct values, 17 rows
 UPDATE wxyc_schema.flowsheet SET artist_name = 'μ-Ziq' WHERE artist_name = 'Î¼-Ziq';
@@ -59,5 +62,3 @@ UPDATE wxyc_schema.flowsheet SET album_title = 'Ψ 847' WHERE album_title = 'Î�
 UPDATE wxyc_schema.flowsheet SET record_label = 'Galerija ŠKUC Izdaja / Dark Entries' WHERE record_label = 'Galerija Å KUC Izdaja / Dark Entries';
 UPDATE wxyc_schema.flowsheet SET record_label = 'Više manje zauvijek' WHERE record_label = 'ViÅ¡e manje zauvijek';
 UPDATE wxyc_schema.flowsheet SET record_label = 'Ω' WHERE record_label = 'Î©';
-
-COMMIT;


### PR DESCRIPTION
## Summary

The original 0064 migration (M2.1, PR #548) wrapped its UPDATEs in `BEGIN;` / `COMMIT;`. drizzle-kit wraps every migration in its own transaction, so the explicit `COMMIT` prematurely closed drizzle's outer transaction and the auto-deploy migrate job exited 1 without recording the hash in `__drizzle_migrations` or persisting the row updates. Confirmed via direct prod query: all 0064 UPDATEs rolled back cleanly (corrupted-form row counts unchanged from pre-PR state).

This PR drops the explicit transaction wrapper so drizzle's outer transaction handles atomicity. The replacement comment block documents the reason for future migration authors.

Refs WXYC/docs#6, follow-up to #548.

## Test plan

- [x] Validator still passes (`node scripts/validate-migrations.mjs`)
- [ ] Post-merge: auto-deploy migrate job applies 0064 cleanly; corrupted forms drop to 0 in `wxyc_schema.flowsheet`