### PR TITLE
Load Sentry instrument.ts via node --import (fixes #766)

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -1,5 +1,7 @@
-// Auth service using Express
-import './instrument.js';
+// Auth service using Express.
+// `instrument.ts` is loaded via `node --import` (see package.json `start`
+// script), not statically imported here, so Sentry's auto-instrumentation
+// runs before `express` is loaded into the module graph.
 import * as Sentry from '@sentry/node';
 import { config } from 'dotenv';
 config();

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./dist/app.js",
   "scripts": {
-    "start": "node dist/app.js",
+    "start": "node --import ./dist/instrument.js dist/app.js",
     "build": "tsup --minify",
     "clean": "rm -rf dist",
     "docker:build": "docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t wxyc_auth_service:ci -f ../../Dockerfile.auth ../../",

--- a/apps/auth/tsup.config.ts
+++ b/apps/auth/tsup.config.ts
@@ -1,13 +1,20 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig((options) => ({
-  entry: ['app.ts'],
+  // `instrument.ts` is a separate entry so it can be loaded via
+  // `node --import ./dist/instrument.js dist/app.js`. Under ESM, all top-level
+  // imports in `app.ts` are hoisted before its body runs, so a static
+  // `import './instrument.js'` would resolve `express` before `Sentry.init`
+  // could install its monkey-patches. `--import` runs the file before any
+  // other module graph entry is evaluated.
+  entry: ['app.ts', 'instrument.ts'],
   outDir: 'dist',
   format: ['esm'],
   platform: 'node',
   target: 'node20',
   clean: true,
   sourcemap: true,
+  splitting: false,
   external: [
     '@wxyc/database',
     'better-auth',
@@ -18,5 +25,5 @@ export default defineConfig((options) => ({
     'postgres',
     '@sentry/node',
   ],
-  onSuccess: options.watch ? 'node ./dist/app.js' : undefined,
+  onSuccess: options.watch ? 'node --import ./dist/instrument.js ./dist/app.js' : undefined,
 }));

--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -1,4 +1,6 @@
-import './instrument.js';
+// `instrument.ts` is loaded via `node --import` (see package.json `start`
+// script), not statically imported here, so Sentry's auto-instrumentation
+// runs before `express` is loaded into the module graph.
 import * as Sentry from '@sentry/node';
 import express from 'express';
 import cors from 'cors';

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "./dist/app.js",
   "scripts": {
-    "start": "node dist/app.js",
+    "start": "node --import ./dist/instrument.js dist/app.js",
     "build": "tsup --minify",
     "clean": "rm -rf dist",
     "docker:build": "docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t wxyc_backend_service:ci -f ../../Dockerfile.backend ../../",

--- a/apps/backend/tsup.config.ts
+++ b/apps/backend/tsup.config.ts
@@ -7,13 +7,20 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export default defineConfig((options) => ({
-  entry: ['app.ts'],
+  // `instrument.ts` is a separate entry so it can be loaded via
+  // `node --import ./dist/instrument.js dist/app.js`. Under ESM, all top-level
+  // imports in `app.ts` are hoisted before its body runs, so a static
+  // `import './instrument.js'` would resolve `express` before `Sentry.init`
+  // could install its monkey-patches. `--import` runs the file before any
+  // other module graph entry is evaluated.
+  entry: ['app.ts', 'instrument.ts'],
   format: ['esm'],
   outDir: 'dist',
   clean: true,
   sourcemap: true,
+  splitting: false,
   external: ['@sentry/node', 'ws'],
-  onSuccess: options.watch ? 'node ./dist/app.js' : undefined,
+  onSuccess: options.watch ? 'node --import ./dist/instrument.js ./dist/app.js' : undefined,
   minify: !options.watch,
 
   loader: {

--- a/tests/unit/config/sentry-instrument.test.ts
+++ b/tests/unit/config/sentry-instrument.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('Sentry instrumentation loading', () => {
+  it.each([
+    ['backend', '../../../apps/backend'],
+    ['auth', '../../../apps/auth'],
+  ])(
+    '%s app loads instrument.ts via node --import so Sentry hooks Express before any import resolves',
+    (_app, relPath) => {
+      const pkg = JSON.parse(readFileSync(resolve(__dirname, relPath, 'package.json'), 'utf-8'));
+      expect(pkg.scripts?.start).toMatch(/--import\s+\.\/dist\/instrument\.js\s+dist\/app\.js/);
+    }
+  );
+
+  it.each([
+    ['backend', '../../../apps/backend/app.ts'],
+    ['auth', '../../../apps/auth/app.ts'],
+  ])(
+    '%s app.ts does not statically import instrument (ESM hoisting would defeat auto-instrumentation)',
+    (_app, relPath) => {
+      const appSource = readFileSync(resolve(__dirname, relPath), 'utf-8');
+      expect(appSource).not.toMatch(/import\s+['"]\.\/instrument(\.js)?['"]/);
+    }
+  );
+
+  it.each([
+    ['backend', '../../../apps/backend/tsup.config.ts'],
+    ['auth', '../../../apps/auth/tsup.config.ts'],
+  ])('%s tsup config emits instrument.ts as a separate entry', (_app, relPath) => {
+    const tsupSource = readFileSync(resolve(__dirname, relPath), 'utf-8');
+    expect(tsupSource).toMatch(/entry:\s*\[[^\]]*['"]instrument\.ts['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

- `apps/auth` and `apps/backend` are ESM, so `import './instrument.js'` at the top of `app.ts` hoists every static import before the body runs — `express` lands in the module graph before `Sentry.init` can monkey-patch it. Sentry emits `[Sentry] express is not instrumented` at startup and never captures HTTP transaction spans.
- Switch to Sentry's documented ESM pattern: `tsup` emits `instrument.ts` as a separate entry, and `start` becomes `node --import ./dist/instrument.js dist/app.js`. The static import in `app.ts` goes away.
- Same change applied to backend; the warning was almost certainly there too (same pattern, same `"type": "module"`), and verifying the auth fix in isolation would just leave the backend bug for next time.
- New `tests/unit/config/sentry-instrument.test.ts` asserts the contract (start script, app.ts, tsup config) for both apps so a future refactor can't silently regress.

## Why no Dockerfile change

`Dockerfile.auth:39` and `Dockerfile.backend:40` already use `CMD ["npm", "start", "--workspace=<pkg>"]`, which routes through the updated `package.json` `start` scripts. The `--import` flag is therefore picked up unchanged in the deployed containers.

Closes #766

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — no new errors
- [x] `npm run test:unit` — 1713/1713 passing (132 suites)
- [x] `npm run build --workspace=@wxyc/auth-service` — emits `dist/instrument.js` + `dist/app.js`
- [x] `npm run build --workspace=@wxyc/backend` — emits `dist/instrument.js` + `dist/app.js`
- [ ] After deploy, confirm `docker logs auth | grep "express is not instrumented"` returns 0 lines
- [ ] After deploy, confirm `docker logs backend` likewise
- [ ] After deploy, confirm Sentry transaction view shows `http.server` spans for `/auth/sign-in/email`, `/auth/token`, etc.