### PR TITLE
ci: validate migrate-dryrun JIT path (no-op tap)

### DIFF
--- a/dev_env/init-db.mjs
+++ b/dev_env/init-db.mjs
@@ -10,6 +10,9 @@
  * 4. Seeds the database ONLY if it's empty
  *
  * Safe to run multiple times (idempotent)
+ *
+ * Note: paths under dev_env/ are part of the db-init paths-filter that
+ * gates the migrate-dryrun CI job (see .github/workflows/test.yml).
  */
 
 import postgres from 'postgres';

--- a/scripts/dryrun-migrate.mjs
+++ b/scripts/dryrun-migrate.mjs
@@ -48,6 +48,11 @@ try {
   await migrate(db, {
     migrationsFolder: join(__dirname, '../shared/database/src/migrations'),
   });
+  // TEMP #757-validation: force failure to exercise the always() teardown.
+  // Will be reverted in the next commit on this branch.
+  if (process.env) {
+    throw new Error('test JIT teardown — synthetic failure for #757 validation');
+  }
   console.log('dryrun-migrate: ok');
 } catch (error) {
   process.stderr.write('\n');

--- a/scripts/dryrun-migrate.mjs
+++ b/scripts/dryrun-migrate.mjs
@@ -48,11 +48,6 @@ try {
   await migrate(db, {
     migrationsFolder: join(__dirname, '../shared/database/src/migrations'),
   });
-  // TEMP #757-validation: force failure to exercise the always() teardown.
-  // Will be reverted in the next commit on this branch.
-  if (process.env) {
-    throw new Error('test JIT teardown — synthetic failure for #757 validation');
-  }
   console.log('dryrun-migrate: ok');
 } catch (error) {
   process.stderr.write('\n');


### PR DESCRIPTION
## Summary

A no-op tap on the `db-init` paths-filter so the `migrate-dryrun` CI job fires end-to-end and we can validate #757's JIT authorize+revoke flow against a real PR. No migration-touching PRs have been opened since #757 merged, so the gate has been unexercised.

The diff is a 3-line comment in `dev_env/init-db.mjs` noting the file's role in the paths-filter — a useful breadcrumb to leave behind, not just throwaway noise.

## Validation plan

- [ ] **A. Happy path.** First push fires `migrate-dryrun`. Job goes green. Authorize step adds the runner's /32 to `wxyc-dryrun-gha`; revoke step removes it.
- [ ] **B. SG clean after success.** `aws ec2 describe-security-groups --group-ids sg-045cc658181f74d36` shows 0 ingress rules on tcp/5432 after the run completes.
- [ ] **C. SG clean after failure.** Follow-up commit on this branch injects `throw new Error('test JIT teardown');` near the top of `scripts/dryrun-migrate.mjs`'s main flow. `migrate-dryrun` fails. Always-run teardown still revokes the /32. Re-running `describe-security-groups` shows 0 ingress rules — proving the revoke path runs even on migrate failure (the criterion that matters most).

After (C), I'll revert the throw commit. Final disposition (merge vs close) is up to you.

## Provisioning state at PR open time

These were applied manually on 2026-05-08 to make the JIT path operational:

- IAM policy `wxyc-gha-rds-dryrun` → v2 default (adds `JITIngressOnDryrunSG` + `DescribeSecurityGroups` statements per #757).
- SG `wxyc-dryrun-gha` (sg-045cc658181f74d36) tagged `Purpose=migrate-dryrun` (the JIT IAM statement is `aws:ResourceTag`-conditioned on this).
- 50 legacy inline CIDRs revoked from the SG (dead weight under JIT).

So the SG enters this validation with a clean ingress (0 rules on tcp/5432). This PR's runs are the first chance to confirm everything is wired correctly.

## References

- WXYC/Backend-Service#757 — the JIT change being validated
- WXYC/Backend-Service#769 — follow-up: provisioner's `iamPolicy` aborts on drift instead of upgrading (motivated by needing to apply v2 manually here)