### PR TITLE
fix(album-metadata-backfill): verifyComplete dual-count replaces LEFT JOIN (closes #1019)

### DIFF
--- a/jobs/album-metadata-backfill/job.ts
+++ b/jobs/album-metadata-backfill/job.ts
@@ -85,31 +85,44 @@ const analyzeTable = async (): Promise<void> => {
 };
 
 /**
- * Verify completeness via the same filter as the INSERT, anti-joined against
- * `album_metadata`. A non-zero count points to either concurrent writes during
- * the run (rare on an off-hours window) or a row that materialized between
- * the INSERT and the verify. Re-running the job is safe — the INSERT is
- * idempotent via `ON CONFLICT DO NOTHING`.
+ * Verify completeness by comparing two aggregate counts: the size of
+ * `album_metadata` against the number of distinct `album_id`s in the enriched
+ * subset of flowsheet (the source set the INSERT enumerated). Both sides run
+ * on already-indexed paths and complete in well under the backend's default
+ * 5 s `statement_timeout`, so this step does not need a `db.transaction`
+ * wrapper.
+ *
+ * The earlier shape (`LEFT JOIN flowsheet → album_metadata` anti-join) scanned
+ * the full ~2.6M-row flowsheet and tripped the 5 s timeout on the 2026-05-22
+ * prod run (BS#1019). The INSERT itself completed cleanly that run; only the
+ * verification gate misfired.
+ *
+ * Invariant: `actual >= expected`. Equality is the steady state today
+ * (D2 backfill only, no live writer to `album_metadata`). Once D3 (#899)
+ * ships, a live UPSERT can land between this job's INSERT and the verify,
+ * producing `actual > expected` legitimately — never the other way around,
+ * since the INSERT is idempotent and never deletes. Re-running the job is
+ * safe (`ON CONFLICT (album_id) DO NOTHING`).
  */
 const verifyComplete = async (): Promise<void> => {
   const result = await db.execute(sql`
-    SELECT count(*)::int AS missing
-    FROM "wxyc_schema"."flowsheet" AS f
-    LEFT JOIN "wxyc_schema"."album_metadata" AS am ON f."album_id" = am."album_id"
-    WHERE f."album_id" IS NOT NULL
-      AND f."metadata_attempt_at" IS NOT NULL
-      AND am."album_id" IS NULL
+    SELECT
+      (SELECT count(*)::int FROM "wxyc_schema"."album_metadata") AS actual,
+      (SELECT count(DISTINCT "album_id")::int FROM "wxyc_schema"."flowsheet"
+        WHERE "album_id" IS NOT NULL
+          AND "metadata_attempt_at" IS NOT NULL) AS expected
   `);
-  const missing = Number((result as unknown as Array<{ missing: number }>)[0]?.missing ?? 0);
-  if (missing > 0) {
+  const row = (result as unknown as Array<{ actual: number; expected: number }>)[0];
+  const actual = Number(row?.actual ?? 0);
+  const expected = Number(row?.expected ?? 0);
+  if (actual < expected) {
     throw new Error(
-      `[${JOB_NAME}] Verification failed: ${missing} flowsheet row(s) still have no matching album_metadata. ` +
+      `[${JOB_NAME}] Verification failed: album_metadata has ${actual} row(s), expected at least ${expected} ` +
+        `from the enriched flowsheet subset. ` +
         `Re-run the backfill — it is idempotent and will pick up the remaining rows.`
     );
   }
-  console.log(
-    `[${JOB_NAME}] Verification passed: every enriched flowsheet row has a corresponding album_metadata row.`
-  );
+  console.log(`[${JOB_NAME}] Verification passed: album_metadata=${actual} >= expected=${expected}.`);
 };
 
 const formatDuration = (ms: number): string => {

--- a/tests/unit/jobs/album-metadata-backfill/job.test.ts
+++ b/tests/unit/jobs/album-metadata-backfill/job.test.ts
@@ -199,34 +199,47 @@ describe('album-metadata-backfill: verifyComplete', () => {
     jest.restoreAllMocks();
   });
 
-  it('passes when zero enriched flowsheet rows are missing from album_metadata', async () => {
-    (db.execute as jest.Mock).mockResolvedValueOnce([{ missing: 0 }]);
+  it('passes when album_metadata count equals the enriched flowsheet album count', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ actual: 7101, expected: 7101 }]);
 
     await expect(verifyComplete()).resolves.toBeUndefined();
   });
 
-  it('throws with a row count and remediation hint when rows are missing', async () => {
-    (db.execute as jest.Mock).mockResolvedValue([{ missing: 137 }]);
+  it('passes when actual > expected (a concurrent live write between INSERT and verify)', async () => {
+    // D3 (#899) will ship a live UPSERT writer into album_metadata. After it
+    // lands, a write that arrives between this job's INSERT and the verify
+    // produces actual > expected without losing data. A strict equality check
+    // would false-fail in that window; `>=` is the correct invariant.
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ actual: 7102, expected: 7101 }]);
 
-    await expect(verifyComplete()).rejects.toThrow(/137 flowsheet row\(s\)/);
+    await expect(verifyComplete()).resolves.toBeUndefined();
+  });
+
+  it('throws with both counts and the idempotent re-run hint when album_metadata is short', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([{ actual: 6964, expected: 7101 }]);
+
+    await expect(verifyComplete()).rejects.toThrow(/6964/);
+    await expect(verifyComplete()).rejects.toThrow(/7101/);
     await expect(verifyComplete()).rejects.toThrow(/idempotent/i);
   });
 
-  it('uses the same filter as the migration (LEFT JOIN to find the residual)', async () => {
-    // The verify query must enumerate the same set as the INSERT's SELECT but
-    // anti-joined against album_metadata. Drift here (e.g., dropping the
-    // metadata_attempt_at filter) would either always pass or always fail.
-    (db.execute as jest.Mock).mockResolvedValueOnce([{ missing: 0 }]);
+  it('uses a dual-count comparison instead of a LEFT JOIN over flowsheet (statement_timeout safe)', async () => {
+    // The previous LEFT JOIN over the 2.6M-row flowsheet timed out under the
+    // backend's default 5 s statement_timeout (BS#1019: prod run 2026-05-22).
+    // Two aggregate counts on already-indexed paths complete well under the
+    // budget, so the verify step doesn't need a db.transaction wrapper.
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ actual: 0, expected: 0 }]);
 
     await verifyComplete();
 
-    const call = findExecuteCallMatching(/SELECT[\s\S]*count[\s\S]*flowsheet/i);
+    const call = findExecuteCallMatching(/SELECT[\s\S]*count[\s\S]*album_metadata/i);
     expect(call).toBeDefined();
     const sqlText = renderSql(call?.[0]);
-    expect(sqlText).toMatch(/LEFT\s+JOIN[\s\S]*album_metadata/i);
-    expect(sqlText).toMatch(/f\."album_id"\s+IS\s+NOT\s+NULL/i);
-    expect(sqlText).toMatch(/f\."metadata_attempt_at"\s+IS\s+NOT\s+NULL/i);
-    expect(sqlText).toMatch(/am\."album_id"\s+IS\s+NULL/i);
+    expect(sqlText).not.toMatch(/LEFT\s+JOIN/i);
+    expect(sqlText).toMatch(/count\([\s\S]*\)[\s\S]*album_metadata/i);
+    expect(sqlText).toMatch(/count\(\s*DISTINCT[\s\S]*album_id[\s\S]*\)[\s\S]*flowsheet/i);
+    expect(sqlText).toMatch(/album_id"?\s+IS\s+NOT\s+NULL/i);
+    expect(sqlText).toMatch(/metadata_attempt_at"?\s+IS\s+NOT\s+NULL/i);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replaces `verifyComplete`'s 2.6M-row LEFT JOIN anti-join with a single composite SELECT of two aggregate counts.
- Drops the dependency on a `db.transaction` wrapper (the dual-count completes well inside the 5 s `DB_STATEMENT_TIMEOUT_MS`).
- Relaxes the success check to `actual >= expected` so a future D3 (#899) live UPSERT landing between the INSERT and the verify won't false-fail.

Closes #1019.

## Background

The 2026-05-22 prod run of `album-metadata-backfill` (PR #1016, BS#898) completed its `INSERT … SELECT DISTINCT ON … ON CONFLICT DO NOTHING` cleanly — 7,101 rows in ~13 s, then `ANALYZE` completed too — but the post-INSERT verification step exited the container non-zero:

```
PostgresError: canceling statement due to statement timeout
  code: '57014'
```

`runBackfill` correctly runs inside `db.transaction(...)` and `SET LOCAL statement_timeout = '15min'` covers it. `verifyComplete`'s LEFT JOIN ran via plain `db.execute` outside any transaction, so the backend default 5 s timeout applied and a 2.6M-row scan blew past it.

Data integrity verified by hand after the run:

```
postgres=> SELECT (SELECT count(*) FROM wxyc_schema.album_metadata) AS am,
                  (SELECT count(DISTINCT album_id) FROM wxyc_schema.flowsheet
                    WHERE album_id IS NOT NULL AND metadata_attempt_at IS NOT NULL) AS expected;
  am  | expected
------+----------
 7101 |     7101
```

This PR turns that ad-hoc dual-count into the job's own verify shape.

## Fix shape

```ts
SELECT
  (SELECT count(*)::int FROM "wxyc_schema"."album_metadata") AS actual,
  (SELECT count(DISTINCT "album_id")::int FROM "wxyc_schema"."flowsheet"
    WHERE "album_id" IS NOT NULL
      AND "metadata_attempt_at" IS NOT NULL) AS expected
```

- `actual >= expected` passes; `actual < expected` throws with both counts and the existing idempotent re-run hint.
- `>=` (not `==`) because once D3 (#899) ships, a live UPSERT can land between this job's INSERT and verify — `actual > expected` is then a normal-running state, not a failure. The other direction can't happen because the INSERT is idempotent and never deletes.

Alternative considered: keep the LEFT JOIN, wrap `verifyComplete` in `db.transaction` with `SET LOCAL statement_timeout = '60s'`. Rejected — the dual-count is cheaper, matches the verification we'd run by hand anyway, and avoids holding a snapshot for the duration of a 2.6M-row scan.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — 0 errors (warnings unchanged from main)
- [x] `npm run format:check` — passes
- [x] `npx jest tests/unit/jobs/album-metadata-backfill` — 16/16 pass
- [x] Unit tests now assert: pass on `actual == expected`, pass on `actual > expected`, throw on `actual < expected` with both counts + idempotent hint in the message, and that the query no longer uses `LEFT JOIN`.

Production data is already correct from the 2026-05-22 run; no follow-up backfill is required to merge this fix.
