### PR TITLE
Denormalize library.artwork_url onto flowsheet on bin-pick

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -606,6 +606,11 @@ export const getAlbumFromDB = async (album_id: number) => {
       album_title: library.album_title,
       record_label: library.label,
       label_id: library.label_id,
+      // Denormalized onto the new flowsheet row at INSERT time so dj-site
+      // and the iOS playlist-proxy see artwork immediately, without waiting
+      // for the asynchronous LML enrichment UPDATE to land. Free-form
+      // entries (no album_id) still rely on enrichment. See #628.
+      artwork_url: library.artwork_url,
     })
     .from(library)
     .innerJoin(artists, eq(artists.id, library.artist_id))

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -440,6 +440,84 @@ describe('flowsheet.controller', () => {
       });
     });
 
+    it('denormalizes artwork_url from the library row onto the new flowsheet entry on the bin-pick path (#628)', async () => {
+      // Bin-pick path eliminates the artwork race entirely when library has
+      // a cached artwork_url: the addEntry response carries the URL, so the
+      // DJ's screen renders artwork immediately rather than waiting up to
+      // 60s for the next dj-site poll to pick up the LML enrichment UPDATE.
+      const albumInfo = {
+        artist_name: 'Jessica Pratt',
+        album_title: 'On Your Own Love Again',
+        record_label: 'Drag City',
+        label_id: 31,
+        artist_id: 9,
+        artwork_url: 'https://example.com/jp-oyola.jpg',
+      };
+      mockGetAlbumFromDB.mockResolvedValue(albumInfo);
+      mockAddTrack.mockResolvedValue({
+        id: 100,
+        show_id: activeShow.id,
+        artist_name: 'Jessica Pratt',
+        album_title: 'On Your Own Love Again',
+        track_title: 'Back, Baby',
+        album_id: 12,
+        rotation_id: null,
+        play_order: 1,
+        add_time: new Date(),
+      });
+
+      const req = createMockBodyReq({
+        artist_name: 'Jessica Pratt',
+        album_title: 'On Your Own Love Again',
+        track_title: 'Back, Baby',
+        record_label: 'Drag City',
+        album_id: 12,
+      });
+      const res = createMockRes();
+
+      await addEntry(req as Request, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(mockAddTrack).toHaveBeenCalledWith(
+        expect.objectContaining({ artwork_url: 'https://example.com/jp-oyola.jpg', album_id: 12 })
+      );
+    });
+
+    it('passes through a null artwork_url when the library row has none (#628)', async () => {
+      const albumInfo = {
+        artist_name: 'Stereolab',
+        album_title: 'Aluminum Tunes',
+        record_label: 'Duophonic',
+        artist_id: 7,
+        artwork_url: null,
+      };
+      mockGetAlbumFromDB.mockResolvedValue(albumInfo);
+      mockAddTrack.mockResolvedValue({
+        id: 101,
+        show_id: activeShow.id,
+        artist_name: 'Stereolab',
+        album_title: 'Aluminum Tunes',
+        track_title: 'Cybele\u2019s Reverie',
+        album_id: 13,
+        rotation_id: null,
+        play_order: 1,
+        add_time: new Date(),
+      });
+
+      const req = createMockBodyReq({
+        artist_name: 'Stereolab',
+        album_title: 'Aluminum Tunes',
+        track_title: 'Cybele\u2019s Reverie',
+        record_label: 'Duophonic',
+        album_id: 13,
+      });
+      const res = createMockRes();
+
+      await addEntry(req as Request, res as Response, mockNext);
+
+      expect(mockAddTrack).toHaveBeenCalledWith(expect.objectContaining({ artwork_url: null, album_id: 13 }));
+    });
+
     it('delegates metadata enrichment without artistId for free-form inserts (no album_id)', async () => {
       const completedEntry = {
         id: 2,


### PR DESCRIPTION
## Summary

- The bin-pick branch of `addEntry` already calls `getAlbumFromDB` to backfill album info, but did not pull `library.artwork_url` even though the column has existed since migration 0045. This patch adds it to the SELECT so the freshly-inserted flowsheet row carries artwork at INSERT time.
- Eliminates the metadata race for bin-picks on every client surface at once: the `addEntry` HTTP response carries the URL to dj-site (which polls every 60s and won't otherwise see it for up to that long), and the playlist-proxy's synchronous `SELECT artwork_url WHERE …` on the tubafrenzy `created` event reads a non-null value.
- Free-form entries (no `album_id`) still rely on the asynchronous LML enrichment UPDATE — the second-emit + in-process proxy re-enrich tracked in the rest of #628 covers that path.

Part of #628 (does not close it; the free-form-entry second-emit fix is the remainder).

## Test plan

- [x] `tests/unit/controllers/flowsheet.controller.test.ts`: new tests for the populated and null `library.artwork_url` cases on the bin-pick path. All 36 tests in that file pass.
- [x] `prettier --check` on the touched files.
- [ ] After merge, run `SELECT count(*) FILTER (WHERE artwork_url IS NOT NULL), count(*) FROM library` against prod to confirm population is high enough that this patch does meaningful work in practice. (If population is low, this still doesn't regress — null artwork_url passes through and the LML enrichment path takes over as before.)
