### PR TITLE
Forward path: addEntry enqueues async LML lookup, sets album_id on confident match

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -8,6 +8,7 @@ import { db, NewFSEntry as FullNewFSEntry, FSEntry, Show, ShowDJ, flowsheet } fr
 type NewFSEntry = Omit<FullNewFSEntry, 'play_order'>;
 import * as flowsheet_service from '../services/flowsheet.service.js';
 import { fetchMetadata } from '../services/metadata/index.js';
+import { runLmlLinkage } from '../services/flowsheet-linkage.service.js';
 import WxycError from '../utils/error.js';
 
 export type QueryParams = {
@@ -46,6 +47,41 @@ export interface IFSEntry extends Omit<FSEntry, 'search_doc' | 'legacy_link_atte
  *
  * Called after a track is inserted. Does not block the HTTP response.
  */
+/**
+ * Fire-and-forget: resolve a canonical entity via LML and link the row to a
+ * library album when there's a single high-confidence match (B-2.1). Only
+ * fires for free-form inserts (no album_id) — bin-picks already carry an
+ * album_id from the catalog click. Logs every non-link outcome at info level
+ * so the operator can spot pattern shifts without a metric pipeline.
+ */
+function fireAndForgetLinkage(completedEntry: FSEntry): void {
+  if (completedEntry.album_id !== null) return;
+  if (!completedEntry.artist_name) return;
+
+  runLmlLinkage({
+    flowsheetId: completedEntry.id,
+    artistName: completedEntry.artist_name,
+    albumTitle: completedEntry.album_title,
+  })
+    .then((outcome) => {
+      if (outcome.status === 'linked') return;
+      console.info(
+        `[Flowsheet] LML linkage outcome=${outcome.status} flowsheet_id=${completedEntry.id} artist="${completedEntry.artist_name}" album="${completedEntry.album_title ?? ''}"`
+      );
+    })
+    .catch((err) => {
+      console.error('[Flowsheet] LML linkage failed:', err);
+      Sentry.captureException(err, {
+        tags: { subsystem: 'flowsheet-linkage' },
+        extra: {
+          flowsheetId: completedEntry.id,
+          artistName: completedEntry.artist_name,
+          albumTitle: completedEntry.album_title,
+        },
+      });
+    });
+}
+
 function fireAndForgetMetadata(completedEntry: FSEntry, artistId?: number): void {
   if (!completedEntry.artist_name) return;
 
@@ -245,6 +281,7 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
 
     const completedEntry: FSEntry = await flowsheet_service.addTrack(fsEntry);
     fireAndForgetMetadata(completedEntry);
+    fireAndForgetLinkage(completedEntry);
     res.status(201).json(completedEntry);
   }
 };

--- a/apps/backend/services/flowsheet-linkage.service.ts
+++ b/apps/backend/services/flowsheet-linkage.service.ts
@@ -1,0 +1,91 @@
+/**
+ * Forward-path LML linkage for newly inserted flowsheet rows (B-2.1).
+ *
+ * When `addEntry` writes a flowsheet row without `album_id`, this service is
+ * fired-and-forgotten to resolve a canonical entity via LML and link the row
+ * to its matching library album. The flow:
+ *
+ *   1. LML lookup on (artist, album) text.
+ *   2. Map result to a (canonical_entity_id, confidence) pair via the same
+ *      helper used by addAlbum (so library and flowsheet land on the same
+ *      identifier scheme).
+ *   3. Gate on AUTO_ACCEPT_THRESHOLD — only `search_type=direct` (≈0.9)
+ *      auto-links per the B-0 calibration. `fallback` (≈0.5) goes to the
+ *      manual review queue (B-3.1) once that ships; for now it returns
+ *      low_confidence and the row stays NULL for B-2.2's sweep to retry.
+ *   4. Resolve the canonical entity to library rows.
+ *      - 0 rows → unmatched (canonical entity not in WXYC library).
+ *      - 1 row  → link with `linkage_source='lml_high_confidence'`.
+ *      - 2+ rows → defer to B-2.3 tie-break. Until B-2.3 lands, we leave the
+ *        row unlinked rather than picking arbitrarily.
+ */
+import { eq } from 'drizzle-orm';
+import { db, flowsheet, library } from '@wxyc/database';
+import { lookupMetadata } from './lml/lml.client.js';
+import { mapLookupToCanonicalEntity } from './library.service.js';
+
+const AUTO_ACCEPT_THRESHOLD = 0.9;
+
+export type LinkageOutcome =
+  | { status: 'linked'; libraryId: number; canonicalEntityId: string; confidence: number }
+  | { status: 'no_canonical_entity' }
+  | { status: 'low_confidence'; canonicalEntityId: string; confidence: number }
+  | { status: 'no_library_match'; canonicalEntityId: string; confidence: number }
+  | { status: 'multi_match'; canonicalEntityId: string; confidence: number; libraryIds: number[] };
+
+async function findLibraryRowsByCanonicalEntity(canonicalEntityId: string): Promise<{ id: number }[]> {
+  return db.select({ id: library.id }).from(library).where(eq(library.canonical_entity_id, canonicalEntityId));
+}
+
+async function setFlowsheetLinkage(
+  flowsheetId: number,
+  libraryId: number,
+  source: string,
+  confidence: number
+): Promise<void> {
+  await db
+    .update(flowsheet)
+    .set({
+      album_id: libraryId,
+      linkage_source: source,
+      linkage_confidence: confidence,
+      linked_at: new Date(),
+    })
+    .where(eq(flowsheet.id, flowsheetId));
+}
+
+export async function runLmlLinkage(args: {
+  flowsheetId: number;
+  artistName: string;
+  albumTitle: string | null | undefined;
+}): Promise<LinkageOutcome> {
+  const { flowsheetId, artistName, albumTitle } = args;
+  const response = await lookupMetadata(artistName, albumTitle ?? undefined);
+  const linkage = mapLookupToCanonicalEntity(response);
+  if (!linkage) return { status: 'no_canonical_entity' };
+  if (linkage.confidence < AUTO_ACCEPT_THRESHOLD) {
+    return { status: 'low_confidence', canonicalEntityId: linkage.id, confidence: linkage.confidence };
+  }
+
+  const matches = await findLibraryRowsByCanonicalEntity(linkage.id);
+  if (matches.length === 0) {
+    return { status: 'no_library_match', canonicalEntityId: linkage.id, confidence: linkage.confidence };
+  }
+
+  if (matches.length > 1) {
+    return {
+      status: 'multi_match',
+      canonicalEntityId: linkage.id,
+      confidence: linkage.confidence,
+      libraryIds: matches.map((m) => m.id),
+    };
+  }
+
+  await setFlowsheetLinkage(flowsheetId, matches[0].id, 'lml_high_confidence', linkage.confidence);
+  return {
+    status: 'linked',
+    libraryId: matches[0].id,
+    canonicalEntityId: linkage.id,
+    confidence: linkage.confidence,
+  };
+}

--- a/tests/unit/controllers/flowsheet.addEntry.linkage.test.ts
+++ b/tests/unit/controllers/flowsheet.addEntry.linkage.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for addEntry enqueueing the LML linkage lookup (B-2.1).
+ *
+ * The forward path inserts the flowsheet row first (so the HTTP response is
+ * never blocked on LML), then fires-and-forgets `runLmlLinkage` only when
+ * `album_id` is absent. Bin-picks (album_id provided) skip the lookup —
+ * they're already linked.
+ */
+import { jest } from '@jest/globals';
+
+const mockGetLatestShow = jest.fn<() => Promise<unknown>>();
+const mockResolveDjNameForShow = jest.fn<() => Promise<string | null>>();
+const mockAddTrack = jest.fn<(entry: unknown) => Promise<unknown>>();
+const mockGetAlbumFromDB = jest.fn<(id: number) => Promise<unknown>>();
+
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getLatestShow: mockGetLatestShow,
+  resolveDjNameForShow: mockResolveDjNameForShow,
+  addTrack: mockAddTrack,
+  getAlbumFromDB: mockGetAlbumFromDB,
+}));
+
+const mockFetchMetadata = jest.fn<() => Promise<unknown>>();
+jest.mock('../../../apps/backend/services/metadata/index', () => ({
+  fetchMetadata: mockFetchMetadata,
+}));
+
+const mockRunLmlLinkage = jest.fn<() => Promise<unknown>>();
+jest.mock('../../../apps/backend/services/flowsheet-linkage.service', () => ({
+  runLmlLinkage: mockRunLmlLinkage,
+}));
+
+import { addEntry } from '../../../apps/backend/controllers/flowsheet.controller';
+
+const makeRes = () => {
+  const res: { status: jest.Mock; json: jest.Mock; send: jest.Mock } = {
+    status: jest.fn(),
+    json: jest.fn(),
+    send: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  res.send.mockReturnValue(res);
+  return res;
+};
+
+describe('addEntry: enqueues LML linkage lookup (B-2.1)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetLatestShow.mockResolvedValue({ id: 1, primary_dj_id: 'user-1', end_time: null });
+    mockResolveDjNameForShow.mockResolvedValue('DJ Stardust');
+    mockRunLmlLinkage.mockResolvedValue({ status: 'no_canonical_entity' });
+    mockFetchMetadata.mockResolvedValue(undefined);
+  });
+
+  it('fires runLmlLinkage when no album_id is provided (free-form track insert)', async () => {
+    mockAddTrack.mockResolvedValue({
+      id: 999,
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      track_title: 'la paradoja',
+      album_id: null,
+    });
+
+    const req = {
+      body: {
+        artist_name: 'Juana Molina',
+        album_title: 'DOGA',
+        track_title: 'la paradoja',
+        record_label: 'Sonamos',
+      },
+    } as unknown as Parameters<typeof addEntry>[0];
+
+    await addEntry(req, makeRes() as unknown as Parameters<typeof addEntry>[1], jest.fn());
+
+    // fire-and-forget — give the microtask a tick to settle
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRunLmlLinkage).toHaveBeenCalledTimes(1);
+    expect(mockRunLmlLinkage).toHaveBeenCalledWith({
+      flowsheetId: 999,
+      artistName: 'Juana Molina',
+      albumTitle: 'DOGA',
+    });
+  });
+
+  it('does NOT fire runLmlLinkage when album_id is already provided (bin pick is already linked)', async () => {
+    mockGetAlbumFromDB.mockResolvedValue({
+      artist_id: 1,
+      artist_name: 'Stereolab',
+      album_title: 'Aluminum Tunes',
+      record_label: 'Duophonic',
+      label_id: null,
+    });
+    mockAddTrack.mockResolvedValue({
+      id: 1000,
+      artist_name: 'Stereolab',
+      album_title: 'Aluminum Tunes',
+      track_title: 'Pop Quiz',
+      album_id: 42,
+    });
+
+    const req = {
+      body: { album_id: 42, track_title: 'Pop Quiz' },
+    } as unknown as Parameters<typeof addEntry>[0];
+
+    await addEntry(req, makeRes() as unknown as Parameters<typeof addEntry>[1], jest.fn());
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRunLmlLinkage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire runLmlLinkage on message-only entries (no artist/album text to look up)', async () => {
+    mockAddTrack.mockResolvedValue({ id: 1001, entry_type: 'message', artist_name: '', album_title: '' });
+
+    const req = { body: { message: 'Top of the hour' } } as unknown as Parameters<typeof addEntry>[0];
+
+    await addEntry(req, makeRes() as unknown as Parameters<typeof addEntry>[1], jest.fn());
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRunLmlLinkage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/flowsheet-linkage.service.test.ts
+++ b/tests/unit/services/flowsheet-linkage.service.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the forward-path LML linkage service (B-2.1).
+ *
+ * After addEntry inserts a flowsheet row without album_id, this service is
+ * fired-and-forgotten to resolve a canonical entity via LML and link the
+ * row to the matching library album. The five outcomes match the issue's
+ * acceptance criteria: linked / no_canonical_entity / low_confidence /
+ * no_library_match / multi_match.
+ */
+import { jest } from '@jest/globals';
+import { db, createMockQueryChain } from '../../mocks/database.mock';
+
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
+
+jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  isLmlConfigured: jest.fn().mockReturnValue(true),
+}));
+
+import { runLmlLinkage } from '../../../apps/backend/services/flowsheet-linkage.service';
+
+const directMatch = (release_id: number) => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id, release_url: '', confidence: 0 } }],
+  search_type: 'direct',
+  song_not_found: false,
+  found_on_compilation: false,
+});
+
+const fallbackMatch = (release_id: number) => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id, release_url: '', confidence: 0 } }],
+  search_type: 'fallback',
+  song_not_found: false,
+  found_on_compilation: false,
+});
+
+const noneMatch = () => ({
+  results: [],
+  search_type: 'none',
+  song_not_found: false,
+  found_on_compilation: false,
+});
+
+describe('runLmlLinkage (B-2.1)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('links the flowsheet row when a direct LML match resolves to exactly one library row', async () => {
+    mockLookupMetadata.mockResolvedValue(directMatch(123456));
+
+    // First chain: SELECT library rows by canonical_entity_id (one match)
+    const selectChain = createMockQueryChain();
+    selectChain.where.mockResolvedValue([{ id: 88 }]);
+    db.select.mockReturnValueOnce(selectChain);
+
+    // Second chain: UPDATE flowsheet
+    const updateChain = createMockQueryChain();
+    db.update.mockReturnValueOnce(updateChain);
+
+    const outcome = await runLmlLinkage({
+      flowsheetId: 7,
+      artistName: 'Juana Molina',
+      albumTitle: 'DOGA',
+    });
+
+    expect(mockLookupMetadata).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+    expect(outcome).toEqual({
+      status: 'linked',
+      libraryId: 88,
+      canonicalEntityId: 'discogs:release:123456',
+      confidence: 0.9,
+    });
+    expect(updateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        album_id: 88,
+        linkage_source: 'lml_high_confidence',
+        linkage_confidence: 0.9,
+        linked_at: expect.any(Date),
+      })
+    );
+  });
+
+  it('returns no_canonical_entity (no link, no DB write) when LML returns search_type=none', async () => {
+    mockLookupMetadata.mockResolvedValue(noneMatch());
+
+    const outcome = await runLmlLinkage({
+      flowsheetId: 7,
+      artistName: 'Some Random Artist',
+      albumTitle: 'Unknown Album',
+    });
+
+    expect(outcome).toEqual({ status: 'no_canonical_entity' });
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('returns low_confidence (no link) for fallback matches — they belong in the review queue (B-3.1)', async () => {
+    mockLookupMetadata.mockResolvedValue(fallbackMatch(987));
+
+    const outcome = await runLmlLinkage({
+      flowsheetId: 7,
+      artistName: 'Andy Stott',
+      albumTitle: 'Faith In Strangers',
+    });
+
+    expect(outcome).toEqual({
+      status: 'low_confidence',
+      canonicalEntityId: 'discogs:release:987',
+      confidence: 0.5,
+    });
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('returns no_library_match when the canonical entity exists but no library row carries it', async () => {
+    mockLookupMetadata.mockResolvedValue(directMatch(555));
+
+    const selectChain = createMockQueryChain();
+    selectChain.where.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(selectChain);
+
+    const outcome = await runLmlLinkage({
+      flowsheetId: 7,
+      artistName: 'Jessica Pratt',
+      albumTitle: 'Quiet Signs',
+    });
+
+    expect(outcome).toEqual({
+      status: 'no_library_match',
+      canonicalEntityId: 'discogs:release:555',
+      confidence: 0.9,
+    });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('returns multi_match (no link, defers to B-2.3 tie-break) when several library rows share the canonical entity', async () => {
+    mockLookupMetadata.mockResolvedValue(directMatch(42));
+
+    const selectChain = createMockQueryChain();
+    selectChain.where.mockResolvedValue([{ id: 10 }, { id: 11 }, { id: 12 }]);
+    db.select.mockReturnValueOnce(selectChain);
+
+    const outcome = await runLmlLinkage({
+      flowsheetId: 7,
+      artistName: 'Stereolab',
+      albumTitle: 'Aluminum Tunes',
+    });
+
+    expect(outcome).toEqual({
+      status: 'multi_match',
+      canonicalEntityId: 'discogs:release:42',
+      confidence: 0.9,
+      libraryIds: [10, 11, 12],
+    });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Wires the live `addEntry` free-form insert path through to LML's canonical-entity lookup so newly-typed flowsheet rows get their `album_id` resolved without blocking the HTTP response.

- New `apps/backend/services/flowsheet-linkage.service.ts::runLmlLinkage` — looks up `(artist, album)` text via LML, maps the response to a `(canonical_entity_id, confidence)` pair using the existing helper from B-1.3, gates on the calibrated auto-accept threshold (0.9, i.e. `search_type=direct`), and resolves the entity to library rows.
- Outcomes: `linked` (single match, sets `album_id` + `linkage_source='lml_high_confidence'` + `linkage_confidence` + `linked_at`), `no_canonical_entity`, `low_confidence` (B-3.1's review queue once it ships), `no_library_match`, `multi_match` (defers to B-2.3's tie-break — for now stays unlinked).
- `flowsheet.controller::fireAndForgetLinkage` mirrors the existing `fireAndForgetMetadata` pattern: only fires when `album_id` is null and there's an `artist_name` to look up.

## Why these thresholds

Per the B-0 calibration ([#492 comment](https://github.com/WXYC/Backend-Service/issues/492#issuecomment-4322346796)): only `search_type=direct` (~0.9) is auto-accept. `fallback` matches are mostly wrong-album-by-right-artist and route to the manual review queue; `alternative`/`compilation`/`song_as_artist` stay below the threshold too. Realistic auto-accept coverage is ~10-15% of the unlinked backlog — the rest needs B-3.1 review or LML matching improvements.

## Test plan

- [x] `npm run test:unit` — 1222 tests pass (5 new for the linkage service, 3 new for `addEntry` wiring)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] Integration coverage for the four LML-result branches (single/multi/no-match/no-candidate) — landing in a follow-up since the service has no DB-side complexity beyond the canonical-entity index already exercised by B-1.2's tests.

## Out of scope

- Backfill of historical entries (B-2.2)
- Tie-break for the multi-match branch (B-2.3 — `runLmlLinkage` already returns the candidate library_ids so B-2.3 just plugs in)
- Manual review queue surface for `low_confidence` / persistent `no_library_match` (B-3.1)

Closes #498