### PR TITLE
Honor SENTRY_TRACES_SAMPLE_RATE in flowsheet job loggers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,7 @@ The reverse direction's local clone is refreshed via `scripts/sync/refresh-local
 
 - `SENTRY_DSN` -- Sentry project DSN (required for error reporting). Without this, Sentry silently disables itself.
 - `SENTRY_RELEASE` -- Set automatically by the deploy action to `<app>@<tag>`
+- `SENTRY_TRACES_SAMPLE_RATE` (default `0`, read by `jobs/flowsheet-etl/logger.ts` and `jobs/flowsheet-metadata-backfill/logger.ts`) -- Per-job tracing sample rate. The job loggers default `tracesSampleRate` to 0 so steady-state runs don't pay the sampling overhead, and `@sentry/node` v10 itself defaults to 0 if the field is omitted (silently producing zero spans). Operators flip this to e.g. `1.0` on `docker run --env-file .env -e SENTRY_TRACES_SAMPLE_RATE=1.0 ...` for one-shot pilots that need span / trace data (see #640). Malformed or out-of-range values fall back to 0. The runtime API container at `apps/backend/instrument.ts` sets its own `tracesSampleRate: 1.0` directly and isn't affected by this knob.
 
 #### Observability tags (Phase A contract)
 

--- a/jobs/flowsheet-etl/logger.ts
+++ b/jobs/flowsheet-etl/logger.ts
@@ -28,21 +28,7 @@ type BaseTags = { repo: string; tool: string; run_id: string };
 
 let baseTags: BaseTags | null = null;
 
-/**
- * Resolve `SENTRY_TRACES_SAMPLE_RATE` from the environment, falling back to
- * `0` (no sampling) when unset. Operators flip this to e.g. `1.0` for
- * one-shot pilots that need span/trace data (see #640); production default
- * stays off so steady-state runs don't pay the sampling overhead. Without
- * this env-controlled hook, `@sentry/node` v10 defaults `tracesSampleRate`
- * to `0`, which silently produces zero spans and breaks any downstream
- * trace-explorer validation that depends on the job emitting them.
- *
- * Malformed values (non-numeric, NaN, Infinity, negative, > 1) fall back to
- * `0` — Sentry rejects out-of-range rates with a runtime warning, and we'd
- * rather no-op silently than crash on a typo'd env var.
- *
- * Exported so unit tests can drive it without mucking with process.env.
- */
+// `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
   if (raw === undefined) return 0;
   const parsed = Number(raw);

--- a/jobs/flowsheet-etl/logger.ts
+++ b/jobs/flowsheet-etl/logger.ts
@@ -29,6 +29,28 @@ type BaseTags = { repo: string; tool: string; run_id: string };
 let baseTags: BaseTags | null = null;
 
 /**
+ * Resolve `SENTRY_TRACES_SAMPLE_RATE` from the environment, falling back to
+ * `0` (no sampling) when unset. Operators flip this to e.g. `1.0` for
+ * one-shot pilots that need span/trace data (see #640); production default
+ * stays off so steady-state runs don't pay the sampling overhead. Without
+ * this env-controlled hook, `@sentry/node` v10 defaults `tracesSampleRate`
+ * to `0`, which silently produces zero spans and breaks any downstream
+ * trace-explorer validation that depends on the job emitting them.
+ *
+ * Malformed values (non-numeric, NaN, Infinity, negative, > 1) fall back to
+ * `0` — Sentry rejects out-of-range rates with a runtime warning, and we'd
+ * rather no-op silently than crash on a typo'd env var.
+ *
+ * Exported so unit tests can drive it without mucking with process.env.
+ */
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+/**
  * Initialize Sentry and the structured logger. Call once at the top of the
  * entrypoint, before any other logic. Returns the resolved `run_id` so the
  * caller can pass it to subprocesses or persist it for cross-system tracing.
@@ -41,6 +63,7 @@ export const initLogger = (config: LoggerConfig): string => {
     dsn: process.env.SENTRY_DSN,
     release: process.env.SENTRY_RELEASE,
     environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
   });
   Sentry.setTag('repo', config.repo);
   Sentry.setTag('tool', config.tool);

--- a/jobs/flowsheet-metadata-backfill/logger.ts
+++ b/jobs/flowsheet-metadata-backfill/logger.ts
@@ -27,21 +27,7 @@ type BaseTags = { repo: string; tool: string; run_id: string };
 
 let baseTags: BaseTags | null = null;
 
-/**
- * Resolve `SENTRY_TRACES_SAMPLE_RATE` from the environment, falling back to
- * `0` (no sampling) when unset. Operators flip this to e.g. `1.0` for
- * one-shot pilots that need span/trace data (see #640); production default
- * stays off so steady-state runs don't pay the sampling overhead. Without
- * this env-controlled hook, `@sentry/node` v10 defaults `tracesSampleRate`
- * to `0`, which silently produces zero spans and breaks any downstream
- * trace-explorer validation that depends on the job emitting them.
- *
- * Malformed values (non-numeric, NaN, Infinity, negative, > 1) fall back to
- * `0` — Sentry rejects out-of-range rates with a runtime warning, and we'd
- * rather no-op silently than crash on a typo'd env var.
- *
- * Exported so unit tests can drive it without mucking with process.env.
- */
+// `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
   if (raw === undefined) return 0;
   const parsed = Number(raw);

--- a/jobs/flowsheet-metadata-backfill/logger.ts
+++ b/jobs/flowsheet-metadata-backfill/logger.ts
@@ -28,6 +28,28 @@ type BaseTags = { repo: string; tool: string; run_id: string };
 let baseTags: BaseTags | null = null;
 
 /**
+ * Resolve `SENTRY_TRACES_SAMPLE_RATE` from the environment, falling back to
+ * `0` (no sampling) when unset. Operators flip this to e.g. `1.0` for
+ * one-shot pilots that need span/trace data (see #640); production default
+ * stays off so steady-state runs don't pay the sampling overhead. Without
+ * this env-controlled hook, `@sentry/node` v10 defaults `tracesSampleRate`
+ * to `0`, which silently produces zero spans and breaks any downstream
+ * trace-explorer validation that depends on the job emitting them.
+ *
+ * Malformed values (non-numeric, NaN, Infinity, negative, > 1) fall back to
+ * `0` — Sentry rejects out-of-range rates with a runtime warning, and we'd
+ * rather no-op silently than crash on a typo'd env var.
+ *
+ * Exported so unit tests can drive it without mucking with process.env.
+ */
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+/**
  * Initialize Sentry and the structured logger. Call once at the top of the
  * entrypoint, before any other logic. Returns the resolved `run_id` so the
  * caller can pass it to subprocesses or persist it for cross-system tracing.
@@ -40,6 +62,7 @@ export const initLogger = (config: LoggerConfig): string => {
     dsn: process.env.SENTRY_DSN,
     release: process.env.SENTRY_RELEASE,
     environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
   });
   Sentry.setTag('repo', config.repo);
   Sentry.setTag('tool', config.tool);

--- a/tests/unit/jobs/flowsheet-etl/logger.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/logger.test.ts
@@ -6,6 +6,29 @@
  * is unset (no panic, no network calls).
  */
 
+import { resolveTracesSampleRate } from '../../../../jobs/flowsheet-etl/logger';
+
+describe('resolveTracesSampleRate', () => {
+  it('defaults to 0 when env var is unset', () => {
+    expect(resolveTracesSampleRate(undefined)).toBe(0);
+  });
+
+  it('parses valid values in [0, 1]', () => {
+    expect(resolveTracesSampleRate('0')).toBe(0);
+    expect(resolveTracesSampleRate('0.5')).toBe(0.5);
+    expect(resolveTracesSampleRate('1')).toBe(1);
+    expect(resolveTracesSampleRate('1.0')).toBe(1);
+  });
+
+  it('falls back to 0 on malformed or out-of-range values', () => {
+    expect(resolveTracesSampleRate('abc')).toBe(0);
+    expect(resolveTracesSampleRate('-0.5')).toBe(0);
+    expect(resolveTracesSampleRate('1.5')).toBe(0);
+    expect(resolveTracesSampleRate('NaN')).toBe(0);
+    expect(resolveTracesSampleRate('Infinity')).toBe(0);
+  });
+});
+
 describe('flowsheet-etl logger', () => {
   const originalDsn = process.env.SENTRY_DSN;
 

--- a/tests/unit/jobs/flowsheet-metadata-backfill/logger.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/logger.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Tests for the flowsheet-metadata-backfill observability logger's pure
+ * helpers. The init / JSON-line behavior mirrors `jobs/flowsheet-etl/logger.ts`
+ * verbatim and is exercised by that job's smoke tests.
+ */
+
+import { resolveTracesSampleRate } from '../../../../jobs/flowsheet-metadata-backfill/logger';
+
+describe('resolveTracesSampleRate', () => {
+  it('defaults to 0 when env var is unset', () => {
+    expect(resolveTracesSampleRate(undefined)).toBe(0);
+  });
+
+  it('parses valid values in [0, 1]', () => {
+    expect(resolveTracesSampleRate('0')).toBe(0);
+    expect(resolveTracesSampleRate('0.5')).toBe(0.5);
+    expect(resolveTracesSampleRate('1')).toBe(1);
+    expect(resolveTracesSampleRate('1.0')).toBe(1);
+  });
+
+  it('falls back to 0 on malformed or out-of-range values', () => {
+    expect(resolveTracesSampleRate('abc')).toBe(0);
+    expect(resolveTracesSampleRate('-0.5')).toBe(0);
+    expect(resolveTracesSampleRate('1.5')).toBe(0);
+    expect(resolveTracesSampleRate('NaN')).toBe(0);
+    expect(resolveTracesSampleRate('Infinity')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `resolveTracesSampleRate()` to both `jobs/flowsheet-etl/logger.ts` and `jobs/flowsheet-metadata-backfill/logger.ts`. The helper reads `SENTRY_TRACES_SAMPLE_RATE` from env and parses to a number in `[0, 1]`, falling back to 0 when unset, malformed, or out of range.
- `Sentry.init()` in both loggers now passes `tracesSampleRate: resolveTracesSampleRate()`. Production behavior is unchanged when the env var is unset (still 0).
- `CLAUDE.md` env-vars section documents the new knob, when to flip it on (one-shot pilots that need span / trace data, e.g. #640), and the relationship to the runtime API container at `apps/backend/instrument.ts` which sets `tracesSampleRate: 1.0` directly and is unaffected.

## Why

`@sentry/node` v10+ defaults `tracesSampleRate` to 0 when omitted. Both job loggers omitted it, so no transactions started, no spans were created, and `@sentry/node`'s undici auto-instrumentation had nothing to attach to. That silently broke the Sentry-side trace validation #640's pilot was meant to perform.

After this lands, operators flip the knob on a `docker run --env-file .env -e SENTRY_TRACES_SAMPLE_RATE=1.0 ...` invocation for the pilot run; steady-state production still runs at 0 to avoid sampling overhead.

#640's [degraded-validation comment](https://github.com/WXYC/Backend-Service/issues/640#issuecomment-4348807361) covers the broader Sentry-side gap that closes when this PR + #678 (BS DSN drift) + #669 / library-metadata-lookup#229 are all in.

## Duplication

The helper is added to both job loggers. They already exist as standalone files for build-graph isolation per their own header docstrings (the `flowsheet-metadata-backfill` one explicitly says "Mirrors `jobs/flowsheet-etl/logger.ts` verbatim"). Sharing this five-line helper would couple the build graphs the existing duplication is designed to keep apart; factoring it into a real shared module is #651's territory. Each job's tests cover its own copy, matching the convention in `orchestrate.ts` for `resolveBatchSize` / `resolveThrottleMs` / `resolvePartitionFilter`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors (pre-existing 331 warnings, none new)
- [x] `npm run format:check` clean
- [x] `npm run test:unit -- --testPathPatterns='jobs/(flowsheet-etl|flowsheet-metadata-backfill)/logger'` — 10/10 passing across both suites
- [x] Full `npm run test:unit` — 1407/1408 passing; the one failure (`tests/unit/routes/internal.route.test.ts`) is a pre-existing local-environment flake (`EADDRNOTAVAIL` / 10s timeout) unrelated to this change
- [ ] CI passes
- [ ] Post-merge smoke check on the next `flowsheet-etl` cron run: `Sentry.init` doesn't error when the env var is unset (default path)

Closes #682