### PR TITLE
fix(docker): wire NPM_TOKEN + .npmrc into enrichment-worker + backfill Dockerfiles

### DIFF
--- a/Dockerfile.enrichment-worker
+++ b/Dockerfile.enrichment-worker
@@ -9,8 +9,10 @@
 #Build stage
 FROM node:24-alpine AS builder
 
+ARG NPM_TOKEN
 WORKDIR /enrichment-worker-builder
 
+COPY ./.npmrc ./
 COPY ./package.json ./package-lock.json ./
 COPY ./tsconfig.base.json ./
 COPY ./shared/database ./shared/database
@@ -22,14 +24,20 @@ RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-cli
 #Production stage
 FROM node:24-alpine AS prod
 
+ARG NPM_TOKEN
 WORKDIR /enrichment-worker
 
+COPY ./.npmrc ./
 COPY ./package* ./
 COPY ./apps/enrichment-worker/package* ./apps/enrichment-worker/
 COPY ./shared/database/package* ./shared/database/
 COPY ./shared/lml-client/package* ./shared/lml-client/
 
-RUN npm install --omit=dev
+# `@wxyc/lml-client` declares `@wxyc/shared` as a registry dependency
+# (GitHub Packages, `@wxyc:registry` in `.npmrc`). Without NPM_TOKEN +
+# .npmrc the prod stage's npm install 401s on @wxyc/shared. Mirrors the
+# pattern in Dockerfile.backend.
+RUN npm install --omit=dev && rm -f .npmrc
 
 COPY --from=builder ./enrichment-worker-builder/apps/enrichment-worker/dist ./apps/enrichment-worker/dist
 COPY --from=builder ./enrichment-worker-builder/shared/database/dist ./shared/database/dist

--- a/Dockerfile.flowsheet-metadata-backfill
+++ b/Dockerfile.flowsheet-metadata-backfill
@@ -1,8 +1,10 @@
 #Build stage
 FROM node:24-alpine AS builder
 
+ARG NPM_TOKEN
 WORKDIR /flowsheet-metadata-backfill-builder
 
+COPY ./.npmrc ./
 COPY ./package.json ./package-lock.json ./
 COPY ./tsconfig.base.json ./
 COPY ./shared/database ./shared/database
@@ -14,14 +16,20 @@ RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-cli
 #Production stage
 FROM node:24-alpine AS prod
 
+ARG NPM_TOKEN
 WORKDIR /flowsheet-metadata-backfill
 
+COPY ./.npmrc ./
 COPY ./package* ./
 COPY ./jobs/flowsheet-metadata-backfill/package* ./jobs/flowsheet-metadata-backfill/
 COPY ./shared/database/package* ./shared/database/
 COPY ./shared/lml-client/package* ./shared/lml-client/
 
-RUN npm install --omit=dev
+# `@wxyc/lml-client` declares `@wxyc/shared` as a registry dependency
+# (GitHub Packages, `@wxyc:registry` in `.npmrc`). Without NPM_TOKEN +
+# .npmrc the prod stage's npm install 401s on @wxyc/shared. Mirrors the
+# pattern in Dockerfile.backend.
+RUN npm install --omit=dev && rm -f .npmrc
 
 COPY --from=builder ./flowsheet-metadata-backfill-builder/jobs/flowsheet-metadata-backfill/dist ./jobs/flowsheet-metadata-backfill/dist
 COPY --from=builder ./flowsheet-metadata-backfill-builder/shared/database/dist ./shared/database/dist


### PR DESCRIPTION
## Summary

Auto Build & Deploy has been red since `c9deea6c` (2026-05-22 23:09 UTC) — both `build (enrichment-worker)` and `build (flowsheet-metadata-backfill)` 401 on `@wxyc/shared` during `npm install --omit=dev` in their prod stages.

Five consecutive failed deploys: `c9deea6c` → `84edfffc` → `f6d47a1d` → `80815db7` → `acd77e7e` (the PR #1013 merge).

## Root cause

`@wxyc/lml-client` declares `@wxyc/shared` as a registry dependency (GitHub Packages, `@wxyc:registry` in `.npmrc`). Both Dockerfiles' prod stages COPY `shared/lml-client/package.json` and then run `npm install --omit=dev`, which tries to fetch `@wxyc/shared` from `npm.pkg.github.com`. Without `.npmrc` + `NPM_TOKEN`, that fetch returns 401:

```
9.473 npm error 401 Unauthorized - GET https://npm.pkg.github.com/download/@wxyc/shared/1.6.0/... - authentication token not provided
```

`Dockerfile.backend` already has the correct pattern: `ARG NPM_TOKEN` + `COPY ./.npmrc ./` in both stages, with `rm -f .npmrc` after install. The pattern was simply missing in the two affected Dockerfiles. `c9deea6c` introduced the `@wxyc/lml-client` COPY into the backfill Dockerfile without the auth bits; PR #1013's new `Dockerfile.enrichment-worker` inherited the broken pattern.

The deploy workflow at `.github/workflows/deploy-base.yml:294` already passes `--build-arg NPM_TOKEN=${{ secrets.NPM_TOKEN }}` to every docker build; the secret was in place, just unused by these two Dockerfiles.

## Changes

- `Dockerfile.enrichment-worker` + `Dockerfile.flowsheet-metadata-backfill`: `ARG NPM_TOKEN` + `COPY ./.npmrc ./` in both builder and prod stages; `rm -f .npmrc` after the prod-stage install so the token doesn't ship in the image layer.

## Test plan

- [x] Local: `git diff` shows minimal patch; ARG/COPY positions match `Dockerfile.backend`.
- [ ] CI: Auto Build & Deploy run on merge — `build (enrichment-worker)` + `build (flowsheet-metadata-backfill)` should both succeed.
- [ ] Post-deploy: `docker ps` on EC2 shows `enrichment-worker` healthy; `flowsheet-metadata-backfill-cron` image has the BS#995 static gate baked in.

## Why this blocks BS#1011

BS#1011 (the historical drain completion) can't proceed until a backfill image with the PR #1001 static gate is on EC2. The current image was built before c9deea6c — it predates the @wxyc/lml-client bundling, so the gate isn't in it. This PR unblocks both:

1. The next Auto Build & Deploy produces a `flowsheet-metadata-backfill` image with the static gate.
2. `enrichment-worker` actually lands on EC2 (BS#892's deploy gate).

## Related

- WXYC/Backend-Service#1011 — blocked by this; resumes after deploy.
- WXYC/Backend-Service#1013 — the PR-3 merge that surfaced the gap.
- `c9deea6c` — the commit that introduced the broken pattern in `Dockerfile.flowsheet-metadata-backfill`.
