### PR TITLE
fix(docker): bundle @wxyc/lml-client workspace into prod images

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -23,12 +23,14 @@ COPY ./package* ./
 COPY ./apps/backend/package* ./apps/backend/
 COPY ./shared/database/package* ./shared/database/
 COPY ./shared/authentication/package* ./shared/authentication/
+COPY ./shared/lml-client/package* ./shared/lml-client/
 
 RUN npm install --omit=dev && rm -f .npmrc
 
 COPY --from=builder ./builder/apps/backend/dist ./apps/backend/dist
 COPY --from=builder ./builder/shared/database/dist ./shared/database/dist
 COPY --from=builder ./builder/shared/authentication/dist ./shared/authentication/dist
+COPY --from=builder ./builder/shared/lml-client/dist ./shared/lml-client/dist
 
 # Inherit the @wxyc/database 5s default. Backend HTTP handlers always finish
 # in milliseconds; anything longer than 5s is an orphan from a request that

--- a/Dockerfile.flowsheet-metadata-backfill
+++ b/Dockerfile.flowsheet-metadata-backfill
@@ -6,9 +6,10 @@ WORKDIR /flowsheet-metadata-backfill-builder
 COPY ./package.json ./package-lock.json ./
 COPY ./tsconfig.base.json ./
 COPY ./shared/database ./shared/database
+COPY ./shared/lml-client ./shared/lml-client
 COPY ./jobs/flowsheet-metadata-backfill ./jobs/flowsheet-metadata-backfill
 
-RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/flowsheet-metadata-backfill
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-client --workspace=@wxyc/flowsheet-metadata-backfill
 
 #Production stage
 FROM node:24-alpine AS prod
@@ -18,11 +19,13 @@ WORKDIR /flowsheet-metadata-backfill
 COPY ./package* ./
 COPY ./jobs/flowsheet-metadata-backfill/package* ./jobs/flowsheet-metadata-backfill/
 COPY ./shared/database/package* ./shared/database/
+COPY ./shared/lml-client/package* ./shared/lml-client/
 
 RUN npm install --omit=dev
 
 COPY --from=builder ./flowsheet-metadata-backfill-builder/jobs/flowsheet-metadata-backfill/dist ./jobs/flowsheet-metadata-backfill/dist
 COPY --from=builder ./flowsheet-metadata-backfill-builder/shared/database/dist ./shared/database/dist
+COPY --from=builder ./flowsheet-metadata-backfill-builder/shared/lml-client/dist ./shared/lml-client/dist
 
 # Long-running per-statement timeout: a per-row UPDATE over the 1.86M-row
 # tail can spend tens of seconds on the rare hot batch (search_doc tsvector


### PR DESCRIPTION
## Summary

- Restore backend deploys after 7b1a95fa silently broke them.
- Add the two missing `shared/lml-client` COPYs to `Dockerfile.backend`'s prod stage (workspace `package.json` so `npm install --omit=dev` sees it, then the built `dist` from the builder).
- Apply the same fix to `Dockerfile.flowsheet-metadata-backfill` on both stages, plus `--workspace=@wxyc/lml-client` in the builder's `npm run build` so the dist exists to copy.

## Root cause

7b1a95fa extracted the LML HTTP client into a new `@wxyc/lml-client` workspace at `shared/lml-client/`. It updated `apps/backend/package.json` + `jobs/flowsheet-metadata-backfill/package.json` to depend on the new workspace, plus `tsconfig.base.json` paths, but it did not update the two Dockerfiles. The builders compiled the new package successfully (the backend builder does `COPY ./shared ./shared`); the prod stages discarded it.

Backend symptom: container crashes on startup with

```
Error: Cannot find package '/application/node_modules/@wxyc/lml-client/index.js'
  imported from /application/apps/backend/dist/app.js
```

This is the failure mode that took prod down on 2026-05-22 and forced a rollback to v0.1.368.

## Verification

Built `Dockerfile.backend` locally with this branch and confirmed:

```
$ docker run --rm bs-backend-1006-test ls /application/shared/lml-client/dist/
index.d.mts  index.d.ts  index.js  index.js.map  index.mjs  index.mjs.map

$ docker run --rm --entrypoint node bs-backend-1006-test -e \
    "import('@wxyc/lml-client').then(m => console.log(Object.keys(m).sort()))"
[ 'LmlClientError', 'Semaphore', 'TokenBucket', 'checkStreamingAvailability',
  'createLmlLimiter', 'getArtistDetails', 'getLmlQueueDepth', 'getRelease',
  'isLmlConfigured', 'lookupMetadata', ... ]
```

That's the surface that `apps/backend/dist/app.js` reaches for at startup; previously the import threw the `Cannot find package` error.

## Why CI didn't catch this

The PR-validation workflow (`test.yml`) doesn't build the deploy Dockerfiles; integration tests run the backend as a plain `node apps/backend/dist/app.js` process against the local repo's `node_modules/`. Only the deploy workflow (`deploy-base.yml`) builds `Dockerfile.${TARGET_APP}`, and that's manual. Worth a follow-up to add a smoke-build to PR validation, filed separately if so.

## Test plan

- [x] Local `docker build --build-arg NPM_TOKEN=… -f Dockerfile.backend .` succeeds.
- [x] Resulting image has `/application/node_modules/@wxyc/lml-client` symlinked to `shared/lml-client/` and `shared/lml-client/dist/index.mjs` present.
- [x] `node -e "import('@wxyc/lml-client')..."` resolves and exposes the expected exports.
- [ ] Post-merge Manual Build & Deploy of `main` starts cleanly and `/healthcheck` returns 200.

Closes #1006.