### PR TITLE
feat(library): add /library/rotation/:rotation_id/tracks for rotation entry picker

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -13,7 +13,13 @@ import * as libraryService from '../services/library.service.js';
 import * as labelsService from '../services/labels.service.js';
 import * as librarySearchService from '../services/library-search.service.js';
 import type { CatalogSort, CatalogOrder } from '../services/library-search.service.js';
-import { checkStreamingAvailability, lookupMetadata, isLmlConfigured } from '../services/lml/lml.client.js';
+import {
+  checkStreamingAvailability,
+  lookupMetadata,
+  isLmlConfigured,
+  getRelease,
+  LmlClientError,
+} from '../services/lml/lml.client.js';
 import { filterSpacerGif } from '../services/metadata/metadata.service.js';
 import WxycError from '../utils/error.js';
 
@@ -316,6 +322,76 @@ export const killRotation: RequestHandler<object, unknown, KillRotationRelease> 
   } else {
     throw new WxycError('Rotation entry not found', 400);
   }
+};
+
+/**
+ * Wire shape returned by `GET /library/rotation/:rotation_id/tracks`. The
+ * dj-site rotation entry picker (`useGetRotationTracksQuery`) consumes this
+ * directly — keep field names + types in lockstep with the dj-site
+ * `RotationTrack` type in `lib/features/rotation/api.ts`.
+ *
+ * Distinct from the `/proxy/library/:libraryId/tracks` shape
+ * (`{position, title, artist_credit, duration_ms}`) consumed by the
+ * catalog-search picker (BS#836 / dj-site#501). Same upstream data, two
+ * pickers with two pre-existing wire contracts.
+ */
+export interface RotationTrack {
+  position: string;
+  title: string;
+  duration: string | null;
+  artists: string[];
+}
+
+/**
+ * GET /library/rotation/:rotation_id/tracks (BS#940)
+ *
+ * Composition for the dj-site rotation entry mode track picker.
+ *   1. Resolve `rotation.album_id` → `library_identity.discogs_release_id`
+ *      via `getDiscogsReleaseIdByRotationId`.
+ *   2. Fetch the tracklist from LML's `GET /api/v1/discogs/release/{id}`.
+ *   3. Project Discogs's per-track `artists` onto the dj-site shape; fall
+ *      back to the release-level artist when a track has no per-track credits
+ *      (Discogs's normal shape for non-V/A releases).
+ *
+ * Degrades gracefully: returns 200 + `[]` when no identity resolves (no
+ * `album_id`, no `library_identity` row, or no `discogs_release_id`) or when
+ * LML 404s the release. Only LML 5xx bubbles up so transient upstream failures
+ * surface rather than silently hiding the dropdown.
+ *
+ * No BS-side cache here — LML's 3-tier cache already deduplicates by release id.
+ * If load justifies it, extract a shared LRU between this and the `/proxy`
+ * sibling.
+ */
+export const getRotationTracks: RequestHandler<{ rotation_id: string }> = async (req, res) => {
+  const rotationId = parseInt(req.params.rotation_id, 10);
+  if (!Number.isInteger(rotationId) || rotationId <= 0) {
+    throw new WxycError('rotation_id must be a positive integer', 400);
+  }
+
+  const discogsReleaseId = await libraryService.getDiscogsReleaseIdByRotationId(rotationId);
+  if (discogsReleaseId === null) {
+    res.status(200).json([]);
+    return;
+  }
+
+  let release;
+  try {
+    release = await getRelease(discogsReleaseId);
+  } catch (err) {
+    if (err instanceof LmlClientError && err.statusCode === 404) {
+      res.status(200).json([]);
+      return;
+    }
+    throw err;
+  }
+
+  const tracks: RotationTrack[] = release.tracklist.map((t) => ({
+    position: t.position,
+    title: t.title,
+    duration: t.duration ?? null,
+    artists: t.artists && t.artists.length > 0 ? t.artists : [release.artist],
+  }));
+  res.status(200).json(tracks);
 };
 
 export const getFormats: RequestHandler = async (req, res) => {

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -22,6 +22,12 @@ library_route.post('/rotation', requirePermissions({ catalog: ['write'] }), libr
 
 library_route.patch('/rotation', requirePermissions({ catalog: ['write'] }), libraryController.killRotation);
 
+library_route.get(
+  '/rotation/:rotation_id/tracks',
+  requirePermissions({ catalog: ['read'] }),
+  libraryController.getRotationTracks
+);
+
 library_route.post('/artists', requirePermissions({ catalog: ['write'] }), libraryController.addArtist);
 
 library_route.get('/artists/peek-code', requirePermissions({ catalog: ['write'] }), libraryController.peekArtistNumber);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -314,6 +314,31 @@ export async function getDiscogsReleaseIdByLegacyId(legacyId: number): Promise<n
   return rows[0]?.discogs_release_id ?? null;
 }
 
+/**
+ * Look up the resolved Discogs release id for a rotation row by its id.
+ * Joins `rotation` → `library_identity` via `rotation.album_id = library_identity.library_id`.
+ *
+ * Returns null when any of these holds (the picker degrades to free-text):
+ *   - rotation row doesn't exist,
+ *   - rotation row has `album_id IS NULL` (unlinked — ~49% of active prod rows),
+ *   - the album row has no `library_identity` entry (not yet backfilled by BS#802), or
+ *   - the identity row has no resolved `discogs_release_id`.
+ *
+ * Used by `/library/rotation/:rotation_id/tracks` (BS#940) to compose against
+ * LML's `/api/v1/discogs/release/{id}` for the rotation entry mode picker.
+ * Parallel to `getDiscogsReleaseIdByLegacyId` (BS#836), which the catalog-search
+ * picker uses via `legacy_release_id`.
+ */
+export async function getDiscogsReleaseIdByRotationId(rotationId: number): Promise<number | null> {
+  const rows = await db
+    .select({ discogs_release_id: library_identity.discogs_release_id })
+    .from(rotation)
+    .innerJoin(library_identity, eq(library_identity.library_id, rotation.album_id))
+    .where(eq(rotation.id, rotationId))
+    .limit(1);
+  return rows[0]?.discogs_release_id ?? null;
+}
+
 export const updateOnStreaming = async (id: number, on_streaming: boolean | null) => {
   const response = await db.update(library).set({ on_streaming }).where(eq(library.id, id)).returning();
   return response[0];

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -13,6 +13,7 @@ const mockGenerateAlbumCodeNumber = jest.fn<(artistId: number) => Promise<number
 const mockCreateLabel = jest.fn<(label: string) => Promise<{ id: number }>>();
 const mockUpdateCanonicalEntity = jest.fn<(id: number, entityId: string, confidence: number) => Promise<unknown>>();
 const mockMapLookupToCanonicalEntity = jest.fn<(response: unknown) => { id: string; confidence: number } | null>();
+const mockGetDiscogsReleaseIdByRotationId = jest.fn<(rotationId: number) => Promise<number | null>>();
 
 jest.mock('../../../apps/backend/services/library.service', () => ({
   getAlbumFromDB: mockGetAlbumFromDB,
@@ -45,6 +46,7 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   insertGenre: jest.fn(),
   insertFormat: jest.fn(),
   isISODate: jest.fn(),
+  getDiscogsReleaseIdByRotationId: mockGetDiscogsReleaseIdByRotationId,
 }));
 
 jest.mock('../../../apps/backend/services/labels.service', () => ({
@@ -54,14 +56,35 @@ jest.mock('../../../apps/backend/services/labels.service', () => ({
 const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
 const mockCheckStreamingAvailability = jest.fn<() => Promise<unknown>>();
 const mockIsLmlConfigured = jest.fn<() => boolean>().mockReturnValue(false);
+const mockGetRelease = jest.fn<(releaseId: number) => Promise<unknown>>();
+
+// LmlClientError needs to be a real class so `err instanceof LmlClientError`
+// in the controller works after mocking. Mirrors the real shape in
+// apps/backend/services/lml/lml.client.ts.
+class MockLmlClientError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = 'LmlClientError';
+    this.statusCode = statusCode;
+  }
+}
 
 jest.mock('../../../apps/backend/services/lml/lml.client', () => ({
   checkStreamingAvailability: mockCheckStreamingAvailability,
   lookupMetadata: mockLookupMetadata,
   isLmlConfigured: mockIsLmlConfigured,
+  getRelease: mockGetRelease,
+  LmlClientError: MockLmlClientError,
 }));
 
-import { markMissing, markFound, searchForAlbum, addAlbum } from '../../../apps/backend/controllers/library.controller';
+import {
+  markMissing,
+  markFound,
+  searchForAlbum,
+  addAlbum,
+  getRotationTracks,
+} from '../../../apps/backend/controllers/library.controller';
 
 function mockResponse(): Response {
   const res = {} as Response;
@@ -426,6 +449,93 @@ describe('library.controller', () => {
         expect(mockLookupMetadata).not.toHaveBeenCalled();
         expect(mockUpdateCanonicalEntity).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('getRotationTracks', () => {
+    // Minimal Discogs release shape needed by the projection. The real
+    // DiscogsReleaseMetadata has more fields; we provide only what the
+    // controller reads.
+    const sampleRelease = {
+      release_id: 4080,
+      title: 'Confield',
+      artist: 'Autechre',
+      tracklist: [
+        { position: 'A1', title: 'VI Scose Poise', duration: '5:30', artists: ['Autechre'] },
+        { position: 'A2', title: 'Cfern', duration: '5:11', artists: [] },
+      ],
+    };
+
+    beforeEach(() => {
+      mockGetDiscogsReleaseIdByRotationId.mockReset();
+      mockGetRelease.mockReset();
+    });
+
+    it('returns 400 for non-numeric rotation_id', async () => {
+      const req = { params: { rotation_id: 'abc' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getRotationTracks(req, res, next)).rejects.toThrow('positive integer');
+      expect(mockGetDiscogsReleaseIdByRotationId).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for non-positive rotation_id', async () => {
+      const req = { params: { rotation_id: '0' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getRotationTracks(req, res, next)).rejects.toThrow('positive integer');
+    });
+
+    it('returns 200 + empty array when no identity resolves (rotation missing, no album_id, or no library_identity row)', async () => {
+      mockGetDiscogsReleaseIdByRotationId.mockResolvedValue(null);
+      const req = { params: { rotation_id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getRotationTracks(req, res, next);
+
+      expect(mockGetDiscogsReleaseIdByRotationId).toHaveBeenCalledWith(42);
+      expect(mockGetRelease).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([]);
+    });
+
+    it('projects Discogs tracklist into RotationTrack shape when identity resolves', async () => {
+      mockGetDiscogsReleaseIdByRotationId.mockResolvedValue(4080);
+      mockGetRelease.mockResolvedValue(sampleRelease);
+      const req = { params: { rotation_id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getRotationTracks(req, res, next);
+
+      expect(mockGetRelease).toHaveBeenCalledWith(4080);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([
+        { position: 'A1', title: 'VI Scose Poise', duration: '5:30', artists: ['Autechre'] },
+        // Empty Discogs track.artists falls back to the release artist so the
+        // dj-site picker always has at least one artist name to render.
+        { position: 'A2', title: 'Cfern', duration: '5:11', artists: ['Autechre'] },
+      ]);
+    });
+
+    it('returns 200 + empty array on LML 404 (release unknown to Discogs)', async () => {
+      mockGetDiscogsReleaseIdByRotationId.mockResolvedValue(9999999);
+      mockGetRelease.mockRejectedValue(new MockLmlClientError('not found', 404));
+      const req = { params: { rotation_id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getRotationTracks(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([]);
+    });
+
+    it('bubbles LML 5xx errors so transient failures surface rather than silently degrading', async () => {
+      mockGetDiscogsReleaseIdByRotationId.mockResolvedValue(4080);
+      mockGetRelease.mockRejectedValue(new MockLmlClientError('upstream timeout', 504));
+      const req = { params: { rotation_id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(getRotationTracks(req, res, next)).rejects.toThrow('upstream timeout');
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds the backend route the dj-site rotation entry picker has been calling — and getting 404 from — since it shipped on 2026-04-20.

`useGetRotationTracksQuery` in [`dj-site/lib/features/rotation/api.ts:36-40`](https://github.com/WXYC/dj-site/blob/main/lib/features/rotation/api.ts#L36-L40) calls `GET /library/rotation/:rotation_id/tracks`. That route has never existed on Backend. Result: every call 404s, dropdown silently never renders, picker falls through to free-text song input. The 2026-05-13 defensive fix WXYC/dj-site#519 muted the resulting JSON-parse toast Holly hit in Slack, which made the silent failure less visible without addressing the wiring.

Not a regression — broken since [`f490b2b`](https://github.com/WXYC/dj-site/commit/f490b2b970d798c0fcd22451e9916b35f7f668b8) (WXYC/dj-site#358) introduced rotation entry mode 2026-04-20.

## What it does

```
GET /library/rotation/:rotation_id/tracks
→ 200 + RotationTrack[]
```

Composition:
1. `getDiscogsReleaseIdByRotationId` — single SQL JOIN `rotation` → `library_identity` via `rotation.album_id`.
2. If null (rotation missing, no album_id, or no resolved identity) → 200 + `[]`.
3. Otherwise call LML `getRelease(discogsReleaseId)`, project into the dj-site `RotationTrack` shape, return.

Response shape (lockstep with [`dj-site RotationTrack`](https://github.com/WXYC/dj-site/blob/main/lib/features/rotation/api.ts#L44-L49)):

```typescript
{ position: string; title: string; duration: string | null; artists: string[] }
```

Returning the exact shape dj-site reads means **zero dj-site changes** — `useGetRotationTracksQuery` works immediately once this lands.

## Notes on shape

- **Track artist fallback**: Discogs emits per-track `artists` only for V/A and split releases. For non-V/A releases `track.artists` is `[]`; we fall back to `[release.artist]` so dj-site always has at least one artist name to render. Mirrors the same fallback in `apps/backend/controllers/proxy.controller.ts:585-588`.
- **Distinct from `/proxy/library/:libraryId/tracks`** (WXYC/Backend-Service#836, catalog-search picker, WXYC/dj-site#501): different consumer, different id semantics (`legacy_release_id` vs `library.id`-via-rotation), different wire shape (`{position, title, artist_credit, duration_ms}`). Same upstream LML release fetch underneath.

## Graceful degrade

- 200 + `[]` for unresolved-identity (rotation missing, NULL `album_id`, no `library_identity` row, NULL `discogs_release_id`).
- 200 + `[]` for LML 404 on the release.
- LML 5xx bubbles up — transient upstream failures surface rather than silently hiding the dropdown forever.

## No BS-side cache

LML's 3-tier cache already deduplicates by release id. If load justifies a second layer, extract a shared LRU between this and the `/proxy/library/:libraryId/tracks` sibling.

## Library_identity prereq

Until the WXYC/Backend-Service#802 consumer job runs in prod and populates `library_identity.discogs_release_id`, every call returns `[]`. The route behaves correctly; populated identity is the prerequisite for any rotation to actually resolve tracks. Worth a comment on WXYC/dj-site#520 once this lands — that tracker currently misdirects to WXYC/Backend-Service#836 as the fix and should be updated.

## Test plan

- [x] Unit: 5 new cases on `library.controller.test.ts` covering non-numeric id (400), non-positive id (400), unresolved identity (200 + `[]`), LML 404 (200 + `[]`), LML 5xx (bubbles). 27/27 in file; 1935/1935 across `library|rotation|lml` patterns.
- [x] Typecheck (`npm run typecheck`), lint (`npm run lint` — 0 new warnings), format (`npm run format:check`), build (`npm run build`) all clean.
- [ ] Local smoke: route registered + reachable (returns 401 unauthenticated, 200 + `[]` authenticated — confirmed via curl). Full end-to-end demo blocked locally because `LIBRARY_METADATA_URL` isn't wired and the mock LML server isn't started by default; not blocking for review since `library_identity` is empty in dev anyway.
- [ ] Integration test: skipped here; if reviewers want one, happy to add a follow-up that seeds a `library_identity` row + verifies the composition. The unit test coverage already exercises the three code paths (resolve null / resolve + LML 200 / resolve + LML 404 / resolve + LML 5xx).

## Related

- Closes #940
- Unblocks WXYC/dj-site rotation entry mode dropdown (no dj-site change needed)
- Tracker: WXYC/dj-site#520 — rotation/flowsheet entry Slack feedback 2026-05-13
- Defensive precursor: WXYC/dj-site#519 — non-JSON 404 toast suppression
- Parallel composition: WXYC/Backend-Service#836 — `/proxy/library/:libraryId/tracks` for catalog-search picker
- Depends on (for actual resolved tracks): WXYC/Backend-Service#802 — `library_identity` backfill