### PR TITLE
feat(enrichment-worker): real CDC liveness detection (BS#1014)

### DIFF
--- a/apps/enrichment-worker/healthcheck.ts
+++ b/apps/enrichment-worker/healthcheck.ts
@@ -7,20 +7,25 @@
  * polls every 30s; an unhealthy container is restarted via
  * `--restart unless-stopped`.
  *
- * Scope: startup + shutdown probe only.
- *   - 200 OK + body `ok` after `startCdcListener()` resolved successfully.
- *   - 503 + body `cdc not connected` during startup (before the listener
- *     resolves) and during shutdown (after SIGTERM/SIGINT begins draining).
+ * Scope: full liveness (BS#1014).
+ *   - 200 OK + body `ok` while the CDC LISTEN connection is alive.
+ *   - 503 + body `cdc not connected` during startup (before
+ *     `startCdcListener()` resolves), during shutdown (after SIGTERM/SIGINT
+ *     begins draining), and after the liveness probe in `@wxyc/database`'s
+ *     `cdc-listener` observes a wedged LISTEN socket (silent PG restart,
+ *     NAT idle timeout, idle-transport death).
  *
- * What this probe does NOT detect: a mid-run LISTEN drop that
- * `@wxyc/database`'s cdc-listener doesn't surface back to its callers (PG
- * restart, network blip without RST, idle-transport death). The
- * `cdcConnected` flag only flips back to `false` in the shutdown path —
- * a silently-dead LISTEN connection will continue to report healthy here.
- * Real liveness detection requires a connection-lifecycle hook in
- * `@wxyc/database` (or a periodic NOTIFY-back probe); tracked at BS#1014.
- * In the meantime, the C6 stranded-claim sweep (#895) recovers any rows
- * lost to a wedged worker — a backstop, not a substitute.
+ * The mid-run failure path is driven by `onCdcConnectionStateChange` in
+ * `@wxyc/database`, which the worker subscribes to in `worker.ts`. When the
+ * periodic `cdc_health` NOTIFY/echo loop fails to round-trip within its
+ * echo-timeout window, the registered callback flips `cdcConnected=false`
+ * and this endpoint starts returning 503; the deploy framework's 30s
+ * `--health-cmd` poll then triggers `--restart unless-stopped`.
+ *
+ * The C6 stranded-claim sweep (#895) is still the backstop for rows missed
+ * during the disconnect-to-restart window (~probe-cycle + echo-timeout +
+ * health-poll). Liveness reduces that window from process lifetime to ~65s
+ * with the default probe sizing.
  *
  * The HTTP server is independently necessary: the deploy framework treats
  * apps/ packages as HTTP services. Without one the container is marked

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -13,7 +13,14 @@
  * @see docs/cdc.md
  */
 
-import { closeDatabaseConnection, onCdcEvent, startCdcListener, stopCdcListener } from '@wxyc/database';
+import {
+  closeDatabaseConnection,
+  enableLivenessProbe,
+  onCdcConnectionStateChange,
+  onCdcEvent,
+  startCdcListener,
+  stopCdcListener,
+} from '@wxyc/database';
 import { makeEnrichmentHandler } from './handler.js';
 import { startHealthcheckServer, type HealthState } from './healthcheck.js';
 
@@ -27,9 +34,23 @@ const main = async (): Promise<void> => {
   const healthState: HealthState = { cdcConnected: false };
   const healthServer = startHealthcheckServer(healthState);
 
+  // BS#1014: dispatched true on initial LISTEN + every postgres-js reconnect,
+  // dispatched false when the liveness probe observes a wedged LISTEN socket.
+  onCdcConnectionStateChange((connected) => {
+    healthState.cdcConnected = connected;
+    console.log(`[enrichment-worker] cdcConnected=${connected}`);
+  });
+
   onCdcEvent(makeEnrichmentHandler());
   await startCdcListener();
+  // Belt-and-suspenders: the onlisten hook should have already flipped this
+  // to true; re-assert in case a future cdc-listener change skips dispatch.
   healthState.cdcConnected = true;
+
+  // BS#1014: probe the LISTEN socket via a sibling NOTIFY/echo loop so a
+  // silent disconnect (PG restart without RST, NAT idle, idle-transport
+  // death) flips cdcConnected=false within ~one probe cycle.
+  await enableLivenessProbe();
 
   console.log('[enrichment-worker] subscribed to CDC; awaiting events');
 

--- a/shared/database/src/cdc-listener.ts
+++ b/shared/database/src/cdc-listener.ts
@@ -4,6 +4,12 @@
  * Creates a dedicated postgres-js connection for LISTEN (the query connection
  * cannot be reused for subscriptions). Parses CDC notification payloads and
  * dispatches them to registered callbacks.
+ *
+ * Liveness (BS#1014): a sibling LISTEN on `cdc_health` plus a periodic
+ * self-NOTIFY echo turns a silently-dead LISTEN connection into a 503 on the
+ * worker's /healthcheck within ~one probe-cycle + echo-timeout. Postgres-js's
+ * `onlisten` callback (third arg of `listen()`) also dispatches connected=true
+ * on the initial subscribe and on every auto-reconnect.
  */
 
 import postgres from 'postgres';
@@ -17,10 +23,19 @@ export interface CdcEvent {
 }
 
 export type CdcEventCallback = (event: CdcEvent) => void;
+export type CdcConnectionStateCallback = (connected: boolean) => void;
 
 const CDC_CHANNEL = 'cdc';
+const HEALTH_CHANNEL = 'cdc_health';
+
 let listenConnection: ReturnType<typeof postgres> | null = null;
 let callbacks: CdcEventCallback[] = [];
+let stateCallbacks: CdcConnectionStateCallback[] = [];
+
+let livenessTimer: ReturnType<typeof setInterval> | null = null;
+let outstandingProbeToken: string | null = null;
+let outstandingProbeAt = 0;
+let lastDispatchedState: boolean | null = null;
 
 /**
  * Registers a callback to receive CDC events.
@@ -31,8 +46,40 @@ export function onCdcEvent(callback: CdcEventCallback): void {
 }
 
 /**
+ * Registers a callback fired on CDC connection-state transitions.
+ *
+ * - `true` on initial successful subscribe and on every postgres-js auto-reconnect
+ *   (re-LISTEN), and on every received liveness echo while the probe is enabled.
+ * - `false` only when the liveness probe is enabled AND the in-flight probe has
+ *   exceeded `echoTimeoutMs` without an echo (or the NOTIFY itself failed).
+ *   Without `enableLivenessProbe()`, the listener has no way to detect a
+ *   silently-dead LISTEN socket and will never dispatch `false` from this path;
+ *   callers that want silent-drop detection must call `enableLivenessProbe()`.
+ *
+ * Duplicate transitions are suppressed: the same state is not re-dispatched
+ * back-to-back (so a healthy probe doesn't churn callbacks every interval).
+ */
+export function onCdcConnectionStateChange(callback: CdcConnectionStateCallback): void {
+  stateCallbacks.push(callback);
+}
+
+function dispatchState(connected: boolean): void {
+  if (lastDispatchedState === connected) return;
+  lastDispatchedState = connected;
+  for (const cb of stateCallbacks) {
+    try {
+      cb(connected);
+    } catch (err) {
+      console.error('[cdc-listener] State callback error:', err);
+    }
+  }
+}
+
+/**
  * Starts the CDC listener. Creates a dedicated LISTEN connection and
- * subscribes to the 'cdc' channel.
+ * subscribes to the 'cdc' channel. The `onlisten` hook dispatches
+ * `connected=true` to any callbacks registered via
+ * `onCdcConnectionStateChange`, including on every postgres-js auto-reconnect.
  */
 export async function startCdcListener(): Promise<void> {
   if (listenConnection) {
@@ -48,32 +95,132 @@ export async function startCdcListener(): Promise<void> {
     password: process.env.DB_PASSWORD,
   });
 
-  await listenConnection.listen(CDC_CHANNEL, (payload: string) => {
-    try {
-      const event = JSON.parse(payload) as CdcEvent;
-      for (const cb of callbacks) {
-        try {
-          cb(event);
-        } catch (err) {
-          console.error('[cdc-listener] Callback error:', err);
+  await listenConnection.listen(
+    CDC_CHANNEL,
+    (payload: string) => {
+      try {
+        const event = JSON.parse(payload) as CdcEvent;
+        for (const cb of callbacks) {
+          try {
+            cb(event);
+          } catch (err) {
+            console.error('[cdc-listener] Callback error:', err);
+          }
         }
+      } catch (err) {
+        console.error('[cdc-listener] Failed to parse CDC payload:', err);
       }
-    } catch (err) {
-      console.error('[cdc-listener] Failed to parse CDC payload:', err);
+    },
+    () => {
+      // Fires on initial subscribe AND on every postgres-js auto-reconnect's
+      // re-LISTEN. Either way the LISTEN is live again, so flip back to true.
+      dispatchState(true);
     }
-  });
+  );
 
   console.log('[cdc-listener] Listening on channel:', CDC_CHANNEL);
+}
+
+export interface LivenessProbeOptions {
+  /** How often to attempt a probe. Default: 10s. */
+  probeIntervalMs?: number;
+  /** How long a probe may remain un-echoed before dispatching connected=false. Default: 25s. */
+  echoTimeoutMs?: number;
+}
+
+/**
+ * Enables periodic self-NOTIFY probes on the `cdc_health` channel.
+ *
+ * Why: postgres-js's `onlisten` hook fires on (re)subscribe but does not fire
+ * on a silent socket death. Without a probe, the LISTEN connection can wedge
+ * (PG restart with no RST, NAT idle timeout, idle-transport death) while the
+ * process keeps reporting healthy. The probe sends a NOTIFY through any pool
+ * connection; if the LISTEN connection is alive, the echo arrives. If not,
+ * the next interval tick observes the un-echoed probe and dispatches
+ * `connected=false`, which the worker's healthcheck consumes to return 503.
+ *
+ * Sizing rationale: with the defaults (10s interval, 25s echo timeout) the
+ * worst-case detection latency is one probe interval + one echo timeout =
+ * 35s, then up to one health-poll cycle (30s) before the deploy framework
+ * acts → ~65s total. Within the C6 stranded-claim sweep's coverage window.
+ *
+ * Must be called after `startCdcListener()`.
+ */
+export async function enableLivenessProbe(opts: LivenessProbeOptions = {}): Promise<void> {
+  if (!listenConnection) {
+    throw new Error('[cdc-listener] enableLivenessProbe called before startCdcListener');
+  }
+  if (livenessTimer) {
+    console.warn('[cdc-listener] Liveness probe already enabled');
+    return;
+  }
+
+  const probeIntervalMs = opts.probeIntervalMs ?? 10_000;
+  const echoTimeoutMs = opts.echoTimeoutMs ?? 25_000;
+
+  await listenConnection.listen(HEALTH_CHANNEL, (payload: string) => {
+    if (payload === outstandingProbeToken) {
+      outstandingProbeToken = null;
+      outstandingProbeAt = 0;
+      dispatchState(true);
+    }
+    // Other workers' probe tokens echo here too (multi-instance deploy).
+    // Ignore them — each instance only cares about its own echo.
+  });
+
+  livenessTimer = setInterval(() => {
+    void runProbeTick(echoTimeoutMs);
+  }, probeIntervalMs);
+
+  console.log(`[cdc-listener] Liveness probe enabled (interval=${probeIntervalMs}ms, echo-timeout=${echoTimeoutMs}ms)`);
+}
+
+async function runProbeTick(echoTimeoutMs: number): Promise<void> {
+  if (!listenConnection) return;
+
+  // If a probe is already outstanding, evaluate whether it's exceeded the
+  // echo timeout. Don't issue a new one — we want a clean failure signal,
+  // not overlapping probes that might mask a wedge.
+  if (outstandingProbeToken !== null) {
+    if (Date.now() - outstandingProbeAt >= echoTimeoutMs) {
+      dispatchState(false);
+    }
+    return;
+  }
+
+  const token = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  outstandingProbeToken = token;
+  outstandingProbeAt = Date.now();
+
+  try {
+    await listenConnection.notify(HEALTH_CHANNEL, token);
+  } catch (err) {
+    console.error('[cdc-listener] Liveness probe NOTIFY failed:', err);
+    // NOTIFY itself failing means the pool can't talk to PG at all. Don't
+    // wait the echo timeout — surface immediately.
+    outstandingProbeToken = null;
+    outstandingProbeAt = 0;
+    dispatchState(false);
+  }
 }
 
 /**
  * Stops the CDC listener and closes the dedicated connection.
  */
 export async function stopCdcListener(): Promise<void> {
+  if (livenessTimer) {
+    clearInterval(livenessTimer);
+    livenessTimer = null;
+  }
+  outstandingProbeToken = null;
+  outstandingProbeAt = 0;
+  lastDispatchedState = null;
+
   if (listenConnection) {
     await listenConnection.end();
     listenConnection = null;
     callbacks = [];
+    stateCallbacks = [];
     console.log('[cdc-listener] Stopped');
   }
 }

--- a/tests/unit/apps/enrichment-worker/healthcheck.test.ts
+++ b/tests/unit/apps/enrichment-worker/healthcheck.test.ts
@@ -1,20 +1,20 @@
 /**
- * Unit tests for enrichment-worker healthcheck.ts (BS#892 / PR-3).
+ * Unit tests for enrichment-worker healthcheck.ts (BS#892 / PR-3, BS#1014).
  *
  * The health server is what `--health-cmd="wget .../healthcheck"` polls
  * every 30s in the deploy. The contract is narrow but load-bearing:
- *   - 200 when the worker has finished startup (cdcConnected=true)
- *   - 503 when starting up or shutting down (cdcConnected=false)
+ *   - 200 when the worker has a live CDC connection (cdcConnected=true)
+ *   - 503 when starting up, shutting down, or after the liveness probe in
+ *     `@wxyc/database`'s `cdc-listener` flips `cdcConnected=false` on a
+ *     silent disconnect (cdcConnected=false)
  *   - 404 for any other path
  *   - URL with a query string still matches (cache-buster from
  *     canary/operator probes)
  *
- * Limitations the tests pin: this is a liveness probe scoped to startup +
- * shutdown. A silently-dead LISTEN connection is NOT detected — that's
- * BS#1014. A regression that flipped `cdcConnected` to false during normal
- * operation (e.g., from an unrelated code path) would surface as 503s
- * here; the unit test for that interaction lives wherever the flip would
- * be wired, not in this file.
+ * The mid-run disconnect path is driven from `worker.ts` via
+ * `onCdcConnectionStateChange` (the liveness machinery itself is tested in
+ * `tests/unit/shared/database/cdc-listener.test.ts`). This file pins the
+ * fact that the server faithfully observes mid-run flips in either direction.
  */
 
 import type { AddressInfo } from 'node:net';
@@ -70,6 +70,29 @@ describe('healthcheck server (BS#892 PR-3)', () => {
     expect((await getStatus(port)).status).toBe(200);
     state.cdcConnected = false;
     expect((await getStatus(port)).status).toBe(503);
+  });
+
+  it('BS#1014: a liveness-driven flip via state callback flows through to /healthcheck', async () => {
+    // Simulates the wiring in worker.ts: onCdcConnectionStateChange
+    // mutates state.cdcConnected, the server reads it on the next poll.
+    // The cdc-listener test pins WHEN the flip happens; this test pins
+    // that the server respects it.
+    const stateCallback = (connected: boolean): void => {
+      state.cdcConnected = connected;
+    };
+
+    stateCallback(true);
+    expect((await getStatus(port)).status).toBe(200);
+
+    // Liveness probe observes a wedged LISTEN
+    stateCallback(false);
+    const after = await getStatus(port);
+    expect(after.status).toBe(503);
+    expect(after.body).toBe('cdc not connected');
+
+    // Postgres-js auto-reconnect → onlisten → connected=true
+    stateCallback(true);
+    expect((await getStatus(port)).status).toBe(200);
   });
 
   it('returns 404 for unknown paths', async () => {

--- a/tests/unit/shared/database/cdc-listener.test.ts
+++ b/tests/unit/shared/database/cdc-listener.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Unit tests for shared/database/src/cdc-listener.ts (BS#1014).
+ *
+ * Pins the new liveness machinery added in this PR:
+ *   - `onCdcConnectionStateChange` dispatches `true` on initial subscribe via
+ *     the postgres-js `onlisten` hook (also fires on auto-reconnect).
+ *   - Duplicate transitions are suppressed (a healthy probe doesn't churn
+ *     callbacks every interval).
+ *   - `enableLivenessProbe` LISTENs on `cdc_health`, NOTIFYs at each tick,
+ *     dispatches `connected=true` on echo, dispatches `connected=false` when
+ *     the in-flight probe exceeds `echoTimeoutMs`.
+ *   - A NOTIFY failure surfaces `connected=false` immediately (no wait).
+ *   - `stopCdcListener` clears the probe timer + module-level state.
+ *
+ * Postgres-js is jest.mock'd; the cdc-listener module is `import()`'d fresh
+ * per test via `jest.resetModules()` so the module-level singletons don't
+ * leak across cases.
+ */
+
+// Mock factory: each test injects a fresh `mockSql` via mockImplementation
+// before the cdc-listener module is loaded.
+const postgresFactory = jest.fn();
+jest.mock('postgres', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => postgresFactory(...args),
+}));
+
+type CdcListenerModule = typeof import('../../../../shared/database/src/cdc-listener');
+
+interface MockSql {
+  listen: jest.Mock;
+  notify: jest.Mock;
+  end: jest.Mock;
+}
+
+interface MockHandles {
+  sql: MockSql;
+  cdcOnNotify?: (payload: string) => void;
+  cdcOnListen?: () => void;
+  healthOnNotify?: (payload: string) => void;
+}
+
+function makeMockSql(): MockHandles {
+  const handles: MockHandles = { sql: {} as MockSql };
+  handles.sql = {
+    listen: jest.fn((channel: string, onnotify: (p: string) => void, onlisten?: () => void) => {
+      if (channel === 'cdc') {
+        handles.cdcOnNotify = onnotify;
+        handles.cdcOnListen = onlisten;
+        if (onlisten) onlisten();
+      } else if (channel === 'cdc_health') {
+        handles.healthOnNotify = onnotify;
+      }
+      return Promise.resolve({ unlisten: jest.fn(() => Promise.resolve()) });
+    }),
+    notify: jest.fn(() => Promise.resolve()),
+    end: jest.fn(() => Promise.resolve()),
+  };
+  return handles;
+}
+
+describe('cdc-listener liveness (BS#1014)', () => {
+  let cdc: CdcListenerModule;
+  let handles: MockHandles;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.resetModules();
+    handles = makeMockSql();
+    postgresFactory.mockReset();
+    postgresFactory.mockReturnValue(handles.sql);
+    cdc = await import('../../../../shared/database/src/cdc-listener');
+  });
+
+  afterEach(async () => {
+    // Always stop cleanly so the timer doesn't leak into the next test.
+    await cdc.stopCdcListener();
+    jest.useRealTimers();
+  });
+
+  describe('onCdcConnectionStateChange (onlisten hook)', () => {
+    it('dispatches true on initial subscribe via the postgres-js onlisten callback', async () => {
+      const cb = jest.fn();
+      cdc.onCdcConnectionStateChange(cb);
+      await cdc.startCdcListener();
+      expect(cb).toHaveBeenCalledWith(true);
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('also dispatches when the onlisten hook fires again (postgres-js auto-reconnect)', async () => {
+      const cb = jest.fn();
+      cdc.onCdcConnectionStateChange(cb);
+      await cdc.startCdcListener();
+      cb.mockClear();
+      // Simulate the listener falsifying then re-listening — only the
+      // false→true transition should dispatch.
+      await cdc.enableLivenessProbe({ probeIntervalMs: 1000, echoTimeoutMs: 100 });
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await Promise.resolve();
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      // Probe timed out → false
+      expect(cb).toHaveBeenLastCalledWith(false);
+      cb.mockClear();
+      // Postgres-js auto-reconnect would fire onlisten again
+      handles.cdcOnListen?.();
+      expect(cb).toHaveBeenCalledWith(true);
+    });
+
+    it('suppresses duplicate same-state dispatches', async () => {
+      const cb = jest.fn();
+      cdc.onCdcConnectionStateChange(cb);
+      await cdc.startCdcListener(); // -> true (1st)
+      handles.cdcOnListen?.(); // -> true again, should be suppressed
+      handles.cdcOnListen?.(); // -> true again, should be suppressed
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('isolates state-callback errors from sibling callbacks', async () => {
+      const consoleErr = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const bad = jest.fn(() => {
+        throw new Error('boom');
+      });
+      const good = jest.fn();
+      cdc.onCdcConnectionStateChange(bad);
+      cdc.onCdcConnectionStateChange(good);
+      await cdc.startCdcListener();
+      expect(bad).toHaveBeenCalledWith(true);
+      expect(good).toHaveBeenCalledWith(true);
+      expect(consoleErr).toHaveBeenCalledWith('[cdc-listener] State callback error:', expect.any(Error));
+      consoleErr.mockRestore();
+    });
+  });
+
+  describe('enableLivenessProbe', () => {
+    it('throws when called before startCdcListener', async () => {
+      await expect(cdc.enableLivenessProbe()).rejects.toThrow(
+        '[cdc-listener] enableLivenessProbe called before startCdcListener'
+      );
+    });
+
+    it('registers a LISTEN on cdc_health and starts an interval timer', async () => {
+      await cdc.startCdcListener();
+      await cdc.enableLivenessProbe({ probeIntervalMs: 5000, echoTimeoutMs: 12_000 });
+      // Two LISTENs total: cdc + cdc_health
+      const channels = handles.sql.listen.mock.calls.map((c) => c[0]);
+      expect(channels).toEqual(['cdc', 'cdc_health']);
+    });
+
+    it('no-ops on second call (warns once)', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      await cdc.startCdcListener();
+      await cdc.enableLivenessProbe({ probeIntervalMs: 5000 });
+      await cdc.enableLivenessProbe({ probeIntervalMs: 5000 });
+      expect(warn).toHaveBeenCalledWith('[cdc-listener] Liveness probe already enabled');
+      warn.mockRestore();
+    });
+
+    it('sends NOTIFY on cdc_health each interval', async () => {
+      await cdc.startCdcListener();
+      await cdc.enableLivenessProbe({ probeIntervalMs: 1000, echoTimeoutMs: 5000 });
+      handles.sql.notify.mockClear();
+      jest.advanceTimersByTime(1000);
+      // Let the queued promise tick run
+      await Promise.resolve();
+      expect(handles.sql.notify).toHaveBeenCalledTimes(1);
+      expect(handles.sql.notify.mock.calls[0][0]).toBe('cdc_health');
+      expect(typeof handles.sql.notify.mock.calls[0][1]).toBe('string');
+    });
+
+    it('dispatches connected=true when its own echo arrives', async () => {
+      const cb = jest.fn();
+      cdc.onCdcConnectionStateChange(cb);
+      await cdc.startCdcListener(); // -> true (initial)
+      await cdc.enableLivenessProbe({ probeIntervalMs: 1000, echoTimeoutMs: 5000 });
+      cb.mockClear();
+
+      // First tick → NOTIFY sent
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await Promise.resolve();
+      const token = handles.sql.notify.mock.calls[0][1] as string;
+
+      // Echo arrives via the cdc_health onnotify
+      // But we're still in "true" state from the initial dispatch, so we
+      // need to flip to false first for the echo to register a transition.
+      // Easier: confirm the suppression-aware path by forcing a state
+      // change first.
+      // Reset by hand: deliver a non-matching payload to no-op the echo
+      // path, then force a timeout to flip to false, then deliver the echo.
+
+      // Step 1: timeout to flip false
+      jest.advanceTimersByTime(5000);
+      await Promise.resolve();
+      expect(cb).toHaveBeenLastCalledWith(false);
+
+      // Step 2: echo of the original token now flips back to true
+      cb.mockClear();
+      handles.healthOnNotify?.(token);
+      expect(cb).toHaveBeenCalledWith(true);
+    });
+
+    it('ignores echoes whose payload does not match the outstanding token', async () => {
+      const cb = jest.fn();
+      cdc.onCdcConnectionStateChange(cb);
+      await cdc.startCdcListener();
+      await cdc.enableLivenessProbe({ probeIntervalMs: 1000, echoTimeoutMs: 5000 });
+
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Force false first so a true-dispatch from a foreign echo would be observable
+      jest.advanceTimersByTime(5000);
+      await Promise.resolve();
+      cb.mockClear();
+
+      handles.healthOnNotify?.('not-my-token');
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('dispatches connected=false when probe exceeds echoTimeoutMs without an echo', async () => {
+      const cb = jest.fn();
+      cdc.onCdcConnectionStateChange(cb);
+      await cdc.startCdcListener();
+      await cdc.enableLivenessProbe({ probeIntervalMs: 1000, echoTimeoutMs: 2000 });
+      cb.mockClear();
+
+      // Tick 1: probe sent at t=1000
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(cb).not.toHaveBeenCalled();
+
+      // Tick 2 (t=2000): probe is 1000ms old, still under 2000ms timeout
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      expect(cb).not.toHaveBeenCalled();
+
+      // Tick 3 (t=3000): probe is 2000ms old, exceeds timeout → false
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+      expect(cb).toHaveBeenCalledWith(false);
+    });
+
+    it('dispatches connected=false immediately if NOTIFY itself rejects', async () => {
+      const cb = jest.fn();
+      cdc.onCdcConnectionStateChange(cb);
+      await cdc.startCdcListener();
+      await cdc.enableLivenessProbe({ probeIntervalMs: 1000, echoTimeoutMs: 30_000 });
+      cb.mockClear();
+      const consoleErr = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      handles.sql.notify.mockRejectedValueOnce(new Error('pool dead'));
+
+      jest.advanceTimersByTime(1000);
+      // Let the failed promise reject + propagate
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(cb).toHaveBeenCalledWith(false);
+      expect(consoleErr).toHaveBeenCalledWith('[cdc-listener] Liveness probe NOTIFY failed:', expect.any(Error));
+      consoleErr.mockRestore();
+    });
+  });
+
+  describe('stopCdcListener', () => {
+    it('clears the liveness probe timer and resets module state', async () => {
+      const cb = jest.fn();
+      cdc.onCdcConnectionStateChange(cb);
+      await cdc.startCdcListener();
+      await cdc.enableLivenessProbe({ probeIntervalMs: 1000, echoTimeoutMs: 2000 });
+      cb.mockClear();
+      handles.sql.notify.mockClear();
+
+      await cdc.stopCdcListener();
+
+      // After stop, advancing time should not produce further NOTIFY calls
+      // or state callbacks.
+      jest.advanceTimersByTime(10_000);
+      await Promise.resolve();
+      expect(handles.sql.notify).not.toHaveBeenCalled();
+      expect(cb).not.toHaveBeenCalled();
+      expect(handles.sql.end).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1014. Follow-up filed during BS#892 PR-3 ([#1013](https://github.com/WXYC/Backend-Service/pull/1013)) to harden the worker's `/healthcheck` against silent LISTEN-socket drops.

## Problem

`apps/enrichment-worker/healthcheck.ts` only toggled `cdcConnected` at two well-defined points:

- `true` after `startCdcListener()` resolved at startup
- `false` when SIGTERM/SIGINT began draining

A mid-run LISTEN drop (PG restart without RST, NAT idle timeout, idle-transport death of the kind tracked in `project_sentry_idle_transport_death.md`) left the process alive, `cdcConnected` stuck on `true`, `/healthcheck` returning 200, and the deploy's `--restart unless-stopped` never firing.

## What this PR adds

Two new exports in `@wxyc/database`'s `cdc-listener`:

- **`onCdcConnectionStateChange(cb)`** — fires `connected=true` via the postgres-js `onlisten` hook (initial subscribe + every auto-reconnect) and via every received liveness-probe echo; fires `connected=false` when the in-flight probe wedges. Duplicate same-state dispatches are suppressed.
- **`enableLivenessProbe({probeIntervalMs, echoTimeoutMs})`** — LISTENs on a sibling `cdc_health` channel, NOTIFYs at each interval tick, and dispatches `connected=false` when the in-flight probe exceeds the echo timeout (or when `NOTIFY` itself rejects).

The worker (`apps/enrichment-worker/worker.ts`) wires `onCdcConnectionStateChange` into `healthState.cdcConnected` and enables the probe right after `startCdcListener()`.

## Failure-detection latency

With the defaults (probe interval 10 s, echo timeout 25 s) the disconnect → 503 latency is one probe cycle + one echo timeout ≈ 35 s, then up to one health-poll cycle (30 s) before `--restart unless-stopped` fires → **~65 s end-to-end**. Comfortably inside the C6 stranded-claim sweep's coverage window.

## Multi-instance safety

Multiple worker instances all LISTEN on `cdc_health`, so each instance sees every NOTIFY from every other instance. Each instance only matches its own outstanding probe token (timestamped + random); foreign echoes are silently dropped.

## What this PR explicitly does NOT do

- **No new NPM dependencies.** `node:http` + `postgres` are already in the worker image.
- **No restructuring of `onCdcEvent`** — `onCdcConnectionStateChange` is a sibling, not a replacement.
- **Doesn't replace BS#895 (C6).** The stranded-claim sweep is still the backstop for rows missed during the disconnect-to-restart window.

## Tests

- **`tests/unit/shared/database/cdc-listener.test.ts`** (new, 13 cases) — `jest.mock('postgres')` + fake timers + per-test `jest.resetModules()` for module-singleton hygiene. Pins:
  - `onlisten` hook dispatches `true` on initial subscribe; auto-reconnect path; duplicate-state suppression; callback-error isolation
  - `enableLivenessProbe` rejects when called before `startCdcListener`; registers `cdc_health` LISTEN; warns + no-ops on double-call
  - Probe sends NOTIFY each interval; matching-token echo dispatches `true`; foreign-token echo is ignored; exceeded echo timeout dispatches `false`; NOTIFY rejection dispatches `false` immediately
  - `stopCdcListener` clears the probe timer + module state
- **`tests/unit/apps/enrichment-worker/healthcheck.test.ts`** adds one case pinning that a liveness-driven flip flows through to `/healthcheck` (the worker's wiring contract).

## Verifying in prod (issue acceptance criteria)

The issue body proposes a manual repro via `SELECT pg_terminate_backend(pid)` against the worker's LISTEN connection. With this PR, the worker should:

1. Stop receiving echoes within one probe cycle.
2. Flip `cdcConnected=false` within one echo-timeout (default 25 s).
3. Return 503 on the next 30 s `/healthcheck` poll.
4. Be restarted by `--restart unless-stopped` within ~2 min total.

Not exercised in CI (requires a real PG connection and a `pg_terminate_backend` privileged call); validate post-deploy.

## Pre-flight

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (436 warnings, pre-existing)
- [x] `npm run format:check` — clean
- [x] `npm run lint:migrations` — n/a (no migrations)
- [x] `npm run build` — all workspaces succeed
- [x] `npm run test:unit` — 2189/2189 pass
- [x] `scripts/check-spacer-gif-callsites.sh` — clean

## Related

- Parent: [BS#892](https://github.com/WXYC/Backend-Service/issues/892) (C2 — CDC consumer)
- Filed during: [#1013](https://github.com/WXYC/Backend-Service/pull/1013) (BS#892 PR-3) — the file-header for `healthcheck.ts` will be updated by this PR to reflect that BS#1014 is now resolved
- Backstop: [BS#895](https://github.com/WXYC/Backend-Service/issues/895) (C6 — stranded-claim sweep) — recovers rows missed during the disconnect-to-restart window
- Sibling failure mode: `project_sentry_idle_transport_death.md` (rom's `@sentry/node` transport dying on sparse-traffic services)