### PR TITLE
Batch artist-identity ETL: O(1) round-trips per run

### DIFF
--- a/jobs/artist-identity-etl/job.ts
+++ b/jobs/artist-identity-etl/job.ts
@@ -16,9 +16,16 @@
  * existing value if non-null (so any value entered by the library staff
  * wins over an LML-derived one), and conflicts are logged but not
  * applied. This matches #506's "never overwrite human edits" requirement.
+ *
+ * Round-trip count: O(1) per run, regardless of LML row count. One bulk
+ * SELECT loads the existing `artists` rows whose name appears in the LML
+ * batch (used for conflict detection), and one bulk UPDATE …
+ * FROM (VALUES …) RETURNING applies the COALESCE-in-SET fill across the
+ * matching artist rows in a single statement (#519 superseded the
+ * earlier per-row N+1 pattern).
  */
 
-import { eq, sql } from 'drizzle-orm';
+import { sql, inArray } from 'drizzle-orm';
 import {
   db,
   artists,
@@ -35,13 +42,13 @@ const JOB_NAME = 'artist-identity-etl';
 type SyncResult = {
   /** LML rows fetched */
   scanned: number;
-  /** LML rows whose library_name matched an artist row */
+  /** LML rows whose library_name matched at least one artist row */
   matched: number;
-  /** Artist rows actually updated (had at least one null to fill) */
+  /** Artist rows actually updated (DB-reported via RETURNING) */
   updated: number;
-  /** Total column writes across all updates */
+  /** Total column writes across all updates (estimated from pre-update snapshot) */
   columnsWritten: number;
-  /** Conflicts detected (existing non-null value differs from LML's value) */
+  /** LML rows where at least one matching artist row had a populated, differing value */
   conflicts: number;
 };
 
@@ -51,13 +58,45 @@ const runIncremental = async (): Promise<SyncResult> => {
 
   const identities = await fetchLmlIdentities(lastRunMs);
 
+  if (identities.length === 0) {
+    await updateLastRun(JOB_NAME, runStartedAt);
+    console.log(`[${JOB_NAME}] Scanned 0 LML rows; nothing to do.`);
+    return { scanned: 0, matched: 0, updated: 0, columnsWritten: 0, conflicts: 0 };
+  }
+
+  // One round-trip: load every artist row whose name is in this LML batch.
+  // artist_name has no unique constraint, so a single name can map to
+  // multiple rows. We keep the first match per name for conflict
+  // detection (preserving the previous loadExisting semantic), but the
+  // bulk UPDATE below applies COALESCE across every matching row.
+  const names = identities.map((i) => i.library_name);
+  const existingRows = await db
+    .select({
+      artist_name: artists.artist_name,
+      discogs_artist_id: artists.discogs_artist_id,
+      musicbrainz_artist_id: artists.musicbrainz_artist_id,
+      wikidata_qid: artists.wikidata_qid,
+      spotify_artist_id: artists.spotify_artist_id,
+      apple_music_artist_id: artists.apple_music_artist_id,
+      bandcamp_id: artists.bandcamp_id,
+    })
+    .from(artists)
+    .where(inArray(artists.artist_name, names));
+
+  const firstByName = new Map<string, ExistingArtistIdentity>();
+  for (const row of existingRows) {
+    if (!firstByName.has(row.artist_name)) {
+      firstByName.set(row.artist_name, row);
+    }
+  }
+
   let matched = 0;
-  let updated = 0;
-  let columnsWritten = 0;
   let conflicts = 0;
+  let columnsWritten = 0;
+  const fillCandidates: LmlIdentity[] = [];
 
   for (const lml of identities) {
-    const existing = await loadExisting(lml.library_name);
+    const existing = firstByName.get(lml.library_name);
     if (!existing) continue;
     matched++;
 
@@ -74,63 +113,78 @@ const runIncremental = async (): Promise<SyncResult> => {
 
     const toFill = columnsToFill(existing, lml);
     if (toFill.length === 0) continue;
-
-    await applyFill(lml, toFill);
-    updated++;
+    fillCandidates.push(lml);
     columnsWritten += toFill.length;
   }
+
+  if (fillCandidates.length === 0) {
+    await updateLastRun(JOB_NAME, runStartedAt);
+    console.log(
+      `[${JOB_NAME}] Scanned ${identities.length} LML rows; ` +
+        `matched ${matched}; updated 0 artists; conflicts=${conflicts}.`
+    );
+    return { scanned: identities.length, matched, updated: 0, columnsWritten: 0, conflicts };
+  }
+
+  // Single bulk UPDATE … FROM (VALUES …). COALESCE-in-SET preserves any
+  // existing non-null value across every matching row, so duplicate
+  // artist_names share the same correctness guarantee as the per-row
+  // path: staff edits always win.
+  //
+  // Per-cell type casts are required because postgres-js infers VALUES
+  // column types from the first row and several columns can legitimately
+  // be NULL there.
+  const valuesRows = fillCandidates.map(
+    (v) =>
+      sql`(${v.library_name}::text, ${v.discogs_artist_id}::integer, ${v.musicbrainz_artist_id}::varchar(64), ${v.wikidata_qid}::varchar(32), ${v.spotify_artist_id}::varchar(64), ${v.apple_music_artist_id}::varchar(64), ${v.bandcamp_id}::varchar(255))`
+  );
+
+  const updated = await db.execute(sql`
+    UPDATE ${artists} a
+    SET
+      discogs_artist_id     = COALESCE(a.discogs_artist_id,     v.discogs_artist_id),
+      musicbrainz_artist_id = COALESCE(a.musicbrainz_artist_id, v.musicbrainz_artist_id),
+      wikidata_qid          = COALESCE(a.wikidata_qid,          v.wikidata_qid),
+      spotify_artist_id     = COALESCE(a.spotify_artist_id,     v.spotify_artist_id),
+      apple_music_artist_id = COALESCE(a.apple_music_artist_id, v.apple_music_artist_id),
+      bandcamp_id           = COALESCE(a.bandcamp_id,           v.bandcamp_id)
+    FROM (VALUES ${sql.join(valuesRows, sql`, `)}) AS v(
+      library_name,
+      discogs_artist_id,
+      musicbrainz_artist_id,
+      wikidata_qid,
+      spotify_artist_id,
+      apple_music_artist_id,
+      bandcamp_id
+    )
+    WHERE a.artist_name = v.library_name
+      AND (
+        (a.discogs_artist_id     IS NULL AND v.discogs_artist_id     IS NOT NULL) OR
+        (a.musicbrainz_artist_id IS NULL AND v.musicbrainz_artist_id IS NOT NULL) OR
+        (a.wikidata_qid          IS NULL AND v.wikidata_qid          IS NOT NULL) OR
+        (a.spotify_artist_id     IS NULL AND v.spotify_artist_id     IS NOT NULL) OR
+        (a.apple_music_artist_id IS NULL AND v.apple_music_artist_id IS NOT NULL) OR
+        (a.bandcamp_id           IS NULL AND v.bandcamp_id           IS NOT NULL)
+      )
+    RETURNING a.id
+  `);
+  const updatedRowCount = Array.isArray(updated) ? updated.length : 0;
 
   await updateLastRun(JOB_NAME, runStartedAt);
   console.log(
     `[${JOB_NAME}] Scanned ${identities.length} LML rows; ` +
-      `matched ${matched}; updated ${updated} artists ` +
-      `(${columnsWritten} columns filled); conflicts=${conflicts}.`
+      `matched ${matched}; updated ${updatedRowCount} artist rows ` +
+      `(${columnsWritten} columns filled across ${fillCandidates.length} LML rows); ` +
+      `conflicts=${conflicts}.`
   );
 
-  return { scanned: identities.length, matched, updated, columnsWritten, conflicts };
-};
-
-const loadExisting = async (artistName: string): Promise<ExistingArtistIdentity | null> => {
-  const [row] = await db
-    .select({
-      artist_name: artists.artist_name,
-      discogs_artist_id: artists.discogs_artist_id,
-      musicbrainz_artist_id: artists.musicbrainz_artist_id,
-      wikidata_qid: artists.wikidata_qid,
-      spotify_artist_id: artists.spotify_artist_id,
-      apple_music_artist_id: artists.apple_music_artist_id,
-      bandcamp_id: artists.bandcamp_id,
-    })
-    .from(artists)
-    .where(eq(artists.artist_name, artistName))
-    .limit(1);
-  return row ?? null;
-};
-
-/**
- * Writes only the columns in `toFill`, and uses `COALESCE(<col>, $value)`
- * in the SET expression so the database itself enforces "fill nulls
- * only" -- existing non-null values are preserved at the row level. This
- * is correctness-critical because `artists.artist_name` has no unique
- * constraint: a name like "Stereolab" might match multiple rows with
- * different existing values. The caller's `loadExisting` only inspects
- * one row, but this UPDATE applies to all matching rows, and COALESCE
- * keeps each row's existing value where one already exists.
- */
-const applyFill = async (lml: LmlIdentity, toFill: Array<keyof Omit<LmlIdentity, 'library_name'>>): Promise<void> => {
-  const set: Record<string, ReturnType<typeof sql>> = {};
-  for (const key of toFill) {
-    const value = lml[key];
-    if (key === 'discogs_artist_id') set.discogs_artist_id = sql`COALESCE(${artists.discogs_artist_id}, ${value})`;
-    else if (key === 'musicbrainz_artist_id')
-      set.musicbrainz_artist_id = sql`COALESCE(${artists.musicbrainz_artist_id}, ${value})`;
-    else if (key === 'wikidata_qid') set.wikidata_qid = sql`COALESCE(${artists.wikidata_qid}, ${value})`;
-    else if (key === 'spotify_artist_id') set.spotify_artist_id = sql`COALESCE(${artists.spotify_artist_id}, ${value})`;
-    else if (key === 'apple_music_artist_id')
-      set.apple_music_artist_id = sql`COALESCE(${artists.apple_music_artist_id}, ${value})`;
-    else if (key === 'bandcamp_id') set.bandcamp_id = sql`COALESCE(${artists.bandcamp_id}, ${value})`;
-  }
-  await db.update(artists).set(set).where(eq(artists.artist_name, lml.library_name));
+  return {
+    scanned: identities.length,
+    matched,
+    updated: updatedRowCount,
+    columnsWritten,
+    conflicts,
+  };
 };
 
 const run = async () => {


### PR DESCRIPTION
## Summary

\`runIncremental\` did one SELECT + one UPDATE per LML row (\`loadExisting\` then \`applyFill\`) — N+1 cost that grows linearly with \`entity.identity\` row count. Replaces that with two round-trips total, independent of LML row count, while preserving the COALESCE-in-SET correctness guarantee from PR #513.

- One bulk SELECT loads every \`artists\` row whose name appears in the LML batch (\`WHERE artist_name IN (…)\`). First match per name feeds the existing \`columnsInConflict\` / \`columnsToFill\` helpers unchanged, so conflict-warning behavior is identical.
- One bulk \`UPDATE … FROM (VALUES …) RETURNING\` applies the COALESCE fill to every matching artist row. \`RETURNING a.id\` gives an actual row count for logging.
- A \`WHERE\` guard excludes rows where the COALESCE would be a no-op (every column either already populated, or LML has nothing for it). Mirrors the previous per-row \`if (toFill.length === 0) continue\` so we don't burn WAL on rows that wouldn't change.
- Per-cell type casts (\`::text\`, \`::integer\`, \`::varchar(64)\`, …) are explicit on every VALUES row because postgres-js infers VALUES column types from the first row and several of these columns can legitimately be NULL there.

Closes #519.

## What stays the same

- COALESCE-in-SET preserves per-row existing values, so duplicate \`artist_name\`s (no unique constraint) keep their separate staff edits.
- Conflict logging fires per LML row × column combination, with the same warning text.
- The pure helpers in \`transform.ts\` (\`columnsToFill\`, \`columnsInConflict\`) are reused as-is — no changes to their unit tests.
- One-shot vs \`--poll\` mode, JOB_NAME, last-run timestamp tracking, notify path — all unchanged.

## What's intentionally out of scope

- **Orchestration tests** — separate issue #520. The LOW-priority test debt that PR #513's review flagged. The COALESCE-correctness coverage that #520 will add tests the same database-level invariant my refactor preserves; landing #520 right after this PR pins the duplicate-name correctness against the bulk path.
- **Name normalization** — separate issue #521.

## Test plan

- [x] \`npm run typecheck\` clean.
- [x] \`npm run lint\` clean (0 errors).
- [x] Existing artist-identity-etl unit tests pass: \`tests/unit/jobs/artist-identity-etl/{transform,fetch-lml}.test.ts\` — 8/8.
- [ ] CI integration tests pass.
- [ ] After merge, \`Auto Build & Deploy\` builds the new \`artist-identity-etl\` image, the next hourly cron tick on EC2 runs it. Log line should now read \`Scanned N LML rows; matched M; updated K artist rows (C columns filled across F LML rows); conflicts=X.\` — the new "K artist rows" / "F LML rows" decomposition makes duplicate-name fan-out visible.

Part of WXYC/wxyc-shared#82 follow-up. Part of [Shared Types Consolidation](https://github.com/orgs/WXYC/projects/16).