### PR TITLE
Scope flowsheet changeOrder play_order renumber to entry's show (closes #712)

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -634,6 +634,7 @@ export const changeOrder = async (entry_id: number, position_new: number): Promi
       const result = await trx
         .select({
           play_order: flowsheet.play_order,
+          show_id: flowsheet.show_id,
         })
         .from(flowsheet)
         .where(eq(flowsheet.id, entry_id))
@@ -644,17 +645,38 @@ export const changeOrder = async (entry_id: number, position_new: number): Promi
       }
 
       const position_old = result[0].play_order;
+      const show_id = result[0].show_id;
+
+      // Defensive: every flowsheet row has show_id post-#693. Be loud, not
+      // silent, if the invariant ever breaks — an unscoped bump UPDATE
+      // (#712) corrupts cross-show play_order ranges in ways that don't
+      // surface until much later.
+      if (show_id == null) {
+        throw new WxycError(`Flowsheet entry ${entry_id} has no show_id`, 500);
+      }
 
       if (position_new < position_old) {
         await trx
           .update(flowsheet)
           .set({ play_order: sql`play_order + 1` })
-          .where(and(gte(flowsheet.play_order, position_new), lte(flowsheet.play_order, position_old - 1)));
+          .where(
+            and(
+              eq(flowsheet.show_id, show_id),
+              gte(flowsheet.play_order, position_new),
+              lte(flowsheet.play_order, position_old - 1)
+            )
+          );
       } else if (position_new > position_old) {
         await trx
           .update(flowsheet)
           .set({ play_order: sql`play_order - 1` })
-          .where(and(gte(flowsheet.play_order, position_old + 1), lte(flowsheet.play_order, position_new)));
+          .where(
+            and(
+              eq(flowsheet.show_id, show_id),
+              gte(flowsheet.play_order, position_old + 1),
+              lte(flowsheet.play_order, position_new)
+            )
+          );
       }
 
       await trx.update(flowsheet).set({ play_order: position_new }).where(eq(flowsheet.id, entry_id));
@@ -667,7 +689,10 @@ export const changeOrder = async (entry_id: number, position_new: number): Promi
   );
 
   updateLastModified();
-  const response = await db.select().from(flowsheet).where(eq(flowsheet.play_order, position_new)).limit(1);
+  // Filter by id, not play_order — post-#693 multiple shows legitimately
+  // share play_order values, so `WHERE play_order = ? LIMIT 1` could
+  // surface a row from a different show.
+  const response = await db.select().from(flowsheet).where(eq(flowsheet.id, entry_id)).limit(1);
 
   return response[0];
 };

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -1,5 +1,22 @@
 const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const postgres = require('postgres');
 const fls_util = require('../utils/flowsheet_util');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+// Per-spec sql client used by the #712 cross-show snapshot test below.
+// Mirrors the client construction in tests/integration/migrations.spec.js.
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
 
 /*
  * Start Show (Primary dj hits /flowsheet/join)
@@ -586,6 +603,57 @@ describe('Shift Flowsheet Entries', () => {
 
     // get_entries_res = await request.get('/flowsheet').query({ limit: 4 }).send().expect(200);
     expect(res.body.play_order).toEqual(entries[0].play_order);
+  });
+
+  // Regression guard for #712. The shape fixture (#701) seeds show 7003
+  // with flowsheet rows at play_orders 1, 2, 3, 4, 5, 471. Pre-#712 the
+  // unscoped bump UPDATEs in `changeOrder` would mutate any row whose
+  // play_order fell in the moved range — including rows in *other* shows
+  // (the active one created by the surrounding describe + the fixture's
+  // ended show 7003). Snapshot show 7003's rows by id+play_order before
+  // the reorder and assert byte-equality after.
+  test('reordering inside the active show does not touch show 7003 (#712)', async () => {
+    const sql = makeSql();
+    try {
+      const before = await sql.unsafe(
+        `SELECT id, play_order FROM "${SCHEMA}".flowsheet WHERE show_id = 7003 ORDER BY id ASC`
+      );
+      // Sanity-check the fixture preconditions so a future fixture edit
+      // can't silently turn this test into a no-op.
+      expect(before.length).toBeGreaterThanOrEqual(6);
+      const orders = before.map((r) => r.play_order).sort((a, b) => a - b);
+      expect(orders).toEqual(expect.arrayContaining([1, 2, 3, 4, 5, 471]));
+
+      // Run a reorder in the active show — the same shape the
+      // "Start > Destination" test above exercises.
+      const get_entries_res = await request.get('/flowsheet').query({ limit: 4 }).send().expect(200);
+      const entries = get_entries_res.body.entries;
+      await request
+        .patch('/flowsheet/play-order')
+        .set('Authorization', global.access_token)
+        .send({ entry_id: entries[0].id, new_position: entries[2].play_order })
+        .expect(200);
+
+      // And the reverse direction, to cover both bump branches.
+      const get_entries_res2 = await request.get('/flowsheet').query({ limit: 4 }).send().expect(200);
+      const entries2 = get_entries_res2.body.entries;
+      await request
+        .patch('/flowsheet/play-order')
+        .set('Authorization', global.access_token)
+        .send({ entry_id: entries2[2].id, new_position: entries2[0].play_order })
+        .expect(200);
+
+      const after = await sql.unsafe(
+        `SELECT id, play_order FROM "${SCHEMA}".flowsheet WHERE show_id = 7003 ORDER BY id ASC`
+      );
+      // Byte-equal pre/post: no row in show 7003 had its play_order
+      // bumped by the reorders above. Pre-#712 some of these rows would
+      // have been mutated (the 1..4 range overlaps with the active
+      // show's bump range), corrupting the fixture for subsequent tests.
+      expect(after).toEqual(before);
+    } finally {
+      await sql.end();
+    }
   });
 });
 

--- a/tests/unit/services/flowsheet.changeOrder.test.ts
+++ b/tests/unit/services/flowsheet.changeOrder.test.ts
@@ -1,7 +1,43 @@
+/**
+ * Regression guards for `changeOrder` in `apps/backend/services/flowsheet.service.ts`.
+ *
+ * Background (#712):
+ *
+ * After #693 (`f71b3ef`) scoped `nextPlayOrder()` to per-show semantics,
+ * inserts began writing low play_orders (1, 2, 3, ...) into multiple
+ * concurrent shows. `changeOrder` was not converted in the same PR: its
+ * two bump UPDATEs filtered only on the play_order range, with no
+ * `eq(flowsheet.show_id, ...)` predicate, so reordering inside one show
+ * would bump rows in *other* shows that happened to occupy the same
+ * play_order values. The shape fixture (#701, `tests/fixtures/shape.sql`)
+ * caught this when seemingly-unrelated tests poked show 7003's
+ * play_orders 1..4 via cross-show reorders.
+ *
+ * Same function, latent sibling bug at the response-SELECT: it filtered
+ * by `play_order = position_new`, which (post-#693) is no longer unique
+ * across shows — postgres could surface a row from a different show.
+ *
+ * The mock-based 404 test below is the original guard. The source-grep
+ * tests below it pin the cross-show isolation + response-correctness
+ * fixes to the function body so a future refactor that drops the
+ * `show_id` predicate or reverts the response SELECT trips immediately.
+ */
+
 import { jest } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
 import { db } from '@wxyc/database';
 import { createMockQueryChain } from '../../mocks/database.mock';
 import WxycError from '../../../apps/backend/utils/error';
+
+const servicePath = path.resolve(__dirname, '../../../apps/backend/services/flowsheet.service.ts');
+const serviceSource = fs.readFileSync(servicePath, 'utf-8');
+
+const extractChangeOrderBody = (): string => {
+  const match = serviceSource.match(/export const changeOrder[\s\S]*?\n\};/);
+  if (!match) throw new Error('changeOrder not found in flowsheet.service.ts');
+  return match[0];
+};
 
 describe('flowsheet.service', () => {
   describe('changeOrder', () => {
@@ -25,6 +61,57 @@ describe('flowsheet.service', () => {
       await expect(changeOrder(999999, 1)).rejects.toMatchObject({
         statusCode: 404,
       });
+    });
+  });
+
+  describe('changeOrder cross-show isolation (#712)', () => {
+    const body = extractChangeOrderBody();
+
+    it('selects show_id alongside play_order so the bump UPDATEs can scope by show', () => {
+      // Pre-#712 the SELECT only pulled play_order; show_id was never read,
+      // so the bump UPDATEs had no value to scope by. The fix adds show_id
+      // to the SELECT projection.
+      expect(body).toMatch(/play_order:\s*flowsheet\.play_order/);
+      expect(body).toMatch(/show_id:\s*flowsheet\.show_id/);
+    });
+
+    it("scopes the bump UPDATEs by the entry's show_id", () => {
+      // The two range-bump UPDATEs (one for position_new < position_old,
+      // one for position_new > position_old) must each include
+      // `eq(flowsheet.show_id, show_id)` in their WHERE. Pre-#712 they
+      // mutated rows in any show whose play_orders fell in the range.
+      const bumpUpdates = body.match(/\.update\(flowsheet\)\s*\.set\(\{\s*play_order:\s*sql`play_order [+-] 1`/g);
+      expect(bumpUpdates).not.toBeNull();
+      expect(bumpUpdates && bumpUpdates.length).toBe(2);
+
+      // Both range-bump UPDATEs must reference show_id in their WHERE.
+      // Conservative shape match: `eq(flowsheet.show_id, show_id)` appears
+      // at least twice in the function body.
+      const showScopedPredicates = body.match(/eq\(flowsheet\.show_id,\s*show_id\)/g) || [];
+      expect(showScopedPredicates.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('guards against a NULL show_id with a loud throw, not a silent skip', () => {
+      // Every flowsheet row has show_id post-#693 (NOT NULL constraint),
+      // but the schema type still allows null in TS land. Be loud, not
+      // silent, if the invariant ever breaks.
+      expect(body).toMatch(/show_id\s*==\s*null|show_id\s*===\s*null/);
+      expect(body).toMatch(/throw new WxycError\([^)]*show_id/);
+    });
+
+    it('filters the response SELECT by entry id, not by play_order', () => {
+      // Pre-#712 the response read `WHERE play_order = position_new
+      // LIMIT 1`, which (post-#693) can return a row from a different
+      // show whose per-show play_order happens to match. The fix uses
+      // the entry's id, which is globally unique by construction.
+      const responseSelect = body.match(/const response\s*=\s*await\s+db\.select\(\)[\s\S]*?\.limit\(1\);/);
+      expect(responseSelect).not.toBeNull();
+      const responseText = responseSelect ? responseSelect[0] : '';
+      expect(responseText).toContain('eq(flowsheet.id, entry_id)');
+      // The matched expression itself must not call eq() against play_order;
+      // strip out the `db.select()` (which contains the column-list builder)
+      // to assert the WHERE predicate explicitly.
+      expect(responseText).not.toMatch(/eq\(flowsheet\.play_order/);
     });
   });
 });


### PR DESCRIPTION
Closes #712.

## Why

After #693 (`f71b3ef`) scoped `nextPlayOrder()` to per-show semantics, inserts started writing low play_orders (1, 2, 3, ...) into multiple concurrent shows. `changeOrder` was not converted in the same PR: its two range-bump UPDATEs filtered only on the play_order range, with no `eq(flowsheet.show_id, ...)` predicate, so reordering inside one show would bump rows in *other* shows that happened to occupy the same play_order values.

The shape fixture (#701) caught this when seemingly-unrelated tests poked show 7003's play_orders 1..4 via cross-show reorders. The bug existed before #693; the regression was the visibility — pre-#693 the play_order space was effectively a single global namespace, so the unscoped UPDATE was internally consistent (still semantically wrong, but harmless). Post-#693 multiple shows legitimately share play_order=1, 2, 3, ..., so the unscoped UPDATE corrupts cross-show ranges.

Same function, latent sibling bug at the response SELECT: it filtered by `play_order = position_new`, which (post-#693) is no longer unique across shows — postgres could surface a row from a different show. Trivial fix in the same PR.

## Code changes (apps/backend/services/flowsheet.service.ts `changeOrder`)

1. SELECT now returns `show_id` alongside `play_order`.
2. Defensive guard throws `WxycError(500)` on a NULL `show_id` (every flowsheet row has `show_id` post-#693, but be loud not silent).
3. Both bump UPDATEs gain an `eq(flowsheet.show_id, show_id)` clause.
4. Response SELECT filters by `id`, not `play_order`.

## Tests added

- **Source-grep guards** in `tests/unit/services/flowsheet.changeOrder.test.ts` pinning: the SELECT projection includes `show_id`; both bump UPDATEs reference `eq(flowsheet.show_id, show_id)`; the NULL-`show_id` throw exists; the response SELECT filters by `eq(flowsheet.id, entry_id)` and not `play_order`.
- **Cross-show isolation integration test** in `tests/integration/flowsheet.spec.js` snapshots show 7003's flowsheet rows by `(id, play_order)` before and after the existing "Shift Flowsheet Entries" reorder operations and asserts byte-equality. This is the assertion the shape fixture was implicitly making at `migrations.spec.js:172`; lifting it into the `changeOrder` integration test makes the regression source explicit instead of relying on the incidental fixture bystander.

The existing "Shift Flowsheet Entries" tests at `flowsheet.spec.js:528-590` pass unmodified — they assert on the moved entry's response play_order, which the fix preserves.

## Out of scope

Filed for follow-up rather than folded in here:

- Branch protection settings (require Integration-Tests = SUCCESS for merge to `main`) — process change, no code.
- `getEntriesByRange`'s stale `orderBy(desc(play_order))` at `flowsheet.service.ts:257` — latent display-order bug across shows.
- `orderMutex` perf optimization (process-global → per-show).
- Re-enabling the legacy mirror's `changeOrder` (currently commented out in `apps/backend/routes/flowsheet.route.ts:45`).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check`
- [x] `npm run test:unit` (1447 passing, including 5 in `flowsheet.changeOrder.test.ts`)
- [x] `npm run test:integration` against fresh DB (198 passing, including the new #712 integration test)
- [x] `migrations.spec.js` shape-fixture assertion at line 172 passes deterministically