### PR TITLE
Filter LmlClientError from Sentry express auto-capture

### DIFF
--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -22,6 +22,7 @@ import { startAlbumPlaysRefresh, stopAlbumPlaysRefresh } from './services/album-
 import { setupCdcWebSocket, shutdownCdcWebSocket } from './services/cdc/index.js';
 import { activeShow } from './middleware/checkActiveShow.js';
 import errorHandler from './middleware/errorHandler.js';
+import { shouldCaptureExpressError } from './middleware/sentryErrorFilter.js';
 import { requestIdMiddleware } from './middleware/requestId.js';
 import { requirePermissions } from '@wxyc/authentication';
 import { closeDatabaseConnection, db } from '@wxyc/database';
@@ -104,7 +105,7 @@ app.get('/healthcheck', async (req, res) => {
 // Internal endpoints (ETL sync notifications, key-authenticated)
 app.use('/internal', internal_route);
 
-Sentry.setupExpressErrorHandler(app);
+Sentry.setupExpressErrorHandler(app, { shouldHandleError: shouldCaptureExpressError });
 app.use(errorHandler);
 
 const server = app.listen(port, () => {

--- a/apps/backend/middleware/sentryErrorFilter.ts
+++ b/apps/backend/middleware/sentryErrorFilter.ts
@@ -1,0 +1,23 @@
+import { LmlClientError } from '../services/lml/lml.client.js';
+
+/**
+ * Decides whether `Sentry.setupExpressErrorHandler` should auto-capture an
+ * error that bubbled to express's error pipeline. Returning false skips the
+ * capture; the error still propagates to the application's `errorHandler` and
+ * the structured response is unaffected.
+ *
+ * `LmlClientError` is excluded because it is an expected external-dependency
+ * signal: the LML client throws it on timeout, non-2xx, or transport failure;
+ * `errorHandler` already translates it into a 502/503/504 response; and the
+ * code paths where LML observability is load-bearing (metadata enrichment,
+ * linkage backfill) capture to Sentry explicitly. Letting the express handler
+ * also capture it produces duplicate noise that drowns out genuine bugs —
+ * see BACKEND-SERVICE-5 (309 events in 75 minutes during the 2026-04-30
+ * cascade from the catalog-search 503 incident).
+ */
+export function shouldCaptureExpressError(error: Error): boolean {
+  if (error instanceof LmlClientError) return false;
+  const statusCode = (error as { statusCode?: number | string }).statusCode;
+  const numeric = typeof statusCode === 'string' ? parseInt(statusCode, 10) : statusCode;
+  return numeric === undefined || Number.isNaN(numeric) || numeric >= 500;
+}

--- a/tests/unit/middleware/sentryErrorFilter.test.ts
+++ b/tests/unit/middleware/sentryErrorFilter.test.ts
@@ -1,0 +1,33 @@
+import { shouldCaptureExpressError } from '../../../apps/backend/middleware/sentryErrorFilter';
+import { LmlClientError } from '../../../apps/backend/services/lml/lml.client';
+import WxycError from '../../../apps/backend/utils/error';
+
+describe('shouldCaptureExpressError', () => {
+  it('skips LmlClientError regardless of status code', () => {
+    expect(shouldCaptureExpressError(new LmlClientError('LML request timed out', 504))).toBe(false);
+    expect(shouldCaptureExpressError(new LmlClientError('LML 500', 502))).toBe(false);
+    expect(shouldCaptureExpressError(new LmlClientError('LML not configured', 503))).toBe(false);
+  });
+
+  it('captures WxycError with 5xx status (genuine internal errors)', () => {
+    expect(shouldCaptureExpressError(new WxycError('database error', 500))).toBe(true);
+    expect(shouldCaptureExpressError(new WxycError('upstream failure', 503))).toBe(true);
+  });
+
+  it('skips WxycError with 4xx status (client errors are not Sentry-worthy)', () => {
+    expect(shouldCaptureExpressError(new WxycError('Album not found', 404))).toBe(false);
+    expect(shouldCaptureExpressError(new WxycError('Bad request', 400))).toBe(false);
+  });
+
+  it('captures generic Errors (no statusCode means unknown crash)', () => {
+    expect(shouldCaptureExpressError(new Error('unexpected'))).toBe(true);
+  });
+
+  it('handles statusCode encoded as a string (express convention)', () => {
+    const stringStatus = Object.assign(new Error('e'), { statusCode: '504' });
+    expect(shouldCaptureExpressError(stringStatus)).toBe(true);
+
+    const stringClient = Object.assign(new Error('e'), { statusCode: '404' });
+    expect(shouldCaptureExpressError(stringClient)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #690.

## Summary
- `Sentry.setupExpressErrorHandler` now receives a `shouldHandleError` predicate that excludes `LmlClientError`. The default 5xx-capture behavior is preserved for everything else.
- The predicate is extracted to `apps/backend/middleware/sentryErrorFilter.ts` so it can be unit-tested without booting the express app.

## Why

Sentry's default predicate captures every error with `statusCode >= 500`. The LML client throws `LmlClientError` with 502/503/504 on upstream failures, but those are already (a) translated into structured responses by `errorHandler` and (b) explicitly captured at the call sites that need LML observability (`subsystem='metadata'` in `enrichment.service.ts`, `subsystem='lml-linkage'` in `linkage-metrics.service.ts`). Auto-capturing them at the express boundary just produced a duplicate noise stream.

The 2026-04-30 catalog-search-503 cascade is the concrete trigger: 309 `LmlClientError` events on `/proxy/library/search` (`BACKEND-SERVICE-5`) in 75 minutes, drowning the queue while the actual incident (a single NULL `library.artist_name` row, [#686](https://github.com/WXYC/Backend-Service/pull/686)) had 2 events.

## Test plan
- [x] `npm run test:unit` (1407 tests, all passing)
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors; pre-existing warnings unchanged)
- [x] `npm run format:check`
- [ ] Verify in production after merge: `BACKEND-SERVICE-5` does not see new `auto.middleware.express` events on the next LML hiccup.