### PR TITLE
Estimate /flowsheet total via pg_class.reltuples (fix 500s on page=0)

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -198,10 +198,32 @@ export const resolveDjNameForShow = async (show: Show): Promise<string | null> =
   return dj?.djName ?? legacy ?? dj?.name ?? null;
 };
 
-/** Count total flowsheet entries (for pagination) */
+/**
+ * Estimate total flowsheet entries for pagination.
+ *
+ * Reads `pg_class.reltuples`, the planner's row-count estimate maintained by
+ * autovacuum/ANALYZE. Constant-time vs. an exact `count(*)` which would
+ * sequentially scan ~2.6M rows and routinely exceed the 5s per-statement
+ * timeout on this RDS instance — that's the immediate cause of
+ * `/flowsheet?page=0&limit=20` 500ing under live load. The estimate is
+ * typically within a few hundred of the true count, which is fine for a
+ * paginated UI's "Page X of N" display; pages near the upper bound may shift
+ * by one as autovacuum lags.
+ *
+ * `reltuples = -1` is the "never analyzed" sentinel; treat it as 0. The same
+ * goes for a missing row (no permissions on `pg_class` would surface as an
+ * error from the surrounding query, not as a missing row).
+ */
 export const getEntryCount = async (): Promise<number> => {
-  const result = await db.select({ count: sql<number>`count(*)::int` }).from(flowsheet);
-  return result[0].count;
+  const schema = process.env.WXYC_SCHEMA_NAME ?? 'wxyc_schema';
+  const result = await db.execute(
+    sql`SELECT GREATEST(reltuples::bigint, 0)::int AS count
+        FROM pg_class
+        WHERE relname = 'flowsheet'
+          AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = ${schema})`
+  );
+  const row = (result as unknown as Array<{ count: number }>)[0];
+  return Number(row?.count ?? 0);
 };
 
 /** Gets flowsheet entries by page with metadata joins */

--- a/tests/unit/services/flowsheet.getEntryCount.test.ts
+++ b/tests/unit/services/flowsheet.getEntryCount.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Source-grep guards for `getEntryCount` in `apps/backend/services/flowsheet.service.ts`.
+ *
+ * The pagination count was originally an exact `count(*)` over the
+ * `wxyc_schema.flowsheet` table. With ~2.6M rows, that query was sequentially
+ * scanning the heap on every `/flowsheet` page load, routinely exceeding the
+ * 5s per-statement timeout under live RDS load and surfacing as 500 errors at
+ * the endpoint. The fix swaps it for the planner's row-count estimate
+ * (`pg_class.reltuples`), which is constant-time.
+ *
+ * These tests source-grep the implementation to lock in the new shape:
+ * future refactors that accidentally revert to `count(*)` will trip the
+ * guard, and the on-prod incident will not recur silently.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const servicePath = path.resolve(__dirname, '../../../apps/backend/services/flowsheet.service.ts');
+const serviceSource = fs.readFileSync(servicePath, 'utf-8');
+
+const extractGetEntryCountBody = (): string => {
+  const match = serviceSource.match(/export const getEntryCount[\s\S]*?\n\};/);
+  if (!match) throw new Error('getEntryCount not found in flowsheet.service.ts');
+  return match[0];
+};
+
+describe('flowsheet.service: getEntryCount uses pg_class.reltuples', () => {
+  const body = extractGetEntryCountBody();
+
+  it('reads from pg_class instead of running count(*)', () => {
+    // The whole point of the rewrite. If anything in the function body still
+    // says count(*) on the flowsheet table, we are back to scanning 2.6M rows
+    // and back to flowsheet-endpoint 500s.
+    expect(body).toMatch(/pg_class/);
+    expect(body).not.toMatch(/count\(\*\)/);
+  });
+
+  it('reads reltuples (the planner row-count estimate)', () => {
+    // reltuples is maintained by autovacuum/ANALYZE; -1 is the never-analyzed
+    // sentinel which we floor to 0 via GREATEST.
+    expect(body).toMatch(/reltuples/);
+    expect(body).toMatch(/GREATEST\(\s*reltuples/);
+  });
+
+  it('scopes the lookup to the configured schema, not just relname', () => {
+    // Two tables named "flowsheet" in different schemas (dev + test workers
+    // sharing a database, or a future tenant scheme) would otherwise return
+    // an arbitrary row. Use relnamespace so the lookup is unambiguous.
+    expect(body).toMatch(/relnamespace/);
+    expect(body).toMatch(/WXYC_SCHEMA_NAME/);
+    // And falls back to wxyc_schema when the env var is unset (matches client.ts).
+    expect(body).toMatch(/['"]wxyc_schema['"]/);
+  });
+
+  it('treats a missing row as 0, not as an error', () => {
+    // First page renders before autovacuum has had a chance to populate
+    // reltuples on a freshly-restored DB. Returning 0 there is benign — the
+    // page just shows totalPages=0 until ANALYZE runs.
+    expect(body).toMatch(/\?\?\s*0/);
+  });
+
+  it('still exports getEntryCount with the same return type as before', () => {
+    // The controller awaits a Promise<number>; downstream type-checking would
+    // catch a signature change, but having an explicit guard here keeps the
+    // intent obvious.
+    expect(body).toMatch(/export const getEntryCount\s*=\s*async\s*\(\)\s*:\s*Promise<number>/);
+  });
+});


### PR DESCRIPTION
Closes #606.

## Summary

- Replace exact `SELECT count(*)` over 2.6M-row flowsheet with `pg_class.reltuples` lookup
- Fixes intermittent 500s on `/flowsheet/?page=0&limit=20` (the count was sitting at ~4-5s, right at the 5s statement_timeout)
- Schema-scoped via `relnamespace + WXYC_SCHEMA_NAME` so multi-tenant or test-worker schemas don't collide
- `reltuples = -1` (never-analyzed) and missing rows floor to 0
- Source-grep test guards against future regressions

## Why

- Pagination "Page X of N" is presentational — being off by a few hundred is invisible
- Autovacuum keeps reltuples reasonably current
- The exact count provides no correctness benefit in the request flow

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors)
- [x] `npm run format:check` clean
- [x] New unit test `tests/unit/services/flowsheet.getEntryCount.test.ts` (5 cases) passes
- [x] Existing controller tests still pass (the controller mocks `getEntryCount`, so its observable behavior is unchanged)
- [ ] After deploy: hit `/flowsheet/?page=0&limit=20`, confirm sub-second response and `total` ≈ true row count