### PR TITLE
Add direct-text-match SQL pre-pass for B-2.2 flowsheet linkage

### DIFF
--- a/scripts/direct-link-flowsheet.sql
+++ b/scripts/direct-link-flowsheet.sql
@@ -1,0 +1,81 @@
+-- Direct text-match pre-pass for the B-2.2 flowsheet → library linkage.
+-- Links unlinked flowsheet rows to library rows whose normalized
+-- (artist_name, album_title) text is identical, skipping the LML round-trip
+-- entirely. Designed to run before flowsheet-lml-link-backfill so the LML
+-- job processes a smaller residual.
+--
+-- Why this exists:
+--   The default linkage path goes through LML, which on cache-miss takes
+--   3-7 s per row. About 6.7% of unlinked flowsheet rows already have an
+--   exact normalized text twin in the library — for those rows the LML
+--   call is wasted work. This SQL pass links them in one transaction.
+--
+-- Normalization (applied to both sides):
+--   - lowercase
+--   - strip leading 'the '
+--   - strip non-alphanumeric (collapses punctuation, parens, dashes)
+--
+-- Confidence: 1.0. The HAVING count(DISTINCT l.id) = 1 clause excludes
+-- ambiguous matches (same normalized text resolves to >1 library row,
+-- ~0.4% of matched rows). Those fall through to LML for B-2.3's tie-break.
+--
+-- Idempotent: the WHERE f.album_id IS NULL guard means re-runs are no-ops.
+-- The first prod run linked 52,984 rows on 2026-04-27.
+--
+-- Reversible:
+--   UPDATE wxyc_schema.flowsheet
+--   SET album_id = NULL,
+--       linkage_source = NULL,
+--       linkage_confidence = NULL,
+--       linked_at = NULL
+--   WHERE linkage_source = 'direct_text_match';
+--
+-- Run procedure (interactive — review the dry-run before committing):
+--   1. Wrap the UPDATE in a transaction with ROLLBACK to verify row count:
+--        BEGIN;
+--        <the UPDATE below>;
+--        SELECT count(*) FROM wxyc_schema.flowsheet WHERE linkage_source = 'direct_text_match';
+--        ROLLBACK;
+--   2. If the count looks right, replace ROLLBACK with COMMIT and re-run.
+--
+-- Or run via scripts/query-flowsheet.sh as a one-shot SQL invocation.
+
+SET statement_timeout = '600s';
+
+WITH unlinked AS (
+  SELECT
+    f.id,
+    lower(regexp_replace(regexp_replace(coalesce(f.artist_name, ''), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi')) AS artist_norm,
+    lower(regexp_replace(regexp_replace(coalesce(f.album_title, ''), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi')) AS album_norm
+  FROM wxyc_schema.flowsheet f
+  WHERE f.album_id IS NULL
+    AND f.entry_type = 'track'
+    AND f.artist_name IS NOT NULL
+    AND f.album_title IS NOT NULL
+    AND (f.legacy_release_id IS NULL OR f.legacy_link_attempted_at IS NOT NULL)
+),
+lib AS (
+  SELECT
+    l.id,
+    lower(regexp_replace(regexp_replace(coalesce(a.artist_name, ''), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi')) AS artist_norm,
+    lower(regexp_replace(regexp_replace(coalesce(l.album_title, ''), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi')) AS album_norm
+  FROM wxyc_schema.library l
+  LEFT JOIN wxyc_schema.artists a ON a.id = l.artist_id
+),
+unique_matches AS (
+  SELECT u.id AS flowsheet_id, min(l.id) AS library_id
+  FROM unlinked u
+  JOIN lib l
+    ON l.artist_norm = u.artist_norm
+   AND l.album_norm  = u.album_norm
+  GROUP BY u.id
+  HAVING count(DISTINCT l.id) = 1
+)
+UPDATE wxyc_schema.flowsheet f
+SET album_id           = m.library_id,
+    linkage_source     = 'direct_text_match',
+    linkage_confidence = 1.0,
+    linked_at          = now()
+FROM unique_matches m
+WHERE f.id = m.flowsheet_id
+  AND f.album_id IS NULL;


### PR DESCRIPTION
## Summary

Adds \`scripts/direct-link-flowsheet.sql\`: a one-shot bulk UPDATE that links unlinked flowsheet rows to library rows whose normalized \`(artist_name, album_title)\` text matches exactly, skipping the LML round-trip entirely.

## Why

Empirical probe of LML's deployment shows cache-miss lookups take 3-7 s each (the long tail goes to Discogs/MusicBrainz). About 6.7% of unlinked flowsheet rows already have an exact normalized text twin in the library — those rows pay full cache-miss latency for no semantic benefit, since 'A' = 'A' doesn't need a fuzzy lookup.

## What it does

1. Normalizes both sides identically: lowercase, strip leading \`the \`, strip non-alphanumeric.
2. Joins flowsheet's unlinked subset against library on the normalized pair.
3. Keeps only flowsheet rows with **exactly one** library candidate (\`HAVING count(DISTINCT) = 1\`); the ~0.4% ambiguous rows fall through to LML for B-2.3's tie-break.
4. Stamps the matching rows with \`linkage_source='direct_text_match'\`, \`linkage_confidence=1.0\`, \`linked_at=now()\`.

## Properties

- **Idempotent**: \`WHERE f.album_id IS NULL\` guard means re-runs are no-ops.
- **High confidence**: 99.6% of normalized matches resolve to exactly one library row; the rest are excluded.
- **Reversible**: \`UPDATE ... SET album_id = NULL WHERE linkage_source = 'direct_text_match'\` undoes it.
- **Doesn't pre-empt LML**: rows the SQL can't link still flow through LML as before.

## First prod run — already applied

Ran against production on 2026-04-27 (during this session). **52,984 rows linked** in a single transaction in under 10 minutes. Verified by:

\`\`\`
direct_linked | first_linked                  | last_linked
--------------+-------------------------------+------------------------------
        52984 | 2026-04-27 23:32:33.202704-04 | 2026-04-27 23:32:33.202704-04
\`\`\`

This PR is the audit trail — committing the script that produced the prod write, with a documented dry-run procedure (\`BEGIN; <UPDATE>; SELECT count; ROLLBACK;\`) for safe future re-application.

## What it saves

\`52,984 rows × ~3 s avg LML latency = ~44 hours of LML capacity reclaimed\` against B-2.2's residual.