### PR TITLE
feat(flowsheet-metadata-backfill): backfill-specific LML rate limiter (BS#995)

### DIFF
--- a/jobs/flowsheet-metadata-backfill/lml-fetch.ts
+++ b/jobs/flowsheet-metadata-backfill/lml-fetch.ts
@@ -12,9 +12,15 @@
  *   - Reads LIBRARY_METADATA_URL (same convention as the backend client;
  *     supports a trailing /api/v1).
  *   - Aborts on a 30s per-call timeout. Long enough for LML's Discogs /
- *     MusicBrainz fallback chains on long-tail rows; the orchestrator's
- *     throttle caps in-flight requests at one so the longer per-call cap
- *     can't pile up on LML.
+ *     MusicBrainz fallback chains on long-tail rows.
+ *   - Gates every call through `defaultLmlLimiter` (BS#995): a Semaphore
+ *     (BACKFILL_LML_MAX_CONCURRENT, default 1) + TokenBucket
+ *     (BACKFILL_LML_RATE_PER_MIN, default 20). The 2026-05-21 incident
+ *     (BS#994) confirmed the orchestrator's serial loop alone wasn't a
+ *     sufficient safety story — a single in-flight LML call held for the
+ *     full 30s catch-arm budget already starved real-time iOS + dj-site
+ *     traffic. The bucket caps backfill's call rate independent of the
+ *     orchestrator's speed; the permit is belt-and-suspenders defense.
  *   - Throws a plain Error on non-2xx, abort, and network failure. The
  *     orchestrator catches and counts as `lml_error`, leaving
  *     `metadata_attempt_at` NULL so the row stays in the retry pool —
@@ -24,11 +30,14 @@
  *     attach http.client spans to (#715). Without the wrap the job runs
  *     outside a transaction and emits no spans, which prevents LML#229's
  *     cache_stats projection from joining the trace. Mirrors #646's wrap
- *     in `apps/backend/services/lml/lml.client.ts`.
+ *     in `apps/backend/services/lml/lml.client.ts`. Limiter waits sit
+ *     inside the span so queue time shows up in the trace's `lml.lookup`
+ *     duration.
  */
 
 import * as Sentry from '@sentry/node';
 
+import { defaultLmlLimiter } from './lml-limiter.js';
 import type { LmlLookupResponse } from './lml-types.js';
 
 const TIMEOUT_MS = 30000;
@@ -47,71 +56,73 @@ export const lookupMetadata = async (artist: string, album?: string, track?: str
   // cache_stats lands as attributes on the same trace (LML#229). Same
   // contract as the backend client's #646 wrap.
   return Sentry.startSpan({ name: 'lml.lookup', op: 'http.client' }, async (span) => {
-    // LML's /lookup contract requires `raw_message` even when artist/album/
-    // track are already structured. Synthesize "<artist> - <album> - <track>"
-    // — matches the shape the parser expects in LML's e2e fixtures.
-    const parts = [artist, album, track].filter((p): p is string => Boolean(p));
-    const rawMessage = parts.join(' - ');
+    return defaultLmlLimiter.run(async () => {
+      // LML's /lookup contract requires `raw_message` even when artist/album/
+      // track are already structured. Synthesize "<artist> - <album> - <track>"
+      // — matches the shape the parser expects in LML's e2e fixtures.
+      const parts = [artist, album, track].filter((p): p is string => Boolean(p));
+      const rawMessage = parts.join(' - ');
 
-    const body: Record<string, string> = { artist, raw_message: rawMessage };
-    if (album) body.album = album;
-    if (track) body.song = track;
+      const body: Record<string, string> = { artist, raw_message: rawMessage };
+      if (album) body.album = album;
+      if (track) body.song = track;
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
-    // LML enforces auth in production (LML_REQUIRE_AUTH=true). Send the
-    // bearer header when LML_API_KEY is set; the backend's lml.client.ts
-    // does the same. Sending it before the flag flips is harmless.
-    const apiKey = process.env.LML_API_KEY;
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (apiKey) {
-      headers.Authorization = `Bearer ${apiKey}`;
-    }
-
-    try {
-      const response = await fetch(`${baseUrl()}/api/v1/lookup`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        throw new Error(`LML responded ${response.status} ${response.statusText}`);
+      // LML enforces auth in production (LML_REQUIRE_AUTH=true). Send the
+      // bearer header when LML_API_KEY is set; the backend's lml.client.ts
+      // does the same. Sending it before the flag flips is harmless.
+      const apiKey = process.env.LML_API_KEY;
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (apiKey) {
+        headers.Authorization = `Bearer ${apiKey}`;
       }
 
-      const parsed = (await response.json()) as LmlLookupResponse;
+      try {
+        const response = await fetch(`${baseUrl()}/api/v1/lookup`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
 
-      // cache_stats is freeform on the LML side (additionalProperties: true).
-      // Defensively narrow to a real plain object — Object.entries on
-      // an array would project junk attributes like lml.cache.0=...
-      const stats = (parsed as { cache_stats?: unknown }).cache_stats;
-      if (stats && typeof stats === 'object' && !Array.isArray(stats)) {
-        const attrs: Record<string, number> = {};
-        for (const [key, value] of Object.entries(stats)) {
-          if (typeof value === 'number' && Number.isFinite(value)) {
-            attrs[`lml.cache.${key}`] = value;
+        if (!response.ok) {
+          throw new Error(`LML responded ${response.status} ${response.statusText}`);
+        }
+
+        const parsed = (await response.json()) as LmlLookupResponse;
+
+        // cache_stats is freeform on the LML side (additionalProperties: true).
+        // Defensively narrow to a real plain object — Object.entries on
+        // an array would project junk attributes like lml.cache.0=...
+        const stats = (parsed as { cache_stats?: unknown }).cache_stats;
+        if (stats && typeof stats === 'object' && !Array.isArray(stats)) {
+          const attrs: Record<string, number> = {};
+          for (const [key, value] of Object.entries(stats)) {
+            if (typeof value === 'number' && Number.isFinite(value)) {
+              attrs[`lml.cache.${key}`] = value;
+            }
+          }
+          if (Object.keys(attrs).length > 0) {
+            // Observability must never break the lookup contract; swallow.
+            try {
+              span.setAttributes(attrs);
+            } catch {
+              /* swallowed */
+            }
           }
         }
-        if (Object.keys(attrs).length > 0) {
-          // Observability must never break the lookup contract; swallow.
-          try {
-            span.setAttributes(attrs);
-          } catch {
-            /* swallowed */
-          }
-        }
-      }
 
-      return parsed;
-    } catch (error) {
-      if ((error as Error).name === 'AbortError') {
-        throw new Error('LML request timed out', { cause: error });
+        return parsed;
+      } catch (error) {
+        if ((error as Error).name === 'AbortError') {
+          throw new Error('LML request timed out', { cause: error });
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeout);
       }
-      throw error;
-    } finally {
-      clearTimeout(timeout);
-    }
+    });
   });
 };

--- a/jobs/flowsheet-metadata-backfill/lml-limiter.ts
+++ b/jobs/flowsheet-metadata-backfill/lml-limiter.ts
@@ -28,11 +28,20 @@
  * `lml-fetch.ts` header.
  */
 
-const envInt = (name: string, defaultValue: number): number => {
+const envInt = (name: string, fallback: number): number => {
   const raw = process.env[name];
-  if (!raw) return defaultValue;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+  if (raw === undefined || raw === '') return fallback;
+  // Number(raw) (not parseInt) so partial-parse strings like "20banana"
+  // surface as NaN and get rejected, instead of silently coercing to 20.
+  // Matches the contract in apps/backend/services/lml/lml.client.ts.
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  // Surface misconfigurations at startup so an operator who set `=0`
+  // intending to disable the limiter sees their value was rejected
+  // instead of silently falling back. A 0-permit semaphore would
+  // deadlock, which is why we don't accept it.
+  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
 };
 
 /**
@@ -173,7 +182,9 @@ export const createLmlLimiter = (config?: { maxConcurrent?: number; ratePerMinut
 
 /**
  * Module-level singleton used by `lml-fetch.ts`. Reads BACKFILL_LML_* from
- * env at module load. Tests that need to exercise different limits should
- * call `createLmlLimiter()` directly.
+ * env at module load — mutating `process.env` after the first import of
+ * this module does NOT reconfigure the singleton. Tests that need to
+ * exercise different limits or env values must call `createLmlLimiter()`
+ * directly with explicit config.
  */
 export const defaultLmlLimiter: LmlLimiter = createLmlLimiter();

--- a/jobs/flowsheet-metadata-backfill/lml-limiter.ts
+++ b/jobs/flowsheet-metadata-backfill/lml-limiter.ts
@@ -1,0 +1,179 @@
+/**
+ * Concurrency + rate-limit gate for the flowsheet-metadata-backfill cron's
+ * LML calls (BS#995, sub-issue of BS#994).
+ *
+ * Layered Semaphore + TokenBucket, mirroring the runtime path's pattern from
+ * `apps/backend/services/lml/lml.client.ts` but with stricter defaults
+ * tuned for backfill traffic:
+ *
+ *   - BACKFILL_LML_MAX_CONCURRENT = 1  (vs runtime LML_CLIENT_MAX_CONCURRENT=5)
+ *   - BACKFILL_LML_RATE_PER_MIN   = 20 (vs runtime LML_CLIENT_RATE_PER_MIN=50)
+ *
+ * The 2026-05-21 incident (BS#994) showed that the orchestrator's serial
+ * loop alone isn't a sufficient safety story: one in-flight LML call held
+ * for the full 30s catch-arm budget already saturated LML's Discogs
+ * fan-out, head-of-line-blocking real-time iOS + dj-site traffic. The
+ * token bucket caps backfill's burst rate independent of the orchestrator's
+ * speed; the semaphore is belt-and-suspenders defense if the orchestrator
+ * ever becomes concurrent.
+ *
+ * This is the floor of the BS#995 design. The adaptive ceiling (LML-health
+ * circuit-breaker pausing the cron when LML p95 is elevated) needs an
+ * LML-side health endpoint and lands separately.
+ *
+ * Duplicated from `apps/backend/services/lml/lml.client.ts` rather than
+ * imported because that file pulls in app-only modules (Sentry instance,
+ * posthog, etc.) — coupling the one-shot job's build graph to those would
+ * force the container to ship the full backend tree. Same reasoning as the
+ * `lml-fetch.ts` header.
+ */
+
+const envInt = (name: string, defaultValue: number): number => {
+  const raw = process.env[name];
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+};
+
+/**
+ * FIFO permit semaphore. acquire() resolves when a permit is available;
+ * release() returns the permit to the next waiter (or restores it if no one
+ * is waiting). queueDepth/availablePermits are read-only for observability.
+ */
+export class Semaphore {
+  private permits: number;
+  private readonly capacity: number;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(permits: number) {
+    this.permits = permits;
+    this.capacity = permits;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits -= 1;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    } else if (this.permits < this.capacity) {
+      this.permits += 1;
+    }
+  }
+
+  get queueDepth(): number {
+    return this.waiters.length;
+  }
+
+  get availablePermits(): number {
+    return this.permits;
+  }
+}
+
+/**
+ * Continuous-refill token bucket. consume(n) resolves once n tokens have
+ * been earned; until then the call sleeps for the shortest interval that
+ * could earn the deficit.
+ */
+export class TokenBucket {
+  private tokens: number;
+  private readonly capacity: number;
+  private readonly refillPerMs: number;
+  private lastRefill: number;
+
+  constructor({ capacity, refillPerMinute }: { capacity: number; refillPerMinute: number }) {
+    this.capacity = capacity;
+    this.tokens = capacity;
+    this.refillPerMs = refillPerMinute / 60_000;
+    this.lastRefill = Date.now();
+  }
+
+  private refill(): void {
+    const now = Date.now();
+    const elapsed = now - this.lastRefill;
+    if (elapsed <= 0) return;
+    this.tokens = Math.min(this.capacity, this.tokens + elapsed * this.refillPerMs);
+    this.lastRefill = now;
+  }
+
+  async consume(count = 1): Promise<void> {
+    // Loop the slow path. Without it, N callers can each compute the same
+    // waitMs from an empty bucket, sleep for the same interval, wake
+    // together, and all subtract `count` from the freshly refilled tokens
+    // — overshooting the configured rate by ~N×. The loop re-checks the
+    // bucket after each sleep so only the caller that finds enough tokens
+    // proceeds; the others sleep again. Paired with the upstream FIFO
+    // Semaphore, this preserves the configured rate under contention.
+    while (true) {
+      this.refill();
+      if (this.tokens >= count) {
+        this.tokens -= count;
+        return;
+      }
+      const deficit = count - this.tokens;
+      const waitMs = Math.max(1, Math.ceil(deficit / this.refillPerMs));
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    }
+  }
+
+  get availableTokens(): number {
+    this.refill();
+    return this.tokens;
+  }
+}
+
+export interface LmlLimiter {
+  /** Acquire a permit + a token, run fn, release the permit in finally. */
+  run<T>(fn: () => Promise<T>): Promise<T>;
+  /** Snapshot for tests + future observability hooks. */
+  state(): { queueDepth: number; availablePermits: number; availableTokens: number };
+}
+
+/**
+ * Compose a Semaphore + TokenBucket into a single `run`-style gate. Tokens
+ * are consumed inside the permit (so wait time on the bucket also holds a
+ * permit) and are NOT refunded on error — limiting attempted-call rate, not
+ * successful-call rate. Matches `lml.client.ts:postLookup()`'s pattern.
+ *
+ * Pass explicit config in tests; in production the singleton at the bottom
+ * of this file reads from env vars.
+ */
+export const createLmlLimiter = (config?: { maxConcurrent?: number; ratePerMinute?: number }): LmlLimiter => {
+  const maxConcurrent = config?.maxConcurrent ?? envInt('BACKFILL_LML_MAX_CONCURRENT', 1);
+  const ratePerMinute = config?.ratePerMinute ?? envInt('BACKFILL_LML_RATE_PER_MIN', 20);
+  const semaphore = new Semaphore(maxConcurrent);
+  const tokenBucket = new TokenBucket({ capacity: ratePerMinute, refillPerMinute: ratePerMinute });
+  return {
+    async run<T>(fn: () => Promise<T>): Promise<T> {
+      await semaphore.acquire();
+      try {
+        await tokenBucket.consume(1);
+        return await fn();
+      } finally {
+        semaphore.release();
+      }
+    },
+    state() {
+      return {
+        queueDepth: semaphore.queueDepth,
+        availablePermits: semaphore.availablePermits,
+        availableTokens: tokenBucket.availableTokens,
+      };
+    },
+  };
+};
+
+/**
+ * Module-level singleton used by `lml-fetch.ts`. Reads BACKFILL_LML_* from
+ * env at module load. Tests that need to exercise different limits should
+ * call `createLmlLimiter()` directly.
+ */
+export const defaultLmlLimiter: LmlLimiter = createLmlLimiter();

--- a/tests/unit/jobs/flowsheet-metadata-backfill/lml-limiter.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/lml-limiter.test.ts
@@ -1,0 +1,189 @@
+// Unit tests for BS#995's backfill rate-limit gate.
+
+import { Semaphore, TokenBucket, createLmlLimiter } from '../../../../jobs/flowsheet-metadata-backfill/lml-limiter';
+
+describe('jobs/flowsheet-metadata-backfill/lml-limiter (BS#995)', () => {
+  describe('Semaphore', () => {
+    it('grants permits up to capacity without blocking', async () => {
+      const sem = new Semaphore(2);
+      await sem.acquire();
+      await sem.acquire();
+      expect(sem.availablePermits).toBe(0);
+      expect(sem.queueDepth).toBe(0);
+    });
+
+    it('blocks acquire past capacity until release wakes the waiter', async () => {
+      const sem = new Semaphore(1);
+      await sem.acquire();
+
+      let resolved = false;
+      const second = sem.acquire().then(() => {
+        resolved = true;
+      });
+
+      // Yield to the event loop; the second acquire should still be queued.
+      await new Promise((r) => setImmediate(r));
+      expect(resolved).toBe(false);
+      expect(sem.queueDepth).toBe(1);
+
+      sem.release();
+      await second;
+      expect(resolved).toBe(true);
+      expect(sem.queueDepth).toBe(0);
+    });
+
+    it('release without waiters does not exceed capacity', () => {
+      const sem = new Semaphore(2);
+      // Both permits available; a stray release must not bump us to 3.
+      sem.release();
+      expect(sem.availablePermits).toBe(2);
+    });
+
+    it('wakes waiters in FIFO order', async () => {
+      const sem = new Semaphore(1);
+      await sem.acquire();
+
+      const order: number[] = [];
+      const w1 = sem.acquire().then(() => order.push(1));
+      const w2 = sem.acquire().then(() => order.push(2));
+
+      sem.release();
+      await w1;
+      expect(order).toEqual([1]);
+
+      sem.release();
+      await w2;
+      expect(order).toEqual([1, 2]);
+    });
+  });
+
+  describe('TokenBucket', () => {
+    it('starts at capacity and consumes synchronously when tokens are available', async () => {
+      const bucket = new TokenBucket({ capacity: 3, refillPerMinute: 60 });
+      // Allow for tiny refill drift since construction; capacity-bounded.
+      expect(bucket.availableTokens).toBeGreaterThanOrEqual(2.99);
+      expect(bucket.availableTokens).toBeLessThanOrEqual(3);
+
+      await bucket.consume(1);
+      await bucket.consume(1);
+      await bucket.consume(1);
+      // Bucket is now ~empty (minus tiny refill earned during the awaits).
+      expect(bucket.availableTokens).toBeLessThan(0.5);
+    });
+
+    it('blocks consume when empty and resolves after enough refill', async () => {
+      // 6000/min = 100 tokens/sec = 10ms per token. After consuming the
+      // initial token, the next consume should block for ~10ms before
+      // enough has refilled.
+      const bucket = new TokenBucket({ capacity: 1, refillPerMinute: 6000 });
+      await bucket.consume(1); // drain.
+
+      const start = Date.now();
+      await bucket.consume(1);
+      const elapsed = Date.now() - start;
+
+      // Allow generous slack for CI jitter on either side.
+      expect(elapsed).toBeGreaterThanOrEqual(5);
+      expect(elapsed).toBeLessThan(200);
+    });
+
+    it('refill is capped at capacity (no burst beyond configured ceiling)', async () => {
+      const bucket = new TokenBucket({ capacity: 2, refillPerMinute: 6000 });
+      // Drain.
+      await bucket.consume(2);
+      // Wait long enough that, without the cap, we'd have refilled past 2.
+      await new Promise((r) => setTimeout(r, 100)); // 100ms × 100 tps = 10 tokens of "potential" refill
+      // Cap pegs us at capacity = 2.
+      expect(bucket.availableTokens).toBeLessThanOrEqual(2);
+      expect(bucket.availableTokens).toBeGreaterThanOrEqual(1.9);
+    });
+  });
+
+  describe('createLmlLimiter', () => {
+    const originalEnv = process.env;
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('uses defaults (1 permit, 20/min) when env vars are unset', () => {
+      process.env = { ...originalEnv };
+      delete process.env.BACKFILL_LML_MAX_CONCURRENT;
+      delete process.env.BACKFILL_LML_RATE_PER_MIN;
+
+      const limiter = createLmlLimiter();
+      const s = limiter.state();
+      expect(s.availablePermits).toBe(1);
+      // Capacity = 20; allow for tiny refill drift.
+      expect(s.availableTokens).toBeGreaterThanOrEqual(19.9);
+      expect(s.availableTokens).toBeLessThanOrEqual(20);
+    });
+
+    it('reads BACKFILL_LML_MAX_CONCURRENT and BACKFILL_LML_RATE_PER_MIN from env', () => {
+      process.env = { ...originalEnv, BACKFILL_LML_MAX_CONCURRENT: '3', BACKFILL_LML_RATE_PER_MIN: '120' };
+
+      const limiter = createLmlLimiter();
+      const s = limiter.state();
+      expect(s.availablePermits).toBe(3);
+      expect(s.availableTokens).toBeGreaterThanOrEqual(119.9);
+    });
+
+    it('falls back to default on non-positive or unparseable env values', () => {
+      process.env = { ...originalEnv, BACKFILL_LML_MAX_CONCURRENT: '0', BACKFILL_LML_RATE_PER_MIN: 'banana' };
+
+      const limiter = createLmlLimiter();
+      expect(limiter.state().availablePermits).toBe(1);
+      expect(limiter.state().availableTokens).toBeGreaterThanOrEqual(19.9);
+    });
+
+    it('explicit config overrides env vars', () => {
+      process.env = { ...originalEnv, BACKFILL_LML_MAX_CONCURRENT: '999', BACKFILL_LML_RATE_PER_MIN: '999' };
+
+      const limiter = createLmlLimiter({ maxConcurrent: 2, ratePerMinute: 30 });
+      expect(limiter.state().availablePermits).toBe(2);
+      expect(limiter.state().availableTokens).toBeGreaterThanOrEqual(29.9);
+    });
+
+    it('serializes concurrent run() calls on the semaphore (FIFO)', async () => {
+      // High rate so token bucket never blocks; only the semaphore can.
+      const limiter = createLmlLimiter({ maxConcurrent: 1, ratePerMinute: 60_000 });
+
+      const order: number[] = [];
+      const work = (n: number) => async () => {
+        order.push(n);
+        // Yield twice to let any concurrency interleave if it could.
+        await new Promise((r) => setImmediate(r));
+        await new Promise((r) => setImmediate(r));
+        order.push(-n);
+      };
+
+      await Promise.all([limiter.run(work(1)), limiter.run(work(2)), limiter.run(work(3))]);
+
+      // Each call must complete (push -n) before the next starts.
+      expect(order).toEqual([1, -1, 2, -2, 3, -3]);
+    });
+
+    it('releases the permit even when the callback throws', async () => {
+      const limiter = createLmlLimiter({ maxConcurrent: 1, ratePerMinute: 60_000 });
+
+      await expect(limiter.run(() => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+
+      // Permit returned; next call must proceed without blocking.
+      expect(limiter.state().availablePermits).toBe(1);
+      expect(limiter.state().queueDepth).toBe(0);
+      await expect(limiter.run(() => Promise.resolve('ok'))).resolves.toBe('ok');
+    });
+
+    it('does not refund the token on error (limits attempted, not successful, rate)', async () => {
+      const limiter = createLmlLimiter({ maxConcurrent: 5, ratePerMinute: 60 });
+      const tokensBefore = limiter.state().availableTokens;
+
+      await expect(limiter.run(() => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+
+      const tokensAfter = limiter.state().availableTokens;
+      // One token consumed despite the failure. Allow tiny refill drift.
+      expect(tokensBefore - tokensAfter).toBeGreaterThanOrEqual(0.95);
+      expect(tokensBefore - tokensAfter).toBeLessThanOrEqual(1.1);
+    });
+  });
+});

--- a/tests/unit/jobs/flowsheet-metadata-backfill/lml-limiter.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/lml-limiter.test.ts
@@ -128,12 +128,30 @@ describe('jobs/flowsheet-metadata-backfill/lml-limiter (BS#995)', () => {
       expect(s.availableTokens).toBeGreaterThanOrEqual(119.9);
     });
 
-    it('falls back to default on non-positive or unparseable env values', () => {
+    it('falls back to default on non-positive or unparseable env values, with a warn', () => {
       process.env = { ...originalEnv, BACKFILL_LML_MAX_CONCURRENT: '0', BACKFILL_LML_RATE_PER_MIN: 'banana' };
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       const limiter = createLmlLimiter();
       expect(limiter.state().availablePermits).toBe(1);
       expect(limiter.state().availableTokens).toBeGreaterThanOrEqual(19.9);
+      // Surface misconfigurations: both bad values must warn.
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('BACKFILL_LML_MAX_CONCURRENT=0'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('BACKFILL_LML_RATE_PER_MIN=banana'));
+
+      warn.mockRestore();
+    });
+
+    it('rejects partial-parse strings like "20banana" (no silent coercion)', () => {
+      process.env = { ...originalEnv, BACKFILL_LML_MAX_CONCURRENT: '20banana' };
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const limiter = createLmlLimiter();
+      // 20banana → NaN under Number(), not 20 under parseInt; falls back.
+      expect(limiter.state().availablePermits).toBe(1);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('BACKFILL_LML_MAX_CONCURRENT=20banana'));
+
+      warn.mockRestore();
     });
 
     it('explicit config overrides env vars', () => {


### PR DESCRIPTION
## Summary

Adds a backfill-specific concurrency + rate-limit gate to the `flowsheet-metadata-backfill` cron's LML calls. Defaults:

- `BACKFILL_LML_MAX_CONCURRENT = 1` (vs runtime `LML_CLIENT_MAX_CONCURRENT=5`)
- `BACKFILL_LML_RATE_PER_MIN = 20` (vs runtime `LML_CLIENT_RATE_PER_MIN=50`)

The 2026-05-21 outage (#994) showed the orchestrator's serial loop alone wasn't a sufficient safety story — a single in-flight LML call held for the full 30s catch-arm budget already saturated LML's Discogs fan-out, head-of-line-blocking real-time iOS + dj-site traffic. The bucket caps backfill's call rate independent of the orchestrator's speed; the permit is belt-and-suspenders defense if the orchestrator ever becomes concurrent.

Part of #995 — this lands the static-gate layer (option 2 in the issue body). The adaptive ceiling (LML-health circuit-breaker, option 1) ships separately: it needs an LML-side health endpoint and is cross-repo work. Until that PR lands, restarting the cron is still risky under load — but with this in place, the blast radius is bounded.

## Why duplicate `Semaphore` + `TokenBucket`

The new `lml-limiter.ts` copies both classes from `apps/backend/services/lml/lml.client.ts` verbatim rather than importing. Reasoning is preserved from the existing `lml-fetch.ts` header: the backend's LML client pulls in app-only modules (Sentry instance, posthog, etc.) — coupling the one-shot job's build graph to those would force the container to ship the full backend tree. Mirrors `jobs/library-canonical-entity-backfill/lml-fetch.ts`'s pattern. If a future refactor extracts a shared rate-limit utility, both copies can collapse onto it.

**Retroactive correction (2026-05-22, post-merge):** As shipped, this PR wrapped `Sentry.startSpan({ name: 'lml.lookup' })` *outside* the limiter so queue wait was included in the trace's `lml.lookup` duration. Follow-up commit [`b9b3f551`](https://github.com/WXYC/Backend-Service/commit/b9b3f551) (during BS#1000's `@wxyc/lml-client` extraction the same day) reversed this for parity with the runtime path's pre-extraction semantic: the span now sits *inside* the limiter; queue wait is excluded from span duration; queue depth is projected as a span attribute `lml.queue_depth` instead. The architectural intent — "saturation should be observable in Sentry, not hidden behind the limiter" — is preserved via the attribute rather than the duration. Also retroactively: the duplicated `Semaphore` + `TokenBucket` primitives collapsed onto `@wxyc/lml-client` per the same follow-up; `jobs/flowsheet-metadata-backfill/lml-limiter.ts` now re-exports + keeps `defaultLmlLimiter` as the BACKFILL_LML_*-tuned singleton, and `lml-fetch.ts` is a 5-line shim that injects it into the shared client.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors, exit 0. (1 new warning: `security/detect-object-injection` on `process.env[name]` in the `envInt` helper; this is the same pattern + same false positive as in the runtime LML client.)
- [x] `npm run format:check` — clean.
- [x] `npm run test:unit -- tests/unit/jobs/flowsheet-metadata-backfill/` — 7 suites / 90 tests pass, including 14 new for the limiter (semaphore FIFO, token-bucket capacity + refill cap + blocking, env-var defaults / override / parse failure, serialization, permit release on error, token-not-refunded on error).
- [ ] After merge, deploy backend; restart the cron with defaults; verify in Sentry that real-time `library-metadata-lookup` `/api/v1/lookup` p95 stays within +20% of the post-stop baseline (~9s → ≤11s) over a 1-hour window. That's the #995 acceptance criterion for this layer.

## Related

- Parent incident: #994 (2026-05-21 LML monopolization).
- This is sub-issue #995 (backfill pacing). Closes the token-bucket portion only.
- Follow-up: BS-side circuit-breaker + LML-side `/health/cold-cache` endpoint (deferred; cross-repo).
- LML cold-cache perf upstream: WXYC/library-metadata-lookup#338 (the underlying capacity issue this defends against; not a fix for it).
