### PR TITLE
Document deploy cadence as a migration-chain risk dimension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,16 @@ GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:
 - CI/CD via GitHub Actions (manual trigger: Actions tab -> CI/CD Pipeline -> Run Workflow)
 - Docker images built with multi-stage Dockerfile (`node:25-alpine`), stored in Amazon ECR
 
+### Deploy cadence and migration-chain risk
+
+Migration-touching PRs should trigger a deploy soon after merge — ideally same-day. Long deploy gaps accumulate migration-chain risk: each new migration sits unapplied on `main`, and a failure on any one of them at deploy time wedges the whole chain.
+
+The canonical recent example is the 2026-05-04 deploy wedge ([run 25337297761](https://github.com/WXYC/Backend-Service/actions/runs/25337297761)), where 4 days of accumulated migrations (0071, 0072, 0073) compounded with a retroactive precondition guard added in commit `2710f2e`. Migration 0071's guard fired against current prod state and aborted the chain, leaving the deploy stuck. Had 0071 deployed in isolation immediately after authoring (2026-05-01), the guard wouldn't have been retrofitted yet, and the wedge wouldn't have happened.
+
+The other defenses in [Project #26 — Migration Deploy Hardening](https://github.com/orgs/WXYC/projects/26) (legible failure output, pre-flight dry-runs against prod-shaped data, validator checks for retroactive risk) reduce the cost of an individual wedge. This cadence note reduces the _likelihood_ by limiting how many migrations stack up between deploys.
+
+**Practical rule of thumb**: when a PR that touches `shared/database/src/migrations/**` merges, run Manual Build & Deploy within 24 hours. The rule is advisory — don't gate merges on cadence, since PR authors don't necessarily own deploys.
+
 ## Database Replication (Local Sync)
 
 PostgreSQL logical replication keeps a local database clone in sync with production RDS in real time. Changes stream continuously with guaranteed delivery — the replication slot retains WAL even if the subscriber is offline.


### PR DESCRIPTION
## Summary

Pure docs change to `Backend-Service/CLAUDE.md`. Adds a "Deploy cadence and migration-chain risk" subsection under Deployment per [`plans/migration-deploy-hardening/730-deploy-cadence-doc.md`](https://github.com/WXYC/Backend-Service/blob/main/plans/migration-deploy-hardening/730-deploy-cadence-doc.md).

Frequent deploys reduce the surface area for any single migration's failure to compound with others. The 2026-05-04 wedge was amplified by 4 days of accumulated migrations (0071+0072+0073) plus a retroactive precondition guard added in commit `2710f2e`. Same-day deploys for migration-touching PRs would have surfaced 0071 in isolation before the guard was retrofitted.

Advisory only — don't gate merges on cadence (PR authors don't necessarily own deploys). The structural defenses in Project #26 (#725, #726, #727, #729) do the heavy lifting; this note reduces likelihood, the others reduce cost-per-incident.

The optional `scripts/migrate-cadence-breadcrumb.mjs` from the plan is **deferred** — no operational appetite for the signal yet, and the docs change is the minimum viable.

## Test plan

- [x] Markdown renders correctly locally.
- [x] Both links resolve (project #26, run 25337297761).
- [x] Prettier passes.

Closes #730