### PR TITLE
Wire Sentry + JSON logs into flowsheet-etl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,21 @@ Connects to tubafrenzy's CDC WebSocket and verifies changes land in Backend-Serv
 - `SENTRY_DSN` -- Sentry project DSN (required for error reporting). Without this, Sentry silently disables itself.
 - `SENTRY_RELEASE` -- Set automatically by the deploy action to `<app>@<tag>`
 
+#### Observability tags (Phase A contract)
+
+ETL/backfill jobs that opt into the Phase A observability contract emit JSON log lines on stdout (errors on stderr) and tag every Sentry event with the same four fields:
+
+| Tag      | Value                                                        |
+| -------- | ------------------------------------------------------------ |
+| `repo`   | `Backend-Service`                                            |
+| `tool`   | `<job-name> <subcommand>` (e.g. `flowsheet-etl incremental`) |
+| `step`   | Per-call: `started`, `bulk-load-shows`, `failed`, etc.       |
+| `run_id` | UUID generated at entrypoint init (one per process)          |
+
+The wireup is per-job: see `jobs/flowsheet-etl/logger.ts` for the canonical pattern (issue #538). The shared Rust/Python `wxyc_etl::logger` foundation lives in the `wxyc-etl` repo and targets non-Node ETLs; Backend-Service mirrors the same tag contract directly so the dashboards in Sentry / log queries are uniform across runtimes. `SENTRY_DSN` is still optional — when unset the SDK no-ops and JSON logging continues to work.
+
+> TODO (separate child task): provision `SENTRY_DSN` for the flowsheet-etl cron in EC2 / GitHub Actions secrets.
+
 ### Legacy mirror queue (`apps/backend/middleware/legacy/commandqueue.mirror.ts`)
 
 Bounded ring-buffer reports written under `mirror-logs/`. Reports never include raw SQL — only length, sha256, and statement count.

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -31,6 +31,7 @@ import {
 import { parseInsertLine } from './parse-dump.js';
 import { mapProdEntryType, resolveEntryTimestamp, parseShowEntryDJName } from './transform.js';
 import { fetchLegacyShows, fetchLegacyEntries, closeLegacyConnection } from './fetch-legacy.js';
+import { initLogger, log, captureError, closeLogger } from './logger.js';
 
 const JOB_NAME = 'flowsheet-etl';
 const BATCH_SIZE = 5000;
@@ -49,7 +50,7 @@ const resetSequences = async () => {
   await db.execute(
     sql`SELECT setval(pg_get_serial_sequence('wxyc_schema.flowsheet', 'play_order'), COALESCE((SELECT MAX(play_order) FROM wxyc_schema.flowsheet), 0) + 1, false)`
   );
-  console.log('[flowsheet-etl] Reset sequences to max(id)+1.');
+  log('info', 'reset-sequences', 'Reset sequences to max(id)+1.');
 };
 
 /**
@@ -66,7 +67,7 @@ const resolveAlbumIds = async () => {
       AND f.legacy_release_id IS NOT NULL
       AND f.album_id IS NULL
   `);
-  console.log(`[flowsheet-etl] Resolved album_id for flowsheet entries.`);
+  log('info', 'resolve-album-ids', 'Resolved album_id for flowsheet entries.');
 };
 
 /**
@@ -101,7 +102,10 @@ const resolveDjNames = async (legacyEntryIds: number[]) => {
       AND f."legacy_entry_id" = ANY(${legacyEntryIds})
   `);
   const updated = Number(result.count ?? 0);
-  console.log(`[flowsheet-etl] Resolved dj_name for ${updated}/${legacyEntryIds.length} new entries.`);
+  log('info', 'resolve-dj-names', `Resolved dj_name for ${updated}/${legacyEntryIds.length} new entries.`, {
+    updated,
+    candidates: legacyEntryIds.length,
+  });
 };
 
 /** Entry types whose legacy ARTIST_NAME text is display content, not a real artist. */
@@ -247,7 +251,7 @@ const importEntries = async (dbClient: DbClient, lines: string[], showIdMap: Map
         entryCount += pendingEntries.length;
         pendingEntries.length = 0;
         if (entryCount % 50000 === 0) {
-          console.log(`[flowsheet-etl] ...${entryCount} entries processed.`);
+          log('info', 'bulk-load-entries', `...${entryCount} entries processed.`, { entryCount });
         }
       }
     }
@@ -262,25 +266,25 @@ const importEntries = async (dbClient: DbClient, lines: string[], showIdMap: Map
 };
 
 const runBulkLoad = async (dumpPath: string, { replace = false } = {}) => {
-  console.log(`[flowsheet-etl] Bulk load from: ${dumpPath}${replace ? ' (--replace: truncate + reimport)' : ''}`);
+  log('info', 'bulk-load-start', `Bulk load from: ${dumpPath}`, { dumpPath, replace });
   const content = readFileSync(dumpPath, 'utf-8');
   const lines = content.split('\n');
 
   const doBulkLoad = async (dbClient: DbClient) => {
     if (replace) {
-      console.log('[flowsheet-etl] Truncating flowsheet and shows tables...');
+      log('info', 'bulk-load-truncate', 'Truncating flowsheet and shows tables...');
       await dbClient.execute(sql`TRUNCATE ${flowsheet}, ${shows} CASCADE`);
     }
 
-    console.log('[flowsheet-etl] Pass 1: Importing shows...');
+    log('info', 'bulk-load-shows', 'Pass 1: Importing shows...');
     const showCount = await importShows(dbClient, lines);
-    console.log(`[flowsheet-etl] Imported ${showCount} shows.`);
+    log('info', 'bulk-load-shows', `Imported ${showCount} shows.`, { showCount });
 
     const showIdMap = await buildShowIdMap(dbClient);
 
-    console.log('[flowsheet-etl] Pass 2: Importing entries...');
+    log('info', 'bulk-load-entries', 'Pass 2: Importing entries...');
     const entryCount = await importEntries(dbClient, lines, showIdMap);
-    console.log(`[flowsheet-etl] Imported ${entryCount} entries.`);
+    log('info', 'bulk-load-entries', `Imported ${entryCount} entries.`, { entryCount });
   };
 
   if (replace) {
@@ -297,7 +301,7 @@ const runBulkLoad = async (dumpPath: string, { replace = false } = {}) => {
   // not the bulk-load path. The bulk load imports raw legacy data; backfilling
   // 2.6M rows in a single UPDATE is exactly the wedge case from issue #511.
   await updateLastRun(JOB_NAME, new Date());
-  console.log('[flowsheet-etl] Recorded last_run for future incremental syncs.');
+  log('info', 'bulk-load-complete', 'Recorded last_run for future incremental syncs.');
 };
 
 // ---- Incremental Sync Mode ----
@@ -440,7 +444,11 @@ export const runIncremental = async (): Promise<SyncResult> => {
   await updateLastRun(JOB_NAME, runStartedAt);
   const parts = [`${showsImported} shows`, `${entriesImported} new entries`];
   if (entriesUpdated > 0) parts.push(`${entriesUpdated} updated entries`);
-  console.log(`[flowsheet-etl] Incremental sync: ${parts.join(', ')}.`);
+  log('info', 'incremental-complete', `Incremental sync: ${parts.join(', ')}.`, {
+    showsImported,
+    entriesImported,
+    entriesUpdated,
+  });
 
   return { showsImported, entriesImported, entriesUpdated };
 };
@@ -448,9 +456,13 @@ export const runIncremental = async (): Promise<SyncResult> => {
 // ---- Main ----
 
 const run = async () => {
+  const args = process.argv.slice(2);
+  const dumpPath = args.find((a) => !a.startsWith('--'));
+  const subcommand = dumpPath ? 'bulk-load' : args.includes('--poll') ? 'poll' : 'incremental';
+  initLogger({ repo: 'Backend-Service', tool: `${JOB_NAME} ${subcommand}` });
+  log('info', 'started', `${JOB_NAME} ${subcommand} started`);
+
   try {
-    const args = process.argv.slice(2);
-    const dumpPath = args.find((a) => !a.startsWith('--'));
     if (dumpPath) {
       await runBulkLoad(dumpPath, { replace: args.includes('--replace') });
     } else if (args.includes('--poll')) {
@@ -470,7 +482,12 @@ const run = async () => {
   }
 };
 
-run().catch((error) => {
-  console.error('[flowsheet-etl] Failed:', error);
-  process.exitCode = 1;
-});
+run()
+  .catch((error) => {
+    log('error', 'failed', `${JOB_NAME} failed`, { error: error instanceof Error ? error.message : String(error) });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    void closeLogger();
+  });

--- a/jobs/flowsheet-etl/logger.ts
+++ b/jobs/flowsheet-etl/logger.ts
@@ -1,0 +1,87 @@
+/**
+ * Observability for flowsheet-etl: Sentry init + JSON logs on stdout/stderr.
+ *
+ * Phase A foundation contract (issue #538): every log line carries the four
+ * tags `repo`, `tool`, `step`, `run_id`. Sentry stays inactive when
+ * SENTRY_DSN is unset (the @sentry/node SDK silently no-ops in that case),
+ * so this module is safe to call from any environment.
+ *
+ * The shared `wxyc_etl::logger` foundation lives in the wxyc-etl repo and
+ * targets Rust/Python ETLs. Backend-Service is Node, so we mirror the
+ * tag contract here in a tiny stdlib-only module instead of pulling in
+ * pino — the only consumer is this one job and the JSON shape is trivial.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+/**
+ * Initialize Sentry and the structured logger. Call once at the top of the
+ * entrypoint, before any other logic. Returns the resolved `run_id` so the
+ * caller can pass it to subprocesses or persist it for cross-system tracing.
+ */
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+/**
+ * Emit a JSON log line. `info`/`warn` go to stdout, `error` goes to stderr
+ * so container log shippers can split streams by severity.
+ *
+ * Silently no-ops when called before `initLogger()` so unit tests that
+ * exercise library functions directly (without invoking the entrypoint)
+ * don't have to thread an init call through every fixture.
+ */
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+/** Capture an exception to Sentry with the current run's tags + an extra `step`. */
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+/** Flush pending Sentry events. Call from the entrypoint's `finally`. */
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/flowsheet-etl/package.json
+++ b/jobs/flowsheet-etl/package.json
@@ -15,6 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@sentry/node": "^10.50.0",
     "@wxyc/database": "^1.0.0"
   },
   "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -474,6 +474,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@sentry/node": "^10.50.0",
         "@wxyc/database": "^1.0.0"
       },
       "devDependencies": {

--- a/tests/unit/jobs/flowsheet-etl/logger.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/logger.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Smoke tests for the flowsheet-etl observability logger.
+ *
+ * Phase A foundation contract: every log line carries the four tags
+ * `repo`, `tool`, `step`, `run_id`. Sentry stays inactive when SENTRY_DSN
+ * is unset (no panic, no network calls).
+ */
+
+describe('flowsheet-etl logger', () => {
+  const originalDsn = process.env.SENTRY_DSN;
+
+  afterEach(() => {
+    if (originalDsn === undefined) {
+      delete process.env.SENTRY_DSN;
+    } else {
+      process.env.SENTRY_DSN = originalDsn;
+    }
+    jest.resetModules();
+  });
+
+  it('initializes without panic when SENTRY_DSN is unset', async () => {
+    delete process.env.SENTRY_DSN;
+    const { initLogger, closeLogger } = await import('../../../../jobs/flowsheet-etl/logger');
+
+    expect(() => initLogger({ repo: 'Backend-Service', tool: 'flowsheet-etl test' })).not.toThrow();
+    await closeLogger();
+  });
+
+  it('emits a JSON line carrying repo/tool/step/run_id tags', async () => {
+    delete process.env.SENTRY_DSN;
+    const { initLogger, log, closeLogger } = await import('../../../../jobs/flowsheet-etl/logger');
+
+    const writes: string[] = [];
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      writes.push(typeof chunk === 'string' ? chunk : (chunk as Buffer).toString());
+      return true;
+    });
+
+    const runId = initLogger({ repo: 'Backend-Service', tool: 'flowsheet-etl incremental' });
+    log('info', 'started', 'incremental sync starting', { extra: 1 });
+    spy.mockRestore();
+    await closeLogger();
+
+    expect(writes.length).toBe(1);
+    const parsed = JSON.parse(writes[0].trim());
+    expect(parsed.repo).toBe('Backend-Service');
+    expect(parsed.tool).toBe('flowsheet-etl incremental');
+    expect(parsed.step).toBe('started');
+    expect(parsed.run_id).toBe(runId);
+    expect(parsed.level).toBe('info');
+    expect(parsed.message).toBe('incremental sync starting');
+    expect(parsed.extra).toBe(1);
+    expect(typeof parsed.timestamp).toBe('string');
+  });
+
+  it('uses an explicit run_id when provided', async () => {
+    delete process.env.SENTRY_DSN;
+    const { initLogger, closeLogger } = await import('../../../../jobs/flowsheet-etl/logger');
+
+    const runId = initLogger({
+      repo: 'Backend-Service',
+      tool: 'flowsheet-etl test',
+      runId: 'fixed-run-id',
+    });
+    expect(runId).toBe('fixed-run-id');
+    await closeLogger();
+  });
+
+  it('writes errors to stderr', async () => {
+    delete process.env.SENTRY_DSN;
+    const { initLogger, log, closeLogger } = await import('../../../../jobs/flowsheet-etl/logger');
+
+    const errWrites: string[] = [];
+    const errSpy = jest.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      errWrites.push(typeof chunk === 'string' ? chunk : (chunk as Buffer).toString());
+      return true;
+    });
+
+    initLogger({ repo: 'Backend-Service', tool: 'flowsheet-etl test' });
+    log('error', 'crash', 'boom');
+    errSpy.mockRestore();
+    await closeLogger();
+
+    expect(errWrites.length).toBe(1);
+    const parsed = JSON.parse(errWrites[0].trim());
+    expect(parsed.level).toBe('error');
+    expect(parsed.step).toBe('crash');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `jobs/flowsheet-etl/logger.ts`: a tiny stdlib-only module that initializes `@sentry/node` and emits JSON log lines (stdout for info/warn, stderr for error) carrying the four Phase A observability tags: `repo`, `tool`, `step`, `run_id`.
- Wires the logger into the flowsheet-etl entrypoint. The subcommand (`bulk-load`, `incremental`, `poll`) is resolved at startup and threaded into the `tool` tag so Sentry / log dashboards can split by mode.
- Converts existing `console.log` / `console.error` calls in the entrypoint to structured `log()` calls. Uncaught errors capture to Sentry with `step='failed'`.
- Adds smoke tests for the logger contract: SENTRY_DSN-unset init, JSON shape, explicit run_id passthrough, stderr routing.
- Documents the four-tag contract under Sentry in `CLAUDE.md`.
- Provisioning the actual `SENTRY_DSN` for the flowsheet-etl cron is left as a TODO for a separate child task (per the issue body).

The shared `wxyc_etl::logger` foundation in WXYC/wxyc-etl targets Rust/Python ETLs. Backend-Service is Node, so this PR mirrors the same tag contract directly in the job rather than pulling in `pino` — the only consumer is this one job and the JSON shape is trivial.

## Test plan

- [x] `npm run test:unit` — 1315/1315 pass (4 new logger smoke tests + 120 existing flowsheet-etl tests still green)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Manual smoke: `node jobs/flowsheet-etl/dist/job.js` (no `SENTRY_DSN`) produces a JSON log line `{"step":"started","repo":"Backend-Service","tool":"flowsheet-etl incremental","run_id":"..."}` on stdout

## Tracking

Closes #538

Parent epic: WXYC/wxyc-etl#44 — [Epic] Sentry + structured JSON logs across all ETLs
Project: https://github.com/orgs/WXYC/projects/19