### PR TITLE
Document the no-match divergence between runtime + backfill enrichment (comment-only)

### DIFF
--- a/apps/backend/services/metadata/enrichment.service.ts
+++ b/apps/backend/services/metadata/enrichment.service.ts
@@ -36,6 +36,16 @@ export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
   })
     .then(async (metadata) => {
       if (!metadata) return;
+      // The `?? null` on the 7 non-search-URL columns nulls them on
+      // no-match. Safe here because the runtime path runs at insert
+      // time on fresh rows — there's nothing to overwrite. The
+      // backfill (`jobs/flowsheet-metadata-backfill/enrich.ts`) takes
+      // the opposite stance on no-match (preserves prior values)
+      // because it runs over rows the recovery script may have
+      // populated. See that file's no-match branch for the rationale;
+      // if the runtime ever runs over rows with prior values
+      // (e.g., a re-enrichment trigger), this side should adopt the
+      // same preserve semantics.
       await db
         .update(flowsheet)
         .set({

--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -150,8 +150,24 @@ export const applyEnrichment = async (row: EnrichRow, response: LmlLookupRespons
     return updated.length === 0 ? 'enriched_match_raced' : 'enriched_match';
   }
 
-  // No-match: synthesize search URLs and stamp. The other 7 metadata
-  // columns stay NULL — same shape the runtime path produces.
+  // No-match: synthesize search URLs and stamp. Critically, the other 7
+  // metadata columns are NOT touched. This diverges from the runtime path
+  // (`apps/backend/services/metadata/enrichment.service.ts`) — the
+  // runtime nulls all 10 columns on no-match because it runs at insert
+  // time over fresh rows with nothing to lose.
+  //
+  // The backfill encounters rows that may already have prior values from
+  // out-of-band paths: the 2026-04-28 inline recovery
+  // (`scripts/backfill-metadata.ts`) wrote the full 10-column payload to
+  // ~618 rows pre-#658, so their `metadata_attempt_at` is NULL even
+  // though `artwork_url` / `discogs_url` / etc are populated. If LML now
+  // returns no-match for such a row, the recovery's prior data is the
+  // better signal and should be preserved. Nulling here would be silent
+  // data loss.
+  //
+  // The divergence is intentional, not a bug. Future: if the runtime
+  // path ever needs to run over rows with prior values (e.g., a
+  // re-enrichment trigger), it should adopt the same preserve semantics.
   const updated = await db
     .update(flowsheet)
     .set({


### PR DESCRIPTION
## Summary

Comment-only PR. The runtime path (`apps/backend/services/metadata/enrichment.service.ts`) and the historical drain backfill (`jobs/flowsheet-metadata-backfill/enrich.ts`) diverge on LML's no-match outcome. Until now the divergence was implicit; this PR makes it explicit in both files so a future contributor doesn't silently "harmonise" them and lose recovered data.

## The divergence

| Path | What happens on LML no-match |
|---|---|
| Runtime (`enrichment.service.ts:.then`) | Nulls all 10 metadata columns + writes 3 synthesized search URLs + stamps marker |
| Backfill (`enrich.ts` no-match branch) | Writes 3 synthesized search URLs + stamps marker, **preserves the other 7** |

## Why the divergence is correct

- **Runtime nulls fresh rows.** The runtime fires at insert time, so the row has no prior values. `?? null` is safe.
- **Backfill encounters rows with prior values.** The 2026-04-28 inline recovery (`scripts/backfill-metadata.ts`, ~618 rows) wrote the full 10-column payload pre-#658, so those rows have `metadata_attempt_at IS NULL` even though `artwork_url` / `discogs_url` / etc are populated. If LML now returns no-match for such a row, the recovery's prior data is the better signal and should be preserved. Nulling here would be silent data loss.

## Why this PR (rather than letting it stay implicit)

The current `enrich.ts` no-match comment claims "The other 7 metadata columns stay NULL — same shape the runtime path produces." That's factually wrong: the columns aren't NULL, they're untouched, and the shape is *not* the same as the runtime's. A future contributor reading that comment could legitimately decide to "fix" the divergence by nulling the columns to match the runtime, and silently lose the recovery data on every no-match row.

This PR replaces that comment with the accurate divergence rationale and adds a cross-pointer in `enrichment.service.ts` so a reader of either file finds the explanation locally.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run format:check` clean
- [x] `npm run test:unit -- --testPathPatterns='metadata'` 64/64 (no behavioral change to test)
- [ ] CI passes

## Out of scope

- No code change. If a future re-enrichment trigger ever runs the runtime over rows with prior values, that PR should adopt the backfill's preserve semantics — that's flagged in the comment but not implemented here.
- No issue filed; the documentation IS the deliverable.