### PR TITLE
E6-5: GET /proxy/library/:libraryId/tracks for flowsheet picker

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -616,14 +616,16 @@ export const libraryTracks: RequestHandler<{ libraryId: string }> = async (req, 
     try {
       const release = await getRelease(discogsReleaseId);
       tracks = projectTracks(release);
-      tracklistCache.set(discogsReleaseId, tracks);
     } catch (err) {
       if (err instanceof LmlClientError && err.statusCode === 404) {
+        // Cache the empty result so repeat requests for a release LML
+        // doesn't know about don't re-hit LML for 10 minutes.
         tracks = [];
       } else {
         throw err;
       }
     }
+    tracklistCache.set(discogsReleaseId, tracks);
   }
 
   const body: LibraryTracksResponse = {

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -19,8 +19,15 @@ import {
   getArtistDetails,
   resolveEntity as lmlResolveEntity,
   searchLibrary,
+  LmlClientError,
 } from '../services/lml/lml.client.js';
-import type { DiscogsMatchResult, DiscogsTrackItem, LookupResponse } from '../services/lml/lml.client.js';
+import type {
+  DiscogsMatchResult,
+  DiscogsReleaseMetadata,
+  DiscogsTrackItem,
+  LookupResponse,
+} from '../services/lml/lml.client.js';
+import { getDiscogsReleaseIdByLegacyId } from '../services/library.service.js';
 import { LRUCache } from 'lru-cache';
 import WxycError from '../utils/error.js';
 
@@ -507,4 +514,124 @@ export const librarySearch: RequestHandler<object, unknown, unknown, LibrarySear
 
   res.set('Cache-Control', 'private, max-age=60');
   res.status(200).json(results);
+};
+
+/**
+ * GET /proxy/library/:libraryId/tracks (E6-5 / BS#836)
+ *
+ * Returns the tracklist for a library release so the dj-site flowsheet
+ * picker can let DJs pick a track by position after selecting a release
+ * (catalog-track-search plan §4.3 / Track 3).
+ *
+ * Composition (BS-side; no new LML endpoint):
+ *   1. Map inbound `libraryId` (LML `library.db.id` = BS `library.legacy_release_id`)
+ *      → resolved Discogs release id via `library_identity`.
+ *   2. Fetch the tracklist from LML's `GET /api/v1/discogs/release/{id}`.
+ *
+ * Degrades gracefully — when no identity is resolved (typical for rows
+ * BS#802's backfill hasn't covered yet) or LML returns 404 on the release,
+ * the response is 200 with `tracks: []` and the picker falls back to
+ * free-text input. Only LML 5xx errors bubble up to the error handler.
+ *
+ * Each hit is cached BS-side by Discogs release id for 10 minutes — a thin
+ * deduplication layer on top of LML's own 3-tier cache.
+ */
+interface LibraryTrackEntry {
+  position: string;
+  title: string;
+  artist_credit: string;
+  duration_ms: number | null;
+}
+
+interface LibraryTracksResponse {
+  library_id: number;
+  discogs_release_id: number | null;
+  source: 'discogs' | null;
+  tracks: LibraryTrackEntry[];
+}
+
+const tracklistCache = new LRUCache<number, LibraryTrackEntry[]>({
+  max: 500,
+  ttl: 1000 * 60 * 10,
+});
+
+/** Test-only: drop cached entries between cases. */
+export function __resetLibraryTracksCacheForTests(): void {
+  tracklistCache.clear();
+}
+
+/**
+ * Parse a Discogs `duration` string ("M:SS", "H:MM:SS", or bare seconds)
+ * into milliseconds. Returns null for empty or unparseable values — Discogs
+ * sometimes leaves the field blank or stores freeform text.
+ */
+function parseDurationMs(raw: string | null | undefined): number | null {
+  if (!raw) return null;
+  const parts = raw.split(':').map((p) => p.trim());
+  if (parts.some((p) => !/^\d+$/.test(p))) return null;
+  const nums = parts.map(Number);
+  let seconds: number;
+  if (nums.length === 1) seconds = nums[0];
+  else if (nums.length === 2) seconds = nums[0] * 60 + nums[1];
+  else if (nums.length === 3) seconds = nums[0] * 3600 + nums[1] * 60 + nums[2];
+  else return null;
+  return seconds * 1000;
+}
+
+function buildArtistCredit(track: DiscogsTrackItem, releaseArtist: string): string {
+  if (track.artists && track.artists.length > 0) return track.artists.join(', ');
+  return releaseArtist;
+}
+
+function projectTracks(release: DiscogsReleaseMetadata): LibraryTrackEntry[] {
+  return release.tracklist.map((t) => ({
+    position: t.position,
+    title: t.title,
+    artist_credit: buildArtistCredit(t, release.artist),
+    duration_ms: parseDurationMs(t.duration),
+  }));
+}
+
+export const libraryTracks: RequestHandler<{ libraryId: string }> = async (req, res) => {
+  const libraryId = parseInt(req.params.libraryId, 10);
+  if (!Number.isInteger(libraryId) || libraryId <= 0) {
+    throw new WxycError('libraryId must be a positive integer', 400);
+  }
+
+  const discogsReleaseId = await getDiscogsReleaseIdByLegacyId(libraryId);
+  if (discogsReleaseId === null) {
+    const body: LibraryTracksResponse = {
+      library_id: libraryId,
+      discogs_release_id: null,
+      source: null,
+      tracks: [],
+    };
+    res.set('Cache-Control', 'private, max-age=600');
+    res.status(200).json(body);
+    return;
+  }
+
+  let tracks = tracklistCache.get(discogsReleaseId);
+  if (!tracks) {
+    try {
+      const release = await getRelease(discogsReleaseId);
+      tracks = projectTracks(release);
+      tracklistCache.set(discogsReleaseId, tracks);
+    } catch (err) {
+      if (err instanceof LmlClientError && err.statusCode === 404) {
+        tracks = [];
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  const body: LibraryTracksResponse = {
+    library_id: libraryId,
+    discogs_release_id: discogsReleaseId,
+    source: 'discogs',
+    tracks,
+  };
+  res.set('Cache-Control', 'private, max-age=600');
+  res.status(200).json(body);
 };

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,7 +21,7 @@
     "@tensorflow/tfjs": "^4.22.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.5.0",
+    "@wxyc/shared": "^1.6.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.16.0",

--- a/apps/backend/routes/proxy.route.ts
+++ b/apps/backend/routes/proxy.route.ts
@@ -15,3 +15,4 @@ proxy_route.get('/metadata/artist', proxyController.getArtistMetadata);
 proxy_route.get('/entity/resolve', proxyController.resolveEntity);
 proxy_route.get('/spotify/track/:id', proxyController.getSpotifyTrack);
 proxy_route.get('/library/search', proxyController.librarySearch);
+proxy_route.get('/library/:libraryId/tracks', proxyController.libraryTracks);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -18,6 +18,7 @@ import {
   format,
   genres,
   library,
+  library_identity,
   rotation,
   LibraryArtistViewEntry,
 } from '@wxyc/database';
@@ -287,6 +288,30 @@ export const insertAlbum = async (newAlbum: NewAlbum) => {
   const response = await db.insert(library).values(newAlbum).returning();
   return response[0];
 };
+
+/**
+ * Look up the resolved Discogs release id for a library row by its
+ * legacy id — the id the dj-site flowsheet picker carries (LML
+ * `library.db.id` = BS `library.legacy_release_id`). JOINs `library`
+ * to `library_identity` via that bridge in a single query.
+ *
+ * Returns null when any of these holds (the picker degrades to free-text):
+ *   - legacy id doesn't map to a BS library row,
+ *   - the row has no `library_identity` entry (not yet backfilled by BS#802), or
+ *   - the identity row has no resolved `discogs_release_id`.
+ *
+ * Used by `/proxy/library/{id}/tracks` (E6-5 / BS#836) to compose against
+ * LML's `/api/v1/discogs/release/{id}` for the tracklist.
+ */
+export async function getDiscogsReleaseIdByLegacyId(legacyId: number): Promise<number | null> {
+  const rows = await db
+    .select({ discogs_release_id: library_identity.discogs_release_id })
+    .from(library)
+    .innerJoin(library_identity, eq(library_identity.library_id, library.id))
+    .where(eq(library.legacy_release_id, legacyId))
+    .limit(1);
+  return rows[0]?.discogs_release_id ?? null;
+}
 
 export const updateOnStreaming = async (id: number, on_streaming: boolean | null) => {
   const response = await db.update(library).set({ on_streaming }).where(eq(library.id, id)).returning();

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,7 +267,7 @@
         "@tensorflow/tfjs": "^4.22.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.5.0",
+        "@wxyc/shared": "^1.6.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.16.0",
@@ -319,9 +319,9 @@
       }
     },
     "apps/backend/node_modules/@wxyc/shared": {
-      "version": "1.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.5.0/d39ca7a99054d44b105dbfc0306de1fb4b68b092",
-      "integrity": "sha512-YyCHTaSdGGwdxXbNUVQiopXyYVWZPgSoQltE6l2aDkK+SX6M9IQiikVNC0307APJc/0GVSdmxU2xhBkOtZgz8w==",
+      "version": "1.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.6.0/0ac95dfea321342ddd9420ad17ce52a7e09fbdc9",
+      "integrity": "sha512-aXL5T714e7B7PYFT+s0IwBN8dh3n8QDEegwgRl7ugK3pSnmoe/tEheHgSAvmYSza+CvfoCfuApUUXPZMAOPSIw==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/tests/integration/library-tracks.spec.js
+++ b/tests/integration/library-tracks.spec.js
@@ -20,48 +20,61 @@ const SHAPE_LIBRARY_ID = 7100;
 const SHAPE_LEGACY_ID = 65880;
 const MOCK_LML_RELEASE_ID = 4080;
 
+// `MOCK_API_URL` is unset in environments not configured for mock-LML tests
+// (so we don't intend to run them). It is set in the CI mock environment and
+// in local dev_env. We use `describe.skip` on the mock-requiring block rather
+// than an in-test `if (!available) return` (which silently passes — the issue
+// raised in PR #922 review iteration 1).
+//
+// When MOCK_API_URL *is* set but unreachable, beforeAll throws and the suite
+// fails loudly — that's the desired behavior: a configured-but-broken mock is
+// an environment problem, not a skippable case.
+const mockApiConfigured = !!process.env.MOCK_API_URL;
+const describeWhenMockConfigured = mockApiConfigured ? describe : describe.skip;
+
 describe('GET /proxy/library/:libraryId/tracks (E6-5)', () => {
   let auth;
   let sql;
-  let mockAvailable;
   const wxycSchema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 
   beforeAll(async () => {
     auth = createAuthRequest(request, global.access_token);
     sql = getTestDb();
-    mockAvailable = await isMockApiAvailable();
-
-    await sql.unsafe(
-      `INSERT INTO ${wxycSchema}.library_identity
-         (library_id, discogs_release_id, last_verified_at, method, confidence)
-       VALUES ($1, $2, NOW(), 'integration-test', 0.95)
-       ON CONFLICT (library_id) DO UPDATE
-         SET discogs_release_id = EXCLUDED.discogs_release_id`,
-      [SHAPE_LIBRARY_ID, MOCK_LML_RELEASE_ID]
-    );
   });
 
-  afterAll(async () => {
-    await sql.unsafe(`DELETE FROM ${wxycSchema}.library_identity WHERE library_id = $1`, [SHAPE_LIBRARY_ID]);
-  });
+  describeWhenMockConfigured('with mock LML available (composes library_identity + LML)', () => {
+    beforeAll(async () => {
+      if (!(await isMockApiAvailable())) {
+        throw new Error('MOCK_API_URL is set but mock-api-server is unreachable; cannot run mock-LML-dependent tests');
+      }
+      await sql.unsafe(
+        `INSERT INTO ${wxycSchema}.library_identity
+           (library_id, discogs_release_id, last_verified_at, method, confidence)
+         VALUES ($1, $2, NOW(), 'integration-test', 0.95)
+         ON CONFLICT (library_id) DO UPDATE
+           SET discogs_release_id = EXCLUDED.discogs_release_id`,
+        [SHAPE_LIBRARY_ID, MOCK_LML_RELEASE_ID]
+      );
+    });
 
-  test('returns the tracklist composed from library_identity + LML when identity is resolved', async () => {
-    if (!mockAvailable) {
-      console.warn('Skipping: mock-api-server not running');
-      return;
-    }
-    const res = await auth.get(`/proxy/library/${SHAPE_LEGACY_ID}/tracks`).expect(200);
+    afterAll(async () => {
+      await sql.unsafe(`DELETE FROM ${wxycSchema}.library_identity WHERE library_id = $1`, [SHAPE_LIBRARY_ID]);
+    });
 
-    expect(res.body.library_id).toBe(SHAPE_LEGACY_ID);
-    expect(res.body.discogs_release_id).toBe(MOCK_LML_RELEASE_ID);
-    expect(res.body.source).toBe('discogs');
-    expect(Array.isArray(res.body.tracks)).toBe(true);
-    expect(res.body.tracks.length).toBeGreaterThanOrEqual(1);
-    res.body.tracks.forEach((t) => {
-      expect(typeof t.position).toBe('string');
-      expect(typeof t.title).toBe('string');
-      expect(typeof t.artist_credit).toBe('string');
-      expect(t.duration_ms === null || typeof t.duration_ms === 'number').toBe(true);
+    test('returns the tracklist composed from library_identity + LML when identity is resolved', async () => {
+      const res = await auth.get(`/proxy/library/${SHAPE_LEGACY_ID}/tracks`).expect(200);
+
+      expect(res.body.library_id).toBe(SHAPE_LEGACY_ID);
+      expect(res.body.discogs_release_id).toBe(MOCK_LML_RELEASE_ID);
+      expect(res.body.source).toBe('discogs');
+      expect(Array.isArray(res.body.tracks)).toBe(true);
+      expect(res.body.tracks.length).toBeGreaterThanOrEqual(1);
+      res.body.tracks.forEach((t) => {
+        expect(typeof t.position).toBe('string');
+        expect(typeof t.title).toBe('string');
+        expect(typeof t.artist_credit).toBe('string');
+        expect(t.duration_ms === null || typeof t.duration_ms === 'number').toBe(true);
+      });
     });
   });
 

--- a/tests/integration/library-tracks.spec.js
+++ b/tests/integration/library-tracks.spec.js
@@ -1,0 +1,83 @@
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+const { getTestDb } = require('../utils/db');
+const { isMockApiAvailable } = require('../utils/mock_api');
+
+/**
+ * Integration tests for GET /proxy/library/:libraryId/tracks (E6-5 / BS#836).
+ *
+ * Composes library_identity (BS PG) + LML's /api/v1/discogs/release/{id}
+ * (mock LML) into the tracklist the dj-site flowsheet picker consumes.
+ *
+ * The library row (id=7100, legacy_release_id=65880) comes from
+ * tests/fixtures/shape.sql. The mock LML's release fixture for Discogs
+ * id 4080 (Confield) lives at dev_env/mock-api-server/src/fixtures/lml.json.
+ * This spec seeds the missing `library_identity` row to bridge the two,
+ * exercises the endpoint, and cleans up.
+ */
+
+const SHAPE_LIBRARY_ID = 7100;
+const SHAPE_LEGACY_ID = 65880;
+const MOCK_LML_RELEASE_ID = 4080;
+
+describe('GET /proxy/library/:libraryId/tracks (E6-5)', () => {
+  let auth;
+  let sql;
+  let mockAvailable;
+  const wxycSchema = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = getTestDb();
+    mockAvailable = await isMockApiAvailable();
+
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.library_identity
+         (library_id, discogs_release_id, last_verified_at, method, confidence)
+       VALUES ($1, $2, NOW(), 'integration-test', 0.95)
+       ON CONFLICT (library_id) DO UPDATE
+         SET discogs_release_id = EXCLUDED.discogs_release_id`,
+      [SHAPE_LIBRARY_ID, MOCK_LML_RELEASE_ID]
+    );
+  });
+
+  afterAll(async () => {
+    await sql.unsafe(`DELETE FROM ${wxycSchema}.library_identity WHERE library_id = $1`, [SHAPE_LIBRARY_ID]);
+  });
+
+  test('returns the tracklist composed from library_identity + LML when identity is resolved', async () => {
+    if (!mockAvailable) {
+      console.warn('Skipping: mock-api-server not running');
+      return;
+    }
+    const res = await auth.get(`/proxy/library/${SHAPE_LEGACY_ID}/tracks`).expect(200);
+
+    expect(res.body.library_id).toBe(SHAPE_LEGACY_ID);
+    expect(res.body.discogs_release_id).toBe(MOCK_LML_RELEASE_ID);
+    expect(res.body.source).toBe('discogs');
+    expect(Array.isArray(res.body.tracks)).toBe(true);
+    expect(res.body.tracks.length).toBeGreaterThanOrEqual(1);
+    res.body.tracks.forEach((t) => {
+      expect(typeof t.position).toBe('string');
+      expect(typeof t.title).toBe('string');
+      expect(typeof t.artist_credit).toBe('string');
+      expect(t.duration_ms === null || typeof t.duration_ms === 'number').toBe(true);
+    });
+  });
+
+  test('returns 200 + empty tracks when no library_identity exists', async () => {
+    // legacy id 999_999_999 has no library row, so no identity either.
+    const res = await auth.get('/proxy/library/999999999/tracks').expect(200);
+    expect(res.body).toEqual({
+      library_id: 999999999,
+      discogs_release_id: null,
+      source: null,
+      tracks: [],
+    });
+  });
+
+  test('returns 400 when libraryId is not a positive integer', async () => {
+    const res = await auth.get('/proxy/library/not-a-number/tracks').expect(400);
+    expect(res.body.message ?? res.body.error ?? '').toMatch(/positive integer/i);
+  });
+});

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -34,6 +34,13 @@ jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
   LmlClientError: MockLmlClientError,
 }));
 
+// library.service mock — only the helper libraryTracks consumes.
+const mockGetDiscogsReleaseIdByLegacyId = jest.fn<(legacyId: number) => Promise<number | null>>();
+
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  getDiscogsReleaseIdByLegacyId: mockGetDiscogsReleaseIdByLegacyId,
+}));
+
 // Artwork finder mock (still used for Last.fm/iTunes fallback in searchArtwork)
 const mockFind = jest.fn<
   () => Promise<{
@@ -76,6 +83,8 @@ import {
   resolveEntity,
   getSpotifyTrack,
   librarySearch,
+  libraryTracks,
+  __resetLibraryTracksCacheForTests,
 } from '../../../apps/backend/controllers/proxy.controller';
 
 // --- Helpers ---
@@ -1038,6 +1047,191 @@ describe('proxy.controller', () => {
       const res = createMockRes();
 
       await expect(librarySearch(req, res as Response, mockNext)).rejects.toThrow(error);
+    });
+  });
+
+  // --- libraryTracks (E6-5 / BS#836) ---
+  //
+  // Composes BS `library_identity.discogs_release_id` (looked up by inbound
+  // LML library.db.id) → LML `GET /api/v1/discogs/release/{id}` for the
+  // tracklist. Returns an empty `tracks` array when identity is unresolved,
+  // so the dj-site flowsheet picker can degrade to free-text input.
+
+  describe('libraryTracks', () => {
+    beforeEach(() => {
+      __resetLibraryTracksCacheForTests();
+    });
+
+    it('throws WxycError 400 when libraryId is not a positive integer', async () => {
+      const req = { params: { libraryId: 'not-a-number' } } as unknown as Request;
+      const res = createMockRes();
+
+      await expect(libraryTracks(req, res as Response, mockNext)).rejects.toThrow(
+        'libraryId must be a positive integer'
+      );
+    });
+
+    it('returns tracklist with mapped fields when identity is found and LML returns the release', async () => {
+      mockGetDiscogsReleaseIdByLegacyId.mockResolvedValue(42);
+      mockGetRelease.mockResolvedValue({
+        release_id: 42,
+        title: 'On Your Own Love Again',
+        artist: 'Jessica Pratt',
+        tracklist: [
+          { position: 'A1', title: 'Wrong Hand', duration: '3:42', artists: [] },
+          { position: 'A2', title: 'Game That I Play', duration: '4:01', artists: [] },
+          { position: 'B1', title: 'Back, Baby', duration: '4:38', artists: [] },
+        ],
+      });
+
+      const req = { params: { libraryId: '12345' } } as unknown as Request;
+      const res = createMockRes();
+
+      await libraryTracks(req, res as Response, mockNext);
+
+      expect(mockGetDiscogsReleaseIdByLegacyId).toHaveBeenCalledWith(12345);
+      expect(mockGetRelease).toHaveBeenCalledWith(42);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        library_id: 12345,
+        discogs_release_id: 42,
+        source: 'discogs',
+        tracks: [
+          { position: 'A1', title: 'Wrong Hand', artist_credit: 'Jessica Pratt', duration_ms: 222000 },
+          { position: 'A2', title: 'Game That I Play', artist_credit: 'Jessica Pratt', duration_ms: 241000 },
+          { position: 'B1', title: 'Back, Baby', artist_credit: 'Jessica Pratt', duration_ms: 278000 },
+        ],
+      });
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=600');
+    });
+
+    it('prefers per-track artist credits over release-level artist (compilation case)', async () => {
+      mockGetDiscogsReleaseIdByLegacyId.mockResolvedValue(99);
+      mockGetRelease.mockResolvedValue({
+        release_id: 99,
+        title: 'Edits',
+        artist: 'Various',
+        tracklist: [
+          {
+            position: '1',
+            title: 'Call Your Name',
+            duration: '5:23',
+            artists: ['Chuquimamani-Condori'],
+          },
+        ],
+      });
+
+      const req = { params: { libraryId: '777' } } as unknown as Request;
+      const res = createMockRes();
+
+      await libraryTracks(req, res as Response, mockNext);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tracks: [
+            { position: '1', title: 'Call Your Name', artist_credit: 'Chuquimamani-Condori', duration_ms: 323000 },
+          ],
+        })
+      );
+    });
+
+    it('returns 200 + empty tracks when no identity is resolved', async () => {
+      mockGetDiscogsReleaseIdByLegacyId.mockResolvedValue(null);
+
+      const req = { params: { libraryId: '12345' } } as unknown as Request;
+      const res = createMockRes();
+
+      await libraryTracks(req, res as Response, mockNext);
+
+      expect(mockGetRelease).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        library_id: 12345,
+        discogs_release_id: null,
+        source: null,
+        tracks: [],
+      });
+    });
+
+    it('returns 200 + empty tracks when LML 404s on the release id', async () => {
+      mockGetDiscogsReleaseIdByLegacyId.mockResolvedValue(42);
+      mockGetRelease.mockRejectedValue(new MockLmlClientError('LML responded with 404: Not Found', 404));
+
+      const req = { params: { libraryId: '12345' } } as unknown as Request;
+      const res = createMockRes();
+
+      await libraryTracks(req, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        library_id: 12345,
+        discogs_release_id: 42,
+        source: 'discogs',
+        tracks: [],
+      });
+    });
+
+    it('rebubbles LML 5xx errors (handled by errorHandler)', async () => {
+      mockGetDiscogsReleaseIdByLegacyId.mockResolvedValue(42);
+      mockGetRelease.mockRejectedValue(new MockLmlClientError('LML responded with 503', 502));
+
+      const req = { params: { libraryId: '12345' } } as unknown as Request;
+      const res = createMockRes();
+
+      await expect(libraryTracks(req, res as Response, mockNext)).rejects.toThrow('LML responded with 503');
+    });
+
+    it('serves a repeat lookup from the BS-side cache without hitting LML twice', async () => {
+      mockGetDiscogsReleaseIdByLegacyId.mockResolvedValue(42);
+      mockGetRelease.mockResolvedValue({
+        release_id: 42,
+        title: 'DOGA',
+        artist: 'Juana Molina',
+        tracklist: [{ position: '5', title: 'la paradoja', duration: '4:12', artists: [] }],
+      });
+
+      const req = { params: { libraryId: '12345' } } as unknown as Request;
+      await libraryTracks(req, createMockRes() as Response, mockNext);
+      await libraryTracks(req, createMockRes() as Response, mockNext);
+
+      expect(mockGetDiscogsReleaseIdByLegacyId).toHaveBeenCalledTimes(2);
+      expect(mockGetRelease).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats H:MM:SS and bare seconds in duration strings; null when unparseable', async () => {
+      mockGetDiscogsReleaseIdByLegacyId.mockResolvedValue(42);
+      mockGetRelease.mockResolvedValue({
+        release_id: 42,
+        title: 'Live in Sentimental Mood',
+        artist: 'Duke Ellington & John Coltrane',
+        tracklist: [
+          { position: '1', title: 'Long Side', duration: '1:02:03', artists: [] },
+          { position: '2', title: 'Short', duration: '45', artists: [] },
+          { position: '3', title: 'Mystery', duration: '', artists: [] },
+          { position: '4', title: 'Garbage', duration: 'about five', artists: [] },
+        ],
+      });
+
+      const req = { params: { libraryId: '12345' } } as unknown as Request;
+      const res = createMockRes();
+
+      await libraryTracks(req, res as Response, mockNext);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tracks: [
+            {
+              position: '1',
+              title: 'Long Side',
+              artist_credit: 'Duke Ellington & John Coltrane',
+              duration_ms: 3723000,
+            },
+            { position: '2', title: 'Short', artist_credit: 'Duke Ellington & John Coltrane', duration_ms: 45000 },
+            { position: '3', title: 'Mystery', artist_credit: 'Duke Ellington & John Coltrane', duration_ms: null },
+            { position: '4', title: 'Garbage', artist_credit: 'Duke Ellington & John Coltrane', duration_ms: null },
+          ],
+        })
+      );
     });
   });
 });

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -1171,6 +1171,18 @@ describe('proxy.controller', () => {
       });
     });
 
+    it('caches LML 404 results so repeat lookups do not re-hit LML', async () => {
+      mockGetDiscogsReleaseIdByLegacyId.mockResolvedValue(42);
+      mockGetRelease.mockRejectedValue(new MockLmlClientError('LML responded with 404: Not Found', 404));
+
+      const req = { params: { libraryId: '12345' } } as unknown as Request;
+      await libraryTracks(req, createMockRes() as Response, mockNext);
+      await libraryTracks(req, createMockRes() as Response, mockNext);
+
+      expect(mockGetDiscogsReleaseIdByLegacyId).toHaveBeenCalledTimes(2);
+      expect(mockGetRelease).toHaveBeenCalledTimes(1);
+    });
+
     it('rebubbles LML 5xx errors (handled by errorHandler)', async () => {
       mockGetDiscogsReleaseIdByLegacyId.mockResolvedValue(42);
       mockGetRelease.mockRejectedValue(new MockLmlClientError('LML responded with 503', 502));


### PR DESCRIPTION
## Summary

Adds the BS-side composition endpoint the dj-site flowsheet picker needs to surface a tracklist after release selection — catalog-track-search v2 plan §4.3 / Track 3.

- `GET /proxy/library/:libraryId/tracks` composes `library_identity.discogs_release_id` (BS PG) with LML's existing `GET /api/v1/discogs/release/{id}` for the tracklist.
- Inbound `libraryId` is the picker's LML `library.db.id` (= BS `library.legacy_release_id`); a single JOIN through `library` → `library_identity` resolves the Discogs release id.
- Returns `200 { library_id, discogs_release_id, source, tracks: [{ position, title, artist_credit, duration_ms }] }` per the issue's acceptance shape. `tracks` is empty when no identity is resolved (BS#802 backfill hasn't covered the row) or LML returns 404 — the picker falls back to free-text input.
- LRU cache on `discogs_release_id` (500 entries, 10 min TTL) deduplicates repeat lookups on top of LML's three-tier cache.
- Bumps `@wxyc/shared` to 1.6.0 to pick up the write-side `track_position` DTO (wxyc-shared#134, just merged); the column migration is BS#835.

No new LML endpoint, no `wxyc_library_identity` projection table — those v1 scopes are superseded (closed `library-metadata-lookup#297`, closed `discogs-etl#196`).

## Test plan

- [x] Unit tests added in `tests/unit/controllers/proxy.controller.test.ts` cover: validation 400, identity-found + LML 200, compilation per-track artist credit, no-identity → empty, LML 404 → empty, LML 5xx bubbles, BS-cache dedup, duration parsing (`H:MM:SS` / `M:SS` / bare seconds / blank / garbage).
- [x] Integration test added at `tests/integration/library-tracks.spec.js` exercises the route against shape-fixture library row 7100 (legacy_release_id 65880) with a seeded `library_identity` row pointing at the mock LML's Confield release (id 4080), plus 200-with-empty-tracks and 400 validation paths.
- [x] Local checks: typecheck ✓, lint ✓ (0 errors), format:check ✓, build ✓, `test:unit` 1866 ✓.
- [ ] CI `ci:testmock` (skipped locally — another worktree holds port 5433; CI will run it).

## Related

- Closes #836
- Sibling write-path: WXYC/Backend-Service#835 (flowsheet_entry.track_position TEXT column)
- Consumer: WXYC/dj-site#501 (picker UI), WXYC/dj-site#502 (Playwright e2e)
- Contract source: wxyc-shared#134 (merged, `@wxyc/shared@1.6.0`)
- Plan: [catalog-track-search §4.3](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md)