### PR TITLE
Pass X-Forwarded-For on auth /healthcheck loopback (fixes #765)

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -256,8 +256,15 @@ if (isTestEnv) {
 app.get('/healthcheck', async (req, res) => {
   const authServiceUrl = `http://localhost:${port}`; // Use the port the server is listening on
   try {
-    // Make an internal HTTP request to the better-auth /ok endpoint
-    const response = await fetch(`${authServiceUrl}/auth/ok`);
+    // Make an internal HTTP request to the better-auth /ok endpoint.
+    // X-Forwarded-For is set to 127.0.0.1 because the loopback fetch has no
+    // real client. Without it, better-auth's getIp returns null and latches
+    // a one-shot "Rate limiting skipped: could not determine client IP"
+    // warning, which silently disables its internal rate limiter for the
+    // rest of the process lifetime. See WXYC/Backend-Service#765.
+    const response = await fetch(`${authServiceUrl}/auth/ok`, {
+      headers: { 'X-Forwarded-For': '127.0.0.1' },
+    });
 
     // Forward the status and body from the /auth/ok response
     const data = (await response.json()) as Record<string, unknown>;

--- a/tests/unit/config/auth-healthcheck-xff.test.ts
+++ b/tests/unit/config/auth-healthcheck-xff.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('auth /healthcheck loopback', () => {
+  // The loopback fetch at apps/auth/app.ts has no real client; without an
+  // X-Forwarded-For header better-auth's getIp returns null in production
+  // and latches "Rate limiting skipped: could not determine client IP" once
+  // per process. See WXYC/Backend-Service#765.
+  const appSource = readFileSync(resolve(__dirname, '../../../apps/auth/app.ts'), 'utf-8');
+
+  it('passes X-Forwarded-For: 127.0.0.1 on the loopback /auth/ok fetch', () => {
+    const fetchBlock = appSource.match(/fetch\(\s*`\$\{authServiceUrl\}\/auth\/ok`[\s\S]*?\)/);
+    expect(fetchBlock).not.toBeNull();
+    if (!fetchBlock) return;
+
+    expect(fetchBlock[0]).toMatch(/['"]X-Forwarded-For['"]\s*:\s*['"]127\.0\.0\.1['"]/i);
+  });
+});


### PR DESCRIPTION
## Summary

- The auth `/healthcheck` handler proxies through `fetch('http://localhost:8082/auth/ok')`. Loopback fetch has no XFF header.
- Better-auth's `getIp` reads `x-forwarded-for` directly (not `req.ip`) and returns null in production when the header is absent — no `req.socket.remoteAddress` fallback, no `LOCALHOST_IP` fallback outside dev/test.
- The first null-IP request latches `ipWarningLogged = true` inside `better-auth/dist/api/rate-limiter/index.mjs`, emits the one-shot "Rate limiting skipped: could not determine client IP" warning, and returns null on every subsequent call without limit-checking — better-auth's internal rate limiter is silently a no-op for the rest of the process.
- Fix: pass `X-Forwarded-For: 127.0.0.1` on the loopback fetch. Zod's `z.ipv4()` accepts 127.0.0.1, so `getIp` returns a valid IP for self-traffic and the latch never fires.
- The healthcheck loopback is the most plausible first trigger: every container healthcheck poll, no real client, hits a path under `/auth` (which is what the rate limiter wraps).

## Why this fix is conservative

Issue #765's acceptance criterion explicitly accepts both outcomes — a real fix or a documented transient-bring-up case. If after deploy the warning still appears, a different first trigger exists (e.g. an upstream-proxy edge case), and the next iteration will instrument header logging to find it. Code-only investigation (the issue body's diagnostic recipe) couldn't disambiguate without prod data; this PR ships a targeted fix for the most likely cause and the warning's one-shot nature makes "still seeing it" a clear signal that a different source needs follow-up.

Closes #765

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint` — no new errors
- [x] `npm run test:unit` — 1708/1708 passing (132 suites)
- [x] New `tests/unit/config/auth-healthcheck-xff.test.ts` asserts the loopback fetch carries the XFF header
- [ ] After deploy, confirm `docker logs auth | grep "could not determine client IP"` returns 0 lines for a fresh container
- [ ] If the warning recurs, follow up with header logging to find the residual source