### PR TITLE
Partition LML backfills across N parallel containers

### DIFF
--- a/jobs/flowsheet-lml-link-backfill/orchestrate.ts
+++ b/jobs/flowsheet-lml-link-backfill/orchestrate.ts
@@ -58,6 +58,41 @@ export const BATCH_SIZE = 500;
  */
 export const THROTTLE_MS = 100;
 
+/**
+ * Resolve PARTITION_INDEX / PARTITION_COUNT env vars into a SQL fragment that
+ * picks every Nth row by id-modulo. The N-container deploy pattern is:
+ *
+ *   PARTITION_COUNT=4 PARTITION_INDEX=0 docker run ...
+ *   PARTITION_COUNT=4 PARTITION_INDEX=1 docker run ...
+ *   ...
+ *
+ * Each container processes a disjoint subset of unlinked flowsheet rows and
+ * they finish in roughly the same wall time. The default (count=1, index=0)
+ * is a no-op pass-through so single-container runs are unaffected.
+ *
+ * Exported so unit tests can drive it without mucking with process.env.
+ */
+export const resolvePartitionFilter = (
+  rawIndex: string | undefined = process.env.PARTITION_INDEX,
+  rawCount: string | undefined = process.env.PARTITION_COUNT
+): { sqlFragment: SQL | null; description: string } => {
+  const count = rawCount === undefined ? 1 : Number(rawCount);
+  const index = rawIndex === undefined ? 0 : Number(rawIndex);
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(`Invalid PARTITION_COUNT=${JSON.stringify(rawCount)}; must be a positive integer.`);
+  }
+  if (!Number.isInteger(index) || index < 0 || index >= count) {
+    throw new Error(`Invalid PARTITION_INDEX=${JSON.stringify(rawIndex)}; must be 0 <= index < PARTITION_COUNT (${count}).`);
+  }
+  if (count === 1) {
+    return { sqlFragment: null, description: 'partition=none' };
+  }
+  return {
+    sqlFragment: sql`AND ("id" % ${count}) = ${index}`,
+    description: `partition=${index}/${count}`,
+  };
+};
+
 export type FlowsheetRow = {
   id: number;
   artist_name: string | null;
@@ -274,7 +309,12 @@ export const processRow = async (
  * union pulls in both the never-had-FK rows (~889K) and the B-0.5 broken-FK
  * residuals stamped by `jobs/broken-fk-recovery`.
  */
-const loadBatch = async (afterId: number, batchSize: number): Promise<FlowsheetRow[]> => {
+const loadBatch = async (
+  afterId: number,
+  batchSize: number,
+  partitionFilter: SQL | null
+): Promise<FlowsheetRow[]> => {
+  const partitionClause = partitionFilter ?? sql``;
   const rows = (await db.execute(sql`
     SELECT "id", "artist_name", "album_title"
     FROM "wxyc_schema"."flowsheet"
@@ -284,6 +324,7 @@ const loadBatch = async (afterId: number, batchSize: number): Promise<FlowsheetR
       AND "album_title" IS NOT NULL
       AND ("legacy_release_id" IS NULL OR "legacy_link_attempted_at" IS NOT NULL)
       AND "id" > ${afterId}
+      ${partitionClause}
     ORDER BY "id" ASC
     LIMIT ${batchSize}
   `)) as unknown as FlowsheetRow[];
@@ -300,12 +341,16 @@ export const runBackfill = async (opts: {
   batchSize?: number;
   throttleMs?: number;
   metrics?: MetricsSink;
+  partition?: { sqlFragment: SQL | null; description: string };
 }): Promise<RunResult> => {
   const batchSize = opts.batchSize ?? BATCH_SIZE;
   const throttleMs = opts.throttleMs ?? THROTTLE_MS;
   const metrics = opts.metrics ?? NULL_METRICS;
+  const partition = opts.partition ?? resolvePartitionFilter();
 
-  console.log(`[${JOB_NAME}] Starting. batchSize=${batchSize} throttleMs=${throttleMs}`);
+  console.log(
+    `[${JOB_NAME}] Starting. batchSize=${batchSize} throttleMs=${throttleMs} ${partition.description}`
+  );
 
   const totals: Totals = {
     scanned: 0,
@@ -319,7 +364,7 @@ export const runBackfill = async (opts: {
   let batchIndex = 0;
 
   while (true) {
-    const rows = await loadBatch(lastId, batchSize);
+    const rows = await loadBatch(lastId, batchSize, partition.sqlFragment);
     if (rows.length === 0) break;
 
     batchIndex += 1;

--- a/jobs/library-canonical-entity-backfill/orchestrate.ts
+++ b/jobs/library-canonical-entity-backfill/orchestrate.ts
@@ -19,7 +19,7 @@
  * `lml-fetch.ts`.
  */
 
-import { sql } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import { db } from '@wxyc/database';
 import type { LmlLookupResponse } from './lml-types.js';
 import { resolveCanonicalEntity, type Resolution } from './resolve.js';
@@ -34,6 +34,42 @@ export const BATCH_SIZE = 500;
  * if LML's deployed rate limit tightens. Tests override to 0.
  */
 export const THROTTLE_MS = 100;
+
+/**
+ * Resolve PARTITION_INDEX / PARTITION_COUNT env vars into a SQL fragment that
+ * picks every Nth row by id-modulo. The N-container deploy pattern is:
+ *
+ *   PARTITION_COUNT=4 PARTITION_INDEX=0 docker run ...
+ *   PARTITION_COUNT=4 PARTITION_INDEX=1 docker run ...
+ *   PARTITION_COUNT=4 PARTITION_INDEX=2 docker run ...
+ *   PARTITION_COUNT=4 PARTITION_INDEX=3 docker run ...
+ *
+ * Each container processes a disjoint subset and they finish in roughly the
+ * same wall time. The default (count=1, index=0) is a no-op pass-through so
+ * single-container runs are unaffected.
+ *
+ * Exported so unit tests can drive it without mucking with process.env.
+ */
+export const resolvePartitionFilter = (
+  rawIndex: string | undefined = process.env.PARTITION_INDEX,
+  rawCount: string | undefined = process.env.PARTITION_COUNT
+): { sqlFragment: SQL | null; description: string } => {
+  const count = rawCount === undefined ? 1 : Number(rawCount);
+  const index = rawIndex === undefined ? 0 : Number(rawIndex);
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(`Invalid PARTITION_COUNT=${JSON.stringify(rawCount)}; must be a positive integer.`);
+  }
+  if (!Number.isInteger(index) || index < 0 || index >= count) {
+    throw new Error(`Invalid PARTITION_INDEX=${JSON.stringify(rawIndex)}; must be 0 <= index < PARTITION_COUNT (${count}).`);
+  }
+  if (count === 1) {
+    return { sqlFragment: null, description: 'partition=none' };
+  }
+  return {
+    sqlFragment: sql`AND ("id" % ${count}) = ${index}`,
+    description: `partition=${index}/${count}`,
+  };
+};
 
 export type LibraryRow = {
   id: number;
@@ -140,7 +176,12 @@ export const processRow = async (
  * short-circuits every row and the job runs at throttle speed without
  * ever calling LML.
  */
-const loadBatch = async (afterId: number, batchSize: number): Promise<LibraryRow[]> => {
+const loadBatch = async (
+  afterId: number,
+  batchSize: number,
+  partitionFilter: SQL | null
+): Promise<LibraryRow[]> => {
+  const partitionClause = partitionFilter ?? sql``;
   const rows = (await db.execute(sql`
     SELECT
       l."id",
@@ -151,6 +192,7 @@ const loadBatch = async (afterId: number, batchSize: number): Promise<LibraryRow
     WHERE l."canonical_entity_id" IS NULL
       AND l."canonical_entity_resolved_at" IS NULL
       AND l."id" > ${afterId}
+      ${partitionClause}
     ORDER BY l."id" ASC
     LIMIT ${batchSize}
   `)) as unknown as LibraryRow[];
@@ -165,18 +207,22 @@ export const runBackfill = async (opts: {
   lookup: LookupFn;
   batchSize?: number;
   throttleMs?: number;
+  partition?: { sqlFragment: SQL | null; description: string };
 }): Promise<RunResult> => {
   const batchSize = opts.batchSize ?? BATCH_SIZE;
   const throttleMs = opts.throttleMs ?? THROTTLE_MS;
+  const partition = opts.partition ?? resolvePartitionFilter();
 
-  console.log(`[${JOB_NAME}] Starting. batchSize=${batchSize} throttleMs=${throttleMs}`);
+  console.log(
+    `[${JOB_NAME}] Starting. batchSize=${batchSize} throttleMs=${throttleMs} ${partition.description}`
+  );
 
   const totals: Totals = { scanned: 0, auto_accept: 0, review: 0, no_match: 0, error: 0 };
   let lastId = 0;
   let batchIndex = 0;
 
   while (true) {
-    const rows = await loadBatch(lastId, batchSize);
+    const rows = await loadBatch(lastId, batchSize, partition.sqlFragment);
     if (rows.length === 0) break;
 
     batchIndex += 1;

--- a/scripts/run-lml-backfill.sh
+++ b/scripts/run-lml-backfill.sh
@@ -1,31 +1,45 @@
 #!/bin/bash
 #
 # Starts (or attaches to) an LML-driven backfill one-shot job on EC2 as a
-# detached docker container. The two callers in tree are
+# detached docker container — optionally as N partitioned containers in
+# parallel for an N-fold throughput speedup. The two callers in tree are
 # `flowsheet-lml-link-backfill` (B-2.2; ~1.18M flowsheet rows) and
 # `library-canonical-entity-backfill` (B-1.2; ~64K library rows). Both
 # call LML once per row at the orchestrator's default throttle.
-# Detached docker (`docker run -d`) means the container survives the SSH
+# Detached docker (`docker run -d`) means each container survives the SSH
 # session ending — no tmux needed (Amazon Linux doesn't ship it).
 #
 # Resumability: re-running this script after a crash or stop is safe.
 # Each backfill's WHERE filter sees only rows that haven't been resolved,
-# so the job picks up where it left off without a persistent cursor.
+# so the job picks up where it left off without a persistent cursor. With
+# partitioning, each partition independently resumes its own subset.
 #
 # Usage:
-#   ./run-lml-backfill.sh start          # default — start the B-2.2 backfill
-#   ./run-lml-backfill.sh attach         # follow logs (Ctrl-C to detach)
-#   ./run-lml-backfill.sh status         # container state + last 20 log lines
-#   ./run-lml-backfill.sh stop           # docker stop the container
+#   ./run-lml-backfill.sh start          # default — start B-2.2, single container
+#   ./run-lml-backfill.sh attach         # follow logs of partition 0
+#   ./run-lml-backfill.sh status         # all containers + last log lines each
+#   ./run-lml-backfill.sh stop           # docker stop all partitions
 #
 #   # Run B-1.2 instead:
 #   BACKFILL=library-canonical-entity-backfill ./scripts/run-lml-backfill.sh start
 #
+#   # Run B-2.2 with 4 partitions in parallel:
+#   PARTITIONS=4 ./scripts/run-lml-backfill.sh start
+#
+#   # Attach to a specific partition (default = 0):
+#   PARTITION=2 ./scripts/run-lml-backfill.sh attach
+#
+# Container naming:
+#   PARTITIONS=1 (default) → container name = $IMAGE_NAME (no suffix)
+#   PARTITIONS=N (>1)      → container names = $IMAGE_NAME-0..$IMAGE_NAME-(N-1)
+#
 # Environment:
-#   BACKFILL          Job to run, also used as the docker container name
+#   BACKFILL          Job to run; doubles as the docker container name prefix
 #                     and the ECR repo name. Must match a directory under
 #                     jobs/ and an image in ECR.
 #                     (default: flowsheet-lml-link-backfill)
+#   PARTITIONS        Number of parallel containers (default: 1).
+#   PARTITION         Which partition to attach to (default: 0).
 #   REMOTE_ENV_PATH   Path to .env on EC2  (default: /home/ec2-user/.env)
 #   IMAGE_TAG         ECR image tag        (default: latest)
 #   SSH_HOST          SSH alias for EC2    (default: wxyc-ec2)
@@ -35,11 +49,34 @@ set -euo pipefail
 REMOTE_ENV_PATH="${REMOTE_ENV_PATH:-/home/ec2-user/.env}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 SSH_HOST="${SSH_HOST:-wxyc-ec2}"
-# IMAGE_NAME doubles as the ECR repo path and the docker container name.
-# Both backfills follow the convention `<job-name>` for repo + container.
 IMAGE_NAME="${BACKFILL:-flowsheet-lml-link-backfill}"
+PARTITIONS="${PARTITIONS:-1}"
+PARTITION="${PARTITION:-0}"
+
+# Validate numeric env vars locally so the SSH'd bash never has to deal
+# with a stray non-integer that would expand into something weird.
+case "$PARTITIONS" in
+  ''|*[!0-9]*) echo "PARTITIONS must be a positive integer (got '$PARTITIONS')" >&2; exit 1 ;;
+esac
+[ "$PARTITIONS" -ge 1 ] || { echo "PARTITIONS must be >= 1" >&2; exit 1; }
+case "$PARTITION" in
+  ''|*[!0-9]*) echo "PARTITION must be a non-negative integer (got '$PARTITION')" >&2; exit 1 ;;
+esac
+[ "$PARTITION" -lt "$PARTITIONS" ] || { echo "PARTITION ($PARTITION) must be < PARTITIONS ($PARTITIONS)" >&2; exit 1; }
 
 CMD="${1:-start}"
+
+# Container-naming helper. Single-container runs keep the bare image name
+# so existing operator muscle memory ("attach to flowsheet-lml-link-backfill")
+# continues to work. Partitioned runs append the index.
+container_name_for_partition() {
+  local idx="$1"
+  if [ "$PARTITIONS" -eq 1 ]; then
+    echo "$IMAGE_NAME"
+  else
+    echo "$IMAGE_NAME-$idx"
+  fi
+}
 
 case "$CMD" in
   start)
@@ -52,16 +89,6 @@ step() { echo "[run-lml-backfill] \$*"; }
 fail() { echo "[run-lml-backfill] ERROR: \$*" >&2; exit 1; }
 
 step "Connected to EC2."
-
-# Refuse to start if a container with the same name is already running;
-# clean up an exited one so a fresh \`docker run\` can reuse the name.
-if docker ps --format '{{.Names}}' | grep -qx '$IMAGE_NAME'; then
-  fail "Container '$IMAGE_NAME' is already running. Run './run-lml-backfill.sh attach'."
-fi
-if docker ps -a --format '{{.Names}}' | grep -qx '$IMAGE_NAME'; then
-  step "Removing previous exited container '$IMAGE_NAME'..."
-  docker rm '$IMAGE_NAME' >/dev/null || fail "docker rm failed."
-fi
 
 [ -f '$REMOTE_ENV_PATH' ] || fail "Missing env file: $REMOTE_ENV_PATH"
 
@@ -101,62 +128,96 @@ IMAGE="\$AWS_ECR_URI/$IMAGE_NAME:$IMAGE_TAG"
 step "Pulling \$IMAGE..."
 docker pull "\$IMAGE" || fail "docker pull failed for \$IMAGE"
 
-step "Starting detached container '$IMAGE_NAME'..."
-# -d: detached; container survives SSH disconnect. No --rm — we want the
-# stopped container to stick around so post-mortem 'docker logs' works.
-# Stdout/stderr are captured by docker's default json-file log driver,
-# accessible via 'docker logs' (the 'attach' and 'status' subcommands).
-# DB_STATEMENT_TIMEOUT_MS=300000 (5 min) overrides the .env default of 5s,
-# which is right for HTTP request handlers but kills the backfill's batch
-# SELECT on the unlinked-flowsheet predicate (a multi-million-row scan).
-# See shared/database/src/client.ts for the per-caller-class rationale.
-CONTAINER_ID=\$(docker run -d --name '$IMAGE_NAME' \\
-  --env-file '$REMOTE_ENV_PATH' \\
-  -e DB_STATEMENT_TIMEOUT_MS=300000 \\
-  "\$IMAGE") \\
-  || fail "docker run failed."
+# Spawn one container per partition. PARTITION_COUNT is the same for all;
+# PARTITION_INDEX varies. The orchestrator's loadBatch uses these env vars
+# to filter rows by 'id % count = index', so the partitions touch disjoint
+# subsets and finish in roughly the same wall time.
+PARTITIONS=$PARTITIONS
+for IDX in \$(seq 0 \$((PARTITIONS - 1))); do
+  if [ "\$PARTITIONS" -eq 1 ]; then
+    NAME='$IMAGE_NAME'
+  else
+    NAME="$IMAGE_NAME-\$IDX"
+  fi
 
-step "Started '$IMAGE_NAME'. Container ID: \${CONTAINER_ID:0:12}"
+  # Refuse to start if a container with that name is already running;
+  # clean up an exited one so a fresh 'docker run' can reuse the name.
+  if docker ps --format '{{.Names}}' | grep -qx "\$NAME"; then
+    fail "Container '\$NAME' is already running. Stop it first."
+  fi
+  if docker ps -a --format '{{.Names}}' | grep -qx "\$NAME"; then
+    step "Removing previous exited container '\$NAME'..."
+    docker rm "\$NAME" >/dev/null || fail "docker rm \$NAME failed."
+  fi
+
+  step "Starting detached container '\$NAME' (PARTITION_INDEX=\$IDX/\$PARTITIONS)..."
+  # -d: detached; container survives SSH disconnect. No --rm — we want the
+  # stopped container to stick around so post-mortem 'docker logs' works.
+  # DB_STATEMENT_TIMEOUT_MS=300000 (5 min) overrides the .env default of 5s,
+  # which is right for HTTP request handlers but kills the backfill's batch
+  # SELECT on the unlinked-flowsheet predicate (a multi-million-row scan).
+  CONTAINER_ID=\$(docker run -d --name "\$NAME" \\
+    --env-file '$REMOTE_ENV_PATH' \\
+    -e DB_STATEMENT_TIMEOUT_MS=300000 \\
+    -e PARTITION_INDEX=\$IDX \\
+    -e PARTITION_COUNT=\$PARTITIONS \\
+    "\$IMAGE") \\
+    || fail "docker run \$NAME failed."
+  step "  Started '\$NAME'. Container ID: \${CONTAINER_ID:0:12}"
+done
+
+step "All \$PARTITIONS partition(s) started."
 echo "Inspect with:"
-echo "  BACKFILL=$IMAGE_NAME ./run-lml-backfill.sh attach    # live tail (Ctrl-C to detach, doesn't stop the job)"
-echo "  BACKFILL=$IMAGE_NAME ./run-lml-backfill.sh status    # one-shot status + last 20 log lines"
-echo "  BACKFILL=$IMAGE_NAME ./run-lml-backfill.sh stop      # stop the container"
+echo "  BACKFILL=$IMAGE_NAME PARTITIONS=$PARTITIONS ./run-lml-backfill.sh status    # all partitions + tails"
+echo "  BACKFILL=$IMAGE_NAME PARTITIONS=$PARTITIONS PARTITION=0 ./run-lml-backfill.sh attach    # follow one"
+echo "  BACKFILL=$IMAGE_NAME PARTITIONS=$PARTITIONS ./run-lml-backfill.sh stop      # stop all partitions"
 EOF
     ;;
 
   attach)
+    NAME=$(container_name_for_partition "$PARTITION")
     # -t forces a TTY so Ctrl-C cleanly detaches docker logs without
-    # killing the SSH session. The --since=0 keeps things tidy on first
-    # attach; --follow streams new lines as they arrive.
-    exec ssh -t "$SSH_HOST" "docker logs -f --tail 50 '$IMAGE_NAME'"
+    # killing the SSH session. --tail 50 keeps things tidy on first attach.
+    exec ssh -t "$SSH_HOST" "docker logs -f --tail 50 '$NAME'"
     ;;
 
   status)
+    # Filter by container-name prefix. Bare $IMAGE_NAME catches both the
+    # single-container case and all '$IMAGE_NAME-N' partitions.
     ssh "$SSH_HOST" bash <<EOF
 set -uo pipefail
-echo "Container:"
+echo "Containers (prefix '$IMAGE_NAME'):"
 docker ps -a --filter "name=$IMAGE_NAME" \\
   --format 'table {{.Names}}\t{{.Status}}\t{{.RunningFor}}' \\
-  || echo "  (not present)"
+  || echo "  (none present)"
 
-echo
-echo "Last 20 log lines:"
-docker logs --tail 20 '$IMAGE_NAME' 2>&1 || echo "  (no logs available)"
+# Per-container last 5 log lines. Walk the names so each gets its own header.
+NAMES=\$(docker ps -a --filter "name=$IMAGE_NAME" --format '{{.Names}}' | sort)
+if [ -n "\$NAMES" ]; then
+  for n in \$NAMES; do
+    echo
+    echo "--- \$n (last 5) ---"
+    docker logs --tail 5 "\$n" 2>&1 || echo "  (no logs)"
+  done
+fi
 EOF
     ;;
 
   stop)
     ssh "$SSH_HOST" bash <<EOF
 set -uo pipefail
-if docker ps --format '{{.Names}}' | grep -qx '$IMAGE_NAME'; then
-  echo "Stopping '$IMAGE_NAME'..."
-  docker stop '$IMAGE_NAME'
-else
-  echo "Container '$IMAGE_NAME' is not running."
+NAMES=\$(docker ps --filter "name=$IMAGE_NAME" --format '{{.Names}}' | sort)
+if [ -z "\$NAMES" ]; then
+  echo "No running containers matching prefix '$IMAGE_NAME'."
+  exit 0
 fi
+for n in \$NAMES; do
+  echo "Stopping '\$n'..."
+  docker stop "\$n"
+done
 
-# Leave the stopped container in place so post-mortem 'docker logs' works.
-# 'start' will 'docker rm' it on the next run.
+# Leave stopped containers in place so post-mortem 'docker logs' works.
+# 'start' will 'docker rm' them on the next run.
 EOF
     ;;
 

--- a/tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-lml-link-backfill/orchestrate.test.ts
@@ -21,6 +21,7 @@ import {
   enqueueReview,
   findLibraryByCanonicalEntity,
   processRow,
+  resolvePartitionFilter,
   runBackfill,
   BATCH_SIZE,
   THROTTLE_MS,
@@ -414,6 +415,41 @@ describe('runBackfill', () => {
     // The throttle is what keeps a multi-day sweep from stampeding LML.
     // Dropping it to 0 risks blowing through LML's rate budget in seconds.
     expect(THROTTLE_MS).toBeGreaterThan(0);
+  });
+
+  describe('resolvePartitionFilter', () => {
+    it('returns no fragment when partitioning is disabled (default count=1)', () => {
+      const r = resolvePartitionFilter(undefined, undefined);
+      expect(r.sqlFragment).toBeNull();
+      expect(r.description).toBe('partition=none');
+    });
+
+    it('returns a modulo fragment when count > 1', () => {
+      const r = resolvePartitionFilter('2', '4');
+      expect(r.sqlFragment).not.toBeNull();
+      expect(r.description).toBe('partition=2/4');
+    });
+
+    it('rejects out-of-range partition index and non-positive count', () => {
+      expect(() => resolvePartitionFilter('4', '4')).toThrow(/PARTITION_INDEX/);
+      expect(() => resolvePartitionFilter('-1', '4')).toThrow(/PARTITION_INDEX/);
+      expect(() => resolvePartitionFilter('0', '0')).toThrow(/PARTITION_COUNT/);
+      expect(() => resolvePartitionFilter('1.5', '4')).toThrow(/PARTITION_INDEX/);
+    });
+  });
+
+  it('plumbs the partition fragment into loadBatch when count > 1', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    await runBackfill({
+      lookup: jest.fn(),
+      throttleMs: 0,
+      partition: resolvePartitionFilter('1', '3'),
+    });
+
+    const select = (db.execute as jest.Mock).mock.calls.find((c) => /SELECT/i.test(renderSql(c[0])));
+    const serialized = JSON.stringify(select?.[0]);
+    expect(serialized).toContain('%');
   });
 
   it('selects only unlinked track rows that have artist+album text', async () => {

--- a/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
@@ -17,6 +17,7 @@ import { db } from '@wxyc/database';
 import {
   applyResolution,
   processRow,
+  resolvePartitionFilter,
   runBackfill,
   BATCH_SIZE,
   THROTTLE_MS,
@@ -220,6 +221,54 @@ describe('runBackfill', () => {
     // Throttle is a real LML rate-limit guard, not a configuration hook —
     // dropping it to 0 risks stampeding LML when the backfill runs.
     expect(THROTTLE_MS).toBeGreaterThan(0);
+  });
+
+  describe('resolvePartitionFilter', () => {
+    it('returns no fragment when partitioning is disabled (default count=1)', () => {
+      const r = resolvePartitionFilter(undefined, undefined);
+      expect(r.sqlFragment).toBeNull();
+      expect(r.description).toBe('partition=none');
+    });
+
+    it('returns a modulo fragment when count > 1', () => {
+      const r = resolvePartitionFilter('2', '4');
+      expect(r.sqlFragment).not.toBeNull();
+      const serialized = JSON.stringify(r.sqlFragment);
+      expect(serialized).toContain('%');
+      expect(r.description).toBe('partition=2/4');
+    });
+
+    it('rejects out-of-range partition index', () => {
+      expect(() => resolvePartitionFilter('4', '4')).toThrow(/PARTITION_INDEX/);
+      expect(() => resolvePartitionFilter('-1', '4')).toThrow(/PARTITION_INDEX/);
+    });
+
+    it('rejects non-positive partition count', () => {
+      expect(() => resolvePartitionFilter('0', '0')).toThrow(/PARTITION_COUNT/);
+      expect(() => resolvePartitionFilter('0', '-1')).toThrow(/PARTITION_COUNT/);
+    });
+
+    it('rejects non-integer values', () => {
+      expect(() => resolvePartitionFilter('1.5', '4')).toThrow(/PARTITION_INDEX/);
+      expect(() => resolvePartitionFilter('0', '2.5')).toThrow(/PARTITION_COUNT/);
+      expect(() => resolvePartitionFilter('abc', '4')).toThrow(/PARTITION_INDEX/);
+    });
+  });
+
+  it('plumbs the partition fragment into loadBatch when count > 1', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    await runBackfill({
+      lookup: jest.fn(),
+      throttleMs: 0,
+      partition: resolvePartitionFilter('1', '3'),
+    });
+
+    const select = findExecuteCallMatching(/SELECT/i);
+    const serialized = JSON.stringify(select?.[0]);
+    // The partition fragment is parameterized with `id % count = index`.
+    // Both numbers appear among the bound values.
+    expect(serialized).toContain('%');
   });
 
   it('iterates batches until loadBatch returns empty', async () => {


### PR DESCRIPTION
## Summary

Both LML backfills (B-1.2 \`library-canonical-entity-backfill\` and B-2.2 \`flowsheet-lml-link-backfill\`) are LML-latency bound: cache-miss rows trigger Discogs/MusicBrainz fallback chains taking multiple seconds, and the orchestrator keeps one in-flight call per container. N parallel containers give an N-fold throughput speedup.

## Orchestrator changes

Adds \`PARTITION_INDEX\` and \`PARTITION_COUNT\` env vars to both orchestrators. The new exported \`resolvePartitionFilter\` helper:

- Validates inputs (\`0 <= index < count\`, both positive integers).
- Emits an \`AND (id % count) = index\` SQL fragment that \`loadBatch\` splices into the existing WHERE.
- Default (\`count=1, index=0\`) is a no-op pass-through so single-container runs are unaffected.

Each container processes a disjoint subset of rows; combined with the existing id-cursor pagination, the partitions resume independently across crashes (the WHERE filter still hides linked/resolved rows on the next sweep).

## Script changes (\`run-lml-backfill.sh\`)

- \`PARTITIONS=N ./scripts/run-lml-backfill.sh start\` spawns N detached containers, named \`<image>-0\` through \`<image>-(N-1)\`.
- \`PARTITIONS=1\` (default) keeps the bare image-name container for backward compatibility.
- \`status\` filters by name prefix and tails each partition (last 5 lines per).
- \`stop\` iterates and stops every running partition.
- \`attach\` takes \`PARTITION=K\` (default 0) for which partition to follow.

## Tests

- \`resolvePartitionFilter\` validation paths.
- Plumbing into \`loadBatch\` with the rendered SQL containing \`%\`.
- The no-op default is verified by the existing 'iterates batches until empty' tests.

All 347 jobs unit tests pass.

## Why now

After the \`library.canonical_entity_id\` JOIN fix (#602), B-1.2 will run for ~1.6h single-container and B-2.2 for ~30 days single-container. With \`PARTITIONS=4\`, those become ~25 min and ~7.5 days; with \`PARTITIONS=8\`, ~12 min and ~4 days. The exact ceiling is whatever LML rate budget tolerates.