### PR TITLE
Reconcile monitor: switch tubafrenzy direction to SSE

### DIFF
--- a/scripts/sync/reconcile.ts
+++ b/scripts/sync/reconcile.ts
@@ -611,6 +611,16 @@ function connectSse(
   const client = url.protocol === 'https:' ? https : http;
   let reconnectDelay = 1000;
 
+  let reconnectScheduled = false;
+  const triggerReconnect = (reason: string) => {
+    if (reconnectScheduled) return;
+    reconnectScheduled = true;
+    console.error(`[${timestamp()}] [${label}] ${reason}`);
+    logInfo(`[${label}] Reconnecting in ${reconnectDelay / 1000}s...`);
+    setTimeout(() => connectSse(label, sseUrl, tableHandlers), reconnectDelay);
+    reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+  };
+
   const req = client.get(
     url,
     {
@@ -621,9 +631,8 @@ function connectSse(
     },
     (res) => {
       if (res.statusCode !== 200) {
-        console.error(`[${timestamp()}] [${label}] SSE error: HTTP ${res.statusCode}`);
         res.resume();
-        scheduleReconnect();
+        triggerReconnect(`SSE error: HTTP ${res.statusCode}`);
         return;
       }
 
@@ -646,27 +655,15 @@ function connectSse(
         }
       });
 
-      res.on('end', () => {
-        console.error(`[${timestamp()}] [${label}] SSE connection ended`);
-        scheduleReconnect();
-      });
-
-      res.on('error', (err) => {
-        console.error(`[${timestamp()}] [${label}] SSE response error:`, err.message);
-      });
+      // Any of end/error/close/aborted leaves the response unusable. The
+      // first one wins; subsequent fires are ignored by triggerReconnect.
+      res.on('end', () => triggerReconnect('SSE connection ended'));
+      res.on('error', (err: Error) => triggerReconnect(`SSE response error: ${err.message}`));
+      res.on('close', () => triggerReconnect('SSE connection closed'));
     }
   );
 
-  req.on('error', (err) => {
-    console.error(`[${timestamp()}] [${label}] SSE request error:`, err.message);
-    scheduleReconnect();
-  });
-
-  function scheduleReconnect() {
-    logInfo(`[${label}] Reconnecting in ${reconnectDelay / 1000}s...`);
-    setTimeout(() => connectSse(label, sseUrl, tableHandlers), reconnectDelay);
-    reconnectDelay = Math.min(reconnectDelay * 2, 30000);
-  }
+  req.on('error', (err) => triggerReconnect(`SSE request error: ${err.message}`));
 }
 
 async function processSseFrame(

--- a/scripts/sync/reconcile.ts
+++ b/scripts/sync/reconcile.ts
@@ -1,9 +1,13 @@
 /**
  * Bidirectional real-time cross-database reconciliation monitor.
  *
- * Connects to BOTH CDC WebSocket endpoints:
- *   - tubafrenzy (MySQL changes) → verifies in Backend-Service PostgreSQL
- *   - Backend-Service (PostgreSQL changes) → verifies in tubafrenzy MySQL
+ * Connects to BOTH CDC endpoints:
+ *   - tubafrenzy (MySQL changes, SSE) → verifies in Backend-Service PostgreSQL
+ *   - Backend-Service (PostgreSQL changes, WebSocket) → verifies in tubafrenzy MySQL
+ *
+ * tubafrenzy uses SSE because Kattare's Apache reverse proxy doesn't support
+ * the WebSocket upgrade (no mod_proxy_wstunnel). Backend-Service uses WebSocket
+ * because nginx is configured for it.
  *
  * On startup, runs a batch comparison of row counts. Then streams CDC events
  * from both sides and cross-checks each one.
@@ -12,7 +16,7 @@
  *   npx tsx scripts/sync/reconcile.ts
  *
  * Environment:
- *   TUBAFRENZY_CDC_URL     tubafrenzy CDC WebSocket URL (default: ws://localhost:8080/cdc)
+ *   TUBAFRENZY_CDC_URL     tubafrenzy CDC SSE URL (default: http://localhost:8080/playlists/cdcStream)
  *   BACKEND_CDC_URL        Backend-Service CDC WebSocket URL (default: ws://localhost:8080/cdc)
  *   CDC_SECRET             Shared secret for CDC auth (required)
  *   PROPAGATION_DELAY_MS   Delay before checking the other database (default: 5000)
@@ -20,13 +24,15 @@
  *   MYSQL_HOST, MYSQL_PORT, MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD  MySQL connection
  */
 
+import http from 'http';
+import https from 'https';
 import WebSocket from 'ws';
 import postgres from 'postgres';
 import mysql from 'mysql2/promise';
 
 // --- Configuration ---
 
-const TUBAFRENZY_CDC_URL = process.env.TUBAFRENZY_CDC_URL ?? 'ws://localhost:8080/cdc';
+const TUBAFRENZY_CDC_URL = process.env.TUBAFRENZY_CDC_URL ?? 'http://localhost:8080/playlists/cdcStream';
 const BACKEND_CDC_URL = process.env.BACKEND_CDC_URL ?? 'ws://localhost:8080/cdc';
 const CDC_SECRET = process.env.CDC_SECRET;
 const PROPAGATION_DELAY_MS = Number(process.env.PROPAGATION_DELAY_MS ?? '5000');
@@ -591,7 +597,113 @@ async function batchReconcile() {
   console.log('');
 }
 
-// --- WebSocket CDC client (generic, used for both directions) ---
+// --- SSE CDC client (used for tubafrenzy, since Kattare's Apache proxy lacks mod_proxy_wstunnel) ---
+
+function connectSse(
+  label: string,
+  sseUrl: string,
+  tableHandlers: Record<string, (event: CdcEvent) => Promise<void>>
+) {
+  const url = new URL(sseUrl);
+  url.searchParams.set('key', CDC_SECRET!);
+  logInfo(`[${label}] Connecting to ${sseUrl}...`);
+
+  const client = url.protocol === 'https:' ? https : http;
+  let reconnectDelay = 1000;
+
+  const req = client.get(
+    url,
+    {
+      headers: {
+        Accept: 'text/event-stream',
+        'Cache-Control': 'no-cache',
+      },
+    },
+    (res) => {
+      if (res.statusCode !== 200) {
+        console.error(`[${timestamp()}] [${label}] SSE error: HTTP ${res.statusCode}`);
+        res.resume();
+        scheduleReconnect();
+        return;
+      }
+
+      logInfo(`[${label}] Connected`);
+      reconnectDelay = 1000;
+
+      res.setEncoding('utf8');
+      let buffer = '';
+
+      res.on('data', (chunk: string) => {
+        buffer += chunk;
+        let idx;
+        // SSE frames are separated by a blank line ("\n\n")
+        while ((idx = buffer.indexOf('\n\n')) !== -1) {
+          const frame = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 2);
+          processSseFrame(label, frame, tableHandlers).catch((err) => {
+            console.error(`[${timestamp()}] [${label}] Error processing frame:`, err);
+          });
+        }
+      });
+
+      res.on('end', () => {
+        console.error(`[${timestamp()}] [${label}] SSE connection ended`);
+        scheduleReconnect();
+      });
+
+      res.on('error', (err) => {
+        console.error(`[${timestamp()}] [${label}] SSE response error:`, err.message);
+      });
+    }
+  );
+
+  req.on('error', (err) => {
+    console.error(`[${timestamp()}] [${label}] SSE request error:`, err.message);
+    scheduleReconnect();
+  });
+
+  function scheduleReconnect() {
+    logInfo(`[${label}] Reconnecting in ${reconnectDelay / 1000}s...`);
+    setTimeout(() => connectSse(label, sseUrl, tableHandlers), reconnectDelay);
+    reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+  }
+}
+
+async function processSseFrame(
+  label: string,
+  frame: string,
+  tableHandlers: Record<string, (event: CdcEvent) => Promise<void>>
+) {
+  const dataLines: string[] = [];
+  for (const line of frame.split('\n')) {
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trimStart());
+    }
+  }
+  if (dataLines.length === 0) return;
+
+  const payload = dataLines.join('\n');
+  const msg = JSON.parse(payload);
+
+  if (msg.type === 'heartbeat' || msg.type === 'connected') {
+    if (msg.type === 'connected') {
+      logInfo(`[${label}] Server time: ${new Date(msg.serverTime).toISOString()}`);
+    }
+    return;
+  }
+
+  const event = msg as CdcEvent;
+  const handler = tableHandlers[event.table];
+
+  if (handler) {
+    await new Promise((resolve) => setTimeout(resolve, PROPAGATION_DELAY_MS));
+    await handler(event);
+  } else if (!UNSYNCED_TABLES.has(event.table)) {
+    logSkipped(event.table, event.id ?? 0, `[${label}] unknown table`);
+  }
+}
+
+// --- WebSocket CDC client (used for Backend-Service direction) ---
 
 function connectCdc(label: string, wsUrl: string, tableHandlers: Record<string, (event: CdcEvent) => Promise<void>>) {
   const url = `${wsUrl}?key=${CDC_SECRET}`;
@@ -682,10 +794,10 @@ async function main() {
   logInfo('Streaming — bidirectional monitoring');
   console.log('='.repeat(60) + '\n');
 
-  // Forward: tubafrenzy changes → check PostgreSQL
-  connectCdc('tubafrenzy→PG', TUBAFRENZY_CDC_URL, TUBAFRENZY_TABLES);
+  // Forward: tubafrenzy changes (SSE — Apache proxy lacks WS upgrade support) → check PostgreSQL
+  connectSse('tubafrenzy→PG', TUBAFRENZY_CDC_URL, TUBAFRENZY_TABLES);
 
-  // Reverse: Backend-Service changes → check MySQL
+  // Reverse: Backend-Service changes (WebSocket via nginx) → check MySQL
   connectCdc('PG→tubafrenzy', BACKEND_CDC_URL, BACKEND_TABLES);
 
   // Graceful shutdown


### PR DESCRIPTION
## Summary
- Replace WebSocket client with SSE client for the tubafrenzy direction in `scripts/sync/reconcile.ts` (Kattare's Apache proxy doesn't support WebSocket upgrade).
- Backend-Service direction still uses WebSocket via nginx.
- Default `TUBAFRENZY_CDC_URL` updated to `http://localhost:8080/playlists/cdcStream`.

## Test plan
- [x] Standalone typecheck of `scripts/sync/reconcile.ts` passes
- [ ] Run monitor against production CDC endpoints and confirm both directions stream events without errors
- [ ] Confirm PR #621 reconciliation fixes hold (no play_order / show-delimiter / library-catalog false positives)

Closes #622