### PR TITLE
Stop catalog-search 503 from caching on a single NULL row, plug ETL leak

### DIFF
--- a/apps/backend/services/library-artist-name-assertion.service.ts
+++ b/apps/backend/services/library-artist-name-assertion.service.ts
@@ -1,26 +1,31 @@
 import { sql } from 'drizzle-orm';
 import * as Sentry from '@sentry/node';
 import { db, library } from '@wxyc/database';
-import WxycError from '../utils/error.js';
 
 /**
- * Thrown by `assertLibraryArtistNamePopulated()` when `library.artist_name`
- * still has at least one NULL row. Carries a 503 status code so the
- * `errorHandler` middleware refuses catalog-search requests with a body that
- * points operators at the backfill job.
+ * Soft data-quality check for the denormalized `library.artist_name` column.
+ *
+ * Originally a hard precondition that 503'd catalog search whenever any row
+ * carried NULL `artist_name`. That fired in prod 2026-04-30: a single ETL row
+ * (Oneohtrix Point Never, "Tranquilizer", added 2026-04-28) was inserted by
+ * `jobs/library-etl/job.ts` without `artist_name` set, and the next backend
+ * restart cached a process-wide 503 — DJs locked out of the flowsheet for the
+ * lifetime of the box.
+ *
+ * The denormalization is non-essential at the read path: search results
+ * project `artists.artist_name` from the JOIN, and trigram predicates that
+ * touch `library.artist_name` can't match a NULL via `%`, so degraded rows
+ * silently drop out of search instead of poisoning it. The remaining role of
+ * this check is observability — one Sentry warning per process when the
+ * column is degraded, so the leak path is visible without taking the station
+ * down.
+ *
+ * The result is memoized so the warning fires at most once per process and
+ * the check stays off the per-search hot path after the first call.
+ * Transient DB errors clear the cache so the next call retries.
  */
-export class LibraryArtistNameMissingError extends WxycError {
-  constructor(nullCount: number) {
-    super(
-      `library.artist_name has ${nullCount} NULL row(s); catalog search is disabled. ` +
-        `Run jobs/library-artist-name-backfill/ and restart the backend.`,
-      503,
-      'LibraryArtistNameMissingError'
-    );
-  }
-}
 
-let _assertionPromise: Promise<void> | null = null;
+let _checkPromise: Promise<void> | null = null;
 
 async function runCheck(): Promise<void> {
   const result = await db.execute(
@@ -29,42 +34,36 @@ async function runCheck(): Promise<void> {
   const rows = result as unknown as Array<{ n: number | string | null }>;
   const n = Number(rows[0]?.n ?? 0);
   if (n > 0) {
-    Sentry.captureMessage('library.artist_name backfill missing — refusing catalog search', {
-      level: 'error',
-      tags: { tool: 'library-search', step: 'startup-assertion' },
+    Sentry.captureMessage(`library.artist_name has ${n} NULL row(s) — denormalization is degraded`, {
+      level: 'warning',
+      tags: { tool: 'library-search', step: 'health-check' },
       extra: { count: n },
     });
-    throw new LibraryArtistNameMissingError(n);
+    console.warn(
+      `[library] library.artist_name has ${n} NULL row(s); search results omit those rows. ` +
+        `Run jobs/library-artist-name-backfill/ to repair.`
+    );
   }
 }
 
 /**
- * Boot-time precondition for catalog search: refuses to serve until
- * `library.artist_name` is fully populated. Called at the top of every
- * public catalog-search entry point in `library.service.ts`.
- *
- * Once `artist_name` is populated, it stays populated, so the result is
- * cached for the lifetime of the process. A `LibraryArtistNameMissingError`
- * is also cached — the operator response is "run the backfill, restart the
- * process" — but transient DB errors clear the cache so the next call retries.
+ * Run the soft data-quality check exactly once per process. Returns void on
+ * both healthy and degraded states; consumers must not branch on the result.
+ * Callable from any catalog-search entry point as a fire-and-observe hook.
  */
-export async function assertLibraryArtistNamePopulated(): Promise<void> {
-  if (_assertionPromise === null) {
-    _assertionPromise = runCheck().catch((err) => {
-      if (!(err instanceof LibraryArtistNameMissingError)) {
-        _assertionPromise = null;
-      }
+export async function checkLibraryArtistNameHealth(): Promise<void> {
+  if (_checkPromise === null) {
+    _checkPromise = runCheck().catch((err) => {
+      _checkPromise = null;
       throw err;
     });
   }
-  return _assertionPromise;
+  return _checkPromise;
 }
 
 /**
- * Test-only: reset the cached assertion state. Production code must not call
- * this — once a process has decided to refuse search, it has to restart to
- * re-check.
+ * Test-only: reset the cached check state so the next call re-queries.
  */
-export function _resetLibraryArtistNameAssertionForTests(): void {
-  _assertionPromise = null;
+export function _resetLibraryArtistNameHealthCheckForTests(): void {
+  _checkPromise = null;
 }

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -20,7 +20,7 @@ import {
 } from '@wxyc/database';
 import { LibraryResult, EnrichedLibraryResult, enrichLibraryResult } from './requestLine/types.js';
 import { lookupMetadata, isLmlConfigured, type LookupResponse } from './lml/lml.client.js';
-import { assertLibraryArtistNamePopulated } from './library-artist-name-assertion.service.js';
+import { checkLibraryArtistNameHealth } from './library-artist-name-assertion.service.js';
 
 /**
  * Source columns on `artists` (and any joined / view-projected row) that
@@ -447,7 +447,7 @@ export const fuzzySearchLibrary = async (
   n = 5,
   on_streaming?: boolean
 ): Promise<LibraryArtistViewEntry[]> => {
-  await assertLibraryArtistNamePopulated();
+  await checkLibraryArtistNameHealth();
 
   // Both-mode default (dj-site sends the same string as artist and title).
   // Route through tsvector + plays.
@@ -731,7 +731,7 @@ export async function searchLibrary(
   limit = 5,
   on_streaming?: boolean
 ): Promise<EnrichedLibraryResult[]> {
-  await assertLibraryArtistNamePopulated();
+  await checkLibraryArtistNameHealth();
 
   let results: LibraryArtistViewEntry[] = [];
 
@@ -754,7 +754,7 @@ export async function searchLibrary(
  * @returns Corrected artist name if a good match is found, null otherwise
  */
 export async function findSimilarArtist(artistName: string, threshold = 0.85): Promise<string | null> {
-  await assertLibraryArtistNamePopulated();
+  await checkLibraryArtistNameHealth();
 
   // Use pg_trgm similarity function to find close matches. Reads from
   // `library` directly so the planner uses the GIN trigram index on
@@ -795,7 +795,7 @@ export async function findSimilarArtist(artistName: string, threshold = 0.85): P
  * @returns Array of enriched library results
  */
 export async function searchAlbumsByTitle(albumTitle: string, limit = 5): Promise<EnrichedLibraryResult[]> {
-  await assertLibraryArtistNamePopulated();
+  await checkLibraryArtistNameHealth();
 
   const rows = (await libraryViewQuery(false)
     .where(sql`${library.album_title} % ${albumTitle}`)
@@ -813,7 +813,7 @@ export async function searchAlbumsByTitle(albumTitle: string, limit = 5): Promis
  * @returns Array of enriched library results
  */
 export async function searchByArtist(artistName: string, limit = 5): Promise<EnrichedLibraryResult[]> {
-  await assertLibraryArtistNamePopulated();
+  await checkLibraryArtistNameHealth();
 
   const rows = (await libraryViewQuery(false)
     .where(sql`${library.artist_name} % ${artistName}`)

--- a/apps/backend/services/requestLine/requestLine.enhanced.service.ts
+++ b/apps/backend/services/requestLine/requestLine.enhanced.service.ts
@@ -22,7 +22,6 @@ import { getConfig, isParsingEnabled } from './config.js';
 import { parseRequest, isParserAvailable } from '../ai/index.js';
 import { executeSearchPipeline, getSearchTypeFromState } from './search/index.js';
 import { findSimilarArtist } from '../library.service.js';
-import { LibraryArtistNameMissingError } from '../library-artist-name-assertion.service.js';
 import { searchTrackReleases, lookupMetadata, validateTrackOnRelease, isLmlConfigured } from '../lml/lml.client.js';
 import { fetchArtworkForItems } from '../artwork/index.js';
 import {
@@ -207,10 +206,6 @@ export async function processRequest(body: RequestLineRequestBody): Promise<Unif
         parsed = { ...parsed, artist: correctedArtist };
       }
     } catch (error) {
-      if (error instanceof LibraryArtistNameMissingError) {
-        // Catalog-search precondition is global; surface the 503 instead of degrading silently.
-        throw error;
-      }
       console.warn('[RequestLine] Artist correction failed:', error);
     }
   }

--- a/apps/backend/services/requestLine/search/strategies/trackOnCompilation.ts
+++ b/apps/backend/services/requestLine/search/strategies/trackOnCompilation.ts
@@ -10,7 +10,6 @@
 
 import { ParsedRequest, EnrichedLibraryResult, SearchState, SearchStrategyType } from '../../types.js';
 import { searchLibrary, searchAlbumsByTitle, filterResultsByArtist } from '../../../library.service.js';
-import { LibraryArtistNameMissingError } from '../../../library-artist-name-assertion.service.js';
 import { extractSignificantWords, isCompilationArtist, STOPWORDS, MAX_SEARCH_RESULTS } from '../../matching/index.js';
 
 // Forward declaration - will be imported when Discogs service is ready
@@ -89,7 +88,6 @@ export async function executeTrackOnCompilation(
       }
     }
   } catch (e) {
-    if (e instanceof LibraryArtistNameMissingError) throw e;
     console.warn(`[Search] Keyword search failed:`, e);
     keywordMatches = [];
   }
@@ -161,7 +159,6 @@ export async function executeTrackOnCompilation(
         }
       }
     } catch (e) {
-      if (e instanceof LibraryArtistNameMissingError) throw e;
       console.warn(`[Search] Failed to search for track on other releases:`, e);
     }
   }

--- a/docs/backfill-precondition-assertions.md
+++ b/docs/backfill-precondition-assertions.md
@@ -2,11 +2,11 @@
 
 ## What this is
 
-A defensive pattern for _code_ changes that depend on a column having been backfilled. The backfill itself runs as a one-shot job under `jobs/<name>-backfill/`; the question is how the runtime guards against being asked to serve traffic before the backfill has run.
+A defensive pattern for _code_ changes that depend on a column having been backfilled. The backfill itself runs as a one-shot job under `jobs/<name>-backfill/`; the question is how the runtime guards against being asked to serve traffic before the backfill has run, or against new leak paths re-introducing NULL rows after the fact.
 
 For _migrations_ that depend on a backfill, the canonical pattern is the `DO $$ ... RAISE EXCEPTION ... END $$;` precondition guard at the top of the migration file (see `0053_flowsheet-dj-name-column.sql` → `jobs/flowsheet-dj-name-backfill/` → `0054_flowsheet-search-doc-with-dj-name.sql`). That guard fires inside the DDL transaction.
 
-This document covers the _runtime_ analog: a boot-time assertion that fails loud when a backfill-dependent code path is called before the backfill has populated the column.
+This document covers the _runtime_ analog: a boot-time data-quality check that flags a backfill-dependent column slipping back into a degraded state.
 
 ## Why
 
@@ -19,55 +19,64 @@ This pattern was introduced after the 2026-04-28 catalog-search incident:
 
 The migration-precondition guard pattern doesn't apply here — there was no follow-up migration after 0058 to refuse, and the `search_doc` column itself was perfectly valid SQL with NULL inputs. The bug was a _code-side_ assumption that the backfill had run.
 
-## The pattern
+## What NOT to do — the 2026-04-30 follow-up incident
 
-For any code path that depends on a backfilled column being non-NULL, gate it behind a boot-time assertion that:
+The original version of this pattern made the runtime check a hard precondition that 503'd the search endpoint for the lifetime of the process whenever any single row had `artist_name IS NULL`. That worked while the column was uniformly empty (the intended trigger), but it weaponized itself against a single bad row:
 
-1. Runs the cheapest possible `SELECT count(*) ... WHERE col IS NULL LIMIT 1` once per process.
-2. Caches the result for the lifetime of the process — once the column is populated, it stays populated, so re-checking on every request is wasted work.
-3. Throws a typed error subclassing `WxycError` with `statusCode: 503` so the existing `errorHandler` middleware refuses requests with a body that points operators at the backfill job.
-4. Logs to Sentry with `tool=<feature>`, `step=startup-assertion`, `count=<n>` so the alert path is observable.
-5. Caches the missing-backfill failure as well as success — the operator response is "run the backfill, restart the process" — but does _not_ cache transient DB errors so the next call retries.
+- 2026-04-28: a new release ("Tranquilizer", Oneohtrix Point Never) was inserted by the library ETL, which had not been updated to set `library.artist_name`.
+- 2026-04-30: the backend container was restarted as part of routine ops. The first authenticated `/library/?artist_name=...` call ran the precondition, found one NULL row out of 64,164, threw 503, and cached the failure for the lifetime of the new process.
+- DJs lost catalog search station-wide for the rest of the on-air session, despite LML being healthy and 64,163 rows being well-formed.
 
-The canonical implementation is `apps/backend/services/library-artist-name-assertion.service.ts`. Mirror it for any new gate.
+The lesson: a process-cached 503 turns "degraded data" into "outage" — and once any future leak path drips a single NULL into the table, every subsequent restart re-poisons. Hard gates that depend on _zero_ NULLs are too brittle; the gate amplifies a row-level data-quality issue into a service-level one.
 
-## When to add a gate
+## The pattern (revised)
 
-When you ship code that reads a backfilled column and silently produces wrong answers if the column has NULL rows. Examples:
+For any code path that depends on a backfilled column, do all of:
 
-- A search index built from a column.
-- A constraint enforced at write time but not at read time.
-- A denormalized join key.
+1. **Make the read path tolerate NULL rows.** Trigram (`%`) and tsvector (`@@`) predicates already drop NULLs naturally — degraded rows fall out of search instead of poisoning it. Project the value from a non-degraded source (e.g., the JOIN target) at the result level so even degraded rows that match a different predicate still serialize correctly.
 
-When _not_ to add a gate:
+2. **Add a soft data-quality check, not a hard gate.** Run the cheapest possible `SELECT count(*) ... WHERE col IS NULL LIMIT 1` once per process, cache the result, and emit a Sentry warning (`level: 'warning'`) if `count > 0`. Do **not** throw — degraded data is observability, not a precondition.
 
-- The column is nullable by design and the code handles NULL correctly.
+3. **Plug the leak path at the source.** If the column is meant to be denormalized at insert time, every insert path needs to set it. Audit `INSERT INTO library` (or whichever table) across the controllers AND every ETL/job. The canonical pattern: lift the canonical value into the helper that returns the FK target so the insert can't compile without it. See `ensureArtist` in `jobs/library-etl/job.ts` for the post-fix shape.
+
+4. **Run the backfill job to repair existing degradation.** `jobs/<name>-backfill/` is the recovery tool, not the prevention tool. It exists for incidents and migrations; the steady-state defense is (1) + (3).
+
+The canonical implementation is `apps/backend/services/library-artist-name-assertion.service.ts` (post-2026-04-30 revision). Mirror it for any new degradation-prone column.
+
+## When to add a soft check
+
+When you ship code that reads a backfilled column and the column is denormalized from another source of truth, so leak paths are realistic. The check exists to make the leak visible in Sentry before it grows.
+
+When _not_ to add a check:
+
+- The column is nullable by design and the code handles NULL correctly already.
 - The dependency is one-way: a migration that depends on a backfill (use the migration-precondition guard instead).
-- The cost of running the gate query exceeds the cost of being wrong (rare — the gate query is a single indexed lookup with `LIMIT 1`).
+- The column has a NOT NULL constraint and the database itself rejects bad inserts.
 
 ## Wiring
 
-Each public entry point on the affected service should `await` the assertion before any other DB work:
+Each public entry point on the affected service should `await` the check before any other DB work:
 
 ```ts
 export async function searchLibrary(...): Promise<...> {
-  await assertLibraryArtistNamePopulated();
+  await checkLibraryArtistNameHealth();
   // ... actual search ...
 }
 ```
 
-The assertion is cached per-process, so subsequent calls are sub-microsecond after the first.
+The check is cached per-process, so subsequent calls are sub-microsecond after the first.
 
 ## Operator response
 
-When the assertion fails, the search endpoint returns 503 with a body like:
+When the check fires a Sentry warning, the operator response is:
 
-```json
-{
-  "message": "library.artist_name has 64163 NULL row(s); catalog search is disabled. Run jobs/library-artist-name-backfill/ and restart the backend."
-}
-```
-
-The operator runs the backfill job (`docker run --rm --env-file .env <image>` on EC2), then restarts the backend container. The next request after restart re-runs the assertion against the populated column, sees count=0, caches success, and serves traffic normally.
-
-A backend restart is required because the assertion caches the failure for the lifetime of the process — once the runtime has decided to refuse search, it won't reconsider until the next process boot. This is intentional: it means a half-finished backfill (partially populated column) can't accidentally re-enable a path that's still serving partially-correct results.
+1. Identify the leak path. Recent inserts with NULL in the affected column are the smoking gun:
+   ```sql
+   SELECT id, artist_id, album_title, add_date
+     FROM library
+    WHERE artist_name IS NULL
+    ORDER BY add_date DESC;
+   ```
+2. Patch the code path that's inserting NULL (controller, ETL, internal endpoint).
+3. Run the backfill job to repair the existing rows: `docker run --rm --env-file .env <library-artist-name-backfill-image>`.
+4. No restart needed — the search functions already tolerate NULLs; the degraded rows just reappear as searchable once backfilled.

--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -360,6 +360,8 @@ const fetchLegacyReleases = async (lastRunMs: number | null) => {
   }
 };
 
+type EnsuredArtist = { id: number; artist_name: string };
+
 const ensureArtist = async (
   dbClient: DbClient,
   artistName: string,
@@ -368,10 +370,10 @@ const ensureArtist = async (
   genreId: number,
   codeLetters: string | null,
   artistGenreCode: number,
-  artistCache: Map<string, number>,
+  artistCache: Map<string, EnsuredArtist>,
   addDate?: string,
   lastModified?: Date
-) => {
+): Promise<EnsuredArtist> => {
   const normalizedLetters = codeLetters ?? '??';
   const artistKey = isVarious
     ? `${artistName.toLowerCase()}|${normalizedLetters}`
@@ -383,14 +385,14 @@ const ensureArtist = async (
   const lettersLower = normalizedLetters.toLowerCase().trim();
   const query = isVarious
     ? dbClient
-        .select({ id: artists.id })
+        .select({ id: artists.id, artist_name: artists.artist_name })
         .from(artists)
         .where(
           and(sql`lower(${artists.artist_name}) = ${nameLower}`, sql`lower(${artists.code_letters}) = ${lettersLower}`)
         )
         .limit(1)
     : dbClient
-        .select({ id: artists.id })
+        .select({ id: artists.id, artist_name: artists.artist_name })
         .from(artists)
         .innerJoin(genre_artist_crossreference, eq(genre_artist_crossreference.artist_id, artists.id))
         .where(
@@ -405,8 +407,9 @@ const ensureArtist = async (
 
   const existing = await query;
   if (existing.length) {
-    artistCache.set(artistKey, existing[0].id);
-    return existing[0].id;
+    const ensured = { id: existing[0].id, artist_name: existing[0].artist_name };
+    artistCache.set(artistKey, ensured);
+    return ensured;
   }
 
   const inserted = await dbClient
@@ -424,8 +427,9 @@ const ensureArtist = async (
   if (!id) {
     throw new Error(`[library-etl] Failed to insert artist ${artistName}.`);
   }
-  artistCache.set(artistKey, id);
-  return id;
+  const ensured = { id, artist_name: artistName };
+  artistCache.set(artistKey, ensured);
+  return ensured;
 };
 
 const ensureGenreArtistCrossref = async (
@@ -868,7 +872,7 @@ const run = async () => {
       const formatRows = await tx.select().from(format);
       const formatMap = new Map(formatRows.map((row) => [row.format_name.toLowerCase(), row.id]));
 
-      const artistCache = new Map<string, number>();
+      const artistCache = new Map<string, EnsuredArtist>();
 
       for (const release of legacyReleases) {
         if (isDbOnlyGenre(release.genre_ref_name)) {
@@ -910,7 +914,7 @@ const run = async () => {
           : normalizeCodeLetters(release.artist_call_letters);
         const artistGenreCode = artistInfo.isVarious ? VARIOUS_ARTISTS_CODE_NUMBER : (release.artist_call_numbers ?? 0);
 
-        const artistId = await ensureArtist(
+        const { id: artistId, artist_name: canonicalArtistName } = await ensureArtist(
           tx,
           artistInfo.name,
           alphabeticalName,
@@ -972,8 +976,14 @@ const run = async () => {
           continue;
         }
 
+        // Denormalize the canonical `artists.artist_name` onto `library.artist_name`
+        // so the column the tsvector / trigram catalog search reads against
+        // (`library.artist_name`) is populated at insert time. Omitting it lets
+        // the row land NULL — invisible to search, and (pre-fix) tripping the
+        // 503-on-any-NULL precondition in library-artist-name-assertion.service.
         await tx.insert(library).values({
           artist_id: artistId,
+          artist_name: canonicalArtistName,
           genre_id: genreId,
           format_id: formatId,
           alternate_artist_name: release.release_alternate_artist_name,

--- a/tests/unit/services/library-artist-name-assertion.test.ts
+++ b/tests/unit/services/library-artist-name-assertion.test.ts
@@ -15,53 +15,60 @@ jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
 import * as Sentry from '@sentry/node';
 
 import {
-  assertLibraryArtistNamePopulated,
-  LibraryArtistNameMissingError,
-  _resetLibraryArtistNameAssertionForTests,
+  checkLibraryArtistNameHealth,
+  _resetLibraryArtistNameHealthCheckForTests,
 } from '../../../apps/backend/services/library-artist-name-assertion.service';
-import {
-  searchLibrary,
-  fuzzySearchLibrary,
-  searchByArtist,
-  searchAlbumsByTitle,
-  findSimilarArtist,
-} from '../../../apps/backend/services/library.service';
-import errorHandler from '../../../apps/backend/middleware/errorHandler';
-import type { Request, Response, NextFunction } from 'express';
 
 describe('library-artist-name-assertion', () => {
   beforeEach(() => {
-    _resetLibraryArtistNameAssertionForTests();
+    _resetLibraryArtistNameHealthCheckForTests();
+    (Sentry.captureMessage as jest.Mock).mockClear();
   });
 
-  describe('assertLibraryArtistNamePopulated', () => {
-    it('passes when count is 0', async () => {
+  describe('checkLibraryArtistNameHealth', () => {
+    it('passes silently when count is 0', async () => {
       db.execute.mockResolvedValueOnce([{ n: 0 }]);
-      await expect(assertLibraryArtistNamePopulated()).resolves.toBeUndefined();
+      await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
     });
 
-    it('throws LibraryArtistNameMissingError when count > 0', async () => {
+    it('regression: does not throw when count > 0 — degraded data must not take catalog search down', async () => {
+      // Production incident 2026-04-30: a DJ on-air could not enter any track
+      // because every /library/?artist_name=... call returned 503. LML was
+      // healthy. The cause was a single NULL row in `library.artist_name`
+      // (Oneohtrix Point Never, "Tranquilizer", added 2026-04-28 by the
+      // library ETL which had not been wired to set artist_name) tripping
+      // the precondition, which then cached the 503 for the lifetime of
+      // the Node process. Every search permanently 503'd until the box
+      // restarted AND the data was clean.
+      //
+      // Post-fix contract: degraded data is observability, not a hard gate.
+      // The health check fires a Sentry warning and returns; search continues
+      // to serve. Trigram and tsvector predicates can't match a NULL with `%`
+      // or `@@`, so degraded rows fall out of search organically — no need
+      // to refuse service.
+      db.execute.mockResolvedValueOnce([{ n: 1 }]);
+      await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
+    });
+
+    it('regression: does not throw on the original 64,163-row degraded state either', async () => {
+      // The 2026-04-28 backfill-missing scenario the assertion was originally
+      // built for. With the soft-check pattern, even a fully-degraded column
+      // doesn't throw — the column is denormalized from `artists.artist_name`
+      // anyway, so search results stay correct via the JOIN projection.
       db.execute.mockResolvedValueOnce([{ n: 64163 }]);
-      await expect(assertLibraryArtistNamePopulated()).rejects.toBeInstanceOf(LibraryArtistNameMissingError);
+      await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
     });
 
-    it('attaches statusCode 503 and a backfill runbook pointer to the error', async () => {
-      db.execute.mockResolvedValueOnce([{ n: 100 }]);
-      await expect(assertLibraryArtistNamePopulated()).rejects.toMatchObject({
-        statusCode: 503,
-        message: expect.stringContaining('jobs/library-artist-name-backfill'),
-      });
-    });
-
-    it('logs to Sentry with tool/step/count tags when the assertion fails', async () => {
+    it('emits a Sentry warning with tool/step/count tags when the column is degraded', async () => {
       db.execute.mockResolvedValueOnce([{ n: 42 }]);
-      await assertLibraryArtistNamePopulated().catch(() => undefined);
+      await checkLibraryArtistNameHealth();
 
       expect(Sentry.captureMessage).toHaveBeenCalledWith(
-        expect.any(String),
+        expect.stringContaining('42 NULL row(s)'),
         expect.objectContaining({
-          level: 'error',
-          tags: expect.objectContaining({ tool: 'library-search', step: 'startup-assertion' }),
+          level: 'warning',
+          tags: expect.objectContaining({ tool: 'library-search', step: 'health-check' }),
           extra: expect.objectContaining({ count: 42 }),
         })
       );
@@ -70,80 +77,34 @@ describe('library-artist-name-assertion', () => {
     it('treats string count from Postgres as numeric', async () => {
       // postgres-js sometimes returns count(*) as a stringified bigint.
       db.execute.mockResolvedValueOnce([{ n: '7' }]);
-      await expect(assertLibraryArtistNamePopulated()).rejects.toBeInstanceOf(LibraryArtistNameMissingError);
+      await checkLibraryArtistNameHealth();
+      expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
     });
 
-    it('caches the success result — only one db call across multiple invocations', async () => {
+    it('caches across multiple invocations — only one db call', async () => {
       db.execute.mockResolvedValueOnce([{ n: 0 }]);
-      await assertLibraryArtistNamePopulated();
-      await assertLibraryArtistNamePopulated();
-      await assertLibraryArtistNamePopulated();
+      await checkLibraryArtistNameHealth();
+      await checkLibraryArtistNameHealth();
+      await checkLibraryArtistNameHealth();
       expect(db.execute).toHaveBeenCalledTimes(1);
     });
 
-    it('caches the missing-backfill failure — only one db call, repeated rejections', async () => {
+    it('caches the degraded state — only one Sentry warning per process', async () => {
       db.execute.mockResolvedValueOnce([{ n: 100 }]);
-      await expect(assertLibraryArtistNamePopulated()).rejects.toBeInstanceOf(LibraryArtistNameMissingError);
-      await expect(assertLibraryArtistNamePopulated()).rejects.toBeInstanceOf(LibraryArtistNameMissingError);
-      await expect(assertLibraryArtistNamePopulated()).rejects.toBeInstanceOf(LibraryArtistNameMissingError);
+      await checkLibraryArtistNameHealth();
+      await checkLibraryArtistNameHealth();
+      await checkLibraryArtistNameHealth();
       expect(db.execute).toHaveBeenCalledTimes(1);
+      expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
     });
 
     it('clears the cache on transient DB errors so the next call retries', async () => {
       db.execute.mockRejectedValueOnce(new Error('connection reset'));
-      await expect(assertLibraryArtistNamePopulated()).rejects.toThrow('connection reset');
+      await expect(checkLibraryArtistNameHealth()).rejects.toThrow('connection reset');
 
       db.execute.mockResolvedValueOnce([{ n: 0 }]);
-      await expect(assertLibraryArtistNamePopulated()).resolves.toBeUndefined();
+      await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
       expect(db.execute).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  describe('catalog search functions are gated by the assertion', () => {
-    beforeEach(() => {
-      // Each test resets the cache (parent beforeEach) and primes the next
-      // db.execute call to report a non-empty NULL count.
-      db.execute.mockResolvedValueOnce([{ n: 100 }]);
-    });
-
-    it('searchLibrary refuses to serve when artist_name has NULLs', async () => {
-      await expect(searchLibrary('autechre')).rejects.toBeInstanceOf(LibraryArtistNameMissingError);
-    });
-
-    it('fuzzySearchLibrary refuses to serve when artist_name has NULLs', async () => {
-      await expect(fuzzySearchLibrary('autechre')).rejects.toBeInstanceOf(LibraryArtistNameMissingError);
-    });
-
-    it('searchByArtist refuses to serve when artist_name has NULLs', async () => {
-      await expect(searchByArtist('autechre')).rejects.toBeInstanceOf(LibraryArtistNameMissingError);
-    });
-
-    it('searchAlbumsByTitle refuses to serve when artist_name has NULLs', async () => {
-      await expect(searchAlbumsByTitle('confield')).rejects.toBeInstanceOf(LibraryArtistNameMissingError);
-    });
-
-    it('findSimilarArtist refuses to serve when artist_name has NULLs', async () => {
-      await expect(findSimilarArtist('autechre')).rejects.toBeInstanceOf(LibraryArtistNameMissingError);
-    });
-  });
-
-  describe('errorHandler middleware → 503 with runbook pointer', () => {
-    it('translates LibraryArtistNameMissingError into a 503 response whose body points at the backfill job', () => {
-      const error = new LibraryArtistNameMissingError(64163);
-      const status = jest.fn().mockReturnThis();
-      const json = jest.fn().mockReturnThis();
-      const res = { status, json } as unknown as Response;
-      const req = { method: 'GET', url: '/library' } as Request;
-      const next = jest.fn() as NextFunction;
-
-      errorHandler(error, req, res, next);
-
-      expect(status).toHaveBeenCalledWith(503);
-      expect(json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('jobs/library-artist-name-backfill'),
-        })
-      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- Soften the `library.artist_name` precondition: emit a Sentry warning instead of throwing a process-cached 503. Read paths already tolerate NULL (results project from the `artists` JOIN; trigram/tsvector predicates can't match NULL), so the hard gate was strictly worse than serving with degraded rows hidden.
- Plug the leak in `jobs/library-etl/job.ts`: `ensureArtist` now returns the canonical `artist_name` from the artists row; the library insert writes it on every new row. The TypeScript signature makes future omissions a build error.
- Update `docs/backfill-precondition-assertions.md` to retract the hard-gate pattern and document the soft-check + leak-plug shape, citing the 2026-04-30 incident.

Closes #685

## Incident context

DJs were locked out of the flowsheet station-wide on 2026-04-30 because a single ETL row (Oneohtrix Point Never, "Tranquilizer", added 2026-04-28) had `library.artist_name IS NULL`, and the boot-time precondition cached the resulting 503 for the lifetime of the Node process. Backfilled the row + restarted to mitigate; this PR is the durable fix.

## Test plan
- [x] `node_modules/.bin/jest --config jest.unit.config.ts tests/unit/services/library-artist-name-assertion.test.ts` — 8/8 pass
- [x] Full unit suite: 1365 tests pass; the 31 failing tests are pre-existing flake (auth.middleware, http.mirror) that pass in isolation
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 errors (329 pre-existing warnings unchanged)
- [ ] CI green on the PR
- [ ] Verify post-merge that prod no longer 503s catalog search if a NULL row leaks (soft check fires Sentry warning instead)

## Out of scope

- Rotation dropdown duplicates + missing entries (147 active rows with `album_id IS NULL`; several albums with 5-9 active rotation rows). Different table, different leak path. Filing separately.
- The `library-artist-name-backfill` job stays as-is; it's still useful as a recovery tool, just no longer load-bearing at startup.