### PR TITLE
Bump aws-actions/configure-aws-credentials to v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -430,7 +430,7 @@ jobs:
         # Long-lived AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY pattern
         # already used by .github/workflows/deploy-base.yml (lines 246, 254,
         # 265, 329, 337, 363, 454). Migrating to OIDC is a separate concern.
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

- Bump `aws-actions/configure-aws-credentials@v4` → `@v6` at `.github/workflows/test.yml:433` so the action runs on Node 24 before GitHub's 2026-06-02 auto-coercion of Node 20 actions.
- The v5/v6 release notes flag two breaking changes: invalid-boolean input rejection (v5) and the Node 24 runner requirement (v6). Neither applies here — this step passes only string secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) and runs on GitHub-hosted runners well past v2.327.1.
- Confirmed `test.yml:433` is the only `aws-actions/*` v4 pin in `.github/workflows/`; nothing to fold in.

## Test plan

- [x] CI passes on the PR
- [ ] First Manual Build & Deploy run after merge succeeds and pushes to ECR cleanly
- [ ] Node 20 deprecation annotation no longer emitted on workflow runs

Closes #846

Sibling tickets (independent, no ordering required): WXYC/wxyc-canary#21 (merged), WXYC/discogs-etl#200.