### PR TITLE
Guard runtime metadata UPDATE on metadata_attempt_at IS NULL + race / linkage tests

### DIFF
--- a/apps/backend/services/metadata/enrichment.service.ts
+++ b/apps/backend/services/metadata/enrichment.service.ts
@@ -11,7 +11,7 @@
  * under `subsystem='metadata'`, never thrown.
  */
 import * as Sentry from '@sentry/node';
-import { eq, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import { db, flowsheet } from '@wxyc/database';
 import { fetchMetadata } from './metadata.service.js';
 
@@ -65,7 +65,16 @@ export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
           // recurring drift-repair sweep — see #639.
           metadata_attempt_at: sql`NOW()`,
         })
-        .where(eq(flowsheet.id, input.flowsheetId));
+        // Mirrors the backfill's idempotency guard in
+        // `jobs/flowsheet-metadata-backfill/enrich.ts` line 173. If a
+        // concurrent writer (drift-repair backfill, or — until C5 — a
+        // duplicate runtime call) already stamped this row, our UPDATE
+        // resolves to 0 rows at row-lock granularity and the prior
+        // stamp is preserved. Backfill semantics on no-match preserve
+        // prior values; the runtime nulls them — making the order of
+        // a race race-sensitive. The IS NULL gate ensures only one
+        // landing wins.
+        .where(sql`"id" = ${input.flowsheetId} AND "metadata_attempt_at" IS NULL`);
     })
     .catch((err) => {
       console.error('[Flowsheet] Metadata fetch failed:', err);

--- a/apps/backend/services/metadata/enrichment.service.ts
+++ b/apps/backend/services/metadata/enrichment.service.ts
@@ -71,8 +71,8 @@ export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
         // duplicate runtime call) already stamped this row, our UPDATE
         // resolves to 0 rows at row-lock granularity and the prior
         // stamp is preserved. Backfill semantics on no-match preserve
-        // prior values; the runtime nulls them — making the order of
-        // a race race-sensitive. The IS NULL gate ensures only one
+        // prior values; the runtime nulls them — so the race outcome
+        // is order-sensitive. The IS NULL gate ensures only one
         // landing wins.
         .where(sql`"id" = ${input.flowsheetId} AND "metadata_attempt_at" IS NULL`);
     })

--- a/tests/unit/services/metadata.enrichment.test.ts
+++ b/tests/unit/services/metadata.enrichment.test.ts
@@ -239,4 +239,61 @@ describe('fireAndForgetMetadataForRow', () => {
       },
     });
   });
+
+  it('UPDATE narrows on metadata_attempt_at IS NULL so a backfill ↔ runtime race cannot double-stamp', async () => {
+    // The drift-repair backfill (`jobs/flowsheet-metadata-backfill/enrich.ts`
+    // line 173) narrows its UPDATE by `WHERE id = $row.id AND
+    // metadata_attempt_at IS NULL`. The runtime path here must do the same
+    // so that a backfill UPDATE that landed first cannot be clobbered by
+    // a runtime UPDATE that races after it (or vice versa). At row-lock
+    // granularity in PG, the second writer's UPDATE then resolves to a
+    // 0-row effect — the stamp stays intact.
+    mockFetchMetadata.mockResolvedValue({
+      album: { artworkUrl: 'https://i.discogs.com/art.jpg' },
+    });
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 42,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const whereCalls = mockDb._chain.where.mock.calls;
+    expect(whereCalls.length).toBeGreaterThan(0);
+    const lastWhereArg = whereCalls[whereCalls.length - 1][0];
+    expect(renderSql(lastWhereArg)).toMatch(/metadata_attempt_at.*IS\s+NULL/i);
+  });
+
+  it('does not write linkage columns (album_id / linkage_source / linkage_confidence / linked_at)', async () => {
+    // `apps/backend/services/flowsheet-linkage.service.ts::setFlowsheetLinkage`
+    // owns these four columns. If a metadata UPDATE and a linkage UPDATE
+    // race on the same flowsheet row, they must touch disjoint columns so
+    // neither clobbers the other. This locks in the column boundary so a
+    // future refactor cannot quietly add e.g. `album_id` to the metadata
+    // set() block.
+    mockFetchMetadata.mockResolvedValue({
+      album: {
+        artworkUrl: 'https://i.discogs.com/art.jpg',
+        discogsUrl: 'https://www.discogs.com/release/12345',
+      },
+      artist: { wikipediaUrl: 'https://en.wikipedia.org/wiki/Autechre' },
+    });
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 42,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs).toBeDefined();
+    expect(setArgs).not.toHaveProperty('album_id');
+    expect(setArgs).not.toHaveProperty('linkage_source');
+    expect(setArgs).not.toHaveProperty('linkage_confidence');
+    expect(setArgs).not.toHaveProperty('linked_at');
+  });
 });


### PR DESCRIPTION
## Summary

- Adds the two independent BS#907 acceptance tests (idempotency race, linkage column-boundary).
- Defers the third BS#907 case (AbortError catch-arm) to ship with BS#873.
- Closes the race that motivated the idempotency test: the runtime UPDATE now narrows on `metadata_attempt_at IS NULL`, matching the backfill's invariant at `jobs/flowsheet-metadata-backfill/enrich.ts:173`. A backfill ↔ runtime race now resolves to one landing winning at row-lock granularity.

## Test plan

- [x] `npx jest tests/unit/services/metadata.enrichment.test.ts` — 10/10 pass (was 8; +2 new).
- [x] `npm run test:unit` — 1931/1931 pass.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean (0 errors).
- [x] `npm run format:check` — clean.

Closes #941