### PR TITLE
Join library against artists in B-1.2 backfill loadBatch

### DIFF
--- a/jobs/library-canonical-entity-backfill/orchestrate.ts
+++ b/jobs/library-canonical-entity-backfill/orchestrate.ts
@@ -132,15 +132,26 @@ export const processRow = async (
  * Read the next batch of unresolved library rows. The id-cursor predicate
  * keeps the SELECT bounded as the run progresses; combined with the
  * canonical_entity_id IS NULL filter, it also makes restarts cheap.
+ *
+ * Joins `artists` because the library's denormalized `artist_name` column
+ * is NULL across the board — the source of truth is
+ * `wxyc_schema.artists.artist_name` reached via the FK `library.artist_id`.
+ * Without the JOIN, processRow's `if (!artist) return 'no_match'`
+ * short-circuits every row and the job runs at throttle speed without
+ * ever calling LML.
  */
 const loadBatch = async (afterId: number, batchSize: number): Promise<LibraryRow[]> => {
   const rows = (await db.execute(sql`
-    SELECT "id", "artist_name", "album_title"
-    FROM "wxyc_schema"."library"
-    WHERE "canonical_entity_id" IS NULL
-      AND "canonical_entity_resolved_at" IS NULL
-      AND "id" > ${afterId}
-    ORDER BY "id" ASC
+    SELECT
+      l."id",
+      a."artist_name" AS "artist_name",
+      l."album_title"
+    FROM "wxyc_schema"."library" l
+    LEFT JOIN "wxyc_schema"."artists" a ON a."id" = l."artist_id"
+    WHERE l."canonical_entity_id" IS NULL
+      AND l."canonical_entity_resolved_at" IS NULL
+      AND l."id" > ${afterId}
+    ORDER BY l."id" ASC
     LIMIT ${batchSize}
   `)) as unknown as LibraryRow[];
   return rows ?? [];

--- a/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
@@ -255,6 +255,25 @@ describe('runBackfill', () => {
     expect(result.totals.scanned).toBe(0);
   });
 
+  it('joins library against artists to read artist_name (denormalized library column is NULL)', async () => {
+    // Regression: the library schema has both `artist_id` (FK) and a
+    // denormalized `artist_name` column. The denormalized column is NULL
+    // on every row in production; the source of truth is
+    // `wxyc_schema.artists.artist_name` reached via the FK. Without the
+    // JOIN, processRow short-circuits to no_match for every row and the
+    // job runs at throttle speed without ever calling LML.
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    await runBackfill({ lookup: jest.fn(), throttleMs: 0 });
+
+    const select = findExecuteCallMatching(/SELECT/i);
+    const sqlText = renderSql(select?.[0]);
+    expect(sqlText).toMatch(/FROM\s+"wxyc_schema"\."library"/i);
+    expect(sqlText).toMatch(/JOIN\s+"wxyc_schema"\."artists"/i);
+    expect(sqlText).toMatch(/a\."artist_name"/i);
+    expect(sqlText).toMatch(/a\."id"\s*=\s*l\."artist_id"/i);
+  });
+
   it('paginates forward by id (last-id cursor restartable across batches)', async () => {
     // The second loadBatch must filter `id > 2` (the last id from batch 1)
     // — otherwise we'd re-scan the same rows forever (the WHERE filter on


### PR DESCRIPTION
## Summary

The B-1.2 backfill (\`library-canonical-entity-backfill\`) processed 2000 rows in 3 minutes and made **zero** LML calls. Every row came back as \`no_match\` — exactly at the throttle's 10/sec rate.

## Root cause

The \`library\` schema has both \`artist_id\` (FK to \`artists\`) and a denormalized \`artist_name\` column. In production, \`artist_name\` is **NULL on every one of the 64,163 rows** — only the FK is populated. The orchestrator's \`loadBatch\` selects \`artist_name\` directly, gets NULL, and \`processRow\` short-circuits at:

\`\`\`ts
if (!artist) {
  // No artist text to query — counts as no_match.
  return 'no_match';
}
\`\`\`

Verified directly:

\`\`\`
 populated | attempted | total
-----------+-----------+-------
         0 |         0 | 64163

 count
-------
     0   ← rows with non-NULL library.artist_name
\`\`\`

## Fix

LEFT JOIN \`wxyc_schema.artists\` on \`library.artist_id\` and project \`artists.artist_name\` as \`artist_name\`. Adds a regression unit test that asserts the rendered SQL has the JOIN clause and reads from \`a.artist_name\`.

## After merge

Restart B-1.2 — it will start producing real \`auto_accept\` / \`review\` / \`no_match\` outcomes and populate \`library.canonical_entity_id\`. That in turn unblocks B-2.2's \`linked\` outcomes (currently zero, because \`linked\` requires a library row with the matching \`canonical_entity_id\`).