### PR TITLE
ci(deploy-base): fail-fast: false on build and deploy matrices

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -197,6 +197,9 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.setup.outputs.has_targets == 'true'
     strategy:
+      # Build all targets independently; one target's build failure shouldn't
+      # mask the rest, so we can ship working images for siblings.
+      fail-fast: false
       matrix:
         target: ${{ fromJSON(needs.setup.outputs.targets) }}
 
@@ -394,6 +397,11 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.setup.outputs.has_targets == 'true'
     strategy:
+      # One target's deploy failure must not cancel sibling deploys mid-flight.
+      # The deploy script does `docker stop && docker rm && docker run`, so a
+      # cancellation between stop and run leaves the service down — turning a
+      # transient ETL pull error into a public-facing outage.
+      fail-fast: false
       matrix:
         target: ${{ fromJSON(needs.setup.outputs.targets) }}
     steps:


### PR DESCRIPTION
## Summary

- Adds `fail-fast: false` to the `build` and `deploy` matrices in `.github/workflows/deploy-base.yml`.
- Stops one matrix target's failure from cancelling sibling deploys mid-stop/start.

Closes #798.

## Why

`Auto Build & Deploy` run [25608365420](https://github.com/WXYC/Backend-Service/actions/runs/25608365420) on commit 4cd5978 hit a transient containerd lease error on the `artist-identity-etl` deploy at 18:17 UTC on 2026-05-09. Default `fail-fast: true` then cancelled five sibling deploys, including `backend`, between their `docker stop` and `docker run` steps. The `backend` container was left in `Exited (0)` and stayed down for ~7 hours until the wxyc-canary CloudWatch alarm fired and a human ran `docker start backend`.

`fail-fast: false` lets each target's deploy run to completion or failure independently. At worst, the failed target is left in its pre-deploy state; sibling user-facing services aren't dragged down with it.

The deploy script's `stop && rm && run` non-atomicity is the deeper hazard (an SSH timeout or runner OOM mid-flight has the same effect even with `fail-fast: false`). That's flagged as a known follow-up in #798 — out of scope for this PR.

## Test plan

- [ ] CI passes on this PR.
- [ ] Confirm the next push to `main` (or a deliberate test push touching at least two targets) shows independent matrix-target lifecycles.
- [ ] Soft-confirm: introduce a temporary forced failure in one ETL target's deploy and verify siblings still complete. (Optional; can be done by Jake out-of-band if desired.)