### PR TITLE
feat(library): LRU cache for Track 2 search

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -905,26 +905,23 @@ export async function searchAlbumsByTitle(albumTitle: string, limit = 5): Promis
  *      fallback strategy and should not double-count.
  *   3. Preserves LML's ordering. BS does not re-rank.
  *
- * Errors at the LML HTTP boundary degrade to an empty result. Catalog search
- * is the only consumer today and treats Track 2 as best-effort.
+ * LML HTTP errors propagate; the wrapper translates them to an empty result
+ * for callers, but the throw lets the wrapper skip cache-poisoning. Catalog
+ * search is the only consumer today and treats Track 2 as best-effort.
  *
- * Results are memoized in a process-local LRU (size 1000, TTL 10 minutes,
- * keyed by lowercased+trimmed query plus a hash of the catalog-track-search
- * flag state). A cache hit short-circuits both the LML round-trip and the BS
- * PG JOIN — see {@link searchLibraryByTrack} for the wrapper.
+ * Results are memoized by the wrapper in a process-local LRU (size 1000, TTL
+ * 10 minutes, keyed by lowercased+trimmed query plus a hash of the
+ * catalog-track-search flag state); see {@link searchLibraryByTrack}.
  *
  * @param query - Track-title query
- * @param limit - Maximum results to return
+ * @param limit - Maximum results to return (pass `Infinity` to disable the
+ *                final-loop cap; the wrapper does this so the cache stores
+ *                un-sliced results and serves any smaller caller-`limit`).
  * @returns Array of enriched library results with `matched_via` populated
+ * @throws Whatever `lookupBySong` throws — the wrapper handles the boundary.
  */
-async function searchLibraryByTrackUncached(query: string, limit: number): Promise<EnrichedLibraryResult[]> {
-  let response: LookupResponse;
-  try {
-    response = await lookupBySong(query);
-  } catch (err) {
-    console.warn('[Library] searchLibraryByTrack: LML lookup failed, returning empty', err);
-    return [];
-  }
+async function searchLibraryByTrackUncachedOrThrow(query: string, limit: number): Promise<EnrichedLibraryResult[]> {
+  const response: LookupResponse = await lookupBySong(query);
 
   const items = response.results ?? [];
   if (items.length === 0) return [];
@@ -1015,6 +1012,12 @@ async function searchLibraryByTrackUncached(query: string, limit: number): Promi
 // of the catalog-track-search feature flags so a flag flip invalidates the
 // cache implicitly (the next call generates a new key prefix).
 //
+// `limit` is intentionally NOT part of the cache key. `searchLibraryByTrack`
+// stores the full LML-bounded result set (LML already caps server-side; the
+// BS JOIN binds to `legacyIds.length`) and slices to the caller's `limit` at
+// read time. This lets a `limit=10` miss serve a subsequent `limit=5` hit
+// without a second LML round-trip.
+//
 // Mirrors the LRUCache shape used in artworkCache (apps/backend/controllers/
 // proxy.controller.ts). Plan reference:
 // https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md#103-latency--cache-budget
@@ -1029,43 +1032,68 @@ function getFlagStateHash(): string {
   return `${c.ctaEnabled ? '1' : '0'}${c.discogsEnabled ? '1' : '0'}`;
 }
 
-function trackSearchCacheKey(query: string, limit: number): string {
-  return `${query.toLowerCase().trim()}:${limit}:${getFlagStateHash()}`;
+function trackSearchCacheKey(query: string): string {
+  return `${query.toLowerCase().trim()}:${getFlagStateHash()}`;
 }
 
 /**
  * Test-only hook for clearing the Track 2 LRU between cases. Production code
  * relies on TTL expiry + flag-state-hash invalidation; tests need a way to
  * reset state between `beforeEach` runs.
+ *
+ * NOTE: this cache is module-scoped, so any test file that exercises the
+ * Track 2 cascade (directly or transitively) must call this in its own
+ * `beforeEach` — otherwise cache state leaks across files within the same
+ * Jest worker. The global unit setup (tests/setup/unit.setup.ts) deliberately
+ * stays free of service imports; per-file discipline is the contract.
  */
 export function __resetTrackSearchCacheForTests(): void {
   trackSearchCache.clear();
 }
 
 /**
- * Memoized wrapper around {@link searchLibraryByTrackUncached}. Cache hits
- * return the full `EnrichedLibraryResult[]` (mapped BS rows, `matched_via`,
- * LML ordering) without touching LML or the BS PG JOIN.
+ * Memoized wrapper around {@link searchLibraryByTrackUncachedOrThrow}. Cache hits
+ * return the mapped `EnrichedLibraryResult[]` (BS rows, `matched_via`, LML
+ * ordering) without touching LML or the BS PG JOIN.
  *
  * Emits a `track_search.cache_hit` attribute on the active Sentry span so the
  * outer instrumentation (E2-8) can break down hit vs. miss latency without
  * this layer creating its own span.
+ *
+ * LML failures are NOT cached: if `lookupBySong` rejects, the wrapper returns
+ * `[]` straight through without polluting the cache. A genuine empty LML
+ * response (no matching releases) IS cached — both because that's the
+ * expected steady-state for nonsense queries and because re-running the
+ * round-trip every time would defeat the cache's purpose.
+ *
+ * The returned array is a shallow copy of the cached entry, so callers can
+ * sort or mutate without bleeding into subsequent hits.
  *
  * @param query - Track-title query
  * @param limit - Maximum results to return
  * @returns Array of enriched library results with `matched_via` populated
  */
 export async function searchLibraryByTrack(query: string, limit: number): Promise<EnrichedLibraryResult[]> {
-  const key = trackSearchCacheKey(query, limit);
+  const key = trackSearchCacheKey(query);
   const cached = trackSearchCache.get(key);
   if (cached !== undefined) {
     Sentry.getActiveSpan()?.setAttribute('track_search.cache_hit', true);
-    return cached;
+    return cached.slice(0, limit);
   }
   Sentry.getActiveSpan()?.setAttribute('track_search.cache_hit', false);
-  const results = await searchLibraryByTrackUncached(query, limit);
-  trackSearchCache.set(key, results);
-  return results;
+  // Fetch the full LML-bounded result; the cache stores the un-sliced array.
+  let results: EnrichedLibraryResult[];
+  let lmlSucceeded = true;
+  try {
+    results = await searchLibraryByTrackUncachedOrThrow(query, Number.POSITIVE_INFINITY);
+  } catch {
+    lmlSucceeded = false;
+    results = [];
+  }
+  if (lmlSucceeded) {
+    trackSearchCache.set(key, results);
+  }
+  return results.slice(0, limit);
 }
 
 /**

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1,4 +1,6 @@
 import { and, asc, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { LRUCache } from 'lru-cache';
+import * as Sentry from '@sentry/node';
 import type { ReconciledIdentity, TrackMatchHint } from '@wxyc/shared/dtos';
 import { RotationAddRequest } from '../controllers/library.controller.js';
 import { db } from '@wxyc/database';
@@ -906,11 +908,16 @@ export async function searchAlbumsByTitle(albumTitle: string, limit = 5): Promis
  * Errors at the LML HTTP boundary degrade to an empty result. Catalog search
  * is the only consumer today and treats Track 2 as best-effort.
  *
+ * Results are memoized in a process-local LRU (size 1000, TTL 10 minutes,
+ * keyed by lowercased+trimmed query plus a hash of the catalog-track-search
+ * flag state). A cache hit short-circuits both the LML round-trip and the BS
+ * PG JOIN — see {@link searchLibraryByTrack} for the wrapper.
+ *
  * @param query - Track-title query
  * @param limit - Maximum results to return
  * @returns Array of enriched library results with `matched_via` populated
  */
-export async function searchLibraryByTrack(query: string, limit: number): Promise<EnrichedLibraryResult[]> {
+async function searchLibraryByTrackUncached(query: string, limit: number): Promise<EnrichedLibraryResult[]> {
   let response: LookupResponse;
   try {
     response = await lookupBySong(query);
@@ -997,6 +1004,67 @@ export async function searchLibraryByTrack(query: string, limit: number): Promis
     results.push(enriched);
     if (results.length >= limit) break;
   }
+  return results;
+}
+
+// --- Track 2 result cache ---
+//
+// LML's /lookup is the slowest hop in the cascade (HTTP + 3-tier cache), and
+// the BS-side bridge query is a 5-way join. Memoizing the final mapped
+// EnrichedLibraryResult[] lets repeat searches skip both. Key includes a hash
+// of the catalog-track-search feature flags so a flag flip invalidates the
+// cache implicitly (the next call generates a new key prefix).
+//
+// Mirrors the LRUCache shape used in artworkCache (apps/backend/controllers/
+// proxy.controller.ts). Plan reference:
+// https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md#103-latency--cache-budget
+
+const trackSearchCache = new LRUCache<string, EnrichedLibraryResult[]>({
+  max: 1000,
+  ttl: 1000 * 60 * 10, // 10 minutes
+});
+
+function getFlagStateHash(): string {
+  const c = getCatalogTrackSearchConfig();
+  return `${c.ctaEnabled ? '1' : '0'}${c.discogsEnabled ? '1' : '0'}`;
+}
+
+function trackSearchCacheKey(query: string, limit: number): string {
+  return `${query.toLowerCase().trim()}:${limit}:${getFlagStateHash()}`;
+}
+
+/**
+ * Test-only hook for clearing the Track 2 LRU between cases. Production code
+ * relies on TTL expiry + flag-state-hash invalidation; tests need a way to
+ * reset state between `beforeEach` runs.
+ */
+export function __resetTrackSearchCacheForTests(): void {
+  trackSearchCache.clear();
+}
+
+/**
+ * Memoized wrapper around {@link searchLibraryByTrackUncached}. Cache hits
+ * return the full `EnrichedLibraryResult[]` (mapped BS rows, `matched_via`,
+ * LML ordering) without touching LML or the BS PG JOIN.
+ *
+ * Emits a `track_search.cache_hit` attribute on the active Sentry span so the
+ * outer instrumentation (E2-8) can break down hit vs. miss latency without
+ * this layer creating its own span.
+ *
+ * @param query - Track-title query
+ * @param limit - Maximum results to return
+ * @returns Array of enriched library results with `matched_via` populated
+ */
+export async function searchLibraryByTrack(query: string, limit: number): Promise<EnrichedLibraryResult[]> {
+  const key = trackSearchCacheKey(query, limit);
+  const cached = trackSearchCache.get(key);
+  if (cached !== undefined) {
+    Sentry.getActiveSpan()?.setAttribute('track_search.cache_hit', true);
+    return cached;
+  }
+  Sentry.getActiveSpan()?.setAttribute('track_search.cache_hit', false);
+  const results = await searchLibraryByTrackUncached(query, limit);
+  trackSearchCache.set(key, results);
   return results;
 }
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -913,14 +913,15 @@ export async function searchAlbumsByTitle(albumTitle: string, limit = 5): Promis
  * 10 minutes, keyed by lowercased+trimmed query plus a hash of the
  * catalog-track-search flag state); see {@link searchLibraryByTrack}.
  *
+ * Always materializes the full LML-bounded result; the caller's `limit` is
+ * applied by the wrapper post-cache so a `limit=10` miss can serve a smaller
+ * `limit=5` hit without a second LML round-trip.
+ *
  * @param query - Track-title query
- * @param limit - Maximum results to return (pass `Infinity` to disable the
- *                final-loop cap; the wrapper does this so the cache stores
- *                un-sliced results and serves any smaller caller-`limit`).
  * @returns Array of enriched library results with `matched_via` populated
  * @throws Whatever `lookupBySong` throws — the wrapper handles the boundary.
  */
-async function searchLibraryByTrackUncachedOrThrow(query: string, limit: number): Promise<EnrichedLibraryResult[]> {
+async function searchLibraryByTrackUncachedOrThrow(query: string): Promise<EnrichedLibraryResult[]> {
   const response: LookupResponse = await lookupBySong(query);
 
   const items = response.results ?? [];
@@ -953,10 +954,9 @@ async function searchLibraryByTrackUncachedOrThrow(query: string, limit: number)
       sql`${rotation.album_id} = ${library.id} AND (${rotation.kill_date} > CURRENT_DATE OR ${rotation.kill_date} IS NULL)`
     )
     .where(inArray(library.legacy_release_id, legacyIds))
-    // Bound by the LML response size (already capped server-side), not the
-    // caller's `limit`. CTA exclusion runs after this query, so a tight
-    // .limit(limit) would let CTA drops shrink the response below what the
-    // caller asked for. We trim to `limit` after exclusion + ordering.
+    // Bound by the LML response size (already capped server-side). The
+    // wrapper trims to caller's `limit` post-cache so the cached entry can
+    // serve any smaller caller-`limit` from a single LML + JOIN round-trip.
     .limit(legacyIds.length)) as unknown as Array<LibraryArtistViewEntry & { legacy_release_id: number | null }>;
 
   // CTA-covered library rows are Track 1's responsibility; filter them out so
@@ -999,7 +999,6 @@ async function searchLibraryByTrackUncachedOrThrow(query: string, limit: number)
       enriched.matched_via = item.matched_via;
     }
     results.push(enriched);
-    if (results.length >= limit) break;
   }
   return results;
 }
@@ -1085,7 +1084,7 @@ export async function searchLibraryByTrack(query: string, limit: number): Promis
   let results: EnrichedLibraryResult[];
   let lmlSucceeded = true;
   try {
-    results = await searchLibraryByTrackUncachedOrThrow(query, Number.POSITIVE_INFINITY);
+    results = await searchLibraryByTrackUncachedOrThrow(query);
   } catch {
     lmlSucceeded = false;
     results = [];

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -19,6 +19,7 @@ import {
   searchAlbumsByTitle,
   searchLibraryByCTA,
   searchLibraryByTrack,
+  __resetTrackSearchCacheForTests,
   getAlbumFromDB,
   markAlbumMissing,
   markAlbumFound,
@@ -267,6 +268,9 @@ describe('library.service', () => {
       // Reset the lazy singleton so each test's per-case env mutations
       // (a few lines below) re-load through `loadConfig()`.
       resetCatalogTrackSearchConfig();
+      // Reset the Track 2 LRU so a hit from a previous test (same query +
+      // flag state) doesn't suppress the LML / DB call this test is asserting.
+      __resetTrackSearchCacheForTests();
     });
 
     afterAll(() => {
@@ -566,6 +570,7 @@ describe('library.service', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
+      __resetTrackSearchCacheForTests();
     });
 
     it('returns enriched results with matched_via propagated from LML', async () => {
@@ -790,6 +795,180 @@ describe('library.service', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0].id).toBe(101);
+    });
+  });
+
+  /**
+   * Track 2 LRU cache (E2-7). Memoizes the final mapped EnrichedLibraryResult[]
+   * keyed by lowercased+trimmed query plus a hash of the catalog-track-search
+   * flag state, so hits skip both the LML round-trip and the BS PG JOIN.
+   */
+  describe('searchLibraryByTrack cache (LRU)', () => {
+    const trackRow = {
+      id: 101,
+      code_letters: 'PR',
+      code_artist_number: 1,
+      code_number: 2,
+      artist_name: 'Jessica Pratt',
+      alphabetical_name: 'Pratt, Jessica',
+      album_title: 'On Your Own Love Again',
+      format_name: 'CD',
+      genre_name: 'Rock',
+      rotation_bin: null,
+      add_date: new Date('2024-02-01'),
+      label: 'Drag City',
+      label_id: null,
+      on_streaming: true,
+      album_artist: null,
+      plays: 12,
+      artwork_url: null,
+      legacy_release_id: 555,
+    };
+
+    const lookupItem = {
+      library_item: {
+        id: 555,
+        title: 'On Your Own Love Again',
+        artist: 'Jessica Pratt',
+        call_number: 'Rock CD PR 1/2',
+        library_url: 'http://www.wxyc.info/wxycdb/libraryRelease?id=555',
+      },
+      matched_via: [{ title: 'Back, Baby', artist_credit: null, confidence: 0.92, source: 'discogs' }],
+    };
+
+    /**
+     * Configure mocks so the *first* call to `searchLibraryByTrack` hits LML +
+     * DB; subsequent calls without resetting the mocks return whatever the
+     * mock would return again (but we'll assert the cache short-circuits
+     * before that).
+     */
+    function primeMocks(): void {
+      mockLookupBySong.mockResolvedValue({
+        results: [lookupItem],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+      const libraryChain = createMockQueryChain([trackRow]);
+      libraryChain.limit = jest.fn().mockResolvedValue([trackRow]);
+      const ctaChain = createMockQueryChain([]);
+      ctaChain.where = jest.fn().mockResolvedValue([]);
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = callIndex === 0 ? libraryChain : ctaChain;
+        callIndex += 1;
+        return chain;
+      });
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      delete process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED;
+      delete process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED;
+      resetCatalogTrackSearchConfig();
+      __resetTrackSearchCacheForTests();
+    });
+
+    afterAll(() => {
+      delete process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED;
+      delete process.env.CATALOG_TRACK_SEARCH_DISCOGS_ENABLED;
+      resetCatalogTrackSearchConfig();
+      __resetTrackSearchCacheForTests();
+    });
+
+    it('first call is a cache miss (invokes LML + DB)', async () => {
+      primeMocks();
+
+      const results = await searchLibraryByTrack('Back, Baby', 10);
+
+      expect(mockLookupBySong).toHaveBeenCalledTimes(1);
+      expect(db.select).toHaveBeenCalled(); // PG JOIN ran
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(101);
+    });
+
+    it('second identical call is a cache hit (skips LML + DB)', async () => {
+      primeMocks();
+
+      const first = await searchLibraryByTrack('Back, Baby', 10);
+      const dbCallCountAfterMiss = db.select.mock.calls.length;
+      const lmlCallCountAfterMiss = mockLookupBySong.mock.calls.length;
+
+      const second = await searchLibraryByTrack('Back, Baby', 10);
+
+      // Neither LML nor any DB select fired on the second call.
+      expect(mockLookupBySong.mock.calls.length).toBe(lmlCallCountAfterMiss);
+      expect(db.select.mock.calls.length).toBe(dbCallCountAfterMiss);
+      // Result identity preserved (the cache stores the exact array reference).
+      expect(second).toBe(first);
+      expect(second[0].id).toBe(101);
+      expect(second[0].matched_via?.[0]).toMatchObject({ source: 'discogs', confidence: 0.92 });
+    });
+
+    it('different queries hit different cache entries (key isolation)', async () => {
+      // Each call needs its own library + CTA chain pair. Use a fresh primeMocks
+      // round per call so db.select has chains queued for both invocations.
+      mockLookupBySong.mockResolvedValue({
+        results: [lookupItem],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+      const libraryChainA = createMockQueryChain([trackRow]);
+      libraryChainA.limit = jest.fn().mockResolvedValue([trackRow]);
+      const ctaChainA = createMockQueryChain([]);
+      ctaChainA.where = jest.fn().mockResolvedValue([]);
+      const libraryChainB = createMockQueryChain([trackRow]);
+      libraryChainB.limit = jest.fn().mockResolvedValue([trackRow]);
+      const ctaChainB = createMockQueryChain([]);
+      ctaChainB.where = jest.fn().mockResolvedValue([]);
+      const chains = [libraryChainA, ctaChainA, libraryChainB, ctaChainB];
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => chains[Math.min(callIndex++, chains.length - 1)]);
+
+      await searchLibraryByTrack('Back, Baby', 10);
+      const callsAfterFirst = mockLookupBySong.mock.calls.length;
+
+      // A different query must re-invoke LML — caches by query, not globally.
+      await searchLibraryByTrack('Different Song', 10);
+
+      expect(mockLookupBySong.mock.calls.length).toBe(callsAfterFirst + 1);
+      expect(mockLookupBySong).toHaveBeenLastCalledWith('Different Song');
+    });
+
+    it('trim + lowercase: variations of the same query share one cache entry', async () => {
+      primeMocks();
+
+      await searchLibraryByTrack('  Back, Baby  ', 10);
+      const callsAfterFirst = mockLookupBySong.mock.calls.length;
+
+      // Normalized identical: lowercase + trim should collapse to the same key.
+      const cached = await searchLibraryByTrack('back, baby', 10);
+
+      expect(mockLookupBySong.mock.calls.length).toBe(callsAfterFirst);
+      expect(cached).toHaveLength(1);
+      expect(cached[0].id).toBe(101);
+    });
+
+    it('flag flip invalidates the cache (same query, different flagStateHash)', async () => {
+      // First call: both flags off (default).
+      primeMocks();
+      await searchLibraryByTrack('Back, Baby', 10);
+      const callsAfterFirst = mockLookupBySong.mock.calls.length;
+
+      // Flip the CTA flag and force a config reload. The flag-state hash
+      // changes, so the cached entry is keyed under the old hash and the new
+      // query must re-fetch from LML.
+      process.env.CATALOG_TRACK_SEARCH_CTA_ENABLED = 'true';
+      resetCatalogTrackSearchConfig();
+
+      // Re-prime the mocks so the second call has fresh chain state.
+      primeMocks();
+      await searchLibraryByTrack('Back, Baby', 10);
+
+      expect(mockLookupBySong.mock.calls.length).toBe(callsAfterFirst + 1);
     });
   });
 

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -900,10 +900,88 @@ describe('library.service', () => {
       // Neither LML nor any DB select fired on the second call.
       expect(mockLookupBySong.mock.calls.length).toBe(lmlCallCountAfterMiss);
       expect(db.select.mock.calls.length).toBe(dbCallCountAfterMiss);
-      // Result identity preserved (the cache stores the exact array reference).
-      expect(second).toBe(first);
+      // Result equality preserved, but the wrapper hands out a shallow copy so
+      // caller-side sorts/mutations don't bleed into subsequent hits.
+      expect(second).toEqual(first);
+      expect(second).not.toBe(first);
       expect(second[0].id).toBe(101);
       expect(second[0].matched_via?.[0]).toMatchObject({ source: 'discogs', confidence: 0.92 });
+    });
+
+    it('does not cache LML failures (next call retries instead of returning poisoned empty)', async () => {
+      // First call: LML rejects. Wrapper degrades to [] but must NOT cache the
+      // empty result — otherwise a transient LML blip would persist for 10
+      // minutes, returning empty for every identical query.
+      mockLookupBySong.mockRejectedValueOnce(new Error('LML 502 Bad Gateway'));
+      db.select.mockReset();
+      const firstResults = await searchLibraryByTrack('Back, Baby', 10);
+      expect(firstResults).toEqual([]);
+      const lmlCallsAfterFailure = mockLookupBySong.mock.calls.length;
+
+      // Second call: LML recovers. The cache must NOT serve the empty result
+      // from the failed call — LML has to be invoked again.
+      primeMocks();
+      const recovered = await searchLibraryByTrack('Back, Baby', 10);
+
+      expect(mockLookupBySong.mock.calls.length).toBe(lmlCallsAfterFailure + 1);
+      expect(recovered).toHaveLength(1);
+      expect(recovered[0].id).toBe(101);
+    });
+
+    it('larger limit miss serves smaller limit hit without re-fetching', async () => {
+      // The cache stores the un-sliced result. A miss at limit=10 plus a
+      // subsequent hit at limit=5 should not re-invoke LML — slicing happens
+      // on the read side.
+      mockLookupBySong.mockResolvedValue({
+        results: [
+          { ...lookupItem, library_item: { ...lookupItem.library_item, id: 555 } },
+          { ...lookupItem, library_item: { ...lookupItem.library_item, id: 556 } },
+          { ...lookupItem, library_item: { ...lookupItem.library_item, id: 557 } },
+        ],
+        search_type: 'direct',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+      const row555 = { ...trackRow, id: 201, legacy_release_id: 555 };
+      const row556 = { ...trackRow, id: 202, legacy_release_id: 556 };
+      const row557 = { ...trackRow, id: 203, legacy_release_id: 557 };
+      const libraryChain = createMockQueryChain([row555, row556, row557]);
+      libraryChain.limit = jest.fn().mockResolvedValue([row555, row556, row557]);
+      const ctaChain = createMockQueryChain([]);
+      ctaChain.where = jest.fn().mockResolvedValue([]);
+      let callIndex = 0;
+      db.select.mockReset();
+      db.select.mockImplementation(() => {
+        const chain = callIndex === 0 ? libraryChain : ctaChain;
+        callIndex += 1;
+        return chain;
+      });
+
+      const big = await searchLibraryByTrack('Back, Baby', 10);
+      expect(big).toHaveLength(3);
+      const callsAfterBig = mockLookupBySong.mock.calls.length;
+
+      // Smaller limit on a primed cache — should hit, not re-fetch.
+      const small = await searchLibraryByTrack('Back, Baby', 2);
+
+      expect(mockLookupBySong.mock.calls.length).toBe(callsAfterBig);
+      expect(small).toHaveLength(2);
+      expect(small.map((r) => r.id)).toEqual([201, 202]);
+    });
+
+    it('returns a shallow copy so caller mutations do not bleed into the next hit', async () => {
+      primeMocks();
+
+      const first = await searchLibraryByTrack('Back, Baby', 10);
+      // Mutate the returned array in place.
+      first.length = 0;
+
+      const second = await searchLibraryByTrack('Back, Baby', 10);
+
+      // Second hit must still produce the cached result, undisturbed by the
+      // first caller's mutation.
+      expect(second).toHaveLength(1);
+      expect(second[0].id).toBe(101);
     });
 
     it('different queries hit different cache entries (key isolation)', async () => {


### PR DESCRIPTION
Closes #827.

LRU cache around `searchLibraryByTrack` (E2-3 / PR #852). Caches the final mapped `EnrichedLibraryResult[]` keyed by lowercased+trimmed query plus a flag-state hash, so hits skip both the LML round-trip and the BS PG JOIN — the two hops Track 2 pays in full today.

## Config

- Size: 1000
- TTL: 10 minutes
- Key: `lowercase(trim(query)) + ':' + limit + ':' + flagStateHash`
- Invalidation: a flag flip changes the `flagStateHash` prefix, so old entries are stranded under the previous key and age out via TTL. No explicit eviction needed.

## Coordination

- Emits `track_search.cache_hit` on the active Sentry span (no-op if no span is active). E2-8 (#828) sets up the parent span; this side does not create one.

## Pattern

Mirrors `artworkCache` in `apps/backend/controllers/proxy.controller.ts` — module-scoped `LRUCache` from the `lru-cache` package, already a backend dep.

## Test discipline

TDD; first commit on the branch added a new `searchLibraryByTrack cache (LRU)` describe block to `tests/unit/services/library.service.test.ts` covering: miss path, hit path (LML + DB not called twice), key isolation across queries, trim+lowercase normalization, and flag-flip invalidation. Existing `searchLibraryByTrack` describe (plus the cascade describe that calls it transitively) now resets the cache in `beforeEach` so process-local memoization doesn't leak across cases. All 1825 unit tests pass.

## Plan

[catalog-track-search plan §10.3 — Latency & cache budget](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md#103-latency--cache-budget)