### PR TITLE
Register CATALOG_TRACK_SEARCH_* feature flags

### DIFF
--- a/apps/backend/config/catalogTrackSearch.ts
+++ b/apps/backend/config/catalogTrackSearch.ts
@@ -32,14 +32,8 @@ export function loadConfig(): CatalogTrackSearchConfig {
   };
 }
 
-/**
- * Singleton config instance.
- */
 let _config: CatalogTrackSearchConfig | null = null;
 
-/**
- * Get the configuration, loading it from the environment on first call.
- */
 export function getConfig(): CatalogTrackSearchConfig {
   if (!_config) {
     _config = loadConfig();

--- a/apps/backend/config/catalogTrackSearch.ts
+++ b/apps/backend/config/catalogTrackSearch.ts
@@ -1,0 +1,57 @@
+/**
+ * Configuration for the catalog track-search cascade.
+ *
+ * `searchLibrary` falls back through three layers when the primary
+ * tsvector+trigram search returns zero hits: Track 1 (CTA — compilation
+ * track-artist) and Track 2 (Discogs `/lookup` via LML). Each layer is
+ * gated by its own flag so rollout can be staged independently.
+ *
+ * Both flags default to `false` so production behavior is unchanged until
+ * an operator opts in. See the plan:
+ * https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md
+ */
+
+export interface CatalogTrackSearchConfig {
+  /** Track 1 — CTA (compilation track-artist) fuzzy fallback. */
+  ctaEnabled: boolean;
+
+  /** Track 2 — Discogs `/lookup` fallback proxied through LML. */
+  discogsEnabled: boolean;
+}
+
+/**
+ * Load the config from environment variables. Both flags are strict-`true`
+ * gated (anything other than the literal string `'true'` reads as `false`)
+ * so an accidental `CATALOG_TRACK_SEARCH_CTA_ENABLED=1` does not silently
+ * enable a fallback layer in production.
+ */
+export function loadConfig(): CatalogTrackSearchConfig {
+  return {
+    ctaEnabled: process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED === 'true',
+    discogsEnabled: process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED === 'true',
+  };
+}
+
+/**
+ * Singleton config instance.
+ */
+let _config: CatalogTrackSearchConfig | null = null;
+
+/**
+ * Get the configuration, loading it from the environment on first call.
+ */
+export function getConfig(): CatalogTrackSearchConfig {
+  if (!_config) {
+    _config = loadConfig();
+  }
+  return _config;
+}
+
+/**
+ * Reset the cached singleton. Tests that mutate
+ * `process.env.CATALOG_TRACK_SEARCH_*_ENABLED` between cases must call this
+ * in `beforeEach` so the next `getConfig()` re-reads the environment.
+ */
+export function resetConfig(): void {
+  _config = null;
+}

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -22,6 +22,7 @@ import {
 import { LibraryResult, EnrichedLibraryResult, enrichLibraryResult } from './requestLine/types.js';
 import { lookupBySong, lookupMetadata, isLmlConfigured, type LookupResponse } from './lml/lml.client.js';
 import { checkLibraryArtistNameHealth } from './library-artist-name-assertion.service.js';
+import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrackSearch.js';
 
 /**
  * Source columns on `artists` (and any joined / view-projected row) that
@@ -807,12 +808,13 @@ export async function searchLibrary(
     }
 
     // Both flags default off so behavior is unchanged until rollout (plan §4).
-    if (process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED === 'true') {
+    const flags = getCatalogTrackSearchConfig();
+    if (flags.ctaEnabled) {
       const ctaResults = await searchLibraryByCTA(query, limit, on_streaming);
       if (ctaResults.length > 0) return ctaResults;
     }
 
-    if (process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED === 'true') {
+    if (flags.discogsEnabled) {
       const trackResults = await searchLibraryByTrack(query, limit);
       if (trackResults.length > 0) return trackResults;
     }

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -84,6 +84,15 @@ Bounded ring-buffer reports written under `mirror-logs/`. Reports never include 
 - `DISCOGS_API_KEY`, `DISCOGS_API_SECRET` — Served to dj-site via `/config/secrets` endpoint. Not used by the backend itself (Discogs access goes through LML).
 - `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`
 
+### Catalog track search
+
+Feature flags for the 0-hit fallback cascade in `searchLibrary` (`apps/backend/services/library.service.ts`). When the primary tsvector + trigram search returns no rows, each enabled layer runs in order and the first non-empty result wins. Both default `false` so production behavior is unchanged until an operator opts in. Loaded by `apps/backend/config/catalogTrackSearch.ts`. Plan: [catalog-track-search](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md).
+
+- `CATALOG_TRACK_SEARCH_CTA_ENABLED` (default `false`) — Track 1: probe the compilation-track-artist (CTA) fuzzy fallback so queries like `"Call Your Name"` match the track listed on a V/A compilation. Set `true` once Phase 1d audit shows healthy coverage.
+- `CATALOG_TRACK_SEARCH_DISCOGS_ENABLED` (default `false`) — Track 2: probe LML's Discogs `/lookup` endpoint and bridge any matched releases back to library rows the CTA layer didn't already cover. Set `true` after Track 1 has soaked.
+
+Strict-`true` gating: only the literal string `'true'` enables a layer. Any other value (including `1`, `TRUE`, missing) reads as `false`.
+
 ## Slack
 
 - `SLACK_WXYC_REQUESTS_APP_ID`, `SLACK_WXYC_REQUESTS_CLIENT_ID`

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -25,6 +25,7 @@ import {
   enrichWithArtwork,
   updateArtworkUrl,
 } from '../../../apps/backend/services/library.service';
+import { resetConfig as resetCatalogTrackSearchConfig } from '../../../apps/backend/config/catalogTrackSearch';
 
 /**
  * Recursively collect every scalar interpolation from a mock-`sql` tagged
@@ -263,6 +264,9 @@ describe('library.service', () => {
       jest.clearAllMocks();
       delete process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED;
       delete process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED;
+      // Reset the lazy singleton so each test's per-case env mutations
+      // (a few lines below) re-load through `loadConfig()`.
+      resetCatalogTrackSearchConfig();
     });
 
     afterAll(() => {
@@ -270,6 +274,7 @@ describe('library.service', () => {
       else process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED = originalCta;
       if (originalDiscogs === undefined) delete process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED;
       else process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED = originalDiscogs;
+      resetCatalogTrackSearchConfig();
     });
 
     /**


### PR DESCRIPTION
## Summary

Registers the two catalog-track-search feature flags formally so `searchLibrary`'s 0-hit fallback cascade reads from a typed config object instead of poking `process.env` directly. Both flags default `false`; production behavior is unchanged.

- New `apps/backend/config/catalogTrackSearch.ts` with a lazy singleton and `resetConfig()` for tests, matching the `requestLine/config.ts` pattern.
- `searchLibrary` reads `getConfig()` once per call and dispatches into the CTA (Track 1) and Discogs `/lookup` (Track 2) layers based on `ctaEnabled` / `discogsEnabled`.
- `docs/env-vars.md` gains a "Catalog track search" subsection under Metadata Services documenting both flags + linking the plan.
- Cascade tests in `tests/unit/services/library.service.test.ts` call `resetConfig()` in `beforeEach`/`afterAll` so per-case env mutations are honored by the lazy singleton.

Bundling 820 + 826 because both touch `apps/backend/config/` and `docs/env-vars.md` — separating them would conflict.

Plan: https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — 0 errors (374 warnings, all pre-existing)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 1820 passed, 142 suites; cascade tests still cover the flag matrix (off / CTA-only / Discogs-only / both, plus explicit `'false'`)

Closes #820, closes #826