### PR TITLE
Restore journal whens for 62/63/64 to match prod __drizzle_migrations

### DIFF
--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -425,21 +425,21 @@
     {
       "idx": 62,
       "version": "7",
-      "when": 1779510400000,
+      "when": 1778510400000,
       "tag": "0062_flowsheet-linkage-audit-columns",
       "breakpoints": true
     },
     {
       "idx": 63,
       "version": "7",
-      "when": 1779596800000,
+      "when": 1778596800000,
       "tag": "0063_flowsheet-legacy-link-attempted-at",
       "breakpoints": true
     },
     {
       "idx": 64,
       "version": "7",
-      "when": 1779683200000,
+      "when": 1778683200000,
       "tag": "0064_propagate-v012-mojibake",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary

The prior hygiene commit (51a0126) bumped journal idx 62 and 63's `when` values to satisfy the validator's monotonic-timestamp check. That fix was also independently applied on main by another commit (idx 61's `when` was bumped, restoring monotonicity from below) — making the hygiene change redundant and **harmful**: prod's `drizzle.__drizzle_migrations` stored `created_at=1778510400000` (idx 62) and `1778596800000` (idx 63) at apply time, so the bumped journal whens (1779510400000, 1779596800000) caused drizzle-kit to treat those entries as unapplied on the next migrate run. It then attempted to re-apply 0062's already-applied DDL, errored, and 0064 never ran. Both auto-deploy migrate runs (24976146489 and 25005381904) failed for this reason.

## Fix

Restore 62/63 to the exact `when`s recorded in prod's `drizzle.__drizzle_migrations`:

| idx | tag | restored when | matches __drizzle_migrations.created_at |
| --- | --- | --- | --- |
| 62 | flowsheet-linkage-audit-columns | 1778510400000 | id 87 |
| 63 | flowsheet-legacy-link-attempted-at | 1778596800000 | id 88 |

64's `when` set to 1778683200000 (one day after 63), so the chain remains monotonic.

## Validator

- Check 1 (monotonic timestamps): passes — 61's `when` was independently fixed on main, so the chain 60→61→62→63→64 climbs.
- Check 3 (orphan SQL): passes — `KNOWN_ORPHAN_TAGS` from 51a0126 still allowlists 0046_cdc_notify_triggers.

## Test plan

- [x] `node scripts/validate-migrations.mjs` passes
- [ ] Post-merge: auto-deploy migrate job applies 0064 cleanly; corrupted forms drop to 0 in `wxyc_schema.flowsheet`

Refs WXYC/docs#6, follow-up to #548 / #555.