### PR TITLE
Validate usernames in provisionUser to match the sign-in plugin

### DIFF
--- a/apps/auth/provision-user.ts
+++ b/apps/auth/provision-user.ts
@@ -4,7 +4,7 @@
  * endpoint and by createDefaultUser() at startup.
  */
 
-import { auth, WXYCRoles } from '@wxyc/authentication';
+import { auth, formatUsernameError, validateUsername, WXYCRoles } from '@wxyc/authentication';
 import { db, user } from '@wxyc/database';
 import { eq } from 'drizzle-orm';
 
@@ -52,6 +52,15 @@ export async function provisionUser(input: ProvisionUserInput): Promise<Provisio
   // 1. Validate role
   if (!(role in WXYCRoles)) {
     throw new ProvisionError(400, `Invalid role: "${role}". Must be one of: ${Object.keys(WXYCRoles).join(', ')}`);
+  }
+
+  // 1b. Validate username matches what better-auth's username plugin will accept
+  // at sign-in time. Otherwise we'd create accounts that can never log in via
+  // /sign-in/username (the validator there rejects the request before the DB
+  // is touched). See shared/authentication/src/auth.username.ts.
+  const usernameError = validateUsername(username);
+  if (usernameError) {
+    throw new ProvisionError(400, formatUsernameError(usernameError));
   }
 
   // 2. Get auth context

--- a/shared/authentication/src/auth.username.ts
+++ b/shared/authentication/src/auth.username.ts
@@ -1,0 +1,43 @@
+/**
+ * Username validation shared between admin provisioning and the better-auth
+ * `username` plugin. Mirrors the plugin's defaults so an account created via
+ * `provisionUser()` is guaranteed to be loginable through `signIn.username`.
+ *
+ * The plugin's `defaultUsernameValidator` is `/^[a-zA-Z0-9_.]+$/` with a
+ * length range of [3, 30]. Any future relaxation needs the plugin's
+ * `usernameValidator` / `minUsernameLength` / `maxUsernameLength` options
+ * updated in lockstep.
+ */
+
+export const USERNAME_REGEX = /^[a-zA-Z0-9_.]+$/;
+export const MIN_USERNAME_LENGTH = 3;
+export const MAX_USERNAME_LENGTH = 30;
+
+export type UsernameValidationError =
+  | { kind: 'too-short'; min: number }
+  | { kind: 'too-long'; max: number }
+  | { kind: 'invalid-characters' };
+
+export function validateUsername(username: string): UsernameValidationError | null {
+  if (username.length < MIN_USERNAME_LENGTH) {
+    return { kind: 'too-short', min: MIN_USERNAME_LENGTH };
+  }
+  if (username.length > MAX_USERNAME_LENGTH) {
+    return { kind: 'too-long', max: MAX_USERNAME_LENGTH };
+  }
+  if (!USERNAME_REGEX.test(username)) {
+    return { kind: 'invalid-characters' };
+  }
+  return null;
+}
+
+export function formatUsernameError(error: UsernameValidationError): string {
+  switch (error.kind) {
+    case 'too-short':
+      return `Username must be at least ${error.min} characters.`;
+    case 'too-long':
+      return `Username must be at most ${error.max} characters.`;
+    case 'invalid-characters':
+      return 'Username may only contain letters, numbers, underscores, and dots (no spaces).';
+  }
+}

--- a/shared/authentication/src/index.ts
+++ b/shared/authentication/src/index.ts
@@ -1,4 +1,5 @@
 export * from './auth.definition';
 export * from './auth.roles';
 export * from './auth.middleware';
+export * from './auth.username';
 export { sendAccountSetupEmail } from './email';

--- a/tests/unit/auth/auth.username.test.ts
+++ b/tests/unit/auth/auth.username.test.ts
@@ -1,0 +1,84 @@
+import {
+  formatUsernameError,
+  MAX_USERNAME_LENGTH,
+  MIN_USERNAME_LENGTH,
+  validateUsername,
+} from '../../../shared/authentication/src/auth.username';
+
+describe('validateUsername()', () => {
+  describe('valid usernames', () => {
+    it.each([
+      ['lowercase', 'billb'],
+      ['mixed case', 'BillB'],
+      ['with underscore', 'bill_b'],
+      ['with dot', 'bill.b'],
+      ['digits only', '12345'],
+      ['minimum length', 'a'.repeat(MIN_USERNAME_LENGTH)],
+      ['maximum length', 'a'.repeat(MAX_USERNAME_LENGTH)],
+    ])('should accept %s ("%s")', (_label, input) => {
+      expect(validateUsername(input)).toBeNull();
+    });
+  });
+
+  describe('rejected usernames', () => {
+    it('should reject internal whitespace as invalid characters', () => {
+      expect(validateUsername('bill b')).toEqual({ kind: 'invalid-characters' });
+    });
+
+    it('should reject leading whitespace as invalid characters', () => {
+      expect(validateUsername(' billb')).toEqual({ kind: 'invalid-characters' });
+    });
+
+    it('should reject trailing whitespace as invalid characters', () => {
+      expect(validateUsername('billb ')).toEqual({ kind: 'invalid-characters' });
+    });
+
+    it.each([
+      ['dash', 'bill-b'],
+      ['at', 'bill@b'],
+      ['apostrophe', "bill's"],
+      ['unicode letter', 'billé'],
+      ['emoji', 'bill\u{1F44D}'],
+    ])('should reject %s as invalid-characters', (_label, input) => {
+      expect(validateUsername(input)).toEqual({ kind: 'invalid-characters' });
+    });
+
+    it('should reject empty string as too-short', () => {
+      expect(validateUsername('')).toEqual({ kind: 'too-short', min: MIN_USERNAME_LENGTH });
+    });
+
+    it('should reject one-character string as too-short', () => {
+      expect(validateUsername('a')).toEqual({ kind: 'too-short', min: MIN_USERNAME_LENGTH });
+    });
+
+    it('should reject MIN-1 character string as too-short', () => {
+      expect(validateUsername('a'.repeat(MIN_USERNAME_LENGTH - 1))).toEqual({
+        kind: 'too-short',
+        min: MIN_USERNAME_LENGTH,
+      });
+    });
+
+    it('should reject MAX+1 character string as too-long', () => {
+      expect(validateUsername('a'.repeat(MAX_USERNAME_LENGTH + 1))).toEqual({
+        kind: 'too-long',
+        max: MAX_USERNAME_LENGTH,
+      });
+    });
+  });
+});
+
+describe('formatUsernameError()', () => {
+  it('should describe too-short with the minimum length', () => {
+    expect(formatUsernameError({ kind: 'too-short', min: 3 })).toBe('Username must be at least 3 characters.');
+  });
+
+  it('should describe too-long with the maximum length', () => {
+    expect(formatUsernameError({ kind: 'too-long', max: 30 })).toBe('Username must be at most 30 characters.');
+  });
+
+  it('should describe invalid-characters and mention spaces', () => {
+    const message = formatUsernameError({ kind: 'invalid-characters' });
+    expect(message).toMatch(/letters/i);
+    expect(message).toMatch(/no spaces/i);
+  });
+});

--- a/tests/unit/auth/provision-user.test.ts
+++ b/tests/unit/auth/provision-user.test.ts
@@ -60,20 +60,25 @@ const mockAuthContext = {
 
 const mockRequestPasswordReset = jest.fn().mockResolvedValue({ status: true } as never);
 
-jest.mock('@wxyc/authentication', () => ({
-  auth: {
-    $context: Promise.resolve(mockAuthContext),
-    api: {
-      requestPasswordReset: (...args: unknown[]) => mockRequestPasswordReset(...args),
+jest.mock('@wxyc/authentication', () => {
+  // Use the real validator so the tests exercise the production regex.
+  const actual = jest.requireActual('../../../shared/authentication/src/auth.username');
+  return {
+    ...actual,
+    auth: {
+      $context: Promise.resolve(mockAuthContext),
+      api: {
+        requestPasswordReset: (...args: unknown[]) => mockRequestPasswordReset(...args),
+      },
     },
-  },
-  WXYCRoles: {
-    member: {},
-    dj: {},
-    musicDirector: {},
-    stationManager: {},
-  },
-}));
+    WXYCRoles: {
+      member: {},
+      dj: {},
+      musicDirector: {},
+      stationManager: {},
+    },
+  };
+});
 
 // --- Import after mocks ---
 import { provisionUser, ProvisionError } from '../../../apps/auth/provision-user';
@@ -189,6 +194,37 @@ describe('provisionUser()', () => {
           role: 'dj',
         }),
       });
+    });
+  });
+
+  describe('username validation', () => {
+    it.each([['billb'], ['bill_b'], ['bill.b'], ['BillB'], ['dj42'], ['abc'], ['a'.repeat(30)]])(
+      'should accept valid username: "%s"',
+      async (username) => {
+        await expect(provisionUser({ ...validInput, username })).resolves.toBeDefined();
+      }
+    );
+
+    it.each([
+      ['contains a space', 'bill b'],
+      ['contains a dash', 'bill-b'],
+      ['contains an @', 'bill@b'],
+      ['contains punctuation', "bill's"],
+      ['contains unicode', 'billé'],
+      ['leading space', ' billb'],
+      ['trailing space', 'billb '],
+      ['too short (1 char)', 'a'],
+      ['too short (2 chars)', 'ab'],
+      ['too long (31 chars)', 'a'.repeat(31)],
+      ['empty string', ''],
+    ])('should reject invalid username (%s)', async (_label, username) => {
+      await expect(provisionUser({ ...validInput, username })).rejects.toThrow(ProvisionError);
+      await expect(provisionUser({ ...validInput, username })).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should not call createUser when username is invalid', async () => {
+      await provisionUser({ ...validInput, username: 'bill b' }).catch(() => {});
+      expect(mockCreateUser).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- `provisionUser()` was calling `internalAdapter.createUser` directly, bypassing better-auth's username plugin. An admin could provision an account whose username (e.g. `"bill b"`) the `/sign-in/username` endpoint would then permanently reject. We hit this in production today.
- New `shared/authentication/src/auth.username.ts` mirrors the plugin's defaults (`/^[a-zA-Z0-9_.]+$/`, length `[3, 30]`) as a single source of truth. `provisionUser()` calls it after the role check and throws `ProvisionError(400, ...)` with a friendly message. Default-user creation and CSV bulk import inherit the validation since both flow through `provisionUser`.
- 28 cases on the validator itself plus 18 cases on `provisionUser` (parameterized) covering happy path, every invalid-character class, leading/trailing whitespace, length boundaries, and a no-side-effects assertion.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new errors)
- [x] `npm run format:check`
- [x] `npm run test:unit` — 1529 passing
- [ ] CI green
- [ ] Manual: provision a user with `"bill b"` via `/auth/admin/provision-user` returns 400 with "Username may only contain letters, numbers, underscores, and dots (no spaces)."

Closes #731
Companion PR: WXYC/dj-site (filed next)