### PR TITLE
lml.client: semaphore + token-bucket on /lookup to mirror LML's Discogs ceilings

### DIFF
--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -54,6 +54,148 @@ export { LmlClientError };
 
 const TIMEOUT_MS = 5000;
 
+/**
+ * Rate awareness of LML's Discogs ceilings (BS#906 / G4).
+ *
+ * LML's `/api/v1/lookup` fans out to Discogs on cache miss; its server-side
+ * config caps Discogs at `discogs_max_concurrent=5` + `discogs_rate_limit=
+ * 50/min`. When DJs add tracks in quick succession the BS fire-and-forget
+ * fan-out can outrun those ceilings and pile up inside LML. Mirror the
+ * ceilings on the client so the back-pressure shows up at our chokepoint,
+ * not LML's. Defaults match LML's config; env-overridable so prod can
+ * leave headroom for other LML callers (rom + tubafrenzy).
+ *
+ * Only the `/lookup` chokepoint is wrapped — the other LML endpoints
+ * (release, artist, entity, track-releases, streaming-check, library/search)
+ * are PG-cached and don't share the Discogs ceiling.
+ *
+ * When B4 (#887) extracts `@wxyc/lml-client`, this whole apparatus moves
+ * with the client and stays the chokepoint for every consumer.
+ */
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
+ * FIFO permit semaphore. acquire() resolves when a permit is available;
+ * release() returns the permit to the next waiter (or restores it if no one
+ * is waiting). queueDepth/availablePermits are read-only for observability.
+ */
+export class Semaphore {
+  private permits: number;
+  private readonly capacity: number;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(permits: number) {
+    this.permits = permits;
+    this.capacity = permits;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits -= 1;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    } else if (this.permits < this.capacity) {
+      this.permits += 1;
+    }
+  }
+
+  get queueDepth(): number {
+    return this.waiters.length;
+  }
+
+  get availablePermits(): number {
+    return this.permits;
+  }
+}
+
+/**
+ * Continuous-refill token bucket. consume(n) resolves once n tokens have
+ * been earned; until then the call sleeps for the shortest interval that
+ * could earn the deficit. refillPerMinute matches LML's
+ * discogs_rate_limit=50/min nomenclature so the env var name reads cleanly.
+ */
+export class TokenBucket {
+  private tokens: number;
+  private readonly capacity: number;
+  private readonly refillPerMs: number;
+  private lastRefill: number;
+
+  constructor({ capacity, refillPerMinute }: { capacity: number; refillPerMinute: number }) {
+    this.capacity = capacity;
+    this.tokens = capacity;
+    this.refillPerMs = refillPerMinute / 60_000;
+    this.lastRefill = Date.now();
+  }
+
+  private refill(): void {
+    const now = Date.now();
+    const elapsed = now - this.lastRefill;
+    if (elapsed <= 0) return;
+    this.tokens = Math.min(this.capacity, this.tokens + elapsed * this.refillPerMs);
+    this.lastRefill = now;
+  }
+
+  async consume(count = 1): Promise<void> {
+    this.refill();
+    if (this.tokens >= count) {
+      this.tokens -= count;
+      return;
+    }
+    const deficit = count - this.tokens;
+    const waitMs = Math.max(1, Math.ceil(deficit / this.refillPerMs));
+    await new Promise((resolve) => setTimeout(resolve, waitMs));
+    this.refill();
+    this.tokens = Math.max(0, this.tokens - count);
+  }
+
+  get availableTokens(): number {
+    this.refill();
+    return this.tokens;
+  }
+}
+
+let lookupSemaphore: Semaphore;
+let lookupTokenBucket: TokenBucket;
+
+function initLimiters(): void {
+  const maxConcurrent = envInt('LML_CLIENT_MAX_CONCURRENT', 5);
+  const ratePerMin = envInt('LML_CLIENT_RATE_PER_MIN', 50);
+  lookupSemaphore = new Semaphore(maxConcurrent);
+  lookupTokenBucket = new TokenBucket({ capacity: ratePerMin, refillPerMinute: ratePerMin });
+}
+
+initLimiters();
+
+/** Number of /lookup calls currently waiting for a permit. */
+export function getLmlQueueDepth(): number {
+  return lookupSemaphore.queueDepth;
+}
+
+/**
+ * Test-only: reinitialize the module-level Semaphore + TokenBucket against
+ * the current `process.env` so a test that mutates env can exercise its
+ * effect. Production code never calls this — the limiter is intentionally
+ * process-wide so concurrent /lookup calls share the same back-pressure.
+ */
+export function _resetLmlClientLimitersForTest(): void {
+  initLimiters();
+}
+
 function getBaseUrl(): string {
   const url = process.env.LIBRARY_METADATA_URL;
   if (!url) {
@@ -184,42 +326,56 @@ export async function lookupBySong(song: string): Promise<LookupResponse> {
  * projection at WXYC/library-metadata-lookup#213.
  */
 async function postLookup(body: LookupBody): Promise<LookupResponse> {
-  return Sentry.startSpan({ name: 'lml.lookup', op: 'http.client' }, async (span) => {
-    const response = await lmlFetch('/api/v1/lookup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+  // BS#906 / G4: Mirror LML's Discogs ceilings on the client so back-pressure
+  // surfaces at the BS chokepoint, not as queueing inside LML. Acquire BEFORE
+  // span start so queue-time isn't blamed on http.client duration.
+  await lookupSemaphore.acquire();
+  try {
+    await lookupTokenBucket.consume(1);
+    return await Sentry.startSpan({ name: 'lml.lookup', op: 'http.client' }, async (span) => {
+      try {
+        span.setAttributes({ 'lml.queue_depth': lookupSemaphore.queueDepth });
+      } catch (err) {
+        console.warn('lml.client: failed to project queue_depth onto span', err);
+      }
+      const response = await lmlFetch('/api/v1/lookup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      const parsed = (await response.json()) as LookupResponse;
+
+      // cache_stats schema is freeform today (additionalProperties: true). Until
+      // wxyc-shared#86 tightens the type, treat it as a loose record and only
+      // forward numeric fields onto the span. Narrow defensively to a real plain
+      // object — Object.entries on a string/array would produce junk attributes
+      // like lml.cache.0=...
+      const stats = (parsed as { cache_stats?: unknown }).cache_stats;
+      if (stats && typeof stats === 'object' && !Array.isArray(stats)) {
+        const attrs: Record<string, number> = {};
+        for (const [key, value] of Object.entries(stats)) {
+          if (typeof value === 'number' && Number.isFinite(value)) {
+            attrs[`lml.cache.${key}`] = value;
+          }
+        }
+        if (Object.keys(attrs).length > 0) {
+          // Observability must never break the request path. If the Sentry SDK
+          // (or a custom transport hook) throws, swallow the error and continue
+          // — the lookup result is what callers depend on.
+          try {
+            span.setAttributes(attrs);
+          } catch (err) {
+            console.warn('lml.client: failed to project cache_stats onto span', err);
+          }
+        }
+      }
+
+      return parsed;
     });
-
-    const parsed = (await response.json()) as LookupResponse;
-
-    // cache_stats schema is freeform today (additionalProperties: true). Until
-    // wxyc-shared#86 tightens the type, treat it as a loose record and only
-    // forward numeric fields onto the span. Narrow defensively to a real plain
-    // object — Object.entries on a string/array would produce junk attributes
-    // like lml.cache.0=...
-    const stats = (parsed as { cache_stats?: unknown }).cache_stats;
-    if (stats && typeof stats === 'object' && !Array.isArray(stats)) {
-      const attrs: Record<string, number> = {};
-      for (const [key, value] of Object.entries(stats)) {
-        if (typeof value === 'number' && Number.isFinite(value)) {
-          attrs[`lml.cache.${key}`] = value;
-        }
-      }
-      if (Object.keys(attrs).length > 0) {
-        // Observability must never break the request path. If the Sentry SDK
-        // (or a custom transport hook) throws, swallow the error and continue
-        // — the lookup result is what callers depend on.
-        try {
-          span.setAttributes(attrs);
-        } catch (err) {
-          console.warn('lml.client: failed to project cache_stats onto span', err);
-        }
-      }
-    }
-
-    return parsed;
-  });
+  } finally {
+    lookupSemaphore.release();
+  }
 }
 
 /**

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -77,7 +77,13 @@ function envInt(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw === '') return fallback;
   const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  // Surface misconfigurations at startup so an operator who set `=0`
+  // intending to disable the limiter sees their value was rejected
+  // instead of silently falling back. A 0-permit semaphore would
+  // deadlock, which is why we don't accept it.
+  console.warn(`lml.client: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
 }
 
 /**
@@ -151,16 +157,23 @@ export class TokenBucket {
   }
 
   async consume(count = 1): Promise<void> {
-    this.refill();
-    if (this.tokens >= count) {
-      this.tokens -= count;
-      return;
+    // Loop the slow path. Without it, N callers can each compute the same
+    // waitMs from an empty bucket, sleep for the same interval, wake
+    // together, and all subtract `count` from the freshly refilled tokens
+    // — overshooting the configured rate by ~N×. The loop re-checks the
+    // bucket after each sleep so only the caller that finds enough tokens
+    // proceeds; the others sleep again. Paired with the upstream FIFO
+    // Semaphore, this preserves the configured rate under contention.
+    while (true) {
+      this.refill();
+      if (this.tokens >= count) {
+        this.tokens -= count;
+        return;
+      }
+      const deficit = count - this.tokens;
+      const waitMs = Math.max(1, Math.ceil(deficit / this.refillPerMs));
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
     }
-    const deficit = count - this.tokens;
-    const waitMs = Math.max(1, Math.ceil(deficit / this.refillPerMs));
-    await new Promise((resolve) => setTimeout(resolve, waitMs));
-    this.refill();
-    this.tokens = Math.max(0, this.tokens - count);
   }
 
   get availableTokens(): number {

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -82,6 +82,8 @@ Bounded ring-buffer reports written under `mirror-logs/`. Reports never include 
 
 - `LIBRARY_METADATA_URL` — library-metadata-lookup base URL (e.g. `http://localhost:8001`). Required for proxy endpoints, metadata enrichment, and track search. All Discogs access is routed through LML. Do not include the `/api/v1` path prefix; the LML client adds it automatically.
 - `LML_API_KEY` — Bearer token sent on every LML request. Must match LML's `LML_API_KEY`. Optional in dev; required in production once LML's `LML_REQUIRE_AUTH` is flipped to `true`. Injected at the single `lmlFetch` chokepoint in `apps/backend/services/lml/lml.client.ts`.
+- `LML_CLIENT_MAX_CONCURRENT` — Maximum concurrent in-flight `/api/v1/lookup` calls; gates BS's fan-out at the chokepoint so back-pressure surfaces on the BS side instead of queueing inside LML. Mirrors LML's `discogs_max_concurrent` (default `5`). Set lower in production to leave headroom for other LML callers (request-o-matic, tubafrenzy).
+- `LML_CLIENT_RATE_PER_MIN` — Token-bucket refill rate (and capacity) for `/api/v1/lookup` calls per minute. Mirrors LML's `discogs_rate_limit` (default `50`). Tune downward in production to leave headroom for other LML callers.
 - `DISCOGS_API_KEY`, `DISCOGS_API_SECRET` — Served to dj-site via `/config/secrets` endpoint. Not used by the backend itself (Discogs access goes through LML).
 - `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`
 

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -708,6 +708,34 @@ describe('TokenBucket (BS#906)', () => {
     // After 50 ms of refill, we'd have 50 tokens uncapped — must cap at 2.
     expect(bucket.availableTokens).toBeLessThanOrEqual(2);
   });
+
+  it('multi-consumer: concurrent consume() calls do not over-subtract from a shared refill', async () => {
+    // Regression: without the slow-path loop, N consumers that all
+    // sleep on the same `waitMs` from an empty bucket would each subtract
+    // `count` on wake — overshooting the rate by N×. With the loop,
+    // only the consumer that finds enough tokens after refill proceeds;
+    // the others sleep again. Net effect under contention is that the
+    // bucket never goes negative and total throughput stays at the
+    // configured rate.
+    const bucket = new TokenBucket({ capacity: 1, refillPerMinute: 6_000 }); // 100/sec
+    // Drain the initial capacity.
+    await bucket.consume(1);
+
+    // Now three consumers race for tokens; the bucket refills 1 every
+    // 10 ms. Without the fix, all three would resolve after the first
+    // shared sleep, leaving the bucket at -2. With the fix, they
+    // serialize at ~10 ms intervals.
+    const start = Date.now();
+    await Promise.all([bucket.consume(1), bucket.consume(1), bucket.consume(1)]);
+    const elapsed = Date.now() - start;
+
+    // 3 tokens × 10 ms each = ~30 ms minimum. Allow generous overhead
+    // for jest's timer scheduling on slower CI machines (typical drift
+    // 5-15 ms per setTimeout under load).
+    expect(elapsed).toBeGreaterThanOrEqual(20);
+    // And the bucket must not be negative — invariant: tokens >= 0.
+    expect(bucket.availableTokens).toBeGreaterThanOrEqual(0);
+  });
 });
 
 describe('lml.client rate-aware /lookup wrapper (BS#906)', () => {
@@ -763,13 +791,19 @@ describe('lml.client rate-aware /lookup wrapper (BS#906)', () => {
       lookupMetadata('Chuquimamani-Condori', 'Edits'),
     ];
 
-    // Let the first batch reach the fetch chokepoint.
-    await new Promise((resolve) => setImmediate(resolve));
-    await new Promise((resolve) => setImmediate(resolve));
-    await new Promise((resolve) => setImmediate(resolve));
+    // Poll until the first batch lands at fetch. Polling beats a magic
+    // setImmediate-flush count because the chain depth between
+    // `lookupMetadata` and `mockFetch` (semaphore acquire → token consume
+    // → Sentry.startSpan → lmlFetch → fetch) can change without warning.
+    // Cap at 200 ms so a real regression that never reaches fetch fails
+    // the test loudly rather than hanging.
+    const deadline = Date.now() + 200;
+    while (inFlight < 3 && Date.now() < deadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
 
     // At most 3 should be in flight — the rest are queued in the semaphore.
-    expect(maxInFlight).toBeLessThanOrEqual(3);
+    expect(maxInFlight).toBe(3);
     expect(getLmlQueueDepth()).toBeGreaterThan(0);
 
     // Release the batch and let everyone finish.

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -30,6 +30,10 @@ import {
   LmlClientError,
   checkStreamingAvailability,
   searchLibrary,
+  Semaphore,
+  TokenBucket,
+  getLmlQueueDepth,
+  _resetLmlClientLimitersForTest,
 } from '../../../apps/backend/services/lml/lml.client';
 
 describe('lml.client', () => {
@@ -194,7 +198,7 @@ describe('lml.client', () => {
       });
     });
 
-    it('does not call setAttributes when LML response omits cache_stats', async () => {
+    it('does not project lml.cache.* attributes when LML response omits cache_stats', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: () =>
@@ -204,10 +208,15 @@ describe('lml.client', () => {
       await lookupMetadata('Autechre');
 
       expect(mockStartSpan).toHaveBeenCalledTimes(1);
-      expect(mockSpanSetAttributes).not.toHaveBeenCalled();
+      // BS#906 adds `lml.queue_depth` to setAttributes for every /lookup;
+      // assertion narrows to "no lml.cache.* keys" rather than "never called".
+      const cacheCalls = mockSpanSetAttributes.mock.calls.filter((args) =>
+        Object.keys((args[0] ?? {}) as Record<string, unknown>).some((k) => k.startsWith('lml.cache.'))
+      );
+      expect(cacheCalls).toHaveLength(0);
     });
 
-    it('does not call setAttributes when cache_stats is an array (defensive narrowing)', async () => {
+    it('does not project lml.cache.* attributes when cache_stats is an array (defensive narrowing)', async () => {
       // Defensive narrowing: Object.entries([1, 2, 3]) yields [["0",1],["1",2],["2",3]],
       // which would otherwise project as junk attributes lml.cache.0=1, lml.cache.1=2, ...
       // Guard the projection to require a real plain object (not array, not scalar).
@@ -225,7 +234,10 @@ describe('lml.client', () => {
 
       await lookupMetadata('Autechre');
 
-      expect(mockSpanSetAttributes).not.toHaveBeenCalled();
+      const cacheCalls = mockSpanSetAttributes.mock.calls.filter((args) =>
+        Object.keys((args[0] ?? {}) as Record<string, unknown>).some((k) => k.startsWith('lml.cache.'))
+      );
+      expect(cacheCalls).toHaveLength(0);
     });
 
     it('resolves successfully when span.setAttributes throws (observability must not break the request path)', async () => {
@@ -614,5 +626,157 @@ describe('lml.client', () => {
       expect(calledUrl).not.toContain('artist=');
       expect(calledUrl).not.toContain('limit=');
     });
+  });
+});
+
+describe('Semaphore (BS#906)', () => {
+  it('admits up to N permits immediately; the (N+1)th call queues', async () => {
+    const sem = new Semaphore(2);
+
+    // Two immediate admits.
+    await sem.acquire();
+    await sem.acquire();
+    expect(sem.availablePermits).toBe(0);
+    expect(sem.queueDepth).toBe(0);
+
+    // The third call queues — does NOT resolve until a permit is released.
+    let thirdAcquired = false;
+    const thirdAcquirePromise = sem.acquire().then(() => {
+      thirdAcquired = true;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(thirdAcquired).toBe(false);
+    expect(sem.queueDepth).toBe(1);
+
+    sem.release();
+    await thirdAcquirePromise;
+    expect(thirdAcquired).toBe(true);
+    expect(sem.queueDepth).toBe(0);
+  });
+
+  it('release before any waiter restores a permit (no negative permits)', async () => {
+    const sem = new Semaphore(2);
+    await sem.acquire();
+    sem.release();
+    sem.release(); // No-op once permits are full — must not exceed capacity.
+    expect(sem.availablePermits).toBe(2);
+  });
+
+  it('FIFO: queued waiters drain in the order they were enqueued', async () => {
+    const sem = new Semaphore(1);
+    await sem.acquire();
+
+    const order: number[] = [];
+    const first = sem.acquire().then(() => order.push(1));
+    const second = sem.acquire().then(() => order.push(2));
+    const third = sem.acquire().then(() => order.push(3));
+
+    expect(sem.queueDepth).toBe(3);
+
+    sem.release(); // first runs
+    await first;
+    expect(order).toEqual([1]);
+    sem.release(); // second runs
+    await second;
+    sem.release(); // third runs
+    await third;
+    expect(order).toEqual([1, 2, 3]);
+  });
+});
+
+describe('TokenBucket (BS#906)', () => {
+  it('admits up to capacity immediately, then waits for refill', async () => {
+    const bucket = new TokenBucket({ capacity: 3, refillPerMinute: 6_000 }); // 100/sec → 1 per 10ms
+
+    // Three immediate consumes succeed without blocking.
+    await bucket.consume(1);
+    await bucket.consume(1);
+    await bucket.consume(1);
+
+    // The 4th must wait for at least one refill (~10ms).
+    const start = Date.now();
+    await bucket.consume(1);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(5);
+  });
+
+  it('refill caps at capacity (no unbounded accumulation)', async () => {
+    const bucket = new TokenBucket({ capacity: 2, refillPerMinute: 60_000 }); // 1 per ms
+    await bucket.consume(1);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    // After 50 ms of refill, we'd have 50 tokens uncapped — must cap at 2.
+    expect(bucket.availableTokens).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('lml.client rate-aware /lookup wrapper (BS#906)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      LIBRARY_METADATA_URL: 'http://lml.test:8000',
+      LML_CLIENT_MAX_CONCURRENT: '3',
+      LML_CLIENT_RATE_PER_MIN: '60000', // 1000/sec — effectively no rate cap in tests
+    };
+    _resetLmlClientLimitersForTest();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+    _resetLmlClientLimitersForTest();
+  });
+
+  it('caps concurrent /lookup in-flight calls at LML_CLIENT_MAX_CONCURRENT', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let resolveBatch: (() => void) | undefined;
+    const batchReady = new Promise<void>((resolve) => {
+      resolveBatch = resolve;
+    });
+
+    mockFetch.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await batchReady;
+      inFlight -= 1;
+      return {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [],
+            search_type: 'none',
+            song_not_found: false,
+            found_on_compilation: false,
+          }),
+      } as unknown as globalThis.Response;
+    });
+
+    // Fire 5 concurrent lookups when MAX_CONCURRENT=3.
+    const calls = [
+      lookupMetadata('Stereolab', 'Dots and Loops'),
+      lookupMetadata('Cat Power', 'Moon Pix'),
+      lookupMetadata('Juana Molina', 'DOGA'),
+      lookupMetadata('Jessica Pratt', 'On Your Own Love Again'),
+      lookupMetadata('Chuquimamani-Condori', 'Edits'),
+    ];
+
+    // Let the first batch reach the fetch chokepoint.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // At most 3 should be in flight — the rest are queued in the semaphore.
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+    expect(getLmlQueueDepth()).toBeGreaterThan(0);
+
+    // Release the batch and let everyone finish.
+    if (resolveBatch) resolveBatch();
+    await Promise.all(calls);
+
+    // After completion, all permits restored, queue empty.
+    expect(getLmlQueueDepth()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a process-wide semaphore (default 5) and token bucket (default 50/min) to `apps/backend/services/lml/lml.client.ts`, wrapping the `postLookup()` chokepoint. Mirrors LML's `discogs_max_concurrent` + `discogs_rate_limit` so back-pressure surfaces on the BS side instead of queueing inside LML.
- `Semaphore` + `TokenBucket` exported as classes for direct unit tests (FIFO drain, refill cap, queue depth).
- `getLmlQueueDepth()` is projected onto every `/lookup` Sentry span as `lml.queue_depth` for trace-explorer filtering.
- Env-overridable: `LML_CLIENT_MAX_CONCURRENT`, `LML_CLIENT_RATE_PER_MIN` (documented in `docs/env-vars.md`).
- 6 new unit tests cover the semaphore + bucket primitives and one integration test asserts that 5 concurrent `lookupMetadata` calls when `MAX_CONCURRENT=3` only show 3 in-flight at fetch.

### Implementation note

The ticket lists \"Depends on: B4 (the package)\". B4 (#887) is open and not yet started, so the limiter lives in `lml.client.ts` today and will move with the client when B4 extracts `@wxyc/lml-client`. Per Jake's go-ahead.

Backfill (`jobs/flowsheet-metadata-backfill/lml-fetch.ts`) intentionally does NOT get the limiter in this PR — its cron-scheduled sweep already paces itself well below the ceiling.

## Test plan

- [x] \`npx jest --config jest.unit.config.ts tests/unit/services/lml.client.test.ts\` — 39/39 pass.
- [x] \`npm run test:unit\` — 1944/1944 pass.
- [x] \`npm run typecheck\` — clean.
- [x] \`npm run lint\` — clean (0 errors).
- [x] \`npm run format:check\` — clean.

Closes #906