### PR TITLE
Accept on_streaming as a sufficient /library query filter (#872)

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -158,13 +158,17 @@ type AlbumQueryParams = {
 
 export const searchForAlbum: RequestHandler = async (req: Request<object, object, object, AlbumQueryParams>, res) => {
   const { query } = req;
+  // `on_streaming` is sufficient on its own to scope the result set (used by
+  // dj-site Classic's "Browse Exclusive Albums" view, which surfaces all
+  // non-streaming releases without a text query). See #872.
   if (
     query.artist_name === undefined &&
     query.album_title === undefined &&
+    query.on_streaming === undefined &&
     (query.code_letters === undefined || query.code_artist_number === undefined)
   ) {
     throw new WxycError(
-      'Missing query parameter. Query must include: artist_name, album_title, or code_letters, code_artist_number, and code_number',
+      'Missing query parameter. Query must include: artist_name, album_title, on_streaming, or code_letters and code_artist_number',
       400
     );
   }

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -229,6 +229,44 @@ describe('library.controller', () => {
       }
     });
 
+    it('returns 400 when no query parameters are supplied', async () => {
+      const req = { query: {} } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(searchForAlbum(req, res, next)).rejects.toThrow('Missing query parameter');
+      expect(mockFuzzySearchLibrary).not.toHaveBeenCalled();
+    });
+
+    it('accepts on_streaming=false as a sufficient filter and returns 200', async () => {
+      const searchResults = [{ id: 1, artist_name: 'Juana Molina', album_title: 'DOGA', on_streaming: false }];
+      mockFuzzySearchLibrary.mockResolvedValue(searchResults);
+      mockEnrichWithArtwork.mockResolvedValue(searchResults);
+
+      const req = { query: { on_streaming: 'false' } } as unknown as Request;
+      const res = mockResponse();
+
+      await searchForAlbum(req, res, next);
+
+      expect(mockFuzzySearchLibrary).toHaveBeenCalledWith(undefined, undefined, undefined, false);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(searchResults);
+    });
+
+    it('accepts on_streaming=true as a sufficient filter and returns 200', async () => {
+      const searchResults = [{ id: 2, artist_name: 'Stereolab', album_title: 'Aluminum Tunes', on_streaming: true }];
+      mockFuzzySearchLibrary.mockResolvedValue(searchResults);
+      mockEnrichWithArtwork.mockResolvedValue(searchResults);
+
+      const req = { query: { on_streaming: 'true' } } as unknown as Request;
+      const res = mockResponse();
+
+      await searchForAlbum(req, res, next);
+
+      expect(mockFuzzySearchLibrary).toHaveBeenCalledWith(undefined, undefined, undefined, true);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(searchResults);
+    });
+
     it('does not propagate enrichment errors as request failures', async () => {
       const searchResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
       mockFuzzySearchLibrary.mockResolvedValue(searchResults);


### PR DESCRIPTION
## Summary

`searchForAlbum` in `apps/backend/controllers/library.controller.ts` rejected `GET /library?on_streaming=false` with 400 because the validation block required at least one of `artist_name`, `album_title`, or `(code_letters + code_artist_number)`. The downstream `libraryService.fuzzySearchLibrary` already accepts the filter standalone; only the controller-level guard was in the way. This PR adds `on_streaming` to the set of sufficient query parameters and updates the error message accordingly. The no-parameter case still 400s.

Unblocks dj-site Classic's "Browse Exclusive Albums" feature ([WXYC/dj-site#532](https://github.com/WXYC/dj-site/issues/532) / [WXYC/dj-site#533](https://github.com/WXYC/dj-site/pull/533)).

Closes #872

## Test plan

- [x] `GET /library?on_streaming=false` returns 200 (covered by unit test `accepts on_streaming=false as a sufficient filter and returns 200`)
- [x] `GET /library?on_streaming=true` returns 200 (covered by unit test `accepts on_streaming=true as a sufficient filter and returns 200`)
- [x] Existing happy paths (`?artist_name=…`, `?album_title=…`) still pass validation unchanged (existing `searchForAlbum` test suite continues to pass)
- [x] A request with NO query parameters still 400s (covered by unit test `returns 400 when no query parameters are supplied`)
- [x] Full unit test suite passes (1858 tests across 143 suites)

## Follow-up

The OpenAPI spec at [`wxyc-shared/api.yaml`](https://github.com/WXYC/wxyc-shared/blob/main/api.yaml) should be updated in a separate PR to document `on_streaming` as a sufficient query filter under `/library` (the issue's acceptance criteria lists this as a separate spec note; not pursued here since it lives in a different repo).