### PR TITLE
feat(proxy): collapse /proxy/metadata/album to a single LML call (feature-flagged)

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -20,7 +20,7 @@ import {
   resolveEntity as lmlResolveEntity,
   searchLibrary,
 } from '../services/lml/lml.client.js';
-import type { DiscogsMatchResult, LookupResponse } from '../services/lml/lml.client.js';
+import type { DiscogsMatchResult, DiscogsTrackItem, LookupResponse } from '../services/lml/lml.client.js';
 import { LRUCache } from 'lru-cache';
 import WxycError from '../utils/error.js';
 
@@ -237,7 +237,7 @@ function populateReleaseMetadata(
     label?: string | null;
     artist_id?: number | null;
     released?: string | null;
-    tracklist?: Array<{ position: string; title: string; duration?: string | null }> | null;
+    tracklist?: DiscogsTrackItem[] | null;
     artwork_url?: string | null;
   }
 ): void {

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -10,6 +10,7 @@
  * `proxyRateLimit` middleware applied at the route level.
  */
 import { RequestHandler } from 'express';
+import * as Sentry from '@sentry/node';
 import { getArtworkFinder } from '../services/artwork/finder.js';
 import { classify as classifyNSFW } from '../services/artwork/nsfw.js';
 import {
@@ -19,8 +20,31 @@ import {
   resolveEntity as lmlResolveEntity,
   searchLibrary,
 } from '../services/lml/lml.client.js';
+import type { DiscogsMatchResult, LookupResponse } from '../services/lml/lml.client.js';
 import { LRUCache } from 'lru-cache';
 import WxycError from '../utils/error.js';
+
+/**
+ * Toggle the single-call /proxy/metadata/album path.
+ *
+ * When `'true'`, we pass `extended: true` to LML's `/api/v1/lookup` and read
+ * the tracklist/genres/styles/label/full_release_date/discogs_artist_id off
+ * the lookup response's `artwork` block directly — no follow-up
+ * `/api/v1/discogs/release/{id}` call. Available since `@wxyc/shared@1.5.0`
+ * + LML#335.
+ *
+ * Defaults off so the flag can ship before production traffic is cut over.
+ * Flip in Railway env (`PROXY_METADATA_SINGLE_LOOKUP=true`) once staging
+ * smoke-tests confirm response parity. Matches the env-var pattern used
+ * for AUTH_BYPASS / TEST_RATE_LIMITING — there's no centralized
+ * feature-flag module in this repo.
+ *
+ * After the cutover is stable, the flag and the legacy two-call branch get
+ * deleted together (separate cleanup PR).
+ */
+function singleLookupEnabled(): boolean {
+  return process.env.PROXY_METADATA_SINGLE_LOOKUP === 'true';
+}
 
 /** Spotify OAuth2 token response. */
 interface SpotifyTokenResponse {
@@ -165,71 +189,151 @@ export const searchArtwork: RequestHandler<object, unknown, unknown, ArtworkSear
 };
 
 /**
+ * Drop Discogs spacer.gif placeholders so the iOS client can draw its own
+ * placeholder rather than rendering a broken/blank image. See #649.
+ */
+function dropSpacerGif(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  return url.includes('spacer.gif') ? undefined : url;
+}
+
+/**
+ * Populate metadata fields that come from the lookup response's artwork block
+ * — release id/url, artwork URL, artist bio/wiki, streaming URLs. These are
+ * present regardless of whether `extended=true` was requested.
+ */
+function populateCommonMetadataFields(metadata: Record<string, unknown>, artwork: DiscogsMatchResult): void {
+  metadata.discogsReleaseId = artwork.release_id;
+  metadata.discogsUrl = artwork.release_url;
+  metadata.artworkUrl = dropSpacerGif(artwork.artwork_url);
+
+  if (artwork.artist_bio) metadata.artistBio = artwork.artist_bio;
+  if (artwork.wikipedia_url) metadata.artistWikipediaUrl = artwork.wikipedia_url;
+
+  if (artwork.spotify_url) metadata.spotifyUrl = artwork.spotify_url;
+  if (artwork.apple_music_url) metadata.appleMusicUrl = artwork.apple_music_url;
+  if (artwork.youtube_music_url) metadata.youtubeMusicUrl = artwork.youtube_music_url;
+  if (artwork.bandcamp_url) metadata.bandcampUrl = artwork.bandcamp_url;
+  if (artwork.soundcloud_url) metadata.soundcloudUrl = artwork.soundcloud_url;
+}
+
+/**
+ * Populate the release-detail fields (tracklist, genres, styles, label,
+ * full release date, discogs artist id, release year). Source-agnostic:
+ * works the same on a `DiscogsMatchResult` with `extended=true` (new path)
+ * or on a `DiscogsReleaseMetadata` from a separate `getRelease()` call
+ * (legacy two-call path).
+ *
+ * On the extended path the release artwork URL is the same as the lookup
+ * artwork URL, so the `prefer release artwork over lookup` logic is a no-op
+ * but kept for symmetry with the legacy path.
+ */
+function populateReleaseMetadata(
+  metadata: Record<string, unknown>,
+  release: {
+    year?: number | null;
+    genres?: string[] | null;
+    styles?: string[] | null;
+    label?: string | null;
+    artist_id?: number | null;
+    released?: string | null;
+    tracklist?: Array<{ position: string; title: string; duration?: string | null }> | null;
+    artwork_url?: string | null;
+  }
+): void {
+  metadata.releaseYear = release.year ?? undefined;
+  metadata.genres = release.genres && release.genres.length > 0 ? release.genres : undefined;
+  metadata.styles = release.styles && release.styles.length > 0 ? release.styles : undefined;
+  metadata.label = release.label ?? undefined;
+  metadata.discogsArtistId = release.artist_id ?? null;
+  metadata.fullReleaseDate = release.released ?? undefined;
+  if (release.tracklist && release.tracklist.length > 0) {
+    metadata.tracklist = release.tracklist.map((t) => ({
+      position: t.position,
+      title: t.title,
+      duration: t.duration ?? undefined,
+    }));
+  }
+  // Prefer release artwork over lookup artwork — but still filter out
+  // spacer.gif placeholders (see #649). On the extended path the values
+  // are typically identical; on the legacy path the release fetch can
+  // surface a higher-quality image.
+  const releaseArtwork = dropSpacerGif(release.artwork_url);
+  if (releaseArtwork) metadata.artworkUrl = releaseArtwork;
+}
+
+/**
  * GET /proxy/metadata/album
  *
  * Fetches album metadata from LML. The LML search response already includes
  * enriched streaming URLs (Spotify, Apple Music, YouTube Music, Bandcamp,
  * SoundCloud), so no direct calls to those APIs are needed.
+ *
+ * Two code paths, selected by `PROXY_METADATA_SINGLE_LOOKUP`:
+ *
+ * - **Single-call** (flag on, future default): LML `/api/v1/lookup` with
+ *   `extended: true` returns release details inline on the top-1 artwork
+ *   block. One round-trip iOS → BS → LML; the LML pipeline runs its release
+ *   and artist fetches concurrently server-side. Subsecond p50 target.
+ *
+ * - **Legacy two-call** (flag off, current default): one lookup followed
+ *   by a separate `/api/v1/discogs/release/{id}` for the release details
+ *   we want to surface. Two LML round-trips, the second one re-fetching
+ *   release data LML already loaded ~100ms earlier during enrichment.
+ *
+ * Sentry annotates the active span with
+ * `proxy.metadata.album.upstream_calls` so the cutover can be graphed by
+ * cohort in the trace explorer.
  */
 export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMetadataQuery> = async (req, res) => {
   const { artistName, releaseTitle, trackTitle } = req.query;
 
   if (!artistName) throw new WxycError('artistName query parameter is required', 400);
 
+  const useSingleLookup = singleLookupEnabled();
   const metadata: Record<string, unknown> = {};
   const searchTerm = releaseTitle || trackTitle || '';
+  let upstreamCalls = 0;
 
-  let artwork;
+  let artwork: DiscogsMatchResult | undefined;
   try {
-    const lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle);
+    let lookupResponse: LookupResponse;
+    if (useSingleLookup) {
+      lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle, { extended: true });
+    } else {
+      lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle);
+    }
+    upstreamCalls += 1;
     artwork = lookupResponse.results?.[0]?.artwork;
   } catch (searchError) {
     console.warn('[ProxyController] LML lookup failed:', searchError);
   }
 
   if (artwork) {
-    metadata.discogsReleaseId = artwork.release_id;
-    metadata.discogsUrl = artwork.release_url;
-    // Drop Discogs spacer.gif placeholder so the iOS client knows to draw its
-    // own placeholder rather than rendering a broken/blank image. See #649
-    // for the full callsite audit.
-    metadata.artworkUrl =
-      artwork.artwork_url && !artwork.artwork_url.includes('spacer.gif') ? artwork.artwork_url : undefined;
+    populateCommonMetadataFields(metadata, artwork);
 
-    // Artist bio and Wikipedia from lookup result
-    if (artwork.artist_bio) metadata.artistBio = artwork.artist_bio;
-    if (artwork.wikipedia_url) metadata.artistWikipediaUrl = artwork.wikipedia_url;
-
-    // Streaming URLs from LML enrichment
-    if (artwork.spotify_url) metadata.spotifyUrl = artwork.spotify_url;
-    if (artwork.apple_music_url) metadata.appleMusicUrl = artwork.apple_music_url;
-    if (artwork.youtube_music_url) metadata.youtubeMusicUrl = artwork.youtube_music_url;
-    if (artwork.bandcamp_url) metadata.bandcampUrl = artwork.bandcamp_url;
-    if (artwork.soundcloud_url) metadata.soundcloudUrl = artwork.soundcloud_url;
-
-    // Fetch enriched release details (tracklist, genres, styles)
-    try {
-      const release = await getRelease(artwork.release_id);
-      metadata.releaseYear = release.year ?? undefined;
-      metadata.genres = release.genres.length > 0 ? release.genres : undefined;
-      metadata.styles = release.styles.length > 0 ? release.styles : undefined;
-      metadata.label = release.label ?? undefined;
-      metadata.discogsArtistId = release.artist_id ?? null;
-      metadata.fullReleaseDate = release.released ?? undefined;
-      if (release.tracklist.length > 0) {
-        metadata.tracklist = release.tracklist.map((t) => ({
-          position: t.position,
-          title: t.title,
-          duration: t.duration ?? undefined,
-        }));
+    if (useSingleLookup) {
+      // The lookup response already carries the release-detail fields
+      // (`extended: true`); no follow-up call needed.
+      populateReleaseMetadata(metadata, {
+        year: artwork.release_year,
+        genres: artwork.genres,
+        styles: artwork.styles,
+        label: artwork.label,
+        artist_id: artwork.discogs_artist_id,
+        released: artwork.full_release_date,
+        tracklist: artwork.tracklist,
+        artwork_url: artwork.artwork_url,
+      });
+    } else {
+      // Legacy path: fetch enriched release details with a second LML call.
+      try {
+        const release = await getRelease(artwork.release_id);
+        upstreamCalls += 1;
+        populateReleaseMetadata(metadata, release);
+      } catch (releaseError) {
+        console.warn('[ProxyController] Failed to fetch release details from LML:', releaseError);
       }
-      // Prefer release artwork over lookup artwork — but still filter out
-      // spacer.gif placeholders (see #649).
-      if (release.artwork_url && !release.artwork_url.includes('spacer.gif')) {
-        metadata.artworkUrl = release.artwork_url;
-      }
-    } catch (releaseError) {
-      console.warn('[ProxyController] Failed to fetch release details from LML:', releaseError);
     }
   }
 
@@ -239,6 +343,18 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   if (!metadata.youtubeMusicUrl) metadata.youtubeMusicUrl = `https://music.youtube.com/search?q=${encodedQuery}`;
   if (!metadata.bandcampUrl) metadata.bandcampUrl = `https://bandcamp.com/search?q=${encodedQuery}`;
   if (!metadata.soundcloudUrl) metadata.soundcloudUrl = `https://soundcloud.com/search?q=${encodedQuery}`;
+
+  // Project the upstream-call count + mode onto the active Sentry span so
+  // we can split p50/p95 by cohort in the trace explorer. Wrap in a
+  // try/except — observability must never break the request path.
+  try {
+    Sentry.getActiveSpan()?.setAttributes({
+      'proxy.metadata.album.upstream_calls': upstreamCalls,
+      'proxy.metadata.album.single_lookup': useSingleLookup,
+    });
+  } catch (err) {
+    console.warn('[ProxyController] failed to project Sentry attrs', err);
+  }
 
   res.set('Cache-Control', 'private, max-age=600');
   res.status(200).json(metadata);

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -456,6 +456,198 @@ describe('proxy.controller', () => {
       expect(result.soundcloudUrl).toContain('soundcloud.com');
       expect(mockGetRelease).not.toHaveBeenCalled();
     });
+
+    // --- Single-call path (PROXY_METADATA_SINGLE_LOOKUP=true) ---
+    //
+    // When the flag is on, `getAlbumMetadata` calls LML once with
+    // `extended: true` and reads the release-detail fields off the lookup
+    // response's `artwork` block. The follow-up `getRelease()` call goes
+    // away. These tests pin the new path's contract; the legacy path's
+    // tests above remain to cover the pre-cutover behavior.
+
+    describe('PROXY_METADATA_SINGLE_LOOKUP=true', () => {
+      const originalFlag = process.env.PROXY_METADATA_SINGLE_LOOKUP;
+
+      beforeEach(() => {
+        process.env.PROXY_METADATA_SINGLE_LOOKUP = 'true';
+      });
+
+      afterEach(() => {
+        if (originalFlag === undefined) delete process.env.PROXY_METADATA_SINGLE_LOOKUP;
+        else process.env.PROXY_METADATA_SINGLE_LOOKUP = originalFlag;
+      });
+
+      it('reads release-detail fields off the lookup artwork and skips getRelease', async () => {
+        mockLookupMetadata.mockResolvedValue({
+          results: [
+            {
+              library_item: {
+                id: 1,
+                title: 'Confield',
+                artist: 'Autechre',
+                call_number: 'Electronic CD AUT 1/1',
+                library_url: '',
+              },
+              artwork: {
+                release_id: 12345,
+                release_url: 'https://www.discogs.com/release/12345',
+                artwork_url: 'https://i.discogs.com/art.jpg',
+                album: 'Confield',
+                artist: 'Autechre',
+                confidence: 0.95,
+                release_year: 2001,
+                spotify_url: 'https://open.spotify.com/album/abc',
+                apple_music_url: 'https://music.apple.com/album/xyz',
+                youtube_music_url: 'https://music.youtube.com/search?q=Autechre+Confield',
+                bandcamp_url: 'https://bandcamp.com/search?q=Autechre+Confield',
+                soundcloud_url: 'https://soundcloud.com/search?q=Autechre+Confield',
+                // Extended-mode fields (new in @wxyc/shared 1.5.0)
+                discogs_artist_id: 3840,
+                tracklist: [
+                  { position: '1', title: 'VI Scose Poise', duration: '6:45' },
+                  { position: '2', title: 'Cfern', duration: '7:01' },
+                ],
+                genres: ['Electronic'],
+                styles: ['IDM', 'Abstract'],
+                label: 'Warp',
+                full_release_date: '2001-04-30',
+              },
+            },
+          ],
+          search_type: 'direct',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+
+        const req = {
+          query: { artistName: 'Autechre', releaseTitle: 'Confield' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        // Same iOS-facing contract as the legacy path.
+        expect(result.discogsReleaseId).toBe(12345);
+        expect(result.discogsUrl).toBe('https://www.discogs.com/release/12345');
+        expect(result.releaseYear).toBe(2001);
+        expect(result.artworkUrl).toBe('https://i.discogs.com/art.jpg');
+        expect(result.genres).toEqual(['Electronic']);
+        expect(result.styles).toEqual(['IDM', 'Abstract']);
+        expect(result.label).toBe('Warp');
+        expect(result.discogsArtistId).toBe(3840);
+        expect(result.fullReleaseDate).toBe('2001-04-30');
+        expect(result.tracklist).toEqual([
+          { position: '1', title: 'VI Scose Poise', duration: '6:45' },
+          { position: '2', title: 'Cfern', duration: '7:01' },
+        ]);
+        // Streaming URLs preserved.
+        expect(result.spotifyUrl).toBe('https://open.spotify.com/album/abc');
+        expect(result.appleMusicUrl).toBe('https://music.apple.com/album/xyz');
+
+        // The whole point of this PR: no follow-up LML call.
+        expect(mockGetRelease).not.toHaveBeenCalled();
+
+        // Lookup was called with `extended: true` so LML knows to populate
+        // the new fields.
+        expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
+          extended: true,
+        });
+      });
+
+      it('falls back to search URLs when LML lookup returns empty results', async () => {
+        mockLookupMetadata.mockResolvedValue({
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+
+        const req = {
+          query: { artistName: 'Obscure Artist', releaseTitle: 'Unknown Album' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect(result.discogsReleaseId).toBeUndefined();
+        // Search URLs still constructed as fallback.
+        expect(result.youtubeMusicUrl).toContain('music.youtube.com');
+        expect(result.bandcampUrl).toContain('bandcamp.com');
+        expect(result.soundcloudUrl).toContain('soundcloud.com');
+        // No follow-up call even in the no-match case.
+        expect(mockGetRelease).not.toHaveBeenCalled();
+      });
+
+      it('falls back to search URLs when LML lookup throws', async () => {
+        mockLookupMetadata.mockRejectedValue(new Error('LML down'));
+
+        const req = {
+          query: { artistName: 'Test Artist', releaseTitle: 'Test Album' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect(result.discogsReleaseId).toBeUndefined();
+        // Search URLs still constructed.
+        expect(result.youtubeMusicUrl).toContain('music.youtube.com');
+        expect(mockGetRelease).not.toHaveBeenCalled();
+      });
+
+      it('strips spacer.gif from artworkUrl on the single-call path (#649)', async () => {
+        mockLookupMetadata.mockResolvedValue({
+          results: [
+            {
+              library_item: {
+                id: 1,
+                title: 'On Your Own Love Again',
+                artist: 'Jessica Pratt',
+                call_number: 'Rock CD PRA 1/1',
+                library_url: '',
+              },
+              artwork: {
+                release_id: 7777,
+                release_url: 'https://www.discogs.com/release/7777',
+                artwork_url: 'https://s.discogs.com/images/spacer.gif',
+                album: 'On Your Own Love Again',
+                artist: 'Jessica Pratt',
+                confidence: 0.92,
+                release_year: 2015,
+                discogs_artist_id: 5555,
+                tracklist: [],
+                genres: ['Rock'],
+                styles: [],
+                label: 'Drag City',
+                full_release_date: '2015-02-03',
+              },
+            },
+          ],
+          search_type: 'direct',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+
+        const req = {
+          query: { artistName: 'Jessica Pratt', releaseTitle: 'On Your Own Love Again' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        // spacer.gif dropped so iOS draws its own placeholder.
+        expect(result.artworkUrl).toBeUndefined();
+        // Other release fields still preserved.
+        expect(result.discogsReleaseId).toBe(7777);
+        expect(result.label).toBe('Drag City');
+      });
+    });
   });
 
   // --- getArtistMetadata ---

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -99,6 +99,62 @@ describe('lml.client', () => {
       expect(callBody.raw_message).toBe('Autechre - Confield');
     });
 
+    it('forwards options.extended=true onto the request body', async () => {
+      // The /proxy/metadata/album single-call path depends on this flag
+      // making it onto the wire. Without it, LML's response would omit
+      // the new release-detail fields and BS would silently degrade to
+      // partial metadata.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield', undefined, { extended: true });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody.extended).toBe(true);
+      // warm_cache stays absent when not requested.
+      expect(callBody.warm_cache).toBeUndefined();
+    });
+
+    it('forwards options.warm_cache=true onto the request body', async () => {
+      // flowsheet-linkage.service.ts depends on this flag making it onto
+      // the wire so LML schedules the fire-and-forget bio warm. There's
+      // no read-side observability for the warm task — if the key never
+      // made it onto the body, the warm would silently never fire.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Stereolab', 'Aluminum Tunes', undefined, { warm_cache: true });
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody.warm_cache).toBe(true);
+      // extended stays absent when not requested.
+      expect(callBody.extended).toBeUndefined();
+    });
+
+    it('omits both option flags from the body when no options are passed', async () => {
+      // Read-path callers (request-line, artwork fallback, library
+      // services) don't pass options. The body must stay byte-identical
+      // to the pre-1.5 shape so legacy LML deploys keep working during
+      // any rollback.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield');
+
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(callBody.extended).toBeUndefined();
+      expect(callBody.warm_cache).toBeUndefined();
+    });
+
     it('wraps the call in a Sentry span and projects cache_stats onto it', async () => {
       const cache_stats = {
         memory_hits: 1,


### PR DESCRIPTION
## Summary

- Behind `PROXY_METADATA_SINGLE_LOOKUP=true`, `getAlbumMetadata` calls LML once with `extended: true` and reads `tracklist`/`genres`/`styles`/`label`/`full_release_date`/`discogs_artist_id` off the lookup response's `artwork` block. **No follow-up `getRelease()` call.**
- Default `false` → byte-identical legacy two-call behavior. Rollback is config-only.
- Projects two Sentry span attrs (`proxy.metadata.album.upstream_calls`, `proxy.metadata.album.single_lookup`) so the cutover can be graphed by cohort in the trace explorer.
- Same iOS-facing JSON shape on both paths — only the data source changes.

This is the read-path half of the BS-side rollout in the subsecond-iOS-metadata initiative. Combined with the write-path warm hook (#875, merged), it positions BS for the iOS single-fetch refactor (next PR).

Closes #883

## Test plan

- [x] `npm run test:unit` — 1852 passed (4 new in `describe('PROXY_METADATA_SINGLE_LOOKUP=true')`)
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [ ] CI green
- [ ] Staging smoke (flag off): hit `/proxy/metadata/album?artistName=Stereolab&releaseTitle=Aluminum%20Tunes&trackTitle=Olv26`; capture response as baseline.
- [ ] Staging smoke (flag on, set in Railway): same request; diff the JSON. Should be identical modulo `null`-vs-`undefined` ordering. Verify Sentry transaction shows `proxy.metadata.album.upstream_calls=1`.
- [ ] Verify no `getRelease` calls in LML access logs when flag is on.