### PR TITLE
Pin legacy_entry_id three-use invariant (doc + CI check)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,6 +169,9 @@ jobs:
       - name: Migration guards (cross-cache-identity)
         run: scripts/check-precondition-guards.sh
 
+      - name: legacy_entry_id writes (three-use invariant)
+        run: node scripts/check-legacy-entry-id-writes.mjs
+
       - name: Build
         run: npm run build
 

--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -272,7 +272,14 @@ const getAddEntrySQL = async (req: Request, entry: FSEntry) => {
 };
 
 export const addEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) => {
-  // Loop guard: entry imported from tubafrenzy by ETL — don't mirror back
+  // Loop guard (use #2 of the legacy_entry_id three-use invariant, BS#908):
+  // `legacy_entry_id != null` is read as a boolean meaning "this row came
+  // from tubafrenzy via ETL or webhook, do not mirror back." Together with
+  // the matching guard in updateEntry below (line ~317) this prevents an
+  // infinite ETL → mirror → webhook → ETL cycle. The three orthogonal uses
+  // and their constraints are documented at `shared/database/src/schema.ts`
+  // on the column declaration; CI enforces no new write site appears
+  // without registering at `scripts/check-legacy-entry-id-writes.mjs`.
   if (entry.legacy_entry_id != null) return;
 
   // Resolve tubafrenzy show ID: (1) in-memory cache, (2) DB, (3) null (auto-resolve)

--- a/scripts/check-legacy-entry-id-writes.mjs
+++ b/scripts/check-legacy-entry-id-writes.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * Enforces the `flowsheet.legacy_entry_id` three-use invariant from BS#908 / Epic H#882.
+ *
+ * `legacy_entry_id` is overloaded across three orthogonal use cases that have
+ * different correctness requirements:
+ *
+ *   1. **Webhook upsert target** (`apps/backend/routes/internal.route.ts`).
+ *      `ON CONFLICT (legacy_entry_id) DO UPDATE`. Needs an actual tubafrenzy
+ *      ID to dedup against. Reads via `flowsheet.legacy_entry_id` column.
+ *
+ *   2. **Mirror loop-guard** (`apps/backend/middleware/legacy/flowsheet.mirror.ts`).
+ *      `if (entry.legacy_entry_id != null) return;` — "this entry came from
+ *      tubafrenzy via ETL, don't mirror back." Treats the column as a boolean
+ *      ("is this row from tubafrenzy?"). Writes happen *after* a successful
+ *      `mirrorCreateEntry` (the inverse direction) to record the just-allocated
+ *      tubafrenzy ID for ETL dedup.
+ *
+ *   3. **ETL incremental sync key** (`jobs/flowsheet-etl/job.ts`).
+ *      Same `ON CONFLICT (legacy_entry_id) DO UPDATE` shape as use #1.
+ *
+ * The three uses are fine today, but fragile: a future change that, say,
+ * populates `legacy_entry_id` to a placeholder for non-tubafrenzy rows would
+ * silently break use #2 (the mirror loop-guard), sending those rows back to
+ * tubafrenzy and creating an infinite mirror loop. This check pins the set of
+ * files allowed to write the column; adding a new write site requires
+ * registering it here with a documented rationale that names which of the
+ * three uses (or a new fourth) it belongs to.
+ *
+ * Wired into CI as the "legacy_entry_id writes" job in `.github/workflows/test.yml`.
+ *
+ * The check is intentionally coarse: it greps for the literal substring
+ * `legacy_entry_id:` (object-literal key shape) anywhere in source, then
+ * compares the producing file against this allowlist. Reads of `legacy_entry_id`
+ * (e.g., `flowsheet.legacy_entry_id` column-reference selection) appear in this
+ * key shape too in service code, so they're allowlisted explicitly with a
+ * "READS only" rationale. A future PR adding a new file that touches the
+ * column — read or write — must update this allowlist with a rationale.
+ *
+ * Exit codes:
+ *   0 — allowlist matches reality. Every allowlisted file contains the pattern;
+ *       no non-allowlisted file does.
+ *   1 — a non-allowlisted file contains the pattern (new write site without
+ *       a registered rationale).
+ *   2 — an allowlisted file no longer contains the pattern (stale allowlist).
+ */
+
+import { readFileSync, readdirSync, statSync, realpathSync } from 'node:fs';
+import { resolve, relative, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+// Allowlist: every file that may contain `legacy_entry_id:` in source.
+// Each entry includes the use-case rationale (1, 2, 3, or "READS only").
+// Adding a new entry requires updating the three-use comment in
+// `shared/database/src/schema.ts` and `apps/backend/middleware/legacy/flowsheet.mirror.ts`
+// so future readers can find the invariant from any write site.
+export const ALLOWLIST = new Map([
+  [
+    'apps/backend/middleware/legacy/flowsheet.mirror.ts',
+    'use #2 (mirror loop-guard, READS) + writes that record the just-allocated tubafrenzy ID after mirrorCreateEntry returns.',
+  ],
+  [
+    'apps/backend/routes/internal.route.ts',
+    'use #1: tubafrenzy webhook upsert. INSERT values + ON CONFLICT target on `flowsheet.legacy_entry_id`.',
+  ],
+  [
+    'jobs/flowsheet-etl/job.ts',
+    'use #3: ETL incremental sync. INSERT values + ON CONFLICT target on `flowsheet.legacy_entry_id`.',
+  ],
+  [
+    'jobs/flowsheet-etl/transform.ts',
+    'use #3 (DTO): produces the row shape consumed by jobs/flowsheet-etl/job.ts insert.',
+  ],
+  ['shared/database/src/schema.ts', 'column declaration.'],
+  ['apps/backend/services/flowsheet.service.ts', 'READS only: selection + result mapping. No writes.'],
+]);
+
+const PATTERN = /\blegacy_entry_id:/;
+
+const SOURCE_ROOTS = ['apps', 'jobs', 'shared/database/src'];
+const SKIP_DIR_NAMES = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  'coverage',
+  'tests',
+  '__tests__',
+  'migrations',
+]);
+const SKIP_FILE_SUFFIXES = ['.d.ts', '.test.ts', '.spec.ts', '.test.tsx', '.spec.tsx', '.json', '.sql'];
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.mjs'];
+
+function listSourceFiles(rootRelativePath) {
+  const absRoot = join(REPO_ROOT, rootRelativePath);
+  let stat;
+  try {
+    stat = statSync(absRoot);
+  } catch {
+    return [];
+  }
+  if (!stat.isDirectory()) return [];
+  const out = [];
+  walk(absRoot, out);
+  return out;
+}
+
+function walk(dir, out) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(entry.name)) continue;
+      walk(join(dir, entry.name), out);
+    } else if (entry.isFile()) {
+      const name = entry.name;
+      if (SKIP_FILE_SUFFIXES.some((s) => name.endsWith(s))) continue;
+      if (!SOURCE_EXTENSIONS.some((s) => name.endsWith(s))) continue;
+      out.push(join(dir, entry.name));
+    }
+  }
+}
+
+function fileMentionsPattern(absPath) {
+  let src;
+  try {
+    src = readFileSync(absPath, 'utf-8');
+  } catch {
+    return false;
+  }
+  return PATTERN.test(src);
+}
+
+function main() {
+  const failures = [];
+  const staleAllowlistEntries = [];
+  const matched = [];
+
+  for (const root of SOURCE_ROOTS) {
+    for (const abs of listSourceFiles(root)) {
+      const rel = relative(REPO_ROOT, abs);
+      if (!fileMentionsPattern(abs)) continue;
+      matched.push(rel);
+      if (!ALLOWLIST.has(rel)) {
+        failures.push(rel);
+      }
+    }
+  }
+
+  for (const [rel] of ALLOWLIST) {
+    const abs = join(REPO_ROOT, rel);
+    if (!fileMentionsPattern(abs)) {
+      staleAllowlistEntries.push(rel);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('FAIL: file(s) reference `legacy_entry_id:` but are not in the allowlist.');
+    console.error('      legacy_entry_id is overloaded across three use cases; any new write site must');
+    console.error('      register its rationale in scripts/check-legacy-entry-id-writes.mjs ALLOWLIST.');
+    console.error('      See BS#908 / Epic H#882 for the invariant.');
+    for (const f of failures) console.error(`      - ${f}`);
+    process.exit(1);
+  }
+
+  if (staleAllowlistEntries.length > 0) {
+    console.error('FAIL: allowlist entries no longer contain `legacy_entry_id:` (stale).');
+    console.error('      Remove the entry from ALLOWLIST or restore the reference.');
+    for (const f of staleAllowlistEntries) console.error(`      - ${f}`);
+    process.exit(2);
+  }
+
+  console.log(`PASS: ${matched.length} source file(s) reference legacy_entry_id; all in the allowlist.`);
+}
+
+// Node ESM "is main module" idiom. realpathSync canonicalizes both sides so
+// macOS's /tmp -> /private/tmp symlink doesn't make a self-invocation look
+// like an import (which would skip main() and silently exit 0).
+const invokedDirectly = (() => {
+  try {
+    const argvPath = realpathSync(resolve(process.argv[1] ?? ''));
+    const selfPath = realpathSync(fileURLToPath(import.meta.url));
+    return argvPath === selfPath;
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main();
+}

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -506,6 +506,21 @@ export const flowsheet = wxyc_schema.table(
     show_id: integer('show_id').references(() => shows.id, { onDelete: 'set null' }),
     album_id: integer('album_id').references(() => library.id, { onDelete: 'set null' }),
     rotation_id: integer('rotation_id').references(() => rotation.id, { onDelete: 'set null' }),
+    // Overloaded across three orthogonal uses with different correctness
+    // requirements (BS#908). Any new write site must register in
+    // scripts/check-legacy-entry-id-writes.mjs ALLOWLIST with a rationale:
+    //   1. Webhook upsert target — apps/backend/routes/internal.route.ts
+    //      uses `ON CONFLICT (legacy_entry_id) DO UPDATE` keyed on the
+    //      tubafrenzy-assigned entry ID.
+    //   2. Mirror loop-guard — apps/backend/middleware/legacy/flowsheet.mirror.ts
+    //      reads `legacy_entry_id != null` as a boolean meaning "this row
+    //      came from tubafrenzy, do not mirror back" (avoids an infinite
+    //      ETL → mirror → webhook → ETL loop).
+    //   3. ETL incremental sync key — jobs/flowsheet-etl/job.ts uses the
+    //      same `ON CONFLICT (legacy_entry_id)` shape as #1.
+    // A future change that populates legacy_entry_id to a placeholder for
+    // non-tubafrenzy rows would silently break use #2; the CI check at
+    // scripts/check-legacy-entry-id-writes.mjs is the guardrail.
     legacy_entry_id: integer('legacy_entry_id'),
     legacy_release_id: integer('legacy_release_id'),
     // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed

--- a/tests/unit/scripts/check-legacy-entry-id-writes.test.ts
+++ b/tests/unit/scripts/check-legacy-entry-id-writes.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Source-grep + runtime tests for `scripts/check-legacy-entry-id-writes.mjs`.
+ *
+ * That script pins the three-use invariant of `flowsheet.legacy_entry_id` from
+ * BS#908 / Epic H#882. The behavioural test (does the script exit non-zero
+ * when a non-allowlisted file gains a `legacy_entry_id:` reference?) runs
+ * here against a temp file so future regressions are caught at PR time.
+ *
+ * The source-grep half pins the allowlist contents: every entry resolves to a
+ * real file that contains the pattern, and every file with the pattern is on
+ * the allowlist. This prevents the script and the tree from drifting silently.
+ *
+ * The pattern this test relies on mirrors `format-pg-error.test.ts`: regex the
+ * script source rather than dynamic-import the .mjs (ts-jest's transform
+ * pattern doesn't cover .mjs and we don't widen it for this).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import * as os from 'os';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const scriptPath = path.join(repoRoot, 'scripts/check-legacy-entry-id-writes.mjs');
+const scriptSource = fs.readFileSync(scriptPath, 'utf-8');
+
+function parseAllowlist(): Map<string, string> {
+  // ALLOWLIST is declared as `new Map([[ 'path', 'rationale' ], ...])`; entries
+  // span multiple lines because the rationales are prose. We regex the
+  // `[ 'key', 'value' ]` pairs out of the source. Single-quoted strings only;
+  // any future PR using double quotes or template literals needs to update this.
+  const blockMatch = scriptSource.match(/ALLOWLIST\s*=\s*new\s+Map\(\[([\s\S]*?)\]\);/);
+  if (!blockMatch) throw new Error('ALLOWLIST not found in check-legacy-entry-id-writes.mjs');
+  const pairRe = /\[\s*'([^']+)'\s*,\s*'([^']+)'\s*,?\s*\]/g;
+  const pairs = new Map<string, string>();
+  let m: RegExpExecArray | null;
+  while ((m = pairRe.exec(blockMatch[1])) !== null) {
+    pairs.set(m[1], m[2]);
+  }
+  if (pairs.size === 0) throw new Error('ALLOWLIST is empty or unparseable');
+  return pairs;
+}
+
+describe('check-legacy-entry-id-writes.mjs', () => {
+  const allowlist = parseAllowlist();
+
+  it('every allowlist entry points to a file that exists', () => {
+    for (const rel of allowlist.keys()) {
+      const abs = path.join(repoRoot, rel);
+      expect(fs.existsSync(abs)).toBe(true);
+    }
+  });
+
+  it('every allowlist entry has the pattern in its referenced file', () => {
+    // If a rationale is "READS only", the file still has the pattern in
+    // read-shaped positions (selection clauses, result mapping).
+    for (const rel of allowlist.keys()) {
+      const abs = path.join(repoRoot, rel);
+      const src = fs.readFileSync(abs, 'utf-8');
+      expect(src).toMatch(/\blegacy_entry_id:/);
+    }
+  });
+
+  it('every rationale names one of the documented uses or "READS only" or "column declaration"', () => {
+    // Pins the invariant prose to the rationale taxonomy. A new allowlist
+    // entry must register its use case in one of these buckets.
+    const acceptable = /(use #1|use #2|use #3|READS only|column declaration)/;
+    for (const [rel, rationale] of allowlist) {
+      if (!acceptable.test(rationale)) {
+        throw new Error(
+          `Rationale for ${rel} must name use #1/#2/#3, READS only, or column declaration. Got: "${rationale}"`
+        );
+      }
+    }
+  });
+
+  it('exits 0 against the current tree', () => {
+    // Empty stdio swallow, exit-code is the assertion.
+    execFileSync('node', [scriptPath], { cwd: repoRoot, stdio: 'pipe' });
+  });
+
+  it('exits 1 when a non-allowlisted file gains the pattern', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legacy-entry-id-test-'));
+    const stubInTree = path.join(repoRoot, 'apps/backend/__pin_test_legacy_entry_id__.ts');
+    fs.writeFileSync(stubInTree, 'export const stub = { legacy_entry_id: 1 };\n');
+    try {
+      let exitCode = 0;
+      try {
+        execFileSync('node', [scriptPath], { cwd: repoRoot, stdio: 'pipe' });
+      } catch (e) {
+        exitCode = (e as { status: number }).status;
+      }
+      expect(exitCode).toBe(1);
+    } finally {
+      fs.unlinkSync(stubInTree);
+      fs.rmdirSync(tmpDir);
+    }
+  });
+
+  it('exits 2 when an allowlist entry no longer contains the pattern', () => {
+    // Synthesize the stale-allowlist failure by injecting a fake allowlist
+    // entry pointing at a freshly-created empty file. The temp script has to
+    // live inside the repo's `scripts/` dir because the script computes
+    // `REPO_ROOT = resolve(__dirname, '..')`; placing it under os.tmpdir()
+    // would make REPO_ROOT resolve to /var/folders/... and every real
+    // allowlist file would be reported missing, accidentally triggering
+    // exit 2 for the wrong reason.
+    const tmpScriptPath = path.join(repoRoot, 'scripts', `__test_check_legacy_${Date.now()}_${process.pid}.mjs`);
+    const tmpStaleFile = path.join(repoRoot, '__pin_test_legacy_entry_id_stale__.ts');
+    fs.writeFileSync(tmpStaleFile, '// intentionally empty\n');
+    // Format-agnostic injection: insert the new entry just before the closing
+    // `])` of the ALLOWLIST Map literal, regardless of whether the surrounding
+    // entries are on one line or several.
+    const injected = scriptSource.replace(
+      /(export const ALLOWLIST = new Map\(\[[\s\S]*?)(\s*\]\);)/,
+      `$1\n  ['__pin_test_legacy_entry_id_stale__.ts', 'column declaration (test stub).'],$2`
+    );
+    if (injected === scriptSource) {
+      throw new Error('Failed to inject test allowlist entry; ALLOWLIST literal not found in source.');
+    }
+    fs.writeFileSync(tmpScriptPath, injected);
+    try {
+      let exitCode = 0;
+      try {
+        execFileSync('node', [tmpScriptPath], { cwd: repoRoot, stdio: 'pipe' });
+      } catch (e) {
+        exitCode = (e as { status: number }).status;
+      }
+      expect(exitCode).toBe(2);
+    } finally {
+      fs.unlinkSync(tmpStaleFile);
+      fs.unlinkSync(tmpScriptPath);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements H1 (Epic H, [project #32](https://github.com/orgs/WXYC/projects/32)) by taking the doc-only path the issue's "Alternative" section permits. Instead of adding a `mirror_origin` column with migration + backfill, this PR:

1. **Documents the three uses inline on the schema column declaration** (`shared/database/src/schema.ts:legacy_entry_id`) — webhook upsert target (#1), mirror loop-guard (#2), ETL incremental sync (#3) — and names the failure mode if anyone populates the column to a placeholder.
2. **Cross-references the invariant from the loop-guard site** (`flowsheet.mirror.ts:addEntry`) so a future reader can find the schema comment from any write site.
3. **Enforces the invariant in CI** via `scripts/check-legacy-entry-id-writes.mjs`, which greps for `legacy_entry_id:` (object-literal key shape) across `apps/`, `jobs/`, `shared/database/src/` and compares against an explicit allowlist. New write sites must register with a rationale that names one of the three uses; stale allowlist entries also fail. Wired into the `lint-and-typecheck` job alongside the existing cross-cache-identity guards.
4. **Pins the script behavior with 6 unit tests** (`tests/unit/scripts/check-legacy-entry-id-writes.test.ts`) covering source-grep + child-process exit codes 0/1/2 and pinning the rationale taxonomy.

## Test plan

- [x] `node scripts/check-legacy-entry-id-writes.mjs` — PASS, 6 source files in allowlist
- [x] `npx jest tests/unit/scripts/check-legacy-entry-id-writes.test.ts` — 6 passed
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 384 pre-existing warnings, 0 errors
- [x] `npm run format:check` — clean

Closes #908