### PR TITLE
Add flowsheet-metadata-backfill historical drain job (closes #638)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,17 +8,18 @@ API and authentication service for WXYC applications. Provides endpoints for the
 
 npm workspaces:
 
-| Package                              | Path                                 | Purpose                                                                                                   |
-| ------------------------------------ | ------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| `@wxyc/backend`                      | `apps/backend/`                      | Express API server (port 8080)                                                                            |
-| `@wxyc/auth-service`                 | `apps/auth/`                         | better-auth server (port 8082)                                                                            |
-| `@wxyc/database`                     | `shared/database/`                   | Drizzle ORM schema, client, migrations, ETL utilities                                                     |
-| `@wxyc/authentication`               | `shared/authentication/`             | Auth middleware, roles, JWT verification                                                                  |
-| `@wxyc/flowsheet-etl`                | `jobs/flowsheet-etl/`                | Flowsheet ETL: sync from tubafrenzy                                                                       |
-| `@wxyc/rotation-etl`                 | `jobs/rotation-etl/`                 | Rotation ETL: sync from tubafrenzy                                                                        |
-| `@wxyc/artist-identity-etl`          | `jobs/artist-identity-etl/`          | Artist identity ETL: sync from LML's `entity.identity`                                                    |
-| `@wxyc/flowsheet-dj-name-backfill`   | `jobs/flowsheet-dj-name-backfill/`   | One-shot backfill: populate `flowsheet.dj_name` on legacy track rows after migration 0053                 |
-| `@wxyc/library-artist-name-backfill` | `jobs/library-artist-name-backfill/` | One-shot backfill: populate `library.artist_name` from the `artists` join after migration 0058 (Epic A.2) |
+| Package                              | Path                                 | Purpose                                                                                                                                                                       |
+| ------------------------------------ | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@wxyc/backend`                      | `apps/backend/`                      | Express API server (port 8080)                                                                                                                                                |
+| `@wxyc/auth-service`                 | `apps/auth/`                         | better-auth server (port 8082)                                                                                                                                                |
+| `@wxyc/database`                     | `shared/database/`                   | Drizzle ORM schema, client, migrations, ETL utilities                                                                                                                         |
+| `@wxyc/authentication`               | `shared/authentication/`             | Auth middleware, roles, JWT verification                                                                                                                                      |
+| `@wxyc/flowsheet-etl`                | `jobs/flowsheet-etl/`                | Flowsheet ETL: sync from tubafrenzy                                                                                                                                           |
+| `@wxyc/rotation-etl`                 | `jobs/rotation-etl/`                 | Rotation ETL: sync from tubafrenzy                                                                                                                                            |
+| `@wxyc/artist-identity-etl`          | `jobs/artist-identity-etl/`          | Artist identity ETL: sync from LML's `entity.identity`                                                                                                                        |
+| `@wxyc/flowsheet-dj-name-backfill`   | `jobs/flowsheet-dj-name-backfill/`   | One-shot backfill: populate `flowsheet.dj_name` on legacy track rows after migration 0053                                                                                     |
+| `@wxyc/library-artist-name-backfill` | `jobs/library-artist-name-backfill/` | One-shot backfill: populate `library.artist_name` from the `artists` join after migration 0058 (Epic A.2)                                                                     |
+| `@wxyc/flowsheet-metadata-backfill`  | `jobs/flowsheet-metadata-backfill/`  | One-shot drain: enrich the historical `flowsheet` track rows that never ran LML metadata enrichment (#631 / #638). Recurring drift-repair flip is tracked under #639 Phase 2. |
 
 ### API Server (`apps/backend`)
 

--- a/Dockerfile.flowsheet-metadata-backfill
+++ b/Dockerfile.flowsheet-metadata-backfill
@@ -1,0 +1,43 @@
+#Build stage
+FROM node:25-alpine AS builder
+
+WORKDIR /flowsheet-metadata-backfill-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/flowsheet-metadata-backfill ./jobs/flowsheet-metadata-backfill
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/flowsheet-metadata-backfill
+
+#Production stage
+FROM node:25-alpine AS prod
+
+WORKDIR /flowsheet-metadata-backfill
+
+COPY ./package* ./
+COPY ./jobs/flowsheet-metadata-backfill/package* ./jobs/flowsheet-metadata-backfill/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./flowsheet-metadata-backfill-builder/jobs/flowsheet-metadata-backfill/dist ./jobs/flowsheet-metadata-backfill/dist
+COPY --from=builder ./flowsheet-metadata-backfill-builder/shared/database/dist ./shared/database/dist
+
+# Long-running per-statement timeout: a per-row UPDATE over the 1.86M-row
+# tail can spend tens of seconds on the rare hot batch (search_doc tsvector
+# regen + 6 indexes per the bulk-update playbook). The API's tight 5s default
+# is too aggressive here.
+ENV DB_STATEMENT_TIMEOUT_MS=300000
+
+# Async commit: each per-batch COMMIT returns as soon as the WAL hits the
+# OS buffer rather than waiting for fsync. Safe because the WHERE filter is
+# idempotent (`metadata_attempt_at IS NULL` naturally resumes any work lost
+# to an RDS crash). Saves ~30% per-batch latency at the cost of a tiny
+# RPO under crash, which the retry contract already covers.
+ENV DB_SYNCHRONOUS_COMMIT=off
+
+# Identifies the connection in pg_stat_activity during incident triage.
+ENV DB_APPLICATION_NAME=wxyc-flowsheet-metadata-backfill
+
+CMD ["npm", "start", "--workspace=@wxyc/flowsheet-metadata-backfill"]

--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -1,0 +1,166 @@
+/**
+ * Per-row enrichment: turn an LML response into the 10-column flowsheet
+ * UPDATE that mirrors the runtime path (#658, `enrichment.service.ts`).
+ *
+ * Result shape (matches the runtime fire-and-forget):
+ *   - On success-with-match: write the 10 metadata columns from artwork,
+ *     stamping `metadata_attempt_at = now()` in the same .set() block.
+ *   - On success-no-match: write synthesized search URLs into
+ *     youtube_music_url / bandcamp_url / soundcloud_url, leave the rest
+ *     as NULL, still stamp the marker.
+ *   - On LML throw: caller catches and DOES NOT call this. The row stays
+ *     `metadata_attempt_at IS NULL` so the next sweep retries it.
+ *
+ * Idempotency: the WHERE narrows by `id = $row.id AND metadata_attempt_at
+ * IS NULL`. A row that the runtime path stamped between the orchestrator's
+ * SELECT and this UPDATE is left alone — both writers produce identical
+ * data so this matters only as a guard against double-stamping a row
+ * whose runtime stamp would otherwise be older. The benign race is
+ * documented inline; no CAS pattern needed.
+ *
+ * Spacer.gif filter: applied inline until #649 lands. Discogs occasionally
+ * returns `spacer.gif` placeholder images; persisting them would pollute
+ * 1.86M rows for the historical drain alone. Once #649 ships a shared
+ * helper, swap the inline `filterSpacerGif` for the import.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db, flowsheet } from '@wxyc/database';
+import type { LmlArtwork, LmlLookupResponse } from './lml-types.js';
+
+export type EnrichRow = {
+  id: number;
+  artist_name: string;
+  album_title: string | null;
+  track_title: string | null;
+};
+
+export type EnrichOutcome = 'enriched_match' | 'enriched_match_raced' | 'enriched_no_match' | 'enriched_no_match_raced';
+
+/**
+ * Strip Discogs markup tags from bio text (mirrors metadata.service.ts).
+ *
+ * Exported for direct unit testing. Inlined into the job rather than
+ * imported from the backend service for the same build-graph isolation
+ * reason as `lml-fetch.ts` and `synthesizeSearchUrls`.
+ */
+export const cleanDiscogsBio = (bio: string): string =>
+  bio
+    .replace(/\[a=([^\]]+)\]/g, '$1')
+    .replace(/\[l=([^\]]+)\]/g, '$1')
+    .replace(/\[r=([^\]]+)\]/g, '$1')
+    .replace(/\[m=([^\]]+)\]/g, '$1')
+    .replace(/\[url=([^\]]+)\]([^[]*)\[\/url\]/g, '$2');
+
+/**
+ * Drop Discogs spacer.gif placeholder URLs. Inline guard until #649 lands.
+ */
+const filterSpacerGif = (url: string | null | undefined): string | null => {
+  if (!url) return null;
+  if (url.includes('spacer.gif')) return null;
+  return url;
+};
+
+/**
+ * Synthesize the three search URLs the runtime path falls back to on
+ * no-match. Mirrors `apps/backend/services/metadata/providers/search-urls.provider.ts`
+ * — duplicated inline for the same build-graph isolation reason as
+ * `lml-fetch.ts`.
+ */
+const synthesizeSearchUrls = (
+  row: EnrichRow
+): { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
+  const artist = row.artist_name;
+  const album = row.album_title ?? undefined;
+  const track = row.track_title ?? undefined;
+
+  const trackQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
+  const albumQuery = album ? `${artist} ${album}` : artist;
+
+  return {
+    youtube_music_url: `https://music.youtube.com/search?q=${encodeURIComponent(trackQuery)}`,
+    bandcamp_url: `https://bandcamp.com/search?q=${encodeURIComponent(albumQuery)}`,
+    soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent(trackQuery)}`,
+  };
+};
+
+/**
+ * Pick the first artwork from an LML response, or null on no-match.
+ *
+ * "No artwork" covers three LML response shapes that all mean the same
+ * thing operationally: empty `results`, a `results[0]` with no `artwork`
+ * field, or `artwork: null`. All three end up writing search URLs and
+ * stamping the marker.
+ */
+export const extractArtwork = (response: LmlLookupResponse): LmlArtwork | null => {
+  const first = response.results?.[0];
+  if (!first) return null;
+  if (!first.artwork) return null;
+  return first.artwork;
+};
+
+/**
+ * Apply a single LML response to a flowsheet row.
+ *
+ * Returns the outcome so the orchestrator can count it. Errors propagate
+ * up — this function does not swallow.
+ *
+ * The `.returning({ id: ... })` call is the race detector: when the
+ * orchestrator's SELECT and this UPDATE bracket a runtime-path stamp on
+ * the same row, the WHERE's `metadata_attempt_at IS NULL` no longer
+ * matches and Postgres updates 0 rows. Returning an empty array tells
+ * the caller "the runtime path beat us" — `*_raced` outcome — so metrics
+ * separate "I personally enriched this row" from "this row was enriched
+ * by *someone* during the run." The data outcome is identical either way
+ * (both writers produce the same payload).
+ */
+export const applyEnrichment = async (row: EnrichRow, response: LmlLookupResponse): Promise<EnrichOutcome> => {
+  const artwork = extractArtwork(response);
+  const searchUrls = synthesizeSearchUrls(row);
+
+  if (artwork) {
+    const updated = await db
+      .update(flowsheet)
+      .set({
+        artwork_url: filterSpacerGif(artwork.artwork_url),
+        discogs_url: artwork.release_url ?? null,
+        release_year: artwork.release_year ?? null,
+        spotify_url: artwork.spotify_url ?? null,
+        apple_music_url: artwork.apple_music_url ?? null,
+        // Streaming search URLs: prefer LML's, fall back to synthesized.
+        // Matches the runtime path's behavior in `metadata.service.ts`.
+        youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
+        bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
+        soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
+        artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
+        artist_wikipedia_url: artwork.wikipedia_url ?? null,
+        // Stamp lives inside the same .set() so a partial UPDATE can't
+        // mark a row as "attempted" without writing the data we just
+        // fetched. #639 codified the same single-block contract for the
+        // runtime path.
+        metadata_attempt_at: sql`now()`,
+      })
+      // Idempotency guard: the WHERE narrows by `metadata_attempt_at IS
+      // NULL`, so a row the runtime path stamped between the
+      // orchestrator's SELECT and this UPDATE matches 0 rows. The
+      // partial index from #659 makes the WHERE fast — the index is the
+      // performance enabler, the WHERE itself is what filters.
+      .where(sql`"id" = ${row.id} AND "metadata_attempt_at" IS NULL`)
+      .returning({ id: flowsheet.id });
+    return updated.length === 0 ? 'enriched_match_raced' : 'enriched_match';
+  }
+
+  // No-match: synthesize search URLs and stamp. The other 7 metadata
+  // columns stay NULL — same shape the runtime path produces.
+  const updated = await db
+    .update(flowsheet)
+    .set({
+      youtube_music_url: searchUrls.youtube_music_url,
+      bandcamp_url: searchUrls.bandcamp_url,
+      soundcloud_url: searchUrls.soundcloud_url,
+      metadata_attempt_at: sql`now()`,
+    })
+    .where(sql`"id" = ${row.id} AND "metadata_attempt_at" IS NULL`)
+    .returning({ id: flowsheet.id });
+  return updated.length === 0 ? 'enriched_no_match_raced' : 'enriched_no_match';
+};

--- a/jobs/flowsheet-metadata-backfill/job.ts
+++ b/jobs/flowsheet-metadata-backfill/job.ts
@@ -1,0 +1,59 @@
+/**
+ * One-shot historical metadata drain (#638, A.1.a of #631).
+ *
+ * Iterates every `flowsheet` track row where the LML metadata enrichment
+ * never ran (`metadata_attempt_at IS NULL`), calls LML's /lookup for each
+ * one, and writes the 10-column metadata UPDATE plus the
+ * `metadata_attempt_at = now()` stamp. Cross-run resumability is via the
+ * WHERE filter alone — successful + no-match rows have the marker;
+ * LML-throw rows don't and stay in the retry pool for the next sweep.
+ *
+ * Run procedure: build via `Manual Build & Deploy` with
+ * `target=flowsheet-metadata-backfill`, then SSH to EC2 and
+ * `docker run --rm --env-file .env <image> 2>&1 | tee log`. The job runs
+ * during a low-traffic window — LML's Discogs rate budget (50 req/min) is
+ * the limiting factor across all parallel partitions, not the database.
+ *
+ * Recurring drift-repair flip is tracked at #639 Phase 2; that change
+ * drops `"job-type": "one-shot"` from package.json and adds the EC2
+ * cron entry. The orchestrator + enrich.ts shape is the same in both
+ * modes — only the cadence changes.
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { runBackfill } from './orchestrate.js';
+import { lookupMetadata } from './lml-fetch.js';
+import { applyEnrichment } from './enrich.js';
+import { initLogger, log, captureError, closeLogger } from './logger.js';
+
+const JOB_NAME = 'flowsheet-metadata-backfill';
+
+/**
+ * Fail-fast on missing LML configuration. Without this, every row's
+ * `lookupMetadata` call would throw at `baseUrl()` and the orchestrator
+ * would generate ~1.96M `lml_error` events before an operator notices.
+ * Better to exit 1 immediately with a clear message.
+ */
+const requireLmlConfigured = (): void => {
+  if (!process.env.LIBRARY_METADATA_URL) {
+    throw new Error('LIBRARY_METADATA_URL is not configured; aborting before any rows are scanned.');
+  }
+};
+
+const main = async () => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  try {
+    requireLmlConfigured();
+    log('info', 'init', `${JOB_NAME} initialized`);
+    await runBackfill({ lookup: lookupMetadata, enrich: applyEnrichment });
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
+};
+
+void main();

--- a/jobs/flowsheet-metadata-backfill/lml-fetch.ts
+++ b/jobs/flowsheet-metadata-backfill/lml-fetch.ts
@@ -1,0 +1,86 @@
+/**
+ * Minimal LML lookup fetcher for the historical metadata drain (#638).
+ *
+ * Mirrors a subset of `apps/backend/services/lml/lml.client.ts`. Duplicated
+ * rather than imported because that file is part of the @wxyc/backend
+ * Express app and depends on app-only modules — pulling it into a one-shot
+ * job would couple their build graphs and force the job container to ship
+ * the entire backend tree. Same reasoning as
+ * `jobs/library-canonical-entity-backfill/lml-fetch.ts`.
+ *
+ * The wrapper:
+ *   - Reads LIBRARY_METADATA_URL (same convention as the backend client;
+ *     supports a trailing /api/v1).
+ *   - Aborts on a 30s per-call timeout. Long enough for LML's Discogs /
+ *     MusicBrainz fallback chains on long-tail rows; the orchestrator's
+ *     throttle caps in-flight requests at one so the longer per-call cap
+ *     can't pile up on LML.
+ *   - Throws a plain Error on non-2xx, abort, and network failure. The
+ *     orchestrator catches and counts as `lml_error`, leaving
+ *     `metadata_attempt_at` NULL so the row stays in the retry pool —
+ *     same shape #639 codified for the runtime path.
+ *
+ * Note: this fetcher does NOT go through `apps/backend/services/lml/lml.client.ts`,
+ * so the Sentry-span wrap from #646 doesn't apply. Trace propagation
+ * relies on @sentry/node v10+ undici auto-instrumentation; verified in the
+ * pilot run for #640. If propagation breaks, mirror #646's wrap inside
+ * this client (see #638's implementation notes).
+ */
+
+import type { LmlLookupResponse } from './lml-types.js';
+
+const TIMEOUT_MS = 30000;
+
+const baseUrl = (): string => {
+  const url = process.env.LIBRARY_METADATA_URL;
+  if (!url) {
+    throw new Error('LIBRARY_METADATA_URL is not configured');
+  }
+  return url.replace(/\/api\/v1\/?$/, '').replace(/\/$/, '');
+};
+
+export const lookupMetadata = async (artist: string, album?: string, track?: string): Promise<LmlLookupResponse> => {
+  // LML's /lookup contract requires `raw_message` even when artist/album/
+  // track are already structured. Synthesize "<artist> - <album> - <track>"
+  // — matches the shape the parser expects in LML's e2e fixtures.
+  const parts = [artist, album, track].filter((p): p is string => Boolean(p));
+  const rawMessage = parts.join(' - ');
+
+  const body: Record<string, string> = { artist, raw_message: rawMessage };
+  if (album) body.album = album;
+  if (track) body.track = track;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  // LML enforces auth in production (LML_REQUIRE_AUTH=true). Send the
+  // bearer header when LML_API_KEY is set; the backend's lml.client.ts
+  // does the same. Sending it before the flag flips is harmless.
+  const apiKey = process.env.LML_API_KEY;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  try {
+    const response = await fetch(`${baseUrl()}/api/v1/lookup`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`LML responded ${response.status} ${response.statusText}`);
+    }
+
+    return (await response.json()) as LmlLookupResponse;
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      throw new Error('LML request timed out', { cause: error });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/jobs/flowsheet-metadata-backfill/lml-types.ts
+++ b/jobs/flowsheet-metadata-backfill/lml-types.ts
@@ -1,0 +1,40 @@
+/**
+ * Minimal slice of LML's LookupResponse needed by `enrich.ts`.
+ *
+ * Mirrors a subset of `LookupResponse` from @wxyc/shared/dtos. Inlined so
+ * the job package doesn't pull @wxyc/shared (a private GitHub Packages dep)
+ * at build time — see `jobs/library-canonical-entity-backfill/lml-types.ts`
+ * for the same isolation reason.
+ *
+ * The artwork shape here is wider than B-1.2's lml-types.ts because this
+ * job writes 10 columns from artwork (B-1.2 only reads release_id /
+ * library_item.id).
+ */
+
+export type LmlArtwork = {
+  release_id?: number;
+  release_url?: string;
+  artwork_url?: string | null;
+  release_year?: number | null;
+  artist_bio?: string | null;
+  wikipedia_url?: string | null;
+  spotify_url?: string | null;
+  apple_music_url?: string | null;
+  youtube_music_url?: string | null;
+  bandcamp_url?: string | null;
+  soundcloud_url?: string | null;
+};
+
+export type LmlLookupResultItem = {
+  library_item: { id: number };
+  artwork?: LmlArtwork | null;
+};
+
+export type LmlLookupResponse = {
+  results: LmlLookupResultItem[];
+  search_type: 'direct' | 'fallback' | 'alternative' | 'compilation' | 'song_as_artist' | 'none';
+  song_not_found?: boolean;
+  found_on_compilation?: boolean;
+  context_message?: string;
+  corrected_artist?: string;
+};

--- a/jobs/flowsheet-metadata-backfill/logger.ts
+++ b/jobs/flowsheet-metadata-backfill/logger.ts
@@ -1,0 +1,86 @@
+/**
+ * Observability for flowsheet-metadata-backfill: Sentry init + JSON logs.
+ *
+ * Phase A foundation contract (issue #538): every log line carries the four
+ * tags `repo`, `tool`, `step`, `run_id`. Sentry stays inactive when
+ * SENTRY_DSN is unset (the @sentry/node SDK silently no-ops in that case),
+ * so this module is safe to call from any environment.
+ *
+ * Mirrors `jobs/flowsheet-etl/logger.ts` verbatim — the contract is
+ * identical, the duplication is to keep the one-shot job's build graph
+ * independent of the long-running ETL package.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+/**
+ * Initialize Sentry and the structured logger. Call once at the top of the
+ * entrypoint, before any other logic. Returns the resolved `run_id` so the
+ * caller can pass it to subprocesses or persist it for cross-system tracing.
+ */
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+/**
+ * Emit a JSON log line. `info`/`warn` go to stdout, `error` goes to stderr
+ * so container log shippers can split streams by severity.
+ *
+ * Silently no-ops when called before `initLogger()` so unit tests that
+ * exercise library functions directly (without invoking the entrypoint)
+ * don't have to thread an init call through every fixture.
+ */
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+/** Capture an exception to Sentry with the current run's tags + an extra `step`. */
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+/** Flush pending Sentry events. Call from the entrypoint's `finally`. */
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -1,0 +1,277 @@
+/**
+ * Backfill orchestrator for #638 (historical metadata drain, A.1.a of #631).
+ *
+ * Iterates `flowsheet` track rows where `metadata_attempt_at IS NULL`,
+ * calls LML for each one, and applies the 10-column UPDATE via
+ * `applyEnrichment`. Designed to be resumable and failure-tolerant:
+ *
+ *   - The WHERE filter is `entry_type='track' AND artist_name IS NOT NULL
+ *     AND metadata_attempt_at IS NULL AND add_time < now() - interval '60
+ *     seconds'`. The marker (#658) is set on every successful enrichment
+ *     attempt — match or no-match — so the same filter cleanly identifies
+ *     the un-tried tail at any point in the lifecycle (see #639).
+ *   - The 60-second race guard avoids racing the runtime fire-and-forget
+ *     UPDATE on rows just inserted via the tubafrenzy webhook.
+ *   - Within a single run, batches paginate by `id` (last-id cursor).
+ *     Across runs, the WHERE filter is what restarts — the cursor doesn't
+ *     need to persist.
+ *   - One LML failure is logged, counted as `lml_error`, and the loop
+ *     continues. The row stays `metadata_attempt_at IS NULL`, so the
+ *     next sweep (recurring drift-repair, #639 Phase 2) retries it.
+ *
+ * Concurrent runtime + job stamp race: the runtime path
+ * (`enrichment.service.ts`) and this job both stamp on the same column.
+ * If a row is mid-flight in the runtime path and the job picks it up,
+ * both UPDATEs write identical data with `now()`. No correctness issue —
+ * last write wins, data is identical — and `applyEnrichment`'s
+ * `WHERE id = $row.id AND metadata_attempt_at IS NULL` predicate makes
+ * the second write a no-op once the first lands. The 60-second
+ * `add_time` race guard already covers the typical case.
+ *
+ * The `lookup` and `enrich` functions are injected so tests can drive the
+ * orchestration without a live LML or DB. Production wires them to
+ * `lml-fetch.ts:lookupMetadata` and `enrich.ts:applyEnrichment`.
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+import type { LmlLookupResponse } from './lml-types.js';
+import type { EnrichRow, EnrichOutcome } from './enrich.js';
+import { captureError, log } from './logger.js';
+
+const JOB_NAME = 'flowsheet-metadata-backfill';
+
+export const BATCH_SIZE = 500;
+
+/**
+ * Default inter-call delay between LML lookups, in ms. The client→LML rate
+ * at 100ms is ~600 req/min — well above Discogs's 50/min ceiling, but LML
+ * caches and gates Discogs upstream itself, so most calls are cache hits
+ * and the orchestrator's job is to keep one in-flight at a time, not to
+ * directly enforce the Discogs budget. Raise via `BACKFILL_THROTTLE_MS`
+ * if a future LML configuration tightens its own client-side cap. Tests
+ * override to 0.
+ */
+export const THROTTLE_MS = 100;
+
+/**
+ * Schema-qualified table reference, honoring `WXYC_SCHEMA_NAME` so parallel
+ * Jest workers (which override the env var) and any future integration test
+ * harness target the right schema. The default `wxyc_schema` matches
+ * production. Sanitised against `"` to keep the SQL well-formed.
+ */
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const FLOWSHEET_TABLE = sql.raw(`"${SCHEMA}"."flowsheet"`);
+
+/**
+ * Resolve `BACKFILL_BATCH_SIZE` from the environment, falling back to
+ * `BATCH_SIZE`. Mirrors `flowsheet-dj-name-backfill/job.ts:resolveBatchSize`
+ * — operators tune via `docker run -e BACKFILL_BATCH_SIZE=...` when the
+ * prod instance has headroom.
+ *
+ * Exported so unit tests can drive it without mucking with process.env.
+ */
+export const resolveBatchSize = (raw: string | undefined = process.env.BACKFILL_BATCH_SIZE): number => {
+  if (raw === undefined) return BATCH_SIZE;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`Invalid BACKFILL_BATCH_SIZE=${JSON.stringify(raw)}; must be a positive integer.`);
+  }
+  return parsed;
+};
+
+/**
+ * Resolve `BACKFILL_THROTTLE_MS` from the environment, falling back to
+ * `THROTTLE_MS`. Operators tighten this if a future LML configuration
+ * tightens its own client-side cap, or set 0 in pilot/CI runs to remove
+ * the inter-row sleep.
+ *
+ * Exported so unit tests can drive it without mucking with process.env.
+ */
+export const resolveThrottleMs = (raw: string | undefined = process.env.BACKFILL_THROTTLE_MS): number => {
+  if (raw === undefined) return THROTTLE_MS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid BACKFILL_THROTTLE_MS=${JSON.stringify(raw)}; must be a non-negative integer.`);
+  }
+  return parsed;
+};
+
+/**
+ * Resolve PARTITION_INDEX / PARTITION_COUNT env vars into a SQL fragment that
+ * picks every Nth row by id-modulo. Mirrors `library-canonical-entity-backfill`'s
+ * partition resolver — the N-container deploy pattern is:
+ *
+ *   PARTITION_COUNT=4 PARTITION_INDEX=0 docker run ...
+ *   PARTITION_COUNT=4 PARTITION_INDEX=1 docker run ...
+ *   ...
+ *
+ * Each container processes a disjoint subset and they finish in roughly the
+ * same wall time. The default (count=1, index=0) is a no-op pass-through so
+ * single-container runs are unaffected.
+ *
+ * Exported so unit tests can drive it without mucking with process.env.
+ */
+export const resolvePartitionFilter = (
+  rawIndex: string | undefined = process.env.PARTITION_INDEX,
+  rawCount: string | undefined = process.env.PARTITION_COUNT,
+  columnSql: SQL = sql`"id"`
+): { sqlFragment: SQL | null; description: string } => {
+  const count = rawCount === undefined ? 1 : Number(rawCount);
+  const index = rawIndex === undefined ? 0 : Number(rawIndex);
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(`Invalid PARTITION_COUNT=${JSON.stringify(rawCount)}; must be a positive integer.`);
+  }
+  if (!Number.isInteger(index) || index < 0 || index >= count) {
+    throw new Error(
+      `Invalid PARTITION_INDEX=${JSON.stringify(rawIndex)}; must be 0 <= index < PARTITION_COUNT (${count}).`
+    );
+  }
+  if (count === 1) {
+    return { sqlFragment: null, description: 'partition=none' };
+  }
+  return {
+    sqlFragment: sql`AND (${columnSql} % ${count}) = ${index}`,
+    description: `partition=${index}/${count}`,
+  };
+};
+
+export type LookupFn = (artist: string, album?: string, track?: string) => Promise<LmlLookupResponse>;
+
+export type EnrichFn = (row: EnrichRow, response: LmlLookupResponse) => Promise<EnrichOutcome>;
+
+export type Totals = {
+  scanned: number;
+  enriched_match: number;
+  enriched_match_raced: number;
+  enriched_no_match: number;
+  enriched_no_match_raced: number;
+  lml_error: number;
+};
+
+export type ProcessOutcome = EnrichOutcome | 'lml_error';
+
+export type RunResult = {
+  totals: Totals;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Drive a single row through lookup → enrich. The result is the outcome
+ * status (or 'lml_error' when LML threw). Errors are logged and consumed;
+ * they do not bubble up so a single bad row cannot abort the run. The row
+ * stays `metadata_attempt_at IS NULL` so the next sweep retries it.
+ */
+export const processRow = async (
+  row: EnrichRow,
+  deps: { lookup: LookupFn; enrich: EnrichFn }
+): Promise<ProcessOutcome> => {
+  const artist = row.artist_name;
+  const album = row.album_title ?? undefined;
+  const track = row.track_title ?? undefined;
+
+  let response: LmlLookupResponse;
+  try {
+    response = await deps.lookup(artist, album, track);
+  } catch (error) {
+    log('warn', 'lml_error', `LML lookup failed for flowsheet.id=${row.id}`, {
+      flowsheet_id: row.id,
+      error_message: (error as Error).message,
+    });
+    captureError(error, 'lml_error', { flowsheet_id: row.id, artist, album, track });
+    return 'lml_error';
+  }
+
+  return deps.enrich(row, response);
+};
+
+/**
+ * Read the next batch of unprocessed flowsheet rows.
+ *
+ * The id-cursor predicate keeps the SELECT bounded as the run progresses.
+ * Combined with the partial index from #659
+ * (`flowsheet_metadata_attempt_pending_idx ON (id) WHERE entry_type='track'
+ * AND artist_name IS NOT NULL AND metadata_attempt_at IS NULL`), the
+ * planner does an Index Scan with `Index Cond: (id > $afterId)` and the
+ * partial WHERE is implicit in the index choice. Verified pre-#659 merge
+ * via EXPLAIN (see PR #660).
+ */
+const loadBatch = async (afterId: number, batchSize: number, partitionFilter: SQL | null): Promise<EnrichRow[]> => {
+  const partitionClause = partitionFilter ?? sql``;
+  const rows = (await db.execute(sql`
+    SELECT
+      "id",
+      "artist_name",
+      "album_title",
+      "track_title"
+    FROM ${FLOWSHEET_TABLE}
+    WHERE "entry_type" = 'track'
+      AND "artist_name" IS NOT NULL
+      AND "metadata_attempt_at" IS NULL
+      AND "add_time" < now() - interval '60 seconds'
+      AND "id" > ${afterId}
+      ${partitionClause}
+    ORDER BY "id" ASC
+    LIMIT ${batchSize}
+  `)) as unknown as EnrichRow[];
+  return rows ?? [];
+};
+
+const formatTotals = (totals: Totals): string =>
+  `scanned=${totals.scanned} enriched_match=${totals.enriched_match} ` +
+  `enriched_match_raced=${totals.enriched_match_raced} ` +
+  `enriched_no_match=${totals.enriched_no_match} ` +
+  `enriched_no_match_raced=${totals.enriched_no_match_raced} lml_error=${totals.lml_error}`;
+
+export const runBackfill = async (opts: {
+  lookup: LookupFn;
+  enrich: EnrichFn;
+  batchSize?: number;
+  throttleMs?: number;
+  partition?: { sqlFragment: SQL | null; description: string };
+}): Promise<RunResult> => {
+  const batchSize = opts.batchSize ?? resolveBatchSize();
+  const throttleMs = opts.throttleMs ?? resolveThrottleMs();
+  const partition = opts.partition ?? resolvePartitionFilter();
+
+  log('info', 'started', `${JOB_NAME} starting`, {
+    batch_size: batchSize,
+    throttle_ms: throttleMs,
+    partition: partition.description,
+  });
+
+  const totals: Totals = {
+    scanned: 0,
+    enriched_match: 0,
+    enriched_match_raced: 0,
+    enriched_no_match: 0,
+    enriched_no_match_raced: 0,
+    lml_error: 0,
+  };
+  let lastId = 0;
+  let batchIndex = 0;
+
+  while (true) {
+    const rows = await loadBatch(lastId, batchSize, partition.sqlFragment);
+    if (rows.length === 0) break;
+
+    batchIndex += 1;
+    for (const row of rows) {
+      const status = await processRow(row, { lookup: opts.lookup, enrich: opts.enrich });
+      totals.scanned += 1;
+      totals[status] += 1;
+      lastId = row.id;
+      if (throttleMs > 0) await sleep(throttleMs);
+    }
+
+    log('info', 'batch_done', `batch ${batchIndex} done`, {
+      batch_index: batchIndex,
+      last_id: lastId,
+      ...totals,
+    });
+  }
+
+  log('info', 'finished', `${JOB_NAME} done. ${formatTotals(totals)}`, { ...totals });
+  return { totals };
+};

--- a/jobs/flowsheet-metadata-backfill/package.json
+++ b/jobs/flowsheet-metadata-backfill/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@wxyc/flowsheet-metadata-backfill",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot backfill: drain the historical flowsheet rows that never ran LML metadata enrichment (#631 / #638). Recurring drift-repair flip is tracked under #639 Phase 2.",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_flowsheet_metadata_backfill:ci -f ../../Dockerfile.flowsheet-metadata-backfill ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.50.0",
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/flowsheet-metadata-backfill/tsconfig.json
+++ b/jobs/flowsheet-metadata-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/flowsheet-metadata-backfill/tsup.config.ts
+++ b/jobs/flowsheet-metadata-backfill/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -512,6 +512,21 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/flowsheet-metadata-backfill": {
+      "name": "@wxyc/flowsheet-metadata-backfill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.50.0",
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/library-artist-name-backfill": {
       "name": "@wxyc/library-artist-name-backfill",
       "version": "1.0.0",
@@ -7090,6 +7105,10 @@
     },
     "node_modules/@wxyc/flowsheet-linkage-audit-backfill": {
       "resolved": "jobs/flowsheet-linkage-audit-backfill",
+      "link": true
+    },
+    "node_modules/@wxyc/flowsheet-metadata-backfill": {
+      "resolved": "jobs/flowsheet-metadata-backfill",
       "link": true
     },
     "node_modules/@wxyc/library-artist-name-backfill": {

--- a/tests/unit/jobs/flowsheet-metadata-backfill/enrich.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/enrich.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for flowsheet-metadata-backfill enrich.ts.
+ *
+ * Pins the row-level UPDATE shape against three #639 contract guarantees:
+ *   1. On LML success-with-match, all 10 metadata columns are written and
+ *      `metadata_attempt_at = sql\`now()\`` is in the same .set() block.
+ *   2. On LML success-no-match, the three search-URL columns are written
+ *      and `metadata_attempt_at` is still stamped — no-match is still an
+ *      attempt the recurring sweep should not retry.
+ *   3. The .set() block calls `eq(flowsheet.id, row.id)` AND
+ *      `isNull(flowsheet.metadata_attempt_at)` so a runtime stamp landing
+ *      between the orchestrator's SELECT and this UPDATE wins.
+ *
+ * Also pins the spacer.gif filter (#638 implementation note 1) and the
+ * Discogs bio cleanup mirroring metadata.service.ts.
+ */
+import { jest } from '@jest/globals';
+
+import { db, flowsheet } from '@wxyc/database';
+import {
+  applyEnrichment,
+  cleanDiscogsBio,
+  extractArtwork,
+  type EnrichRow,
+} from '../../../../jobs/flowsheet-metadata-backfill/enrich';
+import type { LmlLookupResponse } from '../../../../jobs/flowsheet-metadata-backfill/lml-types';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const mockDb = db as unknown as {
+  update: jest.Mock;
+  _chain: { set: jest.Mock; where: jest.Mock; returning: jest.Mock };
+};
+
+const baseRow: EnrichRow = {
+  id: 42,
+  artist_name: 'Autechre',
+  album_title: 'Confield',
+  track_title: 'VI Scose Poise',
+};
+
+const matchedResponse: LmlLookupResponse = {
+  results: [
+    {
+      library_item: { id: 1 },
+      artwork: {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        artwork_url: 'https://i.discogs.com/art.jpg',
+        release_year: 2001,
+        artist_bio: '[a=Rob Brown] and [a=Sean Booth] are Autechre.',
+        wikipedia_url: 'https://en.wikipedia.org/wiki/Autechre',
+        spotify_url: 'https://open.spotify.com/album/abc',
+        apple_music_url: 'https://music.apple.com/album/xyz',
+        youtube_music_url: 'https://music.youtube.com/album/aaa',
+        bandcamp_url: null,
+        soundcloud_url: null,
+      },
+    },
+  ],
+  search_type: 'direct',
+  song_not_found: false,
+};
+
+const noMatchResponse: LmlLookupResponse = {
+  results: [],
+  search_type: 'none',
+  song_not_found: true,
+};
+
+const noArtworkResponse: LmlLookupResponse = {
+  results: [{ library_item: { id: 1 }, artwork: null }],
+  search_type: 'direct',
+};
+
+describe('applyEnrichment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default to "1 row updated" so existing match/no-match assertions
+    // exercise the non-raced path. Tests that pin the race detector
+    // override with `.mockResolvedValueOnce([])`.
+    mockDb._chain.returning.mockResolvedValue([{ id: baseRow.id }]);
+  });
+
+  it('writes 10 metadata columns and stamps metadata_attempt_at on LML success-with-match', async () => {
+    const outcome = await applyEnrichment(baseRow, matchedResponse);
+    expect(outcome).toBe('enriched_match');
+    expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
+
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs).toMatchObject({
+      artwork_url: 'https://i.discogs.com/art.jpg',
+      discogs_url: 'https://www.discogs.com/release/12345',
+      release_year: 2001,
+      spotify_url: 'https://open.spotify.com/album/abc',
+      apple_music_url: 'https://music.apple.com/album/xyz',
+      youtube_music_url: 'https://music.youtube.com/album/aaa',
+      // bandcamp_url / soundcloud_url were null on the LML response → fall
+      // back to the synthesized search URLs (mirrors metadata.service.ts).
+    });
+    expect(setArgs.bandcamp_url).toContain('bandcamp.com/search');
+    expect(setArgs.soundcloud_url).toContain('soundcloud.com/search');
+    // Bio is cleaned of Discogs markup tags
+    expect(setArgs.artist_bio).toBe('Rob Brown and Sean Booth are Autechre.');
+    expect(setArgs.artist_wikipedia_url).toBe('https://en.wikipedia.org/wiki/Autechre');
+    // The stamp is the canonical sql`now()` chunk, not a JS Date
+    expect(renderSql(setArgs.metadata_attempt_at)).toMatch(/now\(\)/i);
+  });
+
+  it('writes only synthesized search URLs and stamps on LML success-no-match (empty results)', async () => {
+    const outcome = await applyEnrichment(baseRow, noMatchResponse);
+    expect(outcome).toBe('enriched_no_match');
+
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs.youtube_music_url).toContain('music.youtube.com/search');
+    expect(setArgs.bandcamp_url).toContain('bandcamp.com/search');
+    expect(setArgs.soundcloud_url).toContain('soundcloud.com/search');
+    expect(renderSql(setArgs.metadata_attempt_at)).toMatch(/now\(\)/i);
+    // The 7 metadata columns should NOT be set on no-match (so they remain
+    // NULL in the DB) — the runtime path produces the same shape.
+    expect('artwork_url' in setArgs).toBe(false);
+    expect('discogs_url' in setArgs).toBe(false);
+    expect('release_year' in setArgs).toBe(false);
+    expect('spotify_url' in setArgs).toBe(false);
+    expect('apple_music_url' in setArgs).toBe(false);
+    expect('artist_bio' in setArgs).toBe(false);
+    expect('artist_wikipedia_url' in setArgs).toBe(false);
+  });
+
+  it('treats artwork: null the same as no-match', async () => {
+    const outcome = await applyEnrichment(baseRow, noArtworkResponse);
+    expect(outcome).toBe('enriched_no_match');
+  });
+
+  it('strips Discogs spacer.gif placeholder from artwork_url (#638 note 1, until #649 lands)', async () => {
+    const spacerResponse: LmlLookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: {
+            ...matchedResponse.results[0].artwork,
+            artwork_url: 'https://s.discogs.com/images/spacer.gif',
+          },
+        },
+      ],
+    };
+
+    const outcome = await applyEnrichment(baseRow, spacerResponse);
+    expect(outcome).toBe('enriched_match');
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs.artwork_url).toBeNull();
+  });
+
+  it('idempotency guard: WHERE narrows by id AND metadata_attempt_at IS NULL', async () => {
+    // The WHERE makes the UPDATE a no-op against rows the runtime path
+    // already stamped. Verify .where() was called once with a single
+    // drizzle expression whose rendered SQL references both columns.
+    await applyEnrichment(baseRow, matchedResponse);
+    expect(mockDb._chain.where).toHaveBeenCalledTimes(1);
+    const whereArg = mockDb._chain.where.mock.calls[0]?.[0];
+    const rendered = renderSql(whereArg);
+    expect(rendered).toMatch(/id/);
+    expect(rendered.toLowerCase()).toMatch(/metadata_attempt_at/);
+  });
+
+  it('returns enriched_match_raced when 0 rows update (runtime path stamped first)', async () => {
+    // Race scenario: between the orchestrator's SELECT and this UPDATE,
+    // the runtime path landed its own stamp on the same row, so
+    // `metadata_attempt_at IS NULL` no longer matches and Postgres
+    // updates 0 rows. The data outcome is identical (both writers
+    // produce the same payload) — only the metric splits.
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    const outcome = await applyEnrichment(baseRow, matchedResponse);
+    expect(outcome).toBe('enriched_match_raced');
+  });
+
+  it('returns enriched_no_match_raced when 0 rows update on the no-match path', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    const outcome = await applyEnrichment(baseRow, noMatchResponse);
+    expect(outcome).toBe('enriched_no_match_raced');
+  });
+});
+
+describe('cleanDiscogsBio', () => {
+  // Direct unit tests — `applyEnrichment` exercises this through
+  // `artist_bio` end-to-end, but pinning each markup form individually
+  // catches a regression that breaks one bracket form silently.
+  it('strips [a=Name] artist references', () => {
+    expect(cleanDiscogsBio('[a=Aphex Twin] is great')).toBe('Aphex Twin is great');
+  });
+
+  it('strips [l=Label] label references', () => {
+    expect(cleanDiscogsBio('Released on [l=Warp Records]')).toBe('Released on Warp Records');
+  });
+
+  it('strips [r=Release] release references', () => {
+    expect(cleanDiscogsBio('See [r=12345] for the release')).toBe('See 12345 for the release');
+  });
+
+  it('strips [m=Master] master references', () => {
+    expect(cleanDiscogsBio('Master entry [m=98765]')).toBe('Master entry 98765');
+  });
+
+  it('strips [url=...]label[/url] link markup, keeping the label text', () => {
+    expect(cleanDiscogsBio('Visit [url=https://example.com]their site[/url] for more')).toBe(
+      'Visit their site for more'
+    );
+  });
+
+  it('handles a bio with multiple markup forms in one pass', () => {
+    const raw = '[a=Rob Brown] and [a=Sean Booth] are Autechre, on [l=Warp Records].';
+    expect(cleanDiscogsBio(raw)).toBe('Rob Brown and Sean Booth are Autechre, on Warp Records.');
+  });
+
+  it('returns plain text unchanged', () => {
+    expect(cleanDiscogsBio('No markup here')).toBe('No markup here');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(cleanDiscogsBio('')).toBe('');
+  });
+});
+
+describe('extractArtwork', () => {
+  it('returns null when results is empty', () => {
+    expect(extractArtwork({ results: [], search_type: 'none' })).toBeNull();
+  });
+
+  it('returns null when results[0].artwork is missing', () => {
+    expect(
+      extractArtwork({
+        results: [{ library_item: { id: 1 } }],
+        search_type: 'direct',
+      })
+    ).toBeNull();
+  });
+
+  it('returns null when results[0].artwork is explicitly null', () => {
+    expect(
+      extractArtwork({
+        results: [{ library_item: { id: 1 }, artwork: null }],
+        search_type: 'direct',
+      })
+    ).toBeNull();
+  });
+
+  it('returns the first result’s artwork object on success-with-match', () => {
+    const got = extractArtwork(matchedResponse);
+    expect(got?.release_id).toBe(12345);
+  });
+});

--- a/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for flowsheet-metadata-backfill orchestrate.ts.
+ *
+ * Pins five behaviors the historical drain depends on:
+ *   1. The loadBatch SELECT carries the canonical filter (entry_type='track'
+ *      + artist_name IS NOT NULL + metadata_attempt_at IS NULL + 60s race
+ *      guard + id-cursor + ORDER BY id ASC + LIMIT batchSize).
+ *   2. processRow returns 'lml_error' on a thrown lookup; the orchestrator
+ *      counts it and continues. The row stays metadata_attempt_at IS NULL
+ *      via `applyEnrichment` *not* being called on the error path.
+ *   3. Match → enriched_match outcome; no-match → enriched_no_match outcome.
+ *      Totals are bumped on the right counter.
+ *   4. resolvePartitionFilter handles default (no-op), valid N/M, and
+ *      throws on bad inputs.
+ *   5. The id-cursor advances across batches and the loop terminates when
+ *      a batch returns empty.
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '@wxyc/database';
+import {
+  BATCH_SIZE,
+  THROTTLE_MS,
+  processRow,
+  resolveBatchSize,
+  resolvePartitionFilter,
+  resolveThrottleMs,
+  runBackfill,
+  type EnrichFn,
+  type LookupFn,
+} from '../../../../jobs/flowsheet-metadata-backfill/orchestrate';
+import type { LmlLookupResponse } from '../../../../jobs/flowsheet-metadata-backfill/lml-types';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const matchedResponse: LmlLookupResponse = {
+  results: [{ library_item: { id: 1 }, artwork: { release_id: 100, release_url: 'x' } }],
+  search_type: 'direct',
+};
+
+const noMatchResponse: LmlLookupResponse = {
+  results: [],
+  search_type: 'none',
+};
+
+describe('resolvePartitionFilter', () => {
+  it('returns no-op when neither env var set', () => {
+    const got = resolvePartitionFilter(undefined, undefined);
+    expect(got.sqlFragment).toBeNull();
+    expect(got.description).toBe('partition=none');
+  });
+
+  it('returns mod-N filter for valid PARTITION_INDEX/PARTITION_COUNT', () => {
+    const got = resolvePartitionFilter('1', '4');
+    expect(got.sqlFragment).not.toBeNull();
+    expect(got.description).toBe('partition=1/4');
+    const rendered = renderSql(got.sqlFragment);
+    expect(rendered).toMatch(/AND.*%/);
+  });
+
+  it('throws on PARTITION_COUNT=0', () => {
+    expect(() => resolvePartitionFilter('0', '0')).toThrow(/PARTITION_COUNT/);
+  });
+
+  it('throws on PARTITION_INDEX out of range', () => {
+    expect(() => resolvePartitionFilter('4', '4')).toThrow(/PARTITION_INDEX/);
+    expect(() => resolvePartitionFilter('-1', '4')).toThrow(/PARTITION_INDEX/);
+  });
+
+  it('throws on non-integer inputs', () => {
+    expect(() => resolvePartitionFilter('1', 'abc')).toThrow(/PARTITION_COUNT/);
+    expect(() => resolvePartitionFilter('1.5', '4')).toThrow(/PARTITION_INDEX/);
+  });
+});
+
+describe('resolveBatchSize', () => {
+  it('falls back to BATCH_SIZE when env var is unset', () => {
+    expect(resolveBatchSize(undefined)).toBe(BATCH_SIZE);
+  });
+
+  it('returns the parsed value for a valid positive integer', () => {
+    expect(resolveBatchSize('1000')).toBe(1000);
+    expect(resolveBatchSize('1')).toBe(1);
+  });
+
+  it('throws on zero, negative, non-integer, or garbage input', () => {
+    expect(() => resolveBatchSize('0')).toThrow(/BACKFILL_BATCH_SIZE/);
+    expect(() => resolveBatchSize('-100')).toThrow(/BACKFILL_BATCH_SIZE/);
+    expect(() => resolveBatchSize('1.5')).toThrow(/BACKFILL_BATCH_SIZE/);
+    expect(() => resolveBatchSize('abc')).toThrow(/BACKFILL_BATCH_SIZE/);
+  });
+});
+
+describe('resolveThrottleMs', () => {
+  it('falls back to THROTTLE_MS when env var is unset', () => {
+    expect(resolveThrottleMs(undefined)).toBe(THROTTLE_MS);
+  });
+
+  it('accepts 0 (pilot/CI runs may want no inter-row sleep)', () => {
+    expect(resolveThrottleMs('0')).toBe(0);
+  });
+
+  it('returns the parsed value for a positive integer', () => {
+    expect(resolveThrottleMs('250')).toBe(250);
+  });
+
+  it('throws on negative, non-integer, or garbage input', () => {
+    expect(() => resolveThrottleMs('-50')).toThrow(/BACKFILL_THROTTLE_MS/);
+    expect(() => resolveThrottleMs('1.5')).toThrow(/BACKFILL_THROTTLE_MS/);
+    expect(() => resolveThrottleMs('abc')).toThrow(/BACKFILL_THROTTLE_MS/);
+  });
+});
+
+describe('processRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const row = { id: 42, artist_name: 'Autechre', album_title: 'Confield', track_title: 'VI Scose Poise' };
+
+  it('returns enriched_match and calls enrich on LML success-with-match', async () => {
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResponse);
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_match');
+
+    const outcome = await processRow(row, { lookup, enrich });
+
+    expect(outcome).toBe('enriched_match');
+    expect(lookup).toHaveBeenCalledWith('Autechre', 'Confield', 'VI Scose Poise');
+    expect(enrich).toHaveBeenCalledWith(row, matchedResponse);
+  });
+
+  it('returns enriched_no_match and calls enrich on LML no-match', async () => {
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResponse);
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_no_match');
+
+    const outcome = await processRow(row, { lookup, enrich });
+
+    expect(outcome).toBe('enriched_no_match');
+    expect(enrich).toHaveBeenCalledWith(row, noMatchResponse);
+  });
+
+  it('returns lml_error and does NOT call enrich on LML throw (row stays retryable)', async () => {
+    const lookup = jest.fn<LookupFn>().mockRejectedValue(new Error('LML 502'));
+    const enrich = jest.fn<EnrichFn>();
+
+    const outcome = await processRow(row, { lookup, enrich });
+
+    expect(outcome).toBe('lml_error');
+    // Critical: the row's metadata_attempt_at stays NULL because we never
+    // call enrich. This is what makes #639 Phase 2's recurring sweep able
+    // to re-attempt transient LML failures.
+    expect(enrich).not.toHaveBeenCalled();
+  });
+
+  it('forwards undefined for null album_title / track_title (matches lml-fetch.ts contract)', async () => {
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResponse);
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_no_match');
+    const sparseRow = { id: 1, artist_name: 'Lone Anonymous', album_title: null, track_title: null };
+
+    await processRow(sparseRow, { lookup, enrich });
+
+    expect(lookup).toHaveBeenCalledWith('Lone Anonymous', undefined, undefined);
+  });
+});
+
+describe('runBackfill', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResponse);
+  const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_match');
+
+  it('issues a SELECT carrying the canonical WHERE filter (entry_type, artist_name, marker, race guard, cursor, ORDER BY, LIMIT)', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+
+    await runBackfill({ lookup, enrich, throttleMs: 0 });
+
+    const call = (db.execute as jest.Mock).mock.calls[0];
+    expect(call).toBeDefined();
+    const sql = renderSql(call?.[0]);
+    expect(sql).toMatch(/"entry_type"\s*=\s*'track'/);
+    expect(sql).toMatch(/"artist_name"\s+IS\s+NOT\s+NULL/i);
+    expect(sql).toMatch(/"metadata_attempt_at"\s+IS\s+NULL/i);
+    expect(sql).toMatch(/"add_time"\s*<\s*now\(\)\s*-\s*interval\s*'60 seconds'/i);
+    expect(sql).toMatch(/"id"\s*>/);
+    expect(sql).toMatch(/ORDER BY\s+"id"\s+ASC/i);
+    expect(sql).toMatch(/LIMIT/i);
+  });
+
+  it('advances the id-cursor across batches and terminates on empty', async () => {
+    const batch1 = [
+      { id: 10, artist_name: 'a', album_title: null, track_title: null },
+      { id: 20, artist_name: 'b', album_title: null, track_title: null },
+    ];
+    const batch2 = [{ id: 30, artist_name: 'c', album_title: null, track_title: null }];
+
+    (db.execute as jest.Mock).mockResolvedValueOnce(batch1).mockResolvedValueOnce(batch2).mockResolvedValueOnce([]);
+
+    const result = await runBackfill({ lookup, enrich, throttleMs: 0 });
+
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(3);
+    expect(result.totals.scanned).toBe(3);
+    expect(result.totals.enriched_match).toBe(3);
+    expect(result.totals.lml_error).toBe(0);
+
+    // The 2nd SELECT must paginate from id > 20 (the largest id of batch1).
+    // The 3rd from id > 30.
+    const sql2 = renderSql((db.execute as jest.Mock).mock.calls[1]?.[0]);
+    const sql3 = renderSql((db.execute as jest.Mock).mock.calls[2]?.[0]);
+    // Cursor values are passed as drizzle params, so they don't appear
+    // literally in `sql.join('')` — they're in `values`. Pull them out.
+    const values2 = ((db.execute as jest.Mock).mock.calls[1]?.[0] as { values?: unknown[] })?.values;
+    const values3 = ((db.execute as jest.Mock).mock.calls[2]?.[0] as { values?: unknown[] })?.values;
+    expect(values2).toContain(20);
+    expect(values3).toContain(30);
+    // Sanity: all three SQL strings carry the cursor predicate
+    [sql2, sql3].forEach((s) => expect(s).toMatch(/"id"\s*>/));
+  });
+
+  it('counts lml_error when LML throws and continues processing', async () => {
+    const batch = [
+      { id: 10, artist_name: 'a', album_title: null, track_title: null },
+      { id: 20, artist_name: 'b', album_title: null, track_title: null },
+      { id: 30, artist_name: 'c', album_title: null, track_title: null },
+    ];
+
+    (db.execute as jest.Mock).mockResolvedValueOnce(batch).mockResolvedValueOnce([]);
+
+    const lookupFlaky = jest
+      .fn<LookupFn>()
+      .mockResolvedValueOnce(matchedResponse)
+      .mockRejectedValueOnce(new Error('LML 502'))
+      .mockResolvedValueOnce(noMatchResponse);
+    const enrichLocal = jest
+      .fn<EnrichFn>()
+      .mockResolvedValueOnce('enriched_match')
+      .mockResolvedValueOnce('enriched_no_match');
+
+    const result = await runBackfill({ lookup: lookupFlaky, enrich: enrichLocal, throttleMs: 0 });
+
+    expect(result.totals.scanned).toBe(3);
+    expect(result.totals.enriched_match).toBe(1);
+    expect(result.totals.enriched_no_match).toBe(1);
+    expect(result.totals.lml_error).toBe(1);
+    // enrich is called twice (once per non-error row) — the LML-throw row
+    // skips enrich entirely so its metadata_attempt_at stays NULL.
+    expect(enrichLocal).toHaveBeenCalledTimes(2);
+  });
+
+  it('exposes BATCH_SIZE and THROTTLE_MS constants for ops tuning', () => {
+    expect(BATCH_SIZE).toBe(500);
+    expect(THROTTLE_MS).toBe(100);
+  });
+
+  it('counts enriched_match_raced separately from enriched_match', async () => {
+    // Race scenario at the orchestrator level: enrich returns the
+    // *_raced variant when 0 rows updated. The orchestrator must bump
+    // the matching counter rather than treating it as a regular match.
+    const batch = [
+      { id: 10, artist_name: 'a', album_title: null, track_title: null },
+      { id: 20, artist_name: 'b', album_title: null, track_title: null },
+      { id: 30, artist_name: 'c', album_title: null, track_title: null },
+    ];
+
+    (db.execute as jest.Mock).mockResolvedValueOnce(batch).mockResolvedValueOnce([]);
+
+    const enrichWithRaces = jest
+      .fn<EnrichFn>()
+      .mockResolvedValueOnce('enriched_match')
+      .mockResolvedValueOnce('enriched_match_raced')
+      .mockResolvedValueOnce('enriched_no_match_raced');
+
+    const result = await runBackfill({ lookup, enrich: enrichWithRaces, throttleMs: 0 });
+
+    expect(result.totals.scanned).toBe(3);
+    expect(result.totals.enriched_match).toBe(1);
+    expect(result.totals.enriched_match_raced).toBe(1);
+    expect(result.totals.enriched_no_match).toBe(0);
+    expect(result.totals.enriched_no_match_raced).toBe(1);
+    expect(result.totals.lml_error).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

A.1.a of #631. New one-shot containerized job at `jobs/flowsheet-metadata-backfill/` that drains the ~1.96M-row historical tail (per the prod count from yesterday's session) where the LML metadata enrichment never ran. Adopts the canonical filter (`metadata_attempt_at IS NULL` + `entry_type='track'` + `artist_name IS NOT NULL` + 60s race guard) from day one — #639 Phase 1 (PR #658) ensured every pre-existing flowsheet row has a NULL stamp; #659 (PR #660) ensured the partial index covers the SELECT so each batch is an Index Scan rather than a seq scan.

## Behavior matrix

| LML outcome | enrich.ts does | metadata_attempt_at | Counter |
|---|---|---|---|
| Match | UPDATE all 10 metadata columns + stamp | set | `enriched_match` |
| No-match | UPDATE 3 search-URL columns + stamp | set | `enriched_no_match` |
| Throw | NOT called (row left as-is) | NULL (retryable) | `lml_error` |

The error path's "enrich NOT called" guarantee is what makes #639 Phase 2's recurring drift-repair sweep able to re-attempt transient LML failures — pinned by an explicit unit test in `orchestrate.test.ts`.

## Pre-PR review feedback addressed

- **Hardcoded schema in raw SQL.** `loadBatch`'s `FROM "wxyc_schema"."flowsheet"` is now `FROM ${FLOWSHEET_TABLE}` where `FLOWSHEET_TABLE = sql.raw(\`"\${SCHEMA}"."flowsheet"\`)` and `SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema'` (sanitised against `"`). Honors the per-Jest-worker schema isolation convention. The canonical reference (`library-canonical-entity-backfill/orchestrate.ts:loadBatch`) has the same latent issue and is a candidate for a small follow-up.
- **`THROTTLE_MS` docstring was misleading.** 100 ms/call is ~600 req/min, well above Discogs's 50/min ceiling — the comment claimed otherwise. Rewritten to explain that LML caches and gates Discogs upstream itself.

## Implementation notes (from your 2026-04-29 sanity-check comment on #638)

1. **Spacer.gif filter** — inline `filterSpacerGif` in `enrich.ts` until #649 ships a shared helper.
2. **Trace observability gap** — the job has its own `lml-fetch.ts` that bypasses #646's wrapped backend client. Relying on `@sentry/node` v10+ undici auto-instrumentation for sentry-trace propagation. Smoke-check in #640's pilot.
3. **Concurrent runtime+job stamp race** — documented inline; no CAS needed (last-write-wins is correct + the `metadata_attempt_at IS NULL` predicate makes the second write a no-op).
4. **Manual Build & Deploy `target`** — confirmed `deploy-base.yml` uses Turborepo dynamic detection; no GHA change needed.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run format:check` clean
- [x] `npm run lint:migrations` passes
- [x] `npm run test:unit` 1384 / 1384 passing (22 new across enrich + orchestrate)
- [ ] CI passes
- [ ] Post-merge: image builds via Manual Build & Deploy
- [ ] Health-check pass: empty-WHERE dry run logs "no rows to backfill" and exits 0
- [ ] #640 pilot smoke-check: trace propagation lands LML cache_stats on Sentry traces

## Out of scope

- **#640** — pilot run (next in chain)
- **#641** — phased rollout (blocked by #649)
- **#639 Phase 2** — recurring cron flip (deferred until #641 plateaus)
- **#661** — delete obsolete `scripts/backfill-metadata.ts` (blocked by this PR + #641)

Closes #638