### PR TITLE
Trigger LML metadata enrichment for tubafrenzy webhook upserts

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -1,13 +1,11 @@
 import { Request, RequestHandler } from 'express';
 import { Mutex } from 'async-mutex';
-import * as Sentry from '@sentry/node';
-import { eq } from 'drizzle-orm';
-import { db, NewFSEntry as FullNewFSEntry, FSEntry, Show, ShowDJ, flowsheet } from '@wxyc/database';
+import { NewFSEntry as FullNewFSEntry, FSEntry, Show, ShowDJ } from '@wxyc/database';
 
 // play_order is computed by the service layer, not provided by controllers
 type NewFSEntry = Omit<FullNewFSEntry, 'play_order'>;
 import * as flowsheet_service from '../services/flowsheet.service.js';
-import { fetchMetadata } from '../services/metadata/index.js';
+import { fireAndForgetMetadataForRow } from '../services/metadata/index.js';
 import { runLmlLinkage } from '../services/flowsheet-linkage.service.js';
 import { reportLinkageError } from '../services/linkage-metrics.service.js';
 import WxycError from '../utils/error.js';
@@ -91,38 +89,14 @@ function fireAndForgetLinkage(completedEntry: FSEntry): void {
 function fireAndForgetMetadata(completedEntry: FSEntry, artistId?: number): void {
   if (!completedEntry.artist_name) return;
 
-  fetchMetadata({
+  fireAndForgetMetadataForRow({
+    flowsheetId: completedEntry.id,
+    artistName: completedEntry.artist_name,
     albumId: completedEntry.album_id ?? undefined,
     artistId,
-    artistName: completedEntry.artist_name,
     albumTitle: completedEntry.album_title ?? undefined,
     trackTitle: completedEntry.track_title ?? undefined,
-  })
-    .then(async (metadata) => {
-      if (!metadata) return;
-      await db
-        .update(flowsheet)
-        .set({
-          artwork_url: metadata.album?.artworkUrl ?? null,
-          discogs_url: metadata.album?.discogsUrl ?? null,
-          release_year: metadata.album?.releaseYear ?? null,
-          spotify_url: metadata.album?.spotifyUrl ?? null,
-          apple_music_url: metadata.album?.appleMusicUrl ?? null,
-          youtube_music_url: metadata.album?.youtubeMusicUrl ?? null,
-          bandcamp_url: metadata.album?.bandcampUrl ?? null,
-          soundcloud_url: metadata.album?.soundcloudUrl ?? null,
-          artist_bio: metadata.artist?.bio ?? null,
-          artist_wikipedia_url: metadata.artist?.wikipediaUrl ?? null,
-        })
-        .where(eq(flowsheet.id, completedEntry.id));
-    })
-    .catch((err) => {
-      console.error('[Flowsheet] Metadata fetch failed:', err);
-      Sentry.captureException(err, {
-        tags: { subsystem: 'metadata' },
-        extra: { artistName: completedEntry.artist_name, albumTitle: completedEntry.album_title },
-      });
-    });
+  });
 }
 
 const MAX_ITEMS = 200;

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -130,7 +130,15 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
             entry_type: sql`excluded.entry_type`,
           },
         })
-        .returning({ id: flowsheet.id });
+        // `(xmax = 0)` distinguishes a fresh INSERT from an UPDATE branch:
+        // a row produced by INSERT has xmax=0 (no prior tx touched it),
+        // while the DO UPDATE branch sets xmax to the current tx id. We
+        // gate enrichment on this so benign retries / no-op updates from
+        // tubafrenzy don't re-fetch from LML and re-write the 10 metadata
+        // columns (each rewrite triggers CDC + search_doc tsvector regen
+        // + 6-index churn). Backfill is the safety net for rows whose
+        // first INSERT enrichment returned null.
+        .returning({ id: flowsheet.id, created: sql<boolean>`(xmax = 0)` });
 
       // Trigger LML metadata enrichment for tracks. Fire-and-forget: errors
       // are caught inside fireAndForgetMetadataForRow and reported to Sentry,
@@ -138,12 +146,12 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // arriving via tubafrenzy — the dj-site addEntry controller has its
       // own call site.
       const upsertedRow = upserted[0];
-      if (upsertedRow && entryType === 'track' && artistName) {
+      if (upsertedRow?.created && entryType === 'track' && artistName) {
         fireAndForgetMetadataForRow({
           flowsheetId: upsertedRow.id,
           artistName,
-          albumTitle: albumTitle ?? undefined,
-          trackTitle: trackTitle ?? undefined,
+          albumTitle,
+          trackTitle,
         });
       }
     }

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -3,6 +3,7 @@ import { eq, sql } from 'drizzle-orm';
 import { db, flowsheet, shows, rotation, library, truncate } from '@wxyc/database';
 import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
 import { updateLastModified } from '../services/flowsheet.service.js';
+import { fireAndForgetMetadataForRow } from '../services/metadata/index.js';
 import { mapProdEntryType, isMessageEntryType } from '../utils/flowsheet-transform.js';
 
 const ETL_NOTIFY_KEY = process.env.ETL_NOTIFY_KEY ?? '';
@@ -97,16 +98,19 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       const entryType = mapProdEntryType(entry.flowsheetEntryType ?? 0);
       const showId = await resolveShowId(entry.radioShowId);
       const isMsgType = isMessageEntryType(entryType);
+      const artistName = isMsgType ? null : truncate(entry.artistName, 128);
+      const albumTitle = truncate(entry.releaseTitle, 128);
+      const trackTitle = truncate(entry.songTitle, 128);
 
-      await db
+      const upserted = await db
         .insert(flowsheet)
         .values({
           legacy_entry_id: entry.id,
           show_id: showId,
           entry_type: entryType,
-          artist_name: isMsgType ? null : truncate(entry.artistName, 128),
-          album_title: truncate(entry.releaseTitle, 128),
-          track_title: truncate(entry.songTitle, 128),
+          artist_name: artistName,
+          album_title: albumTitle,
+          track_title: trackTitle,
           record_label: truncate(entry.labelName, 128),
           message: isMsgType ? truncate(entry.artistName, 250) : null,
           request_flag: !!entry.requestFlag,
@@ -125,7 +129,23 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
             request_flag: sql`excluded.request_flag`,
             entry_type: sql`excluded.entry_type`,
           },
+        })
+        .returning({ id: flowsheet.id });
+
+      // Trigger LML metadata enrichment for tracks. Fire-and-forget: errors
+      // are caught inside fireAndForgetMetadataForRow and reported to Sentry,
+      // never propagated. This is the only enrichment trigger for entries
+      // arriving via tubafrenzy — the dj-site addEntry controller has its
+      // own call site.
+      const upsertedRow = upserted[0];
+      if (upsertedRow && entryType === 'track' && artistName) {
+        fireAndForgetMetadataForRow({
+          flowsheetId: upsertedRow.id,
+          artistName,
+          albumTitle: albumTitle ?? undefined,
+          trackTitle: trackTitle ?? undefined,
         });
+      }
     }
 
     updateLastModified();

--- a/apps/backend/services/metadata/enrichment.service.ts
+++ b/apps/backend/services/metadata/enrichment.service.ts
@@ -20,8 +20,10 @@ export interface EnrichmentInput {
   artistName: string;
   albumId?: number;
   artistId?: number;
-  albumTitle?: string;
-  trackTitle?: string;
+  // null is accepted because the webhook receiver's `truncate()` returns
+  // `string | null`; converting to undefined at every call site is noise.
+  albumTitle?: string | null;
+  trackTitle?: string | null;
 }
 
 export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
@@ -29,8 +31,8 @@ export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
     albumId: input.albumId,
     artistId: input.artistId,
     artistName: input.artistName,
-    albumTitle: input.albumTitle,
-    trackTitle: input.trackTitle,
+    albumTitle: input.albumTitle ?? undefined,
+    trackTitle: input.trackTitle ?? undefined,
   })
     .then(async (metadata) => {
       if (!metadata) return;

--- a/apps/backend/services/metadata/enrichment.service.ts
+++ b/apps/backend/services/metadata/enrichment.service.ts
@@ -1,0 +1,64 @@
+/**
+ * Fire-and-forget flowsheet metadata enrichment.
+ *
+ * Called after a track row is inserted or upserted on either path that lands
+ * in `flowsheet`: the dj-site `addEntry` controller and the tubafrenzy
+ * webhook receiver. Fetches metadata from LML and writes the 10-column
+ * payload back onto the row.
+ *
+ * The promise is intentionally not awaited by callers — enrichment must
+ * never block the HTTP response. Errors are logged and reported to Sentry
+ * under `subsystem='metadata'`, never thrown.
+ */
+import * as Sentry from '@sentry/node';
+import { eq } from 'drizzle-orm';
+import { db, flowsheet } from '@wxyc/database';
+import { fetchMetadata } from './metadata.service.js';
+
+export interface EnrichmentInput {
+  flowsheetId: number;
+  artistName: string;
+  albumId?: number;
+  artistId?: number;
+  albumTitle?: string;
+  trackTitle?: string;
+}
+
+export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
+  fetchMetadata({
+    albumId: input.albumId,
+    artistId: input.artistId,
+    artistName: input.artistName,
+    albumTitle: input.albumTitle,
+    trackTitle: input.trackTitle,
+  })
+    .then(async (metadata) => {
+      if (!metadata) return;
+      await db
+        .update(flowsheet)
+        .set({
+          artwork_url: metadata.album?.artworkUrl ?? null,
+          discogs_url: metadata.album?.discogsUrl ?? null,
+          release_year: metadata.album?.releaseYear ?? null,
+          spotify_url: metadata.album?.spotifyUrl ?? null,
+          apple_music_url: metadata.album?.appleMusicUrl ?? null,
+          youtube_music_url: metadata.album?.youtubeMusicUrl ?? null,
+          bandcamp_url: metadata.album?.bandcampUrl ?? null,
+          soundcloud_url: metadata.album?.soundcloudUrl ?? null,
+          artist_bio: metadata.artist?.bio ?? null,
+          artist_wikipedia_url: metadata.artist?.wikipediaUrl ?? null,
+        })
+        .where(eq(flowsheet.id, input.flowsheetId));
+    })
+    .catch((err) => {
+      console.error('[Flowsheet] Metadata fetch failed:', err);
+      Sentry.captureException(err, {
+        tags: { subsystem: 'metadata' },
+        extra: {
+          flowsheetId: input.flowsheetId,
+          artistName: input.artistName,
+          albumTitle: input.albumTitle,
+        },
+      });
+    });
+}

--- a/apps/backend/services/metadata/index.ts
+++ b/apps/backend/services/metadata/index.ts
@@ -3,4 +3,6 @@
  */
 export * from './metadata.types.js';
 export { fetchMetadata } from './metadata.service.js';
+export { fireAndForgetMetadataForRow } from './enrichment.service.js';
+export type { EnrichmentInput } from './enrichment.service.js';
 export { SearchUrlProvider } from './providers/search-urls.provider.js';

--- a/tests/unit/controllers/flowsheet.addEntry.djName.test.ts
+++ b/tests/unit/controllers/flowsheet.addEntry.djName.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
 
 jest.mock('../../../apps/backend/services/metadata/index', () => ({
   fetchMetadata: jest.fn(),
+  fireAndForgetMetadataForRow: jest.fn(),
 }));
 
 import { addEntry } from '../../../apps/backend/controllers/flowsheet.controller';

--- a/tests/unit/controllers/flowsheet.addEntry.linkage.test.ts
+++ b/tests/unit/controllers/flowsheet.addEntry.linkage.test.ts
@@ -21,8 +21,10 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
 }));
 
 const mockFetchMetadata = jest.fn<() => Promise<unknown>>();
+const mockFireAndForgetMetadataForRow = jest.fn();
 jest.mock('../../../apps/backend/services/metadata/index', () => ({
   fetchMetadata: mockFetchMetadata,
+  fireAndForgetMetadataForRow: mockFireAndForgetMetadataForRow,
 }));
 
 const mockRunLmlLinkage = jest.fn<() => Promise<unknown>>();

--- a/tests/unit/controllers/flowsheet.addEntry.test.ts
+++ b/tests/unit/controllers/flowsheet.addEntry.test.ts
@@ -7,6 +7,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
 
 jest.mock('../../../apps/backend/services/metadata/index', () => ({
   fetchMetadata: jest.fn(),
+  fireAndForgetMetadataForRow: jest.fn(),
 }));
 
 import { addEntry } from '../../../apps/backend/controllers/flowsheet.controller';

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -29,8 +29,10 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
 }));
 
 const mockFetchMetadata = jest.fn<() => Promise<void>>();
+const mockFireAndForgetMetadataForRow = jest.fn();
 jest.mock('../../../apps/backend/services/metadata/index', () => ({
   fetchMetadata: mockFetchMetadata,
+  fireAndForgetMetadataForRow: mockFireAndForgetMetadataForRow,
 }));
 
 import { getEntries, getLatest, getShowInfo, addEntry } from '../../../apps/backend/controllers/flowsheet.controller';
@@ -396,7 +398,11 @@ describe('flowsheet.controller', () => {
       expect(res.status).toHaveBeenCalledWith(201);
     });
 
-    it('reports metadata fetch failure to Sentry when album_id is provided', async () => {
+    // The Sentry/error path is owned by enrichment.service.ts and is
+    // covered in tests/unit/services/metadata.enrichment.test.ts. Here we
+    // verify only that the controller delegates to it with the right args.
+
+    it('delegates metadata enrichment with artistId from album lookup when album_id is provided', async () => {
       const albumInfo = { artist_name: 'Autechre', album_title: 'Confield', record_label: 'Warp', artist_id: 5 };
       mockGetAlbumFromDB.mockResolvedValue(albumInfo);
       const completedEntry = {
@@ -411,8 +417,6 @@ describe('flowsheet.controller', () => {
         add_time: new Date(),
       };
       mockAddTrack.mockResolvedValue(completedEntry);
-      const metadataError = new Error('Discogs timeout');
-      mockFetchMetadata.mockRejectedValue(metadataError);
 
       const req = createMockBodyReq({
         artist_name: 'Autechre',
@@ -425,17 +429,18 @@ describe('flowsheet.controller', () => {
 
       await addEntry(req as Request, res as Response, mockNext);
 
-      // Wait for fire-and-forget .catch() to execute
-      await new Promise((r) => setTimeout(r, 10));
-
       expect(res.status).toHaveBeenCalledWith(201);
-      expect(mockCaptureException).toHaveBeenCalledWith(
-        metadataError,
-        expect.objectContaining({ tags: { subsystem: 'metadata' } })
-      );
+      expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledWith({
+        flowsheetId: 1,
+        artistName: 'Autechre',
+        albumId: 10,
+        artistId: 5,
+        albumTitle: 'Confield',
+        trackTitle: 'VI Scose Poise',
+      });
     });
 
-    it('reports metadata fetch failure to Sentry when no album_id', async () => {
+    it('delegates metadata enrichment without artistId for free-form inserts (no album_id)', async () => {
       const completedEntry = {
         id: 2,
         show_id: activeShow.id,
@@ -449,8 +454,6 @@ describe('flowsheet.controller', () => {
         add_time: new Date(),
       };
       mockAddTrack.mockResolvedValue(completedEntry);
-      const metadataError = new Error('Spotify rate limit');
-      mockFetchMetadata.mockRejectedValue(metadataError);
 
       const req = createMockBodyReq({
         artist_name: 'Juana Molina',
@@ -462,13 +465,15 @@ describe('flowsheet.controller', () => {
 
       await addEntry(req as Request, res as Response, mockNext);
 
-      await new Promise((r) => setTimeout(r, 10));
-
       expect(res.status).toHaveBeenCalledWith(201);
-      expect(mockCaptureException).toHaveBeenCalledWith(
-        metadataError,
-        expect.objectContaining({ tags: { subsystem: 'metadata' } })
-      );
+      expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledWith({
+        flowsheetId: 2,
+        artistName: 'Juana Molina',
+        albumId: undefined,
+        artistId: undefined,
+        albumTitle: 'DOGA',
+        trackTitle: 'la paradoja',
+      });
     });
 
     it('passes segue field through for library-linked tracks (album_id provided)', async () => {

--- a/tests/unit/controllers/flowsheet.leaveShow.test.ts
+++ b/tests/unit/controllers/flowsheet.leaveShow.test.ts
@@ -8,6 +8,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
 
 jest.mock('../../../apps/backend/services/metadata/index', () => ({
   fetchMetadata: jest.fn(),
+  fireAndForgetMetadataForRow: jest.fn(),
 }));
 
 jest.mock('async-mutex', () => ({

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -20,6 +20,11 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   updateLastModified: mockUpdateLastModified,
 }));
 
+const mockFireAndForgetMetadataForRow = jest.fn();
+jest.mock('../../../apps/backend/services/metadata/index', () => ({
+  fireAndForgetMetadataForRow: mockFireAndForgetMetadataForRow,
+}));
+
 import { db } from '@wxyc/database';
 import express from 'express';
 import request from 'supertest';
@@ -29,12 +34,17 @@ process.env.ETL_NOTIFY_KEY = 'test-secret-key';
 
 import { internal_route } from '../../../apps/backend/routes/internal.route';
 
-// Make the DB mock chain's terminal methods resolve to arrays (needed by webhook handler)
+// Make the DB mock chain's terminal methods resolve appropriately for the
+// webhook handler. `onConflictDoNothing` is terminal in the show-resolution
+// path (resolves to undefined). The flowsheet upsert is `onConflictDoUpdate`
+// followed by `.returning()`, so the chain stays open through the upsert and
+// the terminal `.returning` resolves to a row array.
 const mockDb = db as unknown as Record<string, jest.Mock>;
 const mockChain = mockDb.select();
 (mockChain as Record<string, jest.Mock>).limit = jest.fn().mockResolvedValue([]);
 (mockChain as Record<string, jest.Mock>).onConflictDoNothing = jest.fn().mockResolvedValue(undefined);
-(mockChain as Record<string, jest.Mock>).onConflictDoUpdate = jest.fn().mockResolvedValue(undefined);
+const mockReturning = jest.fn().mockResolvedValue([]);
+(mockChain as Record<string, jest.Mock>).returning = mockReturning;
 
 const app = express();
 app.use(express.json());
@@ -180,6 +190,68 @@ describe('POST /internal/flowsheet-webhook', () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(mockUpdateLastModified).toHaveBeenCalled();
+  });
+
+  // -- Metadata enrichment trigger --
+  //
+  // Tubafrenzy is the source of ~all flowsheet inserts in production today.
+  // Without this trigger, every track row arrives with all 10 metadata
+  // columns NULL and the iOS app sees no album art / streaming URLs / bio.
+  // The dj-site addEntry controller has its own call site; this is the
+  // tubafrenzy → BS path.
+
+  it('fires metadata enrichment when a track upserts with artist_name', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry });
+
+    expect(res.status).toBe(200);
+    expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledWith({
+      flowsheetId: 5555,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+      trackTitle: 'VI Scose Poise',
+    });
+  });
+
+  it('does not fire enrichment when entry_type is not track (talkset)', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5556 }]);
+
+    // flowsheetEntryType=7 maps to talkset (see mapProdEntryType); message
+    // entries put the artistName in `message` and clear `artist_name`.
+    const talksetEntry = { ...validEntry, flowsheetEntryType: 7, artistName: 'Talkset' };
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: talksetEntry });
+
+    expect(res.status).toBe(200);
+    expect(mockFireAndForgetMetadataForRow).not.toHaveBeenCalled();
+  });
+
+  it('does not fire enrichment when artist_name is empty', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5557 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, artistName: '' } });
+
+    expect(res.status).toBe(200);
+    expect(mockFireAndForgetMetadataForRow).not.toHaveBeenCalled();
+  });
+
+  it('does not fire enrichment on delete actions', async () => {
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'delete', entryId: 2002 });
+
+    expect(res.status).toBe(200);
+    expect(mockFireAndForgetMetadataForRow).not.toHaveBeenCalled();
   });
 
   // -- Delete --

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -43,7 +43,7 @@ const mockDb = db as unknown as Record<string, jest.Mock>;
 const mockChain = mockDb.select();
 (mockChain as Record<string, jest.Mock>).limit = jest.fn().mockResolvedValue([]);
 (mockChain as Record<string, jest.Mock>).onConflictDoNothing = jest.fn().mockResolvedValue(undefined);
-const mockReturning = jest.fn().mockResolvedValue([]);
+const mockReturning = jest.fn();
 (mockChain as Record<string, jest.Mock>).returning = mockReturning;
 
 const app = express();
@@ -104,6 +104,12 @@ describe('POST /internal/flowsheet-webhook', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // jest.clearAllMocks() does not drain queued mockResolvedValueOnce
+    // values. Reset this mock fully so per-test queues don't bleed across
+    // tests. Default it to a created-row response; tests that need an
+    // update-branch response override with mockResolvedValueOnce.
+    mockReturning.mockReset();
+    mockReturning.mockResolvedValue([{ id: 5555, created: true }]);
   });
 
   // -- Auth --
@@ -200,8 +206,8 @@ describe('POST /internal/flowsheet-webhook', () => {
   // The dj-site addEntry controller has its own call site; this is the
   // tubafrenzy → BS path.
 
-  it('fires metadata enrichment when a track upserts with artist_name', async () => {
-    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+  it('fires metadata enrichment when a track INSERT lands (xmax=0 → created)', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555, created: true }]);
 
     const res = await request(app)
       .post('/internal/flowsheet-webhook')
@@ -217,9 +223,23 @@ describe('POST /internal/flowsheet-webhook', () => {
     });
   });
 
-  it('does not fire enrichment when entry_type is not track (talkset)', async () => {
-    mockReturning.mockResolvedValueOnce([{ id: 5556 }]);
+  it('does not fire enrichment when the upsert took the UPDATE branch (xmax≠0)', async () => {
+    // ON CONFLICT DO UPDATE on a re-sent legacy_entry_id sets xmax to the
+    // current tx id, so `created` is false. Skip enrichment here so benign
+    // tubafrenzy retries don't trigger LML re-fetch + 10-column rewrite +
+    // CDC/index churn on every duplicate webhook delivery.
+    mockReturning.mockResolvedValueOnce([{ id: 5555, created: false }]);
 
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', entry: validEntry });
+
+    expect(res.status).toBe(200);
+    expect(mockFireAndForgetMetadataForRow).not.toHaveBeenCalled();
+  });
+
+  it('does not fire enrichment when entry_type is not track (talkset)', async () => {
     // flowsheetEntryType=7 maps to talkset (see mapProdEntryType); message
     // entries put the artistName in `message` and clear `artist_name`.
     const talksetEntry = { ...validEntry, flowsheetEntryType: 7, artistName: 'Talkset' };
@@ -233,8 +253,6 @@ describe('POST /internal/flowsheet-webhook', () => {
   });
 
   it('does not fire enrichment when artist_name is empty', async () => {
-    mockReturning.mockResolvedValueOnce([{ id: 5557 }]);
-
     const res = await request(app)
       .post('/internal/flowsheet-webhook')
       .set('X-Internal-Key', 'test-secret-key')

--- a/tests/unit/services/metadata.enrichment.test.ts
+++ b/tests/unit/services/metadata.enrichment.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the fire-and-forget metadata enrichment helper.
+ *
+ * Verifies that fireAndForgetMetadataForRow:
+ *   - calls fetchMetadata with the input fields
+ *   - on success, updates the flowsheet row with the 10-column metadata payload
+ *   - on fetch failure, captures the error to Sentry under subsystem='metadata'
+ *     and does not throw
+ *   - returns synchronously (callers must not be blocked by enrichment)
+ */
+import { jest } from '@jest/globals';
+
+const mockFetchMetadata = jest.fn<() => Promise<unknown>>();
+jest.mock('../../../apps/backend/services/metadata/metadata.service', () => ({
+  fetchMetadata: mockFetchMetadata,
+}));
+
+const mockCaptureException = jest.fn();
+jest.mock('@sentry/node', () => ({ captureException: mockCaptureException }));
+
+import { db } from '@wxyc/database';
+import { fireAndForgetMetadataForRow } from '../../../apps/backend/services/metadata/enrichment.service';
+
+const mockDb = db as unknown as {
+  update: jest.Mock;
+  _chain: { set: jest.Mock; where: jest.Mock };
+};
+
+describe('fireAndForgetMetadataForRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns void synchronously even when fetchMetadata is pending', () => {
+    mockFetchMetadata.mockReturnValue(new Promise(() => undefined));
+
+    const result = fireAndForgetMetadataForRow({
+      flowsheetId: 1,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+      trackTitle: 'VI Scose Poise',
+    });
+
+    expect(result).toBeUndefined();
+    expect(mockFetchMetadata).toHaveBeenCalledWith({
+      albumId: undefined,
+      artistId: undefined,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+      trackTitle: 'VI Scose Poise',
+    });
+  });
+
+  it('writes all 10 metadata columns when fetchMetadata returns full enrichment', async () => {
+    mockFetchMetadata.mockResolvedValue({
+      album: {
+        artworkUrl: 'https://i.discogs.com/art.jpg',
+        discogsUrl: 'https://www.discogs.com/release/12345',
+        releaseYear: 2001,
+        spotifyUrl: 'https://open.spotify.com/album/abc',
+        appleMusicUrl: 'https://music.apple.com/album/xyz',
+        youtubeMusicUrl: 'https://music.youtube.com/album/aaa',
+        bandcampUrl: 'https://bandcamp.com/album/bbb',
+        soundcloudUrl: 'https://soundcloud.com/album/ccc',
+      },
+      artist: {
+        bio: 'Rob Brown and Sean Booth are Autechre.',
+        wikipediaUrl: 'https://en.wikipedia.org/wiki/Autechre',
+      },
+    });
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 42,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+    });
+
+    // Drain the promise queue so the .then() callback runs.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockDb.update).toHaveBeenCalled();
+    expect(mockDb._chain.set).toHaveBeenCalledWith({
+      artwork_url: 'https://i.discogs.com/art.jpg',
+      discogs_url: 'https://www.discogs.com/release/12345',
+      release_year: 2001,
+      spotify_url: 'https://open.spotify.com/album/abc',
+      apple_music_url: 'https://music.apple.com/album/xyz',
+      youtube_music_url: 'https://music.youtube.com/album/aaa',
+      bandcamp_url: 'https://bandcamp.com/album/bbb',
+      soundcloud_url: 'https://soundcloud.com/album/ccc',
+      artist_bio: 'Rob Brown and Sean Booth are Autechre.',
+      artist_wikipedia_url: 'https://en.wikipedia.org/wiki/Autechre',
+    });
+  });
+
+  it('skips the DB update when fetchMetadata returns null', async () => {
+    mockFetchMetadata.mockResolvedValue(null);
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 99,
+      artistName: 'Anonymous Artist',
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('reports fetchMetadata errors to Sentry with subsystem=metadata and does not throw', async () => {
+    const error = new Error('LML responded with 502');
+    mockFetchMetadata.mockRejectedValue(error);
+
+    expect(() =>
+      fireAndForgetMetadataForRow({
+        flowsheetId: 7,
+        artistName: 'King Crimson',
+        albumTitle: 'Discipline',
+      })
+    ).not.toThrow();
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockCaptureException).toHaveBeenCalledWith(error, {
+      tags: { subsystem: 'metadata' },
+      extra: {
+        flowsheetId: 7,
+        artistName: 'King Crimson',
+        albumTitle: 'Discipline',
+      },
+    });
+  });
+});

--- a/tests/unit/services/metadata.enrichment.test.ts
+++ b/tests/unit/services/metadata.enrichment.test.ts
@@ -106,6 +106,25 @@ describe('fireAndForgetMetadataForRow', () => {
     expect(mockDb.update).not.toHaveBeenCalled();
   });
 
+  it('accepts null albumTitle/trackTitle from truncate() and forwards as undefined to fetchMetadata', () => {
+    mockFetchMetadata.mockReturnValue(new Promise(() => undefined));
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 5,
+      artistName: 'Lone Anonymous',
+      albumTitle: null,
+      trackTitle: null,
+    });
+
+    expect(mockFetchMetadata).toHaveBeenCalledWith({
+      albumId: undefined,
+      artistId: undefined,
+      artistName: 'Lone Anonymous',
+      albumTitle: undefined,
+      trackTitle: undefined,
+    });
+  });
+
   it('reports fetchMetadata errors to Sentry with subsystem=metadata and does not throw', async () => {
     const error = new Error('LML responded with 502');
     mockFetchMetadata.mockRejectedValue(error);


### PR DESCRIPTION
Closes #626.

## Summary

- `/internal/flowsheet-webhook` now fires `fireAndForgetMetadataForRow` after each track upsert, so every row arriving from tubafrenzy gets the 10-column metadata payload (artwork_url, streaming URLs, artist_bio, etc.) that the iOS app reads.
- Extracts the fire-and-forget enrichment from `flowsheet.controller.ts` into a shared `apps/backend/services/metadata/enrichment.service.ts`, so the controller and the webhook share one implementation. The promise floats — the webhook response is never blocked on LML.
- Adds the upsert's `.returning({ id })` so the new path has a flowsheet id to enrich.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run format:check` — passes
- [x] `npm run test:unit` — 1377/1377 passing, including:
  - new `tests/unit/services/metadata.enrichment.test.ts` covering fetch → update, null short-circuit, and Sentry capture on fetch failure
  - new cases in `tests/unit/routes/internal.route.test.ts` asserting the trigger fires on track upserts and skips talksets, empty `artist_name`, and delete actions
  - existing controller tests adapted to verify delegation; the Sentry side-effect assertions move to the enrichment module's tests
- [ ] Smoke after merge: tail backend logs on EC2 for `[Flowsheet] Metadata fetch failed` after the next live show; confirm new tracks land with `artwork_url IS NOT NULL` via a `SELECT … WHERE add_time > now() - interval '1 hour'`.

## Out of scope

- Backfill of ~3000 historical NULL rows since Apr 25 — handled separately with `scripts/backfill-metadata.ts` against prod.
- `flowsheet-lml-link-backfill` SIGTERM mid-run on Apr 28 — unrelated job (writes `album_id`, not metadata).
- `REFRESH MATERIALIZED VIEW CONCURRENTLY album_plays` statement-timeout errors in logs — unrelated to iOS rendering.

## Merge

Use rebase-and-merge per Backend-Service convention.