### PR TITLE
ci: pre-flight migrate-dryrun against prod-shaped data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
       tests: ${{ steps.changes.outputs.tests }}
       src: ${{ steps.changes.outputs.src }}
       run-integration: ${{ steps.should-run.outputs.run-integration }}
+      db-init: ${{ steps.changes.outputs.db-init }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -364,3 +365,100 @@ jobs:
           name: integration-test-coverage
           path: coverage/
           retention-days: 14
+
+  # Pre-flight migrate-dryrun: restores the most recent automated RDS
+  # snapshot to a sandbox DB instance and runs `node scripts/dryrun-migrate.mjs`
+  # against it. Catches preconditions that depend on prod data shape (e.g.
+  # the `RAISE EXCEPTION` guards added per WXYC/Backend-Service#705) at
+  # PR-review time rather than at deploy time. See WXYC/Backend-Service#726.
+  #
+  # Requires repo-level secrets (one-time ops setup):
+  #   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION — already present
+  #     for the deploy workflow; needs additional rds:* permissions.
+  #   PROD_DB_ID — RDS instance identifier of the prod DB.
+  #   PROD_DB_NAME, PROD_DB_USERNAME, PROD_DB_PASSWORD — match the source
+  #     instance's master credentials (snapshots restore with the source's
+  #     master user).
+  #   SG_DRYRUN_GHA — security group id allowing port 5432 from GitHub
+  #     Actions egress IPs only. See plan #726 §4 for provisioning.
+  migrate-dryrun:
+    name: Migration Dry-Run (prod-shaped data)
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.db-init == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '25'
+          cache: 'npm'
+
+      - name: Install minimal deps for dryrun script
+        # postgres + drizzle-orm are the only runtime imports the script
+        # needs. Install them directly at the repo root rather than running
+        # the full `npm install` (which would build all workspaces). The
+        # script imports `../dev_env/format-pg-error.mjs` by relative path,
+        # so it doesn't need anything inside dev_env to be npm-installed.
+        run: npm install --no-save --no-package-lock --no-audit --no-fund postgres drizzle-orm
+
+      - name: Configure AWS credentials
+        # Long-lived AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY pattern
+        # already used by .github/workflows/deploy-base.yml (lines 246, 254,
+        # 265, 329, 337, 363, 454). Migrating to OIDC is a separate concern.
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Restore latest prod snapshot to ephemeral sandbox
+        id: restore
+        # Publicly accessible because GitHub-hosted runners have no VPC
+        # connectivity to the prod VPC. Ingress is gated by SG_DRYRUN_GHA,
+        # which allows port 5432 from GitHub's documented egress IP ranges
+        # only. The sandbox is torn down in the always-run step below.
+        run: |
+          set -euo pipefail
+          SNAPSHOT_ID=$(aws rds describe-db-snapshots \
+            --db-instance-identifier "${{ secrets.PROD_DB_ID }}" \
+            --snapshot-type automated \
+            --query 'sort_by(DBSnapshots, &SnapshotCreateTime)[-1].DBSnapshotIdentifier' \
+            --output text)
+          SANDBOX_ID="dryrun-${{ github.run_id }}"
+          echo "SANDBOX_ID=$SANDBOX_ID" >> "$GITHUB_ENV"
+          aws rds restore-db-instance-from-db-snapshot \
+            --db-instance-identifier "$SANDBOX_ID" \
+            --db-snapshot-identifier "$SNAPSHOT_ID" \
+            --db-instance-class db.t4g.micro \
+            --publicly-accessible \
+            --vpc-security-group-ids "${{ secrets.SG_DRYRUN_GHA }}"
+          aws rds wait db-instance-available --db-instance-identifier "$SANDBOX_ID"
+          ENDPOINT=$(aws rds describe-db-instances \
+            --db-instance-identifier "$SANDBOX_ID" \
+            --query 'DBInstances[0].Endpoint.Address' --output text)
+          echo "DB_HOST=$ENDPOINT" >> "$GITHUB_ENV"
+
+      - name: Run drizzle:migrate against sandbox
+        env:
+          DB_HOST: ${{ env.DB_HOST }}
+          DB_PORT: '5432'
+          DB_NAME: ${{ secrets.PROD_DB_NAME }}
+          DB_USERNAME: ${{ secrets.PROD_DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.PROD_DB_PASSWORD }}
+        run: node scripts/dryrun-migrate.mjs
+
+      - name: Tear down sandbox
+        # The guard on SANDBOX_ID handles the case where restore failed
+        # before the env var was written; without it, delete-db-instance
+        # would error and obscure the actual failure.
+        if: always()
+        run: |
+          if [ -n "${SANDBOX_ID:-}" ]; then
+            aws rds delete-db-instance \
+              --db-instance-identifier "$SANDBOX_ID" \
+              --skip-final-snapshot \
+              --delete-automated-backups
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,7 @@ GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:
 2. **lint-and-typecheck** -- `typecheck` + `lint` + `format:check` + `build`
 3. **unit-tests** -- Runs affected tests only (`--changedSince=origin/<base>` on PRs)
 4. **integration-tests** -- Only if apps/jobs/shared/tests change. Docker images cached by commit SHA in ECR.
+5. **migrate-dryrun** -- Only when `db-init` paths change (migrations, schema, `init-db.mjs`, etc.). Restores the most recent automated RDS snapshot to a sandbox DB instance, runs `node scripts/dryrun-migrate.mjs` against it, asserts exit 0, tears the sandbox down. Catches preconditions that depend on prod data shape (e.g. the `RAISE EXCEPTION` guards added per WXYC/Backend-Service#705) at PR-review time rather than at deploy time. The script reuses `dev_env/format-pg-error.mjs` (#725) so the underlying Postgres error fields surface in the CI log on failure. To re-test against a fresher snapshot, trigger an on-demand snapshot via the AWS RDS console and rerun the workflow. Provisioning prerequisites (ops, one-time): IAM policy attached to the existing `AWS_ACCESS_KEY_ID` user with `rds:DescribeDBSnapshots`, `rds:DescribeDBInstances`, `rds:RestoreDBInstanceFromDBSnapshot`, `rds:DeleteDBInstance`, `rds:AddTagsToResource`; security group `SG_DRYRUN_GHA` allowing port 5432 from GitHub Actions egress IPs only; repo secrets `PROD_DB_ID`, `PROD_DB_NAME`, `PROD_DB_USERNAME`, `PROD_DB_PASSWORD`, `SG_DRYRUN_GHA`. See WXYC/Backend-Service#726.
 
 ## Deployment
 

--- a/scripts/dryrun-migrate.mjs
+++ b/scripts/dryrun-migrate.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/**
+ * Pre-flight migration dry-run for the migrate-dryrun CI job (#726).
+ *
+ * Runs drizzle-orm's programmatic migrate() against whatever DB the env
+ * vars point at, then exits 0 on success or 1 on failure. On failure, the
+ * shared formatPgError helper from #725 dumps the underlying Postgres
+ * error fields (severity, code, where, etc.) to stderr so a reviewer can
+ * act on the failure without rerunning anything.
+ *
+ * Why this is a separate script and not `node dev_env/init-db.mjs`:
+ * init-db.mjs runs extension installation, journal verification, and
+ * optional seeding. All of those are benign against a snapshot, but each
+ * is a chance for a non-migration failure to mask the signal we care
+ * about. A purpose-built script keeps the failure surface narrow — if the
+ * dry-run exits non-zero, the migration itself is the cause.
+ *
+ * The snapshot already has all extensions installed, so installExtensions
+ * is unnecessary. Verify-journal still runs on the deploy path via
+ * init-db.mjs; not duplicating it here. Seeding wouldn't fire anyway
+ * because the snapshot has data.
+ */
+
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { formatPgError } from '../dev_env/format-pg-error.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const sql = postgres({
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT ?? 5432),
+  database: process.env.DB_NAME,
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  max: 1,
+  // Suppress NOTICE noise on the success path; on failure, formatPgError
+  // surfaces the diagnostic fields anyway.
+  onnotice: () => {},
+});
+
+try {
+  const db = drizzle(sql);
+  await migrate(db, {
+    migrationsFolder: join(__dirname, '../shared/database/src/migrations'),
+  });
+  console.log('dryrun-migrate: ok');
+} catch (error) {
+  process.stderr.write('\n');
+  process.stderr.write(formatPgError(error));
+  process.exitCode = 1;
+} finally {
+  await sql.end();
+}


### PR DESCRIPTION
## Summary

Add a `migrate-dryrun` job to the PR CI workflow per [`plans/migration-deploy-hardening/726-preflight-dryrun.md`](https://github.com/WXYC/Backend-Service/blob/main/plans/migration-deploy-hardening/726-preflight-dryrun.md).

When a PR touches migration / db-init paths, the job restores the most recent automated RDS snapshot to a sandbox DB instance (db.t4g.micro), runs `node scripts/dryrun-migrate.mjs` against it, and tears the sandbox down. Catches preconditions that depend on prod data shape (e.g. the `RAISE EXCEPTION` guards added per #705) at PR-review time rather than at deploy time. Migration 0071 — the prompting case for project #26 — would have failed the dry-run on 2026-05-01 and not made it into production wedged.

## Stacked PR

This PR is **based on `feature/issue-725-surface-migrate-errors`** (PR #736) so it can import `formatPgError` from `dev_env/format-pg-error.mjs`. Once #736 merges, GitHub will retarget this PR's base to `main` automatically (or I'll rebase manually).

## Why a separate `dryrun-migrate.mjs` and not `node dev_env/init-db.mjs`?

`init-db.mjs` runs extension install, journal verification, and optional seeding. All benign against a snapshot, but each is a chance for a non-migration failure to mask the signal we care about. The purpose-built script keeps the failure surface narrow: a non-zero exit means "the migration failed", not "init-db.mjs's seed step misfired against a snapshot". On failure it reuses `formatPgError` from #725, so the underlying Postgres ERROR fields surface in the CI log.

## Ops prerequisites (one-time)

Until these are provisioned, the job will fail-closed (and other CI checks remain unblocked since `migrate-dryrun` only triggers on `db-init` path changes):

1. **IAM policy** on the existing `AWS_ACCESS_KEY_ID` user — add: `rds:DescribeDBSnapshots`, `rds:DescribeDBInstances`, `rds:RestoreDBInstanceFromDBSnapshot`, `rds:DeleteDBInstance`, `rds:AddTagsToResource`.
2. **Security group `SG_DRYRUN_GHA`** in the same VPC as prod RDS, allowing port 5432 from GitHub Actions egress IPs only ([api.github.com/meta](https://api.github.com/meta), `actions` array). Provisioning commands in plan §4.
3. **Repo secrets**: `PROD_DB_ID`, `PROD_DB_NAME`, `PROD_DB_USERNAME`, `PROD_DB_PASSWORD`, `SG_DRYRUN_GHA`.

The `test.yml` docstring and the CLAUDE.md update enumerate these.

## Cost & timing

- Each migration-touching PR spins up + tears down one db.t4g.micro RDS instance.
- ~$0.02/hour × ~5 min wall-clock = ~$0.002 per run; ≪ $5/mo at any plausible PR volume.
- Restore + migrate: 1-2 min for a small DB. Runs in parallel to other CI jobs (`needs: [detect-changes]`), doesn't extend the critical path.

## Test plan

- [x] Workflow YAML parses (Python yaml.safe_load).
- [x] Script syntax-checks (node --check) and imports resolve (drizzle-orm, postgres, formatPgError).
- [x] Format check + lint pass.
- [ ] First CI run after ops prereqs land — the dry-run should restore + migrate cleanly. Failures get the visible PG error block via formatPgError.
- [ ] Self-test against the historical wedge (per plan §6 — re-run at \`2710f2e..main\` to verify the dry-run reproduces 0071's guard).

Closes #726