### PR TITLE
Document filterSpacerGif narrow scope in enrich.ts

### DIFF
--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -20,8 +20,12 @@
  *
  * Spacer.gif filter: applied inline until #649 lands. Discogs occasionally
  * returns `spacer.gif` placeholder images; persisting them would pollute
- * 1.86M rows for the historical drain alone. Once #649 ships a shared
- * helper, swap the inline `filterSpacerGif` for the import.
+ * 1.86M rows for the historical drain alone. Applied only to `artwork_url`
+ * — the other URL columns in the same `.set()` block come from the
+ * `streaming_links` table or LML-constructed search URLs, never Discogs
+ * image responses (verified against `lookup/orchestrator.py:855-970`, see
+ * #679). Once #649 ships a shared helper, swap the inline `filterSpacerGif`
+ * for the import.
  */
 
 import { sql } from 'drizzle-orm';


### PR DESCRIPTION
## Summary

One sentence added to the existing `enrich.ts` file-header `Spacer.gif filter:` block, recording the result of #679's audit: `spacer.gif` cannot reach any URL column other than `artwork_url`, because the streaming URL fields in the same `.set()` block populate from `library.db`'s `streaming_links` table or LML-constructed search URLs, never from Discogs image responses.

## Why

PR #673's review surfaced the question "why isn't `filterSpacerGif` applied to `spotify_url` etc. too?" — #679 answered it via source-trace of `library-metadata-lookup`'s `lookup/orchestrator.py:855-970`. The audit closed; this comment fulfills #679's "add an `enrich.ts` code-comment recording the result so future readers don't re-derive it" AC item.

The function itself isn't changed. This is a 6-insert / 2-delete diff to the file-header docblock — comment-only.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] `npm run test:unit -- --testPathPatterns='jobs/flowsheet-metadata-backfill'` — 43/43 passing across 3 suites (no behavior change)
- [ ] CI passes

Refs #679