### PR TITLE
Bump @wxyc/shared to ^1.3.0 across workspaces (catalog-track-search E7-3)

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^10.52.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^0.13.1",
+    "@wxyc/shared": "^1.3.0",
     "better-auth": "^1.6.9",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,7 +21,7 @@
     "@tensorflow/tfjs": "^4.22.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^0.13.1",
+    "@wxyc/shared": "^1.3.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "@sentry/node": "^10.52.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^0.13.1",
+        "@wxyc/shared": "^1.3.0",
         "better-auth": "^1.6.9",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -121,9 +121,9 @@
       }
     },
     "apps/auth/node_modules/@wxyc/shared": {
-      "version": "0.13.1",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.13.1/d49fb885965a0b83c6b72ee46a323164b761b9ee",
-      "integrity": "sha512-0udkfaimQ3MR4CsutvLhKP+zxbOfI0HlmZhUqk1ZtCluVTyp9x0tfyK+LujwRgKoGY8AveVaoHd+BEBRpFNlxw==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.3.0/921aeb6e4fed2d130c7ac13e032740f1cb2d82ab",
+      "integrity": "sha512-StZ0DDuRcogWO4tD9PM2sd42inlYVb1RAo0wzUO3kj3l0HQh/p93PD6YbkEaKoiWJMxWRzPzSimsZvMdkM9KzQ==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -267,7 +267,7 @@
         "@tensorflow/tfjs": "^4.22.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^0.13.1",
+        "@wxyc/shared": "^1.3.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.16.0",
@@ -319,9 +319,9 @@
       }
     },
     "apps/backend/node_modules/@wxyc/shared": {
-      "version": "0.13.1",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.13.1/d49fb885965a0b83c6b72ee46a323164b761b9ee",
-      "integrity": "sha512-0udkfaimQ3MR4CsutvLhKP+zxbOfI0HlmZhUqk1ZtCluVTyp9x0tfyK+LujwRgKoGY8AveVaoHd+BEBRpFNlxw==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.3.0/921aeb6e4fed2d130c7ac13e032740f1cb2d82ab",
+      "integrity": "sha512-StZ0DDuRcogWO4tD9PM2sd42inlYVb1RAo0wzUO3kj3l0HQh/p93PD6YbkEaKoiWJMxWRzPzSimsZvMdkM9KzQ==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -15440,7 +15440,7 @@
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1045.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^0.9.0",
+        "@wxyc/shared": "^1.3.0",
         "better-auth": "^1.6.9",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -15476,12 +15476,15 @@
       }
     },
     "shared/authentication/node_modules/@wxyc/shared": {
-      "version": "0.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.9.0/98b63615b5d760e2d1539d8236b1eda87f0a0da2",
-      "integrity": "sha512-koNAdEYMrZeOGU3Fj1KsApWC7GVL71XO13OOfR3uNEJvGmELEFlWJ/kc48Ju8Zn1aevt4ckT7fYlTHlmB+qRGw==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.3.0/921aeb6e4fed2d130c7ac13e032740f1cb2d82ab",
+      "integrity": "sha512-StZ0DDuRcogWO4tD9PM2sd42inlYVb1RAo0wzUO3kj3l0HQh/p93PD6YbkEaKoiWJMxWRzPzSimsZvMdkM9KzQ==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=24"
       },
       "peerDependencies": {
         "better-auth": "^1.5.0",

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1045.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^0.9.0",
+    "@wxyc/shared": "^1.3.0",
     "better-auth": "^1.6.9",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"


### PR DESCRIPTION
## Summary

Bumps `@wxyc/shared` from previous pins to `^1.3.0` in all three workspaces that depend on it. Picks up the catalog-track-search E7-1 contract additions published in `@wxyc/shared@1.3.0`:

- `TrackMatchSource` enum + `TrackMatchHint` schema
- optional `matched_via` field on `AlbumSearchResult`, `LibrarySearchItem`, `LookupResultItem`
- optional `track_position` on `FlowsheetEntryResponse`, `FlowsheetSongEntry`

| Workspace | Before | After |
|---|---|---|
| `apps/backend` | `^0.13.1` | `^1.3.0` |
| `apps/auth` | `^0.13.1` | `^1.3.0` |
| `shared/authentication` | `^0.9.0` | `^1.3.0` |

The v1.3.0 delta is purely additive — no Backend code changes required. New fields land in `@wxyc/shared/dtos` and `@wxyc/shared/auth-client/auth` types but are unused in this PR. Track 1/2/3 work (search-side consumption + flowsheet-side persistence) happens in later catalog-track-search PRs.

## Test plan

- [x] `npm install --ignore-scripts` resolves `@wxyc/shared@1.3.0` in all three workspaces
- [x] `npm run typecheck` clean (all 4 workspaces: database, authentication, auth-service, backend)
- [x] `npm run lint` — 0 errors (374 pre-existing warnings unchanged)
- [x] `npm run format:check` clean
- [x] `npm run test:unit` — 1791 tests pass, 142 suites

Closes #837.

## Related

- Parent epic: WXYC/wxyc-shared#110 (E7)
- Blocked by: WXYC/wxyc-shared#113 (E7-2, merged) — `@wxyc/shared@1.3.0` published
- Sibling consumer bumps: WXYC/dj-site#503 (E7-4), WXYC/library-metadata-lookup#298 (E7-5)