### PR TITLE
Replay 0064 mojibake propagation skipped by drizzle cursor

### DIFF
--- a/dev_env/init-db.mjs
+++ b/dev_env/init-db.mjs
@@ -119,6 +119,21 @@ async function runMigrations() {
  * independent check by comparing SHA-256 hashes of migration SQL files against
  * the hashes recorded in drizzle.__drizzle_migrations.
  */
+/**
+ * Tags whose hashes will never be in `drizzle.__drizzle_migrations` because
+ * drizzle's "max(applied.created_at) cursor" silently skipped them and a
+ * later replay migration carries their effects forward. The replays apply
+ * cleanly; the originals stay in the journal so their SQL is on disk and
+ * the validator's "missing SQL" check stays satisfied. See #511 + #550.
+ *
+ * Each entry must include the migration that *replays* it so future
+ * audit tooling can trace cause and effect without grepping git history.
+ */
+const HISTORICAL_REPLACED_TAGS = new Map([
+  ['0054_flowsheet-search-doc-with-dj-name', '0065_replay-flowsheet-search-doc-with-dj-name'],
+  ['0064_propagate-v012-mojibake', '0066_replay-v012-mojibake'],
+]);
+
 async function verifyMigrations() {
   console.log(styleText(['bold'], '🔍 Verifying migration completeness...\n'));
 
@@ -143,19 +158,45 @@ async function verifyMigrations() {
   `;
   const appliedHashes = new Set(dbMigrations.map((m) => m.hash));
 
-  // Check for missing migrations
-  const missing = expectedMigrations.filter((m) => !appliedHashes.has(m.hash));
+  // Check for missing migrations, partitioning into "actual misses" (a real
+  // failure to apply) and "expected absent" (cursor-skipped, replayed by a
+  // later migration that *did* apply).
+  const allMissing = expectedMigrations.filter((m) => !appliedHashes.has(m.hash));
+  const expectedAbsent = [];
+  const realMissing = [];
+  for (const m of allMissing) {
+    if (HISTORICAL_REPLACED_TAGS.has(m.tag)) {
+      const replayTag = HISTORICAL_REPLACED_TAGS.get(m.tag);
+      const replay = expectedMigrations.find((e) => e.tag === replayTag);
+      // Only treat as expected-absent if the replay itself *did* apply.
+      // Otherwise the hole is real and the operator should know.
+      if (replay && appliedHashes.has(replay.hash)) {
+        expectedAbsent.push({ ...m, replayTag });
+      } else {
+        realMissing.push(m);
+      }
+    } else {
+      realMissing.push(m);
+    }
+  }
 
-  if (missing.length > 0) {
+  for (const m of expectedAbsent) {
+    console.warn(
+      `WARN:  Journal entry idx ${m.idx} (${m.tag}) has no row in __drizzle_migrations ` +
+        `(allowlisted: replayed by ${m.replayTag}).`
+    );
+  }
+
+  if (realMissing.length > 0) {
     console.error('MIGRATION VERIFICATION FAILED!');
-    console.error(`${missing.length} migration(s) were NOT applied:\n`);
-    for (const m of missing) {
+    console.error(`${realMissing.length} migration(s) were NOT applied:\n`);
+    for (const m of realMissing) {
       console.error(`  - [idx ${m.idx}] ${m.tag} (when: ${m.when})`);
     }
     console.error('\nThis likely indicates an out-of-order timestamp in _journal.json.');
     console.error('The "when" timestamps MUST be monotonically increasing.');
     console.error('See: https://github.com/WXYC/Backend-Service/issues/400\n');
-    throw new Error(`Migration verification failed: ${missing.length} missing migration(s)`);
+    throw new Error(`Migration verification failed: ${realMissing.length} missing migration(s)`);
   }
 
   // Warn about out-of-order timestamps (prevention for future)
@@ -171,7 +212,15 @@ async function verifyMigrations() {
     prevTag = entry.tag;
   }
 
-  console.log(`All ${expectedMigrations.length} migrations verified as applied.\n`);
+  const appliedCount = expectedMigrations.length - expectedAbsent.length;
+  if (expectedAbsent.length > 0) {
+    console.log(
+      `${appliedCount} of ${expectedMigrations.length} migrations applied; ` +
+        `${expectedAbsent.length} expected absent (allowlisted, see HISTORICAL_REPLACED_TAGS).\n`
+    );
+  } else {
+    console.log(`All ${expectedMigrations.length} migrations verified as applied.\n`);
+  }
 }
 
 /**

--- a/shared/database/src/migrations/0066_replay-v012-mojibake.sql
+++ b/shared/database/src/migrations/0066_replay-v012-mojibake.sql
@@ -1,0 +1,69 @@
+-- 0066: Replay 0064's V012 mojibake propagation, skipped by drizzle's cursor.
+--
+-- 0064 was committed with when=1778683200000, then 0065 landed with
+-- when=1779683200001 (one millisecond above the original cursor) to recover
+-- five other migrations the same cursor bug had stranded earlier (#511).
+-- That bumped drizzle's max(applied_when) cursor to 1779683200001, which
+-- pushed 0064 below the cursor — drizzle now skips it on every migrate
+-- run, the verifier in init-db.mjs reports it missing, migrate exits 1,
+-- and Auto Build & Deploy halts before the deploy step.
+--
+-- This file replays 0064's full effect at when=1779683200002 (two ms above
+-- the original cursor) so drizzle's cursor advances past it cleanly.
+-- Future migrations should land at the next monotonic timestamp above this.
+--
+-- Idempotent by construction: every UPDATE is value-keyed (WHERE col =
+-- corrupted_form). A re-run against an already-corrected row matches
+-- nothing and is a no-op. That property is what makes splitting the
+-- replay into a new migration safe — it does not matter whether 0064
+-- ever ran on this database, ever ran partially, or ran fully; the end
+-- state is the same.
+--
+-- 33 UPDATE statements covering 52 rows in wxyc_schema.flowsheet across
+-- four text columns. Source of truth: M0.1 audit (PR #529,
+-- audit/bs_mojibake_audit.csv). Identical to 0064's body — see that file
+-- for the parent epic and project context (WXYC/docs#6).
+--
+-- Permanent gap in __drizzle_migrations: 0064's hash will never have a
+-- row, by design. The validator and verifier both already tolerate this
+-- shape via the same path they tolerate the 0054/0055/0056/0062/0063
+-- gaps from #551. Audit tooling cross-referencing journal vs applied
+-- should treat 0064 as "expected absent."
+
+-- artist_name: 6 distinct values, 17 rows
+UPDATE wxyc_schema.flowsheet SET artist_name = 'μ-Ziq' WHERE artist_name = 'Î¼-Ziq';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'GrOun士 + Kabamix' WHERE artist_name = 'GrOunå£« + Kabamix';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Luboš Fišer' WHERE artist_name = 'LuboÅ¡ FiÅ¡er';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Mustafah ''Abd Al''-Azīz' WHERE artist_name = 'Mustafah ''Abd Al''-AzÄ«z';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Σtella, Las Palabras' WHERE artist_name = 'Î£tella, Las Palabras';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'μ-ziq' WHERE artist_name = 'Î¼-ziq';
+-- track_title: 17 distinct values, 23 rows
+UPDATE wxyc_schema.flowsheet SET track_title = 'ΩΩΩ' WHERE track_title = 'Î©Î©Î©';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Helvacı' WHERE track_title = 'HelvacÄ±';
+UPDATE wxyc_schema.flowsheet SET track_title = '｡.･BLUSH･.｡' WHERE track_title = 'ï½¡.ï½¥BLUSHï½¥.ï½¡';
+UPDATE wxyc_schema.flowsheet SET track_title = '400米' WHERE track_title = '400ç±³';
+UPDATE wxyc_schema.flowsheet SET track_title = '78 Yilinin En Uzun Dakikası' WHERE track_title = '78 Yilinin En Uzun DakikasÄ±';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Daša' WHERE track_title = 'DaÅ¡a';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Desgraca̧da' WHERE track_title = 'DesgracaÌ§da';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Gadżet elektroniczny' WHERE track_title = 'GadÅ¼et elektroniczny';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Hidden Power (Phase δ)' WHERE track_title = 'Hidden Power (Phase Î´)';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Još Jedna Crta' WHERE track_title = 'JoÅ¡ Jedna Crta';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Poznaješ Li Moje Pravo Lice' WHERE track_title = 'PoznajeÅ¡ Li Moje Pravo Lice';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Yalnızlar Rıhtımı' WHERE track_title = 'YalnÄ±zlar RÄ±htÄ±mÄ±';
+UPDATE wxyc_schema.flowsheet SET track_title = 'tno doɹp' WHERE track_title = 'tno doÉ¹p';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Ševa' WHERE track_title = 'Å eva';
+UPDATE wxyc_schema.flowsheet SET track_title = 'što me vikas, šefijo' WHERE track_title = 'Å¡to me vikas, Å¡efijo';
+UPDATE wxyc_schema.flowsheet SET track_title = 'два TWO' WHERE track_title = 'Ð´Ð²Ð° TWO';
+UPDATE wxyc_schema.flowsheet SET track_title = '夢中人' WHERE track_title = 'å¤¢ä¸­äºº';
+-- album_title: 7 distinct values, 9 rows
+UPDATE wxyc_schema.flowsheet SET album_title = 'د' WHERE album_title = 'Ø¯';
+UPDATE wxyc_schema.flowsheet SET album_title = '繭' WHERE album_title = 'ç¹­';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Atmospheres 第3' WHERE album_title = 'Atmospheres ç¬¬3';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Ege Bamyası' WHERE album_title = 'Ege BamyasÄ±';
+UPDATE wxyc_schema.flowsheet SET album_title = 'En Kotu İyi Olur' WHERE album_title = 'En Kotu Ä°yi Olur';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Škoda Mluvit' WHERE album_title = 'Å koda Mluvit';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Ψ 847' WHERE album_title = 'Î¨ 847';
+-- record_label: 3 distinct values, 3 rows
+UPDATE wxyc_schema.flowsheet SET record_label = 'Galerija ŠKUC Izdaja / Dark Entries' WHERE record_label = 'Galerija Å KUC Izdaja / Dark Entries';
+UPDATE wxyc_schema.flowsheet SET record_label = 'Više manje zauvijek' WHERE record_label = 'ViÅ¡e manje zauvijek';
+UPDATE wxyc_schema.flowsheet SET record_label = 'Ω' WHERE record_label = 'Î©';

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1779683200001,
       "tag": "0065_replay-flowsheet-search-doc-with-dj-name",
       "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1779683200002,
+      "tag": "0066_replay-v012-mojibake",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/unit/scripts/init-db-historical-replaced.test.ts
+++ b/tests/unit/scripts/init-db-historical-replaced.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Source-grep tests for the `HISTORICAL_REPLACED_TAGS` allowlist in
+ * `dev_env/init-db.mjs`. Each entry in that map records a journal tag
+ * whose hash will never appear in `drizzle.__drizzle_migrations` because
+ * drizzle's "max(applied.created_at) cursor" silently skipped it; a
+ * later replay migration carries the effects forward instead.
+ *
+ * The verifier in init-db.mjs tolerates an entry being absent only if
+ * its replay migration *is* applied. This file validates the allowlist
+ * itself: that the migrations it names exist in the journal, that each
+ * skipped entry has a paired replay, and that the replay numerically
+ * follows the original (so its `when` is above drizzle's cursor).
+ *
+ * The behavioural test of the verifier (what happens when a hash is
+ * absent) lives at integration-test time, where a real PG and migrate
+ * runner are available; this file only exercises the data shape so a
+ * future PR cannot list a tag that doesn't exist or point to a replay
+ * that isn't really a replay.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const initDbPath = path.join(repoRoot, 'dev_env/init-db.mjs');
+const journalPath = path.join(repoRoot, 'shared/database/src/migrations/meta/_journal.json');
+
+const initDbSource = fs.readFileSync(initDbPath, 'utf-8');
+const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8')) as {
+  entries: Array<{ idx: number; tag: string; when: number }>;
+};
+const journalTags = new Set(journal.entries.map((e) => e.tag));
+
+/**
+ * Parse the `HISTORICAL_REPLACED_TAGS = new Map([...])` literal out of
+ * init-db.mjs source. The map is plain string-to-string, so a regex
+ * extraction is robust enough; if the structure changes (e.g., to JSON
+ * import) update this and the verifier together.
+ */
+function parseHistoricalReplacedTags(): Map<string, string> {
+  const blockMatch = initDbSource.match(/HISTORICAL_REPLACED_TAGS\s*=\s*new\s+Map\(\[([\s\S]*?)\]\);/);
+  if (!blockMatch) throw new Error('HISTORICAL_REPLACED_TAGS not found in init-db.mjs');
+  const pairs = new Map<string, string>();
+  const pairRe = /\[\s*'([^']+)'\s*,\s*'([^']+)'\s*\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = pairRe.exec(blockMatch[1])) !== null) {
+    pairs.set(m[1], m[2]);
+  }
+  if (pairs.size === 0) throw new Error('HISTORICAL_REPLACED_TAGS is empty');
+  return pairs;
+}
+
+describe('init-db.mjs: HISTORICAL_REPLACED_TAGS allowlist', () => {
+  let allowlist: Map<string, string>;
+
+  beforeAll(() => {
+    allowlist = parseHistoricalReplacedTags();
+  });
+
+  it('every skipped tag exists in the journal', () => {
+    for (const skippedTag of allowlist.keys()) {
+      expect(journalTags.has(skippedTag)).toBe(true);
+    }
+  });
+
+  it('every replay tag exists in the journal', () => {
+    for (const replayTag of allowlist.values()) {
+      expect(journalTags.has(replayTag)).toBe(true);
+    }
+  });
+
+  it('every replay migration sits at a higher idx than the migration it replays', () => {
+    // drizzle applies migrations in journal-array order (and skips entries
+    // below max(applied.created_at)). For a replay to actually run, it
+    // must come *after* the skipped entry in the journal.
+    const idxByTag = new Map<string, number>(journal.entries.map((e) => [e.tag, e.idx]));
+    for (const [skippedTag, replayTag] of allowlist) {
+      const skippedIdx = idxByTag.get(skippedTag);
+      const replayIdx = idxByTag.get(replayTag);
+      if (skippedIdx === undefined || replayIdx === undefined) {
+        throw new Error(`tag missing from journal: ${skippedTag} or ${replayTag}`);
+      }
+      expect(replayIdx).toBeGreaterThan(skippedIdx);
+    }
+  });
+
+  it('every replay migration has a `when` timestamp above the skipped one', () => {
+    // Beyond just sitting at a higher idx, the replay's `when` must be
+    // monotonically above the cursor — otherwise drizzle's filter would
+    // also skip the replay and we'd be in the same bind we are recovering
+    // from.
+    const whenByTag = new Map<string, number>(journal.entries.map((e) => [e.tag, e.when]));
+    for (const [skippedTag, replayTag] of allowlist) {
+      const skippedWhen = whenByTag.get(skippedTag);
+      const replayWhen = whenByTag.get(replayTag);
+      if (skippedWhen === undefined || replayWhen === undefined) {
+        throw new Error(`tag missing from journal: ${skippedTag} or ${replayTag}`);
+      }
+      expect(replayWhen).toBeGreaterThan(skippedWhen);
+    }
+  });
+
+  it('every replay tag is unique (no two skipped tags claim the same replay)', () => {
+    const replayCounts = new Map<string, number>();
+    for (const replayTag of allowlist.values()) {
+      replayCounts.set(replayTag, (replayCounts.get(replayTag) ?? 0) + 1);
+    }
+    for (const [tag, count] of replayCounts) {
+      expect(`${tag}: ${count}`).toBe(`${tag}: 1`);
+    }
+  });
+
+  it('the verifier conditions absence on the replay being applied', () => {
+    // Source-grep guard: the verifier must check `appliedHashes.has(replay.hash)`
+    // before treating the original as expected-absent. Without that check,
+    // a database where neither original nor replay applied would silently
+    // pass verification — the exact opposite of what we want.
+    expect(initDbSource).toMatch(/appliedHashes\.has\(\s*replay\.hash\s*\)/);
+  });
+});


### PR DESCRIPTION
## Summary

- New migration **0066** at `when=1779683200002` replays 0064's value-keyed mojibake UPDATEs verbatim. Idempotent by construction.
- `dev_env/init-db.mjs:verifyMigrations` now tolerates an expected-absent journal entry when its replay has applied. Allowlist is explicit: `HISTORICAL_REPLACED_TAGS` maps each skipped original to its replay (0054→0065, 0064→0066).
- 6 new unit tests in `tests/unit/scripts/init-db-historical-replaced.test.ts` pin the allowlist's shape so a future contributor cannot list a tag that doesn't exist or point to a replay that isn't really a replay.

## Why

PR #551 raised drizzle's cursor to 1779683200001 (0065's `when`) when it cleared the original five stranded migrations. That left 0064 — `when=1778683200000`, in the journal at the natural-monotonic timestamp — sitting *below* the new cursor. Drizzle skips it on every migrate run, the verifier reports it missing, migrate exits 1, Auto Build & Deploy halts before the deploy step. Production has been stuck in this state since #551 merged.

This is the same cursor-skip pattern #511 / #550 / #551 traced — just with a smaller blast radius (one migration instead of five). The fix is structurally identical: a replay at `cursor + 1ms` plus an explicit allowlist for the verifier so it doesn't conflate "expected absent because replayed" with "missing because something broke."

## Why a hash will never be inserted for 0064

Drizzle's migrator uses `journal.when > max(applied.created_at)` as its filter. Once a later migration commits with a larger `created_at`, anything with a smaller `when` is skipped on every subsequent run, with no way to reach `__drizzle_migrations`. The original 0054 hash had the same fate before #551; 0064 is the same shape. Audit tooling cross-referencing journal vs applied should treat both as "expected absent" — the new `HISTORICAL_REPLACED_TAGS` map is the source of truth for that.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors (313 pre-existing warnings)
- [x] `npm run format:check` clean
- [x] `npm run lint:migrations` passes (1 historical allowlisted warning, unchanged)
- [x] `npm run test:unit` 1253 / 1253 passing
- [x] 6 new tests pin: every skipped tag exists in journal, every replay tag exists in journal, every replay sits at a higher idx, every replay has a higher `when`, every replay is unique, and the verifier checks `appliedHashes.has(replay.hash)` before tolerating absence
- [ ] Post-merge: `Auto Build & Deploy` migrate succeeds (drizzle applies 0066 — 33 idempotent UPDATEs against ≤52 rows — verifier passes with allowlist warnings for 0054/0064)
- [ ] Post-merge: `deploy` job runs (was being skipped because migrate failed)
- [ ] Post-merge: spot-check `pg_stat_activity` for new backend connections with `application_name=wxyc-backend`

Refs #511, #550. Follows #551.