### PR TITLE
Manual review queue (CLI for v1) for gray-zone matches

### DIFF
--- a/jobs/flowsheet-lml-link-backfill/orchestrate.ts
+++ b/jobs/flowsheet-lml-link-backfill/orchestrate.ts
@@ -124,6 +124,33 @@ export const applyLink = async (args: {
 };
 
 /**
+ * Persist a flowsheet row to the B-3.1 manual review queue. The
+ * `ON CONFLICT (flowsheet_id) DO NOTHING` guard makes re-runs idempotent
+ * — a second sweep over the same fallback row is a no-op rather than a
+ * UNIQUE-constraint error or a duplicate queue entry. Empty candidate
+ * arrays are valid: the operator can still see the flowsheet text and
+ * skip the entry from the CLI.
+ */
+export const enqueueReview = async (args: {
+  flowsheetId: number;
+  candidateLibraryIds: number[];
+  candidateConfidences: number[];
+  suggestedAction: string;
+}): Promise<void> => {
+  await db.execute(sql`
+    INSERT INTO "wxyc_schema"."flowsheet_linkage_review"
+      ("flowsheet_id", "candidate_library_ids", "candidate_confidences", "suggested_action")
+    VALUES (
+      ${args.flowsheetId},
+      ${args.candidateLibraryIds}::integer[],
+      ${args.candidateConfidences}::real[],
+      ${args.suggestedAction}
+    )
+    ON CONFLICT ("flowsheet_id") DO NOTHING
+  `);
+};
+
+/**
  * Look up the library rows whose `canonical_entity_id` equals the LML-derived
  * entity id. Returns 0, 1, or N ids; the caller branches on count.
  */
@@ -165,13 +192,38 @@ export const processRow = async (
   }
 
   const signal = resolveLmlSignal(response);
-  if (signal.status === 'review') {
-    metrics.recordOutcome('gray_zone_review');
-    return 'review';
-  }
   if (signal.status === 'no_match') {
     metrics.recordOutcome('no_candidate');
     return 'no_match';
+  }
+
+  if (signal.status === 'review') {
+    // Resolve each ranked LML candidate to local library rows via
+    // canonical_entity_id, preserving LML's order. Dedupe across candidates
+    // because a single library row may match multiple LML results (rare but
+    // possible if the canonical entity points at the same Discogs id from
+    // two different fallback search paths). Empty candidate arrays are
+    // intentionally enqueued — the operator can still skip the entry.
+    const candidateLibraryIds: number[] = [];
+    const candidateConfidences: number[] = [];
+    const seen = new Set<number>();
+    for (const canonicalEntityId of signal.candidate_canonical_entity_ids) {
+      const ids = await findLibraryByCanonicalEntity(canonicalEntityId);
+      for (const id of ids) {
+        if (seen.has(id)) continue;
+        seen.add(id);
+        candidateLibraryIds.push(id);
+        candidateConfidences.push(signal.confidence);
+      }
+    }
+    await enqueueReview({
+      flowsheetId: row.id,
+      candidateLibraryIds,
+      candidateConfidences,
+      suggestedAction: 'review_fallback',
+    });
+    metrics.recordOutcome('gray_zone_review');
+    return 'review';
   }
 
   const libraryIds = await findLibraryByCanonicalEntity(signal.canonical_entity_id);

--- a/jobs/flowsheet-lml-link-backfill/resolve.ts
+++ b/jobs/flowsheet-lml-link-backfill/resolve.ts
@@ -22,7 +22,7 @@ import type { LmlLookupResponse } from './lml-types.js';
 
 export type LmlSignal =
   | { status: 'auto_accept'; canonical_entity_id: string; confidence: number }
-  | { status: 'review' }
+  | { status: 'review'; candidate_canonical_entity_ids: string[]; confidence: number }
   | { status: 'no_match' };
 
 /**
@@ -31,6 +31,16 @@ export type LmlSignal =
  * filtering. Mirrors `AUTO_ACCEPT_CONFIDENCE` in B-1.2's resolver.
  */
 export const AUTO_ACCEPT_CONFIDENCE = 0.95;
+
+/**
+ * Synthetic confidence for fallback / alternative / compilation /
+ * song_as_artist hits routed to the B-3.1 review queue. Stored on each
+ * candidate in `flowsheet_linkage_review.candidate_confidences` so an
+ * operator (and downstream analytics) can see at a glance which queue
+ * entries came from a low-confidence heuristic. Collapses to a per-result
+ * number once LML exposes one (WXYC/library-metadata-lookup#158).
+ */
+export const REVIEW_CONFIDENCE = 0.5;
 
 const toCanonicalEntityId = (releaseId: number): string => `discogs:${releaseId}`;
 
@@ -53,5 +63,21 @@ export const resolveLmlSignal = (response: LmlLookupResponse): LmlSignal => {
     };
   }
 
-  return { status: 'review' };
+  // Filter the ranked candidates to results with a pinable release_id —
+  // those are the only ones the orchestrator can resolve to library rows
+  // via `library.canonical_entity_id`. Order is preserved so the CLI walks
+  // candidates in LML's ranking.
+  const candidate_canonical_entity_ids: string[] = [];
+  for (const result of response.results) {
+    const id = result.artwork?.release_id;
+    if (typeof id === 'number') {
+      candidate_canonical_entity_ids.push(toCanonicalEntityId(id));
+    }
+  }
+
+  return {
+    status: 'review',
+    candidate_canonical_entity_ids,
+    confidence: REVIEW_CONFIDENCE,
+  };
 };

--- a/scripts/review-linkage.ts
+++ b/scripts/review-linkage.ts
@@ -1,0 +1,277 @@
+/**
+ * Manual review CLI for B-3.1's flowsheet linkage queue (issue #501).
+ *
+ * Drains `flowsheet_linkage_review` one entry at a time, showing the
+ * operator the flowsheet artist/album/track text and the LML-ranked
+ * library candidates. The operator answers y/n/skip per case:
+ *   - y     → stamp `flowsheet.album_id` with the chosen library row,
+ *             linkage_source='human_review', linked_at=now(); mark the
+ *             review row reviewed_decision='accepted'.
+ *   - n     → mark the review row reviewed_decision='rejected'. The
+ *             flowsheet row stays unmatched so a future LML improvement
+ *             can pick it up.
+ *   - skip  → no DB write. Within this session the case won't recur;
+ *             the next session shows it again.
+ *
+ * Usage:
+ *   npx tsx scripts/review-linkage.ts
+ *
+ * Web UI is out of scope for v1; the CLI is sufficient until volume
+ * justifies otherwise.
+ */
+
+import { config } from 'dotenv';
+config();
+
+import readline from 'node:readline';
+import { sql } from 'drizzle-orm';
+import { db, closeDatabaseConnection } from '@wxyc/database';
+
+export type ReviewCandidate = {
+  libraryId: number;
+  artistName: string | null;
+  albumTitle: string | null;
+  confidence: number;
+};
+
+export type ReviewCase = {
+  reviewId: number;
+  flowsheetId: number;
+  flowsheetArtist: string | null;
+  flowsheetAlbum: string | null;
+  flowsheetTrack: string | null;
+  suggestedAction: string;
+  candidates: ReviewCandidate[];
+};
+
+type QueueRow = {
+  id: number;
+  flowsheet_id: number;
+  candidate_library_ids: number[] | null;
+  candidate_confidences: number[] | null;
+  suggested_action: string;
+  flowsheet_artist: string | null;
+  flowsheet_album: string | null;
+  flowsheet_track: string | null;
+};
+
+type LibraryRow = {
+  id: number;
+  artist_name: string | null;
+  album_title: string | null;
+};
+
+/**
+ * Read the oldest unreviewed queue row plus the metadata for its candidate
+ * library rows. The two-step shape (queue join → library lookup) keeps the
+ * SQL simple; a single CTE-with-array-unnest would also work but is harder
+ * to read and unit-test.
+ *
+ * `excludeIds` is the in-memory skip list: rows the operator skipped within
+ * the current CLI session. They aren't marked reviewed in the DB, so the
+ * next session will see them again — but for the duration of this run we
+ * skip past them.
+ */
+export const loadNextReviewCase = async (excludeIds: number[] = []): Promise<ReviewCase | null> => {
+  // Validated integer IDs are safe to inline via sql.raw; we still coerce
+  // through Number to make the contract explicit.
+  const safeExclusion =
+    excludeIds.length > 0
+      ? sql.raw(`AND r."id" NOT IN (${excludeIds.map((id) => Number(id)).join(', ')})`)
+      : sql.raw('');
+
+  const rows = (await db.execute(sql`
+    SELECT
+      r."id",
+      r."flowsheet_id",
+      r."candidate_library_ids",
+      r."candidate_confidences",
+      r."suggested_action",
+      f."artist_name" AS "flowsheet_artist",
+      f."album_title" AS "flowsheet_album",
+      f."track_title" AS "flowsheet_track"
+    FROM "wxyc_schema"."flowsheet_linkage_review" r
+    JOIN "wxyc_schema"."flowsheet" f ON f."id" = r."flowsheet_id"
+    WHERE r."reviewed_at" IS NULL
+      ${safeExclusion}
+    ORDER BY r."created_at" ASC
+    LIMIT 1
+  `)) as unknown as QueueRow[];
+
+  const head = rows?.[0];
+  if (!head) return null;
+
+  const ids = head.candidate_library_ids ?? [];
+  const confidences = head.candidate_confidences ?? [];
+
+  let libraryRows: LibraryRow[] = [];
+  if (ids.length > 0) {
+    const idList = sql.raw(ids.map((id) => Number(id)).join(', '));
+    libraryRows = (await db.execute(sql`
+      SELECT "id", "artist_name", "album_title"
+      FROM "wxyc_schema"."library"
+      WHERE "id" IN (${idList})
+    `)) as unknown as LibraryRow[];
+  }
+
+  const byId = new Map<number, LibraryRow>();
+  for (const lib of libraryRows ?? []) byId.set(lib.id, lib);
+
+  const candidates: ReviewCandidate[] = ids.map((id, index) => {
+    const lib = byId.get(id);
+    return {
+      libraryId: id,
+      artistName: lib?.artist_name ?? null,
+      albumTitle: lib?.album_title ?? null,
+      confidence: confidences[index] ?? 0,
+    };
+  });
+
+  return {
+    reviewId: head.id,
+    flowsheetId: head.flowsheet_id,
+    flowsheetArtist: head.flowsheet_artist,
+    flowsheetAlbum: head.flowsheet_album,
+    flowsheetTrack: head.flowsheet_track,
+    suggestedAction: head.suggested_action,
+    candidates,
+  };
+};
+
+/**
+ * Accept the operator's pick: stamp the flowsheet row and mark the queue
+ * row reviewed. The `album_id IS NULL` guard on the flowsheet UPDATE is the
+ * same idempotency rail the B-2.2 backfill uses — if a parallel linker got
+ * there first between the queue read and this write, our UPDATE is a no-op
+ * and the queue row still gets marked reviewed (the operator's intent
+ * matches the existing link, so there's nothing left to reconcile).
+ *
+ * The two writes are not wrapped in a transaction. Splitting them keeps
+ * the CLI dead simple, and the failure modes are benign: if the second
+ * UPDATE fails, the next session re-shows the case and an idempotent
+ * accept is a no-op on the flowsheet (already linked) and finally marks
+ * the queue row reviewed.
+ */
+export const acceptReviewCase = async (args: {
+  reviewId: number;
+  flowsheetId: number;
+  libraryId: number;
+}): Promise<void> => {
+  await db.execute(sql`
+    UPDATE "wxyc_schema"."flowsheet"
+    SET "album_id" = ${args.libraryId},
+        "linkage_source" = 'human_review',
+        "linked_at" = now()
+    WHERE "id" = ${args.flowsheetId}
+      AND "album_id" IS NULL
+  `);
+
+  await db.execute(sql`
+    UPDATE "wxyc_schema"."flowsheet_linkage_review"
+    SET "reviewed_at" = now(),
+        "reviewed_decision" = 'accepted'
+    WHERE "id" = ${args.reviewId}
+  `);
+};
+
+export const rejectReviewCase = async (reviewId: number): Promise<void> => {
+  await db.execute(sql`
+    UPDATE "wxyc_schema"."flowsheet_linkage_review"
+    SET "reviewed_at" = now(),
+        "reviewed_decision" = 'rejected'
+    WHERE "id" = ${reviewId}
+  `);
+};
+
+const formatCandidate = (candidate: ReviewCandidate, index: number): string => {
+  const meta = `${candidate.artistName ?? '?'} — ${candidate.albumTitle ?? '?'}`;
+  return `  [${index + 1}] library_id=${candidate.libraryId} | ${meta} | confidence=${candidate.confidence.toFixed(2)}`;
+};
+
+const renderCase = (reviewCase: ReviewCase): string => {
+  const header = `\nReview case #${reviewCase.reviewId} (flowsheet_id=${reviewCase.flowsheetId}, ${reviewCase.suggestedAction})`;
+  const flowsheet =
+    `  Flowsheet text: artist="${reviewCase.flowsheetArtist ?? ''}"` +
+    ` album="${reviewCase.flowsheetAlbum ?? ''}"` +
+    ` track="${reviewCase.flowsheetTrack ?? ''}"`;
+  if (reviewCase.candidates.length === 0) {
+    return `${header}\n${flowsheet}\n  (No local library candidates — only n / s available.)`;
+  }
+  const candidates = reviewCase.candidates.map(formatCandidate).join('\n');
+  return `${header}\n${flowsheet}\nCandidates:\n${candidates}`;
+};
+
+const ask = (rl: readline.Interface, question: string): Promise<string> =>
+  new Promise((resolve) => rl.question(question, (answer) => resolve(answer.trim().toLowerCase())));
+
+const PROMPT = 'Action — accept candidate # / [n]o-match / [s]kip / [q]uit: ';
+
+const main = async (): Promise<void> => {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const skipped: number[] = [];
+  let stats = { accepted: 0, rejected: 0, skipped: 0 };
+
+  try {
+    while (true) {
+      const next = await loadNextReviewCase(skipped);
+      if (!next) {
+        console.log('\nReview queue is empty. Done.');
+        break;
+      }
+
+      console.log(renderCase(next));
+      const answer = await ask(rl, PROMPT);
+
+      if (answer === 'q' || answer === 'quit') {
+        console.log('\nQuitting.');
+        break;
+      }
+      if (answer === 's' || answer === 'skip' || answer === '') {
+        skipped.push(next.reviewId);
+        stats.skipped += 1;
+        continue;
+      }
+      if (answer === 'n' || answer === 'no') {
+        await rejectReviewCase(next.reviewId);
+        stats.rejected += 1;
+        continue;
+      }
+
+      const pick = Number.parseInt(answer, 10);
+      if (!Number.isInteger(pick) || pick < 1 || pick > next.candidates.length) {
+        console.log(`Unrecognized response "${answer}" — skipping.`);
+        skipped.push(next.reviewId);
+        stats.skipped += 1;
+        continue;
+      }
+
+      const candidate = next.candidates[pick - 1];
+      await acceptReviewCase({
+        reviewId: next.reviewId,
+        flowsheetId: next.flowsheetId,
+        libraryId: candidate.libraryId,
+      });
+      stats.accepted += 1;
+    }
+
+    console.log(`\nSession totals: accepted=${stats.accepted} rejected=${stats.rejected} skipped=${stats.skipped}`);
+  } finally {
+    rl.close();
+    await closeDatabaseConnection();
+  }
+};
+
+// Only run main() when invoked as a script. Tests import the helpers
+// directly without triggering the interactive loop.
+const invokedDirectly = (() => {
+  if (typeof process === 'undefined' || !process.argv?.[1]) return false;
+  const arg = process.argv[1];
+  return arg.endsWith('review-linkage.ts') || arg.endsWith('review-linkage.js');
+})();
+
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error('Fatal error:', error);
+    process.exitCode = 1;
+  });
+}

--- a/shared/database/src/migrations/0067_flowsheet-linkage-review.sql
+++ b/shared/database/src/migrations/0067_flowsheet-linkage-review.sql
@@ -1,0 +1,64 @@
+-- Manual review queue for gray-zone LML matches (B-3.1, issue #501).
+--
+-- Holds one row per flowsheet entry whose LML lookup produced something but
+-- not a direct hit (search_type='fallback' under B-0's calibration). The
+-- B-2.2 backfill enqueues these instead of guessing; an operator drains the
+-- queue with `npx tsx scripts/review-linkage.ts`. On accept, the CLI stamps
+-- `flowsheet.album_id` + `linkage_source='human_review'` and marks the queue
+-- row reviewed.
+--
+-- Column choices:
+--   flowsheet_id           — UNIQUE so re-running the backfill is a no-op
+--                            (insert ... on conflict do nothing). Cascades on
+--                            delete because the queue row is meaningless once
+--                            the flowsheet entry is gone.
+--   candidate_library_ids  — INTEGER[] of WXYC library rows resolved from
+--                            LML's ranked results via canonical_entity_id.
+--                            Order matches LML's ranking; the CLI presents
+--                            them in that order. Empty array allowed when
+--                            LML returned results we couldn't match against
+--                            the local library — those still warrant
+--                            human eyeballs because the artist text may
+--                            need correction before another sweep.
+--   candidate_confidences  — REAL[] aligned with candidate_library_ids.
+--                            Sourced from LML's per-result signal; for
+--                            fallback hits LML doesn't expose a number
+--                            today (tracked at WXYC/library-metadata-lookup#158)
+--                            so the resolver synths a single value per
+--                            search_type. Kept as an array so the CLI can
+--                            display per-candidate scores when LML grows them.
+--   suggested_action       — Free-form text identifying which heuristic
+--                            sent this row to review (currently only
+--                            'review_fallback'). Lets future heuristics
+--                            (e.g., low-numeric-confidence direct hits once
+--                            LML exposes a score) land on the same queue
+--                            without a schema change.
+--   created_at             — When the backfill enqueued this row.
+--   reviewed_at            — When the CLI resolved it. NULL until then.
+--   reviewed_decision      — 'accepted' | 'rejected' | 'skipped'. NULL while
+--                            unreviewed; set together with reviewed_at.
+--
+-- Index: partial B-tree on (created_at) WHERE reviewed_at IS NULL keeps the
+-- "next case to review" query bounded to the unreviewed slice. Unreviewed
+-- rows are the only ones the CLI ever scans; reviewed ones are kept for
+-- audit and never queried hot.
+--
+-- Production note: empty CREATE TABLE acquires a brief AccessExclusiveLock
+-- but holds no data, so this is fast on any DB. Index creation on an empty
+-- table is instant.
+
+CREATE TABLE "wxyc_schema"."flowsheet_linkage_review" (
+  "id" serial PRIMARY KEY,
+  "flowsheet_id" integer NOT NULL UNIQUE
+    REFERENCES "wxyc_schema"."flowsheet"("id") ON DELETE CASCADE,
+  "candidate_library_ids" integer[] NOT NULL,
+  "candidate_confidences" real[] NOT NULL,
+  "suggested_action" text NOT NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "reviewed_at" timestamp with time zone,
+  "reviewed_decision" text
+);--> statement-breakpoint
+
+CREATE INDEX "flowsheet_linkage_review_unreviewed_idx"
+  ON "wxyc_schema"."flowsheet_linkage_review" ("created_at")
+  WHERE "reviewed_at" IS NULL;

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1779683200002,
       "tag": "0066_replay-v012-mojibake",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1779769600000,
+      "tag": "0067_flowsheet-linkage-review",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -471,6 +471,35 @@ export const flowsheet = wxyc_schema.table(
   ]
 );
 
+// Manual review queue for gray-zone LML matches (B-3.1, issue #501). The
+// B-2.2 backfill enqueues a row per flowsheet entry whose LML lookup hit a
+// fallback (right-artist, possibly-wrong-album). The CLI in
+// `scripts/review-linkage.ts` drains this queue interactively. See
+// migration 0066 for column rationale.
+export type NewFlowsheetLinkageReview = InferInsertModel<typeof flowsheet_linkage_review>;
+export type FlowsheetLinkageReview = InferSelectModel<typeof flowsheet_linkage_review>;
+export const flowsheet_linkage_review = wxyc_schema.table(
+  'flowsheet_linkage_review',
+  {
+    id: serial('id').primaryKey(),
+    flowsheet_id: integer('flowsheet_id')
+      .references(() => flowsheet.id, { onDelete: 'cascade' })
+      .notNull()
+      .unique(),
+    candidate_library_ids: integer('candidate_library_ids').array().notNull(),
+    candidate_confidences: real('candidate_confidences').array().notNull(),
+    suggested_action: text('suggested_action').notNull(),
+    created_at: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    reviewed_at: timestamp('reviewed_at', { withTimezone: true }),
+    reviewed_decision: text('reviewed_decision'),
+  },
+  (table) => [
+    index('flowsheet_linkage_review_unreviewed_idx')
+      .on(table.created_at)
+      .where(sql`${table.reviewed_at} IS NULL`),
+  ]
+);
+
 export type NewGenre = InferInsertModel<typeof genres>;
 export type Genre = InferSelectModel<typeof genres>;
 export const genres = wxyc_schema.table('genres', {

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -135,6 +135,16 @@ export const flowsheet = {
   linked_at: 'linked_at',
   search_doc: 'search_doc',
 };
+export const flowsheet_linkage_review = {
+  id: 'id',
+  flowsheet_id: 'flowsheet_id',
+  candidate_library_ids: 'candidate_library_ids',
+  candidate_confidences: 'candidate_confidences',
+  suggested_action: 'suggested_action',
+  created_at: 'created_at',
+  reviewed_at: 'reviewed_at',
+  reviewed_decision: 'reviewed_decision',
+};
 export const bins = {};
 export const shows = {
   id: 'id',

--- a/tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts
@@ -18,6 +18,7 @@
 import { db, pickPrimaryLibraryRow } from '@wxyc/database';
 import {
   applyLink,
+  enqueueReview,
   findLibraryByCanonicalEntity,
   processRow,
   runBackfill,
@@ -107,6 +108,58 @@ describe('applyLink', () => {
     const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i);
     const sqlText = renderSql(call?.[0]);
     expect(sqlText).toMatch(/album_id"?\s+IS\s+NULL/i);
+  });
+});
+
+describe('enqueueReview', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('inserts a review row with the candidate ids, confidences and suggested action', async () => {
+    // The B-3.1 CLI scans flowsheet_linkage_review for unreviewed rows and
+    // shows the operator the candidate library rows in LML's ranking order.
+    // The columns persisted here are exactly the contract that CLI reads.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
+
+    await enqueueReview({
+      flowsheetId: 7,
+      candidateLibraryIds: [100, 101],
+      candidateConfidences: [0.5, 0.5],
+      suggestedAction: 'review_fallback',
+    });
+
+    const call = findExecuteCallMatching(/INSERT[\s\S]*flowsheet_linkage_review/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/flowsheet_id/i);
+    expect(sqlText).toMatch(/candidate_library_ids/i);
+    expect(sqlText).toMatch(/candidate_confidences/i);
+    expect(sqlText).toMatch(/suggested_action/i);
+  });
+
+  it('uses ON CONFLICT DO NOTHING on flowsheet_id to make re-runs idempotent', async () => {
+    // The backfill is restartable; without the conflict guard, a second
+    // sweep over the same fallback row would either error on the UNIQUE
+    // constraint or duplicate review rows depending on conflict handling.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+    await enqueueReview({
+      flowsheetId: 7,
+      candidateLibraryIds: [],
+      candidateConfidences: [],
+      suggestedAction: 'review_fallback',
+    });
+
+    const call = findExecuteCallMatching(/INSERT[\s\S]*flowsheet_linkage_review/i);
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/ON\s+CONFLICT[\s\S]*flowsheet_id[\s\S]*DO\s+NOTHING/i);
   });
 });
 
@@ -238,15 +291,55 @@ describe('processRow', () => {
     expect(findExecuteCallMatching(/UPDATE[\s\S]*flowsheet/i)).toBeUndefined();
   });
 
-  it('reports review on a fallback hit without writing', async () => {
-    // Review-flagged rows roll forward to B-3.1; the orchestrator must not
-    // stamp linkage_source on them or B-3.1 misses them.
-    const lookup = jest.fn(() => Promise.resolve(fallbackResponse(33)));
+  it('enqueues a review row on a fallback hit without stamping flowsheet linkage', async () => {
+    // Review-flagged rows roll forward to B-3.1's CLI. The orchestrator must
+    // (a) persist them to flowsheet_linkage_review with the resolved library
+    // candidates, and (b) NOT stamp flowsheet.album_id / linkage_source —
+    // doing so would skip the human-review step entirely.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([{ id: 100 }, { id: 101 }]) // SELECT library for first candidate
+      .mockResolvedValueOnce([]) // SELECT library for second candidate (no match locally)
+      .mockResolvedValueOnce({ count: 1 }); // INSERT review row
+    const lookup = jest.fn(() =>
+      Promise.resolve({
+        results: [
+          { library_item: { id: 1 }, artwork: { release_id: 33 } },
+          { library_item: { id: 2 }, artwork: { release_id: 44 } },
+        ],
+        search_type: 'fallback' as const,
+      })
+    );
 
     const status = await processRow({ id: 7, artist_name: 'Jessica Pratt', album_title: 'On Your Own' }, { lookup });
 
     expect(status).toBe('review');
-    expect((db.execute as jest.Mock).mock.calls.length).toBe(0);
+    expect(findExecuteCallMatching(/UPDATE[\s\S]*flowsheet"\s/i)).toBeUndefined();
+    const insertCall = findExecuteCallMatching(/INSERT[\s\S]*flowsheet_linkage_review/i);
+    expect(insertCall).toBeDefined();
+    const serialized = JSON.stringify(insertCall?.[0]);
+    expect(serialized).toContain('7'); // flowsheet_id
+    expect(serialized).toContain('100'); // resolved library_id from candidate 1
+    expect(serialized).toContain('101');
+  });
+
+  it('enqueues a review row even when no candidate resolves to a local library row', async () => {
+    // Empty candidate arrays are intentional: the operator can still see the
+    // flowsheet text and skip the entry. Skipping the enqueue would silently
+    // hide the case from the queue.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([]) // SELECT library for the only candidate
+      .mockResolvedValueOnce({ count: 1 }); // INSERT review row
+    const lookup = jest.fn(() =>
+      Promise.resolve({
+        results: [{ library_item: { id: 1 }, artwork: { release_id: 33 } }],
+        search_type: 'fallback' as const,
+      })
+    );
+
+    const status = await processRow({ id: 7, artist_name: 'Jessica Pratt', album_title: 'On Your Own' }, { lookup });
+
+    expect(status).toBe('review');
+    expect(findExecuteCallMatching(/INSERT[\s\S]*flowsheet_linkage_review/i)).toBeDefined();
   });
 
   it('reports no_match on an empty LML response without writing', async () => {
@@ -372,8 +465,12 @@ describe('runBackfill', () => {
       .mockResolvedValueOnce([])
       // row 3 — auto_accept, library has two matches → tie-break picks 201, link
       .mockResolvedValueOnce([{ id: 200 }, { id: 201 }])
+      .mockResolvedValueOnce({ count: 1 }) // row 3 applyLink after tie-break picks 201
+      // row 4 — review (fallback): SELECT library for the one candidate +
+      // INSERT into flowsheet_linkage_review
+      .mockResolvedValueOnce([{ id: 300 }])
       .mockResolvedValueOnce({ count: 1 })
-      // rows 4 + 5 fall through to review / no_match (no DB writes)
+      // row 5 — no_match (empty results — no DB writes)
       // batch 2 — empty
       .mockResolvedValueOnce([]);
 

--- a/tests/unit/jobs/flowsheet-lml-link-backfill/resolve.test.ts
+++ b/tests/unit/jobs/flowsheet-lml-link-backfill/resolve.test.ts
@@ -15,7 +15,11 @@
  * library backfill. Future sources (MusicBrainz, etc.) get their own prefix.
  */
 
-import { resolveLmlSignal, AUTO_ACCEPT_CONFIDENCE } from '../../../../jobs/flowsheet-lml-link-backfill/resolve';
+import {
+  resolveLmlSignal,
+  AUTO_ACCEPT_CONFIDENCE,
+  REVIEW_CONFIDENCE,
+} from '../../../../jobs/flowsheet-lml-link-backfill/resolve';
 import type { LmlLookupResponse } from '../../../../jobs/flowsheet-lml-link-backfill/lml-types';
 
 const directResponse = (releaseId: number): LmlLookupResponse => ({
@@ -65,6 +69,47 @@ describe('resolveLmlSignal', () => {
     const result = resolveLmlSignal(fallbackResponse(33));
 
     expect(result.status).toBe('review');
+  });
+
+  it('carries the per-result canonical entity ids on a review signal (B-3.1 queue)', () => {
+    // The B-3.1 review queue persists the ranked candidates so an operator
+    // can pick the right library row. Without the canonical entity ids, the
+    // CLI has nothing to look up and the queue row is useless.
+    const response: LmlLookupResponse = {
+      results: [
+        { library_item: { id: 1 }, artwork: { release_id: 11 } },
+        { library_item: { id: 2 }, artwork: { release_id: 22 } },
+      ],
+      search_type: 'fallback',
+    };
+
+    const result = resolveLmlSignal(response);
+
+    expect(result.status).toBe('review');
+    if (result.status !== 'review') return;
+    expect(result.candidate_canonical_entity_ids).toEqual(['discogs:11', 'discogs:22']);
+    expect(result.confidence).toBe(REVIEW_CONFIDENCE);
+  });
+
+  it('drops review candidates that have no pinable release_id', () => {
+    // No release_id means we can't form a canonical_entity_id to look up
+    // library rows by. Keeping a malformed candidate would make the CLI
+    // present nothing for that slot. Drop them so the array is always
+    // resolvable.
+    const response: LmlLookupResponse = {
+      results: [
+        { library_item: { id: 1 }, artwork: { release_id: 11 } },
+        { library_item: { id: 2 } },
+        { library_item: { id: 3 }, artwork: { release_id: 33 } },
+      ],
+      search_type: 'fallback',
+    };
+
+    const result = resolveLmlSignal(response);
+
+    expect(result.status).toBe('review');
+    if (result.status !== 'review') return;
+    expect(result.candidate_canonical_entity_ids).toEqual(['discogs:11', 'discogs:33']);
   });
 
   it('returns review on alternative / compilation / song_as_artist results', () => {

--- a/tests/unit/scripts/review-linkage.test.ts
+++ b/tests/unit/scripts/review-linkage.test.ts
@@ -19,11 +19,7 @@
  */
 
 import { db } from '@wxyc/database';
-import {
-  loadNextReviewCase,
-  acceptReviewCase,
-  rejectReviewCase,
-} from '../../../scripts/review-linkage';
+import { loadNextReviewCase, acceptReviewCase, rejectReviewCase } from '../../../scripts/review-linkage';
 
 type SqlLike = {
   sql?: string | string[];
@@ -145,9 +141,7 @@ describe('acceptReviewCase', () => {
   });
 
   it("marks the review row reviewed_at=now(), reviewed_decision='accepted'", async () => {
-    (db.execute as jest.Mock)
-      .mockResolvedValueOnce({ count: 1 })
-      .mockResolvedValueOnce({ count: 1 });
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
 
     await acceptReviewCase({ reviewId: 1, flowsheetId: 7, libraryId: 100 });
 
@@ -164,7 +158,7 @@ describe('rejectReviewCase', () => {
     (db.execute as jest.Mock).mockReset();
   });
 
-  it("marks the review row reviewed without touching the flowsheet row", async () => {
+  it('marks the review row reviewed without touching the flowsheet row', async () => {
     // Reject = "this isn't the right album". The flowsheet row's album_id
     // stays NULL so a future LML improvement can pick it up; only the
     // review-queue row is marked done.

--- a/tests/unit/scripts/review-linkage.test.ts
+++ b/tests/unit/scripts/review-linkage.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the B-3.1 manual review CLI core.
+ *
+ * The CLI itself is interactive, so the IO loop isn't unit-tested here —
+ * what we pin is the three DB operations that drive every accept / reject
+ * decision. They have to be exact: a typo in the linkage_source string
+ * would silently misclassify human-review links as ETL links, and missing
+ * the album_id IS NULL guard would let the CLI clobber a row a parallel
+ * forward-path link just stamped.
+ *
+ *   - loadNextReviewCase  → SELECT against flowsheet_linkage_review joined
+ *                            to flowsheet (and library for each candidate),
+ *                            scoped to unreviewed rows in created_at order.
+ *   - acceptReviewCase    → UPDATE flowsheet (album_id + linkage_source +
+ *                            linkage_confidence + linked_at) AND mark the
+ *                            review row reviewed.
+ *   - rejectReviewCase    → mark the review row reviewed without touching
+ *                            the flowsheet row.
+ */
+
+import { db } from '@wxyc/database';
+import {
+  loadNextReviewCase,
+  acceptReviewCase,
+  rejectReviewCase,
+} from '../../../scripts/review-linkage';
+
+type SqlLike = {
+  sql?: string | string[];
+  queryChunks?: Array<string | { value?: string | string[] }>;
+};
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const findExecuteCallMatching = (pattern: RegExp): unknown[] | undefined => {
+  const calls = (db.execute as jest.Mock).mock.calls;
+  return calls.find((call) => pattern.test(renderSql(call[0])));
+};
+
+describe('loadNextReviewCase', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+  });
+
+  it('selects unreviewed rows in created_at order and returns the first', async () => {
+    // The CLI presents one case at a time. It has to pick the oldest
+    // unreviewed row so the queue drains in arrival order; selecting
+    // arbitrarily would make it possible for some rows to languish forever
+    // while newer rows keep cycling to the front.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          flowsheet_id: 7,
+          candidate_library_ids: [100, 101],
+          candidate_confidences: [0.5, 0.5],
+          suggested_action: 'review_fallback',
+          flowsheet_artist: 'Jessica Pratt',
+          flowsheet_album: 'On Your Own',
+          flowsheet_track: 'Back, Baby',
+        },
+      ])
+      .mockResolvedValueOnce([
+        { id: 100, artist_name: 'Jessica Pratt', album_title: 'Quiet Signs' },
+        { id: 101, artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again' },
+      ]);
+
+    const next = await loadNextReviewCase();
+
+    expect(next).not.toBeNull();
+    expect(next?.reviewId).toBe(1);
+    expect(next?.flowsheetId).toBe(7);
+    expect(next?.candidates).toHaveLength(2);
+    expect(next?.candidates[0]).toMatchObject({
+      libraryId: 100,
+      artistName: 'Jessica Pratt',
+      confidence: 0.5,
+    });
+    const selectCall = findExecuteCallMatching(/SELECT[\s\S]*flowsheet_linkage_review/i);
+    const sqlText = renderSql(selectCall?.[0]);
+    expect(sqlText).toMatch(/reviewed_at"?\s+IS\s+NULL/i);
+    expect(sqlText).toMatch(/ORDER\s+BY[\s\S]*created_at/i);
+    expect(sqlText).toMatch(/LIMIT\s+1/i);
+  });
+
+  it('returns null when the queue is empty', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    const next = await loadNextReviewCase();
+
+    expect(next).toBeNull();
+  });
+
+  it('excludes review ids passed in (operator-skipped within the session)', async () => {
+    // "skip" doesn't mark the row reviewed — we just don't want to keep
+    // re-showing it for the duration of the CLI session.
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    await loadNextReviewCase([1, 2, 3]);
+
+    const selectCall = findExecuteCallMatching(/SELECT[\s\S]*flowsheet_linkage_review/i);
+    const serialized = JSON.stringify(selectCall?.[0]);
+    expect(serialized).toContain('1');
+    expect(serialized).toContain('2');
+    expect(serialized).toContain('3');
+  });
+});
+
+describe('acceptReviewCase', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+  });
+
+  it("stamps album_id, linkage_source='human_review', linked_at on the flowsheet row", async () => {
+    // The audit columns are how analytics distinguishes human-curated links
+    // from heuristic ones. linkage_source must be 'human_review' verbatim.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce({ count: 1 }) // UPDATE flowsheet
+      .mockResolvedValueOnce({ count: 1 }); // UPDATE review row
+
+    await acceptReviewCase({ reviewId: 1, flowsheetId: 7, libraryId: 100 });
+
+    const flowsheetUpdate = findExecuteCallMatching(/UPDATE[\s\S]*"flowsheet"[\s\S]*album_id/i);
+    expect(flowsheetUpdate).toBeDefined();
+    const sqlText = renderSql(flowsheetUpdate?.[0]);
+    expect(sqlText).toMatch(/album_id"?\s*=/i);
+    expect(sqlText).toMatch(/linkage_source"?\s*=\s*'human_review'/i);
+    expect(sqlText).toMatch(/linked_at"?\s*=\s*now\(\)/i);
+    expect(sqlText).toMatch(/album_id"?\s+IS\s+NULL/i);
+  });
+
+  it("marks the review row reviewed_at=now(), reviewed_decision='accepted'", async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 1 });
+
+    await acceptReviewCase({ reviewId: 1, flowsheetId: 7, libraryId: 100 });
+
+    const reviewUpdate = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet_linkage_review/i);
+    expect(reviewUpdate).toBeDefined();
+    const sqlText = renderSql(reviewUpdate?.[0]);
+    expect(sqlText).toMatch(/reviewed_at"?\s*=\s*now\(\)/i);
+    expect(sqlText).toMatch(/reviewed_decision"?\s*=\s*'accepted'/i);
+  });
+});
+
+describe('rejectReviewCase', () => {
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+  });
+
+  it("marks the review row reviewed without touching the flowsheet row", async () => {
+    // Reject = "this isn't the right album". The flowsheet row's album_id
+    // stays NULL so a future LML improvement can pick it up; only the
+    // review-queue row is marked done.
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
+
+    await rejectReviewCase(1);
+
+    const reviewUpdate = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet_linkage_review/i);
+    expect(reviewUpdate).toBeDefined();
+    const sqlText = renderSql(reviewUpdate?.[0]);
+    expect(sqlText).toMatch(/reviewed_decision"?\s*=\s*'rejected'/i);
+    expect(findExecuteCallMatching(/UPDATE[\s\S]*"flowsheet"[\s\S]*album_id/i)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #501.

## Summary

Adds the manual review queue for gray-zone LML matches surfaced by the B-2.2 backfill, plus the CLI an operator uses to drain it.

- **`flowsheet_linkage_review` table** (migration `0066`) — one row per flowsheet entry that LML returned a non-direct (fallback / alternative / compilation / song_as_artist) result for. Stores ranked candidate `library` ids, per-candidate confidences, suggested action, and review-decision audit columns. Partial index on `created_at WHERE reviewed_at IS NULL` keeps the CLI's "next case" lookup cheap as the table grows. `flowsheet_id` is `UNIQUE` so the orchestrator can re-run with `ON CONFLICT DO NOTHING`.
- **B-2.2 orchestrator wiring** — the resolver now carries the per-result canonical entity ids on a `review` signal (filtered to results with a pinable Discogs release id). The orchestrator resolves each canonical id to local `library` rows via `library.canonical_entity_id`, dedupes across candidates, and inserts the row into `flowsheet_linkage_review` with `suggested_action='review_fallback'`. Empty candidate arrays are valid: the operator can still see the flowsheet text and skip.
- **`scripts/review-linkage.ts`** — interactive CLI invoked as `npx tsx scripts/review-linkage.ts`. Drains the queue oldest-first, showing artist/album/track text and the ranked candidates. Operator answers `<n>` to accept candidate `n`, `n` for no-match, `s` to skip (in-session only), or `q` to quit. Accept stamps `flowsheet.album_id` with `linkage_source='human_review'`, `linked_at=now()`, guarded by `album_id IS NULL` (same idempotency rail B-2.2 uses) and marks the queue row reviewed. Reject only marks the queue row reviewed — the flowsheet row stays unmatched so a future LML improvement can pick it up. Skip writes nothing; the next session re-shows the case.

Web UI is out of scope for v1; the CLI is sufficient until volume justifies otherwise.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:unit` (1258 tests passing, including new resolver / orchestrator / CLI coverage)
- [x] `node scripts/validate-migrations.mjs`
- [ ] After merge: invoke the B-2.2 backfill against staging, verify gray-zone rows land in `flowsheet_linkage_review`, and walk a handful of cases through the CLI end-to-end.