### PR TITLE
feat(lml): warm discogs-cache on every flowsheet write

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^10.52.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.4.0",
+    "@wxyc/shared": "^1.5.0",
     "better-auth": "^1.6.9",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,7 +21,7 @@
     "@tensorflow/tfjs": "^4.22.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.4.0",
+    "@wxyc/shared": "^1.5.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.16.0",

--- a/apps/backend/services/flowsheet-linkage.service.ts
+++ b/apps/backend/services/flowsheet-linkage.service.ts
@@ -65,7 +65,17 @@ export async function runLmlLinkage(args: {
 
   let response;
   try {
-    response = await lookupMetadata(artistName, albumTitle ?? undefined);
+    // warm_cache=true: this is the write-path entry point for newly inserted
+    // flowsheet rows. LML schedules a fire-and-forget background task that
+    // deep-parses the top-1 artist's bio against the API-capable resolver,
+    // populating the discogs-cache for referenced entities (`[a…]`/`[r…]`/
+    // `[m…]`). Subsequent read-path lookups for the same artist (typically
+    // an iOS listener fetching playcut metadata seconds later) get richer
+    // profile_tokens for free, without adding latency to this write path.
+    // LML bounds concurrent warm tasks process-wide to cap Discogs amplification.
+    response = await lookupMetadata(artistName, albumTitle ?? undefined, undefined, {
+      warm_cache: true,
+    });
   } catch (error) {
     // The forward path is fire-and-forget — we own error reporting here so
     // the caller's `.catch` is only a safety net for unexpected bugs.

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -103,6 +103,36 @@ async function lmlFetch(path: string, init?: RequestInit): Promise<Response> {
 }
 
 /**
+ * Optional flags accepted by LML's `/api/v1/lookup` since `@wxyc/shared@1.5.0`.
+ *
+ * - `extended`: surfaces additional fields on the top-1 `DiscogsMatchResult`
+ *   (tracklist, genres, styles, label, full_release_date, discogs_artist_id,
+ *   artist_image_url, profile_tokens). Use on the read path that already
+ *   intends to consume those fields (e.g. the proxy/metadata/album collapse)
+ *   so a single lookup replaces the follow-up release+artist fetches.
+ *
+ * - `warm_cache`: on the LML side, schedules a fire-and-forget background
+ *   task that runs a deep async parse of the top-1 bio against the
+ *   API-capable resolver, populating the PG cache for referenced entities.
+ *   Use on the write path — DJ-flowsheet commit, rotation add — where a
+ *   subsequent read for the same artist will benefit. Read-path callers
+ *   leave this `false` to avoid amplifying Discogs API load.
+ */
+export interface LookupOptions {
+  extended?: boolean;
+  warm_cache?: boolean;
+}
+
+type LookupBody = {
+  artist?: string;
+  album?: string;
+  song?: string;
+  raw_message: string;
+  extended?: boolean;
+  warm_cache?: boolean;
+};
+
+/**
  * Look up a release in the library catalog via LML's full search pipeline.
  *
  * Provides artist correction, title normalization, fallback strategies,
@@ -111,16 +141,24 @@ async function lmlFetch(path: string, init?: RequestInit): Promise<Response> {
  * @param artist - Artist name
  * @param album - Album/release title
  * @param song - Song/track title
+ * @param options - Optional LML flags. See `LookupOptions`.
  * @returns Lookup results with library items and enriched artwork metadata
  */
-export async function lookupMetadata(artist: string, album?: string, song?: string): Promise<LookupResponse> {
+export async function lookupMetadata(
+  artist: string,
+  album?: string,
+  song?: string,
+  options?: LookupOptions
+): Promise<LookupResponse> {
   // LML's /lookup contract requires `raw_message` even when artist/album/song
   // are already structured. Synthesize a free-form description that the LML
   // parser would have produced — matches the e2e fixtures in LML's repo.
   const rawMessage = [artist, album, song].filter(Boolean).join(' - ');
-  const body: Record<string, string> = { artist, raw_message: rawMessage };
+  const body: LookupBody = { artist, raw_message: rawMessage };
   if (album) body.album = album;
   if (song) body.song = song;
+  if (options?.extended) body.extended = true;
+  if (options?.warm_cache) body.warm_cache = true;
   return postLookup(body);
 }
 
@@ -145,7 +183,7 @@ export async function lookupBySong(song: string): Promise<LookupResponse> {
  * the metadata-backfill pilot or the runtime hot path. Sibling LML-side
  * projection at WXYC/library-metadata-lookup#213.
  */
-async function postLookup(body: Record<string, string>): Promise<LookupResponse> {
+async function postLookup(body: LookupBody): Promise<LookupResponse> {
   return Sentry.startSpan({ name: 'lml.lookup', op: 'http.client' }, async (span) => {
     const response = await lmlFetch('/api/v1/lookup', {
       method: 'POST',

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "@sentry/node": "^10.52.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.4.0",
+        "@wxyc/shared": "^1.5.0",
         "better-auth": "^1.6.9",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -121,9 +121,9 @@
       }
     },
     "apps/auth/node_modules/@wxyc/shared": {
-      "version": "1.4.1",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.4.1/2f1084d423fa6b9e0487034bd09d6a5e0ede1cbb",
-      "integrity": "sha512-ojzbSVtjSy1HQykHGP/3OhaBG5KxAYKMh043W4YJkd/NNQKQQLT1bvkTP6sqzzURhLk02L5kwfYg5PDg8DPCJA==",
+      "version": "1.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.5.0/d39ca7a99054d44b105dbfc0306de1fb4b68b092",
+      "integrity": "sha512-YyCHTaSdGGwdxXbNUVQiopXyYVWZPgSoQltE6l2aDkK+SX6M9IQiikVNC0307APJc/0GVSdmxU2xhBkOtZgz8w==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -267,7 +267,7 @@
         "@tensorflow/tfjs": "^4.22.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.4.0",
+        "@wxyc/shared": "^1.5.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.16.0",
@@ -319,9 +319,9 @@
       }
     },
     "apps/backend/node_modules/@wxyc/shared": {
-      "version": "1.4.1",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.4.1/2f1084d423fa6b9e0487034bd09d6a5e0ede1cbb",
-      "integrity": "sha512-ojzbSVtjSy1HQykHGP/3OhaBG5KxAYKMh043W4YJkd/NNQKQQLT1bvkTP6sqzzURhLk02L5kwfYg5PDg8DPCJA==",
+      "version": "1.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.5.0/d39ca7a99054d44b105dbfc0306de1fb4b68b092",
+      "integrity": "sha512-YyCHTaSdGGwdxXbNUVQiopXyYVWZPgSoQltE6l2aDkK+SX6M9IQiikVNC0307APJc/0GVSdmxU2xhBkOtZgz8w==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -15440,7 +15440,7 @@
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1045.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.4.0",
+        "@wxyc/shared": "^1.5.0",
         "better-auth": "^1.6.9",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -15476,9 +15476,9 @@
       }
     },
     "shared/authentication/node_modules/@wxyc/shared": {
-      "version": "1.4.1",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.4.1/2f1084d423fa6b9e0487034bd09d6a5e0ede1cbb",
-      "integrity": "sha512-ojzbSVtjSy1HQykHGP/3OhaBG5KxAYKMh043W4YJkd/NNQKQQLT1bvkTP6sqzzURhLk02L5kwfYg5PDg8DPCJA==",
+      "version": "1.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.5.0/d39ca7a99054d44b105dbfc0306de1fb4b68b092",
+      "integrity": "sha512-YyCHTaSdGGwdxXbNUVQiopXyYVWZPgSoQltE6l2aDkK+SX6M9IQiikVNC0307APJc/0GVSdmxU2xhBkOtZgz8w==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1045.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.4.0",
+    "@wxyc/shared": "^1.5.0",
     "better-auth": "^1.6.9",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/tests/unit/services/flowsheet-linkage.service.test.ts
+++ b/tests/unit/services/flowsheet-linkage.service.test.ts
@@ -63,7 +63,12 @@ describe('runLmlLinkage (B-2.1)', () => {
       albumTitle: 'DOGA',
     });
 
-    expect(mockLookupMetadata).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+    // Forward-path linkage fires the LML write-path warm so the discogs-cache
+    // gets primed for any bio refs on the artist just played. The next iOS
+    // lookup for the same artist renders richer profile_tokens for free.
+    expect(mockLookupMetadata).toHaveBeenCalledWith('Juana Molina', 'DOGA', undefined, {
+      warm_cache: true,
+    });
     expect(outcome).toEqual({
       status: 'linked',
       libraryId: 88,


### PR DESCRIPTION
## Summary

- `runLmlLinkage` (the forward-path linkage that runs on every `addEntry` insert) now passes `warm_cache: true` on its LML `/api/v1/lookup` call. LML schedules a fire-and-forget background task that deep-parses the top-1 artist's bio against its API-capable resolver, populating the discogs-cache for `[a…]`/`[r…]`/`[m…]` references.
- Adds an optional `LookupOptions` surface to `lookupMetadata` in `lml.client.ts` covering both `warm_cache` (used here) and `extended` (used by a follow-up PR that collapses `/proxy/metadata/album` to a single LML call).
- Bumps `@wxyc/shared` from `^1.4.0` → `^1.5.0` across all workspaces so the schema for the new request flags is available. Strictly additive; no consumer-visible behavior change for non-flowsheet callers.

This is the write-path half of the BS-side rollout in the subsecond-iOS-metadata initiative. Shipping the warm hook first means the discogs-cache is already pre-primed by the time the read-path collapse goes live, so cold-cache iOS metadata renders see the full warm benefit on day one. LML bounds concurrent warm tasks process-wide (`_WARM_CACHE_CONCURRENCY = 4`) to cap Discogs API amplification.

Closes #874

## Test plan

- [x] `npm run test:unit` — 1848 passed (1 modified: `flowsheet-linkage.service.test.ts` asserts the new `warm_cache` arg)
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [ ] CI green
- [ ] Smoke against staging: commit a flowsheet entry for an artist with a richly-cross-referenced Discogs bio (Stereolab is a good one — its bio mentions member artists by ID). Verify subsequent `POST /api/v1/lookup` with `extended=true` for the same artist returns `profile_tokens` with `ArtistLinkToken` entries instead of plain text.