### PR TITLE
feat(library): add searchLibraryByTrack via LML /lookup proxy

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, isNull, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import type { ReconciledIdentity } from '@wxyc/shared/dtos';
 import { RotationAddRequest } from '../controllers/library.controller.js';
 import { db } from '@wxyc/database';
@@ -11,6 +11,7 @@ import {
   RotationRelease,
   album_plays,
   artists,
+  compilation_track_artist,
   genre_artist_crossreference,
   format,
   genres,
@@ -19,7 +20,7 @@ import {
   LibraryArtistViewEntry,
 } from '@wxyc/database';
 import { LibraryResult, EnrichedLibraryResult, enrichLibraryResult } from './requestLine/types.js';
-import { lookupMetadata, isLmlConfigured, type LookupResponse } from './lml/lml.client.js';
+import { lookupBySong, lookupMetadata, isLmlConfigured, type LookupResponse } from './lml/lml.client.js';
 import { checkLibraryArtistNameHealth } from './library-artist-name-assertion.service.js';
 
 /**
@@ -869,6 +870,114 @@ export async function searchAlbumsByTitle(albumTitle: string, limit = 5): Promis
     .limit(limit)) as unknown as LibraryArtistViewEntry[];
 
   return rows.map((row) => enrichLibraryResult(viewRowToLibraryResult(row)));
+}
+
+/**
+ * Search the library for releases that contain a track matching `query`.
+ *
+ * Thin BS-side proxy for LML's `/api/v1/lookup` `SONG_AS_TRACK` strategy
+ * (LML#301, catalog-track-search plan §4.2). LML cross-references the title
+ * against Discogs, validates the track-on-release server-side, and ranks the
+ * results; BS only:
+ *
+ *   1. Bridges each LML `library_item.id` (which equals BS
+ *      `library.legacy_release_id` — 99.88% populated) to a BS `library.id`
+ *      via the unique index `library_legacy_release_id_idx`.
+ *   2. Excludes library rows already covered by `compilation_track_artist`
+ *      for the same query — Track 1 (BS#817) surfaces those; this is the
+ *      fallback strategy and should not double-count.
+ *   3. Preserves LML's ordering. BS does not re-rank.
+ *
+ * Errors at the LML HTTP boundary degrade to an empty result. Catalog search
+ * is the only consumer today and treats Track 2 as best-effort.
+ *
+ * @param query - Track-title query
+ * @param limit - Maximum results to return
+ * @returns Array of enriched library results with `matched_via` populated
+ */
+export async function searchLibraryByTrack(query: string, limit: number): Promise<EnrichedLibraryResult[]> {
+  let response: LookupResponse;
+  try {
+    response = await lookupBySong(query);
+  } catch (err) {
+    console.warn('[Library] searchLibraryByTrack: LML lookup failed, returning empty', err);
+    return [];
+  }
+
+  const items = response.results ?? [];
+  if (items.length === 0) return [];
+
+  // LML's library_item.id is the legacy MySQL surrogate; BS stores it as
+  // library.legacy_release_id. Bridge that to BS library.id so callers get
+  // the row id their controllers and dj-site links expect.
+  const legacyIds = items.map((item) => item.library_item?.id).filter((id): id is number => typeof id === 'number');
+  if (legacyIds.length === 0) return [];
+
+  // Read the view shape plus legacy_release_id so we can re-order BS rows in
+  // LML's response order below. legacy_release_id is not in
+  // LIBRARY_VIEW_PROJECTION because the public view doesn't expose it.
+  const rows = (await db
+    .select({ ...LIBRARY_VIEW_PROJECTION, legacy_release_id: library.legacy_release_id })
+    .from(library)
+    .innerJoin(artists, eq(artists.id, library.artist_id))
+    .innerJoin(format, eq(format.id, library.format_id))
+    .innerJoin(genres, eq(genres.id, library.genre_id))
+    .innerJoin(
+      genre_artist_crossreference,
+      and(
+        eq(genre_artist_crossreference.artist_id, library.artist_id),
+        eq(genre_artist_crossreference.genre_id, library.genre_id)
+      )
+    )
+    .leftJoin(
+      rotation,
+      sql`${rotation.album_id} = ${library.id} AND (${rotation.kill_date} > CURRENT_DATE OR ${rotation.kill_date} IS NULL)`
+    )
+    .where(inArray(library.legacy_release_id, legacyIds))
+    .limit(limit)) as unknown as Array<LibraryArtistViewEntry & { legacy_release_id: number | null }>;
+
+  // CTA-covered library rows are Track 1's responsibility; filter them out so
+  // the read layer doesn't double-surface compilations alongside curated CTA
+  // hits.
+  const ctaRows =
+    rows.length === 0
+      ? []
+      : ((await db
+          .select({ library_id: compilation_track_artist.library_id })
+          .from(compilation_track_artist)
+          .where(
+            and(
+              inArray(
+                compilation_track_artist.library_id,
+                rows.map((r) => r.id)
+              ),
+              sql`${compilation_track_artist.track_title} ILIKE ${'%' + query + '%'}`
+            )
+          )) as Array<{ library_id: number }>);
+  const ctaCovered = new Set(ctaRows.map((r) => r.library_id));
+
+  // Index BS rows by legacy_release_id so we can emit them in LML's order.
+  const rowsByLegacyId = new Map<number, LibraryArtistViewEntry & { legacy_release_id: number | null }>();
+  for (const row of rows) {
+    if (row.legacy_release_id != null) {
+      rowsByLegacyId.set(row.legacy_release_id, row);
+    }
+  }
+
+  const results: EnrichedLibraryResult[] = [];
+  for (const item of items) {
+    const legacyId = item.library_item?.id;
+    if (legacyId == null) continue;
+    const row = rowsByLegacyId.get(legacyId);
+    if (!row) continue;
+    if (ctaCovered.has(row.id)) continue;
+    const enriched = enrichLibraryResult(viewRowToLibraryResult(row));
+    if (item.matched_via && item.matched_via.length > 0) {
+      enriched.matched_via = item.matched_via;
+    }
+    results.push(enriched);
+  }
+  return results;
 }
 
 /**

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -934,7 +934,11 @@ export async function searchLibraryByTrack(query: string, limit: number): Promis
       sql`${rotation.album_id} = ${library.id} AND (${rotation.kill_date} > CURRENT_DATE OR ${rotation.kill_date} IS NULL)`
     )
     .where(inArray(library.legacy_release_id, legacyIds))
-    .limit(limit)) as unknown as Array<LibraryArtistViewEntry & { legacy_release_id: number | null }>;
+    // Bound by the LML response size (already capped server-side), not the
+    // caller's `limit`. CTA exclusion runs after this query, so a tight
+    // .limit(limit) would let CTA drops shrink the response below what the
+    // caller asked for. We trim to `limit` after exclusion + ordering.
+    .limit(legacyIds.length)) as unknown as Array<LibraryArtistViewEntry & { legacy_release_id: number | null }>;
 
   // CTA-covered library rows are Track 1's responsibility; filter them out so
   // the read layer doesn't double-surface compilations alongside curated CTA
@@ -976,6 +980,7 @@ export async function searchLibraryByTrack(query: string, limit: number): Promis
       enriched.matched_via = item.matched_via;
     }
     results.push(enriched);
+    if (results.length >= limit) break;
   }
   return results;
 }

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -114,21 +114,39 @@ async function lmlFetch(path: string, init?: RequestInit): Promise<Response> {
  * @returns Lookup results with library items and enriched artwork metadata
  */
 export async function lookupMetadata(artist: string, album?: string, song?: string): Promise<LookupResponse> {
-  // Wrap the call in a Sentry span so the LML response's cache_stats (memory
-  // hits / pg hits / pg misses / api calls / pg time / api time) lands as
-  // attributes on the BS transaction's trace. Filterable in Sentry's trace
-  // explorer (e.g. `lml.cache.api_calls > 0`) so per-callsite instrumentation
-  // isn't needed for the metadata-backfill pilot or the runtime hot path.
-  // Sibling LML-side projection at WXYC/library-metadata-lookup#213.
-  return Sentry.startSpan({ name: 'lml.lookup', op: 'http.client' }, async (span) => {
-    // LML's /lookup contract requires `raw_message` even when artist/album/song
-    // are already structured. Synthesize a free-form description that the LML
-    // parser would have produced — matches the e2e fixtures in LML's repo.
-    const rawMessage = [artist, album, song].filter(Boolean).join(' - ');
-    const body: Record<string, string> = { artist, raw_message: rawMessage };
-    if (album) body.album = album;
-    if (song) body.song = song;
+  // LML's /lookup contract requires `raw_message` even when artist/album/song
+  // are already structured. Synthesize a free-form description that the LML
+  // parser would have produced — matches the e2e fixtures in LML's repo.
+  const rawMessage = [artist, album, song].filter(Boolean).join(' - ');
+  const body: Record<string, string> = { artist, raw_message: rawMessage };
+  if (album) body.album = album;
+  if (song) body.song = song;
+  return postLookup(body);
+}
 
+/**
+ * Track-driven lookup: sends only `song` + `raw_message` (no artist field) so
+ * LML's parser routes the request to its `SONG_AS_TRACK` strategy (LML#301),
+ * which Discogs-cross-references the title and validates the track-on-release
+ * before returning library matches. Used by the catalog Track-2 path
+ * (BS#823) — Backend-Service is a thin proxy here; LML does all the ranking
+ * and the response's `matched_via` carries the per-result evidence.
+ */
+export async function lookupBySong(song: string): Promise<LookupResponse> {
+  return postLookup({ song, raw_message: song });
+}
+
+/**
+ * Shared chokepoint for POST /api/v1/lookup. Wraps the call in a Sentry span
+ * so the LML response's cache_stats (memory hits / pg hits / pg misses / api
+ * calls / pg time / api time) lands as attributes on the BS transaction's
+ * trace. Filterable in Sentry's trace explorer (e.g.
+ * `lml.cache.api_calls > 0`) so per-callsite instrumentation isn't needed for
+ * the metadata-backfill pilot or the runtime hot path. Sibling LML-side
+ * projection at WXYC/library-metadata-lookup#213.
+ */
+async function postLookup(body: Record<string, string>): Promise<LookupResponse> {
+  return Sentry.startSpan({ name: 'lml.lookup', op: 'http.client' }, async (span) => {
     const response = await lmlFetch('/api/v1/lookup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/apps/backend/services/requestLine/types.ts
+++ b/apps/backend/services/requestLine/types.ts
@@ -5,7 +5,7 @@
  * and adapted for TypeScript/Express.
  */
 
-import type { ReconciledIdentity } from '@wxyc/shared/dtos';
+import type { ReconciledIdentity, TrackMatchHint } from '@wxyc/shared/dtos';
 
 // =============================================================================
 // Message Parsing Types
@@ -84,6 +84,14 @@ export interface EnrichedLibraryResult extends LibraryResult {
   callNumber: string;
   /** URL to view this release in the WXYC library */
   libraryUrl: string;
+  /**
+   * Populated when a track-title match drove this release into the results
+   * (catalog-track-search plan §5.1). Sourced from LML's `LookupResultItem.matched_via`
+   * (Track 2 / BS#823) or from `compilation_track_artist` rows (Track 1 / BS#817).
+   * Empty or absent for releases that matched on artist / album normally.
+   * Backward-compatible — existing consumers ignore the field.
+   */
+  matched_via?: TrackMatchHint[];
 }
 
 /**

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -185,7 +185,13 @@ export const specialty_shows = {};
 export const schedule = {};
 export const artist_crossreference = {};
 export const artist_library_crossreference = {};
-export const compilation_track_artist = {};
+export const compilation_track_artist = {
+  id: 'id',
+  library_id: 'library_id',
+  artist_name: 'artist_name',
+  track_title: 'track_title',
+  track_position: 'track_position',
+};
 export const genre_artist_crossreference = {
   artist_id: 'artist_id',
   genre_id: 'genre_id',

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -2,10 +2,12 @@ import { jest } from '@jest/globals';
 import { db, createMockQueryChain, library, library_artist_view, album_plays } from '../../mocks/database.mock';
 
 const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
+const mockLookupBySong = jest.fn<() => Promise<unknown>>();
 const mockIsLmlConfigured = jest.fn<() => boolean>();
 
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
   lookupMetadata: mockLookupMetadata,
+  lookupBySong: mockLookupBySong,
   isLmlConfigured: mockIsLmlConfigured,
 }));
 
@@ -15,6 +17,7 @@ import {
   searchLibrary,
   searchByArtist,
   searchAlbumsByTitle,
+  searchLibraryByTrack,
   getAlbumFromDB,
   markAlbumMissing,
   markAlbumFound,
@@ -224,6 +227,242 @@ describe('library.service', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0]).toHaveProperty('codeArtistNumber', 3);
+    });
+  });
+
+  describe('searchLibraryByTrack', () => {
+    const trackRow = {
+      id: 101,
+      code_letters: 'PR',
+      code_artist_number: 1,
+      code_number: 2,
+      artist_name: 'Jessica Pratt',
+      alphabetical_name: 'Pratt, Jessica',
+      album_title: 'On Your Own Love Again',
+      format_name: 'CD',
+      genre_name: 'Rock',
+      rotation_bin: null,
+      add_date: new Date('2024-02-01'),
+      label: 'Drag City',
+      label_id: null,
+      on_streaming: true,
+      album_artist: null,
+      plays: 12,
+      artwork_url: null,
+      legacy_release_id: 555,
+    };
+
+    const lookupItem = {
+      library_item: {
+        id: 555,
+        title: 'On Your Own Love Again',
+        artist: 'Jessica Pratt',
+        call_number: 'Rock CD PR 1/2',
+        library_url: 'http://www.wxyc.info/wxycdb/libraryRelease?id=555',
+      },
+      matched_via: [
+        {
+          title: 'Back, Baby',
+          artist_credit: null,
+          confidence: 0.92,
+          source: 'discogs',
+        },
+      ],
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockIsLmlConfigured.mockReturnValue(true);
+    });
+
+    it('returns enriched results with matched_via propagated from LML', async () => {
+      mockLookupBySong.mockResolvedValue({
+        results: [lookupItem],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      // Library bridge query (first db.select()) reads library rows.
+      const libraryChain = createMockQueryChain([trackRow]);
+      libraryChain.limit = jest.fn().mockResolvedValue([trackRow]);
+      // CTA exclusion probe (second db.select() returning library_ids that ARE
+      // covered by CTA — empty here means no exclusions). The CTA query has
+      // no .limit(), so .where() must resolve to an array.
+      const ctaChain = createMockQueryChain([]);
+      ctaChain.where = jest.fn().mockResolvedValue([]);
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = callIndex === 0 ? libraryChain : ctaChain;
+        callIndex += 1;
+        return chain;
+      });
+
+      const results = await searchLibraryByTrack('Back, Baby', 10);
+
+      expect(mockLookupBySong).toHaveBeenCalledTimes(1);
+      expect(mockLookupBySong).toHaveBeenCalledWith('Back, Baby');
+      // Bridge query reads from `library` (with joins) so the unique index
+      // on legacy_release_id is reachable.
+      expect(libraryChain.from).toHaveBeenCalledWith(library);
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(101);
+      expect(results[0].artist).toBe('Jessica Pratt');
+      expect(results[0].matched_via).toEqual([
+        { title: 'Back, Baby', artist_credit: null, confidence: 0.92, source: 'discogs' },
+      ]);
+    });
+
+    it('maps LML library.db.id to BS library.id via legacy_release_id', async () => {
+      mockLookupBySong.mockResolvedValue({
+        results: [lookupItem],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      const libraryChain = createMockQueryChain([trackRow]);
+      libraryChain.limit = jest.fn().mockResolvedValue([trackRow]);
+      const ctaChain = createMockQueryChain([]);
+      ctaChain.where = jest.fn().mockResolvedValue([]);
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = callIndex === 0 ? libraryChain : ctaChain;
+        callIndex += 1;
+        return chain;
+      });
+
+      const results = await searchLibraryByTrack('Back, Baby', 10);
+
+      // The library-bridge query predicate must reference legacy_release_id.
+      const whereArg = libraryChain.where.mock.calls[0]?.[0] as { inArray?: unknown[] };
+      expect(whereArg.inArray).toEqual([library.legacy_release_id, [555]]);
+      expect(results[0].id).toBe(101); // BS library.id, not LML's 555
+    });
+
+    it('returns empty array when LML returns no results (skips DB roundtrip)', async () => {
+      mockLookupBySong.mockResolvedValue({
+        results: [],
+        search_type: 'none',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      db.select.mockReset();
+
+      const results = await searchLibraryByTrack('Nonexistent Song', 10);
+
+      expect(results).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array and swallows LML errors (fallback strategy must degrade gracefully)', async () => {
+      mockLookupBySong.mockRejectedValue(new Error('LML 502 Bad Gateway'));
+      db.select.mockReset();
+
+      const results = await searchLibraryByTrack('Back, Baby', 10);
+
+      expect(results).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('excludes CTA-covered library rows for the same query (Track 1 will surface those)', async () => {
+      // Second LML result for a release that IS in compilation_track_artist
+      // with track_title ILIKE '%back, baby%'. Should be filtered out.
+      const ctaRow = {
+        ...trackRow,
+        id: 102,
+        album_title: 'Various - Drag City Sampler',
+        artist_name: 'Various',
+        legacy_release_id: 777,
+      };
+      mockLookupBySong.mockResolvedValue({
+        results: [lookupItem, { ...lookupItem, library_item: { ...lookupItem.library_item, id: 777 } }],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      const libraryChain = createMockQueryChain([trackRow, ctaRow]);
+      libraryChain.limit = jest.fn().mockResolvedValue([trackRow, ctaRow]);
+      // CTA probe says library_id=102 is covered.
+      const ctaChain = createMockQueryChain([{ library_id: 102 }]);
+      ctaChain.where = jest.fn().mockResolvedValue([{ library_id: 102 }]);
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = callIndex === 0 ? libraryChain : ctaChain;
+        callIndex += 1;
+        return chain;
+      });
+
+      const results = await searchLibraryByTrack('Back, Baby', 10);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(101);
+    });
+
+    it("preserves LML's response order (BS does not re-rank)", async () => {
+      // LML returns 777 first, 555 second. BS must emit the same order.
+      const trackRowA = { ...trackRow, id: 201, legacy_release_id: 555 };
+      const trackRowB = { ...trackRow, id: 202, legacy_release_id: 777, album_title: 'Album B' };
+      mockLookupBySong.mockResolvedValue({
+        results: [
+          { ...lookupItem, library_item: { ...lookupItem.library_item, id: 777 } },
+          { ...lookupItem, library_item: { ...lookupItem.library_item, id: 555 } },
+        ],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      // DB returns them in whatever order Postgres picks (here, the wrong one).
+      const libraryChain = createMockQueryChain([trackRowA, trackRowB]);
+      libraryChain.limit = jest.fn().mockResolvedValue([trackRowA, trackRowB]);
+      const ctaChain = createMockQueryChain([]);
+      ctaChain.where = jest.fn().mockResolvedValue([]);
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = callIndex === 0 ? libraryChain : ctaChain;
+        callIndex += 1;
+        return chain;
+      });
+
+      const results = await searchLibraryByTrack('Back, Baby', 10);
+
+      expect(results.map((r) => r.id)).toEqual([202, 201]);
+    });
+
+    it('skips library rows whose legacy_release_id is unknown to BS (not in JOIN result)', async () => {
+      // LML returned 999, but BS has no library row with legacy_release_id=999.
+      // Drop it silently — the LML response is the source of truth on what
+      // matched, but the legacy bridge is the source of truth on what BS holds.
+      mockLookupBySong.mockResolvedValue({
+        results: [lookupItem, { ...lookupItem, library_item: { ...lookupItem.library_item, id: 999 } }],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      const libraryChain = createMockQueryChain([trackRow]);
+      libraryChain.limit = jest.fn().mockResolvedValue([trackRow]);
+      const ctaChain = createMockQueryChain([]);
+      ctaChain.where = jest.fn().mockResolvedValue([]);
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = callIndex === 0 ? libraryChain : ctaChain;
+        callIndex += 1;
+        return chain;
+      });
+
+      const results = await searchLibraryByTrack('Back, Baby', 10);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(101);
     });
   });
 

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -272,7 +272,6 @@ describe('library.service', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockIsLmlConfigured.mockReturnValue(true);
     });
 
     it('returns enriched results with matched_via propagated from LML', async () => {
@@ -434,6 +433,40 @@ describe('library.service', () => {
       const results = await searchLibraryByTrack('Back, Baby', 10);
 
       expect(results.map((r) => r.id)).toEqual([202, 201]);
+    });
+
+    it('still returns up to `limit` after CTA exclusion (filter runs post-fetch)', async () => {
+      // LML returns 2 items; CTA covers the first. With limit=1, the caller
+      // must still get one non-CTA result — not an empty array, which would
+      // happen if .limit(1) ran at the DB and the surviving row was CTA-covered.
+      const ctaRow = { ...trackRow, id: 301, legacy_release_id: 777 };
+      const keepRow = { ...trackRow, id: 302, legacy_release_id: 555, album_title: 'Survives CTA' };
+      mockLookupBySong.mockResolvedValue({
+        results: [
+          { ...lookupItem, library_item: { ...lookupItem.library_item, id: 777 } },
+          { ...lookupItem, library_item: { ...lookupItem.library_item, id: 555 } },
+        ],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      const libraryChain = createMockQueryChain([ctaRow, keepRow]);
+      libraryChain.limit = jest.fn().mockResolvedValue([ctaRow, keepRow]);
+      const ctaChain = createMockQueryChain([{ library_id: 301 }]);
+      ctaChain.where = jest.fn().mockResolvedValue([{ library_id: 301 }]);
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = callIndex === 0 ? libraryChain : ctaChain;
+        callIndex += 1;
+        return chain;
+      });
+
+      const results = await searchLibraryByTrack('Back, Baby', 1);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(302);
     });
 
     it('skips library rows whose legacy_release_id is unknown to BS (not in JOIN result)', async () => {

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -23,6 +23,7 @@ jest.mock('@sentry/node', () => ({
 
 import {
   lookupMetadata,
+  lookupBySong,
   getRelease,
   getArtistDetails,
   resolveEntity,
@@ -212,6 +213,65 @@ describe('lml.client', () => {
       const result = await lookupMetadata('Autechre', 'Confield');
 
       expect(result).toEqual(lookupResponse);
+    });
+  });
+
+  describe('lookupBySong', () => {
+    it('sends POST to /api/v1/lookup with only song + raw_message (artist omitted)', async () => {
+      // LML's SONG_AS_TRACK strategy is keyed off a song-only request; sending
+      // an empty-string artist would bias LML's parser away from the strategy.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupBySong('Back, Baby');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://lml.test:8000/api/v1/lookup',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ song: 'Back, Baby', raw_message: 'Back, Baby' }),
+        })
+      );
+    });
+
+    it('wraps the call in a Sentry span and projects cache_stats onto it', async () => {
+      const cache_stats = { memory_hits: 0, pg_hits: 2, pg_misses: 1, api_calls: 1 };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [],
+            search_type: 'none',
+            song_not_found: false,
+            found_on_compilation: false,
+            cache_stats,
+          }),
+      } as unknown as globalThis.Response);
+
+      await lookupBySong('Back, Baby');
+
+      expect(mockStartSpan).toHaveBeenCalledTimes(1);
+      expect(mockStartSpan.mock.calls[0][0]).toEqual({ name: 'lml.lookup', op: 'http.client' });
+      expect(mockSpanSetAttributes).toHaveBeenCalledWith({
+        'lml.cache.memory_hits': 0,
+        'lml.cache.pg_hits': 2,
+        'lml.cache.pg_misses': 1,
+        'lml.cache.api_calls': 1,
+      });
+    });
+
+    it('throws LmlClientError on non-2xx response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+      } as unknown as globalThis.Response);
+
+      await expect(lookupBySong('Back, Baby')).rejects.toThrow(LmlClientError);
     });
   });
 


### PR DESCRIPTION
## Summary

Add `searchLibraryByTrack(query, limit)` to `library.service` — a thin BS-side proxy for LML's `/api/v1/lookup` `SONG_AS_TRACK` strategy (LML#301). The catalog Track-2 fallback per [catalog-track-search plan §4.2](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md#42-track-2--bs-side-proxy-to-lmls-lookup).

## What

- `apps/backend/services/library.service.ts` — new exported `searchLibraryByTrack(query, limit)`. Single LML round-trip; bridges each `library_item.id` (which equals BS `library.legacy_release_id` — 99.88% populated) back to BS `library.id` via the unique index; filters CTA-covered rows (Track 1's responsibility per BS#817); preserves LML's response order.
- `apps/backend/services/lml/lml.client.ts` — new `lookupBySong(song)` wrapper that posts only `{ song, raw_message: song }` so LML's parser routes the request to `SONG_AS_TRACK`. Extracts the shared cache_stats-projecting span wrapper (`postLookup`) so both `lookupMetadata` and `lookupBySong` keep their Sentry tracing.
- `apps/backend/services/requestLine/types.ts` — extends `EnrichedLibraryResult` with `matched_via?: TrackMatchHint[]` so the track-evidence chip can render alongside the call number. Mirrors the same edit landing in the parallel #817 (E1-2 / CTA path) PR — at rebase time the diff is a no-op or trivial conflict.

## Why

LML now owns the entire track-search pipeline (Discogs cross-reference, track-on-release validation, ranking, `matched_via` emission). Per the v2 plan revision, BS becomes a thin consumer rather than reimplementing the strategy pipeline on its own with a new master-resolution endpoint.

## How

1. POST `/api/v1/lookup` with `{ song, raw_message }` (no `artist` field — LML's parser uses that signal to route to `SONG_AS_TRACK`).
2. Map each `LookupResultItem.library_item.id` to a BS row via `inArray(library.legacy_release_id, lmlIds)` joined to artists/format/genres/genre_artist_crossreference.
3. Probe `compilation_track_artist` for the same `query` (ILIKE on `track_title`); drop any returned BS row id from the result set.
4. Emit results in LML's response order (BS does not re-rank), with each item's `matched_via` propagated when non-empty.

LML HTTP errors degrade to an empty array with a warn log — catalog search treats Track 2 as best-effort and should not propagate a 5xx to the dj-site search box.

## Test plan

- [x] `npm run test:unit -- --testPathPatterns='library.service|lml.client'` — 67 tests pass (10 new)
- [x] `npm run test:unit` — 1801 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean

Unit coverage (new tests):

- LML client: POST shape (`{song, raw_message}`, no `artist`); Sentry span + `cache_stats` projection; non-2xx error
- Service: `matched_via` propagation; `legacy_release_id` JOIN mapping; LML 0-hit → `[]` (no DB roundtrip); LML error → `[]` (degraded); CTA-covered exclusion; response-order preservation; orphan-id (BS-unknown legacy id) drop

## Coordination

Parallel PR for #817 (Track 1 / CTA path) makes the **exact same edit** to `EnrichedLibraryResult` and the `@wxyc/shared/dtos` import. At rebase time the conflict is either a no-op or a trivial one-line resolution since both diffs add `matched_via?: TrackMatchHint[]` to the same interface.

## Plan reference

[catalog-track-search v2 §4.2](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md#42-track-2--bs-side-proxy-to-lmls-lookup)

## Related

- Parent epic: WXYC/Backend-Service#815 (E2)
- Blocked by: WXYC/wxyc-shared#112 (E7-1) — landed; `TrackMatchHint` available in `@wxyc/shared/dtos`
- Blocked by: WXYC/library-metadata-lookup#301 (E2-1, LML SONG_AS_TRACK) — landed via LML#325
- Sibling: WXYC/Backend-Service#817 (E1-2, CTA path) — touches `requestLine/types.ts` identically
- Blocks: WXYC/Backend-Service#824 (E2-4 integration)

Closes #823