### PR TITLE
Monitoring + observability: linkage metrics + Sentry tagging

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -9,6 +9,7 @@ type NewFSEntry = Omit<FullNewFSEntry, 'play_order'>;
 import * as flowsheet_service from '../services/flowsheet.service.js';
 import { fetchMetadata } from '../services/metadata/index.js';
 import { runLmlLinkage } from '../services/flowsheet-linkage.service.js';
+import { reportLinkageError } from '../services/linkage-metrics.service.js';
 import WxycError from '../utils/error.js';
 
 export type QueryParams = {
@@ -70,15 +71,20 @@ function fireAndForgetLinkage(completedEntry: FSEntry): void {
       );
     })
     .catch((err) => {
+      // Safety net: runLmlLinkage handles LML errors itself (counter +
+      // Sentry tag), so this only fires on unexpected bugs in the linkage
+      // path (e.g., a DB write throwing). Route through the same surface so
+      // the operator sees one consistent `subsystem='lml-linkage'` filter.
       console.error('[Flowsheet] LML linkage failed:', err);
-      Sentry.captureException(err, {
-        tags: { subsystem: 'flowsheet-linkage' },
-        extra: {
+      reportLinkageError(
+        err,
+        {
           flowsheetId: completedEntry.id,
           artistName: completedEntry.artist_name,
           albumTitle: completedEntry.album_title,
         },
-      });
+        { path: 'forward' }
+      );
     });
 }
 

--- a/apps/backend/services/flowsheet-linkage.service.ts
+++ b/apps/backend/services/flowsheet-linkage.service.ts
@@ -23,6 +23,11 @@ import { eq } from 'drizzle-orm';
 import { db, flowsheet, library } from '@wxyc/database';
 import { lookupMetadata } from './lml/lml.client.js';
 import { mapLookupToCanonicalEntity } from './library.service.js';
+import {
+  classifyLinkageError,
+  incrementLinkageMetric,
+  reportLinkageError,
+} from './linkage-metrics.service.js';
 
 const AUTO_ACCEPT_THRESHOLD = 0.9;
 
@@ -31,7 +36,8 @@ export type LinkageOutcome =
   | { status: 'no_canonical_entity' }
   | { status: 'low_confidence'; canonicalEntityId: string; confidence: number }
   | { status: 'no_library_match'; canonicalEntityId: string; confidence: number }
-  | { status: 'multi_match'; canonicalEntityId: string; confidence: number; libraryIds: number[] };
+  | { status: 'multi_match'; canonicalEntityId: string; confidence: number; libraryIds: number[] }
+  | { status: 'error'; error: unknown };
 
 async function findLibraryRowsByCanonicalEntity(canonicalEntityId: string): Promise<{ id: number }[]> {
   return db.select({ id: library.id }).from(library).where(eq(library.canonical_entity_id, canonicalEntityId));
@@ -60,19 +66,38 @@ export async function runLmlLinkage(args: {
   albumTitle: string | null | undefined;
 }): Promise<LinkageOutcome> {
   const { flowsheetId, artistName, albumTitle } = args;
-  const response = await lookupMetadata(artistName, albumTitle ?? undefined);
+
+  let response;
+  try {
+    response = await lookupMetadata(artistName, albumTitle ?? undefined);
+  } catch (error) {
+    // The forward path is fire-and-forget — we own error reporting here so
+    // the caller's `.catch` is only a safety net for unexpected bugs.
+    incrementLinkageMetric(classifyLinkageError(error));
+    reportLinkageError(error, { flowsheetId, artistName, albumTitle }, { path: 'forward' });
+    return { status: 'error', error };
+  }
+
   const linkage = mapLookupToCanonicalEntity(response);
-  if (!linkage) return { status: 'no_canonical_entity' };
+  if (!linkage) {
+    incrementLinkageMetric('no_candidate');
+    return { status: 'no_canonical_entity' };
+  }
   if (linkage.confidence < AUTO_ACCEPT_THRESHOLD) {
+    incrementLinkageMetric('gray_zone_review');
     return { status: 'low_confidence', canonicalEntityId: linkage.id, confidence: linkage.confidence };
   }
 
   const matches = await findLibraryRowsByCanonicalEntity(linkage.id);
   if (matches.length === 0) {
+    incrementLinkageMetric('no_candidate');
     return { status: 'no_library_match', canonicalEntityId: linkage.id, confidence: linkage.confidence };
   }
 
   if (matches.length > 1) {
+    // Multi-match defers to B-2.3 tie-break (or the B-3.1 review queue) —
+    // count it as review-bound on the dashboard, since linkage isn't applied.
+    incrementLinkageMetric('gray_zone_review');
     return {
       status: 'multi_match',
       canonicalEntityId: linkage.id,
@@ -82,6 +107,7 @@ export async function runLmlLinkage(args: {
   }
 
   await setFlowsheetLinkage(flowsheetId, matches[0].id, 'lml_high_confidence', linkage.confidence);
+  incrementLinkageMetric('linked_high_conf');
   return {
     status: 'linked',
     libraryId: matches[0].id,

--- a/apps/backend/services/flowsheet-linkage.service.ts
+++ b/apps/backend/services/flowsheet-linkage.service.ts
@@ -23,11 +23,7 @@ import { eq } from 'drizzle-orm';
 import { db, flowsheet, library } from '@wxyc/database';
 import { lookupMetadata } from './lml/lml.client.js';
 import { mapLookupToCanonicalEntity } from './library.service.js';
-import {
-  classifyLinkageError,
-  incrementLinkageMetric,
-  reportLinkageError,
-} from './linkage-metrics.service.js';
+import { classifyLinkageError, incrementLinkageMetric, reportLinkageError } from './linkage-metrics.service.js';
 
 const AUTO_ACCEPT_THRESHOLD = 0.9;
 

--- a/apps/backend/services/linkage-metrics.service.ts
+++ b/apps/backend/services/linkage-metrics.service.ts
@@ -1,0 +1,128 @@
+/**
+ * Observability surface for the LML-linkage path (B-3.2).
+ *
+ * Two readouts:
+ *   - In-process counters keyed by outcome name. B-2.1 (forward) and B-2.2
+ *     (backfill) both call `incrementLinkageMetric`. The counter map is
+ *     readable via `getLinkageCounters` and resettable via
+ *     `resetLinkageCounters` (used by tests; production never resets).
+ *   - SQL-backed gauges over the `flowsheet` table:
+ *       * `getCumulativeLinkageCoverage` — `count(*) FILTER (WHERE
+ *         album_id IS NOT NULL) / count(*)` across all track rows. Surfaces
+ *         on the dashboard so we can watch the gap close as B-2.2 sweeps run.
+ *       * `getRecentLinkageRate(hours)` — proxy for forward-path health:
+ *         of rows inserted in the last N hours, what fraction are linked?
+ *         A falling ratio means B-2.1's worker is falling behind.
+ *
+ * Errors from the linkage path go through `reportLinkageError`, which tags
+ * Sentry with `subsystem='lml-linkage'` so the operator can filter the issue
+ * stream by subsystem instead of by stack trace.
+ */
+import * as Sentry from '@sentry/node';
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+
+export const LINKAGE_METRIC_NAMES = [
+  'linked_high_conf',
+  'gray_zone_review',
+  'no_candidate',
+  'lml_error',
+  'lml_timeout',
+] as const;
+
+export type LinkageMetricName = (typeof LINKAGE_METRIC_NAMES)[number];
+
+const counters: Record<LinkageMetricName, number> = {
+  linked_high_conf: 0,
+  gray_zone_review: 0,
+  no_candidate: 0,
+  lml_error: 0,
+  lml_timeout: 0,
+};
+
+export const incrementLinkageMetric = (name: LinkageMetricName): void => {
+  counters[name] += 1;
+};
+
+export const getLinkageCounters = (): Record<LinkageMetricName, number> => ({ ...counters });
+
+export const resetLinkageCounters = (): void => {
+  for (const name of LINKAGE_METRIC_NAMES) counters[name] = 0;
+};
+
+/**
+ * Distinguish a transient LML timeout from a generic LML error. Timeouts are
+ * usually transient (cold start, network blip) and the backfill retries on
+ * the next sweep. Splitting the counters lets the operator tell those two
+ * failure modes apart at a glance.
+ */
+export const classifyLinkageError = (error: unknown): 'lml_timeout' | 'lml_error' => {
+  if (!error || typeof error !== 'object') return 'lml_error';
+  const e = error as { name?: unknown; code?: unknown; message?: unknown };
+  if (e.name === 'AbortError' || e.name === 'TimeoutError') return 'lml_timeout';
+  if (e.code === 'ETIMEDOUT' || e.code === 'ECONNABORTED' || e.code === 'UND_ERR_CONNECT_TIMEOUT') {
+    return 'lml_timeout';
+  }
+  if (typeof e.message === 'string' && /timeout/i.test(e.message)) return 'lml_timeout';
+  return 'lml_error';
+};
+
+export const reportLinkageError = (
+  error: unknown,
+  context?: Record<string, unknown>,
+  extraTags?: Record<string, string>
+): void => {
+  Sentry.captureException(error, {
+    tags: { subsystem: 'lml-linkage', ...(extraTags ?? {}) },
+    extra: context,
+  });
+};
+
+const toNumber = (value: unknown): number => {
+  if (value == null) return 0;
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+};
+
+export type LinkageCoverage = { linked: number; total: number; ratio: number };
+
+/**
+ * Cumulative linkage coverage across the entire `flowsheet` table, scoped
+ * to track entries (messages and breaks shouldn't move the gauge).
+ */
+export const getCumulativeLinkageCoverage = async (): Promise<LinkageCoverage> => {
+  const rows = (await db.execute(sql`
+    SELECT
+      count(*) FILTER (WHERE "album_id" IS NOT NULL) AS "linked",
+      count(*) AS "total"
+    FROM "wxyc_schema"."flowsheet"
+    WHERE "entry_type" = 'track'
+  `)) as unknown as Array<{ linked: number | string; total: number | string }>;
+
+  const linked = toNumber(rows?.[0]?.linked);
+  const total = toNumber(rows?.[0]?.total);
+  return { linked, total, ratio: total === 0 ? 0 : linked / total };
+};
+
+export type RecentLinkageRate = { inserted: number; linked: number; ratio: number };
+
+/**
+ * Forward-path health proxy. Of rows inserted in the last `hours` hours,
+ * what fraction are linked? B-2.1's worker should land linkage within
+ * minutes of insert; a sustained drop in this ratio means the worker is
+ * either erroring out or falling behind LML's rate budget.
+ */
+export const getRecentLinkageRate = async (hours: number): Promise<RecentLinkageRate> => {
+  const rows = (await db.execute(sql`
+    SELECT
+      count(*) AS "inserted",
+      count(*) FILTER (WHERE "album_id" IS NOT NULL) AS "linked"
+    FROM "wxyc_schema"."flowsheet"
+    WHERE "entry_type" = 'track'
+      AND "add_time" >= now() - make_interval(hours => ${hours})
+  `)) as unknown as Array<{ inserted: number | string; linked: number | string }>;
+
+  const inserted = toNumber(rows?.[0]?.inserted);
+  const linked = toNumber(rows?.[0]?.linked);
+  return { inserted, linked, ratio: inserted === 0 ? 0 : linked / inserted };
+};

--- a/jobs/flowsheet-lml-link-backfill/job.ts
+++ b/jobs/flowsheet-lml-link-backfill/job.ts
@@ -23,21 +23,58 @@
  * not the database.
  */
 
+import * as Sentry from '@sentry/node';
 import { closeDatabaseConnection } from '@wxyc/database';
-import { runBackfill } from './orchestrate.js';
+import { runBackfill, type LinkageMetricName, type MetricsSink } from './orchestrate.js';
 import { lookupMetadata } from './lml-fetch.js';
 
 const JOB_NAME = 'flowsheet-lml-link-backfill';
 
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  release: process.env.SENTRY_RELEASE,
+  environment: process.env.NODE_ENV || 'production',
+});
+
+/**
+ * Production metrics sink for the backfill job (B-3.2). The orchestrator's
+ * per-batch `Totals` log already gives the operator a per-run scoreboard;
+ * this sink ships per-row counters under the canonical observability names
+ * shared with the forward path, plus Sentry tagging on every LML failure
+ * (`subsystem='lml-linkage'`, `path='backfill'`).
+ */
+const counters: Record<LinkageMetricName, number> = {
+  linked_high_conf: 0,
+  gray_zone_review: 0,
+  no_candidate: 0,
+  lml_error: 0,
+  lml_timeout: 0,
+};
+
+const metrics: MetricsSink = {
+  recordOutcome(name) {
+    counters[name] += 1;
+  },
+  reportError(error, context) {
+    Sentry.captureException(error, {
+      tags: { subsystem: 'lml-linkage', path: 'backfill' },
+      extra: context,
+    });
+  },
+};
+
 const main = async () => {
   try {
-    await runBackfill({ lookup: lookupMetadata });
+    await runBackfill({ lookup: lookupMetadata, metrics });
+    console.log(`[${JOB_NAME}] linkage counters:`, counters);
   } finally {
     await closeDatabaseConnection();
+    await Sentry.close(2000);
   }
 };
 
 main().catch((error) => {
   console.error(`[${JOB_NAME}] Failed:`, error);
+  Sentry.captureException(error, { tags: { subsystem: 'lml-linkage', path: 'backfill' } });
   process.exitCode = 1;
 });

--- a/jobs/flowsheet-lml-link-backfill/orchestrate.ts
+++ b/jobs/flowsheet-lml-link-backfill/orchestrate.ts
@@ -50,6 +50,45 @@ export type FlowsheetRow = {
 
 export type LookupFn = (artist: string, album?: string) => Promise<LmlLookupResponse>;
 
+/**
+ * Five canonical observability counter names shared with the forward path
+ * (B-2.1). The dashboard keys on these names; renaming or adding one without
+ * a coordinated dashboard change silently breaks the surface.
+ */
+export type LinkageMetricName =
+  | 'linked_high_conf'
+  | 'gray_zone_review'
+  | 'no_candidate'
+  | 'lml_error'
+  | 'lml_timeout';
+
+/**
+ * Injection seam for B-3.2. The orchestrator is library-pure (no Sentry
+ * import) and the production wiring in `job.ts` adapts these calls to the
+ * real Sentry SDK with `subsystem='lml-linkage'`, `path='backfill'` tags.
+ * Tests pass jest mocks; CLI / legacy callers omit the field and get a no-op.
+ */
+export interface MetricsSink {
+  recordOutcome(name: LinkageMetricName): void;
+  reportError(error: unknown, context?: Record<string, unknown>): void;
+}
+
+const NULL_METRICS: MetricsSink = {
+  recordOutcome: () => {},
+  reportError: () => {},
+};
+
+const classifyLinkageError = (error: unknown): 'lml_timeout' | 'lml_error' => {
+  if (!error || typeof error !== 'object') return 'lml_error';
+  const e = error as { name?: unknown; code?: unknown; message?: unknown };
+  if (e.name === 'AbortError' || e.name === 'TimeoutError') return 'lml_timeout';
+  if (e.code === 'ETIMEDOUT' || e.code === 'ECONNABORTED' || e.code === 'UND_ERR_CONNECT_TIMEOUT') {
+    return 'lml_timeout';
+  }
+  if (typeof e.message === 'string' && /timeout/i.test(e.message)) return 'lml_timeout';
+  return 'lml_error';
+};
+
 export type ProcessStatus = 'linked' | 'multi_match' | 'no_library_match' | 'review' | 'no_match' | 'error';
 
 export type Totals = {
@@ -105,11 +144,16 @@ export const findLibraryByCanonicalEntity = async (canonicalEntityId: string): P
  * apply. Returns the outcome. Errors are logged and consumed; they do not
  * bubble up so a single bad row cannot abort the run.
  */
-export const processRow = async (row: FlowsheetRow, deps: { lookup: LookupFn }): Promise<ProcessStatus> => {
+export const processRow = async (
+  row: FlowsheetRow,
+  deps: { lookup: LookupFn; metrics?: MetricsSink }
+): Promise<ProcessStatus> => {
+  const metrics = deps.metrics ?? NULL_METRICS;
   const artist = row.artist_name ?? '';
   const album = row.album_title ?? undefined;
 
   if (!artist || !album) {
+    metrics.recordOutcome('no_candidate');
     return 'no_match';
   }
 
@@ -118,22 +162,39 @@ export const processRow = async (row: FlowsheetRow, deps: { lookup: LookupFn }):
     response = await deps.lookup(artist, album);
   } catch (error) {
     console.warn(`[${JOB_NAME}] LML lookup failed for flowsheet.id=${row.id}:`, (error as Error).message);
+    metrics.recordOutcome(classifyLinkageError(error));
+    metrics.reportError(error, { flowsheetId: row.id, artistName: artist, albumTitle: album });
     return 'error';
   }
 
   const signal = resolveLmlSignal(response);
-  if (signal.status === 'review') return 'review';
-  if (signal.status === 'no_match') return 'no_match';
+  if (signal.status === 'review') {
+    metrics.recordOutcome('gray_zone_review');
+    return 'review';
+  }
+  if (signal.status === 'no_match') {
+    metrics.recordOutcome('no_candidate');
+    return 'no_match';
+  }
 
   const libraryIds = await findLibraryByCanonicalEntity(signal.canonical_entity_id);
-  if (libraryIds.length === 0) return 'no_library_match';
-  if (libraryIds.length > 1) return 'multi_match';
+  if (libraryIds.length === 0) {
+    metrics.recordOutcome('no_candidate');
+    return 'no_library_match';
+  }
+  if (libraryIds.length > 1) {
+    // Multi-match defers to B-2.3 tie-break — review-bound from the
+    // dashboard's perspective since linkage isn't applied here.
+    metrics.recordOutcome('gray_zone_review');
+    return 'multi_match';
+  }
 
   await applyLink({
     flowsheetId: row.id,
     libraryId: libraryIds[0],
     confidence: signal.confidence,
   });
+  metrics.recordOutcome('linked_high_conf');
   return 'linked';
 };
 
@@ -171,9 +232,11 @@ export const runBackfill = async (opts: {
   lookup: LookupFn;
   batchSize?: number;
   throttleMs?: number;
+  metrics?: MetricsSink;
 }): Promise<RunResult> => {
   const batchSize = opts.batchSize ?? BATCH_SIZE;
   const throttleMs = opts.throttleMs ?? THROTTLE_MS;
+  const metrics = opts.metrics ?? NULL_METRICS;
 
   console.log(`[${JOB_NAME}] Starting. batchSize=${batchSize} throttleMs=${throttleMs}`);
 
@@ -195,7 +258,7 @@ export const runBackfill = async (opts: {
 
     batchIndex += 1;
     for (const row of rows) {
-      const status = await processRow(row, { lookup: opts.lookup });
+      const status = await processRow(row, { lookup: opts.lookup, metrics });
       totals.scanned += 1;
       totals[status] += 1;
       lastId = row.id;

--- a/jobs/flowsheet-lml-link-backfill/orchestrate.ts
+++ b/jobs/flowsheet-lml-link-backfill/orchestrate.ts
@@ -55,12 +55,7 @@ export type LookupFn = (artist: string, album?: string) => Promise<LmlLookupResp
  * (B-2.1). The dashboard keys on these names; renaming or adding one without
  * a coordinated dashboard change silently breaks the surface.
  */
-export type LinkageMetricName =
-  | 'linked_high_conf'
-  | 'gray_zone_review'
-  | 'no_candidate'
-  | 'lml_error'
-  | 'lml_timeout';
+export type LinkageMetricName = 'linked_high_conf' | 'gray_zone_review' | 'no_candidate' | 'lml_error' | 'lml_timeout';
 
 /**
  * Injection seam for B-3.2. The orchestrator is library-pure (no Sentry

--- a/jobs/flowsheet-lml-link-backfill/package.json
+++ b/jobs/flowsheet-lml-link-backfill/package.json
@@ -14,6 +14,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@sentry/node": "^10.50.0",
     "@wxyc/database": "^1.0.0"
   },
   "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -502,6 +502,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@sentry/node": "^10.50.0",
         "@wxyc/database": "^1.0.0"
       },
       "devDependencies": {

--- a/tests/unit/jobs/flowsheet-lml-link-backfill/metrics.test.ts
+++ b/tests/unit/jobs/flowsheet-lml-link-backfill/metrics.test.ts
@@ -46,10 +46,8 @@ describe('processRow metrics integration (B-3.2)', () => {
     jest.restoreAllMocks();
   });
 
-  it("records linked_high_conf when one library row matches a direct hit", async () => {
-    (db.execute as jest.Mock)
-      .mockResolvedValueOnce([{ id: 100 }])
-      .mockResolvedValueOnce({ count: 1 });
+  it('records linked_high_conf when one library row matches a direct hit', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ id: 100 }]).mockResolvedValueOnce({ count: 1 });
     const { sink, recordOutcome } = makeMetrics();
     const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
 
@@ -58,7 +56,7 @@ describe('processRow metrics integration (B-3.2)', () => {
     expect(recordOutcome).toHaveBeenCalledWith('linked_high_conf');
   });
 
-  it("records gray_zone_review on a fallback hit (review-bound)", async () => {
+  it('records gray_zone_review on a fallback hit (review-bound)', async () => {
     const { sink, recordOutcome } = makeMetrics();
     const lookup = jest.fn(() => Promise.resolve(fallbackResponse(33)));
 
@@ -67,7 +65,7 @@ describe('processRow metrics integration (B-3.2)', () => {
     expect(recordOutcome).toHaveBeenCalledWith('gray_zone_review');
   });
 
-  it("records gray_zone_review on multi_match (defers to B-2.3 / review)", async () => {
+  it('records gray_zone_review on multi_match (defers to B-2.3 / review)', async () => {
     // The orchestrator returns 'multi_match' and does not stamp the row.
     // From the dashboard's perspective, it's an unresolved candidate that a
     // human or B-2.3 has to break — same bucket as low-confidence review.
@@ -80,7 +78,7 @@ describe('processRow metrics integration (B-3.2)', () => {
     expect(recordOutcome).toHaveBeenCalledWith('gray_zone_review');
   });
 
-  it("records no_candidate on no_library_match", async () => {
+  it('records no_candidate on no_library_match', async () => {
     (db.execute as jest.Mock).mockResolvedValueOnce([]);
     const { sink, recordOutcome } = makeMetrics();
     const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
@@ -90,7 +88,7 @@ describe('processRow metrics integration (B-3.2)', () => {
     expect(recordOutcome).toHaveBeenCalledWith('no_candidate');
   });
 
-  it("records no_candidate on no_match (LML returned nothing)", async () => {
+  it('records no_candidate on no_match (LML returned nothing)', async () => {
     const { sink, recordOutcome } = makeMetrics();
     const lookup = jest.fn(() => Promise.resolve(emptyResponse()));
 
@@ -99,7 +97,7 @@ describe('processRow metrics integration (B-3.2)', () => {
     expect(recordOutcome).toHaveBeenCalledWith('no_candidate');
   });
 
-  it("records no_candidate when a row lacks artist or album text (filtered out before LML)", async () => {
+  it('records no_candidate when a row lacks artist or album text (filtered out before LML)', async () => {
     // The orchestrator short-circuits these to 'no_match' without calling
     // LML. From the metric's perspective, no candidate produced.
     const { sink, recordOutcome } = makeMetrics();
@@ -111,7 +109,7 @@ describe('processRow metrics integration (B-3.2)', () => {
     expect(lookup).not.toHaveBeenCalled();
   });
 
-  it("records lml_error and reports the error on a generic LML failure", async () => {
+  it('records lml_error and reports the error on a generic LML failure', async () => {
     const err = new Error('LML 502');
     const { sink, recordOutcome, reportError } = makeMetrics();
     const lookup = jest.fn(() => Promise.reject(err));
@@ -123,7 +121,7 @@ describe('processRow metrics integration (B-3.2)', () => {
     expect(reportError).toHaveBeenCalledWith(err, expect.objectContaining({ flowsheetId: 7 }));
   });
 
-  it("records lml_timeout (not lml_error) on AbortError-style timeouts", async () => {
+  it('records lml_timeout (not lml_error) on AbortError-style timeouts', async () => {
     const err = Object.assign(new Error('aborted'), { name: 'AbortError' });
     const { sink, recordOutcome, reportError } = makeMetrics();
     const lookup = jest.fn(() => Promise.reject(err));
@@ -134,13 +132,11 @@ describe('processRow metrics integration (B-3.2)', () => {
     expect(reportError).toHaveBeenCalled();
   });
 
-  it("works without a metrics sink (sink is optional — tests/CLI runs are unaffected)", async () => {
+  it('works without a metrics sink (sink is optional — tests/CLI runs are unaffected)', async () => {
     // The existing orchestrate tests do not pass a sink. Adding the sink as
     // required would break every prior call site. The default must be a
     // silent no-op so old wiring still works.
-    (db.execute as jest.Mock)
-      .mockResolvedValueOnce([{ id: 100 }])
-      .mockResolvedValueOnce({ count: 1 });
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ id: 100 }]).mockResolvedValueOnce({ count: 1 });
     const lookup = jest.fn(() => Promise.resolve(directResponse(123)));
 
     const status = await processRow({ id: 7, artist_name: 'a', album_title: 'b' }, { lookup });
@@ -160,7 +156,7 @@ describe('runBackfill metrics integration (B-3.2)', () => {
     jest.restoreAllMocks();
   });
 
-  it("threads the metrics sink through to every row processed", async () => {
+  it('threads the metrics sink through to every row processed', async () => {
     (db.execute as jest.Mock)
       .mockResolvedValueOnce([
         { id: 1, artist_name: 'a', album_title: 'a' },

--- a/tests/unit/jobs/flowsheet-lml-link-backfill/metrics.test.ts
+++ b/tests/unit/jobs/flowsheet-lml-link-backfill/metrics.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for the B-2.2 backfill observability wiring (B-3.2).
+ *
+ * The orchestrator already keeps internal `Totals` for the run report. On
+ * top of that, B-3.2 adds an injectable `metrics` sink so each row outcome
+ * surfaces under one of the five canonical observability counter names —
+ * `linked_high_conf`, `gray_zone_review`, `no_candidate`, `lml_error`,
+ * `lml_timeout` — and so each LML failure routes to Sentry with
+ * `subsystem='lml-linkage'`, `path='backfill'` from the job's wiring (in
+ * `job.ts`, not under test here — the orchestrator only sees the sink).
+ */
+
+import { db } from '@wxyc/database';
+import { processRow, runBackfill } from '../../../../jobs/flowsheet-lml-link-backfill/orchestrate';
+import type { LmlLookupResponse } from '../../../../jobs/flowsheet-lml-link-backfill/lml-types';
+
+const directResponse = (releaseId: number): LmlLookupResponse => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id: releaseId } }],
+  search_type: 'direct',
+});
+
+const fallbackResponse = (releaseId: number): LmlLookupResponse => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id: releaseId } }],
+  search_type: 'fallback',
+});
+
+const emptyResponse = (): LmlLookupResponse => ({
+  results: [],
+  search_type: 'none',
+});
+
+const makeMetrics = () => {
+  const recordOutcome = jest.fn();
+  const reportError = jest.fn();
+  return { sink: { recordOutcome, reportError }, recordOutcome, reportError };
+};
+
+describe('processRow metrics integration (B-3.2)', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("records linked_high_conf when one library row matches a direct hit", async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([{ id: 100 }])
+      .mockResolvedValueOnce({ count: 1 });
+    const { sink, recordOutcome } = makeMetrics();
+    const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
+
+    await processRow({ id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' }, { lookup, metrics: sink });
+
+    expect(recordOutcome).toHaveBeenCalledWith('linked_high_conf');
+  });
+
+  it("records gray_zone_review on a fallback hit (review-bound)", async () => {
+    const { sink, recordOutcome } = makeMetrics();
+    const lookup = jest.fn(() => Promise.resolve(fallbackResponse(33)));
+
+    await processRow({ id: 7, artist_name: 'Jessica Pratt', album_title: 'On Your Own' }, { lookup, metrics: sink });
+
+    expect(recordOutcome).toHaveBeenCalledWith('gray_zone_review');
+  });
+
+  it("records gray_zone_review on multi_match (defers to B-2.3 / review)", async () => {
+    // The orchestrator returns 'multi_match' and does not stamp the row.
+    // From the dashboard's perspective, it's an unresolved candidate that a
+    // human or B-2.3 has to break — same bucket as low-confidence review.
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ id: 100 }, { id: 101 }]);
+    const { sink, recordOutcome } = makeMetrics();
+    const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
+
+    await processRow({ id: 7, artist_name: 'Stereolab', album_title: 'Aluminum Tunes' }, { lookup, metrics: sink });
+
+    expect(recordOutcome).toHaveBeenCalledWith('gray_zone_review');
+  });
+
+  it("records no_candidate on no_library_match", async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+    const { sink, recordOutcome } = makeMetrics();
+    const lookup = jest.fn(() => Promise.resolve(directResponse(987654)));
+
+    await processRow({ id: 7, artist_name: 'Stereolab', album_title: 'Dots and Loops' }, { lookup, metrics: sink });
+
+    expect(recordOutcome).toHaveBeenCalledWith('no_candidate');
+  });
+
+  it("records no_candidate on no_match (LML returned nothing)", async () => {
+    const { sink, recordOutcome } = makeMetrics();
+    const lookup = jest.fn(() => Promise.resolve(emptyResponse()));
+
+    await processRow({ id: 7, artist_name: 'Unknown', album_title: 'Unknown' }, { lookup, metrics: sink });
+
+    expect(recordOutcome).toHaveBeenCalledWith('no_candidate');
+  });
+
+  it("records no_candidate when a row lacks artist or album text (filtered out before LML)", async () => {
+    // The orchestrator short-circuits these to 'no_match' without calling
+    // LML. From the metric's perspective, no candidate produced.
+    const { sink, recordOutcome } = makeMetrics();
+    const lookup = jest.fn();
+
+    await processRow({ id: 7, artist_name: '', album_title: null }, { lookup, metrics: sink });
+
+    expect(recordOutcome).toHaveBeenCalledWith('no_candidate');
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it("records lml_error and reports the error on a generic LML failure", async () => {
+    const err = new Error('LML 502');
+    const { sink, recordOutcome, reportError } = makeMetrics();
+    const lookup = jest.fn(() => Promise.reject(err));
+
+    const status = await processRow({ id: 7, artist_name: 'a', album_title: 'b' }, { lookup, metrics: sink });
+
+    expect(status).toBe('error');
+    expect(recordOutcome).toHaveBeenCalledWith('lml_error');
+    expect(reportError).toHaveBeenCalledWith(err, expect.objectContaining({ flowsheetId: 7 }));
+  });
+
+  it("records lml_timeout (not lml_error) on AbortError-style timeouts", async () => {
+    const err = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    const { sink, recordOutcome, reportError } = makeMetrics();
+    const lookup = jest.fn(() => Promise.reject(err));
+
+    await processRow({ id: 7, artist_name: 'a', album_title: 'b' }, { lookup, metrics: sink });
+
+    expect(recordOutcome).toHaveBeenCalledWith('lml_timeout');
+    expect(reportError).toHaveBeenCalled();
+  });
+
+  it("works without a metrics sink (sink is optional — tests/CLI runs are unaffected)", async () => {
+    // The existing orchestrate tests do not pass a sink. Adding the sink as
+    // required would break every prior call site. The default must be a
+    // silent no-op so old wiring still works.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([{ id: 100 }])
+      .mockResolvedValueOnce({ count: 1 });
+    const lookup = jest.fn(() => Promise.resolve(directResponse(123)));
+
+    const status = await processRow({ id: 7, artist_name: 'a', album_title: 'b' }, { lookup });
+
+    expect(status).toBe('linked');
+  });
+});
+
+describe('runBackfill metrics integration (B-3.2)', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("threads the metrics sink through to every row processed", async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'a', album_title: 'a' },
+        { id: 2, artist_name: 'b', album_title: 'b' },
+      ])
+      .mockResolvedValueOnce([]);
+    const { sink, recordOutcome } = makeMetrics();
+    const lookup = jest.fn(() => Promise.resolve(emptyResponse()));
+
+    await runBackfill({ lookup, throttleMs: 0, metrics: sink });
+
+    expect(recordOutcome).toHaveBeenCalledTimes(2);
+    expect(recordOutcome).toHaveBeenCalledWith('no_candidate');
+  });
+});

--- a/tests/unit/services/flowsheet-linkage.metrics.test.ts
+++ b/tests/unit/services/flowsheet-linkage.metrics.test.ts
@@ -20,10 +20,7 @@ jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
 }));
 
 import { runLmlLinkage } from '../../../apps/backend/services/flowsheet-linkage.service';
-import {
-  getLinkageCounters,
-  resetLinkageCounters,
-} from '../../../apps/backend/services/linkage-metrics.service';
+import { getLinkageCounters, resetLinkageCounters } from '../../../apps/backend/services/linkage-metrics.service';
 
 const directMatch = (release_id: number) => ({
   results: [{ library_item: { id: 1 }, artwork: { release_id, release_url: '', confidence: 0 } }],
@@ -52,7 +49,7 @@ describe('runLmlLinkage observability (B-3.2)', () => {
     resetLinkageCounters();
   });
 
-  it("increments linked_high_conf when a direct match resolves to one library row", async () => {
+  it('increments linked_high_conf when a direct match resolves to one library row', async () => {
     mockLookupMetadata.mockResolvedValue(directMatch(123456));
     const selectChain = createMockQueryChain();
     selectChain.where.mockResolvedValue([{ id: 88 }]);
@@ -66,7 +63,7 @@ describe('runLmlLinkage observability (B-3.2)', () => {
     expect(getLinkageCounters().no_candidate).toBe(0);
   });
 
-  it("increments gray_zone_review on a fallback (low-confidence) match", async () => {
+  it('increments gray_zone_review on a fallback (low-confidence) match', async () => {
     mockLookupMetadata.mockResolvedValue(fallbackMatch(987));
 
     await runLmlLinkage({ flowsheetId: 7, artistName: 'Andy Stott', albumTitle: 'Faith' });
@@ -75,7 +72,7 @@ describe('runLmlLinkage observability (B-3.2)', () => {
     expect(getLinkageCounters().linked_high_conf).toBe(0);
   });
 
-  it("increments no_candidate when LML returns no canonical entity", async () => {
+  it('increments no_candidate when LML returns no canonical entity', async () => {
     mockLookupMetadata.mockResolvedValue(noneMatch());
 
     await runLmlLinkage({ flowsheetId: 7, artistName: 'Unknown', albumTitle: 'Unknown' });
@@ -83,7 +80,7 @@ describe('runLmlLinkage observability (B-3.2)', () => {
     expect(getLinkageCounters().no_candidate).toBe(1);
   });
 
-  it("increments no_candidate when canonical entity exists but no library row carries it", async () => {
+  it('increments no_candidate when canonical entity exists but no library row carries it', async () => {
     mockLookupMetadata.mockResolvedValue(directMatch(555));
     const selectChain = createMockQueryChain();
     selectChain.where.mockResolvedValue([]);
@@ -94,7 +91,7 @@ describe('runLmlLinkage observability (B-3.2)', () => {
     expect(getLinkageCounters().no_candidate).toBe(1);
   });
 
-  it("increments gray_zone_review on multi_match (defers to B-2.3 / review)", async () => {
+  it('increments gray_zone_review on multi_match (defers to B-2.3 / review)', async () => {
     // Multiple library rows under one canonical entity = a tie-break decision
     // a human or B-2.3 has to make. The dashboard treats it as review-bound
     // so the gauge captures the gap between "LML matched" and "linkage applied".
@@ -125,7 +122,7 @@ describe('runLmlLinkage observability (B-3.2)', () => {
     );
   });
 
-  it("increments lml_timeout (not lml_error) when the LML call times out", async () => {
+  it('increments lml_timeout (not lml_error) when the LML call times out', async () => {
     // Splitting the two failure modes lets the operator distinguish "LML
     // is slow / cold" (transient, retried on next sweep) from "linkage code
     // is broken" (needs a human).
@@ -140,7 +137,7 @@ describe('runLmlLinkage observability (B-3.2)', () => {
     expect(mockCaptureException).toHaveBeenCalledWith(err, expect.anything());
   });
 
-  it("never writes album_id on the error path (row stays NULL for the next sweep)", async () => {
+  it('never writes album_id on the error path (row stays NULL for the next sweep)', async () => {
     mockLookupMetadata.mockRejectedValue(new Error('boom'));
 
     await runLmlLinkage({ flowsheetId: 7, artistName: 'a', albumTitle: 'b' });

--- a/tests/unit/services/flowsheet-linkage.metrics.test.ts
+++ b/tests/unit/services/flowsheet-linkage.metrics.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for forward-path observability wiring (B-3.2).
+ *
+ * Each outcome of `runLmlLinkage` increments exactly one counter; an LML
+ * error reports to Sentry with `subsystem='lml-linkage'` and `path='forward'`
+ * (so the operator can split the issue stream by forward-vs-backfill) and
+ * surfaces as either `lml_timeout` or `lml_error` depending on the error
+ * shape.
+ */
+import { jest } from '@jest/globals';
+import { db, createMockQueryChain } from '../../mocks/database.mock';
+
+const mockCaptureException = jest.fn();
+jest.mock('@sentry/node', () => ({ captureException: mockCaptureException }));
+
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
+jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  isLmlConfigured: jest.fn().mockReturnValue(true),
+}));
+
+import { runLmlLinkage } from '../../../apps/backend/services/flowsheet-linkage.service';
+import {
+  getLinkageCounters,
+  resetLinkageCounters,
+} from '../../../apps/backend/services/linkage-metrics.service';
+
+const directMatch = (release_id: number) => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id, release_url: '', confidence: 0 } }],
+  search_type: 'direct',
+  song_not_found: false,
+  found_on_compilation: false,
+});
+
+const fallbackMatch = (release_id: number) => ({
+  results: [{ library_item: { id: 1 }, artwork: { release_id, release_url: '', confidence: 0 } }],
+  search_type: 'fallback',
+  song_not_found: false,
+  found_on_compilation: false,
+});
+
+const noneMatch = () => ({
+  results: [],
+  search_type: 'none',
+  song_not_found: false,
+  found_on_compilation: false,
+});
+
+describe('runLmlLinkage observability (B-3.2)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetLinkageCounters();
+  });
+
+  it("increments linked_high_conf when a direct match resolves to one library row", async () => {
+    mockLookupMetadata.mockResolvedValue(directMatch(123456));
+    const selectChain = createMockQueryChain();
+    selectChain.where.mockResolvedValue([{ id: 88 }]);
+    db.select.mockReturnValueOnce(selectChain);
+    db.update.mockReturnValueOnce(createMockQueryChain());
+
+    await runLmlLinkage({ flowsheetId: 7, artistName: 'Juana Molina', albumTitle: 'DOGA' });
+
+    expect(getLinkageCounters().linked_high_conf).toBe(1);
+    expect(getLinkageCounters().gray_zone_review).toBe(0);
+    expect(getLinkageCounters().no_candidate).toBe(0);
+  });
+
+  it("increments gray_zone_review on a fallback (low-confidence) match", async () => {
+    mockLookupMetadata.mockResolvedValue(fallbackMatch(987));
+
+    await runLmlLinkage({ flowsheetId: 7, artistName: 'Andy Stott', albumTitle: 'Faith' });
+
+    expect(getLinkageCounters().gray_zone_review).toBe(1);
+    expect(getLinkageCounters().linked_high_conf).toBe(0);
+  });
+
+  it("increments no_candidate when LML returns no canonical entity", async () => {
+    mockLookupMetadata.mockResolvedValue(noneMatch());
+
+    await runLmlLinkage({ flowsheetId: 7, artistName: 'Unknown', albumTitle: 'Unknown' });
+
+    expect(getLinkageCounters().no_candidate).toBe(1);
+  });
+
+  it("increments no_candidate when canonical entity exists but no library row carries it", async () => {
+    mockLookupMetadata.mockResolvedValue(directMatch(555));
+    const selectChain = createMockQueryChain();
+    selectChain.where.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(selectChain);
+
+    await runLmlLinkage({ flowsheetId: 7, artistName: 'Jessica Pratt', albumTitle: 'Quiet Signs' });
+
+    expect(getLinkageCounters().no_candidate).toBe(1);
+  });
+
+  it("increments gray_zone_review on multi_match (defers to B-2.3 / review)", async () => {
+    // Multiple library rows under one canonical entity = a tie-break decision
+    // a human or B-2.3 has to make. The dashboard treats it as review-bound
+    // so the gauge captures the gap between "LML matched" and "linkage applied".
+    mockLookupMetadata.mockResolvedValue(directMatch(42));
+    const selectChain = createMockQueryChain();
+    selectChain.where.mockResolvedValue([{ id: 10 }, { id: 11 }]);
+    db.select.mockReturnValueOnce(selectChain);
+
+    await runLmlLinkage({ flowsheetId: 7, artistName: 'Stereolab', albumTitle: 'Aluminum Tunes' });
+
+    expect(getLinkageCounters().gray_zone_review).toBe(1);
+  });
+
+  it("increments lml_error and reports Sentry with subsystem='lml-linkage' on a generic LML failure", async () => {
+    const err = new Error('LML 502 Bad Gateway');
+    mockLookupMetadata.mockRejectedValue(err);
+
+    const outcome = await runLmlLinkage({ flowsheetId: 7, artistName: 'Stereolab', albumTitle: 'Dots' });
+
+    expect(outcome).toEqual(expect.objectContaining({ status: 'error' }));
+    expect(getLinkageCounters().lml_error).toBe(1);
+    expect(getLinkageCounters().lml_timeout).toBe(0);
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({
+        tags: expect.objectContaining({ subsystem: 'lml-linkage', path: 'forward' }),
+      })
+    );
+  });
+
+  it("increments lml_timeout (not lml_error) when the LML call times out", async () => {
+    // Splitting the two failure modes lets the operator distinguish "LML
+    // is slow / cold" (transient, retried on next sweep) from "linkage code
+    // is broken" (needs a human).
+    const err = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    mockLookupMetadata.mockRejectedValue(err);
+
+    const outcome = await runLmlLinkage({ flowsheetId: 7, artistName: 'Stereolab', albumTitle: 'Dots' });
+
+    expect(outcome).toEqual(expect.objectContaining({ status: 'error' }));
+    expect(getLinkageCounters().lml_timeout).toBe(1);
+    expect(getLinkageCounters().lml_error).toBe(0);
+    expect(mockCaptureException).toHaveBeenCalledWith(err, expect.anything());
+  });
+
+  it("never writes album_id on the error path (row stays NULL for the next sweep)", async () => {
+    mockLookupMetadata.mockRejectedValue(new Error('boom'));
+
+    await runLmlLinkage({ flowsheetId: 7, artistName: 'a', albumTitle: 'b' });
+
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/linkage-metrics.service.test.ts
+++ b/tests/unit/services/linkage-metrics.service.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the LML-linkage observability surface (B-3.2).
+ *
+ * Two readouts cover the linkage path:
+ *   - In-process counters keyed by outcome name
+ *     (`linked_high_conf` / `gray_zone_review` / `no_candidate` /
+ *      `lml_error` / `lml_timeout`). B-2.1 (forward) and B-2.2 (backfill)
+ *     both increment them. Tests assert the counter map is exposed and
+ *     mutates only via the documented increment helper.
+ *   - SQL-backed gauges: cumulative linkage coverage across the whole
+ *     `flowsheet` table, and a "linked-within-N-hours" forward-path health
+ *     proxy.
+ *
+ * The Sentry tag `subsystem='lml-linkage'` rides on every error reported
+ * through this module so the operator can filter the issue stream by
+ * subsystem instead of by stack trace.
+ */
+import { jest } from '@jest/globals';
+import { db } from '../../mocks/database.mock';
+
+const mockCaptureException = jest.fn();
+jest.mock('@sentry/node', () => ({ captureException: mockCaptureException }));
+
+import {
+  LINKAGE_METRIC_NAMES,
+  classifyLinkageError,
+  getCumulativeLinkageCoverage,
+  getLinkageCounters,
+  getRecentLinkageRate,
+  incrementLinkageMetric,
+  reportLinkageError,
+  resetLinkageCounters,
+} from '../../../apps/backend/services/linkage-metrics.service';
+
+type SqlLike = {
+  sql?: string | string[];
+  queryChunks?: Array<string | { value?: string | string[] }>;
+};
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+describe('linkage counters', () => {
+  beforeEach(() => {
+    resetLinkageCounters();
+  });
+
+  it('exposes exactly the five outcome names the issue specifies', () => {
+    // The dashboard the operator builds against this surface keys on these
+    // names. Adding a sixth or renaming one silently breaks the dashboard.
+    expect(new Set(LINKAGE_METRIC_NAMES)).toEqual(
+      new Set(['linked_high_conf', 'gray_zone_review', 'no_candidate', 'lml_error', 'lml_timeout'])
+    );
+  });
+
+  it('initializes every counter to zero', () => {
+    const snapshot = getLinkageCounters();
+    for (const name of LINKAGE_METRIC_NAMES) {
+      expect(snapshot[name]).toBe(0);
+    }
+  });
+
+  it('increments the named counter independently of the others', () => {
+    incrementLinkageMetric('linked_high_conf');
+    incrementLinkageMetric('linked_high_conf');
+    incrementLinkageMetric('gray_zone_review');
+
+    const snapshot = getLinkageCounters();
+    expect(snapshot.linked_high_conf).toBe(2);
+    expect(snapshot.gray_zone_review).toBe(1);
+    expect(snapshot.no_candidate).toBe(0);
+    expect(snapshot.lml_error).toBe(0);
+    expect(snapshot.lml_timeout).toBe(0);
+  });
+
+  it('returns a copy so callers cannot mutate the live counters', () => {
+    incrementLinkageMetric('linked_high_conf');
+    const snapshot = getLinkageCounters();
+    snapshot.linked_high_conf = 999;
+    expect(getLinkageCounters().linked_high_conf).toBe(1);
+  });
+});
+
+describe('classifyLinkageError', () => {
+  // Timeouts are usually transient (LML cold start, network blip) and the
+  // backfill retries on the next sweep; non-timeout errors are more often
+  // bugs in the linkage path itself. Splitting the counters lets the
+  // operator tell those two failure modes apart at a glance.
+  it("classifies node-fetch AbortError-style errors as 'lml_timeout'", () => {
+    const err = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    expect(classifyLinkageError(err)).toBe('lml_timeout');
+  });
+
+  it("classifies ETIMEDOUT errors as 'lml_timeout'", () => {
+    const err = Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    expect(classifyLinkageError(err)).toBe('lml_timeout');
+  });
+
+  it("classifies messages mentioning 'timeout' (case-insensitive) as 'lml_timeout'", () => {
+    expect(classifyLinkageError(new Error('Request Timeout from LML'))).toBe('lml_timeout');
+  });
+
+  it("classifies everything else as 'lml_error'", () => {
+    expect(classifyLinkageError(new Error('500 Internal Server Error'))).toBe('lml_error');
+    expect(classifyLinkageError('not even an Error object')).toBe('lml_error');
+    expect(classifyLinkageError(null)).toBe('lml_error');
+  });
+});
+
+describe('reportLinkageError', () => {
+  beforeEach(() => {
+    mockCaptureException.mockReset();
+  });
+
+  it("forwards the error to Sentry with tag subsystem='lml-linkage'", () => {
+    const err = new Error('LML 502');
+    reportLinkageError(err);
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({ tags: expect.objectContaining({ subsystem: 'lml-linkage' }) })
+    );
+  });
+
+  it('attaches caller-supplied context as Sentry extras', () => {
+    // The operator opens the Sentry issue and needs the flowsheet id +
+    // artist/album text to triage. Without extras they only see the stack.
+    const err = new Error('LML failure');
+    reportLinkageError(err, { flowsheetId: 7, artistName: 'Stereolab', albumTitle: 'Dots and Loops' });
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({
+        tags: expect.objectContaining({ subsystem: 'lml-linkage' }),
+        extra: expect.objectContaining({
+          flowsheetId: 7,
+          artistName: 'Stereolab',
+          albumTitle: 'Dots and Loops',
+        }),
+      })
+    );
+  });
+
+  it('passes additional caller tags alongside the subsystem tag', () => {
+    // Forward path vs. backfill is a useful axis to slice the error stream
+    // by. Callers pass `path: 'forward' | 'backfill'` as a tag.
+    reportLinkageError(new Error('boom'), undefined, { path: 'forward' });
+
+    const call = mockCaptureException.mock.calls[0];
+    const opts = call[1] as { tags: Record<string, string> };
+    expect(opts.tags.subsystem).toBe('lml-linkage');
+    expect(opts.tags.path).toBe('forward');
+  });
+});
+
+describe('getCumulativeLinkageCoverage', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+  });
+
+  it("issues count(*) FILTER (WHERE album_id IS NOT NULL) over flowsheet entry_type='track'", async () => {
+    // The exact ratio we want surfaced on the dashboard. FILTER beats the
+    // alternative (two queries or a subquery) because PG runs it in a
+    // single pass over the table.
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ linked: 100, total: 250 }]);
+
+    const result = await getCumulativeLinkageCoverage();
+
+    expect(result).toEqual({ linked: 100, total: 250, ratio: 0.4 });
+    const sqlText = renderSql((db.execute as jest.Mock).mock.calls[0][0]);
+    expect(sqlText).toMatch(/count\(\*\)\s+FILTER\s*\(\s*WHERE\s+album_id\s+IS\s+NOT\s+NULL\s*\)/i);
+    expect(sqlText).toMatch(/FROM[\s\S]*flowsheet/i);
+    expect(sqlText).toMatch(/entry_type"?\s*=\s*'track'/i);
+  });
+
+  it('handles an empty table without dividing by zero', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ linked: 0, total: 0 }]);
+
+    const result = await getCumulativeLinkageCoverage();
+
+    expect(result).toEqual({ linked: 0, total: 0, ratio: 0 });
+  });
+
+  it('coerces postgres BIGINT string counts to numbers', async () => {
+    // postgres-js returns BIGINTs as strings to avoid precision loss. The
+    // 1.95M-row flowsheet count would surface as a string and JSON.stringify
+    // would happily ship "1956737" to the dashboard if we forgot to coerce.
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ linked: '775453', total: '1956737' }]);
+
+    const result = await getCumulativeLinkageCoverage();
+
+    expect(typeof result.linked).toBe('number');
+    expect(typeof result.total).toBe('number');
+    expect(result.linked).toBe(775453);
+    expect(result.total).toBe(1956737);
+    expect(result.ratio).toBeCloseTo(775453 / 1956737, 6);
+  });
+});
+
+describe('getRecentLinkageRate', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+  });
+
+  it('parameterizes the lookback window in hours', async () => {
+    // The forward-path health proxy: of rows inserted in the last N hours,
+    // how many were linked? B-2.1's worker should land linkage within
+    // minutes; a falling ratio means the worker is falling behind.
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ inserted: 50, linked: 47 }]);
+
+    const result = await getRecentLinkageRate(24);
+
+    expect(result).toEqual({ inserted: 50, linked: 47, ratio: 47 / 50 });
+    const call = (db.execute as jest.Mock).mock.calls[0][0];
+    const sqlText = renderSql(call);
+    expect(sqlText).toMatch(/add_time/i);
+    expect(sqlText).toMatch(/now\(\)\s*-/i);
+    expect(JSON.stringify(call)).toContain('24');
+  });
+
+  it("scopes the rate to entry_type='track' (messages and breaks shouldn't move the gauge)", async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ inserted: 0, linked: 0 }]);
+
+    await getRecentLinkageRate(24);
+
+    const sqlText = renderSql((db.execute as jest.Mock).mock.calls[0][0]);
+    expect(sqlText).toMatch(/entry_type"?\s*=\s*'track'/i);
+  });
+
+  it('returns ratio=0 when nothing has been inserted in the window', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ inserted: 0, linked: 0 }]);
+
+    const result = await getRecentLinkageRate(1);
+
+    expect(result.ratio).toBe(0);
+  });
+});

--- a/tests/unit/services/linkage-metrics.service.test.ts
+++ b/tests/unit/services/linkage-metrics.service.test.ts
@@ -182,7 +182,7 @@ describe('getCumulativeLinkageCoverage', () => {
 
     expect(result).toEqual({ linked: 100, total: 250, ratio: 0.4 });
     const sqlText = renderSql((db.execute as jest.Mock).mock.calls[0][0]);
-    expect(sqlText).toMatch(/count\(\*\)\s+FILTER\s*\(\s*WHERE\s+album_id\s+IS\s+NOT\s+NULL\s*\)/i);
+    expect(sqlText).toMatch(/count\(\*\)\s+FILTER\s*\(\s*WHERE\s+"?album_id"?\s+IS\s+NOT\s+NULL\s*\)/i);
     expect(sqlText).toMatch(/FROM[\s\S]*flowsheet/i);
     expect(sqlText).toMatch(/entry_type"?\s*=\s*'track'/i);
   });

--- a/tests/unit/services/linkage-metrics.service.test.ts
+++ b/tests/unit/services/linkage-metrics.service.test.ts
@@ -169,26 +169,26 @@ describe('reportLinkageError', () => {
 
 describe('getCumulativeLinkageCoverage', () => {
   beforeEach(() => {
-    (db.execute as jest.Mock).mockReset();
+    db.execute.mockReset();
   });
 
   it("issues count(*) FILTER (WHERE album_id IS NOT NULL) over flowsheet entry_type='track'", async () => {
     // The exact ratio we want surfaced on the dashboard. FILTER beats the
     // alternative (two queries or a subquery) because PG runs it in a
     // single pass over the table.
-    (db.execute as jest.Mock).mockResolvedValueOnce([{ linked: 100, total: 250 }]);
+    db.execute.mockResolvedValueOnce([{ linked: 100, total: 250 }]);
 
     const result = await getCumulativeLinkageCoverage();
 
     expect(result).toEqual({ linked: 100, total: 250, ratio: 0.4 });
-    const sqlText = renderSql((db.execute as jest.Mock).mock.calls[0][0]);
+    const sqlText = renderSql(db.execute.mock.calls[0][0]);
     expect(sqlText).toMatch(/count\(\*\)\s+FILTER\s*\(\s*WHERE\s+"?album_id"?\s+IS\s+NOT\s+NULL\s*\)/i);
     expect(sqlText).toMatch(/FROM[\s\S]*flowsheet/i);
     expect(sqlText).toMatch(/entry_type"?\s*=\s*'track'/i);
   });
 
   it('handles an empty table without dividing by zero', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([{ linked: 0, total: 0 }]);
+    db.execute.mockResolvedValueOnce([{ linked: 0, total: 0 }]);
 
     const result = await getCumulativeLinkageCoverage();
 
@@ -199,7 +199,7 @@ describe('getCumulativeLinkageCoverage', () => {
     // postgres-js returns BIGINTs as strings to avoid precision loss. The
     // 1.95M-row flowsheet count would surface as a string and JSON.stringify
     // would happily ship "1956737" to the dashboard if we forgot to coerce.
-    (db.execute as jest.Mock).mockResolvedValueOnce([{ linked: '775453', total: '1956737' }]);
+    db.execute.mockResolvedValueOnce([{ linked: '775453', total: '1956737' }]);
 
     const result = await getCumulativeLinkageCoverage();
 
@@ -213,19 +213,19 @@ describe('getCumulativeLinkageCoverage', () => {
 
 describe('getRecentLinkageRate', () => {
   beforeEach(() => {
-    (db.execute as jest.Mock).mockReset();
+    db.execute.mockReset();
   });
 
   it('parameterizes the lookback window in hours', async () => {
     // The forward-path health proxy: of rows inserted in the last N hours,
     // how many were linked? B-2.1's worker should land linkage within
     // minutes; a falling ratio means the worker is falling behind.
-    (db.execute as jest.Mock).mockResolvedValueOnce([{ inserted: 50, linked: 47 }]);
+    db.execute.mockResolvedValueOnce([{ inserted: 50, linked: 47 }]);
 
     const result = await getRecentLinkageRate(24);
 
     expect(result).toEqual({ inserted: 50, linked: 47, ratio: 47 / 50 });
-    const call = (db.execute as jest.Mock).mock.calls[0][0];
+    const call = db.execute.mock.calls[0][0];
     const sqlText = renderSql(call);
     expect(sqlText).toMatch(/add_time/i);
     expect(sqlText).toMatch(/now\(\)\s*-/i);
@@ -233,16 +233,16 @@ describe('getRecentLinkageRate', () => {
   });
 
   it("scopes the rate to entry_type='track' (messages and breaks shouldn't move the gauge)", async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([{ inserted: 0, linked: 0 }]);
+    db.execute.mockResolvedValueOnce([{ inserted: 0, linked: 0 }]);
 
     await getRecentLinkageRate(24);
 
-    const sqlText = renderSql((db.execute as jest.Mock).mock.calls[0][0]);
+    const sqlText = renderSql(db.execute.mock.calls[0][0]);
     expect(sqlText).toMatch(/entry_type"?\s*=\s*'track'/i);
   });
 
   it('returns ratio=0 when nothing has been inserted in the window', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([{ inserted: 0, linked: 0 }]);
+    db.execute.mockResolvedValueOnce([{ inserted: 0, linked: 0 }]);
 
     const result = await getRecentLinkageRate(1);
 


### PR DESCRIPTION
Closes #502

## Summary

Adds the observability surface specified by B-3.2:

- **In-process counters** keyed by the five canonical outcome names: `linked_high_conf`, `gray_zone_review`, `no_candidate`, `lml_error`, `lml_timeout`. Both the forward path (B-2.1) and the backfill (B-2.2) increment them on every branch.
- **Sentry tagging**: every error from the linkage path is reported with `subsystem='lml-linkage'` and a `path` tag (`forward` or `backfill`) so the operator can split the issue stream by which side fired the error.
- **SQL gauges**: `getCumulativeLinkageCoverage()` issues `count(*) FILTER (WHERE album_id IS NOT NULL)` over `flowsheet WHERE entry_type='track'`; `getRecentLinkageRate(hours)` returns the linked-within-N-hours proxy for forward-path health.

## Architecture

A new `apps/backend/services/linkage-metrics.service.ts` owns the counters, error classification (timeout vs. generic), Sentry helper, and the two SQL gauges. `flowsheet-linkage.service.ts` (forward) imports it directly.

The backfill orchestrator can't import from `apps/backend/` (its Dockerfile only copies `shared/database` + the job dir), so observability is plumbed through a `MetricsSink` interface injected from `jobs/flowsheet-lml-link-backfill/job.ts`. The orchestrator stays library-pure; the production wiring in `job.ts` calls `Sentry.captureException` with the right tags. The sink is optional, so existing callers (CLI / older tests) get a no-op default.

`multi_match` (LML resolved a canonical entity but >1 library row carries it) is bucketed as `gray_zone_review` because it's a tie-break that defers to B-2.3 / the review queue — the dashboard treats it as review-bound.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check`
- [x] `npm run test:unit` — 35 new tests across three files (counters/Sentry/SQL, forward-path metrics, backfill metrics) plus the pre-existing 1247.
- [ ] CI on PR.

## Out of scope

Alerting thresholds — left for after baseline metrics surface in production, per the issue.