### PR TITLE
Auto-add new users to default org on creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -366,6 +366,12 @@ jobs:
           # tests/unit/services/lml.client.test.ts:792-793.
           LML_CLIENT_MAX_CONCURRENT: '10000'
           LML_CLIENT_RATE_PER_MIN: '60000'
+          # Default org wiring: matches the slug seeded by dev_env/seed_db.sql.
+          # Consumed by the org-sync hooks and the user.create.after
+          # auto-membership hook in shared/authentication/src/auth.definition.ts.
+          # Without this, those hooks log a warning and no-op, which the
+          # auth-auto-membership integration spec specifically exercises.
+          DEFAULT_ORG_SLUG: test-org
         run: |
           node dev_env/mock-api-server/dist/server.js > /tmp/mock-api.log 2>&1 &
           node apps/auth/dist/app.js > /tmp/auth.log 2>&1 &

--- a/apps/auth/provision-user.ts
+++ b/apps/auth/provision-user.ts
@@ -116,16 +116,40 @@ export async function provisionUser(input: ProvisionUserInput): Promise<Provisio
       userId: newUser.id,
     });
 
-    // 8. Create organization membership
-    const createdMember = await adapter.create({
+    // 8. Ensure organization membership exists with the requested role.
+    //    The `databaseHooks.user.create.after` hook in auth.definition.ts
+    //    auto-creates a member row with role='member' for every non-anonymous
+    //    user, so by the time we get here a row may already exist. Upsert
+    //    instead of insert so the caller still gets the role they asked for.
+    const existingMember = await adapter.findOne<{ id: string; userId: string; organizationId: string; role: string }>({
       model: 'member',
-      data: {
-        userId: newUser.id,
-        organizationId: org.id,
-        role,
-        createdAt: new Date(),
-      },
+      where: [
+        { field: 'userId', value: newUser.id },
+        { field: 'organizationId', value: org.id },
+      ],
     });
+
+    let createdMember: { id: string; organizationId: string; role: string; [key: string]: unknown };
+    if (existingMember) {
+      if (existingMember.role !== role) {
+        await adapter.update({
+          model: 'member',
+          where: [{ field: 'id', value: existingMember.id }],
+          update: { role },
+        });
+      }
+      createdMember = { ...existingMember, role };
+    } else {
+      createdMember = (await adapter.create({
+        model: 'member',
+        data: {
+          userId: newUser.id,
+          organizationId: org.id,
+          role,
+          createdAt: new Date(),
+        },
+      })) as typeof createdMember;
+    }
 
     // 9. Sync admin role for stationManager (replicates afterAddMember hook)
     if (ADMIN_SYNC_ROLES.includes(role)) {
@@ -145,7 +169,7 @@ export async function provisionUser(input: ProvisionUserInput): Promise<Provisio
         console.error('[PROVISION USER] Failed to trigger setup email:', error);
       });
 
-    return { user: newUser, member: createdMember as ProvisionUserResult['member'] };
+    return { user: newUser, member: createdMember as unknown as ProvisionUserResult['member'] };
   } catch (error) {
     // Clean up: delete the orphaned user so we don't leave partial state
     try {

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -12,7 +12,8 @@ import {
   organization as organizationPlugin,
   username,
 } from 'better-auth/plugins';
-import { eq, sql } from 'drizzle-orm';
+import { generateId } from '@better-auth/core/utils/id';
+import { and, eq, sql } from 'drizzle-orm';
 import { WXYCRoles } from './auth.roles';
 import { sendEmail, sendOTPEmail, sendResetPasswordEmail, sendVerificationEmailMessage } from './email';
 import { rewriteUrlForFrontend } from './url-rewrite';
@@ -346,6 +347,66 @@ export const auth = betterAuth({
         console.error('Error auto-verifying admin-created user:', error);
       }
     }),
+  },
+
+  // Auto-add every newly created non-anonymous user to the default
+  // organization as a `member`. Acts as a safety net for any code path that
+  // creates users without going through `provisionUser` (e.g. better-auth's
+  // bare `POST /admin/create-user` admin endpoint). Without this, those
+  // users land in `auth_user` with no `auth_member` row, which breaks
+  // `organization.listMembers` (FORBIDDEN) for the affected user and any
+  // call that tries to promote them. provisionUser still sets the requested
+  // role; it now upserts on top of the row this hook auto-creates.
+  databaseHooks: {
+    user: {
+      create: {
+        after: async (createdUser) => {
+          const u = createdUser as { id: string; isAnonymous?: boolean | null };
+          // Anonymous-plugin users are per-device throwaways, not station members.
+          if (u.isAnonymous) return;
+
+          const defaultOrgSlug = process.env.DEFAULT_ORG_SLUG;
+          if (!defaultOrgSlug) {
+            console.warn(`[user.create.after] DEFAULT_ORG_SLUG not set; skipping auto-membership for ${u.id}`);
+            return;
+          }
+
+          try {
+            const orgRows = await db
+              .select({ id: organization.id })
+              .from(organization)
+              .where(eq(organization.slug, defaultOrgSlug))
+              .limit(1);
+            if (orgRows.length === 0) {
+              console.warn(
+                `[user.create.after] No organization with slug "${defaultOrgSlug}"; skipping auto-membership for ${u.id}`
+              );
+              return;
+            }
+
+            const existing = await db
+              .select({ id: member.id })
+              .from(member)
+              .where(and(eq(member.userId, u.id), eq(member.organizationId, orgRows[0].id)))
+              .limit(1);
+            if (existing.length > 0) return;
+
+            await db.insert(member).values({
+              id: generateId(32),
+              userId: u.id,
+              organizationId: orgRows[0].id,
+              role: 'member',
+              createdAt: new Date(),
+            });
+          } catch (error) {
+            // Don't fail user creation just because the safety-net insert
+            // hit a race or transient error — the operator can backfill
+            // with scripts/backfill-missing-org-members.ts.
+            console.error('[user.create.after] Failed to auto-add member row:', error);
+          }
+        },
+      },
+    },
   },
 
   // Enable username-based login

--- a/tests/integration/auth-auto-membership.spec.js
+++ b/tests/integration/auth-auto-membership.spec.js
@@ -1,0 +1,170 @@
+/**
+ * Integration tests for the `databaseHooks.user.create.after` hook in
+ * `shared/authentication/src/auth.definition.ts`.
+ *
+ * The hook is the safety net that ensures every non-anonymous newly created
+ * user gets an `auth_member` row in the default organization. Without it,
+ * users created via better-auth's bare `POST /admin/create-user` endpoint
+ * land in `auth_user` with no membership and trigger a FORBIDDEN on
+ * `organization.listMembers` — the bug that prompted these changes.
+ *
+ * What's covered here:
+ *   1. Bare admin create-user path: the new user gets a member row with
+ *      role=`member`. This is the path that broke before.
+ *   2. provisionUser path: the new user gets a member row with the
+ *      requested role. Proves the upsert refactor in provision-user.ts
+ *      cooperates with the auto-membership hook (the hook fires first
+ *      and inserts role=`member`; provisionUser then upserts to the
+ *      requested role).
+ *
+ * Anonymous-plugin sign-ins are covered by the comment in the hook itself
+ * — exercising them here would also need a publicly reachable anonymous
+ * sign-in endpoint and adds little signal over the unit tests.
+ */
+
+const postgres = require('postgres');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const ORG_SLUG = process.env.DEFAULT_ORG_SLUG || 'test-org';
+
+function getAuthBaseUrl() {
+  if (process.env.BETTER_AUTH_URL) {
+    try {
+      return new URL(process.env.BETTER_AUTH_URL).toString().replace(/\/$/, '');
+    } catch {
+      // fall through
+    }
+  }
+  const host = process.env.AUTH_HOST || 'localhost';
+  const port = process.env.AUTH_PORT || process.env.CI_AUTH_PORT || 8083;
+  return `http://${host}:${port}/auth`;
+}
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+/**
+ * Sign in as test_station_manager and return the Cookie header value to
+ * send on subsequent admin-plugin requests. Admin endpoints authenticate
+ * via the better-auth session cookie, not the JWT used elsewhere in the
+ * integration suite.
+ */
+async function signInAsStationManager(authBaseUrl) {
+  const res = await fetch(`${authBaseUrl}/sign-in/username`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'test_station_manager', password: 'testpassword123' }),
+  });
+  if (!res.ok) {
+    throw new Error(`Sign-in failed: ${res.status} ${await res.text()}`);
+  }
+  const cookies = res.headers.getSetCookie();
+  if (!cookies || cookies.length === 0) {
+    throw new Error('No session cookie returned by sign-in');
+  }
+  return cookies.map((c) => c.split(';')[0].trim()).join('; ');
+}
+
+describe('user.create.after auto-membership hook', () => {
+  const authBaseUrl = getAuthBaseUrl();
+  let sql;
+  let cookie;
+  /** @type {string[]} user ids created by these tests; deleted in afterEach. */
+  const createdUserIds = [];
+
+  beforeAll(async () => {
+    sql = makeSql();
+    cookie = await signInAsStationManager(authBaseUrl);
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end();
+  });
+
+  afterEach(async () => {
+    if (createdUserIds.length === 0) return;
+    // FK on auth_member cascades to auth_user, so removing the user removes
+    // the member row too. We use raw SQL rather than DELETE /admin/remove-user
+    // to keep cleanup independent of the endpoint under test.
+    await sql.unsafe(`DELETE FROM ${SCHEMA}.auth_user WHERE id = ANY(${'$1'}::text[])`, [createdUserIds.splice(0)]);
+  });
+
+  test('bare POST /admin/create-user auto-creates an auth_member row with role=member', async () => {
+    const email = `auto-member-${Date.now()}@test.wxyc.org`;
+    const res = await fetch(`${authBaseUrl}/admin/create-user`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: cookie },
+      body: JSON.stringify({
+        email,
+        password: 'testpassword123',
+        name: 'Auto Member Test',
+        // Bare admin endpoint accepts 'admin'/'user' for the auth_user.role
+        // field. We pass 'user' here so the test exercises the case the
+        // hook was added to repair (non-station-manager user with no
+        // org membership).
+        role: 'user',
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`create-user failed: ${res.status} ${await res.text()}`);
+    }
+    const body = await res.json();
+    expect(body?.user?.id).toBeTruthy();
+    const userId = body.user.id;
+    createdUserIds.push(userId);
+
+    // The hook runs in the `after` phase of internalAdapter.createUser, so
+    // by the time the HTTP response returns the member row is committed.
+    const memberRows = await sql.unsafe(
+      `SELECT m.id, m.role, o.slug
+         FROM ${SCHEMA}.auth_member m
+         JOIN ${SCHEMA}.auth_organization o ON o.id = m.organization_id
+        WHERE m.user_id = $1`,
+      [userId]
+    );
+    expect(memberRows).toHaveLength(1);
+    expect(memberRows[0].role).toBe('member');
+    expect(memberRows[0].slug).toBe(ORG_SLUG);
+  });
+
+  test('POST /admin/provision-user upserts the auto-created member row to the requested role', async () => {
+    const email = `provision-upsert-${Date.now()}@test.wxyc.org`;
+    const username = `prov_upsert_${Date.now()}`;
+    const res = await fetch(`${authBaseUrl}/admin/provision-user`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: cookie },
+      body: JSON.stringify({
+        email,
+        username,
+        password: 'testpassword123',
+        name: 'Provision Upsert Test',
+        organizationSlug: ORG_SLUG,
+        role: 'dj',
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`provision-user failed: ${res.status} ${await res.text()}`);
+    }
+    const body = await res.json();
+    expect(body?.user?.id).toBeTruthy();
+    const userId = body.user.id;
+    createdUserIds.push(userId);
+
+    // Exactly one member row, with the requested role rather than the
+    // hook's default `member`. Confirms provisionUser's upsert overwrote
+    // the row the hook auto-created (rather than racing and crashing on
+    // the unique (organization_id, user_id) constraint).
+    const memberRows = await sql.unsafe(`SELECT role FROM ${SCHEMA}.auth_member WHERE user_id = $1`, [userId]);
+    expect(memberRows).toHaveLength(1);
+    expect(memberRows[0].role).toBe('dj');
+  });
+});

--- a/tests/integration/auth-auto-membership.spec.js
+++ b/tests/integration/auth-auto-membership.spec.js
@@ -24,7 +24,10 @@
 
 const postgres = require('postgres');
 
-const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+// `auth_*` tables live in the default `public` schema (not the WXYC
+// `wxyc_schema` that holds the domain tables — see schema.ts where
+// `user`, `member`, `organization` are pgTable() without a wxyc_schema
+// prefix).
 const ORG_SLUG = process.env.DEFAULT_ORG_SLUG || 'test-org';
 
 function getAuthBaseUrl() {
@@ -95,7 +98,7 @@ describe('user.create.after auto-membership hook', () => {
     // FK on auth_member cascades to auth_user, so removing the user removes
     // the member row too. We use raw SQL rather than DELETE /admin/remove-user
     // to keep cleanup independent of the endpoint under test.
-    await sql.unsafe(`DELETE FROM ${SCHEMA}.auth_user WHERE id = ANY(${'$1'}::text[])`, [createdUserIds.splice(0)]);
+    await sql.unsafe(`DELETE FROM auth_user WHERE id = ANY(${'$1'}::text[])`, [createdUserIds.splice(0)]);
   });
 
   test('bare POST /admin/create-user auto-creates an auth_member row with role=member', async () => {
@@ -126,8 +129,8 @@ describe('user.create.after auto-membership hook', () => {
     // by the time the HTTP response returns the member row is committed.
     const memberRows = await sql.unsafe(
       `SELECT m.id, m.role, o.slug
-         FROM ${SCHEMA}.auth_member m
-         JOIN ${SCHEMA}.auth_organization o ON o.id = m.organization_id
+         FROM auth_member m
+         JOIN auth_organization o ON o.id = m.organization_id
         WHERE m.user_id = $1`,
       [userId]
     );
@@ -163,7 +166,7 @@ describe('user.create.after auto-membership hook', () => {
     // hook's default `member`. Confirms provisionUser's upsert overwrote
     // the row the hook auto-created (rather than racing and crashing on
     // the unique (organization_id, user_id) constraint).
-    const memberRows = await sql.unsafe(`SELECT role FROM ${SCHEMA}.auth_member WHERE user_id = $1`, [userId]);
+    const memberRows = await sql.unsafe(`SELECT role FROM auth_member WHERE user_id = $1`, [userId]);
     expect(memberRows).toHaveLength(1);
     expect(memberRows[0].role).toBe('dj');
   });

--- a/tests/unit/auth/provision-user.test.ts
+++ b/tests/unit/auth/provision-user.test.ts
@@ -40,6 +40,7 @@ const mockLinkAccount = jest.fn();
 const mockDeleteUser = jest.fn();
 const mockAdapterFindOne = jest.fn();
 const mockAdapterCreate = jest.fn();
+const mockAdapterUpdate = jest.fn();
 const mockPasswordHash = jest.fn();
 
 const mockAuthContext = {
@@ -52,6 +53,7 @@ const mockAuthContext = {
   adapter: {
     findOne: mockAdapterFindOne,
     create: mockAdapterCreate,
+    update: mockAdapterUpdate,
   },
   password: {
     hash: mockPasswordHash,
@@ -117,11 +119,21 @@ const fakeMember = {
 
 function setUpHappyPath() {
   mockFindUserByEmail.mockResolvedValue(null);
-  mockAdapterFindOne.mockResolvedValue(fakeOrg);
+  // adapter.findOne is called for both the org lookup and the upsert member
+  // lookup. Default: return the org for {model: 'organization'} and null for
+  // {model: 'member'} (i.e. no existing member row — fall into the insert
+  // branch). Individual tests can override to simulate an existing row from
+  // the databaseHooks.user.create.after auto-membership hook.
+  mockAdapterFindOne.mockImplementation((query: { model: string }) => {
+    if (query?.model === 'organization') return Promise.resolve(fakeOrg);
+    if (query?.model === 'member') return Promise.resolve(null);
+    return Promise.resolve(null);
+  });
   mockCreateUser.mockResolvedValue(fakeUser);
   mockPasswordHash.mockResolvedValue('hashed-password');
   mockLinkAccount.mockResolvedValue(undefined);
   mockAdapterCreate.mockResolvedValue(fakeMember);
+  mockAdapterUpdate.mockResolvedValue(undefined);
   mockDeleteUser.mockResolvedValue(undefined);
 }
 
@@ -194,6 +206,65 @@ describe('provisionUser()', () => {
           role: 'dj',
         }),
       });
+    });
+  });
+
+  describe('upsert against auto-created member row', () => {
+    // The databaseHooks.user.create.after hook in auth.definition.ts
+    // auto-creates a member row with role='member' for every non-anonymous
+    // user. provisionUser must detect this and update the role instead of
+    // attempting a second insert (which would fail on the unique
+    // (organization_id, user_id) constraint).
+    const autoCreatedMember = {
+      id: 'auto-member-id-001',
+      userId: fakeUser.id,
+      organizationId: fakeOrg.id,
+      role: 'member',
+    };
+
+    it('should update the existing member row to the requested role', async () => {
+      mockAdapterFindOne.mockImplementation((query: { model: string }) => {
+        if (query?.model === 'organization') return Promise.resolve(fakeOrg);
+        if (query?.model === 'member') return Promise.resolve(autoCreatedMember);
+        return Promise.resolve(null);
+      });
+
+      const result = await provisionUser({ ...validInput, role: 'musicDirector' });
+
+      expect(mockAdapterUpdate).toHaveBeenCalledWith({
+        model: 'member',
+        where: [{ field: 'id', value: autoCreatedMember.id }],
+        update: { role: 'musicDirector' },
+      });
+      expect(mockAdapterCreate).not.toHaveBeenCalledWith(expect.objectContaining({ model: 'member' }));
+      expect(result.member.role).toBe('musicDirector');
+    });
+
+    it('should skip the update when the auto-created role already matches', async () => {
+      mockAdapterFindOne.mockImplementation((query: { model: string }) => {
+        if (query?.model === 'organization') return Promise.resolve(fakeOrg);
+        if (query?.model === 'member') return Promise.resolve(autoCreatedMember);
+        return Promise.resolve(null);
+      });
+
+      const result = await provisionUser({ ...validInput, role: 'member' });
+
+      expect(mockAdapterUpdate).not.toHaveBeenCalled();
+      expect(mockAdapterCreate).not.toHaveBeenCalledWith(expect.objectContaining({ model: 'member' }));
+      expect(result.member.role).toBe('member');
+    });
+
+    it('should still sync user.role to admin when upserting to stationManager', async () => {
+      mockAdapterFindOne.mockImplementation((query: { model: string }) => {
+        if (query?.model === 'organization') return Promise.resolve(fakeOrg);
+        if (query?.model === 'member') return Promise.resolve(autoCreatedMember);
+        return Promise.resolve(null);
+      });
+
+      await provisionUser({ ...validInput, role: 'stationManager' });
+
+      expect(mockAdapterUpdate).toHaveBeenCalled();
+      expect(mockDbUpdate).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a `databaseHooks.user.create.after` hook in `shared/authentication/src/auth.definition.ts` that auto-inserts an `auth_member` row with `role='member'` for every newly created non-anonymous user, into the org resolved via `DEFAULT_ORG_SLUG`. Closes the hole that WXYC/Backend-Service#1031 just backfilled.
- Refactors `provisionUser` (`apps/auth/provision-user.ts`) to upsert on top of the hook's row instead of inserting (which would now collide on the unique `(organization_id, user_id)` index).
- Adds 3 unit tests covering the upsert branches and 1 integration test covering the end-to-end `/admin/create-user` and `/admin/provision-user` paths.

Closes #1033

## Behaviour after this PR

| Caller | Outcome |
|---|---|
| Anonymous plugin (`/sign-in/anonymous`) | No member row (hook skips on `isAnonymous`) |
| Bare `POST /admin/create-user` | Member row with `role='member'` (safety net) |
| `POST /admin/provision-user` (dj-site Roster create) | Member row with the role the admin requested; `auth_user.role='admin'` synced for stationManager / admin / owner |

The hook resolves the org via the same `DEFAULT_ORG_SLUG` env var the existing `afterAddMember` / `afterUpdateMemberRole` / `afterRemoveMember` hooks already consume, so configuration is unchanged. If the slug is unset or doesn't resolve, the hook logs a warning and no-ops — user creation still succeeds.

## Provision-user upsert

The hook fires inside `internalAdapter.createUser`, which `provisionUser` calls before its own member-create step. After this PR step 8 (`Create organization membership`) becomes:

1. `adapter.findOne` for an existing `(userId, organizationId)` member row.
2. If present and `role` differs, `adapter.update` to the requested role; else no-op.
3. If absent, `adapter.create` as before.

Net effect: provisionUser keeps the same external contract (\"user gets the requested role in the default org\") but cooperates with the hook instead of fighting it.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 2192 passing (49→50 in provision-user.test.ts: 3 new upsert tests added; 2189 → 2192 overall)
- [ ] CI `npm run ci:test` runs the new integration spec end-to-end (validates the bare `/admin/create-user` and the provisionUser upsert against a real PG + auth service)
- [ ] Manual verification post-deploy: create a user via the dj-site Roster page (provisionUser path), verify exactly one `auth_member` row with the requested role
- [ ] Manual verification post-deploy: create a user via bare `POST /auth/admin/create-user` (curl), verify a `member` row was added automatically

## Notes for the reviewer

- I left the `hooks.after` middleware (the auto-verify-email handler) alone — that's a `createAuthMiddleware` endpoint-level hook, distinct from `databaseHooks.user.create.after`. The two coexist.
- The hook deliberately defaults `member.role='member'` rather than mapping `auth_user.role='admin' → stationManager`. The bare admin endpoint can be called with arbitrary `role` values, and silently elevating to stationManager felt riskier than the conservative default. `provisionUser` callers still get the role they asked for via the upsert.