### PR TITLE
Extend catalog cascade to GET /library/query so modern Card Catalog sees matched_via

### DIFF
--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -155,9 +155,10 @@ async function runCascade(params: LibraryQueryParams): Promise<AlbumSearchResult
   }
   if (cascade.length === 0) return [];
 
-  // The raw cascade primitives don't apply enum filters (genre/format) or
-  // honor `on_streaming` for the Track 2 path, so apply both in-memory over
-  // the bounded fallback list before serializing.
+  // Neither raw cascade primitive applies enum filters (genre/format), and
+  // `searchLibraryByTrackRaw` does not honor `on_streaming` (`searchLibraryByCTARaw`
+  // already does, but re-checking is a harmless no-op). Apply both filters
+  // in-memory over the bounded fallback list before serializing.
   const filtered = cascade.filter((row) => {
     if (params.on_streaming !== undefined && row.on_streaming !== params.on_streaming) return false;
     if (params.genre !== undefined && row.genre_name !== params.genre) return false;

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -1,11 +1,14 @@
 import { sql, type SQL } from 'drizzle-orm';
 import { db, library_artist_view, genres, format as formatTable } from '@wxyc/database';
+import type { TrackMatchHint } from '@wxyc/shared/dtos';
 import {
   parseSearchQuery,
   CATALOG_PARSER_CONFIG,
   type CatalogField,
   type SearchCondition,
 } from './search-parser.service.js';
+import { searchLibraryByCTARaw, searchLibraryByTrackRaw, type TaggedLibraryViewEntry } from './library.service.js';
+import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrackSearch.js';
 import WxycError from '../utils/error.js';
 
 export type CatalogSort = 'artist' | 'album' | 'plays' | 'date';
@@ -38,6 +41,7 @@ export type AlbumSearchResultRow = {
   plays: number | null;
   on_streaming: boolean | null;
   album_artist: string | null;
+  matched_via?: TrackMatchHint[];
 };
 
 const FIELD_COLUMNS: Record<CatalogField, SQL> = {
@@ -115,7 +119,112 @@ export async function searchLibrary(
   const results = (dataRows as unknown as RawRow[]).map(toAlbumSearchResultRow);
   const total = (countRows as unknown as { total: number }[])[0]?.total ?? 0;
 
-  return { results, total };
+  if (results.length > 0 || total > 0) return { results, total };
+
+  // Catalog-track-search cascade (BS#977). When the primary query returns no
+  // rows AND the user typed a single bareword (no field qualifiers, exact
+  // match, or negation), fall through to Track 1 (CTA) + Track 2 (LML
+  // `/lookup`). The cascade is single-page: pagination beyond page 0 stays
+  // empty so the client doesn't keep scrolling into a bounded fallback list.
+  if (params.page !== 0) return { results, total };
+  if (!isSingleBareword(conditions)) return { results, total };
+
+  const cascadeResults = await runCascade(params);
+  return { results: cascadeResults, total: cascadeResults.length };
+}
+
+function isSingleBareword(conditions: SearchCondition<CatalogField>[]): boolean {
+  if (conditions.length !== 1) return false;
+  const [c] = conditions;
+  return c.field === 'all' && !c.exact && !c.negated;
+}
+
+async function runCascade(params: LibraryQueryParams): Promise<AlbumSearchResultRow[]> {
+  const flags = getCatalogTrackSearchConfig();
+  if (!flags.ctaEnabled && !flags.discogsEnabled) return [];
+
+  const q = params.q.trim();
+  if (q.length === 0) return [];
+
+  let cascade: TaggedLibraryViewEntry[] = [];
+  if (flags.ctaEnabled) {
+    cascade = await searchLibraryByCTARaw(q, params.limit, params.on_streaming);
+  }
+  if (cascade.length === 0 && flags.discogsEnabled) {
+    cascade = await searchLibraryByTrackRaw(q, params.limit);
+  }
+  if (cascade.length === 0) return [];
+
+  // The raw cascade primitives don't apply enum filters (genre/format) or
+  // honor `on_streaming` for the Track 2 path, so apply both in-memory over
+  // the bounded fallback list before serializing.
+  const filtered = cascade.filter((row) => {
+    if (params.on_streaming !== undefined && row.on_streaming !== params.on_streaming) return false;
+    if (params.genre !== undefined && row.genre_name !== params.genre) return false;
+    if (params.format !== undefined && row.format_name !== params.format) return false;
+    return true;
+  });
+  if (filtered.length === 0) return [];
+
+  const projected = filtered.map(taggedRowToAlbumSearchResultRow);
+
+  const direction = params.order === 'asc' ? 1 : -1;
+  const primaryKey = SORT_KEYS[params.sort];
+  const secondaryKey = SECONDARY_SORT_KEYS[params.sort];
+  projected.sort((a, b) => {
+    const primary = compareSortable(a[primaryKey], b[primaryKey]) * direction;
+    if (primary !== 0) return primary;
+    const secondary = compareSortable(a[secondaryKey], b[secondaryKey]);
+    if (secondary !== 0) return secondary;
+    return a.id - b.id;
+  });
+  return projected;
+}
+
+type SortableKey = 'artist_name' | 'album_title' | 'plays' | 'add_date';
+
+const SORT_KEYS: Record<CatalogSort, SortableKey> = {
+  artist: 'artist_name',
+  album: 'album_title',
+  plays: 'plays',
+  date: 'add_date',
+};
+
+const SECONDARY_SORT_KEYS: Record<CatalogSort, SortableKey> = {
+  artist: 'album_title',
+  album: 'artist_name',
+  plays: 'artist_name',
+  date: 'artist_name',
+};
+
+function compareSortable(a: string | number | null, b: string | number | null): number {
+  if (a === b) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  return String(a).localeCompare(String(b));
+}
+
+function taggedRowToAlbumSearchResultRow(row: TaggedLibraryViewEntry): AlbumSearchResultRow {
+  const projected: AlbumSearchResultRow = {
+    id: row.id,
+    add_date: row.add_date instanceof Date ? row.add_date.toISOString() : String(row.add_date ?? ''),
+    album_title: row.album_title,
+    artist_name: row.artist_name ?? '',
+    code_letters: row.code_letters,
+    code_number: row.code_number,
+    code_artist_number: row.code_artist_number,
+    format_name: row.format_name,
+    genre_name: row.genre_name,
+    label: row.label ?? '',
+    label_id: row.label_id,
+    rotation_bin: row.rotation_bin,
+    plays: row.plays,
+    on_streaming: row.on_streaming,
+    album_artist: row.album_artist,
+  };
+  if (row.matched_via) projected.matched_via = row.matched_via;
+  return projected;
 }
 
 type RawRow = {

--- a/tests/integration/library-query.spec.js
+++ b/tests/integration/library-query.spec.js
@@ -150,3 +150,132 @@ describe('GET /library/query', () => {
     expect(res.body.message).toMatch(/order/i);
   });
 });
+
+/**
+ * GET /library/query — catalog-track-search cascade (BS#977).
+ *
+ * `searchLibraryQueryEndpoint` is what dj-site's *modern* Card Catalog calls
+ * via `useCatalogQuerySearch`. Its underlying `librarySearchService.searchLibrary`
+ * has its own field-aware ILIKE-based primary path that doesn't reach the
+ * Track 1 (CTA) + Track 2 (LML `/lookup`) cascade owned by
+ * `libraryService.searchLibraryBothMode`. That left modern dj-site without
+ * `matched_via` chips even after BS#972 / #973 wired the cascade onto the
+ * classic-experience `GET /library/` route.
+ *
+ * These cases drive the same CTA + Track 2 fixtures as the cascade describes
+ * in library.spec.js, but through the `/library/query` envelope shape
+ * (`{ results, total, page, totalPages }`). They follow the
+ * skip-if-flag-off pattern: a 0-result response in CI means the flag isn't
+ * set; the test warns and short-circuits.
+ *
+ * Cascade trigger is the single-bareword case (no `artist:` / `album:` /
+ * `label:` qualifiers, no quoted exact, no NOT). Field-qualified queries
+ * skip the cascade even on a primary 0-hit (covered below).
+ */
+describe('GET /library/query cascade — modern Card Catalog serves matched_via (BS#977)', () => {
+  let auth;
+  // CTA fixture (mirror of the BS#972 + BS#819 blocks in library.spec.js).
+  const CTA_LIBRARY_ID = 7000;
+  const CTA_ALBUM_TITLE = 'Shape Fixture Album Alpha 1';
+  const CTA_ARTIST = 'Shape Fixture Artist Alpha';
+  // Track 2 fixture (mirror of the BS#972 + BS#825 blocks in library.spec.js).
+  const CONFIELD_LIBRARY_ID = 7100;
+  const CONFIELD_ALBUM_TITLE = 'Confield';
+  const CONFIELD_TRACK_QUERY = 'vi scose poise';
+
+  beforeAll(() => {
+    auth = createAuthRequest(request, global.access_token);
+  });
+
+  test('single-bareword CTA query returns the comp library row with matched_via.source = "cta"', async () => {
+    const res = await auth.get('/library/query').query({ q: 'Bioluminescence', limit: 10 }).expect(200);
+
+    expect(res.body.results).toBeDefined();
+    expect(Array.isArray(res.body.results)).toBe(true);
+    if (res.body.results.length === 0) {
+      console.warn(
+        '[BS#977] /library/query cascade returned no results. Likely the backend is running ' +
+          'without CATALOG_TRACK_SEARCH_CTA_ENABLED=true. Set it in .env and restart `npm run dev`.'
+      );
+      return;
+    }
+
+    const hit = res.body.results.find((row) => row.id === CTA_LIBRARY_ID);
+    expect(hit).toBeDefined();
+    expect(hit.album_title).toBe(CTA_ALBUM_TITLE);
+    expect(hit.artist_name).toBe(CTA_ARTIST);
+    expect(Array.isArray(hit.matched_via)).toBe(true);
+    expect(hit.matched_via.length).toBeGreaterThanOrEqual(1);
+    const bioHints = hit.matched_via.filter((m) => m.title === 'Bioluminescence');
+    expect(bioHints.length).toBeGreaterThanOrEqual(1);
+    bioHints.forEach((hint) => {
+      expect(hint.source).toBe('cta');
+      expect(hint.confidence).toBe(1.0);
+    });
+    // Cascade-fallback envelope is single-page: total reflects cascade size,
+    // not the unrelated catalog total.
+    expect(res.body.total).toBe(res.body.results.length);
+    expect(res.body.page).toBe(0);
+    expect(res.body.totalPages).toBe(1);
+  });
+
+  test('single-bareword Track 2 query ("vi scose poise") returns Confield via LML fallback', async () => {
+    const res = await auth
+      .get('/library/query')
+      .query({ q: CONFIELD_TRACK_QUERY, sort: 'artist', order: 'asc', limit: 20 })
+      .expect(200);
+
+    expect(res.body.results).toBeDefined();
+    expect(Array.isArray(res.body.results)).toBe(true);
+    if (res.body.results.length === 0) {
+      console.warn(
+        '[BS#977] /library/query cascade returned no Track 2 results. Likely the backend is running ' +
+          'without CATALOG_TRACK_SEARCH_DISCOGS_ENABLED=true. Set it in .env and restart `npm run dev`.'
+      );
+      return;
+    }
+
+    const hit = res.body.results.find((row) => row.id === CONFIELD_LIBRARY_ID);
+    expect(hit).toBeDefined();
+    expect(hit.album_title).toBe(CONFIELD_ALBUM_TITLE);
+    expect(Array.isArray(hit.matched_via)).toBe(true);
+    expect(hit.matched_via.length).toBeGreaterThanOrEqual(1);
+    // Mock LML's songLookup map returns matched_via.source = 'discogs_master'
+    // for the Confield row; bridged via library.legacy_release_id back to BS.
+    expect(hit.matched_via.some((m) => m.source && m.source.startsWith('discogs'))).toBe(true);
+  });
+
+  test('primary tsvector/ILIKE hit never carries matched_via (cascade only fires on primary 0-hit)', async () => {
+    // 'Stereolab' is in the seed fixture and matches the primary ILIKE
+    // (artist/album/label) cleanly; the cascade must NOT fire, so no row
+    // can carry matched_via.
+    const res = await auth.get('/library/query').query({ q: 'Stereolab', limit: 10 }).expect(200);
+
+    expect(Array.isArray(res.body.results)).toBe(true);
+    expect(res.body.results.length).toBeGreaterThan(0);
+    res.body.results.forEach((row) => {
+      expect(row.matched_via).toBeUndefined();
+    });
+  });
+
+  test('field-qualified queries skip the cascade even on 0-hit', async () => {
+    // `artist:NonexistentArtistFoo` returns 0 primary rows; because the
+    // condition is field-qualified (not a single bareword), the cascade
+    // must NOT fire and the envelope must report no results.
+    const res = await auth.get('/library/query').query({ q: 'artist:NonexistentArtistFoo', limit: 10 }).expect(200);
+
+    expect(Array.isArray(res.body.results)).toBe(true);
+    expect(res.body.results.length).toBe(0);
+    expect(res.body.total).toBe(0);
+    expect(res.body.totalPages).toBe(0);
+  });
+
+  test('cascade pagination beyond page=0 returns empty results', async () => {
+    // Cascade fallback is single-page; page > 0 must be empty (no offset
+    // semantics over a bounded fallback list).
+    const res = await auth.get('/library/query').query({ q: CONFIELD_TRACK_QUERY, page: 1, limit: 20 }).expect(200);
+
+    expect(Array.isArray(res.body.results)).toBe(true);
+    expect(res.body.results.length).toBe(0);
+  });
+});

--- a/tests/integration/library-query.spec.js
+++ b/tests/integration/library-query.spec.js
@@ -188,6 +188,10 @@ describe('GET /library/query cascade — modern Card Catalog serves matched_via 
   });
 
   test('single-bareword CTA query returns the comp library row with matched_via.source = "cta"', async () => {
+    // 'Bioluminescence' is a CTA-fixture track title that matches no library
+    // artist/album/label by ILIKE, so the primary path returns 0 rows and the
+    // cascade fires; the CTA layer then maps the track back to its parent
+    // comp library row (CTA_LIBRARY_ID) via the curated track→album map.
     const res = await auth.get('/library/query').query({ q: 'Bioluminescence', limit: 10 }).expect(200);
 
     expect(res.body.results).toBeDefined();


### PR DESCRIPTION
Closes #977. Follow-up to #973 (which wired the cascade onto `GET /library/`).

The modern Card Catalog calls `GET /library/query`, which runs its own
field-aware ILIKE primary path in `librarySearchService.searchLibrary`
and never reaches the Track 1 (CTA) + Track 2 (LML `/lookup`) cascade
owned by `libraryService.searchLibraryBothMode`. So even though prod is
running with both `CATALOG_TRACK_SEARCH_*_ENABLED=true`, modern dj-site
showed no chips for `vi scose poise` while classic-experience search did.

## Approach

After the primary `db.execute(dataQuery)` returns 0 rows AND the parsed
query is a single bareword (no `artist:` / `album:` / `label:` qualifier,
no quoted exact, no `NOT`), fall through to:

1. `searchLibraryByCTARaw(q, limit, on_streaming)` — Track 1, gated by `flags.ctaEnabled`
2. on Track 1 0-hit, `searchLibraryByTrackRaw(q, limit)` — Track 2, gated by `flags.discogsEnabled`

Both primitives already return `TaggedLibraryViewEntry[]` (LibraryArtistViewEntry + `matched_via`) and were introduced as reusable building blocks in #973. Genre/format/on_streaming filters and the requested `sort` + `order` apply to the bounded cascade list in-memory before serialization. Cascade fallback is single-page (`page > 0` returns `[]`) so the client doesn't paginate into a bounded list.

With both flags off (the default), the function path is byte-identical to today.

## Trigger detection

Cascade fires when the parsed `SearchCondition[]` is exactly:

```typescript
[{ field: 'all', exact: false, negated: false, ... }]
```

Field-qualified queries like `artist:NonexistentFoo` skip the cascade even on 0-hit — they signal a structured match intent, not a cross-table track lookup.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors on touched files
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 1991 / 1991 pass
- [x] Integration (CI docker stack):
  - `tests/integration/library-query.spec.js` — all 22 pass (17 pre-existing + 5 new BS#977 cascade cases)
  - `tests/integration/library.spec.js` — all 60 pass (no regressions on #972/#973 cascade describes)
  - `tests/integration/library.search-ranking.spec.js` — all 5 pass
- [ ] Once merged + deployed, smoke against prod: `GET /library/query?q=vi+scose+poise` should return `{ results: [{ id: …, matched_via: [{ source: "discogs_release" | "discogs_master", … }] }], total: 1, page: 0, totalPages: 1 }`. Modern Card Catalog chip rendering should turn on automatically (component already wired at `dj-site/src/components/experiences/modern/catalog/Results/Result.tsx:111`).

## Related

- #977 (this fixes)
- #973 (built the reusable `TaggedLibraryViewEntry` + `*Raw` primitives)
- #972 (parent — wired the cascade onto `/library/`)
- Project [Catalog Track Search #30](https://github.com/orgs/WXYC/projects/30)