### PR TITLE
feat(library): add searchLibraryByCTA for compilation track-artist fuzzy search

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1039,7 +1039,9 @@ export async function searchLibraryByCTA(
   on_streaming?: boolean
 ): Promise<EnrichedLibraryResult[]> {
   const trimmed = query.trim();
-  if (trimmed.length === 0) return [];
+  // Mirror searchLibraryBothMode's guard: pure-punctuation queries (`!!!`,
+  // `---`) would otherwise run an unanchored ILIKE scan over every CTA row.
+  if (trimmed.length === 0 || !hasAlphanumeric(trimmed)) return [];
 
   await checkLibraryArtistNameHealth();
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1,5 +1,5 @@
 import { and, asc, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
-import type { ReconciledIdentity } from '@wxyc/shared/dtos';
+import type { ReconciledIdentity, TrackMatchHint } from '@wxyc/shared/dtos';
 import { RotationAddRequest } from '../controllers/library.controller.js';
 import { db } from '@wxyc/database';
 import {
@@ -1001,6 +1001,129 @@ export async function searchByArtist(artistName: string, limit = 5): Promise<Enr
     .limit(limit)) as unknown as LibraryArtistViewEntry[];
 
   return rows.map((row) => enrichLibraryResult(viewRowToLibraryResult(row)));
+}
+
+/**
+ * Row shape returned by `searchLibraryByCTA`: the standard `LibraryArtistViewEntry`
+ * projection plus the matched track_title and artist_name from
+ * `compilation_track_artist`. One row per matched CTA entry; grouped to one
+ * EnrichedLibraryResult per library_id in TS.
+ */
+type CTASearchRow = LibraryArtistViewEntry & {
+  cta_track_title: string | null;
+  cta_artist_name: string;
+};
+
+/**
+ * Search the library for compilation tracks whose `track_title` or
+ * `artist_name` matches `query` via ILIKE. JOINs back to `library` (with the
+ * usual `artists` / `format` / `genres` / `genre_artist_crossreference` joins
+ * used by `library_artist_view`) and returns one enriched library row per
+ * matched release, with `matched_via` listing every matching CTA row.
+ *
+ * Confidence is hardcoded to 1.0 per the catalog-track-search plan's
+ * confidence-by-source table — the curated VA-disambiguation data in
+ * `compilation_track_artist` is treated as authoritative.
+ *
+ * Method is exported for E1-3 to wire into `searchLibraryBothMode`; it is
+ * not yet on the public search path.
+ *
+ * @param query - Free text query matched against `track_title` and `artist_name`
+ * @param limit - Maximum results to return (counts library rows, not CTA rows)
+ * @param on_streaming - Optional filter on `library.on_streaming`
+ * @returns Array of enriched library results with `matched_via` populated
+ */
+export async function searchLibraryByCTA(
+  query: string,
+  limit: number,
+  on_streaming?: boolean
+): Promise<EnrichedLibraryResult[]> {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return [];
+
+  await checkLibraryArtistNameHealth();
+
+  const likePattern = `%${trimmed}%`;
+  const matchPredicate = sql`(${compilation_track_artist.track_title} ILIKE ${likePattern} OR ${compilation_track_artist.artist_name} ILIKE ${likePattern})`;
+  const streamingPredicate = on_streaming !== undefined ? sql` AND ${library.on_streaming} = ${on_streaming}` : sql``;
+
+  // Raw SQL because we need both the library_artist_view projection and the
+  // matched-track columns from `compilation_track_artist` in a single row,
+  // which the chained `libraryViewQuery` shape can't express. `limit` is
+  // applied per-library-row (via the `DENSE_RANK` window) so that callers
+  // get N releases even when a single release contributes multiple hints.
+  const queryStmt = sql`
+    SELECT * FROM (
+      SELECT
+        ${library.id} AS id,
+        ${artists.code_letters} AS code_letters,
+        ${genre_artist_crossreference.artist_genre_code} AS code_artist_number,
+        ${library.code_number} AS code_number,
+        ${artists.artist_name} AS artist_name,
+        ${artists.alphabetical_name} AS alphabetical_name,
+        ${library.album_title} AS album_title,
+        ${format.format_name} AS format_name,
+        ${genres.genre_name} AS genre_name,
+        ${rotation.rotation_bin} AS rotation_bin,
+        ${library.add_date} AS add_date,
+        ${library.label} AS label,
+        ${library.label_id} AS label_id,
+        ${library.on_streaming} AS on_streaming,
+        ${library.album_artist} AS album_artist,
+        ${library.plays} AS plays,
+        ${library.artwork_url} AS artwork_url,
+        ${artists.discogs_artist_id} AS discogs_artist_id,
+        ${artists.musicbrainz_artist_id} AS musicbrainz_artist_id,
+        ${artists.wikidata_qid} AS wikidata_qid,
+        ${artists.spotify_artist_id} AS spotify_artist_id,
+        ${artists.apple_music_artist_id} AS apple_music_artist_id,
+        ${artists.bandcamp_id} AS bandcamp_id,
+        ${compilation_track_artist.track_title} AS cta_track_title,
+        ${compilation_track_artist.artist_name} AS cta_artist_name,
+        DENSE_RANK() OVER (ORDER BY ${library.id}) AS library_rank
+      FROM ${compilation_track_artist}
+      INNER JOIN ${library} ON ${library.id} = ${compilation_track_artist.library_id}
+      INNER JOIN ${artists} ON ${artists.id} = ${library.artist_id}
+      INNER JOIN ${format} ON ${format.id} = ${library.format_id}
+      INNER JOIN ${genres} ON ${genres.id} = ${library.genre_id}
+      INNER JOIN ${genre_artist_crossreference}
+        ON ${genre_artist_crossreference.artist_id} = ${library.artist_id}
+        AND ${genre_artist_crossreference.genre_id} = ${library.genre_id}
+      LEFT JOIN ${rotation}
+        ON ${rotation.album_id} = ${library.id}
+        AND (${rotation.kill_date} > CURRENT_DATE OR ${rotation.kill_date} IS NULL)
+      WHERE ${matchPredicate}${streamingPredicate}
+    ) ranked
+    WHERE library_rank <= ${limit}
+    ORDER BY library_rank, cta_track_title
+  `;
+
+  const rows = (await db.execute(queryStmt)) as unknown as CTASearchRow[];
+  if (rows.length === 0) return [];
+
+  // Group CTA rows by library_id: one EnrichedLibraryResult per release with
+  // a `matched_via` hint per CTA row. Preserves the first-seen ordering so
+  // callers see the same DB sort.
+  const byLibraryId = new Map<number, { row: CTASearchRow; hints: TrackMatchHint[] }>();
+  for (const row of rows) {
+    const existing = byLibraryId.get(row.id);
+    const hint: TrackMatchHint = {
+      title: row.cta_track_title ?? '',
+      artist_credit: row.cta_artist_name,
+      source: 'cta',
+      confidence: 1.0,
+    };
+    if (existing) {
+      existing.hints.push(hint);
+    } else {
+      byLibraryId.set(row.id, { row, hints: [hint] });
+    }
+  }
+
+  return Array.from(byLibraryId.values()).map(({ row, hints }) => ({
+    ...enrichLibraryResult(viewRowToLibraryResult(row)),
+    matched_via: hints,
+  }));
 }
 
 /**

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -17,6 +17,7 @@ import {
   searchLibrary,
   searchByArtist,
   searchAlbumsByTitle,
+  searchLibraryByCTA,
   searchLibraryByTrack,
   getAlbumFromDB,
   markAlbumMissing,
@@ -24,6 +25,28 @@ import {
   enrichWithArtwork,
   updateArtworkUrl,
 } from '../../../apps/backend/services/library.service';
+
+/**
+ * Recursively collect every scalar interpolation from a mock-`sql` tagged
+ * template (and any nested `sql` fragments inside its `values`). The
+ * drizzle-orm auto-mock returns `{ sql, values }` for each tag; the helper
+ * lets tests assert that a specific value landed somewhere in the SQL tree
+ * without caring which sub-fragment owns it.
+ */
+function flattenSqlValues(node: unknown): unknown[] {
+  if (!node || typeof node !== 'object') return [];
+  const values = (node as { values?: unknown[] }).values;
+  if (!Array.isArray(values)) return [];
+  const out: unknown[] = [];
+  for (const value of values) {
+    if (value && typeof value === 'object' && 'sql' in value) {
+      out.push(...flattenSqlValues(value));
+    } else {
+      out.push(value);
+    }
+  }
+  return out;
+}
 
 describe('library.service', () => {
   describe('fuzzySearchLibrary', () => {
@@ -831,8 +854,8 @@ describe('library.service', () => {
       mockLookupMetadata.mockResolvedValue({
         results: [],
         search_type: 'none',
-        song_not_found: false,
         found_on_compilation: false,
+        song_not_found: false,
       });
 
       const results = [{ id: 1, artist_name: 'Obscure Artist', album_title: 'Rare Album', artwork_url: null }];
@@ -841,6 +864,127 @@ describe('library.service', () => {
 
       expect(enriched[0].artwork_url).toBeNull();
       expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('searchLibraryByCTA', () => {
+    const mockCTARow = {
+      id: 11,
+      code_letters: 'VA',
+      code_artist_number: 1,
+      code_number: 5,
+      artist_name: 'Various Artists',
+      alphabetical_name: 'Various Artists',
+      album_title: 'Edits',
+      format_name: 'cd',
+      genre_name: 'Electronic',
+      rotation_bin: null,
+      add_date: new Date('2024-01-15'),
+      label: 'self-released',
+      label_id: null,
+      on_streaming: true,
+      album_artist: null,
+      plays: 0,
+      artwork_url: null,
+      discogs_artist_id: null,
+      musicbrainz_artist_id: null,
+      wikidata_qid: null,
+      spotify_artist_id: null,
+      apple_music_artist_id: null,
+      bandcamp_id: null,
+      cta_track_title: 'Call Your Name',
+      cta_artist_name: 'Chuquimamani-Condori',
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns enriched results with a cta-source TrackMatchHint on track_title match', async () => {
+      db.execute.mockResolvedValue([mockCTARow]);
+
+      const results = await searchLibraryByCTA('Call Your Name', 5);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(11);
+      expect(results[0].artist).toBe('Various Artists');
+      expect(results[0].matched_via).toEqual([
+        {
+          title: 'Call Your Name',
+          artist_credit: 'Chuquimamani-Condori',
+          source: 'cta',
+          confidence: 1.0,
+        },
+      ]);
+    });
+
+    it('returns enriched results with a cta-source TrackMatchHint on artist_name match', async () => {
+      db.execute.mockResolvedValue([mockCTARow]);
+
+      const results = await searchLibraryByCTA('Chuquimamani', 5);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].matched_via?.[0].artist_credit).toBe('Chuquimamani-Condori');
+      expect(results[0].matched_via?.[0].source).toBe('cta');
+      expect(results[0].matched_via?.[0].confidence).toBe(1.0);
+    });
+
+    it('returns an empty array when no rows match', async () => {
+      db.execute.mockResolvedValue([]);
+
+      const results = await searchLibraryByCTA('zzz no match zzz', 5);
+
+      expect(results).toEqual([]);
+    });
+
+    it('returns an empty array without a DB call for an empty / whitespace-only query', async () => {
+      const results = await searchLibraryByCTA('   ', 5);
+
+      expect(results).toEqual([]);
+      expect(db.execute).not.toHaveBeenCalled();
+    });
+
+    it('groups multiple CTA matches against the same library row into one result with multiple hints', async () => {
+      const secondHintRow = {
+        ...mockCTARow,
+        cta_track_title: 'Another Track',
+        cta_artist_name: 'Chuquimamani-Condori',
+      };
+      db.execute.mockResolvedValue([mockCTARow, secondHintRow]);
+
+      const results = await searchLibraryByCTA('Chuquimamani', 5);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].matched_via).toHaveLength(2);
+      expect(results[0].matched_via?.map((h) => h.title)).toEqual(['Call Your Name', 'Another Track']);
+    });
+
+    it('threads on_streaming=true into the SQL predicate', async () => {
+      db.execute.mockResolvedValue([mockCTARow]);
+
+      await searchLibraryByCTA('Chuquimamani', 5, true);
+
+      expect(db.execute).toHaveBeenCalledTimes(1);
+      // The drizzle-orm auto-mock (tests/__mocks__/drizzle-orm.ts) makes each
+      // tagged-template `sql\`...\`` return `{ sql, values }`; nested sql
+      // fragments appear as objects inside the parent's `values` array.
+      // Flatten the tree before asserting on the interpolated `on_streaming`
+      // value.
+      const sqlArg = db.execute.mock.calls[0]?.[0];
+      expect(flattenSqlValues(sqlArg)).toContain(true);
+    });
+
+    it('omits the on_streaming filter when the arg is undefined', async () => {
+      db.execute.mockResolvedValue([mockCTARow]);
+
+      await searchLibraryByCTA('Chuquimamani', 5);
+
+      const sqlArg = db.execute.mock.calls[0]?.[0];
+      const flattened = flattenSqlValues(sqlArg);
+      // No streaming filter, so neither `true` nor `false` should appear
+      // in the SQL values.
+      expect(flattened).not.toContain(true);
+      expect(flattened).not.toContain(false);
     });
   });
 });

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -944,6 +944,13 @@ describe('library.service', () => {
       expect(db.execute).not.toHaveBeenCalled();
     });
 
+    it('returns an empty array without a DB call for pure-punctuation queries', async () => {
+      const results = await searchLibraryByCTA('!!!', 5);
+
+      expect(results).toEqual([]);
+      expect(db.execute).not.toHaveBeenCalled();
+    });
+
     it('groups multiple CTA matches against the same library row into one result with multiple hints', async () => {
       const secondHintRow = {
         ...mockCTARow,


### PR DESCRIPTION
## What

Adds `searchLibraryByCTA(query: string, limit: number, on_streaming?: boolean): Promise<EnrichedLibraryResult[]>` to `apps/backend/services/library.service.ts`. Probes `compilation_track_artist` for ILIKE matches against `track_title` OR `artist_name`, JOINs back to `library` with the standard `library_artist_view` projection (artists / format / genres / genre_artist_crossreference, plus a LEFT JOIN to `rotation`), and returns one `EnrichedLibraryResult` per matched release with `matched_via` listing every CTA row that hit.

Also extends `EnrichedLibraryResult` (in `apps/backend/services/requestLine/types.ts`) with an optional `matched_via?: TrackMatchHint[]` field, sourced from `@wxyc/shared/dtos` per api.yaml v1.3.0 (E7-1).

## Why

E1-2 of the [catalog-track-search plan](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md). The dj-site catalog + flowsheet picker should answer track-title queries (e.g. "Call Your Name") by matching against the curated VA-disambiguation rows in `compilation_track_artist`. This PR exposes the building block; wiring it into `searchLibraryBothMode` is E1-3 (separate ticket).

## How

- Raw SQL via `db.execute(sql\`...\`)` — same pattern as `getRotationFromDB`. Needed because we want both the `library_artist_view` projection and the matched CTA `track_title` / `artist_name` columns in the same row, which the chained `libraryViewQuery` shape can't express in one go.
- `DENSE_RANK() OVER (ORDER BY library.id)` wrapping the inner SELECT, then `WHERE library_rank <= ${limit}` outside — so `limit` counts releases, not CTA rows. A release with multiple matching tracks contributes multiple hints to one result.
- ILIKE against existing `cta_artist_name_idx`; trigram index intentionally not added per ticket guidance ("do NOT add a new trigram index unless perf measurement requires it"). If real-world latency demands it later, that's a follow-up issue.
- Empty / whitespace queries short-circuit to `[]` without a DB roundtrip, matching `searchLibraryBothMode`'s guard.
- Confidence hardcoded to `1.0` per plan §5.2 confidence-by-source table.

## Tests

7 new tests in `tests/unit/services/library.service.test.ts`:

- track_title match populates `matched_via` with the correct hint shape (`source: 'cta'`, `confidence: 1.0`, title + artist_credit set from the CTA row)
- artist_name match populates `matched_via` identically
- no-match returns `[]`
- empty / whitespace-only query returns `[]` without a `db.execute` call
- multiple CTA matches against the same library row return one result with multiple hints (in DB order)
- `on_streaming=true` interpolates into the SQL predicate (verified via a small `flattenSqlValues` helper that walks the nested `sql\`...\`` value tree the drizzle-orm auto-mock produces)
- `on_streaming` omitted from the predicate when the arg is `undefined`

Full suite: 1798 passed, 0 failed. typecheck / lint / format:check / build all clean.

## Plan reference

- Plan: [catalog-track-search](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md) §5.1 / §5.2
- Parent epic: #814 (E1)
- Unblocked by: WXYC/wxyc-shared#112 (E7-1, shipped in @wxyc/shared 1.3.0)

Closes #817