### PR TITLE
Switch run-lml-backfill.sh from tmux to detached docker

### DIFF
--- a/scripts/run-lml-backfill.sh
+++ b/scripts/run-lml-backfill.sh
@@ -1,44 +1,38 @@
 #!/bin/bash
 #
 # Starts (or attaches to) the flowsheet-lml-link-backfill one-shot job on
-# EC2 inside a tmux session. The backfill iterates ~1.18M flowsheet rows
-# where album_id IS NULL, calling LML once per row at the orchestrator's
-# default throttle, so a full sweep takes ~1.5 days. Running it inside
-# tmux means the SSH session can drop without killing the job.
+# EC2 as a detached docker container. The backfill iterates ~1.18M
+# flowsheet rows where album_id IS NULL, calling LML once per row at the
+# orchestrator's default throttle, so a full sweep takes ~1.5 days.
+# Detached docker (`docker run -d`) means the container survives the SSH
+# session ending — no tmux needed (Amazon Linux doesn't ship it).
 #
 # Resumability: re-running this script after a crash or stop is safe.
 # Linked rows fall out of the backfill's WHERE filter on the next sweep,
 # so the job picks up where it left off without a persistent cursor.
 #
 # Usage:
-#   ./run-lml-backfill.sh start          # default — start a new session
-#   ./run-lml-backfill.sh attach         # attach to an in-flight run
-#   ./run-lml-backfill.sh status         # show tmux session + tail of log
-#   ./run-lml-backfill.sh stop           # kill the tmux session (does NOT
-#                                          stop the docker container)
+#   ./run-lml-backfill.sh start          # default — start a new container
+#   ./run-lml-backfill.sh attach         # follow logs (Ctrl-C to detach)
+#   ./run-lml-backfill.sh status         # container state + last 20 log lines
+#   ./run-lml-backfill.sh stop           # docker stop the container
 #
 # Environment:
 #   REMOTE_ENV_PATH   Path to .env on EC2  (default: /home/ec2-user/.env)
 #   IMAGE_TAG         ECR image tag        (default: latest)
 #   SSH_HOST          SSH alias for EC2    (default: wxyc-ec2)
-#   TMUX_SESSION      Remote session name  (default: lml-backfill)
 
 set -euo pipefail
 
 REMOTE_ENV_PATH="${REMOTE_ENV_PATH:-/home/ec2-user/.env}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 SSH_HOST="${SSH_HOST:-wxyc-ec2}"
-TMUX_SESSION="${TMUX_SESSION:-lml-backfill}"
 IMAGE_NAME="flowsheet-lml-link-backfill"
 
 CMD="${1:-start}"
 
 case "$CMD" in
   start)
-    # Building the remote command in pieces for readability. The session
-    # runs: ECR login -> pull -> docker run --rm with .env -> tee log.
-    # `2>&1 | tee` captures both stdout and stderr to the log file while
-    # also showing them on the tmux pane for live monitoring.
     ssh -o ConnectTimeout=10 "$SSH_HOST" bash <<EOF
 set -uo pipefail
 # Note: NOT using -e — we want to keep going past failed greps so we can
@@ -49,8 +43,14 @@ fail() { echo "[run-lml-backfill] ERROR: \$*" >&2; exit 1; }
 
 step "Connected to EC2."
 
-if tmux has-session -t '$TMUX_SESSION' 2>/dev/null; then
-  fail "tmux session '$TMUX_SESSION' is already running. Run './run-lml-backfill.sh attach'."
+# Refuse to start if a container with the same name is already running;
+# clean up an exited one so a fresh \`docker run\` can reuse the name.
+if docker ps --format '{{.Names}}' | grep -qx '$IMAGE_NAME'; then
+  fail "Container '$IMAGE_NAME' is already running. Run './run-lml-backfill.sh attach'."
+fi
+if docker ps -a --format '{{.Names}}' | grep -qx '$IMAGE_NAME'; then
+  step "Removing previous exited container '$IMAGE_NAME'..."
+  docker rm '$IMAGE_NAME' >/dev/null || fail "docker rm failed."
 fi
 
 [ -f '$REMOTE_ENV_PATH' ] || fail "Missing env file: $REMOTE_ENV_PATH"
@@ -73,12 +73,10 @@ AWS_ECR_URI=\$(get_env AWS_ECR_URI)
 if [ -z "\$AWS_ECR_URI" ]; then
   step "AWS_ECR_URI not in .env; recovering from running 'backend' container."
   BACKEND_IMAGE=\$(docker inspect -f '{{.Config.Image}}' backend 2>/dev/null || true)
-  [ -n "\$BACKEND_IMAGE" ] || fail "No running 'backend' container found. Set AWS_ECR_URI in .env (via set-ec2-env-var workflow once it's added to the secrets allowlist) or pass it as the IMAGE_REGISTRY env var."
-  # Strip the trailing /<repo>:<tag> to get the registry URI.
+  [ -n "\$BACKEND_IMAGE" ] || fail "No running 'backend' container found. Set AWS_ECR_URI in .env or pass it via the recovery path."
   AWS_ECR_URI="\${BACKEND_IMAGE%/*}"
 fi
 if [ -z "\$AWS_REGION" ]; then
-  # AWS ECR URIs are <account>.dkr.ecr.<region>.amazonaws.com.
   AWS_REGION=\$(echo "\$AWS_ECR_URI" | awk -F. '{print \$4}')
   [ -n "\$AWS_REGION" ] || fail "Could not derive AWS_REGION from AWS_ECR_URI=\$AWS_ECR_URI"
 fi
@@ -93,59 +91,63 @@ IMAGE="\$AWS_ECR_URI/$IMAGE_NAME:$IMAGE_TAG"
 step "Pulling \$IMAGE..."
 docker pull "\$IMAGE" || fail "docker pull failed for \$IMAGE"
 
-LOG_FILE="\$HOME/lml-backfill-\$(date +%Y%m%d-%H%M%S).log"
-step "Starting tmux session '$TMUX_SESSION'. Log: \$LOG_FILE"
+step "Starting detached container '$IMAGE_NAME'..."
+# -d: detached; container survives SSH disconnect. No --rm — we want the
+# stopped container to stick around so post-mortem 'docker logs' works.
+# Stdout/stderr are captured by docker's default json-file log driver,
+# accessible via 'docker logs' (the 'attach' and 'status' subcommands).
+# DB_STATEMENT_TIMEOUT_MS=300000 (5 min) overrides the .env default of 5s,
+# which is right for HTTP request handlers but kills the backfill's batch
+# SELECT on the unlinked-flowsheet predicate (a multi-million-row scan).
+# See shared/database/src/client.ts for the per-caller-class rationale.
+CONTAINER_ID=\$(docker run -d --name '$IMAGE_NAME' \\
+  --env-file '$REMOTE_ENV_PATH' \\
+  -e DB_STATEMENT_TIMEOUT_MS=300000 \\
+  "\$IMAGE") \\
+  || fail "docker run failed."
 
-tmux new-session -d -s '$TMUX_SESSION' \\
-  "docker run --rm --name $IMAGE_NAME --env-file '$REMOTE_ENV_PATH' \\
-     '\$IMAGE' 2>&1 | tee '\$LOG_FILE'; echo; echo 'Job exited. Press enter.'; read"
-
-step "Started. Inspect with:"
-echo "  ./run-lml-backfill.sh attach"
-echo "  ./run-lml-backfill.sh status"
+step "Started. Container ID: \${CONTAINER_ID:0:12}"
+echo "Inspect with:"
+echo "  ./run-lml-backfill.sh attach    # live tail (Ctrl-C to detach, doesn't stop the job)"
+echo "  ./run-lml-backfill.sh status    # one-shot status + last 20 log lines"
+echo "  ./run-lml-backfill.sh stop      # stop the container"
 EOF
     ;;
 
   attach)
-    # -t forces a TTY so tmux can take over the terminal.
-    exec ssh -t "$SSH_HOST" "tmux attach -t '$TMUX_SESSION'"
+    # -t forces a TTY so Ctrl-C cleanly detaches docker logs without
+    # killing the SSH session. The --since=0 keeps things tidy on first
+    # attach; --follow streams new lines as they arrive.
+    exec ssh -t "$SSH_HOST" "docker logs -f --tail 50 '$IMAGE_NAME'"
     ;;
 
   status)
     ssh "$SSH_HOST" bash <<EOF
-set -e
-if tmux has-session -t '$TMUX_SESSION' 2>/dev/null; then
-  echo "tmux session '$TMUX_SESSION': RUNNING"
-else
-  echo "tmux session '$TMUX_SESSION': not running"
-fi
-
-echo
+set -uo pipefail
 echo "Container:"
-docker ps --filter "name=$IMAGE_NAME" \\
-  --format 'table {{.Names}}\t{{.Status}}\t{{.RunningFor}}' || true
+docker ps -a --filter "name=$IMAGE_NAME" \\
+  --format 'table {{.Names}}\t{{.Status}}\t{{.RunningFor}}' \\
+  || echo "  (not present)"
 
 echo
-LATEST_LOG=\$(ls -t "\$HOME"/lml-backfill-*.log 2>/dev/null | head -1)
-if [ -n "\$LATEST_LOG" ]; then
-  echo "Tail of \$LATEST_LOG:"
-  tail -20 "\$LATEST_LOG"
-else
-  echo "No log files found in \$HOME."
-fi
+echo "Last 20 log lines:"
+docker logs --tail 20 '$IMAGE_NAME' 2>&1 || echo "  (no logs available)"
 EOF
     ;;
 
   stop)
-    # Kills the tmux session. The docker container will be cleaned up by
-    # --rm once it exits, but if you want to kill the running container
-    # too, run `docker kill flowsheet-lml-link-backfill` on EC2.
-    ssh "$SSH_HOST" "tmux kill-session -t '$TMUX_SESSION' 2>/dev/null \
-      && echo 'Killed tmux session.' \
-      || echo 'No tmux session to kill.'"
-    echo "Note: this only stops the tmux pane. Run"
-    echo "  ssh $SSH_HOST docker kill $IMAGE_NAME"
-    echo "to also stop the running container."
+    ssh "$SSH_HOST" bash <<EOF
+set -uo pipefail
+if docker ps --format '{{.Names}}' | grep -qx '$IMAGE_NAME'; then
+  echo "Stopping '$IMAGE_NAME'..."
+  docker stop '$IMAGE_NAME'
+else
+  echo "Container '$IMAGE_NAME' is not running."
+fi
+
+# Leave the stopped container in place so post-mortem 'docker logs' works.
+# 'start' will 'docker rm' it on the next run.
+EOF
     ;;
 
   *)


### PR DESCRIPTION
## Summary

EC2 (Amazon Linux) doesn't ship \`tmux\`, so the original \`tmux new-session\` branch failed with \`tmux: command not found\` and the misleading \`Started. Inspect with...\` line printed anyway. Replaced tmux with \`docker run -d\` (detached): the container persists across SSH disconnect on its own and docker's log driver captures stdout/stderr.

## Changes

- \`start\` — \`docker run -d\`, with auto-\`docker rm\` of any prior exited container so the name is reusable across runs. Also passes \`DB_STATEMENT_TIMEOUT_MS=300000\` (5 min) to override the .env default of 5 s — the backfill's batch SELECT on the unlinked-flowsheet predicate scans multi-million-row state.
- \`attach\` — \`ssh -t\` + \`docker logs -f --tail 50\`. Ctrl-C detaches without killing the job.
- \`status\` — \`docker ps\` + \`docker logs --tail 20\`.
- \`stop\` — \`docker stop\`. Leaves the container in \`exited\` state so post-mortem \`docker logs\` still works; \`start\` removes it on the next run.
- Escaped backticks in the heredoc comments. Local bash was running \`docker logs\`, \`attach\`, and \`status\` as command substitutions while parsing the heredoc — surfacing spurious \`command not found\` errors before any SSH output.

## Verified

This is the script that's been driving the live B-2.2 backfill on EC2. After all the LML-side fixes (raw_message, bearer header, 30s timeout, empty-array literal), \`./scripts/run-lml-backfill.sh start\` runs the job and \`./scripts/run-lml-backfill.sh status\` shows live progress. 48 rows queued to \`flowsheet_linkage_review\` in the first 10 minutes of the working run, with only one transient timeout.