### PR TITLE
[E2 step 0d 1/3] Backend canonical feature-flag inventory + grep-assert (BS#667)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,11 @@ POSTHOG_HOST=https://us.i.posthog.com
 REQUEST_O_MATIC_URL=https://request-o-matic-production.up.railway.app/request
 API_BASE_URL=https://api.wxyc.org
 
+### Cross-cache-identity feature flags
+# Canonical inventory: CLAUDE.md "Cross-cache-identity feature flags (canonical inventory)".
+# Plan: WXYC/wiki plans/library-hook-canonicalization-plan.md §4.2.
+# Both flags default false. Phase state machine documented in CLAUDE.md.
+# Updater is Jake via SSH + edit `.env` on the EC2 host + `docker compose restart backend`.
+BS_USE_LIBRARY_IDENTITY=false
+BS_USE_LIBRARY_IDENTITY_WRITES=false
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Validate migration journal
         run: npm run lint:migrations
 
+      - name: Cross-cache-identity flag-doc consistency
+        run: scripts/check-cross-cache-identity-flags.sh
+
       - name: Build
         run: npm run build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,6 +488,54 @@ The artist identity ETL (`jobs/artist-identity-etl/`) populates the six reconcil
 
 - `DATABASE_URL_DISCOGS` -- PostgreSQL URL for LML's discogs-cache database, where `entity.identity` lives. Required for the artist-identity ETL.
 
+### Cross-cache-identity feature flags (canonical inventory)
+
+This is the **single source of truth** for the cross-cache-identity project's feature flags (plan §4.2). Consumer repos cross-reference this section in their own `.env.example` / CLAUDE.md. When a flag is renamed or its default changes, both the canonical entry here AND the consumer repo's local doc must update in the same PR.
+
+The naming convention is asymmetric on purpose: `*_USE_NEW_HOOK_*` (LML, semantic-index, per-cache) toggles which `wxyc_library` hook table the consumer reads. `BS_USE_LIBRARY_IDENTITY*` (Backend, global) toggles whether Backend reads/writes the new `library_identity` table at all. A unified prefix would be misleading — the LML/SI flags pick a hook to read; the BS flags toggle a brand-new schema.
+
+**Cache repos do NOT use these flags.** `discogs-etl`, `musicbrainz-cache`, and `wikidata-cache` write to BOTH the legacy and new hook tables unconditionally during the dual-run window. Per §4.2: feature flags fit live request paths (LML, SI, Backend); cache loaders are batch ETLs and roll back via redeploy of the prior image. Cache repos therefore intentionally have no cross-cache-identity flags to document.
+
+| Flag                                 | Owning repo             | Scope     | Default | Set true when                                                                      |
+| ------------------------------------ | ----------------------- | --------- | ------- | ---------------------------------------------------------------------------------- |
+| `LML_USE_NEW_HOOK_DISCOGS`           | library-metadata-lookup | per-cache | `false` | Docker discogs cache parity-check passes 7 consecutive days                        |
+| `LML_USE_NEW_HOOK_DISCOGS_FULL`      | library-metadata-lookup | per-cache | `false` | Homebrew (full) discogs cache parity-check passes 7 consecutive days               |
+| `LML_USE_NEW_HOOK_MUSICBRAINZ`       | library-metadata-lookup | per-cache | `false` | musicbrainz cache parity-check passes 7 consecutive days                           |
+| `LML_USE_NEW_HOOK_WIKIDATA`          | library-metadata-lookup | per-cache | `false` | wikidata cache parity-check passes 7 consecutive days                              |
+| `SI_USE_NEW_HOOK_DISCOGS`            | semantic-index          | per-cache | `false` | LML cuts over for that cache + 7 days clean                                        |
+| `SI_USE_NEW_HOOK_MUSICBRAINZ`        | semantic-index          | per-cache | `false` | (same — per cache)                                                                 |
+| `SI_USE_NEW_HOOK_WIKIDATA`           | semantic-index          | per-cache | `false` | (same — per cache)                                                                 |
+| `BS_USE_LIBRARY_IDENTITY`            | Backend-Service         | global    | `false` | All four caches cut over (LML + semantic-index both on new hook)                   |
+| `BS_USE_LIBRARY_IDENTITY_WRITES`     | Backend-Service         | global    | `false` | After 30-day dual-run with `BS_USE_LIBRARY_IDENTITY=true` reads showing clean      |
+| `LML_MANUAL_OVERRIDE_CHECK_DISABLED` | library-metadata-lookup | global    | `false` | Emergency rollback only — disables the §3.2.2.1 manual-override skip endpoint call |
+
+**Backend phase state machine** (the two BS flags compose to define four behavioral states):
+
+| Phase                            | `BS_USE_LIBRARY_IDENTITY` | `BS_USE_LIBRARY_IDENTITY_WRITES` | Reads                                                  | Writes                                                    |
+| -------------------------------- | ------------------------- | -------------------------------- | ------------------------------------------------------ | --------------------------------------------------------- |
+| 1 — substrate landed, no use     | false                     | false                            | `canonical_entity_id` columns only                     | `canonical_entity_id` columns only (new writer gated off) |
+| 2 — read new, write legacy       | true                      | false                            | `library_identity` with `canonical_entity_id` fallback | `canonical_entity_id` columns only                        |
+| 3 — read new, write both         | true                      | true                             | (same as Phase 2)                                      | DUAL-WRITE in one DB transaction                          |
+| 4 — drop legacy (post §4 step 5) | true                      | true                             | `library_identity` only                                | `library_identity` only                                   |
+
+**Flag mechanism (locked):** all flags above are environment variables read via the standard per-language pattern (`process.env.X` in Node.js, `os.getenv()` in Python). No application-level config singleton or feature-flag service. Each repo's `.env.example` (or CLAUDE.md, where `.env.example` doesn't apply) documents the local flags.
+
+**Production locations and approval gates** (per §4.2 rollout checklist):
+
+| Flag                                 | Production location                                  | Updater                                                       | Approval gate                                                    |
+| ------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `LML_USE_NEW_HOOK_*`                 | Railway environment variables for the LML service    | Jake via Railway dashboard                                    | 7 consecutive days of clean parity-check audit (E5 daily report) |
+| `SI_USE_NEW_HOOK_*`                  | EC2 systemd unit env file                            | Jake via SSH + edit env file + restart                        | LML for that cache cut over for 7 days                           |
+| `BS_USE_LIBRARY_IDENTITY`            | EC2 backend container env (`.env` mounted at deploy) | Jake via SSH + edit `.env` + `docker compose restart backend` | All 4 caches cut over (LML + SI both on new hook for all caches) |
+| `BS_USE_LIBRARY_IDENTITY_WRITES`     | (same)                                               | (same)                                                        | 30-day clean dual-run with `BS_USE_LIBRARY_IDENTITY=true`        |
+| `LML_MANUAL_OVERRIDE_CHECK_DISABLED` | Railway environment variables                        | Jake via Railway dashboard                                    | Used only for emergency rollback (no scheduled flip)             |
+
+**No automation flips production flags.** The audit job (E5) reports when a gate's preconditions are met (e.g., `LML_USE_NEW_HOOK_DISCOGS eligible: 7 days clean since 2026-05-15`); Jake then chooses to flip. This matches the project's no-auto-default principle (§4 step 0).
+
+**Sync mechanism (CI grep-assert, per repo):** every repo that documents one or more flags ships a CI check that asserts (a) every flag named in this canonical table appears in the consumer's local doc, and (b) every flag named in the consumer's local doc appears here. The Backend-side script is `scripts/check-cross-cache-identity-flags.sh`; it runs in the existing CI pipeline (`.github/workflows/test.yml`) as a `Cross-cache-identity flag-doc consistency` job. A second-tier check (every flag named in code matches the doc) ships with the E2-BS substrate PR, since the code references don't exist yet at this PR's open time.
+
+**Audit (post-launch).** A quarterly task tracked under `cross-cache-identity-followup` diffs the canonical Backend list against actual code references in each consumer repo.
+
 ## Relationship to Other Repos
 
 - **[dj-site](https://github.com/WXYC/dj-site)** -- React frontend that consumes this API

--- a/scripts/check-cross-cache-identity-flags.sh
+++ b/scripts/check-cross-cache-identity-flags.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Asserts that the cross-cache-identity feature flags documented in CLAUDE.md's
+# canonical inventory match the Backend-owned flags listed in .env.example.
+#
+# Tier 1 (this PR, E2 step 0d): doc-vs-doc consistency only.
+# Tier 2 (E2-BS substrate PR): adds a check that flag names in code match the
+#   doc; this script will be extended at that time.
+#
+# Plan reference: WXYC/wiki plans/library-hook-canonicalization-plan.md §4.2.
+# Canonical table: CLAUDE.md "Cross-cache-identity feature flags (canonical inventory)".
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+ENV_EXAMPLE="$REPO_ROOT/.env.example"
+
+if [[ ! -f "$CLAUDE_MD" ]]; then
+  echo "FAIL: $CLAUDE_MD not found." >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENV_EXAMPLE" ]]; then
+  echo "FAIL: $ENV_EXAMPLE not found." >&2
+  exit 1
+fi
+
+# Extract the Backend-owned flags from the CLAUDE.md canonical table.
+# The table has rows of the form `| `FLAG_NAME` | Backend-Service | ... |`.
+# We extract the first cell (flag name) on rows where the second cell is
+# "Backend-Service".
+canonical_backend_flags=$(
+  awk -F'|' '
+    /^\| `[A-Z_]+`[[:space:]]*\| Backend-Service[[:space:]]*\|/ {
+      # $2 = `FLAG_NAME` — strip backticks + whitespace
+      gsub(/[` ]/, "", $2)
+      print $2
+    }
+  ' "$CLAUDE_MD" | sort -u
+)
+
+if [[ -z "$canonical_backend_flags" ]]; then
+  echo "FAIL: no Backend-Service flags found in CLAUDE.md canonical table." >&2
+  echo "      Expected rows of the form '| \`FLAG_NAME\` | Backend-Service | ... |'." >&2
+  exit 1
+fi
+
+# Extract the cross-cache-identity flags from .env.example.
+# We scope to the lines under the '### Cross-cache-identity feature flags'
+# header until the next header or EOF.
+env_example_flags=$(
+  awk '
+    /^### Cross-cache-identity feature flags/ { in_section = 1; next }
+    /^###/ && in_section { in_section = 0 }
+    in_section && /^[A-Z_]+=/ {
+      split($0, parts, "=")
+      print parts[1]
+    }
+  ' "$ENV_EXAMPLE" | sort -u
+)
+
+if [[ -z "$env_example_flags" ]]; then
+  echo "FAIL: no flags found under the '### Cross-cache-identity feature flags' header in .env.example." >&2
+  exit 1
+fi
+
+# Diff the two sets.
+canonical_only=$(comm -23 <(printf '%s\n' "$canonical_backend_flags") <(printf '%s\n' "$env_example_flags"))
+env_only=$(comm -13 <(printf '%s\n' "$canonical_backend_flags") <(printf '%s\n' "$env_example_flags"))
+
+failed=0
+
+if [[ -n "$canonical_only" ]]; then
+  echo "FAIL: flags in CLAUDE.md canonical table (Backend-Service) missing from .env.example:" >&2
+  echo "$canonical_only" | sed 's/^/  - /' >&2
+  failed=1
+fi
+
+if [[ -n "$env_only" ]]; then
+  echo "FAIL: flags in .env.example missing from CLAUDE.md canonical table:" >&2
+  echo "$env_only" | sed 's/^/  - /' >&2
+  failed=1
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "" >&2
+  echo "Both files must list the same Backend-owned cross-cache-identity flags." >&2
+  echo "Canonical inventory: CLAUDE.md → 'Cross-cache-identity feature flags (canonical inventory)'." >&2
+  exit 1
+fi
+
+count=$(printf '%s\n' "$canonical_backend_flags" | wc -l | tr -d ' ')
+echo "PASS: $count Backend-owned cross-cache-identity flag(s) consistent across CLAUDE.md and .env.example."


### PR DESCRIPTION
## Summary

Backend-Service half of E2 step 0d (1 of 3 PRs). Establishes the **single source of truth** for the cross-cache-identity feature-flag inventory in Backend's CLAUDE.md, plus a tier-1 doc-vs-doc grep-assert wired into CI. Consumer repo PRs (LML, semantic-index) follow as parts 2/3 and 3/3 and cross-reference this PR's canonical section.

## Changes

- `CLAUDE.md` — new "Cross-cache-identity feature flags (canonical inventory)" subsection under "Environment Variables". Captures the locked §4.2 inventory: all 10 flags (LML/SI per-cache + Backend global + emergency rollback), asymmetric naming-convention rationale, the §4.2 rule that cache repos do NOT use these flags (they write to both tables unconditionally), the four-state Backend phase machine, rollout-checklist locations + approval gates, and the no-automation-flips-prod-flags principle.
- `.env.example` — new "Cross-cache-identity feature flags" section with `BS_USE_LIBRARY_IDENTITY=false` and `BS_USE_LIBRARY_IDENTITY_WRITES=false`, cross-referencing the canonical CLAUDE.md section.
- `scripts/check-cross-cache-identity-flags.sh` — tier-1 grep-assert that the Backend-owned flags in the CLAUDE.md canonical table match those in `.env.example`. Tier-2 (every flag named in code matches the doc) ships with the E2-BS substrate PR; the code references don't exist yet.
- `.github/workflows/test.yml` — wires the script as a \"Cross-cache-identity flag-doc consistency\" job between the existing migration-journal validator and the build step.

## Plan vs. issue divergence (calling out for review)

The BS#667 issue body mentions `LML_INCLUDE_IDENTITY_RESPONSE`, `WXYC_LIBRARY_HOOK_VERSION`, and `BS_LIBRARY_IDENTITY_GATE_THRESHOLD` as illustrative examples, but §4.2's locked table does not list them. §4.2 also explicitly states that cache repos have no flags (they write both legacy + new tables unconditionally). The issue body's own language defers to §4.2 (\"Full list lives in §4.2\"). This PR uses §4.2 as canonical. If the three additional flags become real, they ship via a follow-up plan amendment (and the consumer repo amendments).

## Test plan

- [x] `scripts/check-cross-cache-identity-flags.sh` PASSes locally (2 Backend-owned flags consistent across CLAUDE.md and .env.example).
- [x] `npm run format:check` clean.
- [ ] Backend CI green on push.

## Followups

- [ ] LML half of BS#667 (part 2/3): `LML_USE_NEW_HOOK_*` (4 per-cache flags) + `LML_MANUAL_OVERRIDE_CHECK_DISABLED` in `library-metadata-lookup/.env.example` + repo-local grep-assert. Cross-references this PR.
- [ ] semantic-index half of BS#667 (part 3/3): `SI_USE_NEW_HOOK_*` (3 per-cache flags) in `semantic-index/.env.example` + repo-local grep-assert. Cross-references this PR.
- [ ] `cross-cache-identity-followup` issue: quarterly canonical-vs-actual diff audit (per §4.2's audit clause). Filed when this PR + parts 2-3 all merge.
- [ ] E2-BS substrate PR: extends this script with tier-2 (flag names in code match the doc). The substrate PR adds `process.env.BS_USE_LIBRARY_IDENTITY` references that this script cannot check today.

## Plan reference

`WXYC/wiki/plans/library-hook-canonicalization-plan.md` §4.2 (full feature-flag inventory + rollout checklist + Backend phase state machine).

## Related

- Issue: #667 (closes when parts 2/3 + 3/3 also land)
- Epic parent: #663 (E2 — Backend half of cross-cache-identity)
- Companion (E2 step 0b docs): #739