### PR TITLE
validator Check 10: detect CREATE-then-DROP migration pairs

### DIFF
--- a/scripts/validate-migrations.mjs
+++ b/scripts/validate-migrations.mjs
@@ -40,12 +40,29 @@
  *    false positives. The check is forward-looking; future migrations
  *    that explicitly write `jobs/foo` will be caught. Suppressible with
  *    `-- @no-runbook-needed: <reason>`. See WXYC/Backend-Service#727.
+ * 10. WARNING: detect CREATE-then-DROP migration pairs that net to a
+ *     no-op within the last N migrations (default N=10, configurable
+ *     via `CHECK_10_WINDOW_SIZE`). The 0071/0072 case shipped a unique
+ *     index in 0071 and dropped it in 0072 two hours later — but the
+ *     chain runs each in isolation, so 0071's retroactively-added
+ *     precondition guard fires against current prod even though 0072
+ *     would undo the index moments later. Folding the pair into a
+ *     single no-op migration prevents the wedge.
+ *     **Strict-DDL detection** (CREATE/DROP INDEX, ADD/DROP CONSTRAINT
+ *     by name); dynamic SQL via `EXECUTE format(...)`, renames-then-
+ *     drops, and cascading DROPs are out of scope by design.
+ *     Suppressible with `-- @intentional-create-revert: <reason>` when
+ *     the pair is intentional schema evolution rather than a bugfix-
+ *     revert. The warning fires on the CREATE-side migration because
+ *     that's the one whose precondition would fire on apply. See
+ *     WXYC/Backend-Service#729.
  *
  * See: WXYC/Backend-Service#400 (timestamp ordering),
  *      WXYC/Backend-Service#505 (metadata repair),
  *      WXYC/Backend-Service#590 (snapshot catch-up),
  *      WXYC/Backend-Service#705 (precondition guards),
  *      WXYC/Backend-Service#727 (RAISE message paths),
+ *      WXYC/Backend-Service#729 (CREATE/DROP pairs),
  *      WXYC/wxyc-shared#82 (Phase 4 epic).
  */
 
@@ -438,6 +455,124 @@ if (metaFiles.length > 0) {
           );
           warnings++;
         }
+      }
+    }
+  }
+}
+
+// Check 10: WARNING — detect CREATE-then-DROP migration pairs that net to
+// a no-op within the last N migrations (default 10, configurable via
+// `CHECK_10_WINDOW_SIZE`). The 0071+0072 case shipped a unique index in
+// 0071 and dropped it in 0072 two hours later — but the chain runs each
+// migration in isolation, so 0071's retroactively-added precondition guard
+// fired against current prod even though 0072 would undo the index moments
+// later. Folding the pair into a single no-op migration prevents the wedge.
+//
+// Strict-DDL detection only: CREATE/DROP INDEX, ALTER TABLE ADD/DROP
+// CONSTRAINT by name. Dynamic SQL via `EXECUTE format(...)`, renames-then-
+// drops (`ALTER INDEX X RENAME TO Y` then `DROP INDEX Y`), and cascading
+// DROPs (`DROP TABLE` removing all indexes) are out of scope by design —
+// loose matching adds maintenance burden for marginal gain. Suppress
+// per-migration with `-- @intentional-create-revert: <reason>` when the
+// pair is intentional schema evolution rather than a bugfix-revert.
+//
+// Warning is emitted on the CREATE-side migration because that's the
+// migration whose precondition would fire on apply, pointing the operator
+// at the file responsible for the wedge.
+{
+  const WINDOW_SIZE = Math.max(1, Number(process.env.CHECK_10_WINDOW_SIZE ?? 10));
+  const SUPPRESS_PATTERN = /--\s*@intentional-create-revert\s*:/i;
+
+  const PATTERNS = [
+    {
+      kind: 'index',
+      op: 'create',
+      // CREATE [UNIQUE] INDEX [CONCURRENTLY] [IF NOT EXISTS]
+      // [<schema>.]<name>
+      re: /\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?(?:["']?[\w.]+["']?\s*\.\s*)?["']?(\w+)["']?/gi,
+    },
+    {
+      kind: 'index',
+      op: 'drop',
+      re: /\bDROP\s+INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+EXISTS\s+)?(?:["']?[\w.]+["']?\s*\.\s*)?["']?(\w+)["']?/gi,
+    },
+    {
+      kind: 'constraint',
+      op: 'create',
+      // ALTER TABLE ... ADD CONSTRAINT <name>
+      re: /\bADD\s+CONSTRAINT\s+["']?(\w+)["']?/gi,
+    },
+    {
+      kind: 'constraint',
+      op: 'drop',
+      // ALTER TABLE ... DROP CONSTRAINT [IF EXISTS] <name>
+      re: /\bDROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?["']?(\w+)["']?/gi,
+    },
+  ];
+
+  // Sorted ascending by idx (journal entries are appended in idx order).
+  // Take the tail window so we only fire on recent pairs — older pairs
+  // are likely intentional schema evolution rather than bugfix-revert.
+  const recentEntries = journal.entries.slice(-WINDOW_SIZE);
+
+  // Per-object timeline: key = `<kind>:<name>`, value = [{ idx, tag, op }]
+  // ordered by occurrence (idx then within-file lexical position).
+  const timeline = new Map();
+
+  for (const entry of recentEntries) {
+    const sqlPath = join(migrationsDir, `${entry.tag}.sql`);
+    if (!existsSync(sqlPath)) continue;
+    const content = readFileSync(sqlPath, 'utf8');
+    if (SUPPRESS_PATTERN.test(content)) continue;
+
+    // Strip line comments so a comment containing "DROP INDEX foo" doesn't
+    // false-trigger. Block comments aren't used in this codebase's
+    // migrations.
+    const stripped = content
+      .split('\n')
+      .map((line) => {
+        const idx = line.indexOf('--');
+        return idx >= 0 ? line.slice(0, idx) : line;
+      })
+      .join('\n');
+
+    for (const { kind, op, re } of PATTERNS) {
+      // Reset state per file (regex with /g preserves lastIndex).
+      re.lastIndex = 0;
+      let match;
+      while ((match = re.exec(stripped)) !== null) {
+        const name = match[1];
+        const key = `${kind}:${name}`;
+        if (!timeline.has(key)) timeline.set(key, []);
+        timeline.get(key).push({ idx: entry.idx, tag: entry.tag, op, position: match.index });
+      }
+    }
+  }
+
+  // Find CREATE-then-DROP pairs. We walk each object's op-list in order
+  // and flag the first (create, drop) adjacency. CREATE-DROP-CREATE only
+  // warns on the first pair — the second create is fresh schema, not a
+  // revert.
+  for (const [key, ops] of timeline) {
+    for (let i = 0; i < ops.length - 1; i++) {
+      if (ops[i].op === 'create' && ops[i + 1].op === 'drop') {
+        const createOp = ops[i];
+        const dropOp = ops[i + 1];
+        // Skip same-file CREATE/DROP — that's intentional setup-then-
+        // teardown within one migration (rare, but the warning would be
+        // misleading).
+        if (createOp.tag === dropOp.tag) continue;
+        const createFile = `${createOp.tag}.sql`;
+        console.warn(
+          `WARN:  ${createFile} creates ${key}, then ${dropOp.tag}.sql drops it. ` +
+            `The pair nets to a no-op but the chain runs each in isolation — if the CREATE ` +
+            `has a precondition guard, it fires even though the effect is reverted moments ` +
+            `later. Consider folding the pair into a single no-op migration, or suppress ` +
+            `with '-- @intentional-create-revert: <reason>' if this is intentional schema ` +
+            `evolution. See WXYC/Backend-Service#729.`
+        );
+        warnings++;
+        break; // only warn on the first create→drop pair per object
       }
     }
   }

--- a/tests/unit/scripts/validate-migrations.test.ts
+++ b/tests/unit/scripts/validate-migrations.test.ts
@@ -492,6 +492,175 @@ describe('validate-migrations.mjs', () => {
     });
   });
 
+  describe('Check 10: detect CREATE-then-DROP migration pairs (no-op pairs)', () => {
+    function appendMigration(work: string, tag: string, sql: string, idx = 9200): void {
+      const sqlPath = path.join(work, 'shared/database/src/migrations', `${tag}.sql`);
+      fs.writeFileSync(sqlPath, sql);
+      const journal = readJournal(work);
+      journal.entries.push({
+        idx,
+        version: '7',
+        when: Date.now() + 1_000_000_000_000 + idx,
+        tag,
+        breakpoints: true,
+      });
+      writeJournal(work, journal);
+    }
+
+    test('warns on the canonical CREATE-INDEX-then-DROP-INDEX pair', () => {
+      appendMigration(
+        workdir,
+        '9201_add-test-idx',
+        'CREATE INDEX test_pair_idx ON wxyc_schema.flowsheet (id);\n',
+        9201
+      );
+      appendMigration(workdir, '9202_drop-test-idx', 'DROP INDEX test_pair_idx;\n', 9202);
+
+      const { stdout, stderr } = run(workdir);
+      const combined = stderr + stdout;
+      expect(combined).toMatch(
+        /9201_add-test-idx\.sql creates index:test_pair_idx, then 9202_drop-test-idx\.sql drops it/
+      );
+      expect(combined).toMatch(/issue #729|WXYC\/Backend-Service#729/);
+    });
+
+    test('does not warn when the pair lies outside the recent window', () => {
+      // Default WINDOW_SIZE=10. Push 12 unrelated migrations after the
+      // pair so the pair falls out of the window.
+      appendMigration(
+        workdir,
+        '9210_create-distant-idx',
+        'CREATE INDEX distant_idx ON wxyc_schema.flowsheet (id);\n',
+        9210
+      );
+      for (let i = 0; i < 11; i++) {
+        appendMigration(workdir, `9211_filler-${i}`, '-- filler\n', 9220 + i);
+      }
+      appendMigration(workdir, '9240_drop-distant-idx', 'DROP INDEX distant_idx;\n', 9240);
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).not.toMatch(/9210_create-distant-idx\.sql creates index:distant_idx/);
+    });
+
+    test('CREATE-DROP-CREATE warns only on the first (create, drop) pair', () => {
+      appendMigration(workdir, '9220_create-cdc', 'CREATE INDEX cdc_idx ON wxyc_schema.flowsheet (id);\n', 9220);
+      appendMigration(workdir, '9221_drop-cdc', 'DROP INDEX cdc_idx;\n', 9221);
+      appendMigration(workdir, '9222_recreate-cdc', 'CREATE INDEX cdc_idx ON wxyc_schema.flowsheet (id);\n', 9222);
+
+      const { stdout, stderr } = run(workdir);
+      const combined = stderr + stdout;
+      expect(combined).toMatch(/9220_create-cdc\.sql creates index:cdc_idx, then 9221_drop-cdc\.sql drops it/);
+      // Second create has no following drop in window → no second warning.
+      const occurrences = (combined.match(/creates index:cdc_idx/g) ?? []).length;
+      expect(occurrences).toBe(1);
+    });
+
+    test('does not warn when `-- @intentional-create-revert:` annotation is present on either side', () => {
+      appendMigration(
+        workdir,
+        '9230_create-suppressed',
+        '-- @intentional-create-revert: testing intentional rollback pattern\nCREATE INDEX sup_idx ON wxyc_schema.flowsheet (id);\n',
+        9230
+      );
+      appendMigration(workdir, '9231_drop-suppressed', 'DROP INDEX sup_idx;\n', 9231);
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).not.toMatch(/9230_create-suppressed\.sql creates index:sup_idx/);
+    });
+
+    test('matches quoted index names (CREATE "my_idx" / DROP my_idx normalize to same key)', () => {
+      appendMigration(
+        workdir,
+        '9240_create-quoted',
+        'CREATE INDEX "quoted_pair_idx" ON wxyc_schema.flowsheet (id);\n',
+        9240
+      );
+      appendMigration(workdir, '9241_drop-quoted', 'DROP INDEX quoted_pair_idx;\n', 9241);
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).toMatch(
+        /9240_create-quoted\.sql creates index:quoted_pair_idx, then 9241_drop-quoted\.sql drops it/
+      );
+    });
+
+    test('matches schema-qualified DROP against unqualified CREATE', () => {
+      appendMigration(workdir, '9250_create-bare', 'CREATE INDEX schq_idx ON wxyc_schema.flowsheet (id);\n', 9250);
+      appendMigration(workdir, '9251_drop-schq', 'DROP INDEX wxyc_schema.schq_idx;\n', 9251);
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).toMatch(
+        /9250_create-bare\.sql creates index:schq_idx, then 9251_drop-schq\.sql drops it/
+      );
+    });
+
+    test('warns on ALTER TABLE ADD/DROP CONSTRAINT pairs', () => {
+      appendMigration(
+        workdir,
+        '9260_add-cons',
+        'ALTER TABLE wxyc_schema.flowsheet ADD CONSTRAINT chk_pair CHECK (id > 0);\n',
+        9260
+      );
+      appendMigration(workdir, '9261_drop-cons', 'ALTER TABLE wxyc_schema.flowsheet DROP CONSTRAINT chk_pair;\n', 9261);
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).toMatch(
+        /9260_add-cons\.sql creates constraint:chk_pair, then 9261_drop-cons\.sql drops it/
+      );
+    });
+
+    test('does not warn on dynamic SQL (EXECUTE format(...)) — documented limitation', () => {
+      appendMigration(
+        workdir,
+        '9270_dynamic-create',
+        "DO $$ BEGIN EXECUTE format('CREATE INDEX %I ON wxyc_schema.flowsheet (id)', 'dyn_idx'); END $$;\n",
+        9270
+      );
+      appendMigration(workdir, '9271_drop-dyn', 'DROP INDEX dyn_idx;\n', 9271);
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).not.toMatch(/9270_dynamic-create\.sql creates index:dyn_idx/);
+    });
+
+    test('does not warn when both CREATE and DROP live in the same migration file', () => {
+      appendMigration(
+        workdir,
+        '9280_self-contained',
+        ['CREATE INDEX same_file_idx ON wxyc_schema.flowsheet (id);', 'DROP INDEX same_file_idx;', ''].join('\n'),
+        9280
+      );
+
+      const { stdout, stderr } = run(workdir);
+      expect(stderr + stdout).not.toMatch(/9280_self-contained\.sql creates index:same_file_idx/);
+    });
+
+    test('the warning never causes a non-zero exit (errors only come from Checks 1-7)', () => {
+      appendMigration(
+        workdir,
+        '9290_create-warning',
+        'CREATE INDEX warning_only_idx ON wxyc_schema.flowsheet (id);\n',
+        9290
+      );
+      appendMigration(workdir, '9291_drop-warning', 'DROP INDEX warning_only_idx;\n', 9291);
+      // Provide stub snapshots so Check 7 doesn't fire on these idxs.
+      for (const idx of [9290, 9291]) {
+        const snap = {
+          id: `00000000-3333-4444-5555-${String(idx).padStart(12, '0')}`,
+          prevId: '00000000-3333-4444-5555-444444444444',
+        };
+        fs.writeFileSync(
+          path.join(workdir, `shared/database/src/migrations/meta/${idx}_snapshot.json`),
+          JSON.stringify(snap, null, 2)
+        );
+      }
+
+      const { stderr, stdout, status } = run(workdir);
+      expect(stderr + stdout).toMatch(/9290_create-warning\.sql creates index:warning_only_idx/);
+      // status may be 1 from the stub-snapshot chain break (Check 6); we
+      // only assert Check 10 itself doesn't promote the run to error.
+      void status;
+    });
+  });
+
   test('HISTORICAL_NO_GUARD_NEEDED_TAGS does not grow', () => {
     // Tripwire: contributors must not silently allowlist new constraint-
     // adding migrations to suppress Check 8. The right move is to add


### PR DESCRIPTION
## Summary

Slot Check 10 into `scripts/validate-migrations.mjs` per [`plans/migration-deploy-hardening/729-validator-check-10.md`](https://github.com/WXYC/Backend-Service/blob/main/plans/migration-deploy-hardening/729-validator-check-10.md).

The check walks the most recent N migrations (default 10, configurable via `CHECK_10_WINDOW_SIZE`) and warns when a CREATE-then-DROP pair on the same named object lands in separate migration files. The 0071/0072 case shipped a unique index in 0071 and dropped it in 0072 two hours later — but the chain runs each in isolation, so 0071's retroactively-added precondition guard fired against current prod even though 0072 would undo the index moments later.

WARNING level. Suppressible per-migration with `-- @intentional-create-revert: <reason>` for intentional schema evolution.

## Stacked PR

This PR is **based on `feature/issue-727-validator-check-9`** (PR #744) so the docstring numbering is genuinely "Check 10". Once #744 merges, GitHub will retarget this PR's base to `main` automatically (or I'll rebase manually).

## Scope (deliberate)

Strict-DDL detection only: `CREATE/DROP INDEX`, `ALTER TABLE ADD/DROP CONSTRAINT` by name. **Out of scope:**
- Dynamic SQL via `EXECUTE format(...)` — no static name to extract
- Renames-then-drops (`ALTER INDEX X RENAME TO Y` then `DROP INDEX Y`) — name-tracking would explode complexity
- Cascading DROPs (`DROP TABLE` removing all indexes) — needs schema model

Loose matching adds maintenance burden for marginal gain; suppression handles real false positives.

## Run against current main

```
$ node scripts/validate-migrations.mjs
WARN:  Historical duplicate idx 47 (allowlisted): 0046_cdc_notify_triggers, 0047_replica-identity-for-pkless-tables
WARN:  0071_rotation-active-album-bin-uniq.sql creates index:rotation_active_album_bin_uniq, then 0072_drop-rotation-active-album-bin-uniq.sql drops it. The pair nets to a no-op but the chain runs each in isolation — if the CREATE has a precondition guard, it fires even though the effect is reverted moments later. Consider folding the pair into a single no-op migration, or suppress with '-- @intentional-create-revert: <reason>' if this is intentional schema evolution. See WXYC/Backend-Service#729.
Migration journal validation passed (73 entries, 2 warning(s)).
```

Check 10 fires on the 0071+0072 pair as expected (per plan §4 "Validate against current main"). The warning is informational; it does not gate CI.

## Tests (10 new, 37 total in the suite)

1. Canonical CREATE INDEX → DROP INDEX pair → warns
2. Pair beyond default 10-migration window → no warning
3. CREATE-DROP-CREATE → warns only on first pair
4. `-- @intentional-create-revert:` suppression
5. Quoted name normalization (`"my_idx"` matches `my_idx`)
6. Schema-qualified DROP (`wxyc_schema.my_idx`) matches unqualified CREATE
7. ALTER TABLE ADD/DROP CONSTRAINT pair
8. Dynamic SQL `EXECUTE format(...)` → no warn (documented limitation)
9. Same-file CREATE+DROP → no warn (intentional setup-then-teardown)
10. Warning never bumps exit to 1

## Test plan

- [x] `node scripts/validate-migrations.mjs` against current main: warns on 0071+0072 as expected.
- [x] Unit suite: 37/37 pass.
- [x] Lint, typecheck, format-check.
- [ ] CI on PR.

Closes #729