### PR TITLE
deploy: prune stale db-migrate images on EC2 after migrate

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -377,8 +377,17 @@ jobs:
             echo "Running database migrations..."
             docker run --rm --env-file .env -e SKIP_SEED=true $IMAGE_URI
 
-            echo "Cleaning up migration image..."
-            docker rmi $IMAGE_URI || true
+            # Prune stale db-migrate images on the host. We keep the just-applied
+            # SHA tag for one cycle of rollback safety and remove everything else
+            # under the db-migrate repository, including stragglers left by prior
+            # failed deploys (migrate-step failures skip this block under set -e).
+            # The dangling-layer prune mops up any "<none>" artifacts from
+            # interrupted pulls. Failures here don't fail the deploy.
+            echo "Pruning stale db-migrate images (keeping $SHA_TAG)..."
+            docker images "$AWS_ECR_URI/db-migrate" --format '{{.Repository}}:{{.Tag}}' \
+              | grep -v ":$SHA_TAG\$" \
+              | xargs -r docker rmi -f 2>/dev/null || true
+            docker image prune -f 2>/dev/null || true
 
   deploy:
     needs: [setup, handle-git-tags, build, migrate]


### PR DESCRIPTION
## Summary

Replaces the single-image `docker rmi` cleanup in the migrate step with a sweep over every `db-migrate` image on the EC2 host, keeping only the SHA tag the current run just applied. Mops up dangling layers afterwards with `docker image prune -f`.

This catches the stragglers left behind by failed deploys — which is what filled the root partition to 100% on 2026-05-06 (~25 stale `db-migrate:sha-*` builds at 572–573 MB each, ~14 GB total). With this change, every successful migrate also cleans up whatever predecessors didn't.

## Behavior

- Sweep runs inside the existing `set -e` script **after** the migration succeeds. If the migration itself fails, the failing image is preserved for diagnosis.
- The just-applied SHA tag is retained for one cycle of rollback safety.
- Other repositories on the host (`backend`, `auth`, `semantic-index`, `wikijs`, the cron jobs) are unaffected — the prune is scoped via `docker images "$AWS_ECR_URI/db-migrate"`.
- Images backing running containers are protected by Docker itself; `docker rmi -f` against a tag still won't delete the underlying image while a container references it (db-migrate isn't long-running, so this is mostly a non-issue here).
- Cleanup failures are swallowed with `|| true` and never fail the deploy.

## Test plan

- [ ] Manual smoke: trigger Auto Build & Deploy, watch the migrate step's logs to confirm the prune block runs and `db-migrate` image count on EC2 drops to 1 (`docker images db-migrate | wc -l`).
- [ ] Verify the running `backend`, `auth`, `semantic-index`, and `wikijs` images are still present post-deploy.
- [ ] Trigger a second deploy to confirm steady state: `docker images db-migrate | wc -l` stays at 1.

Closes #751