### PR TITLE
Surface Postgres errors when drizzle:migrate fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
             db-init:
               - 'dev_env/Dockerfile.init'
               - 'dev_env/init-db.mjs'
+              - 'dev_env/format-pg-error.mjs'
               - 'dev_env/package.init.json'
               - 'dev_env/seed_db.sql'
               - 'shared/database/src/migrations/**'

--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -21,6 +21,7 @@ COPY shared/database/src/schema.ts ./database/schema.ts
 COPY shared/database/src/migrations ./database/migrations
 COPY dev_env/install_extensions.sql ./install_extensions.sql
 COPY dev_env/init-db.mjs ./
+COPY dev_env/format-pg-error.mjs ./
 
 # Dummy .env file for compatibility
 RUN touch .env

--- a/dev_env/Dockerfile.init
+++ b/dev_env/Dockerfile.init
@@ -12,8 +12,9 @@ RUN npm install --omit=dev
 ENV SCHEMA_LOC='/init/database'
 ENV MIGRATION_LOC='/init/database/migrations'
 
-# Copy init script
+# Copy init script and its helper modules
 COPY dev_env/init-db.mjs ./
+COPY dev_env/format-pg-error.mjs ./
 
 # Dummy .env file for compatibility
 RUN touch .env

--- a/dev_env/format-pg-error.mjs
+++ b/dev_env/format-pg-error.mjs
@@ -1,0 +1,79 @@
+/**
+ * drizzle-kit's CLI spinner buffers Postgres ERROR text, so on migration
+ * failure the deploy log carries only trailing NOTICE lines and operators
+ * have to guess at cause. This helper exists so the programmatic migrate()
+ * caller can dump the diagnostic fields (`severity`, `code`, `where`,
+ * `detail`, `hint`) directly to stderr.
+ *
+ * drizzle-orm wraps Postgres errors in `DrizzleQueryError`, putting the
+ * real PG error under `.cause`. Without walking that chain, the helper
+ * sees only the wrapper's generic "Failed query: ..." message and misses
+ * the very fields it exists to surface. The first object in the chain
+ * carrying a non-message PG field is treated as the underlying error.
+ */
+const FIELD_ORDER = [
+  'code',
+  'severity',
+  'message',
+  'detail',
+  'hint',
+  'where',
+  'schema',
+  'table',
+  'column',
+  'constraint',
+];
+
+const PG_FIELDS = new Set(FIELD_ORDER);
+
+function isPgError(value) {
+  if (!value || typeof value !== 'object') return false;
+  for (const field of PG_FIELDS) {
+    if (field !== 'message' && value[field] !== undefined) return true;
+  }
+  return false;
+}
+
+function findPgErrorInChain(error) {
+  let current = error;
+  // Bound the walk; deeply-nested cause chains are pathological and we'd
+  // rather fall back to the wrapper than loop on a malformed object graph.
+  for (let depth = 0; depth < 10 && current; depth++) {
+    if (isPgError(current)) return current;
+    current = current.cause;
+  }
+  return null;
+}
+
+function dumpFields(target, lines) {
+  for (const field of FIELD_ORDER) {
+    const value = target[field];
+    if (value !== undefined) {
+      lines.push(`${field}: ${value}`);
+    }
+  }
+}
+
+export function formatPgError(error) {
+  const lines = ['=== drizzle:migrate failed ==='];
+
+  if (error && typeof error === 'object') {
+    const pgError = findPgErrorInChain(error);
+    if (pgError && pgError !== error) {
+      // Wrapper carries useful context (e.g. "Failed query: <SQL>"), the
+      // underlying PG error carries the diagnostic fields. Show both.
+      if (error.message) lines.push(`wrapper: ${error.message}`);
+      dumpFields(pgError, lines);
+    } else {
+      dumpFields(error, lines);
+    }
+    if (error.stack) {
+      lines.push(`stack: ${error.stack}`);
+    }
+  } else {
+    lines.push(String(error));
+  }
+
+  lines.push('===');
+  return lines.join('\n') + '\n';
+}

--- a/dev_env/init-db.mjs
+++ b/dev_env/init-db.mjs
@@ -17,11 +17,11 @@ import crypto from 'crypto';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { exec } from 'child_process';
-import { promisify } from 'util';
 import { styleText } from 'node:util';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import { formatPgError } from './format-pg-error.mjs';
 
-const execAsync = promisify(exec);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -35,6 +35,13 @@ const dbConfig = {
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   max: 1,
+  // postgres-js dumps every NOTICE to stderr by default. Migrations like
+  // `DROP INDEX IF EXISTS` legitimately produce many ("index X does not
+  // exist, skipping"). On the success path that noise drowns the only
+  // line that matters ("All N migrations verified as applied"); on the
+  // failure path formatPgError() carries the error fields anyway. Drop
+  // notices here.
+  onnotice: () => {},
 };
 
 const sql = postgres(dbConfig);
@@ -88,25 +95,28 @@ async function installExtensions() {
 }
 
 /**
- * Run Drizzle migrations
+ * Run Drizzle migrations.
+ *
+ * Calls drizzle-orm's programmatic migrate() directly instead of shelling out
+ * to `drizzle-kit migrate`. The CLI buffers Postgres ERROR text behind a
+ * spinner, so on failure the deploy log shows only trailing NOTICE lines and
+ * the operator has to guess the cause (incidents #400, #550, run 25337297761).
+ * The library version surfaces the full error object — code, severity,
+ * message, where (PL/pgSQL stack frame), detail, hint, etc. — via
+ * formatPgError so the deploy log carries enough to act on.
  */
 async function runMigrations() {
   console.log(styleText(['bold'], '🔄 Running Drizzle migrations...'));
 
+  const migrationsDir = process.env.MIGRATION_LOC || join(__dirname, '..', 'shared/database/src/migrations');
+  const db = drizzle(sql);
+
   try {
-    const { stdout, stderr } = await execAsync('npm run drizzle:migrate', {
-      env: { ...process.env },
-      shell: '/bin/sh',
-    });
-
-    if (stdout) console.log(stdout);
-    if (stderr && !stderr.includes('No config path provided')) console.error(stderr);
-
+    await migrate(db, { migrationsFolder: migrationsDir });
     console.log('\nMigrations completed successfully!\n');
   } catch (error) {
-    console.error('Migration failed:', error.message);
-    if (error.stdout) console.error('stdout:', error.stdout);
-    if (error.stderr) console.error('stderr:', error.stderr);
+    process.stderr.write('\n');
+    process.stderr.write(formatPgError(error));
     throw error;
   }
 }

--- a/dev_env/package.init.json
+++ b/dev_env/package.init.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "drizzle-kit": "^0.31.5",
-    "drizzle-orm": "^0.41.0",
+    "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.7"
   }
 }

--- a/tests/unit/scripts/format-pg-error.test.ts
+++ b/tests/unit/scripts/format-pg-error.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Source-grep tests for `dev_env/format-pg-error.mjs`. The helper is invoked
+ * by `dev_env/init-db.mjs` (and, separately, the #726 dry-run script) when a
+ * migration fails. Its job is to dump the diagnostic Postgres error fields
+ * (`code`, `severity`, `where`, etc.) to stderr so the deploy log carries
+ * enough to act on — the failure mode that prompted #725.
+ *
+ * The behavioural test (does the helper actually run and format a real
+ * postgres-js error?) lives at integration time via `npm run ci:testmock`.
+ * This file source-greps the artifact so a future PR cannot silently shrink
+ * the field set or detach the catch block from the helper.
+ *
+ * The test mirrors `init-db-historical-replaced.test.ts`'s approach: regex
+ * the source rather than dynamic-import the .mjs, since ts-jest's transform
+ * pattern doesn't cover .mjs and we don't want to widen it just for this.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const helperPath = path.join(repoRoot, 'dev_env/format-pg-error.mjs');
+const initDbPath = path.join(repoRoot, 'dev_env/init-db.mjs');
+
+const helperSource = fs.readFileSync(helperPath, 'utf-8');
+const initDbSource = fs.readFileSync(initDbPath, 'utf-8');
+
+describe('format-pg-error.mjs', () => {
+  it('exports formatPgError', () => {
+    expect(helperSource).toMatch(/export\s+function\s+formatPgError\s*\(/);
+  });
+
+  it('FIELD_ORDER includes the diagnostic fields postgres-js exposes', () => {
+    // These are the fields that materially help an operator distinguish one
+    // PG failure from another — see plan 725-surface-migrate-errors.md and
+    // the postgres-js error documentation.
+    const required = [
+      'code',
+      'severity',
+      'message',
+      'detail',
+      'hint',
+      'where',
+      'schema',
+      'table',
+      'column',
+      'constraint',
+    ];
+    const blockMatch = helperSource.match(/FIELD_ORDER\s*=\s*\[([\s\S]*?)\];/);
+    if (!blockMatch) throw new Error('FIELD_ORDER literal not found');
+    const declared = Array.from(blockMatch[1].matchAll(/'([^']+)'/g)).map((m) => m[1]);
+    for (const field of required) {
+      expect(declared).toContain(field);
+    }
+  });
+
+  it('emits a leading fence so the failure block stands out in mixed log output', () => {
+    expect(helperSource).toMatch(/=== drizzle:migrate failed ===/);
+  });
+
+  it('walks the cause chain so DrizzleQueryError-wrapped PG errors surface their fields', () => {
+    // drizzle-orm wraps thrown PG errors in `DrizzleQueryError`, putting the
+    // original PostgresError under `.cause`. Without chain-walking, the
+    // helper would only see the wrapper's generic "Failed query: ..." text
+    // and miss `severity`, `code`, `where` — defeating the entire point of
+    // #725. Source-grep for the cause traversal.
+    expect(helperSource).toMatch(/findPgErrorInChain|\.cause/);
+  });
+});
+
+describe('init-db.mjs uses format-pg-error', () => {
+  it('imports formatPgError from the helper module', () => {
+    expect(initDbSource).toMatch(/import\s*\{\s*formatPgError\s*\}\s*from\s*['"]\.\/format-pg-error\.mjs['"]/);
+  });
+
+  it('runMigrations passes the caught error to formatPgError', () => {
+    // Source-grep guard against a future refactor that silently drops the
+    // formatter call (regressing back to the bare `error.message` log that
+    // wedged run 25337297761).
+    expect(initDbSource).toMatch(/formatPgError\s*\(\s*error\s*\)/);
+  });
+
+  it('runMigrations uses programmatic migrate(), not exec(npm run drizzle:migrate)', () => {
+    // The whole point of #725 is to stop shelling out to drizzle-kit so the
+    // CLI's spinner can't eat the Postgres ERROR text.
+    expect(initDbSource).toMatch(/import\s*\{\s*migrate\s*\}\s*from\s*['"]drizzle-orm\/postgres-js\/migrator['"]/);
+    expect(initDbSource).not.toMatch(/execAsync\(\s*['"]npm run drizzle:migrate['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

Replace `execAsync('npm run drizzle:migrate')` in `dev_env/init-db.mjs` with drizzle-orm's programmatic `migrate()`. The CLI buffers Postgres ERROR text behind its spinner, so on failure the deploy log shows only trailing NOTICE lines and leaves operators to guess at the cause — incidents #400, #550, and most recently run 25337297761 on migration 0071's `RAISE EXCEPTION` precondition guard.

The library version exposes the full error object — `code`, `severity`, `where` (PL/pgSQL stack frame), `detail`, `hint`, etc. — via a new `formatPgError` helper. The helper walks the `DrizzleQueryError.cause` chain (drizzle-orm wraps PG errors), so the underlying PostgresError fields are dumped to stderr.

Plan: [`plans/migration-deploy-hardening/725-surface-migrate-errors.md`](https://github.com/WXYC/Backend-Service/blob/main/plans/migration-deploy-hardening/725-surface-migrate-errors.md).

## Changes

- `dev_env/init-db.mjs`: replace `execAsync` shell-out with `migrate(db, { migrationsFolder })`. Add `onnotice: () => {}` to the postgres-js client to suppress success-path NOTICE noise.
- `dev_env/format-pg-error.mjs`: new helper. Walks the cause chain so wrapped PG errors surface their fields.
- `dev_env/package.init.json`: bump `drizzle-orm` from `^0.41.0` to `^0.45.2` to match `shared/database`.
- `dev_env/Dockerfile.init` + `Dockerfile.migrate`: COPY the new helper.
- `.github/workflows/test.yml`: add helper to `db-init` filter so future helper-only edits trigger image rebuild.
- `tests/unit/scripts/format-pg-error.test.ts`: source-grep tests pinning the field set, the cause-chain traversal, and the wiring in `init-db.mjs`.

## Manual repro (per plan Test plan)

Added throwaway `9999_surface-test.sql` with `DO $$ BEGIN RAISE EXCEPTION 'SURFACE_TEST'; END $$;`, ran `node dev_env/init-db.mjs`. Stderr capture (excerpt):

```
=== drizzle:migrate failed ===
wrapper: Failed query: DO $$ BEGIN RAISE EXCEPTION 'SURFACE_TEST'; END $$;
code: P0001
severity: ERROR
message: SURFACE_TEST
where: PL/pgSQL function inline_code_block line 1 at RAISE
===
```

Exit code 1. All three plan-required substrings present (`severity: ERROR`, `message: SURFACE_TEST`, `where:`). Throwaway migration removed before commit.

## Test plan

- [x] Local `db:start` against fresh DB: all 73 migrations apply cleanly, seed runs, verify-step still gates.
- [x] Failure path manual repro per above.
- [x] Unit suite (1668/1668 pass).
- [x] Lint (0 errors), typecheck, format-check.
- [ ] CI integration tests on PR.

Closes #725