### PR TITLE
Add Discogs-bridge and trigram-fuzzy SQL passes for B-2.2 flowsheet linkage

### DIFF
--- a/scripts/build-flowsheet-stamps-sql.py
+++ b/scripts/build-flowsheet-stamps-sql.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Convert a (artist_name, album_title, library_id) stamps CSV into a single
+transactional SQL script that joins the stamps to wxyc_schema.flowsheet on
+exact text equality and writes album_id + linkage metadata.
+
+Used by the B-2.2 sister scripts (discogs-bridge-flowsheet.sql and
+fuzzy-trigram-flowsheet.sql) to ship locally-computed stamps to prod RDS
+without round-tripping through scripts/query-flowsheet.sh — the resulting
+SQL is too large for ssh's inline command buffer, so we emit a file, scp
+it to EC2, and feed it to psql via docker mount.
+
+The output starts with ROLLBACK so the first run is a dry-run; pass
+--commit to flip it to COMMIT.
+
+Usage:
+  python3 scripts/build-flowsheet-stamps-sql.py \
+      --csv /tmp/discogs-bridge-stamps.csv \
+      --linkage-source discogs_local_bridge \
+      --confidence 0.9 \
+      > /tmp/discogs-bridge-update.sql
+
+  python3 scripts/build-flowsheet-stamps-sql.py \
+      --csv /tmp/fuzzy-trigram-stamps.csv \
+      --linkage-source fuzzy_trigram_match \
+      --confidence 0.85 \
+      --commit \
+      > /tmp/fuzzy-trigram-update.sql
+
+Input CSV columns: artist_name, album_title, library_id (header row required).
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+
+
+def pg_quote(s: str) -> str:
+    if s is None:
+        return "NULL"
+    return "'" + s.replace("'", "''") + "'"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--csv", required=True, help="path to stamps CSV")
+    ap.add_argument(
+        "--linkage-source",
+        required=True,
+        help="value to write into flowsheet.linkage_source (e.g. discogs_local_bridge)",
+    )
+    ap.add_argument(
+        "--confidence",
+        required=True,
+        type=float,
+        help="value to write into flowsheet.linkage_confidence (0.0–1.0)",
+    )
+    ap.add_argument(
+        "--commit",
+        action="store_true",
+        help="emit COMMIT instead of ROLLBACK at the end (default: dry-run)",
+    )
+    args = ap.parse_args()
+
+    if not (0.0 <= args.confidence <= 1.0):
+        sys.exit(f"--confidence must be in [0, 1], got {args.confidence}")
+
+    rows: list[tuple[str, str, int]] = []
+    with open(args.csv, newline="") as fh:
+        reader = csv.DictReader(fh)
+        required = {"artist_name", "album_title", "library_id"}
+        missing = required - set(reader.fieldnames or [])
+        if missing:
+            sys.exit(f"CSV missing required columns: {sorted(missing)}")
+        for r in reader:
+            rows.append((r["artist_name"], r["album_title"], int(r["library_id"])))
+
+    if not rows:
+        sys.exit("CSV had no data rows; refusing to emit an empty UPDATE")
+
+    out = sys.stdout
+
+    out.write("SET statement_timeout = '600s';\n")
+    out.write("BEGIN;\n")
+    out.write(
+        "CREATE TEMP TABLE stamps "
+        "(artist_name TEXT, album_title TEXT, library_id INT) "
+        "ON COMMIT DROP;\n"
+    )
+    out.write("INSERT INTO stamps (artist_name, album_title, library_id) VALUES\n")
+    out.write(
+        ",\n".join(
+            f"  ({pg_quote(a)}, {pg_quote(b)}, {lib})" for a, b, lib in rows
+        )
+    )
+    out.write(";\n")
+
+    out.write("SELECT 'temp_rows' AS step, count(*) FROM stamps;\n")
+
+    out.write(
+        "UPDATE wxyc_schema.flowsheet f\n"
+        f"SET album_id = s.library_id,\n"
+        f"    linkage_source = {pg_quote(args.linkage_source)},\n"
+        f"    linkage_confidence = {args.confidence},\n"
+        f"    linked_at = now()\n"
+        "FROM stamps s\n"
+        "WHERE f.artist_name = s.artist_name\n"
+        "  AND f.album_title = s.album_title\n"
+        "  AND f.album_id IS NULL\n"
+        "  AND f.entry_type = 'track';\n"
+    )
+
+    out.write(
+        "SELECT linkage_source, count(*) AS n\n"
+        "FROM wxyc_schema.flowsheet\n"
+        "WHERE linkage_source IS NOT NULL\n"
+        "GROUP BY 1\n"
+        "ORDER BY 1;\n"
+    )
+
+    out.write("COMMIT;\n" if args.commit else "ROLLBACK;\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/discogs-bridge-flowsheet.sql
+++ b/scripts/discogs-bridge-flowsheet.sql
@@ -1,0 +1,244 @@
+-- Discogs-bridge linkage for the B-2.2 flowsheet → library backfill.
+-- Links unlinked flowsheet rows by going via the local Discogs snapshot:
+--   flowsheet (artist, album) text  -- normalized -->  Discogs release/master
+--   library.canonical_entity_id     ----- stamped -->  Discogs release/master
+-- A flowsheet row gets stamped when both sides resolve to the same Discogs
+-- entity, which means the bridge catches cases where flowsheet text differs
+-- from library text (typo, transliteration, alternate edition) but both name
+-- the same album in Discogs. Designed to run after direct-link-flowsheet.sql
+-- and before fuzzy-trigram-flowsheet.sql.
+--
+-- Why this exists:
+--   ~6.7% of unlinked flowsheet pairs match a Discogs entry locally, and a
+--   subset of those bridge to a stamped library row even when the raw text
+--   pair didn't match anything in direct-link's text-only pass. The prod RDS
+--   has no Discogs data of its own, so the matching step runs against the
+--   local discogs-cache PG (port 5433); only the resulting stamps are pushed
+--   back to prod.
+--
+-- Normalization (Strategy 3; applied to both sides on the local cache):
+--   regexp_replace(regexp_replace(lower(f_unaccent(text)),
+--                                 '^the\s+', '', 'i'),
+--                  '[^a-z0-9 ]+', '', 'gi')
+-- f_unaccent requires the unaccent extension, which lives on the local
+-- discogs-cache PG but NOT on prod RDS — that's why this strategy can't
+-- run as a single prod query the way direct-link-flowsheet.sql does.
+--
+-- Confidence: 0.9. Bridges are accepted when:
+--   1. The flowsheet pair resolves to a single Discogs entity (master_id
+--      preferred; release_id fallback). Pairs with multiple distinct
+--      Discogs entities are dropped.
+--   2. That Discogs entity maps to exactly one library_id via
+--      library.canonical_entity_id. If multiple library rows share the
+--      stamp (format variants of the same release) we accept the lowest id;
+--      that's a deliberate same-album tie-break consistent with how the
+--      library backfill picks among aliases.
+--
+-- Idempotent: the WHERE f.album_id IS NULL guard means re-runs are no-ops.
+-- The first prod run linked 13,548 rows on 2026-04-28.
+--
+-- Reversible:
+--   UPDATE wxyc_schema.flowsheet
+--   SET album_id = NULL,
+--       linkage_source = NULL,
+--       linkage_confidence = NULL,
+--       linked_at = NULL
+--   WHERE linkage_source = 'discogs_local_bridge';
+--
+-- Run procedure (three stages — review the dry-run before committing):
+--
+--   STAGE 1: pull inputs from prod (run from a workstation that can reach
+--   prod RDS via scripts/query-flowsheet.sh and run docker locally).
+--
+--     # 1a. Unlinked flowsheet pairs (deduped raw text; we re-normalize
+--     #     locally so we can use unaccent uniformly).
+--     ./scripts/query-flowsheet.sh --sql "
+--       COPY (
+--         SELECT artist_name, album_title, count(*) AS row_count
+--         FROM wxyc_schema.flowsheet
+--         WHERE album_id IS NULL
+--           AND entry_type='track'
+--           AND artist_name IS NOT NULL
+--           AND album_title IS NOT NULL
+--           AND (legacy_release_id IS NULL OR legacy_link_attempted_at IS NOT NULL)
+--         GROUP BY 1, 2
+--       ) TO STDOUT WITH (FORMAT CSV, HEADER true);
+--     " | grep -v '^SET$' > /tmp/flowsheet-raw-pairs.csv
+--
+--     # 1b. Library canonical_entity_id stamps (29K rows after B-1.2).
+--     ./scripts/query-flowsheet.sh --sql "
+--       COPY (
+--         SELECT id, canonical_entity_id
+--         FROM wxyc_schema.library
+--         WHERE canonical_entity_id IS NOT NULL
+--       ) TO STDOUT WITH (FORMAT CSV, HEADER false);
+--     " | grep -v '^SET$' > /tmp/library-stamps.csv
+--
+--   STAGE 2: match against the local Discogs cache. The SQL below runs
+--   inside the discogs-cache-db container (assumes wxyc.release +
+--   wxyc.release_artist + unaccent extension are present from
+--   discogs-etl). After it runs, /tmp/discogs-bridge-stamps.csv on the
+--   container holds the (artist_name, album_title, library_id) tuples.
+--
+--     docker cp /tmp/flowsheet-raw-pairs.csv discogs-cache-db-1:/tmp/
+--     docker cp /tmp/library-stamps.csv      discogs-cache-db-1:/tmp/
+--     docker exec -i discogs-cache-db-1 psql -U discogs -d discogs \
+--       -f /path/to/this/file
+--     docker cp discogs-cache-db-1:/tmp/discogs-bridge-stamps.csv /tmp/
+--
+--   STAGE 3: apply on prod. scripts/build-flowsheet-stamps-sql.py converts
+--   the stamps CSV into a single transactional UPDATE; we scp it to EC2 and
+--   feed it to psql via docker mount because the resulting SQL is too large
+--   for ssh's inline command buffer.
+--
+--     python3 scripts/build-flowsheet-stamps-sql.py \
+--       --csv /tmp/discogs-bridge-stamps.csv \
+--       --linkage-source discogs_local_bridge \
+--       --confidence 0.9 \
+--       > /tmp/discogs-bridge-update.sql
+--     scp /tmp/discogs-bridge-update.sql wxyc-ec2:/tmp/
+--     ssh wxyc-ec2 'docker run --rm -i \
+--       -v /tmp/discogs-bridge-update.sql:/tmp/script.sql:ro \
+--       -e PGPASSWORD="$DB_PASS" postgres:16-alpine \
+--       psql -w "host=$DB_HOST user=$DB_USER dbname=$DB_NAME sslmode=require" \
+--       -v ON_ERROR_STOP=1 -f /tmp/script.sql'
+--
+--   The build-flowsheet-stamps-sql.py output starts with ROLLBACK so the
+--   first run is a dry-run; flip to COMMIT once the row count looks right.
+
+-- ============================================================================
+-- STAGE 2: local matching SQL (runs on discogs-cache, NOT on prod RDS).
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+SET statement_timeout = '0';
+
+-- Inputs: the two CSVs copied into /tmp/ on the container.
+DROP TABLE IF EXISTS public.flowsheet_raw;
+DROP TABLE IF EXISTS public.library_stamps;
+CREATE TABLE public.flowsheet_raw (artist_name TEXT, album_title TEXT, row_count INT);
+CREATE TABLE public.library_stamps (library_id INT, canonical_entity_id TEXT);
+
+\COPY public.flowsheet_raw FROM '/tmp/flowsheet-raw-pairs.csv' WITH (FORMAT CSV, HEADER true);
+\COPY public.library_stamps FROM '/tmp/library-stamps.csv'    WITH (FORMAT CSV);
+
+CREATE INDEX library_stamps_canonical_idx ON public.library_stamps (canonical_entity_id);
+
+-- Re-aggregate on the unaccented, fully normalized form. Doing this locally
+-- (rather than in the prod export) guarantees the same normalization on both
+-- sides of the join — prod has no f_unaccent.
+DROP TABLE IF EXISTS public.flowsheet_pairs;
+CREATE TABLE public.flowsheet_pairs AS
+SELECT
+  regexp_replace(regexp_replace(lower(f_unaccent(coalesce(artist_name, ''))), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi') AS artist_norm,
+  regexp_replace(regexp_replace(lower(f_unaccent(coalesce(album_title, ''))), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi') AS album_norm,
+  sum(row_count) AS row_count
+FROM public.flowsheet_raw
+GROUP BY 1, 2;
+CREATE INDEX flowsheet_pairs_idx ON public.flowsheet_pairs (artist_norm, album_norm);
+
+-- (flowsheet pair) × Discogs match.
+-- ra.extra = 0 keeps only primary artists on each release (skips "extra"
+-- artist credits, which are always denoted as accompaniments rather than
+-- the canonical credit).
+DROP TABLE IF EXISTS public.flowsheet_match;
+CREATE TABLE public.flowsheet_match AS
+SELECT
+  fp.artist_norm,
+  fp.album_norm,
+  count(DISTINCT coalesce(NULLIF(r.master_id, 0), -r.id)) AS distinct_entities,
+  MIN(NULLIF(r.master_id, 0)) AS master_id,
+  MIN(r.id) AS release_id
+FROM public.flowsheet_pairs fp
+JOIN wxyc.release_artist ra
+  ON regexp_replace(regexp_replace(lower(f_unaccent(ra.artist_name)), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi') = fp.artist_norm
+ AND ra.extra = 0
+JOIN wxyc.release r
+  ON r.id = ra.release_id
+ AND regexp_replace(regexp_replace(lower(f_unaccent(r.title)), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi') = fp.album_norm
+WHERE length(trim(fp.artist_norm)) > 0
+  AND length(trim(fp.album_norm)) > 0
+GROUP BY 1, 2;
+
+-- Bridge: each (flowsheet pair, Discogs entity) checked against library
+-- stamps preferring master, falling back to release. We drop pairs where
+-- the Discogs side is ambiguous (multiple distinct entities) AND the
+-- library side disagrees; if all candidates point to the same library_id
+-- we accept that single library_id.
+DROP TABLE IF EXISTS public.flowsheet_bridge_stamps;
+CREATE TABLE public.flowsheet_bridge_stamps AS
+WITH candidates AS (
+  SELECT
+    artist_norm,
+    album_norm,
+    'discogs:master:'  || master_id::text  AS master_cid,
+    'discogs:release:' || release_id::text AS release_cid,
+    master_id
+  FROM public.flowsheet_match
+),
+via_master AS (
+  SELECT c.artist_norm, c.album_norm, ls.library_id
+  FROM candidates c
+  JOIN public.library_stamps ls ON ls.canonical_entity_id = c.master_cid
+  WHERE c.master_id IS NOT NULL
+),
+via_release AS (
+  SELECT c.artist_norm, c.album_norm, ls.library_id
+  FROM candidates c
+  JOIN public.library_stamps ls ON ls.canonical_entity_id = c.release_cid
+)
+SELECT
+  artist_norm,
+  album_norm,
+  MIN(library_id) AS library_id
+FROM (SELECT * FROM via_master UNION ALL SELECT * FROM via_release) m
+GROUP BY 1, 2
+HAVING count(DISTINCT library_id) = 1;
+
+-- Expand back to raw text variants so the prod-side UPDATE can join on
+-- exact (artist_name, album_title) equality (prod has no unaccent).
+\COPY (
+  SELECT fr.artist_name, fr.album_title, fbs.library_id
+  FROM public.flowsheet_raw fr
+  CROSS JOIN LATERAL (
+    SELECT
+      regexp_replace(regexp_replace(lower(f_unaccent(coalesce(fr.artist_name, ''))), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi') AS artist_norm,
+      regexp_replace(regexp_replace(lower(f_unaccent(coalesce(fr.album_title, ''))), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi') AS album_norm
+  ) n
+  JOIN public.flowsheet_bridge_stamps fbs USING (artist_norm, album_norm)
+  ORDER BY fbs.library_id, fr.artist_name
+) TO '/tmp/discogs-bridge-stamps.csv' WITH (FORMAT CSV, HEADER true);
+
+-- ============================================================================
+-- STAGE 3: prod-side UPDATE template.
+--
+-- The actual prod-side SQL is generated by build-flowsheet-stamps-sql.py
+-- (which inlines the CSV as a VALUES clause). The shape it produces is:
+--
+--   SET statement_timeout = '600s';
+--   BEGIN;
+--   CREATE TEMP TABLE stamps (artist_name TEXT, album_title TEXT, library_id INT)
+--     ON COMMIT DROP;
+--   INSERT INTO stamps VALUES
+--     ('Artist 1', 'Album 1', 12345),
+--     ...;
+--   UPDATE wxyc_schema.flowsheet f
+--   SET album_id = s.library_id,
+--       linkage_source = 'discogs_local_bridge',
+--       linkage_confidence = 0.9,
+--       linked_at = now()
+--   FROM stamps s
+--   WHERE f.artist_name = s.artist_name
+--     AND f.album_title = s.album_title
+--     AND f.album_id IS NULL
+--     AND f.entry_type = 'track';
+--   COMMIT;  -- (or ROLLBACK during the dry-run)
+--
+-- Notes:
+--   - artist_name / album_title equality on raw text is intentional: prod
+--     can't replicate the f_unaccent-based normalization, but the raw text
+--     variants we exported above cover every spelling that appeared in the
+--     unlinked residual.
+--   - entry_type='track' guards against accidentally writing album_id onto
+--     break/show-marker rows, which can't have a library link anyway.
+-- ============================================================================

--- a/scripts/fuzzy-trigram-flowsheet.sql
+++ b/scripts/fuzzy-trigram-flowsheet.sql
@@ -1,0 +1,199 @@
+-- Trigram fuzzy-match linkage for the B-2.2 flowsheet → library backfill.
+-- Catches flowsheet rows whose normalized text *almost* matches a library
+-- row but isn't an exact equi-join hit. Designed to run after both
+-- direct-link-flowsheet.sql and discogs-bridge-flowsheet.sql, against the
+-- residual neither could resolve.
+--
+-- Why this exists:
+--   The exact-match passes leave a long tail of typos, missing words,
+--   year/volume suffixes, and "Live"/"Best of" prefixes. Most of those
+--   really do refer to a library row that already exists; pg_trgm's
+--   trigram similarity catches them with high precision when the artist
+--   side is held tight.
+--
+-- Normalization (Strategy 3; same as discogs-bridge-flowsheet.sql):
+--   regexp_replace(regexp_replace(lower(f_unaccent(text)),
+--                                 '^the\s+', '', 'i'),
+--                  '[^a-z0-9 ]+', '', 'gi')
+-- Requires the unaccent + pg_trgm extensions on the matching DB. Both live
+-- on the local discogs-cache PG; prod has only pg_trgm, so the matching
+-- runs locally and only the resulting stamps go to prod.
+--
+-- Thresholds:
+--   similarity(artist_norm, library.artist_norm) >= 0.85
+--   similarity(album_norm,  library.album_norm)  >= 0.70
+-- The artist threshold is intentionally tight because this stage's job is
+-- to be *precise* at the artist level — a wrong artist link is much more
+-- visible than a wrong-edition link. The album threshold sits where the
+-- spot-check turned up no false positives at the sample size used in the
+-- 2026-04-28 run (year/volume suffixes, "Live"/"Best of" prefixes, single
+-- typos all sit between 0.70 and 0.80; below 0.70 starts admitting
+-- substring collisions).
+--
+-- Tie-break for ambiguous library candidates:
+--   - 1 library candidate → accept.
+--   - >1 candidates that all share the same canonical_entity_id stamp
+--     (i.e. format variants of the same release) → accept the lowest id.
+--   - >1 candidates with no shared canonical → reject.
+--
+-- Confidence: 0.85.
+--
+-- Idempotent: WHERE f.album_id IS NULL guard. The first prod run linked
+-- 61,122 rows on 2026-04-28.
+--
+-- Reversible:
+--   UPDATE wxyc_schema.flowsheet
+--   SET album_id = NULL,
+--       linkage_source = NULL,
+--       linkage_confidence = NULL,
+--       linked_at = NULL
+--   WHERE linkage_source = 'fuzzy_trigram_match';
+--
+-- Run procedure (three stages — share STAGE 1 with discogs-bridge):
+--
+--   STAGE 1: pull raw flowsheet pairs and library rows from prod (see
+--   discogs-bridge-flowsheet.sql for the export commands; this strategy
+--   needs the same flowsheet-raw-pairs.csv plus a library-raw.csv with
+--   (id, artist_name, album_title)).
+--
+--     ./scripts/query-flowsheet.sh --sql "
+--       COPY (
+--         SELECT l.id, a.artist_name, l.album_title
+--         FROM wxyc_schema.library l
+--         LEFT JOIN wxyc_schema.artists a ON a.id = l.artist_id
+--       ) TO STDOUT WITH (FORMAT CSV, HEADER true);
+--     " | grep -v '^SET$' > /tmp/library-raw.csv
+--
+--   STAGE 2: match against the local Discogs cache PG (we reuse it because
+--   it already has unaccent + pg_trgm + the trigram-friendly libraries).
+--   The SQL below produces /tmp/fuzzy-trigram-stamps.csv on the container.
+--   STAGE 1's flowsheet_raw + library_stamps tables from
+--   discogs-bridge-flowsheet.sql are reused if both strategies are run in
+--   the same session; otherwise re-create them with the same DDL.
+--
+--     docker cp /tmp/library-raw.csv discogs-cache-db-1:/tmp/
+--     docker exec -i discogs-cache-db-1 psql -U discogs -d discogs \
+--       -f /path/to/this/file
+--     docker cp discogs-cache-db-1:/tmp/fuzzy-trigram-stamps.csv /tmp/
+--
+--   STAGE 3: apply on prod via build-flowsheet-stamps-sql.py (see
+--   discogs-bridge-flowsheet.sql for the full invocation; the only changes
+--   are --linkage-source fuzzy_trigram_match and --confidence 0.85).
+--
+--     python3 scripts/build-flowsheet-stamps-sql.py \
+--       --csv /tmp/fuzzy-trigram-stamps.csv \
+--       --linkage-source fuzzy_trigram_match \
+--       --confidence 0.85 \
+--       > /tmp/fuzzy-trigram-update.sql
+
+-- ============================================================================
+-- STAGE 2: local matching SQL (runs on discogs-cache, NOT on prod RDS).
+-- Assumes flowsheet_raw + library_stamps already exist (from
+-- discogs-bridge-flowsheet.sql). If they don't, recreate them with the
+-- DDL+\COPY blocks from that file before running this one.
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+SET statement_timeout = '0';
+SET pg_trgm.similarity_threshold = 0.6;  -- prefilter for the GIN scan
+
+-- Library raw → normalized + trigram-indexed.
+DROP TABLE IF EXISTS public.library_raw;
+DROP TABLE IF EXISTS public.library_norm;
+CREATE TABLE public.library_raw (id INT, artist_name TEXT, album_title TEXT);
+\COPY public.library_raw FROM '/tmp/library-raw.csv' WITH (FORMAT CSV, HEADER true);
+
+CREATE TABLE public.library_norm AS
+SELECT
+  id,
+  regexp_replace(regexp_replace(lower(f_unaccent(coalesce(artist_name, ''))), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi') AS artist_norm,
+  regexp_replace(regexp_replace(lower(f_unaccent(coalesce(album_title, ''))), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi') AS album_norm
+FROM public.library_raw;
+CREATE INDEX library_norm_artist_trgm ON public.library_norm USING gin (artist_norm gin_trgm_ops);
+CREATE INDEX library_norm_album_trgm  ON public.library_norm USING gin (album_norm  gin_trgm_ops);
+
+-- Flowsheet residual: drop pairs already stamped by direct-link or
+-- discogs-bridge so we only fuzzy against the leftover. If you skipped
+-- those passes, point this at flowsheet_pairs directly.
+DROP TABLE IF EXISTS public.flowsheet_residual;
+CREATE TABLE public.flowsheet_residual AS
+SELECT artist_norm, album_norm, row_count
+FROM public.flowsheet_pairs
+WHERE length(trim(artist_norm)) >= 2
+  AND length(trim(album_norm))  >= 2;
+CREATE INDEX flowsheet_residual_artist_trgm ON public.flowsheet_residual USING gin (artist_norm gin_trgm_ops);
+CREATE INDEX flowsheet_residual_album_trgm  ON public.flowsheet_residual USING gin (album_norm  gin_trgm_ops);
+
+-- All trigram hits above the per-side thresholds.
+DROP TABLE IF EXISTS public.fuzzy_full;
+CREATE TABLE public.fuzzy_full AS
+SELECT
+  fr.artist_norm,
+  fr.album_norm,
+  ln.id AS library_id,
+  similarity(fr.artist_norm, ln.artist_norm)
+    + similarity(fr.album_norm, ln.album_norm) AS combined
+FROM public.flowsheet_residual fr
+JOIN public.library_norm ln
+  ON fr.artist_norm % ln.artist_norm
+ AND fr.album_norm  % ln.album_norm
+WHERE similarity(fr.artist_norm, ln.artist_norm) >= 0.85
+  AND similarity(fr.album_norm,  ln.album_norm)  >= 0.70;
+CREATE INDEX fuzzy_full_idx ON public.fuzzy_full (artist_norm, album_norm);
+
+-- Resolve each pair to a single library_id, applying the canonical-stamp
+-- tie-break for ambiguous candidates.
+DROP TABLE IF EXISTS public.fuzzy_resolved;
+CREATE TABLE public.fuzzy_resolved AS
+WITH per_pair AS (
+  SELECT
+    artist_norm,
+    album_norm,
+    array_agg(library_id ORDER BY combined DESC, library_id) AS lib_ids,
+    count(DISTINCT library_id) AS n_libs
+  FROM public.fuzzy_full
+  GROUP BY 1, 2
+),
+canonical_lookup AS (
+  SELECT pp.artist_norm, pp.album_norm,
+    count(DISTINCT ls.canonical_entity_id) AS distinct_canonicals,
+    count(DISTINCT lib_id) AS lib_with_canonical
+  FROM per_pair pp,
+       unnest(pp.lib_ids) AS lib_id
+  LEFT JOIN public.library_stamps ls ON ls.library_id = lib_id
+  GROUP BY 1, 2
+)
+SELECT
+  pp.artist_norm,
+  pp.album_norm,
+  CASE
+    WHEN pp.n_libs = 1 THEN pp.lib_ids[1]
+    WHEN cl.distinct_canonicals = 1
+     AND cl.lib_with_canonical = pp.n_libs THEN pp.lib_ids[1]
+    ELSE NULL
+  END AS resolved_library_id
+FROM per_pair pp
+LEFT JOIN canonical_lookup cl USING (artist_norm, album_norm);
+
+-- Expand to raw (artist_name, album_title) variants so the prod UPDATE can
+-- equi-join without unaccent.
+\COPY (
+  SELECT fr.artist_name, fr.album_title, fres.resolved_library_id AS library_id
+  FROM public.flowsheet_raw fr
+  CROSS JOIN LATERAL (
+    SELECT
+      regexp_replace(regexp_replace(lower(f_unaccent(coalesce(fr.artist_name, ''))), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi') AS artist_norm,
+      regexp_replace(regexp_replace(lower(f_unaccent(coalesce(fr.album_title, ''))), '^the\s+', '', 'i'), '[^a-z0-9 ]+', '', 'gi') AS album_norm
+  ) n
+  JOIN public.fuzzy_resolved fres USING (artist_norm, album_norm)
+  WHERE fres.resolved_library_id IS NOT NULL
+  ORDER BY fres.resolved_library_id, fr.artist_name
+) TO '/tmp/fuzzy-trigram-stamps.csv' WITH (FORMAT CSV, HEADER true);
+
+-- ============================================================================
+-- STAGE 3: prod-side UPDATE template (same shape as discogs-bridge-flowsheet
+-- with linkage_source='fuzzy_trigram_match' and linkage_confidence=0.85).
+-- See discogs-bridge-flowsheet.sql for the full template; here we only
+-- record the linkage_source/confidence values that build-flowsheet-stamps-sql.py
+-- emits for this strategy.
+-- ============================================================================


### PR DESCRIPTION
Closes #629

Two sister scripts to `scripts/direct-link-flowsheet.sql`, each documenting a strategy that linked unlinked flowsheet rows on 2026-04-28 after the direct-text-match pre-pass had already handled the easy 52,984.

`discogs-bridge-flowsheet.sql` links flowsheet rows whose normalized text resolves to a Discogs release/master that the library has already stamped via `canonical_entity_id` (from B-1.2). The matching step runs against the local discogs-cache PG because prod RDS has no Discogs data and no `unaccent` extension; only the resulting `(artist_name, album_title, library_id)` stamps go to prod, where a temp table joins flowsheet on raw text equality. Confidence 0.9, `linkage_source='discogs_local_bridge'`. First prod run linked 13,548 rows.

`fuzzy-trigram-flowsheet.sql` does the equivalent residual pass with `pg_trgm` similarity instead of canonical-id bridging. Thresholds artist ≥ 0.85 and album ≥ 0.70 keep precision high while admitting typos, year/volume suffixes, and "Live"/"Best of" prefixes; the artist threshold is the tight side because a wrong-artist link is much more visible than a wrong-edition one. When multiple library candidates share a `canonical_entity_id` stamp we accept the lowest id (same-album tie-break). Confidence 0.85, `linkage_source='fuzzy_trigram_match'`. First prod run linked 61,122 rows.

Both files mirror `direct-link-flowsheet.sql`'s documentation pattern: header explains why, normalization, confidence, idempotency guard, reversal SQL, and run procedure. The runtime split (match locally, apply on prod) is documented with the actual shell commands used in the 2026-04-28 run.

`build-flowsheet-stamps-sql.py` is the small helper both strategies share: takes a stamps CSV, emits a transactional INSERT-into-temp-table + UPDATE that scp's cleanly to EC2 (the SQL is too large for ssh's inline command buffer). Defaults to `ROLLBACK` so first runs are dry-runs; `--commit` flips it for the real apply.

## Test plan
- [x] Header docstrings, run procedure, and reversal SQL all line up with what was actually run on 2026-04-28
- [x] `python3 -m py_compile` on the helper passes; `--help` renders cleanly
- [x] Helper output diffed against the SQL we actually shipped: identical except for the ROLLBACK/COMMIT toggle
- [ ] Reviewer spot-check that the SQL-comment shell commands match how `scripts/query-flowsheet.sh` is normally invoked in this repo