### PR TITLE
feat(library): resolve rotation Discogs id via LML /lookup on tier-1/2 miss (#986)

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -347,24 +347,26 @@ export interface RotationTrack {
  *
  * Composition for the dj-site rotation entry mode track picker.
  *   1. Resolve the Discogs release id via `getDiscogsReleaseIdByRotationId`,
- *      which reads `rotation.discogs_release_id` (mirrored from tubafrenzy
- *      by jobs/rotation-etl, migration 0077) and falls back to
- *      `library_identity.discogs_release_id` via the `rotation.album_id`
- *      bridge for post-tubafrenzy-turndown rows.
+ *      which walks three tiers: `rotation.discogs_release_id` (mirrored from
+ *      tubafrenzy by jobs/rotation-etl, migration 0077), `library_identity.
+ *      discogs_release_id` via the `rotation.album_id` bridge, and an LML
+ *      `POST /api/v1/lookup` against the rotation row's `(artist_name,
+ *      album_title)` — the substrate matching tubafrenzy's
+ *      `RotationTracklistCache` (#986). Tier-3 results are cached per
+ *      `rotation_id` in the service layer.
  *   2. Fetch the tracklist from LML's `GET /api/v1/discogs/release/{id}`.
  *   3. Project Discogs's per-track `artists` onto the dj-site shape; fall
  *      back to the release-level artist when a track has no per-track credits
  *      (Discogs's normal shape for non-V/A releases).
  *
- * Degrades gracefully: returns 200 + `[]` when the rotation row doesn't exist
- * or when neither the direct column nor the `library_identity` fallback
- * resolves a release id, and when LML 404s the release. Only LML 5xx bubbles
- * up so transient upstream failures surface rather than silently hiding the
- * dropdown.
+ * Degrades gracefully: returns 200 + `[]` when the rotation row doesn't exist,
+ * when all three resolution tiers miss, and when LML 404s the release. Only
+ * LML 5xx bubbles up so transient upstream failures surface rather than
+ * silently hiding the dropdown.
  *
- * No BS-side cache here — LML's 3-tier cache already deduplicates by release id.
- * If load justifies it, extract a shared LRU between this and the `/proxy`
- * sibling.
+ * No controller-side cache on the `/release/{id}` fetch — LML's 3-tier cache
+ * already deduplicates by release id. The tier-3 lookup is cached at the
+ * service layer (keyed by `rotation_id`).
  */
 export const getRotationTracks: RequestHandler<{ rotation_id: string }> = async (req, res) => {
   const rotationId = parseInt(req.params.rotation_id, 10);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -324,19 +324,67 @@ export async function getDiscogsReleaseIdByLegacyId(legacyId: number): Promise<n
 }
 
 /**
+ * Per-rotation_id LRU for the LML `POST /api/v1/lookup` fallback in
+ * `getDiscogsReleaseIdByRotationId`. The dj-site picker is opened many times
+ * per session against a handful of rotation rows; caching avoids restarting
+ * the LML query for each open. Mirrors tubafrenzy's `RotationTracklistCache`
+ * concept (process-local map keyed by rotation id), minus the warm-on-startup
+ * pass.
+ *
+ * Two caches — positive (resolved release id) and negative (LML returned
+ * nothing) — match the artwork/negativeCache pattern in
+ * `apps/backend/controllers/proxy.controller.ts`. lru-cache v11 constrains
+ * value types to non-nullable, so the negative cache stores `true` and uses
+ * key presence as the signal. Negative TTL is shorter so a row that becomes
+ * resolvable (LML catalog improvements, Discogs additions) recovers within
+ * minutes rather than waiting for the process to restart.
+ */
+const ROTATION_LML_LOOKUP_CACHE_MAX = 500;
+const ROTATION_LML_LOOKUP_TTL_POSITIVE_MS = 60 * 60 * 1000;
+const ROTATION_LML_LOOKUP_TTL_NEGATIVE_MS = 10 * 60 * 1000;
+
+const rotationLmlPositiveCache = new LRUCache<number, number>({
+  max: ROTATION_LML_LOOKUP_CACHE_MAX,
+  ttl: ROTATION_LML_LOOKUP_TTL_POSITIVE_MS,
+  ttlAutopurge: true,
+});
+
+const rotationLmlNegativeCache = new LRUCache<number, true>({
+  max: ROTATION_LML_LOOKUP_CACHE_MAX,
+  ttl: ROTATION_LML_LOOKUP_TTL_NEGATIVE_MS,
+  ttlAutopurge: true,
+});
+
+export function __resetRotationLmlLookupCacheForTests(): void {
+  rotationLmlPositiveCache.clear();
+  rotationLmlNegativeCache.clear();
+}
+
+/**
  * Look up the resolved Discogs release id for a rotation row by its id.
  *
- * Reads `rotation.discogs_release_id` (mirrored from tubafrenzy
- * ROTATION_RELEASE.DISCOGS_RELEASE_ID by jobs/rotation-etl) and falls
- * back to `library_identity.discogs_release_id` via the album_id bridge
- * when the rotation row has no direct value. The fallback covers
- * post-tubafrenzy-turndown rows created via dj-site once BS#801 starts
- * populating release-level identity from LML.
+ * Three-tier resolution to match tubafrenzy's `RotationTracklistCache` parity
+ * (see BS#986):
  *
- * Returns null when neither source has a value: rotation row doesn't
- * exist, the rotation row's direct column is NULL and no library_identity
- * row backs the album, or both sources have NULL. The picker degrades to
- * free-text in any of these cases.
+ *   1. `rotation.discogs_release_id` (direct) — mirrored from tubafrenzy
+ *      `ROTATION_RELEASE.DISCOGS_RELEASE_ID` by `jobs/rotation-etl`. Populated
+ *      via the rotation-add form's paste-URL prefill flow. 0/21,563 rows
+ *      carry a value in prod as of 2026-05-21, so tier 1 is the rare path.
+ *   2. `library_identity.discogs_release_id` via the `album_id` bridge
+ *      (fallback) — written by `jobs/library-identity-consumer` (BS#802),
+ *      but the column is structurally NULL today until BS#801 extends LML's
+ *      `bulk-resolve-libraries` contract with release-level resolution.
+ *   3. LML `POST /api/v1/lookup` on `(rotation.artist_name, rotation.album_title)`
+ *      (runtime) — the same `(artist, title)` lookup tubafrenzy's
+ *      `RotationTracklistCache.fetchAndCache` uses. Per-`rotation_id` LRU
+ *      caches positive and negative results.
+ *
+ * Tier 3 keeps the picker working today; tiers 1 and 2 are the substrate
+ * we hand off to once upstreams catch up.
+ *
+ * Returns null when all three tiers miss: rotation row doesn't exist; the
+ * row has no `artist_name` or `album_title`; LML returns no results,
+ * isn't configured, or fails. The picker degrades to free-text.
  *
  * Used by `/library/rotation/:rotation_id/tracks` (BS#940) to compose
  * against LML's `/api/v1/discogs/release/{id}` for the rotation entry
@@ -348,13 +396,72 @@ export async function getDiscogsReleaseIdByRotationId(rotationId: number): Promi
     .select({
       direct: rotation.discogs_release_id,
       fallback: library_identity.discogs_release_id,
+      artist_name: rotation.artist_name,
+      album_title: rotation.album_title,
     })
     .from(rotation)
     .leftJoin(library_identity, eq(library_identity.library_id, rotation.album_id))
     .where(eq(rotation.id, rotationId))
     .limit(1);
   if (!rows[0]) return null;
-  return rows[0].direct ?? rows[0].fallback ?? null;
+
+  const stored = rows[0].direct ?? rows[0].fallback ?? null;
+  if (stored !== null) return stored;
+
+  return resolveRotationDiscogsReleaseViaLml(rotationId, rows[0].artist_name, rows[0].album_title);
+}
+
+/**
+ * Tier-3 of `getDiscogsReleaseIdByRotationId`. Asks LML to identify the
+ * Discogs release for a rotation row's `(artist_name, album_title)` when
+ * the direct column and `library_identity` fallback both miss. Mirrors
+ * tubafrenzy's `RotationTracklistCache.fetchAndCache`, which calls
+ * `LibrarySearchClient.searchDiscogsRelease` → `POST /api/v1/lookup`.
+ *
+ * Caches positive and negative results per `rotation_id`. The negative
+ * TTL is shorter so rows that become resolvable (LML catalog improvements,
+ * Discogs additions) recover within minutes rather than waiting for a
+ * process restart. No DB cache-through here — tubafrenzy's MySQL column
+ * isn't a write target on this path either, and a column-mix between
+ * paste-URL-prefilled and LML-resolved values would muddy provenance.
+ *
+ * Errors are swallowed: the picker should degrade to free-text rather
+ * than 500 the request. The error is logged for Sentry to pick up; the
+ * `lookupMetadata` chokepoint already wraps the call in a span carrying
+ * `lml.cache.*` attributes for trace-explorer drill-down.
+ */
+async function resolveRotationDiscogsReleaseViaLml(
+  rotationId: number,
+  artistName: string | null,
+  albumTitle: string | null
+): Promise<number | null> {
+  if (!artistName || !albumTitle) return null;
+  if (!isLmlConfigured()) return null;
+
+  const cachedPositive = rotationLmlPositiveCache.get(rotationId);
+  if (cachedPositive !== undefined) return cachedPositive;
+  if (rotationLmlNegativeCache.has(rotationId)) return null;
+
+  let releaseId: number | null;
+  try {
+    const response = await lookupMetadata(artistName, albumTitle);
+    releaseId = response.results?.[0]?.artwork?.release_id ?? null;
+  } catch (err) {
+    console.warn(
+      '[library.service] LML /lookup for rotation_id=%d failed; degrading picker to free-text: %s',
+      rotationId,
+      (err as Error).message
+    );
+    return null;
+  }
+
+  if (releaseId !== null) {
+    rotationLmlPositiveCache.set(rotationId, releaseId);
+  } else {
+    rotationLmlNegativeCache.set(rotationId, true);
+  }
+
+  return releaseId;
 }
 
 export const updateOnStreaming = async (id: number, on_streaming: boolean | null) => {

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -49,6 +49,7 @@ import {
   enrichWithArtwork,
   updateArtworkUrl,
   getDiscogsReleaseIdByRotationId,
+  __resetRotationLmlLookupCacheForTests,
 } from '../../../apps/backend/services/library.service';
 import { resetConfig as resetCatalogTrackSearchConfig } from '../../../apps/backend/config/catalogTrackSearch';
 
@@ -2106,6 +2107,176 @@ describe('library.service', () => {
 
       const result = await getDiscogsReleaseIdByRotationId(404);
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getDiscogsReleaseIdByRotationId — tier-3 LML fallback', () => {
+    // Tier 3 mirrors tubafrenzy's RotationTracklistCache parity (BS#986):
+    // when direct + fallback both miss, ask LML `POST /api/v1/lookup` to
+    // identify the release from (artist_name, album_title). Per-rotation_id
+    // LRU caches positive and negative results so the LML chokepoint isn't
+    // hammered on dropdown opens. These tests pin the fall-through, the
+    // cache behavior, the NULL bypasses, and the graceful-degradation
+    // contract (errors return null, don't bubble).
+
+    function mockRow(row: {
+      direct: number | null;
+      fallback: number | null;
+      artist_name: string | null;
+      album_title: string | null;
+    }): void {
+      const chain = createMockQueryChain();
+      db.select.mockReturnValue(chain);
+      chain.limit = jest.fn().mockResolvedValue([row]);
+    }
+
+    beforeEach(() => {
+      __resetRotationLmlLookupCacheForTests();
+      mockLookupMetadata.mockReset();
+      mockIsLmlConfigured.mockReset();
+      mockIsLmlConfigured.mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      db.select.mockReset();
+    });
+
+    it('falls through to LML and returns results[0].artwork.release_id', async () => {
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+      mockLookupMetadata.mockResolvedValue({
+        results: [{ artwork: { release_id: 4080 } }],
+        search_type: 'direct',
+      });
+
+      const result = await getDiscogsReleaseIdByRotationId(42);
+
+      expect(result).toBe(4080);
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield');
+    });
+
+    it('does not call LML when the direct column has a value', async () => {
+      mockRow({ direct: 12345, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+
+      const result = await getDiscogsReleaseIdByRotationId(42);
+
+      expect(result).toBe(12345);
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
+    });
+
+    it('does not call LML when the fallback has a value', async () => {
+      mockRow({ direct: null, fallback: 99, artist_name: 'Autechre', album_title: 'Confield' });
+
+      const result = await getDiscogsReleaseIdByRotationId(42);
+
+      expect(result).toBe(99);
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
+    });
+
+    it('returns null and does not call LML when artist_name is NULL', async () => {
+      mockRow({ direct: null, fallback: null, artist_name: null, album_title: 'Confield' });
+
+      const result = await getDiscogsReleaseIdByRotationId(42);
+
+      expect(result).toBeNull();
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
+    });
+
+    it('returns null and does not call LML when album_title is NULL', async () => {
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: null });
+
+      const result = await getDiscogsReleaseIdByRotationId(42);
+
+      expect(result).toBeNull();
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
+    });
+
+    it('returns null and does not call LML when LIBRARY_METADATA_URL is unconfigured', async () => {
+      mockIsLmlConfigured.mockReturnValue(false);
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+
+      const result = await getDiscogsReleaseIdByRotationId(42);
+
+      expect(result).toBeNull();
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
+    });
+
+    it('returns null and degrades silently when lookupMetadata throws', async () => {
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+      mockLookupMetadata.mockRejectedValue(new Error('LML 504'));
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const result = await getDiscogsReleaseIdByRotationId(42);
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('returns null when LML returns an empty results array (search_type=none)', async () => {
+      mockRow({ direct: null, fallback: null, artist_name: 'Mystery Artist', album_title: 'Unknown' });
+      mockLookupMetadata.mockResolvedValue({ results: [], search_type: 'none' });
+
+      const result = await getDiscogsReleaseIdByRotationId(42);
+
+      expect(result).toBeNull();
+    });
+
+    it('caches positive results so subsequent calls do not hit LML within TTL', async () => {
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+      mockLookupMetadata.mockResolvedValue({
+        results: [{ artwork: { release_id: 4080 } }],
+        search_type: 'direct',
+      });
+
+      const first = await getDiscogsReleaseIdByRotationId(42);
+      expect(first).toBe(4080);
+
+      // The DB read still happens on every call (this is by design — the LRU
+      // only short-circuits the LML query, which is the expensive bit). The
+      // second call reaches the resolver but hits the cache before LML.
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+      const second = await getDiscogsReleaseIdByRotationId(42);
+      expect(second).toBe(4080);
+
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches negative results so an unresolvable row does not hammer LML', async () => {
+      mockRow({ direct: null, fallback: null, artist_name: 'Mystery Artist', album_title: 'Unknown' });
+      mockLookupMetadata.mockResolvedValue({ results: [], search_type: 'none' });
+
+      const first = await getDiscogsReleaseIdByRotationId(42);
+      expect(first).toBeNull();
+
+      mockRow({ direct: null, fallback: null, artist_name: 'Mystery Artist', album_title: 'Unknown' });
+      const second = await getDiscogsReleaseIdByRotationId(42);
+      expect(second).toBeNull();
+
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache transient LML failures so the next call retries', async () => {
+      // A thrown LML error indicates an upstream blip (timeout, 5xx). Caching
+      // null in that case would lock the picker into degraded mode for the
+      // negative TTL window even after LML recovers. The implementation skips
+      // the cache write on the catch arm — pin that here.
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+      mockLookupMetadata.mockRejectedValueOnce(new Error('LML timeout'));
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const first = await getDiscogsReleaseIdByRotationId(42);
+      expect(first).toBeNull();
+
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+      mockLookupMetadata.mockResolvedValueOnce({
+        results: [{ artwork: { release_id: 4080 } }],
+        search_type: 'direct',
+      });
+      const second = await getDiscogsReleaseIdByRotationId(42);
+      expect(second).toBe(4080);
+
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
+      consoleSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
Closes #986.

## Summary

Extends `getDiscogsReleaseIdByRotationId` with a tier-3 LML `POST /api/v1/lookup` fallback on the rotation row's `(artist_name, album_title)` when both the direct `rotation.discogs_release_id` and the `library_identity` fallback are NULL. Per-`rotation_id` LRU caches positive and negative results so the LML chokepoint isn't hammered on picker dropdown opens. Mirrors tubafrenzy's [`RotationTracklistCache.fetchAndCache`](https://github.com/WXYC/tubafrenzy/blob/main/libs/core/src/main/java/org/wxyc/rotation/RotationTracklistCache.java#L65) — the same path the classic-site picker uses.

Without this, `/library/rotation/:rotation_id/tracks` ([#940](https://github.com/WXYC/Backend-Service/issues/940)) returns `[]` for every existing rotation row in prod: `rotation.discogs_release_id` is mirrored from a tubafrenzy column populated on 0/21,563 rows ([verified 2026-05-21](https://github.com/WXYC/Backend-Service/issues/986)), and `library_identity.discogs_release_id` is structurally NULL until [#801](https://github.com/WXYC/Backend-Service/issues/801) extends the LML bulk-resolve contract with release-level resolution.

## Behavior

Three tiers, walked in order:

1. **`rotation.discogs_release_id`** (direct) — covers future paste-URL-prefill adds
2. **`library_identity.discogs_release_id`** via the `album_id` bridge (fallback) — covers post-[#801](https://github.com/WXYC/Backend-Service/issues/801) release-level identity rows
3. **LML `POST /api/v1/lookup`** on `(artist_name, album_title)` (runtime) — covers the present and most post-turndown rows. Cached per `rotation_id`: positive 1 hr, negative 10 min. Two LRUs to match the artwork/negativeCache pattern in `proxy.controller.ts` (lru-cache v11's `V extends {}` constraint forces splitting the null case onto a separate cache).

Errors from `lookupMetadata` (timeouts, 5xx) are swallowed and **not** cached so a transient LML blip doesn't lock the picker into degraded mode for the negative TTL window. LML's `lookupMetadata` already wraps in a Sentry span carrying `lml.cache.*` attributes, so observability lands without per-callsite instrumentation.

No DB cache-through. Tubafrenzy's MySQL column isn't written by this path either, and a mix between paste-URL-prefilled and LML-resolved values in the same column would muddy provenance for a future audit.

## Files

- `apps/backend/services/library.service.ts` — extends SELECT to include `artist_name` + `album_title`, adds the LRU pair + `__resetRotationLmlLookupCacheForTests`, and the `resolveRotationDiscogsReleaseViaLml` helper
- `apps/backend/controllers/library.controller.ts` — JSDoc on `getRotationTracks` updated for the new tier-3 behavior + service-layer cache note
- `tests/unit/services/library.service.test.ts` — adds an 11-case `getDiscogsReleaseIdByRotationId — tier-3 LML fallback` describe block

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — 0 errors (413 pre-existing warnings only)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 2016/2016 pass (11 new assertions for tier-3 fallback, cache, NULL bypass, error-not-cached)
- [x] `npm run build` — green
- [x] `node scripts/validate-migrations.mjs` — passes (no migrations touched)
- [x] `node scripts/check-bulk-update-analyze.mjs` — passes
- [x] `bash scripts/check-precondition-guards.sh` — passes (no migrations touched)
- [ ] CI green
- [ ] Manual Build & Deploy after merge (no migrations; deploy cadence rule doesn't apply)
- [ ] Post-deploy: verify `/library/rotation/<id>/tracks` returns a non-empty array on a Heavy row that was empty before
- [ ] Post-deploy: verify dj-site rotation entry-mode picker shows tracks for a Heavy release in prod
- [ ] Post-deploy: spot-check Sentry trace explorer for `op:http.client name:lml.lookup` spans tied to `/library/rotation/.../tracks` transactions — confirm the per-request cost is what we expect

## Related

- [#984](https://github.com/WXYC/Backend-Service/pull/984) / [#983](https://github.com/WXYC/Backend-Service/issues/983) — added tier 1 (the column + mirror)
- [#940](https://github.com/WXYC/Backend-Service/issues/940) — `/library/rotation/:rotation_id/tracks` endpoint that consumes this
- [#802](https://github.com/WXYC/Backend-Service/issues/802) — `library-identity-consumer` (tier 2's substrate)
- [#801](https://github.com/WXYC/Backend-Service/issues/801) — release-level resolution in LML's bulk-resolve contract (orthogonal; would populate tier 2 over time, reducing tier-3 traffic)
- [#981](https://github.com/WXYC/Backend-Service/issues/981) — consolidate `getDiscogsReleaseIdBy*` siblings (this PR keeps the function intact for the refactor to fold in)
