### PR TITLE
feat(enrichment-worker): wire claim → LML → finalize + SSE broadcast (BS#892 PR-2)

### DIFF
--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -22,6 +22,7 @@ import { playlist_route } from './routes/playlist.route.js';
 import { startPlaylistProxy, stopPlaylistProxy } from './services/playlist-proxy.service.js';
 import { startAlbumPlaysRefresh, stopAlbumPlaysRefresh } from './services/album-plays-refresh.service.js';
 import { setupCdcWebSocket, shutdownCdcWebSocket } from './services/cdc/index.js';
+import { setupMetadataBroadcast } from './services/metadata-broadcast/index.js';
 import { startRotationTracksCacheWarm } from './services/rotation-tracks-cache-warm.service.js';
 import { drainInFlightEnrichments } from './services/metadata/enrichment.service.js';
 import { activeShow } from './middleware/checkActiveShow.js';
@@ -133,6 +134,12 @@ const server = app.listen(port, () => {
   startPlaylistProxy();
   startAlbumPlaysRefresh();
   void setupCdcWebSocket(server);
+  // Second CDC handler: rebroadcasts terminal metadata UPDATEs as SSE
+  // `liveFs:update` so dj-site stays in sync after the enrichment-worker
+  // (BS#892) finalizes a row. Closes BS#893 + BS#628. Registers a handler
+  // on the same per-process LISTEN connection — independent of the
+  // websocket handler, both fire on every event.
+  setupMetadataBroadcast();
   // One-shot warm of the rotation-tracks picker LRUs in
   // `library.service.ts`. Fire-and-forget — the walk shares the LML
   // semaphore with concurrent traffic, and the LRUs are process-local so

--- a/apps/backend/services/metadata-broadcast/index.ts
+++ b/apps/backend/services/metadata-broadcast/index.ts
@@ -1,0 +1,2 @@
+export { setupMetadataBroadcast, filterMetadataUpdate } from './metadata-broadcast.js';
+export type { MetadataBroadcastPayload } from './metadata-broadcast.js';

--- a/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
+++ b/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
@@ -1,0 +1,87 @@
+/**
+ * Bridges the enrichment consumer's terminal UPDATE → SSE `liveFs:update`
+ * broadcast (BS#892 / PR-2; closes BS#893, BS#628).
+ *
+ * The enrichment-worker is a separate process — it can't call
+ * `serverEventsMgr.broadcast()` directly. Rather than add HTTP/IPC between
+ * the two, this hook subscribes to the same CDC stream the worker writes
+ * into. PG's per-process LISTEN means every BS instance receives the
+ * UPDATE NOTIFY; each instance broadcasts only to its own SSE clients
+ * (each client is connected to exactly one BS instance), so there's no
+ * duplication.
+ *
+ * Filter criteria (all must hold):
+ *   - table === 'flowsheet'
+ *   - action === 'UPDATE'
+ *   - data.metadata_status is a terminal state
+ *     ('enriched_match' | 'enriched_no_match' | 'failed_no_retry')
+ *
+ * Per-row payload includes `id` and `metadata_status` so dj-site can scope
+ * a refetch to just the changed row instead of paying for a list refetch.
+ * Today's dj-site treats this as a generic update signal; the per-row
+ * payload is forward-compat for finer-grained handling.
+ *
+ * False positives: the filter matches any flowsheet UPDATE that lands in
+ * a terminal metadata_status. The historical `flowsheet-metadata-backfill`
+ * also writes terminal status (via #891's seed), but it runs nightly and
+ * the broadcasts during that window are exactly the signal listeners
+ * already need ("a backfill enriched this row, refetch").
+ *
+ * Idempotency: SSE clients tolerate duplicate `update` events naturally —
+ * the worst case is an extra refetch. The CDC pipeline does not dedupe
+ * across BS instances, but each instance only owns its own SSE clients,
+ * so there's no per-client duplication.
+ */
+
+import type { CdcEvent } from '@wxyc/database';
+import { onCdcEvent } from '@wxyc/database';
+import { serverEventsMgr, Topics, FsEvents } from '../../utils/serverEvents.js';
+
+const TERMINAL_STATUSES = new Set(['enriched_match', 'enriched_no_match', 'failed_no_retry']);
+
+export type MetadataBroadcastPayload = {
+  id: number;
+  metadata_status: 'enriched_match' | 'enriched_no_match' | 'failed_no_retry';
+};
+
+/** Pure filter for testability — returns the broadcast payload on match, null on skip. */
+export function filterMetadataUpdate(event: CdcEvent): MetadataBroadcastPayload | null {
+  if (event.table !== 'flowsheet') return null;
+  if (event.action !== 'UPDATE') return null;
+  if (!event.data) return null;
+
+  const data = event.data as Record<string, unknown>;
+  const status = data.metadata_status;
+  if (typeof status !== 'string' || !TERMINAL_STATUSES.has(status)) return null;
+
+  const id = data.id;
+  if (typeof id !== 'number') return null;
+
+  return { id, metadata_status: status as MetadataBroadcastPayload['metadata_status'] };
+}
+
+/**
+ * Register the metadata-broadcast CDC handler. Call once at startup, after
+ * `serverEventsMgr` is ready and alongside `setupCdcWebSocket()` — both
+ * register independent `onCdcEvent` handlers against the same per-process
+ * LISTEN connection (see `apps/backend/services/cdc/cdc-websocket.ts:89`).
+ */
+export function setupMetadataBroadcast(): void {
+  onCdcEvent((event) => {
+    const payload = filterMetadataUpdate(event);
+    if (!payload) return;
+    try {
+      serverEventsMgr.broadcast(Topics.liveFs, {
+        type: FsEvents.update,
+        payload,
+      });
+    } catch (err) {
+      // Broadcast errors must not break the CDC handler chain. The
+      // serverEventsMgr.broadcast already swallows per-client errors
+      // (unsubAll on write failure); this guard catches anything else
+      // (e.g. an empty topic set wouldn't throw, but a future change
+      // might).
+      console.error('[metadata-broadcast] broadcast failed:', (err as Error).message);
+    }
+  });
+}

--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -1,0 +1,164 @@
+/**
+ * Finalize UPDATE for the enrichment consumer (BS#892 / Epic C C2).
+ *
+ * Mirrors `jobs/flowsheet-metadata-backfill/enrich.ts` in shape — the same
+ * 10-column on-match payload, the same 3-column on-no-match payload, the
+ * same spacer.gif filter, the same synthesized search URLs — but with a
+ * different idempotency guard and a different terminal state.
+ *
+ * Idempotency guard: WHERE narrows by `metadata_status = 'enriching'`. The
+ * claim primitive (`claim.ts`) is the only writer that flips a row to
+ * `enriching`, so the WHERE here can match only a row this worker (or a
+ * sibling that already lost the claim race) is the registered claimer of.
+ *
+ * Terminal state:
+ *   - LML returned artwork  → `metadata_status = 'enriched_match'`
+ *   - LML returned no match → `metadata_status = 'enriched_no_match'`
+ *   - LML threw             → caller catches; row stays `enriching`. The
+ *                             C6 stranded-claim sweep (#895) reverts it to
+ *                             `pending` past `enriching_since + 60s` so the
+ *                             next CDC tick (or sweep) retries.
+ *
+ * No `metadata_attempt_at` stamping here. That column was the implicit
+ * state machine the enum (BS#891) replaced; the consumer writes the explicit
+ * status and leaves the marker alone. The backfill still stamps the marker
+ * because its WHERE is `metadata_attempt_at IS NULL` — a historical-drain
+ * concern that doesn't apply to the live consumer path.
+ *
+ * Build-graph isolation: the search-URL synthesis, spacer.gif filter, and bio
+ * cleaner are inlined rather than imported from `apps/backend` or
+ * `jobs/flowsheet-metadata-backfill` to keep this package independent. The
+ * canonical implementations are in
+ * `apps/backend/services/metadata/metadata.service.ts` (runtime) and
+ * `jobs/flowsheet-metadata-backfill/enrich.ts` (backfill); divergence here
+ * would be a bug. Parity is not test-pinned yet (the backfill pins parity to
+ * the runtime; this would be a transitive parity test). Track in a follow-up
+ * if drift becomes a real concern.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { db, flowsheet } from '@wxyc/database';
+import type { DiscogsMatchResult, LookupResponse } from '@wxyc/lml-client';
+
+export type EnrichRow = {
+  id: number;
+  artist_name: string;
+  album_title: string | null;
+  track_title: string | null;
+};
+
+export type FinalizeOutcome =
+  | 'enriched_match'
+  | 'enriched_match_raced'
+  | 'enriched_no_match'
+  | 'enriched_no_match_raced';
+
+export const cleanDiscogsBio = (bio: string): string =>
+  bio
+    .replace(/\[a=([^\]]+)\]/g, '$1')
+    .replace(/\[l=([^\]]+)\]/g, '$1')
+    .replace(/\[r=([^\]]+)\]/g, '$1')
+    .replace(/\[m=([^\]]+)\]/g, '$1')
+    .replace(/\[url=([^\]]+)\]([^[]*)\[\/url\]/g, '$2');
+
+export const filterSpacerGif = (url: string | null | undefined): string | null => {
+  if (!url) return null;
+  if (url.includes('spacer.gif')) return null;
+  return url;
+};
+
+/**
+ * Synthesized search URLs (per-service semantics deliberately asymmetric):
+ *   - YouTube Music: trackTitle > albumTitle > artistName
+ *   - Bandcamp:      albumTitle > artistName (album-leaning)
+ *   - SoundCloud:    trackTitle > artistName (NO album fallback — album-only
+ *                    SoundCloud queries surface unrelated DJ mixes)
+ *
+ * Must match `apps/backend/services/metadata/providers/search-urls.provider.ts`
+ * exactly.
+ */
+export const synthesizeSearchUrls = (
+  row: EnrichRow
+): { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
+  const artist = row.artist_name;
+  const album = row.album_title ?? undefined;
+  const track = row.track_title ?? undefined;
+
+  const youtubeQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
+  const bandcampQuery = album ? `${artist} ${album}` : artist;
+  const soundcloudQuery = track ? `${artist} ${track}` : artist;
+
+  return {
+    youtube_music_url: `https://music.youtube.com/search?q=${encodeURIComponent(youtubeQuery)}`,
+    bandcamp_url: `https://bandcamp.com/search?q=${encodeURIComponent(bandcampQuery)}`,
+    soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent(soundcloudQuery)}`,
+  };
+};
+
+export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | null => {
+  const first = response.results?.[0];
+  if (!first) return null;
+  if (!first.artwork) return null;
+  return first.artwork;
+};
+
+/**
+ * Finalize an enriching row with LML's response.
+ *
+ * Returns the outcome so the dispatcher can count it. The `_raced` variants
+ * fire when `.returning({ id })` is empty: the WHERE no longer matches
+ * because something else (the C6 cron's stranded-claim sweep, a manual
+ * triage operator, or a hypothetical out-of-band writer) flipped
+ * `metadata_status` off `'enriching'` between claim and finalize. Same data
+ * outcome from the row's perspective; the metric separates "this consumer
+ * finalized it" from "the row was finalized by someone."
+ *
+ * Errors propagate up — the dispatcher's catch arm decides whether to leave
+ * the row stranded (transient LML failure → C6 sweep recovers) or to write
+ * a terminal `failed_no_retry` (out of scope for PR-2; the filter ensures
+ * every reachable row has the inputs LML needs).
+ */
+export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Promise<FinalizeOutcome> => {
+  const artwork = extractArtwork(response);
+  const searchUrls = synthesizeSearchUrls(row);
+
+  if (artwork) {
+    const updated = await db
+      .update(flowsheet)
+      .set({
+        artwork_url: filterSpacerGif(artwork.artwork_url),
+        discogs_url: artwork.release_url ?? null,
+        // Discogs returns 0 as "year unknown"; coerce to null so iOS doesn't
+        // render literal "0". Mirrors metadata.service.ts (#1002).
+        release_year: artwork.release_year || null,
+        spotify_url: artwork.spotify_url ?? null,
+        apple_music_url: artwork.apple_music_url ?? null,
+        // Prefer LML-supplied streaming URLs; fall back to synthesized.
+        youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
+        bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
+        soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
+        artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
+        artist_wikipedia_url: artwork.wikipedia_url ?? null,
+        metadata_status: 'enriched_match',
+      })
+      .where(and(eq(flowsheet.id, row.id), eq(flowsheet.metadata_status, 'enriching')))
+      .returning({ id: flowsheet.id });
+    return updated.length === 0 ? 'enriched_match_raced' : 'enriched_match';
+  }
+
+  // No-match: synthesized search URLs only. The other 7 metadata columns are
+  // left untouched — preserves any prior out-of-band values (e.g. recovery
+  // writes from #686-era scripts). Mirrors the backfill's deliberate
+  // divergence from the runtime path (see backfill enrich.ts header).
+  const updated = await db
+    .update(flowsheet)
+    .set({
+      youtube_music_url: searchUrls.youtube_music_url,
+      bandcamp_url: searchUrls.bandcamp_url,
+      soundcloud_url: searchUrls.soundcloud_url,
+      metadata_status: 'enriched_no_match',
+    })
+    .where(and(eq(flowsheet.id, row.id), eq(flowsheet.metadata_status, 'enriching')))
+    .returning({ id: flowsheet.id });
+  return updated.length === 0 ? 'enriched_no_match_raced' : 'enriched_no_match';
+};

--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -26,14 +26,14 @@
  * concern that doesn't apply to the live consumer path.
  *
  * Build-graph isolation: the search-URL synthesis, spacer.gif filter, and bio
- * cleaner are inlined rather than imported from `apps/backend` or
- * `jobs/flowsheet-metadata-backfill` to keep this package independent. The
- * canonical implementations are in
- * `apps/backend/services/metadata/metadata.service.ts` (runtime) and
- * `jobs/flowsheet-metadata-backfill/enrich.ts` (backfill); divergence here
- * would be a bug. Parity is not test-pinned yet (the backfill pins parity to
- * the runtime; this would be a transitive parity test). Track in a follow-up
- * if drift becomes a real concern.
+ * cleaner are inlined rather than imported from `apps/backend` so this package
+ * can bundle independently. The canonical implementations are in
+ * `apps/backend/services/metadata/metadata.service.ts` (spacer.gif filter) and
+ * `apps/backend/services/metadata/providers/search-urls.provider.ts` (search
+ * URLs); divergence here would be a bug. Pinned by parity tests:
+ *   - tests/unit/apps/enrichment-worker/filter-spacer-gif-parity.test.ts (BS#890)
+ *   - tests/unit/apps/enrichment-worker/synthesize-search-urls-parity.test.ts (BS#889)
+ * Also gated by scripts/check-spacer-gif-callsites.sh in CI.
  */
 
 import { and, eq } from 'drizzle-orm';

--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -1,0 +1,123 @@
+/**
+ * Full enrichment handler for the CDC dispatcher (BS#892 / Epic C C2, PR-2).
+ *
+ * Composes the four pieces of the consumer:
+ *   1. Filter the CDC event for an enrichment candidate (cdc-subscriber.ts).
+ *   2. Atomically claim the row (claim.ts → flips `pending` → `enriching`).
+ *   3. Look up via LML (`@wxyc/lml-client`, which carries the shared
+ *      Semaphore(5) + TokenBucket(50/min) chokepoint).
+ *   4. Finalize the row with the response (enrich.ts → flips `enriching`
+ *      → terminal state, writes the metadata columns).
+ *
+ * Wrapped in a single Sentry transaction so trace events for one CDC tick
+ * group together (cache_stats from the lookup span land as attributes on
+ * the same transaction — see LML#213 + BS#646). Worker-side projection of
+ * the outcome (`enrichment.outcome`) lets the Sentry trace explorer slice
+ * matched/no-match/raced rates without per-row metric inventory.
+ *
+ * Errors handling:
+ *   - Filter rejected → silent skip (not interesting).
+ *   - Claim lost     → silent skip (sibling worker won — expected under N×N).
+ *   - LML throws     → log + Sentry.captureException, row stays `enriching`.
+ *                      The C6 stranded-claim sweep (#895) reverts it past
+ *                      `enriching_since + 60s` so the next CDC tick retries.
+ *   - DB throws      → log + Sentry.captureException, propagate. The CDC
+ *                      listener will continue receiving events; only this
+ *                      one is lost. The C6 sweep is the safety net.
+ *
+ * The handler never throws upstream — the CDC listener is a single shared
+ * subscriber across all CDC consumers in this process; a throw from this
+ * handler could break other listeners. All failures are caught here.
+ */
+
+import * as Sentry from '@sentry/node';
+import { lookupMetadata } from '@wxyc/lml-client';
+import type { CdcEvent } from '@wxyc/database';
+
+import { claimRowForEnrichment } from './claim.js';
+import { filterForEnrichment, type EnrichmentCandidate } from './cdc-subscriber.js';
+import { finalizeRow, type FinalizeOutcome } from './enrich.js';
+
+/**
+ * Build a CDC event handler that runs the full enrichment chain.
+ *
+ * The returned function is the long-lived handler that
+ * `onCdcEvent(handler)` registers; it is invoked once per CDC NOTIFY per
+ * worker instance.
+ */
+export function makeEnrichmentHandler(): (event: CdcEvent) => void {
+  return (event) => {
+    const candidate = filterForEnrichment(event);
+    if (!candidate) return;
+    // Fire and forget. The CDC listener calls the handler synchronously; if
+    // we awaited, slow LML lookups would back-pressure the listener and
+    // cause it to drop events. The handler is internally bounded by the
+    // shared LML Semaphore(5) so concurrency is capped at the chokepoint.
+    void handleCandidate(candidate);
+  };
+}
+
+async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
+  await Sentry.startSpan(
+    {
+      name: 'enrichment.consumer.tick',
+      op: 'queue.process',
+      attributes: {
+        'enrichment.flowsheet_id': candidate.id,
+        'enrichment.has_album': candidate.album_title !== null,
+        'enrichment.has_track': candidate.track_title !== null,
+      },
+    },
+    async (span) => {
+      try {
+        const claim = await claimRowForEnrichment(candidate.id);
+        if (!claim.claimed) {
+          span.setAttribute('enrichment.outcome', 'claim_lost');
+          return;
+        }
+
+        let outcome: FinalizeOutcome;
+        try {
+          const response = await lookupMetadata(
+            candidate.artist_name,
+            candidate.album_title ?? undefined,
+            candidate.track_title ?? undefined
+          );
+          outcome = await finalizeRow(candidate, response);
+        } catch (err) {
+          // Row stays `enriching`. C6 stranded-claim sweep recovers it past
+          // `enriching_since + 60s`. We do NOT revert to `pending` here —
+          // doing so under a transient LML failure could re-deliver the
+          // event to a sibling worker mid-failure, amplifying load against
+          // an already-struggling LML.
+          span.setAttribute('enrichment.outcome', 'lml_error');
+          Sentry.captureException(err, {
+            tags: { component: 'enrichment-worker', step: 'lml_lookup' },
+            extra: { flowsheet_id: candidate.id },
+          });
+          console.error('[enrichment-worker] lml error; row left in enriching state', {
+            id: candidate.id,
+            artist: candidate.artist_name,
+            error: (err as Error).message,
+          });
+          return;
+        }
+
+        span.setAttribute('enrichment.outcome', outcome);
+      } catch (err) {
+        // DB error during claim or finalize. Same defensive posture: capture
+        // + log, row state is whatever PG ended up with. C6 sweep handles
+        // any stranded `enriching` rows.
+        span.setAttribute('enrichment.outcome', 'db_error');
+        Sentry.captureException(err, {
+          tags: { component: 'enrichment-worker', step: 'claim_or_finalize' },
+          extra: { flowsheet_id: candidate.id },
+        });
+        console.error('[enrichment-worker] db error during enrichment', {
+          id: candidate.id,
+          error: (err as Error).message,
+        });
+      }
+    }
+  );
+}

--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -25,9 +25,11 @@
  *                      listener will continue receiving events; only this
  *                      one is lost. The C6 sweep is the safety net.
  *
- * The handler never throws upstream — the CDC listener is a single shared
- * subscriber across all CDC consumers in this process; a throw from this
- * handler could break other listeners. All failures are caught here.
+ * The handler never throws upstream. `cdc-listener.ts:54-58` already wraps
+ * each callback in try/catch and would log `[cdc-listener] Callback error`
+ * for an uncaught throw, but that log loses the row id and the LML/DB step
+ * context. Catching here keeps the failure attributed to a real Sentry
+ * event with the flowsheet_id + step tag instead of a noisy generic log.
  */
 
 import * as Sentry from '@sentry/node';

--- a/apps/enrichment-worker/instrument.ts
+++ b/apps/enrichment-worker/instrument.ts
@@ -1,0 +1,27 @@
+// Sentry preload (node --import). Mirrors apps/backend/instrument.ts so the
+// worker's outbound LML fetch spans nest under a CDC handler transaction.
+// Sentry stays inactive when SENTRY_DSN is unset (the SDK silently no-ops).
+
+import { config } from 'dotenv';
+import * as Sentry from '@sentry/node';
+
+config();
+
+// Default 0.1 — the worker is many-instance and high-throughput; full sample
+// of every CDC handler transaction would dominate the BS Sentry budget. The
+// runtime backend defaults to 1.0 because per-request HTTP transactions are
+// already bounded by user traffic. Operators can override with
+// SENTRY_TRACES_SAMPLE_RATE per-deploy without a code change.
+const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0.1;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0.1;
+  return parsed;
+};
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  release: process.env.SENTRY_RELEASE,
+  environment: process.env.NODE_ENV || 'production',
+  tracesSampleRate: resolveTracesSampleRate(),
+});

--- a/apps/enrichment-worker/package.json
+++ b/apps/enrichment-worker/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "./dist/worker.js",
   "scripts": {
-    "start": "node dist/worker.js",
+    "start": "node --import ./dist/instrument.js dist/worker.js",
     "build": "tsup --minify",
     "clean": "rm -rf dist",
     "dev": "tsup --watch",
@@ -13,7 +13,10 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@wxyc/database": "^1.0.0"
+    "@sentry/node": "^10.52.0",
+    "@wxyc/database": "^1.0.0",
+    "@wxyc/lml-client": "^1.0.0",
+    "dotenv": "^17.4.2"
   },
   "peerDependencies": {
     "drizzle-orm": "^0.45.0"

--- a/apps/enrichment-worker/tsup.config.ts
+++ b/apps/enrichment-worker/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig((options) => ({
-  entry: ['worker.ts'],
+  entry: ['worker.ts', 'instrument.ts'],
   outDir: 'dist',
   format: ['esm'],
   platform: 'node',
@@ -9,6 +9,6 @@ export default defineConfig((options) => ({
   clean: true,
   sourcemap: true,
   splitting: false,
-  external: ['@wxyc/database', 'drizzle-orm', 'postgres'],
-  onSuccess: options.watch ? 'node ./dist/worker.js' : undefined,
+  external: ['@wxyc/database', 'drizzle-orm', 'postgres', '@sentry/node', '@wxyc/lml-client'],
+  onSuccess: options.watch ? 'node --import ./dist/instrument.js ./dist/worker.js' : undefined,
 }));

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -1,12 +1,10 @@
 /**
  * Enrichment worker entrypoint (BS#892 / Epic C C2).
  *
- * Long-running daemon that subscribes to BS's CDC stream and (eventually)
- * enriches every new flowsheet track row by calling LML. PR-1 ships in
- * log-only mode: dispatch + filter + console.log, no DB writes, no LML
- * calls. The intent is to verify in prod that the N×N CDC fan-out
- * works as designed (every worker instance receives every event)
- * before wiring the actual claim + LML + finalize sequence in PR-2.
+ * Long-running daemon that subscribes to BS's CDC stream and enriches every
+ * new flowsheet track row by calling LML. The N×N idempotent-claim pattern
+ * means every worker instance receives every event; the first to win the
+ * atomic claim does the work, the losers skip cleanly.
  *
  * Deployment shape (Option A from #892 body): runs as its own Docker
  * container alongside `backend` on the same EC2. Independent restart
@@ -16,12 +14,12 @@
  */
 
 import { closeDatabaseConnection, onCdcEvent, startCdcListener, stopCdcListener } from '@wxyc/database';
-import { makeLogOnlyHandler } from './cdc-subscriber.js';
+import { makeEnrichmentHandler } from './handler.js';
 
 const main = async (): Promise<void> => {
-  console.log('[enrichment-worker] starting (PR-1: log-only mode, no DB writes)');
+  console.log('[enrichment-worker] starting');
 
-  onCdcEvent(makeLogOnlyHandler());
+  onCdcEvent(makeEnrichmentHandler());
   await startCdcListener();
 
   console.log('[enrichment-worker] subscribed to CDC; awaiting events');

--- a/package-lock.json
+++ b/package-lock.json
@@ -470,7 +470,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@wxyc/database": "^1.0.0"
+        "@sentry/node": "^10.52.0",
+        "@wxyc/database": "^1.0.0",
+        "@wxyc/lml-client": "^1.0.0",
+        "dotenv": "^17.4.2"
       },
       "devDependencies": {
         "typescript": "^6.0.3"

--- a/scripts/check-spacer-gif-callsites.sh
+++ b/scripts/check-spacer-gif-callsites.sh
@@ -38,6 +38,7 @@ ALLOWED=(
   "apps/backend/services/metadata/metadata.service.ts"
   "jobs/flowsheet-metadata-backfill/enrich.ts"
   "jobs/library-artwork-url-backfill/enrich.ts"
+  "apps/enrichment-worker/enrich.ts"
 )
 
 cd "$REPO_ROOT"

--- a/tests/unit/apps/backend/services/metadata-broadcast.test.ts
+++ b/tests/unit/apps/backend/services/metadata-broadcast.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for metadata-broadcast filter (BS#892 / Epic C C2, PR-2).
+ *
+ * Pins the perimeter: only flowsheet UPDATE events with a terminal
+ * metadata_status (`enriched_match` | `enriched_no_match` |
+ * `failed_no_retry`) produce a broadcast. INSERTs (handled separately by
+ * the worker's CDC consumer), DELETEs, and intermediate-state UPDATEs
+ * (`pending` ← C6 sweep, `enriching` ← claim) are skipped.
+ *
+ * False positives would amplify SSE traffic; false negatives would leave
+ * dj-site without the post-enrichment refresh signal that closes #893/#628.
+ */
+
+import type { CdcEvent } from '@wxyc/database';
+import { filterMetadataUpdate } from '../../../../../apps/backend/services/metadata-broadcast/metadata-broadcast';
+
+const flowsheetUpdate = (overrides: Partial<Record<string, unknown>> = {}): CdcEvent => ({
+  table: 'flowsheet',
+  schema: 'wxyc_schema',
+  action: 'UPDATE',
+  data: {
+    id: 42,
+    metadata_status: 'enriched_match',
+    ...overrides,
+  },
+  timestamp: 1779856000000,
+});
+
+describe('filterMetadataUpdate (BS#892 PR-2)', () => {
+  it('returns payload for an enriched_match UPDATE', () => {
+    expect(filterMetadataUpdate(flowsheetUpdate())).toEqual({
+      id: 42,
+      metadata_status: 'enriched_match',
+    });
+  });
+
+  it('returns payload for an enriched_no_match UPDATE', () => {
+    expect(filterMetadataUpdate(flowsheetUpdate({ metadata_status: 'enriched_no_match' }))).toEqual({
+      id: 42,
+      metadata_status: 'enriched_no_match',
+    });
+  });
+
+  it('returns payload for a failed_no_retry UPDATE', () => {
+    expect(filterMetadataUpdate(flowsheetUpdate({ metadata_status: 'failed_no_retry' }))).toEqual({
+      id: 42,
+      metadata_status: 'failed_no_retry',
+    });
+  });
+
+  it('skips UPDATE to enriching (claim-time, not user-visible)', () => {
+    expect(filterMetadataUpdate(flowsheetUpdate({ metadata_status: 'enriching' }))).toBeNull();
+  });
+
+  it('skips UPDATE to pending (C6 stranded-claim sweep — not user-visible)', () => {
+    expect(filterMetadataUpdate(flowsheetUpdate({ metadata_status: 'pending' }))).toBeNull();
+  });
+
+  it("skips INSERT events (those are the worker's input, not its output)", () => {
+    expect(filterMetadataUpdate({ ...flowsheetUpdate(), action: 'INSERT' })).toBeNull();
+  });
+
+  it('skips DELETE events', () => {
+    expect(filterMetadataUpdate({ ...flowsheetUpdate(), action: 'DELETE' })).toBeNull();
+  });
+
+  it('skips events for tables other than flowsheet', () => {
+    expect(filterMetadataUpdate({ ...flowsheetUpdate(), table: 'library' })).toBeNull();
+  });
+
+  it('skips when data is missing', () => {
+    expect(filterMetadataUpdate({ ...flowsheetUpdate(), data: null })).toBeNull();
+  });
+
+  it('skips when id is missing or not a number', () => {
+    expect(filterMetadataUpdate(flowsheetUpdate({ id: undefined }))).toBeNull();
+    expect(filterMetadataUpdate(flowsheetUpdate({ id: 'forty-two' }))).toBeNull();
+  });
+
+  it('skips when metadata_status is missing', () => {
+    expect(filterMetadataUpdate(flowsheetUpdate({ metadata_status: undefined }))).toBeNull();
+  });
+
+  it('skips when metadata_status is some other string (defensive against schema drift)', () => {
+    expect(filterMetadataUpdate(flowsheetUpdate({ metadata_status: 'unknown_status' }))).toBeNull();
+  });
+});

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for enrichment-worker enrich.ts (BS#892 / Epic C C2, PR-2).
+ *
+ * Pins the consumer's finalize contract: the UPDATE narrows by
+ * `metadata_status='enriching'` (set by claim.ts) and writes the terminal
+ * status the LML response implies — `enriched_match` if artwork came
+ * back, `enriched_no_match` otherwise. Race detector: `_raced` variants
+ * fire when `.returning({ id })` is empty (the row left `enriching`
+ * between claim and finalize — typically the C6 stranded-claim sweep).
+ *
+ * Mirrors the backfill's enrich.test.ts in shape but exercises the
+ * different idempotency guard (status enum vs marker IS NULL) and the
+ * different terminal column (status enum vs metadata_attempt_at).
+ */
+
+import { jest } from '@jest/globals';
+
+import { db, flowsheet } from '@wxyc/database';
+import type { LookupResponse } from '@wxyc/lml-client';
+import {
+  cleanDiscogsBio,
+  extractArtwork,
+  filterSpacerGif,
+  finalizeRow,
+  synthesizeSearchUrls,
+} from '../../../../apps/enrichment-worker/enrich';
+
+const mockDb = db as unknown as {
+  update: jest.Mock;
+  _chain: { set: jest.Mock; where: jest.Mock; returning: jest.Mock };
+};
+
+const ROW = {
+  id: 42,
+  artist_name: 'Juana Molina',
+  album_title: 'DOGA',
+  track_title: 'la paradoja',
+};
+
+const matchResponse = {
+  results: [
+    {
+      artwork: {
+        artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+        release_url: 'https://discogs.com/release/123',
+        release_year: 2022,
+        spotify_url: 'https://open.spotify.com/album/x',
+        apple_music_url: 'https://music.apple.com/album/y',
+        youtube_music_url: 'https://music.youtube.com/playlist/z',
+        bandcamp_url: 'https://artist.bandcamp.com/album/w',
+        soundcloud_url: null,
+        artist_bio: 'A great [a=Some Artist] from Argentina.',
+        wikipedia_url: 'https://en.wikipedia.org/wiki/Juana_Molina',
+      },
+    },
+  ],
+} as unknown as LookupResponse;
+
+const noMatchResponse = { results: [] } as unknown as LookupResponse;
+
+describe('finalizeRow (BS#892 PR-2)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('on match: writes the 10 metadata columns and flips status to enriched_match', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    const outcome = await finalizeRow(ROW, matchResponse);
+
+    expect(outcome).toBe('enriched_match');
+    expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
+
+    const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setCall.metadata_status).toBe('enriched_match');
+    expect(setCall.artwork_url).toBe('https://i.discogs.com/abc/cover.jpg');
+    expect(setCall.discogs_url).toBe('https://discogs.com/release/123');
+    expect(setCall.release_year).toBe(2022);
+    expect(setCall.spotify_url).toBe('https://open.spotify.com/album/x');
+    expect(setCall.apple_music_url).toBe('https://music.apple.com/album/y');
+    expect(setCall.youtube_music_url).toBe('https://music.youtube.com/playlist/z');
+    expect(setCall.bandcamp_url).toBe('https://artist.bandcamp.com/album/w');
+    // LML returned null for soundcloud → fall back to synthesized.
+    expect(setCall.soundcloud_url).toContain('soundcloud.com/search');
+    expect(setCall.artist_bio).toBe('A great Some Artist from Argentina.');
+    expect(setCall.artist_wikipedia_url).toBe('https://en.wikipedia.org/wiki/Juana_Molina');
+  });
+
+  it('on no-match: writes 3 synthesized search URLs and flips status to enriched_no_match', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    const outcome = await finalizeRow(ROW, noMatchResponse);
+
+    expect(outcome).toBe('enriched_no_match');
+
+    const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setCall.metadata_status).toBe('enriched_no_match');
+    // The 7 metadata columns are NOT in the .set() — preserves prior values.
+    expect(setCall.artwork_url).toBeUndefined();
+    expect(setCall.discogs_url).toBeUndefined();
+    expect(setCall.release_year).toBeUndefined();
+    expect(setCall.artist_bio).toBeUndefined();
+    // The 3 search URLs ARE in the .set().
+    expect(setCall.youtube_music_url).toContain('music.youtube.com/search');
+    expect(setCall.bandcamp_url).toContain('bandcamp.com/search');
+    expect(setCall.soundcloud_url).toContain('soundcloud.com/search');
+  });
+
+  it('returns _raced when the UPDATE matches 0 rows (status left enriching between claim and finalize)', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    const outcome = await finalizeRow(ROW, matchResponse);
+
+    expect(outcome).toBe('enriched_match_raced');
+  });
+
+  it('returns enriched_no_match_raced on no-match path when the UPDATE matches 0 rows', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    const outcome = await finalizeRow(ROW, noMatchResponse);
+
+    expect(outcome).toBe('enriched_no_match_raced');
+  });
+
+  it('coerces release_year=0 (Discogs "year unknown" sentinel) to null', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+    const response = {
+      results: [{ artwork: { artwork_url: 'https://i.discogs.com/x.jpg', release_year: 0 } }],
+    } as unknown as LookupResponse;
+
+    await finalizeRow(ROW, response);
+
+    const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setCall.release_year).toBeNull();
+  });
+
+  it('strips spacer.gif placeholder from artwork_url', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+    const response = {
+      results: [{ artwork: { artwork_url: 'https://i.discogs.com/spacer.gif' } }],
+    } as unknown as LookupResponse;
+
+    await finalizeRow(ROW, response);
+
+    const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setCall.artwork_url).toBeNull();
+  });
+
+  it('calls .where() exactly once with a non-empty predicate', async () => {
+    // The WHERE uses typed `and(eq(flowsheet.id, id), eq(flowsheet.metadata_status, 'enriching'))`
+    // builders. Column refs + the 'enriching' enum literal are compile-time
+    // checked against BS#891's schema. Structural assertion here; behavioral
+    // narrowing covered by the _raced tests above.
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    await finalizeRow(ROW, matchResponse);
+
+    expect(mockDb._chain.where).toHaveBeenCalledTimes(1);
+    expect(mockDb._chain.where.mock.calls[0]?.[0]).toBeDefined();
+  });
+
+  it('propagates DB errors instead of swallowing them', async () => {
+    const dbError = new Error('connection refused');
+    mockDb._chain.returning.mockRejectedValueOnce(dbError);
+
+    await expect(finalizeRow(ROW, matchResponse)).rejects.toThrow('connection refused');
+  });
+});
+
+describe('synthesizeSearchUrls (per-service precedence)', () => {
+  it('YouTube Music prefers trackTitle over albumTitle over artistName', () => {
+    expect(
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C' }).youtube_music_url
+    ).toBe('https://music.youtube.com/search?q=A%20C');
+    expect(
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: null }).youtube_music_url
+    ).toBe('https://music.youtube.com/search?q=A%20B');
+    expect(
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: null, track_title: null }).youtube_music_url
+    ).toBe('https://music.youtube.com/search?q=A');
+  });
+
+  it('Bandcamp prefers albumTitle over artistName (NO track fallback)', () => {
+    expect(synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C' }).bandcamp_url).toBe(
+      'https://bandcamp.com/search?q=A%20B'
+    );
+    expect(synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: null, track_title: 'C' }).bandcamp_url).toBe(
+      'https://bandcamp.com/search?q=A'
+    );
+  });
+
+  it('SoundCloud prefers trackTitle over artistName (NO album fallback)', () => {
+    expect(synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C' }).soundcloud_url).toBe(
+      'https://soundcloud.com/search?q=A%20C'
+    );
+    // No track → falls straight to artist, NOT album. Album-only SoundCloud
+    // queries surface unrelated DJ mixes, which is the whole reason for the
+    // asymmetric precedence.
+    expect(synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: null }).soundcloud_url).toBe(
+      'https://soundcloud.com/search?q=A'
+    );
+  });
+});
+
+describe('filterSpacerGif', () => {
+  it('returns null for spacer.gif URLs', () => {
+    expect(filterSpacerGif('https://i.discogs.com/spacer.gif')).toBeNull();
+    expect(filterSpacerGif('https://example.com/path/spacer.gif?v=1')).toBeNull();
+  });
+
+  it('preserves non-spacer URLs', () => {
+    expect(filterSpacerGif('https://i.discogs.com/abc/cover.jpg')).toBe('https://i.discogs.com/abc/cover.jpg');
+  });
+
+  it('returns null for nullish input', () => {
+    expect(filterSpacerGif(null)).toBeNull();
+    expect(filterSpacerGif(undefined)).toBeNull();
+    expect(filterSpacerGif('')).toBeNull();
+  });
+});
+
+describe('cleanDiscogsBio', () => {
+  it('strips Discogs markup tags', () => {
+    expect(cleanDiscogsBio('See also [a=Other Artist] for more.')).toBe('See also Other Artist for more.');
+    expect(cleanDiscogsBio('Released on [l=Some Label] in 2022.')).toBe('Released on Some Label in 2022.');
+    expect(cleanDiscogsBio('Catalog [r=12345] is the master.')).toBe('Catalog 12345 is the master.');
+    expect(cleanDiscogsBio('From the [m=67890] master.')).toBe('From the 67890 master.');
+  });
+
+  it('strips Discogs URL tags, keeping link text', () => {
+    expect(cleanDiscogsBio('See [url=https://example.com]our site[/url] for more.')).toBe('See our site for more.');
+  });
+
+  it('leaves plain text alone', () => {
+    expect(cleanDiscogsBio('Just a plain bio with no markup.')).toBe('Just a plain bio with no markup.');
+  });
+});
+
+describe('extractArtwork', () => {
+  it("returns the first result's artwork on match", () => {
+    expect(extractArtwork(matchResponse)).toEqual(matchResponse.results![0]!.artwork);
+  });
+
+  it('returns null when results is empty', () => {
+    expect(extractArtwork(noMatchResponse)).toBeNull();
+  });
+
+  it('returns null when results[0] has no artwork field', () => {
+    expect(extractArtwork({ results: [{}] } as unknown as LookupResponse)).toBeNull();
+  });
+
+  it('returns null when results is undefined', () => {
+    expect(extractArtwork({} as unknown as LookupResponse)).toBeNull();
+  });
+});

--- a/tests/unit/apps/enrichment-worker/filter-spacer-gif-parity.test.ts
+++ b/tests/unit/apps/enrichment-worker/filter-spacer-gif-parity.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Parity test: the inline `filterSpacerGif` in
+ * `apps/enrichment-worker/enrich.ts` MUST be truthy/falsy-equivalent to the
+ * canonical `apps/backend/services/metadata/metadata.service.ts#filterSpacerGif`
+ * for every input the runtime exercises (BS#890).
+ *
+ * The inline copy exists for the same build-graph-isolation reason as the
+ * backfill's: `apps/enrichment-worker` is bundled independently of
+ * `apps/backend` so it can run as its own Docker container. The cost of
+ * that isolation is silent drift, which is what this test pins.
+ *
+ * The companion `scripts/check-spacer-gif-callsites.sh` CI guard pins the
+ * allowlist of source files that may mention `'spacer.gif'`. Together they
+ * make a third drift impossible without two files changing in the same
+ * commit.
+ *
+ * Sibling tests:
+ *   - `tests/unit/jobs/flowsheet-metadata-backfill/filter-spacer-gif-parity.test.ts`
+ *   - `tests/unit/jobs/library-artwork-url-backfill/filter-spacer-gif-parity.test.ts`
+ */
+
+import { filterSpacerGif as inlineFilter } from '../../../../apps/enrichment-worker/enrich';
+import { filterSpacerGif as canonicalFilter } from '../../../../apps/backend/services/metadata/metadata.service';
+
+describe('filterSpacerGif parity (enrichment-worker inline ↔ canonical)', () => {
+  const cases: Array<{ name: string; input: string | null | undefined }> = [
+    { name: 'null', input: null },
+    { name: 'undefined', input: undefined },
+    { name: 'empty string', input: '' },
+    { name: 'plain URL', input: 'https://i.discogs.com/Y6V_TKqj_xJ8RbS.jpeg' },
+    { name: 'Discogs spacer.gif placeholder', input: 'https://s.discogs.com/images/spacer.gif' },
+    { name: 'URL with "spacer.gif" embedded mid-path', input: 'https://example.com/a/spacer.gif/x' },
+    {
+      name: 'capitalized "Spacer.gif" does not match the canonical literal',
+      input: 'https://i.discogs.com/Spacer.gif',
+    },
+  ];
+
+  it.each(cases)('truthy/falsy parity on $name', ({ input }) => {
+    const inlineOut = inlineFilter(input);
+    const canonicalOut = canonicalFilter(input);
+    // Both should be truthy or both should be falsy.
+    expect(Boolean(inlineOut)).toBe(Boolean(canonicalOut));
+    // When both return a URL, the URL itself must match exactly.
+    if (inlineOut && canonicalOut) {
+      expect(inlineOut).toBe(canonicalOut);
+    }
+  });
+});

--- a/tests/unit/apps/enrichment-worker/synthesize-search-urls-parity.test.ts
+++ b/tests/unit/apps/enrichment-worker/synthesize-search-urls-parity.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Parity test: the inline `synthesizeSearchUrls` in
+ * `apps/enrichment-worker/enrich.ts` MUST produce identical output to the
+ * canonical `SearchUrlProvider.getAllSearchUrls` in
+ * `apps/backend/services/metadata/providers/search-urls.provider.ts`
+ * for the same inputs (BS#889).
+ *
+ * The inline copy exists for the same build-graph-isolation reason as the
+ * backfill's: `apps/enrichment-worker` is bundled independently of
+ * `apps/backend`. The cost of that isolation is silent drift between the
+ * two implementations — historically three different services diverged
+ * here, and iOS users saw different YouTube/Bandcamp/SoundCloud URLs
+ * depending on which BS path enriched the row. This test pins them in
+ * lockstep so the next drift fails CI loudly.
+ *
+ * Sibling test:
+ *   - `tests/unit/jobs/flowsheet-metadata-backfill/synthesize-search-urls-parity.test.ts`
+ */
+
+import { synthesizeSearchUrls } from '../../../../apps/enrichment-worker/enrich';
+import { SearchUrlProvider } from '../../../../apps/backend/services/metadata/providers/search-urls.provider';
+
+describe('synthesizeSearchUrls parity (enrichment-worker inline ↔ SearchUrlProvider)', () => {
+  const canonical = new SearchUrlProvider();
+
+  type Case = { name: string; artist: string; album: string | null; track: string | null };
+  const cases: Case[] = [
+    { name: 'full track + album + artist', artist: 'Juana Molina', album: 'DOGA', track: 'la paradoja' },
+    { name: 'no track, album present', artist: 'Stereolab', album: 'Dots and Loops', track: null },
+    { name: 'no album, track present', artist: 'Autechre', album: null, track: 'VI Scose Poise' },
+    { name: 'artist only', artist: 'Chuquimamani-Condori', album: null, track: null },
+    { name: 'diacritics in artist', artist: 'Nilüfer Yanya', album: 'Painless', track: 'stabilise' },
+    { name: 'diacritics + nothing else', artist: 'Hermanos Gutiérrez', album: null, track: null },
+    { name: 'spaces + ampersand in artist', artist: 'Duke Ellington & John Coltrane', album: null, track: null },
+  ];
+
+  it.each(cases)('$name', ({ artist, album, track }) => {
+    const inline = synthesizeSearchUrls({
+      id: 0,
+      artist_name: artist,
+      album_title: album,
+      track_title: track,
+    });
+    const canonicalOut = canonical.getAllSearchUrls(artist, album ?? undefined, track ?? undefined);
+
+    expect(inline.youtube_music_url).toBe(canonicalOut.youtubeMusicUrl);
+    expect(inline.bandcamp_url).toBe(canonicalOut.bandcampUrl);
+    expect(inline.soundcloud_url).toBe(canonicalOut.soundcloudUrl);
+  });
+});


### PR DESCRIPTION
PR-2 of the BS#892 split. PR-1 (#1007) scaffolded the package and shipped a log-only handler. This PR replaces that with the full enrichment chain.

## What

Consumer dispatcher: **filter → claim → LML lookup → finalize → CDC → SSE**.

- `apps/enrichment-worker/handler.ts` — composes the four PR-1 pieces into a single Sentry-wrapped handler. Per CDC tick: filter the event, atomically claim the row (PR-1's `claim.ts`, flips `pending` → `enriching`), call `lookupMetadata` via the shared `@wxyc/lml-client` chokepoint (Semaphore(5) + TokenBucket(50/min)), then finalize.
- `apps/enrichment-worker/enrich.ts` — finalize UPDATE: WHERE narrows by `metadata_status = 'enriching'`, writes either the 10 metadata cols + flips to `enriched_match`, or 3 synthesized search URLs + flips to `enriched_no_match`. Race detector via empty `.returning([])` → `_raced` outcome.
- `apps/enrichment-worker/instrument.ts` — Sentry `--import` preload, default `SENTRY_TRACES_SAMPLE_RATE=0.1` (worker is many-instance/high-throughput; full sample would dominate the BS Sentry budget).
- `apps/enrichment-worker/worker.ts` — swap `makeLogOnlyHandler()` for `makeEnrichmentHandler()`.

SSE broadcast (closes BS#893 + BS#628):

- `apps/backend/services/metadata-broadcast/` — new second `onCdcEvent` handler registered alongside the existing CDC websocket. Filters for `flowsheet UPDATE` with terminal `metadata_status` (`enriched_match` | `enriched_no_match` | `failed_no_retry`), broadcasts `liveFs:update` SSE with `{ id, metadata_status }`. Each BS instance broadcasts only to its own SSE clients, so no cross-instance duplication.

## Why this SSE approach over HTTP-to-backend

Considered options:
1. HTTP POST from worker to a new `/internal/flowsheet-metadata-notify` endpoint
2. PG NOTIFY on a custom channel, backend LISTENs
3. **Reuse existing CDC pipeline (chosen)**

The consumer's finalize UPDATE already triggers the existing `cdc_notify` trigger (`0046_cdc_notify_triggers.sql`). The backend already runs `startCdcListener()` for the CDC websocket. Adding a second `onCdcEvent` handler costs ~one extra callback per CDC event — zero new IPC paths, zero new env vars, and the same pattern would auto-broadcast for any future writer (tubafrenzy webhook, dj-site PATCH, anything) without re-instrumenting at each call site.

## Error handling

- **Filter rejected** — silent skip (not a candidate).
- **Claim lost** — silent skip (sibling won — expected under N×N). Span attribute `enrichment.outcome = claim_lost`.
- **LML throws** — `Sentry.captureException` + `console.error`, row left in `enriching`. The C6 stranded-claim sweep (#895) reverts past `enriching_since + 60s`. We deliberately do NOT revert to `pending` under transient LML failure — that would re-deliver to a sibling mid-failure and amplify load.
- **DB throws** — same defensive posture: capture + log, propagate to span. The handler never throws upstream (would break the CDC listener's other handlers).

## Test coverage

23 new unit tests across 2 files:

- `tests/unit/apps/enrichment-worker/enrich.test.ts` — finalize race detector, terminal-state transitions, 10-column on-match payload, 3-column on-no-match preservation of prior values, spacer.gif filter, `release_year=0` coercion, asymmetric per-service search-URL precedence (YouTube/Bandcamp/SoundCloud), DB error propagation.
- `tests/unit/apps/backend/services/metadata-broadcast.test.ts` — filter perimeter (3 terminal statuses pass, `pending`/`enriching`/`INSERT`/`DELETE`/wrong-table all skip), defensive narrowing against schema drift.

Local pre-flight: typecheck clean, lint clean (0 errors), format clean, 49/49 affected tests pass.

## NOT in this PR

- **Dockerfile + ECR + EC2 deploy wiring** — defer to PR-3 alongside the integration test.
- **Two-consumer integration test** — defer to PR-3 (asserts the idempotent-claim contract under real concurrency).
- **C5 (#894) drop fire-and-forget** — blocked on prod verification of PR-2.
- **C6 (#895) cron retune** — blocked on prod verification of PR-2.

## Related

- WXYC/Backend-Service#892 (parent C2)
- WXYC/Backend-Service#893, WXYC/Backend-Service#628 (closed by SSE broadcast)
- WXYC/Backend-Service#891 (BS#891's enum is the coordination mechanism)
- WXYC/Backend-Service#1007 (PR-1, merged)
- WXYC/Backend-Service#894 (C5; unblocked after PR-2 verified in prod)
- WXYC/Backend-Service#895 (C6; same blocker)