### PR TITLE
Clean up stale replication slots in sync scripts

### DIFF
--- a/scripts/sync/setup-replication.sh
+++ b/scripts/sync/setup-replication.sh
@@ -5,9 +5,10 @@
 #
 # This script:
 #   1. Opens an SSH tunnel to RDS (if not already open)
-#   2. Ensures the local database schema exists (via Drizzle migrations)
+#   2. Drops any stale (inactive) replication slots on RDS
 #   3. Creates the publication on RDS (if it doesn't exist)
-#   4. Creates a subscription on the local database
+#   4. Ensures the local database schema exists (via Drizzle migrations)
+#   5. Creates a subscription on the local database
 #
 # The subscription copies all existing data (copy_data=true) and then
 # streams ongoing changes in real time. If the tunnel drops, the
@@ -100,7 +101,31 @@ fi
 
 echo "  wal_level = logical ✓"
 
-# --- Step 4: Create publication on RDS (if it doesn't exist) ---
+# --- Step 4: Drop stale replication slots on RDS ---
+
+echo ""
+echo "Checking for stale replication slots on RDS..."
+STALE_COUNT=$(PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -tAc \
+    "SELECT count(*) FROM pg_replication_slots WHERE NOT active;" 2>/dev/null)
+
+if [ "$STALE_COUNT" -gt 0 ] 2>/dev/null; then
+    echo "  Found $STALE_COUNT inactive slot(s). Dropping..."
+    PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -c "
+    DO \$\$
+    DECLARE r RECORD;
+    BEGIN
+        FOR r IN SELECT slot_name FROM pg_replication_slots WHERE NOT active
+        LOOP
+            PERFORM pg_drop_replication_slot(r.slot_name);
+            RAISE NOTICE 'Dropped stale slot: %', r.slot_name;
+        END LOOP;
+    END \$\$;
+    "
+else
+    echo "  No stale slots found."
+fi
+
+# --- Step 5: Create publication on RDS (if it doesn't exist) ---
 
 echo ""
 echo "Creating publication on RDS..."
@@ -116,7 +141,7 @@ BEGIN
 END $$;
 SQL
 
-# --- Step 5: Ensure local schema exists ---
+# --- Step 6: Ensure local schema exists ---
 
 echo ""
 echo "Ensuring local schema exists (running Drizzle migrations)..."
@@ -129,7 +154,7 @@ else
     echo "Warning: init-db.mjs not found, assuming schema exists."
 fi
 
-# --- Step 6: Create subscription on local database ---
+# --- Step 7: Create subscription on local database ---
 
 echo ""
 echo "Creating subscription on local database..."
@@ -148,7 +173,7 @@ else
     echo "Subscription local_sync created. Initial data copy starting..."
 fi
 
-# --- Step 7: Show replication status ---
+# --- Step 8: Show replication status ---
 
 echo ""
 echo "Replication status:"

--- a/scripts/sync/setup-replication.sh
+++ b/scripts/sync/setup-replication.sh
@@ -101,28 +101,20 @@ fi
 
 echo "  wal_level = logical ✓"
 
-# --- Step 4: Drop stale replication slots on RDS ---
+# --- Step 4: Drop stale local_sync replication slot on RDS ---
 
 echo ""
-echo "Checking for stale replication slots on RDS..."
-STALE_COUNT=$(PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -tAc \
-    "SELECT count(*) FROM pg_replication_slots WHERE NOT active;" 2>/dev/null)
+echo "Checking for stale local_sync replication slot on RDS..."
+SLOT_EXISTS=$(PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -tAc \
+    "SELECT 1 FROM pg_replication_slots WHERE slot_name = 'local_sync' AND NOT active;" 2>/dev/null)
 
-if [ "$STALE_COUNT" -gt 0 ] 2>/dev/null; then
-    echo "  Found $STALE_COUNT inactive slot(s). Dropping..."
-    PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -c "
-    DO \$\$
-    DECLARE r RECORD;
-    BEGIN
-        FOR r IN SELECT slot_name FROM pg_replication_slots WHERE NOT active
-        LOOP
-            PERFORM pg_drop_replication_slot(r.slot_name);
-            RAISE NOTICE 'Dropped stale slot: %', r.slot_name;
-        END LOOP;
-    END \$\$;
-    "
+if [ "$SLOT_EXISTS" = "1" ]; then
+    echo "  Found inactive local_sync slot. Dropping..."
+    PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -c \
+        "SELECT pg_drop_replication_slot('local_sync');"
+    echo "  Dropped."
 else
-    echo "  No stale slots found."
+    echo "  No stale local_sync slot found."
 fi
 
 # --- Step 5: Create publication on RDS (if it doesn't exist) ---

--- a/scripts/sync/teardown-replication.sh
+++ b/scripts/sync/teardown-replication.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Tears down PostgreSQL logical replication: drops the local subscription
-# and kills the SSH tunnel.
+# Tears down PostgreSQL logical replication: drops the local subscription,
+# drops orphaned replication slots on RDS, and kills the SSH tunnel.
 #
 # Usage:
 #   ./teardown-replication.sh
@@ -13,6 +13,7 @@
 #   LOCAL_DB_NAME      Local database name (default: wxyc_db)
 #   LOCAL_DB_USER      Local database user (default: postgres)
 #   LOCAL_DB_PASSWORD   Local database password (default: empty)
+#   REMOTE_ENV_PATH    Path to .env on EC2 (default: /home/ec2-user/.env)
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -23,6 +24,7 @@ LOCAL_DB_PORT="${LOCAL_DB_PORT:-5432}"
 LOCAL_DB_NAME="${LOCAL_DB_NAME:-wxyc_db}"
 LOCAL_DB_USER="${LOCAL_DB_USER:-postgres}"
 LOCAL_DB_PASSWORD="${LOCAL_DB_PASSWORD:-}"
+REMOTE_ENV_PATH="${REMOTE_ENV_PATH:-/home/ec2-user/.env}"
 
 # --- Drop subscription ---
 
@@ -32,6 +34,48 @@ DROP SUBSCRIPTION IF EXISTS local_sync;
 " 2>&1
 
 echo "Subscription dropped."
+
+# --- Drop orphaned replication slots on RDS ---
+
+echo ""
+echo "Checking for orphaned replication slots on RDS..."
+
+# Ensure tunnel is open so we can reach RDS
+if ! lsof -ti :"$TUNNEL_PORT" -sTCP:LISTEN &>/dev/null; then
+    echo "Opening SSH tunnel for RDS cleanup..."
+    "$SCRIPT_DIR/tunnel.sh"
+fi
+
+# Read RDS credentials
+ENV_OUTPUT=$(ssh wxyc-ec2 "grep -E '^DB_(HOST|PORT|USERNAME|PASSWORD|NAME)=' '$REMOTE_ENV_PATH'" 2>/dev/null) || true
+parse_env_var() { echo "$ENV_OUTPUT" | grep "^$1=" | head -1 | cut -d= -f2-; }
+RDS_USER=$(parse_env_var DB_USERNAME)
+RDS_PASS=$(parse_env_var DB_PASSWORD)
+RDS_NAME=$(parse_env_var DB_NAME)
+
+if [ -n "$RDS_USER" ] && [ -n "$RDS_PASS" ] && [ -n "$RDS_NAME" ]; then
+    STALE_COUNT=$(PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -tAc \
+        "SELECT count(*) FROM pg_replication_slots WHERE NOT active;" 2>/dev/null)
+
+    if [ "$STALE_COUNT" -gt 0 ] 2>/dev/null; then
+        echo "  Found $STALE_COUNT inactive slot(s). Dropping..."
+        PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -c "
+        DO \$\$
+        DECLARE r RECORD;
+        BEGIN
+            FOR r IN SELECT slot_name FROM pg_replication_slots WHERE NOT active
+            LOOP
+                PERFORM pg_drop_replication_slot(r.slot_name);
+                RAISE NOTICE 'Dropped slot: %', r.slot_name;
+            END LOOP;
+        END \$\$;
+        "
+    else
+        echo "  No orphaned slots found."
+    fi
+else
+    echo "  Warning: could not read RDS credentials — skipping slot cleanup on publisher."
+fi
 
 # --- Kill tunnel ---
 

--- a/scripts/sync/teardown-replication.sh
+++ b/scripts/sync/teardown-replication.sh
@@ -54,24 +54,16 @@ RDS_PASS=$(parse_env_var DB_PASSWORD)
 RDS_NAME=$(parse_env_var DB_NAME)
 
 if [ -n "$RDS_USER" ] && [ -n "$RDS_PASS" ] && [ -n "$RDS_NAME" ]; then
-    STALE_COUNT=$(PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -tAc \
-        "SELECT count(*) FROM pg_replication_slots WHERE NOT active;" 2>/dev/null)
+    SLOT_EXISTS=$(PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -tAc \
+        "SELECT 1 FROM pg_replication_slots WHERE slot_name = 'local_sync' AND NOT active;" 2>/dev/null)
 
-    if [ "$STALE_COUNT" -gt 0 ] 2>/dev/null; then
-        echo "  Found $STALE_COUNT inactive slot(s). Dropping..."
-        PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -c "
-        DO \$\$
-        DECLARE r RECORD;
-        BEGIN
-            FOR r IN SELECT slot_name FROM pg_replication_slots WHERE NOT active
-            LOOP
-                PERFORM pg_drop_replication_slot(r.slot_name);
-                RAISE NOTICE 'Dropped slot: %', r.slot_name;
-            END LOOP;
-        END \$\$;
-        "
+    if [ "$SLOT_EXISTS" = "1" ]; then
+        echo "  Found inactive local_sync slot. Dropping..."
+        PGPASSWORD="$RDS_PASS" psql -h localhost -p "$TUNNEL_PORT" -U "$RDS_USER" -d "$RDS_NAME" -c \
+            "SELECT pg_drop_replication_slot('local_sync');"
+        echo "  Dropped."
     else
-        echo "  No orphaned slots found."
+        echo "  No local_sync slot to clean up."
     fi
 else
     echo "  Warning: could not read RDS credentials — skipping slot cleanup on publisher."


### PR DESCRIPTION
## Summary

- `setup-replication.sh` now drops the inactive `local_sync` replication slot on RDS before creating a new subscription
- `teardown-replication.sh` now connects to RDS via tunnel and drops the `local_sync` slot on the publisher side, with graceful fallback if RDS credentials are unavailable
- Scoped to the `local_sync` slot only — other subscribers' slots are not touched

Closes #648

## Test plan

- [ ] Run `setup-replication.sh` twice — second run should drop the first run's slot cleanly
- [ ] Run `teardown-replication.sh` — verify `local_sync` is gone from `pg_replication_slots` on RDS
- [ ] Run `teardown-replication.sh` without RDS credentials accessible — verify graceful warning, no crash