### PR TITLE
Bump Express server timeout to 35 s so slow LML lookups don't 502

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Key middleware:
 - `errorHandler` — Centralized error handling returning standardized responses
 - Legacy mirror middleware — Syncs flowsheet data to tubafrenzy. Show lifecycle (`startShow`, `endShow`) and entry CRUD (`addEntry`, `updateEntry`) use HTTP REST calls to tubafrenzy's mirror API. `deleteEntry` uses raw SQL via SSH. Show IDs live in two places: an in-memory `showIdMap` (process-local, populated lazily by `cacheShowId`, cleared on process exit) and the persisted `shows.legacy_show_id` column (written alongside the cache after `mirrorCreateShow`). On BS restart the map starts empty; read paths fall back to the persisted column, paying one extra DB round-trip on the first lookup per show.
 
-Server timeout is 5 seconds globally; SSE routes have no timeout. Swagger API docs are served at `/api-docs` from `app.yaml`.
+Server timeout is 35 seconds globally — strictly greater than the LML client's 30 s `AbortController` (`services/lml/lml.client.ts`) so a slow LML lookup's catch path can flush a 200-with-fallback response instead of racing the socket teardown to a CORS-less 502. SSE routes opt out via `res.setTimeout(0)`. Swagger API docs are served at `/api-docs` from `app.yaml`.
 
 ### Auth Server (`apps/auth`)
 

--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -134,7 +134,11 @@ const server = app.listen(port, () => {
   void setupCdcWebSocket(server);
 });
 
-server.setTimeout(30000);
+// Strictly greater than the LML client's 30 s AbortController
+// (`services/lml/lml.client.ts:66`) so a slow LML lookup's catch path can
+// flush a 200-with-fallback response inside the window instead of racing
+// the socket teardown to a CORS-less 502.
+server.setTimeout(35000);
 
 // --- Memory monitoring ---
 


### PR DESCRIPTION
## Summary

The Express server timeout (`apps/backend/app.ts`) was set to **30 s** — exactly equal to the LML client's `AbortController` timeout in `apps/backend/services/lml/lml.client.ts`. When LML hung the full window, the two timers fired in the same tick: the LML client raised `AbortError` and the controller's catch path started constructing a 200-with-fallback response, while the Express socket was being torn down at the same moment. nginx surfaced the dead upstream connection as a 502 with no `Access-Control-Allow-Origin` header, which the browser reported as a "CORS error" on `/proxy/metadata/album`.

This is the BS side of the same incident WXYC/dj-site#583 closed. That PR stopped the flowsheet render path from triggering the race in the first place; this PR makes the race outcome a 200-with-fallback rather than a 502 even when other callers (iOS, OnAirDJ, `AlbumDetailPanel`, the backfill cron, or anything else that touches a slow LML cold path) hit it.

## Change

- `apps/backend/app.ts`: `server.setTimeout(35000)` (was `30000`). 5 s buffer so the LML AbortController fires first, the controller's catch path runs to `res.json(...)`, and the response flushes inside the server window.
- `CLAUDE.md`: corrects the "Server timeout is 5 seconds globally" line, which had been stale since the value moved to 30 s. New wording explains the relationship to the LML client timeout so future readers don't re-introduce the race by lowering one of the two values.

## What this does NOT fix

This addresses the **symptom shape** — clients see 200-with-fallback-URLs instead of 502-no-CORS. It does not fix:

- The underlying slow LML lookups (LML#338 — cold-cache latency, per-caller rate budgets).
- The `flowsheet-metadata-backfill-cron` monopolizing LML's outbound Discogs slots.
- Real-time clients getting cassette/fallback artwork instead of real artwork when LML can't resolve in time. (This is strictly an improvement over the current behavior, where they get a 502 and no artwork at all.)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 413 warnings (all pre-existing)
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] `npm run test:unit` — 2018/2018 pass
- [ ] **Manual after deploy:** trigger a slow `/proxy/metadata/album` (artist+release that misses LML cache; cleanest repro is during a backfill window). Confirm the response is `200` with `Access-Control-Allow-Origin` present, and the JSON body contains the fallback search URLs even when LML returned no artwork.

## Sibling PRs

- WXYC/dj-site#583 — flowsheet read path stops calling `/proxy/metadata/album` (merged).
- Follow-up upstream: WXYC/library-metadata-lookup#338 — LML cold-cache latency + concurrency caps.