### PR TITLE
Pin better-auth session.expiresIn so DJ sessions don't silently expire (BS#966)

### DIFF
--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -51,6 +51,20 @@ export const auth = betterAuth({
     },
   }),
 
+  // better-auth's default session.expiresIn is 7 days and updateAge is 1 day.
+  // Combined with the bearer plugin's per-renewal token rotation, the 1-day
+  // updateAge cadence surfaced as DJs being silently signed out roughly once
+  // a day on iOS (the client kept using the pre-rotation bearer). The iOS
+  // app now captures the rotated set-auth-token; pinning expiresIn here makes
+  // sessions effectively permanent for daily users (rolling 1-year window on
+  // every renewal), and turning cookieCache off keeps every /auth/token call
+  // routed through the database so the renewal/rotation actually happens.
+  session: {
+    expiresIn: 60 * 60 * 24 * 365,
+    updateAge: 60 * 60 * 24,
+    cookieCache: { enabled: false },
+  },
+
   // Base URL for the auth service
   baseURL: process.env.BETTER_AUTH_URL || 'http://localhost:8082/auth',
 

--- a/tests/unit/authentication/session-config.test.ts
+++ b/tests/unit/authentication/session-config.test.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Without an explicit session config, better-auth defaults to
+// expiresIn = 7 days, updateAge = 1 day. Combined with the bearer plugin's
+// per-renewal token rotation, this surfaced as DJs being silently signed out
+// after roughly a day (the iOS app didn't capture the rotated set-auth-token,
+// so the first 24h-renewal call invalidated their bearer). The iOS app now
+// captures the header, but the backend should also pin these values
+// explicitly so the implicit defaults don't silently shorten sessions again.
+
+// Evaluate a multiplication-only integer expression like "60 * 60 * 24 * 365".
+// Avoids the Function constructor (banned by no-implied-eval).
+function evalMultiplication(expression: string): number {
+  return expression
+    .split('*')
+    .map((factor) => factor.replace(/_/g, '').trim())
+    .reduce((product, factor) => {
+      const value = Number(factor);
+      if (!Number.isFinite(value)) {
+        throw new Error(`Unparseable factor '${factor}' in '${expression}'`);
+      }
+      return product * value;
+    }, 1);
+}
+
+describe('auth.definition.ts session configuration', () => {
+  const authDefPath = path.resolve(__dirname, '../../../shared/authentication/src/auth.definition.ts');
+  let source: string;
+
+  beforeAll(() => {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    source = fs.readFileSync(authDefPath, 'utf-8');
+  });
+
+  it('defines a top-level session block (distinct from the schema mapping)', () => {
+    expect(source).toMatch(/session:\s*\{[\s\S]*?expiresIn/);
+  });
+
+  it('sets expiresIn to at least 30 days', () => {
+    const match = source.match(/session:\s*\{[\s\S]*?expiresIn:\s*([0-9*\s_]+?)[,\n}]/);
+    if (match === null) {
+      throw new Error('session.expiresIn not found in auth.definition.ts');
+    }
+    const seconds = evalMultiplication(match[1]);
+    const minimumSeconds = 30 * 24 * 60 * 60;
+    expect(seconds).toBeGreaterThanOrEqual(minimumSeconds);
+  });
+
+  it('sets updateAge to no more than 1 day so renewal happens daily on use', () => {
+    const match = source.match(/session:\s*\{[\s\S]*?updateAge:\s*([0-9*\s_]+?)[,\n}]/);
+    if (match === null) {
+      throw new Error('session.updateAge not found in auth.definition.ts');
+    }
+    const seconds = evalMultiplication(match[1]);
+    const oneDaySeconds = 24 * 60 * 60;
+    expect(seconds).toBeLessThanOrEqual(oneDaySeconds);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds explicit `session: { expiresIn, updateAge, cookieCache }` to `shared/authentication/src/auth.definition.ts`, replacing the implicit 7d/1d/unset defaults.
- Pins `expiresIn = 1 year`, `updateAge = 1 day`, `cookieCache.enabled = false`. Sessions roll forward with daily use; the DB drives every renewal so the bearer plugin actually rotates `set-auth-token`.
- New regression test `tests/unit/authentication/session-config.test.ts` mirrors the existing `cookie-config.test.ts` pattern and pins `expiresIn ≥ 30 days`, `updateAge ≤ 1 day`.

The root-cause fix lives in `wxyc-dj-tool-ios` (capture the rotated `set-auth-token` header on every `/auth/token` response — that repo has no remote yet, so it's not linked here). This PR is the backend defense-in-depth: even with a perfect client, a DJ who skips a week shouldn't get kicked out on return.

Existing sessions inherit the new TTL on their next refresh; no data migration needed.

Closes #966

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new errors from changed files)
- [x] `npm run format:check`
- [x] `npm run test:unit` (1989 passed)
- [x] `npm run build`
- [ ] After deploy: spot-check `auth_session.expires_at` for a freshly-issued / refreshed session — should be ~1 year out.