### PR TITLE
Support LIBRARY_METADATA_URL in set-ec2-env-var workflow

### DIFF
--- a/.github/workflows/set-ec2-env-var.yml
+++ b/.github/workflows/set-ec2-env-var.yml
@@ -34,12 +34,14 @@ jobs:
           # index `secrets[var]` dynamically, so any new key the workflow
           # supports has to be listed here.
           LML_API_KEY: ${{ secrets.LML_API_KEY }}
+          LIBRARY_METADATA_URL: ${{ secrets.LIBRARY_METADATA_URL }}
         run: |
           set -euo pipefail
           KEY="${{ inputs.key }}"
           SECRET_NAME="${{ inputs.secret_name || inputs.key }}"
           case "$SECRET_NAME" in
             LML_API_KEY) VALUE="$LML_API_KEY" ;;
+            LIBRARY_METADATA_URL) VALUE="$LIBRARY_METADATA_URL" ;;
             *)
               echo "::error::Unsupported secret_name '$SECRET_NAME'. Add it to the resolve step's env block."
               exit 1


### PR DESCRIPTION
Closes #575.

## Summary

Adds `LIBRARY_METADATA_URL` to the secrets allowlist in `.github/workflows/set-ec2-env-var.yml`, so the LML base URL can be upserted into EC2's `.env` without an image rebuild — same path already used for `LML_API_KEY`.

Required by the `flowsheet-lml-link-backfill` and `library-canonical-entity-backfill` jobs, which fail fast on a missing `LIBRARY_METADATA_URL`.

## Follow-up steps to actually use it

1. Add a `LIBRARY_METADATA_URL` repo secret with the production LML base URL.
2. `gh workflow run set-ec2-env-var.yml --ref main -f key=LIBRARY_METADATA_URL`.
3. The workflow restarts the backend container; backfills picking up the new value happens at next `docker run`.