### PR TITLE
fix(flowsheet): order id-range fetch by id, not per-show play_order (#714)

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -248,9 +248,7 @@ export const getEntriesByPage = async (offset: number, limit: number): Promise<I
 };
 
 export const getEntriesByRange = async (startId: number, endId: number): Promise<IFSEntry[]> => {
-  // Order by id, not play_order: post-#693 play_order is per-show, so
-  // an id-range fetch (which can span shows) needs a globally monotonic
-  // sort. Matches `getEntriesByPage`.
+  // play_order is per-show after #693; id is globally monotonic across shows.
   const raw = await db
     .select(FSEntryFieldsRaw)
     .from(flowsheet)

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -248,13 +248,16 @@ export const getEntriesByPage = async (offset: number, limit: number): Promise<I
 };
 
 export const getEntriesByRange = async (startId: number, endId: number): Promise<IFSEntry[]> => {
+  // Order by id, not play_order: post-#693 play_order is per-show, so
+  // an id-range fetch (which can span shows) needs a globally monotonic
+  // sort. Matches `getEntriesByPage`.
   const raw = await db
     .select(FSEntryFieldsRaw)
     .from(flowsheet)
     .leftJoin(rotation, eq(rotation.id, flowsheet.rotation_id))
     .leftJoin(library, eq(library.id, flowsheet.album_id))
     .where(and(gte(flowsheet.id, startId), lte(flowsheet.id, endId)))
-    .orderBy(desc(flowsheet.play_order));
+    .orderBy(desc(flowsheet.id));
 
   return raw.map(transformToIFSEntry);
 };

--- a/tests/__mocks__/drizzle-orm.ts
+++ b/tests/__mocks__/drizzle-orm.ts
@@ -16,3 +16,5 @@ export const asc = jest.fn((col) => ({ asc: col }));
 export const inArray = jest.fn((col, values) => ({ inArray: [col, values] }));
 export const isNull = jest.fn((col) => ({ isNull: col }));
 export const isNotNull = jest.fn((col) => ({ isNotNull: col }));
+export const gte = jest.fn((a, b) => ({ gte: [a, b] }));
+export const lte = jest.fn((a, b) => ({ lte: [a, b] }));

--- a/tests/unit/services/flowsheet.getEntriesByRange.test.ts
+++ b/tests/unit/services/flowsheet.getEntriesByRange.test.ts
@@ -1,20 +1,4 @@
-/**
- * Regression guard for `getEntriesByRange` in
- * `apps/backend/services/flowsheet.service.ts`.
- *
- * Background (#714):
- *
- * After #693 (`f71b3ef`) made `play_order` per-show, ordering the
- * result of an id-range fetch by `desc(flowsheet.play_order)` became
- * meaningless: the range filter is on `flowsheet.id`, which can span
- * multiple shows, so two rows in different shows are compared by
- * play_orders that are no longer globally comparable. The fix matches
- * the sibling `getEntriesByPage` function and orders by the globally
- * monotonic `flowsheet.id` instead.
- *
- * The test mocks the drizzle query chain and asserts the argument
- * passed to `.orderBy(...)` resolves to `desc(flowsheet.id)`.
- */
+// Regression guard for #714: post-#693 play_order is per-show, so an id-range fetch must order by flowsheet.id.
 
 import { jest } from '@jest/globals';
 import { db, flowsheet } from '@wxyc/database';
@@ -48,11 +32,6 @@ describe('flowsheet.service', () => {
 
       expect(orderByMock).toHaveBeenCalledTimes(1);
       const orderByArg = orderByMock.mock.calls[0][0];
-
-      // Under the global drizzle-orm mock (`tests/__mocks__/drizzle-orm.ts`),
-      // `desc(col)` returns `{ desc: col }`. With `flowsheet.id === 'id'`
-      // and `flowsheet.play_order === 'play_order'` from `database.mock.ts`,
-      // the two are easy to tell apart by deep equality.
       expect(orderByArg).toEqual(desc(flowsheet.id));
       expect(orderByArg).not.toEqual(desc(flowsheet.play_order));
     });

--- a/tests/unit/services/flowsheet.getEntriesByRange.test.ts
+++ b/tests/unit/services/flowsheet.getEntriesByRange.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression guard for `getEntriesByRange` in
+ * `apps/backend/services/flowsheet.service.ts`.
+ *
+ * Background (#714):
+ *
+ * After #693 (`f71b3ef`) made `play_order` per-show, ordering the
+ * result of an id-range fetch by `desc(flowsheet.play_order)` became
+ * meaningless: the range filter is on `flowsheet.id`, which can span
+ * multiple shows, so two rows in different shows are compared by
+ * play_orders that are no longer globally comparable. The fix matches
+ * the sibling `getEntriesByPage` function and orders by the globally
+ * monotonic `flowsheet.id` instead.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const servicePath = path.resolve(__dirname, '../../../apps/backend/services/flowsheet.service.ts');
+const serviceSource = fs.readFileSync(servicePath, 'utf-8');
+
+const extractGetEntriesByRangeBody = (): string => {
+  const match = serviceSource.match(/export const getEntriesByRange[\s\S]*?\n\};/);
+  if (!match) throw new Error('getEntriesByRange not found in flowsheet.service.ts');
+  return match[0];
+};
+
+describe('flowsheet.service', () => {
+  describe('getEntriesByRange ordering (#714)', () => {
+    const body = extractGetEntriesByRangeBody();
+
+    it('orders by flowsheet.id, not by play_order', () => {
+      // Post-#693 play_order is per-show, so ordering an id-range fetch
+      // (which can span shows) by play_order interleaves shows in a
+      // meaningless order. The id column is globally monotonic and
+      // matches the ordering used by `getEntriesByPage`.
+      expect(body).toMatch(/\.orderBy\(desc\(flowsheet\.id\)\)/);
+      expect(body).not.toMatch(/\.orderBy\(desc\(flowsheet\.play_order\)\)/);
+    });
+  });
+});

--- a/tests/unit/services/flowsheet.getEntriesByRange.test.ts
+++ b/tests/unit/services/flowsheet.getEntriesByRange.test.ts
@@ -11,31 +11,50 @@
  * play_orders that are no longer globally comparable. The fix matches
  * the sibling `getEntriesByPage` function and orders by the globally
  * monotonic `flowsheet.id` instead.
+ *
+ * The test mocks the drizzle query chain and asserts the argument
+ * passed to `.orderBy(...)` resolves to `desc(flowsheet.id)`.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
-
-const servicePath = path.resolve(__dirname, '../../../apps/backend/services/flowsheet.service.ts');
-const serviceSource = fs.readFileSync(servicePath, 'utf-8');
-
-const extractGetEntriesByRangeBody = (): string => {
-  const match = serviceSource.match(/export const getEntriesByRange[\s\S]*?\n\};/);
-  if (!match) throw new Error('getEntriesByRange not found in flowsheet.service.ts');
-  return match[0];
-};
+import { jest } from '@jest/globals';
+import { db, flowsheet } from '@wxyc/database';
+import { desc } from 'drizzle-orm';
+import { getEntriesByRange } from '../../../apps/backend/services/flowsheet.service';
 
 describe('flowsheet.service', () => {
   describe('getEntriesByRange ordering (#714)', () => {
-    const body = extractGetEntriesByRangeBody();
+    const orderByMock = jest.fn().mockResolvedValue([]);
+    const whereMock = jest.fn().mockReturnValue({ orderBy: orderByMock });
+    const leftJoinMock2 = jest.fn().mockReturnValue({ where: whereMock });
+    const leftJoinMock1 = jest.fn().mockReturnValue({ leftJoin: leftJoinMock2 });
+    const fromMock = jest.fn().mockReturnValue({ leftJoin: leftJoinMock1 });
 
-    it('orders by flowsheet.id, not by play_order', () => {
-      // Post-#693 play_order is per-show, so ordering an id-range fetch
-      // (which can span shows) by play_order interleaves shows in a
-      // meaningless order. The id column is globally monotonic and
-      // matches the ordering used by `getEntriesByPage`.
-      expect(body).toMatch(/\.orderBy\(desc\(flowsheet\.id\)\)/);
-      expect(body).not.toMatch(/\.orderBy\(desc\(flowsheet\.play_order\)\)/);
+    beforeEach(() => {
+      orderByMock.mockReset();
+      orderByMock.mockResolvedValue([]);
+      whereMock.mockReset();
+      whereMock.mockReturnValue({ orderBy: orderByMock });
+      leftJoinMock1.mockReset();
+      leftJoinMock1.mockReturnValue({ leftJoin: leftJoinMock2 });
+      leftJoinMock2.mockReset();
+      leftJoinMock2.mockReturnValue({ where: whereMock });
+      fromMock.mockReset();
+      fromMock.mockReturnValue({ leftJoin: leftJoinMock1 });
+      (db as unknown as { select: jest.Mock }).select = jest.fn().mockReturnValue({ from: fromMock });
+    });
+
+    it('passes desc(flowsheet.id) to orderBy, not desc(flowsheet.play_order)', async () => {
+      await getEntriesByRange(1, 10);
+
+      expect(orderByMock).toHaveBeenCalledTimes(1);
+      const orderByArg = orderByMock.mock.calls[0][0];
+
+      // Under the global drizzle-orm mock (`tests/__mocks__/drizzle-orm.ts`),
+      // `desc(col)` returns `{ desc: col }`. With `flowsheet.id === 'id'`
+      // and `flowsheet.play_order === 'play_order'` from `database.mock.ts`,
+      // the two are easy to tell apart by deep equality.
+      expect(orderByArg).toEqual(desc(flowsheet.id));
+      expect(orderByArg).not.toEqual(desc(flowsheet.play_order));
     });
   });
 });


### PR DESCRIPTION
## Summary

`getEntriesByRange` (`apps/backend/services/flowsheet.service.ts:250`) sorted the result of an id-range fetch by `desc(flowsheet.play_order)`. After #693 (`f71b3ef`) made `play_order` per-show, that ordering became meaningless across shows: the range filter is on `flowsheet.id`, which can span multiple shows, so two rows from different shows are compared by play_orders that aren't globally comparable.

This change orders by `desc(flowsheet.id)` instead — the globally monotonic column already used by the sibling `getEntriesByPage`. One line in the service plus a mock-based behavior test that wires the drizzle query chain and asserts the argument passed to `.orderBy(...)` is `desc(flowsheet.id)`.

(Branch history: the first commit shipped a source-grep regression guard, which a pre-PR-review hook flagged as fragile. The second commit replaces it with a behavior test and adds the missing `gte` / `lte` exports to the global `tests/__mocks__/drizzle-orm.ts`. The third commit trims multi-line comment blocks to comply with the project convention.)

Closes #714.

## Test plan

- [x] `npm run test:unit -- tests/unit/services/flowsheet.getEntriesByRange.test.ts` — new test fails on pre-fix code (`Object: { desc: 'play_order' }` vs expected `{ desc: 'id' }`), passes on post-fix.
- [x] `npm run test:unit -- tests/unit/services/flowsheet` — full flowsheet unit suite (9 files, 68 tests) green.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean (warning count unchanged from main).