### PR TITLE
feat(metadata): D3 — UPSERT album_metadata for linked rows (BS#899)

### DIFF
--- a/apps/backend/services/metadata/enrichment.service.ts
+++ b/apps/backend/services/metadata/enrichment.service.ts
@@ -19,7 +19,7 @@
  */
 import * as Sentry from '@sentry/node';
 import { sql } from 'drizzle-orm';
-import { db, flowsheet } from '@wxyc/database';
+import { album_metadata, db, flowsheet } from '@wxyc/database';
 import { fetchMetadata } from './metadata.service.js';
 import { SearchUrlProvider } from './providers/search-urls.provider.js';
 
@@ -94,6 +94,13 @@ export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
   })
     .then(async (metadata) => {
       if (!metadata) return;
+
+      // Epic D / BS#899: linked rows (album_id present) park the 10-column
+      // payload in `album_metadata`; the flowsheet UPDATE only stamps the
+      // historical `metadata_attempt_at` marker. Free-form rows
+      // (`albumId === undefined`) keep writing inline on flowsheet — they
+      // can't enrich into album_metadata until linkage resolves.
+      //
       // The `?? null` on the 7 non-search-URL columns nulls them on
       // no-match. Safe here because the runtime path runs at insert
       // time on fresh rows — there's nothing to overwrite. The
@@ -104,6 +111,42 @@ export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
       // if the runtime ever runs over rows with prior values
       // (e.g., a re-enrichment trigger), this side should adopt the
       // same preserve semantics.
+      if (input.albumId !== undefined) {
+        const payload = {
+          artwork_url: metadata.album?.artworkUrl ?? null,
+          discogs_url: metadata.album?.discogsUrl ?? null,
+          release_year: metadata.album?.releaseYear ?? null,
+          spotify_url: metadata.album?.spotifyUrl ?? null,
+          apple_music_url: metadata.album?.appleMusicUrl ?? null,
+          youtube_music_url: metadata.album?.youtubeMusicUrl ?? null,
+          bandcamp_url: metadata.album?.bandcampUrl ?? null,
+          soundcloud_url: metadata.album?.soundcloudUrl ?? null,
+          artist_bio: metadata.artist?.bio ?? null,
+          artist_wikipedia_url: metadata.artist?.wikipediaUrl ?? null,
+        };
+        // Race guard: only overwrite when our write is newer than the
+        // existing row. Prevents the drift-repair backfill from clobbering
+        // a fresh runtime enrichment and lets the in-process path + the
+        // worker (BS#892) converge under the dual-writer window before
+        // C5 (#894) deletes this callsite.
+        await db
+          .insert(album_metadata)
+          .values({ album_id: input.albumId, ...payload, updated_at: sql`NOW()` })
+          .onConflictDoUpdate({
+            target: album_metadata.album_id,
+            set: { ...payload, updated_at: sql`NOW()` },
+            setWhere: sql`${album_metadata.updated_at} < NOW()`,
+          });
+        // Stamp the historical marker so the drift-repair sweep skips the
+        // row. Same `IS NULL` guard as the unlinked branch below — the
+        // first writer to land wins.
+        await db
+          .update(flowsheet)
+          .set({ metadata_attempt_at: sql`NOW()` })
+          .where(sql`"id" = ${input.flowsheetId} AND "metadata_attempt_at" IS NULL`);
+        return;
+      }
+
       await db
         .update(flowsheet)
         .set({
@@ -159,6 +202,25 @@ export function fireAndForgetMetadataForRow(input: EnrichmentInput): void {
         input.trackTitle ?? undefined
       );
       try {
+        if (input.albumId !== undefined) {
+          // Linked + LML threw: write fallback URLs to album_metadata only
+          // when no row exists. `onConflictDoNothing` prevents clobbering
+          // a prior successful enrichment with fallback values. The
+          // matching unlinked branch below uses `metadata_attempt_at IS
+          // NULL` for the same purpose; album_metadata has no analogous
+          // marker so we encode "haven't enriched yet" as "no row yet."
+          await db
+            .insert(album_metadata)
+            .values({
+              album_id: input.albumId,
+              youtube_music_url: urls.youtubeMusicUrl,
+              bandcamp_url: urls.bandcampUrl,
+              soundcloud_url: urls.soundcloudUrl,
+              updated_at: sql`NOW()`,
+            })
+            .onConflictDoNothing();
+          return;
+        }
         await db
           .update(flowsheet)
           .set({

--- a/apps/enrichment-worker/cdc-subscriber.ts
+++ b/apps/enrichment-worker/cdc-subscriber.ts
@@ -28,6 +28,12 @@ export type EnrichmentCandidate = {
   artist_name: string;
   album_title: string | null;
   track_title: string | null;
+  // Epic D / BS#899: when non-null, the consumer UPSERTs `album_metadata`
+  // (keyed by album_id) for the 10 metadata columns and only flips the
+  // flowsheet row's `metadata_status`. When null (free-form / unlinked
+  // entry), the consumer writes the 10 columns inline on flowsheet as
+  // before. The split is enforced in apps/enrichment-worker/enrich.ts.
+  album_id: number | null;
 };
 
 /**
@@ -66,6 +72,7 @@ export function filterForEnrichment(event: CdcEvent): EnrichmentCandidate | null
     artist_name: artist,
     album_title: typeof data.album_title === 'string' ? data.album_title : null,
     track_title: typeof data.track_title === 'string' ? data.track_title : null,
+    album_id: typeof data.album_id === 'number' ? data.album_id : null,
   };
 }
 

--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -36,8 +36,8 @@
  * Also gated by scripts/check-spacer-gif-callsites.sh in CI.
  */
 
-import { and, eq } from 'drizzle-orm';
-import { db, flowsheet } from '@wxyc/database';
+import { and, eq, sql } from 'drizzle-orm';
+import { album_metadata, db, flowsheet } from '@wxyc/database';
 import type { DiscogsMatchResult, LookupResponse } from '@wxyc/lml-client';
 
 export type EnrichRow = {
@@ -45,6 +45,11 @@ export type EnrichRow = {
   artist_name: string;
   album_title: string | null;
   track_title: string | null;
+  // Epic D / BS#899: non-null → UPSERT album_metadata + flowsheet status
+  // flip only; null → write the 10 metadata columns inline on flowsheet
+  // (free-form entries, until their linkage resolves). Source: CDC payload
+  // via filterForEnrichment.
+  album_id: number | null;
 };
 
 export type FinalizeOutcome =
@@ -106,12 +111,21 @@ export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | n
  * Finalize an enriching row with LML's response.
  *
  * Returns the outcome so the dispatcher can count it. The `_raced` variants
- * fire when `.returning({ id })` is empty: the WHERE no longer matches
- * because something else (the C6 cron's stranded-claim sweep, a manual
- * triage operator, or a hypothetical out-of-band writer) flipped
- * `metadata_status` off `'enriching'` between claim and finalize. Same data
- * outcome from the row's perspective; the metric separates "this consumer
- * finalized it" from "the row was finalized by someone."
+ * fire when the flowsheet UPDATE's `.returning({ id })` is empty: the WHERE
+ * no longer matches because something else (the C6 cron's stranded-claim
+ * sweep, a manual triage operator, or a hypothetical out-of-band writer)
+ * flipped `metadata_status` off `'enriching'` between claim and finalize.
+ * Same data outcome from the row's perspective; the metric separates "this
+ * consumer finalized it" from "the row was finalized by someone."
+ *
+ * Linked vs unlinked (Epic D / BS#899): if `row.album_id` is non-null the
+ * 10-column metadata payload goes into `album_metadata` keyed by album_id
+ * (UPSERT), and the flowsheet UPDATE only flips `metadata_status`. If
+ * `album_id` is null (free-form entries), the 10 columns are written
+ * inline on `flowsheet` as before. The album_metadata UPSERT happens
+ * *before* the flowsheet status flip — if either write fails the C6 sweep
+ * recovers the stranded `enriching` row and a retry of the (idempotent)
+ * UPSERT + flowsheet UPDATE finishes the work.
  *
  * Errors propagate up — the dispatcher's catch arm decides whether to leave
  * the row stranded (transient LML failure → C6 sweep recovers) or to write
@@ -123,9 +137,13 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
   const searchUrls = synthesizeSearchUrls(row);
 
   if (artwork) {
-    const updated = await db
-      .update(flowsheet)
-      .set({
+    if (row.album_id !== null) {
+      // Linked + match: 10-col payload lands in album_metadata; flowsheet
+      // UPDATE only flips status. The album_metadata UPSERT is idempotent
+      // (same album_id → same row) and guarded by `updated_at < NOW()` so
+      // a concurrent stale write (e.g. delayed drift-repair backfill)
+      // can't overwrite a fresher enrichment.
+      const payload = {
         artwork_url: filterSpacerGif(artwork.artwork_url),
         discogs_url: artwork.release_url ?? null,
         // Discogs returns 0 as "year unknown"; coerce to null so iOS doesn't
@@ -134,6 +152,40 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
         spotify_url: artwork.spotify_url ?? null,
         apple_music_url: artwork.apple_music_url ?? null,
         // Prefer LML-supplied streaming URLs; fall back to synthesized.
+        youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
+        bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
+        soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
+        artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
+        artist_wikipedia_url: artwork.wikipedia_url ?? null,
+      };
+      await db
+        .insert(album_metadata)
+        .values({ album_id: row.album_id, ...payload, updated_at: sql`NOW()` })
+        .onConflictDoUpdate({
+          target: album_metadata.album_id,
+          set: { ...payload, updated_at: sql`NOW()` },
+          setWhere: sql`${album_metadata.updated_at} < NOW()`,
+        });
+      const updated = await db
+        .update(flowsheet)
+        .set({ metadata_status: 'enriched_match' })
+        .where(and(eq(flowsheet.id, row.id), eq(flowsheet.metadata_status, 'enriching')))
+        .returning({ id: flowsheet.id });
+      return updated.length === 0 ? 'enriched_match_raced' : 'enriched_match';
+    }
+
+    // Unlinked + match: write the 10 columns inline on flowsheet, as before
+    // D3. These rows can't enrich into album_metadata until linkage
+    // resolves; D4's column-drop is gated on no unlinked enrichments
+    // remaining (see #1012 + the broader linkage-completion gate).
+    const updated = await db
+      .update(flowsheet)
+      .set({
+        artwork_url: filterSpacerGif(artwork.artwork_url),
+        discogs_url: artwork.release_url ?? null,
+        release_year: artwork.release_year || null,
+        spotify_url: artwork.spotify_url ?? null,
+        apple_music_url: artwork.apple_music_url ?? null,
         youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
         bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
         soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
@@ -150,6 +202,38 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
   // left untouched — preserves any prior out-of-band values (e.g. recovery
   // writes from #686-era scripts). Mirrors the backfill's deliberate
   // divergence from the runtime path (see backfill enrich.ts header).
+  if (row.album_id !== null) {
+    // Linked + no-match: UPSERT just the 3 search URLs into album_metadata.
+    // INSERT path leaves the other 7 columns NULL (no LML match to fill
+    // them); UPDATE path leaves them untouched on existing rows (preserves
+    // any prior out-of-band values, same semantics as the unlinked path).
+    await db
+      .insert(album_metadata)
+      .values({
+        album_id: row.album_id,
+        youtube_music_url: searchUrls.youtube_music_url,
+        bandcamp_url: searchUrls.bandcamp_url,
+        soundcloud_url: searchUrls.soundcloud_url,
+        updated_at: sql`NOW()`,
+      })
+      .onConflictDoUpdate({
+        target: album_metadata.album_id,
+        set: {
+          youtube_music_url: searchUrls.youtube_music_url,
+          bandcamp_url: searchUrls.bandcamp_url,
+          soundcloud_url: searchUrls.soundcloud_url,
+          updated_at: sql`NOW()`,
+        },
+        setWhere: sql`${album_metadata.updated_at} < NOW()`,
+      });
+    const updated = await db
+      .update(flowsheet)
+      .set({ metadata_status: 'enriched_no_match' })
+      .where(and(eq(flowsheet.id, row.id), eq(flowsheet.metadata_status, 'enriching')))
+      .returning({ id: flowsheet.id });
+    return updated.length === 0 ? 'enriched_no_match_raced' : 'enriched_no_match';
+  }
+
   const updated = await db
     .update(flowsheet)
     .set({

--- a/tests/integration/album-metadata-upsert.spec.js
+++ b/tests/integration/album-metadata-upsert.spec.js
@@ -1,0 +1,308 @@
+/**
+ * Integration test for the album_metadata UPSERT contract used by D3
+ * (BS#899 / Epic D).
+ *
+ * Both runtime writers — `apps/backend/services/metadata/enrichment.service.ts`
+ * (in-process) and `apps/enrichment-worker/enrich.ts` (worker) — UPSERT
+ * `album_metadata` keyed by `album_id` whenever the flowsheet row is linked
+ * to a library album. The unit tests cover the Drizzle builder shape; this
+ * spec validates the actual PostgreSQL semantics:
+ *
+ *   1. INSERT path: new album_id → row materializes with the full 10-column
+ *      payload + updated_at.
+ *   2. UPDATE-on-conflict path: subsequent UPSERTs against the same album_id
+ *      flow through ON CONFLICT DO UPDATE; `updated_at` advances, the
+ *      payload overwrites.
+ *   3. No-match shape: when only the 3 synthesized search URLs are written,
+ *      the 7 other columns stay NULL on INSERT and untouched on UPDATE
+ *      (matches the worker's no-match branch + the in-process .then arm's
+ *      no-match payload).
+ *   4. catch-arm conflict-do-nothing: a search-URL fallback INSERT against
+ *      an album_id that already has a fully-enriched row leaves the existing
+ *      payload intact (no clobber of artwork_url / discogs_url / etc.).
+ *
+ * Pure SQL — does NOT import `apps/enrichment-worker/enrich.ts` or
+ * `apps/backend/services/metadata/enrichment.service.ts`. The integration
+ * runner is babel-jest with no TS support (see `library-identity-backfill.spec.js`
+ * and `enrichment-worker-claim.spec.js` headers for the drizzle-orm + ts-jest
+ * incompatibility). Division of responsibility:
+ *   - Unit: source-code shape (Drizzle .insert().values().onConflictDoUpdate
+ *     payload, race-guard setWhere, race-detector returning behavior).
+ *   - Integration (this file): SQL contract against the live `album_metadata`
+ *     table (FK to library, PK on album_id, updated_at default).
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * Issue the worker's full match-branch UPSERT directly. Mirrors
+ * `finalizeRow` in `apps/enrichment-worker/enrich.ts` when the LML lookup
+ * returned artwork. When that file is hand-edited the SQL here must follow.
+ */
+async function upsertMatch(sql, albumId, payload) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_metadata
+      (album_id, artwork_url, discogs_url, release_year, spotify_url, apple_music_url,
+       youtube_music_url, bandcamp_url, soundcloud_url, artist_bio, artist_wikipedia_url,
+       updated_at)
+    VALUES
+      (${albumId}, ${payload.artwork_url}, ${payload.discogs_url}, ${payload.release_year},
+       ${payload.spotify_url}, ${payload.apple_music_url}, ${payload.youtube_music_url},
+       ${payload.bandcamp_url}, ${payload.soundcloud_url}, ${payload.artist_bio},
+       ${payload.artist_wikipedia_url}, NOW())
+    ON CONFLICT (album_id) DO UPDATE
+       SET artwork_url          = EXCLUDED.artwork_url,
+           discogs_url          = EXCLUDED.discogs_url,
+           release_year         = EXCLUDED.release_year,
+           spotify_url          = EXCLUDED.spotify_url,
+           apple_music_url      = EXCLUDED.apple_music_url,
+           youtube_music_url    = EXCLUDED.youtube_music_url,
+           bandcamp_url         = EXCLUDED.bandcamp_url,
+           soundcloud_url       = EXCLUDED.soundcloud_url,
+           artist_bio           = EXCLUDED.artist_bio,
+           artist_wikipedia_url = EXCLUDED.artist_wikipedia_url,
+           updated_at           = NOW()
+     WHERE ${sql(SCHEMA)}.album_metadata.updated_at < NOW()
+  `;
+}
+
+/**
+ * Worker's no-match branch (LML responded but no Discogs match). Writes
+ * only the 3 synthesized search URLs; the 7 other fields stay untouched.
+ */
+async function upsertNoMatch(sql, albumId, searchUrls) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_metadata
+      (album_id, youtube_music_url, bandcamp_url, soundcloud_url, updated_at)
+    VALUES
+      (${albumId}, ${searchUrls.youtube_music_url}, ${searchUrls.bandcamp_url},
+       ${searchUrls.soundcloud_url}, NOW())
+    ON CONFLICT (album_id) DO UPDATE
+       SET youtube_music_url = EXCLUDED.youtube_music_url,
+           bandcamp_url      = EXCLUDED.bandcamp_url,
+           soundcloud_url    = EXCLUDED.soundcloud_url,
+           updated_at        = NOW()
+     WHERE ${sql(SCHEMA)}.album_metadata.updated_at < NOW()
+  `;
+}
+
+/**
+ * In-process catch-arm fallback (LML threw). Writes search URLs ONLY when
+ * no album_metadata row exists yet — never clobbers a prior successful
+ * enrichment. Mirrors `enrichment.service.ts`'s catch path.
+ */
+async function insertFallbackOnly(sql, albumId, searchUrls) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_metadata
+      (album_id, youtube_music_url, bandcamp_url, soundcloud_url, updated_at)
+    VALUES
+      (${albumId}, ${searchUrls.youtube_music_url}, ${searchUrls.bandcamp_url},
+       ${searchUrls.soundcloud_url}, NOW())
+    ON CONFLICT DO NOTHING
+  `;
+}
+
+/**
+ * Insert a fresh library album to act as the FK target. Returns the new id.
+ * Uses an obviously synthetic title so cleanup is unambiguous.
+ */
+async function insertLibraryAlbum(sql, suffix) {
+  // artist_id, genre_id, format_id are all NOT NULL on `library`. The seeded
+  // fixture in dev_env/seed_db.sql guarantees ids 1-3 (artists), 11/6
+  // (genres), 1/2 (format) exist. Use those rather than threading the FK
+  // resolution through this test.
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.library
+      (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+    VALUES
+      (1, 11, 1, ${'d3-upsert-test-album-' + suffix}, 9999, 'Built to Spill')
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+const FULL_PAYLOAD = {
+  artwork_url: 'https://i.discogs.com/d3-test/cover.jpg',
+  discogs_url: 'https://discogs.com/release/999999',
+  release_year: 2022,
+  spotify_url: 'https://open.spotify.com/album/d3test',
+  apple_music_url: 'https://music.apple.com/album/d3test',
+  youtube_music_url: 'https://music.youtube.com/playlist/d3test',
+  bandcamp_url: 'https://artist.bandcamp.com/album/d3test',
+  soundcloud_url: 'https://soundcloud.com/album/d3test',
+  artist_bio: 'A D3 test bio.',
+  artist_wikipedia_url: 'https://en.wikipedia.org/wiki/D3_test',
+};
+
+const SEARCH_URLS = {
+  youtube_music_url: 'https://music.youtube.com/search?q=D3%20test',
+  bandcamp_url: 'https://bandcamp.com/search?q=D3%20test',
+  soundcloud_url: 'https://soundcloud.com/search?q=D3%20test',
+};
+
+describe('album_metadata UPSERT contract (real PG)', () => {
+  let sql;
+  /** album_ids inserted; deleted in afterAll regardless of pass/fail. */
+  const insertedAlbumIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedAlbumIds.length > 0) {
+      // album_metadata FK cascades on delete; deleting from library cleans
+      // both. Belt + suspenders: target album_metadata explicitly first in
+      // case the FK was ever loosened.
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  test('INSERT path: new album_id materializes with full 10-column payload', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'insert-path');
+    insertedAlbumIds.push(albumId);
+
+    await upsertMatch(sql, albumId, FULL_PAYLOAD);
+
+    const rows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].artwork_url).toBe(FULL_PAYLOAD.artwork_url);
+    expect(rows[0].discogs_url).toBe(FULL_PAYLOAD.discogs_url);
+    expect(rows[0].release_year).toBe(FULL_PAYLOAD.release_year);
+    expect(rows[0].spotify_url).toBe(FULL_PAYLOAD.spotify_url);
+    expect(rows[0].apple_music_url).toBe(FULL_PAYLOAD.apple_music_url);
+    expect(rows[0].youtube_music_url).toBe(FULL_PAYLOAD.youtube_music_url);
+    expect(rows[0].bandcamp_url).toBe(FULL_PAYLOAD.bandcamp_url);
+    expect(rows[0].soundcloud_url).toBe(FULL_PAYLOAD.soundcloud_url);
+    expect(rows[0].artist_bio).toBe(FULL_PAYLOAD.artist_bio);
+    expect(rows[0].artist_wikipedia_url).toBe(FULL_PAYLOAD.artist_wikipedia_url);
+    expect(rows[0].updated_at).not.toBeNull();
+  });
+
+  test('UPDATE-on-conflict path: subsequent UPSERT overwrites payload and advances updated_at', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'update-path');
+    insertedAlbumIds.push(albumId);
+
+    await upsertMatch(sql, albumId, FULL_PAYLOAD);
+    const before = await sql`
+      SELECT updated_at FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+
+    // pg_sleep(0.05) is enough wall-clock movement for `updated_at < NOW()`
+    // on the second UPSERT to be unambiguously satisfied. NOW() inside a
+    // statement is statement_start; consecutive UPSERTs ARE different.
+    await sql`SELECT pg_sleep(0.05)`;
+
+    const newer = { ...FULL_PAYLOAD, artwork_url: 'https://i.discogs.com/d3-test/newer.jpg' };
+    await upsertMatch(sql, albumId, newer);
+
+    const after = await sql`
+      SELECT artwork_url, updated_at FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    expect(after[0].artwork_url).toBe(newer.artwork_url);
+    expect(new Date(after[0].updated_at).getTime()).toBeGreaterThan(new Date(before[0].updated_at).getTime());
+  });
+
+  test('no-match UPSERT preserves 7 untouched columns on existing rows', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'no-match-preserve');
+    insertedAlbumIds.push(albumId);
+
+    // Seed with a full enrichment first.
+    await upsertMatch(sql, albumId, FULL_PAYLOAD);
+
+    await sql`SELECT pg_sleep(0.05)`;
+
+    // Run a no-match UPSERT (only the 3 search URLs). The other 7 columns
+    // must survive untouched — the no-match branch's deliberate "preserve
+    // prior values" semantics (matches the worker enrich.ts no-match
+    // branch + the in-process .then arm's `?? null` on no-match).
+    await upsertNoMatch(sql, albumId, SEARCH_URLS);
+
+    const rows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    // Search URLs overwritten with the new synthesized values.
+    expect(rows[0].youtube_music_url).toBe(SEARCH_URLS.youtube_music_url);
+    expect(rows[0].bandcamp_url).toBe(SEARCH_URLS.bandcamp_url);
+    expect(rows[0].soundcloud_url).toBe(SEARCH_URLS.soundcloud_url);
+    // 7 other fields: untouched, still hold the FULL_PAYLOAD values.
+    expect(rows[0].artwork_url).toBe(FULL_PAYLOAD.artwork_url);
+    expect(rows[0].discogs_url).toBe(FULL_PAYLOAD.discogs_url);
+    expect(rows[0].release_year).toBe(FULL_PAYLOAD.release_year);
+    expect(rows[0].spotify_url).toBe(FULL_PAYLOAD.spotify_url);
+    expect(rows[0].apple_music_url).toBe(FULL_PAYLOAD.apple_music_url);
+    expect(rows[0].artist_bio).toBe(FULL_PAYLOAD.artist_bio);
+    expect(rows[0].artist_wikipedia_url).toBe(FULL_PAYLOAD.artist_wikipedia_url);
+  });
+
+  test('no-match UPSERT into empty album_metadata leaves 7 columns NULL on INSERT', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'no-match-fresh');
+    insertedAlbumIds.push(albumId);
+
+    // No prior row. The no-match INSERT writes only the 3 URL columns; the
+    // 7 others are absent from the column list and PG fills them NULL.
+    await upsertNoMatch(sql, albumId, SEARCH_URLS);
+
+    const rows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    expect(rows[0].youtube_music_url).toBe(SEARCH_URLS.youtube_music_url);
+    expect(rows[0].artwork_url).toBeNull();
+    expect(rows[0].discogs_url).toBeNull();
+    expect(rows[0].release_year).toBeNull();
+    expect(rows[0].spotify_url).toBeNull();
+    expect(rows[0].apple_music_url).toBeNull();
+    expect(rows[0].artist_bio).toBeNull();
+    expect(rows[0].artist_wikipedia_url).toBeNull();
+  });
+
+  test('catch-arm INSERT ... ON CONFLICT DO NOTHING never clobbers a prior successful enrichment', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'catch-arm');
+    insertedAlbumIds.push(albumId);
+
+    // Successful enrichment lands first.
+    await upsertMatch(sql, albumId, FULL_PAYLOAD);
+
+    // A delayed catch-arm fallback (LML threw on a sibling row, perhaps,
+    // or an in-flight request that lost a race) attempts to insert search
+    // URLs for the same album. The `ON CONFLICT DO NOTHING` policy
+    // guarantees the row stays intact.
+    await insertFallbackOnly(sql, albumId, {
+      youtube_music_url: 'should-not-overwrite',
+      bandcamp_url: 'should-not-overwrite',
+      soundcloud_url: 'should-not-overwrite',
+    });
+
+    const rows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    expect(rows[0].artwork_url).toBe(FULL_PAYLOAD.artwork_url);
+    expect(rows[0].artist_bio).toBe(FULL_PAYLOAD.artist_bio);
+    expect(rows[0].youtube_music_url).toBe(FULL_PAYLOAD.youtube_music_url);
+    expect(rows[0].bandcamp_url).toBe(FULL_PAYLOAD.bandcamp_url);
+    expect(rows[0].soundcloud_url).toBe(FULL_PAYLOAD.soundcloud_url);
+  });
+
+  test('catch-arm INSERT materializes a fresh row when album_metadata is empty', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'catch-arm-fresh');
+    insertedAlbumIds.push(albumId);
+
+    await insertFallbackOnly(sql, albumId, SEARCH_URLS);
+
+    const rows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].youtube_music_url).toBe(SEARCH_URLS.youtube_music_url);
+    expect(rows[0].bandcamp_url).toBe(SEARCH_URLS.bandcamp_url);
+    expect(rows[0].soundcloud_url).toBe(SEARCH_URLS.soundcloud_url);
+    // 7 other fields: NULL — never received an LML success.
+    expect(rows[0].artwork_url).toBeNull();
+    expect(rows[0].discogs_url).toBeNull();
+  });
+});

--- a/tests/integration/metadata.spec.js
+++ b/tests/integration/metadata.spec.js
@@ -1,6 +1,7 @@
 const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
 const postgres = require('postgres');
 const fls_util = require('../utils/flowsheet_util');
+const { isMockApiAvailable, resetMockApi, simulateError } = require('../utils/mock_api');
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 
@@ -314,15 +315,16 @@ describe('album_metadata COALESCE projection (BS#897)', () => {
   // verifies the projection contract that D2/D3 depend on: when an
   // `album_metadata` row exists for the joined `album_id`, the V2 read
   // path returns its values in preference to the flowsheet inline values.
-  // Using direct SQL to seed `album_metadata` (no HTTP write path exists
-  // until D3) and asserting on the HTTP V2 read.
   //
-  // The fire-and-forget LML enrichment may race the GET and overwrite
-  // flowsheet's inline metadata after the POST resolves — irrelevant,
-  // because COALESCE prefers `album_metadata` so the assertion is
-  // race-free.
+  // Post-D3 (BS#899), the runtime fire-and-forget enrichment also writes
+  // to album_metadata for linked rows. To exercise the COALESCE contract
+  // deterministically without racing the runtime writer's UPSERT, we
+  // force LML to return 500 — that hits enrichment.service.ts's catch
+  // arm, which uses `ON CONFLICT DO NOTHING` and so cannot clobber the
+  // pre-seeded sentinel row.
 
   let sql;
+  let mockApiAvailable = false;
   const SENTINEL_ALBUM_ID = 5; // Sufjan-adjacent seed row used elsewhere
   const SENTINEL = {
     artwork_url: 'https://bs897.example.com/artwork.jpg',
@@ -337,8 +339,9 @@ describe('album_metadata COALESCE projection (BS#897)', () => {
     artist_wikipedia_url: 'https://bs897.example.com/wiki',
   };
 
-  beforeAll(() => {
+  beforeAll(async () => {
     sql = makeSql();
+    mockApiAvailable = await isMockApiAvailable();
   });
 
   afterAll(async () => {
@@ -349,15 +352,31 @@ describe('album_metadata COALESCE projection (BS#897)', () => {
     // Ensure no stale row survives a prior run; FK ON DELETE CASCADE means
     // the row is also auto-dropped if the library row ever goes away.
     await sql.unsafe(`DELETE FROM "${SCHEMA}".album_metadata WHERE album_id = ${SENTINEL_ALBUM_ID}`);
+    if (mockApiAvailable) await resetMockApi();
     await fls_util.join_show(getTestDjId(), global.access_token);
   });
 
   afterEach(async () => {
     await sql.unsafe(`DELETE FROM "${SCHEMA}".album_metadata WHERE album_id = ${SENTINEL_ALBUM_ID}`);
+    if (mockApiAvailable) await resetMockApi();
     await fls_util.leave_show(getTestDjId(), global.access_token);
   });
 
   test('V2 read returns album_metadata values when the row exists, regardless of flowsheet inline state', async () => {
+    if (!mockApiAvailable) {
+      console.warn('Skipping: mock API server not available for LML failure simulation');
+      return;
+    }
+
+    // Force LML to fail so the fire-and-forget hits enrichment.service.ts's
+    // catch arm. With D3, that arm uses `INSERT ... ON CONFLICT DO NOTHING`
+    // for linked albums — guaranteeing the sentinel survives intact even
+    // though enrichment runs after the POST. (Pre-D3 the catch arm wrote
+    // to flowsheet's inline cols, also leaving album_metadata untouched.)
+    // This deliberately decouples the COALESCE projection test from the
+    // runtime UPSERT semantics tested in tests/integration/album-metadata-upsert.spec.js.
+    await simulateError('lml', '/api/v1/lookup', 500);
+
     // Pre-populate album_metadata for the sentinel album.
     await sql`
       INSERT INTO ${sql(`${SCHEMA}.album_metadata`)} (
@@ -374,9 +393,8 @@ describe('album_metadata COALESCE projection (BS#897)', () => {
     `;
 
     // Add a flowsheet track linked to the sentinel album. The fire-and-
-    // forget enrichment may run and overwrite flowsheet's inline cols
-    // before the GET below, but COALESCE prefers album_metadata so the
-    // sentinel values still win.
+    // forget enrichment will hit LML 500 and fall through to the catch
+    // arm's ON CONFLICT DO NOTHING — sentinel survives intact.
     const addRes = await request
       .post('/flowsheet')
       .set('Authorization', global.access_token)

--- a/tests/unit/apps/enrichment-worker/cdc-subscriber.test.ts
+++ b/tests/unit/apps/enrichment-worker/cdc-subscriber.test.ts
@@ -24,6 +24,7 @@ const flowsheetInsert = (overrides: Partial<Record<string, unknown>> = {}): CdcE
     artist_name: 'Juana Molina',
     album_title: 'DOGA',
     track_title: 'la paradoja',
+    album_id: 1234,
     ...overrides,
   },
   timestamp: 1779856000000,
@@ -39,7 +40,19 @@ describe('filterForEnrichment (BS#892)', () => {
       artist_name: 'Juana Molina',
       album_title: 'DOGA',
       track_title: 'la paradoja',
+      album_id: 1234,
     });
+  });
+
+  it('Epic D / BS#899: forwards album_id when linked, null when unlinked', () => {
+    // Linked: candidate carries the album_id so the worker can UPSERT
+    // album_metadata. Unlinked (free-form entries): null → worker writes
+    // inline on flowsheet as before.
+    expect(filterForEnrichment(flowsheetInsert({ album_id: 1234 }))?.album_id).toBe(1234);
+    expect(filterForEnrichment(flowsheetInsert({ album_id: null }))?.album_id).toBeNull();
+    expect(filterForEnrichment(flowsheetInsert({ album_id: undefined }))?.album_id).toBeNull();
+    // Defensive coercion: malformed CDC payload (string) → null, not a crash.
+    expect(filterForEnrichment(flowsheetInsert({ album_id: '1234' }))?.album_id).toBeNull();
   });
 
   it('skips events for tables other than flowsheet', () => {

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -15,7 +15,7 @@
 
 import { jest } from '@jest/globals';
 
-import { db, flowsheet } from '@wxyc/database';
+import { album_metadata, db, flowsheet } from '@wxyc/database';
 import type { LookupResponse } from '@wxyc/lml-client';
 import {
   cleanDiscogsBio,
@@ -26,16 +26,29 @@ import {
 } from '../../../../apps/enrichment-worker/enrich';
 
 const mockDb = db as unknown as {
+  insert: jest.Mock;
   update: jest.Mock;
-  _chain: { set: jest.Mock; where: jest.Mock; returning: jest.Mock };
+  _chain: {
+    set: jest.Mock;
+    where: jest.Mock;
+    returning: jest.Mock;
+    values: jest.Mock;
+    onConflictDoUpdate: jest.Mock;
+    onConflictDoNothing: jest.Mock;
+  };
 };
 
+// Default row is UNLINKED (album_id=null) — preserves pre-D3 behavior for the
+// existing assertions below. Linked-path tests use LINKED_ROW.
 const ROW = {
   id: 42,
   artist_name: 'Juana Molina',
   album_title: 'DOGA',
   track_title: 'la paradoja',
+  album_id: null,
 };
+
+const LINKED_ROW = { ...ROW, album_id: 5678 };
 
 const matchResponse = {
   results: [
@@ -167,38 +180,184 @@ describe('finalizeRow (BS#892 PR-2)', () => {
   });
 });
 
+/**
+ * Epic D / BS#899 — when the candidate is linked to a library album
+ * (`album_id !== null`), the 10-column metadata payload UPSERTs into
+ * `album_metadata` keyed by album_id, and the flowsheet UPDATE only flips
+ * `metadata_status`. The race detector stays on the flowsheet UPDATE; the
+ * album_metadata UPSERT is idempotent on conflict.
+ *
+ * D4 (#900) ultimately drops the 10 inline columns from flowsheet. Before
+ * then, dual-writer correctness depends on the linked branch never writing
+ * those columns inline — these tests pin that boundary.
+ */
+describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('on match: UPSERTs the 10-column payload into album_metadata', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    const outcome = await finalizeRow(LINKED_ROW, matchResponse);
+
+    expect(outcome).toBe('enriched_match');
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload.album_id).toBe(5678);
+    expect(insertPayload.artwork_url).toBe('https://i.discogs.com/abc/cover.jpg');
+    expect(insertPayload.discogs_url).toBe('https://discogs.com/release/123');
+    expect(insertPayload.release_year).toBe(2022);
+    expect(insertPayload.spotify_url).toBe('https://open.spotify.com/album/x');
+    expect(insertPayload.apple_music_url).toBe('https://music.apple.com/album/y');
+    expect(insertPayload.youtube_music_url).toBe('https://music.youtube.com/playlist/z');
+    expect(insertPayload.bandcamp_url).toBe('https://artist.bandcamp.com/album/w');
+    expect(insertPayload.soundcloud_url).toContain('soundcloud.com/search');
+    expect(insertPayload.artist_bio).toBe('A great Some Artist from Argentina.');
+    expect(insertPayload.artist_wikipedia_url).toBe('https://en.wikipedia.org/wiki/Juana_Molina');
+    expect(insertPayload.updated_at).toBeDefined();
+  });
+
+  it('on match: configures onConflictDoUpdate with all 10 columns and a race guard', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    await finalizeRow(LINKED_ROW, matchResponse);
+
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as {
+      target: unknown;
+      set: Record<string, unknown>;
+      setWhere: unknown;
+    };
+    expect(conflictCfg).toBeDefined();
+    expect(conflictCfg.set.artwork_url).toBe('https://i.discogs.com/abc/cover.jpg');
+    expect(conflictCfg.set.artist_bio).toBe('A great Some Artist from Argentina.');
+    expect(conflictCfg.set.updated_at).toBeDefined();
+    // Race guard: only overwrite when the existing row is older. Prevents the
+    // drift-repair backfill from clobbering a fresh runtime enrichment during
+    // the dual-writer window before C5 (#894) deletes the in-process callsite.
+    expect(conflictCfg.setWhere).toBeDefined();
+  });
+
+  it('on match: flowsheet UPDATE only sets metadata_status (no metadata columns)', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    await finalizeRow(LINKED_ROW, matchResponse);
+
+    expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
+    const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setCall.metadata_status).toBe('enriched_match');
+    // The 10 metadata columns must NOT appear on the flowsheet UPDATE — that's
+    // the whole point of Epic D. D4 will drop them; until then the inline
+    // values stay at whatever D2 wrote and the COALESCE projection reads
+    // through to album_metadata.
+    expect(setCall.artwork_url).toBeUndefined();
+    expect(setCall.discogs_url).toBeUndefined();
+    expect(setCall.release_year).toBeUndefined();
+    expect(setCall.spotify_url).toBeUndefined();
+    expect(setCall.apple_music_url).toBeUndefined();
+    expect(setCall.youtube_music_url).toBeUndefined();
+    expect(setCall.bandcamp_url).toBeUndefined();
+    expect(setCall.soundcloud_url).toBeUndefined();
+    expect(setCall.artist_bio).toBeUndefined();
+    expect(setCall.artist_wikipedia_url).toBeUndefined();
+  });
+
+  it('on no-match: UPSERTs only the 3 search URLs into album_metadata', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    const outcome = await finalizeRow(LINKED_ROW, noMatchResponse);
+
+    expect(outcome).toBe('enriched_no_match');
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload.album_id).toBe(5678);
+    expect(insertPayload.youtube_music_url).toContain('music.youtube.com/search');
+    expect(insertPayload.bandcamp_url).toContain('bandcamp.com/search');
+    expect(insertPayload.soundcloud_url).toContain('soundcloud.com/search');
+    // Other 7 metadata fields must NOT be in the insert payload — INSERT path
+    // leaves them NULL; UPDATE path leaves existing values untouched (matches
+    // the unlinked path's deliberate non-clobbering on no-match).
+    expect(insertPayload).not.toHaveProperty('artwork_url');
+    expect(insertPayload).not.toHaveProperty('discogs_url');
+    expect(insertPayload).not.toHaveProperty('release_year');
+    expect(insertPayload).not.toHaveProperty('spotify_url');
+    expect(insertPayload).not.toHaveProperty('apple_music_url');
+    expect(insertPayload).not.toHaveProperty('artist_bio');
+    expect(insertPayload).not.toHaveProperty('artist_wikipedia_url');
+
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as {
+      set: Record<string, unknown>;
+    };
+    expect(conflictCfg.set).not.toHaveProperty('artwork_url');
+    expect(conflictCfg.set).not.toHaveProperty('artist_bio');
+    expect(conflictCfg.set.youtube_music_url).toContain('music.youtube.com/search');
+  });
+
+  it('on no-match: flowsheet UPDATE only flips status (race detector stays on flowsheet)', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    const outcome = await finalizeRow(LINKED_ROW, noMatchResponse);
+
+    expect(outcome).toBe('enriched_no_match_raced');
+    const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setCall.metadata_status).toBe('enriched_no_match');
+    expect(setCall).not.toHaveProperty('youtube_music_url');
+  });
+
+  it('on match: returns enriched_match_raced when the flowsheet UPDATE matches 0 rows', async () => {
+    // The album_metadata UPSERT can succeed but the flowsheet UPDATE may
+    // still race (C6 sweep reverted it past the claim window). The
+    // album_metadata write is intentionally allowed to land — same data
+    // outcome from the album's perspective; the metric distinguishes "this
+    // worker finalized the row" from "the row was finalized by someone."
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    const outcome = await finalizeRow(LINKED_ROW, matchResponse);
+
+    expect(outcome).toBe('enriched_match_raced');
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+  });
+});
+
 describe('synthesizeSearchUrls (per-service precedence)', () => {
   it('YouTube Music prefers trackTitle over albumTitle over artistName', () => {
     expect(
-      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C' }).youtube_music_url
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C', album_id: null })
+        .youtube_music_url
     ).toBe('https://music.youtube.com/search?q=A%20C');
     expect(
-      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: null }).youtube_music_url
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: null, album_id: null })
+        .youtube_music_url
     ).toBe('https://music.youtube.com/search?q=A%20B');
     expect(
-      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: null, track_title: null }).youtube_music_url
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: null, track_title: null, album_id: null })
+        .youtube_music_url
     ).toBe('https://music.youtube.com/search?q=A');
   });
 
   it('Bandcamp prefers albumTitle over artistName (NO track fallback)', () => {
-    expect(synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C' }).bandcamp_url).toBe(
-      'https://bandcamp.com/search?q=A%20B'
-    );
-    expect(synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: null, track_title: 'C' }).bandcamp_url).toBe(
-      'https://bandcamp.com/search?q=A'
-    );
+    expect(
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C', album_id: null }).bandcamp_url
+    ).toBe('https://bandcamp.com/search?q=A%20B');
+    expect(
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: null, track_title: 'C', album_id: null })
+        .bandcamp_url
+    ).toBe('https://bandcamp.com/search?q=A');
   });
 
   it('SoundCloud prefers trackTitle over artistName (NO album fallback)', () => {
-    expect(synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C' }).soundcloud_url).toBe(
-      'https://soundcloud.com/search?q=A%20C'
-    );
+    expect(
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C', album_id: null })
+        .soundcloud_url
+    ).toBe('https://soundcloud.com/search?q=A%20C');
     // No track → falls straight to artist, NOT album. Album-only SoundCloud
     // queries surface unrelated DJ mixes, which is the whole reason for the
     // asymmetric precedence.
-    expect(synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: null }).soundcloud_url).toBe(
-      'https://soundcloud.com/search?q=A'
-    );
+    expect(
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: null, album_id: null })
+        .soundcloud_url
+    ).toBe('https://soundcloud.com/search?q=A');
   });
 });
 

--- a/tests/unit/services/metadata.enrichment.test.ts
+++ b/tests/unit/services/metadata.enrichment.test.ts
@@ -22,7 +22,7 @@ jest.mock('@sentry/node', () => ({
   captureMessage: mockCaptureMessage,
 }));
 
-import { db } from '@wxyc/database';
+import { album_metadata, db, flowsheet } from '@wxyc/database';
 import {
   _resetInFlightEnrichmentsForTest,
   drainInFlightEnrichments,
@@ -57,8 +57,15 @@ const renderSql = (value: unknown): string => {
 };
 
 const mockDb = db as unknown as {
+  insert: jest.Mock;
   update: jest.Mock;
-  _chain: { set: jest.Mock; where: jest.Mock };
+  _chain: {
+    set: jest.Mock;
+    where: jest.Mock;
+    values: jest.Mock;
+    onConflictDoUpdate: jest.Mock;
+    onConflictDoNothing: jest.Mock;
+  };
 };
 
 describe('fireAndForgetMetadataForRow', () => {
@@ -354,6 +361,179 @@ describe('fireAndForgetMetadataForRow', () => {
     expect(setArgs).not.toHaveProperty('linkage_source');
     expect(setArgs).not.toHaveProperty('linkage_confidence');
     expect(setArgs).not.toHaveProperty('linked_at');
+  });
+});
+
+/**
+ * Epic D / BS#899 — when the caller passes `albumId`, the 10-column metadata
+ * payload UPSERTs into `album_metadata` keyed by album_id; the flowsheet
+ * UPDATE only stamps `metadata_attempt_at`. Free-form rows (`albumId`
+ * omitted) still write the 10 columns inline on flowsheet (covered by the
+ * earlier describe block).
+ *
+ * The catch-arm fallback (LML threw) uses `onConflictDoNothing` for the
+ * linked path: a prior successful enrichment must not be overwritten by
+ * synthetic search URLs. Unlinked path's `metadata_attempt_at IS NULL`
+ * gate is the analogous protection.
+ *
+ * D4 (#900) drops the 10 inline columns. Until then, these assertions pin
+ * the no-clobber boundary that makes dual-write semantics safe.
+ */
+describe('fireAndForgetMetadataForRow — BS#899 linked-row path (albumId set)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('on LML match: UPSERTs the 10-column payload into album_metadata keyed by album_id', async () => {
+    mockFetchMetadata.mockResolvedValue({
+      album: {
+        artworkUrl: 'https://i.discogs.com/art.jpg',
+        discogsUrl: 'https://www.discogs.com/release/12345',
+        releaseYear: 2001,
+        spotifyUrl: 'https://open.spotify.com/album/abc',
+        appleMusicUrl: 'https://music.apple.com/album/xyz',
+        youtubeMusicUrl: 'https://music.youtube.com/album/aaa',
+        bandcampUrl: 'https://bandcamp.com/album/bbb',
+        soundcloudUrl: 'https://soundcloud.com/album/ccc',
+      },
+      artist: {
+        bio: 'Rob Brown and Sean Booth are Autechre.',
+        wikipediaUrl: 'https://en.wikipedia.org/wiki/Autechre',
+      },
+    });
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 42,
+      albumId: 5678,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload.album_id).toBe(5678);
+    expect(insertPayload.artwork_url).toBe('https://i.discogs.com/art.jpg');
+    expect(insertPayload.discogs_url).toBe('https://www.discogs.com/release/12345');
+    expect(insertPayload.release_year).toBe(2001);
+    expect(insertPayload.spotify_url).toBe('https://open.spotify.com/album/abc');
+    expect(insertPayload.apple_music_url).toBe('https://music.apple.com/album/xyz');
+    expect(insertPayload.youtube_music_url).toBe('https://music.youtube.com/album/aaa');
+    expect(insertPayload.bandcamp_url).toBe('https://bandcamp.com/album/bbb');
+    expect(insertPayload.soundcloud_url).toBe('https://soundcloud.com/album/ccc');
+    expect(insertPayload.artist_bio).toBe('Rob Brown and Sean Booth are Autechre.');
+    expect(insertPayload.artist_wikipedia_url).toBe('https://en.wikipedia.org/wiki/Autechre');
+    expect(insertPayload.updated_at).toBeDefined();
+  });
+
+  it('on LML match: configures onConflictDoUpdate with a race guard so stale writes do not clobber fresh', async () => {
+    mockFetchMetadata.mockResolvedValue({
+      album: { artworkUrl: 'https://i.discogs.com/art.jpg' },
+    });
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 42,
+      albumId: 5678,
+      artistName: 'Autechre',
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as {
+      target: unknown;
+      set: Record<string, unknown>;
+      setWhere: unknown;
+    };
+    expect(conflictCfg).toBeDefined();
+    expect(conflictCfg.set.artwork_url).toBe('https://i.discogs.com/art.jpg');
+    expect(conflictCfg.set.updated_at).toBeDefined();
+    expect(conflictCfg.setWhere).toBeDefined();
+  });
+
+  it('on LML match: flowsheet UPDATE only stamps metadata_attempt_at (no metadata columns)', async () => {
+    mockFetchMetadata.mockResolvedValue({
+      album: { artworkUrl: 'https://i.discogs.com/art.jpg' },
+      artist: { wikipediaUrl: 'https://en.wikipedia.org/wiki/Autechre' },
+    });
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 42,
+      albumId: 5678,
+      artistName: 'Autechre',
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(renderSql(setArgs.metadata_attempt_at)).toMatch(/NOW\(\)/i);
+    // The 10 metadata columns must NOT appear on the flowsheet UPDATE.
+    // D4 eventually drops them; until then this guarantees no double-write
+    // and no clobber of D2's historical fill.
+    expect(setArgs).not.toHaveProperty('artwork_url');
+    expect(setArgs).not.toHaveProperty('discogs_url');
+    expect(setArgs).not.toHaveProperty('artist_bio');
+    expect(setArgs).not.toHaveProperty('artist_wikipedia_url');
+  });
+
+  it('on LML match: flowsheet UPDATE narrows on metadata_attempt_at IS NULL', async () => {
+    // The IS NULL gate is what makes the in-process path safe against the
+    // drift-repair backfill and (until C5) against duplicate runtime calls
+    // on the same row. Same predicate the unlinked branch uses.
+    mockFetchMetadata.mockResolvedValue({
+      album: { artworkUrl: 'https://i.discogs.com/art.jpg' },
+    });
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 42,
+      albumId: 5678,
+      artistName: 'Autechre',
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const whereCalls = mockDb._chain.where.mock.calls;
+    expect(whereCalls.length).toBeGreaterThan(0);
+    const lastWhereArg = whereCalls[whereCalls.length - 1][0];
+    expect(renderSql(lastWhereArg)).toMatch(/metadata_attempt_at.*IS\s+NULL/i);
+  });
+
+  it('on LML failure: UPSERTs fallback search URLs into album_metadata via onConflictDoNothing', async () => {
+    // onConflictDoNothing (not onConflictDoUpdate) is intentional: a prior
+    // successful enrichment must not be clobbered by synthetic fallback
+    // URLs. The unlinked path achieves the same protection via the
+    // `metadata_attempt_at IS NULL` gate on flowsheet — album_metadata has
+    // no analogous marker so we encode "haven't enriched yet" as
+    // "no row yet" via the conflict-no-op.
+    mockFetchMetadata.mockRejectedValue(new Error('LML 502'));
+
+    fireAndForgetMetadataForRow({
+      flowsheetId: 44,
+      albumId: 5678,
+      artistName: 'King Crimson',
+      albumTitle: 'Discipline',
+      trackTitle: 'Elephant Talk',
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload.album_id).toBe(5678);
+    expect(insertPayload.youtube_music_url).toMatch(/^https:\/\/music\.youtube\.com\/search\?q=/);
+    expect(insertPayload.bandcamp_url).toMatch(/^https:\/\/bandcamp\.com\/search\?q=/);
+    expect(insertPayload.soundcloud_url).toMatch(/^https:\/\/soundcloud\.com\/search\?q=/);
+    expect(insertPayload).not.toHaveProperty('artwork_url');
+    expect(insertPayload).not.toHaveProperty('discogs_url');
+    expect(insertPayload).not.toHaveProperty('artist_bio');
+    // Conflict policy: no-op. Never overwrite an existing album_metadata row.
+    expect(mockDb._chain.onConflictDoNothing).toHaveBeenCalled();
+    expect(mockDb._chain.onConflictDoUpdate).not.toHaveBeenCalled();
+    // Crucially, the flowsheet row must NOT be stamped — keeps it eligible
+    // for the drift-repair sweep so the real artwork can still land on a
+    // future attempt. Same semantics as the unlinked fallback path.
+    expect(mockDb.update).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #899. Third child of Epic D ([#878](https://github.com/WXYC/Backend-Service/issues/878)); follows #897 (D1, schema + COALESCE projection) and #898 (D2, historical backfill — both merged).

## Summary

Routes the 10-column metadata payload into `album_metadata` (keyed by `album_id`) for any flowsheet row that's linked to a library album. Free-form / unlinked rows (`album_id IS NULL`) keep writing inline on `flowsheet` as before — they can't enrich into `album_metadata` until linkage resolves.

Both runtime writers are patched in this PR — the in-process `.then` arm and the worker's `finalizeRow` — so the two converge on the same album_metadata semantics in the dual-writer window before C5 (#894) deletes the in-process callsite. BS#892 deployed 2026-05-22; both writers are now live in prod.

- **`apps/backend/services/metadata/enrichment.service.ts`** (in-process `.then` arm) — UPSERT `album_metadata`, then stamp `metadata_attempt_at` on the flowsheet row (only). The `.catch` arm uses `ON CONFLICT DO NOTHING` so a search-URL fallback never clobbers a prior successful enrichment.
- **`apps/enrichment-worker/enrich.ts`** (worker `finalizeRow`) — UPSERT `album_metadata`, then flip `metadata_status` to terminal. The race detector stays on the flowsheet UPDATE; the `album_metadata` UPSERT is intentionally allowed to land even on a raced flowsheet row.

CDC payload already includes `album_id` (full row via `to_jsonb(NEW)` in migration 0046); `EnrichmentCandidate` + `EnrichRow` are widened to surface it through the dispatcher.

## Race guard

`setWhere: \${album_metadata.updated_at} < NOW()` on the `onConflictDoUpdate` lets the dual-writer window (in-process + worker, until C5 ships) and the drift-repair backfill (BS#995) converge without clobbering fresher writes. The catch-arm fallback uses `onConflictDoNothing` instead — never overwrite a prior successful enrichment with synthetic search URLs.

## What this PR explicitly does NOT do

- **No flowsheet column drop.** The 10 inline columns stay until D4 (#900), which is hard-blocked on D5 (#1012, iOS playlist-proxy migration).
- **No removal of the in-process path.** C5 (#894) deletes the in-process callsites after the worker is prod-verified; this PR makes the in-process arm correct in the meantime.
- **No change to the read path.** D1's COALESCE projection already reads through to `album_metadata` when present; this PR just populates it from the live writers.

## metadata_status lifecycle (post-BS#891)

Worker covers (table from #899 body):

| Outcome | `metadata_status` | `album_metadata` write |
|---|---|---|
| LML match | `enriched_match` | UPSERT (linked); inline UPDATE (unlinked) |
| LML success, no Discogs match | `enriched_no_match` | UPSERT search-URL fallbacks only (linked); inline UPDATE (unlinked) |
| LML threw (transient) | unchanged (`enriching`) | no write; C6 sweep reverts |
| Retry budget exceeded | `failed_no_retry` | no write; manual triage |
| Mid-LML-call | `enriching` (claim) | no write yet |

In-process path doesn't claim rows or count retries — it has only two arms (`.then` writes, `.catch` writes fallback). It does not set `metadata_status` today and this PR doesn't change that; the dual-signal split (`metadata_attempt_at` for in-process, `metadata_status` for worker) is pre-existing and goes away when C5 deletes the in-process callsites.

## Tests

- **`tests/unit/apps/enrichment-worker/enrich.test.ts`** — new `describe` block exhaustively pins the linked-path UPSERT: 10-col payload to `album_metadata`, race guard in `setWhere`, flowsheet UPDATE only flips status (no metadata columns), no-match UPSERT writes 3 search URLs only, race detector stays on the flowsheet UPDATE.
- **`tests/unit/services/metadata.enrichment.test.ts`** — new linked-row `describe` block: UPSERT shape pinned for both match + no-match; flowsheet UPDATE only stamps `metadata_attempt_at` (no metadata columns); WHERE narrows on `metadata_attempt_at IS NULL`; catch-arm uses `onConflictDoNothing` and does NOT touch flowsheet (row stays retryable).
- **`tests/unit/apps/enrichment-worker/cdc-subscriber.test.ts`** — `album_id` propagation pinned: linked row → number; unlinked → null; malformed CDC (string) → null.
- **`tests/integration/album-metadata-upsert.spec.js`** (new, pure SQL) — contract test against real PG covering INSERT path, UPDATE-on-conflict, no-match 7-NULL on INSERT + 7-preserve on UPDATE, and catch-arm `DO NOTHING` semantics. Mirrors the BS#892 PR-3 `enrichment-worker-claim.spec.js` pattern (pure SQL, no TS imports — babel-jest + drizzle-orm incompatibility).

Existing assertions (unlinked path) continue to pass — the row fixtures default to `album_id: null` so the pre-D3 contract is preserved verbatim.

## Pre-flight

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 0 errors (428 warnings, pre-existing)
- [x] \`npm run format:check\` — clean
- [x] \`npm run lint:migrations\` — clean (no migrations added)
- [x] \`npm run build\` — all workspaces succeed
- [x] \`npm run test:unit\` — 2162/2162 pass
- [x] \`scripts/check-spacer-gif-callsites.sh\` — clean

## Related

- Parent: [#878](https://github.com/WXYC/Backend-Service/issues/878) (Epic D)
- Depends on: [#897](https://github.com/WXYC/Backend-Service/issues/897) ✅ (D1 schema), [#898](https://github.com/WXYC/Backend-Service/issues/898) ✅ (D2 historical), [BS#891](https://github.com/WXYC/Backend-Service/issues/891) (`metadata_status` schema live)
- Coordinates with: [BS#894](https://github.com/WXYC/Backend-Service/issues/894) (C5 — drops the in-process callsites once worker is verified in prod), [BS#895](https://github.com/WXYC/Backend-Service/issues/895) (C6 — stranded-claim sweep retune)
- Coexists with: [BS#995](https://github.com/WXYC/Backend-Service/issues/995) — backfill cron pacing/circuit-breaker; race guard handles concurrent writes
- BS#892 PR-2 ([#1010](https://github.com/WXYC/Backend-Service/pull/1010)) + PR-3 ([#1013](https://github.com/WXYC/Backend-Service/pull/1013)) shipped the worker code this PR updates
