### PR TITLE
Add streaming status webhook receiver

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -295,3 +295,67 @@ internal_route.post('/rotation-webhook', async (req, res) => {
     res.status(500).json({ error: 'Internal server error' });
   }
 });
+
+// ---- Streaming Status Webhook ----
+
+/**
+ * Authenticate via Authorization: Bearer token (used by LML streaming webhook).
+ * Separate from authenticateInternal which uses X-Internal-Key.
+ */
+function authenticateBearer(authHeader: string | undefined): boolean {
+  if (!ETL_NOTIFY_KEY || !authHeader) return false;
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return !!match && match[1] === ETL_NOTIFY_KEY;
+}
+
+interface StreamingChange {
+  library_release_id: number;
+  on_streaming: boolean | null;
+}
+
+/**
+ * POST /internal/streaming-status-webhook
+ *
+ * Receives bulk ON_STREAMING updates from LML after each library.db upload.
+ * Updates the `on_streaming` column in the `library` table for each change.
+ *
+ * Auth: Authorization: Bearer <ETL_NOTIFY_KEY>
+ *
+ * Payload:
+ *   { changes: [{ library_release_id: number, on_streaming: boolean | null }], timestamp: string }
+ */
+internal_route.post('/streaming-status-webhook', async (req, res) => {
+  if (!authenticateBearer(req.get('Authorization'))) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const { changes } = req.body ?? {};
+
+  if (!Array.isArray(changes)) {
+    res.status(400).json({ error: 'Missing or invalid field: changes (expected array)' });
+    return;
+  }
+
+  let processed = 0;
+  let errors = 0;
+
+  for (const change of changes as StreamingChange[]) {
+    try {
+      const legacyId = change.library_release_id;
+      const onStreaming = change.on_streaming ?? null;
+
+      await db
+        .update(library)
+        .set({ on_streaming: onStreaming })
+        .where(eq(library.legacy_release_id, legacyId));
+
+      processed++;
+    } catch (e) {
+      console.error('[webhook] Streaming status update error:', e);
+      errors++;
+    }
+  }
+
+  res.json({ processed, errors });
+});

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -340,18 +340,26 @@ internal_route.post('/streaming-status-webhook', async (req, res) => {
   let processed = 0;
   let errors = 0;
 
-  for (const change of changes as StreamingChange[]) {
-    try {
-      const legacyId = change.library_release_id;
-      const onStreaming = change.on_streaming ?? null;
+  try {
+    await db.transaction(async (tx) => {
+      for (const change of changes as StreamingChange[]) {
+        try {
+          const legacyId = change.library_release_id;
+          const onStreaming = change.on_streaming ?? null;
 
-      await db.update(library).set({ on_streaming: onStreaming }).where(eq(library.legacy_release_id, legacyId));
+          await tx.update(library).set({ on_streaming: onStreaming }).where(eq(library.legacy_release_id, legacyId));
 
-      processed++;
-    } catch (e) {
-      console.error('[webhook] Streaming status update error:', e);
-      errors++;
-    }
+          processed++;
+        } catch (e) {
+          console.error('[webhook] Streaming status update error:', e);
+          errors++;
+        }
+      }
+    });
+  } catch (e) {
+    console.error('[webhook] Streaming status transaction error:', e);
+    res.status(500).json({ error: 'Internal server error' });
+    return;
   }
 
   res.json({ processed, errors });

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -345,10 +345,7 @@ internal_route.post('/streaming-status-webhook', async (req, res) => {
       const legacyId = change.library_release_id;
       const onStreaming = change.on_streaming ?? null;
 
-      await db
-        .update(library)
-        .set({ on_streaming: onStreaming })
-        .where(eq(library.legacy_release_id, legacyId));
+      await db.update(library).set({ on_streaming: onStreaming }).where(eq(library.legacy_release_id, legacyId));
 
       processed++;
     } catch (e) {

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -50,14 +50,16 @@ export function createMockQueryChain(resolvedValue: unknown = []): MockQueryChai
 
 export function createMockDb() {
   const mockChain = createMockQueryChain();
-  return {
+  const mockDb = {
     select: mockChain.select,
     insert: mockChain.insert,
     update: mockChain.update,
     delete: mockChain.delete,
     execute: mockChain.execute,
+    transaction: jest.fn(async (fn: (tx: unknown) => Promise<void>) => fn(mockDb)),
     _chain: mockChain,
   };
+  return mockDb;
 }
 
 // Mock database client

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -380,9 +380,7 @@ describe('POST /internal/streaming-status-webhook', () => {
   // -- Auth (Bearer token, not X-Internal-Key) --
 
   it('returns 401 without Authorization header', async () => {
-    const res = await request(app)
-      .post('/internal/streaming-status-webhook')
-      .send({ changes: [] });
+    const res = await request(app).post('/internal/streaming-status-webhook').send({ changes: [] });
 
     expect(res.status).toBe(401);
   });

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -4,6 +4,7 @@
  * - POST /internal/flowsheet-webhook (tubafrenzy webhook receiver)
  * - POST /internal/rotation-sync-notify (rotation ETL SSE notification)
  * - POST /internal/rotation-webhook (tubafrenzy rotation webhook receiver)
+ * - POST /internal/streaming-status-webhook (LML streaming status receiver)
  */
 
 const mockBroadcast = jest.fn();
@@ -366,5 +367,103 @@ describe('POST /internal/rotation-webhook', () => {
       type: 'refetch',
       payload: { source: 'rotation-webhook' },
     });
+  });
+});
+
+// ---- streaming-status-webhook ----
+
+describe('POST /internal/streaming-status-webhook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // -- Auth (Bearer token, not X-Internal-Key) --
+
+  it('returns 401 without Authorization header', async () => {
+    const res = await request(app)
+      .post('/internal/streaming-status-webhook')
+      .send({ changes: [] });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with wrong Bearer token', async () => {
+    const res = await request(app)
+      .post('/internal/streaming-status-webhook')
+      .set('Authorization', 'Bearer wrong-key')
+      .send({ changes: [] });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with X-Internal-Key (must use Bearer)', async () => {
+    const res = await request(app)
+      .post('/internal/streaming-status-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ changes: [] });
+
+    expect(res.status).toBe(401);
+  });
+
+  // -- Validation --
+
+  it('returns 400 when changes field is missing', async () => {
+    const res = await request(app)
+      .post('/internal/streaming-status-webhook')
+      .set('Authorization', 'Bearer test-secret-key')
+      .send({ timestamp: '2026-04-27T00:00:00Z' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('changes');
+  });
+
+  it('returns 400 when changes is not an array', async () => {
+    const res = await request(app)
+      .post('/internal/streaming-status-webhook')
+      .set('Authorization', 'Bearer test-secret-key')
+      .send({ changes: 'not-an-array' });
+
+    expect(res.status).toBe(400);
+  });
+
+  // -- Processing --
+
+  it('returns 200 with processed count for valid changes', async () => {
+    const res = await request(app)
+      .post('/internal/streaming-status-webhook')
+      .set('Authorization', 'Bearer test-secret-key')
+      .send({
+        changes: [
+          { library_release_id: 42, on_streaming: true },
+          { library_release_id: 99, on_streaming: false },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.processed).toBe(2);
+    expect(res.body.errors).toBe(0);
+  });
+
+  it('returns 200 with zero counts for empty changes array', async () => {
+    const res = await request(app)
+      .post('/internal/streaming-status-webhook')
+      .set('Authorization', 'Bearer test-secret-key')
+      .send({ changes: [] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.processed).toBe(0);
+    expect(res.body.errors).toBe(0);
+  });
+
+  it('handles null on_streaming value', async () => {
+    const res = await request(app)
+      .post('/internal/streaming-status-webhook')
+      .set('Authorization', 'Bearer test-secret-key')
+      .send({
+        changes: [{ library_release_id: 42, on_streaming: null }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.processed).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- New `POST /internal/streaming-status-webhook` endpoint receives bulk `on_streaming` updates from LML after each library.db upload
- Updates the `on_streaming` column in the `library` table directly, bypassing the 30-minute ETL sync delay
- Uses `Authorization: Bearer` auth (matching LML's sender format) rather than `X-Internal-Key`; both validate against `ETL_NOTIFY_KEY`

Companion to WXYC/library-metadata-lookup#143 (sender) and WXYC/tubafrenzy#466 (tubafrenzy receiver).

## Test plan

- [x] Auth: no header, wrong Bearer token, X-Internal-Key rejected (must use Bearer)
- [x] Validation: missing changes, non-array changes
- [x] Processing: valid changes, empty array, null on_streaming
- [x] 1347 unit tests pass (no regressions)
- [x] 0 lint errors
- [x] TypeScript typecheck passes