### PR TITLE
Annotate sync-target tables with SOURCE comments + ESLint rule for constraint changes

### DIFF
--- a/eslint-rules/source-tagged-constraint.cjs
+++ b/eslint-rules/source-tagged-constraint.cjs
@@ -1,0 +1,178 @@
+/**
+ * @fileoverview Warns when a constraint (uniqueIndex, check, notNull, unique)
+ * is added to a Drizzle table whose definition is preceded by a `SOURCE:`
+ * comment.
+ *
+ * SOURCE-tagged tables are downstream of an upstream system (tubafrenzy, the
+ * legacy MySQL library, LML's entity.identity, etc.). The upstream owns the
+ * data shape; constraints added at the Drizzle layer can contradict shapes
+ * the upstream permits and block the next ETL pass. See
+ * WXYC/Backend-Service#702 and the 2026-04-30 rotation incident for context.
+ *
+ * The rule emits a warning, never an error. Suppress per occurrence with:
+ *   // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
+ * once the constraint has been confirmed consistent with the upstream's
+ * data shape.
+ *
+ * Authored as CommonJS so the same module loads from both
+ * `eslint.config.mjs` (via ESM default-import interop) and the Jest unit
+ * tests (which run under ts-jest in CJS mode).
+ */
+
+'use strict';
+
+const SOURCE_TAG_RE = /\bSOURCE:\s*/;
+const CONSTRAINT_CALLEES = new Set(['uniqueIndex', 'check']);
+const CONSTRAINT_METHODS = new Set(['notNull', 'unique']);
+
+const MESSAGE =
+  "Adding a constraint to a SOURCE-tagged table ('{{tableName}}'). Confirm the constraint is consistent with the upstream's data shape (see the SOURCE comment on this table). Suppress with `// eslint-disable-next-line wxyc/source-tagged-constraint-confirmed` once verified.";
+
+/**
+ * True if any comment attached above `node` carries the `SOURCE:` marker.
+ */
+function hasSourceTag(sourceCode, node) {
+  const comments = sourceCode.getCommentsBefore(node);
+  if (!comments || comments.length === 0) return false;
+  return comments.some((c) => SOURCE_TAG_RE.test(c.value));
+}
+
+/**
+ * Resolve the table-name string passed as the first argument to
+ * `<schema>.table('<name>', ...)` or `pgTable('<name>', ...)`.
+ * Returns null if it can't be statically determined.
+ */
+function getTableNameArg(callExpr) {
+  const arg0 = callExpr.arguments[0];
+  if (!arg0) return null;
+  if (arg0.type === 'Literal' && typeof arg0.value === 'string') return arg0.value;
+  if (arg0.type === 'TemplateLiteral' && arg0.quasis.length === 1) {
+    return arg0.quasis[0].value.cooked;
+  }
+  return null;
+}
+
+/**
+ * True if the CallExpression is a Drizzle table definition:
+ *   pgTable(...) | someSchema.table(...) | wxyc_schema.table(...)
+ */
+function isTableDefinitionCall(callExpr) {
+  const callee = callExpr.callee;
+  if (callee.type === 'Identifier' && callee.name === 'pgTable') return true;
+  if (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'table'
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Walk up from `node` to find the nearest enclosing CallExpression that
+ * is itself a Drizzle table-definition call. Returns null if none found.
+ */
+function findEnclosingTableDefinition(node) {
+  let current = node.parent;
+  while (current) {
+    if (current.type === 'CallExpression' && isTableDefinitionCall(current)) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Warn when a constraint is added to a SOURCE-tagged Drizzle table. SOURCE-tagged tables are downstream of an upstream system; constraints must accept the upstream shape.',
+    },
+    schema: [],
+    messages: {
+      sourceTaggedConstraint: MESSAGE,
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    // Cache: a table-definition CallExpression -> "is the surrounding
+    // declaration SOURCE-tagged?" The "SOURCE:" comment sits above the
+    // outermost `export const X = ...` or `const X = ...`, not above the
+    // inner CallExpression, so we walk up to find it.
+    const sourceTaggedCache = new WeakMap();
+
+    function tableCallIsSourceTagged(tableCall) {
+      if (sourceTaggedCache.has(tableCall)) {
+        return sourceTaggedCache.get(tableCall);
+      }
+      // Comments may attach to any of: VariableDeclarator,
+      // VariableDeclaration, ExportNamedDeclaration. Probe each ancestor
+      // up to the Program root.
+      const candidates = [];
+      let current = tableCall.parent;
+      while (current && current.type !== 'Program') {
+        if (
+          current.type === 'VariableDeclaration' ||
+          current.type === 'VariableDeclarator' ||
+          current.type === 'ExportNamedDeclaration' ||
+          current.type === 'ExportDefaultDeclaration'
+        ) {
+          candidates.push(current);
+        }
+        current = current.parent;
+      }
+      const tagged = candidates.some((n) => hasSourceTag(sourceCode, n));
+      sourceTaggedCache.set(tableCall, tagged);
+      return tagged;
+    }
+
+    function reportIfSourceTagged(reportNode, callExpr) {
+      const tableCall = findEnclosingTableDefinition(callExpr);
+      if (!tableCall) return;
+      if (!tableCallIsSourceTagged(tableCall)) return;
+      const tableName = getTableNameArg(tableCall) || '<unknown>';
+      context.report({
+        node: reportNode,
+        messageId: 'sourceTaggedConstraint',
+        data: { tableName },
+      });
+    }
+
+    return {
+      // Bare-callee form: `uniqueIndex(...)`, `check(...)`. We only fire on
+      // an Identifier callee, not on member-expression forms like
+      // `obj.uniqueIndex`, which are different APIs.
+      "CallExpression[callee.type='Identifier']"(node) {
+        if (!CONSTRAINT_CALLEES.has(node.callee.name)) return;
+        reportIfSourceTagged(node.callee, node);
+      },
+
+      // Member-callee form: `.notNull()`, `.unique()`.
+      "CallExpression[callee.type='MemberExpression']"(node) {
+        const prop = node.callee.property;
+        if (!prop || prop.type !== 'Identifier') return;
+        if (!CONSTRAINT_METHODS.has(prop.name)) return;
+        reportIfSourceTagged(prop, node);
+      },
+    };
+  },
+};
+
+// Registered under the suppress-friendly name so authors confirm with the
+// rule name in the disable directive itself.
+//
+//   // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
+//   .notNull()
+//
+// The disable directive is the confirmation handshake.
+module.exports = {
+  rules: {
+    'source-tagged-constraint-confirmed': rule,
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import security from 'eslint-plugin-security';
 import prettierConfig from 'eslint-config-prettier';
+import wxycLocalRules from './eslint-rules/source-tagged-constraint.cjs';
 
 export default tseslint.config(
   // Global ignores
@@ -14,6 +15,7 @@ export default tseslint.config(
       'coverage/',
       '**/*.js',
       '**/*.mjs',
+      '**/*.cjs',
       '**/*.d.ts',
       '**/*.d.mts',
       'shared/database/src/migrations/**',
@@ -46,6 +48,24 @@ export default tseslint.config(
         projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
+    },
+  },
+
+  // WXYC custom rules — schema annotations (#702)
+  {
+    files: ['shared/database/**/*.ts'],
+    plugins: {
+      wxyc: wxycLocalRules,
+    },
+    rules: {
+      // Warn when a constraint is added to a SOURCE-tagged table. The rule is
+      // intentionally a warning, not an error — it's a friction point that
+      // forces an explicit acknowledgement, not a CI gate. Suppress per
+      // occurrence with:
+      //   // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
+      // once the constraint has been confirmed consistent with the upstream's
+      // data shape.
+      'wxyc/source-tagged-constraint-confirmed': 'warn',
     },
   },
 

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -230,9 +230,27 @@ export const artists = wxyc_schema.table(
     code_letters: varchar('code_letters', { length: 4 }).notNull(),
     add_date: date('add_date').defaultNow().notNull(),
     last_modified: timestamp('last_modified', { withTimezone: true }).defaultNow().notNull(),
-    // Reconciled external identifiers, populated by an ETL from LML's entity.identity table.
-    // Mirrors the @wxyc/shared ReconciledIdentity schema. All nullable; URL construction is
-    // the consumer's responsibility (templates exist for Spotify, Apple Music, and Bandcamp).
+    /**
+     * SOURCE: LML's `entity.identity` PostgreSQL table via
+     * `jobs/artist-identity-etl/`. Library staff own everything else on
+     * this row; the six reconciled-identity columns below are populated
+     * (null-fill only) by the LML ETL. Shapes LML permits and the ETL
+     * preserves:
+     *
+     *   - All six are nullable. LML resolves identifiers per source
+     *     independently; an artist can have a Discogs match but no
+     *     MusicBrainz match, etc. Do NOT add NOT NULL or any composite
+     *     uniqueness across these columns.
+     *   - Library-staff-entered values win on conflict (the ETL only
+     *     null-fills); a non-null value here is the authoritative one
+     *     even if it differs from LML's current resolution.
+     *   - URL construction is the consumer's responsibility (templates
+     *     exist for Spotify, Apple Music, and Bandcamp).
+     *
+     * Constraints added to these six columns must accept the full LML
+     * shape. See WXYC/Backend-Service#702 + the artist-identity-etl
+     * docs in CLAUDE.md.
+     */
     discogs_artist_id: integer('discogs_artist_id'),
     musicbrainz_artist_id: varchar('musicbrainz_artist_id', { length: 64 }),
     wikidata_qid: varchar('wikidata_qid', { length: 32 }),
@@ -259,30 +277,61 @@ export const format = wxyc_schema.table('format', {
 
 export type NewAlbum = InferInsertModel<typeof library>;
 export type Album = InferSelectModel<typeof library>;
+/**
+ * SOURCE: legacy MySQL via `scripts/run-library-etl.sh` (and tubafrenzy
+ * mirror writes for live additions). Library staff curate the music
+ * collection in tubafrenzy/MySQL; Backend-Service is downstream. Shapes the
+ * upstream permits and the ETL preserves include:
+ *
+ *   - NULL `artist_name` until the A.2 backfill / A.3 live-cascade has run
+ *     for that row. Code paths reading `artist_name` must tolerate NULL.
+ *   - NULL `album_artist`, `label`, `label_id`, `alternate_artist_name`,
+ *     `artwork_url`, `on_streaming`, `code_volume_letters` (genuine library
+ *     metadata gaps).
+ *   - Multiple `library` rows pointing at the same `(artists.id,
+ *     album_title)` — the legacy library is per-physical-format, so a CD
+ *     and an LP issue of the same album are distinct rows.
+ *   - NULL `canonical_entity_id` / `canonical_entity_confidence` /
+ *     `canonical_entity_resolved_at` until LML resolves them (Epic B-1).
+ *   - `legacy_release_id` is unique per row when present, but a small
+ *     residual of rows have NULL `legacy_release_id` (orphaned from the
+ *     ETL's link pass).
+ *
+ * Constraints added here must accept the full upstream shape, or they will
+ * block the next library-etl pass. See WXYC/Backend-Service#702.
+ */
 export const library = wxyc_schema.table(
   'library',
   {
     id: serial('id').primaryKey(),
+    // FK + notNull preserved from the upstream schema; library rows must
+    // belong to an artist in tubafrenzy.
     artist_id: integer('artist_id')
       .references(() => artists.id)
-      .notNull(),
+      .notNull(), // eslint-disable-line wxyc/source-tagged-constraint-confirmed
     genre_id: integer('genre_id')
       .references(() => genres.id)
-      .notNull(),
+      .notNull(), // eslint-disable-line wxyc/source-tagged-constraint-confirmed
     format_id: integer('format_id')
       .references(() => format.id)
-      .notNull(),
+      .notNull(), // eslint-disable-line wxyc/source-tagged-constraint-confirmed
     alternate_artist_name: varchar('alternate_artist_name', { length: 128 }),
     album_artist: varchar('album_artist', { length: 128 }),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     album_title: varchar('album_title', { length: 128 }).notNull(),
     label: varchar('label', { length: 128 }),
     label_id: integer('label_id').references(() => labels.id),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     code_number: smallint('code_number').notNull(),
     code_volume_letters: varchar('code_volume_letters', { length: 4 }),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     disc_quantity: smallint('disc_quantity').default(1).notNull(),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     plays: integer('plays').default(0).notNull(),
     legacy_release_id: integer('legacy_release_id'),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     add_date: timestamp('add_date', { withTimezone: true }).defaultNow().notNull(),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     last_modified: timestamp('last_modified', { withTimezone: true }).defaultNow().notNull(),
     date_lost: timestamp('date_lost', { withTimezone: true }),
     date_found: timestamp('date_found', { withTimezone: true }),
@@ -317,6 +366,10 @@ export const library = wxyc_schema.table(
       genreIdIdx: index('genre_id_idx').on(table.genre_id),
       formatIdIdx: index('format_id_idx').on(table.format_id),
       artistIdIdx: index('artist_id_idx').on(table.artist_id),
+      // legacy_release_id is the surrogate key the legacy MySQL library
+      // assigns each release; one row per legacy_release_id by the upstream
+      // invariant (NULLs allowed for never-imported rows).
+      // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
       legacyReleaseIdIdx: uniqueIndex('library_legacy_release_id_idx').on(table.legacy_release_id),
       albumArtistTrgmIdx: index('album_artist_trgm_idx').using(`gin`, sql`${table.album_artist} gin_trgm_ops`),
       libraryArtistNameTrgmIdx: index('library_artist_name_trgm_idx').using(
@@ -363,6 +416,27 @@ export const flowsheetEntryTypeEnum = wxyc_schema.enum('flowsheet_entry_type', [
   'breakpoint',
   'message',
 ]);
+/**
+ * SOURCE: tubafrenzy via `jobs/rotation-etl/`. The music director writes
+ * rotation rows in tubafrenzy; Backend-Service is downstream. Tubafrenzy
+ * permits and the rotation-etl preserves shapes that constraints added
+ * here can easily contradict:
+ *
+ *   - Multiple active rows per (album_id, rotation_bin) over an album's
+ *     lifecycle (re-bins, re-adds, label-driven re-promotes). Do NOT add
+ *     a partial-unique index on (album_id, rotation_bin) — see PR #696
+ *     and the 2026-04-30 incident.
+ *   - NULL `album_id` (rotation entries that pre-date or didn't link to
+ *     a library row).
+ *   - `kill_date` in the future (scheduled-kill rows are written ahead
+ *     of time and only become "killed" when the date passes).
+ *   - Rows with a populated `legacy_rotation_id` that haven't yet been
+ *     joined to a library row by id.
+ *
+ * Constraints added to this table must accept the full upstream shape, or
+ * they will block the next ETL pass. See WXYC/Backend-Service#702 +
+ * CLAUDE.md (Rotation ETL: sync from tubafrenzy).
+ */
 export const rotation = wxyc_schema.table(
   'rotation',
   {
@@ -370,7 +444,9 @@ export const rotation = wxyc_schema.table(
     album_id: integer('album_id').references(() => library.id, { onDelete: 'cascade' }),
     legacy_rotation_id: integer('legacy_rotation_id'),
     legacy_library_release_id: integer('legacy_library_release_id'),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     rotation_bin: freqEnum('rotation_bin').notNull(),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     add_date: date('add_date').defaultNow().notNull(),
     kill_date: date('kill_date'),
     artist_name: varchar('artist_name', { length: 128 }),
@@ -380,6 +456,9 @@ export const rotation = wxyc_schema.table(
   (table) => {
     return {
       albumIdIdx: index('album_id_idx').on(table.album_id),
+      // legacy_rotation_id is the surrogate key tubafrenzy assigns each
+      // rotation row; one row per legacy_rotation_id by tubafrenzy's invariant.
+      // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
       legacyRotationIdIdx: uniqueIndex('rotation_legacy_rotation_id_idx').on(table.legacy_rotation_id),
     };
   }
@@ -387,6 +466,36 @@ export const rotation = wxyc_schema.table(
 
 export type NewFSEntry = InferInsertModel<typeof flowsheet>;
 export type FSEntry = InferSelectModel<typeof flowsheet>;
+/**
+ * SOURCE: tubafrenzy via the real-time webhook (`/internal/tubafrenzy-event`)
+ * and `jobs/flowsheet-etl/`. DJs write flowsheet entries from tubafrenzy or
+ * dj-site; tubafrenzy is the canonical authority and Backend-Service is
+ * downstream. Shapes the upstream permits and the ETL/webhook preserve
+ * include:
+ *
+ *   - NULL `show_id`, `album_id`, `rotation_id` (entries that pre-date a
+ *     show, talkset / message rows, or never-linked tracks).
+ *   - NULL `track_title`, `album_title`, `artist_name`, `record_label`
+ *     (talkset / breakpoint / message / dj_join / dj_leave entries — see
+ *     `flowsheetEntryTypeEnum` for non-track shapes).
+ *   - `play_order` is set independently by tubafrenzy (webhook path) and
+ *     dj-site (live insert path); the two paths can produce overlapping
+ *     values and the read layer reconciles. Do NOT add a per-show UNIQUE
+ *     on `play_order` — see the 2026-05-01 incident memo.
+ *   - NULL metadata fields (`artwork_url`, `discogs_url`, `*_url`,
+ *     `release_year`, `artist_bio`, `artist_wikipedia_url`,
+ *     `metadata_attempt_at`) are valid before LML enrichment runs;
+ *     `metadata_attempt_at` is specifically NULL on transient LML failures
+ *     so the row stays retryable.
+ *   - `legacy_entry_id` is unique per row when present, but a sizable
+ *     residual of dj-site-originated rows have NULL `legacy_entry_id`.
+ *   - `linkage_source` and `linkage_confidence` are NULL until B-2 / B-3
+ *     resolves a linkage; do not add NOT NULL.
+ *
+ * Constraints added here must accept the full upstream shape, or they will
+ * block the next ETL pass / webhook write. See WXYC/Backend-Service#702 +
+ * the 2026-05-01 flowsheet/rotation incident.
+ */
 export const flowsheet = wxyc_schema.table(
   'flowsheet',
   {
@@ -396,16 +505,21 @@ export const flowsheet = wxyc_schema.table(
     rotation_id: integer('rotation_id').references(() => rotation.id, { onDelete: 'set null' }),
     legacy_entry_id: integer('legacy_entry_id'),
     legacy_release_id: integer('legacy_release_id'),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     entry_type: flowsheetEntryTypeEnum('entry_type').notNull().default('track'),
     track_title: varchar('track_title', { length: 128 }),
     album_title: varchar('album_title', { length: 128 }),
     artist_name: varchar('artist_name', { length: 128 }),
     record_label: varchar('record_label', { length: 128 }),
     label_id: integer('label_id').references(() => labels.id),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     play_order: integer('play_order').notNull(),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     request_flag: boolean('request_flag').default(false).notNull(),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     segue: boolean('segue').default(false).notNull(),
     message: varchar('message', { length: 250 }),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     add_time: timestamp('add_time', { withTimezone: true }).defaultNow().notNull(),
     // Metadata (fetched from LML on insert, stored inline)
     artwork_url: varchar('artwork_url', { length: 512 }),
@@ -463,6 +577,10 @@ export const flowsheet = wxyc_schema.table(
     ),
   },
   (table) => [
+    // legacy_entry_id is the surrogate key tubafrenzy assigns each entry;
+    // unique per row when present (NULL allowed for dj-site-originated rows
+    // before the webhook round-trip).
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     uniqueIndex('flowsheet_legacy_entry_id_idx').on(table.legacy_entry_id),
     index('flowsheet_legacy_release_id_idx').on(table.legacy_release_id),
     index('flowsheet_artist_name_trgm_idx').using('gin', sql`${table.artist_name} gin_trgm_ops`),
@@ -625,6 +743,26 @@ export const artist_crossreference = wxyc_schema.table(
 
 export type NewShow = InferInsertModel<typeof shows>;
 export type Show = InferSelectModel<typeof shows>;
+/**
+ * SOURCE: tubafrenzy via `jobs/flowsheet-etl/` (and the live show-lifecycle
+ * mirror in `apps/backend/middleware/legacy/flowsheet.mirror.ts`).
+ * Tubafrenzy is the canonical authority for the show calendar / who's on
+ * air; Backend-Service is downstream. Shapes the upstream permits and the
+ * ETL preserves include:
+ *
+ *   - NULL `primary_dj_id` (legacy shows that pre-date the auth_user
+ *     migration; "shadow" / fill-in shows logged before the operator
+ *     account was provisioned).
+ *   - NULL `specialty_id` (regular shows).
+ *   - NULL `show_name` (most shows; only specialty shows carry a name).
+ *   - NULL `end_time` (the active show — set when the DJ closes the show).
+ *   - NULL `legacy_show_id`, `legacy_dj_id`, `legacy_dj_name` for shows
+ *     that originated in dj-site (no tubafrenzy round-trip yet).
+ *
+ * Constraints added here must accept the full upstream shape, or they will
+ * block the next flowsheet-etl pass / show-lifecycle webhook.
+ * See WXYC/Backend-Service#702.
+ */
 export const shows = wxyc_schema.table(
   'shows',
   {
@@ -635,10 +773,15 @@ export const shows = wxyc_schema.table(
     legacy_dj_name: varchar('legacy_dj_name', { length: 128 }),
     legacy_dj_id: integer('legacy_dj_id'),
     show_name: varchar('show_name', { length: 128 }),
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     start_time: timestamp('start_time', { withTimezone: true }).defaultNow().notNull(),
     end_time: timestamp('end_time', { withTimezone: true }),
   },
   (table) => [
+    // legacy_show_id is the surrogate key tubafrenzy assigns each show; one
+    // row per legacy_show_id by the upstream invariant. NULL allowed for
+    // dj-site-originated shows.
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     uniqueIndex('shows_legacy_show_id_idx').on(table.legacy_show_id),
     index('shows_legacy_dj_name_trgm_idx').using('gin', sql`${table.legacy_dj_name} gin_trgm_ops`),
   ]

--- a/tests/unit/database/source-tagged-constraint.rule.test.ts
+++ b/tests/unit/database/source-tagged-constraint.rule.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for the wxyc/source-tagged-constraint-confirmed ESLint rule.
+ *
+ * The rule warns when a constraint (uniqueIndex / check / .notNull() /
+ * .unique()) is added to a Drizzle table whose definition is preceded by a
+ * `SOURCE:` comment. The intent is to nudge authors to confirm the new
+ * constraint is consistent with the upstream system's data shape before
+ * shipping it. See WXYC/Backend-Service#702.
+ */
+import { RuleTester } from 'eslint';
+
+// The rule plugin lives at `eslint-rules/source-tagged-constraint.cjs`. The
+// CommonJS extension is deliberate so the same module loads from
+// `eslint.config.mjs` (via ESM default-import interop) and from these
+// ts-jest-compiled tests (which run under CommonJS).
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const wxycLocalRules = require('../../../eslint-rules/source-tagged-constraint.cjs') as {
+  rules: { 'source-tagged-constraint-confirmed': unknown };
+};
+
+const rule = wxycLocalRules.rules['source-tagged-constraint-confirmed'];
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('source-tagged-constraint-confirmed', rule, {
+  valid: [
+    // No SOURCE comment — constraints anywhere are fine.
+    {
+      code: `
+        export const widgets = wxyc_schema.table(
+          'widgets',
+          {
+            id: serial('id').primaryKey(),
+            name: varchar('name').notNull(),
+          },
+          (table) => [uniqueIndex('widgets_name_idx').on(table.name)]
+        );
+      `,
+    },
+    // SOURCE-tagged but no constraints in the body.
+    {
+      code: `
+        /**
+         * SOURCE: tubafrenzy via the rotation-etl. The music director
+         * writes here.
+         */
+        export const rotation = wxyc_schema.table('rotation', {
+          id: serial('id').primaryKey(),
+          rotation_bin: freqEnum('rotation_bin'),
+        });
+      `,
+    },
+    // SOURCE-tagged with constraints, but each is suppressed via inline
+    // disable directive.
+    {
+      code: `
+        /**
+         * SOURCE: tubafrenzy via the rotation-etl.
+         */
+        export const rotation = wxyc_schema.table(
+          'rotation',
+          {
+            id: serial('id').primaryKey(),
+            // eslint-disable-next-line rule-to-test/source-tagged-constraint-confirmed
+            rotation_bin: freqEnum('rotation_bin').notNull(),
+          },
+          (table) => [
+            // eslint-disable-next-line rule-to-test/source-tagged-constraint-confirmed
+            uniqueIndex('rotation_legacy_id_idx').on(table.legacy_id),
+          ]
+        );
+      `,
+    },
+    // Bare-const (no `export`) form — comment attaches to the
+    // VariableDeclaration directly. Suppress directive matches.
+    {
+      code: `
+        /** SOURCE: legacy MySQL via library-etl. */
+        const library = wxyc_schema.table('library', {
+          id: serial('id').primaryKey(),
+          // eslint-disable-next-line rule-to-test/source-tagged-constraint-confirmed
+          album_title: varchar('album_title').notNull(),
+        });
+      `,
+    },
+  ],
+
+  invalid: [
+    // Hostile constraint: `.notNull()` on a SOURCE-tagged column tubafrenzy
+    // permits NULL.
+    {
+      code: `
+        /**
+         * SOURCE: tubafrenzy via the rotation-etl. NULL album_id is
+         * permitted upstream.
+         */
+        export const rotation = wxyc_schema.table('rotation', {
+          id: serial('id').primaryKey(),
+          album_id: integer('album_id').notNull(),
+        });
+      `,
+      errors: [
+        {
+          messageId: 'sourceTaggedConstraint',
+          data: { tableName: 'rotation' },
+        },
+      ],
+    },
+    // Hostile constraint: a partial `uniqueIndex` on (album_id, bin) that
+    // contradicts tubafrenzy's "multiple rows per (album, bin) over an
+    // album lifecycle" invariant. This is the exact PR #696 regression.
+    {
+      code: `
+        /** SOURCE: tubafrenzy via rotation-etl. */
+        export const rotation = wxyc_schema.table(
+          'rotation',
+          {
+            id: serial('id').primaryKey(),
+            album_id: integer('album_id'),
+            rotation_bin: text('rotation_bin'),
+            kill_date: date('kill_date'),
+          },
+          (table) => [
+            uniqueIndex('rotation_album_bin_unique')
+              .on(table.album_id, table.rotation_bin)
+              .where(\`\${table.kill_date} IS NULL\`),
+          ]
+        );
+      `,
+      errors: [{ messageId: 'sourceTaggedConstraint' }],
+    },
+    // Hostile constraint: a `check()` on a SOURCE-tagged table. The
+    // upstream may write rows that violate the check.
+    {
+      code: `
+        /** SOURCE: legacy MySQL via library-etl. */
+        export const library = wxyc_schema.table(
+          'library',
+          {
+            id: serial('id').primaryKey(),
+            plays: integer('plays'),
+          },
+          (table) => [check('plays_positive', \`\${table.plays} > 0\`)]
+        );
+      `,
+      errors: [{ messageId: 'sourceTaggedConstraint' }],
+    },
+    // SOURCE-tagged with multiple unconfirmed constraints — one warning
+    // per constraint.
+    {
+      code: `
+        /** SOURCE: tubafrenzy webhook + flowsheet-etl. */
+        export const flowsheet = wxyc_schema.table(
+          'flowsheet',
+          {
+            id: serial('id').primaryKey(),
+            entry_type: text('entry_type').notNull(),
+            play_order: integer('play_order').notNull(),
+          }
+        );
+      `,
+      errors: [
+        { messageId: 'sourceTaggedConstraint', data: { tableName: 'flowsheet' } },
+        { messageId: 'sourceTaggedConstraint', data: { tableName: 'flowsheet' } },
+      ],
+    },
+    // pgTable-form (auth tables don't use this, but the rule should still
+    // fire on the form).
+    {
+      code: `
+        /** SOURCE: external system. */
+        export const externalThing = pgTable('external_thing', {
+          id: varchar('id').primaryKey(),
+          name: varchar('name').notNull(),
+        });
+      `,
+      errors: [{ messageId: 'sourceTaggedConstraint', data: { tableName: 'external_thing' } }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Adds JSDoc `SOURCE:` annotations above each sync-target Drizzle table in `shared/database/src/schema.ts`, documenting the shapes the upstream system permits that constraints added at the Drizzle layer can easily contradict (and silently break the next ETL pass / webhook write). Annotated: `rotation`, `flowsheet`, `shows`, `library`, plus the reconciled-identity column block on `artists`.

Adds a custom ESLint rule `wxyc/source-tagged-constraint-confirmed` that detects `uniqueIndex(...)` / `check(...)` / `.notNull()` / `.unique()` inside SOURCE-tagged tables and emits a warning. The rule is intentionally a warning, never an error — a friction point that forces an explicit acknowledgement, not a CI gate. Authors suppress per-occurrence by adding `// eslint-disable-next-line wxyc/source-tagged-constraint-confirmed` once the constraint has been confirmed consistent with the upstream's data shape. The existing constraints on the annotated tables (FKs, `uniqueIndex` on `legacy_*_id`, established not-nulls) all carry suppression directives.

Companion: #703 (PR-bot data-shape report) catches it at PR-review time; this PR catches it at write time.

## What changes

- `shared/database/src/schema.ts`: SOURCE JSDoc on `rotation`, `flowsheet`, `shows`, `library`; SOURCE block on the reconciled-identity column group inside `artists`. Existing constraints carry `// eslint-disable-(next-)?line wxyc/source-tagged-constraint-confirmed` directives.
- `eslint-rules/source-tagged-constraint.cjs`: new CommonJS rule plugin (CJS so the same module loads from both the ESM `eslint.config.mjs` and the ts-jest CJS test runner). Walks ancestors looking for the SOURCE marker on the enclosing declaration, then fires on `Identifier`-callee `uniqueIndex` / `check` and `MemberExpression`-callee `.notNull` / `.unique`. Cached per table-call.
- `eslint.config.mjs`: imports the plugin, registers it as `wxyc`, opts in `shared/database/**/*.ts` at `'warn'`. Adds `**/*.cjs` to global ignores so the plugin file isn't subject to typescript-eslint's project service.
- `tests/unit/database/source-tagged-constraint.rule.test.ts`: ESLint `RuleTester` coverage with 4 valid cases (no-SOURCE / suppressed / bare-const) and 5 invalid cases (hostile `notNull`, partial `uniqueIndex` reproducing the PR #696 regression, `check()`, multiple unconfirmed constraints, `pgTable` form).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes — 0 errors, 331 warnings (same baseline as `origin/main`, 0 from the new rule against current schema)
- [x] `npm run format:check` passes
- [x] `npm run test:unit` — 1417 / 1417 tests pass, including 9 new rule tests
- [x] `npm run build` passes
- [x] Manual hostile-constraint check: removing one suppression directive on `rotation.add_date` makes `npx eslint shared/database/src/schema.ts` warn with the rule message naming `'rotation'` as the table.

Closes #702