### PR TITLE
Unblock deploy chain: replay 0064 mojibake + verifier allowlist

### DIFF
--- a/dev_env/init-db.mjs
+++ b/dev_env/init-db.mjs
@@ -119,6 +119,30 @@ async function runMigrations() {
  * independent check by comparing SHA-256 hashes of migration SQL files against
  * the hashes recorded in drizzle.__drizzle_migrations.
  */
+// Tags whose hash is expected NOT to appear in __drizzle_migrations.
+//
+// drizzle's migrator skipped these in production after a journal `when`
+// regression (see #550), and the cursor has since advanced past them.
+// They will never be applied — a follow-up "replay" migration carries
+// their effects under a fresh hash that does land. The verifier needs
+// to know which originals are intentionally absent so it doesn't fail
+// the migrate job for a state we cannot fix retroactively.
+//
+// Each entry is a journal `tag`; both the original and its replay are
+// listed in the comment so future contributors can find the connection.
+const EXPECTED_ABSENT_TAGS = new Set([
+  // 0054 was permanently skipped by drizzle after 0061's far-future
+  // `when` jumped the cursor. PR #551 added 0065 to replay the
+  // search_doc rewrite under a fresh hash.
+  '0054_flowsheet-search-doc-with-dj-name',
+  // 0064 was permanently skipped after commit 7f35fc39 lowered its
+  // `when` below the prod cursor (1779424000000) to match the prod
+  // __drizzle_migrations row that was inserted before the cursor
+  // landing. 0066 replays its mojibake UPDATE block (already idempotent
+  // by design — every UPDATE is keyed on the corrupted value).
+  '0064_propagate-v012-mojibake',
+]);
+
 async function verifyMigrations() {
   console.log(styleText(['bold'], '🔍 Verifying migration completeness...\n'));
 
@@ -143,8 +167,23 @@ async function verifyMigrations() {
   `;
   const appliedHashes = new Set(dbMigrations.map((m) => m.hash));
 
-  // Check for missing migrations
-  const missing = expectedMigrations.filter((m) => !appliedHashes.has(m.hash));
+  // Check for missing migrations, excluding entries we know will never apply
+  const missing = expectedMigrations.filter(
+    (m) => !appliedHashes.has(m.hash) && !EXPECTED_ABSENT_TAGS.has(m.tag),
+  );
+  const allowedAbsent = expectedMigrations.filter(
+    (m) => !appliedHashes.has(m.hash) && EXPECTED_ABSENT_TAGS.has(m.tag),
+  );
+
+  if (allowedAbsent.length > 0) {
+    console.warn(
+      styleText(['yellow'], `Note: ${allowedAbsent.length} journal entry(ies) intentionally absent from __drizzle_migrations:`),
+    );
+    for (const m of allowedAbsent) {
+      console.warn(`  - [idx ${m.idx}] ${m.tag} (replayed under a fresh hash)`);
+    }
+    console.warn('');
+  }
 
   if (missing.length > 0) {
     console.error('MIGRATION VERIFICATION FAILED!');
@@ -171,7 +210,8 @@ async function verifyMigrations() {
     prevTag = entry.tag;
   }
 
-  console.log(`All ${expectedMigrations.length} migrations verified as applied.\n`);
+  const verifiedCount = expectedMigrations.length - allowedAbsent.length;
+  console.log(`All ${verifiedCount} required migrations verified as applied${allowedAbsent.length ? ` (${allowedAbsent.length} allowlisted absent)` : ''}.\n`);
 }
 
 /**

--- a/dev_env/init-db.mjs
+++ b/dev_env/init-db.mjs
@@ -168,16 +168,15 @@ async function verifyMigrations() {
   const appliedHashes = new Set(dbMigrations.map((m) => m.hash));
 
   // Check for missing migrations, excluding entries we know will never apply
-  const missing = expectedMigrations.filter(
-    (m) => !appliedHashes.has(m.hash) && !EXPECTED_ABSENT_TAGS.has(m.tag),
-  );
-  const allowedAbsent = expectedMigrations.filter(
-    (m) => !appliedHashes.has(m.hash) && EXPECTED_ABSENT_TAGS.has(m.tag),
-  );
+  const missing = expectedMigrations.filter((m) => !appliedHashes.has(m.hash) && !EXPECTED_ABSENT_TAGS.has(m.tag));
+  const allowedAbsent = expectedMigrations.filter((m) => !appliedHashes.has(m.hash) && EXPECTED_ABSENT_TAGS.has(m.tag));
 
   if (allowedAbsent.length > 0) {
     console.warn(
-      styleText(['yellow'], `Note: ${allowedAbsent.length} journal entry(ies) intentionally absent from __drizzle_migrations:`),
+      styleText(
+        ['yellow'],
+        `Note: ${allowedAbsent.length} journal entry(ies) intentionally absent from __drizzle_migrations:`
+      )
     );
     for (const m of allowedAbsent) {
       console.warn(`  - [idx ${m.idx}] ${m.tag} (replayed under a fresh hash)`);
@@ -211,7 +210,9 @@ async function verifyMigrations() {
   }
 
   const verifiedCount = expectedMigrations.length - allowedAbsent.length;
-  console.log(`All ${verifiedCount} required migrations verified as applied${allowedAbsent.length ? ` (${allowedAbsent.length} allowlisted absent)` : ''}.\n`);
+  console.log(
+    `All ${verifiedCount} required migrations verified as applied${allowedAbsent.length ? ` (${allowedAbsent.length} allowlisted absent)` : ''}.\n`
+  );
 }
 
 /**

--- a/shared/database/src/migrations/0066_replay-mojibake-fixes.sql
+++ b/shared/database/src/migrations/0066_replay-mojibake-fixes.sql
@@ -1,0 +1,53 @@
+-- 0066: Replay 0064_propagate-v012-mojibake's mojibake fixes.
+--
+-- 0064's `when` was lowered (commit 7f35fc39) below the prod cursor
+-- (1779424000000), which made drizzle silently skip it. Bumping 0064's
+-- `when` back up would put it out of order with 0065 in the journal and
+-- trip the validator. Replaying as a new file at when > prod cursor is
+-- the same shape we used for 0054 -> 0065 in PR #551.
+--
+-- 0064's body was already idempotent — every UPDATE is keyed on the
+-- corrupted value, so a re-run leaves the corrected forms alone. This
+-- file is a verbatim copy from 0064 below the header. Verified locally.
+
+
+-- artist_name: 6 distinct values, 17 rows
+UPDATE wxyc_schema.flowsheet SET artist_name = 'μ-Ziq' WHERE artist_name = 'Î¼-Ziq';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'GrOun士 + Kabamix' WHERE artist_name = 'GrOunå£« + Kabamix';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Luboš Fišer' WHERE artist_name = 'LuboÅ¡ FiÅ¡er';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Mustafah ''Abd Al''-Azīz' WHERE artist_name = 'Mustafah ''Abd Al''-AzÄ«z';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Σtella, Las Palabras' WHERE artist_name = 'Î£tella, Las Palabras';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'μ-ziq' WHERE artist_name = 'Î¼-ziq';
+
+-- track_title: 17 distinct values, 23 rows
+UPDATE wxyc_schema.flowsheet SET track_title = 'ΩΩΩ' WHERE track_title = 'Î©Î©Î©';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Helvacı' WHERE track_title = 'HelvacÄ±';
+UPDATE wxyc_schema.flowsheet SET track_title = '｡.･BLUSH･.｡' WHERE track_title = 'ï½¡.ï½¥BLUSHï½¥.ï½¡';
+UPDATE wxyc_schema.flowsheet SET track_title = '400米' WHERE track_title = '400ç±³';
+UPDATE wxyc_schema.flowsheet SET track_title = '78 Yilinin En Uzun Dakikası' WHERE track_title = '78 Yilinin En Uzun DakikasÄ±';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Daša' WHERE track_title = 'DaÅ¡a';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Desgraca̧da' WHERE track_title = 'DesgracaÌ§da';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Gadżet elektroniczny' WHERE track_title = 'GadÅ¼et elektroniczny';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Hidden Power (Phase δ)' WHERE track_title = 'Hidden Power (Phase Î´)';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Još Jedna Crta' WHERE track_title = 'JoÅ¡ Jedna Crta';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Poznaješ Li Moje Pravo Lice' WHERE track_title = 'PoznajeÅ¡ Li Moje Pravo Lice';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Yalnızlar Rıhtımı' WHERE track_title = 'YalnÄ±zlar RÄ±htÄ±mÄ±';
+UPDATE wxyc_schema.flowsheet SET track_title = 'tno doɹp' WHERE track_title = 'tno doÉ¹p';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Ševa' WHERE track_title = 'Å eva';
+UPDATE wxyc_schema.flowsheet SET track_title = 'što me vikas, šefijo' WHERE track_title = 'Å¡to me vikas, Å¡efijo';
+UPDATE wxyc_schema.flowsheet SET track_title = 'два TWO' WHERE track_title = 'Ð´Ð²Ð° TWO';
+UPDATE wxyc_schema.flowsheet SET track_title = '夢中人' WHERE track_title = 'å¤¢ä¸­äºº';
+
+-- album_title: 7 distinct values, 9 rows
+UPDATE wxyc_schema.flowsheet SET album_title = 'د' WHERE album_title = 'Ø¯';
+UPDATE wxyc_schema.flowsheet SET album_title = '繭' WHERE album_title = 'ç¹­';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Atmospheres 第3' WHERE album_title = 'Atmospheres ç¬¬3';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Ege Bamyası' WHERE album_title = 'Ege BamyasÄ±';
+UPDATE wxyc_schema.flowsheet SET album_title = 'En Kotu İyi Olur' WHERE album_title = 'En Kotu Ä°yi Olur';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Škoda Mluvit' WHERE album_title = 'Å koda Mluvit';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Ψ 847' WHERE album_title = 'Î¨ 847';
+
+-- record_label: 3 distinct values, 3 rows
+UPDATE wxyc_schema.flowsheet SET record_label = 'Galerija ŠKUC Izdaja / Dark Entries' WHERE record_label = 'Galerija Å KUC Izdaja / Dark Entries';
+UPDATE wxyc_schema.flowsheet SET record_label = 'Više manje zauvijek' WHERE record_label = 'ViÅ¡e manje zauvijek';
+UPDATE wxyc_schema.flowsheet SET record_label = 'Ω' WHERE record_label = 'Î©';

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1779683200001,
       "tag": "0065_replay-flowsheet-search-doc-with-dj-name",
       "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1779683200002,
+      "tag": "0066_replay-mojibake-fixes",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

After #551 merged, the auto-deploy migrate step exited 1 because the post-migration verifier in \`dev_env/init-db.mjs\` reported two journal entries with no matching \`__drizzle_migrations\` row. drizzle's actual migration ran fine — 0065 applied and \`flowsheet.search_doc\` now has \`dj_name\` in production — but the verifier tipped the job to failure, which made \`deploy\` skip. Backend is still on \`v0.1.192\`.

The two flagged entries:

- **0054_flowsheet-search-doc-with-dj-name** — drizzle skipped this one in the cursor regression (#550). 0065 carries its effect; the original 0054 hash will never be inserted.
- **0064_propagate-v012-mojibake** — commit \`7f35fc39\` lowered 0064's \`when\` from 1779683200000 to 1778683200000 to match a hand-inserted prod row. That put it below the current prod cursor (1779424000000), so drizzle silently skipped it. The mojibake fixes never reached production.

This PR does two things:

1. **\`shared/database/src/migrations/0066_replay-mojibake-fixes.sql\`** — a verbatim copy of 0064's UPDATE block at \`when=1779683200002\` (above the new cursor of \`1779683200001\` set by 0065). Every UPDATE is value-keyed (\`WHERE col = 'corrupted_form'\`) so a re-run leaves the corrected rows alone — same idempotency 0064 was already designed for. Same shape we used for 0054 → 0065 in #551.
2. **\`dev_env/init-db.mjs\` grows \`EXPECTED_ABSENT_TAGS\`** — an allowlist for journal entries that will never have a matching hash because their effect lives under a different replay file. Verifier reports allowlisted absent entries as a note and only fails on hashes missing outside the allowlist. Each entry's comment ties it back to its replay so the link is greppable.

Closes #550 (the original cursor-skip bug, now fully recovered). Unblocks #517, #518, #519, #520, #521, #523, and the WXYC/wxyc-shared#82 epic — all of which need a successful deploy run.

## Why a replay instead of bumping 0064's \`when\`

Bumping 0064's \`when\` above the cursor would put it after 0065 in journal-array order while keeping idx=64. The validator's monotonic-\`when\` rule iterates the array in order, so any later contributor's natural-timestamp migration would trip on a now-out-of-order entry. Replay-as-0066 keeps the journal monotonic and idx-ordered, which is the same invariant #551's 0065 maintained.

## Test plan

- [x] \`scripts/validate-migrations.mjs\` passes (1 pre-existing allowlisted warning, 0 errors).
- [x] \`npm run typecheck\` clean.
- [x] \`npm run lint\` clean (0 errors).
- [x] **Local DB end-to-end:** \`npm run db:start\` applies all 66 journal entries to a fresh PostgreSQL — no skips, all hashes recorded.
- [ ] CI integration tests pass.
- [ ] After merge, watch \`Auto Build & Deploy\` for the merge commit; \`migrate\` runs 0066 idempotently (most rows already match the corrected form on local; on prod the 60 rows from the audit get fixed), the verifier passes (0054 + 0064 noted as allowlisted absent, all other hashes present), then \`deploy\` runs.
- [ ] After deploy, verify \`SELECT count(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'μ-Ziq'\` is non-zero in prod (one of the corrected forms from the audit).