### PR TITLE
ci(deploy): grant callers contents:write to match deploy-base.yml

### DIFF
--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - main
 
-# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
-# comments on PRs, or creates releases; all writes to external services
-# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+# Caller permissions must equal or exceed the reusable workflow's
+# declared scope; deploy-base.yml requires contents:write to create
+# release tags via github-script. Granting less here makes GHA reject
+# the run at startup with no jobs (#857).
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   trigger-build-and-deploy:

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -12,11 +12,12 @@ on:
         required: false
         type: string
 
-# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
-# comments on PRs, or creates releases; all writes to external services
-# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+# Caller permissions must equal or exceed the reusable workflow's
+# declared scope; deploy-base.yml requires contents:write to create
+# release tags via github-script. Granting less here makes GHA reject
+# the run at startup with no jobs (#857).
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   trigger-build-and-deploy:


### PR DESCRIPTION
## Summary

- Bumps `deploy-auto.yml` and `deploy-manual.yml` from `permissions: contents: read` to `contents: write` so they match the reusable callee `deploy-base.yml`.
- Rewrites the comment headers to explain the invariant (caller scope must equal/exceed callee scope) instead of repeating the original least-privilege claim.

## Why

`deploy-base.yml` needs `contents: write` because the `handle-git-tags` job creates refs via `actions/github-script@v9` (`github.rest.git.createRef`). When [commit a66ed7c](https://github.com/WXYC/Backend-Service/commit/a66ed7c) added top-level `permissions:` to every workflow under principle-of-least-privilege, the callers got `read` and the callee got `write`. GHA rejects the reusable invocation at startup before any job materializes — no logs, just `startup_failure`.

Every Auto Build & Deploy since 2026-05-12 17:13 UTC has had this exact failure mode ([latest example: run 25840686623](https://github.com/WXYC/Backend-Service/actions/runs/25840686623)). [Tonight's manual deploy](https://github.com/WXYC/Backend-Service/actions/runs/25841952787) hit the same wall.

Backend-Service's last successful deploy was [commit 317483c](https://github.com/WXYC/Backend-Service/commit/317483c) (2026-05-12 16:33). Ten commits are stacked on `main`:

| Commit | Subject |
|---|---|
| `d72f032` | test(library): integration coverage for CTA-based track search (#819) |
| `21d3445` | chore(config): drop two restate-the-name JSDoc blocks |
| `95e0f87` | feat(library): register catalog-track-search feature flags |
| `4ed5020` | chore(library): trim cascade comment to a single WHY line |
| `29855bb` | feat(library): wire CTA + LML /lookup as 0-hit fallback layers |
| `1d8cdc5` | fix(library): guard searchLibraryByCTA against pure-punctuation queries |
| `7be555e` | feat(library): add searchLibraryByCTA for compilation track-artist fuzzy search |
| `d4d8a5a` | fix(library): bound JOIN by LML response size, trim limit post-CTA-exclusion |
| `3cc845e` | feat(library): add searchLibraryByTrack via LML /lookup proxy |
| `23e4af1` | Bump aws-actions/configure-aws-credentials to v6 |
| `a66ed7c` | ci: declare workflow-level GITHUB_TOKEN permissions |

The merge of this PR will trigger Auto Build & Deploy, which (if the fix works) will deploy all of the above plus this fix to EC2 in a single run.

## Test plan

- [ ] PR's own CI passes (`test.yml` doesn't touch this regression path; should be green).
- [ ] On merge, Auto Build & Deploy run completes `success` end-to-end.
- [ ] EC2 `backend` container restarts on the new image; `/healthcheck` returns 200.
- [ ] Follow-up: `gh workflow run deploy-manual.yml --ref main -f target=backend` returns `success`.

Closes #857