### PR TITLE
Send LML_API_KEY bearer header from backfill jobs

### DIFF
--- a/jobs/flowsheet-lml-link-backfill/lml-fetch.ts
+++ b/jobs/flowsheet-lml-link-backfill/lml-fetch.ts
@@ -30,10 +30,19 @@ export const lookupMetadata = async (artist: string, album?: string): Promise<Lm
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
+  // LML now enforces auth in production (LML_REQUIRE_AUTH=true). Send the
+  // bearer header when LML_API_KEY is set; the backend's lml.client.ts
+  // does the same. Sending it before the flag flips is harmless.
+  const apiKey = process.env.LML_API_KEY;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
   try {
     const response = await fetch(`${baseUrl()}/api/v1/lookup`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(body),
       signal: controller.signal,
     });

--- a/jobs/library-canonical-entity-backfill/lml-fetch.ts
+++ b/jobs/library-canonical-entity-backfill/lml-fetch.ts
@@ -40,10 +40,19 @@ export const lookupMetadata = async (artist: string, album?: string): Promise<Lm
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
+  // LML now enforces auth in production (LML_REQUIRE_AUTH=true). Send the
+  // bearer header when LML_API_KEY is set; the backend's lml.client.ts
+  // does the same. Sending it before the flag flips is harmless.
+  const apiKey = process.env.LML_API_KEY;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
   try {
     const response = await fetch(`${baseUrl()}/api/v1/lookup`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(body),
       signal: controller.signal,
     });


### PR DESCRIPTION
Closes #588.

## Summary

Production LML now enforces auth and returns 401 to unauthenticated callers. The backend client added the bearer header in \`71808c3\`; the two backfill jobs ship duplicated \`lml-fetch.ts\` files that hadn't been updated.

## Fix

Read \`LML_API_KEY\` from env and add \`Authorization: Bearer\` when set, in both \`jobs/flowsheet-lml-link-backfill/lml-fetch.ts\` and \`jobs/library-canonical-entity-backfill/lml-fetch.ts\`. Matches the backend client's behavior — including being a no-op when the key isn't set.