### PR TITLE
Strip Discogs spacer.gif placeholders at metadata chokepoints

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -190,7 +190,11 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   if (artwork) {
     metadata.discogsReleaseId = artwork.release_id;
     metadata.discogsUrl = artwork.release_url;
-    metadata.artworkUrl = artwork.artwork_url || undefined;
+    // Drop Discogs spacer.gif placeholder so the iOS client knows to draw its
+    // own placeholder rather than rendering a broken/blank image. See #649
+    // for the full callsite audit.
+    metadata.artworkUrl =
+      artwork.artwork_url && !artwork.artwork_url.includes('spacer.gif') ? artwork.artwork_url : undefined;
 
     // Artist bio and Wikipedia from lookup result
     if (artwork.artist_bio) metadata.artistBio = artwork.artist_bio;
@@ -219,8 +223,9 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
           duration: t.duration ?? undefined,
         }));
       }
-      // Prefer release artwork over lookup artwork
-      if (release.artwork_url) {
+      // Prefer release artwork over lookup artwork — but still filter out
+      // spacer.gif placeholders (see #649).
+      if (release.artwork_url && !release.artwork_url.includes('spacer.gif')) {
         metadata.artworkUrl = release.artwork_url;
       }
     } catch (releaseError) {

--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -83,13 +83,28 @@ export async function fetchMetadata(request: MetadataRequest): Promise<Flowsheet
 }
 
 /**
+ * Drop Discogs `spacer.gif` placeholder URLs.
+ *
+ * Discogs returns `spacer.gif` when a release has no real cover artwork.
+ * Persisting that to `flowsheet.artwork_url` would trip the playlist-proxy
+ * partial index ("has artwork") and result in a broken/blank image on iOS.
+ * Filtering at this single chokepoint covers every caller of `fetchMetadata`
+ * (runtime enrichment, iOS playcut detail, and the historical-drain job)
+ * so callers don't have to remember. See #649.
+ */
+function filterSpacerGif(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  return url.includes('spacer.gif') ? undefined : url;
+}
+
+/**
  * Extract album metadata from a DiscogsMatchResult.
  */
 function extractAlbumMetadata(artwork: DiscogsMatchResult): AlbumMetadataResult {
   return {
     discogsReleaseId: artwork.release_id,
     discogsUrl: artwork.release_url,
-    artworkUrl: artwork.artwork_url ?? undefined,
+    artworkUrl: filterSpacerGif(artwork.artwork_url),
     releaseYear: artwork.release_year ?? undefined,
     spotifyUrl: artwork.spotify_url ?? undefined,
     appleMusicUrl: artwork.apple_music_url ?? undefined,

--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -18,14 +18,16 @@
  * whose runtime stamp would otherwise be older. The benign race is
  * documented inline; no CAS pattern needed.
  *
- * Spacer.gif filter: applied inline until #649 lands. Discogs occasionally
- * returns `spacer.gif` placeholder images; persisting them would pollute
- * 1.86M rows for the historical drain alone. Applied only to `artwork_url`
- * — the other URL columns in the same `.set()` block come from the
- * `streaming_links` table or LML-constructed search URLs, never Discogs
- * image responses (verified against `lookup/orchestrator.py:855-970`, see
- * #679). Once #649 ships a shared helper, swap the inline `filterSpacerGif`
- * for the import.
+ * Spacer.gif filter: applied inline. Discogs occasionally returns
+ * `spacer.gif` placeholder images; persisting them would pollute 1.86M rows
+ * for the historical drain alone. The runtime path filters at the chokepoint
+ * in `metadata.service.ts:extractAlbumMetadata` (#649); this job carries
+ * its own copy because `lml-fetch.ts` deliberately does not go through the
+ * backend service (build-graph isolation, see file header). Applied only
+ * to `artwork_url` — the other URL columns in the same `.set()` block come
+ * from the `streaming_links` table or LML-constructed search URLs, never
+ * Discogs image responses (verified against `lookup/orchestrator.py:855-970`,
+ * see #679).
  */
 
 import { sql } from 'drizzle-orm';

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -361,6 +361,76 @@ describe('proxy.controller', () => {
       expect(result.tracklist).toBeUndefined();
     });
 
+    it('strips Discogs spacer.gif placeholder from artworkUrl (#649)', async () => {
+      // The iOS playcut-detail endpoint returns artworkUrl directly to the
+      // client. Discogs occasionally sends spacer.gif as a placeholder when a
+      // release has no real cover art; passing that through results in a
+      // broken/blank image on iOS. Drop it at this callsite the same way
+      // metadata.service.ts does.
+      mockLookupMetadata.mockResolvedValue({
+        results: [
+          {
+            library_item: {
+              id: 1,
+              title: 'On Your Own Love Again',
+              artist: 'Jessica Pratt',
+              call_number: 'Rock CD PRA 1/1',
+              library_url: '',
+            },
+            artwork: {
+              release_id: 7777,
+              release_url: 'https://www.discogs.com/release/7777',
+              artwork_url: 'https://s.discogs.com/images/spacer.gif',
+              album: 'On Your Own Love Again',
+              artist: 'Jessica Pratt',
+              confidence: 0.92,
+              spotify_url: null,
+              apple_music_url: null,
+              youtube_music_url: null,
+              bandcamp_url: null,
+              soundcloud_url: null,
+            },
+          },
+        ],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      mockGetRelease.mockResolvedValue({
+        release_id: 7777,
+        title: 'On Your Own Love Again',
+        artist: 'Jessica Pratt',
+        year: 2015,
+        label: 'Drag City',
+        artist_id: 5555,
+        genres: ['Rock'],
+        styles: [],
+        tracklist: [],
+        artwork_url: 'https://s.discogs.com/images/spacer.gif',
+        release_url: 'https://www.discogs.com/release/7777',
+        released: '2015-02-03',
+        cached: false,
+        artists: [{ artist_id: 5555, name: 'Jessica Pratt', join: '', role: null }],
+      });
+
+      const req = {
+        query: { artistName: 'Jessica Pratt', releaseTitle: 'On Your Own Love Again' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await getAlbumMetadata(req, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const result = (res.json as jest.Mock).mock.calls[0][0];
+      // artworkUrl is dropped entirely so iOS knows to draw its own placeholder.
+      expect(result.artworkUrl).toBeUndefined();
+      // Other Discogs metadata is preserved — spacer.gif is only a cover-art
+      // placeholder, not an "the entire release is bogus" signal.
+      expect(result.discogsReleaseId).toBe(7777);
+      expect(result.label).toBe('Drag City');
+    });
+
     it('returns fallback search URLs when LML search returns empty results', async () => {
       mockLookupMetadata.mockResolvedValue({
         results: [],

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -220,4 +220,30 @@ describe('metadata.service', () => {
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
     expect(result?.album?.discogsReleaseId).toBeUndefined();
   });
+
+  it('strips Discogs spacer.gif placeholder from artworkUrl (#649)', async () => {
+    // Discogs returns spacer.gif when a release has no real cover art.
+    // Persisting that to flowsheet.artwork_url makes the playlist-proxy
+    // partial index treat the row as "has artwork" and iOS shows a
+    // broken/blank image. Drop the URL at the chokepoint so every
+    // downstream caller of fetchMetadata benefits without remembering.
+    const responseWithSpacer = structuredClone(lookupResponseWithResults);
+    responseWithSpacer.results[0].artwork.artwork_url = 'https://s.discogs.com/images/spacer.gif';
+    mockLookupMetadata.mockResolvedValue(responseWithSpacer);
+
+    const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
+
+    expect(result?.album?.artworkUrl).toBeUndefined();
+    // Other album metadata is preserved — the filter only nulls artworkUrl.
+    expect(result?.album?.discogsReleaseId).toBe(12345);
+    expect(result?.album?.releaseYear).toBe(2001);
+  });
+
+  it('preserves non-spacer artwork URLs unchanged (#649 negative case)', async () => {
+    mockLookupMetadata.mockResolvedValue(lookupResponseWithResults);
+
+    const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
+
+    expect(result?.album?.artworkUrl).toBe('https://i.discogs.com/art.jpg');
+  });
 });


### PR DESCRIPTION
## Summary

- Filter `spacer.gif` URLs at the runtime chokepoint in `metadata.service.ts:extractAlbumMetadata` so every caller of `fetchMetadata` benefits — the runtime enrichment write to `flowsheet.artwork_url` (PR #658), the iOS playcut-detail endpoint, and any future LML-backed callsite — without each having to remember.
- Apply the same guard to both artwork-bearing assignments inside `proxy.controller.ts:getAlbumMetadata` (the LML lookup result and the release-detail override) so iOS never receives a placeholder URL it would render as a broken image.
- Update the historical-drain job's docstring at `jobs/flowsheet-metadata-backfill/enrich.ts` — the inline `filterSpacerGif` stays (the job deliberately bypasses `metadata.service.ts` for build-graph isolation, see file header), but the "until #649 lands" wording is now stale.

Closes #649

## Test plan

- [x] Unit test: `metadata.service.fetchMetadata` returns `artworkUrl: undefined` when the LML lookup result's `artwork_url` contains `spacer.gif`, while preserving the rest of the album metadata (release ID, year, etc.).
- [x] Unit test: `metadata.service.fetchMetadata` passes through a non-spacer artwork URL unchanged (negative case to pin the filter scope).
- [x] Unit test: `proxy.controller.getAlbumMetadata` drops `spacer.gif` from the iOS playcut-detail response while preserving Discogs release ID and label.
- [x] Existing `enrich.test.ts` spacer.gif coverage on the backfill job continues to pass — the inline filter is unchanged.
- [x] Local `npm run typecheck`, `npm run format:check`, `npm run lint` (0 errors, pre-existing warnings only), and full `npm run test:unit` (1404/1405 — 1 unrelated flake in `tests/unit/middleware/legacy/http.mirror.test.ts` that passes in isolation on `origin/main` and on this branch).
- [ ] Optional follow-up tracked on #649 acceptance: `SELECT count(*) FROM flowsheet WHERE artwork_url LIKE '%spacer.gif%'` against prod once this lands, to gauge whether a one-time cleanup UPDATE is warranted before #641 runs.

## Related

- Blocks #641 (phased rollout of the historical drain across the ~1.96M-row tail) — the gating ticket the issue called out.
- #638 (closed via #673) shipped the historical-drain job with the inline guard now documented as the deliberate build-graph-isolated copy.
- #650 (factor a `fetchTopArtwork` helper to consolidate the LML lookup-and-pick-first pattern across the eight callsites) is the broader refactor this fix sidesteps; left for a follow-up issue as noted in #649's "Out of scope".
- #679 (audit whether non-artwork URL fields can also carry spacer.gif placeholders) — separate scoping concern, not addressed here.
- LML-side fix (server never sending spacer.gif over the wire) is also called out as out of scope on #649.