### PR TITLE
Honor WXYC_SCHEMA_NAME in library-canonical-entity-backfill orchestrator

### DIFF
--- a/jobs/library-canonical-entity-backfill/orchestrate.ts
+++ b/jobs/library-canonical-entity-backfill/orchestrate.ts
@@ -26,6 +26,17 @@ import { resolveCanonicalEntity, type Resolution } from './resolve.js';
 
 const JOB_NAME = 'library-canonical-entity-backfill';
 
+/**
+ * Schema-qualified table references, honoring `WXYC_SCHEMA_NAME` so parallel
+ * Jest workers (which override the env var) and any future integration test
+ * harness target the right schema. The default `wxyc_schema` matches
+ * production. Sanitised against `"` to keep the SQL well-formed. Same
+ * shape as `jobs/flowsheet-metadata-backfill/orchestrate.ts` (PR #673).
+ */
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const LIBRARY_TABLE = sql.raw(`"${SCHEMA}"."library"`);
+const ARTISTS_TABLE = sql.raw(`"${SCHEMA}"."artists"`);
+
 export const BATCH_SIZE = 500;
 
 /**
@@ -115,7 +126,7 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 export const applyResolution = async (libraryId: number, resolution: Resolution): Promise<void> => {
   if (resolution.status === 'auto_accept') {
     await db.execute(sql`
-      UPDATE "wxyc_schema"."library"
+      UPDATE ${LIBRARY_TABLE}
       SET "canonical_entity_id" = ${resolution.canonical_entity_id},
           "canonical_entity_confidence" = ${resolution.confidence},
           "canonical_entity_resolved_at" = now()
@@ -127,7 +138,7 @@ export const applyResolution = async (libraryId: number, resolution: Resolution)
 
   if (resolution.status === 'review') {
     await db.execute(sql`
-      UPDATE "wxyc_schema"."library"
+      UPDATE ${LIBRARY_TABLE}
       SET "canonical_entity_resolved_at" = now()
       WHERE "id" = ${libraryId}
         AND "canonical_entity_id" IS NULL
@@ -190,8 +201,8 @@ const loadBatch = async (afterId: number, batchSize: number, partitionFilter: SQ
       l."id",
       a."artist_name" AS "artist_name",
       l."album_title"
-    FROM "wxyc_schema"."library" l
-    LEFT JOIN "wxyc_schema"."artists" a ON a."id" = l."artist_id"
+    FROM ${LIBRARY_TABLE} l
+    LEFT JOIN ${ARTISTS_TABLE} a ON a."id" = l."artist_id"
     WHERE l."canonical_entity_id" IS NULL
       AND l."canonical_entity_resolved_at" IS NULL
       AND l."id" > ${afterId}

--- a/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-canonical-entity-backfill/orchestrate.test.ts
@@ -25,24 +25,67 @@ import {
 import type { Resolution } from '../../../../jobs/library-canonical-entity-backfill/resolve';
 import type { LmlLookupResponse } from '../../../../jobs/library-canonical-entity-backfill/lml-types';
 
+/**
+ * Render a drizzle `sql` template object to a string for substring
+ * assertions. Drizzle's `db.execute(sql\`...\`)` argument serializes to
+ * `{ sql: string[], values: unknown[] }` where `sql` is the literal
+ * template fragments and `values` is the interpolated parameters in
+ * positional order. Reconstruct the rendered SQL by interleaving them.
+ *
+ * Each value can itself be a nested `sql.raw(...)` chunk (whose
+ * `queryChunks` re-fold into `value: string[]`), or a parameter, or
+ * another nested SQL template — recurse where applicable.
+ */
+type SqlChunk = {
+  value?: string | string[];
+  queryChunks?: SqlChunk[];
+  raw?: string;
+};
 type SqlLike = {
   sql?: string | string[];
-  queryChunks?: Array<string | { value?: string | string[] }>;
+  values?: unknown[];
+  queryChunks?: Array<string | SqlChunk>;
+  raw?: string;
 };
 const renderSql = (value: unknown): string => {
   const obj = value as SqlLike | null | undefined;
   if (!obj) return '';
-  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (Array.isArray(obj.sql)) {
+    const fragments = obj.sql;
+    const values = obj.values ?? [];
+    let out = '';
+    for (let i = 0; i < fragments.length; i++) {
+      out += fragments[i];
+      if (i < values.length) out += renderValue(values[i]);
+    }
+    return out;
+  }
   if (typeof obj.sql === 'string') return obj.sql;
   if (obj.queryChunks) {
     return obj.queryChunks
       .map((chunk) => {
         if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.queryChunks)) return renderSql(chunk);
         if (Array.isArray(chunk.value)) return chunk.value.join('');
         if (typeof chunk.value === 'string') return chunk.value;
         return '';
       })
       .join('');
+  }
+  return '';
+};
+
+/** Render a single interpolated value: strings/numbers verbatim, nested SQL recursively. */
+const renderValue = (v: unknown): string => {
+  if (v == null) return '';
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return String(v);
+  if (typeof v === 'object') {
+    const o = v as SqlChunk & SqlLike;
+    // sql.raw(...) serializes to { raw: string }
+    if (typeof o.raw === 'string') return o.raw;
+    if (Array.isArray(o.queryChunks) || Array.isArray(o.sql)) return renderSql(o);
+    if (Array.isArray(o.value)) return o.value.join('');
+    if (typeof o.value === 'string') return o.value;
   }
   return '';
 };


### PR DESCRIPTION
## Summary

Same schema-honoring fix that PR #673 applied to `flowsheet-metadata-backfill`, applied to the canonical reference job that #673's reviewer specifically called out as having the same latent issue.

`loadBatch`'s SELECT and `applyResolution`'s two UPDATEs no longer hardcode `"wxyc_schema"."library"` / `"wxyc_schema"."artists"` — they read `WXYC_SCHEMA_NAME` from the env at module load (sanitised against `"`) and interpolate via `sql.raw(...)`. Production targets the default `wxyc_schema` so behavior is unchanged. The fix matters for parallel Jest workers (which set the env var per worker for schema isolation) and any future integration test harness.

## Test renderer extended

The existing `renderSql` helper folded only the literal template fragments (`obj.sql.join('')`); interpolated values were dropped. Now that table names live in interpolations, the four assertions that match `FROM "wxyc_schema"."library"` etc. would have failed against the changed SQL. Helper extended to:

1. Walk `obj.sql` + `obj.values` together, interleaving literals and rendered values.
2. Render `sql.raw(...)` chunks via their `{ raw: string }` serialization shape.
3. Recurse into nested `sql\`...\`` chunks.

Result: the four assertions pass against the rendered output regardless of whether the table name is a literal fragment or an interpolated raw chunk. The renderer is more robust against future test churn.

## Out of scope

The broader sweep of other backfills with the same hardcoded-schema issue (`flowsheet-dj-name-backfill`, `library-artist-name-backfill`, `broken-fk-recovery`, `flowsheet-etl`, `flowsheet-linkage-audit-backfill`, `linkage-metrics.service.ts`, `library-tiebreak.ts`, `review-linkage.ts`) is filed as a separate follow-up so this PR stays bounded to the case PR #673's reviewer flagged.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run format:check` clean
- [x] `npm run lint:migrations` passes
- [x] `npm run test:unit -- --testPathPatterns='library-canonical-entity-backfill'` 30/30 (full suite has unrelated `internal.route` flake)
- [ ] CI passes
- [ ] Post-merge: `Auto Build & Deploy` rebuilds + redeploys `library-canonical-entity-backfill`. No behavioral change in prod.