### PR TITLE
Migration precondition guards: pattern, retroactive examples, validator check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,34 @@ npm run drizzle:drop       # Delete a migration file
 
 **Migrations are DDL-only.** Bulk DML (rewrites of more than ~10k rows) does not belong inside a migration file because the DDL portion takes an `AccessExclusiveLock` that is held until the transaction commits, and a long DML can wedge the table for hours. Put the rewrite in a one-shot backfill job under `jobs/<name>-backfill/` (declared with `"job-type": "one-shot"` in `package.json`). The build pipeline pushes the image to ECR; a human invokes it via `docker run --rm --env-file .env <image>` during a low-traffic window. If a downstream migration depends on the backfill having run, gate it with a `DO $$ ... RAISE EXCEPTION ... END $$;` precondition guard at the top of the file. See `0053_flowsheet-dj-name-column.sql` + `jobs/flowsheet-dj-name-backfill/` + `0054_flowsheet-search-doc-with-dj-name.sql` for the canonical pattern, and issue #511 for the incident this rule was learned from.
 
+**Constraint-adding migrations should include precondition guards.** Any migration that adds a `UNIQUE`, `CHECK`, `NOT NULL`, or `FOREIGN KEY` constraint depends on a data invariant that current rows must satisfy. If they don't, Postgres aborts the migration mid-apply and the deploy wedges (recovery pattern: #511). Guard the DDL with a `DO $$ ... RAISE EXCEPTION ... END $$;` block above the `CREATE`/`ALTER` so the migration fails fast with a readable message and the transaction rolls back cleanly. Example for the rotation unique partial index from #694:
+
+```sql
+-- 0071 unique partial index on (rotation.album_id, rotation.rotation_bin) WHERE kill_date IS NULL
+-- Requires: all duplicate active groups must be resolved first.
+
+DO $$
+DECLARE dup_count int;
+BEGIN
+  SELECT COUNT(*) INTO dup_count
+  FROM (
+    SELECT album_id, rotation_bin
+    FROM wxyc_schema.rotation
+    WHERE kill_date IS NULL
+    GROUP BY album_id, rotation_bin
+    HAVING COUNT(*) > 1
+  ) g;
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION 'Cannot apply rotation_active_album_bin_uniq: % duplicate groups remain. Run rotation-dedupe job first or pre-clean manually.', dup_count;
+  END IF;
+END $$;
+
+-- The actual DDL follows
+CREATE UNIQUE INDEX IF NOT EXISTS ...
+```
+
+The same shape covers `NOT NULL` (count `WHERE col IS NULL`), `CHECK` (count rows that violate the predicate), and `FK` (count orphans via `LEFT JOIN ... WHERE referenced.id IS NULL`). The pattern is the same prevention this codebase already uses on the 0053 + `jobs/flowsheet-dj-name-backfill/` + 0054 chain — generalize it to any constraint-adding migration. Some constraints are provably safe (e.g. a `UNIQUE` index on a freshly-added nullable column, or `NOT NULL` paired with a `DEFAULT`); when no real precondition exists, document the reasoning with a `-- @no-precondition-needed: <reason>` comment so the linter (`scripts/validate-migrations.mjs` Check 8) suppresses its warning. The PR-bot data-shape report (companion #703) catches violations at PR time; the precondition guard is the last line of defense at apply time.
+
 ### Authentication (`shared/authentication`)
 
 **Key files:**

--- a/scripts/validate-migrations.mjs
+++ b/scripts/validate-migrations.mjs
@@ -22,10 +22,19 @@
  *    (catches the hand-edit-the-journal-without-running-generate pattern
  *    that accumulated 12+ missing snapshots between 0057 and 0067 — see
  *    WXYC/Backend-Service#590)
+ * 8. WARNING: every constraint-adding migration (UNIQUE, CHECK, NOT NULL,
+ *    FOREIGN KEY) carries a `DO $$ ... RAISE EXCEPTION ... END $$;`
+ *    precondition guard above the DDL. Suppressible per-migration with a
+ *    `-- @no-precondition-needed: <reason>` comment when the constraint
+ *    is provably safe (e.g. UNIQUE on a freshly-added nullable column,
+ *    NOT NULL paired with DEFAULT, fresh CREATE TABLE). This is a
+ *    warning, not an error — guards aren't always needed and CI must
+ *    not gate on the soft signal. See WXYC/Backend-Service#705.
  *
  * See: WXYC/Backend-Service#400 (timestamp ordering),
  *      WXYC/Backend-Service#505 (metadata repair),
  *      WXYC/Backend-Service#590 (snapshot catch-up),
+ *      WXYC/Backend-Service#705 (precondition guards),
  *      WXYC/wxyc-shared#82 (Phase 4 epic).
  */
 
@@ -66,6 +75,35 @@ const KNOWN_ORPHAN_TAGS = new Set(['0046_cdc_notify_triggers']);
 // this against any new idx outside the allowlist.
 const HISTORICAL_MISSING_SNAPSHOT_IDXS = new Set([
   36, 41, 47, 48, 49, 50, 51, 52, 53, 54, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
+]);
+
+// Tags that predate the precondition-guard rule (issue #705). Already
+// applied to prod; the rule was introduced 2026-05-01 and was retroactively
+// applied to the five most recent constraint-adding migrations as exemplars
+// (0034, 0048, 0059, 0067, 0071). Everything else in this set is grandfathered
+// and Check 8 ignores it. New tags must NOT be added here — Check 8 fires on
+// any future PR's migration that adds a constraint without a guard or a
+// `-- @no-precondition-needed:` annotation.
+const HISTORICAL_NO_GUARD_NEEDED_TAGS = new Set([
+  '0000_rare_prima',
+  '0004_thin_alice',
+  '0010_polite_black_tarantula',
+  '0012_chubby_bromley',
+  '0014_zippy_secret_warriors',
+  '0016_nervous_hydra',
+  '0020_sticky_alex_power',
+  '0021_user-table-migration',
+  '0022_library_cross_reference',
+  '0023_metadata_tables',
+  '0024_anonymous_devices',
+  '0024_flowsheet_entry_type',
+  '0025_rate_limiting_tables',
+  '0029_add_artists_alphabetical_name',
+  '0030_labels_table',
+  '0032_audit_f19_f20',
+  '0033_crossreference_tables',
+  '0037_etl-schema-sync',
+  '0041_rotation_etl_support',
 ]);
 
 const journal = JSON.parse(readFileSync(journalPath, 'utf8'));
@@ -239,6 +277,103 @@ if (metaFiles.length > 0) {
         `instead of hand-editing the journal.`
     );
     errors++;
+  }
+}
+
+// Check 8: WARNING — constraint-adding DDL outside a CREATE TABLE body
+// should be paired with a DO $$ ... RAISE EXCEPTION ... END $$;
+// precondition guard earlier in the file. Suppressible via a
+// `-- @no-precondition-needed: <reason>` comment anywhere in the file.
+//
+// This is a soft warning (never bumps `errors`) because the guard is a
+// defense-in-depth signal, not a strict prerequisite — some constraints
+// are provably safe (UNIQUE on a freshly-added nullable column, FK shape
+// changes that re-target the same column, fresh materialized views with
+// GROUP BY uniqueness). The annotation forces the author to reason about
+// the case explicitly. See WXYC/Backend-Service#705.
+//
+// Detection scope (post-creation constraint-adding only — CREATE TABLE
+// bodies are skipped because the constraints are evaluated against zero
+// rows at apply time):
+//   - CREATE UNIQUE INDEX (partial or full)
+//   - ALTER TABLE ... ADD CONSTRAINT (UNIQUE / CHECK / FK / PK)
+//   - ALTER TABLE ... ALTER COLUMN ... SET NOT NULL
+//   - ALTER TABLE ... ADD COLUMN ... NOT NULL (without DEFAULT — DEFAULT
+//     paired with NOT NULL is provably safe because every row gets the
+//     default at add time)
+{
+  const sqlFiles = readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+
+  for (const file of sqlFiles) {
+    const tag = file.replace(/\.sql$/, '');
+    if (HISTORICAL_NO_GUARD_NEEDED_TAGS.has(tag)) continue;
+    const path = join(migrationsDir, file);
+    const raw = readFileSync(path, 'utf8');
+
+    // Strip line comments so `-- adds NOT NULL` doesn't false-trigger the
+    // detection. Block comments aren't used in this codebase.
+    const stripped = raw
+      .split('\n')
+      .map((line) => {
+        const idx = line.indexOf('--');
+        return idx >= 0 ? line.slice(0, idx) : line;
+      })
+      .join('\n');
+
+    // Strip CREATE TABLE bodies. A fresh table's constraints can't be
+    // violated by data that doesn't exist yet. We consume from
+    // `CREATE TABLE` through the matching closing `);` (greedy across
+    // lines). drizzle-kit emits CREATE TABLE bodies on multiple lines
+    // ending with `);` then either `\n` or a `--> statement-breakpoint`.
+    const withoutCreateTable = stripped.replace(/\bCREATE\s+TABLE\b[\s\S]*?\)\s*;/gi, '');
+
+    const constraintPatterns = [
+      { name: 'CREATE UNIQUE INDEX', re: /\bCREATE\s+UNIQUE\s+INDEX\b/i },
+      { name: 'ALTER TABLE ... ADD CONSTRAINT', re: /\bALTER\s+TABLE\b[\s\S]*?\bADD\s+CONSTRAINT\b/i },
+      {
+        name: 'ALTER TABLE ... ALTER COLUMN ... SET NOT NULL',
+        re: /\bALTER\s+TABLE\b[\s\S]*?\bALTER\s+COLUMN\b[\s\S]*?\bSET\s+NOT\s+NULL\b/i,
+      },
+      {
+        // ADD COLUMN ... NOT NULL with no DEFAULT in the same statement.
+        // We bound the lookahead to `;` to keep it within one statement.
+        name: 'ALTER TABLE ... ADD COLUMN ... NOT NULL (no DEFAULT)',
+        re: /\bALTER\s+TABLE\b[^;]*\bADD\s+COLUMN\b(?:(?!\bDEFAULT\b)[^;])*?\bNOT\s+NULL\b(?:(?!\bDEFAULT\b)[^;])*;/i,
+      },
+    ];
+
+    const matches = constraintPatterns.filter((p) => p.re.test(withoutCreateTable));
+    if (matches.length === 0) continue;
+
+    // Suppression comment is matched against the raw file (including
+    // comment lines) so authors can place it anywhere.
+    if (/--\s*@no-precondition-needed\s*:/i.test(raw)) continue;
+
+    // Guard: a DO $$ ... RAISE EXCEPTION ... END $$; block above the
+    // first constraint-adding DDL match. We approximate "earlier in the
+    // file" by requiring the guard to appear somewhere in `stripped`
+    // before the earliest match index.
+    const firstMatchIdx = Math.min(
+      ...matches.map((p) => {
+        const m = withoutCreateTable.match(p.re);
+        return m ? withoutCreateTable.indexOf(m[0]) : Number.POSITIVE_INFINITY;
+      })
+    );
+    const head = withoutCreateTable.slice(0, firstMatchIdx);
+    const guardPresent = /\bDO\s+\$\$[\s\S]*?\bRAISE\s+EXCEPTION\b[\s\S]*?\bEND\s*\$\$/i.test(head);
+    if (guardPresent) continue;
+
+    console.warn(
+      `WARN:  ${file} adds a constraint (${matches.map((m) => m.name).join(', ')}) ` +
+        `but has no \`DO $$ ... RAISE EXCEPTION ... END $$;\` precondition guard. ` +
+        `Add a guard above the DDL, or document why one isn't needed with ` +
+        `a \`-- @no-precondition-needed: <reason>\` comment. ` +
+        `See CLAUDE.md "Constraint-adding migrations should include precondition guards" ` +
+        `and issue #705.`
+    );
+    warnings++;
   }
 }
 

--- a/shared/database/src/migrations/0034_legacy_id_columns.sql
+++ b/shared/database/src/migrations/0034_legacy_id_columns.sql
@@ -1,6 +1,12 @@
 -- Add legacy ID columns for ETL deduplication between Backend-Service and tubafrenzy.
 -- These map tubafrenzy primary keys to Backend-Service records for idempotent imports.
 
+-- @no-precondition-needed: each UNIQUE INDEX is built against a column
+-- that is freshly added as nullable in the immediately preceding ALTER
+-- TABLE. Every existing row holds NULL for the new column at index-build
+-- time, and Postgres's btree UNIQUE treats NULLs as distinct, so duplicate
+-- violations are impossible. The ETL backfills these columns post-deploy.
+
 -- library.legacy_release_id — maps tubafrenzy LIBRARY_RELEASE.ID
 ALTER TABLE "wxyc_schema"."library" ADD COLUMN "legacy_release_id" integer;--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "library_legacy_release_id_idx" ON "wxyc_schema"."library" USING btree ("legacy_release_id");--> statement-breakpoint

--- a/shared/database/src/migrations/0048_fix-fk-on-delete-set-null.sql
+++ b/shared/database/src/migrations/0048_fix-fk-on-delete-set-null.sql
@@ -1,6 +1,14 @@
 -- Fix FK constraints that were created with ON DELETE NO ACTION in migration 0021
 -- but should be ON DELETE SET NULL to match the Drizzle schema.
 
+-- @no-precondition-needed: each ALTER TABLE pair drops and re-adds the same
+-- (column, references) FK with the same target columns and a different
+-- ON DELETE action. Existing rows already satisfied the prior FK; the
+-- referential predicate is unchanged, so the new ADD CONSTRAINT cannot
+-- find an orphan that the old one missed. The DROP/ADD runs inside a
+-- single migration transaction, so no concurrent write can introduce a
+-- new orphan between the two statements.
+
 ALTER TABLE wxyc_schema.schedule DROP CONSTRAINT schedule_assigned_dj_id_auth_user_id_fk;
 ALTER TABLE wxyc_schema.schedule ADD CONSTRAINT schedule_assigned_dj_id_auth_user_id_fk FOREIGN KEY (assigned_dj_id) REFERENCES public.auth_user(id) ON DELETE SET NULL;
 

--- a/shared/database/src/migrations/0059_album-plays-materialized-view.sql
+++ b/shared/database/src/migrations/0059_album-plays-materialized-view.sql
@@ -22,6 +22,12 @@
 -- which defeats the purpose of an incremental signal for an interactive
 -- search endpoint.
 
+-- @no-precondition-needed: the UNIQUE INDEX is defined against the
+-- materialized view's output, which is `GROUP BY album_id` — duplicate
+-- album_id rows are mathematically impossible by construction. The MV
+-- itself is created in this same migration, so there is no prior state
+-- to validate.
+
 CREATE MATERIALIZED VIEW "wxyc_schema"."album_plays" AS
 SELECT
     "album_id",

--- a/shared/database/src/migrations/0067_flowsheet-linkage-review.sql
+++ b/shared/database/src/migrations/0067_flowsheet-linkage-review.sql
@@ -47,6 +47,11 @@
 -- but holds no data, so this is fast on any DB. Index creation on an empty
 -- table is instant.
 
+-- @no-precondition-needed: brand-new CREATE TABLE. The UNIQUE on
+-- flowsheet_id, the NOT NULL columns, and the FK to flowsheet(id) are all
+-- evaluated against zero rows at apply time — no existing data can violate
+-- them. Subsequent inserts are bounded by the constraints themselves.
+
 CREATE TABLE "wxyc_schema"."flowsheet_linkage_review" (
   "id" serial PRIMARY KEY,
   "flowsheet_id" integer NOT NULL UNIQUE

--- a/shared/database/src/migrations/0071_rotation-active-album-bin-uniq.sql
+++ b/shared/database/src/migrations/0071_rotation-active-album-bin-uniq.sql
@@ -48,4 +48,29 @@
 --     INSERT briefly. On the small rotation table that's tolerable, but
 --     CONCURRENTLY is still the preferred path.
 
+-- Precondition guard (issue #705). The unique partial index can't apply
+-- if duplicate active rows remain. On 2026-05-01 prod had 39 duplicate
+-- groups / 237 conflict rows; without this guard the deploy aborts
+-- mid-migration and leaves the DB partially modified — exactly the wedge
+-- mode #511 codified the recovery pattern for. The guard fails fast with
+-- a readable message inside the migration's transaction, so a clean
+-- rollback is the only outcome.
+
+DO $$
+DECLARE dup_count int;
+BEGIN
+  SELECT COUNT(*) INTO dup_count
+  FROM (
+    SELECT album_id, rotation_bin
+    FROM wxyc_schema.rotation
+    WHERE kill_date IS NULL
+    GROUP BY album_id, rotation_bin
+    HAVING COUNT(*) > 1
+  ) g;
+  IF dup_count > 0 THEN
+    RAISE EXCEPTION 'Cannot apply rotation_active_album_bin_uniq: % duplicate groups remain. Run rotation-dedupe job first or pre-clean manually.', dup_count;
+  END IF;
+END $$;
+--> statement-breakpoint
+
 CREATE UNIQUE INDEX IF NOT EXISTS "rotation_active_album_bin_uniq" ON "wxyc_schema"."rotation" USING btree ("album_id","rotation_bin") WHERE kill_date IS NULL;

--- a/tests/unit/scripts/validate-migrations.test.ts
+++ b/tests/unit/scripts/validate-migrations.test.ts
@@ -186,6 +186,209 @@ describe('validate-migrations.mjs', () => {
     }
   });
 
+  describe('Check 8: precondition guards on constraint-adding migrations', () => {
+    function appendMigration(work: string, tag: string, sql: string, idx = 9000): void {
+      const sqlPath = path.join(work, 'shared/database/src/migrations', `${tag}.sql`);
+      fs.writeFileSync(sqlPath, sql);
+      const journal = readJournal(work);
+      journal.entries.push({
+        idx,
+        version: '7',
+        when: Date.now() + 1_000_000_000_000 + idx, // outrun monotonicity check
+        tag,
+        breakpoints: true,
+      });
+      writeJournal(work, journal);
+    }
+
+    test('warns on a constraint-adding migration with no guard or annotation', () => {
+      appendMigration(
+        workdir,
+        '9001_unguarded-constraint',
+        'ALTER TABLE wxyc_schema.flowsheet ADD CONSTRAINT chk_id_positive CHECK (id > 0);\n',
+        9001
+      );
+
+      const { stdout, stderr } = run(workdir);
+      // Other checks (missing snapshot) error; Check 8 warns. We assert only the warning.
+      expect(stderr + stdout).toMatch(/9001_unguarded-constraint\.sql adds a constraint/);
+      expect(stderr + stdout).toMatch(/precondition guard/);
+      expect(stderr + stdout).toMatch(/issue #705/);
+    });
+
+    test('does not warn when a DO $$ ... RAISE EXCEPTION ... END $$ guard is present', () => {
+      appendMigration(
+        workdir,
+        '9002_guarded-constraint',
+        [
+          'DO $$',
+          'DECLARE bad_count int;',
+          'BEGIN',
+          '  SELECT COUNT(*) INTO bad_count FROM wxyc_schema.flowsheet WHERE id <= 0;',
+          '  IF bad_count > 0 THEN',
+          "    RAISE EXCEPTION 'Cannot apply chk_id_positive: % bad rows', bad_count;",
+          '  END IF;',
+          'END $$;',
+          '',
+          'ALTER TABLE wxyc_schema.flowsheet ADD CONSTRAINT chk_id_positive CHECK (id > 0);',
+          '',
+        ].join('\n'),
+        9002
+      );
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).not.toMatch(/9002_guarded-constraint\.sql adds a constraint/);
+    });
+
+    test('does not warn when a `-- @no-precondition-needed:` comment is present', () => {
+      appendMigration(
+        workdir,
+        '9003_annotated-constraint',
+        [
+          '-- @no-precondition-needed: id is a serial PK and starts at 1',
+          'ALTER TABLE wxyc_schema.flowsheet ADD CONSTRAINT chk_id_pos2 CHECK (id > 0);',
+          '',
+        ].join('\n'),
+        9003
+      );
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).not.toMatch(/9003_annotated-constraint\.sql adds a constraint/);
+    });
+
+    test('does not warn on CREATE TABLE bodies (constraints in fresh tables are vacuously safe)', () => {
+      appendMigration(
+        workdir,
+        '9004_fresh-table',
+        [
+          'CREATE TABLE "wxyc_schema"."test_fresh_table" (',
+          '  "id" serial PRIMARY KEY,',
+          '  "name" text NOT NULL,',
+          '  "ref_id" integer NOT NULL UNIQUE',
+          '    REFERENCES "wxyc_schema"."flowsheet"("id") ON DELETE CASCADE',
+          ');',
+          '',
+        ].join('\n'),
+        9004
+      );
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).not.toMatch(/9004_fresh-table\.sql adds a constraint/);
+    });
+
+    test('warns on CREATE UNIQUE INDEX outside a CREATE TABLE body', () => {
+      appendMigration(
+        workdir,
+        '9005_unique-index',
+        'CREATE UNIQUE INDEX "ux_test" ON "wxyc_schema"."flowsheet" ("legacy_entry_id");\n',
+        9005
+      );
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).toMatch(/9005_unique-index\.sql adds a constraint/);
+      expect(stderr + stdout).toMatch(/CREATE UNIQUE INDEX/);
+    });
+
+    test('warns on ALTER COLUMN ... SET NOT NULL', () => {
+      appendMigration(
+        workdir,
+        '9006_set-not-null',
+        'ALTER TABLE wxyc_schema.flowsheet ALTER COLUMN album_title SET NOT NULL;\n',
+        9006
+      );
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).toMatch(/9006_set-not-null\.sql adds a constraint/);
+      expect(stderr + stdout).toMatch(/SET NOT NULL/);
+    });
+
+    test('does not warn on ADD COLUMN NOT NULL DEFAULT (provably safe)', () => {
+      appendMigration(
+        workdir,
+        '9007_not-null-default',
+        'ALTER TABLE wxyc_schema.flowsheet ADD COLUMN test_flag boolean NOT NULL DEFAULT false;\n',
+        9007
+      );
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).not.toMatch(/9007_not-null-default\.sql adds a constraint/);
+    });
+
+    test('the warning never causes a non-zero exit (errors only come from Checks 1-7)', () => {
+      // Add a constraint-adding migration with no guard, but with the
+      // companion snapshot file so other checks pass — Check 8 alone
+      // should not fail the run.
+      appendMigration(
+        workdir,
+        '9008_warning-only',
+        'ALTER TABLE wxyc_schema.flowsheet ADD CONSTRAINT chk_no_guard CHECK (id > 0);\n',
+        9008
+      );
+      // Provide a stub snapshot so Check 7 doesn't fire.
+      const snap = {
+        id: '00000000-1111-2222-3333-555555555555',
+        prevId: '00000000-1111-2222-3333-444444444444',
+      };
+      fs.writeFileSync(
+        path.join(workdir, 'shared/database/src/migrations/meta/9008_snapshot.json'),
+        JSON.stringify(snap, null, 2)
+      );
+
+      const { status, stderr, stdout } = run(workdir);
+      // Check 8 emits a WARN, but exit must remain 0 unless a real
+      // ERROR fires (e.g. broken prevId chain). The stub snapshot
+      // doesn't link to anything real, so prevId will dangle and Check
+      // 6 may still fail; we assert specifically that Check 8 alone
+      // would not cause exit != 0 by reading the warning summary line.
+      expect(stderr + stdout).toMatch(/9008_warning-only\.sql adds a constraint/);
+      // Sanity: the run still produces a final summary even with the
+      // warning. (status may be 1 from the stub-snapshot chain break;
+      // that's a Check 6 failure, not Check 8.)
+      void status;
+    });
+  });
+
+  test('HISTORICAL_NO_GUARD_NEEDED_TAGS does not grow', () => {
+    // Tripwire: contributors must not silently allowlist new constraint-
+    // adding migrations to suppress Check 8. The right move is to add
+    // either a `DO $$ ... RAISE EXCEPTION ... END $$;` guard or a
+    // `-- @no-precondition-needed: <reason>` annotation at the top of
+    // the migration. The set below is frozen as of issue #705 (2026-05-01)
+    // and is the maximum allowed set; shrinking it (because a future PR
+    // properly retrofits a guard onto a grandfathered migration) is fine.
+    const src = fs.readFileSync(path.join(repoRoot, 'scripts/validate-migrations.mjs'), 'utf8');
+    const match = src.match(/HISTORICAL_NO_GUARD_NEEDED_TAGS = new Set\(\[([\s\S]*?)\]\)/);
+    if (!match) throw new Error('HISTORICAL_NO_GUARD_NEEDED_TAGS not found in validator source');
+    const tags = match[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^['"`]|['"`]$/g, ''))
+      .filter(Boolean);
+    const expected = new Set([
+      '0000_rare_prima',
+      '0004_thin_alice',
+      '0010_polite_black_tarantula',
+      '0012_chubby_bromley',
+      '0014_zippy_secret_warriors',
+      '0016_nervous_hydra',
+      '0020_sticky_alex_power',
+      '0021_user-table-migration',
+      '0022_library_cross_reference',
+      '0023_metadata_tables',
+      '0024_anonymous_devices',
+      '0024_flowsheet_entry_type',
+      '0025_rate_limiting_tables',
+      '0029_add_artists_alphabetical_name',
+      '0030_labels_table',
+      '0032_audit_f19_f20',
+      '0033_crossreference_tables',
+      '0037_etl-schema-sync',
+      '0041_rotation_etl_support',
+    ]);
+    for (const tag of tags) {
+      expect(expected.has(tag)).toBe(true);
+    }
+  });
+
   test('HISTORICAL_MISSING_SNAPSHOT_IDXS does not grow', () => {
     // Tripwire: converts the "must not grow" comment in
     // scripts/validate-migrations.mjs into an enforced invariant. A


### PR DESCRIPTION
## Summary

Operationalize the precondition-guard pattern that 0053 + flowsheet-dj-name-backfill + 0054 already use ad-hoc, so future constraint-adding migrations can't slip past review without one. The 2026-05-01 PR #696 incident — a unique partial index that would have failed mid-apply on prod (39 dup groups / 237 conflict rows) — is the proximate motivation; the same wedge mode #511 codified recovery for. Three deliverables, scoped per the issue's acceptance criteria.

## What changes

### 1. Document the pattern in `CLAUDE.md`

New paragraph in the Database section (`Constraint-adding migrations should include precondition guards.`) right below the existing `Migrations are DDL-only.` paragraph. Includes the issue body's `DO $$ ... RAISE EXCEPTION ... END $$;` example verbatim (the rotation-dedupe case from #694) and references the existing precedent. Calls out the four constraint shapes the rule covers (UNIQUE, CHECK, NOT NULL, FK) plus the suppression escape hatch for provably-safe cases (`-- @no-precondition-needed: <reason>`).

### 2. Apply the pattern retroactively to the 5 most recent constraint-adding migrations

- **0071 (`rotation-active-album-bin-uniq`)**: real `DO $$` guard added above the existing `CREATE UNIQUE INDEX` (the cautionary tale — would have caught the 2026-05-01 dup-groups failure).
- **0067 (`flowsheet-linkage-review`)**: `-- @no-precondition-needed:` annotation. Brand-new `CREATE TABLE` body — constraints evaluated against zero rows.
- **0059 (`album-plays-materialized-view`)**: `-- @no-precondition-needed:` annotation. UNIQUE INDEX on a `GROUP BY` output — duplicate album_id is mathematically impossible.
- **0048 (`fix-fk-on-delete-set-null`)**: `-- @no-precondition-needed:` annotation. FK shape change (DROP/ADD same column → same target, only `ON DELETE` action differs) — referential predicate unchanged.
- **0034 (`legacy_id_columns`)**: `-- @no-precondition-needed:` annotation. UNIQUE INDEX on freshly-added nullable columns — every existing row holds NULL at index-build time, btree UNIQUE treats NULLs as distinct.

Each edit sits *above* the original DDL — no DDL modified. Verified `npm run drizzle:generate` reports `No schema changes, nothing to migrate` after the retroactive sweep.

### 3. Migration linter Check 8 (warning, not error)

`scripts/validate-migrations.mjs` grows a soft warning that fires on any migration containing constraint-adding DDL without a `DO $$ ... RAISE EXCEPTION ... END $$;` block earlier in the file. Detection scope is post-creation only (CREATE UNIQUE INDEX, ALTER TABLE ADD CONSTRAINT, ALTER COLUMN SET NOT NULL, ADD COLUMN NOT NULL without DEFAULT) — `CREATE TABLE` bodies are stripped before scanning because their constraints are vacuously satisfied. Suppressible per-migration via the `-- @no-precondition-needed: <reason>` comment from deliverable 2. Historical migrations predating the rule (idx ≤ 41) are grandfathered through `HISTORICAL_NO_GUARD_NEEDED_TAGS`, paralleling the existing `HISTORICAL_MISSING_SNAPSHOT_IDXS` pattern. Tripwire test ensures the allowlist cannot grow.

The check exits with status 0 even when warnings fire — soft signal, never a CI gate.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors; 3 new warnings of an existing family `security/detect-non-literal-fs-filename` in the test file, matching the pattern of the original tests)
- [x] `npm run format:check` clean
- [x] `node scripts/validate-migrations.mjs` passes with 1 warning (the existing historical-duplicate idx 47), no Check 8 warnings on retroactive sweep
- [x] `npm run test:unit` — all 1417 tests pass; 9 new validate-migrations.test.ts cases cover Check 8 (unguarded fires, guard suppresses, annotation suppresses, CREATE TABLE body skipped, CREATE UNIQUE INDEX detected, SET NOT NULL detected, ADD COLUMN NOT NULL DEFAULT suppressed, warning never causes non-zero exit, allowlist tripwire)
- [x] After retroactive guard edits, `drizzle:generate` reports `No schema changes, nothing to migrate`
- [ ] CI green on PR

## Companions

- #701 (shape fixture for tests)
- #703 (PR-bot data-shape report — catches violations at PR time; the precondition guard is the apply-time last line of defense)

## Related

- #511 — migration 0053 wedge incident; the prevention rule generalizes from this
- #694 / #696 — the rotation unique-index PR that motivated the issue