### PR TITLE
Wire git-merge-append as the journal merge driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+shared/database/src/migrations/meta/_journal.json merge=journal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,19 @@ npm run dev              # Start auth (8082) + backend (8080) concurrently with 
 
 Stop the database with `npm run db:stop`.
 
+### One-time per-clone: register the journal merge driver
+
+`shared/database/src/migrations/meta/_journal.json` is an append-only Drizzle index. Every PR that adds a migration appends an entry; concurrent PRs collide on the array even when the new entries don't overlap. The repo ships `.gitattributes` with `merge=journal`, but the actual merge driver lives in `.git/config` and isn't checked in — each collaborator must register it once after cloning:
+
+```bash
+npx git-merge-append install \
+  --name journal \
+  --array-path entries --key idx --sort-by idx \
+  -- shared/database/src/migrations/meta/_journal.json
+```
+
+After this, `git rebase` / `git merge` resolve concurrent journal appends automatically. If you skipped the install and are mid-rebase with `<<<<<<<` in `_journal.json`, run `npx git-merge-append resolve --array-path entries --key idx --sort-by idx -- shared/database/src/migrations/meta/_journal.json` to fix it post-hoc. See [git-merge-append](https://github.com/jakebromberg/git-merge-append) for details.
+
 ### Code Quality
 
 Pre-push hook (husky) runs automatically:

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-security": "^4.0.0",
+        "git-merge-append": "github:jakebromberg/git-merge-append",
         "husky": "^9.1.7",
         "jest": "^30.3.0",
         "jest-html-reporters": "^3.1.7",
@@ -52,6 +53,19 @@
         "typescript-eslint": "^8.59.0",
         "wait-on": "^9.0.5",
         "ws": "^8.20.0"
+      }
+    },
+    "../../git-merge-append": {
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "git-merge-append": "dist/src/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22",
+        "typescript": "^5.7",
+        "vitest": "^3"
       }
     },
     "apps/auth": {
@@ -9583,6 +9597,15 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/git-merge-append": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/jakebromberg/git-merge-append.git#5c01c012fde9a2166be320d4c2656b8e40b873f7",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "git-merge-append": "dist/src/cli.js"
       }
     },
     "node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-security": "^4.0.0",
+    "git-merge-append": "github:jakebromberg/git-merge-append",
     "husky": "^9.1.7",
     "jest": "^30.3.0",
     "jest-html-reporters": "^3.1.7",


### PR DESCRIPTION
## Summary

`shared/database/src/migrations/meta/_journal.json` is an append-only Drizzle index. Every PR that adds a migration appends an entry to the `entries` array; concurrent PRs from a parallel-PR workflow produce N−1 boilerplate conflicts on that array even when the new entries don't structurally overlap.

This wires up [git-merge-append](https://github.com/jakebromberg/git-merge-append) — a 3-way merge driver that resolves keyed-array appends by key-union without parsing conflict markers — as the registered merge driver for `_journal.json`.

## Changes

- **`.gitattributes`** (new): maps the journal path to `merge=journal` so git invokes the driver during rebase/merge.
- **`CLAUDE.md`**: documents the per-clone `npx git-merge-append install` step. Driver definitions live in `.git/config` (not checked in), so each collaborator must register the driver once after cloning. Includes the `resolve` fallback for the "I forgot to install" case.
- **`package.json` / `package-lock.json`**: pin `git-merge-append` as a devDependency from GitHub.

## Test plan

- [x] Smoke-test against a synthetic 3-way merge of the project's actual `_journal.json` (base = HEAD~10, ours = HEAD, theirs = ours + a synthetic `0099_*` entry). Driver returned exit 0, result included the new entry.
- [ ] After merge, run `npx git-merge-append install --name journal --array-path entries --key idx --sort-by idx -- shared/database/src/migrations/meta/_journal.json` once locally. Subsequent rebases against concurrent journal additions resolve automatically.

## Notes

- The orchestrator at `WXYC/catalog-search-reconciliation` has been updated in tandem to no longer pre-resolve journal conflicts manually — its `setUpWorktree` hook is now a no-op for the journal because worktrees inherit the main repo's `.git/config`.
- Smoke-test target after merge: a future parallel-migration wave should produce zero `_journal.json` conflicts.