### PR TITLE
ci: include jobs/** in test.yml path filters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       apps: ${{ steps.changes.outputs.apps }}
+      jobs: ${{ steps.changes.outputs.jobs }}
       shared: ${{ steps.changes.outputs.shared }}
       tests: ${{ steps.changes.outputs.tests }}
       src: ${{ steps.changes.outputs.src }}
@@ -48,6 +49,8 @@ jobs:
           filters: |
             apps:
               - 'apps/**'
+            jobs:
+              - 'jobs/**'
             shared:
               - 'shared/**'
             tests:
@@ -66,6 +69,7 @@ jobs:
               - 'dev_env/mock-api-server/**'
             src:
               - 'apps/**'
+              - 'jobs/**'
               - 'shared/**'
               - 'tests/**'
               - 'dev_env/mock-api-server/**'
@@ -78,6 +82,7 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" || \
                 "${{ steps.changes.outputs.apps }}" == "true" || \
+                "${{ steps.changes.outputs.jobs }}" == "true" || \
                 "${{ steps.changes.outputs.shared }}" == "true" || \
                 "${{ steps.changes.outputs.tests }}" == "true" ]]; then
             echo "run-integration=true" >> $GITHUB_OUTPUT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,10 +224,10 @@ The CI environment uses `dev_env/docker-compose.yml` with Docker profiles (`ci`,
 
 GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:
 
-1. **detect-changes** -- Paths-filter identifies what changed (backend, auth, shared, tests, db-init)
+1. **detect-changes** -- Paths-filter identifies what changed (apps, jobs, shared, tests, db-init)
 2. **lint-and-typecheck** -- `typecheck` + `lint` + `format:check` + `build`
 3. **unit-tests** -- Runs affected tests only (`--changedSince=origin/<base>` on PRs)
-4. **integration-tests** -- Only if backend/auth/shared/tests changed. Docker images cached by commit SHA in ECR.
+4. **integration-tests** -- Only if apps/jobs/shared/tests change. Docker images cached by commit SHA in ECR.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary

- Adds `jobs/**` to the `dorny/paths-filter` config in `.github/workflows/test.yml` so jobs-only PRs run lint + typecheck + unit + integration like `apps/**` PRs do.
- Introduces a dedicated `jobs` output, includes `jobs/**` in `src`, and references it from the integration-tests `should-run` gate.
- Updates the `CI/CD` section of `CLAUDE.md` to match.

Closes #574.

Background: PR #573 (artist-identity ETL refactor, jobs-only) showed a green CI badge but every step skipped after the path filter — no checks actually ran. The next jobs-only regression would have landed unchecked. Found while investigating #519.

## Test plan

- [ ] CI run on this PR executes lint-and-typecheck, unit-tests, and Integration-Tests jobs (none skipped) — they touch `apps/**`/`shared/**` paths via the workflow file itself, so existing filters would also catch this; the real verification comes from a follow-up jobs-only PR.
- [ ] After merge, open a small jobs-only follow-up (e.g. trivial comment in `jobs/artist-identity-etl/`) and confirm the same three checks all run.