### PR TITLE
fix(internal-route): pass albumId to enrichment from tubafrenzy webhook

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -127,7 +127,7 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
           add_time: entry.startTime ? new Date(entry.startTime) : new Date(),
         })
         .onConflictDoNothing()
-        .returning({ id: flowsheet.id });
+        .returning({ id: flowsheet.id, album_id: flowsheet.album_id });
 
       let upsertedRow = inserted[0];
       const created = !!upsertedRow;
@@ -150,7 +150,7 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
             entry_type: entryType,
           })
           .where(eq(flowsheet.legacy_entry_id, entry.id))
-          .returning({ id: flowsheet.id });
+          .returning({ id: flowsheet.id, album_id: flowsheet.album_id });
         upsertedRow = updated[0];
       }
 
@@ -160,10 +160,13 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // tubafrenzy retries don't trigger LML re-fetch + 10-column rewrite +
       // CDC/index churn on every duplicate webhook delivery. The historical
       // drain at jobs/flowsheet-metadata-backfill/ is the safety net for
-      // rows whose first INSERT enrichment returned null.
+      // rows whose first INSERT enrichment returned null. Passing `albumId`
+      // when the row is library-linked routes D3's in-process writer through
+      // the linked-row branch that UPSERTs `album_metadata` (BS#1028).
       if (created && upsertedRow && entryType === 'track' && artistName) {
         fireAndForgetMetadataForRow({
           flowsheetId: upsertedRow.id,
+          albumId: upsertedRow.album_id ?? undefined,
           artistName,
           albumTitle,
           trackTitle,

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -225,10 +225,13 @@ describe('POST /internal/flowsheet-webhook', () => {
 
   it('fires metadata enrichment on fresh INSERT (RETURNING returns one row)', async () => {
     // Replaces the xmax = 0 trick (BS#909). The INSERT ... ON CONFLICT DO
-    // NOTHING RETURNING { id } either returns one row (we won the insert
-    // race and the row is fresh) or an empty array (someone else inserted
-    // first; we should UPDATE without firing enrichment).
-    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+    // NOTHING RETURNING { id, album_id } either returns one row (we won the
+    // insert race and the row is fresh) or an empty array (someone else
+    // inserted first; we should UPDATE without firing enrichment). When the
+    // inserted row's album_id is non-null, it MUST be passed through so D3's
+    // in-process writer takes the linked-row branch and UPSERTs
+    // album_metadata (BS#1028).
+    mockReturning.mockResolvedValueOnce([{ id: 5555, album_id: 7777 }]);
 
     const res = await request(app)
       .post('/internal/flowsheet-webhook')
@@ -238,6 +241,29 @@ describe('POST /internal/flowsheet-webhook', () => {
     expect(res.status).toBe(200);
     expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledWith({
       flowsheetId: 5555,
+      albumId: 7777,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+      trackTitle: 'VI Scose Poise',
+    });
+  });
+
+  it('passes albumId: undefined when the inserted row has a null album_id', async () => {
+    // Unlinked rows (no library match) come back from RETURNING with
+    // album_id: null. The webhook handler must translate that to
+    // `albumId: undefined` so D3's writer routes through the unlinked-inline
+    // branch (BS#1028).
+    mockReturning.mockResolvedValueOnce([{ id: 5556, album_id: null }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry });
+
+    expect(res.status).toBe(200);
+    expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledWith({
+      flowsheetId: 5556,
+      albumId: undefined,
       artistName: 'Autechre',
       albumTitle: 'Confield',
       trackTitle: 'VI Scose Poise',


### PR DESCRIPTION
## Summary

`apps/backend/routes/internal.route.ts` was calling `fireAndForgetMetadataForRow` from the tubafrenzy webhook handler without passing `albumId`. D3's in-process writer (`apps/backend/services/metadata/enrichment.service.ts:114`) branches on `input.albumId !== undefined`, so tubafrenzy-sourced linked rows took the unlinked-inline branch and never UPSERTed `album_metadata` — even when the row's `album_id` was set in the DB.

Changes:
- Widen `.returning()` on both the INSERT (line ~130) and UPDATE (line ~153) paths to also return `album_id`.
- At the call site (line ~165), pass `albumId: upsertedRow.album_id ?? undefined` — same shape as the dj-site path at `apps/backend/controllers/flowsheet.controller.ts:102`.

## Notes on the `created` guard

The ticket mentions firing "from both the INSERT and UPDATE branches that emit tubafrenzy track rows," but the existing handler intentionally fires only on `created === true` to avoid re-fetch + 10-column rewrite + CDC/tsvector/index churn on benign tubafrenzy retries (the `flowsheet-metadata-backfill` cron is the safety net for first-INSERT enrichment misses). I read this as loose phrasing in the ticket rather than a directive to drop the guard, and have left it in place. Both `.returning()` calls were widened so the field is available if we ever want to relax that guard, but only the INSERT branch passes `albumId` today.

If the reviewer wants the UPDATE branch to also fire enrichment (with the obvious churn cost), I'd file that as a separate PR.

## Test plan

- [x] `npm run test:unit -- --testPathPatterns 'internal\.route\.test'` (40/40 pass)
- [x] `npm run typecheck`
- [x] `npm run lint` (no new errors)
- [x] `npm run format:check`
- [ ] CI green
- [ ] Post-deploy: confirm via Sentry span query that a tubafrenzy-webhook-driven linked row produces an `album_metadata` UPSERT

## Related

- Sibling D3-gap ticket: #1027
- D3 origin: #899
- Closes #1028