### PR TITLE
Add library-artwork-url-backfill one-shot job

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ npm workspaces:
 | `@wxyc/flowsheet-dj-name-backfill`   | `jobs/flowsheet-dj-name-backfill/`   | One-shot backfill: populate `flowsheet.dj_name` on legacy track rows after migration 0053                                                                                     |
 | `@wxyc/library-artist-name-backfill` | `jobs/library-artist-name-backfill/` | One-shot backfill: populate `library.artist_name` from the `artists` join after migration 0058 (Epic A.2)                                                                     |
 | `@wxyc/flowsheet-metadata-backfill`  | `jobs/flowsheet-metadata-backfill/`  | One-shot drain: enrich the historical `flowsheet` track rows that never ran LML metadata enrichment (#631 / #638). Recurring drift-repair flip is tracked under #639 Phase 2. |
+| `@wxyc/library-artwork-url-backfill` | `jobs/library-artwork-url-backfill/` | One-shot warm: populate `library.artwork_url` for Discogs-resolvable rows (joined to `artists.discogs_artist_id`) so search-time `enrichWithArtwork` short-circuits (#637).   |
 
 ### API Server (`apps/backend`)
 

--- a/Dockerfile.library-artwork-url-backfill
+++ b/Dockerfile.library-artwork-url-backfill
@@ -1,0 +1,44 @@
+#Build stage
+FROM node:25-alpine AS builder
+
+WORKDIR /library-artwork-url-backfill-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/library-artwork-url-backfill ./jobs/library-artwork-url-backfill
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/library-artwork-url-backfill
+
+#Production stage
+FROM node:25-alpine AS prod
+
+WORKDIR /library-artwork-url-backfill
+
+COPY ./package* ./
+COPY ./jobs/library-artwork-url-backfill/package* ./jobs/library-artwork-url-backfill/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./library-artwork-url-backfill-builder/jobs/library-artwork-url-backfill/dist ./jobs/library-artwork-url-backfill/dist
+COPY --from=builder ./library-artwork-url-backfill-builder/shared/database/dist ./shared/database/dist
+
+# Long-running per-statement timeout: per-row UPDATEs are tiny (single-column,
+# id-equality WHERE) but the SELECT batch joins library to artists; a tightly
+# scoped 5s default is overkill for the latter and the former. The flowsheet-
+# metadata-backfill precedent uses 300s; keep parity. Disable per-statement
+# timeouts and rely on the orchestrator's per-LML-call abort signal for the
+# only operation that can actually exceed seconds.
+ENV DB_STATEMENT_TIMEOUT_MS=300000
+
+# Async commit: each per-row UPDATE returns as soon as the WAL hits the OS
+# buffer rather than waiting for fsync. Safe because the WHERE filter is
+# idempotent (`artwork_url IS NULL`); any work lost to an RDS crash is picked
+# up on the next sweep. Saves per-batch latency at the cost of a tiny RPO.
+ENV DB_SYNCHRONOUS_COMMIT=off
+
+# Identifies the connection in pg_stat_activity during incident triage.
+ENV DB_APPLICATION_NAME=wxyc-library-artwork-url-backfill
+
+CMD ["npm", "start", "--workspace=@wxyc/library-artwork-url-backfill"]

--- a/jobs/library-artwork-url-backfill/enrich.ts
+++ b/jobs/library-artwork-url-backfill/enrich.ts
@@ -1,0 +1,98 @@
+/**
+ * Per-row enrichment: turn an LML response into a single-column UPDATE on
+ * `library.artwork_url` for #637 (warm the search-path enrichment cache).
+ *
+ * Result shape:
+ *   - On success-with-match (artwork URL present, not a spacer.gif): write
+ *     `artwork_url`. Returns `enriched_match` (or `enriched_match_raced` if
+ *     the search-path runtime stamped the row between this job's SELECT and
+ *     UPDATE — the WHERE narrows by `artwork_url IS NULL` so the second
+ *     write is a no-op).
+ *   - On success-no-match (LML returned no results, or artwork was null /
+ *     filtered out): no UPDATE issued; the row stays NULL so the next sweep
+ *     retries it. Returns `enriched_no_match`. The issue (#637) accepts the
+ *     re-lookup cost on subsequent runs because no-match rows are bounded
+ *     by the resolvable set (~18.5K total) and the run is one-shot.
+ *   - On LML throw: caller catches and DOES NOT call this. Row stays NULL.
+ *
+ * Race contract: the search-path `enrichWithArtwork` service writes
+ * `artwork_url` on first lookup of un-cached albums. If the runtime path
+ * stamps a row between the orchestrator's SELECT and this UPDATE, the
+ * `artwork_url IS NULL` predicate in the WHERE no longer matches and
+ * Postgres updates 0 rows. The `enriched_match_raced` outcome separates
+ * "I personally enriched this row" from "this row was enriched by *someone*
+ * during the run." Data outcome is identical either way.
+ *
+ * Spacer.gif filter: applied inline. Discogs occasionally returns
+ * `spacer.gif` placeholder images; persisting them would defeat the
+ * search-path short-circuit (a non-null spacer URL is still rendered as
+ * broken artwork). Mirrors the inline filter in
+ * `flowsheet-metadata-backfill/enrich.ts` until #649's shared helper lands.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db, library } from '@wxyc/database';
+import type { LmlArtwork, LmlLookupResponse } from './lml-types.js';
+
+export type EnrichRow = {
+  id: number;
+  artist_name: string;
+  album_title: string;
+};
+
+export type EnrichOutcome = 'enriched_match' | 'enriched_match_raced' | 'enriched_no_match';
+
+/**
+ * Drop Discogs spacer.gif placeholder URLs. Inline guard mirroring the one in
+ * `flowsheet-metadata-backfill/enrich.ts`.
+ */
+const filterSpacerGif = (url: string | null | undefined): string | null => {
+  if (!url) return null;
+  if (url.includes('spacer.gif')) return null;
+  return url;
+};
+
+/**
+ * Pick the first artwork from an LML response, or null on no-match.
+ *
+ * "No artwork" covers three response shapes that all mean the same thing
+ * operationally: empty `results`, a `results[0]` with no `artwork` field, or
+ * `artwork: null`. All three end up writing nothing and leaving the row
+ * NULL.
+ */
+export const extractArtwork = (response: LmlLookupResponse): LmlArtwork | null => {
+  const first = response.results?.[0];
+  if (!first) return null;
+  if (!first.artwork) return null;
+  return first.artwork;
+};
+
+/**
+ * Apply a single LML response to a library row.
+ *
+ * Returns the outcome so the orchestrator can count it. Errors propagate up —
+ * this function does not swallow.
+ */
+export const applyEnrichment = async (row: EnrichRow, response: LmlLookupResponse): Promise<EnrichOutcome> => {
+  const artwork = extractArtwork(response);
+  const url = artwork ? filterSpacerGif(artwork.artwork_url) : null;
+
+  if (!url) {
+    // No usable artwork — leave the row NULL so a future sweep can retry.
+    // The issue (#637) accepts the re-lookup cost: no-match rows are bounded
+    // by the resolvable set, and the search-path enrichment will retry
+    // naturally as well.
+    return 'enriched_no_match';
+  }
+
+  const updated = await db
+    .update(library)
+    .set({ artwork_url: url })
+    // Idempotency + race guard: WHERE narrows by `artwork_url IS NULL`. A row
+    // the search-path runtime stamped between the orchestrator's SELECT and
+    // this UPDATE matches 0 rows.
+    .where(sql`"id" = ${row.id} AND "artwork_url" IS NULL`)
+    .returning({ id: library.id });
+
+  return updated.length === 0 ? 'enriched_match_raced' : 'enriched_match';
+};

--- a/jobs/library-artwork-url-backfill/job.ts
+++ b/jobs/library-artwork-url-backfill/job.ts
@@ -1,0 +1,56 @@
+/**
+ * One-shot warm of `library.artwork_url` for Discogs-resolvable rows (#637).
+ *
+ * Iterates every `library` row joined to `artists` where `artwork_url IS NULL`
+ * and `a.discogs_artist_id IS NOT NULL`, calls LML's /lookup for each one,
+ * and writes the artwork URL back via `applyEnrichment`. Cross-run
+ * resumability is via the WHERE filter alone — successful rows have non-null
+ * `artwork_url`; LML-throw and no-match rows stay NULL.
+ *
+ * Run procedure: see Backend-Service/CLAUDE.md and issue #637. Build via
+ * `Manual Build & Deploy` with `target=library-artwork-url-backfill`, then
+ * SSH to EC2 and `docker run --rm --env-file .env <image> 2>&1 | tee log`.
+ *
+ * The ~18,500-row resolvable set finishes in well under an hour at default
+ * throttle. Operators can run multiple containers via `PARTITION_COUNT`/
+ * `PARTITION_INDEX` if wall time matters.
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { runBackfill } from './orchestrate.js';
+import { lookupMetadata } from './lml-fetch.js';
+import { applyEnrichment } from './enrich.js';
+import { initLogger, log, captureError, closeLogger } from './logger.js';
+
+const JOB_NAME = 'library-artwork-url-backfill';
+
+/**
+ * Fail-fast on missing LML configuration. Without this, every row's
+ * `lookupMetadata` call would throw at `baseUrl()` and the orchestrator would
+ * generate ~18,500 `lml_error` events before an operator notices. Better to
+ * exit 1 immediately with a clear message — same posture as the
+ * flowsheet-metadata-backfill entrypoint.
+ */
+const requireLmlConfigured = (): void => {
+  if (!process.env.LIBRARY_METADATA_URL) {
+    throw new Error('LIBRARY_METADATA_URL is not configured; aborting before any rows are scanned.');
+  }
+};
+
+const main = async () => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  try {
+    requireLmlConfigured();
+    log('info', 'init', `${JOB_NAME} initialized`);
+    await runBackfill({ lookup: lookupMetadata, enrich: applyEnrichment });
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
+};
+
+void main();

--- a/jobs/library-artwork-url-backfill/lml-fetch.ts
+++ b/jobs/library-artwork-url-backfill/lml-fetch.ts
@@ -1,0 +1,74 @@
+/**
+ * Minimal LML lookup fetcher for the library.artwork_url backfill (#637).
+ *
+ * Mirrors `jobs/flowsheet-metadata-backfill/lml-fetch.ts` near-verbatim. The
+ * vendored copy (rather than importing `apps/backend/services/lml/lml.client.ts`)
+ * keeps the one-shot job's build graph independent of the @wxyc/backend Express
+ * app. Same isolation reason — see that file's header for the full rationale.
+ *
+ * Per-call budget: 30s. The orchestrator caps in-flight requests at one (via
+ * the inter-row throttle), so the longer per-call timeout cannot pile up on
+ * LML.
+ *
+ * Note: this fetcher does NOT go through `apps/backend/services/lml/lml.client.ts`,
+ * so the Sentry-span wrap from #646 doesn't apply here. Trace propagation
+ * relies on @sentry/node v10+ undici auto-instrumentation; same posture as
+ * `flowsheet-metadata-backfill`.
+ */
+
+import type { LmlLookupResponse } from './lml-types.js';
+
+const TIMEOUT_MS = 30000;
+
+const baseUrl = (): string => {
+  const url = process.env.LIBRARY_METADATA_URL;
+  if (!url) {
+    throw new Error('LIBRARY_METADATA_URL is not configured');
+  }
+  return url.replace(/\/api\/v1\/?$/, '').replace(/\/$/, '');
+};
+
+export const lookupMetadata = async (artist: string, album?: string): Promise<LmlLookupResponse> => {
+  // LML's /lookup contract requires `raw_message` even when artist/album are
+  // already structured. Synthesize "<artist> - <album>" — matches the shape
+  // the parser expects in LML's e2e fixtures.
+  const parts = [artist, album].filter((p): p is string => Boolean(p));
+  const rawMessage = parts.join(' - ');
+
+  const body: Record<string, string> = { artist, raw_message: rawMessage };
+  if (album) body.album = album;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  // LML enforces auth in production (LML_REQUIRE_AUTH=true). Send the bearer
+  // header when LML_API_KEY is set; the backend's lml.client.ts does the same.
+  // Sending it before the flag flips is harmless.
+  const apiKey = process.env.LML_API_KEY;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  try {
+    const response = await fetch(`${baseUrl()}/api/v1/lookup`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`LML responded ${response.status} ${response.statusText}`);
+    }
+
+    return (await response.json()) as LmlLookupResponse;
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      throw new Error('LML request timed out', { cause: error });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/jobs/library-artwork-url-backfill/lml-types.ts
+++ b/jobs/library-artwork-url-backfill/lml-types.ts
@@ -1,0 +1,26 @@
+/**
+ * Minimal slice of LML's LookupResponse needed by `enrich.ts`.
+ *
+ * Mirrors a subset of `LookupResponse` from @wxyc/shared/dtos. Inlined so the
+ * job package doesn't pull @wxyc/shared (a private GitHub Packages dep) at
+ * build time — same isolation reason as `flowsheet-metadata-backfill/lml-types.ts`.
+ *
+ * Slimmer than the flowsheet-metadata-backfill copy: this job writes a single
+ * column (`library.artwork_url`) so only the artwork URL field matters. Other
+ * Discogs fields (release_year, spotify_url, etc.) live on `flowsheet`, not
+ * `library`, and are out of scope per #637.
+ */
+
+export type LmlArtwork = {
+  artwork_url?: string | null;
+};
+
+export type LmlLookupResultItem = {
+  library_item: { id: number };
+  artwork?: LmlArtwork | null;
+};
+
+export type LmlLookupResponse = {
+  results: LmlLookupResultItem[];
+  search_type: 'direct' | 'fallback' | 'alternative' | 'compilation' | 'song_as_artist' | 'none';
+};

--- a/jobs/library-artwork-url-backfill/logger.ts
+++ b/jobs/library-artwork-url-backfill/logger.ts
@@ -1,0 +1,86 @@
+/**
+ * Observability for library-artwork-url-backfill: Sentry init + JSON logs.
+ *
+ * Phase A foundation contract (issue #538): every log line carries the four
+ * tags `repo`, `tool`, `step`, `run_id`. Sentry stays inactive when SENTRY_DSN
+ * is unset (the @sentry/node SDK silently no-ops in that case), so this module
+ * is safe to call from any environment.
+ *
+ * Mirrors `jobs/flowsheet-metadata-backfill/logger.ts` verbatim — the contract
+ * is identical, the duplication is to keep each one-shot job's build graph
+ * independent.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+/**
+ * Initialize Sentry and the structured logger. Call once at the top of the
+ * entrypoint, before any other logic. Returns the resolved `run_id` so the
+ * caller can pass it to subprocesses or persist it for cross-system tracing.
+ */
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+/**
+ * Emit a JSON log line. `info`/`warn` go to stdout, `error` goes to stderr so
+ * container log shippers can split streams by severity.
+ *
+ * Silently no-ops when called before `initLogger()` so unit tests that
+ * exercise library functions directly (without invoking the entrypoint) don't
+ * have to thread an init call through every fixture.
+ */
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+/** Capture an exception to Sentry with the current run's tags + an extra `step`. */
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+/** Flush pending Sentry events. Call from the entrypoint's `finally`. */
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/library-artwork-url-backfill/orchestrate.ts
+++ b/jobs/library-artwork-url-backfill/orchestrate.ts
@@ -17,14 +17,18 @@
  *   - One LML failure is logged, counted as `lml_error`, and the loop
  *     continues. The row stays NULL so a future sweep retries it.
  *
- * Race contract with the search-path runtime: `enrichWithArtwork` (in the
+ * Race interaction with the search-path runtime: `enrichWithArtwork` (in the
  * backend service) writes `library.artwork_url` on first lookup of un-cached
  * albums. The job's `applyEnrichment` narrows its UPDATE by
  * `artwork_url IS NULL`, so a row the runtime stamps between the
- * orchestrator's SELECT and the job's UPDATE matches 0 rows. The
- * `enriched_match_raced` counter tracks how many rows were beaten by the
- * runtime — useful operational signal but not a correctness concern (data
- * is identical either way).
+ * orchestrator's SELECT and the job's UPDATE matches 0 rows — the
+ * `enriched_match_raced` counter tracks this case, useful operational signal
+ * but not a correctness concern (both writers source from the same LML
+ * response, which itself sources from `discogs-cache.release.artwork_url`).
+ * The reverse direction — runtime UPDATE landing AFTER the job's UPDATE —
+ * required hardening on the runtime side: see #718 / PR #720, which adds the
+ * symmetric `AND artwork_url IS NULL` predicate to
+ * `library.service.ts:updateArtworkUrl` so the two writers no longer fight.
  *
  * The `lookup` and `enrich` functions are injected so tests can drive the
  * orchestration without a live LML or DB. Production wires them to
@@ -193,6 +197,19 @@ export const processRow = async (
  * artist_id` is NOT NULL per schema) rather than `library.artist_name` (which
  * was nullable until A.2's backfill shipped) — guarantees a non-null artist
  * for the LML lookup regardless of A.2 backfill state.
+ *
+ * No supporting partial index. The flowsheet-metadata-backfill precedent
+ * relies on `flowsheet_metadata_attempt_pending_idx` (#659) because that
+ * job scans the 1.86M-row flowsheet tail. This job's eligible set is
+ * bounded by the ~24% of artists with a Discogs identity (~5.7K) joined
+ * to their library rows (~18.5K out of 64K total), small enough that an
+ * unindexed seq-scan-then-hash-join per ~37 batches is acceptable for a
+ * one-shot pass during a low-traffic window. If this becomes recurring or
+ * the resolvable set grows materially, ship a partial index migration:
+ * `CREATE INDEX CONCURRENTLY library_artwork_pending_idx ON
+ * wxyc_schema.library (id) WHERE artwork_url IS NULL` (paired with the
+ * artists join, per the deploy runbook for index-with-IF-NOT-EXISTS in
+ * CLAUDE.md).
  */
 const loadBatch = async (afterId: number, batchSize: number, partitionFilter: SQL | null): Promise<EnrichRow[]> => {
   const partitionClause = partitionFilter ?? sql``;

--- a/jobs/library-artwork-url-backfill/orchestrate.ts
+++ b/jobs/library-artwork-url-backfill/orchestrate.ts
@@ -26,9 +26,13 @@
  * but not a correctness concern (both writers source from the same LML
  * response, which itself sources from `discogs-cache.release.artwork_url`).
  * The reverse direction — runtime UPDATE landing AFTER the job's UPDATE —
- * required hardening on the runtime side: see #718 / PR #720, which adds the
- * symmetric `AND artwork_url IS NULL` predicate to
- * `library.service.ts:updateArtworkUrl` so the two writers no longer fight.
+ * needs the symmetric guard on the runtime side. Tracked at #718, addressed
+ * by PR #720 which adds the matching `AND artwork_url IS NULL` predicate to
+ * `library.service.ts:updateArtworkUrl`. Until that lands the asymmetry is
+ * benign because both writers source from the same LML response (and LML
+ * itself sources from `discogs-cache.release.artwork_url`), so the clobbering
+ * write is value-identical — but the symmetric narrowing makes the contract
+ * explicit and forecloses future divergence.
  *
  * The `lookup` and `enrich` functions are injected so tests can drive the
  * orchestration without a live LML or DB. Production wires them to

--- a/jobs/library-artwork-url-backfill/orchestrate.ts
+++ b/jobs/library-artwork-url-backfill/orchestrate.ts
@@ -1,0 +1,270 @@
+/**
+ * Backfill orchestrator for #637 (library.artwork_url warm).
+ *
+ * Iterates `library` rows joined to `artists` where `artwork_url IS NULL` and
+ * the artist has a Discogs identity (`discogs_artist_id IS NOT NULL`). Calls
+ * LML for each one, and applies the single-column UPDATE via `applyEnrichment`.
+ * Designed to be resumable and failure-tolerant:
+ *
+ *   - The WHERE filter is `l.artwork_url IS NULL AND a.discogs_artist_id IS
+ *     NOT NULL`. Re-running picks up only rows the previous run didn't
+ *     finish. Caveat: no-match rows from a prior run are also re-queried —
+ *     accepted per the issue, since the resolvable set is bounded (~18.5K)
+ *     and the job is one-shot.
+ *   - Within a single run, batches paginate by `library.id` (last-id cursor).
+ *     Across runs, the WHERE filter is what restarts — the cursor doesn't
+ *     need to persist.
+ *   - One LML failure is logged, counted as `lml_error`, and the loop
+ *     continues. The row stays NULL so a future sweep retries it.
+ *
+ * Race contract with the search-path runtime: `enrichWithArtwork` (in the
+ * backend service) writes `library.artwork_url` on first lookup of un-cached
+ * albums. The job's `applyEnrichment` narrows its UPDATE by
+ * `artwork_url IS NULL`, so a row the runtime stamps between the
+ * orchestrator's SELECT and the job's UPDATE matches 0 rows. The
+ * `enriched_match_raced` counter tracks how many rows were beaten by the
+ * runtime — useful operational signal but not a correctness concern (data
+ * is identical either way).
+ *
+ * The `lookup` and `enrich` functions are injected so tests can drive the
+ * orchestration without a live LML or DB. Production wires them to
+ * `lml-fetch.ts:lookupMetadata` and `enrich.ts:applyEnrichment`.
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+import type { LmlLookupResponse } from './lml-types.js';
+import type { EnrichRow, EnrichOutcome } from './enrich.js';
+import { captureError, log } from './logger.js';
+
+const JOB_NAME = 'library-artwork-url-backfill';
+
+export const BATCH_SIZE = 500;
+
+/**
+ * Default inter-call delay between LML lookups, in ms. The same baseline as
+ * flowsheet-metadata-backfill (#638): ~600 req/min at 100ms — well above
+ * Discogs's 50/min ceiling, but LML caches and gates Discogs upstream itself
+ * so most calls are local PG reads (`discogs-cache.release.artwork_url`).
+ * The orchestrator's job is to keep one in-flight at a time, not to directly
+ * enforce the Discogs budget. Raise via `BACKFILL_THROTTLE_MS` if needed.
+ * Tests override to 0.
+ */
+export const THROTTLE_MS = 100;
+
+/**
+ * Schema-qualified table references, honoring `WXYC_SCHEMA_NAME` so parallel
+ * Jest workers (which override the env var) and any future integration test
+ * harness target the right schema. Default `wxyc_schema` matches production.
+ * Sanitised against `"` to keep the SQL well-formed.
+ */
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const LIBRARY_TABLE = sql.raw(`"${SCHEMA}"."library"`);
+const ARTISTS_TABLE = sql.raw(`"${SCHEMA}"."artists"`);
+
+/**
+ * Resolve `BACKFILL_BATCH_SIZE` from the environment, falling back to
+ * `BATCH_SIZE`. Mirrors `flowsheet-metadata-backfill/orchestrate.ts:resolveBatchSize`
+ * — operators tune via `docker run -e BACKFILL_BATCH_SIZE=...`.
+ *
+ * Exported so unit tests can drive it without mucking with process.env.
+ */
+export const resolveBatchSize = (raw: string | undefined = process.env.BACKFILL_BATCH_SIZE): number => {
+  if (raw === undefined) return BATCH_SIZE;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`Invalid BACKFILL_BATCH_SIZE=${JSON.stringify(raw)}; must be a positive integer.`);
+  }
+  return parsed;
+};
+
+/**
+ * Resolve `BACKFILL_THROTTLE_MS` from the environment, falling back to
+ * `THROTTLE_MS`. Operators tighten this if a future LML configuration
+ * tightens its own client-side cap, or set 0 in pilot/CI runs to remove
+ * the inter-row sleep.
+ *
+ * Exported so unit tests can drive it without mucking with process.env.
+ */
+export const resolveThrottleMs = (raw: string | undefined = process.env.BACKFILL_THROTTLE_MS): number => {
+  if (raw === undefined) return THROTTLE_MS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid BACKFILL_THROTTLE_MS=${JSON.stringify(raw)}; must be a non-negative integer.`);
+  }
+  return parsed;
+};
+
+/**
+ * Resolve PARTITION_INDEX / PARTITION_COUNT env vars into a SQL fragment that
+ * picks every Nth row by id-modulo. Mirrors the precedent in
+ * `flowsheet-metadata-backfill`. The N-container deploy pattern is:
+ *
+ *   PARTITION_COUNT=4 PARTITION_INDEX=0 docker run ...
+ *   PARTITION_COUNT=4 PARTITION_INDEX=1 docker run ...
+ *   ...
+ *
+ * Each container processes a disjoint subset and they finish in roughly the
+ * same wall time. The default (count=1, index=0) is a no-op pass-through.
+ *
+ * Exported so unit tests can drive it without mucking with process.env.
+ */
+export const resolvePartitionFilter = (
+  rawIndex: string | undefined = process.env.PARTITION_INDEX,
+  rawCount: string | undefined = process.env.PARTITION_COUNT,
+  columnSql: SQL = sql`l."id"`
+): { sqlFragment: SQL | null; description: string } => {
+  const count = rawCount === undefined ? 1 : Number(rawCount);
+  const index = rawIndex === undefined ? 0 : Number(rawIndex);
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(`Invalid PARTITION_COUNT=${JSON.stringify(rawCount)}; must be a positive integer.`);
+  }
+  if (!Number.isInteger(index) || index < 0 || index >= count) {
+    throw new Error(
+      `Invalid PARTITION_INDEX=${JSON.stringify(rawIndex)}; must be 0 <= index < PARTITION_COUNT (${count}).`
+    );
+  }
+  if (count === 1) {
+    return { sqlFragment: null, description: 'partition=none' };
+  }
+  return {
+    sqlFragment: sql`AND (${columnSql} % ${count}) = ${index}`,
+    description: `partition=${index}/${count}`,
+  };
+};
+
+export type LookupFn = (artist: string, album?: string) => Promise<LmlLookupResponse>;
+
+export type EnrichFn = (row: EnrichRow, response: LmlLookupResponse) => Promise<EnrichOutcome>;
+
+export type Totals = {
+  scanned: number;
+  enriched_match: number;
+  enriched_match_raced: number;
+  enriched_no_match: number;
+  lml_error: number;
+};
+
+export type ProcessOutcome = EnrichOutcome | 'lml_error';
+
+export type RunResult = {
+  totals: Totals;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Drive a single row through lookup → enrich. The result is the outcome
+ * status (or 'lml_error' when LML threw). Errors are logged and consumed;
+ * they do not bubble up so a single bad row cannot abort the run. The row
+ * stays `artwork_url IS NULL` so the next sweep retries it.
+ */
+export const processRow = async (
+  row: EnrichRow,
+  deps: { lookup: LookupFn; enrich: EnrichFn }
+): Promise<ProcessOutcome> => {
+  const artist = row.artist_name;
+  const album = row.album_title;
+
+  let response: LmlLookupResponse;
+  try {
+    response = await deps.lookup(artist, album);
+  } catch (error) {
+    log('warn', 'lml_error', `LML lookup failed for library.id=${row.id}`, {
+      library_id: row.id,
+      error_message: (error as Error).message,
+    });
+    captureError(error, 'lml_error', { library_id: row.id, artist, album });
+    return 'lml_error';
+  }
+
+  return deps.enrich(row, response);
+};
+
+/**
+ * Read the next batch of unprocessed library rows.
+ *
+ * Joins `library` to `artists` so the WHERE can filter by both
+ * `l.artwork_url IS NULL` and `a.discogs_artist_id IS NOT NULL` — the latter
+ * is the "Discogs-resolvable" gate per #637. The id-cursor predicate keeps
+ * the SELECT bounded as the run progresses.
+ *
+ * `artist_name` is sourced from the artists join (always populated; `library.
+ * artist_id` is NOT NULL per schema) rather than `library.artist_name` (which
+ * was nullable until A.2's backfill shipped) — guarantees a non-null artist
+ * for the LML lookup regardless of A.2 backfill state.
+ */
+const loadBatch = async (afterId: number, batchSize: number, partitionFilter: SQL | null): Promise<EnrichRow[]> => {
+  const partitionClause = partitionFilter ?? sql``;
+  const rows = (await db.execute(sql`
+    SELECT
+      l."id",
+      a."artist_name" AS "artist_name",
+      l."album_title"
+    FROM ${LIBRARY_TABLE} AS l
+    JOIN ${ARTISTS_TABLE} AS a ON a."id" = l."artist_id"
+    WHERE l."artwork_url" IS NULL
+      AND a."discogs_artist_id" IS NOT NULL
+      AND l."id" > ${afterId}
+      ${partitionClause}
+    ORDER BY l."id" ASC
+    LIMIT ${batchSize}
+  `)) as unknown as EnrichRow[];
+  return rows ?? [];
+};
+
+const formatTotals = (totals: Totals): string =>
+  `scanned=${totals.scanned} enriched_match=${totals.enriched_match} ` +
+  `enriched_match_raced=${totals.enriched_match_raced} ` +
+  `enriched_no_match=${totals.enriched_no_match} lml_error=${totals.lml_error}`;
+
+export const runBackfill = async (opts: {
+  lookup: LookupFn;
+  enrich: EnrichFn;
+  batchSize?: number;
+  throttleMs?: number;
+  partition?: { sqlFragment: SQL | null; description: string };
+}): Promise<RunResult> => {
+  const batchSize = opts.batchSize ?? resolveBatchSize();
+  const throttleMs = opts.throttleMs ?? resolveThrottleMs();
+  const partition = opts.partition ?? resolvePartitionFilter();
+
+  log('info', 'started', `${JOB_NAME} starting`, {
+    batch_size: batchSize,
+    throttle_ms: throttleMs,
+    partition: partition.description,
+  });
+
+  const totals: Totals = {
+    scanned: 0,
+    enriched_match: 0,
+    enriched_match_raced: 0,
+    enriched_no_match: 0,
+    lml_error: 0,
+  };
+  let lastId = 0;
+  let batchIndex = 0;
+
+  while (true) {
+    const rows = await loadBatch(lastId, batchSize, partition.sqlFragment);
+    if (rows.length === 0) break;
+
+    batchIndex += 1;
+    for (const row of rows) {
+      const status = await processRow(row, { lookup: opts.lookup, enrich: opts.enrich });
+      totals.scanned += 1;
+      totals[status] += 1;
+      lastId = row.id;
+      if (throttleMs > 0) await sleep(throttleMs);
+    }
+
+    log('info', 'batch_done', `batch ${batchIndex} done`, {
+      batch_index: batchIndex,
+      last_id: lastId,
+      ...totals,
+    });
+  }
+
+  log('info', 'finished', `${JOB_NAME} done. ${formatTotals(totals)}`, { ...totals });
+  return { totals };
+};

--- a/jobs/library-artwork-url-backfill/package.json
+++ b/jobs/library-artwork-url-backfill/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@wxyc/library-artwork-url-backfill",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot backfill: warm library.artwork_url for Discogs-resolvable rows so search-time enrichWithArtwork short-circuits and the 500ms enrichment budget stops firing on first load (#637).",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_library_artwork_url_backfill:ci -f ../../Dockerfile.library-artwork-url-backfill ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.50.0",
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/library-artwork-url-backfill/tsconfig.json
+++ b/jobs/library-artwork-url-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/library-artwork-url-backfill/tsup.config.ts
+++ b/jobs/library-artwork-url-backfill/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -542,6 +542,21 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/library-artwork-url-backfill": {
+      "name": "@wxyc/library-artwork-url-backfill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.50.0",
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/library-canonical-entity-backfill": {
       "name": "@wxyc/library-canonical-entity-backfill",
       "version": "1.0.0",
@@ -7204,6 +7219,10 @@
     },
     "node_modules/@wxyc/library-artist-name-backfill": {
       "resolved": "jobs/library-artist-name-backfill",
+      "link": true
+    },
+    "node_modules/@wxyc/library-artwork-url-backfill": {
+      "resolved": "jobs/library-artwork-url-backfill",
       "link": true
     },
     "node_modules/@wxyc/library-canonical-entity-backfill": {

--- a/tests/unit/jobs/library-artwork-url-backfill/enrich.test.ts
+++ b/tests/unit/jobs/library-artwork-url-backfill/enrich.test.ts
@@ -17,11 +17,7 @@
 import { jest } from '@jest/globals';
 
 import { db, library } from '@wxyc/database';
-import {
-  applyEnrichment,
-  extractArtwork,
-  type EnrichRow,
-} from '../../../../jobs/library-artwork-url-backfill/enrich';
+import { applyEnrichment, extractArtwork, type EnrichRow } from '../../../../jobs/library-artwork-url-backfill/enrich';
 import type { LmlLookupResponse } from '../../../../jobs/library-artwork-url-backfill/lml-types';
 
 type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };

--- a/tests/unit/jobs/library-artwork-url-backfill/enrich.test.ts
+++ b/tests/unit/jobs/library-artwork-url-backfill/enrich.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for library-artwork-url-backfill enrich.ts.
+ *
+ * Pins the row-level UPDATE shape against #637's contract:
+ *   1. On LML success-with-match (artwork URL present, not a spacer.gif),
+ *      the .set() block writes only `artwork_url` — single-column UPDATE.
+ *   2. On LML success-no-match (empty results, missing artwork field, null
+ *      artwork, or a URL that filters down to null after spacer-stripping),
+ *      no UPDATE is issued — the row stays NULL so a future sweep retries.
+ *   3. The .where() narrows by id AND `artwork_url IS NULL` so a runtime
+ *      stamp landing between the orchestrator's SELECT and this UPDATE wins.
+ *   4. The race detector returns `enriched_match_raced` when 0 rows update.
+ *
+ * Also pins the spacer.gif filter (mirrors flowsheet-metadata-backfill until
+ * #649's shared helper lands).
+ */
+import { jest } from '@jest/globals';
+
+import { db, library } from '@wxyc/database';
+import {
+  applyEnrichment,
+  extractArtwork,
+  type EnrichRow,
+} from '../../../../jobs/library-artwork-url-backfill/enrich';
+import type { LmlLookupResponse } from '../../../../jobs/library-artwork-url-backfill/lml-types';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const mockDb = db as unknown as {
+  update: jest.Mock;
+  _chain: { set: jest.Mock; where: jest.Mock; returning: jest.Mock };
+};
+
+const baseRow: EnrichRow = {
+  id: 42,
+  artist_name: 'Juana Molina',
+  album_title: 'DOGA',
+};
+
+const matchedResponse: LmlLookupResponse = {
+  results: [
+    {
+      library_item: { id: 1 },
+      artwork: { artwork_url: 'https://i.discogs.com/art.jpg' },
+    },
+  ],
+  search_type: 'direct',
+};
+
+const noMatchResponse: LmlLookupResponse = {
+  results: [],
+  search_type: 'none',
+};
+
+const noArtworkResponse: LmlLookupResponse = {
+  results: [{ library_item: { id: 1 }, artwork: null }],
+  search_type: 'direct',
+};
+
+const nullArtworkUrlResponse: LmlLookupResponse = {
+  results: [{ library_item: { id: 1 }, artwork: { artwork_url: null } }],
+  search_type: 'direct',
+};
+
+describe('applyEnrichment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default to "1 row updated" so existing match assertions exercise the
+    // non-raced path. Tests that pin the race detector override with
+    // `.mockResolvedValueOnce([])`.
+    mockDb._chain.returning.mockResolvedValue([{ id: baseRow.id }]);
+  });
+
+  it('writes only artwork_url on LML success-with-match (single-column UPDATE)', async () => {
+    const outcome = await applyEnrichment(baseRow, matchedResponse);
+    expect(outcome).toBe('enriched_match');
+    expect(mockDb.update).toHaveBeenCalledWith(library);
+
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.keys(setArgs)).toEqual(['artwork_url']);
+    expect(setArgs.artwork_url).toBe('https://i.discogs.com/art.jpg');
+  });
+
+  it('does NOT issue an UPDATE on LML success-no-match (empty results)', async () => {
+    const outcome = await applyEnrichment(baseRow, noMatchResponse);
+    expect(outcome).toBe('enriched_no_match');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('treats artwork: null the same as no-match (no UPDATE)', async () => {
+    const outcome = await applyEnrichment(baseRow, noArtworkResponse);
+    expect(outcome).toBe('enriched_no_match');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('treats artwork_url: null the same as no-match (no UPDATE)', async () => {
+    const outcome = await applyEnrichment(baseRow, nullArtworkUrlResponse);
+    expect(outcome).toBe('enriched_no_match');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('strips Discogs spacer.gif placeholder, treating the row as no-match', async () => {
+    // A spacer.gif URL would otherwise persist as a non-null but useless
+    // artwork_url, defeating the search-path short-circuit. The filter drops
+    // it; after that, the row has no artwork to write, so the outcome is
+    // no-match (no UPDATE).
+    const spacerResponse: LmlLookupResponse = {
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { artwork_url: 'https://s.discogs.com/images/spacer.gif' },
+        },
+      ],
+      search_type: 'direct',
+    };
+
+    const outcome = await applyEnrichment(baseRow, spacerResponse);
+    expect(outcome).toBe('enriched_no_match');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('idempotency guard: WHERE narrows by id AND artwork_url IS NULL', async () => {
+    // The WHERE makes the UPDATE a no-op against rows the search-path runtime
+    // already stamped. Verify .where() was called once with a single drizzle
+    // expression whose rendered SQL references both columns.
+    await applyEnrichment(baseRow, matchedResponse);
+    expect(mockDb._chain.where).toHaveBeenCalledTimes(1);
+    const whereArg = mockDb._chain.where.mock.calls[0]?.[0];
+    const rendered = renderSql(whereArg);
+    expect(rendered).toMatch(/id/);
+    expect(rendered.toLowerCase()).toMatch(/artwork_url/);
+  });
+
+  it('returns enriched_match_raced when 0 rows update (search-path stamped first)', async () => {
+    // Race scenario: between the orchestrator's SELECT and this UPDATE, the
+    // search-path enrichment landed its own stamp on the same row, so
+    // `artwork_url IS NULL` no longer matches and Postgres updates 0 rows.
+    // The data outcome is identical (both writers produce the same URL —
+    // both source it from LML / discogs-cache.release.artwork_url). Only the
+    // metric splits.
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    const outcome = await applyEnrichment(baseRow, matchedResponse);
+    expect(outcome).toBe('enriched_match_raced');
+  });
+});
+
+describe('extractArtwork', () => {
+  // Direct unit tests — `applyEnrichment` exercises this end-to-end, but
+  // pinning each shape individually catches a regression that breaks one
+  // case silently.
+  it('returns the artwork from results[0]', () => {
+    expect(extractArtwork(matchedResponse)?.artwork_url).toBe('https://i.discogs.com/art.jpg');
+  });
+
+  it('returns null on empty results', () => {
+    expect(extractArtwork(noMatchResponse)).toBeNull();
+  });
+
+  it('returns null when results[0] has no artwork field', () => {
+    const response: LmlLookupResponse = {
+      results: [{ library_item: { id: 1 } }],
+      search_type: 'direct',
+    };
+    expect(extractArtwork(response)).toBeNull();
+  });
+
+  it('returns null when results[0].artwork is explicitly null', () => {
+    expect(extractArtwork(noArtworkResponse)).toBeNull();
+  });
+});

--- a/tests/unit/jobs/library-artwork-url-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-artwork-url-backfill/orchestrate.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Unit tests for library-artwork-url-backfill orchestrate.ts.
+ *
+ * Pins the orchestrator's contract:
+ *   1. The loadBatch SELECT carries the canonical filter (library JOIN
+ *      artists, l.artwork_url IS NULL, a.discogs_artist_id IS NOT NULL,
+ *      id-cursor, ORDER BY id ASC, LIMIT batchSize).
+ *   2. processRow returns 'lml_error' on a thrown lookup; the orchestrator
+ *      counts it and continues. The row stays artwork_url IS NULL via
+ *      `applyEnrichment` *not* being called on the error path.
+ *   3. Match → enriched_match outcome; no-match → enriched_no_match outcome;
+ *      raced match → enriched_match_raced. Totals are bumped on the right
+ *      counter.
+ *   4. resolvePartitionFilter handles default (no-op), valid N/M, and
+ *      throws on bad inputs.
+ *   5. The id-cursor advances across batches and the loop terminates when
+ *      a batch returns empty.
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '@wxyc/database';
+import {
+  BATCH_SIZE,
+  THROTTLE_MS,
+  processRow,
+  resolveBatchSize,
+  resolvePartitionFilter,
+  resolveThrottleMs,
+  runBackfill,
+  type EnrichFn,
+  type LookupFn,
+} from '../../../../jobs/library-artwork-url-backfill/orchestrate';
+import type { LmlLookupResponse } from '../../../../jobs/library-artwork-url-backfill/lml-types';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const matchedResponse: LmlLookupResponse = {
+  results: [{ library_item: { id: 1 }, artwork: { artwork_url: 'https://i.discogs.com/art.jpg' } }],
+  search_type: 'direct',
+};
+
+const noMatchResponse: LmlLookupResponse = {
+  results: [],
+  search_type: 'none',
+};
+
+describe('resolvePartitionFilter', () => {
+  it('returns no-op when neither env var set', () => {
+    const got = resolvePartitionFilter(undefined, undefined);
+    expect(got.sqlFragment).toBeNull();
+    expect(got.description).toBe('partition=none');
+  });
+
+  it('returns mod-N filter for valid PARTITION_INDEX/PARTITION_COUNT', () => {
+    const got = resolvePartitionFilter('1', '4');
+    expect(got.sqlFragment).not.toBeNull();
+    expect(got.description).toBe('partition=1/4');
+    const rendered = renderSql(got.sqlFragment);
+    expect(rendered).toMatch(/AND.*%/);
+  });
+
+  it('throws on PARTITION_COUNT=0', () => {
+    expect(() => resolvePartitionFilter('0', '0')).toThrow(/PARTITION_COUNT/);
+  });
+
+  it('throws on PARTITION_INDEX out of range', () => {
+    expect(() => resolvePartitionFilter('4', '4')).toThrow(/PARTITION_INDEX/);
+    expect(() => resolvePartitionFilter('-1', '4')).toThrow(/PARTITION_INDEX/);
+  });
+
+  it('throws on non-integer inputs', () => {
+    expect(() => resolvePartitionFilter('1', 'abc')).toThrow(/PARTITION_COUNT/);
+    expect(() => resolvePartitionFilter('1.5', '4')).toThrow(/PARTITION_INDEX/);
+  });
+});
+
+describe('resolveBatchSize', () => {
+  it('falls back to BATCH_SIZE when env var is unset', () => {
+    expect(resolveBatchSize(undefined)).toBe(BATCH_SIZE);
+  });
+
+  it('returns the parsed value for a valid positive integer', () => {
+    expect(resolveBatchSize('1000')).toBe(1000);
+    expect(resolveBatchSize('1')).toBe(1);
+  });
+
+  it('throws on zero, negative, non-integer, or garbage input', () => {
+    expect(() => resolveBatchSize('0')).toThrow(/BACKFILL_BATCH_SIZE/);
+    expect(() => resolveBatchSize('-100')).toThrow(/BACKFILL_BATCH_SIZE/);
+    expect(() => resolveBatchSize('1.5')).toThrow(/BACKFILL_BATCH_SIZE/);
+    expect(() => resolveBatchSize('abc')).toThrow(/BACKFILL_BATCH_SIZE/);
+  });
+});
+
+describe('resolveThrottleMs', () => {
+  it('falls back to THROTTLE_MS when env var is unset', () => {
+    expect(resolveThrottleMs(undefined)).toBe(THROTTLE_MS);
+  });
+
+  it('accepts 0 (pilot/CI runs may want no inter-row sleep)', () => {
+    expect(resolveThrottleMs('0')).toBe(0);
+  });
+
+  it('returns the parsed value for a positive integer', () => {
+    expect(resolveThrottleMs('250')).toBe(250);
+  });
+
+  it('throws on negative, non-integer, or garbage input', () => {
+    expect(() => resolveThrottleMs('-50')).toThrow(/BACKFILL_THROTTLE_MS/);
+    expect(() => resolveThrottleMs('1.5')).toThrow(/BACKFILL_THROTTLE_MS/);
+    expect(() => resolveThrottleMs('abc')).toThrow(/BACKFILL_THROTTLE_MS/);
+  });
+});
+
+describe('processRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const row = { id: 42, artist_name: 'Juana Molina', album_title: 'DOGA' };
+
+  it('returns enriched_match and calls enrich on LML success-with-match', async () => {
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResponse);
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_match');
+
+    const outcome = await processRow(row, { lookup, enrich });
+
+    expect(outcome).toBe('enriched_match');
+    expect(lookup).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+    expect(enrich).toHaveBeenCalledWith(row, matchedResponse);
+  });
+
+  it('returns enriched_no_match and calls enrich on LML no-match', async () => {
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResponse);
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_no_match');
+
+    const outcome = await processRow(row, { lookup, enrich });
+
+    expect(outcome).toBe('enriched_no_match');
+    expect(enrich).toHaveBeenCalledWith(row, noMatchResponse);
+  });
+
+  it('returns lml_error and does NOT call enrich on LML throw (row stays retryable)', async () => {
+    const lookup = jest.fn<LookupFn>().mockRejectedValue(new Error('LML 502'));
+    const enrich = jest.fn<EnrichFn>();
+
+    const outcome = await processRow(row, { lookup, enrich });
+
+    expect(outcome).toBe('lml_error');
+    // Critical: the row's artwork_url stays NULL because we never call
+    // enrich. The next sweep can re-attempt transient LML failures.
+    expect(enrich).not.toHaveBeenCalled();
+  });
+});
+
+describe('runBackfill', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResponse);
+  const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_match');
+
+  it('issues a SELECT joining library + artists with the canonical WHERE filter', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+
+    await runBackfill({ lookup, enrich, throttleMs: 0 });
+
+    const call = (db.execute as jest.Mock).mock.calls[0];
+    expect(call).toBeDefined();
+    // Note: table names come from sql.raw(...) (schema-qualified at module
+    // load) and don't render through the test helper. The structural assertions
+    // below — JOIN keyword, FROM/JOIN aliases, filter predicates, cursor,
+    // ORDER BY, LIMIT — pin everything that matters; the sql.raw table names
+    // would fail at runtime if mis-wired.
+    const sql = renderSql(call?.[0]);
+    expect(sql).toMatch(/JOIN/i);
+    expect(sql).toMatch(/FROM\s+AS\s+l/i);
+    expect(sql).toMatch(/JOIN\s+AS\s+a\s+ON\s+a\."id"\s*=\s*l\."artist_id"/i);
+    expect(sql.toLowerCase()).toMatch(/"artwork_url"\s+is\s+null/);
+    expect(sql.toLowerCase()).toMatch(/"discogs_artist_id"\s+is\s+not\s+null/);
+    expect(sql).toMatch(/l\."id"\s*>/);
+    expect(sql).toMatch(/ORDER BY[\s\S]*l\."id"\s+ASC/i);
+    expect(sql).toMatch(/LIMIT/i);
+  });
+
+  it('advances the id-cursor across batches and terminates on empty', async () => {
+    const batch1 = [
+      { id: 10, artist_name: 'a', album_title: 'a1' },
+      { id: 20, artist_name: 'b', album_title: 'b1' },
+    ];
+    const batch2 = [{ id: 30, artist_name: 'c', album_title: 'c1' }];
+
+    (db.execute as jest.Mock).mockResolvedValueOnce(batch1).mockResolvedValueOnce(batch2).mockResolvedValueOnce([]);
+
+    const result = await runBackfill({ lookup, enrich, throttleMs: 0 });
+
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(3);
+    expect(result.totals.scanned).toBe(3);
+    expect(result.totals.enriched_match).toBe(3);
+    expect(result.totals.lml_error).toBe(0);
+
+    // Cursor values are passed as drizzle params, so they appear in `values`
+    // not `sql`. Pull them out.
+    const values2 = ((db.execute as jest.Mock).mock.calls[1]?.[0] as { values?: unknown[] })?.values;
+    const values3 = ((db.execute as jest.Mock).mock.calls[2]?.[0] as { values?: unknown[] })?.values;
+    expect(values2).toContain(20);
+    expect(values3).toContain(30);
+  });
+
+  it('counts lml_error when LML throws and continues processing', async () => {
+    const batch = [
+      { id: 10, artist_name: 'a', album_title: 'a1' },
+      { id: 20, artist_name: 'b', album_title: 'b1' },
+      { id: 30, artist_name: 'c', album_title: 'c1' },
+    ];
+
+    (db.execute as jest.Mock).mockResolvedValueOnce(batch).mockResolvedValueOnce([]);
+
+    const lookupFlaky = jest
+      .fn<LookupFn>()
+      .mockResolvedValueOnce(matchedResponse)
+      .mockRejectedValueOnce(new Error('LML 502'))
+      .mockResolvedValueOnce(noMatchResponse);
+    const enrichLocal = jest
+      .fn<EnrichFn>()
+      .mockResolvedValueOnce('enriched_match')
+      .mockResolvedValueOnce('enriched_no_match');
+
+    const result = await runBackfill({ lookup: lookupFlaky, enrich: enrichLocal, throttleMs: 0 });
+
+    expect(result.totals.scanned).toBe(3);
+    expect(result.totals.enriched_match).toBe(1);
+    expect(result.totals.enriched_no_match).toBe(1);
+    expect(result.totals.lml_error).toBe(1);
+    // enrich is called twice (once per non-error row) — the LML-throw row
+    // skips enrich entirely so its artwork_url stays NULL.
+    expect(enrichLocal).toHaveBeenCalledTimes(2);
+  });
+
+  it('exposes BATCH_SIZE and THROTTLE_MS constants for ops tuning', () => {
+    expect(BATCH_SIZE).toBe(500);
+    expect(THROTTLE_MS).toBe(100);
+  });
+
+  it('counts enriched_match_raced separately from enriched_match', async () => {
+    // Race scenario at the orchestrator level: enrich returns the *_raced
+    // variant when 0 rows updated. The orchestrator must bump the matching
+    // counter rather than treating it as a regular match.
+    const batch = [
+      { id: 10, artist_name: 'a', album_title: 'a1' },
+      { id: 20, artist_name: 'b', album_title: 'b1' },
+    ];
+
+    (db.execute as jest.Mock).mockResolvedValueOnce(batch).mockResolvedValueOnce([]);
+
+    const enrichWithRaces = jest
+      .fn<EnrichFn>()
+      .mockResolvedValueOnce('enriched_match')
+      .mockResolvedValueOnce('enriched_match_raced');
+
+    const result = await runBackfill({ lookup, enrich: enrichWithRaces, throttleMs: 0 });
+
+    expect(result.totals.scanned).toBe(2);
+    expect(result.totals.enriched_match).toBe(1);
+    expect(result.totals.enriched_match_raced).toBe(1);
+    expect(result.totals.lml_error).toBe(0);
+  });
+});

--- a/tests/unit/jobs/library-artwork-url-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-artwork-url-backfill/orchestrate.test.ts
@@ -201,6 +201,32 @@ describe('runBackfill', () => {
     expect(sql).toMatch(/LIMIT/i);
   });
 
+  it('composes the partition fragment into the SELECT WHERE when partitioning is active', async () => {
+    // resolvePartitionFilter returns an `AND (l."id" % N) = M` SQL fragment
+    // when PARTITION_COUNT > 1. The orchestrator must splice it into the
+    // loadBatch query so each container scans a disjoint slice of ids.
+    // Default (count=1) is exercised by the canonical-WHERE test above.
+    //
+    // The fragment's SQL text doesn't render through this test helper because
+    // it's a nested drizzle SQL object. The drizzle params live in the outer
+    // query's `values` array as a nested SQL object whose own `values` carry
+    // the partition's count/index — flatten and check both are present.
+    (db.execute as jest.Mock).mockResolvedValue([]);
+
+    const partition = resolvePartitionFilter('1', '4');
+    await runBackfill({ lookup, enrich, throttleMs: 0, partition });
+
+    const call = (db.execute as jest.Mock).mock.calls[0];
+    const flattenValues = (v: unknown): unknown[] => {
+      if (Array.isArray(v)) return v.flatMap(flattenValues);
+      if (v && typeof v === 'object' && 'values' in v) return flattenValues((v as { values: unknown[] }).values);
+      return [v];
+    };
+    const flat = flattenValues((call?.[0] as { values?: unknown[] })?.values ?? []);
+    expect(flat).toContain(4); // PARTITION_COUNT
+    expect(flat).toContain(1); // PARTITION_INDEX
+  });
+
   it('advances the id-cursor across batches and terminates on empty', async () => {
     const batch1 = [
       { id: 10, artist_name: 'a', album_title: 'a1' },


### PR DESCRIPTION
## Summary

Adds `jobs/library-artwork-url-backfill/`, a one-shot job that warms `library.artwork_url` for Discogs-resolvable rows by calling LML's `/api/v1/lookup` per row and writing back the artwork URL. Mirrors the proven shape of `jobs/flowsheet-metadata-backfill/` (per-row LML call, vendored thin client, Phase A observability).

## Why

Today only **0.24%** (155 of 64,163) of `library` rows have `artwork_url` populated. Catalog search calls `enrichWithArtwork` against the result top-N on every search; un-cached albums make LML round-trips inside the 500ms enrichment budget (#618). Once `artwork_url` is populated for the resolvable slice, the search-path short-circuits on those rows and the budget stops firing on first load.

**Resolvable slice**: ~18,500 rows where `artists.discogs_artist_id IS NOT NULL` (24.3% of artists post-tonight's entity_resolution run). Cost is well under the original 30-min estimate now that LML serves artwork from `discogs-cache.release.artwork_url` as a local PG read — see issue body for the cost-model verification.

## Architecture

| File | Purpose |
|---|---|
| `jobs/library-artwork-url-backfill/job.ts` | Entrypoint: init logger, fail-fast on missing `LIBRARY_METADATA_URL`, call orchestrator |
| `jobs/library-artwork-url-backfill/orchestrate.ts` | id-cursor pagination, per-row processRow, throttle, partition support, totals tracking |
| `jobs/library-artwork-url-backfill/enrich.ts` | Per-row UPDATE: writes only `artwork_url`, `WHERE id = ? AND artwork_url IS NULL` race guard |
| `jobs/library-artwork-url-backfill/lml-fetch.ts` | Vendored thin LML client (mirrors `flowsheet-metadata-backfill/lml-fetch.ts`) |
| `jobs/library-artwork-url-backfill/lml-types.ts` | Slim slice of LML's response — only `artwork_url` is needed |
| `jobs/library-artwork-url-backfill/logger.ts` | Phase A observability: `repo`/`tool`/`step`/`run_id` tags on every Sentry event + JSON log line |
| `Dockerfile.library-artwork-url-backfill` | Builds the multi-stage image; sets `DB_STATEMENT_TIMEOUT_MS=300000`, `DB_SYNCHRONOUS_COMMIT=off`, `DB_APPLICATION_NAME=wxyc-library-artwork-url-backfill` |
| `tests/unit/jobs/library-artwork-url-backfill/{enrich,orchestrate}.test.ts` | 31 unit tests covering UPDATE shape, race detector, batch SELECT structure, partition resolver, batch advancement, error counting |
| `CLAUDE.md` | New row in the workspaces table |

## Behavior

- **Match**: writes single-column UPDATE on `library.artwork_url`. Outcome `enriched_match`.
- **Match raced**: search-path runtime stamped the row between SELECT and UPDATE; `WHERE artwork_url IS NULL` matches 0 rows. Outcome `enriched_match_raced`. Data is identical either way.
- **No match** (empty results, missing artwork field, null artwork, or spacer.gif filtered to null): no UPDATE issued. Row stays NULL so a future sweep retries. Outcome `enriched_no_match`. Per the issue, the re-lookup cost is bounded (resolvable set ~18.5K) and accepted.
- **LML throw**: caught, logged, counted as `lml_error`; row stays NULL.
- **Spacer.gif**: filtered inline (mirrors `flowsheet-metadata-backfill/enrich.ts` until #649's shared helper lands).

## Run procedure

Build via `Manual Build & Deploy` workflow with `target=library-artwork-url-backfill`. SSH to EC2 and `docker run --rm --env-file .env <image> 2>&1 | tee log`. Operators can run multiple containers in parallel via `PARTITION_COUNT`/`PARTITION_INDEX` env vars if wall time matters.

Defaults: `BATCH_SIZE=500`, `THROTTLE_MS=100`. Tunable via `BACKFILL_BATCH_SIZE` / `BACKFILL_THROTTLE_MS`.

## Test plan

- [x] `npm run typecheck` clean across all workspaces
- [x] `npm run lint` 0 errors (336 pre-existing warnings)
- [x] `npm run format:check` clean
- [x] `npm run test:unit` 1486 / 1486 pass
- [x] `npm run build --workspace=@wxyc/library-artwork-url-backfill` produces `dist/job.js`
- [ ] CI green on this branch
- [ ] Post-merge: build via Manual Build & Deploy, run on EC2, verify `count(*) FILTER (WHERE artwork_url IS NOT NULL)` jumped from ~155 to ~18,500-ish

## Cross-repo runtime risks

Per #637's body, these cap the realized hit rate but do not block:

- LML#196 — production LML's Discogs API auth is broken (cache-only). Cache-miss rows won't resolve until LML can talk to Discogs again.
- LML#200 — `/lookup` doesn't enrich direct library hits with Discogs artwork. Affects observed hit rate.
- LML#201 — Discogs 429 cascade in LML throws away work after retry exhaustion. Suggests rate-limited execution if observed misses inflate.

## Out of scope

- Periodic refresh of stale artwork (separate cron concern).
- Backfilling rows whose artist isn't yet Discogs-resolved — those expand naturally as LML#207 / LML#211 ship.

Closes #637