### PR TITLE
Rotation dedup: collapse NULL-album_id duplicates by (artist, album) hash

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -179,7 +179,7 @@ type RotationRow = Omit<Rotation, 'reconciled_identity'> & ReconciledIdentitySou
  *   from rotation's denormalized snapshot columns when the library
  *   join is NULL.
  *
- * - **DISTINCT ON `(coalesce(album_id::bigint, -(hashtext(lower(artist)||'|'||lower(album))::bigint) - 1), rotation_bin)`
+ * - **DISTINCT ON `(coalesce(album_id::bigint, -(abs(hashtext(lower(artist)||'|'||lower(album))::bigint) + 1)), rotation_bin)`
  *   ORDER BY same key, then `add_date DESC, id ASC`.**
  *   Tubafrenzy permits multiple active rows per
  *   `(album_id, rotation_bin)` over an album's lifecycle (re-bins,
@@ -197,10 +197,10 @@ type RotationRow = Omit<Rotation, 'reconciled_identity'> & ReconciledIdentitySou
  *   prior `-id` trick was unique-per-row and never collapsed.
  *   `hashtext` is deterministic and cheap; collisions at this row
  *   count are negligible (birthday-bound ~32k for a 32-bit space and
- *   we're at ~151). The cast to `bigint` before negating guards
- *   against the latent `integer out of range` Postgres raises when
- *   `-INT_MIN` would overflow int4; `- 1` keeps the negated key
- *   strictly negative so it can't collide with any positive album_id.
+ *   we're at ~151). `abs(hashtext::bigint) + 1` is always >= 1 (no
+ *   int4 overflow on `abs(INT_MIN)` because it widens to bigint
+ *   cleanly); negating gives a strictly negative key so it can never
+ *   collide with a positive `album_id`.
  *
  * - **`kill_date IS NULL OR kill_date > CURRENT_DATE`.** Active rows
  *   only; the planner-stable predicate also excludes future-dated
@@ -210,14 +210,18 @@ export const getRotationFromDB = async (): Promise<Rotation[]> => {
   // Stable partition key for the DISTINCT ON / ORDER BY: real album_id when
   // present, else a hash of the (artist_name, album_title) snapshot so
   // unlinked duplicates collapse together (#862). The expression is computed
-  // entirely in bigint so it cannot overflow: `hashtext` returns int4, and
-  // negating `INT_MIN` would otherwise raise `integer out of range` on Postgres
-  // — vanishingly unlikely per row but a latent runtime error with no guard.
-  // Casting the hash to bigint first and shifting by -1 keeps the negated key
-  // strictly negative (so it can't collide with any positive `album_id`).
+  // entirely in bigint to defuse two latent failures:
+  //   1. `hashtext` returns int4; negating `INT_MIN` raises `integer out of
+  //      range` on Postgres rather than wrapping.
+  //   2. Naïvely negating a negative `hashtext` produces a positive value
+  //      that could collide with a real positive `album_id` in the COALESCE
+  //      and silently drop a real-album row from the output.
+  // `abs(hashtext::bigint) + 1` is always >= 1 (no overflow because
+  // `abs(INT_MIN)` widens to bigint cleanly); negating gives <= -1 — strictly
+  // negative, so it can never collide with a positive `album_id`.
   const partitionKey = sql`COALESCE(
     ${rotation.album_id}::bigint,
-    -(hashtext(lower(coalesce(${rotation.artist_name}, '')) || '|' || lower(coalesce(${rotation.album_title}, '')))::bigint) - 1
+    -(abs(hashtext(lower(coalesce(${rotation.artist_name}, '')) || '|' || lower(coalesce(${rotation.album_title}, '')))::bigint) + 1)
   )`;
   const query = sql`
     SELECT DISTINCT ON (${partitionKey}, ${rotation.rotation_bin})

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -179,7 +179,7 @@ type RotationRow = Omit<Rotation, 'reconciled_identity'> & ReconciledIdentitySou
  *   from rotation's denormalized snapshot columns when the library
  *   join is NULL.
  *
- * - **DISTINCT ON `(coalesce(album_id, -hashtext(lower(artist)||'|'||lower(album))::int), rotation_bin)`
+ * - **DISTINCT ON `(coalesce(album_id::bigint, -(hashtext(lower(artist)||'|'||lower(album))::bigint) - 1), rotation_bin)`
  *   ORDER BY same key, then `add_date DESC, id ASC`.**
  *   Tubafrenzy permits multiple active rows per
  *   `(album_id, rotation_bin)` over an album's lifecycle (re-bins,
@@ -197,7 +197,10 @@ type RotationRow = Omit<Rotation, 'reconciled_identity'> & ReconciledIdentitySou
  *   prior `-id` trick was unique-per-row and never collapsed.
  *   `hashtext` is deterministic and cheap; collisions at this row
  *   count are negligible (birthday-bound ~32k for a 32-bit space and
- *   we're at ~151).
+ *   we're at ~151). The cast to `bigint` before negating guards
+ *   against the latent `integer out of range` Postgres raises when
+ *   `-INT_MIN` would overflow int4; `- 1` keeps the negated key
+ *   strictly negative so it can't collide with any positive album_id.
  *
  * - **`kill_date IS NULL OR kill_date > CURRENT_DATE`.** Active rows
  *   only; the planner-stable predicate also excludes future-dated
@@ -206,10 +209,15 @@ type RotationRow = Omit<Rotation, 'reconciled_identity'> & ReconciledIdentitySou
 export const getRotationFromDB = async (): Promise<Rotation[]> => {
   // Stable partition key for the DISTINCT ON / ORDER BY: real album_id when
   // present, else a hash of the (artist_name, album_title) snapshot so
-  // unlinked duplicates collapse together (#862).
+  // unlinked duplicates collapse together (#862). The expression is computed
+  // entirely in bigint so it cannot overflow: `hashtext` returns int4, and
+  // negating `INT_MIN` would otherwise raise `integer out of range` on Postgres
+  // — vanishingly unlikely per row but a latent runtime error with no guard.
+  // Casting the hash to bigint first and shifting by -1 keeps the negated key
+  // strictly negative (so it can't collide with any positive `album_id`).
   const partitionKey = sql`COALESCE(
-    ${rotation.album_id},
-    -hashtext(lower(coalesce(${rotation.artist_name}, '')) || '|' || lower(coalesce(${rotation.album_title}, '')))::int
+    ${rotation.album_id}::bigint,
+    -(hashtext(lower(coalesce(${rotation.artist_name}, '')) || '|' || lower(coalesce(${rotation.album_title}, '')))::bigint) - 1
   )`;
   const query = sql`
     SELECT DISTINCT ON (${partitionKey}, ${rotation.rotation_bin})

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -179,25 +179,40 @@ type RotationRow = Omit<Rotation, 'reconciled_identity'> & ReconciledIdentitySou
  *   from rotation's denormalized snapshot columns when the library
  *   join is NULL.
  *
- * - **DISTINCT ON `(coalesce(album_id, -id), rotation_bin)` ORDER BY
- *   `coalesce(album_id, -id), rotation_bin, add_date DESC, id ASC`.**
+ * - **DISTINCT ON `(coalesce(album_id, -hashtext(lower(artist)||'|'||lower(album))::int), rotation_bin)`
+ *   ORDER BY same key, then `add_date DESC, id ASC`.**
  *   Tubafrenzy permits multiple active rows per
  *   `(album_id, rotation_bin)` over an album's lifecycle (re-bins,
  *   re-adds, label-driven re-promotes); we collapse those duplicates
  *   to one row per group on the way out, picking the most-recently
  *   added (tie-broken by lowest rotation id for deterministic output).
- *   The `coalesce(album_id, -id)` trick keeps NULL-album rows in
- *   separate groups (Postgres DISTINCT ON treats NULLs as equal
- *   without it, which would collapse the 147 NULL-album rows down
- *   to one).
+ *   When `album_id IS NULL` (151/310 active rows in the 2026-05-14
+ *   prod snapshot — tubafrenzy entries that never resolved to a
+ *   library row), we partition on a hash of the denormalized
+ *   `(artist_name, album_title)` snapshot columns instead. This both
+ *   keeps NULL-album rows in their own groups (Postgres DISTINCT ON
+ *   would otherwise treat NULLs as equal and collapse all 151 to one)
+ *   AND collapses unlinked dupes that share the same release — fixing
+ *   #862, where the dropdown surfaced the same release ×3 because the
+ *   prior `-id` trick was unique-per-row and never collapsed.
+ *   `hashtext` is deterministic and cheap; collisions at this row
+ *   count are negligible (birthday-bound ~32k for a 32-bit space and
+ *   we're at ~151).
  *
  * - **`kill_date IS NULL OR kill_date > CURRENT_DATE`.** Active rows
  *   only; the planner-stable predicate also excludes future-dated
  *   kills correctly.
  */
 export const getRotationFromDB = async (): Promise<Rotation[]> => {
+  // Stable partition key for the DISTINCT ON / ORDER BY: real album_id when
+  // present, else a hash of the (artist_name, album_title) snapshot so
+  // unlinked duplicates collapse together (#862).
+  const partitionKey = sql`COALESCE(
+    ${rotation.album_id},
+    -hashtext(lower(coalesce(${rotation.artist_name}, '')) || '|' || lower(coalesce(${rotation.album_title}, '')))::int
+  )`;
   const query = sql`
-    SELECT DISTINCT ON (COALESCE(${rotation.album_id}, -${rotation.id}), ${rotation.rotation_bin})
+    SELECT DISTINCT ON (${partitionKey}, ${rotation.rotation_bin})
       ${library.id} AS id,
       ${artists.code_letters} AS code_letters,
       ${genre_artist_crossreference.artist_genre_code} AS code_artist_number,
@@ -230,7 +245,7 @@ export const getRotationFromDB = async (): Promise<Rotation[]> => {
       ON ${genre_artist_crossreference.artist_id} = ${library.artist_id}
       AND ${genre_artist_crossreference.genre_id} = ${library.genre_id}
     WHERE ${rotation.kill_date} > CURRENT_DATE OR ${rotation.kill_date} IS NULL
-    ORDER BY COALESCE(${rotation.album_id}, -${rotation.id}),
+    ORDER BY ${partitionKey},
              ${rotation.rotation_bin},
              ${rotation.add_date} DESC,
              ${rotation.id} ASC

--- a/tests/fixtures/shape.sql
+++ b/tests/fixtures/shape.sql
@@ -107,6 +107,10 @@ SELECT setval('wxyc_schema.library_id_seq', 7099, true);
 --   * 2 NULL album_id rows (rotation.album_id is FK-ON-DELETE-CASCADE
 --     nullable). Real prod has these from tubafrenzy adds where the
 --     library row was later deleted.
+--   * 1 additional NULL album_id row matching Orphan One's
+--     (artist, album, bin) so the read collapses unlinked duplicates
+--     via the hash partition key (#862; 151/310 active rotation rows
+--     in the 2026-05-14 prod snapshot had album_id IS NULL).
 --   * 1 row with kill_date > CURRENT_DATE (the planner-stable predicate
 --     `kill_date IS NULL` does NOT exclude this row even though the
 --     semantically-richer "is active" predicate would).
@@ -127,6 +131,9 @@ VALUES
   -- 2 rows with NULL album_id (orphaned tubafrenzy rows)
   (7007, NULL, 'L', '2024-05-20', NULL, 'Shape Fixture Orphan One',   'Shape Fixture Orphan Album One', NULL,                70007),
   (7008, NULL, 'M', '2024-07-04', NULL, 'Shape Fixture Orphan Two',   'Shape Fixture Orphan Album Two', NULL,                70008),
+  -- Second NULL-album row matching Orphan One's (artist, album, bin) so the
+  -- hash partition key collapses unlinked duplicates (#862).
+  (7015, NULL, 'L', '2024-09-12', NULL, 'Shape Fixture Orphan One',   'Shape Fixture Orphan Album One', NULL,                70015),
   -- 1 row with kill_date > CURRENT_DATE (future-dated retirement).
   -- The planner-stable `WHERE kill_date IS NULL` predicate does NOT
   -- exclude this row, so a unique partial index over that predicate

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -258,9 +258,10 @@ describe('Library Rotation', () => {
     test('surfaces rotation rows with NULL album_id using denormalized snapshot fields (#689)', async () => {
       const res = await auth.get('/library/rotation').expect(200);
 
-      // The shape fixture seeds 2 rotation rows with album_id IS NULL.
-      // They should appear with id=null and artist_name/album_title
-      // populated from rotation's denormalized columns.
+      // The shape fixture seeds NULL-album rotation rows that all start
+      // with 'Shape Fixture Orphan' in artist_name. After #862's hash-
+      // partitioned dedup, the two rows in Orphan One's (artist, album,
+      // bin) group collapse to one, leaving 2 distinct fixture orphans.
       const orphans = res.body.filter((r) => r.id === null);
       expect(orphans.length).toBeGreaterThanOrEqual(2);
 
@@ -284,6 +285,23 @@ describe('Library Rotation', () => {
         album_title: 'Shape Fixture Orphan Album Two',
         rotation_bin: 'M',
       });
+    });
+
+    test('collapses NULL-album rows sharing (artist, album, rotation_bin) to one (#862)', async () => {
+      // The shape fixture seeds two NULL-album_id rotation rows (ids
+      // 7007 and 7015) with identical artist/album/bin. The pre-#862
+      // partition key was `coalesce(album_id, -id)`, which was unique
+      // per row and let both survive DISTINCT ON; the hash partition
+      // key collapses them to a single row. Pick the most-recently
+      // added (rotation_add_date '2024-09-12' from row 7015) per the
+      // ORDER BY add_date DESC, id ASC.
+      const res = await auth.get('/library/rotation').expect(200);
+
+      const orphanOneRows = res.body.filter(
+        (r) => r.id === null && r.artist_name === 'Shape Fixture Orphan One' && r.rotation_bin === 'L'
+      );
+      expect(orphanOneRows).toHaveLength(1);
+      expect(orphanOneRows[0].rotation_add_date).toBe('2024-09-12');
     });
   });
 

--- a/tests/unit/services/library.rotation.test.ts
+++ b/tests/unit/services/library.rotation.test.ts
@@ -348,6 +348,9 @@ describe('library.service / getRotationFromDB', () => {
       const stringified = JSON.stringify(sqlArg);
       expect(stringified).toMatch(/hashtext/);
       expect(stringified).toMatch(/lower/);
+      // The expression must be evaluated in bigint to defuse the
+      // `-INT_MIN` int4 overflow Postgres would otherwise raise.
+      expect(stringified).toMatch(/::bigint/);
       // The pre-#862 `-rotation.id` partition trick should no longer
       // appear in the query.
       expect(stringified).not.toMatch(/-"rotation"\."id"/);

--- a/tests/unit/services/library.rotation.test.ts
+++ b/tests/unit/services/library.rotation.test.ts
@@ -290,5 +290,67 @@ describe('library.service / getRotationFromDB', () => {
 
       expect(result).toEqual([]);
     });
+
+    /**
+     * #862: NULL-album_id rows with the same (artist, album, bin) used
+     * to escape DISTINCT ON because the old partition key was
+     * `-rotation.id` (unique per row). The new key hashes the
+     * denormalized (artist_name, album_title) snapshot columns when
+     * album_id IS NULL, so unlinked dupes collapse. Postgres returns
+     * the post-collapse shape; we assert the serializer ships exactly
+     * one row through with the most-recent rotation_add_date (per
+     * ORDER BY add_date DESC).
+     */
+    it('passes through collapsed NULL-album duplicate groups as a single row (#862)', async () => {
+      const collapsed = orphanRow({
+        rotation_id: 7015,
+        artist_name: 'Shape Fixture Orphan One',
+        album_title: 'Shape Fixture Orphan Album One',
+        alphabetical_name: 'Shape Fixture Orphan One',
+        rotation_bin: 'L',
+        rotation_add_date: '2024-09-12',
+      });
+      db.execute.mockResolvedValueOnce([collapsed]);
+
+      const result = await getRotationFromDB();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: null,
+        rotation_id: 7015,
+        artist_name: 'Shape Fixture Orphan One',
+        album_title: 'Shape Fixture Orphan Album One',
+        rotation_bin: 'L',
+        rotation_add_date: '2024-09-12',
+      });
+    });
+  });
+
+  /**
+   * SQL-shape contract: the rotation query has to use a hash-based
+   * partition key when album_id IS NULL (#862). The unit-level mock
+   * can't observe Postgres's DISTINCT ON behavior, so this test
+   * inspects the SQL template handed to `db.execute` to make sure the
+   * intended fragment is wired in. Integration coverage of the actual
+   * dedup against real rows lives in tests/integration/library.spec.js.
+   */
+  describe('SQL shape', () => {
+    it('uses hashtext on (artist_name, album_title) as the NULL-album partition key (#862)', async () => {
+      db.execute.mockResolvedValueOnce([]);
+
+      await getRotationFromDB();
+
+      expect(db.execute).toHaveBeenCalledTimes(1);
+      const sqlArg = db.execute.mock.calls[0][0];
+      // Drizzle SQL objects expose their literal text fragments via
+      // `queryChunks` (an array of StringChunk + Column objects).
+      // Stringify and assert the new partition key is present.
+      const stringified = JSON.stringify(sqlArg);
+      expect(stringified).toMatch(/hashtext/);
+      expect(stringified).toMatch(/lower/);
+      // The pre-#862 `-rotation.id` partition trick should no longer
+      // appear in the query.
+      expect(stringified).not.toMatch(/-"rotation"\."id"/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `getRotationFromDB`'s DISTINCT ON partition key was `COALESCE(album_id, -id)`. When `album_id IS NULL` (151 of 310 active rows in the 2026-05-14 prod snapshot — tubafrenzy adds where the mirror never resolved a library row), the `-id` fallback was unique per row and never collapsed dupes. The dropdown surfaced unlinked releases ×3 (Veronique Diabolique — Cafe Solitude, Sparrowhouse — Falls EP).
- Replace the NULL fallback with `-(abs(hashtext(lower(artist_name) || '|' || lower(album_title))::bigint) + 1)` so rotation rows sharing the denormalized snapshot collapse together. ORDER BY shape preserved; most-recent `rotation_add_date` still wins.
- Bigint arithmetic + `abs(...) + 1` defuses two latent failures: `-INT_MIN` int4 overflow (Postgres raises `integer out of range`) and sign-flip collision with positive `album_id` values.

## Test plan

- [x] Unit tests pass (`npm run test:unit`) — 1835/1835.
- [x] `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check` pass.
- [ ] CI integration tests pass against the updated `tests/fixtures/shape.sql` (adds row 7015, a second NULL-album row matching Orphan One's (artist, album, bin)).
- [ ] Verify post-deploy on prod that the user-visible 3× repeats are gone.

Closes #862.