### PR TITLE
Accept track_position in POST/PATCH flowsheet controllers (BS#943)

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -37,6 +37,14 @@ components:
           type: string
         request_flag:
           type: boolean
+        track_position:
+          type: string
+          nullable: true
+          description: >
+            Discogs `release_track.position` (e.g. "A1", "B2") captured by the
+            dj-site flowsheet picker (E6-6, dj-site#501). Optional; `null` for
+            entries added without a position. Wired through POST /flowsheet and
+            PATCH /flowsheet by BS#943.
 
     FlowsheetEntryV2:
       type: object
@@ -442,6 +450,12 @@ paths:
                   type: string
                 track_title:
                   type: string
+                track_position:
+                  type: string
+                  nullable: true
+                  description: >
+                    Discogs `release_track.position`; pass `null` to clear.
+                    See FlowsheetEntry.track_position.
                 record_label:
                   type: string
                 request_flag:

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -186,6 +186,10 @@ export type FSEntryRequestBody = {
   artist_name: string;
   album_title: string;
   track_title: string;
+  // Discogs `release_track.position` for the chosen track when the dj-site
+  // flowsheet picker (E6-6) selected one off a release; NULL/undefined for
+  // free-text entries and message rows. Schema in BS#835 / migration 0076.
+  track_position?: string | null;
   album_id?: number;
   rotation_id?: number;
   record_label: string;
@@ -249,6 +253,7 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
       album_id: body.album_id,
       ...albumInfo,
       track_title: body.track_title,
+      track_position: body.track_position ?? null,
       rotation_id: body.rotation_id,
       request_flag: body.request_flag,
       segue: body.segue ?? false,
@@ -289,6 +294,11 @@ export type UpdateRequestBody = {
   artist_name?: string;
   album_title?: string;
   track_title?: string;
+  // Discogs `release_track.position` updates when the picker is used in edit
+  // mode on an existing row. Service `updateEntry` does a passthrough
+  // `db.update(flowsheet).set(data)` so widening this type is the entire
+  // wiring. Schema in BS#835 / migration 0076.
+  track_position?: string | null;
   record_label?: string;
   label_id?: number;
   request_flag?: boolean;

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -315,6 +315,43 @@ describe('Add to Flowsheet', () => {
     expect(res.body.record_label).toEqual('Mini Records');
   });
 
+  test('With track_position (BS#943, album_id branch)', async () => {
+    // The dj-site flowsheet picker (E6-6) calls /proxy/library/{id}/tracks
+    // after a release pick, then submits the chosen track with the library
+    // `album_id` plus the Discogs `release_track.position` string (e.g. "A1").
+    // BS#835 shipped the column + read projection; this pins the controller
+    // forwarding it through to PG and the V2 read shape returning it.
+    const res = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: 1, // Built to Spill - Keep it Like a Secret
+        track_title: 'Carry the Zero',
+        track_position: 'A1',
+      })
+      .expect(201);
+
+    expect(res.body.track_title).toEqual('Carry the Zero');
+    expect(res.body.track_position).toEqual('A1');
+  });
+
+  test('With track_position (BS#943, free-form branch)', async () => {
+    const res = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        artist_name: 'Juana Molina',
+        album_title: 'DOGA',
+        track_title: 'la paradoja',
+        track_position: 'B2',
+        record_label: 'Sonamos',
+      })
+      .expect(201);
+
+    expect(res.body.track_title).toEqual('la paradoja');
+    expect(res.body.track_position).toEqual('B2');
+  });
+
   test('Flowsheet Message', async () => {
     const res = await request
       .post('/flowsheet')

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -371,6 +371,65 @@ describe('Add to Flowsheet', () => {
 });
 
 /*
+ * Update Flowsheet Entries
+ */
+describe('Update Flowsheet Entries', () => {
+  beforeEach(async () => {
+    await fls_util.join_show(global.primary_dj_id, global.access_token);
+  });
+
+  afterEach(async () => {
+    await fls_util.leave_show(global.primary_dj_id, global.access_token);
+  });
+
+  test('PATCH updates track_position end-to-end (BS#943)', async () => {
+    // The unit test for `updateEntry` mocks the service. This pins the
+    // actual UPDATE wire path through Postgres: a row with
+    // `track_position: 'A1'` posted, patched to 'B2', then cleared to null.
+    // Drizzle's `db.update(flowsheet).set(data).returning()` is the entire
+    // wiring on the service side; the PATCH response is the updated row,
+    // so we can read `track_position` directly off the response body.
+    const created = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: 1, // Built to Spill - Keep it Like a Secret
+        track_title: 'Carry the Zero',
+        track_position: 'A1',
+      })
+      .expect(201);
+
+    expect(created.body.track_position).toEqual('A1');
+    const entry_id = created.body.id;
+    expect(entry_id).toBeDefined();
+
+    const patched = await request
+      .patch('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        entry_id,
+        data: { track_position: 'B2' },
+      })
+      .expect(200);
+
+    expect(patched.body.id).toEqual(entry_id);
+    expect(patched.body.track_position).toEqual('B2');
+
+    const cleared = await request
+      .patch('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        entry_id,
+        data: { track_position: null },
+      })
+      .expect(200);
+
+    expect(cleared.body.id).toEqual(entry_id);
+    expect(cleared.body.track_position).toBeNull();
+  });
+});
+
+/*
  * Retrieve Flowsheet Entries
  */
 describe('Retrieve Flowsheet Entries', () => {

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -15,6 +15,7 @@ const mockAddTrack = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockGetLatestShow = jest.fn<() => Promise<Record<string, unknown> | null>>();
 const mockGetAlbumFromDB = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockResolveDjNameForShow = jest.fn<() => Promise<string | null>>();
+const mockUpdateEntry = jest.fn<() => Promise<Record<string, unknown>>>();
 
 jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getEntriesByPage: mockGetEntriesByPage,
@@ -26,6 +27,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getLatestShow: mockGetLatestShow,
   getAlbumFromDB: mockGetAlbumFromDB,
   resolveDjNameForShow: mockResolveDjNameForShow,
+  updateEntry: mockUpdateEntry,
 }));
 
 const mockFetchMetadata = jest.fn<() => Promise<void>>();
@@ -35,7 +37,13 @@ jest.mock('../../../apps/backend/services/metadata/index', () => ({
   fireAndForgetMetadataForRow: mockFireAndForgetMetadataForRow,
 }));
 
-import { getEntries, getLatest, getShowInfo, addEntry } from '../../../apps/backend/controllers/flowsheet.controller';
+import {
+  getEntries,
+  getLatest,
+  getShowInfo,
+  addEntry,
+  updateEntry,
+} from '../../../apps/backend/controllers/flowsheet.controller';
 import WxycError from '../../../apps/backend/utils/error';
 
 // Helper to create mock Express req/res/next
@@ -612,6 +620,117 @@ describe('flowsheet.controller', () => {
       expect(res.status).toHaveBeenCalledWith(201);
     });
 
+    it('forwards track_position into NewFSEntry for the album_id branch (BS#943)', async () => {
+      // The dj-site flowsheet picker (E6-6) calls /proxy/library/{id}/tracks
+      // after a release is selected, then submits the chosen track with the
+      // library `album_id` plus the Discogs `release_track.position` string
+      // (e.g. "A1"). Schema/projection landed in BS#835; this pins the
+      // controller wiring that lets the value reach the DB.
+      const albumInfo = {
+        artist_name: 'Autechre',
+        album_title: 'Confield',
+        record_label: 'Warp',
+        artist_id: 5,
+      };
+      mockGetAlbumFromDB.mockResolvedValue(albumInfo);
+      mockAddTrack.mockResolvedValue({
+        id: 1,
+        show_id: activeShow.id,
+        artist_name: 'Autechre',
+        album_title: 'Confield',
+        track_title: 'VI Scose Poise',
+        track_position: 'A1',
+        album_id: 10,
+        play_order: 1,
+        add_time: new Date(),
+      });
+
+      const req = createMockBodyReq({
+        track_title: 'VI Scose Poise',
+        track_position: 'A1',
+        album_id: 10,
+      });
+      const res = createMockRes();
+
+      await addEntry(req as Request, res as Response, mockNext);
+
+      expect(mockAddTrack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          album_id: 10,
+          track_title: 'VI Scose Poise',
+          track_position: 'A1',
+          show_id: activeShow.id,
+        })
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('forwards track_position into NewFSEntry for the free-form branch (BS#943)', async () => {
+      // Free-form fallback: dj-site sends snapshot fields without album_id but
+      // still carries a position the DJ entered or that survived from a
+      // rotation-snapshot pick.
+      mockAddTrack.mockResolvedValue({
+        id: 2,
+        show_id: activeShow.id,
+        artist_name: 'Juana Molina',
+        album_title: 'DOGA',
+        track_title: 'la paradoja',
+        track_position: 'B2',
+        record_label: 'Sonamos',
+        album_id: null,
+        play_order: 2,
+        add_time: new Date(),
+      });
+
+      const req = createMockBodyReq({
+        artist_name: 'Juana Molina',
+        album_title: 'DOGA',
+        track_title: 'la paradoja',
+        track_position: 'B2',
+        record_label: 'Sonamos',
+      });
+      const res = createMockRes();
+
+      await addEntry(req as Request, res as Response, mockNext);
+
+      expect(mockGetAlbumFromDB).not.toHaveBeenCalled();
+      expect(mockAddTrack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artist_name: 'Juana Molina',
+          track_title: 'la paradoja',
+          track_position: 'B2',
+          show_id: activeShow.id,
+        })
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('does not forward track_position on the message-only branch (BS#943)', async () => {
+      // Talkset/breakpoint/PSA rows are entry_type != 'track'; the column is
+      // semantically track-only. Even if a malformed payload includes
+      // track_position on a message entry, the controller should not pass it
+      // through.
+      mockAddTrack.mockResolvedValue({
+        id: 3,
+        show_id: activeShow.id,
+        entry_type: 'talkset',
+        message: 'Talkset',
+        play_order: 3,
+        add_time: new Date(),
+      });
+
+      const req = createMockBodyReq({
+        message: 'Talkset',
+        track_position: 'A1',
+      });
+      const res = createMockRes();
+
+      await addEntry(req as Request, res as Response, mockNext);
+
+      expect(mockAddTrack).toHaveBeenCalledWith(expect.not.objectContaining({ track_position: expect.anything() }));
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
     it('does not set entry_type to message for track entries', async () => {
       const trackBody = {
         artist_name: 'Autechre',
@@ -641,6 +760,40 @@ describe('flowsheet.controller', () => {
         })
       );
       expect(res.status).toHaveBeenCalledWith(201);
+    });
+  });
+
+  describe('updateEntry', () => {
+    it('forwards track_position from data into the service update payload (BS#943)', async () => {
+      // Picker edit flow: user changes the track on an existing entry; the
+      // PATCH body carries the new position. The service `updateEntry` does a
+      // straight `db.update(flowsheet).set(data)`, so the controller only
+      // needs the type widening — but we pin the contract here so a future
+      // regression that strips fields shows up loudly.
+      mockUpdateEntry.mockResolvedValue({
+        id: 99,
+        track_title: 'la paradoja',
+        track_position: 'A2',
+      });
+
+      const req = {
+        body: {
+          entry_id: 99,
+          data: {
+            track_title: 'la paradoja',
+            track_position: 'A2',
+          },
+        },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await updateEntry(req, res as Response, mockNext);
+
+      expect(mockUpdateEntry).toHaveBeenCalledWith(
+        99,
+        expect.objectContaining({ track_position: 'A2', track_title: 'la paradoja' })
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
     });
   });
 });


### PR DESCRIPTION
## Summary

Wires the V1 `POST /flowsheet` and `PATCH /flowsheet/entries/:id` controllers to accept `track_position` on the request body and forward it through to the DB. BS#835 / PR #932 shipped the column, the read projection, and the V2 wire shape — but the controllers were silently dropping the field. Without this wiring the dj-site flowsheet picker (E6-6, [WXYC/dj-site#501](https://github.com/WXYC/dj-site/issues/501)) would write `track_position` over the wire and the column would stay NULL forever.

## Changes

| Layer | Edit |
|---|---|
| `FSEntryRequestBody` | `track_position?: string \| null` |
| `UpdateRequestBody` | `track_position?: string \| null` |
| `addEntry` album_id branch | explicit `track_position: body.track_position ?? null` into `NewFSEntry` |
| `addEntry` free-form branch | no code change — the existing `...body` spread propagates once the type allows it |
| `addEntry` message-only branch | no change (track_position is `entry_type='track'`-only by design; regression test pins this) |
| `updateEntry` | no code change — `db.update(flowsheet).set(data)` already passes any field on the type-widened `data` through |

## Test plan

- [x] 3 new unit cases on `addEntry`:
  - album_id branch — `track_position` lands in the `addTrack` call
  - free-form branch — same
  - message-only branch — `track_position` does NOT land (negative case)
- [x] 1 new unit case on `updateEntry` — forwards `track_position` via the service
- [x] 2 new integration tests on `POST /flowsheet`:
  - album_id branch round-trip: `track_position: 'A1'` written and read back
  - free-form branch round-trip: `track_position: 'B2'` written and read back
- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors (396 pre-existing warnings unchanged)
- [x] `npm run format:check` clean
- [x] `npm run test:unit` — 1937 passing (151 suites)

## Why this is split from BS#835

PR #932 was scoped to the schema + read projection. Splitting the controller wiring into its own PR keeps the storage change reviewable on its own, lets the controller wiring land closer to dj-site#501 (the actual writer), and means a hypothetical revert of #932 wouldn't snag this on the way out.

## Project-32 compatibility

Same posture as BS#835: this PR doesn't touch `apps/backend/services/metadata/`, `apps/backend/services/lml/`, or any of the project-#32 surfaces. Controller-layer-only.

Closes #943.
