### PR TITLE
Add implementation plans for Migration Deploy Hardening (Project #26)

### DIFF
--- a/plans/migration-deploy-hardening/725-surface-migrate-errors.md
+++ b/plans/migration-deploy-hardening/725-surface-migrate-errors.md
@@ -1,0 +1,108 @@
+# Plan: Surface drizzle:migrate's underlying Postgres ERROR in deploy logs
+
+- **Issue**: WXYC/Backend-Service#725
+- **Project**: [Migration Deploy Hardening](https://github.com/orgs/WXYC/projects/26) — Phase 1 (visibility)
+- **Size**: XS
+
+## Context
+
+When `drizzle-kit migrate` (invoked by `dev_env/init-db.mjs`) fails, the underlying Postgres `ERROR` text is shadowed by drizzle-kit's spinner ANSI redraws. The deploy log shows only trailing `NOTICE` lines and an empty stderr, leaving operators to infer the failure from timing. Same failure mode bit us in #400 and #550; recurred 2026-05-04 (run 25337297761) on migration 0071's `RAISE EXCEPTION` precondition guard.
+
+## Approach
+
+Stop shelling out to `drizzle-kit migrate`. Use drizzle-orm's programmatic `migrate()` directly — same function the CLI ultimately calls, but exposed as a library so we own the error surface. Wrap in try/catch; on catch, dump the full Postgres error fields (`code`, `message`, `where`, `detail`, `hint`) to stderr before re-throwing.
+
+drizzle-orm exports the function from `drizzle-orm/postgres-js/migrator`. Already installed (`shared/database` depends on `drizzle-orm`); no new dep.
+
+## Implementation
+
+### Step 0 — Confirm drizzle-orm version compatibility in `dev_env/`
+
+`dev_env/package.init.json` currently pins a different `drizzle-orm` minor than `shared/database/package.json` (e.g., `^0.41.0` vs `^0.45.2` at time of writing). The `migrate()` function is stable across these but verify before relying on it: install dev_env's pin and confirm `drizzle-orm/postgres-js/migrator` exports `migrate()` with the documented signature. If the gap is wider than a minor, bump `dev_env/package.init.json` to match `shared/database`'s drizzle-orm version.
+
+### Step 1 — Replace the exec call in `dev_env/init-db.mjs`
+
+Current shape (around the `🔄 Running Drizzle migrations...` log):
+
+```js
+const { stdout, stderr } = await execAsync('npm run drizzle:migrate', { cwd: __dirname });
+```
+
+New shape:
+
+```js
+// init-db.mjs is plain JavaScript — no TypeScript type assertions. Use
+// optional-chaining / direct property access instead.
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+
+const db = drizzle(sql);  // sql is the existing postgres-js client
+try {
+  await migrate(db, { migrationsFolder: join(__dirname, 'database/migrations') });
+} catch (error) {
+  // Postgres errors carry semantic fields beyond .message — dump them all so
+  // an operator reading the deploy log sees the actual failure cause, not a
+  // generic "exit 1". The most diagnostic field is usually .where (the
+  // PL/pgSQL stack frame) for RAISE EXCEPTION, and .detail for constraint
+  // violations.
+  process.stderr.write('\n=== drizzle:migrate failed ===\n');
+  if (error && typeof error === 'object') {
+    for (const field of ['code', 'severity', 'message', 'detail', 'hint', 'where', 'schema', 'table', 'column', 'constraint']) {
+      const value = error[field];
+      if (value !== undefined) {
+        process.stderr.write(`${field}: ${value}\n`);
+      }
+    }
+    if (error.stack) {
+      process.stderr.write(`stack: ${error.stack}\n`);
+    }
+  } else {
+    process.stderr.write(String(error) + '\n');
+  }
+  process.stderr.write('===\n');
+  throw error;
+}
+```
+
+**Note for #726**: extract the formatting block into a reusable `formatPgError(error)` function exported from a small helper module (e.g., `dev_env/format-pg-error.mjs`) so the pre-flight dry-run script #726 ships can import it directly without duplicating the field list.
+
+### Step 2 — Verify the existing `drizzle:migrate` script remains usable
+
+`dev_env/package.init.json` defines `drizzle:migrate` as `drizzle-kit migrate --config 'drizzle.config.ts'`. Keep it — useful for ad-hoc CLI runs where the spinner output is fine. Just don't invoke it from `init-db.mjs`.
+
+### Step 3 — Keep the existing journal-skip detection (Step 3 of init-db.mjs)
+
+The existing post-migrate verification ("Verifies all journal migrations were applied") catches the silent-skip case where Drizzle's `when`-cursor logic skips a migration. Belt-and-suspenders; don't remove it.
+
+## Test plan (TDD)
+
+The failure mode is environmental (CI log capture), not unit-testable in isolation. Use a manual repro:
+
+1. Add a temporary throwaway migration `9999_surface-test.sql` with `DO $$ BEGIN RAISE EXCEPTION 'SURFACE_TEST'; END $$;` and a journal entry.
+2. Run `node dev_env/init-db.mjs` against a local DB.
+3. Assert: capture stderr; the script must exit non-zero AND its captured stderr must contain the substrings `severity: ERROR`, `message: SURFACE_TEST`, and `where:` (the PL/pgSQL stack frame). Wrap as a shell one-liner so it's repeatable: `node dev_env/init-db.mjs 2>&1 | tee /tmp/out.log; grep -q 'SURFACE_TEST' /tmp/out.log && grep -q 'severity: ERROR' /tmp/out.log && grep -q 'where:' /tmp/out.log || { echo FAIL; exit 1; }`.
+4. Compare against current behavior (re-run with the existing exec-based shell-out): only the spinner trailing characters appear; no `SURFACE_TEST` text. The grep above exits 1.
+5. Delete the throwaway migration before merging.
+
+Optional unit test: extract the error-formatting block into a pure function (`formatPgError(err): string`) and unit-test against a synthetic `{ code: '...', message: '...', where: '...' }` object. Lower value (the actual failure mode is the integration with drizzle-orm's library), but cheap.
+
+## Risks / gotchas
+
+1. **drizzle-orm and drizzle-kit version skew.** `init-db.mjs` is currently in `dev_env/` with its own `package.init.json` listing minimal deps. Confirm `drizzle-orm` is installed in that mini-package; if only `drizzle-kit` is, add `drizzle-orm` (it's tiny — `migrate()` is a few hundred lines).
+2. **postgres-js client lifecycle.** Currently the script creates `const sql = postgres(dbConfig)` at module top. The `drizzle()` wrapper re-uses that client, but `migrate()` may issue its own `BEGIN`/`COMMIT` — verify the client's `max: 1` setting (already configured) doesn't deadlock against migrate's transaction.
+3. **NOTICE handling.** drizzle-kit prints PG NOTICEs (the harmless `schema "drizzle" already exists, skipping` ones). drizzle-orm's `migrate()` may or may not surface them. If absent, that's fine — we don't need them for diagnosis. If they pollute the success-path log, suppress with `sql.options.onnotice = () => {}` on the client.
+4. **The error object's shape varies by Postgres driver.** postgres-js wraps errors with the `severity` / `code` / `where` fields; pg uses different field names. We're on postgres-js per `drizzle.config.ts`, so the field list above is correct, but if anyone migrates the project to `pg` later, the formatter needs updating.
+
+## Acceptance criteria
+
+- [ ] `dev_env/init-db.mjs` no longer calls `npm run drizzle:migrate` via `execAsync`; it imports and calls `migrate()` from `drizzle-orm/postgres-js/migrator`.
+- [ ] Manual repro (per Test Plan step 1-4) confirms `RAISE EXCEPTION` text appears verbatim in stderr.
+- [ ] Success-path: a clean migrate on a fresh dev DB completes silently and exits 0; `__drizzle_migrations` cursor advances correctly.
+- [ ] Existing journal-skip detection (init-db.mjs step 3) still runs after the migrate.
+- [ ] No regression in `npm run ci:testmock` (which exercises the full init-db flow).
+
+## Out of scope
+
+- Filing upstream improvements to drizzle-kit's spinner.
+- Removing the `drizzle:migrate` script from `package.init.json` (keep for ad-hoc use).
+- Sentry breadcrumb integration for migration runs (separate, optional, deferred to #730 or later).

--- a/plans/migration-deploy-hardening/726-preflight-dryrun.md
+++ b/plans/migration-deploy-hardening/726-preflight-dryrun.md
@@ -1,0 +1,310 @@
+# Plan: Pre-flight migration dry-run against prod-shaped data before merge
+
+- **Issue**: WXYC/Backend-Service#726
+- **Project**: [Migration Deploy Hardening](https://github.com/orgs/WXYC/projects/26) — Phase 2 (prevention, highest leverage)
+- **Size**: M — has real engineering choices
+
+## Context
+
+PR CI runs migrations against a fresh dev DB with no data. Migrations whose preconditions check against current data shape (e.g., 0071's `RAISE EXCEPTION` on duplicate active rotation groups) never fire at PR time. The failure surfaces at deploy against prod, where the data shape that triggers the guard exists.
+
+The local replication tunnel (`scripts/sync/setup-replication.sh`) already keeps a local PG in sync with prod. A pre-flight that uses that infrastructure (or an equivalent CI-side snapshot) would have caught 0071 at PR-review time on 2026-05-01, before #718's manual recovery was needed.
+
+**Hard ordering recommendation**: #725 (legible failure output) should land before this PR opens for review, OR be merged as a sibling commit on the same branch. Without #725, a failing dry-run produces the same opaque "exit 1" the deploy currently does — the dry-run runs, but a reviewer can't act on the failure because the actual error text is shadowed. If timing forces shipping #726 first, gate the merge on a follow-up that lands #725 within the same week and label this PR `blocked-on-#725-for-legible-output` in the title.
+
+**Branch + commit conventions** (from CLAUDE.md): branch `feature/issue-726-migrate-dryrun`. Commit messages: scope to `ci:` for the workflow change and `docs:` for the CLAUDE.md update. Two commits is fine, one is fine — author's call.
+
+## Approach decision
+
+Three options were laid out in #726's body:
+
+a. **Daily-refreshed RDS snapshot in CI** — restore a snapshot to a sandboxed test DB before each migrate-touching PR run. Highest fidelity, ~1-2min restore time, no ongoing maintenance.
+b. **Persistent sandbox DB kept fresh by the replication tunnel** — long-lived PG subscribing to prod; CI connects for dry-runs. Fastest, requires reset-between-PRs choreography.
+c. **Operator's laptop replica + push-button command** — no CI integration; relies on author running `npm run db:dryrun-migrate` locally. Lowest engineering, lowest enforcement.
+
+**Recommended: (a) — daily snapshot restored fresh per run.** Rationale:
+
+- Bounded restore time (~1-2 min) parallelizes with other CI jobs; doesn't gate the critical path.
+- Zero state contamination across PRs (each run gets a clean snapshot).
+- No persistent infrastructure to maintain (the snapshot pipeline is one of: a scheduled GHA workflow, a Lambda, or an RDS automated snapshot).
+- Aligns with the "ephemeral CI" pattern the rest of the deploy uses.
+
+(b) is faster but risks state corruption if a previous run mutated the sandbox in a way the next test depended on; reset-via-snapshot defeats the speed advantage anyway. (c) is the fallback if budget kills (a).
+
+This plan assumes (a). If RDS snapshot economics or AWS access make it untenable, the implementer should revisit and pick (c) with a manually-enforced "ran the dry-run before merging" PR-checklist box.
+
+## Implementation
+
+### Step 1 — Verify RDS snapshot availability
+
+RDS automated snapshots run daily; the prod DB likely has 7-day retention by default. Confirm:
+
+```bash
+aws rds describe-db-snapshots --db-instance-identifier <prod-id> --snapshot-type automated --max-items 5
+```
+
+If automated snapshots aren't enabled, enable them in the RDS console (one-time, ops). If they are, we have the source.
+
+### Step 2 — Expose the existing `db-init` filter as a job output
+
+Verified state of `.github/workflows/test.yml` (lines 32-65 at time of writing):
+
+- `detect-changes` job already declares outputs: `apps`, `jobs`, `shared`, `tests`, `src`, `run-integration`. **It does NOT expose `db-init`** even though the filter exists.
+- The `db-init` filter (lines 58-64) already covers the right paths: `dev_env/init-db.mjs`, `shared/database/src/migrations/**`, `shared/database/src/schema.ts`, plus `dev_env/{Dockerfile.init,package.init.json,seed_db.sql}`.
+
+No filter changes needed. Just expose `db-init` as a job output:
+
+```yaml
+detect-changes:
+  outputs:
+    apps: ${{ steps.changes.outputs.apps }}
+    jobs: ${{ steps.changes.outputs.jobs }}
+    shared: ${{ steps.changes.outputs.shared }}
+    tests: ${{ steps.changes.outputs.tests }}
+    src: ${{ steps.changes.outputs.src }}
+    run-integration: ${{ steps.should-run.outputs.run-integration }}
+    db-init: ${{ steps.changes.outputs.db-init }}  # NEW
+```
+
+The `db-init` name is correct as the trigger condition for `migrate-dryrun` — it covers exactly the paths whose changes could move the migration result on prod-shaped data.
+
+### Step 3 — Add the `migrate-dryrun` CI job
+
+```yaml
+migrate-dryrun:
+  name: Migration Dry-Run (prod-shaped data)
+  needs: [detect-changes]
+  if: needs.detect-changes.outputs.db-init == 'true'
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+
+    # Match the existing AWS credential pattern used throughout
+    # .github/workflows/deploy-base.yml (lines 246, 254, 265, 329, 337, 363, 454).
+    # Long-lived AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY secrets, scoped via
+    # IAM policy. Migrating the whole repo to OIDC is a separate concern; not
+    # in scope for this PR.
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Restore latest prod snapshot to sandbox
+      run: |
+        SNAPSHOT_ID=$(aws rds describe-db-snapshots \
+          --db-instance-identifier ${{ secrets.PROD_DB_ID }} \
+          --snapshot-type automated \
+          --query 'sort_by(DBSnapshots, &SnapshotCreateTime)[-1].DBSnapshotIdentifier' \
+          --output text)
+        SANDBOX_ID="dryrun-${{ github.run_id }}"
+        # Publicly accessible because GitHub Actions runners have no VPC
+        # connectivity to the prod VPC. Ingress is gated by the dedicated
+        # security group SG_DRYRUN_GHA, which allows port 5432 from GitHub's
+        # documented egress IP ranges only — see Step 4's network prereq.
+        aws rds restore-db-instance-from-db-snapshot \
+          --db-instance-identifier "$SANDBOX_ID" \
+          --db-snapshot-identifier "$SNAPSHOT_ID" \
+          --db-instance-class db.t4g.micro \
+          --publicly-accessible \
+          --vpc-security-group-ids ${{ secrets.SG_DRYRUN_GHA }}
+        aws rds wait db-instance-available --db-instance-identifier "$SANDBOX_ID"
+        echo "SANDBOX_ID=$SANDBOX_ID" >> $GITHUB_ENV
+
+    - name: Get sandbox endpoint
+      run: |
+        ENDPOINT=$(aws rds describe-db-instances \
+          --db-instance-identifier "$SANDBOX_ID" \
+          --query 'DBInstances[0].Endpoint.Address' --output text)
+        echo "DB_HOST=$ENDPOINT" >> $GITHUB_ENV
+
+    # Run ONLY the migrate step, not the full init-db.mjs pipeline. init-db
+    # also installs extensions, optionally seeds, and runs journal-skip
+    # verification — all benign against a snapshot but the brittler the
+    # pre-flight, the more chances for a non-migration failure to mask the
+    # signal we care about. A purpose-built dryrun-migrate.mjs is shorter,
+    # narrower, and reuses the same drizzle-orm migrate() + formatPgError
+    # helper #725 introduces.
+    - name: Run drizzle:migrate against sandbox
+      env:
+        DB_HOST: ${{ env.DB_HOST }}
+        DB_PORT: '5432'
+        DB_NAME: ${{ secrets.PROD_DB_NAME }}
+        DB_USERNAME: ${{ secrets.PROD_DB_USERNAME }}
+        DB_PASSWORD: ${{ secrets.PROD_DB_PASSWORD }}
+      run: node scripts/dryrun-migrate.mjs
+
+    - name: Tear down sandbox
+      if: always()
+      run: |
+        if [ -n "$SANDBOX_ID" ]; then
+          aws rds delete-db-instance \
+            --db-instance-identifier "$SANDBOX_ID" \
+            --skip-final-snapshot \
+            --delete-automated-backups
+        fi
+```
+
+**Key points:**
+
+- `if: needs.detect-changes.outputs.db-init == 'true'` — only runs when migration / db-init files change.
+- `needs: [detect-changes]` — runs in parallel to other CI jobs; doesn't extend the critical path.
+- Sandbox DB instance class is small (`db.t4g.micro`) — cheap; dry-run is the only workload.
+- `if: always()` on teardown + the `if [ -n "$SANDBOX_ID" ]` guard — even if restore fails before `SANDBOX_ID` is set, we don't try to delete an unset id (would error and obscure the actual failure).
+
+### Step 4 — IAM policy for the AWS_ACCESS_KEY_ID user
+
+The existing IAM user behind `AWS_ACCESS_KEY_ID` already has ECR + EC2 permissions for the deploy. Add a narrowly-scoped RDS policy attached to the same user (or a sibling user if separation is preferred):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "rds:DescribeDBSnapshots",
+        "rds:DescribeDBInstances",
+        "rds:RestoreDBInstanceFromDBSnapshot",
+        "rds:ModifyDBInstance",
+        "rds:DeleteDBInstance",
+        "rds:AddTagsToResource"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+`Resource: "*"` is appropriate here because the snapshot identifiers are dynamically picked; we can narrow to `arn:aws:rds:*:*:snapshot:rds:<prefix>-*` once the naming pattern is stable. Document the policy attachment as an ops step, not part of the PR diff.
+
+**Network prerequisite**: the sandbox DB is provisioned with `--publicly-accessible` because the standard GitHub Actions `ubuntu-latest` runner has no VPC connectivity to the prod VPC. Ingress is gated by a dedicated security group (`SG_DRYRUN_GHA`) that allows port 5432 from GitHub's documented egress IP ranges only (see [GitHub's hosted-runner IP allowlist](https://api.github.com/meta) — the `actions` array). Provision the security group as a one-time ops step:
+
+```bash
+# Create SG in the same VPC as the prod RDS subnet group
+aws ec2 create-security-group --group-name dryrun-gha-ingress \
+  --description "GHA runner → ephemeral RDS dryrun ingress" \
+  --vpc-id <prod-vpc-id>
+# For each CIDR in https://api.github.com/meta -> .actions:
+aws ec2 authorize-security-group-ingress --group-id sg-... \
+  --protocol tcp --port 5432 --cidr <gha-cidr>
+# Save the SG id as the SG_DRYRUN_GHA secret
+```
+
+Alternative: use a self-hosted runner inside the prod VPC. More secure (no public ingress at all) but more operational overhead. Defer unless the public-accessible posture becomes a real concern.
+
+### Step 3.5 — Add `scripts/dryrun-migrate.mjs`
+
+The CI step calls this purpose-built script rather than `node dev_env/init-db.mjs`. init-db.mjs runs extensions install, migrations, journal verification, and optional seeding — all benign against a snapshot but they bloat the failure surface (a future change to init-db.mjs that touches data could silently mask a migration failure in the dry-run). A narrow script that does ONLY the migrate is cleaner.
+
+Sketch (full implementation lives in this PR's scope):
+
+```js
+// scripts/dryrun-migrate.mjs
+//
+// Purpose-built migration dry-run for the Migration Deploy Hardening
+// pre-flight CI job (#726). Runs drizzle-orm's programmatic migrate()
+// against whatever DB the env vars point at, dumps Postgres ERROR fields
+// on failure (reuses the formatter #725 introduces), exits 0 on success
+// or 1 on failure.
+
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { formatPgError } from '../dev_env/format-pg-error.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const sql = postgres({
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT ?? 5432),
+  database: process.env.DB_NAME,
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  max: 1,
+});
+
+try {
+  const db = drizzle(sql);
+  await migrate(db, { migrationsFolder: join(__dirname, '../shared/database/src/migrations') });
+  console.log('dryrun-migrate: ok');
+} catch (error) {
+  process.stderr.write('\n=== dryrun-migrate failed ===\n');
+  process.stderr.write(formatPgError(error));
+  process.stderr.write('===\n');
+  process.exitCode = 1;
+} finally {
+  await sql.end();
+}
+```
+
+This script does NOT call init-db.mjs's installExtensions, verify-journal, or seed steps. The snapshot already has all extensions installed, so installExtensions is unnecessary. Verify-journal is best done separately (and is preserved on the deploy path via init-db.mjs). Seed wouldn't fire anyway because the snapshot has data.
+
+New repo secrets to provision (one-time, ops). All are repo-level GitHub Actions secrets (Settings → Secrets and variables → Actions → New repository secret), not environment-scoped — the job runs on the standard `ubuntu-latest` runner and doesn't need GitHub environment protection rules:
+
+- `PROD_DB_ID` — RDS instance identifier of the prod DB (e.g., `wxyc-prod-db`).
+- `PROD_DB_NAME` — Postgres database name.
+- `PROD_DB_USERNAME`, `PROD_DB_PASSWORD` — match the RDS master credentials (snapshots restore with the source instance's master user). If `init-db.mjs` expects a non-master user, provision a dedicated migration user in the source DB first; otherwise the master credentials work.
+
+### Step 5 — Document in CLAUDE.md
+
+Update the "## CI/CD" section of `Backend-Service/CLAUDE.md` (currently 4 numbered steps describing the existing CI jobs). Add a new bullet after step 4:
+
+> 5. **migrate-dryrun** (new, see WXYC/Backend-Service#726) — Only runs when `db-init` paths change (migrations, schema, init-db.mjs, etc.). Restores the most recent automated RDS snapshot to a sandbox DB instance, runs `node dev_env/init-db.mjs` against it, asserts exit 0, tears down. Catches preconditions that depend on prod data shape (e.g., the `RAISE EXCEPTION` guards added per WXYC/Backend-Service#705) at PR-review time rather than at deploy time. Failure surfaces the underlying Postgres error in the CI log (depends on WXYC/Backend-Service#725 — wrap drizzle:migrate). To re-test against a fresher snapshot: trigger an on-demand snapshot via the AWS RDS console and rerun the workflow.
+
+### Step 6 — Self-test against the historical wedge
+
+This is the regression test for the whole project. Concrete steps:
+
+1. `git fetch origin` and identify the commit just before the wedge: `git log --oneline -- shared/database/src/migrations/0071*` finds `be0bbf6` (initial 0071, no precondition) and `2710f2e` (precondition retrofit). The wedge surfaces between `2710f2e` and the deploy run.
+2. From a feature branch with the new CI step, push a draft PR whose only change is touching one of the `db-init` paths (e.g., a one-character whitespace change in `dev_env/init-db.mjs`), so `migrate-dryrun` triggers.
+3. Verify the dry-run reproduces today's wedge: 0071's precondition guard fires with the visible `RAISE EXCEPTION` message in the CI log, exit 1.
+4. Once verified, revert the synthetic change and document the run id in this issue's resolution comment so future maintainers can trace the regression test back.
+
+If the snapshot used by the dry-run is fresher than the prod state at the time of the wedge (i.e., 0071+0072 have been manually applied via #718's INSERT), the wedge won't reproduce on that snapshot. Use an older snapshot (RDS keeps automated snapshots for the configured retention window — usually 7 days) or trigger an on-demand snapshot from a checkpoint that predates the manual recovery.
+
+## Test plan
+
+- **Smoke**: PR that touches a non-migration file → `migrate-dryrun` is skipped (paths-filter works).
+- **Happy path**: PR adds a new migration that's a no-op against prod state (e.g., `CREATE TABLE foo (id SERIAL)`) → dry-run passes.
+- **Caught-at-PR**: PR adds a migration with a precondition guard that would fail against current prod (mimic 0071's shape) → dry-run fails with the visible guard message; CI blocks merge.
+- **Sandbox cleanup**: regardless of dry-run outcome, the RDS sandbox instance is deleted within 5 minutes of job completion (verify by querying RDS API after a synthetic test).
+
+## Risks / gotchas
+
+1. **AWS credentials in CI.** Need an IAM role with `rds:RestoreDBInstanceFromDBSnapshot`, `rds:DeleteDBInstance`, `rds:DescribeDBSnapshots`, `rds:DescribeDBInstances`. Provision via OIDC (no long-lived secrets); existing deploy workflow already has an IAM role pattern to copy from.
+2. **Snapshot size and restore cost.** A small DB restores in 1-2 min; a 100GB+ DB can take 15-20 min. If prod is large, the dry-run gates merge for a long time. Mitigation: use a smaller scratch instance class (compute is decoupled from storage on RDS), and accept the wall-clock cost as the price of preventing prod wedges.
+3. **Sandbox DB networking.** Resolved per Step 2/3.5: `--publicly-accessible` with a dedicated security group (`SG_DRYRUN_GHA`) gated to GitHub Actions' documented egress IP ranges. Self-hosted-runner-in-VPC is the more-secure alternative, deferred unless public-accessible posture becomes a concern. The security group provisioning is a one-time ops step (commands in Step 2's network-prereq block).
+4. **Cost.** Each PR run with migrations spins up + tears down an RDS instance. At db.t4g.micro pricing, ~$0.02/hour; even with 5-min runs and 50 migration PRs/month, this is < $5/mo. Negligible.
+5. **Flakiness from snapshot lag.** Automated snapshots run daily; a migration that depends on data younger than the most-recent snapshot won't see it. Mitigation: also wire an on-demand snapshot trigger (manually invokable when needed) so an author can `gh workflow run snapshot-prod-now.yml` before opening their PR if the data shape they care about is fresh.
+6. **Dry-run mutates the snapshot.** That's fine — the sandbox is ephemeral. But the implementer must NOT reuse a snapshot across runs (snapshot-restore-mutate-snapshot would corrupt state).
+
+## Acceptance criteria
+
+- [ ] CI job `migrate-dryrun` runs on every PR that touches `shared/database/src/migrations/**`, `shared/database/src/schema.ts`, or `dev_env/init-db.mjs`.
+- [ ] On a fresh-snapshot run, the job restores a sandbox, runs `node dev_env/init-db.mjs`, asserts exit 0, tears down.
+- [ ] Postgres ERROR text from any migration failure reaches the CI log (depends on #725 — flag this as a soft-blocker if #725 hasn't landed).
+- [ ] Self-test: re-run the workflow at `2710f2e..main` (using a backup of prod's pre-recovery state if needed) reproduces today's wedge with the visible guard message.
+- [ ] CLAUDE.md "CI/CD" section documents the new job and how to debug failures.
+- [ ] No persistent RDS instance leaks after a 24-hour soak test (verify with `aws rds describe-db-instances --query "DBInstances[?DBInstanceIdentifier!~\`prod\`]"`).
+
+## Alternatives if (a) is infeasible
+
+- **(b) — persistent sandbox**: spin up a long-lived `wxyc-staging-replica` RDS instance subscribing to prod via logical replication; have the CI step run migrations inside a SAVEPOINT it always rolls back. Risk: `DDL` doesn't always SAVEPOINT cleanly; some migrations create permanent state (e.g., extensions). Workable but fragile.
+- **(c) — local-only**: add `npm run db:dryrun-migrate` script that documents the local replication setup and runs migrate against the operator's clone. PR-template checkbox: "I ran `npm run db:dryrun-migrate` locally and it passed." Lowest enforcement; useful as a fallback or interim while (a) is being provisioned.
+
+## Out of scope
+
+- Pre-flight for non-migration changes (the dev DB suffices for those).
+- Drizzle-side improvements (idempotency, parallel migration apply, etc.).
+- Auto-rolling back successful dry-runs that fail later in CI (the sandbox is already torn down per run; no rollback needed).
+
+## References
+
+- `scripts/sync/setup-replication.sh` — existing replication infrastructure
+- `.github/workflows/test.yml` — existing PR CI
+- `.github/workflows/deploy-base.yml:314` — current migrate step (the failure surface this prevents)
+- RCA for run 25337297761
+- WXYC/Backend-Service#725 — soft prerequisite for legible failure output

--- a/plans/migration-deploy-hardening/727-validator-check-9.md
+++ b/plans/migration-deploy-hardening/727-validator-check-9.md
@@ -1,0 +1,133 @@
+# Plan: validate-migrations Check 9 — RAISE EXCEPTION messages must cite reachable paths
+
+- **Issue**: WXYC/Backend-Service#727
+- **Project**: [Migration Deploy Hardening](https://github.com/orgs/WXYC/projects/26) — Phase 2 (prevention)
+- **Size**: XS
+
+## Context
+
+Migration 0071's `RAISE EXCEPTION` says: `'Cannot apply ... Run rotation-dedupe job first or pre-clean manually.'`. The cited rotation-dedupe job exists only on the unmerged feature branch `task/694-rotation-dedupe`. An operator hitting 0071 in prod who follows the runbook hits a broken pointer.
+
+Low-severity, high-confusion failure mode. The whole point of a guard's RAISE message is to give the operator a runnable next step.
+
+## Approach
+
+Slot a new Check 9 into `scripts/validate-migrations.mjs`. Mirror Check 8's pattern: walk SQL files, regex-extract a target shape, emit `reportWarning` per finding. Warning, not error — false positives are tolerable; the goal is informational.
+
+## Implementation
+
+### Step 1 — Read the existing Check 8 to lock the pattern
+
+`scripts/validate-migrations.mjs` line 283 onwards is the Check 8 reference. Note its conventions:
+
+- Walks `shared/database/src/migrations/*.sql`.
+- Uses `reportWarning(file, message)` (not `reportError`).
+- Suppression syntax: `-- @no-precondition-needed: <reason>` comment in the file.
+- Does NOT block CI (warnings only).
+
+### Step 2 — Implement Check 9
+
+Add to the validator after Check 8:
+
+```js
+// Check 9: WARNING — RAISE EXCEPTION messages should cite paths reachable
+// from main. Migrations whose precondition guards reference a runbook (e.g.
+// "Run rotation-dedupe job first") that points to an unmerged feature branch
+// give operators a broken next-step. The check extracts path-shaped tokens
+// from RAISE EXCEPTION strings and warns when fs.existsSync returns false.
+//
+// Suppressible per-migration with `-- @no-runbook-needed: <reason>` for
+// migrations whose RAISE message intentionally cites a path-shaped string
+// that isn't a real path (false positive on URLs, doc references, etc.).
+//
+// See: WXYC/Backend-Service#727.
+function checkRunbookReferences() {
+  const RAISE_PATTERN = /RAISE\s+EXCEPTION\s+(['"])((?:\\.|[^\\])*?)\1/gi;
+  // Path-shaped tokens: top-level directory we'd recognize, followed by /...
+  // Loose by design — the warning suppression handles real false positives.
+  const PATH_PATTERN = /\b(jobs|scripts|apps|shared)\/[A-Za-z0-9_./-]+/g;
+  const SUPPRESS_PATTERN = /--\s*@no-runbook-needed:/;
+
+  for (const file of sqlFiles) {
+    const content = fs.readFileSync(file, 'utf8');
+    if (SUPPRESS_PATTERN.test(content)) continue;
+
+    let match;
+    while ((match = RAISE_PATTERN.exec(content)) !== null) {
+      const messageText = match[2];
+      const paths = messageText.match(PATH_PATTERN) ?? [];
+      for (const candidate of paths) {
+        const repoPath = path.join(repoRoot, candidate);
+        if (!fs.existsSync(repoPath)) {
+          reportWarning(
+            file,
+            `RAISE EXCEPTION cites '${candidate}' which doesn't exist on main. ` +
+              `Either merge the runbook before this migration ships, rephrase the ` +
+              `message, or suppress with '-- @no-runbook-needed: <reason>'.`
+          );
+        }
+      }
+    }
+  }
+}
+```
+
+### Step 3 — Wire into the existing checks runner
+
+Add `checkRunbookReferences()` to the existing list of check function calls (the spot where checks 1-8 are invoked). Order doesn't matter — checks are independent.
+
+### Step 4 — Update the docstring
+
+The validator's top-of-file docstring enumerates checks 1-8. Add Check 9 with the same shape, scope-explicit upfront so a future operator reading the warning understands its boundaries without consulting this issue:
+
+> 9. WARNING: RAISE EXCEPTION messages cite **explicit paths** to directories (`jobs/`, `scripts/`, `apps/`, `shared/`) that exist on main. **Scope limitation:** free-form prose references (e.g., "Run rotation-dedupe job" without a `jobs/` prefix) are not detected; only explicit path-shaped patterns match. Suppressible per-migration with `-- @no-runbook-needed: <reason>`. See WXYC/Backend-Service#727.
+
+### Step 5 — Run against current main
+
+The check will fire on at least one current migration (0071 cites `rotation-dedupe job` — though note the current text is "rotation-dedupe job" without a path prefix, so the regex may NOT match). Examples:
+
+- 0071: cites "rotation-dedupe job" — no `jobs/` prefix in the actual string, so the path regex misses it. Decide: tighten the regex (false-positive-prone) or accept this as a Check 9 limitation (a future migration that DOES write `jobs/rotation-dedupe` will trigger it; pre-existing prose-style references are out of scope).
+
+Document the decision in the Check 9 docstring.
+
+## Test plan (TDD)
+
+Existing tests for the validator live at `tests/unit/scripts/validate-migrations.test.ts` (TypeScript, Jest config `jest.unit.config.ts`). They spawn the validator as a subprocess against temporary migration fixtures. Append Check 9's tests there; do not create a new test file under `scripts/__tests__/`.
+
+Tests:
+
+1. **Happy path**: migration with `RAISE EXCEPTION 'See jobs/library-artist-name-backfill for prior art'` → no warning (path exists).
+2. **Broken reference**: migration with `RAISE EXCEPTION 'Run jobs/this-does-not-exist first'` → warning emitted naming both the file and the missing path.
+3. **Multiple paths in one message**: warning emitted per missing path, none for present ones.
+4. **Suppression**: file with both a broken-reference message and `-- @no-runbook-needed: see #N`-style comment → no warning.
+5. **No RAISE EXCEPTION at all**: no warning (no false positive on every migration).
+6. **Path-shaped string in message that isn't followed by `jobs/`/`scripts/` etc.**: no warning (regex doesn't fire on free-form prose like "rotation-dedupe job").
+
+Use temp-directory fixtures with synthetic SQL files; don't depend on real migrations changing.
+
+## Risks / gotchas
+
+1. **Regex false positives.** A RAISE message that mentions a documentation page or external URL whose path component happens to start with `jobs/`/`scripts/` would warn. Suppression syntax handles it, and the warning's job is to inform — false-positive cost is low (just suppress).
+2. **Regex false negatives.** Free-form prose ("Run rotation-dedupe job first" — no `jobs/` prefix) won't match. That's a deliberate limitation; tightening the regex would inflate false positives. Document the limitation in the docstring; accept that this check catches the explicit-path case (which is the higher-confidence signal anyway).
+3. **The 0071 case (the prompting issue) won't trip Check 9 as written.** This is fine — 0071's recovery is being handled separately via #718. The check is forward-looking: future authors who DO write `jobs/foo-bar` in a RAISE message will be caught.
+4. **CI integration.** Check 9 is a warning, not an error, so it doesn't gate CI. The validator's exit code logic should remain unchanged (errors fail; warnings inform).
+
+## Acceptance criteria
+
+- [ ] Check 9 implemented in `scripts/validate-migrations.mjs` following Check 8's pattern.
+- [ ] Docstring at top of file enumerates Check 9 alongside the existing 8.
+- [ ] Unit tests cover happy path, broken reference (single + multiple paths), suppression, no-RAISE, and prose-style false-negative.
+- [ ] Validator's exit code logic unchanged (warnings inform, don't fail CI).
+- [ ] Run validator against current main; document any current Check 9 hits or non-hits in PR description.
+
+## Out of scope
+
+- Validating that the cited path is *runnable* (executable, has a README). Existence is the bar.
+- Tightening the regex to catch prose-style references. The signal/noise becomes too low.
+- Auto-fixing or auto-rephrasing messages. Human judgment.
+
+## References
+
+- `scripts/validate-migrations.mjs` — existing 8-check infrastructure
+- Migration 0071 — the prompting case (note: existing form won't trip the regex; the check is forward-looking)
+- WXYC/Backend-Service#705 — Check 8 precedent (precondition guards)

--- a/plans/migration-deploy-hardening/728-audit-retroactive-guards.md
+++ b/plans/migration-deploy-hardening/728-audit-retroactive-guards.md
@@ -1,0 +1,108 @@
+# Plan: Audit the four other migrations 2710f2e retroactively guarded
+
+- **Issue**: WXYC/Backend-Service#728
+- **Project**: [Migration Deploy Hardening](https://github.com/orgs/WXYC/projects/26) — Phase 1 (audit)
+- **Size**: S — investigation + comments, no production code changes
+
+## Context
+
+Commit `2710f2e` ("Migration precondition guards: pattern, retroactive examples, validator check", 2026-05-01) retrofitted `DO $$ ... RAISE EXCEPTION ... END $$;` precondition guards onto 5 recent constraint-adding migrations as exemplars. Migration 0071 is one of those five and wedged today's deploy because its retroactive guard fires against current prod data shape.
+
+The other 4 migrations in that commit are unaudited. Each could be a deferred wedge waiting for the next deploy that crosses its `__drizzle_migrations` cursor.
+
+## Approach
+
+Investigation. No production code change unless a wedge is found, in which case file follow-ups (one per finding) under this project.
+
+## Implementation
+
+### Step 1 — Enumerate the 5 migrations
+
+```bash
+git show 2710f2e --stat -- 'shared/database/src/migrations/*.sql'
+```
+
+Capture the list. Should include 0071 (already known) plus 4 others. Record their paths.
+
+### Step 2 — Determine prod's current `__drizzle_migrations` cursor
+
+After the manual recovery for #718 (the 0071/0072 backfill INSERTs land), the cursor will be at `1779856000004` (0072's `when`). Confirm with:
+
+```bash
+ssh wxyc-ec2 "docker exec <db-container> psql -U <user> -d <db> -c 'SELECT MAX(created_at) FROM drizzle.__drizzle_migrations'"
+```
+
+Or, if logical replication is current, query the local replica. Do whichever doesn't add prod load.
+
+**Replica freshness check before running guard SELECTs.** Logical replication has bounded but non-zero lag; `srsubstate = 'r'` means "subscriber is ready to receive", not "subscriber is at the tip". Before trusting any guard-predicate SELECT against the replica, confirm:
+
+```sql
+SELECT
+  subname,
+  pg_wal_lsn_diff(pg_current_wal_lsn(), latest_end_lsn) AS lag_bytes,
+  EXTRACT(EPOCH FROM (now() - latest_end_time)) AS lag_seconds
+FROM pg_stat_subscription;
+```
+
+Require `lag_seconds < 60` and `lag_bytes < 1000` before running any Bucket B/C SELECT. Otherwise wait for the replication slot to catch up, or fall back to querying prod directly via the SSH tunnel — note in the audit comment which path was used per finding so the freshness assumption is auditable.
+
+### Step 3 — Bucket each retroactively-guarded migration
+
+For each of the 5 migrations (including 0071 for completeness):
+
+| Migration | when | cursor < when? | Bucket |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+- **Bucket A** (cursor >= when): migration was applied before the guard was added. Guard never runs again. Safe.
+- **Bucket B** (cursor < when, guard predicate is currently false): guard exists, guard would run on next migrate, but it'll pass. Safe.
+- **Bucket C** (cursor < when, guard predicate is currently true): wedge in queue. **File follow-up.**
+
+For Bucket B/C migrations, run the precondition guard's SELECT against the local replica (which mirrors prod data shape). The SELECT lives inside the `DO $$ ... BEGIN SELECT ... INTO ... FROM ... HAVING ... ; ... END $$;` block — extract and run the inner SELECT directly. If `count > 0`, it's Bucket C.
+
+### Step 4 — Document findings
+
+Comment on issue #728 with the bucketing table. For Bucket C entries, file follow-up issues under the Migration Deploy Hardening project. Each follow-up should:
+
+- State the wedge mode plainly: "migration N's guard fires because <data condition>".
+- Link to the migration file and the prod query that confirmed the failure.
+- Recommend a fix from #718's three options: manual `__drizzle_migrations` insert, run the runbook the guard cites, or fold-with-its-revert if applicable.
+
+### Step 5 — Update CLAUDE.md if a pattern emerges
+
+If 2+ Bucket C wedges surface, the retrofitting practice itself needs a note in CLAUDE.md's migration section warning future authors to bucket each retrofit explicitly before merging.
+
+## Test plan
+
+This is investigation, not code. The "test" is reproducibility:
+
+- Each Bucket A claim must be backed by `cursor >= when` evidence.
+- Each Bucket B claim must show the guard's SELECT returning 0 rows against the replica.
+- Each Bucket C finding must show the SELECT returning >0 rows.
+
+Capture the SQL and outputs as a comment on #728 so a future audit can re-run them.
+
+## Risks / gotchas
+
+1. **The local replica may lag prod.** Logical replication has bounded latency but is not transactional with prod. If a Bucket B SELECT returns 0 rows at audit time but prod has stale data the replica hasn't caught up to, the audit can miss a Bucket C. Mitigation: check `pg_stat_subscription` shows current state before running SELECTs; or wait for a quiescent window.
+2. **A guard's predicate may reference a table the replica doesn't replicate.** The replication tunnel covers `wxyc_schema` per the publication setup — confirm it covers all tables the guards reference (rotation, flowsheet, library, etc.). If a guard touches an auth table, the audit may need to query prod directly.
+3. **Re-merging the rotation-dedupe job (currently on `task/694-rotation-dedupe`) is its own decision.** If the audit reveals 0071 is the only Bucket C and the recommended fix is "merge the dedupe job", that's a different conversation. Don't auto-merge.
+
+## Acceptance criteria
+
+- [ ] All 5 migrations 2710f2e touched are bucketed (table posted as comment on #728).
+- [ ] Each Bucket B/C finding includes the SQL run and the row count returned.
+- [ ] Bucket C findings each have a filed follow-up issue under project #26.
+- [ ] If 2+ Bucket C findings: a CLAUDE.md update lands warning future authors about retrofitting guards onto already-authored migrations without bucketing them first.
+
+## Out of scope
+
+- Auditing migrations 2710f2e didn't touch. The risk window is specifically retroactive guards on already-authored migrations.
+- Deciding whether to merge `task/694-rotation-dedupe`. Surface the dependency; let the user choose.
+- Changing the precondition-guards pattern itself (it's correct for new migrations; the failure mode is retroactive application).
+
+## References
+
+- `2710f2e` — the retrofitting commit
+- Issue #718 — the recovery for 0071 specifically
+- Run 25337297761 — the deploy that exposed the wedge

--- a/plans/migration-deploy-hardening/729-validator-check-10.md
+++ b/plans/migration-deploy-hardening/729-validator-check-10.md
@@ -1,0 +1,186 @@
+# Plan: validate-migrations Check 10 — flag un-deployed CREATE-then-DROP migration pairs
+
+- **Issue**: WXYC/Backend-Service#729
+- **Project**: [Migration Deploy Hardening](https://github.com/orgs/WXYC/projects/26) — Phase 3 (structural)
+- **Size**: M — most experimental of the project's checks; SQL parsing via regex is brittle by design
+
+**Numbering**: this plan uses "Check 10" assuming #727's "Check 9" has landed first. If #729 ships before #727, slot this in as "Check 9" instead and renumber when #727 lands. The check is independent of #727's content.
+
+## Context
+
+Migrations 0071 and 0072 net to a no-op: 0071 creates a unique partial index on `rotation`; 0072 drops it. They shipped as two separate migrations because they were authored two hours apart on 2026-05-01. The chain runs each migration in isolation, so 0071's retroactively-added precondition guard fires before 0072 has a chance to undo its sibling. Folding the pair into a single no-op migration would have prevented today's wedge.
+
+A validator check that detects this pattern at PR time would let authors fold pairs before merge — converting "two ships that net to a no-op" into "one migration with a `-- intentionally a no-op` comment".
+
+## Why this is hard
+
+SQL parsing via regex can't see:
+
+- DDL composed via `EXECUTE format(...)`.
+- DDL with quoted identifiers across multiple variants (`"my_idx"` vs `my_idx` vs `wxyc_schema."my_idx"`).
+- Renames (`ALTER INDEX X RENAME TO Y` then `DROP INDEX Y` — the rename hides the create).
+- Cascading DROPs (`DROP TABLE foo` removes any indexes on it; the validator would need a schema model to track).
+
+Acceptance criteria below set the bar: catch the canonical CREATE-then-DROP-by-name pair (the 0071/0072 case). Document false-negative cases in the docstring; don't try to be exhaustive.
+
+## Approach
+
+Slot Check 10 into `scripts/validate-migrations.mjs` after Check 9. WARNING level (not error). Suppression syntax `-- @intentional-create-revert: <reason>`.
+
+Two design choices:
+
+1. **Window definition**: how recently does the CREATE need to be relative to the DROP? Options:
+   - **Last successful prod deploy** (uses GH API to fetch deploy run, parse cursor) — most accurate, requires network access from the validator.
+   - **Last N migrations** (configurable, default 10) — cheap, deterministic, runs offline.
+   - **All un-merged-to-prod migrations** (parses `_journal.json` against a known-deployed cursor file) — middle ground.
+
+   **Recommended: Last N migrations.** Works offline, no GH API dep, the N=10 default catches the 0071/0072 case (they're 1 apart) and any plausible future case.
+
+2. **Object-name extraction**: how loose to be?
+   - Strict: only catch named objects in standard DDL forms (CREATE INDEX X, DROP INDEX X; ALTER TABLE T ADD CONSTRAINT C, ALTER TABLE T DROP CONSTRAINT C; CREATE TABLE T, DROP TABLE T).
+   - Loose: try to match across variations (rename detection, schema-qualified names).
+
+   **Recommended: Strict.** Loose adds maintenance burden for marginal gain. Document the strict list in the docstring; loose-match cases can suppress with the comment.
+
+## Implementation
+
+### Step 1 — Read Check 8 and Check 9 to lock the pattern
+
+Both already in `scripts/validate-migrations.mjs`. Same shape: walk SQL files, regex, emit `reportWarning`.
+
+### Step 2 — Implement Check 10
+
+```js
+// Check 10: WARNING — detect CREATE-then-DROP migration pairs that net to
+// a no-op within the last N migrations. Pairs like 0071+0072 (CREATE INDEX
+// then DROP INDEX of the same name) ship as two migrations but conceptually
+// undo each other; folding them prevents the chain from running each in
+// isolation, which matters when the CREATE has a precondition that fires
+// against current prod state. Suppressible with a per-migration comment
+// `-- @intentional-create-revert: <reason>` when the pair is intentional
+// schema evolution rather than a bugfix-revert.
+//
+// Limitations: parses bare DDL via regex. Misses dynamic SQL (EXECUTE
+// format(...)), renames-then-drops, cascading DROPs. Strict by design — see
+// WXYC/Backend-Service#729 for design rationale.
+//
+// Window: last N migrations (default 10), configurable via
+// `process.env.CHECK_10_WINDOW_SIZE`.
+function checkCreateThenDropPairs() {
+  const WINDOW_SIZE = Number(process.env.CHECK_10_WINDOW_SIZE ?? 10);
+  const SUPPRESS_PATTERN = /--\s*@intentional-create-revert:/;
+
+  // Sorted by idx ascending — already what _journal.json gives us.
+  const recent = journalEntries.slice(-WINDOW_SIZE);
+
+  // Build per-object op-list: key = `<kind>:<name>`, value = [{idx, op}].
+  // Kinds: 'index', 'constraint', 'table', 'column'.
+  // Names are normalized: strip outer quotes, strip schema prefix.
+  const timeline = new Map();
+  const PATTERNS = [
+    // CREATE [UNIQUE] INDEX [IF NOT EXISTS] <name>
+    { kind: 'index', op: 'create', re: /CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:["']?[\w.]+["']?\.)?["']?(\w+)["']?/gi },
+    // DROP INDEX [IF EXISTS] [schema.]<name>
+    { kind: 'index', op: 'drop', re: /DROP\s+INDEX\s+(?:IF\s+EXISTS\s+)?(?:["']?[\w.]+["']?\.)?["']?(\w+)["']?/gi },
+    // ALTER TABLE <t> ADD CONSTRAINT <name>
+    { kind: 'constraint', op: 'create', re: /ADD\s+CONSTRAINT\s+["']?(\w+)["']?/gi },
+    // ALTER TABLE <t> DROP CONSTRAINT [IF EXISTS] <name>
+    { kind: 'constraint', op: 'drop', re: /DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?["']?(\w+)["']?/gi },
+    // (Tables and columns are not in the canonical 0071/0072 case; skip
+    // unless real-world need surfaces.)
+  ];
+
+  for (const entry of recent) {
+    const file = path.join(migrationsDir, `${entry.tag}.sql`);
+    if (!fs.existsSync(file)) continue;
+    const content = fs.readFileSync(file, 'utf8');
+    if (SUPPRESS_PATTERN.test(content)) continue;
+
+    for (const { kind, op, re } of PATTERNS) {
+      let match;
+      while ((match = re.exec(content)) !== null) {
+        const name = match[1];
+        const key = `${kind}:${name}`;
+        if (!timeline.has(key)) timeline.set(key, []);
+        timeline.get(key).push({ idx: entry.idx, tag: entry.tag, op });
+      }
+    }
+  }
+
+  // Find pairs: for each object, if there's a create followed by a drop with
+  // no further create in between, warn.
+  for (const [key, ops] of timeline) {
+    for (let i = 0; i < ops.length - 1; i++) {
+      if (ops[i].op === 'create' && ops[i + 1].op === 'drop') {
+        const [createOp, dropOp] = [ops[i], ops[i + 1]];
+        const message =
+          `Migration ${createOp.tag} creates ${key}, ` +
+          `migration ${dropOp.tag} drops it. The pair nets to a no-op but the ` +
+          `chain runs each migration in isolation — if the CREATE has a precondition, ` +
+          `it fires even though the effect is reverted moments later. Consider folding ` +
+          `the pair into a single no-op migration, or suppress with ` +
+          `'-- @intentional-create-revert: <reason>' if this is intentional schema evolution.`;
+        // Warn on the CREATE side (the one whose precondition would fire).
+        const createFile = path.join(migrationsDir, `${createOp.tag}.sql`);
+        reportWarning(createFile, message);
+      }
+    }
+  }
+}
+```
+
+### Step 3 — Wire into the runner + update docstring
+
+Same pattern as Check 9. Add `checkCreateThenDropPairs()` to the runner; add Check 10 description to top-of-file docstring.
+
+### Step 4 — Validate against current main
+
+Expected hit on current main: `0071_rotation-active-album-bin-uniq` (creates `rotation_active_album_bin_uniq` index) + `0072_drop-rotation-active-album-bin-uniq` (drops it). Confirm Check 10 emits the warning.
+
+If 0071 has already been "resolved" via the manual `__drizzle_migrations` insert from #718, Check 10 still warns at PR time on any future similar pair — that's the point.
+
+## Test plan (TDD)
+
+Existing tests for the validator live at `tests/unit/scripts/validate-migrations.test.ts` (TypeScript, Jest config `jest.unit.config.ts`). They spawn the validator as a subprocess against temporary migration fixtures. Append Check 10's tests there; do not create a new test file.
+
+1. **Happy path**: 10 sequential migrations, no CREATE/DROP-of-same-name pair → no warning.
+2. **Canonical pair (0071/0072 shape)**: synthetic migrations with `CREATE INDEX foo ...` + `DROP INDEX foo` → warning emitted on the CREATE migration.
+3. **Beyond window**: pair separated by > WINDOW_SIZE migrations → no warning.
+4. **CREATE-DROP-CREATE**: same name created, dropped, then created again — should warn on the first (create, drop) pair only, not on the second create.
+5. **Suppression**: pair with `-- @intentional-create-revert: schema evolution from #N` → no warning.
+6. **Quoted variants**: `CREATE INDEX "my_idx"` matched against `DROP INDEX my_idx` → warning (name normalization).
+7. **Schema-qualified DROP**: `DROP INDEX wxyc_schema.my_idx` matched against `CREATE INDEX my_idx` → warning.
+8. **CONSTRAINT pair**: `ALTER TABLE t ADD CONSTRAINT c ...` + `ALTER TABLE t DROP CONSTRAINT c` → warning.
+9. **Dynamic SQL**: `EXECUTE format('CREATE INDEX %I', name)` + `DROP INDEX foo` → no warning (documented limitation).
+
+Use temp-directory fixtures with synthetic SQL files.
+
+## Risks / gotchas
+
+1. **Regex SQL parsing has known limits.** Acceptable — Check 10 is a hint, not a guarantee. If false positives become noisy, suppression syntax handles it; if false negatives bite, #726 (pre-flight dry-run) catches the runtime failure.
+2. **Window size is a tuning knob.** Default 10 is enough to catch 0071/0072 (1-apart) and any reasonable future pair. If a pair lands more than 10 apart, that's likely intentional schema evolution that *shouldn't* be folded — the false-negative is correct behavior.
+3. **The warning-on-CREATE choice.** Could warn on either migration in the pair. CREATE-side is preferred because that's the migration whose precondition would fire — pointing the operator's eye at the migration that causes the wedge. Document the choice in the check's docstring.
+4. **CONSTRAINT-name extraction is fragile.** The `ADD CONSTRAINT <name>` pattern is consistent in our migrations, but Postgres allows `CHECK (...)` without a name (auto-generated). Auto-generated names won't match across the pair. Acceptable false-negative; document.
+
+## Acceptance criteria
+
+- [ ] Check 10 implemented as a WARNING (not error), suppressible with `-- @intentional-create-revert: <reason>`.
+- [ ] Runs on every PR via the existing validator invocation.
+- [ ] Repro test: validator emits a warning on current main HEAD for the 0071+0072 pair (run before any cleanup of those migrations).
+- [ ] Unit tests cover the 9 cases listed in Test Plan.
+- [ ] Validator's exit code logic unchanged.
+- [ ] Docstring lists Check 10 alongside Checks 1-9; documents the strict-DDL-only design choice and suppression syntax.
+
+## Out of scope
+
+- Detecting renames (`ALTER INDEX X RENAME TO Y`) and chasing the renamed object through the timeline.
+- Detecting cascading DROPs (`DROP TABLE` removing all indexes on the table).
+- Auto-folding pairs (would rewrite migration history; CLAUDE.md generally forbids).
+- Cross-PR detection (the check looks at the current state of `_journal.json` only — a pair split across two un-merged PRs is invisible until both merge).
+
+## References
+
+- `scripts/validate-migrations.mjs` — existing 9-check infrastructure (assumes #727 lands first, but Check 10 doesn't depend on Check 9)
+- 0071+0072 — the prompting case
+- WXYC/Backend-Service#705 — Check 8 precedent (precondition guards)
+- WXYC/Backend-Service#727 — Check 9 (sibling effort)

--- a/plans/migration-deploy-hardening/730-deploy-cadence-doc.md
+++ b/plans/migration-deploy-hardening/730-deploy-cadence-doc.md
@@ -1,0 +1,84 @@
+# Plan: Document deploy cadence as a migration-chain risk dimension in CLAUDE.md
+
+- **Issue**: WXYC/Backend-Service#730
+- **Project**: [Migration Deploy Hardening](https://github.com/orgs/WXYC/projects/26) — Phase 3 (docs)
+- **Size**: XS — pure docs change, with optional script
+
+## Context
+
+The 2026-05-04 deploy wedge was amplified by 4 days of accumulated migrations (0071, 0072, 0073) since the prior successful deploy on 2026-04-30. Each migration in isolation might have been caught; together they hid the failure (0071+0072 net to a no-op, but the chain runs each in isolation). Subsequently, the precondition-guard pattern was retroactively retrofit onto 0071 — changing its behavior 2 hours after the original author moved on.
+
+Frequent deploys reduce the surface area for any single migration's failure mode to compound with others. Daily-or-faster cadence on migration-touching PRs would have shown 0071 in isolation, before #2710f2e changed its behavior.
+
+## Approach
+
+Pure docs change to `Backend-Service/CLAUDE.md`. Single new subsection under "## Deployment". Optionally pair with a small standalone script that emits a Sentry breadcrumb on each migrate run noting "N un-deployed migrations on main since last successful prod deploy" — defer to follow-up if anyone wants the operational signal.
+
+## Implementation
+
+### Step 1 — Add subsection to CLAUDE.md
+
+Locate the existing "## Deployment" section (currently 4 lines). Add the following subsection immediately after:
+
+```markdown
+### Deploy cadence and migration-chain risk
+
+Migration-touching PRs should trigger a deploy soon after merge — ideally same-day. Long deploy gaps accumulate migration-chain risk: each new migration sits unapplied on `main`, and a failure on any one of them at deploy time wedges the whole chain.
+
+The canonical recent example is the 2026-05-04 deploy wedge (run [25337297761](https://github.com/WXYC/Backend-Service/actions/runs/25337297761)), where 4 days of accumulated migrations (0071, 0072, 0073) compounded with a retroactive precondition guard added in commit `2710f2e`. Migration 0071's guard fired against current prod state and aborted the chain, leaving the deploy stuck. Had 0071 deployed in isolation immediately after authoring (2026-05-01), the guard wouldn't have been retrofitted yet, and the wedge wouldn't have happened.
+
+The other defenses in [Project #26 — Migration Deploy Hardening](https://github.com/orgs/WXYC/projects/26) (legible failure output, pre-flight dry-runs against prod-shaped data) reduce the cost of an individual wedge. This cadence note reduces the *likelihood* by limiting how many migrations stack up between deploys.
+
+**Practical rule of thumb**: when a PR that touches `shared/database/src/migrations/**` merges, run Manual Build & Deploy within 24 hours.
+```
+
+### Step 2 — (Optional) Operational signal script
+
+If anyone wants visibility into the gap, a small script under `scripts/` could emit on each migrate run:
+
+```js
+// scripts/migrate-cadence-breadcrumb.mjs (sketch)
+// Reads __drizzle_migrations cursor, compares to journal length, logs gap.
+// Wired into init-db.mjs after migrate completes.
+const cursor = await sql`SELECT MAX(created_at) FROM drizzle.__drizzle_migrations`;
+const journal = JSON.parse(readFileSync('database/migrations/meta/_journal.json'));
+const undeployed = journal.entries.filter(e => Number(e.when) > Number(cursor[0].max));
+if (undeployed.length > 3) {
+  console.warn(`[cadence] ${undeployed.length} migrations applied this run; consider deploying more frequently. Sentry breadcrumb emitted.`);
+  // Optionally: Sentry.addBreadcrumb({ category: 'migrate-cadence', level: 'info', message: `...`, data: { undeployed: undeployed.length } });
+}
+```
+
+Defer this step to follow-up unless there's appetite. The docs change is the minimum viable.
+
+## Test plan
+
+- **Docs change**: render the markdown locally; confirm formatting, link to project #26 resolves, link to run 25337297761 resolves.
+- **Optional script**: unit-test the gap calculation against a mock cursor + journal. Don't need to test the Sentry side-effect.
+
+## Risks / gotchas
+
+1. **The "rule of thumb" is advisory.** Don't gate merges on cadence; that punishes the wrong people (PR authors don't necessarily own deploys). The doc just informs decisions; the real defense is the Phase 1 + Phase 2 work in this project.
+2. **The optional script adds noise.** If implemented, calibrate the threshold (default `> 3` undeployed migrations is arbitrary — tune based on actual run frequency).
+
+## Acceptance criteria
+
+- [ ] CLAUDE.md "Deployment" section grows a "Deploy cadence and migration-chain risk" subsection (text per Step 1).
+- [ ] References the 2026-05-04 incident as the canonical example.
+- [ ] Links to project #26 and to the failed run.
+- [ ] (Optional) Operational script lands under `scripts/` and is documented in CLAUDE.md.
+
+## Why this is the lowest-priority item in the project
+
+The root cause of the 2026-05-04 wedge was visibility (the spinner ate the error → #725) and PR-time prevention (no precondition dry-run against prod-shaped data → #726). Frequent deploys don't fix either; they just reduce blast radius. Once #725 + #726 ship, this docs note becomes mostly informational. Worth landing for completeness — and the optional script could provide a useful operational signal — but neither blocks anything.
+
+## Out of scope
+
+- Automated deploy-after-merge (would change the deploy authorization model; bigger conversation).
+- Per-migration deploy gating (don't punish PR authors).
+- Cross-repo deploy cadence (this repo's deploy cadence has no bearing on LML, dj-site, etc.).
+
+## References
+
+- RCA for run 25337297761
+- Project #26 README — articulates how this item fits the broader picture


### PR DESCRIPTION
## Summary

Six implementation plans for the issues filed under [Project #26 — Migration Deploy Hardening](https://github.com/orgs/WXYC/projects/26), in response to the 2026-05-04 deploy wedge ([run 25337297761](https://github.com/WXYC/Backend-Service/actions/runs/25337297761)).

Plans live at `plans/migration-deploy-hardening/<issue>-<slug>.md`. Each is implementation-ready with file paths, code skeletons, TDD test cases, risks/gotchas, and acceptance criteria mirroring the issue's checklist.

| Plan | Issue | Phase | Size |
|---|---|---|---|
| 725-surface-migrate-errors.md | #725 | 1 (visibility) | XS |
| 728-audit-retroactive-guards.md | #728 | 1 (audit) | S |
| 727-validator-check-9.md | #727 | 2 (prevention) | XS |
| 726-preflight-dryrun.md | #726 | 2 (prevention, highest leverage) | M |
| 729-validator-check-10.md | #729 | 3 (structural) | M |
| 730-deploy-cadence-doc.md | #730 | 3 (docs) | XS |

## How these plans were drafted

1. **Investigation first** — read `dev_env/init-db.mjs`, `scripts/validate-migrations.mjs`, `Dockerfile.migrate`, `.github/workflows/{test,deploy-base,deploy-manual}.yml`, `scripts/sync/setup-replication.sh`, and the `task/694-rotation-dedupe` worktree to understand the actual code surface.
2. **Drafted with concrete file:line references** rather than abstract guidance — each plan names the file an implementer will touch.
3. **Submitted via `/review-plan` skill**, then revised based on review feedback. Five approved with suggestions on first pass; #726 requested changes due to two HIGH findings (`detect-changes` already exposes a `db-init` filter; AWS credential pattern was OIDC vs the repo's existing long-lived `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`). Revised and re-reviewed; approved.
4. **Pre-PR review caught three additional blockers** that the per-plan reviews missed: TypeScript syntax in a `.mjs` file (#725); networking contradiction between Step 3's `--no-publicly-accessible` and Risks-#3's "public + IP allowlist" recommendation (#726); brittle reliance on the full `init-db.mjs` pipeline for a dry-run that should only exercise migrate (#726). All three resolved before this PR opened — see the script `scripts/dryrun-migrate.mjs` introduced as part of the #726 plan, and the network prerequisite block now documenting the `SG_DRYRUN_GHA` security group provisioning.
5. **Cross-plan consistency** — all plans reference the existing `tests/unit/scripts/validate-migrations.test.ts` for validator tests, all use the CLAUDE.md branch naming conventions, all have tense-neutral cross-references between issues so a reader doesn't get confused if plans land in a different order than the project README's recommendation.

## Recommended landing order (from project #26 README)

Phase 1 — visibility:
1. #725 (smallest, biggest unblock — gives the rest of the project legible failure output)
2. #728 (audit; investigation only, no production code)

Phase 2 — prevention:
3. #727 (slot-in validator check, well-templated by Check 8)
4. #726 (the substantial one — has real engineering choices about replica freshness / CI wiring)

Phase 3 — structural & docs:
5. #729 (most experimental of the lot)
6. #730 (informational; mostly redundant if Phase 2 lands)

No hard blocking chain — each issue is independently deliverable. The phasing above is a recommendation.

## Test plan

- [x] All 6 plans pass `/review-plan` review
- [x] All 6 plans pass the pre-PR-review hook
- [x] Plans reference real file paths and existing infrastructure (validated during drafting)
- [ ] Future PRs implementing each plan will include the per-plan acceptance criteria as their own checklists

## Out of scope for this PR

- Implementing any of the plans (each gets its own PR per the project's #26 phasing)
- Updating the recovery RCA for the original wedge (handled out-of-band via #718's manual `__drizzle_migrations` insert)