### PR TITLE
Track in-flight enrichment promises; drain on shutdown

### DIFF
--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -22,6 +22,7 @@ import { playlist_route } from './routes/playlist.route.js';
 import { startPlaylistProxy, stopPlaylistProxy } from './services/playlist-proxy.service.js';
 import { startAlbumPlaysRefresh, stopAlbumPlaysRefresh } from './services/album-plays-refresh.service.js';
 import { setupCdcWebSocket, shutdownCdcWebSocket } from './services/cdc/index.js';
+import { drainInFlightEnrichments } from './services/metadata/enrichment.service.js';
 import { activeShow } from './middleware/checkActiveShow.js';
 import errorHandler from './middleware/errorHandler.js';
 import { shouldCaptureExpressError } from './middleware/sentryErrorFilter.js';
@@ -148,11 +149,30 @@ memoryLogTimer.unref();
 
 // --- Graceful shutdown ---
 
+// 2 s matches the BS#905 proposal: bounded by the EC2 SIGTERM-to-SIGKILL
+// grace window (10 s total above; 5 s before forced socket close), and long
+// enough to let a healthy LML round-trip complete. Tuning this without also
+// reducing the 5 s force-close timer below would just push the floor lower.
+const ENRICHMENT_DRAIN_DEADLINE_MS = 2_000;
+
 function shutdown(signal: string): void {
   console.log(`[shutdown] Received ${signal}, shutting down...`);
   stopPlaylistProxy();
   stopAlbumPlaysRefresh();
   void shutdownCdcWebSocket();
+  // BS#905: observe enrichments abandoned mid-flight. Sentry captureMessage
+  // fires only when at least one promise is still pending after the deadline,
+  // so a clean shutdown stays silent. Drain happens in parallel with
+  // server.close() — they don't depend on each other.
+  void drainInFlightEnrichments(ENRICHMENT_DRAIN_DEADLINE_MS).then((remaining) => {
+    if (remaining > 0) {
+      Sentry.captureMessage(`Backend exiting with ${remaining} in-flight enrichment promise(s)`, {
+        level: 'warning',
+        tags: { subsystem: 'metadata', metric: 'in_flight_dropped' },
+        extra: { remaining, signal, deadline_ms: ENRICHMENT_DRAIN_DEADLINE_MS },
+      });
+    }
+  });
   server.close(() => {
     closeDatabaseConnection()
       .then(() => process.exit(0))

--- a/apps/backend/services/metadata/enrichment.service.ts
+++ b/apps/backend/services/metadata/enrichment.service.ts
@@ -51,11 +51,18 @@ export function _resetInFlightEnrichmentsForTest(): void {
 }
 
 /**
- * Wait up to `deadlineMs` for every in-flight enrichment to settle, then
- * return the count still pending. Always returns — never throws or rejects
- * for individual promise rejections (they're already handled via .catch).
- * Returns 0 immediately when the registry is empty so a healthy shutdown
- * pays no setTimeout cost.
+ * Wait up to `deadlineMs` for every enrichment in the snapshot taken at call
+ * time to settle, then return the *current registry size* — which may
+ * include promises added during the wait (a request that arrives between
+ * SIGTERM and `server.close()` completing its drain can still fire enrichment
+ * before the HTTP layer rejects it). The returned count is therefore a drop
+ * *estimate*, not a strict count of unsettled snapshot members. That's the
+ * right shape for a `level: 'warning'` Sentry signal; precision was never
+ * the point.
+ *
+ * Never throws or rejects for individual promise rejections (they're already
+ * handled via .catch). Returns 0 immediately when the registry is empty so
+ * a healthy shutdown pays no setTimeout cost.
  */
 export async function drainInFlightEnrichments(deadlineMs: number): Promise<number> {
   if (inFlightEnrichments.size === 0) return 0;

--- a/apps/backend/services/metadata/enrichment.service.ts
+++ b/apps/backend/services/metadata/enrichment.service.ts
@@ -9,6 +9,13 @@
  * The promise is intentionally not awaited by callers — enrichment must
  * never block the HTTP response. Errors are logged and reported to Sentry
  * under `subsystem='metadata'`, never thrown.
+ *
+ * To make process exits observable (BS#905), each fire-and-forget promise
+ * registers itself in `inFlightEnrichments` and unregisters via `.finally`.
+ * `drainInFlightEnrichments` is called from the SIGTERM/SIGINT shutdown path
+ * in `apps/backend/app.ts` so an exiting BS gets a Sentry breadcrumb naming
+ * how many enrichments were abandoned mid-flight. Post-Epic C the runtime
+ * path is gone and this whole apparatus retires alongside it.
  */
 import * as Sentry from '@sentry/node';
 import { sql } from 'drizzle-orm';
@@ -26,8 +33,49 @@ export interface EnrichmentInput {
   trackTitle?: string | null;
 }
 
+const inFlightEnrichments = new Set<Promise<unknown>>();
+
+export function getInFlightEnrichmentCount(): number {
+  return inFlightEnrichments.size;
+}
+
+/**
+ * Test-only: clear the registry without awaiting any of the in-flight
+ * promises. Production code must never call this — drained enrichments
+ * still mutate the DB once their fetch resolves, so dropping them on the
+ * floor mid-flight is exactly the bug this module avoids. The leading
+ * underscore + Sentry-ignore convention keeps that intent loud.
+ */
+export function _resetInFlightEnrichmentsForTest(): void {
+  inFlightEnrichments.clear();
+}
+
+/**
+ * Wait up to `deadlineMs` for every in-flight enrichment to settle, then
+ * return the count still pending. Always returns — never throws or rejects
+ * for individual promise rejections (they're already handled via .catch).
+ * Returns 0 immediately when the registry is empty so a healthy shutdown
+ * pays no setTimeout cost.
+ */
+export async function drainInFlightEnrichments(deadlineMs: number): Promise<number> {
+  if (inFlightEnrichments.size === 0) return 0;
+  const snapshot = Array.from(inFlightEnrichments);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.allSettled(snapshot),
+      new Promise<void>((resolve) => {
+        timeoutId = setTimeout(resolve, deadlineMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+  return inFlightEnrichments.size;
+}
+
 export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
-  fetchMetadata({
+  const promise = fetchMetadata({
     albumId: input.albumId,
     artistId: input.artistId,
     artistName: input.artistName,
@@ -87,4 +135,13 @@ export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
         },
       });
     });
+
+  inFlightEnrichments.add(promise);
+  // .finally chains after the .catch above, so the registry always reaches
+  // size 0 whether the fetch resolved or rejected — drain accuracy depends
+  // on it. Failure to unregister would slow-leak the registry and inflate
+  // the shutdown-time "dropped" count.
+  void promise.finally(() => {
+    inFlightEnrichments.delete(promise);
+  });
 }

--- a/tests/unit/services/metadata.enrichment.test.ts
+++ b/tests/unit/services/metadata.enrichment.test.ts
@@ -16,10 +16,19 @@ jest.mock('../../../apps/backend/services/metadata/metadata.service', () => ({
 }));
 
 const mockCaptureException = jest.fn();
-jest.mock('@sentry/node', () => ({ captureException: mockCaptureException }));
+const mockCaptureMessage = jest.fn();
+jest.mock('@sentry/node', () => ({
+  captureException: mockCaptureException,
+  captureMessage: mockCaptureMessage,
+}));
 
 import { db } from '@wxyc/database';
-import { fireAndForgetMetadataForRow } from '../../../apps/backend/services/metadata/enrichment.service';
+import {
+  _resetInFlightEnrichmentsForTest,
+  drainInFlightEnrichments,
+  fireAndForgetMetadataForRow,
+  getInFlightEnrichmentCount,
+} from '../../../apps/backend/services/metadata/enrichment.service';
 
 /**
  * Render a drizzle `sql` template object to a string for substring assertions.
@@ -266,6 +275,15 @@ describe('fireAndForgetMetadataForRow', () => {
     expect(renderSql(lastWhereArg)).toMatch(/metadata_attempt_at.*IS\s+NULL/i);
   });
 
+  // Drain the registry between drain-suite tests so module-level state
+  // doesn't leak. Each test below either fires a resolving fetch (cleared
+  // by .finally) or explicitly drains. This is the safety net.
+  afterEach(async () => {
+    if (getInFlightEnrichmentCount() > 0) {
+      await drainInFlightEnrichments(1000);
+    }
+  });
+
   it('does not write linkage columns (album_id / linkage_source / linkage_confidence / linked_at)', async () => {
     // `apps/backend/services/flowsheet-linkage.service.ts::setFlowsheetLinkage`
     // owns these four columns. If a metadata UPDATE and a linkage UPDATE
@@ -295,5 +313,116 @@ describe('fireAndForgetMetadataForRow', () => {
     expect(setArgs).not.toHaveProperty('linkage_source');
     expect(setArgs).not.toHaveProperty('linkage_confidence');
     expect(setArgs).not.toHaveProperty('linked_at');
+  });
+});
+
+describe('in-flight enrichment registry + drain (BS#905)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // The earlier `fireAndForgetMetadataForRow` describe block fires
+    // never-resolving promises in a few tests (e.g., the synchronous-return
+    // test). Those entries persist in the module-level registry and would
+    // otherwise inflate this block's counts. Reset isolates the suite.
+    _resetInFlightEnrichmentsForTest();
+  });
+
+  // Belt-and-suspenders: ensure no test leaves residue in the module-level
+  // registry that would influence the next test's getInFlightEnrichmentCount().
+  afterEach(async () => {
+    if (getInFlightEnrichmentCount() > 0) {
+      await drainInFlightEnrichments(1000);
+    }
+  });
+
+  it('registers each fire-and-forget call and unregisters once the promise settles', async () => {
+    mockFetchMetadata.mockResolvedValue({
+      album: { artworkUrl: 'https://i.discogs.com/art.jpg' },
+    });
+
+    expect(getInFlightEnrichmentCount()).toBe(0);
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 1,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+    });
+
+    // Synchronous: the registry must show the entry before any microtasks run.
+    expect(getInFlightEnrichmentCount()).toBe(1);
+
+    // Drain the .then + .catch + .finally chain.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(getInFlightEnrichmentCount()).toBe(0);
+  });
+
+  it('unregisters even when fetchMetadata rejects (failure path still drains via .finally)', async () => {
+    mockFetchMetadata.mockRejectedValue(new Error('LML 502'));
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 2,
+      artistName: 'King Crimson',
+      albumTitle: 'Discipline',
+    });
+
+    expect(getInFlightEnrichmentCount()).toBe(1);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(getInFlightEnrichmentCount()).toBe(0);
+  });
+
+  it('drainInFlightEnrichments returns 0 immediately when the registry is empty', async () => {
+    const remaining = await drainInFlightEnrichments(2000);
+    expect(remaining).toBe(0);
+  });
+
+  it('drainInFlightEnrichments awaits in-flight promises and returns 0 when they settle inside the deadline', async () => {
+    let resolveFetch: (value: unknown) => void = () => undefined;
+    mockFetchMetadata.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 3,
+      artistName: 'Stereolab',
+      albumTitle: 'Dots and Loops',
+    });
+
+    expect(getInFlightEnrichmentCount()).toBe(1);
+
+    // Resolve the pending fetch on the next tick — well within the deadline.
+    setImmediate(() => resolveFetch(null));
+
+    const remaining = await drainInFlightEnrichments(2000);
+    expect(remaining).toBe(0);
+  });
+
+  it('drainInFlightEnrichments returns the unsettled count after the deadline elapses (no leak past deadline)', async () => {
+    // Never-resolving fetch — a process exit that would have dropped this
+    // enrichment in prod is what the metric is measuring.
+    mockFetchMetadata.mockReturnValue(new Promise(() => undefined));
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 4,
+      artistName: 'Jessica Pratt',
+      albumTitle: 'On Your Own Love Again',
+    });
+    fireAndForgetMetadataForRow({
+      flowsheetId: 5,
+      artistName: 'Juana Molina',
+      albumTitle: 'DOGA',
+    });
+
+    expect(getInFlightEnrichmentCount()).toBe(2);
+
+    // 50 ms is the test's "you're done waiting" deadline. The drain returns
+    // the count of pending promises after the deadline, NOT throws.
+    const remaining = await drainInFlightEnrichments(50);
+    expect(remaining).toBe(2);
   });
 });

--- a/tests/unit/services/metadata.enrichment.test.ts
+++ b/tests/unit/services/metadata.enrichment.test.ts
@@ -350,10 +350,11 @@ describe('in-flight enrichment registry + drain (BS#905)', () => {
     // Synchronous: the registry must show the entry before any microtasks run.
     expect(getInFlightEnrichmentCount()).toBe(1);
 
-    // Drain the .then + .catch + .finally chain.
-    await new Promise((resolve) => setImmediate(resolve));
-    await new Promise((resolve) => setImmediate(resolve));
+    // Use the drain instead of double-setImmediate so the assertion stays
+    // correct if the .then / .catch / .finally chain depth ever changes.
+    const remaining = await drainInFlightEnrichments(1000);
 
+    expect(remaining).toBe(0);
     expect(getInFlightEnrichmentCount()).toBe(0);
   });
 
@@ -368,9 +369,9 @@ describe('in-flight enrichment registry + drain (BS#905)', () => {
 
     expect(getInFlightEnrichmentCount()).toBe(1);
 
-    await new Promise((resolve) => setImmediate(resolve));
-    await new Promise((resolve) => setImmediate(resolve));
+    const remaining = await drainInFlightEnrichments(1000);
 
+    expect(remaining).toBe(0);
     expect(getInFlightEnrichmentCount()).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

- Adds an in-flight Promise registry to `apps/backend/services/metadata/enrichment.service.ts`. Each `fireAndForgetMetadataForRow` call registers its promise and unregisters via `.finally`.
- Exports `getInFlightEnrichmentCount()` and `drainInFlightEnrichments(deadlineMs)`.
- Wires the drain into the existing `shutdown(signal)` in `apps/backend/app.ts` with a 2 s deadline. On a healthy shutdown the registry is empty and the drain returns 0 silently. If any promises remain after the deadline (deploy, OOM, scale-down), a `Sentry.captureMessage` fires at level `warning` with `subsystem='metadata'`, `metric='in_flight_dropped'`.
- 5 new unit tests cover the registry lifecycle (fire registers / settle unregisters), the success-and-failure paths for `.finally`, and the drain semantics (empty, drains-in-time, deadline-elapses).

### Implementation note

The BS#905 proposal lists `process.on('beforeExit')`, but `beforeExit` doesn't fire on signal-initiated shutdown (Express keeps the loop alive), so the existing `shutdown(signal)` handler at `apps/backend/app.ts:151` is the only path that runs in prod. Drain is wired there. Semantics match the proposal.

## Test plan

- [x] `npx jest --config jest.unit.config.ts tests/unit/services/metadata.enrichment.test.ts` — 15/15 pass.
- [x] `npm run test:unit` — 1938/1938 pass.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean (0 errors).
- [x] `npm run format:check` — clean.

Closes #905