### PR TITLE
Set trust proxy on the auth Express app so per-IP rate limits actually work

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -18,6 +18,14 @@ const port = process.env.AUTH_PORT || '8082';
 
 const app = express();
 
+// Trust the reverse proxy (nginx / ALB) so req.ip resolves to the real
+// client IP from X-Forwarded-For. Without this, express-rate-limit warns
+// `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` and falls back to the direct socket
+// IP — which is the proxy itself, identical for every client. The /sign-in
+// rate limit (10 / 15 min) then becomes a single global bucket shared by
+// every caller. Mirrors the same line in apps/backend/app.ts.
+app.set('trust proxy', true);
+
 // Parse JSON bodies first (needed for auth endpoints)
 app.use(express.json());
 

--- a/tests/unit/config/trust-proxy.test.ts
+++ b/tests/unit/config/trust-proxy.test.ts
@@ -2,9 +2,11 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
 describe('Express trust proxy configuration', () => {
-  const appSource = readFileSync(resolve(__dirname, '../../../apps/backend/app.ts'), 'utf-8');
-
-  it('should enable trust proxy so req.ip reflects the real client IP behind a reverse proxy', () => {
+  it.each([
+    ['backend', '../../../apps/backend/app.ts'],
+    ['auth', '../../../apps/auth/app.ts'],
+  ])('%s app enables trust proxy so req.ip reflects the real client IP behind a reverse proxy', (_app, relPath) => {
+    const appSource = readFileSync(resolve(__dirname, relPath), 'utf-8');
     expect(appSource).toMatch(/app\.set\(\s*['"]trust proxy['"]/);
   });
 });


### PR DESCRIPTION
Closes #763

## Summary

- Add `app.set('trust proxy', true)` to `apps/auth/app.ts`, mirroring `apps/backend/app.ts:35`.
- Parameterize `tests/unit/config/trust-proxy.test.ts` over both apps so the next service that forgets this gets a failing test.

## Why

Without trust proxy, `express-rate-limit` can't trust `X-Forwarded-For` and falls back to the direct socket IP — which behind nginx is the proxy itself, identical for every client. The 10-per-15-min limit on `/auth/sign-in` etc. has therefore been a single global bucket shared by every caller, not per-IP. Incident detail in #763.

## Scope

This PR fixes only the express-rate-limit cascade. The same `docker logs auth` output that confirmed the cause exposed two more independent issues; both have follow-up tickets so this PR can stay narrow:

- **#765** — better-auth's *own* internal rate limiter is silently disabled because `getIp` returns null despite XFF being set. better-auth doesn't read `req.ip`, so `trust proxy` doesn't help it. Needs separate diagnosis of the actual XFF value the auth container receives.
- **#766** — Sentry isn't auto-instrumenting Express in the auth service (and likely backend) under ESM. The instrumentation file needs to be loaded via `node --import` at startup, not via top-level `import` from `app.ts`. Auto HTTP transaction tracing has been missing since the auth service went ESM.

Neither blocks this PR; this PR doesn't fully close the parent incident either, but it does close the verified narrow cause.

## Test plan

- [x] `npm run typecheck` (3 workspaces, all clean)
- [x] `npm run lint` (0 errors; 364 preexisting warnings, none new)
- [x] `npm run format:check`
- [x] `npm run test:unit -- tests/unit/config/trust-proxy.test.ts` — 2 / 2 pass (backend + auth)
- [ ] Post-deploy: `ssh wxyc-ec2 docker logs auth | grep ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` returns nothing for the new container's lifetime.
- [ ] Post-deploy: signing in from two different DJ workstations within 15 min does not produce a 429 on the second one.

## Sizing note

Once per-IP semantics are restored, `limit: 10` per 15 min may be too tight for shared NAT scenarios; worth watching and possibly raising to ~20. Out of scope for this PR.

## Related

- WXYC/wxyc-canary#7 (defense-in-depth retry on the canary's auth precondition; doesn't replace this fix).
- ca4acc8 — historical fix that added the same line on the backend in Feb 2026.