### PR TITLE
Pin lml.cache.pg_negative_* projection (E1)

### DIFF
--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -240,6 +240,49 @@ describe('lml.client', () => {
       expect(cacheCalls).toHaveLength(0);
     });
 
+    // E1 / BS#901: LML#354 added `pg_negative_hits` and `pg_negative_misses`
+    // to cache_stats. The existing projection iterates every numeric field,
+    // so these keys flow through with zero code change. This test pins that
+    // contract — if a future refactor narrows the projection (e.g., a hard-
+    // coded whitelist of known keys), the new keys would silently disappear
+    // from Sentry traces and we'd lose visibility into the negative-cache
+    // hit rate post-deploy. Companion to WXYC/library-metadata-lookup#341.
+    it('projects pg_negative_hits and pg_negative_misses onto the span (LML#341/A4 cache_stats)', async () => {
+      const cache_stats = {
+        memory_hits: 0,
+        pg_hits: 0,
+        pg_misses: 0,
+        pg_negative_hits: 5,
+        pg_negative_misses: 3,
+        api_calls: 0,
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [],
+            search_type: 'none',
+            song_not_found: false,
+            found_on_compilation: false,
+            cache_stats,
+          }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield');
+
+      // Both new keys must reach the span as lml.cache.<key>.
+      const projected = mockSpanSetAttributes.mock.calls
+        .map((args) => (args[0] ?? {}) as Record<string, unknown>)
+        .find((attrs) => 'lml.cache.pg_negative_hits' in attrs);
+      expect(projected).toBeDefined();
+      expect(projected).toEqual(
+        expect.objectContaining({
+          'lml.cache.pg_negative_hits': 5,
+          'lml.cache.pg_negative_misses': 3,
+        })
+      );
+    });
+
     it('resolves successfully when span.setAttributes throws (observability must not break the request path)', async () => {
       // Wrapping in try/catch keeps lookupMetadata's contract: a Sentry/SDK bug
       // in setAttributes must not surface as a failed metadata lookup.


### PR DESCRIPTION
## Summary

E1's acceptance criterion is \"No code change in BS unless LML's response shape changes.\" LML#341 / A4 added `pg_negative_hits` and `pg_negative_misses` to the `/api/v1/lookup` response's `cache_stats` block, but the response shape itself is unchanged — `cache_stats` was already a freeform `additionalProperties: true` dict, so BS's existing projection in `apps/backend/services/lml/lml.client.ts:postLookup` (which iterates every numeric field and emits each as `lml.cache.<key>` on the Sentry span) picks up the new keys automatically.

This PR adds a regression test pinning that contract — if a future refactor narrows the projection (e.g. a hard-coded whitelist of known keys), the new pg_negative_* keys would silently disappear from Sentry traces and we'd lose visibility into the negative-cache hit rate post-deploy. No production-code change.

## Test plan

- [x] `npx jest --config jest.unit.config.ts tests/unit/services/lml.client.test.ts` — 41/41 pass (40 existing + 1 new).
- [x] `npm run test:unit` — 1956/1956 pass.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean (0 errors).
- [x] `npm run format:check` — clean.

## Deploy note

The new keys start firing in prod as soon as LML's staging + prod environments pick up library-metadata-lookup#354 (just merged at 3dd928c). The discogs-etl migration (WXYC/discogs-etl#225, merged 87fb523) must be applied to staging + prod discogs-cache via `alembic upgrade head` before LML#354 sees benefit; until then, `lookup_negative_hit` swallows the table-missing error and falls through to the API exactly as today.

Closes #901