### PR TITLE
fix(metadata): coerce Discogs release_year=0 to undefined

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -242,7 +242,10 @@ function populateReleaseMetadata(
     artwork_url?: string | null;
   }
 ): void {
-  metadata.releaseYear = release.year ?? undefined;
+  // Discogs returns 0 as "year unknown"; coerce to undefined so it doesn't
+  // leak to iOS as a literal "0" on the playcut detail view. Mirrors the
+  // chokepoint in `metadata.service.ts#extractAlbumMetadata`. #1002.
+  metadata.releaseYear = release.year || undefined;
   metadata.genres = release.genres && release.genres.length > 0 ? release.genres : undefined;
   metadata.styles = release.styles && release.styles.length > 0 ? release.styles : undefined;
   metadata.label = release.label ?? undefined;

--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -111,7 +111,10 @@ function extractAlbumMetadata(artwork: DiscogsMatchResult): AlbumMetadataResult 
     discogsReleaseId: artwork.release_id,
     discogsUrl: artwork.release_url,
     artworkUrl: filterSpacerGif(artwork.artwork_url),
-    releaseYear: artwork.release_year ?? undefined,
+    // Discogs returns 0 as "year unknown"; coerce to undefined so it doesn't
+    // leak to iOS as a literal "0" or persist as 0 in flowsheet.release_year.
+    // #1002.
+    releaseYear: artwork.release_year || undefined,
     spotifyUrl: artwork.spotify_url ?? undefined,
     appleMusicUrl: artwork.apple_music_url ?? undefined,
     youtubeMusicUrl: artwork.youtube_music_url ?? undefined,

--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -149,7 +149,11 @@ export const applyEnrichment = async (row: EnrichRow, response: LookupResponse):
       .set({
         artwork_url: filterSpacerGif(artwork.artwork_url),
         discogs_url: artwork.release_url ?? null,
-        release_year: artwork.release_year ?? null,
+        // Discogs returns 0 as "year unknown"; coerce to null so the column
+        // doesn't carry a sentinel that iOS renders as literal "0". Mirrors
+        // the runtime path in `metadata.service.ts#extractAlbumMetadata`.
+        // #1002.
+        release_year: artwork.release_year || null,
         spotify_url: artwork.spotify_url ?? null,
         apple_music_url: artwork.apple_music_url ?? null,
         // Streaming search URLs: prefer LML's, fall back to synthesized.

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -680,6 +680,57 @@ describe('proxy.controller', () => {
         expect(result.discogsReleaseId).toBe(7777);
         expect(result.label).toBe('Drag City');
       });
+
+      it('coerces Discogs release_year=0 sentinel to undefined (#1002)', async () => {
+        // Discogs returns 0 when a release has no verified year. The iOS
+        // playcut detail view renders this as "Release year: 0" if the
+        // proxy passes it through. Mirrors the chokepoint in
+        // `metadata.service.ts#extractAlbumMetadata`.
+        mockLookupMetadata.mockResolvedValue({
+          results: [
+            {
+              library_item: {
+                id: 1,
+                title: 'DOGA',
+                artist: 'Juana Molina',
+                call_number: 'Rock CD MOL 1/1',
+                library_url: '',
+              },
+              artwork: {
+                release_id: 8888,
+                release_url: 'https://www.discogs.com/release/8888',
+                artwork_url: 'https://i.discogs.com/art.jpg',
+                album: 'DOGA',
+                artist: 'Juana Molina',
+                confidence: 0.93,
+                release_year: 0,
+                discogs_artist_id: 4444,
+                tracklist: [],
+                genres: ['Rock'],
+                styles: [],
+                label: 'Sonamos',
+                full_release_date: null,
+              },
+            },
+          ],
+          search_type: 'direct',
+          song_not_found: false,
+          found_on_compilation: false,
+        });
+
+        const req = {
+          query: { artistName: 'Juana Molina', releaseTitle: 'DOGA' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect(result.releaseYear).toBeUndefined();
+        // Other release fields still preserved.
+        expect(result.discogsReleaseId).toBe(8888);
+        expect(result.label).toBe('Sonamos');
+      });
     });
   });
 

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -246,4 +246,21 @@ describe('metadata.service', () => {
 
     expect(result?.album?.artworkUrl).toBe('https://i.discogs.com/art.jpg');
   });
+
+  it('coerces Discogs release_year=0 sentinel to undefined (#1002)', async () => {
+    // Discogs returns 0 when a release has no verified year. Passing it through
+    // as a literal 0 leaks to the iOS playcut detail view as "Release year: 0"
+    // and persists as 0 in flowsheet.release_year. Year 0 has no real-world
+    // music-release meaning, so the chokepoint coerces it to undefined.
+    const responseYearZero = structuredClone(lookupResponseWithResults);
+    responseYearZero.results[0].artwork.release_year = 0;
+    mockLookupMetadata.mockResolvedValue(responseYearZero);
+
+    const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
+
+    expect(result?.album?.releaseYear).toBeUndefined();
+    // Other album metadata is preserved — the coercion only nulls releaseYear.
+    expect(result?.album?.discogsReleaseId).toBe(12345);
+    expect(result?.album?.artworkUrl).toBe('https://i.discogs.com/art.jpg');
+  });
 });


### PR DESCRIPTION
## Summary

- `extractAlbumMetadata` and the historical-drain `applyEnrichment` were using `??` to fall back from `null/undefined` to `undefined/null`, but Discogs returns `0` as a "year unknown" sentinel that `??` doesn't catch. Switched to `||` at both call sites so year 0 (which has no real-world music-release meaning anyway) drops to the right empty value at the chokepoint instead of leaking to iOS as literal "0" or persisting as 0 in `flowsheet.release_year`.
- New unit test mirrors the existing #649 `spacer.gif` coverage pattern.

## Blast radius

11,824 existing prod rows have `release_year = 0` today. After this lands, run the one-shot:

```sql
UPDATE wxyc_schema.flowsheet SET release_year = NULL WHERE release_year = 0;
```

…to clean those up. Single statement; the schema doesn't change.

## Test plan

- [x] New unit test in `tests/unit/services/metadata.service.test.ts` for the year-0 coercion
- [x] Targeted typecheck on `apps/backend` + `jobs/flowsheet-metadata-backfill` clean
- [x] Targeted lint on the 3 changed files clean
- [x] All 13 tests in `metadata.service.test.ts` pass
- [x] `format:check` clean
- [ ] CI green
- [ ] Post-merge: run the UPDATE above on prod RDS

Closes #1002