### PR TITLE
Cross-link CLAUDE.md to the org cache-hierarchy reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ CLAUDE.md is a router for the always-loaded reference card. Topic depth lives in
 - **[`docs/cdc.md`](docs/cdc.md)** — CDC WebSocket endpoint, event format, reconciliation monitor
 - **[`docs/deploy.md`](docs/deploy.md)** — Deploy cadence, migration-chain risk, deploy-wedge anatomy, CI workflow pin maintenance (permissions, gha/v1 pins, caller-callee permissions trap from #857)
 
+For the org-wide cache-hierarchy reference (BS's `proxy.controller` LRUs in context with the upstream iOS caches and downstream LML caches), see [`WXYC/wiki/architecture/cache-hierarchy.md`](https://github.com/WXYC/wiki/blob/main/architecture/cache-hierarchy.md).
+
 Read the relevant topic doc before doing work in that area.
 
 ## Architecture


### PR DESCRIPTION
Adds a one-line pointer in CLAUDE.md to the new `WXYC/wiki/architecture/cache-hierarchy.md` (just merged in [WXYC/wiki#70](https://github.com/WXYC/wiki/pull/70)).

BS's `proxy.controller` LRUs are Tier 3 in that map; the wiki doc puts them in context with the iOS upstream caches (Tiers 1+2) and the LML caches below (Tiers 4+5). Cross-link plan from E2 ([project #32](https://github.com/orgs/WXYC/projects/32)).