### PR TITLE
test(config): pin Dockerfile CMD invariant for Sentry --import chain

### DIFF
--- a/tests/unit/config/dockerfile-cmd.test.ts
+++ b/tests/unit/config/dockerfile-cmd.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('Dockerfile CMD invariant for Sentry --import chain', () => {
+  it.each([
+    ['auth', '../../../Dockerfile.auth'],
+    ['backend', '../../../Dockerfile.backend'],
+  ])(
+    '%s Dockerfile CMD either delegates to npm start (which carries --import) or inlines --import directly',
+    (_app, relPath) => {
+      const dockerfile = readFileSync(resolve(__dirname, relPath), 'utf-8');
+      const cmdMatch = dockerfile.match(/^CMD\s+(\[.+\]|.+)$/m);
+      expect(cmdMatch).not.toBeNull();
+      if (!cmdMatch) return;
+      const cmd = cmdMatch[1];
+      const delegatesToNpmStart = /"npm"\s*,\s*"start"\s*,\s*"--workspace=/.test(cmd);
+      const inlinesImport = cmd.includes('--import') && cmd.includes('./dist/instrument.js');
+      expect(delegatesToNpmStart || inlinesImport).toBe(true);
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- Adds a parameterized test reading `Dockerfile.auth` and `Dockerfile.backend` that asserts the `CMD` line either delegates to `npm start --workspace=...` or directly carries `--import ./dist/instrument.js`.
- Closes the gap that PR #767's `sentry-instrument.test.ts` pinned the package.json `start` chain but not the Dockerfile entrypoint that calls it.
- Either form is accepted so the Dockerfiles retain flexibility — what the test pins is the invariant that Sentry instrumentation runs before the app loads.

## Why

PR #767 fixed Sentry ESM auto-instrumentation by switching from `import './instrument.js'` (broken under ESM hoisting) to `node --import ./dist/instrument.js dist/app.js`. The fix chains through (1) Dockerfile CMD → (2) package.json `start` script → (3) the `--import` flag. Steps 2 and 3 were pinned. Step 1 was not. A future Dockerfile edit that inlined the start command — e.g., `CMD ["node", "dist/app.js"]` for image-size or COPY-script-removal reasons — would silently regress Sentry HTTP-transaction capture while leaving the unit suite green.

## Test plan

- [x] New test passes against current Dockerfiles (`CMD ["npm", "start", "--workspace=@wxyc/auth-service"]` and `CMD ["npm", "start", "--workspace=@wxyc/backend"]`).
- [x] New test fails when CMD is mutated to `CMD ["node", "dist/app.js"]` (regression case verified locally).
- [x] `npm run typecheck` passes.
- [x] `npm run lint` — 0 errors. New test contributes 1 `security/detect-non-literal-fs-filename` warning, matching the existing `tests/unit/config/sentry-instrument.test.ts` pattern.
- [x] `npm run format:check` passes.

Closes #773