### PR TITLE
Declare flowsheet_show_id_idx in schema source (no-op against prod)

### DIFF
--- a/shared/database/src/migrations/0068_flowsheet-show-id-idx.sql
+++ b/shared/database/src/migrations/0068_flowsheet-show-id-idx.sql
@@ -1,0 +1,27 @@
+-- B-tree index on flowsheet.show_id.
+--
+-- show_id is an FK reference to shows(id), but PostgreSQL does not auto-
+-- index FK columns. Without this index, every query that filters by
+-- show_id sequentially scans the 2.6M-row flowsheet table — including the
+-- /flowsheet `?shows_limit=N` listing endpoint that the dj-site polls every
+-- 60 seconds. During incident #511 those scans accumulated as orphan
+-- queries against a bloated table, contributing to the cascade.
+--
+-- The index was created manually in production via
+-- `CREATE INDEX CONCURRENTLY` on 2026-04-27 to unblock /flowsheet without
+-- holding a ShareLock during the build. This migration declares the same
+-- index so the schema source matches reality and fresh dev databases get
+-- it on init. `IF NOT EXISTS` makes it idempotent against the production
+-- DB where the index is already present.
+--
+-- This is NOT `CONCURRENTLY` because Drizzle wraps each migration file in
+-- a transaction and `CREATE INDEX CONCURRENTLY cannot run inside a
+-- transaction block`. On an empty/small dev database the regular build
+-- finishes in milliseconds; the brief ShareLock that conflicts with
+-- writers is acceptable. If a future fresh-load path needs to apply this
+-- against a full-size table, run it as a one-shot job (CONCURRENTLY)
+-- instead and then mark the migration applied — the same pattern used for
+-- migration 0057 (`flowsheet_artwork_lookup_idx`).
+
+CREATE INDEX IF NOT EXISTS "flowsheet_show_id_idx"
+  ON "wxyc_schema"."flowsheet" ("show_id");

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -463,6 +463,13 @@
       "when": 1779769600000,
       "tag": "0067_flowsheet-linkage-review",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1779856000000,
+      "tag": "0068_flowsheet-show-id-idx",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -468,6 +468,10 @@ export const flowsheet = wxyc_schema.table(
     index('flowsheet_artwork_lookup_idx')
       .on(sql`(lower(trim(${table.artist_name})) || '-' || lower(trim(coalesce(${table.album_title}, ''))))`)
       .where(sql`${table.artwork_url} IS NOT NULL`),
+    // FK columns aren't auto-indexed by Postgres. Without this, the
+    // /flowsheet `?shows_limit=N` listing endpoint sequentially scans the
+    // 2.6M-row table on every dj-site poll. See migration 0068 + issue #511.
+    index('flowsheet_show_id_idx').on(table.show_id),
   ]
 );
 


### PR DESCRIPTION
## Summary

Migration **0068** declares the `flowsheet_show_id_idx` B-tree on `flowsheet.show_id` that was created manually in production via `CREATE INDEX CONCURRENTLY` during incident #511. `IF NOT EXISTS` makes the migration idempotent against the production database where the index already exists. Schema declaration mirrors the migration so drift detection sees it.

## Why

`show_id` is an FK to `shows(id)`. Postgres doesn't auto-index FK columns, so every `/flowsheet?shows_limit=N` request was sequentially scanning the 2.6M-row table on every dj-site poll (60s interval). EXPLAIN before vs after the manual index:

```
-- Before
Seq Scan on flowsheet  (cost=0..6,500,000 rows=...)

-- After
Index Scan using flowsheet_show_id_idx on flowsheet  (cost=0.43..1240 rows=352)
```

The endpoint went from 5s timeouts → ~100ms.

## What this PR does and doesn't

- **Adds** the migration source so fresh dev DBs get the index on init.
- **Declares** the index in `schema.ts` so drizzle-kit drift detection doesn't see it as a missing object.
- **Does NOT change anything in production** — the index was already created manually. `CREATE INDEX IF NOT EXISTS` is a no-op when the index exists.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors (315 pre-existing warnings)
- [x] `npm run format:check` clean
- [x] `npm run lint:migrations` passes
- [x] `npm run test:unit` 1311 / 1311 passing
- [ ] Post-merge: drizzle-kit applies the migration, reports CREATE INDEX (no-op due to IF NOT EXISTS), records hash in `__drizzle_migrations`. Auto Build & Deploy proceeds normally.

Refs #511.