### PR TITLE
fix(enrichment-worker): move publishPort 8083 → 8084 (collides with semantic-index)

### DIFF
--- a/apps/enrichment-worker/package.json
+++ b/apps/enrichment-worker/package.json
@@ -4,7 +4,7 @@
   "description": "WXYC enrichment worker: CDC-driven consumer that enriches flowsheet track rows with LML metadata. Replaces the in-BS fire-and-forget enrichment pattern with an N×N idempotent-claim worker (Epic C C2 / BS#892).",
   "type": "module",
   "main": "./dist/worker.js",
-  "publishPort": "8083",
+  "publishPort": "8084",
   "scripts": {
     "start": "node --import ./dist/instrument.js dist/worker.js",
     "build": "tsup --minify",


### PR DESCRIPTION
## Problem

BS#892 PR-3 ([#1013](https://github.com/WXYC/Backend-Service/pull/1013)) set `apps/enrichment-worker/package.json:7` `"publishPort": "8083"`. That collides with **semantic-index** — co-located on the same EC2 (1.9 GiB `t3.small`), serving `explore.wxyc.org` on port 8083.

The `deploy-service` composite action at [`.github/actions/deploy-service/action.yml:67`](https://github.com/WXYC/Backend-Service/blob/main/.github/actions/deploy-service/action.yml#L67) does:

```bash
docker ps --filter "publish=$PUBLISH_PORT" --format "{{.ID}}" | xargs -r docker stop
```

So when enrichment-worker deployed for the first time tonight (after PR [#1015](https://github.com/WXYC/Backend-Service/pull/1015) unblocked the Docker build), it stopped semantic-index. `explore.wxyc.org` started serving the enrichment-worker's bare `/healthcheck` response.

Manually restored just now:
```
ssh wxyc-ec2 'docker stop enrichment-worker && docker start semantic-index'
```

That restored `explore.wxyc.org` but took the CDC consumer offline. The runtime fire-and-forget enrichment path (still in place, not yet removed by #894) is doing inline enrichment, so users don't see broken metadata — but the worker should come back up properly once this lands.

## Fix

Move enrichment-worker's `publishPort` from 8083 → **8084**. Per `reference_ec2_access.md` memory, this is the next free port on the host:

| Service | Port |
|---|---|
| `backend` | 8080 |
| `auth` | 8082 |
| `semantic-index` | 8083 (serves explore.wxyc.org) |
| `enrichment-worker` | **8084** (this PR) |
| `wikijs` | 127.0.0.1:3000 (loopback, no collision) |

## How this slipped through

In my [#1013 review comment](https://github.com/WXYC/Backend-Service/pull/1013#issuecomment-4523599170), I flagged `publishPort: "8083"` only as a string-vs-number consistency concern. The collision with semantic-index wasn't surfaced — semantic-index's port assignment is in a separate repo and was only in operational memory, not the code surfaces I was reviewing. Future port-additions on this box deserve a manual cross-check against `reference_ec2_access.md`'s service table.

## Test plan

- [x] `git diff` — one-line `package.json` change; nothing else touched.
- [ ] CI on this PR.
- [ ] After merge + Auto Build & Deploy: verify on EC2 that `enrichment-worker` is healthy on port 8084 and `semantic-index` remains healthy on 8083.
- [ ] Verify `explore.wxyc.org` continues to serve.

## Related

- [#1013](https://github.com/WXYC/Backend-Service/pull/1013) — introduced the 8083 publishPort.
- [#1015](https://github.com/WXYC/Backend-Service/pull/1015) — unblocked the Docker build, which then triggered the first enrichment-worker deploy that surfaced the collision.
- [`reference_ec2_access.md`](https://github.com/WXYC/Backend-Service/blob/main/CLAUDE.md) — port assignments on the shared EC2.
