### PR TITLE
library-etl: upsert on legacy_release_id conflict

### DIFF
--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -839,6 +839,43 @@ const findExistingRelease = async (
   return response.length > 0 ? response[0] : null;
 };
 
+/**
+ * Columns the library-etl is the source of truth for — i.e. the columns it
+ * writes during INSERT and refreshes from `excluded.*` on a legacy_release_id
+ * conflict. Pinned by a unit test so PG-only / LML-resolved columns (`id`,
+ * `plays`, `label`, `label_id`, `artwork_url`, `canonical_entity_*`,
+ * `search_doc`) can't drift into the SET list and clobber human-curated or
+ * downstream-resolved fields. `legacy_release_id` is the conflict key itself
+ * and is intentionally excluded from the SET list.
+ */
+export const LEGACY_SOURCED_LIBRARY_COLUMNS = [
+  'artist_id',
+  'artist_name',
+  'genre_id',
+  'format_id',
+  'alternate_artist_name',
+  'album_artist',
+  'album_title',
+  'code_number',
+  'code_volume_letters',
+  'disc_quantity',
+  'add_date',
+  'last_modified',
+  'date_lost',
+  'date_found',
+  'on_streaming',
+] as const;
+
+type LegacySourcedColumn = (typeof LEGACY_SOURCED_LIBRARY_COLUMNS)[number];
+
+const buildLegacySourcedSetMap = (): Record<LegacySourcedColumn, ReturnType<typeof sql>> => {
+  const map = {} as Record<LegacySourcedColumn, ReturnType<typeof sql>>;
+  for (const column of LEGACY_SOURCED_LIBRARY_COLUMNS) {
+    map[column] = sql.raw(`excluded."${column}"`);
+  }
+  return map;
+};
+
 const run = async () => {
   try {
     const runStartedAt = new Date();
@@ -852,6 +889,7 @@ const run = async () => {
     }
 
     let insertedCount = 0;
+    let updatedFromLegacyConflictCount = 0;
     let skippedCount = 0;
 
     await db.transaction(async (tx) => {
@@ -976,21 +1014,36 @@ const run = async () => {
           continue;
         }
 
+        // Pre-flight by legacy_release_id so we can split the inserted vs
+        // conflict-updated counters in the final log line. The row landed in
+        // findExistingRelease's null branch, so the only way the upsert below
+        // hits the UPDATE path is via the unique index on legacy_release_id —
+        // i.e. an upstream edit since the last sync changed the canonical
+        // tuple while preserving the legacy id. Knowing which case fired is
+        // operationally useful (a sustained non-zero conflict count signals
+        // upstream churn worth investigating).
+        const conflictRows = await tx
+          .select({ id: library.id })
+          .from(library)
+          .where(eq(library.legacy_release_id, release.release_id))
+          .limit(1);
+        const willConflictOnLegacyId = conflictRows.length > 0;
+
         // Denormalize the canonical `artists.artist_name` onto `library.artist_name`
         // so the column the tsvector / trigram catalog search reads against
         // (`library.artist_name`) is populated at insert time. Omitting it lets
         // the row land NULL — invisible to search, and (pre-fix) tripping the
         // 503-on-any-NULL precondition in library-artist-name-assertion.service.
         //
-        // ON CONFLICT (legacy_release_id) DO UPDATE handles the case where the
-        // canonical-tuple lookup above missed (e.g. the legacy row's artist /
-        // code-letters / album-title was edited upstream since the last sync,
-        // so the tuple no longer matches the existing PG row) but a row with
-        // this `legacy_release_id` already exists. Without it, the INSERT
-        // violates `library_legacy_release_id_idx` and aborts the whole run on
-        // first conflict (see #752). The SET list mirrors the VALUES list:
-        // every column the ETL is the source of truth for gets refreshed,
-        // while PG-only columns (id, artwork_url, created_at) stay untouched.
+        // ON CONFLICT (legacy_release_id) DO UPDATE handles the case the
+        // pre-flight above identified: the canonical-tuple lookup missed but
+        // a row already exists with this legacy_release_id. Without it, the
+        // INSERT violates `library_legacy_release_id_idx` and aborts the
+        // whole run on first conflict (#752). The SET list is built from
+        // LEGACY_SOURCED_LIBRARY_COLUMNS, which is also exported and pinned
+        // by a unit test — so PG-only / LML-resolved columns (id, plays,
+        // label, label_id, artwork_url, canonical_entity_*, search_doc)
+        // can't drift into the SET list by accident.
         await tx
           .insert(library)
           .values({
@@ -1013,26 +1066,14 @@ const run = async () => {
           })
           .onConflictDoUpdate({
             target: library.legacy_release_id,
-            set: {
-              artist_id: sql`excluded.artist_id`,
-              artist_name: sql`excluded.artist_name`,
-              genre_id: sql`excluded.genre_id`,
-              format_id: sql`excluded.format_id`,
-              alternate_artist_name: sql`excluded.alternate_artist_name`,
-              album_artist: sql`excluded.album_artist`,
-              album_title: sql`excluded.album_title`,
-              code_number: sql`excluded.code_number`,
-              code_volume_letters: sql`excluded.code_volume_letters`,
-              disc_quantity: sql`excluded.disc_quantity`,
-              add_date: sql`excluded.add_date`,
-              last_modified: sql`excluded.last_modified`,
-              date_lost: sql`excluded.date_lost`,
-              date_found: sql`excluded.date_found`,
-              on_streaming: sql`excluded.on_streaming`,
-            },
+            set: buildLegacySourcedSetMap(),
           });
 
-        insertedCount += 1;
+        if (willConflictOnLegacyId) {
+          updatedFromLegacyConflictCount += 1;
+        } else {
+          insertedCount += 1;
+        }
       }
 
       // --- Cross-reference imports ---
@@ -1088,7 +1129,9 @@ const run = async () => {
       await updateLastRun(tx, JOB_NAME, runStartedAt);
     });
 
-    console.log(`[library-etl] Completed. Inserted ${insertedCount}, skipped ${skippedCount}.`);
+    console.log(
+      `[library-etl] Completed. Inserted ${insertedCount}, updated via legacy-id conflict ${updatedFromLegacyConflictCount}, skipped ${skippedCount}.`
+    );
   } finally {
     await closeDatabaseConnection();
     legacyDB.close();
@@ -1113,6 +1156,7 @@ export {
   parseReleaseRows,
   buildArtistCacheKey,
   buildAlbumCacheKey,
+  buildLegacySourcedSetMap,
 };
 
 run().catch((error) => {

--- a/jobs/library-etl/job.ts
+++ b/jobs/library-etl/job.ts
@@ -981,24 +981,56 @@ const run = async () => {
         // (`library.artist_name`) is populated at insert time. Omitting it lets
         // the row land NULL — invisible to search, and (pre-fix) tripping the
         // 503-on-any-NULL precondition in library-artist-name-assertion.service.
-        await tx.insert(library).values({
-          artist_id: artistId,
-          artist_name: canonicalArtistName,
-          genre_id: genreId,
-          format_id: formatId,
-          alternate_artist_name: release.release_alternate_artist_name,
-          album_artist: release.release_album_artist,
-          album_title: albumTitle,
-          code_number: release.release_call_numbers ?? 0,
-          code_volume_letters: codeVolumeLetters,
-          disc_quantity: formatParsed.discQuantity,
-          legacy_release_id: release.release_id,
-          add_date: toDateOrUndefined(release.release_time_created),
-          last_modified: toDateOrUndefined(release.release_last_modified),
-          date_lost: toDateOrUndefined(release.date_lost),
-          date_found: toDateOrUndefined(release.date_found),
-          on_streaming: release.release_on_streaming,
-        });
+        //
+        // ON CONFLICT (legacy_release_id) DO UPDATE handles the case where the
+        // canonical-tuple lookup above missed (e.g. the legacy row's artist /
+        // code-letters / album-title was edited upstream since the last sync,
+        // so the tuple no longer matches the existing PG row) but a row with
+        // this `legacy_release_id` already exists. Without it, the INSERT
+        // violates `library_legacy_release_id_idx` and aborts the whole run on
+        // first conflict (see #752). The SET list mirrors the VALUES list:
+        // every column the ETL is the source of truth for gets refreshed,
+        // while PG-only columns (id, artwork_url, created_at) stay untouched.
+        await tx
+          .insert(library)
+          .values({
+            artist_id: artistId,
+            artist_name: canonicalArtistName,
+            genre_id: genreId,
+            format_id: formatId,
+            alternate_artist_name: release.release_alternate_artist_name,
+            album_artist: release.release_album_artist,
+            album_title: albumTitle,
+            code_number: release.release_call_numbers ?? 0,
+            code_volume_letters: codeVolumeLetters,
+            disc_quantity: formatParsed.discQuantity,
+            legacy_release_id: release.release_id,
+            add_date: toDateOrUndefined(release.release_time_created),
+            last_modified: toDateOrUndefined(release.release_last_modified),
+            date_lost: toDateOrUndefined(release.date_lost),
+            date_found: toDateOrUndefined(release.date_found),
+            on_streaming: release.release_on_streaming,
+          })
+          .onConflictDoUpdate({
+            target: library.legacy_release_id,
+            set: {
+              artist_id: sql`excluded.artist_id`,
+              artist_name: sql`excluded.artist_name`,
+              genre_id: sql`excluded.genre_id`,
+              format_id: sql`excluded.format_id`,
+              alternate_artist_name: sql`excluded.alternate_artist_name`,
+              album_artist: sql`excluded.album_artist`,
+              album_title: sql`excluded.album_title`,
+              code_number: sql`excluded.code_number`,
+              code_volume_letters: sql`excluded.code_volume_letters`,
+              disc_quantity: sql`excluded.disc_quantity`,
+              add_date: sql`excluded.add_date`,
+              last_modified: sql`excluded.last_modified`,
+              date_lost: sql`excluded.date_lost`,
+              date_found: sql`excluded.date_found`,
+              on_streaming: sql`excluded.on_streaming`,
+            },
+          });
 
         insertedCount += 1;
       }

--- a/tests/unit/jobs/library-etl.test.ts
+++ b/tests/unit/jobs/library-etl.test.ts
@@ -64,12 +64,16 @@ jest.mock('@wxyc/database', () => {
   };
 });
 
-jest.mock('drizzle-orm', () => ({
-  eq: jest.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
-  and: jest.fn((...args: unknown[]) => ({ and: args })),
-  isNull: jest.fn((col: unknown) => ({ isNull: col })),
-  sql: jest.fn(),
-}));
+jest.mock('drizzle-orm', () => {
+  const sqlFn: jest.Mock & { raw?: jest.Mock } = jest.fn();
+  sqlFn.raw = jest.fn((fragment: string) => ({ raw: fragment }));
+  return {
+    eq: jest.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
+    and: jest.fn((...args: unknown[]) => ({ and: args })),
+    isNull: jest.fn((col: unknown) => ({ isNull: col })),
+    sql: sqlFn,
+  };
+});
 
 import {
   parseTabRow,
@@ -87,6 +91,7 @@ import {
   parseLegacyCompilationTrackRows,
   parseReleaseRows,
   buildArtistCacheKey,
+  buildLegacySourcedSetMap,
   buildAlbumCacheKey,
 } from '../../../jobs/library-etl/job';
 
@@ -548,6 +553,71 @@ describe('library-etl job helpers', () => {
 
     it('returns empty array for empty input', () => {
       expect(parseReleaseRows('', 17)).toEqual([]);
+    });
+  });
+
+  // The SET map keys are the contract for what the legacy_release_id ON CONFLICT
+  // path is allowed to overwrite. Pinning the keys prevents accidental drift —
+  // e.g. somebody adds artwork_url or canonical_entity_id to the upsert and
+  // clobbers LML-resolved data on every legacy edit. Acceptance criterion from
+  // #752: "the SET list updates only the columns the ETL is the source of
+  // truth for (don't clobber human-curated fields)."
+  describe('buildLegacySourcedSetMap', () => {
+    const expectedKeys = [
+      'artist_id',
+      'artist_name',
+      'genre_id',
+      'format_id',
+      'alternate_artist_name',
+      'album_artist',
+      'album_title',
+      'code_number',
+      'code_volume_letters',
+      'disc_quantity',
+      'add_date',
+      'last_modified',
+      'date_lost',
+      'date_found',
+      'on_streaming',
+    ].sort();
+
+    it('includes every legacy-sourced library column', () => {
+      const map = buildLegacySourcedSetMap();
+      expect(Object.keys(map).sort()).toEqual(expectedKeys);
+    });
+
+    it('excludes the conflict key itself and all PG-only / LML-resolved columns', () => {
+      const map = buildLegacySourcedSetMap();
+      // legacy_release_id is the conflict key — there's no point updating it
+      // to itself, and including it would shadow the partial-index uniqueness
+      // semantics in confusing ways.
+      expect(map).not.toHaveProperty('legacy_release_id');
+      // DB-managed surrogate / counters.
+      expect(map).not.toHaveProperty('id');
+      expect(map).not.toHaveProperty('plays');
+      // Human-curated / staff-assigned (label resolution is a separate path).
+      expect(map).not.toHaveProperty('label');
+      expect(map).not.toHaveProperty('label_id');
+      // LML-resolved (Epic B). The library-etl run must not stomp these on a
+      // legacy edit, since LML's resolution is independent of the legacy tuple.
+      expect(map).not.toHaveProperty('artwork_url');
+      expect(map).not.toHaveProperty('canonical_entity_id');
+      expect(map).not.toHaveProperty('canonical_entity_confidence');
+      expect(map).not.toHaveProperty('canonical_entity_resolved_at');
+      // Generated column.
+      expect(map).not.toHaveProperty('search_doc');
+    });
+
+    it('produces excluded.<column> SQL fragments for each key', () => {
+      const map = buildLegacySourcedSetMap();
+      // The mocked sql.raw returns { raw: <fragment> }, so we can read the
+      // fragment back out and assert it references the matching excluded
+      // column. This guards against e.g. all keys mapping to the same fragment
+      // by mistake (a refactor accidentally reusing one variable).
+      for (const key of expectedKeys) {
+        const fragment = (map as Record<string, { raw?: string }>)[key];
+        expect(fragment.raw).toBe(`excluded."${key}"`);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

`library-etl-cron` was failing on EC2 with:

```
duplicate key value violates unique constraint "library_legacy_release_id_idx"
DETAIL: Key (legacy_release_id)=(52314) already exists.
```

The INSERT into `library` blew up whenever `findExistingRelease` (the canonical-tuple lookup on `artist_id, genre_id, album_title, code_number, code_volume_letters`) missed but a row with the same `legacy_release_id` already lived in PG. That happens whenever an upstream tubafrenzy edit changes one of the tuple columns between syncs — the lookup no longer matches, the INSERT fires for what is logically the same release, and the unique index aborts the run on the first conflicting row. Releases queued behind it don't get applied either.

## Change

Add `ON CONFLICT (legacy_release_id) DO UPDATE` so the conflict turns into an in-place update of the legacy-sourced columns. Two follow-ups on top of the minimal fix:

- **Split counters.** A single `insertedCount` would lie whenever the conflict path fired (it'd tick up on UPDATEs too). Pre-flight by `legacy_release_id` to determine which path the upsert will take, then split into `insertedCount` and `updatedFromLegacyConflictCount`. The completion log now reads `Inserted N, updated via legacy-id conflict K, skipped M`. A sustained non-zero conflict count is also a useful signal — upstream churn worth investigating.
- **Pin the SET keys.** Extract `LEGACY_SOURCED_LIBRARY_COLUMNS` and `buildLegacySourcedSetMap()`, then add a unit test that asserts (a) the SET map covers exactly the legacy-sourced columns, (b) `id`, `plays`, `label`, `label_id`, `artwork_url`, `canonical_entity_*`, `search_doc` are absent, and (c) each fragment is `excluded."<column>"`. If somebody later adds `artwork_url` to the upsert, the test fails before LML-resolved data gets clobbered on the next legacy edit.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run test:unit` — 131/131 suites, 1700/1700 tests pass (3 new pin tests).
- [x] `npm run format:check` — clean.
- [x] `npm run lint` — 0 errors.
- [ ] Once deployed, manual verification: re-run library-etl twice in a row against a dataset containing `legacy_release_id=52314`; expect both runs to complete without unique-violation, and the row to reflect the latest legacy values.

Closes #752