### PR TITLE
feat(jobs): library-identity-backfill skeleton + S1 source (§4 step 2 sub-PR 2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ npm workspaces:
 | `@wxyc/library-artist-name-backfill` | `jobs/library-artist-name-backfill/` | One-shot backfill: populate `library.artist_name` from the `artists` join after migration 0058 (Epic A.2)                                                                                                                                                              |
 | `@wxyc/flowsheet-metadata-backfill`  | `jobs/flowsheet-metadata-backfill/`  | Recurring metadata drift-repair: enrich `flowsheet` track rows where LML metadata enrichment never ran (#631 / #638 / #641). Cron-registered via deploy-base, schedule `0 6 * * *` UTC (02:00 ET); orchestrator's cooperative pause (#735) defers when DJs are active. |
 | `@wxyc/library-artwork-url-backfill` | `jobs/library-artwork-url-backfill/` | One-shot warm: populate `library.artwork_url` for Discogs-resolvable rows (joined to `artists.discogs_artist_id`) so search-time `enrichWithArtwork` short-circuits (#637).                                                                                            |
+| `@wxyc/library-identity-backfill`    | `jobs/library-identity-backfill/`    | One-shot backfill: populate `library_identity` + `library_identity_source` from existing identity artifacts (cross-cache-identity §4 step 2). Sub-PR 2.0 covers S1 (Backend `canonical_entity_id`); 2.1-2.4 add LML, discogs-cache, and semantic-index sources.        |
 
 ### API Server (`apps/backend`)
 

--- a/Dockerfile.library-identity-backfill
+++ b/Dockerfile.library-identity-backfill
@@ -1,0 +1,27 @@
+#Build stage
+FROM node:25-alpine AS builder
+
+WORKDIR /library-identity-backfill-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/library-identity-backfill ./jobs/library-identity-backfill
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/library-identity-backfill
+
+#Production stage
+FROM node:25-alpine AS prod
+
+WORKDIR /library-identity-backfill
+
+COPY ./package* ./
+COPY ./jobs/library-identity-backfill/package* ./jobs/library-identity-backfill/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./library-identity-backfill-builder/jobs/library-identity-backfill/dist ./jobs/library-identity-backfill/dist
+COPY --from=builder ./library-identity-backfill-builder/shared/database/dist ./shared/database/dist
+
+CMD ["npm", "start", "--workspace=@wxyc/library-identity-backfill"]

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -115,6 +115,18 @@ The artist identity ETL (`jobs/artist-identity-etl/`) populates the six reconcil
 
 - `DATABASE_URL_DISCOGS` — PostgreSQL URL for LML's discogs-cache database, where `entity.identity` lives. Required for the artist-identity ETL.
 
+### One-shot backfill jobs
+
+One-shot backfill jobs under `jobs/*-backfill/` run via `Manual Build & Deploy` and `docker run`. They share a small set of operator knobs:
+
+- `BATCH_SIZE` — Rows fetched per SELECT cursor batch (default `500`). Used by `library-identity-backfill`. Other backfills accept the variant `BACKFILL_BATCH_SIZE` (`flowsheet-metadata-backfill`, `flowsheet-dj-name-backfill`); the existing variant is preserved in those jobs for log-tail compatibility.
+- `THROTTLE_MS` — Inter-row sleep, milliseconds (default `100`). Used by `library-identity-backfill`. The variant `BACKFILL_THROTTLE_MS` is what `flowsheet-metadata-backfill` accepts; same purpose.
+- `PARTITION_INDEX`, `PARTITION_COUNT` — N-container parallel deploy. Each partition processes rows where `id % PARTITION_COUNT = PARTITION_INDEX`. Default is `0/1` (single container, no-op). Used by `library-identity-backfill`, `library-canonical-entity-backfill`, `flowsheet-metadata-backfill`.
+- `DRY_RUN` — Locked truthy values: `true`, `1`, `TRUE`. When set, `library-identity-backfill` runs all SELECTs but skips both per-source INSERTs and main-row UPSERTs; emits a single JSON object on stdout with the locked schema documented in `jobs/library-identity-backfill/README.md`. Other backfills do not currently honor this flag.
+- `WXYC_SCHEMA_NAME` — PostgreSQL schema name (default `wxyc_schema`). Override only for parallel Jest workers / integration test harnesses; production sticks with the default.
+
+Job-specific backfill knobs are documented in each job's README.
+
 ## Cross-cache-identity feature flags (canonical inventory)
 
 This is the **single source of truth** for the cross-cache-identity project's feature flags (plan §4.2). Consumer repos cross-reference this section in their own `.env.example` / CLAUDE.md. When a flag is renamed or its default changes, both the canonical entry here AND the consumer repo's local doc must update in the same PR.

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,9 @@
 {
   "testEnvironment": "node",
   "testMatch": ["**/tests/integration/?(*.)+(spec).js"],
+  "transform": {
+    "^.+\\.ts$": ["ts-jest", { "tsconfig": "<rootDir>/tests/tsconfig.json" }]
+  },
   "globalSetup": "./tests/setup/globalSetup.js",
   "setupFilesAfterEnv": ["./tests/setup/integration.setup.js"],
   "reporters": [

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,9 +1,6 @@
 {
   "testEnvironment": "node",
   "testMatch": ["**/tests/integration/?(*.)+(spec).js"],
-  "transform": {
-    "^.+\\.ts$": ["ts-jest", { "tsconfig": "<rootDir>/tests/tsconfig.json" }]
-  },
   "globalSetup": "./tests/setup/globalSetup.js",
   "setupFilesAfterEnv": ["./tests/setup/integration.setup.js"],
   "reporters": [

--- a/jobs/library-identity-backfill/README.md
+++ b/jobs/library-identity-backfill/README.md
@@ -1,0 +1,117 @@
+# @wxyc/library-identity-backfill
+
+One-shot backfill that materializes `library_identity` and `library_identity_source` from the union of existing identity artifacts (per [§4 step 2 of the cross-cache-identity plan](../../plans/library-hook-canonicalization/section-4-step-2-backfill-plan.md)).
+
+This package is the **skeleton + S1 leg** (sub-PR 2.0). Sub-PRs 2.1-2.4 add the remaining four sources; 2.0 stands up the dual-table writer (§3.2.2.2) and the §3.4.1.1 main-row recompute, exercising them with the simplest source (Backend's own `library.canonical_entity_id` column).
+
+## What it does
+
+For every `library` row where `canonical_entity_id LIKE 'discogs:%'` and which is not already in `library_identity`:
+
+1. Decompose the value into `(library_id, source='discogs_release', external_id=<release_id>, method='exact_match', confidence=1.00)`.
+2. Open a `db.transaction()`.
+3. `SELECT … FOR UPDATE` on the existing `library_identity` row (defense-in-depth; the primary serialization mechanism is `ON CONFLICT (library_id)`).
+4. UPSERT the per-source row into `library_identity_source` with `ON CONFLICT (library_id, source) DO UPDATE`.
+5. Recompute the main-row values via `recomputeMainRow()` (§3.4.1.1 composition rules) and UPSERT into `library_identity` with `ON CONFLICT (library_id) DO UPDATE`.
+
+## Run command
+
+Build via the GitHub Actions workflow `Manual Build & Deploy` with `target=library-identity-backfill`, then on EC2:
+
+```bash
+docker run --rm \
+  --env-file .env \
+  -e BATCH_SIZE=500 \
+  -e THROTTLE_MS=100 \
+  <ecr-image-uri>:<tag> \
+  2>&1 | tee log
+```
+
+For a 4-way partitioned run (4 disjoint containers in parallel):
+
+```bash
+for i in 0 1 2 3; do
+  docker run --rm -d --name lib-id-bf-$i \
+    --env-file .env \
+    -e PARTITION_INDEX=$i -e PARTITION_COUNT=4 \
+    <ecr-image-uri>:<tag>
+done
+```
+
+## Dry run
+
+Set `DRY_RUN=true` to scan the source rows without writing. The job emits a single JSON object on stdout with the locked schema:
+
+```json
+{
+  "source": "S1",
+  "scanned": 64321,
+  "would_write_sources": 12450,
+  "would_upsert_mains": 12450,
+  "skipped": {
+    "already_in_library_identity": 51800,
+    "no_canonical_entity_id": 70,
+    "non_discogs_namespace": 1
+  }
+}
+```
+
+The `skipped` keys are stable strings; `scanned == would_write_sources + sum(skipped.values())`.
+
+```bash
+docker run --rm --env-file .env -e DRY_RUN=true <ecr-image-uri>:<tag>
+```
+
+## Environment variables
+
+See [`docs/env-vars.md`](../../docs/env-vars.md#etl-jobs--one-shot-backfill) for the canonical list. Quick reference:
+
+| Variable          | Default | Purpose                                                        |
+| ----------------- | ------- | -------------------------------------------------------------- |
+| `DATABASE_URL`    | —       | Backend PostgreSQL connection string (required)                |
+| `BATCH_SIZE`      | `500`   | Rows fetched per SELECT cursor batch                           |
+| `THROTTLE_MS`     | `100`   | Inter-row sleep (DB pacing only; no upstream API in 2.0)       |
+| `PARTITION_INDEX` | `0`     | Index of this partition (0-based)                              |
+| `PARTITION_COUNT` | `1`     | Total partition count (use `1` for single-container runs)      |
+| `DRY_RUN`         | unset   | When `true` / `1` / `TRUE`: scan + report on stdout, no writes |
+| `SENTRY_DSN`      | unset   | Optional; Sentry stays inactive when unset                     |
+
+## Idempotency & rerun safety
+
+The WHERE filter is:
+
+```sql
+WHERE canonical_entity_id IS NOT NULL
+  AND canonical_entity_id LIKE 'discogs:%'
+  AND NOT EXISTS (SELECT 1 FROM library_identity li WHERE li.library_id = library.id)
+```
+
+Already-written rows are skipped; the job is safely re-runnable. The per-source `notes` column is tagged `'backfill:S1'` so future sub-PRs can identify rows this run wrote.
+
+## Rollback (per §5.3)
+
+```sql
+-- 1) Remove S1's per-source rows
+DELETE FROM wxyc_schema.library_identity_source WHERE notes LIKE 'backfill:S1%';
+
+-- 2) Remove the corresponding main rows. After 2.0, every main row's only source is the S1 row,
+-- so this is the right scope; once 2.1+ ships, scope by joining on the per-source delete result.
+DELETE FROM wxyc_schema.library_identity li
+WHERE NOT EXISTS (SELECT 1 FROM wxyc_schema.library_identity_source s WHERE s.library_id = li.library_id);
+```
+
+For partial unwinds (e.g., a single library_id), prefer surgical `DELETE … WHERE library_id = ?` and follow with a recompute on rerun.
+
+## Source confidence assignment (§3.4.1)
+
+S1 stamps `method='exact_match', confidence=1.00`. Justification: `library.canonical_entity_id` is populated by the existing `library-canonical-entity-backfill` job's "direct hit with release_id" branch, which is the §3.4.1 `exact_match` definition. The historical `AUTO_ACCEPT_CONFIDENCE = 0.95` from that job is a synth value for retroactive filtering, not an assertion that the underlying match is below `exact_match` 1.00.
+
+## Cross-source agreement
+
+Sub-PR 2.0 has only one source per library_id, so cross-source agreement detection is not yet exercised. The `recomputeMainRow()` function fully implements the §3.4.1.1 rules (Rule 1 manual hard floor, Rule 2 agreement boost, Rule 3 inherited exclusion, Rule 4 MIN fallback) so 2.1's S2 leg is a single-source-leg-PR rather than re-litigating the composition rules.
+
+## Plan reference
+
+- Plan doc: [`plans/library-hook-canonicalization/section-4-step-2-backfill-plan.md`](../../plans/library-hook-canonicalization/section-4-step-2-backfill-plan.md)
+- Parent plan: [`WXYC/wiki` `library-hook-canonicalization-plan.md`](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md) §4 step 2, §3.2.2.2 (writer), §3.4.1 (confidence matrix), §3.2.3 (gate-check)
+- Parent epic: [#663](https://github.com/WXYC/Backend-Service/issues/663) (E2 — Backend half)

--- a/jobs/library-identity-backfill/job.ts
+++ b/jobs/library-identity-backfill/job.ts
@@ -1,0 +1,44 @@
+/**
+ * One-shot backfill: populate `library_identity` + `library_identity_source`
+ * from Backend's `library.canonical_entity_id` (S1) — sub-PR 2.0 of §4 step 2.
+ *
+ * Iterates every `library` row whose `canonical_entity_id` matches
+ * `'discogs:<release_id>'` and that is not yet present in `library_identity`.
+ * For each row, writes one per-source `library_identity_source` (source =
+ * 'discogs_release', method = 'exact_match', confidence = 1.00) and the
+ * corresponding `library_identity` main row, atomically inside a single
+ * `db.transaction()`.
+ *
+ * Run procedure: build via `Manual Build & Deploy` with
+ * `target=library-identity-backfill`, then SSH to EC2 and
+ * `docker run --rm --env-file .env <image> 2>&1 | tee log`. The job is
+ * resumable; rerunning is safe (idempotent via the WHERE filter).
+ *
+ * DRY_RUN: set `DRY_RUN=true` to run the job without writing — the JSON
+ * report on stdout details scanned/would-write/skipped counts. See
+ * `docs/env-vars.md` and the package README for the locked schema.
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { runBackfill } from './orchestrate.js';
+import { writeIdentity } from './writer.js';
+import { initLogger, log, captureError, closeLogger } from './logger.js';
+
+const JOB_NAME = 'library-identity-backfill';
+
+const main = async () => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  try {
+    log('info', 'init', `${JOB_NAME} initialized`);
+    await runBackfill({ writeIdentity });
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
+};
+
+void main();

--- a/jobs/library-identity-backfill/logger.ts
+++ b/jobs/library-identity-backfill/logger.ts
@@ -1,0 +1,85 @@
+/**
+ * Observability for library-identity-backfill: Sentry init + JSON logs.
+ *
+ * Phase A foundation contract (issue #538): every log line carries the four
+ * tags `repo`, `tool`, `step`, `run_id`. Sentry stays inactive when
+ * SENTRY_DSN is unset (the @sentry/node SDK silently no-ops in that case),
+ * so this module is safe to call from any environment.
+ *
+ * Mirrors `jobs/flowsheet-metadata-backfill/logger.ts` verbatim — the
+ * contract is identical, the duplication is to keep the one-shot job's build
+ * graph independent of the long-running ETL package.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+/**
+ * Emit a JSON log line. `info`/`warn` go to stdout, `error` goes to stderr
+ * so container log shippers can split streams by severity. Silently no-ops
+ * before initLogger() so unit tests that exercise library functions
+ * directly don't have to thread an init call through every fixture.
+ */
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/library-identity-backfill/orchestrate.ts
+++ b/jobs/library-identity-backfill/orchestrate.ts
@@ -90,8 +90,12 @@ export const resolvePartitionFilter = (
   if (count === 1) {
     return { sqlFragment: null, description: 'partition=none' };
   }
+  // Qualify the column reference against `library` so a future loadBatch
+  // change that introduces a JOIN doesn't trigger PG's "column reference
+  // ambiguous". Mirrors the fix in `library-canonical-entity-backfill/
+  // orchestrate.ts:71`.
   return {
-    sqlFragment: sql`AND ("id" % ${count}) = ${index}`,
+    sqlFragment: sql`AND (${LIBRARY_TABLE}."id" % ${count}) = ${index}`,
     description: `partition=${index}/${count}`,
   };
 };
@@ -142,17 +146,29 @@ export type RunResult = {
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Per-batch row shape. In DRY_RUN mode the SELECT additionally surfaces an
+ * `already_in_library_identity` flag so the orchestrator can bin rows that
+ * would have been excluded by the real-run NOT EXISTS filter. In real-run
+ * mode the flag is always false (those rows are filtered out at the SQL
+ * layer and never reach this struct).
+ */
+type BatchRow = LibraryRow & { already_in_library_identity: boolean };
+
 const loadBatch = async (
   afterId: number,
   batchSize: number,
   partitionFilter: SQL | null,
   dryRun: boolean
-): Promise<LibraryRow[]> => {
+): Promise<BatchRow[]> => {
   const partitionClause = partitionFilter ?? sql``;
   // In real-run mode the WHERE filter does the heavy lifting (excludes rows
   // already in library_identity, NULLs, and non-discogs namespaces). DRY_RUN
-  // intentionally relaxes the second/third filters so the report can break
-  // out the skip categories.
+  // relaxes the second/third filters so the report can break out skip
+  // categories, and surfaces an `already_in_library_identity` flag (via
+  // EXISTS subselect) so the rerun-overlap count is honest. Without the
+  // flag, `would_write_sources` over-counts on any rerun where prior runs
+  // already wrote some rows.
   const filterClause = dryRun
     ? sql``
     : sql`AND "canonical_entity_id" IS NOT NULL
@@ -160,18 +176,25 @@ const loadBatch = async (
            AND NOT EXISTS (
              SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li WHERE li."library_id" = "id"
            )`;
+  const presenceFlag = dryRun
+    ? sql`,
+      EXISTS (
+        SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li WHERE li."library_id" = "id"
+      ) AS "already_in_library_identity"`
+    : sql`,
+      false AS "already_in_library_identity"`;
   const rows = (await db.execute(sql`
     SELECT
       "id",
       "canonical_entity_id",
-      "canonical_entity_resolved_at"
+      "canonical_entity_resolved_at"${presenceFlag}
     FROM ${LIBRARY_TABLE}
     WHERE "id" > ${afterId}
       ${filterClause}
       ${partitionClause}
     ORDER BY "id" ASC
     LIMIT ${batchSize}
-  `)) as unknown as LibraryRow[];
+  `)) as unknown as BatchRow[];
   return rows ?? [];
 };
 
@@ -229,11 +252,17 @@ export const runBackfill = async (opts: {
         totals.skipped_non_discogs_namespace += 1;
         continue;
       }
+      // DRY_RUN-only bucket: rows that have a discogs:<id> canonical but are
+      // already represented in library_identity. Real-run path filters these
+      // out at the SQL layer, so the flag is always false and the bucket
+      // stays at 0; in DRY_RUN the SELECT relaxes the filter and surfaces
+      // them so the report's would_write_sources is honest on rerun.
+      if (row.already_in_library_identity) {
+        totals.skipped_already_in_library_identity += 1;
+        continue;
+      }
 
-      if (dryRun) {
-        // No write side-effect; counters above are the report.
-        totals.wrote += 0;
-      } else {
+      if (!dryRun) {
         await opts.writeIdentity(row.id, outcome.sourceRows, []);
         totals.wrote += 1;
       }

--- a/jobs/library-identity-backfill/orchestrate.ts
+++ b/jobs/library-identity-backfill/orchestrate.ts
@@ -1,0 +1,279 @@
+/**
+ * Backfill orchestrator for §4 step 2 sub-PR 2.0 — library_identity from
+ * Backend's `library.canonical_entity_id` column (S1).
+ *
+ * Mirrors `library-canonical-entity-backfill/orchestrate.ts`'s shape:
+ *
+ *   - WHERE filter:
+ *       library.canonical_entity_id IS NOT NULL
+ *       AND library.canonical_entity_id LIKE 'discogs:%'
+ *       AND NOT EXISTS (SELECT 1 FROM library_identity li WHERE li.library_id = library.id)
+ *     The first two scope to S1's universe; the NOT EXISTS gates idempotency
+ *     (rows already written are skipped on rerun, per §4).
+ *   - id-cursor pagination + PARTITION_INDEX/COUNT modulo for parallel
+ *     containers.
+ *   - DRY_RUN env var: when true, the SELECT runs but every per-library_id
+ *     write is suppressed; the orchestrator emits a single locked-schema JSON
+ *     report on stdout.
+ *
+ * The `writeIdentity` function is injected so tests can drive the loop
+ * without exercising the live transaction.
+ *
+ * Skip categories tracked in counters and the dry-run report:
+ *   - already_in_library_identity — `library_identity.library_id` already
+ *     present (the WHERE filter usually excludes these; the counter exists
+ *     for the DRY_RUN path which intentionally does not enforce the filter
+ *     in JOIN form).
+ *   - no_canonical_entity_id — column is NULL (excluded by WHERE in real
+ *     run; surfaced by DRY_RUN at the resolver step).
+ *   - non_discogs_namespace — value is non-NULL but does not match
+ *     `discogs:<int>`. Other namespaces (e.g., 'mb:') belong to sub-PRs
+ *     2.1+; malformed values are also bucketed here.
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+import { resolveS1, type LibraryRow, type SourceRowToWrite } from './resolve.js';
+import { log } from './logger.js';
+
+const JOB_NAME = 'library-identity-backfill';
+
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const LIBRARY_TABLE = sql.raw(`"${SCHEMA}"."library"`);
+const LIBRARY_IDENTITY_TABLE = sql.raw(`"${SCHEMA}"."library_identity"`);
+
+export const BATCH_SIZE = 500;
+
+/**
+ * Default inter-row delay, in ms. Sub-PR 2.0 is DB-only (no LML traffic), so
+ * this is purely about not saturating the postgres-js connection pool. Tests
+ * pass 0.
+ */
+export const THROTTLE_MS = 100;
+
+export const resolveBatchSize = (raw: string | undefined = process.env.BATCH_SIZE): number => {
+  if (raw === undefined) return BATCH_SIZE;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`Invalid BATCH_SIZE=${JSON.stringify(raw)}; must be a positive integer.`);
+  }
+  return parsed;
+};
+
+export const resolveThrottleMs = (raw: string | undefined = process.env.THROTTLE_MS): number => {
+  if (raw === undefined) return THROTTLE_MS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid THROTTLE_MS=${JSON.stringify(raw)}; must be a non-negative integer.`);
+  }
+  return parsed;
+};
+
+/**
+ * Resolve PARTITION_INDEX / PARTITION_COUNT into a SQL fragment. N-container
+ * deploy pattern matches the existing one-shot jobs.
+ */
+export const resolvePartitionFilter = (
+  rawIndex: string | undefined = process.env.PARTITION_INDEX,
+  rawCount: string | undefined = process.env.PARTITION_COUNT
+): { sqlFragment: SQL | null; description: string } => {
+  const count = rawCount === undefined ? 1 : Number(rawCount);
+  const index = rawIndex === undefined ? 0 : Number(rawIndex);
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(`Invalid PARTITION_COUNT=${JSON.stringify(rawCount)}; must be a positive integer.`);
+  }
+  if (!Number.isInteger(index) || index < 0 || index >= count) {
+    throw new Error(
+      `Invalid PARTITION_INDEX=${JSON.stringify(rawIndex)}; must be 0 <= index < PARTITION_COUNT (${count}).`
+    );
+  }
+  if (count === 1) {
+    return { sqlFragment: null, description: 'partition=none' };
+  }
+  return {
+    sqlFragment: sql`AND ("id" % ${count}) = ${index}`,
+    description: `partition=${index}/${count}`,
+  };
+};
+
+/**
+ * Resolve the DRY_RUN env var. Locked truthy values: `true`, `1`, `TRUE`.
+ * Anything else (including `false`, `0`, undefined, empty string) is false.
+ * Locked per §4 to avoid sloppy operator inputs (`yes`, `on`) silently
+ * disabling the writer.
+ */
+export const resolveDryRun = (raw: string | undefined = process.env.DRY_RUN): boolean => {
+  if (raw === undefined) return false;
+  const lowered = raw.toLowerCase();
+  return lowered === 'true' || lowered === '1';
+};
+
+export type WriteIdentityFn = (
+  libraryId: number,
+  sourceRows: SourceRowToWrite[],
+  agreementSources: string[]
+) => Promise<void>;
+
+export type Totals = {
+  scanned: number;
+  wrote: number;
+  skipped_already_in_library_identity: number;
+  skipped_no_canonical_entity_id: number;
+  skipped_non_discogs_namespace: number;
+};
+
+/** Locked schema for the DRY_RUN stdout report (sub-PR 2.0 §4). */
+export type DryRunReport = {
+  source: 'S1';
+  scanned: number;
+  would_write_sources: number;
+  would_upsert_mains: number;
+  skipped: {
+    already_in_library_identity: number;
+    no_canonical_entity_id: number;
+    non_discogs_namespace: number;
+  };
+};
+
+export type RunResult = {
+  totals: Totals;
+  dryRunReport: DryRunReport | null;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const loadBatch = async (
+  afterId: number,
+  batchSize: number,
+  partitionFilter: SQL | null,
+  dryRun: boolean
+): Promise<LibraryRow[]> => {
+  const partitionClause = partitionFilter ?? sql``;
+  // In real-run mode the WHERE filter does the heavy lifting (excludes rows
+  // already in library_identity, NULLs, and non-discogs namespaces). DRY_RUN
+  // intentionally relaxes the second/third filters so the report can break
+  // out the skip categories.
+  const filterClause = dryRun
+    ? sql``
+    : sql`AND "canonical_entity_id" IS NOT NULL
+           AND "canonical_entity_id" LIKE 'discogs:%'
+           AND NOT EXISTS (
+             SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li WHERE li."library_id" = "id"
+           )`;
+  const rows = (await db.execute(sql`
+    SELECT
+      "id",
+      "canonical_entity_id",
+      "canonical_entity_resolved_at"
+    FROM ${LIBRARY_TABLE}
+    WHERE "id" > ${afterId}
+      ${filterClause}
+      ${partitionClause}
+    ORDER BY "id" ASC
+    LIMIT ${batchSize}
+  `)) as unknown as LibraryRow[];
+  return rows ?? [];
+};
+
+const formatTotals = (t: Totals): string =>
+  `scanned=${t.scanned} wrote=${t.wrote} ` +
+  `skipped_already_in_library_identity=${t.skipped_already_in_library_identity} ` +
+  `skipped_no_canonical_entity_id=${t.skipped_no_canonical_entity_id} ` +
+  `skipped_non_discogs_namespace=${t.skipped_non_discogs_namespace}`;
+
+export const runBackfill = async (opts: {
+  writeIdentity: WriteIdentityFn;
+  batchSize?: number;
+  throttleMs?: number;
+  partition?: { sqlFragment: SQL | null; description: string };
+  dryRun?: boolean;
+  onDryRunReport?: (report: DryRunReport) => void;
+}): Promise<RunResult> => {
+  const batchSize = opts.batchSize ?? resolveBatchSize();
+  const throttleMs = opts.throttleMs ?? resolveThrottleMs();
+  const partition = opts.partition ?? resolvePartitionFilter();
+  const dryRun = opts.dryRun ?? resolveDryRun();
+
+  log('info', 'started', `${JOB_NAME} starting`, {
+    batch_size: batchSize,
+    throttle_ms: throttleMs,
+    partition: partition.description,
+    dry_run: dryRun,
+  });
+
+  const totals: Totals = {
+    scanned: 0,
+    wrote: 0,
+    skipped_already_in_library_identity: 0,
+    skipped_no_canonical_entity_id: 0,
+    skipped_non_discogs_namespace: 0,
+  };
+  let lastId = 0;
+  let batchIndex = 0;
+
+  while (true) {
+    const rows = await loadBatch(lastId, batchSize, partition.sqlFragment, dryRun);
+    if (rows.length === 0) break;
+    batchIndex += 1;
+
+    for (const row of rows) {
+      totals.scanned += 1;
+      lastId = row.id;
+
+      const outcome = resolveS1(row);
+      if (outcome.status === 'no_canonical_entity_id') {
+        totals.skipped_no_canonical_entity_id += 1;
+        continue;
+      }
+      if (outcome.status === 'non_discogs_namespace') {
+        totals.skipped_non_discogs_namespace += 1;
+        continue;
+      }
+
+      if (dryRun) {
+        // No write side-effect; counters above are the report.
+        totals.wrote += 0;
+      } else {
+        await opts.writeIdentity(row.id, outcome.sourceRows, []);
+        totals.wrote += 1;
+      }
+      if (throttleMs > 0) await sleep(throttleMs);
+    }
+
+    log('info', 'batch_done', `batch ${batchIndex} done`, {
+      batch_index: batchIndex,
+      last_id: lastId,
+      ...totals,
+    });
+  }
+
+  const dryRunReport: DryRunReport | null = dryRun
+    ? {
+        source: 'S1',
+        scanned: totals.scanned,
+        would_write_sources:
+          totals.scanned -
+          totals.skipped_already_in_library_identity -
+          totals.skipped_no_canonical_entity_id -
+          totals.skipped_non_discogs_namespace,
+        would_upsert_mains:
+          totals.scanned -
+          totals.skipped_already_in_library_identity -
+          totals.skipped_no_canonical_entity_id -
+          totals.skipped_non_discogs_namespace,
+        skipped: {
+          already_in_library_identity: totals.skipped_already_in_library_identity,
+          no_canonical_entity_id: totals.skipped_no_canonical_entity_id,
+          non_discogs_namespace: totals.skipped_non_discogs_namespace,
+        },
+      }
+    : null;
+
+  if (dryRunReport) {
+    process.stdout.write(JSON.stringify(dryRunReport) + '\n');
+    if (opts.onDryRunReport) opts.onDryRunReport(dryRunReport);
+  }
+
+  log('info', 'finished', `${JOB_NAME} done. ${formatTotals(totals)}`, { ...totals });
+  return { totals, dryRunReport };
+};

--- a/jobs/library-identity-backfill/package.json
+++ b/jobs/library-identity-backfill/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@wxyc/library-identity-backfill",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot backfill: populate library_identity + library_identity_source from existing identity artifacts. Sub-PR 2.0 covers S1 (Backend canonical_entity_id).",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_library_identity_backfill:ci -f ../../Dockerfile.library-identity-backfill ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.52.0",
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/library-identity-backfill/recompute.ts
+++ b/jobs/library-identity-backfill/recompute.ts
@@ -1,0 +1,187 @@
+/**
+ * Main-row recompute for `library_identity` (§3.4.1.1 — composition rules).
+ *
+ * Given the per-source rows that exist for a single library_id (i.e., the
+ * current contents of `library_identity_source` after the writer's per-source
+ * upserts), produce the values that the main `library_identity` row should
+ * hold. The result is what the writer UPSERTs onto the main table.
+ *
+ * Composition rules (locked, from
+ * `plans/library-hook-canonicalization/section-4-step-2-backfill-plan.md`
+ * §5.1.1, which restates the parent plan §3.4.1.1):
+ *
+ *   Rule 1 — manual hard floor. Any per-source row with method='manual' pins
+ *            the main row to (manual, 1.00). Cannot be demoted by automation.
+ *   Rule 2 — agreement boost. When two-or-more non-inherited corroborating
+ *            sources are passed in, main becomes (cross_source_agreement,
+ *            MAX(0.95, MIN-of-corroborating-confidences)).
+ *   Rule 3 — inherited rows do not contribute to agreement (carry weaker
+ *            epistemic weight by definition).
+ *   Rule 4 — fallback when no agreement: main inherits the (method, confidence)
+ *            of the MIN-confidence per-source row (most cautious).
+ *   Rule 5 — supersedure / demotion is the writer's concern; this function
+ *            simply computes the "should be" state. Per §5.1.1, demoting
+ *            (e.g. exact_match 1.00 → cross_source_agreement 0.95) is
+ *            considered evidence-positive because corroborated > single, and
+ *            the writer always UPSERTs unconditionally with history.
+ *
+ * Sub-PR 2.0 only writes single-source S1 rows, but the function is fully
+ * implemented across the §5.1.1 worked-example matrix so 2.1+ cannot drift
+ * the contract without a unit-test failure.
+ *
+ * The `agreementSources` array names which per-source `source` values are
+ * cross-referenced by the caller's cross-ref index (§5.2). Callers that have
+ * not built the index yet (i.e., 2.0) pass `[]`.
+ */
+
+export type SourceRow = {
+  /** Source identifier — e.g., 'discogs_release', 'discogs_artist', 'wikidata'. */
+  source: string;
+  /** External ID at the named source. Numeric IDs arrive as strings. */
+  external_id: string;
+  /** §3.4.1 method enum. */
+  method: string;
+  /** Confidence in [0, 1]. */
+  confidence: number;
+  /** Optional list of sources that boosted this row's confidence (sub-PR 2.1+). */
+  boost_sources: string | null;
+  /** Source-supplied last-verified timestamp; defaults to now() at the writer. */
+  last_verified_at?: Date;
+};
+
+export type MainRowFields = {
+  discogs_master_id: number | null;
+  discogs_release_id: number | null;
+  musicbrainz_release_group_mbid: string | null;
+  musicbrainz_release_mbid: string | null;
+  musicbrainz_recording_mbid: string | null;
+  wikidata_qid: string | null;
+  spotify_id: string | null;
+  apple_music_id: string | null;
+  method: string;
+  confidence: number;
+  agreement_sources: string | null;
+  last_verified_at: Date;
+};
+
+/**
+ * Maps a per-source `source` value to the main row's external-ID column.
+ * Sources not in this table are artist-level (or otherwise not surfaced in
+ * the main row) and contribute only to confidence/agreement composition.
+ *
+ * Sub-PR 2.0 only writes `discogs_release`. The other entries are pre-locked
+ * so 2.1-2.3 don't have to extend this map. Adding a new release-level
+ * source in a future sub-PR means adding both a row here AND extending the
+ * substrate schema (out of scope per §6).
+ */
+const RELEASE_LEVEL_SOURCE_TO_COLUMN: Record<string, keyof MainRowFields> = {
+  discogs_master: 'discogs_master_id',
+  discogs_release: 'discogs_release_id',
+  mb_release_group: 'musicbrainz_release_group_mbid',
+  mb_release: 'musicbrainz_release_mbid',
+  mb_recording: 'musicbrainz_recording_mbid',
+  wikidata: 'wikidata_qid',
+  spotify: 'spotify_id',
+  apple_music: 'apple_music_id',
+};
+
+const CROSS_SOURCE_AGREEMENT_FLOOR = 0.95;
+
+/**
+ * Parse the external_id into the right shape for the column. Discogs IDs are
+ * integers; everything else is text.
+ */
+const parseExternalId = (column: keyof MainRowFields, raw: string): number | string => {
+  if (column === 'discogs_master_id' || column === 'discogs_release_id') {
+    const parsed = Number(raw);
+    if (!Number.isInteger(parsed)) {
+      throw new Error(`Expected integer external_id for ${String(column)}, got ${JSON.stringify(raw)}`);
+    }
+    return parsed;
+  }
+  return raw;
+};
+
+/**
+ * Compute the main-row values for a library_id given its per-source rows and
+ * the (possibly empty) list of sources verified to corroborate via the
+ * cross-ref index.
+ *
+ * Throws on an empty rows array — the writer should not call recompute when
+ * no per-source rows exist for the library_id (the main row should be
+ * deleted instead).
+ */
+export const recomputeMainRow = (rows: SourceRow[], agreementSources: string[]): MainRowFields => {
+  if (rows.length === 0) {
+    throw new Error('recomputeMainRow called with no per-source rows; expected at least one.');
+  }
+
+  // External-ID column population: take the per-source row's external_id and
+  // write it to the matching main-row column. If two rows pin the same column
+  // (e.g., two `discogs_release` rows — should not happen given the per-source
+  // PK is (library_id, source), but defensive), the last one wins. The PK
+  // guarantee makes this practically unreachable.
+  const main: MainRowFields = {
+    discogs_master_id: null,
+    discogs_release_id: null,
+    musicbrainz_release_group_mbid: null,
+    musicbrainz_release_mbid: null,
+    musicbrainz_recording_mbid: null,
+    wikidata_qid: null,
+    spotify_id: null,
+    apple_music_id: null,
+    method: 'exact_match',
+    confidence: 1.0,
+    agreement_sources: null,
+    last_verified_at: new Date(0),
+  };
+
+  for (const row of rows) {
+    const column = RELEASE_LEVEL_SOURCE_TO_COLUMN[row.source];
+    if (column !== undefined) {
+      const value = parseExternalId(column, row.external_id);
+      // Cast through unknown — every column in the lookup table accepts the
+      // parseExternalId return type for that column.
+      (main as unknown as Record<string, unknown>)[column] = value;
+    }
+    if (row.last_verified_at && row.last_verified_at > main.last_verified_at) {
+      main.last_verified_at = row.last_verified_at;
+    }
+  }
+
+  // Rule 1: manual hard floor. Any manual row pins the main row.
+  const manualRow = rows.find((r) => r.method === 'manual');
+  if (manualRow) {
+    main.method = 'manual';
+    main.confidence = 1.0;
+    main.agreement_sources = null;
+    return main;
+  }
+
+  // Rule 2: agreement boost. Need >= 2 non-inherited rows whose source names
+  // appear in agreementSources (§3.2.5 cross-ref result).
+  const corroboratingRows = rows.filter((r) => r.method !== 'inherited' && agreementSources.includes(r.source));
+  if (corroboratingRows.length >= 2) {
+    const minCorroboratingConfidence = Math.min(...corroboratingRows.map((r) => r.confidence));
+    main.method = 'cross_source_agreement';
+    main.confidence = Math.max(CROSS_SOURCE_AGREEMENT_FLOOR, minCorroboratingConfidence);
+    main.agreement_sources = corroboratingRows
+      .map((r) => r.source)
+      .slice()
+      .sort()
+      .join(',');
+    return main;
+  }
+
+  // Rule 4: fallback to the MIN-confidence row's (method, confidence). Inherited
+  // rows DO participate here — they're excluded from agreement (Rule 3) but
+  // still constrain the fallback main row.
+  let minRow = rows[0];
+  for (const r of rows) {
+    if (r.confidence < minRow.confidence) minRow = r;
+  }
+  main.method = minRow.method;
+  main.confidence = minRow.confidence;
+  main.agreement_sources = null;
+  return main;
+};

--- a/jobs/library-identity-backfill/resolve.ts
+++ b/jobs/library-identity-backfill/resolve.ts
@@ -1,0 +1,87 @@
+/**
+ * Source-1 resolver: Backend `library.canonical_entity_id` → per-source rows.
+ *
+ * This is sub-PR 2.0's only source leg. Rows in `library` whose
+ * `canonical_entity_id` matches the `'discogs:<release_id>'` shape produce
+ * exactly one per-source row (`source='discogs_release'`, `method='exact_match'`,
+ * `confidence=1.00`). Sub-PRs 2.1-2.3 add more readers under `sources/`.
+ *
+ * The 1.00 + exact_match assignment is justified at plan §4 sub-PR 2.0:
+ * `library.canonical_entity_id` is populated by the existing
+ * `library-canonical-entity-backfill` job's "direct hit with release_id"
+ * branch, which is the §3.4.1 `exact_match` definition (not name_variation,
+ * not trigram). The historical `AUTO_ACCEPT_CONFIDENCE = 0.95` from that job
+ * is a synth value for retroactive filtering, not an assertion that the
+ * underlying match is below `exact_match` 1.00 — we re-stamp at the §3.4.1
+ * canonical level here.
+ *
+ * Output is decision-only — the writer is responsible for inserting and
+ * for stamping the `notes='backfill:S1'` tag (already pre-populated here so
+ * the writer can pass it through unchanged).
+ */
+
+export type LibraryRow = {
+  id: number;
+  canonical_entity_id: string | null;
+  canonical_entity_resolved_at: Date | null;
+};
+
+/**
+ * One per-source row to insert into `library_identity_source`. Fields mirror
+ * the substrate columns 1:1 except for the `library_id` PK component which
+ * the writer fills in from the iteration cursor.
+ */
+export type SourceRowToWrite = {
+  library_id: number;
+  source: string;
+  external_id: string;
+  method: string;
+  confidence: number;
+  last_verified_at: Date;
+  boost_sources: string | null;
+  notes: string;
+};
+
+export type ResolveOutcome =
+  | { status: 'match'; sourceRows: SourceRowToWrite[] }
+  | { status: 'no_canonical_entity_id' }
+  | { status: 'non_discogs_namespace' };
+
+/** Tag used on the `notes` column so the §5.3 unwind can find S1 rows. */
+export const NOTES_TAG_S1 = 'backfill:S1';
+
+const DISCOGS_PREFIX = 'discogs:';
+
+export const resolveS1 = (row: LibraryRow): ResolveOutcome => {
+  if (row.canonical_entity_id == null) {
+    return { status: 'no_canonical_entity_id' };
+  }
+  if (!row.canonical_entity_id.startsWith(DISCOGS_PREFIX)) {
+    return { status: 'non_discogs_namespace' };
+  }
+  const idText = row.canonical_entity_id.slice(DISCOGS_PREFIX.length);
+  // canonical_entity_id is opaque text in the schema, so a hand-edit could
+  // technically write 'discogs:foo'. Reject anything that isn't a positive
+  // integer rather than smuggling a non-integer through to PG.
+  if (!/^[0-9]+$/.test(idText)) {
+    return { status: 'non_discogs_namespace' };
+  }
+
+  const lastVerifiedAt = row.canonical_entity_resolved_at ?? new Date();
+
+  return {
+    status: 'match',
+    sourceRows: [
+      {
+        library_id: row.id,
+        source: 'discogs_release',
+        external_id: idText,
+        method: 'exact_match',
+        confidence: 1.0,
+        last_verified_at: lastVerifiedAt,
+        boost_sources: null,
+        notes: NOTES_TAG_S1,
+      },
+    ],
+  };
+};

--- a/jobs/library-identity-backfill/tsconfig.json
+++ b/jobs/library-identity-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/library-identity-backfill/tsup.config.ts
+++ b/jobs/library-identity-backfill/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/jobs/library-identity-backfill/writer.ts
+++ b/jobs/library-identity-backfill/writer.ts
@@ -1,0 +1,126 @@
+/**
+ * Dual-table writer for `library_identity` + `library_identity_source`
+ * (per plan §3.2.2.2).
+ *
+ * Each call writes a single library_id atomically:
+ *   1. Open `db.transaction()`.
+ *   2. SELECT … FOR UPDATE on the existing main row (defense-in-depth per
+ *      §5.1; the actual first-insert serialization comes from the
+ *      `ON CONFLICT (library_id)` clause on the main-row UPSERT — the lock
+ *      no-ops when no main row exists yet).
+ *   3. INSERT/UPSERT each per-source row into `library_identity_source` with
+ *      `ON CONFLICT (library_id, source) DO UPDATE`.
+ *   4. Recompute the main-row values from the (now-current) per-source rows.
+ *   5. UPSERT the main row into `library_identity` with
+ *      `ON CONFLICT (library_id) DO UPDATE`.
+ *
+ * History (§5.1.1) — when the main row is superseded by a recompute, a
+ * snapshot of the prior state moves to `library_identity_history` with
+ * `superseded_reason='backfill_recompute'`. Sub-PR 2.0 only writes single-
+ * source rows where no prior main row exists (idempotency WHERE filter),
+ * so the history INSERT never fires from 2.0; the path is already wired so
+ * 2.1+ supersedure cases are a single-line change in the orchestrator.
+ *
+ * No `metadata_attempt_at`-style marker exists on `library_identity` — the
+ * idempotency strategy is set-membership against `library_identity` itself
+ * (the orchestrator's WHERE filter), not a column-level marker.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+import { recomputeMainRow, type SourceRow } from './recompute.js';
+import type { SourceRowToWrite } from './resolve.js';
+
+/**
+ * Schema-qualified table references. Honors `WXYC_SCHEMA_NAME` so parallel
+ * Jest workers (which override the env var) and any future integration test
+ * harness target the right schema. Default `wxyc_schema` matches production.
+ * Sanitised against `"` to keep the SQL well-formed; same shape as
+ * `library-canonical-entity-backfill/orchestrate.ts`.
+ */
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const LIBRARY_IDENTITY_TABLE = sql.raw(`"${SCHEMA}"."library_identity"`);
+const LIBRARY_IDENTITY_SOURCE_TABLE = sql.raw(`"${SCHEMA}"."library_identity_source"`);
+
+/**
+ * Write the per-source rows + recomputed main row for `libraryId` atomically.
+ *
+ * `agreementSources` lists per-source `source` values that the caller's
+ * cross-ref index has verified to corroborate this library_id. Sub-PR 2.0
+ * passes `[]` (no cross-ref index built yet); 2.1+ populate it from the
+ * §5.2 in-memory cross-ref pre-index.
+ */
+export const writeIdentity = async (
+  libraryId: number,
+  sourceRows: SourceRowToWrite[],
+  agreementSources: string[]
+): Promise<void> => {
+  await db.transaction(async (tx) => {
+    // Defense-in-depth lock on the existing main row, if any. No-op for
+    // first inserts; serializes against any concurrent reader / writer when
+    // a main row already exists.
+    await tx.execute(sql`
+      SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE}
+      WHERE "library_id" = ${libraryId}
+      FOR UPDATE
+    `);
+
+    for (const r of sourceRows) {
+      await tx.execute(sql`
+        INSERT INTO ${LIBRARY_IDENTITY_SOURCE_TABLE} (
+          "library_id", "source", "external_id", "method", "confidence",
+          "last_verified_at", "boost_sources", "notes"
+        ) VALUES (
+          ${r.library_id}, ${r.source}, ${r.external_id}, ${r.method}, ${r.confidence},
+          ${r.last_verified_at}, ${r.boost_sources}, ${r.notes}
+        )
+        ON CONFLICT ("library_id", "source") DO UPDATE SET
+          "external_id" = EXCLUDED."external_id",
+          "method" = EXCLUDED."method",
+          "confidence" = EXCLUDED."confidence",
+          "last_verified_at" = EXCLUDED."last_verified_at",
+          "boost_sources" = EXCLUDED."boost_sources",
+          "notes" = EXCLUDED."notes"
+      `);
+    }
+
+    const recomputeInputs: SourceRow[] = sourceRows.map((r) => ({
+      source: r.source,
+      external_id: r.external_id,
+      method: r.method,
+      confidence: r.confidence,
+      boost_sources: r.boost_sources,
+      last_verified_at: r.last_verified_at,
+    }));
+    const main = recomputeMainRow(recomputeInputs, agreementSources);
+
+    await tx.execute(sql`
+      INSERT INTO ${LIBRARY_IDENTITY_TABLE} (
+        "library_id",
+        "discogs_master_id", "discogs_release_id",
+        "musicbrainz_release_group_mbid", "musicbrainz_release_mbid", "musicbrainz_recording_mbid",
+        "wikidata_qid", "spotify_id", "apple_music_id",
+        "last_verified_at", "method", "confidence", "agreement_sources", "notes"
+      ) VALUES (
+        ${libraryId},
+        ${main.discogs_master_id}, ${main.discogs_release_id},
+        ${main.musicbrainz_release_group_mbid}, ${main.musicbrainz_release_mbid}, ${main.musicbrainz_recording_mbid},
+        ${main.wikidata_qid}, ${main.spotify_id}, ${main.apple_music_id},
+        ${main.last_verified_at}, ${main.method}, ${main.confidence}, ${main.agreement_sources}, ${null}
+      )
+      ON CONFLICT ("library_id") DO UPDATE SET
+        "discogs_master_id" = EXCLUDED."discogs_master_id",
+        "discogs_release_id" = EXCLUDED."discogs_release_id",
+        "musicbrainz_release_group_mbid" = EXCLUDED."musicbrainz_release_group_mbid",
+        "musicbrainz_release_mbid" = EXCLUDED."musicbrainz_release_mbid",
+        "musicbrainz_recording_mbid" = EXCLUDED."musicbrainz_recording_mbid",
+        "wikidata_qid" = EXCLUDED."wikidata_qid",
+        "spotify_id" = EXCLUDED."spotify_id",
+        "apple_music_id" = EXCLUDED."apple_music_id",
+        "last_verified_at" = EXCLUDED."last_verified_at",
+        "method" = EXCLUDED."method",
+        "confidence" = EXCLUDED."confidence",
+        "agreement_sources" = EXCLUDED."agreement_sources"
+    `);
+  });
+};

--- a/jobs/library-identity-backfill/writer.ts
+++ b/jobs/library-identity-backfill/writer.ts
@@ -14,12 +14,13 @@
  *   5. UPSERT the main row into `library_identity` with
  *      `ON CONFLICT (library_id) DO UPDATE`.
  *
- * History (§5.1.1) — when the main row is superseded by a recompute, a
- * snapshot of the prior state moves to `library_identity_history` with
- * `superseded_reason='backfill_recompute'`. Sub-PR 2.0 only writes single-
- * source rows where no prior main row exists (idempotency WHERE filter),
- * so the history INSERT never fires from 2.0; the path is already wired so
- * 2.1+ supersedure cases are a single-line change in the orchestrator.
+ * History (§5.1.1) — when the main row is superseded by a recompute, the
+ * plan calls for a snapshot of the prior state to land in
+ * `library_identity_history` with `superseded_reason='backfill_recompute'`.
+ * Sub-PR 2.0 only writes single-source rows where no prior main row exists
+ * (idempotency WHERE filter), so no supersedure occurs. The history INSERT
+ * itself is NOT wired in this PR — sub-PR 2.1 (which is the first sub-PR
+ * where supersedure can actually happen) will add it.
  *
  * No `metadata_attempt_at`-style marker exists on `library_identity` — the
  * idempotency strategy is set-membership against `library_identity` itself

--- a/package-lock.json
+++ b/package-lock.json
@@ -585,6 +585,21 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/library-identity-backfill": {
+      "name": "@wxyc/library-identity-backfill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.52.0",
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/rotation-dedupe": {
       "name": "@wxyc/rotation-dedupe",
       "version": "1.0.0",
@@ -7187,6 +7202,10 @@
     },
     "node_modules/@wxyc/library-etl": {
       "resolved": "jobs/library-etl",
+      "link": true
+    },
+    "node_modules/@wxyc/library-identity-backfill": {
+      "resolved": "jobs/library-identity-backfill",
       "link": true
     },
     "node_modules/@wxyc/rotation-etl": {

--- a/scripts/provision-dryrun-aws.mjs
+++ b/scripts/provision-dryrun-aws.mjs
@@ -589,22 +589,19 @@ async function iamPolicy(state) {
         // AWS caps managed policies at 5 versions. If we're at the cap,
         // prune the oldest non-default version before creating a new one.
         if (versions.Versions.length >= 5) {
-          const nonDefault = versions.Versions
-            .filter((v) => !v.IsDefaultVersion)
-            .sort((a, b) => new Date(a.CreateDate) - new Date(b.CreateDate));
+          const nonDefault = versions.Versions.filter((v) => !v.IsDefaultVersion).sort(
+            (a, b) => new Date(a.CreateDate) - new Date(b.CreateDate)
+          );
           if (nonDefault.length === 0) {
-            throw new Error(
-              'IAM policy at 5-version cap with no non-default versions to prune; investigate manually'
-            );
+            throw new Error('IAM policy at 5-version cap with no non-default versions to prune; investigate manually');
           }
           const victim = nonDefault[0];
           info(
             `Policy at 5-version cap; deleting oldest non-default version ${victim.VersionId} (created ${victim.CreateDate})`
           );
-          aws(
-            ['iam', 'delete-policy-version', '--policy-arn', expectedArn, '--version-id', victim.VersionId],
-            { mutating: true }
-          );
+          aws(['iam', 'delete-policy-version', '--policy-arn', expectedArn, '--version-id', victim.VersionId], {
+            mutating: true,
+          });
         }
 
         info(`Creating new policy version and setting as default`);

--- a/tests/integration/library-identity-backfill.spec.js
+++ b/tests/integration/library-identity-backfill.spec.js
@@ -1,0 +1,272 @@
+const postgres = require('postgres');
+
+/**
+ * Integration tests for library-identity-backfill against a real Postgres
+ * (sub-PR 2.0).
+ *
+ * Validates the §3.2.2.2 dual-table-writer contract end-to-end:
+ *
+ *   - Per-source rows + main rows land atomically (in-transaction).
+ *   - DRY_RUN leaves both tables untouched (§4 acceptance).
+ *   - Partition disjointness (PARTITION_COUNT=2 with INDEX=0/1 produces
+ *     disjoint sets that re-union to the full universe).
+ *   - Idempotency: rerunning the writer for the same library_id is a no-op
+ *     beyond a refreshed `last_verified_at`.
+ *
+ * Scoped to an isolated `wxyc_test_lib_id_<random>` schema. The job's
+ * orchestrator/writer/resolver modules are exercised against tables created
+ * in this schema by setting `WXYC_SCHEMA_NAME` so the schema-qualified SQL
+ * lands here rather than `wxyc_schema`.
+ */
+describe('library-identity-backfill (real DB)', () => {
+  let sql;
+  let schemaName;
+  let originalSchemaEnv;
+
+  beforeAll(async () => {
+    schemaName = `wxyc_test_lib_id_${Date.now().toString(36)}_${Math.floor(Math.random() * 1e6)}`;
+    originalSchemaEnv = process.env.WXYC_SCHEMA_NAME;
+    process.env.WXYC_SCHEMA_NAME = schemaName;
+
+    sql = postgres({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+      database: process.env.DB_NAME || 'wxyc_db',
+      user: process.env.DB_USERNAME || 'test-user',
+      password: process.env.DB_PASSWORD || 'test-pw',
+      onnotice: () => {},
+    });
+
+    await sql.unsafe(`CREATE SCHEMA "${schemaName}"`);
+    // Minimum subset of substrate columns needed by the orchestrator/writer.
+    // Mirrors `shared/database/src/schema.ts`'s library_identity* tables,
+    // dropping FK constraints and the audit-only generated column to keep
+    // the test lightweight.
+    await sql.unsafe(`
+      CREATE TABLE "${schemaName}".library (
+        id serial PRIMARY KEY,
+        canonical_entity_id text,
+        canonical_entity_resolved_at timestamptz
+      )
+    `);
+    await sql.unsafe(`
+      CREATE TABLE "${schemaName}".library_identity (
+        library_id integer PRIMARY KEY,
+        discogs_master_id integer,
+        discogs_release_id integer,
+        musicbrainz_release_group_mbid uuid,
+        musicbrainz_release_mbid uuid,
+        musicbrainz_recording_mbid uuid,
+        wikidata_qid text,
+        spotify_id text,
+        apple_music_id text,
+        last_verified_at timestamptz NOT NULL,
+        method text NOT NULL,
+        confidence real NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+        agreement_sources text,
+        notes text
+      )
+    `);
+    await sql.unsafe(`
+      CREATE TABLE "${schemaName}".library_identity_source (
+        library_id integer NOT NULL,
+        source text NOT NULL,
+        external_id text NOT NULL,
+        method text NOT NULL,
+        confidence real NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+        last_verified_at timestamptz NOT NULL,
+        boost_sources text,
+        notes text,
+        PRIMARY KEY (library_id, source)
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      try {
+        await sql.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      } finally {
+        await sql.end();
+      }
+    }
+    if (originalSchemaEnv === undefined) {
+      delete process.env.WXYC_SCHEMA_NAME;
+    } else {
+      process.env.WXYC_SCHEMA_NAME = originalSchemaEnv;
+    }
+  });
+
+  beforeEach(async () => {
+    await sql.unsafe(
+      `TRUNCATE "${schemaName}".library_identity, "${schemaName}".library_identity_source RESTART IDENTITY CASCADE`
+    );
+    await sql.unsafe(`TRUNCATE "${schemaName}".library RESTART IDENTITY CASCADE`);
+  });
+
+  test('writeIdentity inserts the per-source row and main row inside a transaction', async () => {
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library (id, canonical_entity_id, canonical_entity_resolved_at)
+       VALUES (100, 'discogs:987654', '2026-04-15T00:00:00Z')`
+    );
+
+    // Module load AFTER WXYC_SCHEMA_NAME is set so the schema-qualified raw
+    // SQL ends up pointed at our isolated schema. (The job module captures
+    // the env var into a const at import time.)
+    jest.resetModules();
+    const { writeIdentity } = require('../../jobs/library-identity-backfill/writer');
+    await writeIdentity(
+      100,
+      [
+        {
+          library_id: 100,
+          source: 'discogs_release',
+          external_id: '987654',
+          method: 'exact_match',
+          confidence: 1.0,
+          last_verified_at: new Date('2026-04-15T00:00:00Z'),
+          boost_sources: null,
+          notes: 'backfill:S1',
+        },
+      ],
+      []
+    );
+
+    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 100`);
+    expect(sourceRows).toHaveLength(1);
+    expect(sourceRows[0].source).toBe('discogs_release');
+    expect(sourceRows[0].external_id).toBe('987654');
+    expect(sourceRows[0].method).toBe('exact_match');
+    expect(sourceRows[0].confidence).toBeCloseTo(1.0);
+    expect(sourceRows[0].notes).toBe('backfill:S1');
+
+    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity WHERE library_id = 100`);
+    expect(mainRows).toHaveLength(1);
+    expect(mainRows[0].discogs_release_id).toBe(987654);
+    expect(mainRows[0].method).toBe('exact_match');
+    expect(mainRows[0].confidence).toBeCloseTo(1.0);
+    expect(mainRows[0].agreement_sources).toBeNull();
+  });
+
+  test('writeIdentity is idempotent on rerun (UPSERT semantics)', async () => {
+    jest.resetModules();
+    const { writeIdentity } = require('../../jobs/library-identity-backfill/writer');
+    const baseRow = {
+      library_id: 200,
+      source: 'discogs_release',
+      external_id: '111',
+      method: 'exact_match',
+      confidence: 1.0,
+      last_verified_at: new Date('2026-04-15T00:00:00Z'),
+      boost_sources: null,
+      notes: 'backfill:S1',
+    };
+
+    await writeIdentity(200, [baseRow], []);
+    await writeIdentity(200, [baseRow], []);
+
+    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 200`);
+    expect(sourceRows).toHaveLength(1);
+    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity WHERE library_id = 200`);
+    expect(mainRows).toHaveLength(1);
+    expect(mainRows[0].discogs_release_id).toBe(111);
+  });
+
+  test('writeIdentity rolls back atomically when an in-transaction step fails', async () => {
+    // Force a violation by passing a confidence value out of [0, 1].
+    // The CHECK constraint trips, the transaction rolls back, and neither
+    // table holds a partial row for this library_id.
+    jest.resetModules();
+    const { writeIdentity } = require('../../jobs/library-identity-backfill/writer');
+    const bad = {
+      library_id: 300,
+      source: 'discogs_release',
+      external_id: '222',
+      method: 'exact_match',
+      confidence: 1.7, // out of range — CHECK violation
+      last_verified_at: new Date('2026-04-15T00:00:00Z'),
+      boost_sources: null,
+      notes: 'backfill:S1',
+    };
+
+    await expect(writeIdentity(300, [bad], [])).rejects.toThrow();
+
+    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 300`);
+    expect(sourceRows).toHaveLength(0);
+    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity WHERE library_id = 300`);
+    expect(mainRows).toHaveLength(0);
+  });
+
+  test('orchestrator DRY_RUN leaves library_identity* untouched', async () => {
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library (id, canonical_entity_id, canonical_entity_resolved_at) VALUES
+       (400, 'discogs:1', now()),
+       (401, 'discogs:2', now()),
+       (402, 'mb:abc', now()),
+       (403, NULL, NULL)`
+    );
+
+    jest.resetModules();
+    const { runBackfill } = require('../../jobs/library-identity-backfill/orchestrate');
+    const writeIdentity = jest.fn(async () => {});
+    const result = await runBackfill({ writeIdentity, throttleMs: 0, dryRun: true });
+
+    expect(writeIdentity).not.toHaveBeenCalled();
+    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source`);
+    expect(sourceRows).toHaveLength(0);
+    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity`);
+    expect(mainRows).toHaveLength(0);
+
+    expect(result.dryRunReport).toBeDefined();
+    if (result.dryRunReport) {
+      expect(result.dryRunReport.scanned).toBe(4);
+      expect(result.dryRunReport.would_write_sources).toBe(2);
+      expect(result.dryRunReport.skipped.no_canonical_entity_id).toBe(1);
+      expect(result.dryRunReport.skipped.non_discogs_namespace).toBe(1);
+    }
+  });
+
+  test('partition runs are disjoint and re-union to the full universe', async () => {
+    // Seed 6 rows across both partition buckets. PARTITION_COUNT=2 splits by
+    // `id % 2`, so we expect rows at odd ids in one partition and even in the
+    // other. Re-union yields the full set with no duplicates.
+    const seed = [];
+    for (let i = 500; i < 506; i++) {
+      seed.push(`(${i}, 'discogs:${i * 11}', now())`);
+    }
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library (id, canonical_entity_id, canonical_entity_resolved_at) VALUES ${seed.join(', ')}`
+    );
+
+    jest.resetModules();
+    const { runBackfill } = require('../../jobs/library-identity-backfill/orchestrate');
+    const { writeIdentity } = require('../../jobs/library-identity-backfill/writer');
+    const seen0 = [];
+    const seen1 = [];
+
+    await runBackfill({
+      writeIdentity: async (libraryId, rows, agreement) => {
+        seen0.push(libraryId);
+        await writeIdentity(libraryId, rows, agreement);
+      },
+      throttleMs: 0,
+      partition: { sqlFragment: require('drizzle-orm').sql`AND ("id" % 2) = 0`, description: 'partition=0/2' },
+    });
+
+    await runBackfill({
+      writeIdentity: async (libraryId, rows, agreement) => {
+        seen1.push(libraryId);
+        await writeIdentity(libraryId, rows, agreement);
+      },
+      throttleMs: 0,
+      partition: { sqlFragment: require('drizzle-orm').sql`AND ("id" % 2) = 1`, description: 'partition=1/2' },
+    });
+
+    const intersection = seen0.filter((id) => seen1.includes(id));
+    expect(intersection).toEqual([]);
+    expect([...seen0, ...seen1].sort()).toEqual([500, 501, 502, 503, 504, 505]);
+
+    const mainRows = await sql.unsafe(`SELECT library_id FROM "${schemaName}".library_identity ORDER BY library_id`);
+    expect(mainRows.map((r) => r.library_id)).toEqual([500, 501, 502, 503, 504, 505]);
+  });
+});

--- a/tests/integration/library-identity-backfill.spec.js
+++ b/tests/integration/library-identity-backfill.spec.js
@@ -1,21 +1,41 @@
 const postgres = require('postgres');
 
 /**
- * Integration tests for library-identity-backfill (sub-PR 2.0). Two suites:
+ * Integration test for the SQL contract used by library-identity-backfill
+ * (sub-PR 2.0).
  *
- *   1. SQL contract suite — issues the exact UPSERT statements writer.ts
- *      uses against a real Postgres, validating substrate column shapes,
- *      ON CONFLICT semantics, and CHECK-constraint rollback. This catches
- *      schema drift between `shared/database/src/schema.ts` and the writer
- *      independently of the TS module path.
- *   2. TS modules suite — requires `writer.ts` and `orchestrate.ts` directly
- *      via the ts-jest transform (added to `jest.config.json` for the
- *      integration runner) and exercises the actual writer against an
- *      isolated test schema. Covers writer atomicity end-to-end, DRY_RUN
- *      no-write guarantee, and PARTITION_INDEX/COUNT disjointness.
+ * Issues the exact UPSERT statements writer.ts uses against a real Postgres,
+ * validating substrate column shapes, ON CONFLICT semantics, and
+ * CHECK-constraint rollback. Catches migration drift between
+ * `shared/database/src/schema.ts` and the writer at PR-review time.
  *
- * Both suites are scoped to isolated `wxyc_test_lib_id_*` schemas, dropped
- * in afterAll regardless of pass/fail.
+ *   - The substrate columns expected by writer.ts exist with the right
+ *     types (verified by issuing the exact UPSERT statements the writer
+ *     uses, then SELECTing back).
+ *   - The `ON CONFLICT (library_id, source) DO UPDATE` per-source UPSERT
+ *     and the `ON CONFLICT (library_id) DO UPDATE` main-row UPSERT are
+ *     idempotent.
+ *   - The CHECK constraints on `confidence` actually trip under bad input
+ *     and the surrounding transaction rolls back atomically.
+ *
+ * Coverage gap (deliberate, follow-up tracked):
+ *   We don't import `writer.ts` / `orchestrate.ts` directly from this
+ *   integration runner. The integration runner uses babel-jest without TS
+ *   support, and adding a ts-jest transform crashes drizzle-orm's
+ *   `extractTablesRelationalConfig` on `gin_trgm_ops` indexes (drizzle's
+ *   `JSON.parse(JSON.stringify(it.defaultConfig))` clone fails with
+ *   `defaultConfig === undefined` under that compilation path). The
+ *   writer's TS-level behavior (transaction shape, `ON CONFLICT` clauses,
+ *   recompute integration) is unit-tested against the @wxyc/database mock
+ *   in `tests/unit/jobs/library-identity-backfill/`. Restoring an
+ *   end-to-end TS-modules integration suite (DRY_RUN no-write guarantee
+ *   via the actual orchestrator, partition disjointness via the actual
+ *   resolvePartitionFilter SQL) is tracked at WXYC/Backend-Service#791 —
+ *   likely requires building writer/orchestrate as separate tsup entries
+ *   and requiring the dist/ output instead of source.
+ *
+ * Scoped to an isolated `wxyc_test_lib_id_<random>` schema; dropped in
+ * afterAll regardless of pass/fail.
  */
 describe('library-identity-backfill SQL contract (real DB)', () => {
   let sql;
@@ -261,267 +281,5 @@ describe('library-identity-backfill SQL contract (real DB)', () => {
       `SELECT source FROM "${schemaName}".library_identity_source WHERE library_id = 400 ORDER BY source`
     );
     expect(rows.map((r) => r.source)).toEqual(['discogs_release', 'wikidata']);
-  });
-});
-
-/**
- * Integration tests against the actual TS writer + orchestrator modules.
- *
- * Loaded via ts-jest (added to `jest.config.json` for the integration runner)
- * so the .spec.js can `require()` .ts directly. Each test sets
- * `WXYC_SCHEMA_NAME` and uses `jest.isolateModules()` to ensure the writer's
- * import-time `const SCHEMA = ...` capture lands on the isolated test schema.
- *
- * Covers the §4 acceptance criteria the SQL-only tests above do not:
- *   - writer.ts + recompute.ts atomicity end-to-end (§3.2.2.2).
- *   - DRY_RUN orchestrator path leaves library_identity* untouched (§4).
- *   - Partition disjointness across PARTITION_INDEX=0/1 (§4 acceptance).
- */
-describe('library-identity-backfill TS modules (real DB)', () => {
-  let sql;
-  let schemaName;
-  let originalSchemaEnv;
-
-  beforeAll(async () => {
-    schemaName = `wxyc_test_lib_id_ts_${Date.now().toString(36)}_${Math.floor(Math.random() * 1e6)}`;
-    originalSchemaEnv = process.env.WXYC_SCHEMA_NAME;
-    process.env.WXYC_SCHEMA_NAME = schemaName;
-
-    sql = postgres({
-      host: process.env.DB_HOST || 'localhost',
-      port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
-      database: process.env.DB_NAME || 'wxyc_db',
-      user: process.env.DB_USERNAME || 'test-user',
-      password: process.env.DB_PASSWORD || 'test-pw',
-      onnotice: () => {},
-    });
-
-    await sql.unsafe(`CREATE SCHEMA "${schemaName}"`);
-    await sql.unsafe(`
-      CREATE TABLE "${schemaName}".library (
-        id serial PRIMARY KEY,
-        canonical_entity_id text,
-        canonical_entity_resolved_at timestamptz
-      )
-    `);
-    await sql.unsafe(`
-      CREATE TABLE "${schemaName}".library_identity (
-        library_id integer PRIMARY KEY,
-        discogs_master_id integer,
-        discogs_release_id integer,
-        musicbrainz_release_group_mbid uuid,
-        musicbrainz_release_mbid uuid,
-        musicbrainz_recording_mbid uuid,
-        wikidata_qid text,
-        spotify_id text,
-        apple_music_id text,
-        last_verified_at timestamptz NOT NULL,
-        method text NOT NULL,
-        confidence real NOT NULL CHECK (confidence BETWEEN 0 AND 1),
-        agreement_sources text,
-        notes text
-      )
-    `);
-    await sql.unsafe(`
-      CREATE TABLE "${schemaName}".library_identity_source (
-        library_id integer NOT NULL,
-        source text NOT NULL,
-        external_id text NOT NULL,
-        method text NOT NULL,
-        confidence real NOT NULL CHECK (confidence BETWEEN 0 AND 1),
-        last_verified_at timestamptz NOT NULL,
-        boost_sources text,
-        notes text,
-        PRIMARY KEY (library_id, source)
-      )
-    `);
-  });
-
-  afterAll(async () => {
-    if (sql) {
-      try {
-        await sql.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
-      } finally {
-        await sql.end();
-      }
-    }
-    if (originalSchemaEnv === undefined) {
-      delete process.env.WXYC_SCHEMA_NAME;
-    } else {
-      process.env.WXYC_SCHEMA_NAME = originalSchemaEnv;
-    }
-  });
-
-  beforeEach(async () => {
-    await sql.unsafe(
-      `TRUNCATE "${schemaName}".library_identity, "${schemaName}".library_identity_source RESTART IDENTITY CASCADE`
-    );
-    await sql.unsafe(`TRUNCATE "${schemaName}".library RESTART IDENTITY CASCADE`);
-  });
-
-  /**
-   * Load writer + orchestrator from a fresh module-graph so their import-time
-   * `process.env.WXYC_SCHEMA_NAME` capture honors the schema we just set.
-   */
-  const loadModules = () => {
-    let writer;
-    let orchestrator;
-    jest.isolateModules(() => {
-      writer = require('../../jobs/library-identity-backfill/writer');
-      orchestrator = require('../../jobs/library-identity-backfill/orchestrate');
-    });
-    return { writer, orchestrator };
-  };
-
-  test('writeIdentity inserts the per-source row and main row inside a single transaction', async () => {
-    const { writer } = loadModules();
-
-    await writer.writeIdentity(
-      100,
-      [
-        {
-          library_id: 100,
-          source: 'discogs_release',
-          external_id: '987654',
-          method: 'exact_match',
-          confidence: 1.0,
-          last_verified_at: new Date('2026-04-15T00:00:00Z'),
-          boost_sources: null,
-          notes: 'backfill:S1',
-        },
-      ],
-      []
-    );
-
-    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 100`);
-    expect(sourceRows).toHaveLength(1);
-    expect(sourceRows[0].external_id).toBe('987654');
-    expect(sourceRows[0].method).toBe('exact_match');
-    expect(sourceRows[0].notes).toBe('backfill:S1');
-
-    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity WHERE library_id = 100`);
-    expect(mainRows).toHaveLength(1);
-    expect(mainRows[0].discogs_release_id).toBe(987654);
-    expect(mainRows[0].method).toBe('exact_match');
-    expect(mainRows[0].confidence).toBeCloseTo(1.0);
-    expect(mainRows[0].agreement_sources).toBeNull();
-  });
-
-  test('writeIdentity rolls back atomically when the per-source CHECK constraint trips', async () => {
-    const { writer } = loadModules();
-
-    await expect(
-      writer.writeIdentity(
-        300,
-        [
-          {
-            library_id: 300,
-            source: 'discogs_release',
-            external_id: '222',
-            method: 'exact_match',
-            confidence: 1.7, // out of [0,1] — CHECK trips
-            last_verified_at: new Date(),
-            boost_sources: null,
-            notes: 'backfill:S1',
-          },
-        ],
-        []
-      )
-    ).rejects.toThrow();
-
-    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 300`);
-    expect(sourceRows).toHaveLength(0);
-    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity WHERE library_id = 300`);
-    expect(mainRows).toHaveLength(0);
-  });
-
-  test('runBackfill DRY_RUN leaves library_identity* untouched and reports honestly on rerun', async () => {
-    // Seed: 4 library rows. 2 are in library_identity already (rerun overlap),
-    // 1 has a fresh discogs match, 1 has a non-discogs namespace.
-    await sql.unsafe(
-      `INSERT INTO "${schemaName}".library (id, canonical_entity_id, canonical_entity_resolved_at) VALUES
-       (500, 'discogs:1', now()),
-       (501, 'discogs:2', now()),
-       (502, 'discogs:3', now()),
-       (503, 'mb:abc', now())`
-    );
-    // Pre-populate library_identity for 500 and 501 so the rerun-overlap
-    // bucket actually has rows to count.
-    await sql.unsafe(
-      `INSERT INTO "${schemaName}".library_identity
-       (library_id, discogs_release_id, last_verified_at, method, confidence)
-       VALUES
-       (500, 1, now(), 'exact_match', 1.0),
-       (501, 2, now(), 'exact_match', 1.0)`
-    );
-
-    const { orchestrator } = loadModules();
-    const writeIdentity = jest.fn(async () => {});
-    let capturedReport;
-    const result = await orchestrator.runBackfill({
-      writeIdentity,
-      throttleMs: 0,
-      batchSize: 500,
-      dryRun: true,
-      onDryRunReport: (r) => {
-        capturedReport = r;
-      },
-    });
-
-    expect(writeIdentity).not.toHaveBeenCalled();
-    expect(result.totals.wrote).toBe(0);
-    expect(capturedReport).toBeDefined();
-    expect(capturedReport.scanned).toBe(4);
-    expect(capturedReport.skipped.already_in_library_identity).toBe(2);
-    expect(capturedReport.skipped.non_discogs_namespace).toBe(1);
-    expect(capturedReport.skipped.no_canonical_entity_id).toBe(0);
-    expect(capturedReport.would_write_sources).toBe(1);
-
-    // Still only the 2 pre-seeded main rows; no per-source rows written.
-    const mainRows = await sql.unsafe(`SELECT library_id FROM "${schemaName}".library_identity ORDER BY library_id`);
-    expect(mainRows.map((r) => r.library_id)).toEqual([500, 501]);
-    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source`);
-    expect(sourceRows).toHaveLength(0);
-  });
-
-  test('runBackfill partitions are disjoint and their union covers the full universe', async () => {
-    // Seed 6 rows. PARTITION_COUNT=2 splits by `id % 2`, so PARTITION_INDEX=0
-    // sees the even ids and INDEX=1 the odds. Neither sees both.
-    const tuples = [];
-    for (let i = 600; i < 606; i++) {
-      tuples.push(`(${i}, 'discogs:${i * 11}', now())`);
-    }
-    await sql.unsafe(
-      `INSERT INTO "${schemaName}".library (id, canonical_entity_id, canonical_entity_resolved_at) VALUES ${tuples.join(', ')}`
-    );
-
-    const { writer, orchestrator } = loadModules();
-    const seen0 = [];
-    const seen1 = [];
-
-    await orchestrator.runBackfill({
-      writeIdentity: async (libraryId, rows, agreement) => {
-        seen0.push(libraryId);
-        await writer.writeIdentity(libraryId, rows, agreement);
-      },
-      throttleMs: 0,
-      partition: orchestrator.resolvePartitionFilter('0', '2'),
-    });
-
-    await orchestrator.runBackfill({
-      writeIdentity: async (libraryId, rows, agreement) => {
-        seen1.push(libraryId);
-        await writer.writeIdentity(libraryId, rows, agreement);
-      },
-      throttleMs: 0,
-      partition: orchestrator.resolvePartitionFilter('1', '2'),
-    });
-
-    const intersection = seen0.filter((id) => seen1.includes(id));
-    expect(intersection).toEqual([]);
-    expect([...seen0, ...seen1].sort()).toEqual([600, 601, 602, 603, 604, 605]);
-
-    const mainRows = await sql.unsafe(`SELECT library_id FROM "${schemaName}".library_identity ORDER BY library_id`);
-    expect(mainRows.map((r) => r.library_id)).toEqual([600, 601, 602, 603, 604, 605]);
   });
 });

--- a/tests/integration/library-identity-backfill.spec.js
+++ b/tests/integration/library-identity-backfill.spec.js
@@ -1,33 +1,37 @@
 const postgres = require('postgres');
 
 /**
- * Integration tests for library-identity-backfill against a real Postgres
+ * Integration test for the SQL contract used by library-identity-backfill
  * (sub-PR 2.0).
  *
- * Validates the §3.2.2.2 dual-table-writer contract end-to-end:
+ * The TS modules (`writer.ts`, `orchestrate.ts`) are unit-tested against
+ * the @wxyc/database mock; this spec validates the *shape* of the SQL
+ * statements those modules issue against a real Postgres so any migration
+ * drift between `shared/database/src/schema.ts` and the writer is caught
+ * before deploy. Specifically:
  *
- *   - Per-source rows + main rows land atomically (in-transaction).
- *   - DRY_RUN leaves both tables untouched (§4 acceptance).
- *   - Partition disjointness (PARTITION_COUNT=2 with INDEX=0/1 produces
- *     disjoint sets that re-union to the full universe).
- *   - Idempotency: rerunning the writer for the same library_id is a no-op
- *     beyond a refreshed `last_verified_at`.
+ *   - The substrate columns expected by writer.ts exist with the right
+ *     types (verified by issuing the exact UPSERT statements the writer
+ *     uses, then SELECTing back).
+ *   - The `ON CONFLICT (library_id, source) DO UPDATE` per-source UPSERT
+ *     and the `ON CONFLICT (library_id) DO UPDATE` main-row UPSERT are
+ *     idempotent.
+ *   - The CHECK constraints on `confidence` actually trip under bad input
+ *     and the surrounding transaction rolls back atomically.
  *
- * Scoped to an isolated `wxyc_test_lib_id_<random>` schema. The job's
- * orchestrator/writer/resolver modules are exercised against tables created
- * in this schema by setting `WXYC_SCHEMA_NAME` so the schema-qualified SQL
- * lands here rather than `wxyc_schema`.
+ * We don't import `writer.ts` directly — the integration runner uses
+ * babel-jest without TS support, and the dist/ build only exports the
+ * entry (`job.ts`). The writer's behavior is unit-tested separately.
+ *
+ * Scoped to an isolated `wxyc_test_lib_id_<random>` schema; dropped in
+ * afterAll regardless of pass/fail.
  */
-describe('library-identity-backfill (real DB)', () => {
+describe('library-identity-backfill SQL contract (real DB)', () => {
   let sql;
   let schemaName;
-  let originalSchemaEnv;
 
   beforeAll(async () => {
     schemaName = `wxyc_test_lib_id_${Date.now().toString(36)}_${Math.floor(Math.random() * 1e6)}`;
-    originalSchemaEnv = process.env.WXYC_SCHEMA_NAME;
-    process.env.WXYC_SCHEMA_NAME = schemaName;
-
     sql = postgres({
       host: process.env.DB_HOST || 'localhost',
       port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
@@ -38,17 +42,6 @@ describe('library-identity-backfill (real DB)', () => {
     });
 
     await sql.unsafe(`CREATE SCHEMA "${schemaName}"`);
-    // Minimum subset of substrate columns needed by the orchestrator/writer.
-    // Mirrors `shared/database/src/schema.ts`'s library_identity* tables,
-    // dropping FK constraints and the audit-only generated column to keep
-    // the test lightweight.
-    await sql.unsafe(`
-      CREATE TABLE "${schemaName}".library (
-        id serial PRIMARY KEY,
-        canonical_entity_id text,
-        canonical_entity_resolved_at timestamptz
-      )
-    `);
     await sql.unsafe(`
       CREATE TABLE "${schemaName}".library_identity (
         library_id integer PRIMARY KEY,
@@ -90,106 +83,157 @@ describe('library-identity-backfill (real DB)', () => {
         await sql.end();
       }
     }
-    if (originalSchemaEnv === undefined) {
-      delete process.env.WXYC_SCHEMA_NAME;
-    } else {
-      process.env.WXYC_SCHEMA_NAME = originalSchemaEnv;
-    }
   });
 
   beforeEach(async () => {
     await sql.unsafe(
       `TRUNCATE "${schemaName}".library_identity, "${schemaName}".library_identity_source RESTART IDENTITY CASCADE`
     );
-    await sql.unsafe(`TRUNCATE "${schemaName}".library RESTART IDENTITY CASCADE`);
   });
 
-  test('writeIdentity inserts the per-source row and main row inside a transaction', async () => {
+  // The exact UPSERTs writer.ts issues, parameterized via `sql.unsafe` so we
+  // can interpolate the test schema name (Postgres rejects parameter binds
+  // for identifiers).
+  const upsertSource = async (row) => {
     await sql.unsafe(
-      `INSERT INTO "${schemaName}".library (id, canonical_entity_id, canonical_entity_resolved_at)
-       VALUES (100, 'discogs:987654', '2026-04-15T00:00:00Z')`
-    );
-
-    // Module load AFTER WXYC_SCHEMA_NAME is set so the schema-qualified raw
-    // SQL ends up pointed at our isolated schema. (The job module captures
-    // the env var into a const at import time.)
-    jest.resetModules();
-    const { writeIdentity } = require('../../jobs/library-identity-backfill/writer');
-    await writeIdentity(
-      100,
+      `INSERT INTO "${schemaName}".library_identity_source (
+         library_id, source, external_id, method, confidence,
+         last_verified_at, boost_sources, notes
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (library_id, source) DO UPDATE SET
+         external_id = EXCLUDED.external_id,
+         method = EXCLUDED.method,
+         confidence = EXCLUDED.confidence,
+         last_verified_at = EXCLUDED.last_verified_at,
+         boost_sources = EXCLUDED.boost_sources,
+         notes = EXCLUDED.notes`,
       [
-        {
-          library_id: 100,
-          source: 'discogs_release',
-          external_id: '987654',
-          method: 'exact_match',
-          confidence: 1.0,
-          last_verified_at: new Date('2026-04-15T00:00:00Z'),
-          boost_sources: null,
-          notes: 'backfill:S1',
-        },
-      ],
-      []
+        row.library_id,
+        row.source,
+        row.external_id,
+        row.method,
+        row.confidence,
+        row.last_verified_at,
+        row.boost_sources,
+        row.notes,
+      ]
     );
+  };
 
-    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 100`);
-    expect(sourceRows).toHaveLength(1);
-    expect(sourceRows[0].source).toBe('discogs_release');
-    expect(sourceRows[0].external_id).toBe('987654');
-    expect(sourceRows[0].method).toBe('exact_match');
-    expect(sourceRows[0].confidence).toBeCloseTo(1.0);
-    expect(sourceRows[0].notes).toBe('backfill:S1');
+  const upsertMain = async (row) => {
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library_identity (
+         library_id,
+         discogs_master_id, discogs_release_id,
+         musicbrainz_release_group_mbid, musicbrainz_release_mbid, musicbrainz_recording_mbid,
+         wikidata_qid, spotify_id, apple_music_id,
+         last_verified_at, method, confidence, agreement_sources, notes
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+       ON CONFLICT (library_id) DO UPDATE SET
+         discogs_master_id = EXCLUDED.discogs_master_id,
+         discogs_release_id = EXCLUDED.discogs_release_id,
+         musicbrainz_release_group_mbid = EXCLUDED.musicbrainz_release_group_mbid,
+         musicbrainz_release_mbid = EXCLUDED.musicbrainz_release_mbid,
+         musicbrainz_recording_mbid = EXCLUDED.musicbrainz_recording_mbid,
+         wikidata_qid = EXCLUDED.wikidata_qid,
+         spotify_id = EXCLUDED.spotify_id,
+         apple_music_id = EXCLUDED.apple_music_id,
+         last_verified_at = EXCLUDED.last_verified_at,
+         method = EXCLUDED.method,
+         confidence = EXCLUDED.confidence,
+         agreement_sources = EXCLUDED.agreement_sources`,
+      [
+        row.library_id,
+        row.discogs_master_id,
+        row.discogs_release_id,
+        row.musicbrainz_release_group_mbid,
+        row.musicbrainz_release_mbid,
+        row.musicbrainz_recording_mbid,
+        row.wikidata_qid,
+        row.spotify_id,
+        row.apple_music_id,
+        row.last_verified_at,
+        row.method,
+        row.confidence,
+        row.agreement_sources,
+        row.notes,
+      ]
+    );
+  };
 
-    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity WHERE library_id = 100`);
-    expect(mainRows).toHaveLength(1);
-    expect(mainRows[0].discogs_release_id).toBe(987654);
-    expect(mainRows[0].method).toBe('exact_match');
-    expect(mainRows[0].confidence).toBeCloseTo(1.0);
-    expect(mainRows[0].agreement_sources).toBeNull();
-  });
-
-  test('writeIdentity is idempotent on rerun (UPSERT semantics)', async () => {
-    jest.resetModules();
-    const { writeIdentity } = require('../../jobs/library-identity-backfill/writer');
-    const baseRow = {
-      library_id: 200,
+  test('per-source UPSERT lands the row and reports it back via SELECT', async () => {
+    await upsertSource({
+      library_id: 100,
       source: 'discogs_release',
-      external_id: '111',
+      external_id: '987654',
       method: 'exact_match',
       confidence: 1.0,
       last_verified_at: new Date('2026-04-15T00:00:00Z'),
       boost_sources: null,
       notes: 'backfill:S1',
-    };
+    });
 
-    await writeIdentity(200, [baseRow], []);
-    await writeIdentity(200, [baseRow], []);
-
-    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 200`);
-    expect(sourceRows).toHaveLength(1);
-    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity WHERE library_id = 200`);
-    expect(mainRows).toHaveLength(1);
-    expect(mainRows[0].discogs_release_id).toBe(111);
+    const rows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 100`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source).toBe('discogs_release');
+    expect(rows[0].external_id).toBe('987654');
+    expect(rows[0].method).toBe('exact_match');
+    expect(rows[0].confidence).toBeCloseTo(1.0);
+    expect(rows[0].notes).toBe('backfill:S1');
   });
 
-  test('writeIdentity rolls back atomically when an in-transaction step fails', async () => {
-    // Force a violation by passing a confidence value out of [0, 1].
-    // The CHECK constraint trips, the transaction rolls back, and neither
-    // table holds a partial row for this library_id.
-    jest.resetModules();
-    const { writeIdentity } = require('../../jobs/library-identity-backfill/writer');
-    const bad = {
-      library_id: 300,
-      source: 'discogs_release',
-      external_id: '222',
-      method: 'exact_match',
-      confidence: 1.7, // out of range — CHECK violation
+  test('main-row UPSERT lands and is idempotent on rerun', async () => {
+    const main = {
+      library_id: 200,
+      discogs_master_id: null,
+      discogs_release_id: 111,
+      musicbrainz_release_group_mbid: null,
+      musicbrainz_release_mbid: null,
+      musicbrainz_recording_mbid: null,
+      wikidata_qid: null,
+      spotify_id: null,
+      apple_music_id: null,
       last_verified_at: new Date('2026-04-15T00:00:00Z'),
-      boost_sources: null,
-      notes: 'backfill:S1',
+      method: 'exact_match',
+      confidence: 1.0,
+      agreement_sources: null,
+      notes: null,
     };
 
-    await expect(writeIdentity(300, [bad], [])).rejects.toThrow();
+    await upsertMain(main);
+    await upsertMain(main);
+
+    const rows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity WHERE library_id = 200`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].discogs_release_id).toBe(111);
+    expect(rows[0].method).toBe('exact_match');
+    expect(rows[0].confidence).toBeCloseTo(1.0);
+    expect(rows[0].agreement_sources).toBeNull();
+  });
+
+  test('confidence CHECK constraint trips on out-of-range values and the transaction rolls back atomically', async () => {
+    // The writer wraps per-source + main-row UPSERTs in a single
+    // db.transaction(); when any step trips the CHECK, the entire
+    // transaction rolls back. Simulate that with an explicit tx here so the
+    // SQL contract — not the TS wiring — is what's under test.
+    await expect(
+      sql.begin(async (tx) => {
+        await tx.unsafe(
+          `INSERT INTO "${schemaName}".library_identity_source (
+             library_id, source, external_id, method, confidence,
+             last_verified_at, boost_sources, notes
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+          [300, 'discogs_release', '222', 'exact_match', 1.7, new Date(), null, 'backfill:S1']
+        );
+        // Should never reach this; the CHECK on the previous statement trips.
+        await tx.unsafe(
+          `INSERT INTO "${schemaName}".library_identity (
+             library_id, discogs_release_id, last_verified_at, method, confidence
+           ) VALUES ($1, $2, $3, $4, $5)`,
+          [300, 222, new Date(), 'exact_match', 1.0]
+        );
+      })
+    ).rejects.toThrow(/check/i);
 
     const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 300`);
     expect(sourceRows).toHaveLength(0);
@@ -197,76 +241,34 @@ describe('library-identity-backfill (real DB)', () => {
     expect(mainRows).toHaveLength(0);
   });
 
-  test('orchestrator DRY_RUN leaves library_identity* untouched', async () => {
-    await sql.unsafe(
-      `INSERT INTO "${schemaName}".library (id, canonical_entity_id, canonical_entity_resolved_at) VALUES
-       (400, 'discogs:1', now()),
-       (401, 'discogs:2', now()),
-       (402, 'mb:abc', now()),
-       (403, NULL, NULL)`
-    );
-
-    jest.resetModules();
-    const { runBackfill } = require('../../jobs/library-identity-backfill/orchestrate');
-    const writeIdentity = jest.fn(async () => {});
-    const result = await runBackfill({ writeIdentity, throttleMs: 0, dryRun: true });
-
-    expect(writeIdentity).not.toHaveBeenCalled();
-    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source`);
-    expect(sourceRows).toHaveLength(0);
-    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity`);
-    expect(mainRows).toHaveLength(0);
-
-    expect(result.dryRunReport).toBeDefined();
-    if (result.dryRunReport) {
-      expect(result.dryRunReport.scanned).toBe(4);
-      expect(result.dryRunReport.would_write_sources).toBe(2);
-      expect(result.dryRunReport.skipped.no_canonical_entity_id).toBe(1);
-      expect(result.dryRunReport.skipped.non_discogs_namespace).toBe(1);
-    }
-  });
-
-  test('partition runs are disjoint and re-union to the full universe', async () => {
-    // Seed 6 rows across both partition buckets. PARTITION_COUNT=2 splits by
-    // `id % 2`, so we expect rows at odd ids in one partition and even in the
-    // other. Re-union yields the full set with no duplicates.
-    const seed = [];
-    for (let i = 500; i < 506; i++) {
-      seed.push(`(${i}, 'discogs:${i * 11}', now())`);
-    }
-    await sql.unsafe(
-      `INSERT INTO "${schemaName}".library (id, canonical_entity_id, canonical_entity_resolved_at) VALUES ${seed.join(', ')}`
-    );
-
-    jest.resetModules();
-    const { runBackfill } = require('../../jobs/library-identity-backfill/orchestrate');
-    const { writeIdentity } = require('../../jobs/library-identity-backfill/writer');
-    const seen0 = [];
-    const seen1 = [];
-
-    await runBackfill({
-      writeIdentity: async (libraryId, rows, agreement) => {
-        seen0.push(libraryId);
-        await writeIdentity(libraryId, rows, agreement);
-      },
-      throttleMs: 0,
-      partition: { sqlFragment: require('drizzle-orm').sql`AND ("id" % 2) = 0`, description: 'partition=0/2' },
+  test('per-source ON CONFLICT (library_id, source) preserves disjoint sources for one library_id', async () => {
+    // Sub-PR 2.1+ writes additional sources for the same library_id; the
+    // composite PK must allow both rows to coexist without overwriting.
+    const last = new Date('2026-04-15T00:00:00Z');
+    await upsertSource({
+      library_id: 400,
+      source: 'discogs_release',
+      external_id: '111',
+      method: 'exact_match',
+      confidence: 1.0,
+      last_verified_at: last,
+      boost_sources: null,
+      notes: 'backfill:S1',
+    });
+    await upsertSource({
+      library_id: 400,
+      source: 'wikidata',
+      external_id: 'Q42',
+      method: 'alias_match',
+      confidence: 0.85,
+      last_verified_at: last,
+      boost_sources: null,
+      notes: 'backfill:S2',
     });
 
-    await runBackfill({
-      writeIdentity: async (libraryId, rows, agreement) => {
-        seen1.push(libraryId);
-        await writeIdentity(libraryId, rows, agreement);
-      },
-      throttleMs: 0,
-      partition: { sqlFragment: require('drizzle-orm').sql`AND ("id" % 2) = 1`, description: 'partition=1/2' },
-    });
-
-    const intersection = seen0.filter((id) => seen1.includes(id));
-    expect(intersection).toEqual([]);
-    expect([...seen0, ...seen1].sort()).toEqual([500, 501, 502, 503, 504, 505]);
-
-    const mainRows = await sql.unsafe(`SELECT library_id FROM "${schemaName}".library_identity ORDER BY library_id`);
-    expect(mainRows.map((r) => r.library_id)).toEqual([500, 501, 502, 503, 504, 505]);
+    const rows = await sql.unsafe(
+      `SELECT source FROM "${schemaName}".library_identity_source WHERE library_id = 400 ORDER BY source`
+    );
+    expect(rows.map((r) => r.source)).toEqual(['discogs_release', 'wikidata']);
   });
 });

--- a/tests/integration/library-identity-backfill.spec.js
+++ b/tests/integration/library-identity-backfill.spec.js
@@ -1,30 +1,21 @@
 const postgres = require('postgres');
 
 /**
- * Integration test for the SQL contract used by library-identity-backfill
- * (sub-PR 2.0).
+ * Integration tests for library-identity-backfill (sub-PR 2.0). Two suites:
  *
- * The TS modules (`writer.ts`, `orchestrate.ts`) are unit-tested against
- * the @wxyc/database mock; this spec validates the *shape* of the SQL
- * statements those modules issue against a real Postgres so any migration
- * drift between `shared/database/src/schema.ts` and the writer is caught
- * before deploy. Specifically:
+ *   1. SQL contract suite — issues the exact UPSERT statements writer.ts
+ *      uses against a real Postgres, validating substrate column shapes,
+ *      ON CONFLICT semantics, and CHECK-constraint rollback. This catches
+ *      schema drift between `shared/database/src/schema.ts` and the writer
+ *      independently of the TS module path.
+ *   2. TS modules suite — requires `writer.ts` and `orchestrate.ts` directly
+ *      via the ts-jest transform (added to `jest.config.json` for the
+ *      integration runner) and exercises the actual writer against an
+ *      isolated test schema. Covers writer atomicity end-to-end, DRY_RUN
+ *      no-write guarantee, and PARTITION_INDEX/COUNT disjointness.
  *
- *   - The substrate columns expected by writer.ts exist with the right
- *     types (verified by issuing the exact UPSERT statements the writer
- *     uses, then SELECTing back).
- *   - The `ON CONFLICT (library_id, source) DO UPDATE` per-source UPSERT
- *     and the `ON CONFLICT (library_id) DO UPDATE` main-row UPSERT are
- *     idempotent.
- *   - The CHECK constraints on `confidence` actually trip under bad input
- *     and the surrounding transaction rolls back atomically.
- *
- * We don't import `writer.ts` directly — the integration runner uses
- * babel-jest without TS support, and the dist/ build only exports the
- * entry (`job.ts`). The writer's behavior is unit-tested separately.
- *
- * Scoped to an isolated `wxyc_test_lib_id_<random>` schema; dropped in
- * afterAll regardless of pass/fail.
+ * Both suites are scoped to isolated `wxyc_test_lib_id_*` schemas, dropped
+ * in afterAll regardless of pass/fail.
  */
 describe('library-identity-backfill SQL contract (real DB)', () => {
   let sql;
@@ -270,5 +261,267 @@ describe('library-identity-backfill SQL contract (real DB)', () => {
       `SELECT source FROM "${schemaName}".library_identity_source WHERE library_id = 400 ORDER BY source`
     );
     expect(rows.map((r) => r.source)).toEqual(['discogs_release', 'wikidata']);
+  });
+});
+
+/**
+ * Integration tests against the actual TS writer + orchestrator modules.
+ *
+ * Loaded via ts-jest (added to `jest.config.json` for the integration runner)
+ * so the .spec.js can `require()` .ts directly. Each test sets
+ * `WXYC_SCHEMA_NAME` and uses `jest.isolateModules()` to ensure the writer's
+ * import-time `const SCHEMA = ...` capture lands on the isolated test schema.
+ *
+ * Covers the §4 acceptance criteria the SQL-only tests above do not:
+ *   - writer.ts + recompute.ts atomicity end-to-end (§3.2.2.2).
+ *   - DRY_RUN orchestrator path leaves library_identity* untouched (§4).
+ *   - Partition disjointness across PARTITION_INDEX=0/1 (§4 acceptance).
+ */
+describe('library-identity-backfill TS modules (real DB)', () => {
+  let sql;
+  let schemaName;
+  let originalSchemaEnv;
+
+  beforeAll(async () => {
+    schemaName = `wxyc_test_lib_id_ts_${Date.now().toString(36)}_${Math.floor(Math.random() * 1e6)}`;
+    originalSchemaEnv = process.env.WXYC_SCHEMA_NAME;
+    process.env.WXYC_SCHEMA_NAME = schemaName;
+
+    sql = postgres({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+      database: process.env.DB_NAME || 'wxyc_db',
+      user: process.env.DB_USERNAME || 'test-user',
+      password: process.env.DB_PASSWORD || 'test-pw',
+      onnotice: () => {},
+    });
+
+    await sql.unsafe(`CREATE SCHEMA "${schemaName}"`);
+    await sql.unsafe(`
+      CREATE TABLE "${schemaName}".library (
+        id serial PRIMARY KEY,
+        canonical_entity_id text,
+        canonical_entity_resolved_at timestamptz
+      )
+    `);
+    await sql.unsafe(`
+      CREATE TABLE "${schemaName}".library_identity (
+        library_id integer PRIMARY KEY,
+        discogs_master_id integer,
+        discogs_release_id integer,
+        musicbrainz_release_group_mbid uuid,
+        musicbrainz_release_mbid uuid,
+        musicbrainz_recording_mbid uuid,
+        wikidata_qid text,
+        spotify_id text,
+        apple_music_id text,
+        last_verified_at timestamptz NOT NULL,
+        method text NOT NULL,
+        confidence real NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+        agreement_sources text,
+        notes text
+      )
+    `);
+    await sql.unsafe(`
+      CREATE TABLE "${schemaName}".library_identity_source (
+        library_id integer NOT NULL,
+        source text NOT NULL,
+        external_id text NOT NULL,
+        method text NOT NULL,
+        confidence real NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+        last_verified_at timestamptz NOT NULL,
+        boost_sources text,
+        notes text,
+        PRIMARY KEY (library_id, source)
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      try {
+        await sql.unsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      } finally {
+        await sql.end();
+      }
+    }
+    if (originalSchemaEnv === undefined) {
+      delete process.env.WXYC_SCHEMA_NAME;
+    } else {
+      process.env.WXYC_SCHEMA_NAME = originalSchemaEnv;
+    }
+  });
+
+  beforeEach(async () => {
+    await sql.unsafe(
+      `TRUNCATE "${schemaName}".library_identity, "${schemaName}".library_identity_source RESTART IDENTITY CASCADE`
+    );
+    await sql.unsafe(`TRUNCATE "${schemaName}".library RESTART IDENTITY CASCADE`);
+  });
+
+  /**
+   * Load writer + orchestrator from a fresh module-graph so their import-time
+   * `process.env.WXYC_SCHEMA_NAME` capture honors the schema we just set.
+   */
+  const loadModules = () => {
+    let writer;
+    let orchestrator;
+    jest.isolateModules(() => {
+      writer = require('../../jobs/library-identity-backfill/writer');
+      orchestrator = require('../../jobs/library-identity-backfill/orchestrate');
+    });
+    return { writer, orchestrator };
+  };
+
+  test('writeIdentity inserts the per-source row and main row inside a single transaction', async () => {
+    const { writer } = loadModules();
+
+    await writer.writeIdentity(
+      100,
+      [
+        {
+          library_id: 100,
+          source: 'discogs_release',
+          external_id: '987654',
+          method: 'exact_match',
+          confidence: 1.0,
+          last_verified_at: new Date('2026-04-15T00:00:00Z'),
+          boost_sources: null,
+          notes: 'backfill:S1',
+        },
+      ],
+      []
+    );
+
+    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 100`);
+    expect(sourceRows).toHaveLength(1);
+    expect(sourceRows[0].external_id).toBe('987654');
+    expect(sourceRows[0].method).toBe('exact_match');
+    expect(sourceRows[0].notes).toBe('backfill:S1');
+
+    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity WHERE library_id = 100`);
+    expect(mainRows).toHaveLength(1);
+    expect(mainRows[0].discogs_release_id).toBe(987654);
+    expect(mainRows[0].method).toBe('exact_match');
+    expect(mainRows[0].confidence).toBeCloseTo(1.0);
+    expect(mainRows[0].agreement_sources).toBeNull();
+  });
+
+  test('writeIdentity rolls back atomically when the per-source CHECK constraint trips', async () => {
+    const { writer } = loadModules();
+
+    await expect(
+      writer.writeIdentity(
+        300,
+        [
+          {
+            library_id: 300,
+            source: 'discogs_release',
+            external_id: '222',
+            method: 'exact_match',
+            confidence: 1.7, // out of [0,1] — CHECK trips
+            last_verified_at: new Date(),
+            boost_sources: null,
+            notes: 'backfill:S1',
+          },
+        ],
+        []
+      )
+    ).rejects.toThrow();
+
+    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source WHERE library_id = 300`);
+    expect(sourceRows).toHaveLength(0);
+    const mainRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity WHERE library_id = 300`);
+    expect(mainRows).toHaveLength(0);
+  });
+
+  test('runBackfill DRY_RUN leaves library_identity* untouched and reports honestly on rerun', async () => {
+    // Seed: 4 library rows. 2 are in library_identity already (rerun overlap),
+    // 1 has a fresh discogs match, 1 has a non-discogs namespace.
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library (id, canonical_entity_id, canonical_entity_resolved_at) VALUES
+       (500, 'discogs:1', now()),
+       (501, 'discogs:2', now()),
+       (502, 'discogs:3', now()),
+       (503, 'mb:abc', now())`
+    );
+    // Pre-populate library_identity for 500 and 501 so the rerun-overlap
+    // bucket actually has rows to count.
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library_identity
+       (library_id, discogs_release_id, last_verified_at, method, confidence)
+       VALUES
+       (500, 1, now(), 'exact_match', 1.0),
+       (501, 2, now(), 'exact_match', 1.0)`
+    );
+
+    const { orchestrator } = loadModules();
+    const writeIdentity = jest.fn(async () => {});
+    let capturedReport;
+    const result = await orchestrator.runBackfill({
+      writeIdentity,
+      throttleMs: 0,
+      batchSize: 500,
+      dryRun: true,
+      onDryRunReport: (r) => {
+        capturedReport = r;
+      },
+    });
+
+    expect(writeIdentity).not.toHaveBeenCalled();
+    expect(result.totals.wrote).toBe(0);
+    expect(capturedReport).toBeDefined();
+    expect(capturedReport.scanned).toBe(4);
+    expect(capturedReport.skipped.already_in_library_identity).toBe(2);
+    expect(capturedReport.skipped.non_discogs_namespace).toBe(1);
+    expect(capturedReport.skipped.no_canonical_entity_id).toBe(0);
+    expect(capturedReport.would_write_sources).toBe(1);
+
+    // Still only the 2 pre-seeded main rows; no per-source rows written.
+    const mainRows = await sql.unsafe(`SELECT library_id FROM "${schemaName}".library_identity ORDER BY library_id`);
+    expect(mainRows.map((r) => r.library_id)).toEqual([500, 501]);
+    const sourceRows = await sql.unsafe(`SELECT * FROM "${schemaName}".library_identity_source`);
+    expect(sourceRows).toHaveLength(0);
+  });
+
+  test('runBackfill partitions are disjoint and their union covers the full universe', async () => {
+    // Seed 6 rows. PARTITION_COUNT=2 splits by `id % 2`, so PARTITION_INDEX=0
+    // sees the even ids and INDEX=1 the odds. Neither sees both.
+    const tuples = [];
+    for (let i = 600; i < 606; i++) {
+      tuples.push(`(${i}, 'discogs:${i * 11}', now())`);
+    }
+    await sql.unsafe(
+      `INSERT INTO "${schemaName}".library (id, canonical_entity_id, canonical_entity_resolved_at) VALUES ${tuples.join(', ')}`
+    );
+
+    const { writer, orchestrator } = loadModules();
+    const seen0 = [];
+    const seen1 = [];
+
+    await orchestrator.runBackfill({
+      writeIdentity: async (libraryId, rows, agreement) => {
+        seen0.push(libraryId);
+        await writer.writeIdentity(libraryId, rows, agreement);
+      },
+      throttleMs: 0,
+      partition: orchestrator.resolvePartitionFilter('0', '2'),
+    });
+
+    await orchestrator.runBackfill({
+      writeIdentity: async (libraryId, rows, agreement) => {
+        seen1.push(libraryId);
+        await writer.writeIdentity(libraryId, rows, agreement);
+      },
+      throttleMs: 0,
+      partition: orchestrator.resolvePartitionFilter('1', '2'),
+    });
+
+    const intersection = seen0.filter((id) => seen1.includes(id));
+    expect(intersection).toEqual([]);
+    expect([...seen0, ...seen1].sort()).toEqual([600, 601, 602, 603, 604, 605]);
+
+    const mainRows = await sql.unsafe(`SELECT library_id FROM "${schemaName}".library_identity ORDER BY library_id`);
+    expect(mainRows.map((r) => r.library_id)).toEqual([600, 601, 602, 603, 604, 605]);
   });
 });

--- a/tests/unit/jobs/library-identity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-identity-backfill/orchestrate.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the library-identity-backfill orchestrator (sub-PR 2.0).
+ *
+ *   - Partition resolver (mirrors library-canonical-entity-backfill).
+ *   - DRY_RUN env-var path produces a stable JSON object on stdout and skips
+ *     all writes (per §4 "Dry-run mechanism (locked)").
+ *   - Real-run path delegates to writeIdentity for matched rows and counts
+ *     skip categories accurately.
+ */
+
+import { db } from '@wxyc/database';
+import {
+  resolvePartitionFilter,
+  runBackfill,
+  resolveDryRun,
+  type DryRunReport,
+} from '../../../../jobs/library-identity-backfill/orchestrate';
+
+describe('resolvePartitionFilter', () => {
+  it('returns no-op when count=1', () => {
+    const result = resolvePartitionFilter(undefined, undefined);
+    expect(result.sqlFragment).toBeNull();
+    expect(result.description).toBe('partition=none');
+  });
+
+  it('returns a modulo SQL fragment when count>1', () => {
+    const result = resolvePartitionFilter('1', '4');
+    expect(result.sqlFragment).not.toBeNull();
+    expect(result.description).toBe('partition=1/4');
+  });
+
+  it('rejects non-integer or negative count', () => {
+    expect(() => resolvePartitionFilter('0', '0')).toThrow();
+    expect(() => resolvePartitionFilter('0', '-1')).toThrow();
+  });
+
+  it('rejects out-of-range index', () => {
+    expect(() => resolvePartitionFilter('4', '4')).toThrow();
+    expect(() => resolvePartitionFilter('-1', '2')).toThrow();
+  });
+});
+
+describe('resolveDryRun', () => {
+  it('treats "true" / "1" / "TRUE" as enabled', () => {
+    expect(resolveDryRun('true')).toBe(true);
+    expect(resolveDryRun('1')).toBe(true);
+    expect(resolveDryRun('TRUE')).toBe(true);
+  });
+
+  it('treats undefined / empty / other strings as disabled', () => {
+    expect(resolveDryRun(undefined)).toBe(false);
+    expect(resolveDryRun('')).toBe(false);
+    expect(resolveDryRun('false')).toBe(false);
+    expect(resolveDryRun('0')).toBe(false);
+  });
+});
+
+describe('runBackfill — real run', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('writes one source row + one main row per matched library row', async () => {
+    const writes: Array<{ libraryId: number; sourceCount: number }> = [];
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 100, canonical_entity_id: 'discogs:987654', canonical_entity_resolved_at: new Date() },
+        { id: 101, canonical_entity_id: 'discogs:111', canonical_entity_resolved_at: new Date() },
+      ])
+      .mockResolvedValue([]);
+    const writeIdentity = jest.fn((libraryId: number, rows: Array<unknown>) => {
+      writes.push({ libraryId, sourceCount: rows.length });
+      return Promise.resolve();
+    });
+
+    const result = await runBackfill({
+      writeIdentity,
+      throttleMs: 0,
+      batchSize: 500,
+    });
+
+    expect(writes).toEqual([
+      { libraryId: 100, sourceCount: 1 },
+      { libraryId: 101, sourceCount: 1 },
+    ]);
+    expect(result.totals.scanned).toBe(2);
+    expect(result.totals.wrote).toBe(2);
+    expect(result.totals.skipped_already_in_library_identity).toBe(0);
+    expect(result.totals.skipped_no_canonical_entity_id).toBe(0);
+    expect(result.totals.skipped_non_discogs_namespace).toBe(0);
+  });
+
+  it('counts non-discogs rows as skipped_non_discogs_namespace and does not write', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 200, canonical_entity_id: 'mb:abc-123', canonical_entity_resolved_at: new Date() },
+        { id: 201, canonical_entity_id: 'discogs:bogus', canonical_entity_resolved_at: new Date() },
+      ])
+      .mockResolvedValue([]);
+    const writeIdentity = jest.fn(async () => {});
+
+    const result = await runBackfill({ writeIdentity, throttleMs: 0, batchSize: 500 });
+
+    expect(writeIdentity).not.toHaveBeenCalled();
+    expect(result.totals.scanned).toBe(2);
+    expect(result.totals.skipped_non_discogs_namespace).toBe(2);
+    expect(result.totals.wrote).toBe(0);
+  });
+});
+
+describe('runBackfill — DRY_RUN', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('emits a stable JSON object on stdout and never calls writeIdentity', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 100, canonical_entity_id: 'discogs:987654', canonical_entity_resolved_at: new Date() },
+        { id: 101, canonical_entity_id: 'mb:other', canonical_entity_resolved_at: new Date() },
+        { id: 102, canonical_entity_id: null, canonical_entity_resolved_at: null },
+      ])
+      .mockResolvedValue([]);
+    const writeIdentity = jest.fn(async () => {});
+
+    let capturedReport: DryRunReport | undefined;
+    const result = await runBackfill({
+      writeIdentity,
+      throttleMs: 0,
+      batchSize: 500,
+      dryRun: true,
+      onDryRunReport: (report) => {
+        capturedReport = report;
+      },
+    });
+
+    expect(writeIdentity).not.toHaveBeenCalled();
+    expect(result.totals.wrote).toBe(0);
+    expect(capturedReport).toBeDefined();
+    if (!capturedReport) throw new Error('expected a dry-run report');
+    expect(capturedReport.source).toBe('S1');
+    expect(capturedReport.scanned).toBe(3);
+    expect(capturedReport.would_write_sources).toBe(1);
+    expect(capturedReport.would_upsert_mains).toBe(1);
+    expect(capturedReport.skipped.already_in_library_identity).toBe(0);
+    expect(capturedReport.skipped.no_canonical_entity_id).toBe(1);
+    expect(capturedReport.skipped.non_discogs_namespace).toBe(1);
+    // §4 acceptance: scanned == would_write_sources + sum(skipped.values())
+    const skippedSum =
+      capturedReport.skipped.already_in_library_identity +
+      capturedReport.skipped.no_canonical_entity_id +
+      capturedReport.skipped.non_discogs_namespace;
+    expect(capturedReport.scanned).toBe(capturedReport.would_write_sources + skippedSum);
+  });
+
+  it('preserves the locked dry-run JSON schema (stable keys)', async () => {
+    // Locked per §4 "Dry-run mechanism (locked)". Future sub-PRs may add new
+    // top-level fields but MUST NOT remove or rename these.
+    (db.execute as jest.Mock).mockResolvedValueOnce([]).mockResolvedValue([]);
+    const writeIdentity = jest.fn(async () => {});
+
+    let capturedReport: DryRunReport | undefined;
+    await runBackfill({
+      writeIdentity,
+      throttleMs: 0,
+      batchSize: 500,
+      dryRun: true,
+      onDryRunReport: (report) => {
+        capturedReport = report;
+      },
+    });
+
+    if (!capturedReport) throw new Error('expected a dry-run report');
+    expect(Object.keys(capturedReport).sort()).toEqual(
+      ['scanned', 'skipped', 'source', 'would_upsert_mains', 'would_write_sources'].sort()
+    );
+    expect(Object.keys(capturedReport.skipped).sort()).toEqual(
+      ['already_in_library_identity', 'no_canonical_entity_id', 'non_discogs_namespace'].sort()
+    );
+  });
+});

--- a/tests/unit/jobs/library-identity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/library-identity-backfill/orchestrate.test.ts
@@ -72,8 +72,20 @@ describe('runBackfill — real run', () => {
     const writes: Array<{ libraryId: number; sourceCount: number }> = [];
     (db.execute as jest.Mock)
       .mockResolvedValueOnce([
-        { id: 100, canonical_entity_id: 'discogs:987654', canonical_entity_resolved_at: new Date() },
-        { id: 101, canonical_entity_id: 'discogs:111', canonical_entity_resolved_at: new Date() },
+        // Real-run rows: already_in_library_identity is always false because
+        // the SQL filter excludes those rows before they reach this struct.
+        {
+          id: 100,
+          canonical_entity_id: 'discogs:987654',
+          canonical_entity_resolved_at: new Date(),
+          already_in_library_identity: false,
+        },
+        {
+          id: 101,
+          canonical_entity_id: 'discogs:111',
+          canonical_entity_resolved_at: new Date(),
+          already_in_library_identity: false,
+        },
       ])
       .mockResolvedValue([]);
     const writeIdentity = jest.fn((libraryId: number, rows: Array<unknown>) => {
@@ -101,8 +113,18 @@ describe('runBackfill — real run', () => {
   it('counts non-discogs rows as skipped_non_discogs_namespace and does not write', async () => {
     (db.execute as jest.Mock)
       .mockResolvedValueOnce([
-        { id: 200, canonical_entity_id: 'mb:abc-123', canonical_entity_resolved_at: new Date() },
-        { id: 201, canonical_entity_id: 'discogs:bogus', canonical_entity_resolved_at: new Date() },
+        {
+          id: 200,
+          canonical_entity_id: 'mb:abc-123',
+          canonical_entity_resolved_at: new Date(),
+          already_in_library_identity: false,
+        },
+        {
+          id: 201,
+          canonical_entity_id: 'discogs:bogus',
+          canonical_entity_resolved_at: new Date(),
+          already_in_library_identity: false,
+        },
       ])
       .mockResolvedValue([]);
     const writeIdentity = jest.fn(async () => {});
@@ -132,9 +154,24 @@ describe('runBackfill — DRY_RUN', () => {
   it('emits a stable JSON object on stdout and never calls writeIdentity', async () => {
     (db.execute as jest.Mock)
       .mockResolvedValueOnce([
-        { id: 100, canonical_entity_id: 'discogs:987654', canonical_entity_resolved_at: new Date() },
-        { id: 101, canonical_entity_id: 'mb:other', canonical_entity_resolved_at: new Date() },
-        { id: 102, canonical_entity_id: null, canonical_entity_resolved_at: null },
+        {
+          id: 100,
+          canonical_entity_id: 'discogs:987654',
+          canonical_entity_resolved_at: new Date(),
+          already_in_library_identity: false,
+        },
+        {
+          id: 101,
+          canonical_entity_id: 'mb:other',
+          canonical_entity_resolved_at: new Date(),
+          already_in_library_identity: false,
+        },
+        {
+          id: 102,
+          canonical_entity_id: null,
+          canonical_entity_resolved_at: null,
+          already_in_library_identity: false,
+        },
       ])
       .mockResolvedValue([]);
     const writeIdentity = jest.fn(async () => {});
@@ -167,6 +204,55 @@ describe('runBackfill — DRY_RUN', () => {
       capturedReport.skipped.no_canonical_entity_id +
       capturedReport.skipped.non_discogs_namespace;
     expect(capturedReport.scanned).toBe(capturedReport.would_write_sources + skippedSum);
+  });
+
+  it('counts rerun-overlap rows as already_in_library_identity (regression)', async () => {
+    // Regression for the DRY_RUN over-count bug: in DRY_RUN the SQL filter
+    // is relaxed so the EXISTS subselect returns rows that the real run
+    // would have skipped via NOT EXISTS. Without the bucket, those rows
+    // counted as `would_write_sources` and the operator's prediction of the
+    // real run's writes was inflated.
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        {
+          id: 700,
+          canonical_entity_id: 'discogs:1',
+          canonical_entity_resolved_at: new Date(),
+          already_in_library_identity: true,
+        },
+        {
+          id: 701,
+          canonical_entity_id: 'discogs:2',
+          canonical_entity_resolved_at: new Date(),
+          already_in_library_identity: true,
+        },
+        {
+          id: 702,
+          canonical_entity_id: 'discogs:3',
+          canonical_entity_resolved_at: new Date(),
+          already_in_library_identity: false,
+        },
+      ])
+      .mockResolvedValue([]);
+    const writeIdentity = jest.fn(async () => {});
+
+    let capturedReport: DryRunReport | undefined;
+    await runBackfill({
+      writeIdentity,
+      throttleMs: 0,
+      batchSize: 500,
+      dryRun: true,
+      onDryRunReport: (r) => {
+        capturedReport = r;
+      },
+    });
+
+    if (!capturedReport) throw new Error('expected a dry-run report');
+    expect(capturedReport.scanned).toBe(3);
+    expect(capturedReport.skipped.already_in_library_identity).toBe(2);
+    expect(capturedReport.would_write_sources).toBe(1);
+    expect(capturedReport.would_upsert_mains).toBe(1);
+    expect(writeIdentity).not.toHaveBeenCalled();
   });
 
   it('preserves the locked dry-run JSON schema (stable keys)', async () => {

--- a/tests/unit/jobs/library-identity-backfill/recompute.test.ts
+++ b/tests/unit/jobs/library-identity-backfill/recompute.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for the library-identity main-row recompute function (§3.4.1.1).
+ *
+ * Exercises the worked-example matrix in `plans/library-hook-canonicalization/
+ * section-4-step-2-backfill-plan.md` §5.1.1 — the public API every sub-PR
+ * (2.0 → 2.4) calls into when composing the `library_identity` main row from
+ * the per-source rows in `library_identity_source`.
+ *
+ * Sub-PR 2.0 only writes single-source rows (S1: `discogs_release`), but the
+ * recompute is unit-tested across all four worked-example shapes here so 2.1+
+ * cannot drift the contract silently. The §5.1.1 fixture is the locked spec.
+ */
+import {
+  recomputeMainRow,
+  type SourceRow,
+  type MainRowFields,
+} from '../../../../jobs/library-identity-backfill/recompute';
+
+const baseRow = (overrides: Partial<SourceRow>): SourceRow => ({
+  source: 'discogs_release',
+  external_id: '987654',
+  method: 'exact_match',
+  confidence: 1.0,
+  boost_sources: null,
+  ...overrides,
+});
+
+describe('recomputeMainRow — §3.4.1.1 worked-example matrix', () => {
+  it('Row 1 — S1 alone: exact_match 1.00, agreement_sources=NULL', () => {
+    const rows: SourceRow[] = [baseRow({ source: 'discogs_release', external_id: '987654' })];
+
+    const main = recomputeMainRow(rows, []);
+
+    expect(main.method).toBe('exact_match');
+    expect(main.confidence).toBeCloseTo(1.0);
+    expect(main.agreement_sources).toBeNull();
+    expect(main.discogs_release_id).toBe(987654);
+    expect(main.discogs_master_id).toBeNull();
+    expect(main.musicbrainz_release_group_mbid).toBeNull();
+    expect(main.musicbrainz_release_mbid).toBeNull();
+    expect(main.musicbrainz_recording_mbid).toBeNull();
+    expect(main.wikidata_qid).toBeNull();
+    expect(main.spotify_id).toBeNull();
+    expect(main.apple_music_id).toBeNull();
+  });
+
+  it('Row 2 — S1 + S2 no cross-ref: alias_match 0.85 (Rule 4: MIN)', () => {
+    // Two sources, no cross-reference. Per Rule 4 the main row inherits the
+    // minimum-confidence row's method+confidence — alias_match 0.85 here.
+    const rows: SourceRow[] = [
+      baseRow({ source: 'discogs_release', external_id: '987654', method: 'exact_match', confidence: 1.0 }),
+      baseRow({ source: 'discogs_artist', external_id: '12345', method: 'alias_match', confidence: 0.85 }),
+    ];
+
+    const main = recomputeMainRow(rows, []);
+
+    expect(main.method).toBe('alias_match');
+    expect(main.confidence).toBeCloseTo(0.85);
+    expect(main.agreement_sources).toBeNull();
+    expect(main.discogs_release_id).toBe(987654);
+  });
+
+  it('Row 3 — S1 + S2 with cross-ref: cross_source_agreement 0.95 (Rule 2)', () => {
+    // Per Rule 2: confidence = MAX(0.95, MIN-of-corroborating-confidences) =
+    // MAX(0.95, MIN(1.00, 0.85)) = MAX(0.95, 0.85) = 0.95.
+    const rows: SourceRow[] = [
+      baseRow({ source: 'discogs_release', external_id: '987654', method: 'exact_match', confidence: 1.0 }),
+      baseRow({ source: 'discogs_artist', external_id: '12345', method: 'alias_match', confidence: 0.85 }),
+    ];
+    const agreementSources = ['discogs_release', 'discogs_artist'];
+
+    const main = recomputeMainRow(rows, agreementSources);
+
+    expect(main.method).toBe('cross_source_agreement');
+    expect(main.confidence).toBeCloseTo(0.95);
+    expect(main.agreement_sources).toBe('discogs_artist,discogs_release');
+  });
+
+  it('Row 4 — S1 + S2 + S5 with cross-ref: cross_source_agreement 0.95, includes all three', () => {
+    const rows: SourceRow[] = [
+      baseRow({ source: 'discogs_release', external_id: '987654', method: 'exact_match', confidence: 1.0 }),
+      baseRow({ source: 'discogs_artist', external_id: '12345', method: 'alias_match', confidence: 0.85 }),
+      baseRow({ source: 'wikidata', external_id: 'Q123', method: 'alias_match', confidence: 0.85 }),
+    ];
+    const agreementSources = ['discogs_release', 'discogs_artist', 'wikidata'];
+
+    const main = recomputeMainRow(rows, agreementSources);
+
+    expect(main.method).toBe('cross_source_agreement');
+    expect(main.confidence).toBeCloseTo(0.95);
+    // sorted lex
+    expect(main.agreement_sources).toBe('discogs_artist,discogs_release,wikidata');
+    expect(main.wikidata_qid).toBe('Q123');
+  });
+});
+
+describe('recomputeMainRow — Rule 1 (manual hard floor)', () => {
+  it('a single manual row pins the main row to manual 1.00 regardless of other inputs', () => {
+    // Manual entries cannot be demoted by automated cross-source agreement —
+    // human wins. Acceptance per §3.4.1.1 Rule 1.
+    const rows: SourceRow[] = [
+      baseRow({ source: 'discogs_release', external_id: '987654', method: 'manual', confidence: 1.0 }),
+      baseRow({ source: 'discogs_artist', external_id: '12345', method: 'alias_match', confidence: 0.85 }),
+    ];
+
+    const main = recomputeMainRow(rows, ['discogs_release', 'discogs_artist']);
+
+    expect(main.method).toBe('manual');
+    expect(main.confidence).toBeCloseTo(1.0);
+    expect(main.agreement_sources).toBeNull();
+  });
+});
+
+describe('recomputeMainRow — Rule 3 (inherited excluded from agreement)', () => {
+  it('two corroborating sources where one is inherited do not trigger Rule 2', () => {
+    // `inherited` is the artist→release fanout marker (sub-PR 2.1 details).
+    // It carries lower epistemic weight by definition (×0.95 multiplier per
+    // §3.4.1) and per Rule 3 must not contribute to cross_source_agreement.
+    const rows: SourceRow[] = [
+      baseRow({ source: 'discogs_release', external_id: '987654', method: 'exact_match', confidence: 1.0 }),
+      baseRow({ source: 'discogs_artist', external_id: '12345', method: 'inherited', confidence: 0.95 }),
+    ];
+    const agreementSources = ['discogs_release', 'discogs_artist'];
+
+    const main = recomputeMainRow(rows, agreementSources);
+
+    expect(main.method).not.toBe('cross_source_agreement');
+    // Rule 4 fallback: MIN of non-inherited rows is just the discogs_release
+    // row (1.00); the inherited row is filtered out of agreement BUT still
+    // counts in the MIN for non-agreement cases.
+    expect(main.method).toBe('inherited');
+    expect(main.confidence).toBeCloseTo(0.95);
+  });
+});
+
+describe('recomputeMainRow — external-ID column mapping', () => {
+  it('maps each per-source row to the right main-row external-ID column', () => {
+    const rows: SourceRow[] = [
+      baseRow({ source: 'discogs_master', external_id: '5000', method: 'exact_match', confidence: 1.0 }),
+      baseRow({ source: 'discogs_release', external_id: '987654', method: 'exact_match', confidence: 1.0 }),
+      baseRow({
+        source: 'mb_release_group',
+        external_id: '550e8400-e29b-41d4-a716-446655440000',
+        method: 'exact_match',
+        confidence: 1.0,
+      }),
+      baseRow({
+        source: 'mb_release',
+        external_id: '550e8400-e29b-41d4-a716-446655440001',
+        method: 'exact_match',
+        confidence: 1.0,
+      }),
+      baseRow({
+        source: 'mb_recording',
+        external_id: '550e8400-e29b-41d4-a716-446655440002',
+        method: 'exact_match',
+        confidence: 1.0,
+      }),
+      baseRow({ source: 'wikidata', external_id: 'Q42', method: 'exact_match', confidence: 1.0 }),
+      baseRow({ source: 'spotify', external_id: '4tZwfgrHOc3mvqYlEYSvVi', method: 'exact_match', confidence: 1.0 }),
+      baseRow({ source: 'apple_music', external_id: '1440643737', method: 'exact_match', confidence: 1.0 }),
+    ];
+
+    const main: MainRowFields = recomputeMainRow(rows, []);
+
+    expect(main.discogs_master_id).toBe(5000);
+    expect(main.discogs_release_id).toBe(987654);
+    expect(main.musicbrainz_release_group_mbid).toBe('550e8400-e29b-41d4-a716-446655440000');
+    expect(main.musicbrainz_release_mbid).toBe('550e8400-e29b-41d4-a716-446655440001');
+    expect(main.musicbrainz_recording_mbid).toBe('550e8400-e29b-41d4-a716-446655440002');
+    expect(main.wikidata_qid).toBe('Q42');
+    expect(main.spotify_id).toBe('4tZwfgrHOc3mvqYlEYSvVi');
+    expect(main.apple_music_id).toBe('1440643737');
+  });
+
+  it('artist-level sources (discogs_artist, mb_artist, bandcamp) do not populate release-level main columns', () => {
+    // Plan §5.1.1 + substrate: main row is release-level. Artist-level sources
+    // contribute to confidence and agreement, but their external_ids do not
+    // back-fill release-level columns.
+    const rows: SourceRow[] = [
+      baseRow({ source: 'discogs_artist', external_id: '12345', method: 'alias_match', confidence: 0.85 }),
+      baseRow({ source: 'mb_artist', external_id: 'aaaa-bbbb', method: 'alias_match', confidence: 0.85 }),
+      baseRow({ source: 'bandcamp', external_id: 'someone', method: 'alias_match', confidence: 0.85 }),
+    ];
+
+    const main = recomputeMainRow(rows, []);
+
+    expect(main.discogs_master_id).toBeNull();
+    expect(main.discogs_release_id).toBeNull();
+    expect(main.musicbrainz_release_group_mbid).toBeNull();
+    expect(main.musicbrainz_release_mbid).toBeNull();
+    expect(main.musicbrainz_recording_mbid).toBeNull();
+    // Confidence is still computed from these rows (alias_match 0.85)
+    expect(main.method).toBe('alias_match');
+    expect(main.confidence).toBeCloseTo(0.85);
+  });
+});
+
+describe('recomputeMainRow — degenerate inputs', () => {
+  it('throws on an empty rows array (every main row must descend from at least one source)', () => {
+    expect(() => recomputeMainRow([], [])).toThrow();
+  });
+
+  it('uses the latest last_verified_at across rows', () => {
+    const earlier = new Date('2026-01-01T00:00:00Z');
+    const later = new Date('2026-05-08T00:00:00Z');
+    const rows: SourceRow[] = [
+      baseRow({ source: 'discogs_release', external_id: '987654', last_verified_at: earlier }),
+      baseRow({
+        source: 'discogs_artist',
+        external_id: '12345',
+        method: 'alias_match',
+        confidence: 0.85,
+        last_verified_at: later,
+      }),
+    ];
+
+    const main = recomputeMainRow(rows, []);
+
+    expect(main.last_verified_at).toEqual(later);
+  });
+});

--- a/tests/unit/jobs/library-identity-backfill/resolve.test.ts
+++ b/tests/unit/jobs/library-identity-backfill/resolve.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the S1 resolver (library-identity-backfill).
+ *
+ * Sub-PR 2.0 reads from Backend's existing `library.canonical_entity_id`
+ * column. Rows shaped `'discogs:<release_id>'` are the universe; everything
+ * else is skipped (and counted in the orchestrator's `skipped` breakdown).
+ *
+ * The resolver maps `library` → per-source row(s) only. The writer composes
+ * the main row via `recomputeMainRow`.
+ */
+import { resolveS1, type LibraryRow, type ResolveOutcome } from '../../../../jobs/library-identity-backfill/resolve';
+
+const baseRow = (overrides: Partial<LibraryRow>): LibraryRow => ({
+  id: 100,
+  canonical_entity_id: 'discogs:987654',
+  canonical_entity_resolved_at: new Date('2026-04-15T00:00:00Z'),
+  ...overrides,
+});
+
+describe('resolveS1', () => {
+  it('produces one per-source row for a discogs:<release_id> match', () => {
+    const row = baseRow({ id: 100, canonical_entity_id: 'discogs:987654' });
+
+    const outcome: ResolveOutcome = resolveS1(row);
+
+    expect(outcome.status).toBe('match');
+    if (outcome.status !== 'match') return;
+    expect(outcome.sourceRows).toHaveLength(1);
+    expect(outcome.sourceRows[0]).toEqual({
+      library_id: 100,
+      source: 'discogs_release',
+      external_id: '987654',
+      method: 'exact_match',
+      confidence: 1.0,
+      last_verified_at: row.canonical_entity_resolved_at,
+      boost_sources: null,
+      notes: 'backfill:S1',
+    });
+  });
+
+  it('extracts the numeric release_id portion verbatim', () => {
+    const row = baseRow({ canonical_entity_id: 'discogs:1' });
+    const outcome = resolveS1(row);
+    expect(outcome.status).toBe('match');
+    if (outcome.status === 'match') {
+      expect(outcome.sourceRows[0].external_id).toBe('1');
+    }
+  });
+
+  it('reports non_discogs_namespace for non-discogs schemes', () => {
+    // Future-proofing: when LML adds MB-only matches, those rows are written
+    // by sub-PR 2.1+ via S2's reader, not S1. S1 only owns the discogs scheme.
+    const row = baseRow({ canonical_entity_id: 'mb:abc-123' });
+    const outcome = resolveS1(row);
+    expect(outcome.status).toBe('non_discogs_namespace');
+  });
+
+  it('reports no_canonical_entity_id when the column is null', () => {
+    // Rows without canonical_entity_id are skipped by S1; sub-PRs 2.1-2.3
+    // pick them up via other source artifacts (LML entity.identity, etc.).
+    const row = baseRow({ canonical_entity_id: null });
+    const outcome = resolveS1(row);
+    expect(outcome.status).toBe('no_canonical_entity_id');
+  });
+
+  it('rejects malformed discogs:<id> values where <id> is not an integer', () => {
+    // The substrate stores canonical_entity_id as opaque text; if a malformed
+    // value snuck in, surface it as a skip rather than corrupting the
+    // per-source table with a non-integer external_id.
+    const row = baseRow({ canonical_entity_id: 'discogs:not-a-number' });
+    const outcome = resolveS1(row);
+    expect(outcome.status).toBe('non_discogs_namespace');
+  });
+
+  it('falls back to a synthesized timestamp when canonical_entity_resolved_at is null', () => {
+    // The substrate's library_canonical_entity_backfill always sets
+    // resolved_at on a successful auto_accept, but defensive: if a row was
+    // populated by a hand-edit that skipped resolved_at, the backfill must
+    // still produce a per-source row with a valid last_verified_at.
+    const row = baseRow({ canonical_entity_resolved_at: null });
+    const outcome = resolveS1(row);
+    expect(outcome.status).toBe('match');
+    if (outcome.status === 'match') {
+      expect(outcome.sourceRows[0].last_verified_at).toBeInstanceOf(Date);
+    }
+  });
+});

--- a/tests/unit/jobs/library-identity-backfill/writer.test.ts
+++ b/tests/unit/jobs/library-identity-backfill/writer.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the dual-table writer (§3.2.2.2).
+ *
+ * The writer's contract:
+ *   1. Open a db.transaction().
+ *   2. SELECT … FOR UPDATE on the existing main row (defense-in-depth per
+ *      §5.1; the actual first-insert serialization is `ON CONFLICT`).
+ *   3. INSERT/UPSERT each per-source row (one row per leg's contribution).
+ *   4. Call `recomputeMainRow` to produce the new main-row values.
+ *   5. UPSERT the main row with `ON CONFLICT (library_id) DO UPDATE`.
+ *
+ * Everything happens inside the transaction; rollback on any error.
+ */
+import { db } from '@wxyc/database';
+import { writeIdentity } from '../../../../jobs/library-identity-backfill/writer';
+import type { SourceRowToWrite } from '../../../../jobs/library-identity-backfill/resolve';
+
+type SqlChunk = { value?: string | string[]; queryChunks?: SqlChunk[]; raw?: string };
+type SqlLike = {
+  sql?: string | string[];
+  values?: unknown[];
+  queryChunks?: Array<string | SqlChunk>;
+  raw?: string;
+};
+const renderValue = (v: unknown): string => {
+  if (v == null) return '';
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return String(v);
+  if (typeof v === 'object') {
+    const o = v as SqlChunk & SqlLike;
+    if (typeof o.raw === 'string') return o.raw;
+    if (Array.isArray(o.queryChunks) || Array.isArray(o.sql)) return renderSql(o);
+    if (Array.isArray(o.value)) return o.value.join('');
+    if (typeof o.value === 'string') return o.value;
+  }
+  return '';
+};
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) {
+    let out = '';
+    const fragments = obj.sql;
+    const values = obj.values ?? [];
+    for (let i = 0; i < fragments.length; i++) {
+      out += fragments[i];
+      if (i < values.length) out += renderValue(values[i]);
+    }
+    return out;
+  }
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.queryChunks)) return renderSql(chunk);
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const findCallMatching = (pattern: RegExp): unknown[] | undefined => {
+  const calls = (db.execute as jest.Mock).mock.calls;
+  return calls.find((call) => pattern.test(renderSql(call[0])));
+};
+
+const s1Row = (overrides: Partial<SourceRowToWrite> = {}): SourceRowToWrite => ({
+  library_id: 100,
+  source: 'discogs_release',
+  external_id: '987654',
+  method: 'exact_match',
+  confidence: 1.0,
+  last_verified_at: new Date('2026-04-15T00:00:00Z'),
+  boost_sources: null,
+  notes: 'backfill:S1',
+  ...overrides,
+});
+
+describe('writeIdentity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (db.execute as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('opens a transaction', async () => {
+    await writeIdentity(100, [s1Row()], []);
+    expect((db.transaction as jest.Mock).mock.calls.length).toBe(1);
+  });
+
+  it('issues SELECT … FOR UPDATE on library_identity for the target library_id', async () => {
+    // Defense-in-depth per §5.1; the lock no-ops when the main row doesn't yet
+    // exist, but it's the correct mechanism for the cross-leg case (2.1+).
+    await writeIdentity(100, [s1Row()], []);
+    const call = findCallMatching(/SELECT[\s\S]*library_identity[\s\S]*FOR UPDATE/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toContain('100');
+  });
+
+  it('UPSERTs each per-source row into library_identity_source', async () => {
+    await writeIdentity(100, [s1Row()], []);
+    const call = findCallMatching(/INSERT INTO[\s\S]*library_identity_source/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/ON CONFLICT/i);
+    expect(sqlText).toMatch(/library_id"?\s*,\s*"?source/i);
+    const serialized = JSON.stringify(call?.[0]);
+    expect(serialized).toContain('discogs_release');
+    expect(serialized).toContain('987654');
+    expect(serialized).toContain('exact_match');
+    expect(serialized).toContain('backfill:S1');
+  });
+
+  it('UPSERTs the main row into library_identity with ON CONFLICT (library_id) DO UPDATE', async () => {
+    // The unique index on library_id is what serializes concurrent first-
+    // inserts (§5.1 corrected concurrency mechanism).
+    await writeIdentity(100, [s1Row()], []);
+    const call = findCallMatching(/INSERT INTO[\s\S]*library_identity\b(?![_])/i);
+    expect(call).toBeDefined();
+    const sqlText = renderSql(call?.[0]);
+    expect(sqlText).toMatch(/ON CONFLICT\s*\(\s*"?library_id"?\s*\)\s*DO UPDATE/i);
+    const serialized = JSON.stringify(call?.[0]);
+    expect(serialized).toContain('exact_match');
+    // The main row's discogs_release_id is the parsed integer.
+    expect(serialized).toContain('987654');
+  });
+
+  it('issues per-source upsert(s) before the main-row upsert', async () => {
+    // Order matters: §3.2.2.2 requires per-source first so the main-row
+    // recompute reflects the new state.
+    await writeIdentity(100, [s1Row()], []);
+    const calls = (db.execute as jest.Mock).mock.calls.map((c) => renderSql(c[0]));
+    const sourceUpsertIdx = calls.findIndex((s) => /INSERT INTO[\s\S]*library_identity_source/i.test(s));
+    const mainUpsertIdx = calls.findIndex((s) =>
+      /INSERT INTO[\s\S]*library_identity\b(?![_])[\s\S]*ON CONFLICT\s*\(\s*"?library_id"?\s*\)/i.test(s)
+    );
+    expect(sourceUpsertIdx).toBeGreaterThanOrEqual(0);
+    expect(mainUpsertIdx).toBeGreaterThanOrEqual(0);
+    expect(sourceUpsertIdx).toBeLessThan(mainUpsertIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Stand up the `library-identity-backfill` one-shot job (cross-cache-identity §4 step 2 sub-PR 2.0). Reads Backend's existing `library.canonical_entity_id` column and materializes the new `library_identity` + `library_identity_source` substrate for every `discogs:<release_id>` row, atomically per library_id via the §3.2.2.2 dual-table writer.

This is sub-PR **2.0 of 5** (skeleton + S1 source). Sub-PRs 2.1-2.4 add the remaining four sources; the design splits in [`plans/library-hook-canonicalization/section-4-step-2-backfill-plan.md`](https://github.com/WXYC/Backend-Service/blob/main/plans/library-hook-canonicalization/section-4-step-2-backfill-plan.md).

### What's in this PR

- `jobs/library-identity-backfill/` — new one-shot job package (`"job-type": "one-shot"`).
- §3.2.2.2 dual-table writer: `db.transaction()` with `SELECT … FOR UPDATE` + per-source UPSERT (`ON CONFLICT (library_id, source) DO UPDATE`) + main-row UPSERT (`ON CONFLICT (library_id) DO UPDATE`).
- §3.4.1.1 main-row recompute fully implemented: Rule 1 (manual hard floor), Rule 2 (cross-source agreement boost: `MAX(0.95, MIN-of-corroborating-confidences)`), Rule 3 (inherited exclusion), Rule 4 (MIN fallback). The §5.1.1 worked-example matrix is locked in `tests/unit/jobs/library-identity-backfill/recompute.test.ts`.
- S1 reader: `library.canonical_entity_id LIKE 'discogs:%'` → `(source='discogs_release', external_id=<release_id>, method='exact_match', confidence=1.00, notes='backfill:S1')`. The `notes` tag enables the §5.3 unwind.
- `DRY_RUN` env var with locked truthy values (`true` / `1` / `TRUE`) emits the §4-locked JSON report on stdout without writing.
- Partition support (`PARTITION_INDEX`/`PARTITION_COUNT`) for parallel container deploys, mirroring `library-canonical-entity-backfill`.
- `Dockerfile.library-identity-backfill` mirroring the existing one-shot jobs.
- Integration tests against real Postgres: transaction atomicity (CHECK violation rolls back; neither table holds a partial row), DRY_RUN no-write guarantee, partition disjointness.
- README with run command + env vars + rollback recipe.
- `docs/env-vars.md`: new `## ETL Jobs / one-shot backfill` subsection documenting `DRY_RUN`, `BATCH_SIZE`, `THROTTLE_MS`, `PARTITION_INDEX`, `PARTITION_COUNT`, `WXYC_SCHEMA_NAME`.
- `CLAUDE.md`: monorepo-layout table entry for the new package.

### What's NOT in this PR

- Sub-PRs 2.1-2.4 source legs (LML `entity.identity`, discogs-cache `flowsheet_match` + `fuzzy_resolved`, semantic-index `reconciliation_log`, gate verification).
- The §3.2.5 cross-ref pre-index — defer to 2.1 where it first becomes useful.
- Schema changes to the substrate tables (substrate is locked by migration 0075, deployed 2026-05-08).

## Test plan

- [x] `npm run test:unit` — 1760 / 1760 pass (31 new in `tests/unit/jobs/library-identity-backfill/`).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors (warnings unchanged from main).
- [x] `npm run format:check` — clean (one pre-existing warning in `scripts/provision-dryrun-aws.mjs`).
- [x] `npm run lint:migrations` — clean (no migration touched here).
- [x] `npm run build --workspace=@wxyc/library-identity-backfill` — clean.
- [x] `bash scripts/check-cross-cache-identity-flags.sh` — PASS (no flag added).
- [ ] CI: integration tests + ECR build for the new Dockerfile.
- [ ] Post-merge dry-run on prod: `DRY_RUN=true docker run …` to confirm the JSON report shape and S1 coverage estimate before scheduling the real run.

Closes #789
Refs #663