### PR TITLE
Qualify partition fragment column to fix ambiguous-id crash

### DIFF
--- a/jobs/flowsheet-lml-link-backfill/orchestrate.ts
+++ b/jobs/flowsheet-lml-link-backfill/orchestrate.ts
@@ -74,7 +74,11 @@ export const THROTTLE_MS = 100;
  */
 export const resolvePartitionFilter = (
   rawIndex: string | undefined = process.env.PARTITION_INDEX,
-  rawCount: string | undefined = process.env.PARTITION_COUNT
+  rawCount: string | undefined = process.env.PARTITION_COUNT,
+  // The flowsheet loadBatch reads from a single (unaliased) table, so the
+  // unqualified `"id"` is unambiguous. Parameter is here for symmetry with
+  // the B-1.2 backfill (which JOINs and must qualify).
+  columnSql: SQL = sql`"id"`
 ): { sqlFragment: SQL | null; description: string } => {
   const count = rawCount === undefined ? 1 : Number(rawCount);
   const index = rawIndex === undefined ? 0 : Number(rawIndex);
@@ -88,7 +92,7 @@ export const resolvePartitionFilter = (
     return { sqlFragment: null, description: 'partition=none' };
   }
   return {
-    sqlFragment: sql`AND ("id" % ${count}) = ${index}`,
+    sqlFragment: sql`AND (${columnSql} % ${count}) = ${index}`,
     description: `partition=${index}/${count}`,
   };
 };

--- a/jobs/library-canonical-entity-backfill/orchestrate.ts
+++ b/jobs/library-canonical-entity-backfill/orchestrate.ts
@@ -52,7 +52,12 @@ export const THROTTLE_MS = 100;
  */
 export const resolvePartitionFilter = (
   rawIndex: string | undefined = process.env.PARTITION_INDEX,
-  rawCount: string | undefined = process.env.PARTITION_COUNT
+  rawCount: string | undefined = process.env.PARTITION_COUNT,
+  // Default qualifier targets the library table's `id` column. The B-1.2
+  // loadBatch joins library against artists, both of which have an `id`
+  // column; an unqualified `"id"` here would be ambiguous and PG would
+  // reject the query with `column reference "id" is ambiguous`.
+  columnSql: SQL = sql`l."id"`
 ): { sqlFragment: SQL | null; description: string } => {
   const count = rawCount === undefined ? 1 : Number(rawCount);
   const index = rawIndex === undefined ? 0 : Number(rawIndex);
@@ -66,7 +71,7 @@ export const resolvePartitionFilter = (
     return { sqlFragment: null, description: 'partition=none' };
   }
   return {
-    sqlFragment: sql`AND ("id" % ${count}) = ${index}`,
+    sqlFragment: sql`AND (${columnSql} % ${count}) = ${index}`,
     description: `partition=${index}/${count}`,
   };
 };

--- a/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
@@ -271,6 +271,26 @@ describe('runBackfill', () => {
     expect(serialized).toContain('%');
   });
 
+  it('qualifies the partition column as l."id" so it does not collide with artists.id', async () => {
+    // Regression for the first prod run with PARTITIONS=4: every container
+    // crashed with `column reference "id" is ambiguous` because the
+    // partition fragment used unqualified "id" while loadBatch joins
+    // library against artists (both have an `id` column). The default
+    // qualifier in B-1.2's resolvePartitionFilter must be `l."id"`.
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    await runBackfill({
+      lookup: jest.fn(),
+      throttleMs: 0,
+      partition: resolvePartitionFilter('1', '3'),
+    });
+
+    const select = findExecuteCallMatching(/SELECT/i);
+    const serialized = JSON.stringify(select?.[0]);
+    // Qualified `l."id"` survives JSON serialization as `l.\\"id\\"`.
+    expect(serialized).toContain('l.\\"id\\"');
+  });
+
   it('iterates batches until loadBatch returns empty', async () => {
     // First batch: two rows. Second batch: one row. Third batch: empty → terminate.
     // 3 SELECTs (loadBatch) + (2 + 1) UPDATEs = 6 db.execute calls in this scenario.


### PR DESCRIPTION
## Summary

The first prod run of partitioned B-1.2 (\`PARTITIONS=4\`) crashed all 4 containers immediately with:

\`\`\`
DrizzleQueryError: column reference "id" is ambiguous
\`\`\`

\`B-1.2\`'s \`loadBatch\` joins library against artists (both have an \`id\` column), and the partition fragment from #603 emitted unqualified \`"id"\`. Postgres can't tell which table to apply the modulo to.

## Fix

Adds an optional \`columnSql\` parameter to \`resolvePartitionFilter\` in both orchestrators. B-1.2 defaults to \`l."id"\` (the library alias) since its \`loadBatch\` JOINs. B-2.2 defaults to bare \`"id"\` since it reads from a single (unaliased) table — semantically a no-op for B-2.2 today, but the parameter exists for symmetry and to pre-empt the same bug if a future change adds a JOIN.

## Tests

Adds a regression test asserting B-1.2's rendered SQL contains \`l."id"\`. 51/51 partition + orchestrate tests pass.