### PR TITLE
#804 adopt HealthCheckResponse from @wxyc/shared on /healthcheck

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -13,6 +13,7 @@ import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
 import { closeDatabaseConnection } from '@wxyc/database';
+import type { HealthCheckResponse } from '@wxyc/shared/dtos';
 import { provisionUser, ProvisionError } from './provision-user';
 import { resolveOrganization } from './resolve-organization';
 
@@ -254,7 +255,15 @@ if (isTestEnv) {
   app.use('/auth', toNodeHandler(auth));
 }
 
-//endpoint for healthchecks
+// Liveness/readiness endpoint. Body conforms to HealthCheckResponse from
+// @wxyc/shared (api.yaml v1.3.0 / @wxyc/shared v0.13.0); the shape is the
+// cross-language contract owned by wxyc-fastapi and adopted here so every
+// WXYC service exposes the same status enum + per-dependency `services`
+// map. Status codes are preserved verbatim — the upstream /auth/ok status
+// is forwarded on the proxy-reachable branch and the catch branch keeps
+// 500 — only the body shape changes. wxyc-canary checks `r.ok` only, so
+// the body change is non-breaking for the alarm. See
+// WXYC/Backend-Service#804.
 app.get('/healthcheck', async (req, res) => {
   const authServiceUrl = `http://localhost:${port}`; // Use the port the server is listening on
   try {
@@ -271,13 +280,20 @@ app.get('/healthcheck', async (req, res) => {
       headers: { 'X-Real-IP': '127.0.0.1' },
     });
 
-    // Forward the status and body from the /auth/ok response
-    const data = (await response.json()) as Record<string, unknown>;
-    res.status(response.status).json(data);
+    // Forward the upstream status verbatim. Drain the body so the socket is
+    // freed but discard the legacy `{ ok: true }` payload — the response
+    // shape is the shared HealthCheckResponse, derived purely from
+    // response.ok rather than the upstream body.
+    await response.text().catch(() => undefined);
+    const body: HealthCheckResponse = response.ok
+      ? { status: 'healthy', services: { auth: 'ok' } }
+      : { status: 'unhealthy', services: { auth: 'unavailable' } };
+    res.status(response.status).json(body);
   } catch (error) {
     console.error('Error proxying /healthcheck to /auth/ok:', error);
     // If the internal call fails, it indicates a problem with the auth service itself
-    res.status(500).json({ message: 'Healthcheck failed: Could not reach internal /auth/ok endpoint' });
+    const body: HealthCheckResponse = { status: 'unhealthy', services: { auth: 'unavailable' } };
+    res.status(500).json(body);
   }
 });
 

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,6 +19,7 @@
     "@sentry/node": "^10.52.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
+    "@wxyc/shared": "^0.13.0",
     "better-auth": "^1.6.9",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -30,6 +30,7 @@ import { responseMetricsMiddleware } from './middleware/responseMetrics.js';
 import { requirePermissions } from '@wxyc/authentication';
 import { closeDatabaseConnection, db } from '@wxyc/database';
 import { sql } from 'drizzle-orm';
+import type { HealthCheckResponse } from '@wxyc/shared/dtos';
 
 const port = process.env.PORT || 8080;
 const app = express();
@@ -102,13 +103,20 @@ app.get('/testAuth', requirePermissions({ flowsheet: ['read'] }), async (req, re
   res.json({ message: 'Authenticated!' });
 });
 
-//endpoint for healthchecks
+// Liveness/readiness endpoint. Body conforms to HealthCheckResponse from
+// @wxyc/shared (api.yaml v1.3.0 / @wxyc/shared v0.13.0); the shape is the
+// cross-language contract owned by wxyc-fastapi and adopted here so every
+// WXYC service exposes the same status enum + per-dependency `services`
+// map. wxyc-canary checks `r.ok` only, so the body change is non-breaking
+// for the alarm. See WXYC/Backend-Service#804.
 app.get('/healthcheck', async (req, res) => {
   try {
     await db.execute(sql`SELECT 1`);
-    res.json({ message: 'Healthy!' });
+    const body: HealthCheckResponse = { status: 'healthy', services: { database: 'ok' } };
+    res.json(body);
   } catch {
-    res.status(503).json({ message: 'Database unreachable' });
+    const body: HealthCheckResponse = { status: 'unhealthy', services: { database: 'unavailable' } };
+    res.status(503).json(body);
   }
 });
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,7 +21,7 @@
     "@tensorflow/tfjs": "^4.22.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^0.9.0",
+    "@wxyc/shared": "^0.13.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "@sentry/node": "^10.52.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
+        "@wxyc/shared": "^0.13.0",
         "better-auth": "^1.6.9",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -114,6 +115,19 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "apps/auth/node_modules/@wxyc/shared": {
+      "version": "0.13.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.13.0/99a2464e6b2ef74302497935684ef4917b82f33b",
+      "integrity": "sha512-y8EZntNilF53NHUf0tgQNpPnGiVQXuiWIoQyjzhAKyGIIVRXygIXhkFoO+1mtRSemnS/YaFYEgO7BBUxbsNfdA==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "better-auth": "^1.5.0",
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "apps/auth/node_modules/better-auth": {
@@ -247,7 +261,7 @@
         "@tensorflow/tfjs": "^4.22.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^0.9.0",
+        "@wxyc/shared": "^0.13.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.16.0",
@@ -299,9 +313,9 @@
       }
     },
     "apps/backend/node_modules/@wxyc/shared": {
-      "version": "0.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.9.0/98b63615b5d760e2d1539d8236b1eda87f0a0da2",
-      "integrity": "sha512-koNAdEYMrZeOGU3Fj1KsApWC7GVL71XO13OOfR3uNEJvGmELEFlWJ/kc48Ju8Zn1aevt4ckT7fYlTHlmB+qRGw==",
+      "version": "0.13.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.13.0/99a2464e6b2ef74302497935684ef4917b82f33b",
+      "integrity": "sha512-y8EZntNilF53NHUf0tgQNpPnGiVQXuiWIoQyjzhAKyGIIVRXygIXhkFoO+1mtRSemnS/YaFYEgO7BBUxbsNfdA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/tests/integration/metadata.spec.js
+++ b/tests/integration/metadata.spec.js
@@ -293,8 +293,10 @@ describe('Metadata with Rotation Entries', () => {
 
 describe('Metadata Service Initialization', () => {
   test('Backend healthcheck passes (metadata service initialized)', async () => {
+    // Body conforms to HealthCheckResponse from @wxyc/shared (#804).
     const res = await request.get('/healthcheck').expect(200);
-    expect(res.body.message).toEqual('Healthy!');
+    expect(res.body.status).toEqual('healthy');
+    expect(res.body.services).toEqual({ database: 'ok' });
   });
 });
 

--- a/tests/unit/config/healthcheck-shape.test.ts
+++ b/tests/unit/config/healthcheck-shape.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Source-grep regression tests for the /healthcheck response shape.
+ *
+ * Both `apps/backend/app.ts` and `apps/auth/app.ts` must return bodies that
+ * conform to `HealthCheckResponse` from `@wxyc/shared` (added in v0.13.0):
+ * `{status: 'healthy' | 'degraded' | 'unhealthy'}` plus an optional
+ * `services` map per `ReadinessResponse`. wxyc-canary's check is `r.ok`-only,
+ * so the body change is non-breaking, but we still pin the shape so future
+ * edits don't drift away from the cross-language contract.
+ *
+ * Source-grep style mirrors `auth-healthcheck-ip-header.test.ts`: we assert
+ * what the route bodies look like by reading app.ts as a string. This
+ * sidesteps the need to spin up Express + the database for what is really a
+ * contract assertion. The integration test `tests/integration/metadata.spec.js`
+ * exercises the live request/response path.
+ *
+ * Background: WXYC/Backend-Service#804, WXYC/wxyc-shared#108.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const backendAppSource = readFileSync(resolve(__dirname, '../../../apps/backend/app.ts'), 'utf-8');
+const authAppSource = readFileSync(resolve(__dirname, '../../../apps/auth/app.ts'), 'utf-8');
+
+describe('/healthcheck response shape (HealthCheckResponse from @wxyc/shared)', () => {
+  describe('apps/backend/app.ts', () => {
+    it('imports the HealthCheckResponse type from @wxyc/shared/dtos', () => {
+      expect(backendAppSource).toMatch(
+        /import\s+type\s+\{[^}]*\bHealthCheckResponse\b[^}]*\}\s+from\s+['"]@wxyc\/shared\/dtos['"]/
+      );
+    });
+
+    it('healthy success body uses status: "healthy" with a services map reporting database: "ok"', () => {
+      // Match `status: 'healthy'` (single or double quote) somewhere after the
+      // try/await db.execute block, and a `database: 'ok'` entry. Keeping the
+      // assertion narrow so cosmetic diff (e.g. property order) doesn't trip.
+      expect(backendAppSource).toMatch(/status\s*:\s*['"]healthy['"]/);
+      expect(backendAppSource).toMatch(/database\s*:\s*['"]ok['"]/);
+    });
+
+    it('failure body uses status: "unhealthy" with services.database: "unavailable" and 503 status', () => {
+      expect(backendAppSource).toMatch(/status\s*:\s*['"]unhealthy['"]/);
+      expect(backendAppSource).toMatch(/database\s*:\s*['"]unavailable['"]/);
+      // The catch branch must still set 503 (canary alarm depends on it).
+      expect(backendAppSource).toMatch(/\.status\(\s*503\s*\)/);
+    });
+
+    it('does not return the legacy {message: "Healthy!"} shape', () => {
+      expect(backendAppSource).not.toMatch(/message\s*:\s*['"]Healthy!['"]/);
+    });
+  });
+
+  describe('apps/auth/app.ts', () => {
+    it('imports the HealthCheckResponse type from @wxyc/shared/dtos', () => {
+      expect(authAppSource).toMatch(
+        /import\s+type\s+\{[^}]*\bHealthCheckResponse\b[^}]*\}\s+from\s+['"]@wxyc\/shared\/dtos['"]/
+      );
+    });
+
+    it('healthy success body uses status: "healthy" with a services map reporting auth: "ok"', () => {
+      expect(authAppSource).toMatch(/status\s*:\s*['"]healthy['"]/);
+      expect(authAppSource).toMatch(/auth\s*:\s*['"]ok['"]/);
+    });
+
+    it('failure body uses status: "unhealthy" with services.auth: "unavailable"', () => {
+      expect(authAppSource).toMatch(/status\s*:\s*['"]unhealthy['"]/);
+      expect(authAppSource).toMatch(/auth\s*:\s*['"]unavailable['"]/);
+    });
+
+    it('preserves status codes: forwards /auth/ok response.status on success, 500 in the catch branch', () => {
+      // Per #804: "Do NOT change status codes". The current auth handler
+      // forwards whatever /auth/ok returns (so a degraded auth surface gets
+      // the same non-2xx the backend got) and falls back to 500 on a
+      // network/parse failure. Preserve both branches.
+      expect(authAppSource).toMatch(/\.status\(\s*response\.status\s*\)/);
+      expect(authAppSource).toMatch(/\.status\(\s*500\s*\)/);
+    });
+
+    it('does not return the legacy {message: "Healthcheck failed: ..."} shape', () => {
+      expect(authAppSource).not.toMatch(/message\s*:\s*['"]Healthcheck failed/);
+    });
+
+    it('preserves the X-Real-IP loopback header (regression for #774)', () => {
+      // The new handler must keep passing X-Real-IP: 127.0.0.1 to /auth/ok
+      // so better-auth's getIp doesn't latch the warning that disables its
+      // rate limiter (see #765 and the auth-healthcheck-ip-header test).
+      const fetchBlock = authAppSource.match(/fetch\(\s*`\$\{authServiceUrl\}\/auth\/ok`[\s\S]*?\)/);
+      expect(fetchBlock).not.toBeNull();
+      if (fetchBlock) {
+        expect(fetchBlock[0]).toMatch(/['"]X-Real-IP['"]\s*:\s*['"]127\.0\.0\.1['"]/i);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Both `apps/backend/app.ts` and `apps/auth/app.ts` `/healthcheck` handlers now return bodies that conform to `HealthCheckResponse` from [@wxyc/shared v0.13.0](https://github.com/WXYC/wxyc-shared/releases/tag/v0.13.0) (schema added in [WXYC/wxyc-shared#108](https://github.com/WXYC/wxyc-shared/pull/108) / merged today as [WXYC/wxyc-shared#114](https://github.com/WXYC/wxyc-shared/pull/114), `api.yaml` v1.3.0).
- Backend success: `{status: "healthy", services: {database: "ok"}}` (200). Backend failure: `{status: "unhealthy", services: {database: "unavailable"}}` (503, unchanged from today's behavior).
- Auth success: `{status: "healthy", services: {auth: "ok"}}` with `response.status` from `/auth/ok` forwarded verbatim. Auth failure (catch branch): `{status: "unhealthy", services: {auth: "unavailable"}}` (500, unchanged).
- Adds `@wxyc/shared@^0.13.0` to `apps/auth/package.json` (it was not previously a dependency there) and bumps the same dep in `apps/backend/package.json` from `^0.9.0`.

## Why

Every WXYC service should report health in the same shape so dashboards, canaries, and load-balancer hooks don't need per-service decoders. The schema is owned by `wxyc-fastapi` (Python) and adopted here on the Node side via the generated `@wxyc/shared` TS types; this PR is the Node-side adoption.

## Constraints honored

- **Status codes preserved.** 200 on backend success, 503 on backend failure, `response.status` forwarded for the auth proxy-reachable branch, 500 in the auth catch branch. No condition that decides 503 was changed.
- **wxyc-canary stays green.** [`wxyc-canary/src/checks.ts`](https://github.com/WXYC/wxyc-canary/blob/main/src/checks.ts#L13-L21) checks `r.ok` only — the body change is non-breaking for that alarm.
- **#774 / #765 X-Real-IP regression preserved** on the auth handler; covered by both the existing `auth-healthcheck-ip-header.test.ts` suite and a new explicit assertion in `healthcheck-shape.test.ts`.

## Test plan

- [x] `npm run typecheck` (clean)
- [x] `npm run lint` (0 errors, baseline warnings)
- [x] `npm run format:check` (clean)
- [x] `npm run build` (all workspaces)
- [x] `npm run test:unit` (1791 passed; new `tests/unit/config/healthcheck-shape.test.ts` covers both handlers)
- [x] Updated `tests/integration/metadata.spec.js` healthcheck assertion to the new shape (`status` + `services.database === 'ok'`); will run in CI's integration job
- [ ] CI green on PR
- [ ] Auto-deploy fires post-rebase-merge; canary `backend-healthcheck` stays green

## Related

- Schema producer: [WXYC/wxyc-shared#108](https://github.com/WXYC/wxyc-shared/pull/108) (proposal) and [WXYC/wxyc-shared#114](https://github.com/WXYC/wxyc-shared/pull/114) (merged + published as v0.13.0)
- Canary check that monitors this endpoint: [`wxyc-canary/src/checks.ts` `backend-healthcheck`](https://github.com/WXYC/wxyc-canary/blob/main/src/checks.ts#L13-L21)

Closes #804