### PR TITLE
Replace xmax=0 with ON CONFLICT DO NOTHING + explicit UPDATE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -346,6 +346,11 @@ jobs:
           TUBAFRENZY_URL: http://localhost:9090
           MIRROR_API_KEY: ci-test-mirror-key
           MOCK_API_PORT: '9090'
+          # Internal endpoints (ETL notify, tubafrenzy webhook).
+          # authenticateInternal() fails closed on an empty key, so the
+          # tubafrenzy-webhook integration spec needs this wired explicitly.
+          # Matches the spec's INTERNAL_KEY fallback default.
+          ETL_NOTIFY_KEY: test-secret-key
         run: |
           node dev_env/mock-api-server/dist/server.js > /tmp/mock-api.log 2>&1 &
           node apps/auth/dist/app.js > /tmp/auth.log 2>&1 &

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -102,7 +102,15 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       const albumTitle = truncate(entry.releaseTitle, 128);
       const trackTitle = truncate(entry.songTitle, 128);
 
-      const upserted = await db
+      // INSERT ... ON CONFLICT DO NOTHING RETURNING { id }: either we win
+      // the insert and PG hands back exactly one row, or a concurrent
+      // INSERT / prior webhook delivery already claimed the
+      // `legacy_entry_id` and RETURNING is empty. The empty-RETURNING
+      // signal replaces the previous `(xmax = 0)` system-column trick
+      // (BS#909): same correctness, no MVCC-internal dependency, race-
+      // safe under concurrent webhook delivery (acceptance criterion (c)
+      // — exactly one delivery fires enrichment per legacy_entry_id).
+      const inserted = await db
         .insert(flowsheet)
         .values({
           legacy_entry_id: entry.id,
@@ -118,35 +126,42 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
           play_order: entry.sequenceWithinShow ?? 0,
           add_time: entry.startTime ? new Date(entry.startTime) : new Date(),
         })
-        .onConflictDoUpdate({
-          target: flowsheet.legacy_entry_id,
-          set: {
-            artist_name: sql`excluded.artist_name`,
-            album_title: sql`excluded.album_title`,
-            track_title: sql`excluded.track_title`,
-            record_label: sql`excluded.record_label`,
-            message: sql`excluded.message`,
-            request_flag: sql`excluded.request_flag`,
-            entry_type: sql`excluded.entry_type`,
-          },
-        })
-        // `(xmax = 0)` distinguishes a fresh INSERT from an UPDATE branch:
-        // a row produced by INSERT has xmax=0 (no prior tx touched it),
-        // while the DO UPDATE branch sets xmax to the current tx id. We
-        // gate enrichment on this so benign retries / no-op updates from
-        // tubafrenzy don't re-fetch from LML and re-write the 10 metadata
-        // columns (each rewrite triggers CDC + search_doc tsvector regen
-        // + 6-index churn). Backfill is the safety net for rows whose
-        // first INSERT enrichment returned null.
-        .returning({ id: flowsheet.id, created: sql<boolean>`(xmax = 0)` });
+        .onConflictDoNothing()
+        .returning({ id: flowsheet.id });
+
+      let upsertedRow = inserted[0];
+      const created = !!upsertedRow;
+
+      if (!created) {
+        // Conflict path: refresh the mutable subset of fields on the row
+        // tubafrenzy is updating. Matches the original ON CONFLICT DO
+        // UPDATE set-list — show_id / play_order / segue / add_time stay
+        // anchored to the first INSERT's values, mutable metadata-ish
+        // fields move with the latest webhook payload.
+        const updated = await db
+          .update(flowsheet)
+          .set({
+            artist_name: artistName,
+            album_title: albumTitle,
+            track_title: trackTitle,
+            record_label: truncate(entry.labelName, 128),
+            message: isMsgType ? truncate(entry.artistName, 250) : null,
+            request_flag: !!entry.requestFlag,
+            entry_type: entryType,
+          })
+          .where(eq(flowsheet.legacy_entry_id, entry.id))
+          .returning({ id: flowsheet.id });
+        upsertedRow = updated[0];
+      }
 
       // Trigger LML metadata enrichment for tracks. Fire-and-forget: errors
       // are caught inside fireAndForgetMetadataForRow and reported to Sentry,
-      // never propagated. This is the only enrichment trigger for entries
-      // arriving via tubafrenzy — the dj-site addEntry controller has its
-      // own call site.
-      const upsertedRow = upserted[0];
-      if (upsertedRow?.created && entryType === 'track' && artistName) {
+      // never propagated. Only fires on the *fresh INSERT* branch so benign
+      // tubafrenzy retries don't trigger LML re-fetch + 10-column rewrite +
+      // CDC/index churn on every duplicate webhook delivery. The historical
+      // drain at jobs/flowsheet-metadata-backfill/ is the safety net for
+      // rows whose first INSERT enrichment returned null.
+      if (created && upsertedRow && entryType === 'track' && artistName) {
         fireAndForgetMetadataForRow({
           flowsheetId: upsertedRow.id,
           artistName,

--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -187,6 +187,11 @@ services:
       # Mirror: route HTTP mirror through mock tubafrenzy
       - TUBAFRENZY_URL=http://mock-api:9090
       - MIRROR_API_KEY=ci-test-mirror-key
+      # Internal endpoints (ETL notify, tubafrenzy webhook). The
+      # authenticateInternal() check fails closed on an empty key, so the
+      # tubafrenzy-webhook integration spec needs this wired explicitly.
+      # Matches the test's fallback default.
+      - ETL_NOTIFY_KEY=${ETL_NOTIFY_KEY:-test-secret-key}
       # Rate limiting configuration
       # Set TEST_RATE_LIMITING=true to enable rate limiting in test mode
       # Use ci:env:full and ci:test:full npm scripts to run with rate limiting enabled

--- a/tests/integration/internal-flowsheet-webhook.spec.js
+++ b/tests/integration/internal-flowsheet-webhook.spec.js
@@ -1,0 +1,118 @@
+/**
+ * Integration tests for POST /internal/flowsheet-webhook (BS#909 / H2).
+ *
+ * The webhook receives tubafrenzy flowsheet events. The acceptance criterion
+ * tested here is (c) from issue #909: under a concurrent INSERT race (two
+ * webhook deliveries with the same `legacy_entry_id` arriving in flight), PG's
+ * INSERT ... ON CONFLICT DO NOTHING serializes the two writes and exactly one
+ * delivery sees a fresh INSERT (and would fire enrichment); the other sees an
+ * empty RETURNING and falls through to UPDATE without re-firing.
+ *
+ * This integration test exercises that against real Postgres. The unit-test
+ * companion at `tests/unit/routes/internal.route.test.ts` covers fresh-INSERT
+ * and ON-CONFLICT branches individually with mocked DB chains; only the
+ * concurrent race needs a real engine because the guarantee is the engine's,
+ * not the handler's.
+ */
+
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const postgres = require('postgres');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const INTERNAL_KEY = process.env.ETL_NOTIFY_KEY || 'test-secret-key';
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 4,
+  });
+}
+
+describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)', () => {
+  let sql;
+
+  beforeAll(() => {
+    sql = makeSql();
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end();
+  });
+
+  // Use a legacy_entry_id deep in a range that's unlikely to collide with any
+  // fixture or other spec's writes. The afterEach cleanup deletes by this id.
+  const LEGACY_ENTRY_ID = 9_999_991;
+
+  afterEach(async () => {
+    await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [LEGACY_ENTRY_ID]);
+  });
+
+  const buildEntry = (overrides = {}) => ({
+    id: LEGACY_ENTRY_ID,
+    radioShowId: 0,
+    flowsheetEntryType: 6,
+    artistName: 'Chuquimamani-Condori',
+    songTitle: 'Call Your Name',
+    releaseTitle: 'Edits',
+    labelName: 'self-released',
+    startTime: 1706799600000,
+    requestFlag: false,
+    sequenceWithinShow: 1,
+    libraryReleaseId: 0,
+    rotationReleaseId: 0,
+    ...overrides,
+  });
+
+  test('two concurrent webhook deliveries produce exactly one row', async () => {
+    const entry = buildEntry();
+    const responses = await Promise.all([
+      request.post('/internal/flowsheet-webhook').set('X-Internal-Key', INTERNAL_KEY).send({ action: 'create', entry }),
+      request.post('/internal/flowsheet-webhook').set('X-Internal-Key', INTERNAL_KEY).send({ action: 'create', entry }),
+    ]);
+
+    // Both webhook calls succeed (one inserts, one updates); HTTP 200 either way.
+    for (const r of responses) expect(r.status).toBe(200);
+
+    // Exactly one row exists for this legacy_entry_id.
+    const rows = await sql.unsafe(`SELECT id, artist_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+      LEGACY_ENTRY_ID,
+    ]);
+    expect(rows.length).toBe(1);
+    expect(rows[0].artist_name).toBe('Chuquimamani-Condori');
+  });
+
+  test('a second delivery with different mutable fields refreshes those fields', async () => {
+    // First delivery: fresh INSERT — the row carries the initial payload.
+    const initial = buildEntry({ artistName: 'Juana Molina', songTitle: 'la paradoja', releaseTitle: 'DOGA' });
+    const firstRes = await request
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({ action: 'create', entry: initial });
+    expect(firstRes.status).toBe(200);
+
+    // Second delivery: same legacy_entry_id, refreshed mutable fields. The
+    // INSERT branch sees a conflict, so the handler falls through to the
+    // explicit UPDATE path. We assert the row's mutable subset moved.
+    const refreshed = buildEntry({
+      artistName: 'Juana Molina',
+      songTitle: 'la paradoja',
+      releaseTitle: 'DOGA (remastered)',
+    });
+    const secondRes = await request
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({ action: 'update', entry: refreshed });
+    expect(secondRes.status).toBe(200);
+
+    const rows = await sql.unsafe(`SELECT album_title FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+      LEGACY_ENTRY_ID,
+    ]);
+    expect(rows.length).toBe(1);
+    expect(rows[0].album_title).toBe('DOGA (remastered)');
+  });
+});

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -35,14 +35,26 @@ process.env.ETL_NOTIFY_KEY = 'test-secret-key';
 import { internal_route } from '../../../apps/backend/routes/internal.route';
 
 // Make the DB mock chain's terminal methods resolve appropriately for the
-// webhook handler. `onConflictDoNothing` is terminal in the show-resolution
-// path (resolves to undefined). The flowsheet upsert is `onConflictDoUpdate`
-// followed by `.returning()`, so the chain stays open through the upsert and
-// the terminal `.returning` resolves to a row array.
+// webhook handler. Three chain shapes feed through `mockReturning`:
+//   1. Show resolution `select.from.where.limit` → returns [{ id }] or [].
+//   2. Flowsheet INSERT ... ON CONFLICT DO NOTHING RETURNING { id }
+//      → returns [{ id }] when a fresh row was inserted, [] on conflict.
+//   3. Flowsheet UPDATE ... WHERE ... RETURNING { id } (taken only after a
+//      conflict on the INSERT) → returns [{ id }].
+// Tests queue results with `mockReturning.mockResolvedValueOnce` in the order
+// the handler invokes them. After replacing the xmax = 0 trick (BS#909), the
+// `created` boolean comes from the INSERT's RETURNING shape: a single row
+// means we just inserted (fresh); an empty array means the row pre-existed
+// and we should fall through to the explicit UPDATE without firing enrichment.
 const mockDb = db as unknown as Record<string, jest.Mock>;
 const mockChain = mockDb.select();
-(mockChain as Record<string, jest.Mock>).limit = jest.fn().mockResolvedValue([]);
-(mockChain as Record<string, jest.Mock>).onConflictDoNothing = jest.fn().mockResolvedValue(undefined);
+// `mockChain.limit` and `mockChain.returning` are the two terminal points the
+// webhook handler awaits. Everything in between (`.from`, `.where`,
+// `.onConflictDoNothing`, etc.) keeps returning `mockChain` so the chain is
+// composable in any order. We override only the terminals so per-test
+// `mockResolvedValueOnce` queues control what each resolved branch sees.
+const mockLimit = jest.fn();
+(mockChain as Record<string, jest.Mock>).limit = mockLimit;
 const mockReturning = jest.fn();
 (mockChain as Record<string, jest.Mock>).returning = mockReturning;
 
@@ -105,11 +117,16 @@ describe('POST /internal/flowsheet-webhook', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // jest.clearAllMocks() does not drain queued mockResolvedValueOnce
-    // values. Reset this mock fully so per-test queues don't bleed across
-    // tests. Default it to a created-row response; tests that need an
-    // update-branch response override with mockResolvedValueOnce.
+    // values. Reset both mocks fully so per-test queues don't bleed across
+    // tests. Default `mockReturning` to a fresh-INSERT response (one row);
+    // tests that need a conflict response queue `[]` first, then a
+    // separate update-branch row. `mockLimit` covers the show-resolution
+    // SELECT (returns [] = no existing show, fall through to the inline
+    // INSERT ... ON CONFLICT DO NOTHING + re-SELECT chain in resolveShowId).
     mockReturning.mockReset();
-    mockReturning.mockResolvedValue([{ id: 5555, created: true }]);
+    mockReturning.mockResolvedValue([{ id: 5555 }]);
+    mockLimit.mockReset();
+    mockLimit.mockResolvedValue([{ id: 9999 }]);
   });
 
   // -- Auth --
@@ -206,8 +223,12 @@ describe('POST /internal/flowsheet-webhook', () => {
   // The dj-site addEntry controller has its own call site; this is the
   // tubafrenzy → BS path.
 
-  it('fires metadata enrichment when a track INSERT lands (xmax=0 → created)', async () => {
-    mockReturning.mockResolvedValueOnce([{ id: 5555, created: true }]);
+  it('fires metadata enrichment on fresh INSERT (RETURNING returns one row)', async () => {
+    // Replaces the xmax = 0 trick (BS#909). The INSERT ... ON CONFLICT DO
+    // NOTHING RETURNING { id } either returns one row (we won the insert
+    // race and the row is fresh) or an empty array (someone else inserted
+    // first; we should UPDATE without firing enrichment).
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
 
     const res = await request(app)
       .post('/internal/flowsheet-webhook')
@@ -223,12 +244,14 @@ describe('POST /internal/flowsheet-webhook', () => {
     });
   });
 
-  it('does not fire enrichment when the upsert took the UPDATE branch (xmax≠0)', async () => {
-    // ON CONFLICT DO UPDATE on a re-sent legacy_entry_id sets xmax to the
-    // current tx id, so `created` is false. Skip enrichment here so benign
-    // tubafrenzy retries don't trigger LML re-fetch + 10-column rewrite +
-    // CDC/index churn on every duplicate webhook delivery.
-    mockReturning.mockResolvedValueOnce([{ id: 5555, created: false }]);
+  it('does not fire enrichment when the INSERT hits ON CONFLICT (RETURNING empty)', async () => {
+    // Conflict path: INSERT returns []; handler falls through to an explicit
+    // UPDATE that refreshes mutable fields. The UPDATE's RETURNING yields
+    // the row's id for the SSE broadcast, but enrichment must NOT fire — a
+    // benign tubafrenzy retry must not re-trigger the 10-column metadata
+    // rewrite + CDC/tsvector/index churn.
+    mockReturning.mockResolvedValueOnce([]); // INSERT conflict
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]); // UPDATE returning
 
     const res = await request(app)
       .post('/internal/flowsheet-webhook')
@@ -237,6 +260,36 @@ describe('POST /internal/flowsheet-webhook', () => {
 
     expect(res.status).toBe(200);
     expect(mockFireAndForgetMetadataForRow).not.toHaveBeenCalled();
+  });
+
+  it('handles the concurrent-INSERT race: only the winner fires enrichment', async () => {
+    // Issue #909 acceptance criterion (c): concurrent INSERT race. With
+    // ON CONFLICT DO NOTHING RETURNING, PG serializes the two INSERTs and
+    // exactly one returns a row (the winner). The loser's INSERT RETURNING
+    // is empty and the handler falls through to UPDATE without enrichment.
+    // We simulate the two webhook calls in the same describe block back-to-
+    // back: first call wins (RETURNING [row]), second call loses (RETURNING
+    // []), then sees the existing row and UPDATEs it.
+
+    // Winner: fresh INSERT, fires enrichment.
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+    const winnerRes = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry });
+    expect(winnerRes.status).toBe(200);
+    expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledTimes(1);
+
+    // Loser: same payload, INSERT conflicts, falls through to UPDATE.
+    mockReturning.mockResolvedValueOnce([]); // INSERT conflict
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]); // UPDATE returning
+    const loserRes = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry });
+    expect(loserRes.status).toBe(200);
+    // Enrichment count must still be 1 — the loser must not re-fire.
+    expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledTimes(1);
   });
 
   it('does not fire enrichment when entry_type is not track (talkset)', async () => {


### PR DESCRIPTION
## Summary

Implements H2 (Epic H, [project #32](https://github.com/orgs/WXYC/projects/32)) by replacing the `(xmax = 0)` PG MVCC system-column trick in `apps/backend/routes/internal.route.ts` flowsheet-webhook handler with an explicit `INSERT ... ON CONFLICT DO NOTHING RETURNING { id }` + fallthrough UPDATE pattern. The new shape:

- Tries to claim the row via the INSERT.
- If RETURNING gives us one row → fresh INSERT, fire enrichment.
- If RETURNING is empty → conflict (a concurrent delivery or prior webhook already claimed this `legacy_entry_id`); fall through to an explicit UPDATE that refreshes only the mutable subset (artist/album/track/label/message/request_flag/entry_type — same set as the original ON CONFLICT DO UPDATE). Enrichment does NOT fire.

The acceptance criterion (c) from #909 — concurrent INSERT race — is now exercised against real Postgres via a new integration test, and the unit test for the same branch pins exactly-once enrichment across two deliveries with the same `legacy_entry_id`.

## Why this matters

The original `(xmax = 0)` trick was clever but PG-internal. A DB engine migration would silently break the `created` boolean and every benign tubafrenzy retry would re-trigger LML's 10-column enrichment rewrite + CDC/tsvector/index churn. The new shape is portable (any engine with INSERT-IGNORE-style semantics) and obvious to readers.

## Test coverage

- Unit (`tests/unit/routes/internal.route.test.ts`):
  - Existing 37 tests pass with renamed expectations matching the new RETURNING-shape semantics.
  - New test pins the concurrent-race contract: winner fires enrichment exactly once; loser falls through to UPDATE without re-firing.
- Integration (`tests/integration/internal-flowsheet-webhook.spec.js`, new):
  - Two concurrent webhook deliveries against real Postgres → exactly one row exists.
  - Sequential same-id deliveries with different mutable fields → the second delivery's UPDATE branch refreshes the mutable subset.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 391 pre-existing warnings (7 new from `sql.unsafe(...)` in integration test, all `detect-non-literal-fs-filename` / similar warn-only), 0 errors
- [x] `npm run format:check` — clean
- [x] `npx jest tests/unit/routes/internal.route.test.ts` — 39 passed (37 existing + 2 new)
- [ ] CI integration suite runs `tests/integration/internal-flowsheet-webhook.spec.js` against the dockerized PG

Closes #909