### PR TITLE
Scope nextPlayOrder() to current show, not global max

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -24,12 +24,20 @@ import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
 let lastModifiedAt: Date = new Date();
 
 /**
- * Compute the next play_order value for a new flowsheet entry.
- * play_order is manually managed (not a serial/sequence), so we derive it
- * from the current max value.
+ * Compute the next play_order value for a new flowsheet entry within a given
+ * show. play_order is manually managed (not a serial/sequence) and is scoped
+ * per show — tubafrenzy's webhook writes per-show play_orders (1, 2, 3, ...)
+ * and Backend-Service inserts must continue that sequence rather than picking
+ * up the global table max. Without the `WHERE show_id = ?` predicate a brand
+ * new track in show B would inherit `max + 1` from a prior show A's late
+ * additions, producing the discontinuous play_order sequence that breaks
+ * dj-site's optimistic update + cache reconciliation (#693).
  */
-const nextPlayOrder = async (): Promise<number> => {
-  const result = await db.select({ max: sql<number>`coalesce(max(${flowsheet.play_order}), 0)` }).from(flowsheet);
+const nextPlayOrder = async (showId: number): Promise<number> => {
+  const result = await db
+    .select({ max: sql<number>`coalesce(max(${flowsheet.play_order}), 0)` })
+    .from(flowsheet)
+    .where(eq(flowsheet.show_id, showId));
   return result[0].max + 1;
 };
 
@@ -293,7 +301,10 @@ export const addTrack = async (entry: Omit<NewFSEntry, 'play_order'>): Promise<F
   //   }
   // }
 
-  const play_order = await nextPlayOrder();
+  if (entry.show_id == null) {
+    throw new WxycError('Cannot add flowsheet entry without show_id', 400);
+  }
+  const play_order = await nextPlayOrder(entry.show_id);
   const response = await db
     .insert(flowsheet)
     .values({ ...entry, play_order })
@@ -393,7 +404,7 @@ export const startShow = async (dj_id: string, show_name?: string, specialty_id?
   await db.insert(flowsheet).values({
     show_id: new_show[0].id,
     entry_type: 'show_start',
-    play_order: await nextPlayOrder(),
+    play_order: await nextPlayOrder(new_show[0].id),
     message: `Start of Show: DJ ${dj_info.djName || dj_info.name} joined the set at ${new Date().toLocaleString(
       'en-US',
       {
@@ -457,7 +468,7 @@ const createJoinNotification = async (id: string, show_id: number): Promise<FSEn
     .values({
       show_id: show_id,
       entry_type: 'dj_join',
-      play_order: await nextPlayOrder(),
+      play_order: await nextPlayOrder(show_id),
       message: message,
     })
     .returning();
@@ -492,7 +503,7 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
   await db.insert(flowsheet).values({
     show_id: currentShow.id,
     entry_type: 'show_end',
-    play_order: await nextPlayOrder(),
+    play_order: await nextPlayOrder(currentShow.id),
     message: `End of Show: ${dj_name} left the set at ${new Date().toLocaleString('en-US', {
       timeZone: 'America/New_York',
     })}`,
@@ -539,7 +550,7 @@ const createLeaveNotification = async (dj_id: string, show_id: number): Promise<
     .values({
       show_id: show_id,
       entry_type: 'dj_leave',
-      play_order: await nextPlayOrder(),
+      play_order: await nextPlayOrder(show_id),
       message: message,
     })
     .returning();

--- a/tests/unit/services/flowsheet.nextPlayOrder.test.ts
+++ b/tests/unit/services/flowsheet.nextPlayOrder.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression guard for WXYC/Backend-Service#693.
+ *
+ * `nextPlayOrder()` originally took the global max(play_order) across the
+ * entire `flowsheet` table and returned global_max + 1. With tubafrenzy's
+ * webhook writing per-show play_orders (1, 2, 3, ...) and dj-site's adds going
+ * through Backend-Service, a brand-new show would jump from per-show
+ * play_order=4 (last tubafrenzy row) straight to play_order=471 (global max+1
+ * pulled from a prior show's last entry). The discontinuity broke dj-site's
+ * optimistic-update + cache reconciliation in `infinite-cache.ts`, surfacing
+ * as "won't let me delete or reorder anything" for the on-air DJ.
+ *
+ * The fix scopes the max() to the row's own show via a `WHERE show_id = ?`
+ * predicate. This test simulates the exact scenario from the issue:
+ *   - Show A: per-show max play_order = 470
+ *   - Show B (the one we're inserting into): per-show max play_order = 4
+ * and asserts that an insert into show B picks 5 (B's max + 1), not 471
+ * (A's global max + 1).
+ *
+ * The DB driver is mocked at chain granularity. We verify two things:
+ *   1. The SELECT max chain receives a `where(...)` call (proving scope).
+ *   2. The new row inserted via the INSERT chain carries play_order=5.
+ */
+
+import { db, createMockQueryChain } from '../../mocks/database.mock';
+import { addTrack } from '../../../apps/backend/services/flowsheet.service';
+
+describe('flowsheet.service: nextPlayOrder is scoped per show (#693)', () => {
+  it("addTrack uses the new entry's show_id when computing play_order", async () => {
+    // Show A has per-show max play_order=470 (from a prior on-air DJ's late
+    // additions). Show B is the new one we're inserting into; its per-show
+    // max is 4 (tubafrenzy webhook seeded it). The bug returned 471 here;
+    // the fix returns 5.
+    const SHOW_B_MAX = 4;
+
+    // SELECT chain: returns the per-show max; the test verifies that .where()
+    // was called on it (i.e. the query is scoped, not global).
+    const selectChain = createMockQueryChain([{ max: SHOW_B_MAX }]);
+    // The drizzle pattern is `await db.select().from().where()` — make the
+    // chain awaitable so the await resolves to the per-show max.
+    (selectChain as unknown as { then: (resolve: (v: unknown) => void) => void }).then = (
+      resolve: (v: unknown) => void
+    ) => resolve([{ max: SHOW_B_MAX }]);
+    db.select.mockReturnValueOnce(selectChain);
+
+    // INSERT chain: returns the inserted row so addTrack can return it.
+    const insertReturnRow = { id: 12345, play_order: SHOW_B_MAX + 1, show_id: 1946734 };
+    const insertChain = createMockQueryChain([insertReturnRow]);
+    db.insert.mockReturnValueOnce(insertChain);
+
+    const newEntry = {
+      show_id: 1946734, // Show B (the one DJ Emily was on, per the issue body)
+      entry_type: 'track' as const,
+      artist_name: 'Motor City Drum Ensemble',
+      album_title: 'L.O.V.E.',
+      track_title: 'L.O.V.E.',
+      record_label: 'Hot Wax',
+      dj_name: 'DJ Emily',
+    };
+
+    const result = await addTrack(newEntry);
+
+    // 1. The SELECT max query must be scoped by show_id. If `nextPlayOrder()`
+    //    is still global, .where() is never called on the select chain.
+    expect(selectChain.where).toHaveBeenCalled();
+
+    // 2. The inserted row must carry play_order = SHOW_B_MAX + 1 = 5,
+    //    not the global max + 1 (471 in the live incident).
+    const insertedValues = insertChain.values.mock.calls[0]?.[0] as { play_order: number };
+    expect(insertedValues.play_order).toBe(SHOW_B_MAX + 1);
+
+    expect(result).toEqual(insertReturnRow);
+  });
+});


### PR DESCRIPTION
Closes #693.

## Summary

`nextPlayOrder()` was returning the global `max(play_order)` across the 2.6M-row flowsheet table and adding 1, with no `WHERE show_id = ?` predicate. Tubafrenzy's webhook writes per-show play_orders (1, 2, 3, ...), so a dj-site add into the current show would jump from per-show 4 (last tubafrenzy row) straight to 471 (global max + 1 inherited from a prior show's late additions). The 467-row discontinuity inside a single show broke dj-site's optimistic-update + cache reconciliation in `infinite-cache.ts`, surfacing to the on-air DJ as "won't let me delete or reorder anything" while DELETE/PATCH succeeded server-side.

## What changed

`nextPlayOrder()` now takes a `showId: number` argument and scopes the SELECT with `where(eq(flowsheet.show_id, showId))`. Five call sites in `apps/backend/services/flowsheet.service.ts` were updated to pass the show being inserted into: `addTrack` (line 307; new 400 guard for missing `entry.show_id`), `startShow` (line 407, passes the freshly-inserted show id), `createJoinNotification` (line 471, has `show_id` as a parameter), `endShow` (line 506, uses `currentShow.id`), and `createLeaveNotification` (line 553, has `show_id` as a parameter).

Existing rows in shows with non-monotonic play_orders are not auto-fixed by this change. The issue body explicitly puts that out of scope; operators can rewrite a misbehaving show's sequence with `ROW_NUMBER() OVER (PARTITION BY show_id ORDER BY add_time)` if needed.

A new unit test in `tests/unit/services/flowsheet.nextPlayOrder.test.ts` simulates the live incident: show A with per-show max 470, show B with per-show max 4, asserts that `addTrack` into show B yields `play_order=5` (B's max + 1), not 471. The test verifies both that the SELECT chain receives a `where(...)` call (proving the query is scoped, not global) and that the inserted row carries the per-show value. Confirmed failing against the unfixed code before applying the fix; passing after.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check`
- [x] `npm run test:unit` — 1408 tests pass, including the new regression guard
- [ ] CI integration tests against live PG