### PR TITLE
fix(library-identity-consumer): surface PG diagnostics at every catch site, not one

### DIFF
--- a/jobs/library-identity-consumer/logger.ts
+++ b/jobs/library-identity-consumer/logger.ts
@@ -84,3 +84,63 @@ export const closeLogger = async (): Promise<void> => {
   await Sentry.close(2000);
   baseTags = null;
 };
+
+/**
+ * The PG diagnostic fields worth logging, lifted off a wrapped driver error.
+ *
+ * Drizzle wraps every postgres-js failure in a `DrizzleQueryError` whose
+ * `.message` is hardcoded to `Failed query: <SQL>\nparams: <params>`. The part
+ * that says what actually went wrong — the SQLSTATE code, the detail line, the
+ * offending constraint or column — lives on `.cause`. Logging only `.message`
+ * therefore produces a fleet of identical "Failed query" lines with no
+ * diagnostic in any of them, which is exactly what the 2026-05-20 first run
+ * emitted: many failures, one indistinguishable message, and no way to tell a
+ * unique-violation from a not-null violation without a manual psql repro.
+ *
+ * Returned as a flat object so a caller can spread it straight into a `log()`
+ * fields bag. Every field is `undefined` for a non-PG error, and
+ * `JSON.stringify` drops undefined values, so a non-database failure logs
+ * exactly as it did before — no empty `pg_*` keys, no shape change for the
+ * consumers of these log lines.
+ *
+ * Deliberately total: `unknown` in, never throws. A catch block is the worst
+ * possible place to add a new way to fail, so this reads defensively rather
+ * than casting — a string thrown by a library, a null, or an error whose
+ * `.cause` is itself a string all fall through to all-undefined.
+ */
+export type PgDiagnostics = {
+  pg_message?: string;
+  pg_code?: string;
+  pg_detail?: string;
+  pg_constraint?: string;
+  pg_column?: string;
+  pg_table?: string;
+  pg_routine?: string;
+};
+
+const str = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
+
+export const pgDiagnostics = (error: unknown): PgDiagnostics => {
+  if (typeof error !== 'object' || error === null) return {};
+  const cause = (error as { cause?: unknown }).cause;
+  if (typeof cause !== 'object' || cause === null) return {};
+  const c = cause as Record<string, unknown>;
+  return {
+    pg_message: str(c.message),
+    pg_code: str(c.code),
+    pg_detail: str(c.detail),
+    pg_constraint: str(c.constraint_name),
+    pg_column: str(c.column_name),
+    pg_table: str(c.table_name),
+    pg_routine: str(c.routine),
+  };
+};
+
+/**
+ * `error.message` without the `(error as Error)` cast that throws on a thrown
+ * string or null. Pairs with {@link pgDiagnostics} at every catch site.
+ */
+export const errorMessage = (error: unknown): string =>
+  typeof error === 'object' && error !== null && typeof (error as { message?: unknown }).message === 'string'
+    ? (error as { message: string }).message
+    : String(error);

--- a/jobs/library-identity-consumer/orchestrate.ts
+++ b/jobs/library-identity-consumer/orchestrate.ts
@@ -234,11 +234,19 @@ export const runConsumer = async (opts: {
             // psql repro.
             const err = error as { message?: string; cause?: unknown };
             const cause = err.cause as
-              | { message?: string; code?: string; detail?: string; constraint_name?: string; column_name?: string; table_name?: string; routine?: string }
+              | {
+                  message?: string;
+                  code?: string;
+                  detail?: string;
+                  constraint_name?: string;
+                  column_name?: string;
+                  table_name?: string;
+                  routine?: string;
+                }
               | undefined;
             log('warn', 'writer_error', `writer failed for library_id=${result.library_id}`, {
               library_id: result.library_id,
-              error_message: err.message,
+              error_message: err.message ?? String(error),
               pg_message: cause?.message,
               pg_code: cause?.code,
               pg_detail: cause?.detail,

--- a/jobs/library-identity-consumer/orchestrate.ts
+++ b/jobs/library-identity-consumer/orchestrate.ts
@@ -225,9 +225,27 @@ export const runConsumer = async (opts: {
             totals.rows_resolved += 1;
             totals.source_rows_skipped_null_confidence += outcome.source_rows_skipped_null_confidence;
           } catch (error) {
+            // Drizzle wraps every postgres-js failure in DrizzleQueryError, whose
+            // `.message` is hardcoded to "Failed query: <SQL>\nparams: <params>".
+            // The actual PG error (code, detail, constraint_name, column_name) lives
+            // on `.cause`. Logging only `.message` produced a fleet of identical
+            // "Failed query" log lines during the 2026-05-20 first run with no PG
+            // diagnostic — surfacing both makes failures debuggable without a manual
+            // psql repro.
+            const err = error as { message?: string; cause?: unknown };
+            const cause = err.cause as
+              | { message?: string; code?: string; detail?: string; constraint_name?: string; column_name?: string; table_name?: string; routine?: string }
+              | undefined;
             log('warn', 'writer_error', `writer failed for library_id=${result.library_id}`, {
               library_id: result.library_id,
-              error_message: (error as Error).message,
+              error_message: err.message,
+              pg_message: cause?.message,
+              pg_code: cause?.code,
+              pg_detail: cause?.detail,
+              pg_constraint: cause?.constraint_name,
+              pg_column: cause?.column_name,
+              pg_table: cause?.table_name,
+              pg_routine: cause?.routine,
             });
             captureError(error, 'writer_error', { library_id: result.library_id });
             totals.rows_skipped.writer_error += 1;

--- a/jobs/library-identity-consumer/orchestrate.ts
+++ b/jobs/library-identity-consumer/orchestrate.ts
@@ -49,7 +49,7 @@ import type { SQL } from 'drizzle-orm';
 import { loadBatch, type Cohort, type LibraryRow } from './select.js';
 import type { BulkResolveInput, BulkResolveResponse, BulkResolveResult } from './lml-types.js';
 import type { CompilationWriteOutcome } from './writer.js';
-import { captureError, log } from './logger.js';
+import { captureError, errorMessage, log, pgDiagnostics } from './logger.js';
 
 const JOB_NAME = 'library-identity-consumer';
 
@@ -284,7 +284,8 @@ export const runConsumer = async (opts: {
       log('warn', 'lml_error', `LML bulk-resolve failed for batch ${batchIndex}`, {
         batch_index: batchIndex,
         batch_size: rows.length,
-        error_message: (error as Error).message,
+        error_message: errorMessage(error),
+        ...pgDiagnostics(error),
       });
       captureError(error, 'lml_error', { batch_index: batchIndex, batch_size: rows.length });
       // Count every row in this batch as skipped (lml_error). The next run
@@ -384,7 +385,8 @@ export const runConsumer = async (opts: {
           } catch (error) {
             log('warn', 'writer_error', `writer failed for library_id=${result.library_id}`, {
               library_id: result.library_id,
-              error_message: (error as Error).message,
+              error_message: errorMessage(error),
+              ...pgDiagnostics(error),
             });
             captureError(error, 'writer_error', { library_id: result.library_id });
             totals.rows_skipped.writer_error += 1;
@@ -441,7 +443,8 @@ export const runConsumer = async (opts: {
           log('warn', 'writer_error', `writeCompilationTracks failed for batch ${batchIndex}`, {
             batch_index: batchIndex,
             library_ids: resolvedCompilationResults.map((r) => r.library_id),
-            error_message: (error as Error).message,
+            error_message: errorMessage(error),
+            ...pgDiagnostics(error),
           });
           captureError(error, 'writer_error', {
             batch_index: batchIndex,
@@ -493,7 +496,8 @@ export const runConsumer = async (opts: {
         log('warn', 'stamp_error', `failed to stamp unresolved_attempted_at for batch ${batchIndex}`, {
           batch_index: batchIndex,
           count: idsToStamp.length,
-          error_message: (error as Error).message,
+          error_message: errorMessage(error),
+          ...pgDiagnostics(error),
         });
         captureError(error, 'stamp_error', { batch_index: batchIndex, count: idsToStamp.length });
       }

--- a/tests/unit/jobs/library-identity-consumer/logger.test.ts
+++ b/tests/unit/jobs/library-identity-consumer/logger.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the library-identity-consumer logger's pure helpers.
+ *
+ * `pgDiagnostics` exists because Drizzle wraps every postgres-js failure in a
+ * `DrizzleQueryError` whose `.message` is the hardcoded
+ * `Failed query: <SQL>\nparams: <params>` — the SQLSTATE code, detail line, and
+ * offending constraint all live on `.cause`. These tests pin the two properties
+ * the catch sites depend on: a wrapped driver error yields its diagnostics, and
+ * anything else yields an object that spreads to nothing.
+ *
+ * The init / JSON-line behavior is shared verbatim with the sibling job loggers
+ * and is exercised by `tests/unit/jobs/flowsheet-etl/logger.test.ts`.
+ */
+
+import {
+  errorMessage,
+  pgDiagnostics,
+  resolveTracesSampleRate,
+} from '../../../../jobs/library-identity-consumer/logger';
+
+/** Shaped like a real DrizzleQueryError wrapping a postgres-js error. */
+const drizzleError = (cause: Record<string, unknown>): Error => {
+  const err = new Error('Failed query: insert into "library_identity" ...\nparams: 1,2,3');
+  (err as Error & { cause?: unknown }).cause = cause;
+  return err;
+};
+
+describe('resolveTracesSampleRate', () => {
+  it('defaults to 1 when env var is unset', () => {
+    expect(resolveTracesSampleRate(undefined)).toBe(1);
+  });
+
+  it('parses valid values in [0, 1]', () => {
+    expect(resolveTracesSampleRate('0')).toBe(0);
+    expect(resolveTracesSampleRate('0.5')).toBe(0.5);
+    expect(resolveTracesSampleRate('1')).toBe(1);
+  });
+
+  it('falls back to 1 on malformed or out-of-range values', () => {
+    expect(resolveTracesSampleRate('abc')).toBe(1);
+    expect(resolveTracesSampleRate('-0.5')).toBe(1);
+    expect(resolveTracesSampleRate('1.5')).toBe(1);
+  });
+});
+
+describe('pgDiagnostics', () => {
+  it('lifts the PG fields off a wrapped driver error', () => {
+    const error = drizzleError({
+      message: 'duplicate key value violates unique constraint "library_identity_pkey"',
+      code: '23505',
+      detail: 'Key (library_id)=(4271) already exists.',
+      constraint_name: 'library_identity_pkey',
+      column_name: 'library_id',
+      table_name: 'library_identity',
+      routine: '_bt_check_unique',
+    });
+
+    expect(pgDiagnostics(error)).toEqual({
+      pg_message: 'duplicate key value violates unique constraint "library_identity_pkey"',
+      pg_code: '23505',
+      pg_detail: 'Key (library_id)=(4271) already exists.',
+      pg_constraint: 'library_identity_pkey',
+      pg_column: 'library_id',
+      pg_table: 'library_identity',
+      pg_routine: '_bt_check_unique',
+    });
+  });
+
+  it('distinguishes two failures whose DrizzleQueryError messages are identical', () => {
+    // The whole point: `.message` is the same query text for both, so only
+    // `.cause` can tell a unique violation from a not-null violation.
+    const sql = 'Failed query: insert into "library_identity" ...\nparams: 1,2,3';
+    const unique = drizzleError({ code: '23505', constraint_name: 'library_identity_pkey' });
+    const notNull = drizzleError({ code: '23502', column_name: 'canonical_entity_id' });
+
+    expect(unique.message).toBe(sql);
+    expect(notNull.message).toBe(sql);
+    expect(pgDiagnostics(unique).pg_code).toBe('23505');
+    expect(pgDiagnostics(notNull).pg_code).toBe('23502');
+  });
+
+  it('omits fields the driver did not set, so JSON.stringify drops them', () => {
+    const diagnostics = pgDiagnostics(drizzleError({ code: '23505' }));
+
+    expect(diagnostics.pg_code).toBe('23505');
+    expect(diagnostics.pg_detail).toBeUndefined();
+    // A log line for a partial diagnostic must not sprout empty keys.
+    expect(JSON.parse(JSON.stringify({ ...diagnostics }))).toEqual({ pg_code: '23505' });
+  });
+
+  it.each([
+    ['a plain Error with no cause', new Error('boom')],
+    ['a thrown string', 'boom'],
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['an error whose cause is a string', Object.assign(new Error('boom'), { cause: 'nested' })],
+  ])('returns an empty object for %s', (_label, thrown) => {
+    // Spreading the result must be a no-op — a catch block is the worst place
+    // to introduce a new way to throw.
+    expect(pgDiagnostics(thrown)).toEqual({});
+    expect({ error_message: 'x', ...pgDiagnostics(thrown) }).toEqual({ error_message: 'x' });
+  });
+
+  it('ignores non-string diagnostic values rather than logging objects', () => {
+    expect(pgDiagnostics(drizzleError({ code: 23505, detail: { nested: true } }))).toEqual({
+      pg_message: undefined,
+      pg_code: undefined,
+      pg_detail: undefined,
+      pg_constraint: undefined,
+      pg_column: undefined,
+      pg_table: undefined,
+      pg_routine: undefined,
+    });
+  });
+});
+
+describe('errorMessage', () => {
+  it('reads .message from an Error', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it.each([
+    ['a thrown string', 'boom', 'boom'],
+    ['null', null, 'null'],
+    ['undefined', undefined, 'undefined'],
+    ['a number', 42, '42'],
+    ['an object with a non-string message', { message: 7 }, '[object Object]'],
+  ])('stringifies %s instead of throwing', (_label, thrown, expected) => {
+    // `(error as Error).message` returns undefined here, and the JSON logger
+    // then drops the key entirely — the failure logs as if it had no message.
+    expect(errorMessage(thrown)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Rewrites the original one-site fix to cover the class. Drizzle wraps every postgres-js failure in a `DrizzleQueryError` whose `.message` is hardcoded to `Failed query: <SQL>\nparams: <params>`; the SQLSTATE code, detail line, and offending constraint all live on `.cause`. That is why the 2026-05-20 first run emitted a fleet of identical "Failed query" lines with no diagnostic in any of them — a unique violation and a not-null violation on the same statement log byte-for-byte identically.

`orchestrate.ts` has **four** catch sites that log `error_message`, and **three are database writes** with exactly this problem:

| line | step | write |
|---|---|---|
| 281 | `lml_error` | — (LML HTTP) |
| 384 | `writer_error` | per-row writer ← *the only site the original fix touched* |
| 440 | `writer_error` | `writeCompilationTracks` batch |
| 492 | `stamp_error` | `stampUnresolvedAttemptedAt` update |

The other two would have gone on emitting the same undiagnosable line, in the same run, for the same reason.

## Approach

`pgDiagnostics(error)` in `logger.ts` lifts the seven fields off `.cause` and returns them flat, to be spread into a `log()` fields bag:

```ts
log('warn', 'writer_error', `writer failed for library_id=${result.library_id}`, {
  library_id: result.library_id,
  error_message: errorMessage(error),
  ...pgDiagnostics(error),
});
```

Two properties the catch sites depend on, both pinned by tests:

- **Invisible when it doesn't apply.** Every field is `undefined` for a non-PG error and `JSON.stringify` drops undefined values, so a non-database failure logs exactly as before — no empty `pg_*` keys, no shape change for anything consuming these lines.
- **Total.** `unknown` in, never throws. A catch block is the worst possible place to add a new way to fail, so it reads defensively rather than casting: a thrown string, a `null`, an error whose `.cause` is itself a string, and a driver handing back a numeric `code` all fall through to all-undefined.

The same reasoning retires `(error as Error).message`, which returns `undefined` for a thrown non-Error and then has the key silently dropped by the JSON logger — the failure logs as though it had no message at all. `errorMessage(error)` replaces it at all four sites.

The `lml_error` site gets both helpers too. `pgDiagnostics` no-ops there today since it isn't a Drizzle write, but the `errorMessage` hardening applies to any thrown value, and keeping all four identical is what stops the next one drifting.

## Scope

This pattern recurs across roughly two dozen catch sites in other jobs. Promoting the helper into a shared package is a separate change — every job already carries its own duplicated `logger.ts` by existing convention, so this follows it rather than reforming it here.

## Test plan

- [x] `npm run build` — pass
- [x] `npm run typecheck` — pass; plus `tsc --noEmit -p jobs/library-identity-consumer/tsconfig.json` (root typecheck does not cover `jobs/**`)
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — pass
- [x] `npm run test:unit` — 8061 tests / 462 suites pass
- [x] 19 new assertions in `tests/unit/jobs/library-identity-consumer/logger.test.ts`, including a case asserting that two errors with **identical** `.message` are distinguishable by `pg_code` alone — the actual bug
- [x] No `(error as Error).message` remains in `orchestrate.ts`
