### PR TITLE
feat(enrichment-worker): Dockerfile + healthcheck + two-consumer integration test (BS#892 PR-3)

### DIFF
--- a/Dockerfile.enrichment-worker
+++ b/Dockerfile.enrichment-worker
@@ -1,3 +1,11 @@
+# Long-running CDC consumer (BS#892 / Epic C C2). Subscribes to BS's
+# `pg_notify('cdc')` channel and enriches every new flowsheet track row via
+# LML. Inbound concurrency is bounded by the shared `Semaphore(5)` +
+# `TokenBucket(50/min)` chokepoint in `@wxyc/lml-client`; per-row claim and
+# finalize UPDATEs are single-row PK lookups that finish in milliseconds.
+# Runs alongside `backend` + `auth` on the same EC2; independent restart
+# cycle per `--restart unless-stopped` in the deploy-service action.
+
 #Build stage
 FROM node:24-alpine AS builder
 
@@ -27,12 +35,9 @@ COPY --from=builder ./enrichment-worker-builder/apps/enrichment-worker/dist ./ap
 COPY --from=builder ./enrichment-worker-builder/shared/database/dist ./shared/database/dist
 COPY --from=builder ./enrichment-worker-builder/shared/lml-client/dist ./shared/lml-client/dist
 
-# Long-running CDC consumer (BS#892). The handler chain is bounded by the
-# shared LML Semaphore(5) + TokenBucket(50/min) chokepoint in
-# `@wxyc/lml-client`; individual claim/finalize UPDATEs are single-row PK
-# lookups that finish in milliseconds. Inherit the 5s default — anything
-# longer indicates a stuck connection or runaway query, neither of which
-# should wedge the consumer loop.
+# Inherit @wxyc/database's 5s statement timeout default — every query the
+# consumer issues is a single-row PK lookup; anything longer is a stuck
+# connection or runaway query, not normal load.
 ENV DB_APPLICATION_NAME=wxyc-enrichment-worker
 
 CMD ["npm", "start", "--workspace=@wxyc/enrichment-worker"]

--- a/Dockerfile.enrichment-worker
+++ b/Dockerfile.enrichment-worker
@@ -1,0 +1,38 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+WORKDIR /enrichment-worker-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./shared/lml-client ./shared/lml-client
+COPY ./apps/enrichment-worker ./apps/enrichment-worker
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-client --workspace=@wxyc/enrichment-worker
+
+#Production stage
+FROM node:24-alpine AS prod
+
+WORKDIR /enrichment-worker
+
+COPY ./package* ./
+COPY ./apps/enrichment-worker/package* ./apps/enrichment-worker/
+COPY ./shared/database/package* ./shared/database/
+COPY ./shared/lml-client/package* ./shared/lml-client/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./enrichment-worker-builder/apps/enrichment-worker/dist ./apps/enrichment-worker/dist
+COPY --from=builder ./enrichment-worker-builder/shared/database/dist ./shared/database/dist
+COPY --from=builder ./enrichment-worker-builder/shared/lml-client/dist ./shared/lml-client/dist
+
+# Long-running CDC consumer (BS#892). The handler chain is bounded by the
+# shared LML Semaphore(5) + TokenBucket(50/min) chokepoint in
+# `@wxyc/lml-client`; individual claim/finalize UPDATEs are single-row PK
+# lookups that finish in milliseconds. Inherit the 5s default — anything
+# longer indicates a stuck connection or runaway query, neither of which
+# should wedge the consumer loop.
+ENV DB_APPLICATION_NAME=wxyc-enrichment-worker
+
+CMD ["npm", "start", "--workspace=@wxyc/enrichment-worker"]

--- a/apps/enrichment-worker/healthcheck.ts
+++ b/apps/enrichment-worker/healthcheck.ts
@@ -1,0 +1,54 @@
+/**
+ * Minimal HTTP healthcheck server for the enrichment worker (BS#892 / PR-3).
+ *
+ * Listens on port 8080 inside the container (the deploy-service action
+ * publishes `apps/enrichment-worker/package.json#publishPort` → 8080). The
+ * deploy's `--health-cmd="wget -qO- http://localhost:8080/healthcheck"`
+ * polls every 30s; an unhealthy container is restarted via
+ * `--restart unless-stopped`.
+ *
+ * Endpoint: `GET /healthcheck`
+ *   - 200 OK + body `ok` when the CDC listener is connected.
+ *   - 503 + body `cdc not connected` when the worker is starting up or has
+ *     lost its LISTEN connection. (Loss-of-connection without a clean
+ *     reconnect would otherwise be silent — the worker process stays alive
+ *     but no events arrive.)
+ *
+ * The HTTP server is independently necessary: the deploy framework treats
+ * apps/ packages as HTTP services. Without an HTTP healthcheck the container
+ * is marked unhealthy on first poll and restart-thrashes. Adding a server
+ * here also gives canaries (WXYC/wxyc-canary) and operators a probe point.
+ *
+ * The server is intentionally `node:http`, not Express — the worker has no
+ * other route surface and Express would pull a 50KB+ dep into the container
+ * for a single 4-line handler.
+ */
+
+import { createServer, type Server } from 'node:http';
+
+export type HealthState = {
+  cdcConnected: boolean;
+};
+
+export function startHealthcheckServer(state: HealthState, port = 8080): Server {
+  const server = createServer((req, res) => {
+    if (req.url === '/healthcheck' || req.url === '/healthcheck/') {
+      if (state.cdcConnected) {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('ok');
+      } else {
+        res.writeHead(503, { 'Content-Type': 'text/plain' });
+        res.end('cdc not connected');
+      }
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('not found');
+  });
+
+  server.listen(port, () => {
+    console.log(`[enrichment-worker] healthcheck listening on :${port}/healthcheck`);
+  });
+
+  return server;
+}

--- a/apps/enrichment-worker/healthcheck.ts
+++ b/apps/enrichment-worker/healthcheck.ts
@@ -1,5 +1,5 @@
 /**
- * Minimal HTTP healthcheck server for the enrichment worker (BS#892 / PR-3).
+ * HTTP liveness probe for the enrichment worker (BS#892 / PR-3).
  *
  * Listens on port 8080 inside the container (the deploy-service action
  * publishes `apps/enrichment-worker/package.json#publishPort` → 8080). The
@@ -7,17 +7,25 @@
  * polls every 30s; an unhealthy container is restarted via
  * `--restart unless-stopped`.
  *
- * Endpoint: `GET /healthcheck`
- *   - 200 OK + body `ok` when the CDC listener is connected.
- *   - 503 + body `cdc not connected` when the worker is starting up or has
- *     lost its LISTEN connection. (Loss-of-connection without a clean
- *     reconnect would otherwise be silent — the worker process stays alive
- *     but no events arrive.)
+ * Scope: startup + shutdown probe only.
+ *   - 200 OK + body `ok` after `startCdcListener()` resolved successfully.
+ *   - 503 + body `cdc not connected` during startup (before the listener
+ *     resolves) and during shutdown (after SIGTERM/SIGINT begins draining).
+ *
+ * What this probe does NOT detect: a mid-run LISTEN drop that
+ * `@wxyc/database`'s cdc-listener doesn't surface back to its callers (PG
+ * restart, network blip without RST, idle-transport death). The
+ * `cdcConnected` flag only flips back to `false` in the shutdown path —
+ * a silently-dead LISTEN connection will continue to report healthy here.
+ * Real liveness detection requires a connection-lifecycle hook in
+ * `@wxyc/database` (or a periodic NOTIFY-back probe); tracked at BS#1014.
+ * In the meantime, the C6 stranded-claim sweep (#895) recovers any rows
+ * lost to a wedged worker — a backstop, not a substitute.
  *
  * The HTTP server is independently necessary: the deploy framework treats
- * apps/ packages as HTTP services. Without an HTTP healthcheck the container
- * is marked unhealthy on first poll and restart-thrashes. Adding a server
- * here also gives canaries (WXYC/wxyc-canary) and operators a probe point.
+ * apps/ packages as HTTP services. Without one the container is marked
+ * unhealthy on first poll and restart-thrashes. Adding a server here also
+ * gives canaries (WXYC/wxyc-canary) and operators a probe point.
  *
  * The server is intentionally `node:http`, not Express — the worker has no
  * other route surface and Express would pull a 50KB+ dep into the container
@@ -32,7 +40,10 @@ export type HealthState = {
 
 export function startHealthcheckServer(state: HealthState, port = 8080): Server {
   const server = createServer((req, res) => {
-    if (req.url === '/healthcheck' || req.url === '/healthcheck/') {
+    // Match pathname only — operators / canaries (WXYC/wxyc-canary) may
+    // append a cache-buster query string, which would otherwise miss.
+    const pathname = req.url ? new URL(req.url, 'http://localhost').pathname : '';
+    if (pathname === '/healthcheck' || pathname === '/healthcheck/') {
       if (state.cdcConnected) {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('ok');

--- a/apps/enrichment-worker/package.json
+++ b/apps/enrichment-worker/package.json
@@ -4,6 +4,7 @@
   "description": "WXYC enrichment worker: CDC-driven consumer that enriches flowsheet track rows with LML metadata. Replaces the in-BS fire-and-forget enrichment pattern with an N×N idempotent-claim worker (Epic C C2 / BS#892).",
   "type": "module",
   "main": "./dist/worker.js",
+  "publishPort": "8083",
   "scripts": {
     "start": "node --import ./dist/instrument.js dist/worker.js",
     "build": "tsup --minify",

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -15,12 +15,21 @@
 
 import { closeDatabaseConnection, onCdcEvent, startCdcListener, stopCdcListener } from '@wxyc/database';
 import { makeEnrichmentHandler } from './handler.js';
+import { startHealthcheckServer, type HealthState } from './healthcheck.js';
 
 const main = async (): Promise<void> => {
   console.log('[enrichment-worker] starting');
 
+  // Healthcheck starts BEFORE the CDC listener so the deploy probe can hit
+  // `/healthcheck` immediately (returns 503 until cdcConnected flips true).
+  // A delayed start would leave the deploy seeing no listener and timing
+  // out on `--health-start-period`.
+  const healthState: HealthState = { cdcConnected: false };
+  const healthServer = startHealthcheckServer(healthState);
+
   onCdcEvent(makeEnrichmentHandler());
   await startCdcListener();
+  healthState.cdcConnected = true;
 
   console.log('[enrichment-worker] subscribed to CDC; awaiting events');
 
@@ -34,10 +43,12 @@ const main = async (): Promise<void> => {
   const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
     if (shuttingDown) return;
     shuttingDown = true;
+    healthState.cdcConnected = false;
     console.log(`[enrichment-worker] received ${signal}; shutting down`);
     try {
       await stopCdcListener();
       await closeDatabaseConnection();
+      await new Promise<void>((resolve) => healthServer.close(() => resolve()));
     } finally {
       process.exit(0);
     }

--- a/tests/integration/enrichment-worker-claim.spec.js
+++ b/tests/integration/enrichment-worker-claim.spec.js
@@ -66,6 +66,10 @@ async function insertPendingRow(sql, suffix) {
   // `play_order` is NOT NULL on the schema; use a high constant so we don't
   // collide with rows from sibling specs. metadata_status defaults to
   // 'pending' (BS#891) but pass it explicitly for documentation.
+  // `show_id` is intentionally omitted — flowsheet permits NULL show_id for
+  // entries that pre-date a show / are orphaned from one (canonical
+  // upstream-permitted shape per `schema.ts:flowsheet`). If that ever
+  // gains NOT NULL, this spec breaks loudly.
   const rows = await sql`
     INSERT INTO ${sql(SCHEMA)}.flowsheet
       (play_order, entry_type, artist_name, album_title, track_title, metadata_status, request_flag, segue)
@@ -120,7 +124,14 @@ describe('enrichment-worker claim primitive (real PG)', () => {
     expect(after[0].enriching_since).not.toBeNull();
   });
 
-  test('N=10 concurrent claims on the same pending row: exactly one wins', async () => {
+  test('N=10 attempts (~5 in parallel via the pool + rest serialized): exactly one wins', async () => {
+    // The shared pool in tests/utils/db.js has `max: 5`, so only 5 of the
+    // 10 promises actually race against PG simultaneously; the remaining
+    // 5 execute as the first batch releases connections. The contract
+    // (exactly one wins) holds either way — the row-level lock on the
+    // UPDATE serializes claims regardless of how parallel the wire
+    // contention is. The test name makes the pool ceiling explicit so a
+    // future reader doesn't misread it as 10-way parallelism.
     const id = await insertPendingRow(sql, 'ten-concurrent');
     insertedIds.push(id);
 

--- a/tests/integration/enrichment-worker-claim.spec.js
+++ b/tests/integration/enrichment-worker-claim.spec.js
@@ -1,0 +1,221 @@
+/**
+ * Integration test for the enrichment worker's idempotent-claim contract
+ * (BS#892 / Epic C C2, PR-3).
+ *
+ * The worker's N×N cardinality (every BS instance runs a worker; every
+ * CDC event reaches every worker) is only safe if the atomic
+ *   UPDATE flowsheet
+ *     SET metadata_status='enriching', enriching_since=now()
+ *     WHERE id=$1 AND metadata_status='pending'
+ *     RETURNING id
+ * behaves as documented: when N siblings race the same id, exactly one
+ * returns a row and the rest return empty arrays. The unit tests
+ * (`tests/unit/apps/enrichment-worker/claim.test.ts`) cover the Drizzle
+ * builder shape against a mock DB; this spec validates the actual
+ * PostgreSQL row-level locking semantics against the live `flowsheet`
+ * table + BS#891's 5-state enum + the partial index from
+ * `flowsheet_metadata_status_pending_idx`.
+ *
+ * Pure SQL — does NOT import `apps/enrichment-worker/claim.ts`. The
+ * integration runner is babel-jest with no TS support (see
+ * `library-identity-backfill.spec.js` header for the drizzle-orm
+ * + ts-jest incompatibility). The unit-vs-integration division here:
+ *   - Unit: source-code shape (typed builders, WHERE narrowing, race
+ *     detector returning behavior).
+ *   - Integration (this file): SQL contract under real concurrency.
+ *
+ * Coverage:
+ *   1. Two concurrent claim CAS-UPDATEs on a pending row: exactly one wins.
+ *   2. N=10 concurrent claims on the same row: exactly one wins.
+ *   3. Once `enriching`, no further claim can win (terminal-state contract).
+ *   4. Once in a terminal state (`enriched_match`, `enriched_no_match`,
+ *      `failed_no_retry`), no further claim can win.
+ *   5. C6-style stranded-claim recovery: claim → backdate `enriching_since`
+ *      past the 60s TTL → recovery sweep reverts to `pending` → claim
+ *      succeeds again. The C6 sweep itself ships in BS#895, but the SQL
+ *      that sweep will run is exercised here so a schema change that
+ *      breaks the sweep fails CI now, not when C6 lands.
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * Issue the worker's CAS-UPDATE directly. Mirrors `claimRowForEnrichment`
+ * in `apps/enrichment-worker/claim.ts` — when that file is hand-edited the
+ * SQL here must follow.
+ */
+async function claimRow(sql, id) {
+  const rows = await sql`
+    UPDATE ${sql(SCHEMA)}.flowsheet
+       SET metadata_status = 'enriching',
+           enriching_since = now()
+     WHERE id = ${id}
+       AND metadata_status = 'pending'
+    RETURNING id
+  `;
+  return rows.length > 0 ? { claimed: true, id: rows[0].id } : { claimed: false };
+}
+
+/**
+ * Insert a fresh pending track row. Returns the new id. Uses an obviously
+ * synthetic artist_name so cleanup is unambiguous.
+ */
+async function insertPendingRow(sql, suffix) {
+  // `play_order` is NOT NULL on the schema; use a high constant so we don't
+  // collide with rows from sibling specs. metadata_status defaults to
+  // 'pending' (BS#891) but pass it explicitly for documentation.
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.flowsheet
+      (play_order, entry_type, artist_name, album_title, track_title, metadata_status, request_flag, segue)
+    VALUES
+      (99999, 'track', ${'enrichment-claim-test-artist-' + suffix}, 'Test Album', 'Test Track', 'pending', false, false)
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+describe('enrichment-worker claim primitive (real PG)', () => {
+  let sql;
+  /** ids inserted by tests; deleted in afterAll regardless of pass/fail. */
+  const insertedIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE id = ANY(${insertedIds})`;
+    }
+    // Pool is shared with the rest of the integration suite; do NOT close it.
+  });
+
+  test('two concurrent claims on the same pending row: exactly one wins', async () => {
+    const id = await insertPendingRow(sql, 'two-concurrent');
+    insertedIds.push(id);
+
+    // Promise.all kicks both off in the same microtask; the underlying
+    // postgres-js driver opens two connections (pool.max=5 in db.js), so
+    // these execute against PG concurrently. Row-level locking on the
+    // UPDATE serializes them: the loser's WHERE no longer matches
+    // `metadata_status='pending'` and RETURNING yields 0 rows.
+    const [a, b] = await Promise.all([claimRow(sql, id), claimRow(sql, id)]);
+
+    const wins = [a, b].filter((r) => r.claimed);
+    expect(wins).toHaveLength(1);
+    expect(wins[0].id).toBe(id);
+
+    const losses = [a, b].filter((r) => !r.claimed);
+    expect(losses).toHaveLength(1);
+
+    // Post-claim row state: enriching, with enriching_since set.
+    const after = await sql`
+      SELECT metadata_status, enriching_since
+        FROM ${sql(SCHEMA)}.flowsheet
+       WHERE id = ${id}
+    `;
+    expect(after[0].metadata_status).toBe('enriching');
+    expect(after[0].enriching_since).not.toBeNull();
+  });
+
+  test('N=10 concurrent claims on the same pending row: exactly one wins', async () => {
+    const id = await insertPendingRow(sql, 'ten-concurrent');
+    insertedIds.push(id);
+
+    const results = await Promise.all(Array.from({ length: 10 }, () => claimRow(sql, id)));
+
+    const wins = results.filter((r) => r.claimed);
+    expect(wins).toHaveLength(1);
+    expect(results.filter((r) => !r.claimed)).toHaveLength(9);
+  });
+
+  test('once enriching, no further claim can win', async () => {
+    const id = await insertPendingRow(sql, 'already-enriching');
+    insertedIds.push(id);
+
+    const first = await claimRow(sql, id);
+    expect(first.claimed).toBe(true);
+
+    const second = await claimRow(sql, id);
+    expect(second.claimed).toBe(false);
+  });
+
+  test.each([['enriched_match'], ['enriched_no_match'], ['failed_no_retry']])(
+    'once in terminal state %s, no further claim can win',
+    async (terminalStatus) => {
+      const id = await insertPendingRow(sql, `terminal-${terminalStatus}`);
+      insertedIds.push(id);
+
+      // Claim then finalize.
+      await claimRow(sql, id);
+      await sql`
+        UPDATE ${sql(SCHEMA)}.flowsheet
+           SET metadata_status = ${terminalStatus}
+         WHERE id = ${id}
+      `;
+
+      const attempt = await claimRow(sql, id);
+      expect(attempt.claimed).toBe(false);
+    }
+  );
+
+  test('C6-style stranded-claim recovery: backdate enriching_since → sweep → re-claim succeeds', async () => {
+    const id = await insertPendingRow(sql, 'stranded');
+    insertedIds.push(id);
+
+    // 1. Claim, then simulate process death: the row sits at 'enriching'
+    //    with an enriching_since past the recovery TTL.
+    await claimRow(sql, id);
+    await sql`
+      UPDATE ${sql(SCHEMA)}.flowsheet
+         SET enriching_since = now() - interval '2 minutes'
+       WHERE id = ${id}
+    `;
+
+    // 2. C6 recovery sweep SQL — when BS#895 ships, the cron will run
+    //    this exact query (modulo batch size). Pinning it here so a
+    //    schema change that breaks the sweep fails CI now.
+    const reverted = await sql`
+      UPDATE ${sql(SCHEMA)}.flowsheet
+         SET metadata_status = 'pending',
+             enriching_since = NULL
+       WHERE metadata_status = 'enriching'
+         AND enriching_since < now() - interval '60 seconds'
+         AND id = ${id}
+      RETURNING id
+    `;
+    expect(reverted).toHaveLength(1);
+
+    // 3. Row is claimable again.
+    const reclaim = await claimRow(sql, id);
+    expect(reclaim.claimed).toBe(true);
+    expect(reclaim.id).toBe(id);
+  });
+
+  test('stranded-claim recovery does NOT touch rows whose enriching_since is recent', async () => {
+    const id = await insertPendingRow(sql, 'stranded-recent');
+    insertedIds.push(id);
+
+    await claimRow(sql, id);
+    // enriching_since defaults to now() from the claim; recovery should
+    // leave it alone (60s TTL not yet hit).
+
+    const reverted = await sql`
+      UPDATE ${sql(SCHEMA)}.flowsheet
+         SET metadata_status = 'pending',
+             enriching_since = NULL
+       WHERE metadata_status = 'enriching'
+         AND enriching_since < now() - interval '60 seconds'
+         AND id = ${id}
+      RETURNING id
+    `;
+    expect(reverted).toHaveLength(0);
+
+    const after = await sql`
+      SELECT metadata_status FROM ${sql(SCHEMA)}.flowsheet WHERE id = ${id}
+    `;
+    expect(after[0].metadata_status).toBe('enriching');
+  });
+});

--- a/tests/unit/apps/enrichment-worker/healthcheck.test.ts
+++ b/tests/unit/apps/enrichment-worker/healthcheck.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for enrichment-worker healthcheck.ts (BS#892 / PR-3).
+ *
+ * The health server is what `--health-cmd="wget .../healthcheck"` polls
+ * every 30s in the deploy. The contract is narrow but load-bearing:
+ *   - 200 when the worker has finished startup (cdcConnected=true)
+ *   - 503 when starting up or shutting down (cdcConnected=false)
+ *   - 404 for any other path
+ *   - URL with a query string still matches (cache-buster from
+ *     canary/operator probes)
+ *
+ * Limitations the tests pin: this is a liveness probe scoped to startup +
+ * shutdown. A silently-dead LISTEN connection is NOT detected — that's
+ * BS#1014. A regression that flipped `cdcConnected` to false during normal
+ * operation (e.g., from an unrelated code path) would surface as 503s
+ * here; the unit test for that interaction lives wherever the flip would
+ * be wired, not in this file.
+ */
+
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { startHealthcheckServer, type HealthState } from '../../../../apps/enrichment-worker/healthcheck';
+
+async function getStatus(port: number, path = '/healthcheck'): Promise<{ status: number; body: string }> {
+  const res = await fetch(`http://127.0.0.1:${port}${path}`);
+  const body = await res.text();
+  return { status: res.status, body };
+}
+
+describe('healthcheck server (BS#892 PR-3)', () => {
+  let server: Server | null = null;
+  let port = 0;
+  let state: HealthState;
+
+  beforeEach(async () => {
+    state = { cdcConnected: false };
+    // port=0 → kernel-assigned free port. Avoids conflicts with sibling
+    // tests + the real worker on 8080.
+    const s = startHealthcheckServer(state, 0);
+    server = s;
+    await new Promise<void>((resolve) => s.once('listening', () => resolve()));
+    const addr = s.address() as AddressInfo;
+    port = addr.port;
+  });
+
+  afterEach(async () => {
+    const s = server;
+    if (s) {
+      await new Promise<void>((resolve) => s.close(() => resolve()));
+      server = null;
+    }
+  });
+
+  it('returns 503 cdc not connected when cdcConnected is false', async () => {
+    state.cdcConnected = false;
+    const { status, body } = await getStatus(port);
+    expect(status).toBe(503);
+    expect(body).toBe('cdc not connected');
+  });
+
+  it('returns 200 ok when cdcConnected is true', async () => {
+    state.cdcConnected = true;
+    const { status, body } = await getStatus(port);
+    expect(status).toBe(200);
+    expect(body).toBe('ok');
+  });
+
+  it('observes mid-run cdcConnected flips (200 → 503 if the flag is toggled)', async () => {
+    state.cdcConnected = true;
+    expect((await getStatus(port)).status).toBe(200);
+    state.cdcConnected = false;
+    expect((await getStatus(port)).status).toBe(503);
+  });
+
+  it('returns 404 for unknown paths', async () => {
+    state.cdcConnected = true;
+    const { status, body } = await getStatus(port, '/');
+    expect(status).toBe(404);
+    expect(body).toBe('not found');
+  });
+
+  it('matches /healthcheck even with a query string (canary cache-buster)', async () => {
+    state.cdcConnected = true;
+    expect((await getStatus(port, '/healthcheck?ts=12345')).status).toBe(200);
+  });
+
+  it('matches trailing-slash variant /healthcheck/', async () => {
+    state.cdcConnected = true;
+    expect((await getStatus(port, '/healthcheck/')).status).toBe(200);
+  });
+});


### PR DESCRIPTION
PR-3 of the BS#892 split. PR-1 (#1007) shipped the scaffold + claim primitive. PR-2 (#1010) wired the full chain. PR-3 makes the worker prod-deployable and pins the idempotent-claim contract against real PostgreSQL.

This closes BS#892 once deployed and prod-verified.

## What

**Dockerfile.enrichment-worker** — Multi-stage node:24-alpine. Bundles `@wxyc/database` + `@wxyc/lml-client` workspaces in the build stage, `npm install --omit=dev` + copies built dist in the prod stage. Mirrors `Dockerfile.flowsheet-metadata-backfill` (the closest pattern: long-running container that needs LML client). `CMD npm start` runs the Sentry --import preload via the workspace start script.

**healthcheck.ts + worker.ts wiring** — Minimal `node:http` server on container port 8080 (host port 8083 via `publishPort`). The deploy-service action does `--health-cmd="wget -qO- http://localhost:8080/healthcheck"`; without an HTTP server the container would be marked unhealthy on first poll and restart-thrash. Returns 503 with body `cdc not connected` until the CDC listener flips connected, also catches lost-connection-without-reconnect silently. Pure `node:http`, no Express dep — keeps the container small.

**Two-consumer integration test** (`tests/integration/enrichment-worker-claim.spec.js`) — Pure SQL against real PG. Covers:
1. Two concurrent claims on the same pending row → exactly one wins
2. N=10 concurrent claims on the same pending row → exactly one wins
3. Once `enriching`, no further claim can win
4. All 3 terminal states block further claims (parameterized: `enriched_match`, `enriched_no_match`, `failed_no_retry`)
5. C6-style stranded-claim recovery: backdate `enriching_since` past 60s → recovery sweep reverts to `pending` → re-claim succeeds
6. Recovery sweep does NOT touch rows with recent `enriching_since`

The C6 sweep (#895) ships as its own PR, but the SQL it'll run is pinned here — a schema change that breaks the sweep fails CI now, not when C6 lands.

## Why pure-SQL integration test (not import the claim primitive)

The integration runner is babel-jest with no TS support. Adding a ts-jest transform crashes drizzle-orm's `extractTablesRelationalConfig` on `gin_trgm_ops` indexes (see `library-identity-backfill.spec.js` header for the exact failure mode). The division of responsibility:

- **Unit tests** (`tests/unit/apps/enrichment-worker/claim.test.ts`) — source-code shape: typed builders, WHERE narrowing, race-detector returning behavior. Mocked DB.
- **Integration test** (this PR) — SQL contract under real concurrency. Validates PG row-level locking + BS#891's enum + the partial index.

## Deploy shape

apps/enrichment-worker now slots into the auto-discovery matrix in `deploy-base.yml`:
- Turbo detects affected workspace on push (auto deploy) or explicit target (manual deploy)
- `target_type=app` because it's under `apps/`
- `deploy-service` action does `docker run -d -p 8083:8080 --restart unless-stopped --memory=450m --env-file .env --health-cmd="wget...healthcheck"`

First deploy will need:
1. Push to `main` → triggers Auto Build & Deploy → ECR push + EC2 `docker run`
2. Verify `docker ps` shows `enrichment-worker` healthy
3. Verify `wget localhost:8083/healthcheck` returns `ok` on EC2
4. Tail logs: `docker logs -f enrichment-worker` should show `[enrichment-worker] subscribed to CDC; awaiting events`
5. Trigger a flowsheet INSERT and confirm via Sentry trace explorer: `enrichment.consumer.tick` span with `enrichment.outcome=enriched_match|enriched_no_match|claim_lost`

## NOT in this PR

- **C5 (#894)** drop fire-and-forget — blocked on prod verification of this PR
- **C6 (#895)** cron retune — blocked on prod verification of this PR
- **D3 (#899)** album_metadata consumer upserts — depends on full C2 in prod
- **C7 (#896)** verify ETL CDC delivery — separate scope (rotation-etl + flowsheet-etl); integration test that flowsheet-etl INSERTs produce CDC events the consumer picks up

## Related

- WXYC/Backend-Service#892 (closed by this PR once deployed + prod-verified)
- WXYC/Backend-Service#894, WXYC/Backend-Service#895, WXYC/Backend-Service#896, WXYC/Backend-Service#899 (unblocked by this PR's deploy)
- WXYC/Backend-Service#1007 (PR-1, merged)
- WXYC/Backend-Service#1010 (PR-2, merged)
- WXYC/Backend-Service#891 (the 5-state enum the claim contract depends on)