### PR TITLE
Format set-ec2-env-var workflow with prettier

### DIFF
--- a/.github/workflows/set-ec2-env-var.yml
+++ b/.github/workflows/set-ec2-env-var.yml
@@ -15,11 +15,11 @@ on:
   workflow_dispatch:
     inputs:
       key:
-        description: "Env var name to upsert in .env on EC2"
+        description: 'Env var name to upsert in .env on EC2'
         required: true
         type: string
       secret_name:
-        description: "GH secret name holding the value (defaults to `key`)"
+        description: 'GH secret name holding the value (defaults to `key`)'
         required: false
         type: string
 


### PR DESCRIPTION
Two-line quote-style fix. \`set-ec2-env-var.yml\` was committed in #569 without prettier; #569's CI skipped \`lint-and-typecheck\` because the path filter excludes workflow-only changes, so the warn never surfaced.

It surfaced now on #535's CI (the bearer-header PR runs the lint job because its diff touches \`lml.client.ts\`), failing prettier on the workflow file from main: https://github.com/WXYC/Backend-Service/actions/runs/25012243354/job/73250757683

\`npx prettier --write .github/workflows/set-ec2-env-var.yml\` is the entire fix.