### PR TITLE
Use PG text array literals in enqueueReview to fix empty-array crash

### DIFF
--- a/jobs/flowsheet-lml-link-backfill/orchestrate.ts
+++ b/jobs/flowsheet-lml-link-backfill/orchestrate.ts
@@ -26,8 +26,24 @@
  * `lml-fetch.ts`.
  */
 
-import { sql } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import { db, pickPrimaryLibraryRow } from '@wxyc/database';
+
+/**
+ * Build a typed Postgres array literal from a JS number array.
+ *
+ * Drizzle's sql tag interpolates a JS array as a parenthesized list:
+ * `[1, 2]` becomes `(1, 2)`, and `[]` becomes `()`. The empty form fails
+ * the `::integer[]` cast with 42601 (`syntax error at or near ")"`),
+ * crashing the backfill the first time `enqueueReview` is called with no
+ * candidate library rows. We side-step the issue by serializing to PG's
+ * array text literal (`'{1,2,3}'`, or `'{}'` for empty) and parameter-
+ * binding that string. Values are typed `number[]` so the join is safe.
+ */
+const numberArrayLit = (values: number[], pgType: 'integer' | 'real'): SQL => {
+  const literal = `{${values.join(',')}}`;
+  return sql`${literal}::${sql.raw(pgType)}[]`;
+};
 import type { LmlLookupResponse } from './lml-types.js';
 import { resolveLmlSignal } from './resolve.js';
 
@@ -142,8 +158,8 @@ export const enqueueReview = async (args: {
       ("flowsheet_id", "candidate_library_ids", "candidate_confidences", "suggested_action")
     VALUES (
       ${args.flowsheetId},
-      ${args.candidateLibraryIds}::integer[],
-      ${args.candidateConfidences}::real[],
+      ${numberArrayLit(args.candidateLibraryIds, 'integer')},
+      ${numberArrayLit(args.candidateConfidences, 'real')},
       ${args.suggestedAction}
     )
     ON CONFLICT ("flowsheet_id") DO NOTHING

--- a/tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts
@@ -161,6 +161,34 @@ describe('enqueueReview', () => {
     const sqlText = renderSql(call?.[0]);
     expect(sqlText).toMatch(/ON\s+CONFLICT[\s\S]*flowsheet_id[\s\S]*DO\s+NOTHING/i);
   });
+
+  it('emits a well-formed empty array literal when no candidates were found', async () => {
+    // Drizzle's sql tag inlines an empty JS array as `()`, which fails
+    // the `::integer[]` cast at runtime with PG 42601. The fix serializes
+    // to PG's array text literal `{}` and parameter-binds it. Assert on
+    // the serialized SQL object (renderSql doesn't recurse into nested
+    // sql fragments, but JSON.stringify reaches them).
+    (db.execute as jest.Mock).mockResolvedValueOnce({ count: 1 });
+
+    await enqueueReview({
+      flowsheetId: 99,
+      candidateLibraryIds: [],
+      candidateConfidences: [],
+      suggestedAction: 'review_fallback',
+    });
+
+    const call = findExecuteCallMatching(/INSERT[\s\S]*flowsheet_linkage_review/i);
+    const serialized = JSON.stringify(call?.[0]);
+    // The broken shape that crashed the first prod run.
+    expect(serialized).not.toMatch(/\(\s*\)\s*::\s*(integer|real)\s*\[\s*\]/i);
+    // The empty array is serialized as PG text literal `{}` (bound as a
+    // parameter — appears once for each of the two array columns).
+    expect(serialized.match(/"\{\}"/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+    // Both PG type names appear via sql.raw fragments inside the nested
+    // sql object: `{"raw":"integer"}` and `{"raw":"real"}`.
+    expect(serialized).toContain('{"raw":"integer"}');
+    expect(serialized).toContain('{"raw":"real"}');
+  });
 });
 
 describe('findLibraryByCanonicalEntity', () => {


### PR DESCRIPTION
Closes #586.

## Summary

The \`flowsheet-lml-link-backfill\` job crashed on the first flowsheet row that hit the \`review\` outcome (flowsheet.id=156) with PG 42601 'syntax error at or near \")\"'. Drizzle's \`sql\` tag inlines an empty JS array as \`()\` which fails the \`::integer[]\` cast.

## Fix

Switch to PG's array text literal format (\`'{}'\`, \`'{1,2}'\`) and parameter-bind it. Works for both empty and non-empty cases without per-call branching.

## Tests

24/24 orchestrate tests pass. Adds a regression test asserting the serialized SQL never contains \`()::integer[]\` and that \`{}\` is bound as the empty-array string literal.

## After merge

Re-run the backfill via \`./scripts/run-lml-backfill.sh start\` once the auto-deploy rebuilds the image.