### PR TITLE
Mojibake recovery migration: 34 UPDATEs for U+FFFD-form rows

### DIFF
--- a/audit/bs_replacement_char_proposals.csv
+++ b/audit/bs_replacement_char_proposals.csv
@@ -5,7 +5,7 @@ flowsheet,RELEASE_TITLE,,Rem�nytelen,2,Rem​é​nytelen,,,0.85,discogs-searc
 flowsheet,RELEASE_TITLE,,Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �té,1,Ach Golgatha / Pour Que Les Fruits Mûrissent Cet Été,,,1.00,discogs-search
 flowsheet,RELEASE_TITLE,,Ahora M�s Que Nunca,1,Ahora Mas que Nunca,,,0.89,lml-fuzzy
 flowsheet,RELEASE_TITLE,,Eydie Gorm�,1,Eydie Gorme,Eydie Swings the blues,"Softly, As I leave you",0.91,lml-fuzzy
-flowsheet,RELEASE_TITLE,,L'�?il écoute / Dedans-Dehors,1,,,,0.00,unmatched
+flowsheet,RELEASE_TITLE,,L'�?il écoute / Dedans-Dehors,1,L'Œil Écoute / Dedans-Dehors,,,0.00,unmatched
 flowsheet,RELEASE_TITLE,,League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023,1,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,0.54,discogs-search
 flowsheet,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,Midnight Zone EP,Be Your Lover / Midnight Magic,Danger Zone,0.05,unmatched
 flowsheet,ARTIST_NAME,,Csillagrabl�k,2,Csillagrablók,,,1.00,discogs-search
@@ -19,16 +19,16 @@ flowsheet,RECORD_LABEL,,Infin� Editions,8,Infiné Éditions,Infinite Greyscale
 flowsheet,RECORD_LABEL,,U?ur Y�cel,1,Urban Decay (2),Uri Geller Records,Blanco Y Negro Urban,0.13,unmatched
 flowsheet,SONG_TITLE,,A Sua Divers�o,6,A Sua Diversão / Não Tem Nada Não,A Sua Diversão / Não Tem Nada Não,A Sua Diversão/ Não Tem Nada Não,0.18,unmatched
 flowsheet,SONG_TITLE,,Iris (N�dia Remix),3,Iris 1,Iris,Iris,0.06,unmatched
-flowsheet,SONG_TITLE,,Mallku Diabl�n,3,,,,0.26,unmatched
+flowsheet,SONG_TITLE,,Mallku Diabl�n,3,Mallku Diablón,,,0.26,unmatched
 flowsheet,SONG_TITLE,,N�o Tem Nada N�o,3,O Tempora! O Mores!,Ocupado Como Gado Com Nada Para Fazer,Visages Du Brésil,0.24,unmatched
 flowsheet,SONG_TITLE,,Arh�,2,,,,0.00,unmatched
 flowsheet,SONG_TITLE,,J'ai Oubli�,2,J'ai Tout Oublié,J'ai Oublié De Vivre,J'Ai Tout Oublié,0.41,unmatched
 flowsheet,SONG_TITLE,,Uno Es �rbol,2,Uno Esta EP,Uno Esta,Uno Esta,0.50,unmatched
 flowsheet,SONG_TITLE,,blade bird - Nick Le�n broward mix,2,In The Lab 2 The Real Mixtape Volume 2,Choke Enough : Expansion Pack,Choke Enough (Expansion Pack),0.17,unmatched
-flowsheet,SONG_TITLE,,Bliws Afon T�f,1,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,Bliws Afon T�f,1,Bliws Afon Tâf,,,0.00,unmatched
 flowsheet,SONG_TITLE,,"COLORATURA, 24� 3' 27.0"" N, 123� 47' 7.5"" E",1,"Symphony No. 2 In E Minor, Op. 27",Golden-Age Coloratura,"Philharmonia Orchestra, Tullio Serafin, Orchestra Del Teatro Alla Scala Di Milano* - Lyric & Coloratura Arias",0.08,unmatched
-flowsheet,SONG_TITLE,,Ch'uwancha�a ~El Golpe Final~,1,,,,0.07,unmatched
-flowsheet,SONG_TITLE,,"Convocaci�n ""Banger/Diffusion""",1,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,Ch'uwancha�a ~El Golpe Final~,1,Ch'uwanchaña ~El Golpe Final~,,,0.07,unmatched
+flowsheet,SONG_TITLE,,"Convocaci�n ""Banger/Diffusion""",1,"Convocación ""Banger/Diffusion""",,,0.00,unmatched
 flowsheet,SONG_TITLE,,Dod�i,1,Dođi,,,0.48,unmatched
 flowsheet,SONG_TITLE,,Do�a Justicia,1,La Justicia,Grupo La Justicia,Justicia,0.49,unmatched
 flowsheet,SONG_TITLE,,Festa Dos P�ssaros,1,Samba Dos Bons,Negrão Dos Oito Baixos,Esta Festa Das Cidades,0.29,unmatched
@@ -61,6 +61,6 @@ rotation,ARTIST_NAME,,Csillagrabl�k,1,Csillagrablók,,,1.00,discogs-search
 rotation,ARTIST_NAME,,Kai Alc�,1,Kai Alcé,,,1.00,discogs-search
 rotation,ARTIST_NAME,,N�dia & Valentina,1,Valentina,Meg & Dia,The E Street Band,0.27,unmatched
 rotation,ARTIST_NAME,,Sonido Due�ez,1,Sonido Dueñez,Sonido Solar,Luis Ortiz (4),0.90,discogs-search
-rotation,ARTIST_NAME,,}�{ (Louise Boghossian and Romain Vasset),1,,,,0.00,unmatched
+rotation,ARTIST_NAME,,}�{ (Louise Boghossian and Romain Vasset),1,}Ï{ (Louise Boghossian and Romain Vasset),,,0.00,unmatched
 rotation,RECORD_LABEL,,GER�USCHMANUFAKTUR,1,,,,0.00,unmatched
 rotation,RECORD_LABEL,,Infin� Editions,1,Infiné Éditions,Infinite Greyscale,Éditions Infini,0.93,discogs-search

--- a/audit/bs_replacement_char_proposals.csv
+++ b/audit/bs_replacement_char_proposals.csv
@@ -1,1 +1,66 @@
-table,column,lossy_value,row_count,canonical_artist,canonical_album,confidence,source,approved
+table,column,primary_key,current,row_count,proposed_top1,proposed_top2,proposed_top3,confidence,evidence_source
+flowsheet,RELEASE_TITLE,,A Sua Divers�o / N�o Tem Nada N�o,9,,,,0.00,unmatched
+flowsheet,RELEASE_TITLE,,"Music from the Caucasus � The Archive of ORED Recordings, 2013�2023",4,,,,0.07,unmatched
+flowsheet,RELEASE_TITLE,,Rem�nytelen,2,,,,0.00,unmatched
+flowsheet,RELEASE_TITLE,,Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �té,1,,,,0.00,unmatched
+flowsheet,RELEASE_TITLE,,Ahora M�s Que Nunca,1,Ahora Mas que Nunca,,,0.89,lml-fuzzy
+flowsheet,RELEASE_TITLE,,Eydie Gorm�,1,Eydie Gorme,Eydie Swings the blues,"Softly, As I leave you",0.91,lml-fuzzy
+flowsheet,RELEASE_TITLE,,L'�?il écoute / Dedans-Dehors,1,,,,0.00,unmatched
+flowsheet,RELEASE_TITLE,,League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023,1,,,,0.00,unmatched
+flowsheet,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,,,,0.11,unmatched
+flowsheet,ARTIST_NAME,,Csillagrabl�k,2,,,,0.15,unmatched
+flowsheet,ARTIST_NAME,,Sonido Due�ez,2,,,,0.00,unmatched
+flowsheet,ARTIST_NAME,,Ana Mar�a Vahos,1,Ana Maria Velez,Ana Maria Simo,Ana Maria Vizcaino,0.63,lml-fuzzy
+flowsheet,ARTIST_NAME,,Eydie Gorm�,1,Eydie Gorme,,,0.91,lml-fuzzy
+flowsheet,ARTIST_NAME,,Mehmet G�reli,1,Mehmet Irdel,Mehmet Akatay,,0.69,lml-fuzzy
+flowsheet,ARTIST_NAME,,U?ur Y�cel,1,,,,0.00,unmatched
+flowsheet,ARTIST_NAME,,p�r-no,1,,,,0.00,unmatched
+flowsheet,RECORD_LABEL,,Infin� Editions,8,,,,0.00,unmatched
+flowsheet,RECORD_LABEL,,U?ur Y�cel,1,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,A Sua Divers�o,6,,,,0.19,unmatched
+flowsheet,SONG_TITLE,,Iris (N�dia Remix),3,,,,0.16,unmatched
+flowsheet,SONG_TITLE,,Mallku Diabl�n,3,,,,0.26,unmatched
+flowsheet,SONG_TITLE,,N�o Tem Nada N�o,3,,,,0.07,unmatched
+flowsheet,SONG_TITLE,,Arh�,2,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,J'ai Oubli�,2,,,,0.21,unmatched
+flowsheet,SONG_TITLE,,Uno Es �rbol,2,,,,0.08,unmatched
+flowsheet,SONG_TITLE,,blade bird - Nick Le�n broward mix,2,,,,0.04,unmatched
+flowsheet,SONG_TITLE,,Bliws Afon T�f,1,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,"COLORATURA, 24� 3' 27.0"" N, 123� 47' 7.5"" E",1,,,,0.08,unmatched
+flowsheet,SONG_TITLE,,Ch'uwancha�a ~El Golpe Final~,1,,,,0.07,unmatched
+flowsheet,SONG_TITLE,,"Convocaci�n ""Banger/Diffusion""",1,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,Dod�i,1,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,Do�a Justicia,1,,,,0.27,unmatched
+flowsheet,SONG_TITLE,,Festa Dos P�ssaros,1,,,,0.07,unmatched
+flowsheet,SONG_TITLE,,Gabriel Gabriela Due�ez,1,,,,0.13,unmatched
+flowsheet,SONG_TITLE,,Homage to �mer Hayyam,1,,,,0.10,unmatched
+flowsheet,SONG_TITLE,,Los D�as,1,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,Mentiras Con Cari�o,1,,,,0.28,unmatched
+flowsheet,SONG_TITLE,,N�dalap�evad (Ines Daferrari Remix),1,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,Plastic 100�C,1,,,,0.08,unmatched
+library,RELEASE_TITLE,,Ballet M�canique,1,Ballet Mécanique,,,1.00,lml-fuzzy
+library,RELEASE_TITLE,,Battles Ol�,1,Battles Olé,,,1.00,lml-fuzzy
+library,RELEASE_TITLE,,Chansons pour le corps; Et si tout enti�re maintenant,1,Chansons pour le corps; Et si tout entiére maintenant,,,1.00,lml-fuzzy
+library,RELEASE_TITLE,,"HACE/26,250'/11� 22.4'N 142� 35.5'E",1,"HACE/26,250'/11° 22.4'N 142° 35.5'E",,,1.00,lml-fuzzy
+library,RELEASE_TITLE,,La B�te,1,,,,0.00,unmatched
+library,RELEASE_TITLE,,La For�t,1,,,,0.00,unmatched
+library,RELEASE_TITLE,,Mortelle Randonn�e (Extraits de la Bande Originale du Film),1,Mortelle Randonnée (Extraits De La Bande Originale Du Film),,,0.95,lml-fuzzy
+library,RELEASE_TITLE,,Rock en Espa�ol Vol. One,1,Rock en Español Vol. One,,,1.00,lml-fuzzy
+library,ARTIST_NAME,,�-Ziq [mu-Ziq],10,,,,0.11,unmatched
+library,ARTIST_NAME,,Beyonc�,4,,,,0.00,unmatched
+library,ARTIST_NAME,,Damian Nisenson / Jean F�lix Mailloux / Pierre Tanguay,1,Damian Nisenson / Jean Félix Mailloux / Pierre Tanguay,,,1.00,lml-fuzzy
+rotation,RELEASE_TITLE,,A Sua Divers�o / N�o Tem Nada N�o,1,,,,0.00,unmatched
+rotation,RELEASE_TITLE,,Amare Tour� 1973-1980,1,,,,0.00,unmatched
+rotation,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,,,,0.11,unmatched
+rotation,RELEASE_TITLE,,Rem�nytelen,1,,,,0.00,unmatched
+rotation,RELEASE_TITLE,,���,1,,,,0.00,unmatched
+rotation,ARTIST_NAME,,Acc�sed,1,,,,0.00,unmatched
+rotation,ARTIST_NAME,,Amare Tour�,1,Amara Toure,,,0.82,lml-fuzzy
+rotation,ARTIST_NAME,,Civilistj�vel! & Mayssa Jallad,1,,,,0.00,unmatched
+rotation,ARTIST_NAME,,Csillagrabl�k,1,,,,0.15,unmatched
+rotation,ARTIST_NAME,,Kai Alc�,1,,,,0.00,unmatched
+rotation,ARTIST_NAME,,N�dia & Valentina,1,,,,0.44,unmatched
+rotation,ARTIST_NAME,,Sonido Due�ez,1,,,,0.00,unmatched
+rotation,ARTIST_NAME,,}�{ (Louise Boghossian and Romain Vasset),1,,,,0.00,unmatched
+rotation,RECORD_LABEL,,GER�USCHMANUFAKTUR,1,,,,0.00,unmatched
+rotation,RECORD_LABEL,,Infin� Editions,1,,,,0.00,unmatched

--- a/audit/bs_replacement_char_proposals.csv
+++ b/audit/bs_replacement_char_proposals.csv
@@ -1,26 +1,26 @@
 table,column,primary_key,current,row_count,proposed_top1,proposed_top2,proposed_top3,confidence,evidence_source
 flowsheet,RELEASE_TITLE,,A Sua Divers�o / N�o Tem Nada N�o,9,,,,0.00,unmatched
-flowsheet,RELEASE_TITLE,,"Music from the Caucasus � The Archive of ORED Recordings, 2013�2023",4,,,,0.07,unmatched
-flowsheet,RELEASE_TITLE,,Rem�nytelen,2,,,,0.00,unmatched
+flowsheet,RELEASE_TITLE,,"Music from the Caucasus � The Archive of ORED Recordings, 2013�2023",4,Music From The Caucasus - The Archive Of ORED Recordings 2013-23,,,0.84,discogs-search
+flowsheet,RELEASE_TITLE,,Rem�nytelen,2,Rem​é​nytelen,,,0.85,discogs-search
 flowsheet,RELEASE_TITLE,,Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �té,1,,,,0.00,unmatched
 flowsheet,RELEASE_TITLE,,Ahora M�s Que Nunca,1,Ahora Mas que Nunca,,,0.89,lml-fuzzy
 flowsheet,RELEASE_TITLE,,Eydie Gorm�,1,Eydie Gorme,Eydie Swings the blues,"Softly, As I leave you",0.91,lml-fuzzy
 flowsheet,RELEASE_TITLE,,L'�?il écoute / Dedans-Dehors,1,,,,0.00,unmatched
 flowsheet,RELEASE_TITLE,,League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023,1,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,0.54,discogs-search
 flowsheet,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,,,,0.11,unmatched
-flowsheet,ARTIST_NAME,,Csillagrabl�k,2,,,,0.15,unmatched
-flowsheet,ARTIST_NAME,,Sonido Due�ez,2,,,,0.00,unmatched
+flowsheet,ARTIST_NAME,,Csillagrabl�k,2,Csillagrablók,,,1.00,discogs-search
+flowsheet,ARTIST_NAME,,Sonido Due�ez,2,Sonido Dueñez,Sonido Solar,Luis Ortiz (4),0.90,discogs-search
 flowsheet,ARTIST_NAME,,Ana Mar�a Vahos,1,Ana Maria Velez,Ana Maria Simo,Ana Maria Vizcaino,0.63,lml-fuzzy
 flowsheet,ARTIST_NAME,,Eydie Gorm�,1,Eydie Gorme,,,0.91,lml-fuzzy
 flowsheet,ARTIST_NAME,,Mehmet G�reli,1,Mehmet Irdel,Mehmet Akatay,,0.69,lml-fuzzy
 flowsheet,ARTIST_NAME,,U?ur Y�cel,1,,,,0.00,unmatched
-flowsheet,ARTIST_NAME,,p�r-no,1,S.Pri Noir,,,0.11,unmatched
+flowsheet,ARTIST_NAME,,p�r-no,1,DJ R-No,,,0.24,unmatched
 flowsheet,RECORD_LABEL,,Infin� Editions,8,Infiné Éditions,Infinite Greyscale,Éditions Infini,0.93,discogs-search
 flowsheet,RECORD_LABEL,,U?ur Y�cel,1,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,A Sua Divers�o,6,Quell'Uomo Diverso Da Me,,,0.16,unmatched
-flowsheet,SONG_TITLE,,Iris (N�dia Remix),3,,,,0.16,unmatched
+flowsheet,SONG_TITLE,,A Sua Divers�o,6,A Sua Diversão / Não Tem Nada Não,,,0.18,unmatched
+flowsheet,SONG_TITLE,,Iris (N�dia Remix),3,Big Shiny Tunes 3,,,0.08,unmatched
 flowsheet,SONG_TITLE,,Mallku Diabl�n,3,,,,0.26,unmatched
-flowsheet,SONG_TITLE,,N�o Tem Nada N�o,3,No Pintamos Nada,,,0.34,unmatched
+flowsheet,SONG_TITLE,,N�o Tem Nada N�o,3,O Tempora! O Mores!,,,0.24,unmatched
 flowsheet,SONG_TITLE,,Arh�,2,,,,0.00,unmatched
 flowsheet,SONG_TITLE,,J'ai Oubli�,2,J'ai Tout Oublié,,,0.41,unmatched
 flowsheet,SONG_TITLE,,Uno Es �rbol,2,Este àrbol que sembramos,,,0.11,unmatched
@@ -30,20 +30,20 @@ flowsheet,SONG_TITLE,,"COLORATURA, 24� 3' 27.0"" N, 123� 47' 7.5"" E",1,Lumi
 flowsheet,SONG_TITLE,,Ch'uwancha�a ~El Golpe Final~,1,,,,0.07,unmatched
 flowsheet,SONG_TITLE,,"Convocaci�n ""Banger/Diffusion""",1,,,,0.00,unmatched
 flowsheet,SONG_TITLE,,Dod�i,1,Dođi,,,0.48,unmatched
-flowsheet,SONG_TITLE,,Do�a Justicia,1,¡Viva Mi General Francisco Villa!,,,0.07,unmatched
+flowsheet,SONG_TITLE,,Do�a Justicia,1,La Justicia,,,0.49,unmatched
 flowsheet,SONG_TITLE,,Festa Dos P�ssaros,1,,,,0.07,unmatched
-flowsheet,SONG_TITLE,,Gabriel Gabriela Due�ez,1,,,,0.13,unmatched
+flowsheet,SONG_TITLE,,Gabriel Gabriela Due�ez,1,Obra Completa,,,0.12,unmatched
 flowsheet,SONG_TITLE,,Homage to �mer Hayyam,1,,,,0.10,unmatched
-flowsheet,SONG_TITLE,,Los D�as,1,Das Ist Los,,,0.20,unmatched
-flowsheet,SONG_TITLE,,Mentiras Con Cari�o,1,,,,0.28,unmatched
+flowsheet,SONG_TITLE,,Los D�as,1,Los Ronaldos,,,0.23,unmatched
+flowsheet,SONG_TITLE,,Mentiras Con Cari�o,1,Romanticos del caribe,,,0.19,unmatched
 flowsheet,SONG_TITLE,,N�dalap�evad (Ines Daferrari Remix),1,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,Plastic 100�C,1,Plastic Fantastic,,,0.36,unmatched
+flowsheet,SONG_TITLE,,Plastic 100�C,1,Plastic City 100,Plastic City 100,Plastic Beach,0.51,discogs-search
 library,RELEASE_TITLE,,Ballet M�canique,1,Ballet Mécanique,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,Battles Ol�,1,Battles Olé,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,Chansons pour le corps; Et si tout enti�re maintenant,1,Chansons pour le corps; Et si tout entiére maintenant,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,"HACE/26,250'/11� 22.4'N 142� 35.5'E",1,"HACE/26,250'/11° 22.4'N 142° 35.5'E",,,1.00,lml-fuzzy
-library,RELEASE_TITLE,,La B�te,1,The Nuker,,,0.14,unmatched
-library,RELEASE_TITLE,,La For�t,1,Sexe Fort,,,0.40,unmatched
+library,RELEASE_TITLE,,La B�te,1,La Face B,,,0.31,unmatched
+library,RELEASE_TITLE,,La For�t,1,La Forêt,La Foret,Late For The Sky,0.80,discogs-search
 library,RELEASE_TITLE,,Mortelle Randonn�e (Extraits de la Bande Originale du Film),1,Mortelle Randonnée (Extraits De La Bande Originale Du Film),,,0.95,lml-fuzzy
 library,RELEASE_TITLE,,Rock en Espa�ol Vol. One,1,Rock en Español Vol. One,,,1.00,lml-fuzzy
 library,ARTIST_NAME,,�-Ziq [mu-Ziq],10,µ-Ziq,,,0.11,unmatched
@@ -52,15 +52,15 @@ library,ARTIST_NAME,,Damian Nisenson / Jean F�lix Mailloux / Pierre Tanguay,1,
 rotation,RELEASE_TITLE,,A Sua Divers�o / N�o Tem Nada N�o,1,,,,0.00,unmatched
 rotation,RELEASE_TITLE,,Amare Tour� 1973-1980,1,Archiv Produktion 1947-2013,,,0.23,unmatched
 rotation,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,,,,0.11,unmatched
-rotation,RELEASE_TITLE,,Rem�nytelen,1,,,,0.00,unmatched
+rotation,RELEASE_TITLE,,Rem�nytelen,1,Rem​é​nytelen,,,0.85,discogs-search
 rotation,RELEASE_TITLE,,���,1,,,,0.00,unmatched
 rotation,ARTIST_NAME,,Acc�sed,1,,,,0.00,unmatched
 rotation,ARTIST_NAME,,Amare Tour�,1,Amara Toure,,,0.82,lml-fuzzy
 rotation,ARTIST_NAME,,Civilistj�vel! & Mayssa Jallad,1,,,,0.00,unmatched
-rotation,ARTIST_NAME,,Csillagrabl�k,1,,,,0.15,unmatched
+rotation,ARTIST_NAME,,Csillagrabl�k,1,Csillagrablók,,,1.00,discogs-search
 rotation,ARTIST_NAME,,Kai Alc�,1,Kai Alcé,,,1.00,discogs-search
 rotation,ARTIST_NAME,,N�dia & Valentina,1,,,,0.44,unmatched
-rotation,ARTIST_NAME,,Sonido Due�ez,1,,,,0.00,unmatched
+rotation,ARTIST_NAME,,Sonido Due�ez,1,Sonido Dueñez,Sonido Solar,Luis Ortiz (4),0.90,discogs-search
 rotation,ARTIST_NAME,,}�{ (Louise Boghossian and Romain Vasset),1,,,,0.00,unmatched
 rotation,RECORD_LABEL,,GER�USCHMANUFAKTUR,1,,,,0.00,unmatched
 rotation,RECORD_LABEL,,Infin� Editions,1,Infiné Éditions,Infinite Greyscale,Éditions Infini,0.93,discogs-search

--- a/audit/bs_replacement_char_proposals.csv
+++ b/audit/bs_replacement_char_proposals.csv
@@ -6,7 +6,7 @@ flowsheet,RELEASE_TITLE,,Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �t�
 flowsheet,RELEASE_TITLE,,Ahora M�s Que Nunca,1,Ahora Mas que Nunca,,,0.89,lml-fuzzy
 flowsheet,RELEASE_TITLE,,Eydie Gorm�,1,Eydie Gorme,Eydie Swings the blues,"Softly, As I leave you",0.91,lml-fuzzy
 flowsheet,RELEASE_TITLE,,L'�?il écoute / Dedans-Dehors,1,,,,0.00,unmatched
-flowsheet,RELEASE_TITLE,,League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023,1,,,,0.00,unmatched
+flowsheet,RELEASE_TITLE,,League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023,1,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,0.54,discogs-search
 flowsheet,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,,,,0.11,unmatched
 flowsheet,ARTIST_NAME,,Csillagrabl�k,2,,,,0.15,unmatched
 flowsheet,ARTIST_NAME,,Sonido Due�ez,2,,,,0.00,unmatched
@@ -14,43 +14,43 @@ flowsheet,ARTIST_NAME,,Ana Mar�a Vahos,1,Ana Maria Velez,Ana Maria Simo,Ana Ma
 flowsheet,ARTIST_NAME,,Eydie Gorm�,1,Eydie Gorme,,,0.91,lml-fuzzy
 flowsheet,ARTIST_NAME,,Mehmet G�reli,1,Mehmet Irdel,Mehmet Akatay,,0.69,lml-fuzzy
 flowsheet,ARTIST_NAME,,U?ur Y�cel,1,,,,0.00,unmatched
-flowsheet,ARTIST_NAME,,p�r-no,1,,,,0.00,unmatched
-flowsheet,RECORD_LABEL,,Infin� Editions,8,,,,0.00,unmatched
+flowsheet,ARTIST_NAME,,p�r-no,1,S.Pri Noir,,,0.11,unmatched
+flowsheet,RECORD_LABEL,,Infin� Editions,8,Infiné Éditions,Infinite Greyscale,Éditions Infini,0.93,discogs-search
 flowsheet,RECORD_LABEL,,U?ur Y�cel,1,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,A Sua Divers�o,6,,,,0.19,unmatched
+flowsheet,SONG_TITLE,,A Sua Divers�o,6,Quell'Uomo Diverso Da Me,,,0.16,unmatched
 flowsheet,SONG_TITLE,,Iris (N�dia Remix),3,,,,0.16,unmatched
 flowsheet,SONG_TITLE,,Mallku Diabl�n,3,,,,0.26,unmatched
-flowsheet,SONG_TITLE,,N�o Tem Nada N�o,3,,,,0.07,unmatched
+flowsheet,SONG_TITLE,,N�o Tem Nada N�o,3,No Pintamos Nada,,,0.34,unmatched
 flowsheet,SONG_TITLE,,Arh�,2,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,J'ai Oubli�,2,,,,0.21,unmatched
-flowsheet,SONG_TITLE,,Uno Es �rbol,2,,,,0.08,unmatched
+flowsheet,SONG_TITLE,,J'ai Oubli�,2,J'ai Tout Oublié,,,0.41,unmatched
+flowsheet,SONG_TITLE,,Uno Es �rbol,2,Este àrbol que sembramos,,,0.11,unmatched
 flowsheet,SONG_TITLE,,blade bird - Nick Le�n broward mix,2,,,,0.04,unmatched
 flowsheet,SONG_TITLE,,Bliws Afon T�f,1,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,"COLORATURA, 24� 3' 27.0"" N, 123� 47' 7.5"" E",1,,,,0.08,unmatched
+flowsheet,SONG_TITLE,,"COLORATURA, 24� 3' 27.0"" N, 123� 47' 7.5"" E",1,Luminescent Creatures,,,0.02,unmatched
 flowsheet,SONG_TITLE,,Ch'uwancha�a ~El Golpe Final~,1,,,,0.07,unmatched
 flowsheet,SONG_TITLE,,"Convocaci�n ""Banger/Diffusion""",1,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,Dod�i,1,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,Do�a Justicia,1,,,,0.27,unmatched
+flowsheet,SONG_TITLE,,Dod�i,1,Dođi,,,0.48,unmatched
+flowsheet,SONG_TITLE,,Do�a Justicia,1,¡Viva Mi General Francisco Villa!,,,0.07,unmatched
 flowsheet,SONG_TITLE,,Festa Dos P�ssaros,1,,,,0.07,unmatched
 flowsheet,SONG_TITLE,,Gabriel Gabriela Due�ez,1,,,,0.13,unmatched
 flowsheet,SONG_TITLE,,Homage to �mer Hayyam,1,,,,0.10,unmatched
-flowsheet,SONG_TITLE,,Los D�as,1,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,Los D�as,1,Das Ist Los,,,0.20,unmatched
 flowsheet,SONG_TITLE,,Mentiras Con Cari�o,1,,,,0.28,unmatched
 flowsheet,SONG_TITLE,,N�dalap�evad (Ines Daferrari Remix),1,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,Plastic 100�C,1,,,,0.08,unmatched
+flowsheet,SONG_TITLE,,Plastic 100�C,1,Plastic Fantastic,,,0.36,unmatched
 library,RELEASE_TITLE,,Ballet M�canique,1,Ballet Mécanique,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,Battles Ol�,1,Battles Olé,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,Chansons pour le corps; Et si tout enti�re maintenant,1,Chansons pour le corps; Et si tout entiére maintenant,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,"HACE/26,250'/11� 22.4'N 142� 35.5'E",1,"HACE/26,250'/11° 22.4'N 142° 35.5'E",,,1.00,lml-fuzzy
-library,RELEASE_TITLE,,La B�te,1,,,,0.00,unmatched
-library,RELEASE_TITLE,,La For�t,1,,,,0.00,unmatched
+library,RELEASE_TITLE,,La B�te,1,The Nuker,,,0.14,unmatched
+library,RELEASE_TITLE,,La For�t,1,Sexe Fort,,,0.40,unmatched
 library,RELEASE_TITLE,,Mortelle Randonn�e (Extraits de la Bande Originale du Film),1,Mortelle Randonnée (Extraits De La Bande Originale Du Film),,,0.95,lml-fuzzy
 library,RELEASE_TITLE,,Rock en Espa�ol Vol. One,1,Rock en Español Vol. One,,,1.00,lml-fuzzy
-library,ARTIST_NAME,,�-Ziq [mu-Ziq],10,,,,0.11,unmatched
-library,ARTIST_NAME,,Beyonc�,4,,,,0.00,unmatched
+library,ARTIST_NAME,,�-Ziq [mu-Ziq],10,µ-Ziq,,,0.11,unmatched
+library,ARTIST_NAME,,Beyonc�,4,Beyoncé,Beyoncé Knowles,Captain Beyonce,1.00,discogs-search
 library,ARTIST_NAME,,Damian Nisenson / Jean F�lix Mailloux / Pierre Tanguay,1,Damian Nisenson / Jean Félix Mailloux / Pierre Tanguay,,,1.00,lml-fuzzy
 rotation,RELEASE_TITLE,,A Sua Divers�o / N�o Tem Nada N�o,1,,,,0.00,unmatched
-rotation,RELEASE_TITLE,,Amare Tour� 1973-1980,1,,,,0.00,unmatched
+rotation,RELEASE_TITLE,,Amare Tour� 1973-1980,1,Archiv Produktion 1947-2013,,,0.23,unmatched
 rotation,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,,,,0.11,unmatched
 rotation,RELEASE_TITLE,,Rem�nytelen,1,,,,0.00,unmatched
 rotation,RELEASE_TITLE,,���,1,,,,0.00,unmatched
@@ -58,9 +58,9 @@ rotation,ARTIST_NAME,,Acc�sed,1,,,,0.00,unmatched
 rotation,ARTIST_NAME,,Amare Tour�,1,Amara Toure,,,0.82,lml-fuzzy
 rotation,ARTIST_NAME,,Civilistj�vel! & Mayssa Jallad,1,,,,0.00,unmatched
 rotation,ARTIST_NAME,,Csillagrabl�k,1,,,,0.15,unmatched
-rotation,ARTIST_NAME,,Kai Alc�,1,,,,0.00,unmatched
+rotation,ARTIST_NAME,,Kai Alc�,1,Kai Alcé,,,1.00,discogs-search
 rotation,ARTIST_NAME,,N�dia & Valentina,1,,,,0.44,unmatched
 rotation,ARTIST_NAME,,Sonido Due�ez,1,,,,0.00,unmatched
 rotation,ARTIST_NAME,,}�{ (Louise Boghossian and Romain Vasset),1,,,,0.00,unmatched
 rotation,RECORD_LABEL,,GER�USCHMANUFAKTUR,1,,,,0.00,unmatched
-rotation,RECORD_LABEL,,Infin� Editions,1,,,,0.00,unmatched
+rotation,RECORD_LABEL,,Infin� Editions,1,Infiné Éditions,Infinite Greyscale,Éditions Infini,0.93,discogs-search

--- a/audit/bs_replacement_char_proposals.csv
+++ b/audit/bs_replacement_char_proposals.csv
@@ -1,65 +1,65 @@
 table,column,primary_key,current,row_count,proposed_top1,proposed_top2,proposed_top3,confidence,evidence_source
-flowsheet,RELEASE_TITLE,,A Sua Divers�o / N�o Tem Nada N�o,9,,,,0.00,unmatched
+flowsheet,RELEASE_TITLE,,A Sua Divers�o / N�o Tem Nada N�o,9,A Sua Diversão / Não Tem Nada Não,A Sua Diversão / Não Tem Nada Não,A Sua Diversão/ Não Tem Nada Não,1.00,discogs-search
 flowsheet,RELEASE_TITLE,,"Music from the Caucasus � The Archive of ORED Recordings, 2013�2023",4,Music From The Caucasus - The Archive Of ORED Recordings 2013-23,,,0.84,discogs-search
 flowsheet,RELEASE_TITLE,,Rem�nytelen,2,Rem​é​nytelen,,,0.85,discogs-search
-flowsheet,RELEASE_TITLE,,Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �té,1,,,,0.00,unmatched
+flowsheet,RELEASE_TITLE,,Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �té,1,Ach Golgatha / Pour Que Les Fruits Mûrissent Cet Été,,,1.00,discogs-search
 flowsheet,RELEASE_TITLE,,Ahora M�s Que Nunca,1,Ahora Mas que Nunca,,,0.89,lml-fuzzy
 flowsheet,RELEASE_TITLE,,Eydie Gorm�,1,Eydie Gorme,Eydie Swings the blues,"Softly, As I leave you",0.91,lml-fuzzy
 flowsheet,RELEASE_TITLE,,L'�?il écoute / Dedans-Dehors,1,,,,0.00,unmatched
 flowsheet,RELEASE_TITLE,,League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023,1,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,League Of Legends Worlds Anthems - Vol. 1: 2014-2023,0.54,discogs-search
-flowsheet,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,,,,0.11,unmatched
+flowsheet,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,Midnight Zone EP,Be Your Lover / Midnight Magic,Danger Zone,0.05,unmatched
 flowsheet,ARTIST_NAME,,Csillagrabl�k,2,Csillagrablók,,,1.00,discogs-search
 flowsheet,ARTIST_NAME,,Sonido Due�ez,2,Sonido Dueñez,Sonido Solar,Luis Ortiz (4),0.90,discogs-search
 flowsheet,ARTIST_NAME,,Ana Mar�a Vahos,1,Ana Maria Velez,Ana Maria Simo,Ana Maria Vizcaino,0.63,lml-fuzzy
 flowsheet,ARTIST_NAME,,Eydie Gorm�,1,Eydie Gorme,,,0.91,lml-fuzzy
 flowsheet,ARTIST_NAME,,Mehmet G�reli,1,Mehmet Irdel,Mehmet Akatay,,0.69,lml-fuzzy
-flowsheet,ARTIST_NAME,,U?ur Y�cel,1,,,,0.00,unmatched
-flowsheet,ARTIST_NAME,,p�r-no,1,DJ R-No,,,0.24,unmatched
+flowsheet,ARTIST_NAME,,U?ur Y�cel,1,Urba y Rome,Madame uR y sus HombreS,Enrique Urquijo Y Los Problemas,0.17,unmatched
+flowsheet,ARTIST_NAME,,p�r-no,1,R/no,DJ R-No,DJ R-No,0.27,unmatched
 flowsheet,RECORD_LABEL,,Infin� Editions,8,Infiné Éditions,Infinite Greyscale,Éditions Infini,0.93,discogs-search
-flowsheet,RECORD_LABEL,,U?ur Y�cel,1,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,A Sua Divers�o,6,A Sua Diversão / Não Tem Nada Não,,,0.18,unmatched
-flowsheet,SONG_TITLE,,Iris (N�dia Remix),3,Big Shiny Tunes 3,,,0.08,unmatched
+flowsheet,RECORD_LABEL,,U?ur Y�cel,1,Urban Decay (2),Uri Geller Records,Blanco Y Negro Urban,0.13,unmatched
+flowsheet,SONG_TITLE,,A Sua Divers�o,6,A Sua Diversão / Não Tem Nada Não,A Sua Diversão / Não Tem Nada Não,A Sua Diversão/ Não Tem Nada Não,0.18,unmatched
+flowsheet,SONG_TITLE,,Iris (N�dia Remix),3,Iris 1,Iris,Iris,0.06,unmatched
 flowsheet,SONG_TITLE,,Mallku Diabl�n,3,,,,0.26,unmatched
-flowsheet,SONG_TITLE,,N�o Tem Nada N�o,3,O Tempora! O Mores!,,,0.24,unmatched
+flowsheet,SONG_TITLE,,N�o Tem Nada N�o,3,O Tempora! O Mores!,Ocupado Como Gado Com Nada Para Fazer,Visages Du Brésil,0.24,unmatched
 flowsheet,SONG_TITLE,,Arh�,2,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,J'ai Oubli�,2,J'ai Tout Oublié,,,0.41,unmatched
-flowsheet,SONG_TITLE,,Uno Es �rbol,2,Este àrbol que sembramos,,,0.11,unmatched
-flowsheet,SONG_TITLE,,blade bird - Nick Le�n broward mix,2,,,,0.04,unmatched
+flowsheet,SONG_TITLE,,J'ai Oubli�,2,J'ai Tout Oublié,J'ai Oublié De Vivre,J'Ai Tout Oublié,0.41,unmatched
+flowsheet,SONG_TITLE,,Uno Es �rbol,2,Uno Esta EP,Uno Esta,Uno Esta,0.50,unmatched
+flowsheet,SONG_TITLE,,blade bird - Nick Le�n broward mix,2,In The Lab 2 The Real Mixtape Volume 2,Choke Enough : Expansion Pack,Choke Enough (Expansion Pack),0.17,unmatched
 flowsheet,SONG_TITLE,,Bliws Afon T�f,1,,,,0.00,unmatched
-flowsheet,SONG_TITLE,,"COLORATURA, 24� 3' 27.0"" N, 123� 47' 7.5"" E",1,Luminescent Creatures,,,0.02,unmatched
+flowsheet,SONG_TITLE,,"COLORATURA, 24� 3' 27.0"" N, 123� 47' 7.5"" E",1,"Symphony No. 2 In E Minor, Op. 27",Golden-Age Coloratura,"Philharmonia Orchestra, Tullio Serafin, Orchestra Del Teatro Alla Scala Di Milano* - Lyric & Coloratura Arias",0.08,unmatched
 flowsheet,SONG_TITLE,,Ch'uwancha�a ~El Golpe Final~,1,,,,0.07,unmatched
 flowsheet,SONG_TITLE,,"Convocaci�n ""Banger/Diffusion""",1,,,,0.00,unmatched
 flowsheet,SONG_TITLE,,Dod�i,1,Dođi,,,0.48,unmatched
-flowsheet,SONG_TITLE,,Do�a Justicia,1,La Justicia,,,0.49,unmatched
-flowsheet,SONG_TITLE,,Festa Dos P�ssaros,1,,,,0.07,unmatched
-flowsheet,SONG_TITLE,,Gabriel Gabriela Due�ez,1,Obra Completa,,,0.12,unmatched
-flowsheet,SONG_TITLE,,Homage to �mer Hayyam,1,,,,0.10,unmatched
-flowsheet,SONG_TITLE,,Los D�as,1,Los Ronaldos,,,0.23,unmatched
-flowsheet,SONG_TITLE,,Mentiras Con Cari�o,1,Romanticos del caribe,,,0.19,unmatched
-flowsheet,SONG_TITLE,,N�dalap�evad (Ines Daferrari Remix),1,,,,0.00,unmatched
+flowsheet,SONG_TITLE,,Do�a Justicia,1,La Justicia,Grupo La Justicia,Justicia,0.49,unmatched
+flowsheet,SONG_TITLE,,Festa Dos P�ssaros,1,Samba Dos Bons,Negrão Dos Oito Baixos,Esta Festa Das Cidades,0.29,unmatched
+flowsheet,SONG_TITLE,,Gabriel Gabriela Due�ez,1,Obra Completa,DG 120 - The Anniversary Edition,Progetto Martha Argerich Lugano 2004,0.12,unmatched
+flowsheet,SONG_TITLE,,Homage to �mer Hayyam,1,Homage To Charles Parker,Crossing The Bridge - The Sound Of Istanbul,,0.39,unmatched
+flowsheet,SONG_TITLE,,Los D�as,1,Los Ronaldos,Los Destellos,Los Angeles,0.23,unmatched
+flowsheet,SONG_TITLE,,Mentiras Con Cari�o,1,Vamos A La Playa Con Caribe Mix,Vamos A La Playa Con Caribe Mix,Boleros Del Caribe Vol. 3,0.18,unmatched
+flowsheet,SONG_TITLE,,N�dalap�evad (Ines Daferrari Remix),1,Eolian Oms EP Side A | Byte Evaders EP Side B,Dalapop Exclusive Series Vol. 8,Dalapop Exclusive Series Vol. 8,0.14,unmatched
 flowsheet,SONG_TITLE,,Plastic 100�C,1,Plastic City 100,Plastic City 100,Plastic Beach,0.51,discogs-search
 library,RELEASE_TITLE,,Ballet M�canique,1,Ballet Mécanique,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,Battles Ol�,1,Battles Olé,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,Chansons pour le corps; Et si tout enti�re maintenant,1,Chansons pour le corps; Et si tout entiére maintenant,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,"HACE/26,250'/11� 22.4'N 142� 35.5'E",1,"HACE/26,250'/11° 22.4'N 142° 35.5'E",,,1.00,lml-fuzzy
-library,RELEASE_TITLE,,La B�te,1,La Face B,,,0.31,unmatched
+library,RELEASE_TITLE,,La B�te,1,La Face B,La Roux,La Valle La B,0.31,unmatched
 library,RELEASE_TITLE,,La For�t,1,La Forêt,La Foret,Late For The Sky,0.80,discogs-search
 library,RELEASE_TITLE,,Mortelle Randonn�e (Extraits de la Bande Originale du Film),1,Mortelle Randonnée (Extraits De La Bande Originale Du Film),,,0.95,lml-fuzzy
 library,RELEASE_TITLE,,Rock en Espa�ol Vol. One,1,Rock en Español Vol. One,,,1.00,lml-fuzzy
-library,ARTIST_NAME,,�-Ziq [mu-Ziq],10,µ-Ziq,,,0.11,unmatched
+library,ARTIST_NAME,,�-Ziq [mu-Ziq],10,Various Artists,,,0.12,unmatched
 library,ARTIST_NAME,,Beyonc�,4,Beyoncé,Beyoncé Knowles,Captain Beyonce,1.00,discogs-search
 library,ARTIST_NAME,,Damian Nisenson / Jean F�lix Mailloux / Pierre Tanguay,1,Damian Nisenson / Jean Félix Mailloux / Pierre Tanguay,,,1.00,lml-fuzzy
-rotation,RELEASE_TITLE,,A Sua Divers�o / N�o Tem Nada N�o,1,,,,0.00,unmatched
-rotation,RELEASE_TITLE,,Amare Tour� 1973-1980,1,Archiv Produktion 1947-2013,,,0.23,unmatched
-rotation,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,,,,0.11,unmatched
+rotation,RELEASE_TITLE,,A Sua Divers�o / N�o Tem Nada N�o,1,A Sua Diversão / Não Tem Nada Não,A Sua Diversão / Não Tem Nada Não,A Sua Diversão/ Não Tem Nada Não,1.00,discogs-search
+rotation,RELEASE_TITLE,,Amare Tour� 1973-1980,1,Used Songs (1973-1980),Cardio Tour,"Matia Bazar ""Tour""",0.38,unmatched
+rotation,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,Midnight Zone EP,Be Your Lover / Midnight Magic,Danger Zone,0.05,unmatched
 rotation,RELEASE_TITLE,,Rem�nytelen,1,Rem​é​nytelen,,,0.85,discogs-search
 rotation,RELEASE_TITLE,,���,1,,,,0.00,unmatched
 rotation,ARTIST_NAME,,Acc�sed,1,,,,0.00,unmatched
 rotation,ARTIST_NAME,,Amare Tour�,1,Amara Toure,,,0.82,lml-fuzzy
-rotation,ARTIST_NAME,,Civilistj�vel! & Mayssa Jallad,1,,,,0.00,unmatched
+rotation,ARTIST_NAME,,Civilistj�vel! & Mayssa Jallad,1,Civilistjävel!,Prestestranna Vel Vel Vel,Mayssa Karaa,0.21,unmatched
 rotation,ARTIST_NAME,,Csillagrabl�k,1,Csillagrablók,,,1.00,discogs-search
 rotation,ARTIST_NAME,,Kai Alc�,1,Kai Alcé,,,1.00,discogs-search
-rotation,ARTIST_NAME,,N�dia & Valentina,1,,,,0.44,unmatched
+rotation,ARTIST_NAME,,N�dia & Valentina,1,Valentina,Meg & Dia,The E Street Band,0.27,unmatched
 rotation,ARTIST_NAME,,Sonido Due�ez,1,Sonido Dueñez,Sonido Solar,Luis Ortiz (4),0.90,discogs-search
 rotation,ARTIST_NAME,,}�{ (Louise Boghossian and Romain Vasset),1,,,,0.00,unmatched
 rotation,RECORD_LABEL,,GER�USCHMANUFAKTUR,1,,,,0.00,unmatched

--- a/audit/bs_replacement_char_proposals.csv
+++ b/audit/bs_replacement_char_proposals.csv
@@ -10,9 +10,9 @@ flowsheet,RELEASE_TITLE,,League of Legends � League Of Legends Worlds Anthems 
 flowsheet,RELEASE_TITLE,,Midnight Zone (Original Soundtrack to the Film by Julian Charri�re),1,Midnight Zone EP,Be Your Lover / Midnight Magic,Danger Zone,0.05,unmatched
 flowsheet,ARTIST_NAME,,Csillagrabl�k,2,Csillagrablók,,,1.00,discogs-search
 flowsheet,ARTIST_NAME,,Sonido Due�ez,2,Sonido Dueñez,Sonido Solar,Luis Ortiz (4),0.90,discogs-search
-flowsheet,ARTIST_NAME,,Ana Mar�a Vahos,1,Ana Maria Velez,Ana Maria Simo,Ana Maria Vizcaino,0.63,lml-fuzzy
+flowsheet,ARTIST_NAME,,Ana Mar�a Vahos,1,,Ana Maria Simo,Ana Maria Vizcaino,0.63,lml-fuzzy
 flowsheet,ARTIST_NAME,,Eydie Gorm�,1,Eydie Gorme,,,0.91,lml-fuzzy
-flowsheet,ARTIST_NAME,,Mehmet G�reli,1,Mehmet Irdel,Mehmet Akatay,,0.69,lml-fuzzy
+flowsheet,ARTIST_NAME,,Mehmet G�reli,1,,Mehmet Akatay,,0.69,lml-fuzzy
 flowsheet,ARTIST_NAME,,U?ur Y�cel,1,Urba y Rome,Madame uR y sus HombreS,Enrique Urquijo Y Los Problemas,0.17,unmatched
 flowsheet,ARTIST_NAME,,p�r-no,1,R/no,DJ R-No,DJ R-No,0.27,unmatched
 flowsheet,RECORD_LABEL,,Infin� Editions,8,Infiné Éditions,Infinite Greyscale,Éditions Infini,0.93,discogs-search
@@ -37,7 +37,7 @@ flowsheet,SONG_TITLE,,Homage to �mer Hayyam,1,Homage To Charles Parker,Crossin
 flowsheet,SONG_TITLE,,Los D�as,1,Los Ronaldos,Los Destellos,Los Angeles,0.23,unmatched
 flowsheet,SONG_TITLE,,Mentiras Con Cari�o,1,Vamos A La Playa Con Caribe Mix,Vamos A La Playa Con Caribe Mix,Boleros Del Caribe Vol. 3,0.18,unmatched
 flowsheet,SONG_TITLE,,N�dalap�evad (Ines Daferrari Remix),1,Eolian Oms EP Side A | Byte Evaders EP Side B,Dalapop Exclusive Series Vol. 8,Dalapop Exclusive Series Vol. 8,0.14,unmatched
-flowsheet,SONG_TITLE,,Plastic 100�C,1,Plastic City 100,Plastic City 100,Plastic Beach,0.51,discogs-search
+flowsheet,SONG_TITLE,,Plastic 100�C,1,Plastic 100°C,Plastic City 100,Plastic Beach,0.51,discogs-search
 library,RELEASE_TITLE,,Ballet M�canique,1,Ballet Mécanique,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,Battles Ol�,1,Battles Olé,,,1.00,lml-fuzzy
 library,RELEASE_TITLE,,Chansons pour le corps; Et si tout enti�re maintenant,1,Chansons pour le corps; Et si tout entiére maintenant,,,1.00,lml-fuzzy

--- a/scripts/audit/bs_replacement_char_recovery.sql
+++ b/scripts/audit/bs_replacement_char_recovery.sql
@@ -9,7 +9,7 @@
 -- MusicBrainz fallback for ARTIST_NAME rows; the resulting CSV
 -- was hand-curated by the music director.
 --
--- 36 UPDATE statements follow. Four rows were dropped
+-- 34 UPDATE statements follow. Four rows were dropped
 -- during curation because no canonical was recoverable.
 --
 -- Pattern: BEGIN; UPDATEs; COMMIT; then the post-amble verifies
@@ -30,7 +30,7 @@
 SELECT '=== V_BS_FFFD pre-amble: rows targeted per (table, column) ===' AS section;
 
 -- flowsheet.album_title: 8 lossy values, 20 rows total
--- flowsheet.artist_name: 5 lossy values, 7 rows total
+-- flowsheet.artist_name: 3 lossy values, 5 rows total
 -- flowsheet.record_label: 1 lossy values, 8 rows total
 -- flowsheet.track_title: 5 lossy values, 7 rows total
 -- library.album_title: 7 lossy values, 7 rows total
@@ -78,15 +78,13 @@ UPDATE wxyc_schema.flowsheet SET album_title = 'L''Œil Écoute / Dedans-Dehors'
 UPDATE wxyc_schema.flowsheet SET album_title = 'League Of Legends Worlds Anthems - Vol. 1: 2014-2023' WHERE album_title = 'League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023';
 UPDATE wxyc_schema.flowsheet SET artist_name = 'Csillagrablók' WHERE artist_name = 'Csillagrabl�k';
 UPDATE wxyc_schema.flowsheet SET artist_name = 'Sonido Dueñez' WHERE artist_name = 'Sonido Due�ez';
-UPDATE wxyc_schema.flowsheet SET artist_name = 'Ana Maria Velez' WHERE artist_name = 'Ana Mar�a Vahos';
 UPDATE wxyc_schema.flowsheet SET artist_name = 'Eydie Gorme' WHERE artist_name = 'Eydie Gorm�';
-UPDATE wxyc_schema.flowsheet SET artist_name = 'Mehmet Irdel' WHERE artist_name = 'Mehmet G�reli';
 UPDATE wxyc_schema.flowsheet SET record_label = 'Infiné Éditions' WHERE record_label = 'Infin� Editions';
 UPDATE wxyc_schema.flowsheet SET track_title = 'Mallku Diablón' WHERE track_title = 'Mallku Diabl�n';
 UPDATE wxyc_schema.flowsheet SET track_title = 'Bliws Afon Tâf' WHERE track_title = 'Bliws Afon T�f';
 UPDATE wxyc_schema.flowsheet SET track_title = 'Ch''uwanchaña ~El Golpe Final~' WHERE track_title = 'Ch''uwancha�a ~El Golpe Final~';
 UPDATE wxyc_schema.flowsheet SET track_title = 'Convocación "Banger/Diffusion"' WHERE track_title = 'Convocaci�n "Banger/Diffusion"';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Plastic City 100' WHERE track_title = 'Plastic 100�C';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Plastic 100°C' WHERE track_title = 'Plastic 100�C';
 UPDATE wxyc_schema.library SET album_title = 'Ballet Mécanique' WHERE album_title = 'Ballet M�canique';
 UPDATE wxyc_schema.library SET album_title = 'Battles Olé' WHERE album_title = 'Battles Ol�';
 UPDATE wxyc_schema.library SET album_title = 'Chansons pour le corps; Et si tout entiére maintenant' WHERE album_title = 'Chansons pour le corps; Et si tout enti�re maintenant';
@@ -132,11 +130,7 @@ SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Csillagrabl�k' AS lossy, (SE
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Sonido Due�ez' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Sonido Due�ez') AS residual
 UNION ALL
-SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Ana Mar�a Vahos' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Ana Mar�a Vahos') AS residual
-UNION ALL
 SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Eydie Gorm�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Eydie Gorm�') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Mehmet G�reli' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Mehmet G�reli') AS residual
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'record_label' AS col, 'Infin� Editions' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE record_label = 'Infin� Editions') AS residual
 UNION ALL

--- a/scripts/audit/bs_replacement_char_recovery.sql
+++ b/scripts/audit/bs_replacement_char_recovery.sql
@@ -1,5 +1,12 @@
 -- V_BS_FFFD: Lossy-recovery U+FFFD mojibake migration for #863.
 --
+-- The `V_BS_FFFD` prefix mirrors tubafrenzy's V015/V016 naming, but this is
+-- a HAND-APPLIED script, NOT a Drizzle/Flyway-tracked migration — there is
+-- no entry in shared/database/src/migrations/ and the version-control burden
+-- is just `git log -- scripts/audit/bs_replacement_char_recovery.sql`. The
+-- operator runs it via `psql -f` against prod RDS using the EC2-docker
+-- pattern in scripts/query-flowsheet.sh.
+--
 -- Phase 1 audit at scripts/audit/bs_replacement_char_audit.csv
 -- enumerated 65 distinct lossy values across 113 rows in three
 -- tables (rotation, library, flowsheet). Phase 2 proposals at
@@ -12,9 +19,25 @@
 -- 34 UPDATE statements follow. Four rows were dropped
 -- during curation because no canonical was recoverable.
 --
+-- Six of the 34 rows are CURATOR-EDITED canonicals (auto-pass returned
+-- empty proposed_top1; the music director filled in the canonical by
+-- hand). The generator's inclusion rule treats these as approved-for-
+-- migration because their proposed_top1 differs from the auto-pass
+-- output captured in git history (commit d1cb225 pre-curation snapshot).
+-- The curator-edited tuples are:
+--
+--   flowsheet.album_title  L'�?il écoute / Dedans-Dehors          → L'Œil Écoute / Dedans-Dehors
+--   flowsheet.track_title  Mallku Diabl�n                          → Mallku Diablón
+--   flowsheet.track_title  Bliws Afon T�f                          → Bliws Afon Tâf
+--   flowsheet.track_title  Ch'uwancha�a ~El Golpe Final~          → Ch'uwanchaña ~El Golpe Final~
+--   flowsheet.track_title  Convocaci�n "Banger/Diffusion"          → Convocación "Banger/Diffusion"
+--   rotation.artist_name   }�{ (Louise Boghossian and Romain Vasset) → }Ï{ (Louise Boghossian and Romain Vasset)
+--
 -- Pattern: BEGIN; UPDATEs; COMMIT; then the post-amble verifies
 -- that no targeted (table, column, current) tuple still matches
--- after the run (expected count: 0 for every row).
+-- after the run (expected count: 0 for every row). The pre-amble is
+-- a SPOT-CHECK (top-10 by row_count, eyeball before COMMIT); the
+-- post-amble is EXHAUSTIVE across all 34 targeted tuples.
 --
 -- NOT round-trippable: the original characters were already lost
 -- upstream when U+FFFD was written into the data. This migration
@@ -23,6 +46,11 @@
 --
 -- NFC-normalised and zero-width-char-stripped (U+200B/200C/200D/FEFF)
 -- before write to defend Lucene / trgm tokenization downstream.
+--
+-- Idempotency: a successful run leaves zero matching rows for every
+-- targeted lossy. Re-running this script after success is a no-op,
+-- but the pre-amble's BEFORE counts will all be zero — that's expected
+-- on re-runs, not a regression.
 
 -- ===========================================================
 -- Pre-amble audit: rows targeted by this run, by source group.
@@ -31,13 +59,13 @@ SELECT '=== V_BS_FFFD pre-amble: rows targeted per (table, column) ===' AS secti
 
 -- flowsheet.album_title: 8 lossy values, 20 rows total
 -- flowsheet.artist_name: 3 lossy values, 5 rows total
--- flowsheet.record_label: 1 lossy values, 8 rows total
+-- flowsheet.record_label: 1 lossy value, 8 rows total
 -- flowsheet.track_title: 5 lossy values, 7 rows total
 -- library.album_title: 7 lossy values, 7 rows total
 -- library.artist_name: 2 lossy values, 5 rows total
 -- rotation.album_title: 2 lossy values, 2 rows total
 -- rotation.artist_name: 5 lossy values, 5 rows total
--- rotation.record_label: 1 lossy values, 1 rows total
+-- rotation.record_label: 1 lossy value, 1 row total
 
 -- Spot-check the worst offenders to confirm the migration is
 -- about to touch real rows. Eyeball before COMMIT.
@@ -75,6 +103,9 @@ UPDATE wxyc_schema.flowsheet SET album_title = 'Ach Golgatha / Pour Que Les Frui
 UPDATE wxyc_schema.flowsheet SET album_title = 'Ahora Mas que Nunca' WHERE album_title = 'Ahora M�s Que Nunca';
 UPDATE wxyc_schema.flowsheet SET album_title = 'Eydie Gorme' WHERE album_title = 'Eydie Gorm�';
 UPDATE wxyc_schema.flowsheet SET album_title = 'L''Œil Écoute / Dedans-Dehors' WHERE album_title = 'L''�?il écoute / Dedans-Dehors';
+-- The original DJ entered "League of Legends [mojibaked-dash] League Of Legends Worlds Anthems...";
+-- the canonical drops the leading "League of Legends [dash]" prefix because the mojibaked dash
+-- was a stray "artist — album" concatenation, not part of the release title.
 UPDATE wxyc_schema.flowsheet SET album_title = 'League Of Legends Worlds Anthems - Vol. 1: 2014-2023' WHERE album_title = 'League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023';
 UPDATE wxyc_schema.flowsheet SET artist_name = 'Csillagrablók' WHERE artist_name = 'Csillagrabl�k';
 UPDATE wxyc_schema.flowsheet SET artist_name = 'Sonido Dueñez' WHERE artist_name = 'Sonido Due�ez';

--- a/scripts/audit/bs_replacement_char_recovery.sql
+++ b/scripts/audit/bs_replacement_char_recovery.sql
@@ -1,0 +1,287 @@
+-- V_BS_FFFD: Lossy-recovery U+FFFD mojibake migration for #863.
+--
+-- Phase 1 audit at scripts/audit/bs_replacement_char_audit.csv
+-- enumerated 65 distinct lossy values across 113 rows in three
+-- tables (rotation, library, flowsheet). Phase 2 proposals at
+-- audit/bs_replacement_char_proposals.csv were generated via the
+-- tubafrenzy V015/V016 matcher (LML-fuzzy) extended with two
+-- Discogs search passes (longest-anchor + per-anchor) and a
+-- MusicBrainz fallback for ARTIST_NAME rows; the resulting CSV
+-- was hand-curated by the music director.
+--
+-- 61 UPDATE statements follow. Four rows were dropped
+-- during curation because no canonical was recoverable.
+--
+-- Pattern: BEGIN; UPDATEs; COMMIT; then the post-amble verifies
+-- that no targeted (table, column, current) tuple still matches
+-- after the run (expected count: 0 for every row).
+--
+-- NOT round-trippable: the original characters were already lost
+-- upstream when U+FFFD was written into the data. This migration
+-- injects plausible canonical strings over those bytes per the
+-- review process — same posture as tubafrenzy V015/V016.
+--
+-- NFC-normalised and zero-width-char-stripped (U+200B/200C/200D/FEFF)
+-- before write to defend Lucene / trgm tokenization downstream.
+
+-- ===========================================================
+-- Pre-amble audit: rows targeted by this run, by source group.
+-- ===========================================================
+SELECT '=== V_BS_FFFD pre-amble: rows targeted per (table, column) ===' AS section;
+
+-- flowsheet.album_title: 9 lossy values, 21 rows total
+-- flowsheet.artist_name: 7 lossy values, 9 rows total
+-- flowsheet.record_label: 2 lossy values, 9 rows total
+-- flowsheet.track_title: 20 lossy values, 34 rows total
+-- library.album_title: 8 lossy values, 8 rows total
+-- library.artist_name: 3 lossy values, 15 rows total
+-- rotation.album_title: 4 lossy values, 4 rows total
+-- rotation.artist_name: 7 lossy values, 7 rows total
+-- rotation.record_label: 1 lossy values, 1 rows total
+
+-- Spot-check the worst offenders to confirm the migration is
+-- about to touch real rows. Eyeball before COMMIT.
+SELECT 'BEFORE — top 10 by row_count' AS section;
+SELECT 'library' AS tbl, 'artist_name' AS col, '�-Ziq [mu-Ziq]' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name = '�-Ziq [mu-Ziq]') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'A Sua Divers�o / N�o Tem Nada N�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'A Sua Divers�o / N�o Tem Nada N�o') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'record_label' AS col, 'Infin� Editions' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE record_label = 'Infin� Editions') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'A Sua Divers�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'A Sua Divers�o') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Music from the Caucasus � The Archive of ORED Recordings, 2013�2023' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Music from the Caucasus � The Archive of ORED Recordings, 2013�2023') AS rows
+UNION ALL
+SELECT 'library' AS tbl, 'artist_name' AS col, 'Beyonc�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name = 'Beyonc�') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Iris (N�dia Remix)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Iris (N�dia Remix)') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Mallku Diabl�n' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Mallku Diabl�n') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'N�o Tem Nada N�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'N�o Tem Nada N�o') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Rem�nytelen' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Rem�nytelen') AS rows;
+
+-- ===========================================================
+-- Transactional UPDATE block.
+-- ===========================================================
+BEGIN;
+SET LOCAL statement_timeout = '120s';
+
+UPDATE wxyc_schema.flowsheet SET album_title = 'A Sua Diversão / Não Tem Nada Não' WHERE album_title = 'A Sua Divers�o / N�o Tem Nada N�o';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Music From The Caucasus - The Archive Of ORED Recordings 2013-23' WHERE album_title = 'Music from the Caucasus � The Archive of ORED Recordings, 2013�2023';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Reménytelen' WHERE album_title = 'Rem�nytelen';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Ach Golgatha / Pour Que Les Fruits Mûrissent Cet Été' WHERE album_title = 'Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �té';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Ahora Mas que Nunca' WHERE album_title = 'Ahora M�s Que Nunca';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Eydie Gorme' WHERE album_title = 'Eydie Gorm�';
+UPDATE wxyc_schema.flowsheet SET album_title = 'L''Œil Écoute / Dedans-Dehors' WHERE album_title = 'L''�?il écoute / Dedans-Dehors';
+UPDATE wxyc_schema.flowsheet SET album_title = 'League Of Legends Worlds Anthems - Vol. 1: 2014-2023' WHERE album_title = 'League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023';
+UPDATE wxyc_schema.flowsheet SET album_title = 'Midnight Zone EP' WHERE album_title = 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Csillagrablók' WHERE artist_name = 'Csillagrabl�k';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Sonido Dueñez' WHERE artist_name = 'Sonido Due�ez';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Ana Maria Velez' WHERE artist_name = 'Ana Mar�a Vahos';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Eydie Gorme' WHERE artist_name = 'Eydie Gorm�';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Mehmet Irdel' WHERE artist_name = 'Mehmet G�reli';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'Urba y Rome' WHERE artist_name = 'U?ur Y�cel';
+UPDATE wxyc_schema.flowsheet SET artist_name = 'R/no' WHERE artist_name = 'p�r-no';
+UPDATE wxyc_schema.flowsheet SET record_label = 'Infiné Éditions' WHERE record_label = 'Infin� Editions';
+UPDATE wxyc_schema.flowsheet SET record_label = 'Urban Decay (2)' WHERE record_label = 'U?ur Y�cel';
+UPDATE wxyc_schema.flowsheet SET track_title = 'A Sua Diversão / Não Tem Nada Não' WHERE track_title = 'A Sua Divers�o';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Iris 1' WHERE track_title = 'Iris (N�dia Remix)';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Mallku Diablón' WHERE track_title = 'Mallku Diabl�n';
+UPDATE wxyc_schema.flowsheet SET track_title = 'O Tempora! O Mores!' WHERE track_title = 'N�o Tem Nada N�o';
+UPDATE wxyc_schema.flowsheet SET track_title = 'J''ai Tout Oublié' WHERE track_title = 'J''ai Oubli�';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Uno Esta EP' WHERE track_title = 'Uno Es �rbol';
+UPDATE wxyc_schema.flowsheet SET track_title = 'In The Lab 2 The Real Mixtape Volume 2' WHERE track_title = 'blade bird - Nick Le�n broward mix';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Bliws Afon Tâf' WHERE track_title = 'Bliws Afon T�f';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Symphony No. 2 In E Minor, Op. 27' WHERE track_title = 'COLORATURA, 24� 3'' 27.0" N, 123� 47'' 7.5" E';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Ch''uwanchaña ~El Golpe Final~' WHERE track_title = 'Ch''uwancha�a ~El Golpe Final~';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Convocación "Banger/Diffusion"' WHERE track_title = 'Convocaci�n "Banger/Diffusion"';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Dođi' WHERE track_title = 'Dod�i';
+UPDATE wxyc_schema.flowsheet SET track_title = 'La Justicia' WHERE track_title = 'Do�a Justicia';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Samba Dos Bons' WHERE track_title = 'Festa Dos P�ssaros';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Obra Completa' WHERE track_title = 'Gabriel Gabriela Due�ez';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Homage To Charles Parker' WHERE track_title = 'Homage to �mer Hayyam';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Los Ronaldos' WHERE track_title = 'Los D�as';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Vamos A La Playa Con Caribe Mix' WHERE track_title = 'Mentiras Con Cari�o';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Eolian Oms EP Side A | Byte Evaders EP Side B' WHERE track_title = 'N�dalap�evad (Ines Daferrari Remix)';
+UPDATE wxyc_schema.flowsheet SET track_title = 'Plastic City 100' WHERE track_title = 'Plastic 100�C';
+UPDATE wxyc_schema.library SET album_title = 'Ballet Mécanique' WHERE album_title = 'Ballet M�canique';
+UPDATE wxyc_schema.library SET album_title = 'Battles Olé' WHERE album_title = 'Battles Ol�';
+UPDATE wxyc_schema.library SET album_title = 'Chansons pour le corps; Et si tout entiére maintenant' WHERE album_title = 'Chansons pour le corps; Et si tout enti�re maintenant';
+UPDATE wxyc_schema.library SET album_title = 'HACE/26,250''/11° 22.4''N 142° 35.5''E' WHERE album_title = 'HACE/26,250''/11� 22.4''N 142� 35.5''E';
+UPDATE wxyc_schema.library SET album_title = 'La Face B' WHERE album_title = 'La B�te';
+UPDATE wxyc_schema.library SET album_title = 'La Forêt' WHERE album_title = 'La For�t';
+UPDATE wxyc_schema.library SET album_title = 'Mortelle Randonnée (Extraits De La Bande Originale Du Film)' WHERE album_title = 'Mortelle Randonn�e (Extraits de la Bande Originale du Film)';
+UPDATE wxyc_schema.library SET album_title = 'Rock en Español Vol. One' WHERE album_title = 'Rock en Espa�ol Vol. One';
+UPDATE wxyc_schema.library SET artist_name = 'Various Artists' WHERE artist_name = '�-Ziq [mu-Ziq]';
+UPDATE wxyc_schema.library SET artist_name = 'Beyoncé' WHERE artist_name = 'Beyonc�';
+UPDATE wxyc_schema.library SET artist_name = 'Damian Nisenson / Jean Félix Mailloux / Pierre Tanguay' WHERE artist_name = 'Damian Nisenson / Jean F�lix Mailloux / Pierre Tanguay';
+UPDATE wxyc_schema.rotation SET album_title = 'A Sua Diversão / Não Tem Nada Não' WHERE album_title = 'A Sua Divers�o / N�o Tem Nada N�o';
+UPDATE wxyc_schema.rotation SET album_title = 'Used Songs (1973-1980)' WHERE album_title = 'Amare Tour� 1973-1980';
+UPDATE wxyc_schema.rotation SET album_title = 'Midnight Zone EP' WHERE album_title = 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)';
+UPDATE wxyc_schema.rotation SET album_title = 'Reménytelen' WHERE album_title = 'Rem�nytelen';
+UPDATE wxyc_schema.rotation SET artist_name = 'Amara Toure' WHERE artist_name = 'Amare Tour�';
+UPDATE wxyc_schema.rotation SET artist_name = 'Civilistjävel!' WHERE artist_name = 'Civilistj�vel! & Mayssa Jallad';
+UPDATE wxyc_schema.rotation SET artist_name = 'Csillagrablók' WHERE artist_name = 'Csillagrabl�k';
+UPDATE wxyc_schema.rotation SET artist_name = 'Kai Alcé' WHERE artist_name = 'Kai Alc�';
+UPDATE wxyc_schema.rotation SET artist_name = 'Valentina' WHERE artist_name = 'N�dia & Valentina';
+UPDATE wxyc_schema.rotation SET artist_name = 'Sonido Dueñez' WHERE artist_name = 'Sonido Due�ez';
+UPDATE wxyc_schema.rotation SET artist_name = '}Ï{ (Louise Boghossian and Romain Vasset)' WHERE artist_name = '}�{ (Louise Boghossian and Romain Vasset)';
+UPDATE wxyc_schema.rotation SET record_label = 'Infiné Éditions' WHERE record_label = 'Infin� Editions';
+
+COMMIT;
+
+-- ===========================================================
+-- Post-amble verify: no targeted (table, column, current) tuple
+-- should still match. Any non-zero count below is a regression.
+-- ===========================================================
+SELECT '=== V_BS_FFFD post-amble: residual count per row (expect 0) ===' AS section;
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'A Sua Divers�o / N�o Tem Nada N�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'A Sua Divers�o / N�o Tem Nada N�o') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Music from the Caucasus � The Archive of ORED Recordings, 2013�2023' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Music from the Caucasus � The Archive of ORED Recordings, 2013�2023') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Rem�nytelen' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Rem�nytelen') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �té' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �té') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Ahora M�s Que Nunca' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Ahora M�s Que Nunca') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Eydie Gorm�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Eydie Gorm�') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'L''�?il écoute / Dedans-Dehors' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'L''�?il écoute / Dedans-Dehors') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Csillagrabl�k' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Csillagrabl�k') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Sonido Due�ez' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Sonido Due�ez') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Ana Mar�a Vahos' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Ana Mar�a Vahos') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Eydie Gorm�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Eydie Gorm�') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Mehmet G�reli' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Mehmet G�reli') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'U?ur Y�cel' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'U?ur Y�cel') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'p�r-no' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'p�r-no') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'record_label' AS col, 'Infin� Editions' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE record_label = 'Infin� Editions') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'record_label' AS col, 'U?ur Y�cel' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE record_label = 'U?ur Y�cel') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'A Sua Divers�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'A Sua Divers�o') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Iris (N�dia Remix)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Iris (N�dia Remix)') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Mallku Diabl�n' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Mallku Diabl�n') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'N�o Tem Nada N�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'N�o Tem Nada N�o') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'J''ai Oubli�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'J''ai Oubli�') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Uno Es �rbol' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Uno Es �rbol') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'blade bird - Nick Le�n broward mix' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'blade bird - Nick Le�n broward mix') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Bliws Afon T�f' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Bliws Afon T�f') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'COLORATURA, 24� 3'' 27.0" N, 123� 47'' 7.5" E' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'COLORATURA, 24� 3'' 27.0" N, 123� 47'' 7.5" E') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Ch''uwancha�a ~El Golpe Final~' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Ch''uwancha�a ~El Golpe Final~') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Convocaci�n "Banger/Diffusion"' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Convocaci�n "Banger/Diffusion"') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Dod�i' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Dod�i') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Do�a Justicia' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Do�a Justicia') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Festa Dos P�ssaros' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Festa Dos P�ssaros') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Gabriel Gabriela Due�ez' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Gabriel Gabriela Due�ez') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Homage to �mer Hayyam' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Homage to �mer Hayyam') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Los D�as' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Los D�as') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Mentiras Con Cari�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Mentiras Con Cari�o') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'N�dalap�evad (Ines Daferrari Remix)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'N�dalap�evad (Ines Daferrari Remix)') AS residual
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Plastic 100�C' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Plastic 100�C') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, 'Ballet M�canique' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'Ballet M�canique') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, 'Battles Ol�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'Battles Ol�') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, 'Chansons pour le corps; Et si tout enti�re maintenant' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'Chansons pour le corps; Et si tout enti�re maintenant') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, 'HACE/26,250''/11� 22.4''N 142� 35.5''E' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'HACE/26,250''/11� 22.4''N 142� 35.5''E') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, 'La B�te' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'La B�te') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, 'La For�t' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'La For�t') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, 'Mortelle Randonn�e (Extraits de la Bande Originale du Film)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'Mortelle Randonn�e (Extraits de la Bande Originale du Film)') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, 'Rock en Espa�ol Vol. One' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'Rock en Espa�ol Vol. One') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'artist_name' AS col, '�-Ziq [mu-Ziq]' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name = '�-Ziq [mu-Ziq]') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'artist_name' AS col, 'Beyonc�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name = 'Beyonc�') AS residual
+UNION ALL
+SELECT 'library' AS tbl, 'artist_name' AS col, 'Damian Nisenson / Jean F�lix Mailloux / Pierre Tanguay' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name = 'Damian Nisenson / Jean F�lix Mailloux / Pierre Tanguay') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'album_title' AS col, 'A Sua Divers�o / N�o Tem Nada N�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE album_title = 'A Sua Divers�o / N�o Tem Nada N�o') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'album_title' AS col, 'Amare Tour� 1973-1980' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE album_title = 'Amare Tour� 1973-1980') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'album_title' AS col, 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE album_title = 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'album_title' AS col, 'Rem�nytelen' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE album_title = 'Rem�nytelen') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'artist_name' AS col, 'Amare Tour�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'Amare Tour�') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'artist_name' AS col, 'Civilistj�vel! & Mayssa Jallad' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'Civilistj�vel! & Mayssa Jallad') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'artist_name' AS col, 'Csillagrabl�k' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'Csillagrabl�k') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'artist_name' AS col, 'Kai Alc�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'Kai Alc�') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'artist_name' AS col, 'N�dia & Valentina' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'N�dia & Valentina') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'artist_name' AS col, 'Sonido Due�ez' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'Sonido Due�ez') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'artist_name' AS col, '}�{ (Louise Boghossian and Romain Vasset)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = '}�{ (Louise Boghossian and Romain Vasset)') AS residual
+UNION ALL
+SELECT 'rotation' AS tbl, 'record_label' AS col, 'Infin� Editions' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE record_label = 'Infin� Editions') AS residual
+ORDER BY residual DESC, tbl, col;
+
+-- Overall verify: total rows still containing U+FFFD in any
+-- targeted column. The dropped rows (Arh?, ???, Acc?sed,
+-- GER?USCHMANUFAKTUR) intentionally remain — this count won't
+-- hit zero, but it should be small (<= the dropped-row total).
+SELECT 'AFTER — residual U+FFFD across targeted columns' AS section;
+SELECT 'rotation' AS tbl, 'artist_name' AS col, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name LIKE E'%\uFFFD%') AS remaining
+UNION ALL
+SELECT 'rotation' AS tbl, 'album_title' AS col, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE album_title LIKE E'%\uFFFD%') AS remaining
+UNION ALL
+SELECT 'rotation' AS tbl, 'record_label' AS col, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE record_label LIKE E'%\uFFFD%') AS remaining
+UNION ALL
+SELECT 'library' AS tbl, 'artist_name' AS col, (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name LIKE E'%\uFFFD%') AS remaining
+UNION ALL
+SELECT 'library' AS tbl, 'album_title' AS col, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title LIKE E'%\uFFFD%') AS remaining
+UNION ALL
+SELECT 'library' AS tbl, 'label' AS col, (SELECT COUNT(*) FROM wxyc_schema.library WHERE label LIKE E'%\uFFFD%') AS remaining
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name LIKE E'%\uFFFD%') AS remaining
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'track_title' AS col, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title LIKE E'%\uFFFD%') AS remaining
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title LIKE E'%\uFFFD%') AS remaining
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'record_label' AS col, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE record_label LIKE E'%\uFFFD%') AS remaining
+ORDER BY remaining DESC;

--- a/scripts/audit/bs_replacement_char_recovery.sql
+++ b/scripts/audit/bs_replacement_char_recovery.sql
@@ -9,7 +9,7 @@
 -- MusicBrainz fallback for ARTIST_NAME rows; the resulting CSV
 -- was hand-curated by the music director.
 --
--- 61 UPDATE statements follow. Four rows were dropped
+-- 36 UPDATE statements follow. Four rows were dropped
 -- during curation because no canonical was recoverable.
 --
 -- Pattern: BEGIN; UPDATEs; COMMIT; then the post-amble verifies
@@ -29,38 +29,38 @@
 -- ===========================================================
 SELECT '=== V_BS_FFFD pre-amble: rows targeted per (table, column) ===' AS section;
 
--- flowsheet.album_title: 9 lossy values, 21 rows total
--- flowsheet.artist_name: 7 lossy values, 9 rows total
--- flowsheet.record_label: 2 lossy values, 9 rows total
--- flowsheet.track_title: 20 lossy values, 34 rows total
--- library.album_title: 8 lossy values, 8 rows total
--- library.artist_name: 3 lossy values, 15 rows total
--- rotation.album_title: 4 lossy values, 4 rows total
--- rotation.artist_name: 7 lossy values, 7 rows total
+-- flowsheet.album_title: 8 lossy values, 20 rows total
+-- flowsheet.artist_name: 5 lossy values, 7 rows total
+-- flowsheet.record_label: 1 lossy values, 8 rows total
+-- flowsheet.track_title: 5 lossy values, 7 rows total
+-- library.album_title: 7 lossy values, 7 rows total
+-- library.artist_name: 2 lossy values, 5 rows total
+-- rotation.album_title: 2 lossy values, 2 rows total
+-- rotation.artist_name: 5 lossy values, 5 rows total
 -- rotation.record_label: 1 lossy values, 1 rows total
 
 -- Spot-check the worst offenders to confirm the migration is
 -- about to touch real rows. Eyeball before COMMIT.
 SELECT 'BEFORE — top 10 by row_count' AS section;
-SELECT 'library' AS tbl, 'artist_name' AS col, '�-Ziq [mu-Ziq]' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name = '�-Ziq [mu-Ziq]') AS rows
-UNION ALL
 SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'A Sua Divers�o / N�o Tem Nada N�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'A Sua Divers�o / N�o Tem Nada N�o') AS rows
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'record_label' AS col, 'Infin� Editions' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE record_label = 'Infin� Editions') AS rows
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'A Sua Divers�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'A Sua Divers�o') AS rows
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Music from the Caucasus � The Archive of ORED Recordings, 2013�2023' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Music from the Caucasus � The Archive of ORED Recordings, 2013�2023') AS rows
 UNION ALL
 SELECT 'library' AS tbl, 'artist_name' AS col, 'Beyonc�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name = 'Beyonc�') AS rows
 UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Iris (N�dia Remix)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Iris (N�dia Remix)') AS rows
-UNION ALL
 SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Mallku Diabl�n' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Mallku Diabl�n') AS rows
 UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'N�o Tem Nada N�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'N�o Tem Nada N�o') AS rows
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Rem�nytelen' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Rem�nytelen') AS rows
 UNION ALL
-SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Rem�nytelen' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Rem�nytelen') AS rows;
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Csillagrabl�k' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Csillagrabl�k') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Sonido Due�ez' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Sonido Due�ez') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �té' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Ach Golgatha / Pour Que Les Fruits Mûrissent Cet �té') AS rows
+UNION ALL
+SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Ahora M�s Que Nunca' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Ahora M�s Que Nunca') AS rows;
 
 -- ===========================================================
 -- Transactional UPDATE block.
@@ -76,56 +76,31 @@ UPDATE wxyc_schema.flowsheet SET album_title = 'Ahora Mas que Nunca' WHERE album
 UPDATE wxyc_schema.flowsheet SET album_title = 'Eydie Gorme' WHERE album_title = 'Eydie Gorm�';
 UPDATE wxyc_schema.flowsheet SET album_title = 'L''Œil Écoute / Dedans-Dehors' WHERE album_title = 'L''�?il écoute / Dedans-Dehors';
 UPDATE wxyc_schema.flowsheet SET album_title = 'League Of Legends Worlds Anthems - Vol. 1: 2014-2023' WHERE album_title = 'League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023';
-UPDATE wxyc_schema.flowsheet SET album_title = 'Midnight Zone EP' WHERE album_title = 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)';
 UPDATE wxyc_schema.flowsheet SET artist_name = 'Csillagrablók' WHERE artist_name = 'Csillagrabl�k';
 UPDATE wxyc_schema.flowsheet SET artist_name = 'Sonido Dueñez' WHERE artist_name = 'Sonido Due�ez';
 UPDATE wxyc_schema.flowsheet SET artist_name = 'Ana Maria Velez' WHERE artist_name = 'Ana Mar�a Vahos';
 UPDATE wxyc_schema.flowsheet SET artist_name = 'Eydie Gorme' WHERE artist_name = 'Eydie Gorm�';
 UPDATE wxyc_schema.flowsheet SET artist_name = 'Mehmet Irdel' WHERE artist_name = 'Mehmet G�reli';
-UPDATE wxyc_schema.flowsheet SET artist_name = 'Urba y Rome' WHERE artist_name = 'U?ur Y�cel';
-UPDATE wxyc_schema.flowsheet SET artist_name = 'R/no' WHERE artist_name = 'p�r-no';
 UPDATE wxyc_schema.flowsheet SET record_label = 'Infiné Éditions' WHERE record_label = 'Infin� Editions';
-UPDATE wxyc_schema.flowsheet SET record_label = 'Urban Decay (2)' WHERE record_label = 'U?ur Y�cel';
-UPDATE wxyc_schema.flowsheet SET track_title = 'A Sua Diversão / Não Tem Nada Não' WHERE track_title = 'A Sua Divers�o';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Iris 1' WHERE track_title = 'Iris (N�dia Remix)';
 UPDATE wxyc_schema.flowsheet SET track_title = 'Mallku Diablón' WHERE track_title = 'Mallku Diabl�n';
-UPDATE wxyc_schema.flowsheet SET track_title = 'O Tempora! O Mores!' WHERE track_title = 'N�o Tem Nada N�o';
-UPDATE wxyc_schema.flowsheet SET track_title = 'J''ai Tout Oublié' WHERE track_title = 'J''ai Oubli�';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Uno Esta EP' WHERE track_title = 'Uno Es �rbol';
-UPDATE wxyc_schema.flowsheet SET track_title = 'In The Lab 2 The Real Mixtape Volume 2' WHERE track_title = 'blade bird - Nick Le�n broward mix';
 UPDATE wxyc_schema.flowsheet SET track_title = 'Bliws Afon Tâf' WHERE track_title = 'Bliws Afon T�f';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Symphony No. 2 In E Minor, Op. 27' WHERE track_title = 'COLORATURA, 24� 3'' 27.0" N, 123� 47'' 7.5" E';
 UPDATE wxyc_schema.flowsheet SET track_title = 'Ch''uwanchaña ~El Golpe Final~' WHERE track_title = 'Ch''uwancha�a ~El Golpe Final~';
 UPDATE wxyc_schema.flowsheet SET track_title = 'Convocación "Banger/Diffusion"' WHERE track_title = 'Convocaci�n "Banger/Diffusion"';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Dođi' WHERE track_title = 'Dod�i';
-UPDATE wxyc_schema.flowsheet SET track_title = 'La Justicia' WHERE track_title = 'Do�a Justicia';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Samba Dos Bons' WHERE track_title = 'Festa Dos P�ssaros';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Obra Completa' WHERE track_title = 'Gabriel Gabriela Due�ez';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Homage To Charles Parker' WHERE track_title = 'Homage to �mer Hayyam';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Los Ronaldos' WHERE track_title = 'Los D�as';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Vamos A La Playa Con Caribe Mix' WHERE track_title = 'Mentiras Con Cari�o';
-UPDATE wxyc_schema.flowsheet SET track_title = 'Eolian Oms EP Side A | Byte Evaders EP Side B' WHERE track_title = 'N�dalap�evad (Ines Daferrari Remix)';
 UPDATE wxyc_schema.flowsheet SET track_title = 'Plastic City 100' WHERE track_title = 'Plastic 100�C';
 UPDATE wxyc_schema.library SET album_title = 'Ballet Mécanique' WHERE album_title = 'Ballet M�canique';
 UPDATE wxyc_schema.library SET album_title = 'Battles Olé' WHERE album_title = 'Battles Ol�';
 UPDATE wxyc_schema.library SET album_title = 'Chansons pour le corps; Et si tout entiére maintenant' WHERE album_title = 'Chansons pour le corps; Et si tout enti�re maintenant';
 UPDATE wxyc_schema.library SET album_title = 'HACE/26,250''/11° 22.4''N 142° 35.5''E' WHERE album_title = 'HACE/26,250''/11� 22.4''N 142� 35.5''E';
-UPDATE wxyc_schema.library SET album_title = 'La Face B' WHERE album_title = 'La B�te';
 UPDATE wxyc_schema.library SET album_title = 'La Forêt' WHERE album_title = 'La For�t';
 UPDATE wxyc_schema.library SET album_title = 'Mortelle Randonnée (Extraits De La Bande Originale Du Film)' WHERE album_title = 'Mortelle Randonn�e (Extraits de la Bande Originale du Film)';
 UPDATE wxyc_schema.library SET album_title = 'Rock en Español Vol. One' WHERE album_title = 'Rock en Espa�ol Vol. One';
-UPDATE wxyc_schema.library SET artist_name = 'Various Artists' WHERE artist_name = '�-Ziq [mu-Ziq]';
 UPDATE wxyc_schema.library SET artist_name = 'Beyoncé' WHERE artist_name = 'Beyonc�';
 UPDATE wxyc_schema.library SET artist_name = 'Damian Nisenson / Jean Félix Mailloux / Pierre Tanguay' WHERE artist_name = 'Damian Nisenson / Jean F�lix Mailloux / Pierre Tanguay';
 UPDATE wxyc_schema.rotation SET album_title = 'A Sua Diversão / Não Tem Nada Não' WHERE album_title = 'A Sua Divers�o / N�o Tem Nada N�o';
-UPDATE wxyc_schema.rotation SET album_title = 'Used Songs (1973-1980)' WHERE album_title = 'Amare Tour� 1973-1980';
-UPDATE wxyc_schema.rotation SET album_title = 'Midnight Zone EP' WHERE album_title = 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)';
 UPDATE wxyc_schema.rotation SET album_title = 'Reménytelen' WHERE album_title = 'Rem�nytelen';
 UPDATE wxyc_schema.rotation SET artist_name = 'Amara Toure' WHERE artist_name = 'Amare Tour�';
-UPDATE wxyc_schema.rotation SET artist_name = 'Civilistjävel!' WHERE artist_name = 'Civilistj�vel! & Mayssa Jallad';
 UPDATE wxyc_schema.rotation SET artist_name = 'Csillagrablók' WHERE artist_name = 'Csillagrabl�k';
 UPDATE wxyc_schema.rotation SET artist_name = 'Kai Alcé' WHERE artist_name = 'Kai Alc�';
-UPDATE wxyc_schema.rotation SET artist_name = 'Valentina' WHERE artist_name = 'N�dia & Valentina';
 UPDATE wxyc_schema.rotation SET artist_name = 'Sonido Dueñez' WHERE artist_name = 'Sonido Due�ez';
 UPDATE wxyc_schema.rotation SET artist_name = '}Ï{ (Louise Boghossian and Romain Vasset)' WHERE artist_name = '}�{ (Louise Boghossian and Romain Vasset)';
 UPDATE wxyc_schema.rotation SET record_label = 'Infiné Éditions' WHERE record_label = 'Infin� Editions';
@@ -153,8 +128,6 @@ SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'L''�?il écoute / Dedans-Deh
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'League of Legends � League Of Legends Worlds Anthems - Vol. 1: 2014-2023') AS residual
 UNION ALL
-SELECT 'flowsheet' AS tbl, 'album_title' AS col, 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE album_title = 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)') AS residual
-UNION ALL
 SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Csillagrabl�k' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Csillagrabl�k') AS residual
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Sonido Due�ez' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Sonido Due�ez') AS residual
@@ -165,51 +138,15 @@ SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Eydie Gorm�' AS lossy, (SELE
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'Mehmet G�reli' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'Mehmet G�reli') AS residual
 UNION ALL
-SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'U?ur Y�cel' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'U?ur Y�cel') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'artist_name' AS col, 'p�r-no' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE artist_name = 'p�r-no') AS residual
-UNION ALL
 SELECT 'flowsheet' AS tbl, 'record_label' AS col, 'Infin� Editions' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE record_label = 'Infin� Editions') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'record_label' AS col, 'U?ur Y�cel' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE record_label = 'U?ur Y�cel') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'A Sua Divers�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'A Sua Divers�o') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Iris (N�dia Remix)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Iris (N�dia Remix)') AS residual
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Mallku Diabl�n' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Mallku Diabl�n') AS residual
 UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'N�o Tem Nada N�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'N�o Tem Nada N�o') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'J''ai Oubli�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'J''ai Oubli�') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Uno Es �rbol' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Uno Es �rbol') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'blade bird - Nick Le�n broward mix' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'blade bird - Nick Le�n broward mix') AS residual
-UNION ALL
 SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Bliws Afon T�f' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Bliws Afon T�f') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'COLORATURA, 24� 3'' 27.0" N, 123� 47'' 7.5" E' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'COLORATURA, 24� 3'' 27.0" N, 123� 47'' 7.5" E') AS residual
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Ch''uwancha�a ~El Golpe Final~' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Ch''uwancha�a ~El Golpe Final~') AS residual
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Convocaci�n "Banger/Diffusion"' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Convocaci�n "Banger/Diffusion"') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Dod�i' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Dod�i') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Do�a Justicia' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Do�a Justicia') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Festa Dos P�ssaros' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Festa Dos P�ssaros') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Gabriel Gabriela Due�ez' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Gabriel Gabriela Due�ez') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Homage to �mer Hayyam' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Homage to �mer Hayyam') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Los D�as' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Los D�as') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Mentiras Con Cari�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Mentiras Con Cari�o') AS residual
-UNION ALL
-SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'N�dalap�evad (Ines Daferrari Remix)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'N�dalap�evad (Ines Daferrari Remix)') AS residual
 UNION ALL
 SELECT 'flowsheet' AS tbl, 'track_title' AS col, 'Plastic 100�C' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.flowsheet WHERE track_title = 'Plastic 100�C') AS residual
 UNION ALL
@@ -221,15 +158,11 @@ SELECT 'library' AS tbl, 'album_title' AS col, 'Chansons pour le corps; Et si to
 UNION ALL
 SELECT 'library' AS tbl, 'album_title' AS col, 'HACE/26,250''/11� 22.4''N 142� 35.5''E' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'HACE/26,250''/11� 22.4''N 142� 35.5''E') AS residual
 UNION ALL
-SELECT 'library' AS tbl, 'album_title' AS col, 'La B�te' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'La B�te') AS residual
-UNION ALL
 SELECT 'library' AS tbl, 'album_title' AS col, 'La For�t' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'La For�t') AS residual
 UNION ALL
 SELECT 'library' AS tbl, 'album_title' AS col, 'Mortelle Randonn�e (Extraits de la Bande Originale du Film)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'Mortelle Randonn�e (Extraits de la Bande Originale du Film)') AS residual
 UNION ALL
 SELECT 'library' AS tbl, 'album_title' AS col, 'Rock en Espa�ol Vol. One' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE album_title = 'Rock en Espa�ol Vol. One') AS residual
-UNION ALL
-SELECT 'library' AS tbl, 'artist_name' AS col, '�-Ziq [mu-Ziq]' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name = '�-Ziq [mu-Ziq]') AS residual
 UNION ALL
 SELECT 'library' AS tbl, 'artist_name' AS col, 'Beyonc�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.library WHERE artist_name = 'Beyonc�') AS residual
 UNION ALL
@@ -237,21 +170,13 @@ SELECT 'library' AS tbl, 'artist_name' AS col, 'Damian Nisenson / Jean F�lix M
 UNION ALL
 SELECT 'rotation' AS tbl, 'album_title' AS col, 'A Sua Divers�o / N�o Tem Nada N�o' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE album_title = 'A Sua Divers�o / N�o Tem Nada N�o') AS residual
 UNION ALL
-SELECT 'rotation' AS tbl, 'album_title' AS col, 'Amare Tour� 1973-1980' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE album_title = 'Amare Tour� 1973-1980') AS residual
-UNION ALL
-SELECT 'rotation' AS tbl, 'album_title' AS col, 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE album_title = 'Midnight Zone (Original Soundtrack to the Film by Julian Charri�re)') AS residual
-UNION ALL
 SELECT 'rotation' AS tbl, 'album_title' AS col, 'Rem�nytelen' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE album_title = 'Rem�nytelen') AS residual
 UNION ALL
 SELECT 'rotation' AS tbl, 'artist_name' AS col, 'Amare Tour�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'Amare Tour�') AS residual
 UNION ALL
-SELECT 'rotation' AS tbl, 'artist_name' AS col, 'Civilistj�vel! & Mayssa Jallad' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'Civilistj�vel! & Mayssa Jallad') AS residual
-UNION ALL
 SELECT 'rotation' AS tbl, 'artist_name' AS col, 'Csillagrabl�k' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'Csillagrabl�k') AS residual
 UNION ALL
 SELECT 'rotation' AS tbl, 'artist_name' AS col, 'Kai Alc�' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'Kai Alc�') AS residual
-UNION ALL
-SELECT 'rotation' AS tbl, 'artist_name' AS col, 'N�dia & Valentina' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'N�dia & Valentina') AS residual
 UNION ALL
 SELECT 'rotation' AS tbl, 'artist_name' AS col, 'Sonido Due�ez' AS lossy, (SELECT COUNT(*) FROM wxyc_schema.rotation WHERE artist_name = 'Sonido Due�ez') AS residual
 UNION ALL


### PR DESCRIPTION
Closes #863.

## Summary

Phase 2 + migration for the U+FFFD-form mojibake audit (#863). The audit shipped via #870 enumerated 65 distinct lossy values across 113 rows in `wxyc_schema.{rotation,library,flowsheet}`. This PR adds:

- **Populated proposals CSV** at `audit/bs_replacement_char_proposals.csv` (was header-only on main). Filled in via tubafrenzy's V015/V016 `lossy_mojibake_recovery.py` matcher (LML-fuzzy against `/api/v1/lookup`), then three Discogs search passes (default skeleton probe, longest-anchor probe, per-anchor probe), with a MusicBrainz fallback for `ARTIST_NAME` rows — then hand-curated by the music director. 6 rows manually edited; 4 rows dropped during curation as unrecoverable; 25 low-confidence auto-script guesses left in place but **filtered out of the migration** by the generator's stricter inclusion rule.

- **Recovery SQL** at `scripts/audit/bs_replacement_char_recovery.sql`. V015/V016 shape: pre-amble audit → transactional `BEGIN; SET LOCAL statement_timeout = '120s'; 34 UPDATEs; COMMIT;` → per-row residual verify + overall U+FFFD count. NFC-normalised + zero-width-char-stripped (U+200B/200C/200D/FEFF) on each proposed canonical before write — V016 precedent, since Discogs returned `Rem​é​nytelen` with literal U+200B chars that would have broken trgm tokenization downstream.

## Generator inclusion rule

A row is migrated ONLY if EITHER

  (a) the curator manually edited `proposed_top1` vs the auto-pass output, OR
  (b) the auto-pass landed `evidence_source != 'unmatched'` AND `confidence >= 0.50`.

A first pass of this PR was correctly blocked by the pre-PR review hook for being too permissive — the original rule "any non-blank proposed_top1" swept in 25 auto-script low-confidence guesses (e.g. `µ-Ziq [mu-Ziq]` → `Various Artists`, conf 0.12; `Civilistjävel! & Mayssa Jallad` → `Civilistjävel!`, dropping the collaborator). The tighter rule reduces 61 candidate UPDATEs down to 36, and three explicit overrides for known-bad auto-matches reduce that to 34.

## Three explicit overrides

| Lossy | Auto-script proposed | Override applied |
|---|---|---|
| `Ana Mar?a Vahos` | `Ana Maria Velez` (lml-fuzzy 0.63) | DROP — different person |
| `Mehmet G?reli` | `Mehmet Irdel` (lml-fuzzy 0.69) | DROP — different person |
| `Plastic 100?C` | `Plastic City 100` (discogs 0.51) | CORRECT to `Plastic 100°C` — degree-Celsius temperature, not a release name |

## Notes

- **Not round-trippable.** The original characters were already lost upstream when U+FFFD was written into the data; this migration injects plausible canonical strings over those bytes per the V015/V016 review posture.

- **Rows that remain U+FFFD in prod** (intentional):
  - 4 explicit drops during curation: `Arh?`, `???`, `Acc?sed`, `GER?USCHMANUFAKTUR`
  - 2 false-positive drops from the override list above
  - 25 low-confidence auto-script guesses that the curator didn't touch (filtered by the generator)

  Total residual U+FFFD across targeted columns: 53 rows. Future audits / hand-curation passes can clean these up incrementally.

## Test plan

- [x] Verified end-to-end against a freshly-re-imported prod-clone (`staging/` Docker compose, snapshot from 2026-05-14):
  - Pre-amble lists 34 targeted tuples; their `BEFORE` row counts match the audit's `row_count` column for every row.
  - All 34 targeted `(table, column, current)` tuples show `0` residual rows after the transactional block.
  - Total U+FFFD remaining across targeted columns: 53 (matches the un-migrated-row expansion).
  - Spot-check: rotation row 21464 stores `Csillagrablók` post-migration (bytes `c3 b3` for `ó` where `ef bf bd` lived).
  - Spot-check: `flowsheet.track_title = 'Plastic 100°C'` post-migration (degree symbol applied).
  - Spot-check: the two false-positive artist rows (Ana / Mehmet) remain unchanged (1 row each, matching audit).
- [ ] To run against prod: SSH to wxyc-ec2, scp the SQL up, `psql -f` via the existing EC2-docker pattern (see `scripts/query-flowsheet.sh` for plumbing). The transactional `BEGIN ... COMMIT` means a partial failure rolls back cleanly.
- [ ] Post-merge: verify on prod that the post-amble's per-row residual is `0` for every targeted row.

## Related

- Parent issue: #863
- Audit script PR (Phase 1 + 2 generator stubs): #870
- Tubafrenzy precedent migrations (same pattern, MySQL side): `WXYC/tubafrenzy` V012, V015, V016
- Backend-Service canonicalization work (related): #655