### PR TITLE
Bump backfill LML timeout from 5s to 30s

### DIFF
--- a/jobs/flowsheet-lml-link-backfill/lml-fetch.ts
+++ b/jobs/flowsheet-lml-link-backfill/lml-fetch.ts
@@ -9,7 +9,12 @@
 
 import type { LmlLookupResponse } from './lml-types.js';
 
-const TIMEOUT_MS = 5000;
+// 30s, not the backend client's 5s. The backfill processes long-tail rows
+// LML hasn't cached, which trigger Discogs/MusicBrainz fallback chains that
+// routinely exceed 5s. The orchestrator's throttle (100ms between rows)
+// caps in-flight requests at one, so the longer per-call cap doesn't risk
+// piling up on LML; it just lets slow lookups complete instead of failing.
+const TIMEOUT_MS = 30000;
 
 const baseUrl = (): string => {
   const url = process.env.LIBRARY_METADATA_URL;

--- a/jobs/library-canonical-entity-backfill/lml-fetch.ts
+++ b/jobs/library-canonical-entity-backfill/lml-fetch.ts
@@ -19,7 +19,12 @@
 
 import type { LmlLookupResponse } from './lml-types.js';
 
-const TIMEOUT_MS = 5000;
+// 30s, not the backend client's 5s. The backfill processes long-tail rows
+// LML hasn't cached, which trigger Discogs/MusicBrainz fallback chains that
+// routinely exceed 5s. The orchestrator's throttle (100ms between rows)
+// caps in-flight requests at one, so the longer per-call cap doesn't risk
+// piling up on LML; it just lets slow lookups complete instead of failing.
+const TIMEOUT_MS = 30000;
 
 const baseUrl = (): string => {
   const url = process.env.LIBRARY_METADATA_URL;


### PR DESCRIPTION
## Summary

The B-2.2 backfill's first authenticated production run timed out on every row with \`LML request timed out\` after 5s. Probe from EC2 shows LML cache hits at ~600ms — well under 5s — but the backfill targets long-tail rows that LML hasn't seen, which trigger Discogs/MusicBrainz fallback chains. Those routinely exceed 5s.

## Fix

Bump \`TIMEOUT_MS\` from 5000 to 30000 in both \`jobs/flowsheet-lml-link-backfill/lml-fetch.ts\` and \`jobs/library-canonical-entity-backfill/lml-fetch.ts\`.

## Why this is safe

The orchestrator processes one row at a time and throttles 100ms between rows, so the per-call cap doesn't compound — at most one LML request is in flight. Slow cache misses get to complete instead of becoming retries on the next sweep.