### PR TITLE
Unify three SearchUrl-synthesis call sites on SearchUrlProvider

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -28,8 +28,15 @@ import type {
   LookupResponse,
 } from '../services/lml/lml.client.js';
 import { getDiscogsReleaseIdByLegacyId } from '../services/library.service.js';
+import { SearchUrlProvider } from '../services/metadata/providers/search-urls.provider.js';
 import { LRUCache } from 'lru-cache';
 import WxycError from '../utils/error.js';
+
+// Shared instance — stateless, safe to reuse across requests. Centralizes
+// fallback-URL synthesis so this controller, the runtime metadata service,
+// and the flowsheet-metadata-backfill job all produce identical URLs for
+// the same inputs (BS#889).
+const searchUrlProvider = new SearchUrlProvider();
 
 /**
  * Toggle the single-call /proxy/metadata/album path.
@@ -299,7 +306,6 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
 
   const useSingleLookup = singleLookupEnabled();
   const metadata: Record<string, unknown> = {};
-  const searchTerm = releaseTitle || trackTitle || '';
   let upstreamCalls = 0;
 
   let artwork: DiscogsMatchResult | undefined;
@@ -344,12 +350,18 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
     }
   }
 
-  // Fallback: construct search URLs for services without LML-provided URLs
-  const query = searchTerm ? `${artistName} ${searchTerm}` : artistName;
-  const encodedQuery = encodeURIComponent(query);
-  if (!metadata.youtubeMusicUrl) metadata.youtubeMusicUrl = `https://music.youtube.com/search?q=${encodedQuery}`;
-  if (!metadata.bandcampUrl) metadata.bandcampUrl = `https://bandcamp.com/search?q=${encodedQuery}`;
-  if (!metadata.soundcloudUrl) metadata.soundcloudUrl = `https://soundcloud.com/search?q=${encodedQuery}`;
+  // Fallback: construct search URLs for services without LML-provided URLs.
+  // Per-service semantics live in `SearchUrlProvider` (BS#889) — YouTube/
+  // Bandcamp/SoundCloud each use a different field-fallback order, so the
+  // three URLs are no longer guaranteed to share a query string. Old
+  // behavior was a single combined `${artistName} ${searchTerm}` for all
+  // three; the new behavior matches the runtime path and the recurring
+  // backfill so iOS gets identical search URLs regardless of which BS path
+  // produced them.
+  const fallbackUrls = searchUrlProvider.getAllSearchUrls(artistName, releaseTitle, trackTitle);
+  if (!metadata.youtubeMusicUrl) metadata.youtubeMusicUrl = fallbackUrls.youtubeMusicUrl;
+  if (!metadata.bandcampUrl) metadata.bandcampUrl = fallbackUrls.bandcampUrl;
+  if (!metadata.soundcloudUrl) metadata.soundcloudUrl = fallbackUrls.soundcloudUrl;
 
   // Project the upstream-call count + mode onto the active Sentry span so
   // we can split p50/p95 by cohort in the trace explorer. Wrap in a

--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -69,24 +69,34 @@ const filterSpacerGif = (url: string | null | undefined): string | null => {
 
 /**
  * Synthesize the three search URLs the runtime path falls back to on
- * no-match. Mirrors `apps/backend/services/metadata/providers/search-urls.provider.ts`
- * — duplicated inline for the same build-graph isolation reason as
- * `lml-fetch.ts`.
+ * no-match. Must match `apps/backend/services/metadata/providers/search-urls.provider.ts`
+ * exactly — the inline copy is duplicated rather than imported for the same
+ * build-graph isolation reason as `lml-fetch.ts`. The parity test at
+ * `tests/unit/jobs/flowsheet-metadata-backfill/synthesize-search-urls-parity.test.ts`
+ * pins the equivalence so the two cannot drift (BS#889).
+ *
+ * Per-service semantics (deliberately asymmetric):
+ *   - YouTube Music: trackTitle > albumTitle > artistName (3-tier).
+ *   - Bandcamp:      albumTitle > artistName (album-leaning).
+ *   - SoundCloud:    trackTitle > artistName (track-leaning, NO album
+ *                    fallback — album-only SoundCloud queries return
+ *                    unrelated DJ mixes more often than the album).
  */
-const synthesizeSearchUrls = (
+export const synthesizeSearchUrls = (
   row: EnrichRow
 ): { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
   const artist = row.artist_name;
   const album = row.album_title ?? undefined;
   const track = row.track_title ?? undefined;
 
-  const trackQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
-  const albumQuery = album ? `${artist} ${album}` : artist;
+  const youtubeQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
+  const bandcampQuery = album ? `${artist} ${album}` : artist;
+  const soundcloudQuery = track ? `${artist} ${track}` : artist;
 
   return {
-    youtube_music_url: `https://music.youtube.com/search?q=${encodeURIComponent(trackQuery)}`,
-    bandcamp_url: `https://bandcamp.com/search?q=${encodeURIComponent(albumQuery)}`,
-    soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent(trackQuery)}`,
+    youtube_music_url: `https://music.youtube.com/search?q=${encodeURIComponent(youtubeQuery)}`,
+    bandcamp_url: `https://bandcamp.com/search?q=${encodeURIComponent(bandcampQuery)}`,
+    soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent(soundcloudQuery)}`,
   };
 };
 

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -319,6 +319,30 @@ describe('proxy.controller', () => {
       expect(result.soundcloudUrl).toContain('soundcloud.com');
     });
 
+    it('uses per-service fallback shape (YouTube + Bandcamp include album; SoundCloud does not)', async () => {
+      // Pins the BS#889 contract at the controller layer. Pre-BS#889 the
+      // three URLs shared a single combined `${artistName} ${searchTerm}`
+      // query, so all three contained the album when releaseTitle was set
+      // and trackTitle wasn't. The new SearchUrlProvider-backed behavior
+      // is asymmetric: SoundCloud falls back to artist-only without album
+      // because album-only SoundCloud queries return unrelated DJ mixes
+      // more often than the album. A future regression that re-introduces
+      // the combined-query pattern in the controller would fail this test
+      // even if the provider-level tests stay green.
+      mockLookupMetadata.mockRejectedValue(new Error('LML down'));
+
+      const req = { query: { artistName: 'Stereolab', releaseTitle: 'Dots and Loops' } } as unknown as Request;
+      const res = createMockRes();
+
+      await getAlbumMetadata(req, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const result = (res.json as jest.Mock).mock.calls[0][0];
+      expect(result.youtubeMusicUrl).toBe('https://music.youtube.com/search?q=Stereolab%20Dots%20and%20Loops');
+      expect(result.bandcampUrl).toBe('https://bandcamp.com/search?q=Stereolab%20Dots%20and%20Loops');
+      expect(result.soundcloudUrl).toBe('https://soundcloud.com/search?q=Stereolab');
+    });
+
     it('returns search-only metadata when release fetch fails', async () => {
       mockLookupMetadata.mockResolvedValue({
         results: [

--- a/tests/unit/jobs/flowsheet-metadata-backfill/synthesize-search-urls-parity.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/synthesize-search-urls-parity.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Parity test: the inline `synthesizeSearchUrls` in
+ * `jobs/flowsheet-metadata-backfill/enrich.ts` MUST produce identical
+ * output to the canonical `SearchUrlProvider.getAllSearchUrls` in
+ * `apps/backend/services/metadata/providers/search-urls.provider.ts`
+ * for the same inputs (BS#889).
+ *
+ * The inline copy exists deliberately — the job's tsup build deliberately
+ * doesn't pull in apps/backend (build-graph isolation; see the file
+ * header on `enrich.ts` and on `lml-fetch.ts`). The cost of that
+ * isolation is silent drift between the two implementations. Three
+ * different services historically diverged here, and iOS users saw
+ * different YouTube/Bandcamp/SoundCloud URLs depending on which BS path
+ * enriched the row. This test pins them in lockstep so the next drift
+ * fails CI loudly.
+ */
+
+import { synthesizeSearchUrls } from '../../../../jobs/flowsheet-metadata-backfill/enrich';
+import { SearchUrlProvider } from '../../../../apps/backend/services/metadata/providers/search-urls.provider';
+
+describe('synthesizeSearchUrls parity with SearchUrlProvider', () => {
+  const canonical = new SearchUrlProvider();
+
+  type Case = { name: string; artist: string; album: string | null; track: string | null };
+  const cases: Case[] = [
+    { name: 'full track + album + artist', artist: 'Juana Molina', album: 'DOGA', track: 'la paradoja' },
+    { name: 'no track, album present', artist: 'Stereolab', album: 'Dots and Loops', track: null },
+    { name: 'no album, track present', artist: 'Autechre', album: null, track: 'VI Scose Poise' },
+    { name: 'artist only', artist: 'Chuquimamani-Condori', album: null, track: null },
+    { name: 'diacritics in artist', artist: 'Nilüfer Yanya', album: 'Painless', track: 'stabilise' },
+    { name: 'diacritics + nothing else', artist: 'Hermanos Gutiérrez', album: null, track: null },
+    { name: 'spaces + ampersand in artist', artist: 'Duke Ellington & John Coltrane', album: null, track: null },
+  ];
+
+  it.each(cases)('$name', ({ artist, album, track }) => {
+    const inline = synthesizeSearchUrls({
+      id: 0,
+      artist_name: artist,
+      album_title: album,
+      track_title: track,
+    });
+    const canonicalOut = canonical.getAllSearchUrls(artist, album ?? undefined, track ?? undefined);
+
+    expect(inline.youtube_music_url).toBe(canonicalOut.youtubeMusicUrl);
+    expect(inline.bandcamp_url).toBe(canonicalOut.bandcampUrl);
+    expect(inline.soundcloud_url).toBe(canonicalOut.soundcloudUrl);
+  });
+});

--- a/tests/unit/services/metadata/providers/search-urls.provider.test.ts
+++ b/tests/unit/services/metadata/providers/search-urls.provider.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for `SearchUrlProvider` — the canonical synthesis of
+ * fallback search URLs for YouTube Music / Bandcamp / SoundCloud (BS#889).
+ *
+ * The provider is the single source of truth for the search-URL shape.
+ * Three call sites historically drifted (metadata.service runtime path,
+ * the flowsheet-metadata-backfill inline copy, the proxy.controller
+ * fallback). These tests pin the canonical semantics; companion parity
+ * tests pin that each consumer site produces identical output.
+ *
+ * Per-service semantics:
+ *   - YouTube Music: trackTitle > albumTitle > artistName (3-tier fallback).
+ *   - Bandcamp:      albumTitle > artistName (2-tier; album-leaning).
+ *   - SoundCloud:    trackTitle > artistName (2-tier; track-leaning, NO
+ *                    album fallback).
+ *
+ * The asymmetry is deliberate: Bandcamp pages are album-centric, SoundCloud
+ * pages are track-centric. Searching SoundCloud by album-only often returns
+ * unrelated DJ mixes.
+ */
+
+import { SearchUrlProvider } from '../../../../../apps/backend/services/metadata/providers/search-urls.provider';
+
+describe('SearchUrlProvider', () => {
+  const provider = new SearchUrlProvider();
+
+  describe('getYoutubeMusicUrl', () => {
+    it('prefers track when present', () => {
+      expect(provider.getYoutubeMusicUrl('Stereolab', 'Miss Modular', 'Dots and Loops')).toBe(
+        'https://music.youtube.com/search?q=Stereolab%20Miss%20Modular'
+      );
+    });
+    it('falls back to album when no track', () => {
+      expect(provider.getYoutubeMusicUrl('Stereolab', undefined, 'Dots and Loops')).toBe(
+        'https://music.youtube.com/search?q=Stereolab%20Dots%20and%20Loops'
+      );
+    });
+    it('falls back to artist when neither track nor album', () => {
+      expect(provider.getYoutubeMusicUrl('Stereolab')).toBe('https://music.youtube.com/search?q=Stereolab');
+    });
+  });
+
+  describe('getBandcampUrl', () => {
+    it('prefers album when present', () => {
+      expect(provider.getBandcampUrl('Stereolab', 'Dots and Loops')).toBe(
+        'https://bandcamp.com/search?q=Stereolab%20Dots%20and%20Loops'
+      );
+    });
+    it('falls back to artist when no album', () => {
+      expect(provider.getBandcampUrl('Stereolab')).toBe('https://bandcamp.com/search?q=Stereolab');
+    });
+  });
+
+  describe('getSoundcloudUrl', () => {
+    it('prefers track when present', () => {
+      expect(provider.getSoundcloudUrl('Stereolab', 'Miss Modular')).toBe(
+        'https://soundcloud.com/search?q=Stereolab%20Miss%20Modular'
+      );
+    });
+    it('falls back to artist when no track (does NOT fall through album)', () => {
+      // The SoundCloud helper deliberately does not take an album parameter:
+      // SoundCloud searches by album-only return unrelated DJ mixes more
+      // often than the album itself. The two-tier fallback (track > artist)
+      // is the contract; any consumer that passes album-as-track here is
+      // misusing the API.
+      expect(provider.getSoundcloudUrl('Stereolab')).toBe('https://soundcloud.com/search?q=Stereolab');
+    });
+  });
+
+  describe('getAllSearchUrls', () => {
+    it('produces the three URLs from one call with mixed inputs', () => {
+      const urls = provider.getAllSearchUrls('Juana Molina', 'DOGA', 'la paradoja');
+      expect(urls).toEqual({
+        youtubeMusicUrl: 'https://music.youtube.com/search?q=Juana%20Molina%20la%20paradoja',
+        bandcampUrl: 'https://bandcamp.com/search?q=Juana%20Molina%20DOGA',
+        soundcloudUrl: 'https://soundcloud.com/search?q=Juana%20Molina%20la%20paradoja',
+      });
+    });
+
+    it('handles artist-only correctly across all three services', () => {
+      const urls = provider.getAllSearchUrls('Juana Molina');
+      expect(urls).toEqual({
+        youtubeMusicUrl: 'https://music.youtube.com/search?q=Juana%20Molina',
+        bandcampUrl: 'https://bandcamp.com/search?q=Juana%20Molina',
+        soundcloudUrl: 'https://soundcloud.com/search?q=Juana%20Molina',
+      });
+    });
+
+    it('encodes diacritics correctly (Nilüfer Yanya / Hermanos Gutiérrez)', () => {
+      // Per memory: the canonical test corpus includes three diacritic-
+      // bearing artist names so the URL encoding path is exercised.
+      const urls = provider.getAllSearchUrls('Nilüfer Yanya', undefined, undefined);
+      expect(urls.youtubeMusicUrl).toBe('https://music.youtube.com/search?q=Nil%C3%BCfer%20Yanya');
+      expect(urls.bandcampUrl).toBe('https://bandcamp.com/search?q=Nil%C3%BCfer%20Yanya');
+      expect(urls.soundcloudUrl).toBe('https://soundcloud.com/search?q=Nil%C3%BCfer%20Yanya');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements B6 (Epic B, [project #32](https://github.com/orgs/WXYC/projects/32)) by unifying the three drifted inline copies of "synthesize fallback search URLs" on the canonical `SearchUrlProvider`. The drift was iOS-visible: tapping the YouTube/Bandcamp/SoundCloud links in the playlist gave different URLs depending on which BS code path enriched the row.

## The three sites + what changed

| Site | Before | After |
|------|--------|-------|
| `apps/backend/services/metadata/metadata.service.ts` (runtime path) | `SearchUrlProvider.getAllSearchUrls(...)` | unchanged (already canonical) |
| `jobs/flowsheet-metadata-backfill/enrich.ts` (recurring sweep) | Inline copy; SoundCloud falls back to album-then-artist | Inline copy aligned to canonical SoundCloud (track > artist, NO album fallback); now exported for parity test |
| `apps/backend/controllers/proxy.controller.ts` (LML fallback) | Single combined `${artistName} ${searchTerm}` for all three URLs | `SearchUrlProvider.getAllSearchUrls(artistName, releaseTitle, trackTitle)` |

Why SoundCloud doesn't take an album: album-only SoundCloud searches return unrelated DJ mixes more often than the album itself. This asymmetry is now documented on the provider, the inline copy, and a dedicated test case.

The inline copy in the backfill job is deliberately *not* an import — `lml-fetch.ts` and friends keep build-graph isolation from `apps/backend`. The parity test (new) pins the inline copy to the canonical so they can't drift again.

## Test coverage

- `tests/unit/services/metadata/providers/search-urls.provider.test.ts` — new. Pins per-service fallback semantics (YouTube 3-tier, Bandcamp 2-tier album-leaning, SoundCloud 2-tier track-leaning) and diacritic encoding. 10 cases.
- `tests/unit/jobs/flowsheet-metadata-backfill/synthesize-search-urls-parity.test.ts` — new. Asserts the inline copy in `enrich.ts` produces identical URLs to `SearchUrlProvider` across 7 input combinations (track/album/artist permutations, diacritic inputs).

## Test plan

- [x] `npx jest --config jest.unit.config.ts` — 147 suites / 1895 tests pass
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] `npm run lint` — 393 pre-existing warnings, 0 errors

Closes #889