### PR TITLE
feat(metadata-backfill): wrap lookupMetadata in Sentry.startSpan (#715)

### DIFF
--- a/jobs/flowsheet-metadata-backfill/lml-fetch.ts
+++ b/jobs/flowsheet-metadata-backfill/lml-fetch.ts
@@ -95,11 +95,11 @@ export const lookupMetadata = async (artist: string, album?: string, track?: str
           }
         }
         if (Object.keys(attrs).length > 0) {
-          // Observability must never break the request path.
+          // Observability must never break the lookup contract; swallow.
           try {
             span.setAttributes(attrs);
-          } catch (err) {
-            console.warn('lml-fetch: failed to project cache_stats onto span', err);
+          } catch {
+            /* swallowed */
           }
         }
       }

--- a/jobs/flowsheet-metadata-backfill/lml-fetch.ts
+++ b/jobs/flowsheet-metadata-backfill/lml-fetch.ts
@@ -19,13 +19,15 @@
  *     orchestrator catches and counts as `lml_error`, leaving
  *     `metadata_attempt_at` NULL so the row stays in the retry pool —
  *     same shape #639 codified for the runtime path.
- *
- * Note: this fetcher does NOT go through `apps/backend/services/lml/lml.client.ts`,
- * so the Sentry-span wrap from #646 doesn't apply. Trace propagation
- * relies on @sentry/node v10+ undici auto-instrumentation; verified in the
- * pilot run for #640. If propagation breaks, mirror #646's wrap inside
- * this client (see #638's implementation notes).
+ *   - Wraps the fetch in `Sentry.startSpan({name: 'lml.lookup', op: 'http.client'})`
+ *     so undici auto-instrumentation has a parent transaction context to
+ *     attach http.client spans to (#715). Without the wrap the job runs
+ *     outside a transaction and emits no spans, which prevents LML#229's
+ *     cache_stats projection from joining the trace. Mirrors #646's wrap
+ *     in `apps/backend/services/lml/lml.client.ts`.
  */
+
+import * as Sentry from '@sentry/node';
 
 import type { LmlLookupResponse } from './lml-types.js';
 
@@ -40,47 +42,76 @@ const baseUrl = (): string => {
 };
 
 export const lookupMetadata = async (artist: string, album?: string, track?: string): Promise<LmlLookupResponse> => {
-  // LML's /lookup contract requires `raw_message` even when artist/album/
-  // track are already structured. Synthesize "<artist> - <album> - <track>"
-  // — matches the shape the parser expects in LML's e2e fixtures.
-  const parts = [artist, album, track].filter((p): p is string => Boolean(p));
-  const rawMessage = parts.join(' - ');
+  // Wrap the call in a Sentry span so undici auto-instrumentation has a
+  // parent transaction to attach http.client spans to, and LML's
+  // cache_stats lands as attributes on the same trace (LML#229). Same
+  // contract as the backend client's #646 wrap.
+  return Sentry.startSpan({ name: 'lml.lookup', op: 'http.client' }, async (span) => {
+    // LML's /lookup contract requires `raw_message` even when artist/album/
+    // track are already structured. Synthesize "<artist> - <album> - <track>"
+    // — matches the shape the parser expects in LML's e2e fixtures.
+    const parts = [artist, album, track].filter((p): p is string => Boolean(p));
+    const rawMessage = parts.join(' - ');
 
-  const body: Record<string, string> = { artist, raw_message: rawMessage };
-  if (album) body.album = album;
-  if (track) body.track = track;
+    const body: Record<string, string> = { artist, raw_message: rawMessage };
+    if (album) body.album = album;
+    if (track) body.track = track;
 
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
-  // LML enforces auth in production (LML_REQUIRE_AUTH=true). Send the
-  // bearer header when LML_API_KEY is set; the backend's lml.client.ts
-  // does the same. Sending it before the flag flips is harmless.
-  const apiKey = process.env.LML_API_KEY;
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (apiKey) {
-    headers.Authorization = `Bearer ${apiKey}`;
-  }
-
-  try {
-    const response = await fetch(`${baseUrl()}/api/v1/lookup`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      throw new Error(`LML responded ${response.status} ${response.statusText}`);
+    // LML enforces auth in production (LML_REQUIRE_AUTH=true). Send the
+    // bearer header when LML_API_KEY is set; the backend's lml.client.ts
+    // does the same. Sending it before the flag flips is harmless.
+    const apiKey = process.env.LML_API_KEY;
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (apiKey) {
+      headers.Authorization = `Bearer ${apiKey}`;
     }
 
-    return (await response.json()) as LmlLookupResponse;
-  } catch (error) {
-    if ((error as Error).name === 'AbortError') {
-      throw new Error('LML request timed out', { cause: error });
+    try {
+      const response = await fetch(`${baseUrl()}/api/v1/lookup`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`LML responded ${response.status} ${response.statusText}`);
+      }
+
+      const parsed = (await response.json()) as LmlLookupResponse;
+
+      // cache_stats is freeform on the LML side (additionalProperties: true).
+      // Defensively narrow to a real plain object — Object.entries on
+      // an array would project junk attributes like lml.cache.0=...
+      const stats = (parsed as { cache_stats?: unknown }).cache_stats;
+      if (stats && typeof stats === 'object' && !Array.isArray(stats)) {
+        const attrs: Record<string, number> = {};
+        for (const [key, value] of Object.entries(stats)) {
+          if (typeof value === 'number' && Number.isFinite(value)) {
+            attrs[`lml.cache.${key}`] = value;
+          }
+        }
+        if (Object.keys(attrs).length > 0) {
+          // Observability must never break the request path.
+          try {
+            span.setAttributes(attrs);
+          } catch (err) {
+            console.warn('lml-fetch: failed to project cache_stats onto span', err);
+          }
+        }
+      }
+
+      return parsed;
+    } catch (error) {
+      if ((error as Error).name === 'AbortError') {
+        throw new Error('LML request timed out', { cause: error });
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
     }
-    throw error;
-  } finally {
-    clearTimeout(timeout);
-  }
+  });
 };

--- a/tests/unit/jobs/flowsheet-metadata-backfill/lml-fetch.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/lml-fetch.test.ts
@@ -1,0 +1,110 @@
+// Unit test for #715: lookupMetadata wraps fetch in Sentry.startSpan and projects cache_stats.
+
+import { jest } from '@jest/globals';
+
+const mockFetch = jest.fn<typeof global.fetch>();
+global.fetch = mockFetch;
+
+const mockSpanSetAttributes = jest.fn();
+type SpanLike = { setAttributes: typeof mockSpanSetAttributes };
+const mockStartSpan = jest.fn(
+  async (_opts: { name: string; op: string }, callback: (span: SpanLike) => unknown) =>
+    await callback({ setAttributes: mockSpanSetAttributes })
+);
+jest.mock('@sentry/node', () => ({
+  startSpan: (opts: { name: string; op: string }, callback: (span: SpanLike) => unknown) =>
+    mockStartSpan(opts, callback),
+}));
+
+import { lookupMetadata } from '../../../../jobs/flowsheet-metadata-backfill/lml-fetch';
+
+describe('jobs/flowsheet-metadata-backfill/lml-fetch', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, LIBRARY_METADATA_URL: 'http://lml.test:8000' };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('lookupMetadata Sentry instrumentation (#715)', () => {
+    it('wraps the call in a Sentry span with name=lml.lookup, op=http.client', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], search_type: 'none' }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield', 'VI Scose Poise');
+
+      expect(mockStartSpan).toHaveBeenCalledTimes(1);
+      expect(mockStartSpan.mock.calls[0][0]).toEqual({ name: 'lml.lookup', op: 'http.client' });
+    });
+
+    it('projects numeric cache_stats fields onto the span as lml.cache.<key>', async () => {
+      const cache_stats = {
+        memory_hits: 1,
+        pg_hits: 4,
+        pg_misses: 2,
+        api_calls: 3,
+        pg_time_ms: 7.5,
+        api_time_ms: 250,
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], search_type: 'none', cache_stats }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield');
+
+      expect(mockSpanSetAttributes).toHaveBeenCalledWith({
+        'lml.cache.memory_hits': 1,
+        'lml.cache.pg_hits': 4,
+        'lml.cache.pg_misses': 2,
+        'lml.cache.api_calls': 3,
+        'lml.cache.pg_time_ms': 7.5,
+        'lml.cache.api_time_ms': 250,
+      });
+    });
+
+    it('does not call setAttributes when LML response omits cache_stats', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], search_type: 'none' }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre');
+
+      expect(mockStartSpan).toHaveBeenCalledTimes(1);
+      expect(mockSpanSetAttributes).not.toHaveBeenCalled();
+    });
+
+    it('does not call setAttributes when cache_stats is an array (defensive narrowing)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [], search_type: 'none', cache_stats: [1, 2, 3] }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre');
+
+      expect(mockSpanSetAttributes).not.toHaveBeenCalled();
+    });
+
+    it('resolves the lookup even when span.setAttributes throws', async () => {
+      const lookupResponse = { results: [], search_type: 'none' as const, cache_stats: { memory_hits: 1 } };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(lookupResponse),
+      } as unknown as globalThis.Response);
+      mockSpanSetAttributes.mockImplementation(() => {
+        throw new Error('sentry boom');
+      });
+
+      const result = await lookupMetadata('Autechre');
+
+      expect(result).toEqual(lookupResponse);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors #646's `Sentry.startSpan` wrap into `jobs/flowsheet-metadata-backfill/lml-fetch.ts`. The job runs as a CLI process — no HTTP server, so without an active transaction context @sentry/node v10's undici auto-instrumentation emits zero http.client spans (empirically verified during the 2026-05-04 pilot per #715's body).

The wrap creates `{name: 'lml.lookup', op: 'http.client'}` around the fetch, then projects numeric `cache_stats` fields onto the span as `lml.cache.<key>`. setAttributes errors are swallowed silently so observability never surfaces as a failed metadata lookup. Same body shape and defensive narrowing as the backend client.

Closes #715.

## Test plan

- [x] `npm run test:unit -- tests/unit/jobs/flowsheet-metadata-backfill/lml-fetch.test.ts` — 5 new tests pass on post-fix code (each fails on pre-fix as expected). Cases mirror `tests/unit/services/lml.client.test.ts`: span name+op contract, cache_stats projection, omitted cache_stats path, defensive array-narrowing, and the setAttributes-throws fallback.
- [x] `npm run test:unit -- tests/unit/jobs/flowsheet-metadata-backfill` — full job suite (4 files, 60 tests) green.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean (warning count unchanged from main).
- [ ] Post-merge smoke per the issue body: re-run a small bounded backfill (e.g. `timeout 600 docker run ... -e SENTRY_TRACES_SAMPLE_RATE=1.0 ...`) and confirm via Sentry MCP / trace explorer that spans tagged with the run's `run_id` appear and that linked LML transactions carry `lml.cache.*` attributes.