### PR TITLE
feat(library): wire CTA + LML /lookup as 0-hit fallback in searchLibrary

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -800,14 +800,30 @@ export async function searchLibrary(
 ): Promise<EnrichedLibraryResult[]> {
   await checkLibraryArtistNameHealth();
 
-  let results: LibraryArtistViewEntry[] = [];
-
   if (query) {
-    results = await searchLibraryBothMode(query, limit, on_streaming);
-  } else if (artist || title) {
-    results = await fuzzySearchLibrary(artist, title, limit, on_streaming);
+    const primary = await searchLibraryBothMode(query, limit, on_streaming);
+    if (primary.length > 0) {
+      return primary.map((row) => enrichLibraryResult(viewRowToLibraryResult(row)));
+    }
+
+    // Catalog-track-search cascade (plan §4): when tsvector + trigram return
+    // 0 hits, probe CTA (Track 1), then LML /lookup (Track 2). Direct hits
+    // always outrank both fallback layers. Each layer is gated on its own
+    // env flag; defaults are off so out-of-the-box behavior is unchanged.
+    if (process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED === 'true') {
+      const ctaResults = await searchLibraryByCTA(query, limit, on_streaming);
+      if (ctaResults.length > 0) return ctaResults;
+    }
+
+    if (process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED === 'true') {
+      const trackResults = await searchLibraryByTrack(query, limit);
+      if (trackResults.length > 0) return trackResults;
+    }
+
+    return [];
   }
 
+  const results = artist || title ? await fuzzySearchLibrary(artist, title, limit, on_streaming) : [];
   return results.map((row) => enrichLibraryResult(viewRowToLibraryResult(row)));
 }
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -806,10 +806,7 @@ export async function searchLibrary(
       return primary.map((row) => enrichLibraryResult(viewRowToLibraryResult(row)));
     }
 
-    // Catalog-track-search cascade (plan §4): when tsvector + trigram return
-    // 0 hits, probe CTA (Track 1), then LML /lookup (Track 2). Direct hits
-    // always outrank both fallback layers. Each layer is gated on its own
-    // env flag; defaults are off so out-of-the-box behavior is unchanged.
+    // Both flags default off so behavior is unchanged until rollout (plan §4).
     if (process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED === 'true') {
       const ctaResults = await searchLibraryByCTA(query, limit, on_streaming);
       if (ctaResults.length > 0) return ctaResults;

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -189,6 +189,272 @@ describe('library.service', () => {
     });
   });
 
+  /**
+   * Track-search cascade (E1-3 + E2-4): when the tsvector + trigram primary
+   * returns 0 hits, probe CTA (Track 1), then LML /lookup (Track 2). Each
+   * layer is gated by its own env flag; flags default false so out-of-the-box
+   * behavior is identical to today.
+   */
+  describe('searchLibrary cascade (CTA + LML fallback)', () => {
+    const ctaRow = {
+      id: 11,
+      code_letters: 'VA',
+      code_artist_number: 1,
+      code_number: 5,
+      artist_name: 'Various Artists',
+      alphabetical_name: 'Various Artists',
+      album_title: 'Edits',
+      format_name: 'cd',
+      genre_name: 'Electronic',
+      rotation_bin: null,
+      add_date: new Date('2024-01-15'),
+      label: 'self-released',
+      label_id: null,
+      on_streaming: true,
+      album_artist: null,
+      plays: 0,
+      artwork_url: null,
+      discogs_artist_id: null,
+      musicbrainz_artist_id: null,
+      wikidata_qid: null,
+      spotify_artist_id: null,
+      apple_music_artist_id: null,
+      bandcamp_id: null,
+      cta_track_title: 'Call Your Name',
+      cta_artist_name: 'Chuquimamani-Condori',
+    };
+
+    const trackRow = {
+      id: 101,
+      code_letters: 'PR',
+      code_artist_number: 1,
+      code_number: 2,
+      artist_name: 'Jessica Pratt',
+      alphabetical_name: 'Pratt, Jessica',
+      album_title: 'On Your Own Love Again',
+      format_name: 'CD',
+      genre_name: 'Rock',
+      rotation_bin: null,
+      add_date: new Date('2024-02-01'),
+      label: 'Drag City',
+      label_id: null,
+      on_streaming: true,
+      album_artist: null,
+      plays: 12,
+      artwork_url: null,
+      legacy_release_id: 555,
+    };
+
+    const lookupItem = {
+      library_item: {
+        id: 555,
+        title: 'On Your Own Love Again',
+        artist: 'Jessica Pratt',
+        call_number: 'Rock CD PR 1/2',
+        library_url: 'http://www.wxyc.info/wxycdb/libraryRelease?id=555',
+      },
+      matched_via: [{ title: 'Back, Baby', artist_credit: null, confidence: 0.92, source: 'discogs_release' }],
+    };
+
+    const originalCta = process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED;
+    const originalDiscogs = process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      delete process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED;
+      delete process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED;
+    });
+
+    afterAll(() => {
+      if (originalCta === undefined) delete process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED;
+      else process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED = originalCta;
+      if (originalDiscogs === undefined) delete process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED;
+      else process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED = originalDiscogs;
+    });
+
+    /**
+     * Tsvector returns 0; trigram returns whatever `trigramRows` says.
+     * Returns the recorded call counts so tests can assert the cascade order.
+     */
+    function setUpPrimarySearchMocks(trigramRows: object[] = []): void {
+      const tsvectorChain = createMockQueryChain([]);
+      tsvectorChain.limit = jest.fn().mockResolvedValue([]);
+      const trigramChain = createMockQueryChain(trigramRows);
+      trigramChain.limit = jest.fn().mockResolvedValue(trigramRows);
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = callIndex === 0 ? tsvectorChain : trigramChain;
+        callIndex += 1;
+        return chain;
+      });
+    }
+
+    /**
+     * Add a third + fourth `db.select` chain for `searchLibraryByTrack`'s
+     * library-bridge + cta-exclusion queries on top of the primary mocks.
+     */
+    function setUpPrimaryAndTrackMocks(trackRows: object[], ctaCoveredIds: number[] = []): void {
+      const tsvectorChain = createMockQueryChain([]);
+      tsvectorChain.limit = jest.fn().mockResolvedValue([]);
+      const trigramChain = createMockQueryChain([]);
+      trigramChain.limit = jest.fn().mockResolvedValue([]);
+      const libraryChain = createMockQueryChain(trackRows);
+      libraryChain.limit = jest.fn().mockResolvedValue(trackRows);
+      const ctaChain = createMockQueryChain(ctaCoveredIds.map((id) => ({ library_id: id })));
+      ctaChain.where = jest.fn().mockResolvedValue(ctaCoveredIds.map((id) => ({ library_id: id })));
+      const chains = [tsvectorChain, trigramChain, libraryChain, ctaChain];
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = chains[Math.min(callIndex, chains.length - 1)];
+        callIndex += 1;
+        return chain;
+      });
+    }
+
+    it('flag-off baseline: tsvector+trigram return 0 and no fallback fires', async () => {
+      setUpPrimarySearchMocks();
+      db.execute.mockResolvedValue([]);
+
+      const results = await searchLibrary('nilufer yanya');
+
+      expect(results).toEqual([]);
+      expect(db.execute).not.toHaveBeenCalled();
+      expect(mockLookupBySong).not.toHaveBeenCalled();
+    });
+
+    it('flag-off: tsvector hit still returns primary results unchanged', async () => {
+      const chain = createMockQueryChain([mockViewRow]);
+      db.select.mockReturnValue(chain);
+      chain.limit = jest.fn().mockResolvedValue([mockViewRow]);
+      db.execute.mockResolvedValue([]);
+
+      const results = await searchLibrary('Autechre');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].matched_via).toBeUndefined();
+      expect(db.execute).not.toHaveBeenCalled();
+      expect(mockLookupBySong).not.toHaveBeenCalled();
+    });
+
+    it('CTA flag on, primary returns 0 → CTA fires and matched_via.source=cta', async () => {
+      process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED = 'true';
+      setUpPrimarySearchMocks();
+      db.execute.mockResolvedValue([ctaRow]);
+
+      const results = await searchLibrary('Call Your Name');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(11);
+      expect(results[0].matched_via?.[0]).toMatchObject({ source: 'cta', title: 'Call Your Name', confidence: 1.0 });
+      expect(mockLookupBySong).not.toHaveBeenCalled();
+    });
+
+    it('CTA flag on, primary returns >0 → CTA NOT called (direct hits outrank fallback)', async () => {
+      process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED = 'true';
+      const chain = createMockQueryChain([mockViewRow]);
+      db.select.mockReturnValue(chain);
+      chain.limit = jest.fn().mockResolvedValue([mockViewRow]);
+
+      const results = await searchLibrary('Autechre');
+
+      expect(results).toHaveLength(1);
+      expect(db.execute).not.toHaveBeenCalled();
+    });
+
+    it('Both flags on, primary 0 + CTA >0 → LML NOT called (CTA suppresses Track 2)', async () => {
+      process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED = 'true';
+      process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED = 'true';
+      setUpPrimarySearchMocks();
+      db.execute.mockResolvedValue([ctaRow]);
+
+      const results = await searchLibrary('Call Your Name');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].matched_via?.[0].source).toBe('cta');
+      expect(mockLookupBySong).not.toHaveBeenCalled();
+    });
+
+    it('Both flags on, primary 0 + CTA 0 → LML fires and matched_via propagates', async () => {
+      process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED = 'true';
+      process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED = 'true';
+      mockLookupBySong.mockResolvedValue({
+        results: [lookupItem],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+      setUpPrimaryAndTrackMocks([trackRow]);
+      db.execute.mockResolvedValue([]);
+
+      const results = await searchLibrary('Back, Baby');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(101);
+      expect(results[0].matched_via?.[0]).toMatchObject({ source: 'discogs_release', confidence: 0.92 });
+    });
+
+    it('LML flag on alone (CTA flag off), primary 0 → LML fires directly', async () => {
+      process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED = 'true';
+      mockLookupBySong.mockResolvedValue({
+        results: [lookupItem],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+      setUpPrimaryAndTrackMocks([trackRow]);
+
+      const results = await searchLibrary('Back, Baby');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(101);
+      // CTA flag was off; the CTA probe should not have been queried.
+      expect(db.execute).not.toHaveBeenCalled();
+    });
+
+    it('Both flags on, all three layers miss → empty array', async () => {
+      process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED = 'true';
+      process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED = 'true';
+      setUpPrimarySearchMocks();
+      db.execute.mockResolvedValue([]);
+      mockLookupBySong.mockResolvedValue({
+        results: [],
+        search_type: 'none',
+        song_not_found: true,
+        found_on_compilation: false,
+      });
+
+      const results = await searchLibrary('xyzzy-unknown-track');
+
+      expect(results).toEqual([]);
+      expect(db.execute).toHaveBeenCalledTimes(1);
+      expect(mockLookupBySong).toHaveBeenCalledTimes(1);
+    });
+
+    it('CTA flag off, LML flag off: explicit "false" values keep cascade dormant', async () => {
+      process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED = 'false';
+      process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED = 'false';
+      setUpPrimarySearchMocks();
+
+      await searchLibrary('Call Your Name');
+
+      expect(db.execute).not.toHaveBeenCalled();
+      expect(mockLookupBySong).not.toHaveBeenCalled();
+    });
+
+    it('threads on_streaming into the CTA fallback when flag is on', async () => {
+      process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED = 'true';
+      setUpPrimarySearchMocks();
+      db.execute.mockResolvedValue([ctaRow]);
+
+      await searchLibrary('Call Your Name', undefined, undefined, 5, true);
+
+      const sqlArg = db.execute.mock.calls[0]?.[0];
+      expect(flattenSqlValues(sqlArg)).toContain(true);
+    });
+  });
+
   describe('fuzzySearchLibrary Both-mode routing', () => {
     beforeEach(() => {
       jest.clearAllMocks();


### PR DESCRIPTION
## Summary

Wires `searchLibraryByCTA` (Track 1, BS#817) and `searchLibraryByTrack` (Track 2, BS#823) into the existing `searchLibrary` cascade. Plan §4 order: **tsvector → trigram → CTA → LML /lookup**.

Each fallback layer is gated by its own env flag. Both default off — out-of-the-box behavior is identical to today.

| Flag | Default | Gate for |
|---|---|---|
| `CATALOG_TRACK_SEARCH_CTA_ENABLED` | `false` | `searchLibraryByCTA` fires when primary returns 0 |
| `CATALOG_TRACK_SEARCH_DISCOGS_ENABLED` | `false` | `searchLibraryByTrack` fires when CTA also returns 0 |

Formal flag registration in `apps/backend/config/` lives in follow-up tickets [#819 (E1-5)](https://github.com/WXYC/Backend-Service/issues/819) and [#826 (E2-6)](https://github.com/WXYC/Backend-Service/issues/826) — this PR just reads `process.env.*` directly (the only callers today), matching how `LIBRARY_METADATA_URL` and `LML_API_KEY` are read in `lml.client.ts`.

## Why integrate at `searchLibrary` rather than `searchLibraryBothMode`

Both linked issues say to wire into `searchLibraryBothMode`, but that function returns `LibraryArtistViewEntry[]` while the new methods return `EnrichedLibraryResult[]` with `matched_via` populated. Wiring at `searchLibrary` (one frame up) keeps the cascade contained at a single level and preserves `matched_via` end-to-end without changing the existing primary-search return shape. Existing callers of `searchLibraryBothMode` (e.g. `fuzzySearchLibrary`'s both-mode default at L521) are unchanged.

## Cascade contract (verified by tests)

| Primary | CTA flag | CTA result | LML flag | LML called? | Returns |
|---|---|---|---|---|---|
| ≥1 hit | any | — | any | no | primary results, `matched_via` absent |
| 0 hits | off | — | off | no | `[]` |
| 0 hits | on | ≥1 | any | no | CTA results, `matched_via.source = "cta"` |
| 0 hits | on | 0 | off | no | `[]` |
| 0 hits | on | 0 | on | yes | LML results, `matched_via.source = "discogs_*"` |
| 0 hits | off | — | on | yes | LML results (CTA layer skipped) |

## Test plan

- [x] `npm run test:unit` — 1820/1820 passing (10 new cascade tests added to `library.service.test.ts`)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (existing security/object-injection warnings only)
- [x] `npm run format:check` — clean

## Closes

Closes #818, closes #824

## Related

- Built on #851 (`searchLibraryByCTA`) and #852 (`searchLibraryByTrack`)
- Track 1 fixture seeding lives in [#821 (E1-4)](https://github.com/WXYC/Backend-Service/issues/821), unblocked by this PR
- Flag registration: [#819 (E1-5)](https://github.com/WXYC/Backend-Service/issues/819) and [#826 (E2-6)](https://github.com/WXYC/Backend-Service/issues/826)
- Plan: https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md §4