### PR TITLE
Extend reltuples workaround docstring with re-evaluation trigger

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -221,6 +221,15 @@ export const resolveDjNameForShow = async (show: Show): Promise<string | null> =
  * `reltuples = -1` is the "never analyzed" sentinel; treat it as 0. The same
  * goes for a missing row (no permissions on `pg_class` would surface as an
  * error from the surrounding query, not as a missing row).
+ *
+ * Re-evaluation trigger: revisit when `flowsheet` exceeds ~5M rows (currently
+ * ~2.6M). At that scale the ±1% planner estimate drifts ±50k per page bucket
+ * and the UI's "Page X of N" starts skipping numbers visibly. Alternatives at
+ * that point, cheapest to costliest: (1) drop `totalPages` from the response
+ * and let clients infer "more pages?" from `results.length === limit`,
+ * (2) refresh a materialized count on a cron, (3) bump the RDS instance class
+ * so an exact `COUNT(*)` fits the 5s statement timeout. (Storage size bumps
+ * are not on the table — gp3 conversions are reversible, sizing up is not.)
  */
 export const getEntryCount = async (): Promise<number> => {
   const schema = process.env.WXYC_SCHEMA_NAME ?? 'wxyc_schema';


### PR DESCRIPTION
## Summary

- Extends the JSDoc on `flowsheet.service.ts:getEntryCount` with a re-evaluation trigger: revisit when `flowsheet` exceeds ~5M rows (currently ~2.6M).
- Names the symptom that would force the decision (UI page numbers visibly skipping) and the alternatives in cost order: drop `totalPages` from the response, refresh a materialized count on a cron, or bump the RDS instance class.
- Explicitly records that storage size bumps are out of scope (gp3 size-ups are non-reversible).

This is the H4 child of [Epic H](https://github.com/WXYC/Backend-Service/issues/882) (Post-launch service hardening, [project #32](https://github.com/orgs/WXYC/projects/32)): "documented, no action."

## Test plan

- [x] `npm run lint` — 374 pre-existing warnings, 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — clean across all workspaces

Closes #911