### PR TITLE
feat(lml): per-call timeout override; tighten rotation picker to 5 s (#992)

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -342,6 +342,16 @@ export async function getDiscogsReleaseIdByLegacyId(legacyId: number): Promise<n
 const ROTATION_LML_LOOKUP_CACHE_MAX = 500;
 const ROTATION_LML_LOOKUP_TTL_POSITIVE_MS = 60 * 60 * 1000;
 const ROTATION_LML_LOOKUP_TTL_NEGATIVE_MS = 10 * 60 * 1000;
+/**
+ * Per-call LML timeout for the picker's tier-3 lookup (BS#992). The default
+ * `TIMEOUT_MS` in the LML client is 30 s — appropriate for fire-and-forget
+ * enrichment paths but unacceptable for a user-visible dropdown that's
+ * already a degrades-to-free-text flow. The shorter budget also frees the
+ * shared LML semaphore permit ~6× sooner so other concurrent callers
+ * (`/proxy/metadata/album`, `/library/query`) aren't queued behind a
+ * single hung tier-3 lookup.
+ */
+const ROTATION_LML_LOOKUP_TIMEOUT_MS = 5000;
 
 const rotationLmlPositiveCache = new LRUCache<number, number>({
   max: ROTATION_LML_LOOKUP_CACHE_MAX,
@@ -425,10 +435,11 @@ export async function getDiscogsReleaseIdByRotationId(rotationId: number): Promi
  * isn't a write target on this path either, and a column-mix between
  * paste-URL-prefilled and LML-resolved values would muddy provenance.
  *
- * Errors are swallowed: the picker should degrade to free-text rather
- * than 500 the request. The error is logged for Sentry to pick up; the
- * `lookupMetadata` chokepoint already wraps the call in a span carrying
- * `lml.cache.*` attributes for trace-explorer drill-down.
+ * Bounded at `ROTATION_LML_LOOKUP_TIMEOUT_MS` (5 s) per call — fast-fail
+ * for the user-visible picker (BS#992). Caller errors are swallowed so
+ * the picker degrades to free-text rather than 500ing; the LML client
+ * already wraps the call in a Sentry span carrying `lml.cache.*` and
+ * `lml.queue_depth` attributes for trace-explorer drill-down.
  */
 async function resolveRotationDiscogsReleaseViaLml(
   rotationId: number,
@@ -444,7 +455,9 @@ async function resolveRotationDiscogsReleaseViaLml(
 
   let releaseId: number | null;
   try {
-    const response = await lookupMetadata(artistName, albumTitle);
+    const response = await lookupMetadata(artistName, albumTitle, undefined, {
+      timeoutMs: ROTATION_LML_LOOKUP_TIMEOUT_MS,
+    });
     releaseId = response.results?.[0]?.artwork?.release_id ?? null;
   } catch (err) {
     console.warn(

--- a/apps/backend/services/lml/lml.client.ts
+++ b/apps/backend/services/lml/lml.client.ts
@@ -228,10 +228,16 @@ function getBaseUrl(): string {
   return url.replace(/\/api\/v1\/?$/, '').replace(/\/$/, '');
 }
 
-async function lmlFetch(path: string, init?: RequestInit): Promise<Response> {
+async function lmlFetch(path: string, init?: RequestInit, timeoutMs?: number): Promise<Response> {
   const url = `${getBaseUrl()}${path}`;
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  // Per-call override lets user-visible read paths (e.g. the rotation tracks
+  // picker, BS#992) fast-fail at a tighter budget than the default 30 s,
+  // freeing the LML semaphore permit sooner so other concurrent callers
+  // don't queue behind a single hung Discogs round-trip. Defaults to
+  // TIMEOUT_MS so existing fire-and-forget callers are unchanged.
+  const effectiveTimeoutMs = timeoutMs ?? TIMEOUT_MS;
+  const timeout = setTimeout(() => controller.abort(), effectiveTimeoutMs);
 
   // Merge LML_API_KEY bearer header at the single chokepoint. LML rolls auth
   // out gradually (LML_REQUIRE_AUTH defaults false on the server), so sending
@@ -287,6 +293,15 @@ async function lmlFetch(path: string, init?: RequestInit): Promise<Response> {
 export interface LookupOptions {
   extended?: boolean;
   warm_cache?: boolean;
+  /**
+   * Per-call override for the LML fetch timeout (ms). Defaults to `TIMEOUT_MS`
+   * (30 s) — appropriate for fire-and-forget enrichment paths where
+   * thoroughness matters and a 30 s socket lifetime is cheap. Set lower for
+   * user-visible request paths where fast-fail beats thoroughness; the
+   * shorter budget also releases the LML semaphore permit sooner, reducing
+   * head-of-line blocking on the shared chokepoint (BS#906 / BS#992).
+   */
+  timeoutMs?: number;
 }
 
 type LookupBody = {
@@ -325,7 +340,7 @@ export async function lookupMetadata(
   if (song) body.song = song;
   if (options?.extended) body.extended = true;
   if (options?.warm_cache) body.warm_cache = true;
-  return postLookup(body);
+  return postLookup(body, options?.timeoutMs);
 }
 
 /**
@@ -349,7 +364,7 @@ export async function lookupBySong(song: string): Promise<LookupResponse> {
  * the metadata-backfill pilot or the runtime hot path. Sibling LML-side
  * projection at WXYC/library-metadata-lookup#213.
  */
-async function postLookup(body: LookupBody): Promise<LookupResponse> {
+async function postLookup(body: LookupBody, timeoutMs?: number): Promise<LookupResponse> {
   // BS#906 / G4: Mirror LML's Discogs ceilings on the client so back-pressure
   // surfaces at the BS chokepoint, not as queueing inside LML. Acquire BEFORE
   // span start so queue-time isn't blamed on http.client duration.
@@ -362,11 +377,15 @@ async function postLookup(body: LookupBody): Promise<LookupResponse> {
       } catch (err) {
         console.warn('lml.client: failed to project queue_depth onto span', err);
       }
-      const response = await lmlFetch('/api/v1/lookup', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
+      const response = await lmlFetch(
+        '/api/v1/lookup',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+        timeoutMs
+      );
 
       const parsed = (await response.json()) as LookupResponse;
 

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -2151,7 +2151,9 @@ describe('library.service', () => {
       const result = await getDiscogsReleaseIdByRotationId(42);
 
       expect(result).toBe(4080);
-      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield');
+      // The picker passes a 5 s budget so a hung LML call doesn't stall the
+      // dropdown for 30 s and tie up the shared LML semaphore permit (BS#992).
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, { timeoutMs: 5000 });
     });
 
     it('does not call LML when the direct column has a value', async () => {

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -141,6 +141,46 @@ describe('lml.client', () => {
       expect(callBody.extended).toBeUndefined();
     });
 
+    it('uses the default 30 s LML timeout when options.timeoutMs is not set', async () => {
+      // The lmlFetch chokepoint sets up a setTimeout to abort the request
+      // after its budget. Spy on it instead of using fake timers — we only
+      // care that the right deadline was scheduled, not that it fires.
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield');
+
+      const lmlTimeoutCalls = setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 30000);
+      expect(lmlTimeoutCalls).toHaveLength(1);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('honors options.timeoutMs as a per-call override (picker fast-fail, BS#992)', async () => {
+      // The rotation tracks picker passes timeoutMs: 5000 so the user-visible
+      // dropdown doesn't burn 30 s on a hung LML call. Pin that the override
+      // reaches the AbortController setTimeout — without this, the option
+      // would silently no-op and tier-3 would inherit the 30 s budget.
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Autechre', 'Confield', undefined, { timeoutMs: 5000 });
+
+      const lmlTimeoutCalls = setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 5000);
+      expect(lmlTimeoutCalls).toHaveLength(1);
+      // Default 30 s timeout should NOT have been scheduled when the override is set.
+      const defaultCalls = setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 30000);
+      expect(defaultCalls).toHaveLength(0);
+      setTimeoutSpy.mockRestore();
+    });
+
     it('omits both option flags from the body when no options are passed', async () => {
       // Read-path callers (request-line, artwork fallback, library
       // services) don't pass options. The body must stay byte-identical


### PR DESCRIPTION
Closes #992.

## Summary

Adds `LookupOptions.timeoutMs` so user-visible LML callers can fast-fail at a tighter budget than the default 30 s. The rotation tracks picker tier-3 lookup (the only user-visible path that ships with this PR) passes a 5 s budget so a hung LML call returns 200 + `[]` in ~5 s instead of 30 s and releases the LML semaphore permit 6× faster — head-of-line blocking on `/proxy/metadata/album` and `/library/query` drops correspondingly.

All existing callers keep the 30 s default unchanged.

## Why

24 h after #987 merged, the picker endpoint is at p95 = 30 s on 181 opens. Only 16 of those (~9%) had successful tier-3 resolutions; the other ~165 either short-circuited via the negative LRU (fast) or **hung for exactly 30 s and returned `[]`** (slow). From the DJ's POV: most picker opens spin for 30 s, then show empty. Free-text degrade is the contract; 30 s of spinner before the degrade is not.

The 30 s ceiling is `TIMEOUT_MS = 30000` in `lml.client.ts`. That budget exists for fire-and-forget enrichment paths (metadata backfill, request-line, artwork providers) — but the picker doesn't fit that mold. See #992 for the full data — same 30 s pattern was already hitting `/proxy/metadata/album` at 217 hits/24 h, predates this PR.

## Behavior

`lmlFetch` accepts an optional third parameter `timeoutMs`. `postLookup` threads it through from `LookupOptions.timeoutMs`. `lookupMetadata` is the public entry point — existing callers (no options, or options without `timeoutMs`) keep the 30 s default; `library.service.ts` `resolveRotationDiscogsReleaseViaLml` passes `{ timeoutMs: 5000 }`.

When the 5 s budget fires, `AbortController` aborts the fetch → `LmlClientError(504)` thrown → caught in `resolveRotationDiscogsReleaseViaLml` → returns `null` → controller returns 200 + `[]`. The semaphore permit is released the moment the abort fires (semaphore `release()` runs in the `finally` arm of `postLookup`), so the next queued caller can proceed immediately.

## Out of scope

- **Caching timeout-induced nulls.** Today errors aren't cached so the picker retries on the next open; with the 5 s budget, that means burning 5 s per retry during sustained LML outages. Worth a follow-up if post-rollout data shows it. Filed mention in #992.
- **Root cause** — why LML is hanging at all. Belongs in the [Post-launch service hardening](https://github.com/orgs/WXYC/projects/32) project; this PR is the cheap UX win that buys time for that work.
- **One-shot warm pass for the 310 active rotation rows.** Would populate the negative LRU offline so picker users don't see any LML latency. Worth filing as a follow-up after this lands.

## Files

- `apps/backend/services/lml/lml.client.ts` — `LookupOptions.timeoutMs` + threading through `lmlFetch` (defaulted to `TIMEOUT_MS` for backward compat)
- `apps/backend/services/library.service.ts` — `ROTATION_LML_LOOKUP_TIMEOUT_MS = 5000` + JSDoc update on `resolveRotationDiscogsReleaseViaLml`
- `tests/unit/services/lml.client.test.ts` — 2 new tests pinning the default + override budgets via `setTimeout` spy
- `tests/unit/services/library.service.test.ts` — existing tier-3 test asserts the picker call passes `{ timeoutMs: 5000 }`

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — 0 errors (413 pre-existing warnings only)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 2018/2018 pass (2 new assertions on the budget propagation, 1 updated to assert the option lands at the callsite)
- [x] `npm run build` — green
- [x] `node scripts/validate-migrations.mjs` — passes (no migrations touched)
- [x] `node scripts/check-bulk-update-analyze.mjs` — passes
- [x] `bash scripts/check-precondition-guards.sh` — passes
- [ ] CI green
- [ ] Manual Build & Deploy after merge (no migrations; deploy cadence rule doesn't apply, but a deploy is needed to roll out the new timeout)
- [ ] Post-deploy: re-check `GET /library/rotation/:rotation_id/tracks` p95 in Sentry. Expect drop from 30 s → ≤ 5 s + lookup latency for tier-3 timeout cases
- [ ] Post-deploy: confirm `/proxy/metadata/album` 30 s hangs *also* drop (semaphore permits free up 6× faster on tier-3 timeouts)

## Related

- [#987](https://github.com/WXYC/Backend-Service/pull/987) — added the tier-3 LML lookup that this PR makes fast-fail
- [#986](https://github.com/WXYC/Backend-Service/issues/986) — picker parity work
- [#906](https://github.com/WXYC/Backend-Service/issues/906) — `lookupSemaphore` + `lookupTokenBucket` introduction (the chokepoint this fix helps)
- [#873](https://github.com/WXYC/Backend-Service/issues/873) / [Post-launch service hardening](https://github.com/orgs/WXYC/projects/32) — upstream root-cause work this defers to
