### PR TITLE
feat(dev_env): add prod-clone fixture so db:start gives realistic data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,9 @@ npm run db:start         # Start PostgreSQL in Docker (port 5432)
 npm run dev              # Start auth (8082) + backend (8080) concurrently with hot reload
 ```
 
-Stop the database with `npm run db:stop`.
+Stop the database with `npm run db:stop` (this runs `docker compose down -v` — the `-v` drops the `pg-data` named volume, so the dev DB is recreated from scratch on the next `db:start`).
+
+**Dev DB fixture**: `db:start` seeds the dev DB from two files, in order: `dev_env/seed_db.sql` (auth fixtures, test users, genres/formats with fixed IDs — identical to CI) and `dev_env/seed-clone.sql` (a ~14 MB `pg_dump` snapshot of prod's `artists / library / rotation / format / genre_artist_crossreference`, taken via the staging postgres clone — TRUNCATEs the small fixtures from the first file in the same transaction before loading). The clone gives realistic data for UI/feature work; CI never mounts the clone (only `db-init` does) so integration tests keep running against the small seed and the fixed IDs they assume. To refresh the clone, follow the recipe in the comment at the top of `dev_env/seed-clone.sql`.
 
 ### One-time per-clone setup
 

--- a/dev_env/Dockerfile.init
+++ b/dev_env/Dockerfile.init
@@ -8,6 +8,14 @@ COPY dev_env/package.init.json ./package.json
 # Install minimal dependencies (postgres, drizzle-kit, drizzle-orm)
 RUN npm install --omit=dev
 
+# `psql` is needed for the optional clone fixture (dev_env/seed-clone.sql,
+# mounted only into db-init / not ci-db-init). The clone uses pg_dump's
+# `COPY ... FROM stdin` form which the postgres-js JS driver doesn't speak;
+# init-db.mjs shells out to psql when the file is present. See BS#947.
+# Placed after `npm install` so dependency-only Dockerfile edits don't
+# invalidate this layer (and vice versa).
+RUN apk add --no-cache postgresql-client
+
 # Set drizzle env vars for migration paths (matches docker-compose volume mounts)
 ENV SCHEMA_LOC='/init/database'
 ENV MIGRATION_LOC='/init/database/migrations'

--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -43,6 +43,10 @@ services:
       - ../shared/database/src/migrations:/init/database/migrations
       - ./install_extensions.sql:/init/install_extensions.sql
       - ./seed_db.sql:/init/seed_db.sql
+      # Dev-only prod-clone fixture (BS#947). Mounted here but NOT into
+      # ci-db-init, so CI keeps its small seed_db.sql fixture and existing
+      # integration tests' fixed-ID assumptions.
+      - ./seed-clone.sql:/init/seed-clone.sql
 
   ci-db:
     image: postgres:18.0-alpine

--- a/dev_env/init-db.mjs
+++ b/dev_env/init-db.mjs
@@ -17,7 +17,8 @@
 
 import postgres from 'postgres';
 import crypto from 'crypto';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
+import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { styleText } from 'node:util';
@@ -290,6 +291,60 @@ async function seedDatabase() {
 }
 
 /**
+ * Load the dev-only prod-clone fixture when present.
+ *
+ * The fixture lives at `/init/seed-clone.sql` and is mounted only into the
+ * `db-init` container (not `ci-db-init`), so its presence is the gate — when
+ * the file exists, we replace the small `seed_db.sql` fixture with a
+ * pg_dump'd snapshot of prod's `artists / library / rotation / format /
+ * genre_artist_crossreference`. CI never sees the file and continues to run
+ * against the small seed and its fixed IDs.
+ *
+ * Shells out to `psql` rather than feeding the file through the postgres-js
+ * driver because the dump uses `COPY ... FROM stdin` for compactness, which
+ * postgres-js's simple-query path can't parse. `psql` handles it natively;
+ * Dockerfile.init installs `postgresql-client` for this purpose. See BS#947.
+ */
+async function loadCloneFixture() {
+  const clonePath = join(__dirname, './seed-clone.sql');
+  if (!existsSync(clonePath)) {
+    return; // CI path — file isn't mounted there. Silent skip is correct.
+  }
+
+  console.log(styleText(['bold'], '🪞 Loading prod-clone fixture (dev only)...\n'));
+
+  const args = [
+    '-h',
+    dbConfig.host,
+    '-p',
+    String(dbConfig.port),
+    '-U',
+    dbConfig.username,
+    '-d',
+    dbConfig.database,
+    '-v',
+    'ON_ERROR_STOP=1',
+    '-f',
+    clonePath,
+    '-q', // quiet — suppress COPY-progress chatter; errors still print
+  ];
+
+  await new Promise((resolve, reject) => {
+    const child = spawn('psql', args, {
+      env: { ...process.env, PGPASSWORD: dbConfig.password },
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    child.once('error', reject);
+    child.once('exit', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`psql exited with code ${code} loading seed-clone.sql`));
+    });
+  });
+
+  console.log('Clone fixture loaded successfully!\n');
+}
+
+/**
  * Verify that critical seed data was persisted.
  *
  * Catches silent failures where the seed appears to succeed but no rows
@@ -352,6 +407,12 @@ async function main() {
       } else {
         await seedDatabase();
         await verifySeedData();
+        // Dev-only: overlay the prod-clone fixture on top of the small seed
+        // (the clone TRUNCATEs the small artists/library/rotation/format/
+        // genre_artist_crossreference rows in the same transaction before
+        // loading the snapshot). File-existence gate keeps CI out — only
+        // db-init mounts seed-clone.sql.
+        await loadCloneFixture();
       }
     }
 


### PR DESCRIPTION
## Problem

\`npm run db:start\` against the dev profile only ever seeded from \`dev_env/seed_db.sql\` — a ~9-library / 2-rotation fixture sized for integration-test isolation. Realistic dev work (rotation entry flow, anything that wants \`wxyc_schema.library_identity\` to resolve, UI work against the catalog) required a manual \`pg_dump\` from \`staging-postgres-1\` after every \`db:start\`. \`db:stop\` runs \`docker compose down -v\` and drops the \`pg-data\` named volume, so the manual reload had to happen every restart.

This surfaced today previewing WXYC/Backend-Service#944 — the new rotation tracks dropdown couldn't be exercised against realistic rows because the small seed has 2 rotation rows and 0 library_identity rows.

## Change

\`db:start\` now seeds in two passes:

1. \`dev_env/seed_db.sql\` — unchanged. Auth fixtures, test users, genres/formats with fixed IDs. **Still the only seed CI sees**, so integration tests keep running against the small fixture and the fixed IDs they assume.
2. \`dev_env/seed-clone.sql\` (new, ~14 MB) — \`pg_dump --data-only --no-owner\` snapshot of the staging postgres clone covering \`artists / library / rotation / format / genre_artist_crossreference\`. TRUNCATEs the small fixtures from the first pass in the same transaction, then loads the snapshot. Wrapped in BEGIN/COMMIT so a load failure leaves the small seed intact.

File-existence is the gate. The clone is mounted only into \`db-init\`, not \`ci-db-init\` (see the compose diff) — \`init-db.mjs\` calls \`existsSync('/init/seed-clone.sql')\` and silently skips when absent. CI keeps the small seed; no test impact.

## Why psql

The clone uses pg_dump's \`COPY ... FROM stdin\` form for compactness (~14 MB vs. ~80 MB with \`--inserts\`). The postgres-js simple-query path can't parse \`COPY\` data. \`init-db.mjs\` shells out to \`psql\` for this load only; \`Dockerfile.init\` adds \`apk add --no-cache postgresql-client\` placed after \`npm install\` so dependency-only Dockerfile edits don't invalidate this layer (and vice versa).

## Refresh recipe

Documented in the header comment of \`dev_env/seed-clone.sql\`:

1. \`cd staging && docker compose up -d postgres\` (port 5434).
2. \`PGPASSWORD=postgres pg_dump -h localhost -p 5434 -U postgres -d wxyc_db --data-only --no-owner -t wxyc_schema.format -t wxyc_schema.artists -t wxyc_schema.genre_artist_crossreference -t wxyc_schema.library -t wxyc_schema.rotation > /tmp/dump.sql\`.
3. Strip pg_dump 18's \`\\restrict\`/\`\\unrestrict\` lines (psql < 18 doesn't recognize them).
4. Replace the body of \`dev_env/seed-clone.sql\` (everything after the leading TRUNCATE block).

Expected cadence: ~quarterly when prod schema drift makes it worth re-pulling, not every prod data change.

## Test plan

- [x] \`npm run db:stop && npm run db:start\` against dev profile (after \`docker compose build db-init\` to pick up the new Dockerfile layer): \`21,563\` rotation / \`64,193\` library / \`24,078\` artists / \`12\` auth_user / \`15\` genres. Verified.
- [x] \`format:check\` clean.
- [ ] CI integration tests run unchanged. (CI is the existing acceptance bar — the change to \`init-db.mjs\` for the dev path is gated on file existence, the file isn't mounted into \`ci-db-init\`, the image layer is the only shared change. Watching the integration-tests job here will confirm.)

## Notes

- 14 MB blob is by far the largest file in the repo (next largest is 16 KB \`seed_db.sql\`). Refresh cadence is quarterly so the git history impact is manageable, but worth flagging.
- The snapshot has \`library_identity\` empty (0 rows) — matches current prod as of 2026-05-12. Once WXYC/Backend-Service#802's consumer job runs in prod and populates the cross-cache-identity table, the next refresh carries those resolved rows into dev, which is what makes WXYC/Backend-Service#944's rotation tracks dropdown actually populate end-to-end in dev.

## Related

- Closes #947
- Triggered by WXYC/Backend-Service#944 (rotation tracks route; needs realistic rotation data to demo)
- Depends-on (for dropdown to populate): WXYC/Backend-Service#802 (library_identity consumer job; once it runs in prod, future refreshes carry the resolved rows)