### PR TITLE
verify: migrate-dryrun JIT-ingress end-to-end (synthetic test)

### DIFF
--- a/shared/database/src/migrations/PRECONDITION_NOTES.md
+++ b/shared/database/src/migrations/PRECONDITION_NOTES.md
@@ -23,3 +23,11 @@ The `UNIQUE INDEX` is defined against the materialized view's output, which is `
 ## 0067_flowsheet-linkage-review
 
 Brand-new `CREATE TABLE`. The `UNIQUE` on `flowsheet_id`, the `NOT NULL` columns, and the FK to `flowsheet(id)` are all evaluated against zero rows at apply time — no existing data can violate them. Subsequent inserts are bounded by the constraints themselves.
+
+---
+
+## When to add a new entry
+
+If you're authoring a new migration that adds a constraint but provably doesn't need a runtime guard, prefer the inline `-- @no-precondition-needed: <reason>` annotation in the .sql file itself. The annotation is read at PR time by `scripts/validate-migrations.mjs` Check 8 and never has to change after apply.
+
+Add an entry to **this** file only when an already-applied migration needs its rationale captured retroactively. Editing the .sql file post-apply changes its hash and wedges the deploy verifier (Check 11). The corresponding tag must also be added to `HISTORICAL_NO_GUARD_NEEDED_TAGS` in `scripts/validate-migrations.mjs` so Check 8 stays quiet.


### PR DESCRIPTION
## Synthetic verification PR

This PR exists to verify the migrate-dryrun JIT-ingress path from #758 end-to-end. The single edit to `shared/database/src/migrations/PRECONDITION_NOTES.md` documents when to use the inline `-- @no-precondition-needed:` annotation vs an entry in this file — a doc gap that was implicit in the original PR. The load-bearing purpose for this PR is touching a `db-init`-filter path so the `migrate-dryrun` job fires.

## What I'm watching

The "Migration Dry-Run (prod-shaped data)" job. Specifically:

1. `Authorize runner IP on SG_DRYRUN_GHA` succeeds (was the `AccessDenied` failure mode if the IAM patch from PR #758 / #761 hadn't been applied).
2. `Restore latest prod snapshot to ephemeral sandbox` succeeds.
3. `Run drizzle:migrate against sandbox` reaches the sandbox without `CONNECT_TIMEOUT` (the failure mode #757 fixed).
4. `Revoke runner IP from SG_DRYRUN_GHA` cleans up the transient ingress rule.
5. `Tear down sandbox` succeeds.

## Disposition

If green: the doc improvement is fine to land but isn't the point — the load-bearing outcome is a clean run. Either merge or close. Then flip `migrate-dryrun` to a required check in branch protection (last remaining step of #728's Phase 2).

If red: investigate, possibly amend the IAM/SG configuration, possibly retry.

Refs #757, #728 (Phase 2), #761
