### PR TITLE
Cap LML artwork enrichment on the catalog search hot path

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -175,9 +175,37 @@ export const searchForAlbum: RequestHandler = async (req: Request<object, object
   const onStreaming = query.on_streaming === 'true' ? true : query.on_streaming === 'false' ? false : undefined;
 
   const response = await libraryService.fuzzySearchLibrary(query.artist_name, query.album_title, query.n, onStreaming);
-  const enriched = await libraryService.enrichWithArtwork(response);
+  const enriched = await raceEnrichmentBudget(response, libraryService.enrichWithArtwork(response));
   res.status(200).json(enriched.map((row) => libraryService.serializeLibraryArtistViewEntry(row)));
 };
+
+/**
+ * Cap how long an interactive search will wait on artwork enrichment. LML's
+ * own per-call timeout is 5s — appropriate for non-interactive callers
+ * (request line, single-album lookup) but unacceptable on the search hot path
+ * where one cache-miss gates the entire response. If the budget elapses we
+ * return the raw search rows; the in-flight LML lookups keep running and still
+ * write artwork_url to the DB, so subsequent searches benefit.
+ */
+const SEARCH_ENRICHMENT_BUDGET_MS = Number(process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS ?? 500);
+
+async function raceEnrichmentBudget<T>(unenriched: T[], enrichment: Promise<T[]>): Promise<T[]> {
+  let budgetTimer: ReturnType<typeof setTimeout> | undefined;
+  const budget = new Promise<T[]>((resolve) => {
+    budgetTimer = setTimeout(() => resolve(unenriched), SEARCH_ENRICHMENT_BUDGET_MS);
+  });
+  // Swallow rejections from the enrichment promise so the budget path can win
+  // without an unhandledRejection. enrichWithArtwork already collects per-row
+  // failures internally; this guard covers the rare case it throws as a whole.
+  enrichment.catch((err) => {
+    console.warn('[Library] Search-time artwork enrichment failed:', err);
+  });
+  try {
+    return await Promise.race([enrichment, budget]);
+  } finally {
+    if (budgetTimer) clearTimeout(budgetTimer);
+  }
+}
 
 type NewArtistRequest = {
   artist_name: string;

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -209,9 +209,8 @@ describe('library.controller', () => {
       const previous = process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
       process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = '20';
       jest.resetModules();
-      const { searchForAlbum: searchWithTightBudget } = await import(
-        '../../../apps/backend/controllers/library.controller'
-      );
+      const { searchForAlbum: searchWithTightBudget } =
+        await import('../../../apps/backend/controllers/library.controller');
 
       const req = { query: { artist_name: 'Autechre' } } as unknown as Request;
       const res = mockResponse();
@@ -243,9 +242,8 @@ describe('library.controller', () => {
       const previous = process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
       process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = '5';
       jest.resetModules();
-      const { searchForAlbum: searchWithTightBudget } = await import(
-        '../../../apps/backend/controllers/library.controller'
-      );
+      const { searchForAlbum: searchWithTightBudget } =
+        await import('../../../apps/backend/controllers/library.controller');
 
       const req = { query: { artist_name: 'Autechre' } } as unknown as Request;
       const res = mockResponse();

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -181,7 +181,7 @@ describe('library.controller', () => {
   });
 
   describe('searchForAlbum', () => {
-    it('calls enrichWithArtwork after fuzzy search', async () => {
+    it('returns enriched results when enrichment finishes within the budget', async () => {
       const searchResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
       const enrichedResults = [
         { id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: 'https://i.discogs.com/confield.jpg' },
@@ -200,16 +200,67 @@ describe('library.controller', () => {
       expect(res.json).toHaveBeenCalledWith(enrichedResults);
     });
 
-    it('rejects when enrichment throws', async () => {
+    it('returns raw results without waiting when enrichment exceeds the budget', async () => {
       const searchResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
       mockFuzzySearchLibrary.mockResolvedValue(searchResults);
-      const enrichError = new Error('enrichment failed');
-      mockEnrichWithArtwork.mockRejectedValue(enrichError);
+      // Enrichment that never resolves within any reasonable budget.
+      mockEnrichWithArtwork.mockReturnValue(new Promise<unknown[]>(() => undefined));
+
+      const previous = process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
+      process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = '20';
+      jest.resetModules();
+      const { searchForAlbum: searchWithTightBudget } = await import(
+        '../../../apps/backend/controllers/library.controller'
+      );
 
       const req = { query: { artist_name: 'Autechre' } } as unknown as Request;
       const res = mockResponse();
 
-      await expect(searchForAlbum(req, res, next)).rejects.toThrow(enrichError);
+      const start = Date.now();
+      await searchWithTightBudget(req, res, next);
+      const elapsed = Date.now() - start;
+
+      try {
+        expect(elapsed).toBeLessThan(500);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith(searchResults);
+      } finally {
+        if (previous === undefined) delete process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
+        else process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = previous;
+      }
+    });
+
+    it('does not propagate enrichment errors as request failures', async () => {
+      const searchResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
+      mockFuzzySearchLibrary.mockResolvedValue(searchResults);
+      const enrichError = new Error('enrichment failed');
+      // Reject *after* the budget would naturally fire — the budget should win
+      // and the rejection should be swallowed.
+      mockEnrichWithArtwork.mockReturnValue(
+        new Promise<unknown[]>((_, reject) => setTimeout(() => reject(enrichError), 50))
+      );
+
+      const previous = process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
+      process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = '5';
+      jest.resetModules();
+      const { searchForAlbum: searchWithTightBudget } = await import(
+        '../../../apps/backend/controllers/library.controller'
+      );
+
+      const req = { query: { artist_name: 'Autechre' } } as unknown as Request;
+      const res = mockResponse();
+
+      try {
+        await expect(searchWithTightBudget(req, res, next)).resolves.toBeUndefined();
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith(searchResults);
+        // Give the late rejection time to settle into the catch handler so the
+        // assertion below isn't subject to a process-level unhandledRejection.
+        await new Promise((resolve) => setTimeout(resolve, 75));
+      } finally {
+        if (previous === undefined) delete process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
+        else process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = previous;
+      }
     });
   });
 


### PR DESCRIPTION
Closes #617

## Summary

Catalog search responses were occasionally taking 5+ seconds because `enrichWithArtwork` blocks the response on `Promise.allSettled` over per-row LML lookups, and LML's per-call timeout is 5s. One cache-miss → Discogs hop on a single result is enough to gate every keystroke a DJ types in the card catalog.

This change wraps the search-time enrichment in `Promise.race` against a `LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS` timer (default 500 ms, env-overridable). If the budget elapses, the controller returns the raw rows. The in-flight LML calls keep running and still write `artwork_url` back to the DB, so subsequent searches benefit from the cache that was just warmed.

Late rejections from the enrichment promise are caught and logged so the budget path can win without an `unhandledRejection`.

## Scope

- `apps/backend/controllers/library.controller.ts` — only the search controller. Other LML callers (request line, single-album lookup) keep the full 5 s budget. The `enrichWithArtwork` service stays callable as-is by every existing caller.
- New unit tests for: enrichment within budget, enrichment past budget (asserts <500 ms response and raw payload), late-rejection swallowing.

## Test plan

- [x] `npx jest tests/unit/controllers/library.controller.test.ts` passes (18 tests, including 3 new `searchForAlbum` cases).
- [x] `npm run typecheck` passes.
- [x] `npm run test:unit` passes the controller and library suites.
- [ ] Manual prod verification: `GET /library/?artist_name=adult&album_title=adult&n=10` returns under ~600 ms instead of ~5200 ms.