### PR TITLE
feat(library): GET /library/query endpoint for catalog query-builder UI

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^10.52.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.3.0",
+    "@wxyc/shared": "^1.4.0",
     "better-auth": "^1.6.9",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -12,7 +12,6 @@ import {
 import * as libraryService from '../services/library.service.js';
 import * as labelsService from '../services/labels.service.js';
 import * as librarySearchService from '../services/library-search.service.js';
-import { UnknownEnumError } from '../services/library-search.service.js';
 import type { CatalogSort, CatalogOrder } from '../services/library-search.service.js';
 import { checkStreamingAvailability, lookupMetadata, isLmlConfigured } from '../services/lml/lml.client.js';
 import WxycError from '../utils/error.js';
@@ -417,31 +416,38 @@ const MAX_LIMIT = 100;
 
 export const searchLibraryQueryEndpoint: RequestHandler<object, unknown, unknown, LibraryQueryParams> = async (
   req,
-  res,
-  next
+  res
 ) => {
   const q = req.query.q ?? '';
 
   const page = parseInt(req.query.page ?? '0');
   if (isNaN(page) || page < 0) {
-    res.status(400).json({ message: 'page must be a non-negative integer' });
-    return;
+    throw new WxycError('page must be a non-negative integer', 400);
   }
 
   const limit = parseInt(req.query.limit ?? String(DEFAULT_LIMIT));
   if (isNaN(limit) || limit < 1) {
-    res.status(400).json({ message: 'limit must be a positive integer' });
-    return;
+    throw new WxycError('limit must be a positive integer', 400);
   }
   if (limit > MAX_LIMIT) {
-    res.status(400).json({ message: `limit must not exceed ${MAX_LIMIT}` });
-    return;
+    throw new WxycError(`limit must not exceed ${MAX_LIMIT}`, 400);
   }
 
-  const sort = (VALID_CATALOG_SORTS.includes(req.query.sort as CatalogSort) ? req.query.sort : 'album') as CatalogSort;
-  const order = (
-    VALID_CATALOG_ORDERS.includes(req.query.order as CatalogOrder) ? req.query.order : 'asc'
-  ) as CatalogOrder;
+  let sort: CatalogSort = 'album';
+  if (req.query.sort !== undefined) {
+    if (!VALID_CATALOG_SORTS.includes(req.query.sort as CatalogSort)) {
+      throw new WxycError(`sort must be one of: ${VALID_CATALOG_SORTS.join(', ')}`, 400);
+    }
+    sort = req.query.sort as CatalogSort;
+  }
+
+  let order: CatalogOrder = 'asc';
+  if (req.query.order !== undefined) {
+    if (!VALID_CATALOG_ORDERS.includes(req.query.order as CatalogOrder)) {
+      throw new WxycError(`order must be one of: ${VALID_CATALOG_ORDERS.join(', ')}`, 400);
+    }
+    order = req.query.order as CatalogOrder;
+  }
 
   const onStreamingRaw = req.query.on_streaming;
   let on_streaming: boolean | undefined;
@@ -449,32 +455,23 @@ export const searchLibraryQueryEndpoint: RequestHandler<object, unknown, unknown
     if (onStreamingRaw === 'true') on_streaming = true;
     else if (onStreamingRaw === 'false') on_streaming = false;
     else {
-      res.status(400).json({ message: 'on_streaming must be "true" or "false"' });
-      return;
+      throw new WxycError('on_streaming must be "true" or "false"', 400);
     }
   }
 
   const genre = req.query.genre || undefined;
   const format = req.query.format || undefined;
 
-  try {
-    const { results, total } = await librarySearchService.searchLibrary({
-      q,
-      page,
-      limit,
-      sort,
-      order,
-      on_streaming,
-      genre,
-      format,
-    });
-    const totalPages = Math.ceil(total / limit);
-    res.status(200).json({ results, total, page, totalPages });
-  } catch (e) {
-    if (e instanceof UnknownEnumError) {
-      res.status(400).json({ message: e.message });
-      return;
-    }
-    next(e);
-  }
+  const { results, total } = await librarySearchService.searchLibrary({
+    q,
+    page,
+    limit,
+    sort,
+    order,
+    on_streaming,
+    genre,
+    format,
+  });
+  const totalPages = Math.ceil(total / limit);
+  res.status(200).json({ results, total, page, totalPages });
 };

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -11,6 +11,9 @@ import {
 } from '@wxyc/database';
 import * as libraryService from '../services/library.service.js';
 import * as labelsService from '../services/labels.service.js';
+import * as librarySearchService from '../services/library-search.service.js';
+import { UnknownEnumError } from '../services/library-search.service.js';
+import type { CatalogSort, CatalogOrder } from '../services/library-search.service.js';
 import { checkStreamingAvailability, lookupMetadata, isLmlConfigured } from '../services/lml/lml.client.js';
 import WxycError from '../utils/error.js';
 
@@ -390,4 +393,88 @@ export const markFound: RequestHandler<{ id: string }> = async (req, res) => {
 
   const album = await libraryService.getAlbumFromDB(albumId);
   res.status(200).json(album);
+};
+
+// ---------------------------------------------------------------------------
+// GET /library/query — query-builder search over the catalog
+// ---------------------------------------------------------------------------
+
+type LibraryQueryParams = {
+  q?: string;
+  page?: string;
+  limit?: string;
+  sort?: string;
+  order?: string;
+  on_streaming?: string;
+  genre?: string;
+  format?: string;
+};
+
+const VALID_CATALOG_SORTS: CatalogSort[] = ['artist', 'album', 'plays', 'date'];
+const VALID_CATALOG_ORDERS: CatalogOrder[] = ['asc', 'desc'];
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+export const searchLibraryQueryEndpoint: RequestHandler<object, unknown, unknown, LibraryQueryParams> = async (
+  req,
+  res,
+  next
+) => {
+  const q = req.query.q ?? '';
+
+  const page = parseInt(req.query.page ?? '0');
+  if (isNaN(page) || page < 0) {
+    res.status(400).json({ message: 'page must be a non-negative integer' });
+    return;
+  }
+
+  const limit = parseInt(req.query.limit ?? String(DEFAULT_LIMIT));
+  if (isNaN(limit) || limit < 1) {
+    res.status(400).json({ message: 'limit must be a positive integer' });
+    return;
+  }
+  if (limit > MAX_LIMIT) {
+    res.status(400).json({ message: `limit must not exceed ${MAX_LIMIT}` });
+    return;
+  }
+
+  const sort = (VALID_CATALOG_SORTS.includes(req.query.sort as CatalogSort) ? req.query.sort : 'album') as CatalogSort;
+  const order = (
+    VALID_CATALOG_ORDERS.includes(req.query.order as CatalogOrder) ? req.query.order : 'asc'
+  ) as CatalogOrder;
+
+  const onStreamingRaw = req.query.on_streaming;
+  let on_streaming: boolean | undefined;
+  if (onStreamingRaw !== undefined) {
+    if (onStreamingRaw === 'true') on_streaming = true;
+    else if (onStreamingRaw === 'false') on_streaming = false;
+    else {
+      res.status(400).json({ message: 'on_streaming must be "true" or "false"' });
+      return;
+    }
+  }
+
+  const genre = req.query.genre || undefined;
+  const format = req.query.format || undefined;
+
+  try {
+    const { results, total } = await librarySearchService.searchLibrary({
+      q,
+      page,
+      limit,
+      sort,
+      order,
+      on_streaming,
+      genre,
+      format,
+    });
+    const totalPages = Math.ceil(total / limit);
+    res.status(200).json({ results, total, page, totalPages });
+  } catch (e) {
+    if (e instanceof UnknownEnumError) {
+      res.status(400).json({ message: e.message });
+      return;
+    }
+    next(e);
+  }
 };

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,7 +21,7 @@
     "@tensorflow/tfjs": "^4.22.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.3.0",
+    "@wxyc/shared": "^1.4.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.16.0",

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -12,6 +12,8 @@ library_route.get('/search', requirePermissions({}), trackActivity, requestLineC
 
 library_route.get('/', requirePermissions({ catalog: ['read'] }), libraryController.searchForAlbum);
 
+library_route.get('/query', requirePermissions({ catalog: ['read'] }), libraryController.searchLibraryQueryEndpoint);
+
 library_route.post('/', requirePermissions({ catalog: ['write'] }), libraryController.addAlbum);
 
 library_route.get('/rotation', requirePermissions({ catalog: ['read'] }), libraryController.getRotation);

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -6,6 +6,7 @@ import {
   type CatalogField,
   type SearchCondition,
 } from './search-parser.service.js';
+import WxycError from '../utils/error.js';
 
 export type CatalogSort = 'artist' | 'album' | 'plays' | 'date';
 export type CatalogOrder = 'asc' | 'desc';
@@ -255,10 +256,9 @@ async function getFormatSet(): Promise<Set<string>> {
   return formatCache.values;
 }
 
-export class UnknownEnumError extends Error {
+export class UnknownEnumError extends WxycError {
   constructor(message: string) {
-    super(message);
-    this.name = 'UnknownEnumError';
+    super(message, 400, 'UnknownEnumError');
   }
 }
 
@@ -275,10 +275,4 @@ async function validateEnumFilters(genre?: string, format?: string): Promise<voi
       throw new UnknownEnumError(`Unknown format: ${format}`);
     }
   }
-}
-
-/** For tests: drop the cached enum values so the next call re-queries. */
-export function __resetEnumCachesForTests(): void {
-  genreCache = null;
-  formatCache = null;
 }

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -1,0 +1,284 @@
+import { sql, type SQL } from 'drizzle-orm';
+import { db, library_artist_view, genres, format as formatTable } from '@wxyc/database';
+import {
+  parseSearchQuery,
+  CATALOG_PARSER_CONFIG,
+  type CatalogField,
+  type SearchCondition,
+} from './search-parser.service.js';
+
+export type CatalogSort = 'artist' | 'album' | 'plays' | 'date';
+export type CatalogOrder = 'asc' | 'desc';
+
+export type LibraryQueryParams = {
+  q: string;
+  page: number;
+  limit: number;
+  sort: CatalogSort;
+  order: CatalogOrder;
+  on_streaming?: boolean;
+  genre?: string;
+  format?: string;
+};
+
+export type AlbumSearchResultRow = {
+  id: number;
+  add_date: string;
+  album_title: string;
+  artist_name: string;
+  code_letters: string;
+  code_number: number;
+  code_artist_number: number;
+  format_name: string;
+  genre_name: string;
+  label: string;
+  label_id: number | null;
+  rotation_bin: string | null;
+  plays: number | null;
+  on_streaming: boolean | null;
+  album_artist: string | null;
+};
+
+const FIELD_COLUMNS: Record<CatalogField, SQL> = {
+  artist_name: sql`${library_artist_view.artist_name}`,
+  album_title: sql`${library_artist_view.album_title}`,
+  label: sql`${library_artist_view.label}`,
+};
+
+const SORT_COLUMNS: Record<CatalogSort, SQL> = {
+  artist: sql`${library_artist_view.artist_name}`,
+  album: sql`${library_artist_view.album_title}`,
+  plays: sql`${library_artist_view.plays}`,
+  date: sql`${library_artist_view.add_date}`,
+};
+
+const SECONDARY_SORT: Record<CatalogSort, SQL> = {
+  artist: sql`${library_artist_view.album_title}`,
+  album: sql`${library_artist_view.artist_name}`,
+  plays: sql`${library_artist_view.artist_name}`,
+  date: sql`${library_artist_view.artist_name}`,
+};
+
+/**
+ * Search the catalog with parsed query conditions, enum filters, sort,
+ * and offset pagination. Reads `library_artist_view` so callers get the
+ * same flat shape as the `/library/` endpoint.
+ *
+ * Pagination is offset-based (catalog sorts are non-temporal — relevance,
+ * title, plays, addition date — and the secondary `artist_name` tiebreaker
+ * makes paginated results deterministic without a cursor). When `q` is
+ * empty, the call degenerates to a sorted page over the filter intersection.
+ */
+export async function searchLibrary(
+  params: LibraryQueryParams
+): Promise<{ results: AlbumSearchResultRow[]; total: number }> {
+  await validateEnumFilters(params.genre, params.format);
+
+  const conditions = parseSearchQuery(params.q, CATALOG_PARSER_CONFIG);
+  const queryWhere = buildWhereClause(conditions);
+  const filterWhere = buildFilterClause(params);
+
+  const where = combineWhere(queryWhere, filterWhere);
+
+  const orderDirection = params.order === 'asc' ? sql`ASC` : sql`DESC`;
+  const orderBy = sql`${SORT_COLUMNS[params.sort]} ${orderDirection}, ${SECONDARY_SORT[params.sort]} ASC, ${library_artist_view.id} ASC`;
+
+  const offset = params.page * params.limit;
+  const fromClause = where ? sql`FROM ${library_artist_view} WHERE ${where}` : sql`FROM ${library_artist_view}`;
+
+  const dataQuery = sql`
+    SELECT
+      ${library_artist_view.id} AS id,
+      ${library_artist_view.add_date} AS add_date,
+      ${library_artist_view.album_title} AS album_title,
+      ${library_artist_view.artist_name} AS artist_name,
+      ${library_artist_view.code_letters} AS code_letters,
+      ${library_artist_view.code_number} AS code_number,
+      ${library_artist_view.code_artist_number} AS code_artist_number,
+      ${library_artist_view.format_name} AS format_name,
+      ${library_artist_view.genre_name} AS genre_name,
+      ${library_artist_view.label} AS label,
+      ${library_artist_view.label_id} AS label_id,
+      ${library_artist_view.rotation_bin} AS rotation_bin,
+      ${library_artist_view.plays} AS plays,
+      ${library_artist_view.on_streaming} AS on_streaming,
+      ${library_artist_view.album_artist} AS album_artist
+    ${fromClause}
+    ORDER BY ${orderBy}
+    LIMIT ${params.limit} OFFSET ${offset}
+  `;
+  const countQuery = sql`SELECT COUNT(*)::int AS total ${fromClause}`;
+
+  const [dataRows, countRows] = await Promise.all([db.execute(dataQuery), db.execute(countQuery)]);
+
+  const results = (dataRows as unknown as RawRow[]).map(toAlbumSearchResultRow);
+  const total = (countRows as unknown as { total: number }[])[0]?.total ?? 0;
+
+  return { results, total };
+}
+
+type RawRow = {
+  id: number;
+  add_date: Date | string;
+  album_title: string;
+  artist_name: string | null;
+  code_letters: string;
+  code_number: number;
+  code_artist_number: number;
+  format_name: string;
+  genre_name: string;
+  label: string | null;
+  label_id: number | null;
+  rotation_bin: string | null;
+  plays: number | null;
+  on_streaming: boolean | null;
+  album_artist: string | null;
+};
+
+function toAlbumSearchResultRow(row: RawRow): AlbumSearchResultRow {
+  return {
+    id: row.id,
+    add_date: row.add_date instanceof Date ? row.add_date.toISOString() : String(row.add_date ?? ''),
+    album_title: row.album_title,
+    artist_name: row.artist_name ?? '',
+    code_letters: row.code_letters,
+    code_number: row.code_number,
+    code_artist_number: row.code_artist_number,
+    format_name: row.format_name,
+    genre_name: row.genre_name,
+    label: row.label ?? '',
+    label_id: row.label_id,
+    rotation_bin: row.rotation_bin,
+    plays: row.plays,
+    on_streaming: row.on_streaming,
+    album_artist: row.album_artist,
+  };
+}
+
+function buildWhereClause(conditions: SearchCondition<CatalogField>[]): SQL | null {
+  if (conditions.length === 0) return null;
+
+  const fragments = conditions
+    .map((c) => ({ operator: c.operator, fragment: buildConditionFragment(c) }))
+    .filter((f): f is { operator: 'AND' | 'OR'; fragment: SQL } => f.fragment !== null);
+
+  if (fragments.length === 0) return null;
+
+  let result = fragments[0].fragment;
+  for (let i = 1; i < fragments.length; i++) {
+    const { operator, fragment } = fragments[i];
+    result = operator === 'OR' ? sql`${result} OR ${fragment}` : sql`${result} AND ${fragment}`;
+  }
+  return sql`(${result})`;
+}
+
+function buildConditionFragment(condition: SearchCondition<CatalogField>): SQL | null {
+  const { field, value, exact, negated } = condition;
+  const fragment = field === 'all' ? buildAllFieldMatch(value, exact) : buildColumnMatch(field, value, exact);
+  return negated ? sql`NOT (${fragment})` : fragment;
+}
+
+function buildColumnMatch(field: CatalogField, value: string, exact: boolean): SQL {
+  const col = FIELD_COLUMNS[field];
+  if (exact) {
+    return sql`${col} = ${value}`;
+  }
+  return sql`${col} ILIKE ${'%' + value + '%'}`;
+}
+
+function buildAllFieldMatch(value: string, exact: boolean): SQL {
+  if (exact) {
+    return sql`(${library_artist_view.artist_name} = ${value} OR ${library_artist_view.album_title} = ${value} OR ${library_artist_view.label} = ${value})`;
+  }
+  // Trigram-backed ILIKE across artist/album/label. Tsvector ranking is the
+  // deferred follow-up flagged in the plan (add `label` to library.search_doc
+  // first, then route this branch through it); v1 stays correct and reviewable
+  // with the same path the flowsheet trigram fallback uses.
+  const pattern = '%' + value + '%';
+  return sql`(${library_artist_view.artist_name} ILIKE ${pattern} OR ${library_artist_view.album_title} ILIKE ${pattern} OR ${library_artist_view.label} ILIKE ${pattern})`;
+}
+
+function buildFilterClause(params: LibraryQueryParams): SQL | null {
+  const parts: SQL[] = [];
+  if (params.on_streaming !== undefined) {
+    parts.push(sql`${library_artist_view.on_streaming} = ${params.on_streaming}`);
+  }
+  if (params.genre !== undefined) {
+    parts.push(sql`${library_artist_view.genre_name} = ${params.genre}`);
+  }
+  if (params.format !== undefined) {
+    parts.push(sql`${library_artist_view.format_name} = ${params.format}`);
+  }
+  if (parts.length === 0) return null;
+  let result = parts[0];
+  for (let i = 1; i < parts.length; i++) {
+    result = sql`${result} AND ${parts[i]}`;
+  }
+  return result;
+}
+
+function combineWhere(a: SQL | null, b: SQL | null): SQL | null {
+  if (a && b) return sql`${a} AND ${b}`;
+  return a ?? b;
+}
+
+// --- Enum validation ---
+
+type EnumCache = { values: Set<string>; expiresAt: number };
+const ENUM_TTL_MS = 60_000;
+let genreCache: EnumCache | null = null;
+let formatCache: EnumCache | null = null;
+
+async function loadGenres(): Promise<Set<string>> {
+  const rows = await db.select({ name: genres.genre_name }).from(genres);
+  return new Set(rows.map((r) => r.name));
+}
+
+async function loadFormats(): Promise<Set<string>> {
+  const rows = await db.select({ name: formatTable.format_name }).from(formatTable);
+  return new Set(rows.map((r) => r.name));
+}
+
+async function getGenreSet(): Promise<Set<string>> {
+  const now = Date.now();
+  if (!genreCache || genreCache.expiresAt < now) {
+    genreCache = { values: await loadGenres(), expiresAt: now + ENUM_TTL_MS };
+  }
+  return genreCache.values;
+}
+
+async function getFormatSet(): Promise<Set<string>> {
+  const now = Date.now();
+  if (!formatCache || formatCache.expiresAt < now) {
+    formatCache = { values: await loadFormats(), expiresAt: now + ENUM_TTL_MS };
+  }
+  return formatCache.values;
+}
+
+export class UnknownEnumError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnknownEnumError';
+  }
+}
+
+async function validateEnumFilters(genre?: string, format?: string): Promise<void> {
+  if (genre !== undefined) {
+    const set = await getGenreSet();
+    if (!set.has(genre)) {
+      throw new UnknownEnumError(`Unknown genre: ${genre}`);
+    }
+  }
+  if (format !== undefined) {
+    const set = await getFormatSet();
+    if (!set.has(format)) {
+      throw new UnknownEnumError(`Unknown format: ${format}`);
+    }
+  }
+}
+
+/** For tests: drop the cached enum values so the next call re-queries. */
+export function __resetEnumCachesForTests(): void {
+  genreCache = null;
+  formatCache = null;
+}

--- a/apps/backend/services/search-parser.service.ts
+++ b/apps/backend/services/search-parser.service.ts
@@ -1,55 +1,100 @@
 /**
- * Parses playlist search query strings into structured conditions.
+ * Parses search query strings into structured conditions.
  *
  * Supports:
  * - Simple terms: `autechre` (searches all text fields)
- * - Field prefixes: `artist:autechre`, `song:poise`, `album:confield`, `label:warp`, `dj:jake`
- * - Date filters: `date:2024-06-15`, `dateRange:2024-01-01..2024-12-31`
+ * - Field prefixes per the caller's config (e.g., `artist:autechre`, `album:confield`)
  * - Boolean operators: `AND`, `OR`, `NOT`
  * - Exact match: `artist:"Cat Power"` (quoted values)
+ *
+ * The parser is generic over the field set. Callers pass a {@link ParserConfig}
+ * declaring their prefix map and (optional) per-field validators. Two named
+ * configs ship in this module: {@link FLOWSHEET_PARSER_CONFIG} and
+ * {@link CATALOG_PARSER_CONFIG}. Adding a third surface means a third
+ * `*_PARSER_CONFIG` constant — the tokenizer and condition builder stay
+ * field-agnostic.
  */
 
 export type SearchOperator = 'AND' | 'OR';
 
-export type SearchField =
-  | 'artist_name'
-  | 'track_title'
-  | 'album_title'
-  | 'record_label'
-  | 'dj_name'
-  | 'add_time'
-  | 'add_time_range'
-  | 'all';
+/** Tokens the condition builder always produces, in addition to caller fields. */
+export type IntrinsicField = 'all';
 
-export type SearchCondition = {
+export type SearchCondition<F extends string = string> = {
   operator: SearchOperator;
-  field: SearchField;
+  field: F | IntrinsicField;
   value: string;
   exact: boolean;
   negated: boolean;
 };
 
-const FIELD_PREFIXES: Record<string, SearchField> = {
-  'artist:': 'artist_name',
-  'song:': 'track_title',
-  'album:': 'album_title',
-  'label:': 'record_label',
-  'dj:': 'dj_name',
-  'date:': 'add_time',
-  'dateRange:': 'add_time_range',
+export type ParserConfig<F extends string> = {
+  /**
+   * Maps a literal prefix (e.g., `'artist:'`) to a domain field token. The
+   * prefix must end with `:` — the tokenizer matches the whole prefix
+   * including punctuation.
+   */
+  fieldPrefixes: Record<string, F>;
+  /**
+   * Optional per-field value validators. When a validator returns `false` the
+   * condition is dropped silently and the parser advances. Use this for
+   * shape-constrained fields like dates.
+   */
+  validators?: Partial<Record<F, (value: string) => boolean>>;
 };
 
 const OPERATORS = ['AND', 'OR', 'NOT'] as const;
 
 const DATE_PATTERN = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
 
+const isDate = (value: string): boolean => DATE_PATTERN.test(value);
+const isDateRange = (value: string): boolean => {
+  const [start, end] = value.split('..');
+  return Boolean(start && end && isDate(start) && isDate(end));
+};
+
+export type FlowsheetField =
+  | 'artist_name'
+  | 'track_title'
+  | 'album_title'
+  | 'record_label'
+  | 'dj_name'
+  | 'add_time'
+  | 'add_time_range';
+
+export const FLOWSHEET_PARSER_CONFIG: ParserConfig<FlowsheetField> = {
+  fieldPrefixes: {
+    'artist:': 'artist_name',
+    'song:': 'track_title',
+    'album:': 'album_title',
+    'label:': 'record_label',
+    'dj:': 'dj_name',
+    'date:': 'add_time',
+    'dateRange:': 'add_time_range',
+  },
+  validators: {
+    add_time: isDate,
+    add_time_range: isDateRange,
+  },
+};
+
+export type CatalogField = 'artist_name' | 'album_title' | 'label';
+
+export const CATALOG_PARSER_CONFIG: ParserConfig<CatalogField> = {
+  fieldPrefixes: {
+    'artist:': 'artist_name',
+    'album:': 'album_title',
+    'label:': 'label',
+  },
+};
+
 /** Parse a search query string into structured conditions. */
-export function parseSearchQuery(q: string): SearchCondition[] {
+export function parseSearchQuery<F extends string>(q: string, config: ParserConfig<F>): SearchCondition<F>[] {
   const trimmed = q.trim();
   if (!trimmed) return [];
 
-  const tokens = tokenize(trimmed);
-  return buildConditions(tokens);
+  const tokens = tokenize(trimmed, config);
+  return buildConditions(tokens, config);
 }
 
 // --- Tokenizer ---
@@ -57,8 +102,9 @@ export function parseSearchQuery(q: string): SearchCondition[] {
 type TokenType = 'OPERATOR' | 'FIELD_PREFIX' | 'QUOTED_VALUE' | 'BARE_VALUE';
 type Token = { type: TokenType; value: string };
 
-function tokenize(input: string): Token[] {
+function tokenize<F extends string>(input: string, config: ParserConfig<F>): Token[] {
   const tokens: Token[] = [];
+  const prefixes = Object.keys(config.fieldPrefixes);
   let i = 0;
 
   while (i < input.length) {
@@ -77,7 +123,7 @@ function tokenize(input: string): Token[] {
     }
 
     // Check for field prefixes
-    const prefixMatch = tryMatchFieldPrefix(input, i);
+    const prefixMatch = tryMatchFieldPrefix(input, i, prefixes);
     if (prefixMatch) {
       tokens.push({ type: 'FIELD_PREFIX', value: prefixMatch });
       i += prefixMatch.length;
@@ -120,8 +166,8 @@ function tryMatchOperator(input: string, pos: number): string | null {
   return null;
 }
 
-function tryMatchFieldPrefix(input: string, pos: number): string | null {
-  for (const prefix of Object.keys(FIELD_PREFIXES)) {
+function tryMatchFieldPrefix(input: string, pos: number, prefixes: string[]): string | null {
+  for (const prefix of prefixes) {
     if (input.slice(pos, pos + prefix.length) === prefix) {
       return prefix;
     }
@@ -131,11 +177,11 @@ function tryMatchFieldPrefix(input: string, pos: number): string | null {
 
 // --- Condition builder ---
 
-function buildConditions(tokens: Token[]): SearchCondition[] {
-  const conditions: SearchCondition[] = [];
+function buildConditions<F extends string>(tokens: Token[], config: ParserConfig<F>): SearchCondition<F>[] {
+  const conditions: SearchCondition<F>[] = [];
   let currentOperator: SearchOperator = 'AND';
   let negated = false;
-  let currentField: SearchField | null = null;
+  let currentField: F | null = null;
   let i = 0;
 
   while (i < tokens.length) {
@@ -152,7 +198,7 @@ function buildConditions(tokens: Token[]): SearchCondition[] {
     }
 
     if (token.type === 'FIELD_PREFIX') {
-      currentField = FIELD_PREFIXES[token.value];
+      currentField = config.fieldPrefixes[token.value];
       i++;
       continue;
     }
@@ -166,23 +212,13 @@ function buildConditions(tokens: Token[]): SearchCondition[] {
         continue;
       }
 
-      // Validate date values before accepting them
-      if (currentField === 'add_time' && !DATE_PATTERN.test(value)) {
+      // Validate field-shaped values before accepting them.
+      if (currentField && config.validators?.[currentField] && !config.validators[currentField]!(value)) {
         currentField = null;
         currentOperator = 'AND';
         negated = false;
         i++;
         continue;
-      }
-      if (currentField === 'add_time_range') {
-        const [start, end] = value.split('..');
-        if (!start || !end || !DATE_PATTERN.test(start) || !DATE_PATTERN.test(end)) {
-          currentField = null;
-          currentOperator = 'AND';
-          negated = false;
-          i++;
-          continue;
-        }
       }
 
       conditions.push({

--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -1,6 +1,11 @@
 import { sql, type SQL } from 'drizzle-orm';
 import { db, flowsheet } from '@wxyc/database';
-import { parseSearchQuery, type SearchCondition } from './search-parser.service.js';
+import {
+  parseSearchQuery,
+  FLOWSHEET_PARSER_CONFIG,
+  type FlowsheetField,
+  type SearchCondition,
+} from './search-parser.service.js';
 
 export type SearchParams = {
   q: string;
@@ -89,7 +94,7 @@ export async function searchFlowsheet(
   params: SearchParams
 ): Promise<{ results: SearchResult[]; total: number; nextCursor?: string }> {
   const { q, page, limit, sort, order, cursor } = params;
-  const conditions = parseSearchQuery(q);
+  const conditions = parseSearchQuery(q, FLOWSHEET_PARSER_CONFIG);
 
   const whereClause = buildWhereClause(conditions);
   const orderDirection = order === 'asc' ? sql`ASC` : sql`DESC`;
@@ -172,7 +177,7 @@ function transformRow(row: SearchResultRow): SearchResult {
   };
 }
 
-function buildWhereClause(conditions: SearchCondition[]): SQL | null {
+function buildWhereClause(conditions: SearchCondition<FlowsheetField>[]): SQL | null {
   if (conditions.length === 0) return null;
 
   const parts: { operator: 'AND' | 'OR'; fragment: SQL }[] = [];
@@ -199,7 +204,7 @@ function buildWhereClause(conditions: SearchCondition[]): SQL | null {
   return sql`(${result})`;
 }
 
-function buildConditionFragment(condition: SearchCondition): SQL | null {
+function buildConditionFragment(condition: SearchCondition<FlowsheetField>): SQL | null {
   const { field, value, exact, negated } = condition;
 
   let fragment: SQL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "@sentry/node": "^10.52.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.3.0",
+        "@wxyc/shared": "^1.4.0",
         "better-auth": "^1.6.9",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -121,9 +121,9 @@
       }
     },
     "apps/auth/node_modules/@wxyc/shared": {
-      "version": "1.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.3.0/921aeb6e4fed2d130c7ac13e032740f1cb2d82ab",
-      "integrity": "sha512-StZ0DDuRcogWO4tD9PM2sd42inlYVb1RAo0wzUO3kj3l0HQh/p93PD6YbkEaKoiWJMxWRzPzSimsZvMdkM9KzQ==",
+      "version": "1.4.1",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.4.1/2f1084d423fa6b9e0487034bd09d6a5e0ede1cbb",
+      "integrity": "sha512-ojzbSVtjSy1HQykHGP/3OhaBG5KxAYKMh043W4YJkd/NNQKQQLT1bvkTP6sqzzURhLk02L5kwfYg5PDg8DPCJA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -267,7 +267,7 @@
         "@tensorflow/tfjs": "^4.22.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.3.0",
+        "@wxyc/shared": "^1.4.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.16.0",
@@ -319,9 +319,9 @@
       }
     },
     "apps/backend/node_modules/@wxyc/shared": {
-      "version": "1.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.3.0/921aeb6e4fed2d130c7ac13e032740f1cb2d82ab",
-      "integrity": "sha512-StZ0DDuRcogWO4tD9PM2sd42inlYVb1RAo0wzUO3kj3l0HQh/p93PD6YbkEaKoiWJMxWRzPzSimsZvMdkM9KzQ==",
+      "version": "1.4.1",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.4.1/2f1084d423fa6b9e0487034bd09d6a5e0ede1cbb",
+      "integrity": "sha512-ojzbSVtjSy1HQykHGP/3OhaBG5KxAYKMh043W4YJkd/NNQKQQLT1bvkTP6sqzzURhLk02L5kwfYg5PDg8DPCJA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -15440,7 +15440,7 @@
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1045.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.3.0",
+        "@wxyc/shared": "^1.4.0",
         "better-auth": "^1.6.9",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -15476,9 +15476,9 @@
       }
     },
     "shared/authentication/node_modules/@wxyc/shared": {
-      "version": "1.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.3.0/921aeb6e4fed2d130c7ac13e032740f1cb2d82ab",
-      "integrity": "sha512-StZ0DDuRcogWO4tD9PM2sd42inlYVb1RAo0wzUO3kj3l0HQh/p93PD6YbkEaKoiWJMxWRzPzSimsZvMdkM9KzQ==",
+      "version": "1.4.1",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.4.1/2f1084d423fa6b9e0487034bd09d6a5e0ede1cbb",
+      "integrity": "sha512-ojzbSVtjSy1HQykHGP/3OhaBG5KxAYKMh043W4YJkd/NNQKQQLT1bvkTP6sqzzURhLk02L5kwfYg5PDg8DPCJA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1045.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.3.0",
+    "@wxyc/shared": "^1.4.0",
     "better-auth": "^1.6.9",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/tests/integration/library-query.spec.js
+++ b/tests/integration/library-query.spec.js
@@ -139,4 +139,14 @@ describe('GET /library/query', () => {
   test('rejects malformed on_streaming with 400', async () => {
     await auth.get('/library/query').query({ on_streaming: 'maybe' }).expect(400);
   });
+
+  test('rejects unknown sort with 400', async () => {
+    const res = await auth.get('/library/query').query({ sort: 'banana' }).expect(400);
+    expect(res.body.message).toMatch(/sort/i);
+  });
+
+  test('rejects unknown order with 400', async () => {
+    const res = await auth.get('/library/query').query({ order: 'sideways' }).expect(400);
+    expect(res.body.message).toMatch(/order/i);
+  });
 });

--- a/tests/integration/library-query.spec.js
+++ b/tests/integration/library-query.spec.js
@@ -1,0 +1,142 @@
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+
+/**
+ * Integration coverage for GET /library/query — the new query-builder endpoint.
+ *
+ * Sibling to library.search-ranking.spec.js (which exercises the older
+ * `/library/` endpoint). This one verifies the parsed-query field semantics
+ * (artist:/album:/label:, NOT, quoted exact), the filter params (on_streaming,
+ * genre, format), pagination + total, and validation errors.
+ */
+describe('GET /library/query', () => {
+  let auth;
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  test('returns the response envelope shape', async () => {
+    const res = await auth.get('/library/query').query({ limit: 1 }).expect(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        results: expect.any(Array),
+        total: expect.any(Number),
+        page: expect.any(Number),
+        totalPages: expect.any(Number),
+      })
+    );
+  });
+
+  test('empty q returns a sorted page of the catalog', async () => {
+    const res = await auth.get('/library/query').query({ sort: 'album', order: 'asc', limit: 5 }).expect(200);
+
+    expect(res.body.results.length).toBeGreaterThan(0);
+    const titles = res.body.results.map((r) => r.album_title);
+    const sorted = [...titles].sort((a, b) => a.localeCompare(b));
+    expect(titles).toEqual(sorted);
+  });
+
+  test('artist: prefix filters by artist name', async () => {
+    const res = await auth.get('/library/query').query({ q: 'artist:Stereolab', limit: 10 }).expect(200);
+
+    expect(res.body.results.length).toBeGreaterThanOrEqual(2);
+    for (const row of res.body.results) {
+      expect(row.artist_name).toBe('Stereolab');
+    }
+  });
+
+  test('album: prefix filters by album title', async () => {
+    const res = await auth.get('/library/query').query({ q: 'album:Confield', limit: 10 }).expect(200);
+
+    expect(res.body.results.length).toBeGreaterThan(0);
+    for (const row of res.body.results) {
+      expect(row.album_title.toLowerCase()).toContain('confield');
+    }
+  });
+
+  test('NOT excludes matching rows', async () => {
+    const baseline = await auth.get('/library/query').query({ q: 'artist:Stereolab', limit: 10 }).expect(200);
+    const negated = await auth
+      .get('/library/query')
+      .query({ q: 'artist:Stereolab AND NOT album:"Mars Audiac Quintet"', limit: 10 })
+      .expect(200);
+
+    expect(baseline.body.results.length).toBeGreaterThan(negated.body.results.length);
+    for (const row of negated.body.results) {
+      expect(row.album_title).not.toBe('Mars Audiac Quintet');
+    }
+  });
+
+  test('quoted value does exact match', async () => {
+    const exact = await auth.get('/library/query').query({ q: 'artist:"Stereolab"', limit: 10 }).expect(200);
+    expect(exact.body.results.length).toBeGreaterThan(0);
+    for (const row of exact.body.results) {
+      expect(row.artist_name).toBe('Stereolab');
+    }
+  });
+
+  test('genre filter restricts results', async () => {
+    const res = await auth.get('/library/query').query({ genre: 'Rock', limit: 50 }).expect(200);
+    expect(res.body.results.length).toBeGreaterThan(0);
+    for (const row of res.body.results) {
+      expect(row.genre_name).toBe('Rock');
+    }
+  });
+
+  test('format filter restricts results', async () => {
+    const res = await auth.get('/library/query').query({ format: 'cd', limit: 50 }).expect(200);
+    expect(res.body.results.length).toBeGreaterThan(0);
+    for (const row of res.body.results) {
+      expect(row.format_name).toBe('cd');
+    }
+  });
+
+  test('stable pagination across same-primary-sort rows', async () => {
+    // Sort by album asc — Stereolab's two records share artist but have
+    // distinct titles, and the secondary `artist_name` sort gives the same
+    // ordering across page boundaries.
+    const page1 = await auth
+      .get('/library/query')
+      .query({ sort: 'album', order: 'asc', limit: 3, page: 0 })
+      .expect(200);
+    const page2 = await auth
+      .get('/library/query')
+      .query({ sort: 'album', order: 'asc', limit: 3, page: 1 })
+      .expect(200);
+
+    const ids1 = new Set(page1.body.results.map((r) => r.id));
+    for (const row of page2.body.results) {
+      expect(ids1.has(row.id)).toBe(false);
+    }
+    expect(page1.body.total).toBe(page2.body.total);
+  });
+
+  test('totalPages reflects total / limit', async () => {
+    const res = await auth.get('/library/query').query({ limit: 1 }).expect(200);
+    expect(res.body.totalPages).toBe(Math.ceil(res.body.total / 1));
+  });
+
+  test('rejects unknown genre with 400', async () => {
+    const res = await auth.get('/library/query').query({ genre: 'NotARealGenre' }).expect(400);
+    expect(res.body.message).toMatch(/genre/i);
+  });
+
+  test('rejects unknown format with 400', async () => {
+    const res = await auth.get('/library/query').query({ format: 'NotARealFormat' }).expect(400);
+    expect(res.body.message).toMatch(/format/i);
+  });
+
+  test('rejects out-of-range limit with 400', async () => {
+    await auth.get('/library/query').query({ limit: 999 }).expect(400);
+    await auth.get('/library/query').query({ limit: 0 }).expect(400);
+  });
+
+  test('rejects negative page with 400', async () => {
+    await auth.get('/library/query').query({ page: -1 }).expect(400);
+  });
+
+  test('rejects malformed on_streaming with 400', async () => {
+    await auth.get('/library/query').query({ on_streaming: 'maybe' }).expect(400);
+  });
+});

--- a/tests/unit/services/library-parser.service.test.ts
+++ b/tests/unit/services/library-parser.service.test.ts
@@ -1,0 +1,72 @@
+import { parseSearchQuery, CATALOG_PARSER_CONFIG } from '../../../apps/backend/services/search-parser.service';
+
+const parse = (q: string) => parseSearchQuery(q, CATALOG_PARSER_CONFIG);
+
+describe('parseSearchQuery (catalog config)', () => {
+  describe('field prefixes', () => {
+    it.each([
+      ['artist:autechre', 'artist_name', 'autechre'],
+      ['album:confield', 'album_title', 'confield'],
+      ['label:warp', 'label', 'warp'],
+    ])('parses %s as field=%s value=%s', (input, expectedField, expectedValue) => {
+      expect(parse(input)).toEqual([
+        { operator: 'AND', field: expectedField, value: expectedValue, exact: false, negated: false },
+      ]);
+    });
+  });
+
+  describe('flowsheet-only prefixes fall back to all', () => {
+    it.each([
+      ['song:poise', 'song:poise'],
+      ['dj:jake', 'dj:jake'],
+      ['date:2024-06-15', 'date:2024-06-15'],
+      ['dateRange:2024-01-01..2024-12-31', 'dateRange:2024-01-01..2024-12-31'],
+    ])('treats %s as a bare all-field term (no flowsheet prefixes in catalog)', (input, expected) => {
+      // The catalog config does not register `song:`, `dj:`, `date:`, or
+      // `dateRange:` prefixes, so the tokenizer sees a bare value containing
+      // a colon — which it parses as a single all-field term.
+      expect(parse(input)).toEqual([{ operator: 'AND', field: 'all', value: expected, exact: false, negated: false }]);
+    });
+  });
+
+  describe('operators and quoting', () => {
+    it('parses AND between fields', () => {
+      expect(parse('artist:foo AND label:bar')).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'foo', exact: false, negated: false },
+        { operator: 'AND', field: 'label', value: 'bar', exact: false, negated: false },
+      ]);
+    });
+
+    it('parses OR between fields', () => {
+      expect(parse('artist:foo OR artist:bar')).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'foo', exact: false, negated: false },
+        { operator: 'OR', field: 'artist_name', value: 'bar', exact: false, negated: false },
+      ]);
+    });
+
+    it('negates with NOT', () => {
+      expect(parse('artist:foo AND NOT label:warp')).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'foo', exact: false, negated: false },
+        { operator: 'AND', field: 'label', value: 'warp', exact: false, negated: true },
+      ]);
+    });
+
+    it('parses quoted value as exact match', () => {
+      expect(parse('artist:"Cat Power"')).toEqual([
+        { operator: 'AND', field: 'artist_name', value: 'Cat Power', exact: true, negated: false },
+      ]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array for empty input', () => {
+      expect(parse('')).toEqual([]);
+    });
+
+    it('treats a bare term as all-field', () => {
+      expect(parse('stereolab')).toEqual([
+        { operator: 'AND', field: 'all', value: 'stereolab', exact: false, negated: false },
+      ]);
+    });
+  });
+});

--- a/tests/unit/services/search-parser.service.test.ts
+++ b/tests/unit/services/search-parser.service.test.ts
@@ -1,15 +1,23 @@
-import { parseSearchQuery } from '../../../apps/backend/services/search-parser.service';
+import {
+  parseSearchQuery,
+  FLOWSHEET_PARSER_CONFIG,
+  type FlowsheetField,
+  type ParserConfig,
+} from '../../../apps/backend/services/search-parser.service';
+
+const parse = (q: string, config: ParserConfig<FlowsheetField> = FLOWSHEET_PARSER_CONFIG) =>
+  parseSearchQuery(q, config);
 
 describe('parseSearchQuery', () => {
   describe('simple terms', () => {
     it('parses a bare term as all-field search', () => {
-      const result = parseSearchQuery('autechre');
+      const result = parse('autechre');
 
       expect(result).toEqual([{ operator: 'AND', field: 'all', value: 'autechre', exact: false, negated: false }]);
     });
 
     it('parses multiple bare terms as separate AND conditions', () => {
-      const result = parseSearchQuery('autechre confield');
+      const result = parse('autechre confield');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'all', value: 'autechre', exact: false, negated: false },
@@ -26,7 +34,7 @@ describe('parseSearchQuery', () => {
       ['label:warp', 'record_label', 'warp'],
       ['dj:jake', 'dj_name', 'jake'],
     ])('parses %s as field=%s value=%s', (input, expectedField, expectedValue) => {
-      const result = parseSearchQuery(input);
+      const result = parse(input);
 
       expect(result).toEqual([
         { operator: 'AND', field: expectedField, value: expectedValue, exact: false, negated: false },
@@ -36,7 +44,7 @@ describe('parseSearchQuery', () => {
 
   describe('operators', () => {
     it('parses AND between two field terms', () => {
-      const result = parseSearchQuery('artist:autechre AND album:confield');
+      const result = parse('artist:autechre AND album:confield');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: false },
@@ -45,7 +53,7 @@ describe('parseSearchQuery', () => {
     });
 
     it('parses OR between two field terms', () => {
-      const result = parseSearchQuery('artist:autechre OR artist:stereolab');
+      const result = parse('artist:autechre OR artist:stereolab');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: false },
@@ -54,7 +62,7 @@ describe('parseSearchQuery', () => {
     });
 
     it('parses NOT as negation on the following condition', () => {
-      const result = parseSearchQuery('NOT artist:autechre');
+      const result = parse('NOT artist:autechre');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: true },
@@ -62,7 +70,7 @@ describe('parseSearchQuery', () => {
     });
 
     it('parses operator + NOT combination', () => {
-      const result = parseSearchQuery('artist:stereolab AND NOT artist:autechre');
+      const result = parse('artist:stereolab AND NOT artist:autechre');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'artist_name', value: 'stereolab', exact: false, negated: false },
@@ -73,7 +81,7 @@ describe('parseSearchQuery', () => {
 
   describe('exact match (quoted values)', () => {
     it('parses quoted value as exact match', () => {
-      const result = parseSearchQuery('artist:"Autechre"');
+      const result = parse('artist:"Autechre"');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'artist_name', value: 'Autechre', exact: true, negated: false },
@@ -81,7 +89,7 @@ describe('parseSearchQuery', () => {
     });
 
     it('parses quoted value with spaces', () => {
-      const result = parseSearchQuery('artist:"Cat Power"');
+      const result = parse('artist:"Cat Power"');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'artist_name', value: 'Cat Power', exact: true, negated: false },
@@ -89,13 +97,13 @@ describe('parseSearchQuery', () => {
     });
 
     it('parses bare quoted value as all-field exact match', () => {
-      const result = parseSearchQuery('"Juana Molina"');
+      const result = parse('"Juana Molina"');
 
       expect(result).toEqual([{ operator: 'AND', field: 'all', value: 'Juana Molina', exact: true, negated: false }]);
     });
 
     it('handles unmatched quote by treating rest of string as value', () => {
-      const result = parseSearchQuery('artist:"Autechre');
+      const result = parse('artist:"Autechre');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'artist_name', value: 'Autechre', exact: true, negated: false },
@@ -105,7 +113,7 @@ describe('parseSearchQuery', () => {
 
   describe('date and dateRange', () => {
     it('parses date prefix', () => {
-      const result = parseSearchQuery('date:2024-06-15');
+      const result = parse('date:2024-06-15');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'add_time', value: '2024-06-15', exact: false, negated: false },
@@ -113,7 +121,7 @@ describe('parseSearchQuery', () => {
     });
 
     it('parses dateRange prefix with .. separator', () => {
-      const result = parseSearchQuery('dateRange:2024-01-01..2024-12-31');
+      const result = parse('dateRange:2024-01-01..2024-12-31');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'add_time_range', value: '2024-01-01..2024-12-31', exact: false, negated: false },
@@ -123,7 +131,7 @@ describe('parseSearchQuery', () => {
 
   describe('complex queries', () => {
     it('parses mixed field and operator query', () => {
-      const result = parseSearchQuery('artist:autechre AND song:poise AND NOT label:warp');
+      const result = parse('artist:autechre AND song:poise AND NOT label:warp');
 
       expect(result).toHaveLength(3);
       expect(result[0]).toMatchObject({ field: 'artist_name', value: 'autechre', negated: false });
@@ -132,7 +140,7 @@ describe('parseSearchQuery', () => {
     });
 
     it('parses field prefix with simple query and OR', () => {
-      const result = parseSearchQuery('artist:autechre OR artist:"Cat Power"');
+      const result = parse('artist:autechre OR artist:"Cat Power"');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: false },
@@ -143,7 +151,7 @@ describe('parseSearchQuery', () => {
 
   describe('date validation', () => {
     it.each(['2024-06-15', '2004-11-01', '2026-12-31'])('accepts valid date %s', (date) => {
-      const result = parseSearchQuery(`date:${date}`);
+      const result = parse(`date:${date}`);
 
       expect(result).toEqual([{ operator: 'AND', field: 'add_time', value: date, exact: false, negated: false }]);
     });
@@ -151,14 +159,14 @@ describe('parseSearchQuery', () => {
     it.each(['garbage', 'not-a-date', '2024/06/15', '15-06-2024', '2024-13-01', '2024-06-32'])(
       'rejects invalid date %s',
       (date) => {
-        const result = parseSearchQuery(`date:${date}`);
+        const result = parse(`date:${date}`);
 
         expect(result).toEqual([]);
       }
     );
 
     it('accepts valid dateRange', () => {
-      const result = parseSearchQuery('dateRange:2024-01-01..2024-12-31');
+      const result = parse('dateRange:2024-01-01..2024-12-31');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'add_time_range', value: '2024-01-01..2024-12-31', exact: false, negated: false },
@@ -168,7 +176,7 @@ describe('parseSearchQuery', () => {
     it.each(['garbage..also-garbage', '2024-01-01..not-a-date', 'not-a-date..2024-12-31'])(
       'rejects dateRange with invalid dates: %s',
       (range) => {
-        const result = parseSearchQuery(`dateRange:${range}`);
+        const result = parse(`dateRange:${range}`);
 
         expect(result).toEqual([]);
       }
@@ -177,21 +185,21 @@ describe('parseSearchQuery', () => {
 
   describe('edge cases', () => {
     it('returns empty array for empty string', () => {
-      expect(parseSearchQuery('')).toEqual([]);
+      expect(parse('')).toEqual([]);
     });
 
     it('returns empty array for whitespace-only string', () => {
-      expect(parseSearchQuery('   ')).toEqual([]);
+      expect(parse('   ')).toEqual([]);
     });
 
     it('ignores field prefix with no value', () => {
-      const result = parseSearchQuery('artist:');
+      const result = parse('artist:');
 
       expect(result).toEqual([]);
     });
 
     it('handles multiple spaces between tokens', () => {
-      const result = parseSearchQuery('artist:autechre   AND   album:confield');
+      const result = parse('artist:autechre   AND   album:confield');
 
       expect(result).toEqual([
         { operator: 'AND', field: 'artist_name', value: 'autechre', exact: false, negated: false },


### PR DESCRIPTION
## Summary

- Adds `GET /library/query` to drive a multi-row query-builder UI on dj-site's catalog page (artist:/album:/label:, AND/OR/NOT, quoted exact match) plus filter params (on_streaming, genre, format).
- Generalizes `parseSearchQuery` into `parseSearchQuery<F>(q, config)`. Exports `FLOWSHEET_PARSER_CONFIG` (preserving today's flowsheet behavior) and `CATALOG_PARSER_CONFIG`.
- Reads `library_artist_view` with deterministic pagination (configurable sort + `artist_name`/`album_title` tiebreaker). Validates `genre`/`format` against cached enum sets and returns `400 { message: "Unknown genre: …" }` for bad input.
- Bumps `@wxyc/shared` to `^1.4.0` across workspaces.

Backend half of the [catalog query-builder plan](https://github.com/WXYC/dj-site/blob/main/plans/catalog-query-builder.md) (PR 1b). Predecessor PR 1a (wxyc-shared `LibraryQueryResponse` + path declaration) merged as [wxyc-shared#126](https://github.com/WXYC/wxyc-shared/pull/126); successor PR 2 (dj-site catalog UI) is blocked on this.

## Why `/library/query` and not `/library/search`

`/library/search` is already mounted to the request-line controller (Slack request bot, distinct response envelope, public-after-auth scope, external consumers). Repurposing it would entangle two contracts. `/library/query` keeps the request-line surface narrow while giving the catalog UI a dedicated query-builder-backed endpoint.

## Why a separate service file

`library-search.service.ts` is a new sibling to `library.service.ts` rather than another export on the existing service. The new code only consumes the parsed-query → SQL translation path; it doesn't share helpers with the existing artist/album/rotation operations and would otherwise add ~300 lines to an already 1,100-line file. Mirrors the `search.service.ts` / `library.service.ts` split that already exists for flowsheet.

## Why no tsvector path for `all` queries in v1

The plan flagged a tsvector + trigram hybrid for `all`-field queries, but `library.search_doc` covers artist + album only — `label` is a deferred follow-up (separate ticket). Routing `all` through tsvector now would give partial coverage (label has to ride a trigram OR anyway) plus the gymnastics of predicating on `library.search_doc` while reading from `library_artist_view`. v1 uses trigram-backed ILIKE across the three columns (same path as flowsheet's trigram fallback). When `label` lands in `search_doc`, wiring tsvector through this same call site is a small follow-up.

## Test plan

- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run lint` — 0 errors (374 pre-existing warnings on untouched files)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 1833 tests pass, including the refactored flowsheet parser plus 13 new catalog-config tests
- [ ] Integration suite — needs Docker DB; will run in CI

Closes #856