### PR TITLE
Tests + docs for Epic B (B-3.3)

### DIFF
--- a/dev_env/seed_db.sql
+++ b/dev_env/seed_db.sql
@@ -199,6 +199,23 @@ INSERT INTO wxyc_schema.library(
     artist_id, genre_id, format_id, album_title, code_number)
     VALUES (7, 11, 2, 'Mars Audiac Quintet', 2);
 
+-- Autechre + Confield for the B-2.1 forward-path linkage E2E. The mock LML
+-- fixture (dev_env/mock-api-server/src/fixtures/lml.json) returns release_id
+-- 4080 for an "autechre" lookup; pre-stamping the library row with the
+-- matching canonical entity id lets the resolver find a single library row
+-- and link the flowsheet entry without any additional setup.
+INSERT INTO wxyc_schema.artists(artist_name, alphabetical_name, code_letters)
+  VALUES ('Autechre', 'Autechre', 'AU');
+
+INSERT INTO wxyc_schema.genre_artist_crossreference(artist_id, genre_id, artist_genre_code)
+  VALUES (8, 15, 1);
+
+INSERT INTO wxyc_schema.library(
+    artist_id, genre_id, format_id, album_title, code_number,
+    canonical_entity_id, canonical_entity_confidence, canonical_entity_resolved_at)
+    VALUES (8, 15, 1, 'Confield', 1,
+            'discogs:release:4080', 0.9, NOW());
+
 -- Mirror the A.2 backfill outcome for all seeded library rows so the new
 -- tsvector path (which reads library.artist_name directly) and the trigram
 -- fallback (which uses the GIN index on library.artist_name) have populated

--- a/docs/flowsheet-linkage/README.md
+++ b/docs/flowsheet-linkage/README.md
@@ -6,10 +6,10 @@ How a flowsheet `track` row gets matched to the library album it represents, why
 
 Of ~1.96M flowsheet `track` rows on production at the start of Epic B, only ~775K (40%) had `album_id` populated. The remaining 60% split into two buckets:
 
-| Bucket | Count | % | Cause |
-| --- | ---: | ---: | --- |
-| `legacy_release_id` set, FK doesn't resolve | ~292K | 15% | The release id pointed at a tubafrenzy library row that no longer exists in PG (renumbered, deleted, or never imported). |
-| No `legacy_release_id` at all | ~889K | 45% | DJ typed the entry by hand instead of picking from the bin. tubafrenzy never had an id to give us; the gap is structural, not a regression. |
+| Bucket                                      | Count |   % | Cause                                                                                                                                       |
+| ------------------------------------------- | ----: | --: | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `legacy_release_id` set, FK doesn't resolve | ~292K | 15% | The release id pointed at a tubafrenzy library row that no longer exists in PG (renumbered, deleted, or never imported).                    |
+| No `legacy_release_id` at all               | ~889K | 45% | DJ typed the entry by hand instead of picking from the bin. tubafrenzy never had an id to give us; the gap is structural, not a regression. |
 
 Without a populated `album_id` we can't compute per-album play counts (which power Epic A's ranking), can't enrich a free-form entry with the same metadata a bin-pick gets, and can't run any analysis that wants to join flowsheet → library (genre over time, label distribution, rotation effectiveness). Closing the gap unblocks all of those.
 
@@ -49,29 +49,29 @@ Library-side resolution runs the same first three steps on insert (B-1.3) and as
 
 LML does not currently return per-result confidence. We derive a coarse band from `search_type`, calibrated against a 100-case hand-judged sample (issue #492):
 
-| `search_type` | Stored confidence | Action | Rationale |
-| --- | ---: | --- | --- |
-| `direct` | 0.9 | auto-accept | All hand-judged cases were correct — pure typo/punctuation wins. |
-| `fallback` | 0.5 | review queue | Mostly wrong-album-by-right-artist. Not zero signal, but not safe to auto-link. |
-| `alternative` | 0.3 | review queue | Same artist, different album candidate. Treated as fallback. |
-| `compilation` | 0.3 | review queue | Compilation track candidates; only sometimes the right release. |
-| `song_as_artist` | 0.3 | review queue | Treats the song title as an artist — usually a miss but occasionally rescues a misfiled entry. |
-| `none` | null | discard | Zero results. The next sweep retries. |
+| `search_type`    | Stored confidence | Action       | Rationale                                                                                      |
+| ---------------- | ----------------: | ------------ | ---------------------------------------------------------------------------------------------- |
+| `direct`         |               0.9 | auto-accept  | All hand-judged cases were correct — pure typo/punctuation wins.                               |
+| `fallback`       |               0.5 | review queue | Mostly wrong-album-by-right-artist. Not zero signal, but not safe to auto-link.                |
+| `alternative`    |               0.3 | review queue | Same artist, different album candidate. Treated as fallback.                                   |
+| `compilation`    |               0.3 | review queue | Compilation track candidates; only sometimes the right release.                                |
+| `song_as_artist` |               0.3 | review queue | Treats the song title as an artist — usually a miss but occasionally rescues a misfiled entry. |
+| `none`           |              null | discard      | Zero results. The next sweep retries.                                                          |
 
 The auto-accept gate is `linkage.confidence < AUTO_ACCEPT_THRESHOLD` where `AUTO_ACCEPT_THRESHOLD = 0.9`, so `direct` (==0.9) auto-links and everything else routes to review or is discarded. The stored value is captured at link time on `library.canonical_entity_confidence` and `flowsheet.linkage_confidence` so future analyses can re-judge weak matches once LML exposes a real per-result signal.
 
 ## Schema
 
-| Column | Type | Migration | Purpose |
-| --- | --- | --- | --- |
-| `library.canonical_entity_id` | `text` | 0061 | Opaque, source-namespaced (`discogs:release:<id>`). B-tree indexed for the flowsheet-side lookup. |
-| `library.canonical_entity_confidence` | `real` | 0061 | Confidence band stored at link time. |
-| `library.canonical_entity_resolved_at` | `timestamptz` | 0061 | Audit + retry policy. NULL means "never resolved". |
-| `flowsheet.linkage_source` | `text` | 0062 | One of `etl_legacy_id`, `dj_bin_pick`, `lml_high_confidence`, `human_review`, `tubafrenzy_mirror`. |
-| `flowsheet.linkage_confidence` | `real` | 0062 | Confidence band stored at link time. |
-| `flowsheet.linked_at` | `timestamptz` | 0062 | Stamps when the link was made (lets B-2.2 retry rules age weak matches). |
-| `flowsheet.legacy_link_attempted_at` | `timestamptz` | 0063 | Marker stamped by `jobs/broken-fk-recovery` when the FK resolver tried and failed. Lets B-2.2 sweep both never-had-FK rows AND broken-FK residuals in the same pass. |
-| `flowsheet_linkage_review` | table | 0067 | Manual review queue: stores the flowsheet id, ranked candidate library ids and confidences, and the operator's decision. |
+| Column                                 | Type          | Migration | Purpose                                                                                                                                                              |
+| -------------------------------------- | ------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `library.canonical_entity_id`          | `text`        | 0061      | Opaque, source-namespaced (`discogs:release:<id>`). B-tree indexed for the flowsheet-side lookup.                                                                    |
+| `library.canonical_entity_confidence`  | `real`        | 0061      | Confidence band stored at link time.                                                                                                                                 |
+| `library.canonical_entity_resolved_at` | `timestamptz` | 0061      | Audit + retry policy. NULL means "never resolved".                                                                                                                   |
+| `flowsheet.linkage_source`             | `text`        | 0062      | One of `etl_legacy_id`, `dj_bin_pick`, `lml_high_confidence`, `human_review`, `tubafrenzy_mirror`.                                                                   |
+| `flowsheet.linkage_confidence`         | `real`        | 0062      | Confidence band stored at link time.                                                                                                                                 |
+| `flowsheet.linked_at`                  | `timestamptz` | 0062      | Stamps when the link was made (lets B-2.2 retry rules age weak matches).                                                                                             |
+| `flowsheet.legacy_link_attempted_at`   | `timestamptz` | 0063      | Marker stamped by `jobs/broken-fk-recovery` when the FK resolver tried and failed. Lets B-2.2 sweep both never-had-FK rows AND broken-FK residuals in the same pass. |
+| `flowsheet_linkage_review`             | table         | 0067      | Manual review queue: stores the flowsheet id, ranked candidate library ids and confidences, and the operator's decision.                                             |
 
 Migration numbers are illustrative — the canonical numbers are in `shared/database/src/migrations/meta/_journal.json`.
 
@@ -79,21 +79,21 @@ Migration numbers are illustrative — the canonical numbers are in `shared/data
 
 ### Live write paths
 
-| Path | File | Behavior |
-| --- | --- | --- |
-| `addAlbum` (library) | `apps/backend/services/library.service.ts` | After insert, kicks off LML lookup + writes `canonical_entity_id` if a candidate exists. Failure is non-fatal — the row stays unresolved and the B-1.2 backfill re-tries it later. |
+| Path                   | File                                                                        | Behavior                                                                                                                                                                                                                                                                        |
+| ---------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `addAlbum` (library)   | `apps/backend/services/library.service.ts`                                  | After insert, kicks off LML lookup + writes `canonical_entity_id` if a candidate exists. Failure is non-fatal — the row stays unresolved and the B-1.2 backfill re-tries it later.                                                                                              |
 | `addEntry` (flowsheet) | `apps/backend/controllers/flowsheet.controller.ts` → `fireAndForgetLinkage` | Skips if `album_id` is already set (bin-pick) or `artist_name` is empty (message). Otherwise calls `runLmlLinkage` after the HTTP response is sent. Errors are routed through `reportLinkageError` so the operator sees one consistent `subsystem='lml-linkage'` Sentry filter. |
 
 `fireAndForgetLinkage` runs after `res.send()`; the HTTP response is never blocked on LML. The unit suite proves both paths in `tests/unit/controllers/flowsheet.addEntry.linkage.test.ts`; the integration spec at `tests/integration/flowsheet-linkage.spec.js` exercises the full live stack end-to-end against the mock LML server.
 
 ### Backfill jobs
 
-| Job | Path | Inputs | Outputs |
-| --- | --- | --- | --- |
-| Library canonical-entity backfill | `jobs/library-canonical-entity-backfill/` | `library` rows where `canonical_entity_id IS NULL` | Stamps `canonical_entity_id`, `_confidence`, `_resolved_at`. Throttled, restartable via id cursor. |
-| Broken-FK recovery | `jobs/broken-fk-recovery/` | `flowsheet` rows with `legacy_release_id` whose FK doesn't resolve | Re-runs the legacy-id resolver. Stamps `legacy_link_attempted_at` on rows that still don't resolve so the next job can pick them up. |
-| Flowsheet LML-link backfill | `jobs/flowsheet-lml-link-backfill/` | `flowsheet` rows where `album_id IS NULL AND entry_type='track'` AND `(legacy_release_id IS NULL OR legacy_link_attempted_at IS NOT NULL)` | Same logic as the forward path: links high-confidence matches, enqueues fallbacks for review. |
-| Flowsheet linkage audit backfill | `jobs/flowsheet-linkage-audit-backfill/` | All `flowsheet` rows with `album_id` already populated | Stamps `linkage_source` retroactively for the legacy-linked rows so audits can attribute every linked row to a source. |
+| Job                               | Path                                      | Inputs                                                                                                                                     | Outputs                                                                                                                              |
+| --------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Library canonical-entity backfill | `jobs/library-canonical-entity-backfill/` | `library` rows where `canonical_entity_id IS NULL`                                                                                         | Stamps `canonical_entity_id`, `_confidence`, `_resolved_at`. Throttled, restartable via id cursor.                                   |
+| Broken-FK recovery                | `jobs/broken-fk-recovery/`                | `flowsheet` rows with `legacy_release_id` whose FK doesn't resolve                                                                         | Re-runs the legacy-id resolver. Stamps `legacy_link_attempted_at` on rows that still don't resolve so the next job can pick them up. |
+| Flowsheet LML-link backfill       | `jobs/flowsheet-lml-link-backfill/`       | `flowsheet` rows where `album_id IS NULL AND entry_type='track'` AND `(legacy_release_id IS NULL OR legacy_link_attempted_at IS NOT NULL)` | Same logic as the forward path: links high-confidence matches, enqueues fallbacks for review.                                        |
+| Flowsheet linkage audit backfill  | `jobs/flowsheet-linkage-audit-backfill/`  | All `flowsheet` rows with `album_id` already populated                                                                                     | Stamps `linkage_source` retroactively for the legacy-linked rows so audits can attribute every linked row to a source.               |
 
 All jobs share the package layout in `CLAUDE.md`'s "Migrations are DDL-only" section: `"job-type": "one-shot"` in `package.json`, ECR-built Docker image, invoked via `docker run --rm --env-file .env <image>` during a low-traffic window.
 
@@ -134,10 +134,10 @@ A web UI is out of scope for v1. Volume needs to materially exceed the CLI's thr
 
 Epic A (catalog search ranking, see `docs/catalog-search/`) and Epic B share two surfaces:
 
-| Surface | Role in Epic A | Role in Epic B |
-| --- | --- | --- |
-| `library.artist_name` (denormalized) | Drives the `search_doc` tsvector and the `library_artist_name_trgm_idx` trigram index. | Read by the LML-linkage forward path indirectly via `library` joins, but linkage matches on `canonical_entity_id`, not text. |
-| `album_plays` materialized view | Powers the play-count factor in the catalog ranker. | The view aggregates `flowsheet WHERE entry_type='track' GROUP BY album_id`. **Every row Epic B links makes Epic A's ranker more accurate.** Going from 40% → ~55% linkage moves ~290K plays from "uncounted" to "counted" in the per-album rollup. |
+| Surface                              | Role in Epic A                                                                         | Role in Epic B                                                                                                                                                                                                                                     |
+| ------------------------------------ | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `library.artist_name` (denormalized) | Drives the `search_doc` tsvector and the `library_artist_name_trgm_idx` trigram index. | Read by the LML-linkage forward path indirectly via `library` joins, but linkage matches on `canonical_entity_id`, not text.                                                                                                                       |
+| `album_plays` materialized view      | Powers the play-count factor in the catalog ranker.                                    | The view aggregates `flowsheet WHERE entry_type='track' GROUP BY album_id`. **Every row Epic B links makes Epic A's ranker more accurate.** Going from 40% → ~55% linkage moves ~290K plays from "uncounted" to "counted" in the per-album rollup. |
 
 Implication: Epic B is most valuable to Epic A when the backfill has run to completion. The deploy order is forward path first, then backfill, so coverage doesn't drift further during the multi-day backfill.
 

--- a/docs/flowsheet-linkage/README.md
+++ b/docs/flowsheet-linkage/README.md
@@ -1,0 +1,153 @@
+# Flowsheet ↔ Library Linkage
+
+How a flowsheet `track` row gets matched to the library album it represents, why we route the match through LML's canonical-entity layer instead of text-comparing the two tables, and where the seams are between this work and Epic A's catalog search.
+
+## Why this exists
+
+Of ~1.96M flowsheet `track` rows on production at the start of Epic B, only ~775K (40%) had `album_id` populated. The remaining 60% split into two buckets:
+
+| Bucket | Count | % | Cause |
+| --- | ---: | ---: | --- |
+| `legacy_release_id` set, FK doesn't resolve | ~292K | 15% | The release id pointed at a tubafrenzy library row that no longer exists in PG (renumbered, deleted, or never imported). |
+| No `legacy_release_id` at all | ~889K | 45% | DJ typed the entry by hand instead of picking from the bin. tubafrenzy never had an id to give us; the gap is structural, not a regression. |
+
+Without a populated `album_id` we can't compute per-album play counts (which power Epic A's ranking), can't enrich a free-form entry with the same metadata a bin-pick gets, and can't run any analysis that wants to join flowsheet → library (genre over time, label distribution, rotation effectiveness). Closing the gap unblocks all of those.
+
+## What we deliberately did not do
+
+A direct exact-text match between `flowsheet.{artist_name,album_title}` and `library.{artist_name,album_title}` is **not** part of the pipeline. The empirical recovery on a production sample is ~0.13% (1,568 of 1.18M unlinked rows), and LML's lookup already runs exact → normalized → fuzzy internally — pre-filtering by exact text would just shadow LML's pipeline without adding signal. Every match flows through LML.
+
+## Architecture
+
+Two-sided canonical resolution. Library rows and flowsheet rows both resolve to the same opaque external identifier (a Discogs release id today; the column type allows MusicBrainz / other resolvers later). Linkage flows through that identifier, not through text:
+
+```
+flowsheet row (no album_id, has artist + album text)
+  │
+  ▼
+LML.lookupMetadata(artist, album)   (LML internally tries exact → normalized → fuzzy)
+  │
+  ▼
+mapLookupToCanonicalEntity         → "discogs:release:<id>" + coarse confidence
+  │
+  ▼
+confidence ≥ AUTO_ACCEPT_THRESHOLD ?
+  ├── no  → enqueue flowsheet_linkage_review for human triage
+  └── yes
+       │
+       ▼
+     SELECT id FROM library WHERE canonical_entity_id = $1
+       │
+       ├── 0 rows  → unmatched (canonical entity exists, WXYC doesn't own it)
+       ├── 1 row   → link with linkage_source='lml_high_confidence'
+       └── 2+ rows → tie-break (rotation > format > plays > id), then link
+```
+
+Library-side resolution runs the same first three steps on insert (B-1.3) and as a one-time backfill (B-1.2). That's the reason the flowsheet-side step 4 is a single index lookup, not a fuzzy join — by the time we get to step 4 both sides are already pointing at the same opaque id.
+
+## Confidence thresholds (B-0 calibration)
+
+LML does not currently return per-result confidence. We derive a coarse band from `search_type`, calibrated against a 100-case hand-judged sample (issue #492):
+
+| `search_type` | Stored confidence | Action | Rationale |
+| --- | ---: | --- | --- |
+| `direct` | 0.9 | auto-accept | All hand-judged cases were correct — pure typo/punctuation wins. |
+| `fallback` | 0.5 | review queue | Mostly wrong-album-by-right-artist. Not zero signal, but not safe to auto-link. |
+| `alternative` | 0.3 | review queue | Same artist, different album candidate. Treated as fallback. |
+| `compilation` | 0.3 | review queue | Compilation track candidates; only sometimes the right release. |
+| `song_as_artist` | 0.3 | review queue | Treats the song title as an artist — usually a miss but occasionally rescues a misfiled entry. |
+| `none` | null | discard | Zero results. The next sweep retries. |
+
+The auto-accept gate is `linkage.confidence < AUTO_ACCEPT_THRESHOLD` where `AUTO_ACCEPT_THRESHOLD = 0.9`, so `direct` (==0.9) auto-links and everything else routes to review or is discarded. The stored value is captured at link time on `library.canonical_entity_confidence` and `flowsheet.linkage_confidence` so future analyses can re-judge weak matches once LML exposes a real per-result signal.
+
+## Schema
+
+| Column | Type | Migration | Purpose |
+| --- | --- | --- | --- |
+| `library.canonical_entity_id` | `text` | 0061 | Opaque, source-namespaced (`discogs:release:<id>`). B-tree indexed for the flowsheet-side lookup. |
+| `library.canonical_entity_confidence` | `real` | 0061 | Confidence band stored at link time. |
+| `library.canonical_entity_resolved_at` | `timestamptz` | 0061 | Audit + retry policy. NULL means "never resolved". |
+| `flowsheet.linkage_source` | `text` | 0062 | One of `etl_legacy_id`, `dj_bin_pick`, `lml_high_confidence`, `human_review`, `tubafrenzy_mirror`. |
+| `flowsheet.linkage_confidence` | `real` | 0062 | Confidence band stored at link time. |
+| `flowsheet.linked_at` | `timestamptz` | 0062 | Stamps when the link was made (lets B-2.2 retry rules age weak matches). |
+| `flowsheet.legacy_link_attempted_at` | `timestamptz` | 0063 | Marker stamped by `jobs/broken-fk-recovery` when the FK resolver tried and failed. Lets B-2.2 sweep both never-had-FK rows AND broken-FK residuals in the same pass. |
+| `flowsheet_linkage_review` | table | 0067 | Manual review queue: stores the flowsheet id, ranked candidate library ids and confidences, and the operator's decision. |
+
+Migration numbers are illustrative — the canonical numbers are in `shared/database/src/migrations/meta/_journal.json`.
+
+## Components
+
+### Live write paths
+
+| Path | File | Behavior |
+| --- | --- | --- |
+| `addAlbum` (library) | `apps/backend/services/library.service.ts` | After insert, kicks off LML lookup + writes `canonical_entity_id` if a candidate exists. Failure is non-fatal — the row stays unresolved and the B-1.2 backfill re-tries it later. |
+| `addEntry` (flowsheet) | `apps/backend/controllers/flowsheet.controller.ts` → `fireAndForgetLinkage` | Skips if `album_id` is already set (bin-pick) or `artist_name` is empty (message). Otherwise calls `runLmlLinkage` after the HTTP response is sent. Errors are routed through `reportLinkageError` so the operator sees one consistent `subsystem='lml-linkage'` Sentry filter. |
+
+`fireAndForgetLinkage` runs after `res.send()`; the HTTP response is never blocked on LML. The unit suite proves both paths in `tests/unit/controllers/flowsheet.addEntry.linkage.test.ts`; the integration spec at `tests/integration/flowsheet-linkage.spec.js` exercises the full live stack end-to-end against the mock LML server.
+
+### Backfill jobs
+
+| Job | Path | Inputs | Outputs |
+| --- | --- | --- | --- |
+| Library canonical-entity backfill | `jobs/library-canonical-entity-backfill/` | `library` rows where `canonical_entity_id IS NULL` | Stamps `canonical_entity_id`, `_confidence`, `_resolved_at`. Throttled, restartable via id cursor. |
+| Broken-FK recovery | `jobs/broken-fk-recovery/` | `flowsheet` rows with `legacy_release_id` whose FK doesn't resolve | Re-runs the legacy-id resolver. Stamps `legacy_link_attempted_at` on rows that still don't resolve so the next job can pick them up. |
+| Flowsheet LML-link backfill | `jobs/flowsheet-lml-link-backfill/` | `flowsheet` rows where `album_id IS NULL AND entry_type='track'` AND `(legacy_release_id IS NULL OR legacy_link_attempted_at IS NOT NULL)` | Same logic as the forward path: links high-confidence matches, enqueues fallbacks for review. |
+| Flowsheet linkage audit backfill | `jobs/flowsheet-linkage-audit-backfill/` | All `flowsheet` rows with `album_id` already populated | Stamps `linkage_source` retroactively for the legacy-linked rows so audits can attribute every linked row to a source. |
+
+All jobs share the package layout in `CLAUDE.md`'s "Migrations are DDL-only" section: `"job-type": "one-shot"` in `package.json`, ECR-built Docker image, invoked via `docker run --rm --env-file .env <image>` during a low-traffic window.
+
+### Tie-break (B-2.3)
+
+When the canonical-entity lookup returns multiple library rows, `pickPrimaryLibraryRow` (`shared/database/src/library-tiebreak.ts`) picks one by:
+
+1. Currently in rotation (most recent rotation row wins).
+2. Format preference (CD > vinyl > vinyl 12" > vinyl 7" > vinyl 10" > cdr).
+3. Most flowsheet plays in the last 12 months.
+4. Lowest `library.id` (deterministic tiebreaker — proxies "first imported, longest in the catalog").
+
+Returns `null` only when the candidate set raced with a concurrent delete; callers treat that as a transient no-match and let the next sweep retry. Both forward and backfill paths share this helper so the same album wins the tie-break in every context.
+
+### Review queue (B-3.1)
+
+`flowsheet_linkage_review` rows are drained one at a time by the CLI at `scripts/review-linkage.ts`:
+
+```bash
+npx tsx scripts/review-linkage.ts
+```
+
+For each case the operator sees the flowsheet artist/album/track text and the LML-ranked library candidates. The keys are `y` (accept the suggested candidate, stamp `flowsheet.album_id` + `linkage_source='human_review'`), `n` (reject; flowsheet stays unmatched so a future LML improvement can pick it up), or `skip` (no DB write; the case re-appears in the next session).
+
+A web UI is out of scope for v1. Volume needs to materially exceed the CLI's throughput before that calculus changes.
+
+### Observability (B-3.2)
+
+`apps/backend/services/linkage-metrics.service.ts` exposes:
+
+- **In-process counters** keyed by outcome (`linked_high_conf`, `gray_zone_review`, `no_candidate`, `lml_error`, `lml_timeout`). Both forward and backfill paths increment them.
+- **SQL-backed gauges**:
+  - `getCumulativeLinkageCoverage()` — fraction of all track rows with `album_id` set. Watch this fall as B-2.2 sweeps run.
+  - `getRecentLinkageRate(hours)` — fraction of recently inserted rows that are linked. A falling ratio means the forward worker is behind.
+- **Sentry tagging**: `reportLinkageError` tags every captured exception with `subsystem='lml-linkage'` and `path='forward'|'backfill'|'review'` so the operator can filter the Sentry issue stream by subsystem instead of by stack trace.
+
+## Cross-epic interaction with Epic A
+
+Epic A (catalog search ranking, see `docs/catalog-search/`) and Epic B share two surfaces:
+
+| Surface | Role in Epic A | Role in Epic B |
+| --- | --- | --- |
+| `library.artist_name` (denormalized) | Drives the `search_doc` tsvector and the `library_artist_name_trgm_idx` trigram index. | Read by the LML-linkage forward path indirectly via `library` joins, but linkage matches on `canonical_entity_id`, not text. |
+| `album_plays` materialized view | Powers the play-count factor in the catalog ranker. | The view aggregates `flowsheet WHERE entry_type='track' GROUP BY album_id`. **Every row Epic B links makes Epic A's ranker more accurate.** Going from 40% → ~55% linkage moves ~290K plays from "uncounted" to "counted" in the per-album rollup. |
+
+Implication: Epic B is most valuable to Epic A when the backfill has run to completion. The deploy order is forward path first, then backfill, so coverage doesn't drift further during the multi-day backfill.
+
+## Related issues
+
+- Epic B: [#484](https://github.com/WXYC/Backend-Service/issues/484)
+- B-0 calibration data: [#492](https://github.com/WXYC/Backend-Service/issues/492)
+- B-2.1 forward path: [#498](https://github.com/WXYC/Backend-Service/issues/498)
+- B-2.2 backfill: [#499](https://github.com/WXYC/Backend-Service/issues/499)
+- B-2.3 tie-break: [#500](https://github.com/WXYC/Backend-Service/issues/500)
+- B-3.1 review queue: [#501](https://github.com/WXYC/Backend-Service/issues/501)
+- B-3.2 metrics: [#502](https://github.com/WXYC/Backend-Service/issues/502)
+- B-3.3 (this doc): [#503](https://github.com/WXYC/Backend-Service/issues/503)

--- a/tests/integration/flowsheet-linkage.spec.js
+++ b/tests/integration/flowsheet-linkage.spec.js
@@ -1,0 +1,140 @@
+/**
+ * Forward-path flowsheet linkage E2E (B-2.1, B-3.3).
+ *
+ * Exercises the full async link path that Epic B's forward path is built on:
+ *
+ *   POST /flowsheet (free-form, no album_id)
+ *     → controller fires `runLmlLinkage` after responding
+ *       → LML lookup (mock-api fixture)
+ *         → mapLookupToCanonicalEntity → `discogs:release:<id>`
+ *           → seeded library row matches by canonical_entity_id
+ *             → flowsheet.album_id + linkage_source + linkage_confidence persisted
+ *
+ * The unit suite (B-2.1) already covers each layer with mocks. This spec is
+ * the cross-layer integration: real Express server, real PostgreSQL, real
+ * Drizzle queries, mock LML over HTTP. Hits the seeded `Autechre / Confield`
+ * fixture (mock release_id 4080) which the seed pre-populates with
+ * `canonical_entity_id = 'discogs:release:4080'` so the resolver finds a
+ * single matching library row.
+ *
+ * Uses `secondary_dj_id` to avoid conflicts with concurrent flowsheet specs
+ * and queries the database directly because `linkage_source` /
+ * `linkage_confidence` are intentionally not exposed on the V2 read path.
+ */
+
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const fls_util = require('../utils/flowsheet_util');
+const { isMockApiAvailable, resetMockApi } = require('../utils/mock_api');
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const AUTECHRE_CANONICAL_ENTITY_ID = 'discogs:release:4080';
+const AUTO_ACCEPT_CONFIDENCE = 0.9; // SEARCH_TYPE_CONFIDENCE.direct in library.service.ts
+
+let mockApiAvailable = false;
+const getTestDjId = () => global.secondary_dj_id;
+
+/** Poll the flowsheet row until linkage_source is set, or time out. */
+async function waitForLinkage(entryId, ms = 3000) {
+  const sql = getTestDb();
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    const rows = await sql`
+      SELECT album_id, linkage_source, linkage_confidence, linked_at
+      FROM ${sql(SCHEMA)}.flowsheet
+      WHERE id = ${entryId}
+    `;
+    if (rows[0]?.linkage_source) return rows[0];
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return null;
+}
+
+/** Read a flowsheet row's linkage columns once (no polling). */
+async function readLinkage(entryId) {
+  const sql = getTestDb();
+  const rows = await sql`
+    SELECT album_id, linkage_source, linkage_confidence, linked_at
+    FROM ${sql(SCHEMA)}.flowsheet
+    WHERE id = ${entryId}
+  `;
+  return rows[0] ?? null;
+}
+
+beforeAll(async () => {
+  mockApiAvailable = await isMockApiAvailable();
+  if (!mockApiAvailable) {
+    console.warn('Skipping flowsheet-linkage tests: mock API server not available');
+  }
+});
+
+describe('Forward-path flowsheet linkage (B-2.1 E2E)', () => {
+  beforeEach(async () => {
+    if (!mockApiAvailable) return;
+    await resetMockApi();
+    await fls_util.join_show(getTestDjId(), global.access_token);
+  });
+
+  afterEach(async () => {
+    if (!mockApiAvailable) return;
+    await fls_util.leave_show(getTestDjId(), global.access_token);
+  });
+
+  test('free-form Autechre/Confield insert auto-links to seeded library row via LML', async () => {
+    if (!mockApiAvailable) return;
+
+    const addRes = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        artist_name: 'Autechre',
+        album_title: 'Confield',
+        track_title: 'VI Scose Poise',
+      })
+      .expect(201);
+
+    // Insert returns immediately; album_id is null until the fire-and-forget link lands.
+    expect(addRes.body.album_id).toBeNull();
+
+    const linked = await waitForLinkage(addRes.body.id);
+    expect(linked).not.toBeNull();
+    expect(linked.linkage_source).toBe('lml_high_confidence');
+    expect(Number(linked.linkage_confidence)).toBeCloseTo(AUTO_ACCEPT_CONFIDENCE, 2);
+    expect(linked.linked_at).not.toBeNull();
+    expect(linked.album_id).not.toBeNull();
+
+    // album_id resolves to the seeded Autechre library row carrying the canonical entity id.
+    const sql = getTestDb();
+    const libRows = await sql`
+      SELECT canonical_entity_id, album_title
+      FROM ${sql(SCHEMA)}.library
+      WHERE id = ${linked.album_id}
+    `;
+    expect(libRows[0]?.canonical_entity_id).toBe(AUTECHRE_CANONICAL_ENTITY_ID);
+    expect(libRows[0]?.album_title).toBe('Confield');
+  });
+
+  test('bin-pick (album_id provided) is already linked and skips LML linkage', async () => {
+    if (!mockApiAvailable) return;
+
+    const addRes = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: 1, // Built to Spill - Keep it Like a Secret (seeded)
+        track_title: 'The Plan',
+      })
+      .expect(201);
+
+    expect(addRes.body.album_id).toBe(1);
+
+    // Give fire-and-forget a chance to (incorrectly) fire — assert it stays inert.
+    await new Promise((r) => setTimeout(r, 250));
+    const row = await readLinkage(addRes.body.id);
+    expect(row).not.toBeNull();
+    expect(row.linkage_source).toBeNull();
+    expect(row.linkage_confidence).toBeNull();
+    expect(row.linked_at).toBeNull();
+    expect(row.album_id).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #503.

## Summary

- Adds an end-to-end integration spec for the B-2.1 forward path: real Express server, real PostgreSQL, mock LML over HTTP. Verifies that a free-form `addEntry` call (artist + album text, no `album_id`) resolves through the canonical-entity layer and lands `album_id` + `linkage_source='lml_high_confidence'` + `linkage_confidence ≈ 0.9` on the row, and that bin-picks (`album_id` provided) correctly skip the linkage path.
- Pre-stamps the CI seed with an Autechre / Confield library row carrying `canonical_entity_id = 'discogs:release:4080'` so the spec resolves against an existing fixture in the mock LML server (no test-only seed flag needed).
- Adds `docs/flowsheet-linkage/README.md` covering the canonical-entity layer, the matching pipeline, the B-0 confidence calibration, the schema columns + their migrations, the live + backfill paths, the B-2.3 tie-break, the B-3.1 review queue CLI, the B-3.2 metrics + Sentry surface, and the cross-epic interaction with Epic A's `album_plays` materialized view.

## Out of scope (for follow-up issues)

- The two operational items in #503's scope — production deploy of B-2.1 and the B-2.2 backfill run — are infrastructure tasks performed outside this PR. Once this lands, the deploy + backfill follow with the existing one-shot job pattern (`docker run --rm --env-file .env <image>`); the cumulative coverage gain will be reported as a closing comment on #503.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:unit` — 1311 tests pass
- [ ] `npm run ci:testmock` — runs the new integration spec against the Docker stack (orchestrator / CI to verify)