### PR TITLE
Read-side rotation dedup + include NULL album_id rows (closes #694, closes #689)

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -124,68 +124,118 @@ export const insertFormat = async (new_format: NewAlbumFormat) => {
 };
 
 export interface Rotation {
-  id: number;
-  code_letters: string;
-  code_artist_number: number;
-  code_number: number;
-  artist_name: string;
-  alphabetical_name: string;
-  album_title: string;
+  id: number | null;
+  code_letters: string | null;
+  code_artist_number: number | null;
+  code_number: number | null;
+  artist_name: string | null;
+  alphabetical_name: string | null;
+  album_title: string | null;
   record_label: string | null;
   label_id: number | null;
-  genre_name: string;
-  format_name: string;
+  genre_name: string | null;
+  format_name: string | null;
   rotation_id: number;
-  add_date: Date;
+  add_date: Date | null;
   rotation_add_date: string;
   rotation_bin: 'S' | 'L' | 'M' | 'H' | 'N';
   rotation_kill_date: string | null;
-  plays: number;
+  plays: number | null;
   reconciled_identity: ReconciledIdentity | null;
 }
 
-export const getRotationFromDB = async (): Promise<Rotation[]> => {
-  const rotation_albums = await db
-    .select({
-      id: library.id,
-      code_letters: artists.code_letters,
-      code_artist_number: genre_artist_crossreference.artist_genre_code,
-      code_number: library.code_number,
-      artist_name: artists.artist_name,
-      alphabetical_name: artists.alphabetical_name,
-      album_title: library.album_title,
-      record_label: library.label,
-      label_id: library.label_id,
-      genre_name: genres.genre_name,
-      format_name: format.format_name,
-      rotation_id: rotation.id,
-      add_date: library.add_date,
-      rotation_add_date: rotation.add_date,
-      rotation_bin: rotation.rotation_bin,
-      rotation_kill_date: rotation.kill_date,
-      plays: library.plays,
-      discogs_artist_id: artists.discogs_artist_id,
-      musicbrainz_artist_id: artists.musicbrainz_artist_id,
-      wikidata_qid: artists.wikidata_qid,
-      spotify_artist_id: artists.spotify_artist_id,
-      apple_music_artist_id: artists.apple_music_artist_id,
-      bandcamp_id: artists.bandcamp_id,
-    })
-    .from(library)
-    .innerJoin(rotation, eq(library.id, rotation.album_id))
-    .innerJoin(artists, eq(artists.id, library.artist_id))
-    .innerJoin(format, eq(library.format_id, format.id))
-    .innerJoin(genres, eq(library.genre_id, genres.id))
-    .innerJoin(
-      genre_artist_crossreference,
-      and(
-        eq(genre_artist_crossreference.artist_id, library.artist_id),
-        eq(genre_artist_crossreference.genre_id, library.genre_id)
-      )
-    )
-    .where(sql`${rotation.kill_date} > CURRENT_DATE OR ${rotation.kill_date} IS NULL`);
+/**
+ * Raw row shape returned by the rotation query before reconciled-identity
+ * serialization. Mirrors the SELECT list in `getRotationFromDB`. Carries
+ * the six external-ID columns flat; `serializeReconciledIdentity` strips
+ * them and replaces them with a nested `reconciled_identity` object.
+ *
+ * Most fields are nullable because the LEFT JOINs (#689) intentionally
+ * surface rotation rows whose `album_id` doesn't resolve to a `library`
+ * row; those rows fall back to rotation's denormalized
+ * artist/album/label snapshot fields and have NULL ancillary metadata
+ * (`code_letters`, `genre_name`, `format_name`, identity ids).
+ */
+type RotationRow = Omit<Rotation, 'reconciled_identity'> & ReconciledIdentitySource;
 
-  return rotation_albums.map((row) => serializeReconciledIdentity(row));
+/**
+ * Read-side query for `GET /library/rotation`.
+ *
+ * **Shape rules** (see #689 / #694, BS CLAUDE.md `SOURCE: tubafrenzy`
+ * annotation on the rotation table). Tubafrenzy is the upstream writer
+ * and BS is downstream; we cannot constrain what tubafrenzy writes, so
+ * the read collapses the full upstream shape on the way out.
+ *
+ * - **LEFT JOIN to library, artists, format, genres,
+ *   genre_artist_crossreference.** Tubafrenzy permits rotation rows
+ *   with NULL `album_id` (rotation entries that pre-date or didn't
+ *   link to a library row); ~147 such rows are currently active in
+ *   prod and were dropped by the previous INNER JOIN. We instead
+ *   surface them and `COALESCE` artist_name/album_title/record_label
+ *   from rotation's denormalized snapshot columns when the library
+ *   join is NULL.
+ *
+ * - **DISTINCT ON `(coalesce(album_id, -id), rotation_bin)` ORDER BY
+ *   `coalesce(album_id, -id), rotation_bin, add_date DESC, id ASC`.**
+ *   Tubafrenzy permits multiple active rows per
+ *   `(album_id, rotation_bin)` over an album's lifecycle (re-bins,
+ *   re-adds, label-driven re-promotes); we collapse those duplicates
+ *   to one row per group on the way out, picking the most-recently
+ *   added (tie-broken by lowest rotation id for deterministic output).
+ *   The `coalesce(album_id, -id)` trick keeps NULL-album rows in
+ *   separate groups (Postgres DISTINCT ON treats NULLs as equal
+ *   without it, which would collapse the 147 NULL-album rows down
+ *   to one).
+ *
+ * - **`kill_date IS NULL OR kill_date > CURRENT_DATE`.** Active rows
+ *   only; the planner-stable predicate also excludes future-dated
+ *   kills correctly.
+ */
+export const getRotationFromDB = async (): Promise<Rotation[]> => {
+  const query = sql`
+    SELECT DISTINCT ON (COALESCE(${rotation.album_id}, -${rotation.id}), ${rotation.rotation_bin})
+      ${library.id} AS id,
+      ${artists.code_letters} AS code_letters,
+      ${genre_artist_crossreference.artist_genre_code} AS code_artist_number,
+      ${library.code_number} AS code_number,
+      COALESCE(${artists.artist_name}, ${rotation.artist_name}) AS artist_name,
+      COALESCE(${artists.alphabetical_name}, ${rotation.artist_name}) AS alphabetical_name,
+      COALESCE(${library.album_title}, ${rotation.album_title}) AS album_title,
+      COALESCE(${library.label}, ${rotation.record_label}) AS record_label,
+      ${library.label_id} AS label_id,
+      ${genres.genre_name} AS genre_name,
+      ${format.format_name} AS format_name,
+      ${rotation.id} AS rotation_id,
+      ${library.add_date} AS add_date,
+      ${rotation.add_date} AS rotation_add_date,
+      ${rotation.rotation_bin} AS rotation_bin,
+      ${rotation.kill_date} AS rotation_kill_date,
+      ${library.plays} AS plays,
+      ${artists.discogs_artist_id} AS discogs_artist_id,
+      ${artists.musicbrainz_artist_id} AS musicbrainz_artist_id,
+      ${artists.wikidata_qid} AS wikidata_qid,
+      ${artists.spotify_artist_id} AS spotify_artist_id,
+      ${artists.apple_music_artist_id} AS apple_music_artist_id,
+      ${artists.bandcamp_id} AS bandcamp_id
+    FROM ${rotation}
+    LEFT JOIN ${library} ON ${library.id} = ${rotation.album_id}
+    LEFT JOIN ${artists} ON ${artists.id} = ${library.artist_id}
+    LEFT JOIN ${format} ON ${library.format_id} = ${format.id}
+    LEFT JOIN ${genres} ON ${library.genre_id} = ${genres.id}
+    LEFT JOIN ${genre_artist_crossreference}
+      ON ${genre_artist_crossreference.artist_id} = ${library.artist_id}
+      AND ${genre_artist_crossreference.genre_id} = ${library.genre_id}
+    WHERE ${rotation.kill_date} > CURRENT_DATE OR ${rotation.kill_date} IS NULL
+    ORDER BY COALESCE(${rotation.album_id}, -${rotation.id}),
+             ${rotation.rotation_bin},
+             ${rotation.add_date} DESC,
+             ${rotation.id} ASC
+  `;
+
+  const response = await db.execute(query);
+  const rows = response as unknown as RotationRow[];
+
+  return rows.map((row) => serializeReconciledIdentity(row));
 };
 
 export const addToRotation = async (newRotation: RotationAddRequest) => {

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -226,6 +226,65 @@ describe('Library Rotation', () => {
         expect(row).not.toHaveProperty('bandcamp_id');
       }
     });
+
+    // The shape fixture (tests/fixtures/shape.sql, BS#701) seeds 3 duplicate
+    // active rotation groups + 2 NULL-album_id rows. The next two tests
+    // assert the read-side fix for #694 (dedup) + #689 (NULL-album surface).
+
+    test('collapses duplicate active rows per (album_id, rotation_bin) to one (#694)', async () => {
+      const res = await auth.get('/library/rotation').expect(200);
+
+      // Group fixture rotation rows by (album_id, rotation_bin) for the
+      // shape-fixture albums (id range 7000-7099). Each group should
+      // resolve to exactly one row in the response.
+      const fixtureRows = res.body.filter((r) => r.id !== null && r.id >= 7000 && r.id < 7100);
+      const groups = new Map();
+      for (const row of fixtureRows) {
+        const key = `${row.id}|${row.rotation_bin}`;
+        groups.set(key, (groups.get(key) || 0) + 1);
+      }
+      for (const [key, count] of groups.entries()) {
+        expect({ key, count }).toEqual({ key, count: 1 });
+      }
+
+      // Specifically: album 7000 in bin 'H' had 3 active rows in the
+      // fixture; assert the response has exactly one entry with the
+      // most-recent rotation_add_date.
+      const album7000H = res.body.filter((r) => r.id === 7000 && r.rotation_bin === 'H');
+      expect(album7000H).toHaveLength(1);
+      expect(album7000H[0].rotation_add_date).toBe('2024-08-22');
+    });
+
+    test('surfaces rotation rows with NULL album_id using denormalized snapshot fields (#689)', async () => {
+      const res = await auth.get('/library/rotation').expect(200);
+
+      // The shape fixture seeds 2 rotation rows with album_id IS NULL.
+      // They should appear with id=null and artist_name/album_title
+      // populated from rotation's denormalized columns.
+      const orphans = res.body.filter((r) => r.id === null);
+      expect(orphans.length).toBeGreaterThanOrEqual(2);
+
+      const fixtureOrphans = orphans.filter((r) => r.artist_name && r.artist_name.startsWith('Shape Fixture Orphan'));
+      expect(fixtureOrphans).toHaveLength(2);
+
+      const orphanOne = fixtureOrphans.find((r) => r.artist_name === 'Shape Fixture Orphan One');
+      expect(orphanOne).toBeDefined();
+      expect(orphanOne).toMatchObject({
+        id: null,
+        artist_name: 'Shape Fixture Orphan One',
+        album_title: 'Shape Fixture Orphan Album One',
+        rotation_bin: 'L',
+      });
+
+      const orphanTwo = fixtureOrphans.find((r) => r.artist_name === 'Shape Fixture Orphan Two');
+      expect(orphanTwo).toBeDefined();
+      expect(orphanTwo).toMatchObject({
+        id: null,
+        artist_name: 'Shape Fixture Orphan Two',
+        album_title: 'Shape Fixture Orphan Album Two',
+        rotation_bin: 'M',
+      });
+    });
   });
 
   describe('POST /library/rotation', () => {

--- a/tests/unit/services/library.rotation.test.ts
+++ b/tests/unit/services/library.rotation.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Unit tests for `getRotationFromDB` (read-side fix for #689 / #694).
+ *
+ * The read query is the only thing that defends the dropdown shape because
+ * tubafrenzy is the upstream writer and BS cannot constrain what it writes.
+ * Three shapes the test covers:
+ *
+ *   1. Duplicate active rows for the same `(album_id, rotation_bin)` —
+ *      collapsed to one row per group via `DISTINCT ON ... ORDER BY
+ *      add_date DESC, id ASC`.
+ *   2. Rows with `album_id IS NULL` — surface via the LEFT JOIN with
+ *      artist/album/label fields populated from the rotation row's
+ *      denormalized snapshot columns.
+ *   3. The mixed case (real albums + duplicates + NULL-album rows)
+ *      together — exercises the `coalesce(album_id, -id)` partition
+ *      key that keeps NULL rows in distinct groups.
+ *
+ * The query itself uses raw `sql` template + `db.execute` (because
+ * Drizzle's query builder doesn't surface `DISTINCT ON`), so the tests
+ * mock `db.execute` directly with the rows the underlying SQL would
+ * have returned post-DISTINCT-ON. That asserts the *serialization*
+ * layer (LEFT JOIN nullability, identity stripping, COALESCE shape)
+ * without re-implementing Postgres's deduplication semantics.
+ *
+ * Integration coverage of the actual SQL (DISTINCT ON dedup against
+ * the shape fixture's 3 duplicate groups + 2 NULL-album rows) lives in
+ * `tests/integration/library.spec.js`.
+ */
+import { jest } from '@jest/globals';
+import { db } from '../../mocks/database.mock';
+
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
+const mockIsLmlConfigured = jest.fn<() => boolean>();
+
+jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  isLmlConfigured: mockIsLmlConfigured,
+}));
+
+import { getRotationFromDB } from '../../../apps/backend/services/library.service';
+
+type RawRotationRow = {
+  id: number | null;
+  code_letters: string | null;
+  code_artist_number: number | null;
+  code_number: number | null;
+  artist_name: string | null;
+  alphabetical_name: string | null;
+  album_title: string | null;
+  record_label: string | null;
+  label_id: number | null;
+  genre_name: string | null;
+  format_name: string | null;
+  rotation_id: number;
+  add_date: Date | null;
+  rotation_add_date: string;
+  rotation_bin: 'S' | 'L' | 'M' | 'H' | 'N';
+  rotation_kill_date: string | null;
+  plays: number | null;
+  discogs_artist_id: number | null;
+  musicbrainz_artist_id: string | null;
+  wikidata_qid: string | null;
+  spotify_artist_id: string | null;
+  apple_music_artist_id: string | null;
+  bandcamp_id: string | null;
+};
+
+/** Build a fully-populated joined-album row for the rotation query. */
+function joinedRow(overrides: Partial<RawRotationRow> = {}): RawRotationRow {
+  return {
+    id: 1,
+    code_letters: 'JU',
+    code_artist_number: 1,
+    code_number: 1,
+    artist_name: 'Juana Molina',
+    alphabetical_name: 'Juana Molina',
+    album_title: 'DOGA',
+    record_label: 'Sonamos',
+    label_id: 10,
+    genre_name: 'Rock',
+    format_name: 'CD',
+    rotation_id: 100,
+    add_date: new Date('2024-01-15'),
+    rotation_add_date: '2024-01-15',
+    rotation_bin: 'H',
+    rotation_kill_date: null,
+    plays: 5,
+    discogs_artist_id: null,
+    musicbrainz_artist_id: null,
+    wikidata_qid: null,
+    spotify_artist_id: null,
+    apple_music_artist_id: null,
+    bandcamp_id: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a row that the LEFT JOIN to library produced with NULL on the
+ * library/artists/format/genres side — i.e. a rotation row whose
+ * `album_id` was NULL or didn't resolve. The COALESCEs in the SELECT
+ * surface artist_name/album_title/record_label from the rotation row's
+ * denormalized columns, so those *do* end up populated; everything else
+ * derived from the joined tables is NULL.
+ */
+function orphanRow(overrides: Partial<RawRotationRow> = {}): RawRotationRow {
+  return {
+    id: null, // library.id (no joined library row)
+    code_letters: null, // artists.code_letters
+    code_artist_number: null, // genre_artist_crossreference.artist_genre_code
+    code_number: null, // library.code_number
+    artist_name: 'Shape Fixture Orphan One', // COALESCE(artists.artist_name, rotation.artist_name)
+    alphabetical_name: 'Shape Fixture Orphan One', // COALESCE(artists.alphabetical_name, rotation.artist_name)
+    album_title: 'Shape Fixture Orphan Album One', // COALESCE(library.album_title, rotation.album_title)
+    record_label: null, // COALESCE(library.label, rotation.record_label) — null on both sides here
+    label_id: null,
+    genre_name: null, // genres.genre_name
+    format_name: null, // format.format_name
+    rotation_id: 200,
+    add_date: null, // library.add_date
+    rotation_add_date: '2024-05-20',
+    rotation_bin: 'L',
+    rotation_kill_date: null,
+    plays: null, // library.plays
+    discogs_artist_id: null,
+    musicbrainz_artist_id: null,
+    wikidata_qid: null,
+    spotify_artist_id: null,
+    apple_music_artist_id: null,
+    bandcamp_id: null,
+    ...overrides,
+  };
+}
+
+describe('library.service / getRotationFromDB', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('post-DISTINCT-ON serialization', () => {
+    /**
+     * Postgres collapses 3 active rows for the same (album_id,
+     * rotation_bin) to 1 via DISTINCT ON. This test asserts that when
+     * the SQL returns the post-collapse shape (1 row, the most-recent
+     * add per group), the serializer passes it through cleanly with
+     * the reconciled-identity rewrite.
+     */
+    it('returns one row per (album_id, rotation_bin) group with the latest add_date', async () => {
+      const collapsed = joinedRow({
+        rotation_id: 7002, // The 2024-08-22 row, latest of the 3-row Little Brother group
+        rotation_add_date: '2024-08-22',
+      });
+      db.execute.mockResolvedValueOnce([collapsed]);
+
+      const result = await getRotationFromDB();
+
+      expect(db.execute).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        rotation_id: 7002,
+        rotation_add_date: '2024-08-22',
+        rotation_bin: 'H',
+      });
+      // Reconciled-identity rewrite: nested object replaces flat columns.
+      expect(result[0]).toHaveProperty('reconciled_identity');
+      expect(result[0]).not.toHaveProperty('discogs_artist_id');
+      expect(result[0]).not.toHaveProperty('musicbrainz_artist_id');
+    });
+
+    /**
+     * Two rotation rows with NULL `album_id` (different rotation_ids)
+     * survive the LEFT JOIN. Each has its own row in the response with
+     * artist_name/album_title coming from rotation's denormalized
+     * columns (via COALESCE in the SELECT).
+     */
+    it('surfaces NULL-album_id rows with denormalized artist/album fields populated', async () => {
+      const orphan1 = orphanRow({
+        rotation_id: 7007,
+        rotation_bin: 'L',
+        rotation_add_date: '2024-05-20',
+        artist_name: 'Shape Fixture Orphan One',
+        album_title: 'Shape Fixture Orphan Album One',
+        alphabetical_name: 'Shape Fixture Orphan One',
+      });
+      const orphan2 = orphanRow({
+        rotation_id: 7008,
+        rotation_bin: 'M',
+        rotation_add_date: '2024-07-04',
+        artist_name: 'Shape Fixture Orphan Two',
+        album_title: 'Shape Fixture Orphan Album Two',
+        alphabetical_name: 'Shape Fixture Orphan Two',
+      });
+      db.execute.mockResolvedValueOnce([orphan1, orphan2]);
+
+      const result = await getRotationFromDB();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        id: null,
+        rotation_id: 7007,
+        artist_name: 'Shape Fixture Orphan One',
+        album_title: 'Shape Fixture Orphan Album One',
+        rotation_bin: 'L',
+        // ancillary metadata that came from the (NULL) joined tables stays null
+        code_letters: null,
+        genre_name: null,
+        format_name: null,
+        plays: null,
+      });
+      expect(result[1]).toMatchObject({
+        id: null,
+        rotation_id: 7008,
+        artist_name: 'Shape Fixture Orphan Two',
+        album_title: 'Shape Fixture Orphan Album Two',
+        rotation_bin: 'M',
+      });
+      // Both rows still get the reconciled_identity rewrite (nested null object).
+      expect(result[0].reconciled_identity).toBeNull();
+      expect(result[1].reconciled_identity).toBeNull();
+    });
+
+    /**
+     * Mixed shape: 5 distinct linked rows (e.g. albums 7000/7001/7002
+     * with their duplicate groups already collapsed by DISTINCT ON, plus
+     * 2 stand-alone rows on different albums) and 3 NULL-album_id rows.
+     * Asserts the serializer handles the heterogeneous wave without
+     * dropping or coalescing across album boundaries.
+     */
+    it('handles mixed linked + NULL-album rows in one response', async () => {
+      const linked = [
+        joinedRow({ id: 7000, rotation_id: 7002, rotation_bin: 'H', artist_name: 'Alpha' }),
+        joinedRow({ id: 7001, rotation_id: 7006, rotation_bin: 'M', artist_name: 'Beta' }),
+        joinedRow({ id: 7002, rotation_id: 7004, rotation_bin: 'L', artist_name: 'Gamma' }),
+        joinedRow({ id: 7003, rotation_id: 7012, rotation_bin: 'M', artist_name: 'Delta' }),
+        joinedRow({ id: 7005, rotation_id: 7013, rotation_bin: 'H', artist_name: 'Epsilon' }),
+      ];
+      const orphans = [
+        orphanRow({ rotation_id: 9001, artist_name: 'Orphan A' }),
+        orphanRow({ rotation_id: 9002, artist_name: 'Orphan B' }),
+        orphanRow({ rotation_id: 9003, artist_name: 'Orphan C' }),
+      ];
+      db.execute.mockResolvedValueOnce([...linked, ...orphans]);
+
+      const result = await getRotationFromDB();
+
+      expect(result).toHaveLength(8); // 5 linked + 3 orphans
+      // Linked rows preserve their library id; orphans have null id.
+      const linkedIds = result.filter((r) => r.id !== null).map((r) => r.id);
+      expect(linkedIds).toEqual([7000, 7001, 7002, 7003, 7005]);
+      const orphanRows = result.filter((r) => r.id === null);
+      expect(orphanRows).toHaveLength(3);
+      expect(orphanRows.map((r) => r.artist_name)).toEqual(['Orphan A', 'Orphan B', 'Orphan C']);
+      // None of the rows leak the flat external-ID columns.
+      for (const row of result) {
+        expect(row).not.toHaveProperty('discogs_artist_id');
+        expect(row).not.toHaveProperty('musicbrainz_artist_id');
+        expect(row).not.toHaveProperty('wikidata_qid');
+        expect(row).not.toHaveProperty('spotify_artist_id');
+        expect(row).not.toHaveProperty('apple_music_artist_id');
+        expect(row).not.toHaveProperty('bandcamp_id');
+        expect(row).toHaveProperty('reconciled_identity');
+      }
+    });
+
+    /**
+     * COALESCE picks library.label when present and falls back to
+     * rotation.record_label when the joined library row is NULL or
+     * library.label is NULL. Asserts both branches.
+     */
+    it('COALESCEs record_label across the library and rotation snapshot columns', async () => {
+      const fromLibrary = joinedRow({
+        record_label: 'Sonamos', // COALESCE(library.label='Sonamos', rotation.record_label='ignored') = 'Sonamos'
+      });
+      const fromRotation = orphanRow({
+        rotation_id: 9100,
+        record_label: 'Drag City', // COALESCE(library.label=NULL, rotation.record_label='Drag City')
+      });
+      db.execute.mockResolvedValueOnce([fromLibrary, fromRotation]);
+
+      const result = await getRotationFromDB();
+
+      expect(result[0].record_label).toBe('Sonamos');
+      expect(result[1].record_label).toBe('Drag City');
+    });
+
+    it('returns an empty array when there are no active rotation rows', async () => {
+      db.execute.mockResolvedValueOnce([]);
+
+      const result = await getRotationFromDB();
+
+      expect(result).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Rewrite `getRotationFromDB` so the rotation dropdown reflects the upstream shape tubafrenzy actually writes — multiple active rows per `(album_id, rotation_bin)` over an album's lifecycle, and rotation rows with NULL `album_id` whose denormalized artist/album/label snapshot fields carry the display data. The previous query INNER JOINed library and dropped ~147 active NULL-album rows on prod and surfaced 35 albums as duplicates (up to 9× for Little Brother in Heavy, the on-air report from 2026-04-30).

The fix is read-side because tubafrenzy is the upstream writer and BS is downstream. We cannot constrain what tubafrenzy commits to its rotation table; the read collapses the full upstream shape on the way out.

## What changes

- **`apps/backend/services/library.service.ts`**: rewrite the rotation query as a raw `sql` template with `db.execute` (Drizzle's builder doesn't surface `DISTINCT ON`).
  - `LEFT JOIN` library/artists/format/genres/genre_artist_crossreference so rows with no resolved `album_id` survive.
  - `DISTINCT ON (COALESCE(rotation.album_id, -rotation.id), rotation.rotation_bin)` ORDER BY same key, then `rotation.add_date DESC, rotation.id ASC` so duplicates collapse to the most-recently-added row (tie-broken deterministically). The `COALESCE(album_id, -id)` partition key keeps NULL-album rows in their own groups; without it, Postgres treats NULLs as equal in DISTINCT ON and the 147 NULL-album rows would collapse down to one.
  - `COALESCE` `artist_name`/`alphabetical_name`/`album_title`/`record_label` with `rotation.artist_name`/`rotation.album_title`/`rotation.record_label` so NULL-album rows still ship populated display fields.
  - Active-row predicate (`kill_date IS NULL OR kill_date > CURRENT_DATE`) is preserved.
  - The `Rotation` interface widens LEFT-JOIN-derived fields to nullable (`id`, `code_letters`, `code_artist_number`, `code_number`, `alphabetical_name`, `genre_name`, `format_name`, `plays`, `add_date`). The `reconciled_identity` rewrite is preserved end-to-end.

- **`tests/unit/services/library.rotation.test.ts`** (new): 5 unit tests covering post-DISTINCT-ON serialization for the collapsed-duplicate, NULL-album, mixed-shape, COALESCE-fallback, and empty cases. Mocks `db.execute` directly with rows the underlying SQL would have returned post-DISTINCT-ON; asserts the serialization layer (LEFT JOIN nullability, identity stripping, COALESCE shape) without re-implementing Postgres dedup semantics.

- **`tests/integration/library.spec.js`**: 2 new tests exercise the actual SQL against the shape fixture seeded by BS#701 (3 duplicate active groups + 2 NULL-album_id rows) — assert each fixture `(album_id, rotation_bin)` group resolves to exactly one row, with the most-recent `add_date` winning, and that both NULL-album fixture rows surface with their denormalized artist/album fields populated.

## Why this is the right shape

Tubafrenzy is the canonical writer of rotation rows; BS mirrors via `jobs/rotation-etl/`. The rotation table's `SOURCE: tubafrenzy` annotation in `shared/database/src/schema.ts` (landed via PR #709) explicitly forbids adding a partial-unique index on `(album_id, rotation_bin)` because the upstream's own UI permits the duplicate shape over an album's lifecycle. PR #696 attempted the write-side approach (unique index + dedupe job); it was reverted via PR #698 today because the next ETL pass would have rejected the entire incoming batch.

The defense lives at the read because that's the only layer that can collapse the shape without constraining the upstream. Tubafrenzy's denormalized `artist_name`/`album_title`/`record_label` columns on the rotation row are explicitly there as fallback display fields when `album_id` doesn't resolve to a library row; the prior INNER JOIN ignored them. This PR honors that contract.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new errors (only pre-existing security-rule warnings in unrelated files)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 1443/1443 pass (5 new tests in `library.rotation.test.ts`)
- [ ] `npm run test:integration` — exercises the new tests against the shape fixture; CI handles via `npm run ci:testmock` (no local `.env` available in the worktree)
- [ ] Manual verification on prod after merge: hit `GET /library/rotation` and confirm (a) no `(id, rotation_bin)` group has more than one row in the response, (b) NULL-id rows appear with `artist_name`/`album_title` populated from rotation's snapshot columns, and (c) total active row count returns the previously-dropped ~147 entries.

Closes #694
Closes #689