### PR TITLE
Document showIdMap cache lifetime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Key middleware:
 - `anonymousAuth` — Validates better-auth session
 - `rateLimiting` — Rate limits on registration and song requests
 - `errorHandler` — Centralized error handling returning standardized responses
-- Legacy mirror middleware — Syncs flowsheet data to tubafrenzy. Show lifecycle (`startShow`, `endShow`) and entry CRUD (`addEntry`, `updateEntry`) use HTTP REST calls to tubafrenzy's mirror API. `deleteEntry` uses raw SQL via SSH. Show IDs are cached in-memory (`showIdMap`) and persisted to `shows.legacy_show_id` for restart resilience.
+- Legacy mirror middleware — Syncs flowsheet data to tubafrenzy. Show lifecycle (`startShow`, `endShow`) and entry CRUD (`addEntry`, `updateEntry`) use HTTP REST calls to tubafrenzy's mirror API. `deleteEntry` uses raw SQL via SSH. Show IDs live in two places: an in-memory `showIdMap` (process-local, populated lazily by `cacheShowId`, cleared on process exit) and the persisted `shows.legacy_show_id` column (written alongside the cache after `mirrorCreateShow`). On BS restart the map starts empty; read paths fall back to the persisted column, paying one extra DB round-trip on the first lookup per show.
 
 Server timeout is 5 seconds globally; SSE routes have no timeout. Swagger API docs are served at `/api-docs` from `app.yaml`.
 

--- a/apps/backend/middleware/legacy/http.mirror.ts
+++ b/apps/backend/middleware/legacy/http.mirror.ts
@@ -15,7 +15,16 @@ const MIRROR_API_KEY = process.env.MIRROR_API_KEY ?? '';
 /** In-memory map: Backend-Service play_order → tubafrenzy entry ID */
 const entryIdMap = new Map<number, number>();
 
-/** In-memory map: Backend-Service show ID → tubafrenzy show ID */
+/**
+ * In-memory map: Backend-Service show ID → tubafrenzy show ID.
+ *
+ * Process-local, non-durable. Populated lazily by `cacheShowId` after a
+ * successful `mirrorCreateShow`; cleared on process exit. On BS restart the
+ * map starts empty — restart resilience comes from `shows.legacy_show_id`
+ * (persisted by `flowsheet.mirror.ts:52` after the same `mirrorCreateShow`
+ * call) which the mirror read path falls back to when the cache misses
+ * (`flowsheet.mirror.ts:84`: `getCachedShowId(show.id) ?? show.legacy_show_id`).
+ */
 const showIdMap = new Map<number, number>();
 
 interface MirrorEntry {


### PR DESCRIPTION
## Summary

- Adds a JSDoc block on `showIdMap` (`apps/backend/middleware/legacy/http.mirror.ts:19`) spelling out: process-local + non-durable, populated lazily by `cacheShowId`, cleared on process exit. Cross-references the persisted `shows.legacy_show_id` column as the restart-resilience source, with the exact fallback line at `flowsheet.mirror.ts:84` (`getCachedShowId(show.id) ?? show.legacy_show_id`).
- Refines the CLAUDE.md mirror-middleware bullet from the compressed "cached in-memory and persisted ... for restart resilience" to spell out the two-tier read pattern (in-memory cache → persisted column fallback → one extra DB round-trip on first lookup per show after restart).

This is the H3 child of [Epic H](https://github.com/WXYC/Backend-Service/issues/882) (Post-launch service hardening, [project #32](https://github.com/orgs/WXYC/projects/32)). Option 1 from the issue (docs only); the Redis/disk-cache alternative is not pursued since cold-start latency is sub-second and not worth new infra.

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run check:doc-budget` — pre-existing warning at 17,160 chars; this PR adds ~270 chars to the bullet but doesn't extract a section

Closes #910