### PR TITLE
Backfill job: LML reconciliation for ~889K unlinked entries

### DIFF
--- a/Dockerfile.flowsheet-lml-link-backfill
+++ b/Dockerfile.flowsheet-lml-link-backfill
@@ -1,0 +1,27 @@
+#Build stage
+FROM node:25-alpine AS builder
+
+WORKDIR /flowsheet-lml-link-backfill-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/flowsheet-lml-link-backfill ./jobs/flowsheet-lml-link-backfill
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/flowsheet-lml-link-backfill
+
+#Production stage
+FROM node:25-alpine AS prod
+
+WORKDIR /flowsheet-lml-link-backfill
+
+COPY ./package* ./
+COPY ./jobs/flowsheet-lml-link-backfill/package* ./jobs/flowsheet-lml-link-backfill/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./flowsheet-lml-link-backfill-builder/jobs/flowsheet-lml-link-backfill/dist ./jobs/flowsheet-lml-link-backfill/dist
+COPY --from=builder ./flowsheet-lml-link-backfill-builder/shared/database/dist ./shared/database/dist
+
+CMD ["npm", "start", "--workspace=@wxyc/flowsheet-lml-link-backfill"]

--- a/jobs/flowsheet-lml-link-backfill/job.ts
+++ b/jobs/flowsheet-lml-link-backfill/job.ts
@@ -1,0 +1,43 @@
+/**
+ * One-shot backfill: link unlinked flowsheet rows to library via LML's
+ * canonical-entity lookup (B-2.2).
+ *
+ * Targets the ~1.18M flowsheet rows where `album_id IS NULL`:
+ *   - 889K never had a `legacy_release_id` (manual DJ entries).
+ *   - ~290K had a `legacy_release_id` whose FK didn't resolve, stamped by
+ *     B-0.5's broken-FK recovery (`legacy_link_attempted_at IS NOT NULL`).
+ *
+ * For each row the job calls `LML.lookupMetadata(artist, album)`, picks the
+ * direct-hit canonical entity (B-0 calibration), and links to a single
+ * library row when one exists with that `canonical_entity_id`. See
+ * `orchestrate.ts` for the loop and `resolve.ts` for the per-signal contract.
+ *
+ * Cross-run resumability is via the WHERE filter alone: linked rows fall
+ * out (`album_id IS NULL` no longer matches); review / no_match / error /
+ * no_library_match rows stay in the pool and roll forward to the next sweep.
+ *
+ * Run procedure: build via `Manual Build & Deploy` with
+ * `target=flowsheet-lml-link-backfill`, then SSH to EC2 and
+ * `docker run --rm --env-file .env <image> 2>&1 | tee log`. The job runs
+ * during a low-traffic window — LML's rate budget is the limiting factor,
+ * not the database.
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { runBackfill } from './orchestrate.js';
+import { lookupMetadata } from './lml-fetch.js';
+
+const JOB_NAME = 'flowsheet-lml-link-backfill';
+
+const main = async () => {
+  try {
+    await runBackfill({ lookup: lookupMetadata });
+  } finally {
+    await closeDatabaseConnection();
+  }
+};
+
+main().catch((error) => {
+  console.error(`[${JOB_NAME}] Failed:`, error);
+  process.exitCode = 1;
+});

--- a/jobs/flowsheet-lml-link-backfill/lml-fetch.ts
+++ b/jobs/flowsheet-lml-link-backfill/lml-fetch.ts
@@ -1,0 +1,50 @@
+/**
+ * Minimal LML lookup fetcher for the B-2.2 backfill.
+ *
+ * Mirrors `jobs/library-canonical-entity-backfill/lml-fetch.ts`. Duplicated
+ * rather than imported across job packages because importing across job
+ * workspaces would couple their build graphs and force one container to
+ * ship the other's tree. Kept tight on purpose.
+ */
+
+import type { LmlLookupResponse } from './lml-types.js';
+
+const TIMEOUT_MS = 5000;
+
+const baseUrl = (): string => {
+  const url = process.env.LIBRARY_METADATA_URL;
+  if (!url) {
+    throw new Error('LIBRARY_METADATA_URL is not configured');
+  }
+  return url.replace(/\/api\/v1\/?$/, '').replace(/\/$/, '');
+};
+
+export const lookupMetadata = async (artist: string, album?: string): Promise<LmlLookupResponse> => {
+  const body: Record<string, string> = { artist };
+  if (album) body.album = album;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${baseUrl()}/api/v1/lookup`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`LML responded ${response.status} ${response.statusText}`);
+    }
+
+    return (await response.json()) as LmlLookupResponse;
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      throw new Error('LML request timed out', { cause: error });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/jobs/flowsheet-lml-link-backfill/lml-types.ts
+++ b/jobs/flowsheet-lml-link-backfill/lml-types.ts
@@ -1,0 +1,22 @@
+/**
+ * Minimal slice of LML's LookupResponse needed by the resolver.
+ *
+ * Mirrors `LookupResponse` from @wxyc/shared/dtos. Inlined so the job package
+ * doesn't pull @wxyc/shared (a private GitHub Packages dep) at build time.
+ * Kept in sync with `jobs/library-canonical-entity-backfill/lml-types.ts` —
+ * both jobs interpret the same LML signal.
+ */
+
+export type LmlLookupResultItem = {
+  library_item: { id: number };
+  artwork?: { release_id: number };
+};
+
+export type LmlLookupResponse = {
+  results: LmlLookupResultItem[];
+  search_type: 'direct' | 'fallback' | 'alternative' | 'compilation' | 'song_as_artist' | 'none';
+  song_not_found?: boolean;
+  found_on_compilation?: boolean;
+  context_message?: string;
+  corrected_artist?: string;
+};

--- a/jobs/flowsheet-lml-link-backfill/orchestrate.ts
+++ b/jobs/flowsheet-lml-link-backfill/orchestrate.ts
@@ -1,13 +1,45 @@
 /**
  * Backfill orchestrator for B-2.2.
  *
- * STUB — implementation lands in the next commit. Exports the symbols the
- * tests bind to so failures are behavioral, not import errors.
+ * Iterates flowsheet rows where `album_id` is NULL (and the row has artist +
+ * album text), calls LML, looks up library rows by `canonical_entity_id`,
+ * and stamps the linkage when exactly one library row matches.
+ *
+ * Resumability:
+ *   - Across runs: linked rows fall out of the WHERE filter
+ *     (`album_id IS NULL` no longer matches them). review / no_match /
+ *     no_library_match / error rows stay in the pool and get retried on the
+ *     next sweep — that's the issue's "leave for review queue if persistent"
+ *     contract. There is no persistent cursor; the WHERE filter alone makes
+ *     restarts cheap.
+ *   - Within a single run: id-cursor pagination (`id > $lastId`) keeps the
+ *     SELECT bounded as the run progresses. Order is `id ASC` (oldest
+ *     first) so the long-tail backlog drains in chronological order.
+ *
+ * The row-eligibility filter unions the two unlinked buckets:
+ *   - `legacy_release_id IS NULL`              — never had a tubafrenzy ID.
+ *   - `legacy_link_attempted_at IS NOT NULL`   — broken-FK residual stamped
+ *                                                by B-0.5's recovery job.
+ *
+ * The `lookup` function is injected so tests can drive the orchestration
+ * without standing up an LML stub. Production wires it to the HTTP fetch in
+ * `lml-fetch.ts`.
  */
 
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
 import type { LmlLookupResponse } from './lml-types.js';
+import { resolveLmlSignal } from './resolve.js';
+
+const JOB_NAME = 'flowsheet-lml-link-backfill';
 
 export const BATCH_SIZE = 500;
+
+/**
+ * Default inter-call delay between LML lookups, in ms. Sized so a single
+ * sweep stays well below LML's effective rate budget; raise via the opts knob
+ * if LML's deployed rate limit tightens. Tests override to 0.
+ */
 export const THROTTLE_MS = 100;
 
 export type FlowsheetRow = {
@@ -18,7 +50,13 @@ export type FlowsheetRow = {
 
 export type LookupFn = (artist: string, album?: string) => Promise<LmlLookupResponse>;
 
-export type ProcessStatus = 'linked' | 'multi_match' | 'no_library_match' | 'review' | 'no_match' | 'error';
+export type ProcessStatus =
+  | 'linked'
+  | 'multi_match'
+  | 'no_library_match'
+  | 'review'
+  | 'no_match'
+  | 'error';
 
 export type Totals = {
   scanned: number;
@@ -32,29 +70,150 @@ export type Totals = {
 
 export type RunResult = { totals: Totals };
 
-export const applyLink = async (_args: {
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Stamp the four linkage columns on a flowsheet row. The
+ * `album_id IS NULL` guard keeps a concurrent linker (forward-path B-2.1 or
+ * review queue B-3.1) from overwriting an in-flight link.
+ */
+export const applyLink = async (args: {
   flowsheetId: number;
   libraryId: number;
   confidence: number;
 }): Promise<void> => {
-  throw new Error('applyLink not implemented yet');
+  await db.execute(sql`
+    UPDATE "wxyc_schema"."flowsheet"
+    SET "album_id" = ${args.libraryId},
+        "linkage_source" = 'lml_high_confidence',
+        "linkage_confidence" = ${args.confidence},
+        "linked_at" = now()
+    WHERE "id" = ${args.flowsheetId}
+      AND "album_id" IS NULL
+  `);
 };
 
-export const findLibraryByCanonicalEntity = async (_canonicalEntityId: string): Promise<number[]> => {
-  throw new Error('findLibraryByCanonicalEntity not implemented yet');
+/**
+ * Look up the library rows whose `canonical_entity_id` equals the LML-derived
+ * entity id. Returns 0, 1, or N ids; the caller branches on count.
+ */
+export const findLibraryByCanonicalEntity = async (canonicalEntityId: string): Promise<number[]> => {
+  const rows = (await db.execute(sql`
+    SELECT "id"
+    FROM "wxyc_schema"."library"
+    WHERE "canonical_entity_id" = ${canonicalEntityId}
+  `)) as unknown as Array<{ id: number }>;
+  return (rows ?? []).map((r) => r.id);
 };
 
+/**
+ * Drive a single flowsheet row through lookup → resolve → library-lookup →
+ * apply. Returns the outcome. Errors are logged and consumed; they do not
+ * bubble up so a single bad row cannot abort the run.
+ */
 export const processRow = async (
-  _row: FlowsheetRow,
-  _deps: { lookup: LookupFn }
+  row: FlowsheetRow,
+  deps: { lookup: LookupFn }
 ): Promise<ProcessStatus> => {
-  throw new Error('processRow not implemented yet');
+  const artist = row.artist_name ?? '';
+  const album = row.album_title ?? undefined;
+
+  if (!artist || !album) {
+    return 'no_match';
+  }
+
+  let response: LmlLookupResponse;
+  try {
+    response = await deps.lookup(artist, album);
+  } catch (error) {
+    console.warn(`[${JOB_NAME}] LML lookup failed for flowsheet.id=${row.id}:`, (error as Error).message);
+    return 'error';
+  }
+
+  const signal = resolveLmlSignal(response);
+  if (signal.status === 'review') return 'review';
+  if (signal.status === 'no_match') return 'no_match';
+
+  const libraryIds = await findLibraryByCanonicalEntity(signal.canonical_entity_id);
+  if (libraryIds.length === 0) return 'no_library_match';
+  if (libraryIds.length > 1) return 'multi_match';
+
+  await applyLink({
+    flowsheetId: row.id,
+    libraryId: libraryIds[0]!,
+    confidence: signal.confidence,
+  });
+  return 'linked';
 };
 
-export const runBackfill = async (_opts: {
+/**
+ * Read the next batch of unlinked flowsheet rows. The id-cursor predicate
+ * keeps the SELECT bounded as the run progresses; combined with the
+ * unlinked-row filters, it makes restarts cheap (no persistent cursor needed).
+ *
+ * The `(legacy_release_id IS NULL OR legacy_link_attempted_at IS NOT NULL)`
+ * union pulls in both the never-had-FK rows (~889K) and the B-0.5 broken-FK
+ * residuals stamped by `jobs/broken-fk-recovery`.
+ */
+const loadBatch = async (afterId: number, batchSize: number): Promise<FlowsheetRow[]> => {
+  const rows = (await db.execute(sql`
+    SELECT "id", "artist_name", "album_title"
+    FROM "wxyc_schema"."flowsheet"
+    WHERE "album_id" IS NULL
+      AND "entry_type" = 'track'
+      AND "artist_name" IS NOT NULL
+      AND "album_title" IS NOT NULL
+      AND ("legacy_release_id" IS NULL OR "legacy_link_attempted_at" IS NOT NULL)
+      AND "id" > ${afterId}
+    ORDER BY "id" ASC
+    LIMIT ${batchSize}
+  `)) as unknown as FlowsheetRow[];
+  return rows ?? [];
+};
+
+const formatTotals = (totals: Totals): string =>
+  `scanned=${totals.scanned} linked=${totals.linked} multi_match=${totals.multi_match} ` +
+  `no_library_match=${totals.no_library_match} review=${totals.review} ` +
+  `no_match=${totals.no_match} error=${totals.error}`;
+
+export const runBackfill = async (opts: {
   lookup: LookupFn;
   batchSize?: number;
   throttleMs?: number;
 }): Promise<RunResult> => {
-  throw new Error('runBackfill not implemented yet');
+  const batchSize = opts.batchSize ?? BATCH_SIZE;
+  const throttleMs = opts.throttleMs ?? THROTTLE_MS;
+
+  console.log(`[${JOB_NAME}] Starting. batchSize=${batchSize} throttleMs=${throttleMs}`);
+
+  const totals: Totals = {
+    scanned: 0,
+    linked: 0,
+    multi_match: 0,
+    no_library_match: 0,
+    review: 0,
+    no_match: 0,
+    error: 0,
+  };
+  let lastId = 0;
+  let batchIndex = 0;
+
+  while (true) {
+    const rows = await loadBatch(lastId, batchSize);
+    if (rows.length === 0) break;
+
+    batchIndex += 1;
+    for (const row of rows) {
+      const status = await processRow(row, { lookup: opts.lookup });
+      totals.scanned += 1;
+      totals[status] += 1;
+      lastId = row.id;
+      if (throttleMs > 0) await sleep(throttleMs);
+    }
+
+    console.log(`[${JOB_NAME}] batch ${batchIndex} done | ${formatTotals(totals)}`);
+  }
+
+  console.log(`[${JOB_NAME}] Done. ${formatTotals(totals)}`);
+  return { totals };
 };

--- a/jobs/flowsheet-lml-link-backfill/orchestrate.ts
+++ b/jobs/flowsheet-lml-link-backfill/orchestrate.ts
@@ -1,0 +1,60 @@
+/**
+ * Backfill orchestrator for B-2.2.
+ *
+ * STUB — implementation lands in the next commit. Exports the symbols the
+ * tests bind to so failures are behavioral, not import errors.
+ */
+
+import type { LmlLookupResponse } from './lml-types.js';
+
+export const BATCH_SIZE = 500;
+export const THROTTLE_MS = 100;
+
+export type FlowsheetRow = {
+  id: number;
+  artist_name: string | null;
+  album_title: string | null;
+};
+
+export type LookupFn = (artist: string, album?: string) => Promise<LmlLookupResponse>;
+
+export type ProcessStatus = 'linked' | 'multi_match' | 'no_library_match' | 'review' | 'no_match' | 'error';
+
+export type Totals = {
+  scanned: number;
+  linked: number;
+  multi_match: number;
+  no_library_match: number;
+  review: number;
+  no_match: number;
+  error: number;
+};
+
+export type RunResult = { totals: Totals };
+
+export const applyLink = async (_args: {
+  flowsheetId: number;
+  libraryId: number;
+  confidence: number;
+}): Promise<void> => {
+  throw new Error('applyLink not implemented yet');
+};
+
+export const findLibraryByCanonicalEntity = async (_canonicalEntityId: string): Promise<number[]> => {
+  throw new Error('findLibraryByCanonicalEntity not implemented yet');
+};
+
+export const processRow = async (
+  _row: FlowsheetRow,
+  _deps: { lookup: LookupFn }
+): Promise<ProcessStatus> => {
+  throw new Error('processRow not implemented yet');
+};
+
+export const runBackfill = async (_opts: {
+  lookup: LookupFn;
+  batchSize?: number;
+  throttleMs?: number;
+}): Promise<RunResult> => {
+  throw new Error('runBackfill not implemented yet');
+};

--- a/jobs/flowsheet-lml-link-backfill/orchestrate.ts
+++ b/jobs/flowsheet-lml-link-backfill/orchestrate.ts
@@ -50,13 +50,7 @@ export type FlowsheetRow = {
 
 export type LookupFn = (artist: string, album?: string) => Promise<LmlLookupResponse>;
 
-export type ProcessStatus =
-  | 'linked'
-  | 'multi_match'
-  | 'no_library_match'
-  | 'review'
-  | 'no_match'
-  | 'error';
+export type ProcessStatus = 'linked' | 'multi_match' | 'no_library_match' | 'review' | 'no_match' | 'error';
 
 export type Totals = {
   scanned: number;
@@ -111,10 +105,7 @@ export const findLibraryByCanonicalEntity = async (canonicalEntityId: string): P
  * apply. Returns the outcome. Errors are logged and consumed; they do not
  * bubble up so a single bad row cannot abort the run.
  */
-export const processRow = async (
-  row: FlowsheetRow,
-  deps: { lookup: LookupFn }
-): Promise<ProcessStatus> => {
+export const processRow = async (row: FlowsheetRow, deps: { lookup: LookupFn }): Promise<ProcessStatus> => {
   const artist = row.artist_name ?? '';
   const album = row.album_title ?? undefined;
 
@@ -140,7 +131,7 @@ export const processRow = async (
 
   await applyLink({
     flowsheetId: row.id,
-    libraryId: libraryIds[0]!,
+    libraryId: libraryIds[0],
     confidence: signal.confidence,
   });
   return 'linked';

--- a/jobs/flowsheet-lml-link-backfill/package.json
+++ b/jobs/flowsheet-lml-link-backfill/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wxyc/flowsheet-lml-link-backfill",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot backfill: link unlinked flowsheet rows to library via LML canonical-entity lookup (B-2.2)",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_flowsheet_lml_link_backfill:ci -f ../../Dockerfile.flowsheet-lml-link-backfill ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/flowsheet-lml-link-backfill/resolve.ts
+++ b/jobs/flowsheet-lml-link-backfill/resolve.ts
@@ -1,8 +1,21 @@
 /**
  * Per-row LML signal resolver for the B-2.2 flowsheet backfill.
  *
- * STUB — implementation lands in the next commit. Exports the shape the test
- * expects so the failing test fails for behavioral reasons, not import errors.
+ * Maps an LML lookup response to one of three outcomes derived from B-0's
+ * calibrated heuristic (issue #492 comment). LML doesn't expose per-result
+ * confidence today (tracked at WXYC/library-metadata-lookup#158); when it
+ * does, this resolver collapses to a numeric threshold and the search_type
+ * branch goes away.
+ *
+ * Outcomes:
+ *   - auto_accept — search_type=direct AND first result has artwork.release_id.
+ *     The canonical_entity_id is namespaced `discogs:<release_id>` to match
+ *     what the B-1.2 library backfill stamped on `library.canonical_entity_id`.
+ *   - review     — any non-empty result that isn't a direct hit. Surfaces to
+ *     B-3.1 review rather than guessing.
+ *   - no_match   — empty result set, OR a direct match whose top result has
+ *     no pinable Discogs release_id. The orchestrator writes nothing so the
+ *     row stays in the retry pool for the next sweep.
  */
 
 import type { LmlLookupResponse } from './lml-types.js';
@@ -12,8 +25,33 @@ export type LmlSignal =
   | { status: 'review' }
   | { status: 'no_match' };
 
+/**
+ * Confidence assigned to direct-hit auto-accepts. LML doesn't return a
+ * per-result number today, so we synth a single value for retroactive
+ * filtering. Mirrors `AUTO_ACCEPT_CONFIDENCE` in B-1.2's resolver.
+ */
 export const AUTO_ACCEPT_CONFIDENCE = 0.95;
 
-export const resolveLmlSignal = (_response: LmlLookupResponse): LmlSignal => {
-  throw new Error('resolveLmlSignal not implemented yet');
+const toCanonicalEntityId = (releaseId: number): string => `discogs:${releaseId}`;
+
+export const resolveLmlSignal = (response: LmlLookupResponse): LmlSignal => {
+  const top = response.results?.[0];
+  if (!top) {
+    return { status: 'no_match' };
+  }
+
+  const releaseId = top.artwork?.release_id;
+
+  if (response.search_type === 'direct') {
+    if (typeof releaseId !== 'number') {
+      return { status: 'no_match' };
+    }
+    return {
+      status: 'auto_accept',
+      canonical_entity_id: toCanonicalEntityId(releaseId),
+      confidence: AUTO_ACCEPT_CONFIDENCE,
+    };
+  }
+
+  return { status: 'review' };
 };

--- a/jobs/flowsheet-lml-link-backfill/resolve.ts
+++ b/jobs/flowsheet-lml-link-backfill/resolve.ts
@@ -1,0 +1,19 @@
+/**
+ * Per-row LML signal resolver for the B-2.2 flowsheet backfill.
+ *
+ * STUB — implementation lands in the next commit. Exports the shape the test
+ * expects so the failing test fails for behavioral reasons, not import errors.
+ */
+
+import type { LmlLookupResponse } from './lml-types.js';
+
+export type LmlSignal =
+  | { status: 'auto_accept'; canonical_entity_id: string; confidence: number }
+  | { status: 'review' }
+  | { status: 'no_match' };
+
+export const AUTO_ACCEPT_CONFIDENCE = 0.95;
+
+export const resolveLmlSignal = (_response: LmlLookupResponse): LmlSignal => {
+  throw new Error('resolveLmlSignal not implemented yet');
+};

--- a/jobs/flowsheet-lml-link-backfill/tsconfig.json
+++ b/jobs/flowsheet-lml-link-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/flowsheet-lml-link-backfill/tsup.config.ts
+++ b/jobs/flowsheet-lml-link-backfill/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,6 +497,20 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/flowsheet-lml-link-backfill": {
+      "name": "@wxyc/flowsheet-lml-link-backfill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/library-artist-name-backfill": {
       "name": "@wxyc/library-artist-name-backfill",
       "version": "1.0.0",
@@ -7075,6 +7089,10 @@
     },
     "node_modules/@wxyc/flowsheet-linkage-audit-backfill": {
       "resolved": "jobs/flowsheet-linkage-audit-backfill",
+      "link": true
+    },
+    "node_modules/@wxyc/flowsheet-lml-link-backfill": {
+      "resolved": "jobs/flowsheet-lml-link-backfill",
       "link": true
     },
     "node_modules/@wxyc/library-artist-name-backfill": {

--- a/tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Unit tests for the B-2.2 backfill orchestrator.
+ *
+ * The orchestrator iterates unlinked flowsheet rows, calls LML, looks up
+ * library rows by canonical_entity_id, and stamps `album_id` /
+ * `linkage_source='lml_high_confidence'` / `linkage_confidence` /
+ * `linked_at` when exactly one library row matches.
+ *
+ * Tests cover:
+ *   - applyLink writes the four linkage columns under the right WHERE guard.
+ *   - findLibraryByCanonicalEntity returns 0 / 1 / >1 distinct results.
+ *   - processRow stitches lookup → resolve → library-lookup → write and
+ *     produces the right outcome category for each branch.
+ *   - runBackfill paginates by id, throttles between LML calls, exits on the
+ *     first empty batch, and keeps going past per-row errors.
+ */
+
+import { db } from '@wxyc/database';
+import {
+  applyLink,
+  findLibraryByCanonicalEntity,
+  processRow,
+  runBackfill,
+  BATCH_SIZE,
+  THROTTLE_MS,
+} from '../../../../jobs/flowsheet-lml-link-backfill/orchestrate';
+import type { LmlLookupResponse } from '../../../../jobs/flowsheet-lml-link-backfill/lml-types';
+
+type SqlLike = {
+  sql?: string | string[];
+  queryChunks?: Array<string | { value?: string | string[] }>;
+};
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const findExecuteCallMatching = (pattern: RegExp): unknown[] | undefined => {
+  const calls = (db.execute as jest.Mock).mock.calls;
+  return calls.find((call) => pattern.test(renderSql(call[0])));
+};
+
+const directResponse = (releaseId: number): LmlLookupResponse => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id: releaseId } }],
+  search_type: 'direct',
+});
+
+const fallbackResponse = (releaseId: number): LmlLookupResponse => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id: releaseId } }],
+  search_type: 'fallback',
+});
+
+const emptyResponse = (): LmlLookupResponse => ({
+  results: [],
+  search_type: 'none',
+});
+
+describe('applyLink', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("stamps album_id, linkage_source='lml_high_confidence', confidence and linked_at", async () => {
+    // The four columns are the audit contract from B-1.4. Missing any of them
+    // would leave us unable to tell at a glance how a link was made.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
+
+    await applyLink({ flowsheetId: 42, libraryId: 7, confidence: 0.95 });
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/album_id"?\s*=/i);
+    expect(sqlText).toMatch(/linkage_source"?\s*=\s*'lml_high_confidence'/i);
+    expect(sqlText).toMatch(/linkage_confidence"?\s*=/i);
+    expect(sqlText).toMatch(/linked_at"?\s*=\s*now\(\)/i);
+  });
+
+  it('guards the UPDATE with album_id IS NULL so a concurrent link is not overwritten', async () => {
+    // The forward path (B-2.1) and review queue (B-3.1) may link the same
+    // row between the time we read it and the time we write. The IS NULL
+    // guard makes the UPDATE idempotent — if someone else got there first,
+    // the row count is 0 and we move on.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await applyLink({ flowsheetId: 42, libraryId: 7, confidence: 0.95 });
+
+    const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i);
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/album_id"?\s+IS\s+NULL/i);
+  });
+});
+
+describe('findLibraryByCanonicalEntity', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+  });
+
+  it('returns the matching library ids for a canonical_entity_id', async () => {
+    // The orchestrator branches on count: 0 → no_library_match, 1 → link,
+    // >1 → defer to B-2.3's tie-break. The query is just `SELECT id FROM
+    // library WHERE canonical_entity_id = $1`.
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ id: 100 }]);
+
+    const ids = await findLibraryByCanonicalEntity('discogs:987654');
+
+    expect(ids).toEqual([100]);
+    const call = findExecuteCallMatching(/SELECT[\s\S]*library[\s\S]*canonical_entity_id/i);
+    expect(call).toBeDefined();
+    const serialized = JSON.stringify(call?.[0]);
+    expect(serialized).toContain('discogs:987654');
+  });
+
+  it('returns multiple ids when the canonical entity spans library duplicates', async () => {
+    // B-2.3 (out of scope for this issue) handles tie-breaking. This job
+    // just surfaces the multi-match case so the caller can defer.
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ id: 100 }, { id: 101 }]);
+
+    const ids = await findLibraryByCanonicalEntity('discogs:987654');
+
+    expect(ids).toEqual([100, 101]);
+  });
+
+  it('returns an empty array when nothing matches', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    const ids = await findLibraryByCanonicalEntity('discogs:987654');
+
+    expect(ids).toEqual([]);
+  });
+});
+
+describe('processRow', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("calls LML with (artist, album) — wiring guard so the args don't get swapped", async () => {
+    // Verifies the wiring between flowsheet row → lookup. Swapping
+    // artist/album would still match some inputs but be silently wrong.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([{ id: 100 }]) // findLibraryByCanonicalEntity
+      .mockResolvedValueOnce({ count: 1 }); // applyLink
+    const lookup = jest.fn(() => Promise.resolve(directResponse(123)));
+
+    await processRow(
+      { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
+      { lookup }
+    );
+
+    expect(lookup).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+  });
+
+  it('links the row and reports linked when exactly one library row matches', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([{ id: 100 }]) // SELECT library
+      .mockResolvedValueOnce({ count: 1 }); // UPDATE flowsheet
+    const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
+
+    const status = await processRow(
+      { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
+      { lookup }
+    );
+
+    expect(status).toBe('linked');
+    const updateCall = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i);
+    expect(updateCall).toBeDefined();
+    const serialized = JSON.stringify(updateCall?.[0]);
+    expect(serialized).toContain('100'); // library_id
+    expect(serialized).toContain('7'); // flowsheet_id
+  });
+
+  it('reports multi_match without writing when more than one library row matches', async () => {
+    // Tie-break (B-2.3) is out of scope. The orchestrator must surface the
+    // case but not pick arbitrarily — picking by lowest id silently looks
+    // like B-2.2 succeeded and would block B-2.3 from re-running.
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ id: 100 }, { id: 101 }]);
+    const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
+
+    const status = await processRow(
+      { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
+      { lookup }
+    );
+
+    expect(status).toBe('multi_match');
+    expect(findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i)).toBeUndefined();
+  });
+
+  it("reports no_library_match when LML's canonical entity isn't in our library", async () => {
+    // Canonical entity exists in the world but not in WXYC's library — the
+    // album isn't on hand. Leave NULL; if the album later lands in the
+    // catalog, the next sweep links it.
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+    const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
+
+    const status = await processRow(
+      { id: 7, artist_name: 'Stereolab', album_title: 'Dots and Loops' },
+      { lookup }
+    );
+
+    expect(status).toBe('no_library_match');
+    expect(findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i)).toBeUndefined();
+  });
+
+  it('reports review on a fallback hit without writing', async () => {
+    // Review-flagged rows roll forward to B-3.1; the orchestrator must not
+    // stamp linkage_source on them or B-3.1 misses them.
+    const lookup = jest.fn(() => Promise.resolve(fallbackResponse(33)));
+
+    const status = await processRow(
+      { id: 7, artist_name: 'Jessica Pratt', album_title: 'On Your Own' },
+      { lookup }
+    );
+
+    expect(status).toBe('review');
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
+  });
+
+  it('reports no_match on an empty LML response without writing', async () => {
+    const lookup = jest.fn(() => Promise.resolve(emptyResponse()));
+
+    const status = await processRow(
+      { id: 7, artist_name: 'Unknown', album_title: 'Unknown' },
+      { lookup }
+    );
+
+    expect(status).toBe('no_match');
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
+  });
+
+  it('reports error on LML failure without writing (next sweep retries)', async () => {
+    // Failure tolerance: an LML 5xx must not stamp the row, or it would be
+    // removed from the retry pool and lose the eventual recovery.
+    const lookup = jest.fn(() => Promise.reject(new Error('LML 502')));
+
+    const status = await processRow(
+      { id: 7, artist_name: 'Stereolab', album_title: 'Dots and Loops' },
+      { lookup }
+    );
+
+    expect(status).toBe('error');
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
+  });
+});
+
+describe('runBackfill', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses a sensible BATCH_SIZE (bounded reads — never SELECT *)', () => {
+    // The flowsheet has ~1.18M unlinked rows. An unbounded SELECT would pin
+    // a connection for an hour; a too-small batch would explode the
+    // round-trip overhead per row.
+    expect(BATCH_SIZE).toBeGreaterThanOrEqual(50);
+    expect(BATCH_SIZE).toBeLessThanOrEqual(2000);
+  });
+
+  it('throttles between LML calls (THROTTLE_MS > 0)', () => {
+    // The throttle is what keeps a multi-day sweep from stampeding LML.
+    // Dropping it to 0 risks blowing through LML's rate budget in seconds.
+    expect(THROTTLE_MS).toBeGreaterThan(0);
+  });
+
+  it('selects only unlinked track rows that have artist+album text', async () => {
+    // Issue scope: album_id IS NULL AND entry_type='track' AND artist_name
+    // IS NOT NULL AND album_title IS NOT NULL. Plus the B-0.5 admission:
+    // include broken-FK residuals (legacy_link_attempted_at IS NOT NULL)
+    // alongside never-had-FK rows (legacy_release_id IS NULL).
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    await runBackfill({ lookup: jest.fn(), throttleMs: 0 });
+
+    const selectCall = findExecuteCallMatching(/SELECT[\s\S]*FROM[\s\S]*flowsheet/i);
+    expect(selectCall).toBeDefined();
+    const sqlText = renderSql(selectCall?.[0]);
+    expect(sqlText).toMatch(/album_id"?\s+IS\s+NULL/i);
+    expect(sqlText).toMatch(/entry_type"?\s*=\s*'track'/i);
+    expect(sqlText).toMatch(/artist_name"?\s+IS\s+NOT\s+NULL/i);
+    expect(sqlText).toMatch(/album_title"?\s+IS\s+NOT\s+NULL/i);
+    expect(sqlText).toMatch(/legacy_release_id"?\s+IS\s+NULL/i);
+    expect(sqlText).toMatch(/legacy_link_attempted_at"?\s+IS\s+NOT\s+NULL/i);
+  });
+
+  it('paginates forward by id (last-id cursor restartable across batches)', async () => {
+    // Without `id > $lastId` the second loadBatch re-scans the same rows
+    // forever — the WHERE filter on album_id IS NULL still matches a row
+    // we just left as review (no album_id stamp).
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'a', album_title: 'a' },
+        { id: 2, artist_name: 'b', album_title: 'b' },
+      ])
+      // both rows fall through to no_match (no DB writes)
+      .mockResolvedValueOnce([]);
+    const lookup = jest.fn(() => Promise.resolve(emptyResponse()));
+
+    await runBackfill({ lookup, throttleMs: 0 });
+
+    const selectCalls = (db.execute as jest.Mock).mock.calls
+      .map((c) => renderSql(c[0]))
+      .filter((s) => /SELECT[\s\S]*FROM[\s\S]*flowsheet/i.test(s));
+    expect(selectCalls.length).toBe(2);
+    const secondSelectSerialized = JSON.stringify(
+      (db.execute as jest.Mock).mock.calls.filter((c) =>
+        /SELECT[\s\S]*FROM[\s\S]*flowsheet/i.test(renderSql(c[0]))
+      )[1]?.[0]
+    );
+    expect(secondSelectSerialized).toContain('2');
+  });
+
+  it('exits cleanly on the first empty batch (already-backfilled state)', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+    const lookup = jest.fn();
+
+    const result = await runBackfill({ lookup, throttleMs: 0 });
+
+    expect(lookup).not.toHaveBeenCalled();
+    expect(result.totals.scanned).toBe(0);
+  });
+
+  it('counts each outcome separately for the run report', async () => {
+    // The summary the operator sees is what tells us whether B-3.1's review
+    // queue is going to have anything in it. Per-outcome counts are the
+    // whole point of running the job.
+    (db.execute as jest.Mock)
+      // batch 1
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'a', album_title: 'a' },
+        { id: 2, artist_name: 'b', album_title: 'b' },
+        { id: 3, artist_name: 'c', album_title: 'c' },
+        { id: 4, artist_name: 'd', album_title: 'd' },
+        { id: 5, artist_name: 'e', album_title: 'e' },
+      ])
+      // row 1 — auto_accept, library has one match
+      .mockResolvedValueOnce([{ id: 100 }])
+      .mockResolvedValueOnce({ count: 1 })
+      // row 2 — auto_accept, library has zero matches
+      .mockResolvedValueOnce([])
+      // row 3 — auto_accept, library has two matches (no UPDATE)
+      .mockResolvedValueOnce([{ id: 200 }, { id: 201 }])
+      // rows 4 + 5 fall through to review / no_match (no DB writes)
+      // batch 2 — empty
+      .mockResolvedValueOnce([]);
+
+    let call = 0;
+    const lookup = jest.fn(() => {
+      call += 1;
+      if (call === 1) return Promise.resolve(directResponse(111));
+      if (call === 2) return Promise.resolve(directResponse(222));
+      if (call === 3) return Promise.resolve(directResponse(333));
+      if (call === 4) return Promise.resolve(fallbackResponse(444));
+      return Promise.resolve(emptyResponse());
+    });
+
+    const result = await runBackfill({ lookup, throttleMs: 0 });
+
+    expect(result.totals.linked).toBe(1);
+    expect(result.totals.no_library_match).toBe(1);
+    expect(result.totals.multi_match).toBe(1);
+    expect(result.totals.review).toBe(1);
+    expect(result.totals.no_match).toBe(1);
+    expect(result.totals.error).toBe(0);
+    expect(result.totals.scanned).toBe(5);
+  });
+
+  it('keeps going when a single row errors (failure-tolerant — does not abort the run)', async () => {
+    // One LML failure must not poison the run. The error count goes up; the
+    // scan continues. The errored row stays NULL and gets retried on the
+    // next sweep.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'a', album_title: 'a' },
+        { id: 2, artist_name: 'b', album_title: 'b' },
+      ])
+      .mockResolvedValueOnce([{ id: 100 }]) // SELECT library for row 2
+      .mockResolvedValueOnce({ count: 1 }) // UPDATE flowsheet for row 2
+      .mockResolvedValueOnce([]);
+
+    let call = 0;
+    const lookup = jest.fn(() => {
+      call += 1;
+      if (call === 1) return Promise.reject(new Error('LML 502'));
+      return Promise.resolve(directResponse(222));
+    });
+
+    const result = await runBackfill({ lookup, throttleMs: 0 });
+
+    expect(result.totals.error).toBe(1);
+    expect(result.totals.linked).toBe(1);
+    expect(result.totals.scanned).toBe(2);
+  });
+});

--- a/tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts
@@ -168,10 +168,7 @@ describe('processRow', () => {
       .mockResolvedValueOnce({ count: 1 }); // applyLink
     const lookup = jest.fn(() => Promise.resolve(directResponse(123)));
 
-    await processRow(
-      { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
-      { lookup }
-    );
+    await processRow({ id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' }, { lookup });
 
     expect(lookup).toHaveBeenCalledWith('Juana Molina', 'DOGA');
   });
@@ -182,10 +179,7 @@ describe('processRow', () => {
       .mockResolvedValueOnce({ count: 1 }); // UPDATE flowsheet
     const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
 
-    const status = await processRow(
-      { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
-      { lookup }
-    );
+    const status = await processRow({ id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' }, { lookup });
 
     expect(status).toBe('linked');
     const updateCall = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i);
@@ -202,10 +196,7 @@ describe('processRow', () => {
     (db.execute as jest.Mock).mockResolvedValueOnce([{ id: 100 }, { id: 101 }]);
     const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
 
-    const status = await processRow(
-      { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
-      { lookup }
-    );
+    const status = await processRow({ id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' }, { lookup });
 
     expect(status).toBe('multi_match');
     expect(findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i)).toBeUndefined();
@@ -218,10 +209,7 @@ describe('processRow', () => {
     (db.execute as jest.Mock).mockResolvedValueOnce([]);
     const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
 
-    const status = await processRow(
-      { id: 7, artist_name: 'Stereolab', album_title: 'Dots and Loops' },
-      { lookup }
-    );
+    const status = await processRow({ id: 7, artist_name: 'Stereolab', album_title: 'Dots and Loops' }, { lookup });
 
     expect(status).toBe('no_library_match');
     expect(findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i)).toBeUndefined();
@@ -232,10 +220,7 @@ describe('processRow', () => {
     // stamp linkage_source on them or B-3.1 misses them.
     const lookup = jest.fn(() => Promise.resolve(fallbackResponse(33)));
 
-    const status = await processRow(
-      { id: 7, artist_name: 'Jessica Pratt', album_title: 'On Your Own' },
-      { lookup }
-    );
+    const status = await processRow({ id: 7, artist_name: 'Jessica Pratt', album_title: 'On Your Own' }, { lookup });
 
     expect(status).toBe('review');
     expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
@@ -244,10 +229,7 @@ describe('processRow', () => {
   it('reports no_match on an empty LML response without writing', async () => {
     const lookup = jest.fn(() => Promise.resolve(emptyResponse()));
 
-    const status = await processRow(
-      { id: 7, artist_name: 'Unknown', album_title: 'Unknown' },
-      { lookup }
-    );
+    const status = await processRow({ id: 7, artist_name: 'Unknown', album_title: 'Unknown' }, { lookup });
 
     expect(status).toBe('no_match');
     expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
@@ -258,10 +240,7 @@ describe('processRow', () => {
     // removed from the retry pool and lose the eventual recovery.
     const lookup = jest.fn(() => Promise.reject(new Error('LML 502')));
 
-    const status = await processRow(
-      { id: 7, artist_name: 'Stereolab', album_title: 'Dots and Loops' },
-      { lookup }
-    );
+    const status = await processRow({ id: 7, artist_name: 'Stereolab', album_title: 'Dots and Loops' }, { lookup });
 
     expect(status).toBe('error');
     expect((db.execute as jest.Mock).mock.calls.length).toBe(0);

--- a/tests/unit/jobs/flowsheet-lml-link-backfill/resolve.test.ts
+++ b/tests/unit/jobs/flowsheet-lml-link-backfill/resolve.test.ts
@@ -15,10 +15,7 @@
  * library backfill. Future sources (MusicBrainz, etc.) get their own prefix.
  */
 
-import {
-  resolveLmlSignal,
-  AUTO_ACCEPT_CONFIDENCE,
-} from '../../../../jobs/flowsheet-lml-link-backfill/resolve';
+import { resolveLmlSignal, AUTO_ACCEPT_CONFIDENCE } from '../../../../jobs/flowsheet-lml-link-backfill/resolve';
 import type { LmlLookupResponse } from '../../../../jobs/flowsheet-lml-link-backfill/lml-types';
 
 const directResponse = (releaseId: number): LmlLookupResponse => ({
@@ -73,9 +70,24 @@ describe('resolveLmlSignal', () => {
   it('returns review on alternative / compilation / song_as_artist results', () => {
     // Anything non-empty that isn't a direct hit is gray-zone — surface to
     // review rather than guessing.
-    expect(resolveLmlSignal({ results: [{ library_item: { id: 1 }, artwork: { release_id: 1 } }], search_type: 'alternative' }).status).toBe('review');
-    expect(resolveLmlSignal({ results: [{ library_item: { id: 1 }, artwork: { release_id: 1 } }], search_type: 'compilation' }).status).toBe('review');
-    expect(resolveLmlSignal({ results: [{ library_item: { id: 1 }, artwork: { release_id: 1 } }], search_type: 'song_as_artist' }).status).toBe('review');
+    expect(
+      resolveLmlSignal({
+        results: [{ library_item: { id: 1 }, artwork: { release_id: 1 } }],
+        search_type: 'alternative',
+      }).status
+    ).toBe('review');
+    expect(
+      resolveLmlSignal({
+        results: [{ library_item: { id: 1 }, artwork: { release_id: 1 } }],
+        search_type: 'compilation',
+      }).status
+    ).toBe('review');
+    expect(
+      resolveLmlSignal({
+        results: [{ library_item: { id: 1 }, artwork: { release_id: 1 } }],
+        search_type: 'song_as_artist',
+      }).status
+    ).toBe('review');
   });
 
   it('returns no_match on an empty results set', () => {

--- a/tests/unit/jobs/flowsheet-lml-link-backfill/resolve.test.ts
+++ b/tests/unit/jobs/flowsheet-lml-link-backfill/resolve.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the B-2.2 per-row LML signal resolver.
+ *
+ * Mirrors the B-1.2 resolver's contract: maps an LML lookup response to one
+ * of three outcomes derived from the B-0 calibrated heuristic (issue #492):
+ *
+ *   - auto_accept — search_type=direct AND first result has artwork.release_id.
+ *   - review     — any non-empty result that isn't a direct hit (LML found
+ *                  *something* by the artist, but not the exact release).
+ *   - no_match   — empty result set, OR a direct match whose top result has
+ *                  no pinable Discogs release_id. Retried on the next sweep.
+ *
+ * The auto_accept canonical_entity_id is namespaced `discogs:<release_id>` so
+ * it joins the `library.canonical_entity_id` rows populated by the B-1.2
+ * library backfill. Future sources (MusicBrainz, etc.) get their own prefix.
+ */
+
+import {
+  resolveLmlSignal,
+  AUTO_ACCEPT_CONFIDENCE,
+} from '../../../../jobs/flowsheet-lml-link-backfill/resolve';
+import type { LmlLookupResponse } from '../../../../jobs/flowsheet-lml-link-backfill/lml-types';
+
+const directResponse = (releaseId: number): LmlLookupResponse => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id: releaseId } }],
+  search_type: 'direct',
+});
+
+const fallbackResponse = (releaseId: number): LmlLookupResponse => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id: releaseId } }],
+  search_type: 'fallback',
+});
+
+const emptyResponse = (): LmlLookupResponse => ({
+  results: [],
+  search_type: 'none',
+});
+
+describe('resolveLmlSignal', () => {
+  it('returns auto_accept on a direct hit with a Discogs release_id', () => {
+    // search_type=direct is the calibrated auto-accept signal (B-0). Without a
+    // pinable release_id we can't form a canonical_entity_id to join against
+    // library.canonical_entity_id, so we drop to no_match (see separate case).
+    const result = resolveLmlSignal(directResponse(987654));
+
+    expect(result.status).toBe('auto_accept');
+    if (result.status !== 'auto_accept') return;
+    expect(result.canonical_entity_id).toBe('discogs:987654');
+    expect(result.confidence).toBe(AUTO_ACCEPT_CONFIDENCE);
+  });
+
+  it('namespaces the canonical_entity_id with the discogs scheme', () => {
+    // Library rows populated by the B-1.2 backfill are stored with a
+    // `discogs:<release_id>` prefix. If this resolver drifts to a different
+    // scheme, the orchestrator's library lookup quietly returns zero matches
+    // for every row and the backfill writes nothing.
+    const result = resolveLmlSignal(directResponse(111));
+
+    expect(result.status).toBe('auto_accept');
+    if (result.status !== 'auto_accept') return;
+    expect(result.canonical_entity_id).toMatch(/^discogs:/);
+  });
+
+  it('returns review on a fallback hit', () => {
+    // B-0 calibration: search_type=fallback is "wrong-album-by-right-artist"
+    // — LML returns *something* by the artist when it can't find the release.
+    // These go to B-3.1 review, not auto-accept.
+    const result = resolveLmlSignal(fallbackResponse(33));
+
+    expect(result.status).toBe('review');
+  });
+
+  it('returns review on alternative / compilation / song_as_artist results', () => {
+    // Anything non-empty that isn't a direct hit is gray-zone — surface to
+    // review rather than guessing.
+    expect(resolveLmlSignal({ results: [{ library_item: { id: 1 }, artwork: { release_id: 1 } }], search_type: 'alternative' }).status).toBe('review');
+    expect(resolveLmlSignal({ results: [{ library_item: { id: 1 }, artwork: { release_id: 1 } }], search_type: 'compilation' }).status).toBe('review');
+    expect(resolveLmlSignal({ results: [{ library_item: { id: 1 }, artwork: { release_id: 1 } }], search_type: 'song_as_artist' }).status).toBe('review');
+  });
+
+  it('returns no_match on an empty results set', () => {
+    // 0 results = "discard, retry on next sweep" per B-0.
+    expect(resolveLmlSignal(emptyResponse()).status).toBe('no_match');
+  });
+
+  it('returns no_match on a direct hit without a pinable release_id', () => {
+    // A direct match whose top result has no artwork.release_id can't be
+    // pinned to a canonical entity. Retry on the next sweep — perhaps LML's
+    // cache has filled in by then.
+    const response: LmlLookupResponse = {
+      results: [{ library_item: { id: 1 } }],
+      search_type: 'direct',
+    };
+
+    expect(resolveLmlSignal(response).status).toBe('no_match');
+  });
+});


### PR DESCRIPTION
Closes #499

## Summary

Adds `jobs/flowsheet-lml-link-backfill/`, a one-shot worker that links the ~1.18M unlinked flowsheet rows to the library by routing each row through LML's canonical-entity resolver.

Targets:
- 889K rows that never had a `legacy_release_id` (manual DJ entries).
- ~290K rows with a `legacy_release_id` whose FK didn't resolve, stamped by B-0.5's `legacy_link_attempted_at`.

For each row the orchestrator calls `LML.lookupMetadata(artist, album)`, applies B-0's calibrated heuristic (auto-accept on `search_type=direct` with a Discogs `release_id`; review on fallback / alternative / compilation; no_match on empty), looks up library rows whose `canonical_entity_id` equals `discogs:<release_id>`, and stamps `album_id` + `linkage_source='lml_high_confidence'` + `linkage_confidence` + `linked_at` when exactly one library row matches.

Mirrors B-1.2's job shape (`jobs/library-canonical-entity-backfill/`):
- 500-row id-cursor batches; throttled at 100 ms between LML calls.
- Failure-tolerant: per-row LML errors are logged and counted, the loop continues.
- Resumable via the WHERE filter alone — linked rows fall out of `album_id IS NULL`; review / no_match / no_library_match / multi_match / error roll forward to the next sweep.
- Multi-match and tie-break are deferred to B-2.3 (out of scope per the issue).

## Test plan

- [x] Unit tests for the resolver (`tests/unit/jobs/flowsheet-lml-link-backfill/resolve.test.ts`) — covers each LML `search_type` branch and the no-`release_id` edge case.
- [x] Unit tests for the orchestrator (`tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts`) — covers `applyLink` SQL shape, library lookup, the six processRow outcomes, batch pagination, throttle, and the failure-tolerant loop.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run test:unit` all green locally.
- [ ] Stage smoke run on a small id range once the image is deployed.