### PR TITLE
Converge backfill-metadata script with runtime enrichment + doc polish

### DIFF
--- a/docs/metadata-service/README.md
+++ b/docs/metadata-service/README.md
@@ -6,6 +6,19 @@ This document describes how the backend service fetches and serves album/artist 
 
 When a track is added to the flowsheet, the backend fetches metadata from [library-metadata-lookup](https://github.com/WXYC/library-metadata-lookup) (LML) asynchronously and stores it directly on the flowsheet row. Subsequent GET requests return the metadata inline with the entry. LML handles its own caching of Discogs API data, so no additional cache layer is needed on the backend.
 
+```mermaid
+graph TD
+    djsite[dj-site] -->|POST /flowsheet| ctrl[flowsheet.controller.ts]
+    tuba[tubafrenzy] -->|POST /internal/flowsheet-webhook| webhook[internal.route.ts]
+    ctrl & webhook --> helper[fireAndForgetMetadataForRow<br/>enrichment.service.ts]
+    helper --> fetchm[fetchMetadata<br/>metadata.service.ts]
+    fetchm --> lml[(LML /api/v1/lookup)]
+    helper -->|UPDATE 10 metadata columns| pg[(flowsheet)]
+    djsite -.->|GET /flowsheet| pg
+    proxy[playlist-proxy.service.ts] -.->|SELECT artwork_url| pg
+    proxy -.->|grouped response| ios[iOS]
+```
+
 ## Architecture
 
 | Component                                                                       | Responsibility                                                                                           |
@@ -42,7 +55,7 @@ Both flowsheet write paths converge on the same shared helper, `fireAndForgetMet
 2. If the entry has an `artist_name`, `fireAndForgetMetadataForRow` is invoked.
 3. The HTTP response returns immediately (metadata columns are null).
 4. The helper calls LML's `/api/v1/lookup` endpoint.
-5. On a result with artwork, the row is updated with all 10 metadata columns.
+5. The row is updated with all 10 metadata columns (see "Always-Update Semantics" below).
 6. On the next GET request, the metadata is included in the response.
 
 ### Tubafrenzy webhook path: `POST /internal/flowsheet-webhook`
@@ -51,7 +64,7 @@ Both flowsheet write paths converge on the same shared helper, `fireAndForgetMet
 2. The upsert uses `RETURNING { id, created: (xmax = 0) }`. The `xmax = 0` predicate distinguishes a fresh INSERT from the `ON CONFLICT DO UPDATE` branch.
 3. **Enrichment is gated on `created`.** Benign retries / no-op updates from tubafrenzy do not re-fetch from LML and do not re-write the metadata columns. This avoids amplifying CDC trigger fires + search_doc tsvector regen + 6-index updates on every duplicate webhook delivery.
 4. On INSERT, `fireAndForgetMetadataForRow` runs identically to the dj-site path.
-5. The `liveFs` SSE refetch event broadcasts immediately after the upsert (does not wait for enrichment to land — see [#628](https://github.com/WXYC/Backend-Service/issues/628) for the follow-up to re-emit after enrichment).
+5. The `liveFs` SSE refetch event broadcasts immediately after the upsert and does not wait for enrichment to land. **iOS does not subscribe to `liveFs`** — it gets data via `apps/backend/services/playlist-proxy.service.ts`, which subscribes to _tubafrenzy's_ SSE and synchronously SELECTs `flowsheet.artwork_url` per entry. The metadata UPDATE from the floating enrichment promise typically commits ~1–2s after the proxy's SELECT, so iOS shows the new track without art for that window. See [#628](https://github.com/WXYC/Backend-Service/issues/628) for the follow-up that addresses both consumer paths.
 
 ### LML Endpoint Used
 
@@ -61,13 +74,15 @@ Both flowsheet write paths converge on the same shared helper, `fireAndForgetMet
 
 The legacy per-component endpoints (`/api/v1/discogs/search`, `/api/v1/discogs/release/{id}`, `/api/v1/discogs/artist/{id}`) are still available on LML and are used by other Backend-Service paths (catalog search, proxy endpoints), but the metadata enrichment path consolidates onto `/lookup`.
 
-### Fallback Behavior
+### Always-Update Semantics
 
-When LML returns no results or is unavailable, the metadata service constructs search URLs for YouTube Music, Bandcamp, and SoundCloud as a bare minimum. These are generic search links, not direct album/track URLs. They give iOS/dj-site at least a "search for this on $service" affordance for the long tail of releases LML can't match.
+`fetchMetadata` always returns a non-null result when LML is configured: when LML returns no artwork, the service fills in `youtube_music_url`, `bandcamp_url`, and `soundcloud_url` with `search?q=<artist> <title>` URLs as a bare-minimum fallback. These are generic search links, not direct album/track URLs — they give iOS / dj-site at least a "search for this on $service" affordance for the long tail of releases LML can't match.
+
+The helper writes all 10 columns on every successful enrichment. A successful enrichment with no artwork still writes search URLs into 3 of those columns and `null` into the other 7. This means **`bandcamp_url IS NULL` is a reliable "this row has never been enriched" signal** — useful for idempotent backfill filters and for distinguishing "we tried and LML found nothing" from "we never tried."
 
 ## One-shot Recovery: `scripts/backfill-metadata.ts`
 
-For populating metadata on rows inserted before this enrichment was wired in (or for rows where a prior enrichment returned null because LML's cache hadn't been populated yet), there's a one-shot script:
+For populating metadata on rows inserted before enrichment was wired in (PR #627), or for rows where a prior enrichment failed silently because LML auth was misconfigured (see Configuration), there's a one-shot script:
 
 ```bash
 dotenvx run -f .env -- npx tsx scripts/backfill-metadata.ts
@@ -78,9 +93,9 @@ Env knobs:
 - `BACKFILL_LIMIT` — number of entries to process (default `1000`)
 - `BACKFILL_DRY_RUN` — set `true` to preview without updating
 
-The script's WHERE filter is `WHERE artwork_url IS NULL` and it only updates rows when LML returns artwork. No-match rows are left null (so they'll be re-attempted on a future run if the LML matcher improves).
+**Same semantics as the runtime path.** The script always UPDATEs every fetched row, including no-artwork rows that get only the search-URL fallbacks. Filter is `WHERE bandcamp_url IS NULL AND entry_type = 'track'`, so re-runs naturally skip rows already touched by any prior enrichment regardless of artwork outcome.
 
-For the historical tail (~1.86M legacy NULL rows as of 2026-04-28), see [#631](https://github.com/WXYC/Backend-Service/issues/631) — that work needs a containerized backfill job rather than the inline script.
+For the historical tail (legacy NULL rows accumulated before #627 deployed), see [#631](https://github.com/WXYC/Backend-Service/issues/631) — that work needs a containerized backfill job rather than the inline script.
 
 ## Conditional GET (304 Not Modified)
 
@@ -106,6 +121,45 @@ The flowsheet endpoints support conditional requests via the `Last-Modified` hea
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `LIBRARY_METADATA_URL` | LML service base URL (e.g. `http://localhost:8001`). Without this, metadata fetching is silently skipped.                |
 | `LML_API_KEY`          | Bearer token sent on every LML request. Required in production once LML's `LML_REQUIRE_AUTH` is `true`. Optional in dev. |
+
+> ⚠️ **Silent-failure mode.** If `LML_API_KEY` is missing or stale in a deployment where LML enforces auth, every `/lookup` call returns 401. `metadata.service.ts:58-60` catches the error as a `console.warn` and `fetchMetadata` returns null; `fireAndForgetMetadataForRow` then short-circuits without an UPDATE. There's no Sentry escalation, no 5xx — just every flowsheet row writing with all metadata columns null and no obvious symptom. If iOS / dj-site show empty art on every new track, this is the first thing to check.
+
+## Troubleshooting
+
+When iOS or dj-site is missing artwork, walk these in order:
+
+1. **Confirm the row exists.**
+
+   ```sql
+   SELECT id, artist_name, album_title, artwork_url, bandcamp_url
+   FROM wxyc_schema.flowsheet
+   WHERE id = <id>;
+   ```
+
+   If `bandcamp_url IS NULL`, no enrichment ever ran on this row — go to step 2. If `bandcamp_url IS NOT NULL` but `artwork_url IS NULL`, enrichment ran and LML found no match — that's a coverage issue, not a wiring issue (see step 5).
+
+2. **Confirm enrichment fired.** Look for `[Flowsheet] Metadata fetch failed` in backend logs around the row's `add_time`. If you see it, the enrichment ran and threw — read the cause. If you see _nothing_, the helper was never called: check that the row's source path (dj-site addEntry vs tubafrenzy webhook) wires `fireAndForgetMetadataForRow`. The webhook path additionally requires `entry_type='track'`, non-null `artist_name`, and the `xmax = 0` (true INSERT) gate.
+
+3. **Confirm LML auth.** SSH to the backend host and run:
+
+   ```sh
+   curl -sf -X POST "$LIBRARY_METADATA_URL/api/v1/lookup" \
+     -H "Authorization: Bearer $LML_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"artist":"King Crimson","album":"Discipline","raw_message":"King Crimson Discipline"}'
+   ```
+
+   If it returns `{"detail":"Missing authorization"}` or 401, the key on this host doesn't match LML's expected key. See the silent-failure callout in Configuration above.
+
+4. **Confirm LML is healthy.**
+
+   ```sh
+   curl -sf "$LIBRARY_METADATA_URL/health"
+   ```
+
+   Expect `status: healthy` with all three services (`database`, `discogs_api`, `discogs_cache`) reporting `ok`. A `degraded` Discogs status means the upstream Discogs token is broken — separate operational issue.
+
+5. **Confirm LML can match this artist.** Hit the lookup endpoint directly with the row's exact field values (see step 3's curl). If the response has `song_not_found: true` and `cache_stats.api_calls > 0`, LML actively searched and decided not to match — typically a coverage gap (obscure artist, collaboration trio name, etc.) rather than a Backend-Service bug. File against [`library-metadata-lookup`](https://github.com/WXYC/library-metadata-lookup) with the reproducer.
 
 ## Migration History
 

--- a/docs/metadata-service/README.md
+++ b/docs/metadata-service/README.md
@@ -8,12 +8,14 @@ When a track is added to the flowsheet, the backend fetches metadata from [libra
 
 ## Architecture
 
-| Component                | Responsibility                                                                                                   |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| **Flowsheet Controller** | Handles HTTP requests, triggers async metadata fetch, updates the flowsheet row                                  |
-| **Flowsheet Service**    | Database queries returning entries with inline metadata                                                          |
-| **Metadata Service**     | Calls LML for Discogs data and enriched streaming URLs                                                           |
-| **LML**                  | External service: Discogs search, release details, artist details, streaming URL enrichment (with its own cache) |
+| Component                                                                       | Responsibility                                                                                           |
+| ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Flowsheet Controller** (`apps/backend/controllers/flowsheet.controller.ts`)   | Handles `POST /flowsheet` from dj-site; calls the shared enrichment helper after the row is inserted     |
+| **Webhook Receiver** (`apps/backend/routes/internal.route.ts`)                  | Handles `POST /internal/flowsheet-webhook` from tubafrenzy; calls the shared enrichment helper on INSERT |
+| **Enrichment Service** (`apps/backend/services/metadata/enrichment.service.ts`) | Shared `fireAndForgetMetadataForRow` — fetches metadata and updates the flowsheet row                    |
+| **Metadata Service** (`apps/backend/services/metadata/metadata.service.ts`)     | `fetchMetadata` — calls LML's `/lookup` endpoint and shapes the response into the column-mapped result   |
+| **LML Client** (`apps/backend/services/lml/lml.client.ts`)                      | Single HTTP chokepoint with timeout + bearer auth header                                                 |
+| **LML**                                                                         | External service: unified `/lookup` endpoint with 3-tier caching (memory + PostgreSQL + Discogs API)     |
 
 ### Metadata Fields on Flowsheet
 
@@ -30,28 +32,55 @@ When a track is added to the flowsheet, the backend fetches metadata from [libra
 | `artist_bio`           | text         | LML (Discogs artist profile, markup stripped) |
 | `artist_wikipedia_url` | varchar(512) | LML (Discogs artist URLs)                     |
 
-## Fire-and-Forget Metadata Fetch
+## Fire-and-Forget Enrichment
 
-When a track is added, metadata is fetched asynchronously without blocking the response:
+Both flowsheet write paths converge on the same shared helper, `fireAndForgetMetadataForRow` (`apps/backend/services/metadata/enrichment.service.ts`). The promise is intentionally not awaited — enrichment must never block the HTTP response. Errors are logged and reported to Sentry under `subsystem='metadata'`, never thrown.
 
-1. `POST /flowsheet` inserts the entry to the database
-2. If the entry has an `artist_name`, `fetchMetadata()` is called asynchronously
-3. The HTTP response returns immediately (metadata columns are null)
-4. `fetchMetadata()` calls LML's Discogs search, release details, and artist details endpoints
-5. On success, the flowsheet row is updated with the metadata via `db.update(flowsheet).set(...)`
-6. On the next GET request, the metadata is included in the response
+### dj-site path: `POST /flowsheet`
 
-### LML Endpoints Used
+1. The controller inserts the entry to the database.
+2. If the entry has an `artist_name`, `fireAndForgetMetadataForRow` is invoked.
+3. The HTTP response returns immediately (metadata columns are null).
+4. The helper calls LML's `/api/v1/lookup` endpoint.
+5. On a result with artwork, the row is updated with all 10 metadata columns.
+6. On the next GET request, the metadata is included in the response.
 
-| Endpoint                           | Data Retrieved                                                                    |
-| ---------------------------------- | --------------------------------------------------------------------------------- |
-| `POST /api/v1/discogs/search`      | artwork_url, release_url, release_year, streaming URLs, artist_bio, wikipedia_url |
-| `GET /api/v1/discogs/release/{id}` | Enriched artwork_url, year, artist_id                                             |
-| `GET /api/v1/discogs/artist/{id}`  | Artist profile (bio), Wikipedia URL                                               |
+### Tubafrenzy webhook path: `POST /internal/flowsheet-webhook`
+
+1. The receiver upserts the row from the tubafrenzy event payload.
+2. The upsert uses `RETURNING { id, created: (xmax = 0) }`. The `xmax = 0` predicate distinguishes a fresh INSERT from the `ON CONFLICT DO UPDATE` branch.
+3. **Enrichment is gated on `created`.** Benign retries / no-op updates from tubafrenzy do not re-fetch from LML and do not re-write the metadata columns. This avoids amplifying CDC trigger fires + search_doc tsvector regen + 6-index updates on every duplicate webhook delivery.
+4. On INSERT, `fireAndForgetMetadataForRow` runs identically to the dj-site path.
+5. The `liveFs` SSE refetch event broadcasts immediately after the upsert (does not wait for enrichment to land — see [#628](https://github.com/WXYC/Backend-Service/issues/628) for the follow-up to re-emit after enrichment).
+
+### LML Endpoint Used
+
+| Endpoint              | Purpose                                                                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /api/v1/lookup` | Unified lookup: artist correction, title normalization, fallback strategies, artwork, streaming URLs, artist metadata in a single call |
+
+The legacy per-component endpoints (`/api/v1/discogs/search`, `/api/v1/discogs/release/{id}`, `/api/v1/discogs/artist/{id}`) are still available on LML and are used by other Backend-Service paths (catalog search, proxy endpoints), but the metadata enrichment path consolidates onto `/lookup`.
 
 ### Fallback Behavior
 
-When LML returns no results or is unavailable, the metadata service constructs search URLs for YouTube Music, Bandcamp, and SoundCloud as a bare minimum. These are generic search links, not direct album/track URLs.
+When LML returns no results or is unavailable, the metadata service constructs search URLs for YouTube Music, Bandcamp, and SoundCloud as a bare minimum. These are generic search links, not direct album/track URLs. They give iOS/dj-site at least a "search for this on $service" affordance for the long tail of releases LML can't match.
+
+## One-shot Recovery: `scripts/backfill-metadata.ts`
+
+For populating metadata on rows inserted before this enrichment was wired in (or for rows where a prior enrichment returned null because LML's cache hadn't been populated yet), there's a one-shot script:
+
+```bash
+dotenvx run -f .env -- npx tsx scripts/backfill-metadata.ts
+```
+
+Env knobs:
+
+- `BACKFILL_LIMIT` — number of entries to process (default `1000`)
+- `BACKFILL_DRY_RUN` — set `true` to preview without updating
+
+The script's WHERE filter is `WHERE artwork_url IS NULL` and it only updates rows when LML returns artwork. No-match rows are left null (so they'll be re-attempted on a future run if the LML matcher improves).
+
+For the historical tail (~1.86M legacy NULL rows as of 2026-04-28), see [#631](https://github.com/WXYC/Backend-Service/issues/631) — that work needs a containerized backfill job rather than the inline script.
 
 ## Conditional GET (304 Not Modified)
 
@@ -73,7 +102,10 @@ The flowsheet endpoints support conditional requests via the `Last-Modified` hea
 
 ## Configuration
 
-The `LIBRARY_METADATA_URL` environment variable must be set to the LML service base URL (e.g., `http://localhost:8001`). Without this, metadata fetching is silently skipped and all metadata columns remain null.
+| Env var                | Purpose                                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `LIBRARY_METADATA_URL` | LML service base URL (e.g. `http://localhost:8001`). Without this, metadata fetching is silently skipped.                |
+| `LML_API_KEY`          | Bearer token sent on every LML request. Required in production once LML's `LML_REQUIRE_AUTH` is `true`. Optional in dev. |
 
 ## Migration History
 

--- a/scripts/backfill-metadata.ts
+++ b/scripts/backfill-metadata.ts
@@ -1,8 +1,16 @@
 /**
- * Backfill metadata for recent flowsheet entries missing artwork.
+ * Backfill metadata for recent flowsheet entries missing enrichment.
  *
- * Fetches metadata from LML for the most recent 1000 track entries that have
- * null artwork_url, then updates each row with the full metadata payload.
+ * Mirrors the runtime path (`apps/backend/services/metadata/enrichment.service.ts`)
+ * exactly: every row passing the WHERE filter gets an UPDATE, including
+ * rows where LML returned no artwork. `metadata.service.ts` always fills in
+ * YouTube Music / Bandcamp / SoundCloud search-URL fallbacks regardless of
+ * whether LML found a match, so iOS / dj-site at least get a "search for
+ * this on $service" affordance for the long tail of releases LML can't pin.
+ *
+ * Idempotency: the WHERE filter excludes rows that already have the
+ * search-URL fallback populated (`bandcamp_url IS NULL`). Re-runs naturally
+ * skip rows touched by any prior enrichment, regardless of artwork status.
  *
  * Usage:
  *   dotenvx run -f .env -- npx tsx scripts/backfill-metadata.ts
@@ -32,6 +40,12 @@ async function main(): Promise<void> {
   console.log(`🔧 Backfill metadata from LML (${process.env.LIBRARY_METADATA_URL})`);
   console.log(`   Limit: ${LIMIT}, Dry run: ${DRY_RUN}`);
 
+  // Filter on `bandcamp_url IS NULL` rather than `artwork_url IS NULL`.
+  // Every successful enrichment — artwork or not — writes a non-null
+  // bandcamp_url via the search-URL fallback in metadata.service.ts. Using
+  // bandcamp_url as the "untouched" sentinel keeps re-runs idempotent: a
+  // row processed by any prior run falls out of the filter regardless of
+  // whether LML found artwork.
   const entries = await db
     .select({
       id: flowsheet.id,
@@ -40,14 +54,14 @@ async function main(): Promise<void> {
       track_title: flowsheet.track_title,
     })
     .from(flowsheet)
-    .where(and(isNull(flowsheet.artwork_url), isNotNull(flowsheet.artist_name), eq(flowsheet.entry_type, 'track')))
+    .where(and(isNull(flowsheet.bandcamp_url), isNotNull(flowsheet.artist_name), eq(flowsheet.entry_type, 'track')))
     .orderBy(desc(flowsheet.id))
     .limit(LIMIT);
 
   console.log(`\n📦 Found ${entries.length} entries to backfill.\n`);
 
-  let updated = 0;
-  let skipped = 0;
+  let withArtwork = 0;
+  let searchUrlsOnly = 0;
   let failed = 0;
 
   for (const entry of entries) {
@@ -58,34 +72,42 @@ async function main(): Promise<void> {
         trackTitle: entry.track_title ?? undefined,
       });
 
-      if (!metadata?.album?.artworkUrl) {
-        skipped++;
-        console.log(`   ⏭  #${entry.id} "${entry.artist_name}" — no artwork found`);
+      // `fetchMetadata` returns null only when LIBRARY_METADATA_URL is
+      // missing (we've already guarded that at startup). Otherwise it
+      // always returns a non-null result — search-URL fallbacks fill in
+      // whenever LML doesn't return artwork.
+      if (!metadata) {
+        failed++;
+        console.error(`   ❌ #${entry.id} "${entry.artist_name}" — fetchMetadata returned null`);
         continue;
       }
 
+      const hasArtwork = !!metadata.album?.artworkUrl;
+      const summary = hasArtwork ? `${metadata.album!.artworkUrl}` : '(no artwork; search URLs only)';
+
       if (DRY_RUN) {
-        console.log(`   🔍 #${entry.id} "${entry.artist_name}" — would set artwork_url = ${metadata.album.artworkUrl}`);
+        console.log(`   🔍 #${entry.id} "${entry.artist_name}" — would update — ${summary}`);
       } else {
         await db
           .update(flowsheet)
           .set({
-            artwork_url: metadata.album.artworkUrl ?? null,
-            discogs_url: metadata.album.discogsUrl ?? null,
-            release_year: metadata.album.releaseYear ?? null,
-            spotify_url: metadata.album.spotifyUrl ?? null,
-            apple_music_url: metadata.album.appleMusicUrl ?? null,
-            youtube_music_url: metadata.album.youtubeMusicUrl ?? null,
-            bandcamp_url: metadata.album.bandcampUrl ?? null,
-            soundcloud_url: metadata.album.soundcloudUrl ?? null,
+            artwork_url: metadata.album?.artworkUrl ?? null,
+            discogs_url: metadata.album?.discogsUrl ?? null,
+            release_year: metadata.album?.releaseYear ?? null,
+            spotify_url: metadata.album?.spotifyUrl ?? null,
+            apple_music_url: metadata.album?.appleMusicUrl ?? null,
+            youtube_music_url: metadata.album?.youtubeMusicUrl ?? null,
+            bandcamp_url: metadata.album?.bandcampUrl ?? null,
+            soundcloud_url: metadata.album?.soundcloudUrl ?? null,
             artist_bio: metadata.artist?.bio ?? null,
             artist_wikipedia_url: metadata.artist?.wikipediaUrl ?? null,
           })
           .where(eq(flowsheet.id, entry.id));
 
-        console.log(`   ✅ #${entry.id} "${entry.artist_name}" — ${metadata.album.artworkUrl}`);
+        console.log(`   ${hasArtwork ? '✅' : '🔗'} #${entry.id} "${entry.artist_name}" — ${summary}`);
       }
-      updated++;
+      if (hasArtwork) withArtwork++;
+      else searchUrlsOnly++;
     } catch (err) {
       failed++;
       console.error(`   ❌ #${entry.id} "${entry.artist_name}" — ${(err as Error).message}`);
@@ -93,9 +115,9 @@ async function main(): Promise<void> {
   }
 
   console.log('\n📊 Backfill complete:');
-  console.log(`   Updated: ${updated}`);
-  console.log(`   Skipped: ${skipped} (no artwork found)`);
-  console.log(`   Failed:  ${failed}`);
+  console.log(`   With artwork:     ${withArtwork}`);
+  console.log(`   Search URLs only: ${searchUrlsOnly}`);
+  console.log(`   Failed:           ${failed}`);
 
   await closeDatabaseConnection();
 }


### PR DESCRIPTION
## Summary

Two related changes in one PR:

1. **Converge `scripts/backfill-metadata.ts` semantics with the runtime path.** The script was the older "skip if LML returned no artwork" pattern; the deployed runtime path (`metadata.service.ts:67-79` + `enrichment.service.ts`) writes all 10 metadata columns on every successful enrichment, including no-artwork rows that get YouTube Music / Bandcamp / SoundCloud search-URL fallbacks. That's the deliberate design ("Fill missing search URLs (always available, no API calls)"). The script now matches:
   - Always UPDATE every fetched row, including no-artwork hits.
   - WHERE filter is `bandcamp_url IS NULL` (the search-URL fallback is the reliable "this row has never been enriched" sentinel) instead of `artwork_url IS NULL`. Re-runs are cleanly idempotent regardless of artwork outcome.

2. **README polish to match.** The doc would have shipped describing stale semantics. Updated to:
   - New "Always-Update Semantics" subsection explaining the `bandcamp_url`-as-sentinel convention.
   - Mermaid diagram of both write paths converging on the shared helper, with the iOS `playlist-proxy.service.ts` read path drawn as the dotted-line consumer.
   - Made the iOS-vs-dj-site SSE distinction explicit (iOS does **not** subscribe to `liveFs`; reads via `playlist-proxy.service.ts`).
   - Strengthened the `LML_API_KEY` callout to surface the silent-401-on-every-row failure mode that prompted the original investigation.
   - New "Troubleshooting" section: 5-step walk from "iOS missing artwork" through row existence, enrichment fire, LML auth, LML health, and matcher coverage. Includes the curl recipe and SQL queries used during the live debugging session.
   - Removed the "as of 2026-04-28, ~1.86M legacy NULL rows" anchor (would rot); pointer to #631 instead.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run test:unit -- metadata.service metadata.enrichment` — 15/15 passing
- Script change is filter + UPDATE-semantics only; no new code paths to test beyond the existing `fetchMetadata` coverage (which continues to pass).
- Smoke validation pre-merge: dry-run the updated script with `BACKFILL_DRY_RUN=true BACKFILL_LIMIT=10` against staging, confirm all 10 fetched rows show "would update" (including no-artwork rows that previously would have been skipped).

## Merge

Use rebase-and-merge per Backend-Service convention.
