### PR TITLE
auth: allow 2-character usernames

### DIFF
--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -115,7 +115,7 @@ export const auth = betterAuth({
 
   plugins: [
     admin(),
-    username(),
+    username({ minUsernameLength: 2 }),
     anonymous({
       emailDomainName: 'anonymous.wxyc.org',
     }),


### PR DESCRIPTION
## Summary

- Configure the better-auth `username()` plugin with `minUsernameLength: 2` (default was 3).
- Lets users with 2-char usernames (e.g. `bb`) sign in. Default `usernameValidator` still applies.

## Test plan

- [x] `npm run typecheck` (passes locally)
- [x] `npm run lint` (no errors; existing warnings only)
- [x] `npm run format:check` (clean)
- [ ] Post-deploy: confirm a 2-char username can sign in against prod auth.

## Deploy

Auth service redeploy required.

Closes #749