### PR TITLE
Treat null album_id as free-form insert in flowsheet.controller

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -231,7 +231,13 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
     throw new WxycError('Bad Request, Missing query parameter: track_title', 400);
   }
 
-  if (body.album_id !== undefined) {
+  // Use `!= null` rather than `!== undefined` so an explicit `album_id: null`
+  // (sent by dj-site when the user picks a rotation row whose source has
+  // `album_id IS NULL` — BS#689 surfaced 147 such rows) falls through to the
+  // snapshot-fields branch below. The `!= null` predicate matches both `null`
+  // and `undefined`; only an actual library id enters the lookup branch.
+  // See BS#933.
+  if (body.album_id != null) {
     //backfill album info from library before adding to flowsheet
     const albumInfo = await flowsheet_service.getAlbumFromDB(body.album_id);
 

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -288,6 +288,33 @@ describe('Add to Flowsheet', () => {
     expect(res.body.track_title).toEqual('Carry the Zero');
   });
 
+  test('With album_id explicitly null + rotation snapshot fields (BS#933)', async () => {
+    // BS#689 made the rotation dropdown LEFT JOIN library so unlinked
+    // rotation rows (album_id IS NULL) become selectable. dj-site dispatches
+    // the chosen row with `album_id: null` and the rotation snapshot fields
+    // (artist_name, album_title, record_label). The controller must treat
+    // this as a free-form insert — not a library lookup — and return 201,
+    // not 500. Without the BS#933 fix the snapshot path crashed with a
+    // TypeError because `getAlbumFromDB(null)` returned undefined.
+    const res = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: null,
+        artist_name: 'Coupé Cloué',
+        album_title: 'Maintenant ou Jamais',
+        track_title: 'Manman',
+        record_label: 'Mini Records',
+      })
+      .expect(201);
+
+    expect(res.body).toBeDefined();
+    expect(res.body.artist_name).toEqual('Coupé Cloué');
+    expect(res.body.album_title).toEqual('Maintenant ou Jamais');
+    expect(res.body.track_title).toEqual('Manman');
+    expect(res.body.record_label).toEqual('Mini Records');
+  });
+
   test('Flowsheet Message', async () => {
     const res = await request
       .post('/flowsheet')

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -440,6 +440,59 @@ describe('flowsheet.controller', () => {
       });
     });
 
+    it('falls through to free-form path when album_id is explicitly null (BS#933)', async () => {
+      // BS#689 made the rotation dropdown LEFT JOIN library so unlinked
+      // rotation rows (album_id IS NULL) become selectable; their dropdown
+      // entries carry a NULL id. dj-site dispatches `album_id: null` along
+      // with the rotation snapshot fields (artist_name / album_title /
+      // record_label). Before the fix, the controller branched on
+      // `body.album_id !== undefined` — `null !== undefined` was true, so
+      // it called getAlbumFromDB(null), which returned undefined, and the
+      // next line TypeErrored when it tried to set record_label on it.
+      // The fix flips the predicate to `!= null` so null falls through to
+      // the snapshot-fields branch.
+      const completedEntry = {
+        id: 3,
+        show_id: activeShow.id,
+        artist_name: 'Coupé Cloué',
+        album_title: 'Maintenant ou Jamais',
+        track_title: 'Manman',
+        record_label: 'Mini Records',
+        album_id: null,
+        rotation_id: 99,
+        play_order: 3,
+        add_time: new Date(),
+      };
+      mockAddTrack.mockResolvedValue(completedEntry);
+
+      const req = createMockBodyReq({
+        artist_name: 'Coupé Cloué',
+        album_title: 'Maintenant ou Jamais',
+        track_title: 'Manman',
+        record_label: 'Mini Records',
+        album_id: null,
+        rotation_id: 99,
+      });
+      const res = createMockRes();
+
+      await addEntry(req as Request, res as Response, mockNext);
+
+      // getAlbumFromDB must not be invoked — null album_id is not a library lookup.
+      expect(mockGetAlbumFromDB).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(mockAddTrack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artist_name: 'Coupé Cloué',
+          album_title: 'Maintenant ou Jamais',
+          track_title: 'Manman',
+          record_label: 'Mini Records',
+          album_id: null,
+          rotation_id: 99,
+          show_id: activeShow.id,
+        })
+      );
+    });
+
     it('delegates metadata enrichment without artistId for free-form inserts (no album_id)', async () => {
       const completedEntry = {
         id: 2,


### PR DESCRIPTION
## Summary

**Production-impacting fix** — POST /flowsheet was returning 500 for DJs adding rotation entries whose source rotation row has `album_id IS NULL`. Closes [#933](https://github.com/WXYC/Backend-Service/issues/933).

## The bug

After [#689](https://github.com/WXYC/Backend-Service/issues/689) the rotation dropdown LEFT JOINs library so unlinked rotation rows (147 in prod) become selectable. Each unlinked dropdown row's `id` is `library.id` = `NULL`. dj-site dispatches `album_id: null` with the rotation snapshot fields.

`apps/backend/controllers/flowsheet.controller.ts:234` branched on `body.album_id !== undefined`. `null !== undefined` is `true`, so it called `getAlbumFromDB(null)` → returned `undefined` → next line tried to set `record_label` on `undefined` → TypeError → 500.

## The fix

One-line predicate flip: `!== undefined` → `!= null`. The `!= null` predicate matches both `null` and `undefined`, so explicit-null falls through to the existing snapshot-fields branch, which inserts a free-form row using `artist_name` / `album_title` / `record_label` from the body — exactly what dj-site sends with the rotation snapshot.

## Test coverage

- `tests/unit/controllers/flowsheet.controller.test.ts` — new unit case pinning the null path: `getAlbumFromDB` must not be called; `addTrack` is invoked with the snapshot fields; 201 returned. The test reproduces the exact crash before the fix (TypeError at `flowsheet.controller.ts:239`).
- `tests/integration/flowsheet.spec.js` — new integration test against real PG covering the same null + snapshot payload, asserting 201 + correct body shape.

## Test plan

- [x] `npx jest --config jest.unit.config.ts tests/unit/controllers/flowsheet.controller.test.ts` — 35 passed (1 new)
- [x] `npm run typecheck` clean
- [x] `npm run lint` — 393 pre-existing warnings, 0 errors
- [x] `npm run format:check` clean
- [ ] CI integration suite runs the new test against the dockerized PG
- [ ] Post-deploy: verify Sentry POST /flowsheet `internal_error` count with `http.response.status_code: 500` drops to ~0 in the 24h after deploy

## Out of scope

- Per the issue: not adjusting `getAlbumFromDB` to throw 400 on missing id (deferred to a hardening follow-up if a reviewer prefers).
- Per the issue: not modifying dj-site `RotationEntryFields.handleSelectRelease` — the upstream BS fix makes a dj-site change non-load-bearing.

Closes #933