### PR TITLE
Send raw_message in all LML /lookup requests

### DIFF
--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -112,7 +112,11 @@ async function lmlFetch(path: string, init?: RequestInit): Promise<Response> {
  * @returns Lookup results with library items and enriched artwork metadata
  */
 export async function lookupMetadata(artist: string, album?: string, song?: string): Promise<LookupResponse> {
-  const body: Record<string, string> = { artist };
+  // LML's /lookup contract requires `raw_message` even when artist/album/song
+  // are already structured. Synthesize a free-form description that the LML
+  // parser would have produced — matches the e2e fixtures in LML's repo.
+  const rawMessage = [artist, album, song].filter(Boolean).join(' - ');
+  const body: Record<string, string> = { artist, raw_message: rawMessage };
   if (album) body.album = album;
   if (song) body.song = song;
 

--- a/jobs/flowsheet-lml-link-backfill/lml-fetch.ts
+++ b/jobs/flowsheet-lml-link-backfill/lml-fetch.ts
@@ -20,7 +20,11 @@ const baseUrl = (): string => {
 };
 
 export const lookupMetadata = async (artist: string, album?: string): Promise<LmlLookupResponse> => {
-  const body: Record<string, string> = { artist };
+  // LML's /lookup contract requires `raw_message` even when artist/album are
+  // already structured. Synthesize "<artist> - <album>" — matches the shape
+  // the parser expects in LML's e2e fixtures.
+  const rawMessage = album ? `${artist} - ${album}` : artist;
+  const body: Record<string, string> = { artist, raw_message: rawMessage };
   if (album) body.album = album;
 
   const controller = new AbortController();

--- a/jobs/library-canonical-entity-backfill/lml-fetch.ts
+++ b/jobs/library-canonical-entity-backfill/lml-fetch.ts
@@ -30,7 +30,11 @@ const baseUrl = (): string => {
 };
 
 export const lookupMetadata = async (artist: string, album?: string): Promise<LmlLookupResponse> => {
-  const body: Record<string, string> = { artist };
+  // LML's /lookup contract requires `raw_message` even when artist/album are
+  // already structured. Synthesize "<artist> - <album>" — matches the shape
+  // the parser expects in LML's e2e fixtures.
+  const rawMessage = album ? `${artist} - ${album}` : artist;
+  const body: Record<string, string> = { artist, raw_message: rawMessage };
   if (album) body.album = album;
 
   const controller = new AbortController();

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -29,7 +29,7 @@ describe('lml.client', () => {
   });
 
   describe('lookupMetadata', () => {
-    it('sends POST to /api/v1/lookup with artist, album, and song', async () => {
+    it('sends POST to /api/v1/lookup with artist, album, song, and synthesized raw_message', async () => {
       const mockResponse = { results: [], search_type: 'none', song_not_found: false, found_on_compilation: false };
       mockFetch.mockResolvedValue({
         ok: true,
@@ -43,12 +43,17 @@ describe('lml.client', () => {
         expect.objectContaining({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ artist: 'Autechre', album: 'Confield', song: 'VI Scose Poise' }),
+          body: JSON.stringify({
+            artist: 'Autechre',
+            raw_message: 'Autechre - Confield - VI Scose Poise',
+            album: 'Confield',
+            song: 'VI Scose Poise',
+          }),
         })
       );
     });
 
-    it('omits album and song when not provided', async () => {
+    it('omits album and song when not provided; raw_message falls back to the artist', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () =>
@@ -60,12 +65,12 @@ describe('lml.client', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         'http://lml.test:8000/api/v1/lookup',
         expect.objectContaining({
-          body: JSON.stringify({ artist: 'Autechre' }),
+          body: JSON.stringify({ artist: 'Autechre', raw_message: 'Autechre' }),
         })
       );
     });
 
-    it('does not include raw_message in the request body', async () => {
+    it('synthesizes raw_message from artist and album when song is omitted', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () =>
@@ -75,7 +80,7 @@ describe('lml.client', () => {
       await lookupMetadata('Autechre', 'Confield');
 
       const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
-      expect(callBody).not.toHaveProperty('raw_message');
+      expect(callBody.raw_message).toBe('Autechre - Confield');
     });
   });
 


### PR DESCRIPTION
Closes #584.

## Summary

Production LML rejects \`/api/v1/lookup\` with HTTP 422 when \`raw_message\` is missing. The B-2.2 backfill's first production run hit this on every flowsheet row. The same omission affects two other callers: the backend's LML client and the B-1.2 canonical-entity backfill.

## Fix

Synthesize \`raw_message\` as the present structured fields joined by \` - \` at all three callsites. \"\<artist\> - \<album\> - \<song\>\" matches the shape LML's parser would have produced from a free-form input — same form used in LML's e2e fixtures.

## Tests

Updates the existing lml.client unit test from \"does not include raw_message\" to \"synthesizes raw_message from artist and album\". 22/22 lml.client tests pass.

## After merge

The \`flowsheet-lml-link-backfill\` image will rebuild via auto-deploy. Then \`./scripts/run-lml-backfill.sh start\` should produce \`linked\` outcomes instead of 422s.