### PR TITLE
Add shape fixture so constraint failures surface in CI integration tests

### DIFF
--- a/tests/fixtures/shape.sql
+++ b/tests/fixtures/shape.sql
@@ -1,0 +1,225 @@
+-- ==============================================================================
+-- Shape fixture for integration tests (issue #701)
+-- ==============================================================================
+-- Hand-curated edge-case rows that constraint-adding migrations would trip
+-- over against real production data. Loaded by tests/setup/globalSetup.js
+-- AFTER drizzle:migrate creates the schema and AFTER seed_db.sql seeds the
+-- baseline rows.
+--
+-- The fixture is the test-side complement to the writeup in #701: any
+-- migration that adds a UNIQUE / CHECK / NOT NULL constraint that's safe
+-- against an empty test DB but lethal against real prod data should now
+-- fail at fixture-load time (or in tests/integration/migrations.spec.ts)
+-- in CI rather than in production. Recent example the fixture catches:
+-- PR #696's `CREATE UNIQUE INDEX ... ON rotation (album_id, rotation_bin)
+-- WHERE kill_date IS NULL` (3 duplicate groups in this fixture).
+--
+-- All inserts use ON CONFLICT (id) DO NOTHING so the file is idempotent
+-- against repeat runs against the same schema. The conflict target is
+-- always the primary key; we deliberately do NOT use a bare ON CONFLICT
+-- DO NOTHING because that would silently swallow violations of the
+-- unique partial indexes / CHECK constraints we want this fixture to
+-- exercise.
+--
+-- ID conventions, picked to never collide with seed_db.sql (which uses
+-- IDs 1-9 for artists/albums and creates rotation rows by serial) or
+-- with rows integration tests insert at runtime:
+--
+--   artists, library, rotation, shows, labels: id range 7000-7099
+--   genre_artist_crossreference uses (artist_id, genre_id) so its
+--   uniqueness is naturally namespaced by the artist_id range.
+--
+-- Sequence values are advanced past the fixture range with setval() so
+-- subsequent serial inserts (from tests or app code) don't collide.
+-- ==============================================================================
+
+-- ------------------------------------------------------------------------------
+-- Labels
+-- ------------------------------------------------------------------------------
+INSERT INTO wxyc_schema.labels (id, label_name)
+VALUES
+  (7000, 'Shape Fixture Label A'),
+  (7001, 'Shape Fixture Label B')
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval('wxyc_schema.labels_id_seq', 7099, true);
+
+-- ------------------------------------------------------------------------------
+-- Artists (code_letters intentionally outside the canonical seeded set)
+-- ------------------------------------------------------------------------------
+INSERT INTO wxyc_schema.artists (id, artist_name, alphabetical_name, code_letters)
+VALUES
+  (7000, 'Shape Fixture Artist Alpha', 'Shape Fixture Artist Alpha', 'XA'),
+  (7001, 'Shape Fixture Artist Beta',  'Shape Fixture Artist Beta',  'XB'),
+  (7002, 'Shape Fixture Artist Gamma', 'Shape Fixture Artist Gamma', 'XC')
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval('wxyc_schema.artists_id_seq', 7099, true);
+
+-- Crossreference rows so library_artist_view INNER JOINs resolve. The
+-- (artist_id, genre_id) unique key is namespaced by our 7000-range
+-- artist IDs, so no conflict target is needed beyond the implicit
+-- compound key.
+INSERT INTO wxyc_schema.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
+VALUES
+  (7000, 11, 700),
+  (7001, 11, 701),
+  (7002, 11, 702)
+ON CONFLICT (artist_id, genre_id) DO NOTHING;
+
+-- ------------------------------------------------------------------------------
+-- Library
+--
+-- 10 rows total. Includes:
+--   * 1 row with NULL artist_name (#625-style assertion target)
+--   * 6 well-formed rows, used as targets for rotation/flowsheet rows below
+--   * 3 padding rows for variety (different formats / genres)
+-- ------------------------------------------------------------------------------
+INSERT INTO wxyc_schema.library
+  (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, label, label_id)
+VALUES
+  -- artist_name populated (the normal A.2-backfilled state)
+  (7000, 7000, 11, 1, 'Shape Fixture Album Alpha 1',  1, 'Shape Fixture Artist Alpha', 'Shape Fixture Label A', 7000),
+  (7001, 7000, 11, 1, 'Shape Fixture Album Alpha 2',  2, 'Shape Fixture Artist Alpha', 'Shape Fixture Label A', 7000),
+  (7002, 7001, 11, 2, 'Shape Fixture Album Beta 1',   1, 'Shape Fixture Artist Beta',  'Shape Fixture Label B', 7001),
+  (7003, 7001, 11, 2, 'Shape Fixture Album Beta 2',   2, 'Shape Fixture Artist Beta',  NULL,                    NULL),
+  (7004, 7002, 11, 1, 'Shape Fixture Album Gamma 1',  1, 'Shape Fixture Artist Gamma', NULL,                    NULL),
+  (7005, 7002, 11, 1, 'Shape Fixture Album Gamma 2',  2, 'Shape Fixture Artist Gamma', NULL,                    NULL),
+  -- 1 row with NULL artist_name. Pre-#625 shape: would trip the
+  -- library-artist-name-assertion service if encountered at boot.
+  (7006, 7000, 11, 1, 'Shape Fixture Album NULL-artist',  3, NULL,                       NULL,                    NULL),
+  -- Padding rows for rotation-bin variety
+  (7007, 7001, 11, 1, 'Shape Fixture Album Beta 3',   3, 'Shape Fixture Artist Beta',  NULL,                    NULL),
+  (7008, 7002, 11, 2, 'Shape Fixture Album Gamma 3',  3, 'Shape Fixture Artist Gamma', NULL,                    NULL),
+  (7009, 7000, 11, 2, 'Shape Fixture Album Alpha 3',  4, 'Shape Fixture Artist Alpha', NULL,                    NULL)
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval('wxyc_schema.library_id_seq', 7099, true);
+
+-- ------------------------------------------------------------------------------
+-- Rotation (~15 rows)
+--
+-- Edge cases:
+--   * 3 duplicate groups for (album_id, rotation_bin) WHERE kill_date IS NULL.
+--     This is exactly the shape #696's unique partial index would have
+--     rejected: 3 distinct rotation rows on album 7000 in bin 'H', 2 on
+--     album 7002 in bin 'L', 2 on album 7001 in bin 'M'.
+--   * 2 NULL album_id rows (rotation.album_id is FK-ON-DELETE-CASCADE
+--     nullable). Real prod has these from tubafrenzy adds where the
+--     library row was later deleted.
+--   * 1 row with kill_date > CURRENT_DATE (the planner-stable predicate
+--     `kill_date IS NULL` does NOT exclude this row even though the
+--     semantically-richer "is active" predicate would).
+-- ------------------------------------------------------------------------------
+INSERT INTO wxyc_schema.rotation
+  (id, album_id, rotation_bin, add_date, kill_date, artist_name, album_title, record_label, legacy_rotation_id)
+VALUES
+  -- Duplicate group 1: album 7000, bin 'H', 3 active rows
+  (7000, 7000, 'H', '2024-01-01', NULL, 'Shape Fixture Artist Alpha', 'Shape Fixture Album Alpha 1', 'Shape Fixture Label A', 70000),
+  (7001, 7000, 'H', '2024-03-15', NULL, 'Shape Fixture Artist Alpha', 'Shape Fixture Album Alpha 1', 'Shape Fixture Label A', 70001),
+  (7002, 7000, 'H', '2024-08-22', NULL, 'Shape Fixture Artist Alpha', 'Shape Fixture Album Alpha 1', 'Shape Fixture Label A', 70002),
+  -- Duplicate group 2: album 7002, bin 'L', 2 active rows
+  (7003, 7002, 'L', '2024-02-01', NULL, 'Shape Fixture Artist Gamma', 'Shape Fixture Album Gamma 1', NULL,                    70003),
+  (7004, 7002, 'L', '2024-06-10', NULL, 'Shape Fixture Artist Gamma', 'Shape Fixture Album Gamma 1', NULL,                    70004),
+  -- Duplicate group 3: album 7001, bin 'M', 2 active rows
+  (7005, 7001, 'M', '2024-04-01', NULL, 'Shape Fixture Artist Beta',  'Shape Fixture Album Beta 1',  'Shape Fixture Label B', 70005),
+  (7006, 7001, 'M', '2024-10-12', NULL, 'Shape Fixture Artist Beta',  'Shape Fixture Album Beta 1',  'Shape Fixture Label B', 70006),
+  -- 2 rows with NULL album_id (orphaned tubafrenzy rows)
+  (7007, NULL, 'L', '2024-05-20', NULL, 'Shape Fixture Orphan One',   'Shape Fixture Orphan Album One', NULL,                70007),
+  (7008, NULL, 'M', '2024-07-04', NULL, 'Shape Fixture Orphan Two',   'Shape Fixture Orphan Album Two', NULL,                70008),
+  -- 1 row with kill_date > CURRENT_DATE (future-dated retirement).
+  -- The planner-stable `WHERE kill_date IS NULL` predicate does NOT
+  -- exclude this row, so a unique partial index over that predicate
+  -- would still consider it. We add it on a NEW (album, bin) pair so
+  -- it doesn't itself create a duplicate group.
+  (7009, 7004, 'S', '2024-09-01', '2099-12-31', 'Shape Fixture Artist Gamma', 'Shape Fixture Album Gamma 1', NULL,            70009),
+  -- Killed (kill_date in the past) rows for `WHERE kill_date IS NOT NULL` paths
+  (7010, 7000, 'L', '2023-01-01', '2023-12-31', 'Shape Fixture Artist Alpha', 'Shape Fixture Album Alpha 1', 'Shape Fixture Label A', 70010),
+  (7011, 7001, 'H', '2023-02-01', '2023-11-15', 'Shape Fixture Artist Beta',  'Shape Fixture Album Beta 1',  'Shape Fixture Label B', 70011),
+  -- A few non-duplicate active rows for plain-shape coverage
+  (7012, 7003, 'M', '2024-11-01', NULL, 'Shape Fixture Artist Beta',  'Shape Fixture Album Beta 2', NULL,                    70012),
+  (7013, 7005, 'H', '2024-11-15', NULL, 'Shape Fixture Artist Gamma', 'Shape Fixture Album Gamma 2', NULL,                   70013),
+  (7014, 7007, 'L', '2024-12-01', NULL, 'Shape Fixture Artist Beta',  'Shape Fixture Album Beta 3', NULL,                    70014)
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval('wxyc_schema.rotation_id_seq', 7099, true);
+
+-- ------------------------------------------------------------------------------
+-- Shows
+--
+-- Edge cases:
+--   * 2 shows with end_time IS NULL (active / never-ended). Real prod
+--     has these from DJs who started a show and didn't formally
+--     end it.
+--   * 1 show with legacy_show_id set (tubafrenzy-mirrored show; the
+--     unique index on legacy_show_id would forbid duplicates if any
+--     future migration tries to enforce a stricter shape).
+--   * 1 ended show that owns the multi-play_order flowsheet rows
+--     below.
+-- ------------------------------------------------------------------------------
+INSERT INTO wxyc_schema.shows
+  (id, primary_dj_id, show_name, start_time, end_time, legacy_show_id, legacy_dj_name)
+VALUES
+  -- Active show #1 (end_time IS NULL)
+  (7000, NULL, 'Shape Fixture Active Show One', '2024-12-01 18:00:00+00', NULL, NULL,    'Shape Fixture DJ One'),
+  -- Active show #2 (end_time IS NULL)
+  (7001, NULL, 'Shape Fixture Active Show Two', '2024-12-02 20:00:00+00', NULL, NULL,    'Shape Fixture DJ Two'),
+  -- Ended show with legacy_show_id (tubafrenzy mirror)
+  (7002, NULL, 'Shape Fixture Ended Legacy Show', '2024-11-15 18:00:00+00', '2024-11-15 21:00:00+00', 700002, 'Shape Fixture Legacy DJ'),
+  -- Ended show that owns the multi-play_order flowsheet rows below
+  (7003, NULL, 'Shape Fixture Mixed-Play-Order Show', '2024-11-20 18:00:00+00', '2024-11-20 21:00:00+00', NULL, 'Shape Fixture DJ Mixed')
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval('wxyc_schema.shows_id_seq', 7099, true);
+
+-- ------------------------------------------------------------------------------
+-- Flowsheet (~10 rows across 2 shows)
+--
+-- Edge cases:
+--   * Show 7003 contains play_orders 1, 2, 3, 4, AND 471 — the
+--     471 row exposes the per-show vs global-MAX assumption that
+--     #693 (BS#693) hit on prod when nextPlayOrder() did SELECT
+--     MAX(play_order) FROM flowsheet (no WHERE show_id) and
+--     legacy tubafrenzy webhook-set play_orders mixed with dj-site
+--     globally-maxed play_orders.
+--   * Show 7000 carries a mix of entry_types (track + dj_join +
+--     show_start) so any assumption that flowsheet is track-only
+--     also surfaces.
+--   * 1 track row with metadata_attempt_at = NULL (the explicit
+--     "still-pending" shape #638 / #639 Phase 2 sweep targets).
+--     The artist_name is non-NULL on that row so the partial
+--     index `flowsheet_metadata_attempt_pending_idx` would index
+--     it.
+-- ------------------------------------------------------------------------------
+INSERT INTO wxyc_schema.flowsheet
+  (id, show_id, album_id, entry_type, track_title, album_title, artist_name, record_label,
+   play_order, request_flag, segue, message, add_time, dj_name, metadata_attempt_at)
+VALUES
+  -- Show 7003: mixed play_orders within a single show (1, 2, 3, 4, 471)
+  (7000, 7003, 7000, 'track', 'Shape Track One',   'Shape Fixture Album Alpha 1', 'Shape Fixture Artist Alpha', 'Shape Fixture Label A',
+   1, false, false, NULL, '2024-11-20 18:05:00+00', 'Shape Fixture DJ Mixed', '2024-11-20 18:05:01+00'),
+  (7001, 7003, 7001, 'track', 'Shape Track Two',   'Shape Fixture Album Alpha 2', 'Shape Fixture Artist Alpha', 'Shape Fixture Label A',
+   2, false, false, NULL, '2024-11-20 18:10:00+00', 'Shape Fixture DJ Mixed', '2024-11-20 18:10:01+00'),
+  (7002, 7003, 7002, 'track', 'Shape Track Three', 'Shape Fixture Album Beta 1',  'Shape Fixture Artist Beta',  'Shape Fixture Label B',
+   3, false, false, NULL, '2024-11-20 18:15:00+00', 'Shape Fixture DJ Mixed', '2024-11-20 18:15:01+00'),
+  (7003, 7003, 7003, 'track', 'Shape Track Four',  'Shape Fixture Album Beta 2',  'Shape Fixture Artist Beta',  NULL,
+   4, false, false, NULL, '2024-11-20 18:20:00+00', 'Shape Fixture DJ Mixed', '2024-11-20 18:20:01+00'),
+  -- The 471 outlier in the SAME show (#693 incident shape)
+  (7004, 7003, 7004, 'track', 'Shape Track 471',   'Shape Fixture Album Gamma 1', 'Shape Fixture Artist Gamma', NULL,
+   471, false, false, NULL, '2024-11-20 18:25:00+00', 'Shape Fixture DJ Mixed', '2024-11-20 18:25:01+00'),
+  -- 1 track row with metadata_attempt_at = NULL (still-pending shape)
+  (7005, 7003, 7005, 'track', 'Shape Track Pending Metadata', 'Shape Fixture Album Gamma 2', 'Shape Fixture Artist Gamma', NULL,
+   5, false, false, NULL, '2024-11-20 18:30:00+00', 'Shape Fixture DJ Mixed', NULL),
+  -- Show 7000: mixed entry_types
+  (7006, 7000, NULL, 'show_start', NULL, NULL, NULL, NULL,
+   1, false, false, 'Show start marker', '2024-12-01 18:00:00+00', 'Shape Fixture DJ One', NULL),
+  (7007, 7000, NULL, 'dj_join',    NULL, NULL, NULL, NULL,
+   2, false, false, NULL, '2024-12-01 18:01:00+00', 'Shape Fixture DJ One', NULL),
+  (7008, 7000, 7006, 'track', 'Shape Track NULL-artist source', 'Shape Fixture Album NULL-artist', NULL, NULL,
+   3, false, false, NULL, '2024-12-01 18:05:00+00', 'Shape Fixture DJ One', '2024-12-01 18:05:01+00'),
+  -- Show 7001: a row with NULL album_id (free-form text-only entry)
+  (7009, 7001, NULL, 'track', 'Shape Track Free-Form', 'Shape Fixture Free-Form Album', 'Shape Fixture Free-Form Artist', NULL,
+   1, false, false, NULL, '2024-12-02 20:05:00+00', 'Shape Fixture DJ Two', '2024-12-02 20:05:01+00')
+ON CONFLICT (id) DO NOTHING;
+
+SELECT setval('wxyc_schema.flowsheet_id_seq', 7099, true);

--- a/tests/integration/migrations.spec.js
+++ b/tests/integration/migrations.spec.js
@@ -1,0 +1,269 @@
+/**
+ * Migrations against the shape fixture (issue #701).
+ *
+ * Drizzle's migration runner is normally exercised against an empty
+ * schema (CI's `npm run db:start` boots a fresh Docker volume and
+ * applies every migration end-to-end). PR #696 demonstrated the gap
+ * that creates: the unique partial index in 0071 passed CI cleanly
+ * because the test rotation table was empty, but would have failed
+ * against prod data because of 39 duplicate active groups.
+ *
+ * This spec closes the gap by asserting that:
+ *
+ *   1. Every entry in `_journal.json` has a row in
+ *      `drizzle.__drizzle_migrations` (the runtime cursor didn't skip
+ *      anything; mirrors the verifier in dev_env/init-db.mjs but
+ *      against the per-worker schema this spec actually exercises).
+ *   2. The shape fixture (tests/fixtures/shape.sql) is loaded into the
+ *      per-worker `wxyc_schema` — its load-bearing edge cases are
+ *      present. globalSetup loads the fixture before any spec runs
+ *      (after migrations have already been applied at db:start time),
+ *      so the fixture's mere existence is the structural guarantee
+ *      that NONE of the existing migrations forbid the fixture's
+ *      shape. Future PRs that add a constraint-bearing migration
+ *      whose constraint the fixture violates will fail at
+ *      globalSetup time (or directly in this spec, if the fixture
+ *      load reaches the assertion phase) — long before a deploy
+ *      attempts the migration against prod.
+ *   3. `drizzle:migrate` is idempotent against the loaded fixture:
+ *      re-running it must report no pending migrations and must not
+ *      delete fixture rows.
+ *
+ * The unit suite covers each individual migration's structural form;
+ * this spec is the cross-migration shape-validity guard. Companion
+ * lines of defense:
+ *   - PR-bot data-shape report (#703)
+ *   - Precondition guards on constraint-adding migrations (#705)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { execSync } = require('child_process');
+const postgres = require('postgres');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const MIGRATIONS_DIR = path.join(REPO_ROOT, 'shared', 'database', 'src', 'migrations');
+const FIXTURE_PATH = path.join(__dirname, '..', 'fixtures', 'shape.sql');
+
+/**
+ * Tags whose hash will never appear in `drizzle.__drizzle_migrations`
+ * because drizzle's "max(applied.created_at) cursor" skipped them and
+ * a later replay migration carries their effects forward. Mirrors
+ * `HISTORICAL_REPLACED_TAGS` in dev_env/init-db.mjs (kept in sync
+ * manually; if this list drifts the verifier and the spec disagree).
+ */
+const HISTORICAL_REPLACED_TAGS = new Map([
+  ['0054_flowsheet-search-doc-with-dj-name', '0065_replay-flowsheet-search-doc-with-dj-name'],
+  ['0064_propagate-v012-mojibake', '0066_replay-v012-mojibake'],
+]);
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+describe('Drizzle migrations + shape fixture (issue #701)', () => {
+  let sql;
+
+  beforeAll(() => {
+    sql = makeSql();
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end();
+  });
+
+  test('every journal migration is recorded in drizzle.__drizzle_migrations (or has a known replay)', async () => {
+    const journal = JSON.parse(fs.readFileSync(path.join(MIGRATIONS_DIR, 'meta', '_journal.json'), 'utf8'));
+
+    const expectedMigrations = journal.entries.map((entry) => {
+      const sqlPath = path.join(MIGRATIONS_DIR, `${entry.tag}.sql`);
+      const sqlContent = fs.readFileSync(sqlPath, 'utf8');
+      const hash = crypto.createHash('sha256').update(sqlContent).digest('hex');
+      return { tag: entry.tag, idx: entry.idx, when: entry.when, hash };
+    });
+
+    const dbMigrations = await sql`
+      SELECT hash FROM drizzle.__drizzle_migrations
+    `;
+    const appliedHashes = new Set(dbMigrations.map((m) => m.hash));
+
+    const missing = expectedMigrations.filter((m) => !appliedHashes.has(m.hash));
+    const trulyMissing = [];
+    for (const m of missing) {
+      if (HISTORICAL_REPLACED_TAGS.has(m.tag)) {
+        const replayTag = HISTORICAL_REPLACED_TAGS.get(m.tag);
+        const replay = expectedMigrations.find((e) => e.tag === replayTag);
+        if (replay && appliedHashes.has(replay.hash)) {
+          // Replayed by a later migration that did apply: expected absent.
+          continue;
+        }
+      }
+      trulyMissing.push(m);
+    }
+
+    expect(trulyMissing).toEqual([]);
+  });
+
+  test('shape fixture is loaded: 3 duplicate active rotation groups, NULL artist_name, mixed play_orders', async () => {
+    // The fixture is loaded by tests/setup/globalSetup.js before any spec
+    // runs. Asserting its load-bearing edge cases survived migrations is
+    // the cross-migration shape-validity guard.
+    const dupActive = await sql.unsafe(`
+      SELECT album_id, rotation_bin, COUNT(*)::int AS n
+        FROM "${SCHEMA}".rotation
+       WHERE kill_date IS NULL
+         AND album_id IS NOT NULL
+         AND id BETWEEN 7000 AND 7099
+       GROUP BY album_id, rotation_bin
+      HAVING COUNT(*) > 1
+    `);
+    expect(dupActive.length).toBeGreaterThanOrEqual(3);
+
+    const nullAlbumRotation = await sql.unsafe(`
+      SELECT COUNT(*)::int AS n
+        FROM "${SCHEMA}".rotation
+       WHERE album_id IS NULL
+         AND id BETWEEN 7000 AND 7099
+    `);
+    expect(nullAlbumRotation[0].n).toBeGreaterThanOrEqual(2);
+
+    const futureKill = await sql.unsafe(`
+      SELECT COUNT(*)::int AS n
+        FROM "${SCHEMA}".rotation
+       WHERE kill_date > CURRENT_DATE
+         AND id BETWEEN 7000 AND 7099
+    `);
+    expect(futureKill[0].n).toBeGreaterThanOrEqual(1);
+
+    const nullArtistLibrary = await sql.unsafe(`
+      SELECT COUNT(*)::int AS n
+        FROM "${SCHEMA}".library
+       WHERE artist_name IS NULL
+         AND id BETWEEN 7000 AND 7099
+    `);
+    expect(nullArtistLibrary[0].n).toBeGreaterThanOrEqual(1);
+
+    const activeShows = await sql.unsafe(`
+      SELECT COUNT(*)::int AS n
+        FROM "${SCHEMA}".shows
+       WHERE end_time IS NULL
+         AND id BETWEEN 7000 AND 7099
+    `);
+    expect(activeShows[0].n).toBeGreaterThanOrEqual(2);
+
+    const flowsheetPlayOrders = await sql.unsafe(`
+      SELECT play_order
+        FROM "${SCHEMA}".flowsheet
+       WHERE show_id = 7003
+       ORDER BY play_order ASC
+    `);
+    const orders = flowsheetPlayOrders.map((r) => r.play_order);
+    expect(orders).toEqual(expect.arrayContaining([1, 2, 3, 4, 471]));
+
+    const pendingMetadata = await sql.unsafe(`
+      SELECT COUNT(*)::int AS n
+        FROM "${SCHEMA}".flowsheet
+       WHERE entry_type = 'track'
+         AND artist_name IS NOT NULL
+         AND metadata_attempt_at IS NULL
+         AND id BETWEEN 7000 AND 7099
+    `);
+    expect(pendingMetadata[0].n).toBeGreaterThanOrEqual(1);
+  });
+
+  test('drizzle:migrate is idempotent against the loaded fixture', async () => {
+    // Re-run drizzle-kit migrate against the same DB. Every existing
+    // migration's hash is already in __drizzle_migrations, so this
+    // call must be a structural no-op. If a future PR adds a
+    // migration whose constraints the fixture violates, this call
+    // fails because the new migration's `CREATE UNIQUE INDEX` (or
+    // similar) reports a constraint error before drizzle records the
+    // hash.
+    //
+    // We use `npx drizzle-kit migrate` directly (not the package
+    // script) to avoid dotenvx's interactive prompting in test
+    // environments that lack a .env. The required env vars are
+    // already set by integration.setup.js / dotenvx in the harness.
+    const env = {
+      ...process.env,
+      // Drizzle reads these via drizzle.config.ts.
+      DB_HOST: process.env.DB_HOST || 'localhost',
+      DB_PORT: process.env.DB_PORT || process.env.CI_DB_PORT || '5433',
+      DB_NAME: process.env.DB_NAME || 'wxyc_db',
+      DB_USERNAME: process.env.DB_USERNAME || 'test-user',
+      DB_PASSWORD: process.env.DB_PASSWORD || 'test-pw',
+    };
+
+    let stdout;
+    try {
+      stdout = execSync('npx drizzle-kit migrate --config drizzle.config.ts', {
+        cwd: REPO_ROOT,
+        env,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      throw new Error(
+        `drizzle:migrate failed against the loaded shape fixture. ` +
+          `If you just added a migration with a new constraint, the fixture row(s) it ` +
+          `forbids are likely the cause — see tests/fixtures/shape.sql.\n\n` +
+          `stdout: ${err.stdout?.toString() || ''}\n` +
+          `stderr: ${err.stderr?.toString() || ''}`
+      );
+    }
+
+    // Drizzle prints "[~] Pulling schema from database..." or
+    // "Reading config file" but for a no-op migration prints no
+    // CREATE/ALTER lines. We assert the run succeeded without
+    // attempting to interpret the exact output, which has changed
+    // across drizzle-kit versions.
+    expect(typeof stdout).toBe('string');
+
+    // Sanity: confirm no fixture rows were dropped by the migrate run.
+    const fixtureCount = await sql.unsafe(`
+      SELECT
+        (SELECT COUNT(*)::int FROM "${SCHEMA}".rotation WHERE id BETWEEN 7000 AND 7099) AS rotation,
+        (SELECT COUNT(*)::int FROM "${SCHEMA}".library  WHERE id BETWEEN 7000 AND 7099) AS library,
+        (SELECT COUNT(*)::int FROM "${SCHEMA}".shows    WHERE id BETWEEN 7000 AND 7099) AS shows,
+        (SELECT COUNT(*)::int FROM "${SCHEMA}".flowsheet WHERE id BETWEEN 7000 AND 7099) AS flowsheet
+    `);
+    expect(fixtureCount[0].rotation).toBeGreaterThanOrEqual(15);
+    expect(fixtureCount[0].library).toBeGreaterThanOrEqual(10);
+    expect(fixtureCount[0].shows).toBeGreaterThanOrEqual(4);
+    expect(fixtureCount[0].flowsheet).toBeGreaterThanOrEqual(10);
+  }, 60000);
+
+  test('shape fixture file matches the documented edge-case shape', () => {
+    // Cheap structural assertion against the fixture file itself, so
+    // a future contributor who edits shape.sql can't silently remove
+    // the load-bearing rows. The numeric thresholds match the issue
+    // body's "Initial fixture content" list.
+    const raw = fs.readFileSync(FIXTURE_PATH, 'utf8');
+    const inserts = (raw.match(/INSERT INTO/gi) || []).length;
+    expect(inserts).toBeGreaterThanOrEqual(5);
+
+    // Targeted ON CONFLICT (...) DO NOTHING is the documented
+    // idempotency contract — a bare ON CONFLICT DO NOTHING (no
+    // target) would silently absorb the unique-constraint violations
+    // the fixture exists to expose. Tables that use `ON CONFLICT (id)
+    // DO NOTHING` are scoped to PK collisions only; the
+    // genre_artist_crossreference junction table uses
+    // `ON CONFLICT (artist_id, genre_id) DO NOTHING` because it has
+    // no `id` column. Both forms are fine; only the BARE form is
+    // forbidden.
+    expect(raw).toMatch(/ON CONFLICT \(id\) DO NOTHING/i);
+    const bareOnConflict = raw.match(/ON CONFLICT\s+DO\s+NOTHING/gi);
+    expect(bareOnConflict).toBeNull();
+  });
+});

--- a/tests/setup/globalSetup.js
+++ b/tests/setup/globalSetup.js
@@ -1,4 +1,70 @@
+const { readFileSync } = require('fs');
+const path = require('path');
+const postgres = require('postgres');
 const waitOn = require('wait-on');
+
+/**
+ * Load the shape fixture (tests/fixtures/shape.sql) into the per-worker
+ * schema. Called after services are confirmed ready and before any
+ * integration spec runs. Idempotent: every INSERT carries
+ * `ON CONFLICT (id) DO NOTHING` so re-running the fixture against an
+ * already-populated schema is a no-op.
+ *
+ * The schema name is read from `WXYC_SCHEMA_NAME` so the fixture lands
+ * in the same per-worker schema the application code reads. The
+ * migrations themselves hardcode `wxyc_schema`, so today this always
+ * resolves to `wxyc_schema` in CI; the env var is honored for
+ * forward-compatibility with the parallel-worker isolation roadmap.
+ *
+ * Conflict targets are deliberately scoped to the primary key
+ * (`ON CONFLICT (id) DO NOTHING`) so unique-constraint violations the
+ * fixture is designed to expose (e.g. the duplicate rotation groups
+ * #696 would have rejected) surface as errors rather than silent
+ * dedupe.
+ *
+ * See tests/fixtures/shape.sql for the row content and
+ * https://github.com/WXYC/Backend-Service/issues/701 for the rationale.
+ */
+async function loadShapeFixture() {
+  const dbHost = process.env.DB_HOST || 'localhost';
+  const dbPort = parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10);
+  const dbName = process.env.DB_NAME || 'wxyc_db';
+  const dbUser = process.env.DB_USERNAME || 'test-user';
+  const dbPass = process.env.DB_PASSWORD || 'test-pw';
+
+  const fixturePath = path.join(__dirname, '..', 'fixtures', 'shape.sql');
+  const rawSql = readFileSync(fixturePath, 'utf8');
+
+  // Honor WXYC_SCHEMA_NAME for forward-compat with the parallel-worker
+  // isolation roadmap. Today the migrations themselves hardcode
+  // `wxyc_schema` so this rewrite is a no-op in CI; once the migrations
+  // pick up the env var, the fixture will follow without code changes.
+  const schemaName = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+  const fixtureSql = schemaName === 'wxyc_schema' ? rawSql : rawSql.replace(/\bwxyc_schema\b/g, schemaName);
+
+  console.log('🧪 Loading shape fixture from', fixturePath, 'into schema', schemaName);
+
+  const sql = postgres({
+    host: dbHost,
+    port: dbPort,
+    database: dbName,
+    user: dbUser,
+    password: dbPass,
+    max: 1,
+    onnotice: () => {},
+  });
+
+  try {
+    // Run the whole fixture in a single transaction so a partial failure
+    // rolls back rather than leaving the schema half-populated.
+    await sql.begin(async (tx) => {
+      await tx.unsafe(fixtureSql);
+    });
+    console.log('✅ Shape fixture loaded.');
+  } finally {
+    await sql.end();
+  }
+}
 
 module.exports = async () => {
   // Sensible defaults for ports/hosts used in CI
@@ -40,4 +106,19 @@ module.exports = async () => {
     console.error('❌ Error waiting for services:', err);
     throw err;
   }
+
+  // Load the shape fixture into the per-worker schema. Runs after
+  // services are confirmed ready (which means migrations and seed have
+  // already been applied via dev_env/init-db.mjs at db:start time).
+  // This injects the realistic edge-case rows (duplicate rotation
+  // groups, NULL artist_name, mixed play_orders, etc.) that
+  // constraint-adding migrations need to be tested against.
+  try {
+    await loadShapeFixture();
+  } catch (err) {
+    console.error('❌ Error loading shape fixture:', err);
+    throw err;
+  }
 };
+
+module.exports.loadShapeFixture = loadShapeFixture;


### PR DESCRIPTION
## Summary

Closes #701. Companion to #703 (PR-bot data-shape report) and #705 (precondition guards on constraint-adding migrations) — three layers of defense against the failure mode where a constraint-adding migration passes CI cleanly but aborts against real prod data.

PR #696 added a unique partial index on `rotation (album_id, rotation_bin) WHERE kill_date IS NULL`. CI passed because the test rotation table had zero rows to violate the constraint. Against prod (39 duplicate active groups, 237 conflict rows) the migration would have aborted at `CREATE UNIQUE INDEX` time. We caught it manually pre-merge by querying prod, not by CI.

## What changes

**`tests/fixtures/shape.sql`** — a small, hand-curated fixture covering the edge cases the issue body lists. Lives under `tests/fixtures/` (new directory). Inserts use `ON CONFLICT (id) DO NOTHING` so loading is idempotent against re-runs, but the conflict target is deliberately scoped to the primary key: a bare `ON CONFLICT DO NOTHING` would silently absorb the unique-constraint violations the fixture exists to expose.

Coverage:
- 3 duplicate `(album_id, rotation_bin)` groups in rotation (exactly the shape #696 would have rejected)
- 2 NULL `album_id` rotation rows (orphaned tubafrenzy adds)
- 1 row with `kill_date > CURRENT_DATE` (planner-stable predicates do not exclude this)
- A flowsheet show with mixed `play_order` values 1, 2, 3, 4, 471 (per-show vs global-MAX distinction #693 hit on prod)
- 1 flowsheet row with `metadata_attempt_at = NULL` (still-pending shape #638 / #639 Phase 2 sweep targets)
- 1 library row with NULL `artist_name` (#625 boot-assertion target)
- 2 shows with `end_time IS NULL` (active / never-ended) plus 1 with `legacy_show_id` set

Fixture IDs use the 7000–7099 range to avoid collisions with `seed_db.sql` (uses IDs 1–9) and with rows integration tests insert by serial; sequence values are advanced past the fixture range with `setval()`.

**`tests/setup/globalSetup.js`** — loads the fixture into the per-worker schema after services are confirmed ready (and after `drizzle:migrate` ran at `db:start` time). Honors `WXYC_SCHEMA_NAME` for forward-compat with the parallel-worker isolation roadmap. Today migrations themselves hardcode `wxyc_schema`, so the rewrite is a no-op in CI.

**`tests/integration/migrations.spec.js`** — three assertions:
1. Every journal entry has a row in `drizzle.__drizzle_migrations` (or a known replay).
2. The fixture's load-bearing edge cases are present and queryable after migrations apply.
3. `drizzle:migrate` is idempotent against the loaded fixture (sanity check that re-running doesn't drop fixture rows).

The actual catch for a future PR's bad constraint migration happens at `globalSetup` time — the fixture load fails before any spec runs. The migration spec is the explicit assertion that this gate is in place.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new errors; warnings unchanged)
- [x] `npm run format:check`
- [x] `npm run test:unit` (1408 tests passing)
- [ ] `npm run db:start` + `npm run test:integration` — could not run locally because Docker port 5432/5433 were occupied by another worktree's containers; CI to verify
- [ ] CI green