### PR TITLE
ci: JIT-authorize runner IP on SG_DRYRUN_GHA per dryrun run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -374,13 +374,18 @@ jobs:
   #
   # Requires repo-level secrets (one-time ops setup):
   #   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION — already present
-  #     for the deploy workflow; needs additional rds:* permissions.
+  #     for the deploy workflow; needs additional rds:* permissions plus
+  #     ec2:AuthorizeSecurityGroupIngress / ec2:RevokeSecurityGroupIngress
+  #     on SGs tagged Purpose=migrate-dryrun (#757).
   #   PROD_DB_ID — RDS instance identifier of the prod DB.
   #   PROD_DB_NAME, PROD_DB_USERNAME, PROD_DB_PASSWORD — match the source
   #     instance's master credentials (snapshots restore with the source's
   #     master user).
-  #   SG_DRYRUN_GHA — security group id allowing port 5432 from GitHub
-  #     Actions egress IPs only. See plan #726 §4 for provisioning.
+  #   SG_DRYRUN_GHA — security group id. Created tagged Purpose=migrate-dryrun
+  #     by scripts/provision-dryrun-aws.mjs. The job authorizes its
+  #     runner's /32 just-in-time and revokes it in always() teardown,
+  #     so the SG carries no persistent ingress rules between runs.
+  #     See WXYC/Backend-Service#726 (preflight) and #757 (JIT ingress).
   migrate-dryrun:
     name: Migration Dry-Run (prod-shaped data)
     needs: [detect-changes]
@@ -419,12 +424,42 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
+      - name: Authorize runner IP on SG_DRYRUN_GHA
+        # GitHub Actions runners pull from a pool of ~3000 egress CIDRs that
+        # rotate monthly (api.github.com/meta `.actions`). The default AWS
+        # SG rule limit is 60, so bulk-authorizing the entire pool is not
+        # an option. Instead, authorize just this run's runner IP /32 here
+        # and revoke it in the always() teardown step below. Net result:
+        # SG carries one transient rule per concurrent run; quota usage is
+        # bounded by run concurrency (db-init paths change rarely, so this
+        # stays well under 60 in practice).
+        run: |
+          set -euo pipefail
+          RUNNER_IP=$(curl -sS --max-time 10 https://checkip.amazonaws.com | tr -d '[:space:]')
+          if [[ ! "$RUNNER_IP" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "checkip.amazonaws.com returned unexpected payload: ${RUNNER_IP}" >&2
+            exit 1
+          fi
+          echo "RUNNER_IP=${RUNNER_IP}" >> "$GITHUB_ENV"
+          # Tolerate InvalidPermission.Duplicate so a re-run that hits the
+          # same runner is a no-op rather than a hard failure.
+          aws ec2 authorize-security-group-ingress \
+            --group-id "${{ secrets.SG_DRYRUN_GHA }}" \
+            --protocol tcp --port 5432 \
+            --cidr "${RUNNER_IP}/32" \
+            2> >(grep -v 'InvalidPermission.Duplicate' >&2) \
+            || aws ec2 describe-security-groups \
+              --group-ids "${{ secrets.SG_DRYRUN_GHA }}" \
+              --query "SecurityGroups[0].IpPermissions[?FromPort==\`5432\`].IpRanges[?CidrIp=='${RUNNER_IP}/32']" \
+              --output text | grep -q "${RUNNER_IP}"
+
       - name: Restore latest prod snapshot to ephemeral sandbox
         id: restore
         # Publicly accessible because GitHub-hosted runners have no VPC
-        # connectivity to the prod VPC. Ingress is gated by SG_DRYRUN_GHA,
-        # which allows port 5432 from GitHub's documented egress IP ranges
-        # only. The sandbox is torn down in the always-run step below.
+        # connectivity to the prod VPC. Ingress is gated by SG_DRYRUN_GHA;
+        # the JIT-authorize step above adds this runner's /32 just before
+        # the connection. The sandbox and the SG rule are both torn down
+        # in the always-run steps below.
         run: |
           set -euo pipefail
           SNAPSHOT_ID=$(aws rds describe-db-snapshots \
@@ -454,6 +489,21 @@ jobs:
           DB_USERNAME: ${{ secrets.PROD_DB_USERNAME }}
           DB_PASSWORD: ${{ secrets.PROD_DB_PASSWORD }}
         run: node scripts/dryrun-migrate.mjs
+
+      - name: Revoke runner IP from SG_DRYRUN_GHA
+        # Always runs so a failure in any earlier step still cleans up the
+        # transient ingress rule. The guard on RUNNER_IP handles the case
+        # where the authorize step failed before the env var was written.
+        if: always()
+        run: |
+          if [ -n "${RUNNER_IP:-}" ]; then
+            aws ec2 revoke-security-group-ingress \
+              --group-id "${{ secrets.SG_DRYRUN_GHA }}" \
+              --protocol tcp --port 5432 \
+              --cidr "${RUNNER_IP}/32" \
+              2> >(grep -v 'InvalidPermission.NotFound' >&2) \
+              || true
+          fi
 
       - name: Tear down sandbox
         # The guard on SANDBOX_ID handles the case where restore failed

--- a/scripts/provision-dryrun-aws.mjs
+++ b/scripts/provision-dryrun-aws.mjs
@@ -83,6 +83,30 @@ const IAM_POLICY_DOCUMENT = {
       Action: ['rds:DeleteDBInstance', 'rds:AddTagsToResource'],
       Resource: `arn:aws:rds:${AWS_REGION}:${AWS_ACCOUNT}:db:dryrun-*`,
     },
+    {
+      // Per-run JIT ingress to the SG: the workflow authorizes the
+      // runner's /32 just before connecting and revokes it in the
+      // always-teardown step. Scoped via the `Purpose=migrate-dryrun`
+      // tag set at SG-create time (see `sgCreate` below) so this
+      // permission cannot touch any other security group.
+      Sid: 'JITIngressOnDryrunSG',
+      Effect: 'Allow',
+      Action: ['ec2:AuthorizeSecurityGroupIngress', 'ec2:RevokeSecurityGroupIngress'],
+      Resource: `arn:aws:ec2:${AWS_REGION}:${AWS_ACCOUNT}:security-group/*`,
+      Condition: {
+        StringEquals: {
+          'aws:ResourceTag/Purpose': 'migrate-dryrun',
+        },
+      },
+    },
+    {
+      // describe-security-groups is needed by the workflow's idempotent
+      // duplicate-rule check. Read-only and SG-only.
+      Sid: 'DescribeSecurityGroups',
+      Effect: 'Allow',
+      Action: 'ec2:DescribeSecurityGroups',
+      Resource: '*',
+    },
   ],
 };
 
@@ -727,6 +751,19 @@ async function sgCreate(state, vpcId) {
   if (existing.SecurityGroups.length > 0) {
     sgId = existing.SecurityGroups[0].GroupId;
     ok(`Found existing SG ${sgId}`);
+    // Backfill the Purpose tag on SGs created before #757. The IAM
+    // JITIngressOnDryrunSG statement scopes by this tag, so an
+    // un-tagged SG would silently AccessDenied during the workflow's
+    // authorize step.
+    const existingTags = existing.SecurityGroups[0].Tags || [];
+    const hasPurposeTag = existingTags.some((t) => t.Key === 'Purpose' && t.Value === 'migrate-dryrun');
+    if (!hasPurposeTag) {
+      info(`Backfilling Purpose=migrate-dryrun tag on existing SG`);
+      aws(['ec2', 'create-tags', '--resources', sgId, '--tags', 'Key=Purpose,Value=migrate-dryrun'], {
+        mutating: true,
+      });
+      ok(`Tagged ${sgId}`);
+    }
   } else {
     if (!FLAG.yes && !FLAG.dryRun) {
       info(`About to create SG "${SG_NAME}" in VPC ${vpcId}.`);
@@ -742,6 +779,12 @@ async function sgCreate(state, vpcId) {
         'Migrate-dryrun: GitHub Actions ingress to ephemeral RDS sandbox on 5432',
         '--vpc-id',
         vpcId,
+        // The Purpose=migrate-dryrun tag is load-bearing: the IAM
+        // policy's JITIngressOnDryrunSG statement scopes by this tag,
+        // so an SG without it cannot be authorized/revoked by the
+        // workflow's JIT ingress steps.
+        '--tag-specifications',
+        'ResourceType=security-group,Tags=[{Key=Purpose,Value=migrate-dryrun}]',
         '--output',
         'json',
       ],


### PR DESCRIPTION
## Summary

The `migrate-dryrun` job has been failing every run since `SG_DRYRUN_GHA` was provisioned at 2026-05-06 21:01 UTC. Switches to per-run JIT ingress: authorize the runner's `/32` just before connect, revoke in `always()` teardown.

Closes #757.

## Why bulk-authorize doesn't work

`api.github.com/meta` `.actions` publishes ~3000 IPv4 CIDRs and rotates monthly. AWS default SG rule limit is 60. `scripts/provision-dryrun-aws.mjs` capped at 50, so ~98% of runners landed outside the allowlist:

```
=== drizzle:migrate failed ===
wrapper: Failed query: CREATE SCHEMA IF NOT EXISTS "drizzle"
code: CONNECT_TIMEOUT
message: write CONNECT_TIMEOUT dryrun-<runId>.cc7ob5nnabjm.***.rds.amazonaws.com:5432
```

5 consecutive failures on `bugfix/migrate-hash-drift-guard` (runs 25455386429, 25460590257, 25460963546, 25463595152, 25464108426, 25464586076) — same shape, same step.

## What changed

**`.github/workflows/test.yml` `migrate-dryrun` job:**
- New step `Authorize runner IP on SG_DRYRUN_GHA` before the snapshot restore: detects runner public IP via `checkip.amazonaws.com`, authorizes `<RUNNER_IP>/32` on TCP/5432 against `SG_DRYRUN_GHA`, exports `RUNNER_IP` to `$GITHUB_ENV`. Tolerates `InvalidPermission.Duplicate` so a same-runner re-run is a no-op.
- New step `Revoke runner IP from SG_DRYRUN_GHA` after migrate, before sandbox teardown: `if: always()`, guards on `RUNNER_IP` (handles authorize-failed case), tolerates `InvalidPermission.NotFound` so a partial-state cleanup doesn't poison the run.

**`scripts/provision-dryrun-aws.mjs` `IAM_POLICY_DOCUMENT`:**
- New statement `JITIngressOnDryrunSG`: `ec2:Authorize/RevokeSecurityGroupIngress`, scoped via `aws:ResourceTag/Purpose=migrate-dryrun`. Cannot touch any SG without that tag.
- New statement `DescribeSecurityGroups`: `ec2:DescribeSecurityGroups` on `*` (read-only, needed by the workflow's idempotent duplicate-rule check).

**`scripts/provision-dryrun-aws.mjs` `sgCreate`:**
- New SGs get tagged `Purpose=migrate-dryrun` via `--tag-specifications` at create time.
- Existing-SG branch backfills the tag if missing (the SG provisioned today doesn't have it; re-running the provisioner after this lands will add it).

## Ops follow-ups

The IAM policy update is gated by the provisioner's drift-detection (it aborts on policy mismatch). To roll forward, ops needs to:

1. **Detach the existing policy from the GHA user.**
2. **Delete the existing policy** (`aws iam delete-policy --policy-arn arn:aws:iam::203767826763:policy/wxyc-gha-rds-dryrun`).
3. **Re-run the provisioner** with `--yes`. The fresh-create branch will install the updated document and tag the existing SG.

Alternatively, manually patch the policy via `aws iam create-policy-version --set-as-default ...` against the new document JSON. The provisioner won't notice the patched-in-place version since drift-check compares the default version to its template.

## Test plan

- [x] `npm run format:check` clean
- [x] `npm run typecheck` clean
- [x] `npm run lint` no new errors (warnings are existing)
- [ ] After ops applies the IAM update + tag: a `db-init`-touching PR run shows the `Authorize runner IP` step succeeding and the migrate step reaching the sandbox
- [ ] Inducing a migrate failure (e.g. push a temporarily-broken migration on a test branch) confirms the revoke step still runs and the SG ends up clean
- [ ] `aws ec2 describe-security-groups --group-ids $SG_DRYRUN_GHA` shows zero ingress rules between runs
