### PR TITLE
fix(flowsheet-metadata-backfill): UPSERT album_metadata for linked rows (BS#1027)

### DIFF
--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -1,37 +1,41 @@
 /**
- * Per-row enrichment: turn an LML response into the 10-column flowsheet
- * UPDATE that mirrors the runtime path (#658, `enrichment.service.ts`).
+ * Per-row enrichment: turn an LML response into either a flowsheet inline
+ * UPDATE (free-form / unlinked rows) or an `album_metadata` UPSERT plus a
+ * marker-only flowsheet UPDATE (linked rows). Mirrors the D3 worker pattern
+ * in `apps/enrichment-worker/enrich.ts` (BS#899) and closes the historical
+ * inline-only drain (BS#1027).
  *
- * Result shape (matches the runtime fire-and-forget):
- *   - On success-with-match: write the 10 metadata columns from artwork,
- *     stamping `metadata_attempt_at = now()` in the same .set() block.
- *   - On success-no-match: write synthesized search URLs into
- *     youtube_music_url / bandcamp_url / soundcloud_url, leave the rest
- *     as NULL, still stamp the marker.
+ * Result shape:
+ *   - Linked (album_id != null) + match: UPSERT `album_metadata` with the
+ *     10-column payload (race-guarded by `updated_at < NOW()`), then
+ *     UPDATE `flowsheet` to stamp `metadata_attempt_at = now()` only.
+ *   - Linked + no-match: UPSERT just the 3 synthesized search URLs into
+ *     `album_metadata`, then stamp the marker on `flowsheet`.
+ *   - Unlinked (album_id IS NULL) + match: write the 10 metadata columns
+ *     inline on `flowsheet`, stamping the marker in the same .set() block.
+ *   - Unlinked + no-match: write the 3 synthesized search URLs inline on
+ *     `flowsheet`, stamp the marker.
  *   - On LML throw: caller catches and DOES NOT call this. The row stays
  *     `metadata_attempt_at IS NULL` so the next sweep retries it.
  *
- * Idempotency: the WHERE narrows by `id = $row.id AND metadata_attempt_at
- * IS NULL`. A row that the runtime path stamped between the orchestrator's
- * SELECT and this UPDATE is left alone — both writers produce identical
- * data so this matters only as a guard against double-stamping a row
- * whose runtime stamp would otherwise be older. The benign race is
- * documented inline; no CAS pattern needed.
+ * Idempotency guard: the flowsheet WHERE narrows by `id = $row.id AND
+ * metadata_attempt_at IS NULL`. Critically different from the worker
+ * (`apps/enrichment-worker/enrich.ts`), which guards on
+ * `metadata_status='enriching'`: the backfill operates on rows the consumer
+ * never claimed (no `enriching` transition), so the marker is the right
+ * invariant. Borrow the album_metadata UPSERT shape from the worker; do
+ * NOT borrow its status-based guard.
  *
  * Spacer.gif filter: applied inline. Discogs occasionally returns
- * `spacer.gif` placeholder images; persisting them would pollute 1.86M rows
- * for the historical drain alone. The runtime path filters at the chokepoint
- * in `metadata.service.ts:extractAlbumMetadata` (#649); this job carries
- * its own copy because `lml-fetch.ts` deliberately does not go through the
- * backend service (build-graph isolation, see file header). Applied only
- * to `artwork_url` — the other URL columns in the same `.set()` block come
- * from the `streaming_links` table or LML-constructed search URLs, never
- * Discogs image responses (verified against `lookup/orchestrator.py:855-970`,
- * see #679).
+ * `spacer.gif` placeholder images; persisting them would pollute the
+ * historical drain. The runtime path filters at the chokepoint in
+ * `metadata.service.ts:extractAlbumMetadata` (#649); this job carries its
+ * own copy because `lml-fetch.ts` deliberately does not go through the
+ * backend service (build-graph isolation, see file header).
  */
 
-import { sql } from 'drizzle-orm';
-import { db, flowsheet } from '@wxyc/database';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { album_metadata, db, flowsheet } from '@wxyc/database';
 import type { DiscogsMatchResult, LookupResponse } from '@wxyc/lml-client';
 
 export type EnrichRow = {
@@ -39,6 +43,11 @@ export type EnrichRow = {
   artist_name: string;
   album_title: string | null;
   track_title: string | null;
+  // BS#1027 / Epic D: non-null → UPSERT album_metadata + flowsheet marker
+  // stamp only; null → write the 10 metadata columns inline on flowsheet
+  // (free-form entries, until their linkage resolves). Sourced from the
+  // orchestrator's SELECT (`loadBatch` in orchestrate.ts).
+  album_id: number | null;
 };
 
 export type EnrichOutcome = 'enriched_match' | 'enriched_match_raced' | 'enriched_no_match' | 'enriched_no_match_raced';
@@ -143,60 +152,108 @@ export const applyEnrichment = async (row: EnrichRow, response: LookupResponse):
   const artwork = extractArtwork(response);
   const searchUrls = synthesizeSearchUrls(row);
 
+  // Marker-only flowsheet UPDATE used on the linked path. Stamp lives alone
+  // in the .set() because the 10 metadata columns landed in album_metadata
+  // a step earlier; the flowsheet write only records "we attempted this
+  // row" so the next sweep skips it.
+  const markerWhere = and(eq(flowsheet.id, row.id), isNull(flowsheet.metadata_attempt_at));
+
   if (artwork) {
+    const payload = {
+      artwork_url: filterSpacerGif(artwork.artwork_url),
+      discogs_url: artwork.release_url ?? null,
+      // Discogs returns 0 as "year unknown"; coerce to null so the column
+      // doesn't carry a sentinel that iOS renders as literal "0". Mirrors
+      // the runtime path in `metadata.service.ts#extractAlbumMetadata` (#1002).
+      release_year: artwork.release_year || null,
+      spotify_url: artwork.spotify_url ?? null,
+      apple_music_url: artwork.apple_music_url ?? null,
+      // Streaming search URLs: prefer LML's, fall back to synthesized.
+      youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
+      bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
+      soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
+      artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
+      artist_wikipedia_url: artwork.wikipedia_url ?? null,
+    };
+
+    if (row.album_id !== null) {
+      // Linked + match: 10-col payload lands in album_metadata; flowsheet
+      // UPDATE only stamps the marker. The album_metadata UPSERT is
+      // idempotent (same album_id → same row) and guarded by
+      // `updated_at < NOW()` so a delayed backfill cycle can't overwrite
+      // a fresher runtime or worker enrichment of the same album_id.
+      await db
+        .insert(album_metadata)
+        .values({ album_id: row.album_id, ...payload, updated_at: sql`NOW()` })
+        .onConflictDoUpdate({
+          target: album_metadata.album_id,
+          set: { ...payload, updated_at: sql`NOW()` },
+          setWhere: sql`${album_metadata.updated_at} < NOW()`,
+        });
+      const updated = await db
+        .update(flowsheet)
+        .set({ metadata_attempt_at: sql`now()` })
+        .where(markerWhere)
+        .returning({ id: flowsheet.id });
+      return updated.length === 0 ? 'enriched_match_raced' : 'enriched_match';
+    }
+
+    // Unlinked + match: write the 10 columns inline on flowsheet — as
+    // before BS#1027. These rows can't enrich into album_metadata until
+    // linkage resolves; D4's column-drop is gated on no unlinked
+    // enrichments remaining.
     const updated = await db
       .update(flowsheet)
       .set({
-        artwork_url: filterSpacerGif(artwork.artwork_url),
-        discogs_url: artwork.release_url ?? null,
-        // Discogs returns 0 as "year unknown"; coerce to null so the column
-        // doesn't carry a sentinel that iOS renders as literal "0". Mirrors
-        // the runtime path in `metadata.service.ts#extractAlbumMetadata`.
-        // #1002.
-        release_year: artwork.release_year || null,
-        spotify_url: artwork.spotify_url ?? null,
-        apple_music_url: artwork.apple_music_url ?? null,
-        // Streaming search URLs: prefer LML's, fall back to synthesized.
-        // Matches the runtime path's behavior in `metadata.service.ts`.
-        youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
-        bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
-        soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
-        artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
-        artist_wikipedia_url: artwork.wikipedia_url ?? null,
+        ...payload,
         // Stamp lives inside the same .set() so a partial UPDATE can't
         // mark a row as "attempted" without writing the data we just
-        // fetched. #639 codified the same single-block contract for the
-        // runtime path.
+        // fetched (#639 codified this single-block contract).
         metadata_attempt_at: sql`now()`,
       })
-      // Idempotency guard: the WHERE narrows by `metadata_attempt_at IS
-      // NULL`, so a row the runtime path stamped between the
-      // orchestrator's SELECT and this UPDATE matches 0 rows. The
-      // partial index from #659 makes the WHERE fast — the index is the
-      // performance enabler, the WHERE itself is what filters.
       .where(sql`"id" = ${row.id} AND "metadata_attempt_at" IS NULL`)
       .returning({ id: flowsheet.id });
     return updated.length === 0 ? 'enriched_match_raced' : 'enriched_match';
   }
 
-  // No-match: synthesize search URLs and stamp. Critically, the other 7
-  // metadata columns are NOT touched. This diverges from the runtime path
-  // (`apps/backend/services/metadata/enrichment.service.ts`) — the
-  // runtime nulls all 10 columns on no-match because it runs at insert
-  // time over fresh rows with nothing to lose.
-  //
-  // The backfill encounters rows that may already have prior values from
-  // out-of-band paths: the 2026-04-28 inline recovery
-  // (`scripts/backfill-metadata.ts`) wrote the full 10-column payload to
-  // ~618 rows pre-#658, so their `metadata_attempt_at` is NULL even
-  // though `artwork_url` / `discogs_url` / etc are populated. If LML now
-  // returns no-match for such a row, the recovery's prior data is the
-  // better signal and should be preserved. Nulling here would be silent
-  // data loss.
-  //
-  // The divergence is intentional, not a bug. Future: if the runtime
-  // path ever needs to run over rows with prior values (e.g., a
-  // re-enrichment trigger), it should adopt the same preserve semantics.
+  // No-match: synthesize search URLs and stamp. The other 7 metadata
+  // columns are NOT touched on either branch. The backfill encounters rows
+  // that may already have prior values from out-of-band paths (e.g. the
+  // 2026-04-28 inline recovery, `scripts/backfill-metadata.ts`), so nulling
+  // them on a no-match would be silent data loss.
+  if (row.album_id !== null) {
+    // Linked + no-match: UPSERT just the 3 search URLs into album_metadata.
+    // INSERT path leaves the other 7 columns NULL (no LML match to fill
+    // them); UPDATE path leaves them untouched on existing rows
+    // (preserves any prior out-of-band values, matching the unlinked
+    // path's deliberate non-clobbering on no-match).
+    await db
+      .insert(album_metadata)
+      .values({
+        album_id: row.album_id,
+        youtube_music_url: searchUrls.youtube_music_url,
+        bandcamp_url: searchUrls.bandcamp_url,
+        soundcloud_url: searchUrls.soundcloud_url,
+        updated_at: sql`NOW()`,
+      })
+      .onConflictDoUpdate({
+        target: album_metadata.album_id,
+        set: {
+          youtube_music_url: searchUrls.youtube_music_url,
+          bandcamp_url: searchUrls.bandcamp_url,
+          soundcloud_url: searchUrls.soundcloud_url,
+          updated_at: sql`NOW()`,
+        },
+        setWhere: sql`${album_metadata.updated_at} < NOW()`,
+      });
+    const updated = await db
+      .update(flowsheet)
+      .set({ metadata_attempt_at: sql`now()` })
+      .where(markerWhere)
+      .returning({ id: flowsheet.id });
+    return updated.length === 0 ? 'enriched_no_match_raced' : 'enriched_no_match';
+  }
+
   const updated = await db
     .update(flowsheet)
     .set({

--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -292,7 +292,8 @@ const loadBatch = async (afterId: number, batchSize: number, partitionFilter: SQ
       "id",
       "artist_name",
       "album_title",
-      "track_title"
+      "track_title",
+      "album_id"
     FROM ${FLOWSHEET_TABLE}
     WHERE "entry_type" = 'track'
       AND "artist_name" IS NOT NULL

--- a/tests/integration/flowsheet-metadata-backfill-upsert.spec.js
+++ b/tests/integration/flowsheet-metadata-backfill-upsert.spec.js
@@ -1,0 +1,366 @@
+/**
+ * Integration test for the flowsheet-metadata-backfill writer contract
+ * (BS#1027 / Epic D).
+ *
+ * The historical drain in `jobs/flowsheet-metadata-backfill/enrich.ts`
+ * used to write the 10-column metadata payload inline on `flowsheet` for
+ * every enriched row, regardless of `album_id`. D3 (#899) patched the two
+ * runtime writers to UPSERT `album_metadata` for linked rows but did not
+ * patch this drain — every cycle re-introduced inline-only drift and
+ * blocked D4 (#900). #1027 mirrors the D3 worker pattern into this job.
+ *
+ * This spec validates the four-way matrix:
+ *   - Linked + match: `album_metadata` row materializes with the full
+ *     10-column payload; the flowsheet inline columns stay untouched
+ *     (album_id, marker stamped, no inline writes).
+ *   - Linked + no-match: only the 3 search URLs land in `album_metadata`;
+ *     the 7 other columns are NULL on INSERT; flowsheet inline columns
+ *     stay untouched.
+ *   - Unlinked + match: 10 inline columns land on `flowsheet`; no
+ *     `album_metadata` row materializes.
+ *   - Unlinked + no-match: 3 search URLs land on `flowsheet` inline; no
+ *     `album_metadata` row materializes.
+ *
+ * Also pins:
+ *   - The `setWhere: updated_at < NOW()` race guard prevents a delayed
+ *     backfill cycle from clobbering a fresher runtime/worker enrichment
+ *     of the same album_id.
+ *   - The `metadata_attempt_at` marker stamp happens on all four branches.
+ *   - The marker-based idempotency guard (`metadata_attempt_at IS NULL`)
+ *     leaves an already-stamped flowsheet row untouched (returning empty
+ *     → raced metric in the application layer).
+ *
+ * Pure SQL — does NOT import `jobs/flowsheet-metadata-backfill/enrich.ts`.
+ * Integration runner is babel-jest with no TS support; mirrors the
+ * sibling worker spec at `album-metadata-upsert.spec.js` in shape.
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * Issue the backfill's linked+match UPSERT directly. Mirrors
+ * `applyEnrichment` in `jobs/flowsheet-metadata-backfill/enrich.ts` when
+ * the LML lookup returned artwork on a linked row. When that file is
+ * hand-edited the SQL here must follow.
+ */
+async function upsertLinkedMatch(sql, albumId, payload) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_metadata
+      (album_id, artwork_url, discogs_url, release_year, spotify_url, apple_music_url,
+       youtube_music_url, bandcamp_url, soundcloud_url, artist_bio, artist_wikipedia_url,
+       updated_at)
+    VALUES
+      (${albumId}, ${payload.artwork_url}, ${payload.discogs_url}, ${payload.release_year},
+       ${payload.spotify_url}, ${payload.apple_music_url}, ${payload.youtube_music_url},
+       ${payload.bandcamp_url}, ${payload.soundcloud_url}, ${payload.artist_bio},
+       ${payload.artist_wikipedia_url}, NOW())
+    ON CONFLICT (album_id) DO UPDATE
+       SET artwork_url          = EXCLUDED.artwork_url,
+           discogs_url          = EXCLUDED.discogs_url,
+           release_year         = EXCLUDED.release_year,
+           spotify_url          = EXCLUDED.spotify_url,
+           apple_music_url      = EXCLUDED.apple_music_url,
+           youtube_music_url    = EXCLUDED.youtube_music_url,
+           bandcamp_url         = EXCLUDED.bandcamp_url,
+           soundcloud_url       = EXCLUDED.soundcloud_url,
+           artist_bio           = EXCLUDED.artist_bio,
+           artist_wikipedia_url = EXCLUDED.artist_wikipedia_url,
+           updated_at           = NOW()
+     WHERE ${sql(SCHEMA)}.album_metadata.updated_at < NOW()
+  `;
+}
+
+async function upsertLinkedNoMatch(sql, albumId, searchUrls) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_metadata
+      (album_id, youtube_music_url, bandcamp_url, soundcloud_url, updated_at)
+    VALUES
+      (${albumId}, ${searchUrls.youtube_music_url}, ${searchUrls.bandcamp_url},
+       ${searchUrls.soundcloud_url}, NOW())
+    ON CONFLICT (album_id) DO UPDATE
+       SET youtube_music_url = EXCLUDED.youtube_music_url,
+           bandcamp_url      = EXCLUDED.bandcamp_url,
+           soundcloud_url    = EXCLUDED.soundcloud_url,
+           updated_at        = NOW()
+     WHERE ${sql(SCHEMA)}.album_metadata.updated_at < NOW()
+  `;
+}
+
+/** Marker-only flowsheet stamp used on both linked branches after the album_metadata UPSERT. */
+async function stampMarker(sql, flowsheetId) {
+  const rows = await sql`
+    UPDATE ${sql(SCHEMA)}.flowsheet
+       SET metadata_attempt_at = NOW()
+     WHERE id = ${flowsheetId}
+       AND metadata_attempt_at IS NULL
+    RETURNING id
+  `;
+  return rows.length;
+}
+
+/** Unlinked+match writes the 10 inline columns and the marker on flowsheet. */
+async function inlineMatch(sql, flowsheetId, payload) {
+  const rows = await sql`
+    UPDATE ${sql(SCHEMA)}.flowsheet
+       SET artwork_url          = ${payload.artwork_url},
+           discogs_url          = ${payload.discogs_url},
+           release_year         = ${payload.release_year},
+           spotify_url          = ${payload.spotify_url},
+           apple_music_url      = ${payload.apple_music_url},
+           youtube_music_url    = ${payload.youtube_music_url},
+           bandcamp_url         = ${payload.bandcamp_url},
+           soundcloud_url       = ${payload.soundcloud_url},
+           artist_bio           = ${payload.artist_bio},
+           artist_wikipedia_url = ${payload.artist_wikipedia_url},
+           metadata_attempt_at  = NOW()
+     WHERE id = ${flowsheetId}
+       AND metadata_attempt_at IS NULL
+    RETURNING id
+  `;
+  return rows.length;
+}
+
+/** Unlinked+no-match writes the 3 search URLs and the marker inline. */
+async function inlineNoMatch(sql, flowsheetId, searchUrls) {
+  const rows = await sql`
+    UPDATE ${sql(SCHEMA)}.flowsheet
+       SET youtube_music_url   = ${searchUrls.youtube_music_url},
+           bandcamp_url        = ${searchUrls.bandcamp_url},
+           soundcloud_url      = ${searchUrls.soundcloud_url},
+           metadata_attempt_at = NOW()
+     WHERE id = ${flowsheetId}
+       AND metadata_attempt_at IS NULL
+    RETURNING id
+  `;
+  return rows.length;
+}
+
+/**
+ * Insert a fresh library album to act as the FK target. Returns the new id.
+ * Uses the seeded artist/genre/format ids from dev_env/seed_db.sql.
+ */
+async function insertLibraryAlbum(sql, suffix) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.library
+      (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+    VALUES
+      (1, 11, 1, ${'bs1027-backfill-test-album-' + suffix}, 9999, 'Built to Spill')
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+/** Insert a fresh flowsheet row, optionally linked to an album. */
+async function insertFlowsheetRow(sql, suffix, albumId = null) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.flowsheet
+      (play_order, entry_type, artist_name, album_title, track_title,
+       request_flag, segue, album_id)
+    VALUES
+      (99999, 'track', ${'bs1027-backfill-test-artist-' + suffix},
+       'Test Album', 'Test Track', false, false, ${albumId})
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+const FULL_PAYLOAD = {
+  artwork_url: 'https://i.discogs.com/bs1027/cover.jpg',
+  discogs_url: 'https://discogs.com/release/1027',
+  release_year: 2025,
+  spotify_url: 'https://open.spotify.com/album/bs1027',
+  apple_music_url: 'https://music.apple.com/album/bs1027',
+  youtube_music_url: 'https://music.youtube.com/playlist/bs1027',
+  bandcamp_url: 'https://artist.bandcamp.com/album/bs1027',
+  soundcloud_url: 'https://soundcloud.com/album/bs1027',
+  artist_bio: 'A BS#1027 test bio.',
+  artist_wikipedia_url: 'https://en.wikipedia.org/wiki/BS1027_test',
+};
+
+const SEARCH_URLS = {
+  youtube_music_url: 'https://music.youtube.com/search?q=BS1027%20test',
+  bandcamp_url: 'https://bandcamp.com/search?q=BS1027%20test',
+  soundcloud_url: 'https://soundcloud.com/search?q=BS1027%20test',
+};
+
+describe('flowsheet-metadata-backfill writer contract (real PG, BS#1027)', () => {
+  let sql;
+  /** Cleanup arrays: deletion order matters (flowsheet → album_metadata → library). */
+  const insertedFlowsheetIds = [];
+  const insertedAlbumIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedFlowsheetIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE id = ANY(${insertedFlowsheetIds})`;
+    }
+    if (insertedAlbumIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  test('linked + match: album_metadata row materializes; flowsheet inline columns stay NULL', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'linked-match');
+    insertedAlbumIds.push(albumId);
+    const flowsheetId = await insertFlowsheetRow(sql, 'linked-match', albumId);
+    insertedFlowsheetIds.push(flowsheetId);
+
+    await upsertLinkedMatch(sql, albumId, FULL_PAYLOAD);
+    const stamped = await stampMarker(sql, flowsheetId);
+    expect(stamped).toBe(1);
+
+    // album_metadata holds the 10-column payload
+    const amRows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    expect(amRows).toHaveLength(1);
+    expect(amRows[0].artwork_url).toBe(FULL_PAYLOAD.artwork_url);
+    expect(amRows[0].discogs_url).toBe(FULL_PAYLOAD.discogs_url);
+    expect(amRows[0].release_year).toBe(FULL_PAYLOAD.release_year);
+    expect(amRows[0].artist_bio).toBe(FULL_PAYLOAD.artist_bio);
+
+    // flowsheet inline columns must stay NULL — that's the whole point of #1027
+    const fsRows = await sql`
+      SELECT artwork_url, discogs_url, release_year, spotify_url, apple_music_url,
+             youtube_music_url, bandcamp_url, soundcloud_url, artist_bio,
+             artist_wikipedia_url, metadata_attempt_at
+      FROM ${sql(SCHEMA)}.flowsheet WHERE id = ${flowsheetId}
+    `;
+    expect(fsRows[0].artwork_url).toBeNull();
+    expect(fsRows[0].discogs_url).toBeNull();
+    expect(fsRows[0].release_year).toBeNull();
+    expect(fsRows[0].spotify_url).toBeNull();
+    expect(fsRows[0].apple_music_url).toBeNull();
+    expect(fsRows[0].youtube_music_url).toBeNull();
+    expect(fsRows[0].bandcamp_url).toBeNull();
+    expect(fsRows[0].soundcloud_url).toBeNull();
+    expect(fsRows[0].artist_bio).toBeNull();
+    expect(fsRows[0].artist_wikipedia_url).toBeNull();
+    // marker IS stamped
+    expect(fsRows[0].metadata_attempt_at).not.toBeNull();
+  });
+
+  test('linked + no-match: 3 URLs land in album_metadata, 7 columns NULL, flowsheet inline stays NULL', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'linked-no-match');
+    insertedAlbumIds.push(albumId);
+    const flowsheetId = await insertFlowsheetRow(sql, 'linked-no-match', albumId);
+    insertedFlowsheetIds.push(flowsheetId);
+
+    await upsertLinkedNoMatch(sql, albumId, SEARCH_URLS);
+    const stamped = await stampMarker(sql, flowsheetId);
+    expect(stamped).toBe(1);
+
+    const amRows = await sql`
+      SELECT * FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    expect(amRows).toHaveLength(1);
+    expect(amRows[0].youtube_music_url).toBe(SEARCH_URLS.youtube_music_url);
+    expect(amRows[0].bandcamp_url).toBe(SEARCH_URLS.bandcamp_url);
+    expect(amRows[0].soundcloud_url).toBe(SEARCH_URLS.soundcloud_url);
+    expect(amRows[0].artwork_url).toBeNull();
+    expect(amRows[0].discogs_url).toBeNull();
+    expect(amRows[0].release_year).toBeNull();
+    expect(amRows[0].spotify_url).toBeNull();
+    expect(amRows[0].apple_music_url).toBeNull();
+    expect(amRows[0].artist_bio).toBeNull();
+    expect(amRows[0].artist_wikipedia_url).toBeNull();
+
+    const fsRows = await sql`
+      SELECT artwork_url, youtube_music_url, bandcamp_url, soundcloud_url, metadata_attempt_at
+      FROM ${sql(SCHEMA)}.flowsheet WHERE id = ${flowsheetId}
+    `;
+    expect(fsRows[0].artwork_url).toBeNull();
+    expect(fsRows[0].youtube_music_url).toBeNull();
+    expect(fsRows[0].bandcamp_url).toBeNull();
+    expect(fsRows[0].soundcloud_url).toBeNull();
+    expect(fsRows[0].metadata_attempt_at).not.toBeNull();
+  });
+
+  test('unlinked + match: 10 inline columns land on flowsheet; no album_metadata row created', async () => {
+    const flowsheetId = await insertFlowsheetRow(sql, 'unlinked-match', null);
+    insertedFlowsheetIds.push(flowsheetId);
+
+    const matched = await inlineMatch(sql, flowsheetId, FULL_PAYLOAD);
+    expect(matched).toBe(1);
+
+    const fsRows = await sql`
+      SELECT artwork_url, discogs_url, release_year, spotify_url, apple_music_url,
+             youtube_music_url, bandcamp_url, soundcloud_url, artist_bio,
+             artist_wikipedia_url, metadata_attempt_at, album_id
+      FROM ${sql(SCHEMA)}.flowsheet WHERE id = ${flowsheetId}
+    `;
+    expect(fsRows[0].album_id).toBeNull();
+    expect(fsRows[0].artwork_url).toBe(FULL_PAYLOAD.artwork_url);
+    expect(fsRows[0].discogs_url).toBe(FULL_PAYLOAD.discogs_url);
+    expect(fsRows[0].release_year).toBe(FULL_PAYLOAD.release_year);
+    expect(fsRows[0].artist_bio).toBe(FULL_PAYLOAD.artist_bio);
+    expect(fsRows[0].metadata_attempt_at).not.toBeNull();
+  });
+
+  test('unlinked + no-match: 3 URLs land inline; no album_metadata row created', async () => {
+    const flowsheetId = await insertFlowsheetRow(sql, 'unlinked-no-match', null);
+    insertedFlowsheetIds.push(flowsheetId);
+
+    const matched = await inlineNoMatch(sql, flowsheetId, SEARCH_URLS);
+    expect(matched).toBe(1);
+
+    const fsRows = await sql`
+      SELECT youtube_music_url, bandcamp_url, soundcloud_url, artwork_url,
+             metadata_attempt_at, album_id
+      FROM ${sql(SCHEMA)}.flowsheet WHERE id = ${flowsheetId}
+    `;
+    expect(fsRows[0].album_id).toBeNull();
+    expect(fsRows[0].youtube_music_url).toBe(SEARCH_URLS.youtube_music_url);
+    expect(fsRows[0].bandcamp_url).toBe(SEARCH_URLS.bandcamp_url);
+    expect(fsRows[0].soundcloud_url).toBe(SEARCH_URLS.soundcloud_url);
+    expect(fsRows[0].artwork_url).toBeNull();
+    expect(fsRows[0].metadata_attempt_at).not.toBeNull();
+  });
+
+  test('race guard: a delayed backfill upsert does NOT clobber a fresher album_metadata row', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'race-guard');
+    insertedAlbumIds.push(albumId);
+
+    // Simulate the runtime/worker writing a fresh enrichment first.
+    await upsertLinkedMatch(sql, albumId, FULL_PAYLOAD);
+    const before = await sql`
+      SELECT updated_at FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+
+    // Simulate a delayed backfill cycle attempting to clobber with stale data
+    // in the SAME statement. The `setWhere: updated_at < NOW()` in the same
+    // INSERT statement evaluates NOW() at statement_start: if the existing
+    // updated_at equals or exceeds that, the UPDATE arm short-circuits.
+    // Verify by issuing the same UPSERT again immediately (within the same
+    // statement timestamp, both values equal → < is false).
+    await upsertLinkedMatch(sql, albumId, { ...FULL_PAYLOAD, artwork_url: 'stale-clobber' });
+
+    const after = await sql`
+      SELECT artwork_url, updated_at FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    // The race guard either kept the prior artwork_url or advanced — what
+    // matters: 'stale-clobber' never lands when guarded properly. The
+    // statement_start equality keeps the row unchanged.
+    expect(after[0].artwork_url).toBe(FULL_PAYLOAD.artwork_url);
+    expect(new Date(after[0].updated_at).getTime()).toBe(new Date(before[0].updated_at).getTime());
+  });
+
+  test('marker idempotency: stamping an already-stamped flowsheet row returns 0 (raced outcome)', async () => {
+    const flowsheetId = await insertFlowsheetRow(sql, 'marker-raced', null);
+    insertedFlowsheetIds.push(flowsheetId);
+
+    // First stamp lands.
+    const first = await stampMarker(sql, flowsheetId);
+    expect(first).toBe(1);
+
+    // Second stamp races against the marker IS NULL guard.
+    const second = await stampMarker(sql, flowsheetId);
+    expect(second).toBe(0);
+  });
+});

--- a/tests/integration/flowsheet-metadata-backfill-upsert.spec.js
+++ b/tests/integration/flowsheet-metadata-backfill-upsert.spec.js
@@ -323,32 +323,69 @@ describe('flowsheet-metadata-backfill writer contract (real PG, BS#1027)', () =>
     expect(fsRows[0].metadata_attempt_at).not.toBeNull();
   });
 
-  test('race guard: a delayed backfill upsert does NOT clobber a fresher album_metadata row', async () => {
+  test('race guard: a stale backfill upsert against a future-dated album_metadata row leaves it untouched', async () => {
     const albumId = await insertLibraryAlbum(sql, 'race-guard');
     insertedAlbumIds.push(albumId);
 
-    // Simulate the runtime/worker writing a fresh enrichment first.
-    await upsertLinkedMatch(sql, albumId, FULL_PAYLOAD);
+    // Simulate a fresher runtime/worker write whose updated_at is ahead of
+    // the current clock. NOW() in PG is statement_start, so consecutive
+    // statements naturally see a slightly larger NOW() value — without the
+    // future-dating below, a delayed backfill's NOW() would always satisfy
+    // `existing.updated_at < NOW()` and the guard would never fire. Setting
+    // updated_at to NOW() + INTERVAL '1 hour' explicitly models the
+    // semantics the guard protects against: a later writer that has
+    // already landed a fresher enrichment.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, discogs_url, release_year, spotify_url, apple_music_url,
+         youtube_music_url, bandcamp_url, soundcloud_url, artist_bio, artist_wikipedia_url,
+         updated_at)
+      VALUES
+        (${albumId}, ${FULL_PAYLOAD.artwork_url}, ${FULL_PAYLOAD.discogs_url},
+         ${FULL_PAYLOAD.release_year}, ${FULL_PAYLOAD.spotify_url},
+         ${FULL_PAYLOAD.apple_music_url}, ${FULL_PAYLOAD.youtube_music_url},
+         ${FULL_PAYLOAD.bandcamp_url}, ${FULL_PAYLOAD.soundcloud_url},
+         ${FULL_PAYLOAD.artist_bio}, ${FULL_PAYLOAD.artist_wikipedia_url},
+         NOW() + INTERVAL '1 hour')
+    `;
     const before = await sql`
-      SELECT updated_at FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+      SELECT artwork_url, updated_at FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
     `;
 
-    // Simulate a delayed backfill cycle attempting to clobber with stale data
-    // in the SAME statement. The `setWhere: updated_at < NOW()` in the same
-    // INSERT statement evaluates NOW() at statement_start: if the existing
-    // updated_at equals or exceeds that, the UPDATE arm short-circuits.
-    // Verify by issuing the same UPSERT again immediately (within the same
-    // statement timestamp, both values equal → < is false).
+    // Attempt the stale backfill UPSERT. The setWhere clause
+    // `album_metadata.updated_at < NOW()` evaluates the existing row's
+    // future updated_at against the current NOW() — false → UPDATE arm
+    // short-circuits, 'stale-clobber' never lands.
     await upsertLinkedMatch(sql, albumId, { ...FULL_PAYLOAD, artwork_url: 'stale-clobber' });
 
     const after = await sql`
       SELECT artwork_url, updated_at FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
     `;
-    // The race guard either kept the prior artwork_url or advanced — what
-    // matters: 'stale-clobber' never lands when guarded properly. The
-    // statement_start equality keeps the row unchanged.
     expect(after[0].artwork_url).toBe(FULL_PAYLOAD.artwork_url);
     expect(new Date(after[0].updated_at).getTime()).toBe(new Date(before[0].updated_at).getTime());
+  });
+
+  test('race guard: a backfill upsert against a stale album_metadata row DOES overwrite', async () => {
+    // The complement of the future-dated test: when the existing row is
+    // genuinely older than NOW(), the guard allows the UPDATE arm to land.
+    // Without this, the previous test could pass for the wrong reason
+    // (e.g. if the setWhere clause was mistakenly always-false).
+    const albumId = await insertLibraryAlbum(sql, 'race-guard-stale');
+    insertedAlbumIds.push(albumId);
+
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, updated_at)
+      VALUES
+        (${albumId}, 'old-artwork', NOW() - INTERVAL '1 hour')
+    `;
+
+    await upsertLinkedMatch(sql, albumId, FULL_PAYLOAD);
+
+    const after = await sql`
+      SELECT artwork_url FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    expect(after[0].artwork_url).toBe(FULL_PAYLOAD.artwork_url);
   });
 
   test('marker idempotency: stamping an already-stamped flowsheet row returns 0 (raced outcome)', async () => {

--- a/tests/unit/jobs/flowsheet-metadata-backfill/enrich.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/enrich.test.ts
@@ -16,7 +16,7 @@
  */
 import { jest } from '@jest/globals';
 
-import { db, flowsheet } from '@wxyc/database';
+import { album_metadata, db, flowsheet } from '@wxyc/database';
 import {
   applyEnrichment,
   cleanDiscogsBio,
@@ -45,8 +45,15 @@ const renderSql = (value: unknown): string => {
 };
 
 const mockDb = db as unknown as {
+  insert: jest.Mock;
   update: jest.Mock;
-  _chain: { set: jest.Mock; where: jest.Mock; returning: jest.Mock };
+  _chain: {
+    set: jest.Mock;
+    where: jest.Mock;
+    returning: jest.Mock;
+    values: jest.Mock;
+    onConflictDoUpdate: jest.Mock;
+  };
 };
 
 const baseRow: EnrichRow = {
@@ -54,7 +61,10 @@ const baseRow: EnrichRow = {
   artist_name: 'Autechre',
   album_title: 'Confield',
   track_title: 'VI Scose Poise',
+  album_id: null,
 };
+
+const linkedRow: EnrichRow = { ...baseRow, album_id: 5678 };
 
 const matchedResponse: LookupResponse = {
   results: [
@@ -198,6 +208,159 @@ describe('applyEnrichment', () => {
 
     const outcome = await applyEnrichment(baseRow, noMatchResponse);
     expect(outcome).toBe('enriched_no_match_raced');
+  });
+});
+
+/**
+ * Epic D / BS#1027 — when the backfill row is linked to a library album
+ * (`album_id !== null`), the 10-column metadata payload UPSERTs into
+ * `album_metadata` keyed by album_id, and the flowsheet UPDATE only stamps
+ * `metadata_attempt_at`. The race detector stays on the flowsheet UPDATE
+ * (marker IS NULL guard), and the album_metadata UPSERT carries a
+ * `updated_at < NOW()` setWhere so a delayed backfill cycle can't clobber
+ * a fresher runtime/worker enrichment. Mirrors the D3 worker pattern in
+ * `apps/enrichment-worker/enrich.ts` (BS#899).
+ *
+ * Critical contract difference from the worker: the backfill stamps
+ * `metadata_attempt_at` and guards on `metadata_attempt_at IS NULL`. The
+ * worker uses `metadata_status='enriching'`. The backfill operates on rows
+ * the consumer never claimed, so the marker is the right invariant.
+ */
+describe('applyEnrichment (BS#1027) — linked row UPSERTs album_metadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb._chain.returning.mockResolvedValue([{ id: linkedRow.id }]);
+  });
+
+  it('on match: UPSERTs the 10-column payload into album_metadata keyed by album_id', async () => {
+    const outcome = await applyEnrichment(linkedRow, matchedResponse);
+    expect(outcome).toBe('enriched_match');
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload.album_id).toBe(linkedRow.album_id);
+    expect(insertPayload.artwork_url).toBe('https://i.discogs.com/art.jpg');
+    expect(insertPayload.discogs_url).toBe('https://www.discogs.com/release/12345');
+    expect(insertPayload.release_year).toBe(2001);
+    expect(insertPayload.spotify_url).toBe('https://open.spotify.com/album/abc');
+    expect(insertPayload.apple_music_url).toBe('https://music.apple.com/album/xyz');
+    expect(insertPayload.youtube_music_url).toBe('https://music.youtube.com/album/aaa');
+    // bandcamp + soundcloud were null on LML → fall back to synthesized.
+    expect(insertPayload.bandcamp_url).toContain('bandcamp.com/search');
+    expect(insertPayload.soundcloud_url).toContain('soundcloud.com/search');
+    expect(insertPayload.artist_bio).toBe('Rob Brown and Sean Booth are Autechre.');
+    expect(insertPayload.artist_wikipedia_url).toBe('https://en.wikipedia.org/wiki/Autechre');
+    expect(insertPayload.updated_at).toBeDefined();
+  });
+
+  it('on match: onConflictDoUpdate carries all 10 columns + race guard setWhere(updated_at < NOW())', async () => {
+    await applyEnrichment(linkedRow, matchedResponse);
+
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as {
+      target: unknown;
+      set: Record<string, unknown>;
+      setWhere: unknown;
+    };
+    expect(conflictCfg).toBeDefined();
+    expect(conflictCfg.set.artwork_url).toBe('https://i.discogs.com/art.jpg');
+    expect(conflictCfg.set.artist_bio).toBe('Rob Brown and Sean Booth are Autechre.');
+    expect(conflictCfg.set.updated_at).toBeDefined();
+    // The race guard prevents stale backfill writes from clobbering a fresher
+    // runtime / worker enrichment of the same album_id.
+    expect(conflictCfg.setWhere).toBeDefined();
+    expect(renderSql(conflictCfg.setWhere)).toMatch(/<\s*NOW\(\)/i);
+  });
+
+  it('on match: flowsheet UPDATE stamps only metadata_attempt_at (no inline metadata columns)', async () => {
+    await applyEnrichment(linkedRow, matchedResponse);
+
+    expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(renderSql(setArgs.metadata_attempt_at)).toMatch(/now\(\)/i);
+    // The 10 metadata columns must NOT appear on the flowsheet UPDATE — that's
+    // the whole point of the D3 dual-write split. The inline drift this fixes
+    // is exactly this previous behavior.
+    expect(setArgs).not.toHaveProperty('artwork_url');
+    expect(setArgs).not.toHaveProperty('discogs_url');
+    expect(setArgs).not.toHaveProperty('release_year');
+    expect(setArgs).not.toHaveProperty('spotify_url');
+    expect(setArgs).not.toHaveProperty('apple_music_url');
+    expect(setArgs).not.toHaveProperty('youtube_music_url');
+    expect(setArgs).not.toHaveProperty('bandcamp_url');
+    expect(setArgs).not.toHaveProperty('soundcloud_url');
+    expect(setArgs).not.toHaveProperty('artist_bio');
+    expect(setArgs).not.toHaveProperty('artist_wikipedia_url');
+  });
+
+  it('on match: flowsheet WHERE still uses the marker-IS-NULL race detector (one where call, non-empty predicate)', async () => {
+    // Linked path uses typed `and(eq(flowsheet.id, row.id), isNull(flowsheet.metadata_attempt_at))`
+    // builders. Column refs are compile-time checked against the schema; the
+    // race-detector behavior is covered by the _raced tests below.
+    await applyEnrichment(linkedRow, matchedResponse);
+    expect(mockDb._chain.where).toHaveBeenCalledTimes(1);
+    expect(mockDb._chain.where.mock.calls[0]?.[0]).toBeDefined();
+  });
+
+  it('on no-match: UPSERTs only the 3 search URLs into album_metadata', async () => {
+    const outcome = await applyEnrichment(linkedRow, noMatchResponse);
+    expect(outcome).toBe('enriched_no_match');
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload.album_id).toBe(linkedRow.album_id);
+    expect(insertPayload.youtube_music_url).toContain('music.youtube.com/search');
+    expect(insertPayload.bandcamp_url).toContain('bandcamp.com/search');
+    expect(insertPayload.soundcloud_url).toContain('soundcloud.com/search');
+    // 7 other metadata fields must NOT be in the insert payload — INSERT path
+    // leaves them NULL; UPDATE path leaves existing values untouched.
+    expect(insertPayload).not.toHaveProperty('artwork_url');
+    expect(insertPayload).not.toHaveProperty('discogs_url');
+    expect(insertPayload).not.toHaveProperty('release_year');
+    expect(insertPayload).not.toHaveProperty('spotify_url');
+    expect(insertPayload).not.toHaveProperty('apple_music_url');
+    expect(insertPayload).not.toHaveProperty('artist_bio');
+    expect(insertPayload).not.toHaveProperty('artist_wikipedia_url');
+
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as {
+      set: Record<string, unknown>;
+      setWhere: unknown;
+    };
+    expect(conflictCfg.set).not.toHaveProperty('artwork_url');
+    expect(conflictCfg.set).not.toHaveProperty('artist_bio');
+    expect(conflictCfg.set.youtube_music_url).toContain('music.youtube.com/search');
+    expect(conflictCfg.setWhere).toBeDefined();
+    expect(renderSql(conflictCfg.setWhere)).toMatch(/<\s*NOW\(\)/i);
+  });
+
+  it('on no-match: flowsheet UPDATE stamps only metadata_attempt_at (no inline URLs)', async () => {
+    await applyEnrichment(linkedRow, noMatchResponse);
+
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(renderSql(setArgs.metadata_attempt_at)).toMatch(/now\(\)/i);
+    expect(setArgs).not.toHaveProperty('youtube_music_url');
+    expect(setArgs).not.toHaveProperty('bandcamp_url');
+    expect(setArgs).not.toHaveProperty('soundcloud_url');
+  });
+
+  it('on match: returns enriched_match_raced when the flowsheet UPDATE matches 0 rows', async () => {
+    // album_metadata UPSERT lands; flowsheet UPDATE races because the
+    // marker was already stamped by another writer (runtime/worker path) in
+    // the window between the orchestrator's SELECT and this UPDATE.
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    const outcome = await applyEnrichment(linkedRow, matchedResponse);
+    expect(outcome).toBe('enriched_match_raced');
+    // The album_metadata UPSERT still ran — same data outcome from the
+    // album's perspective; only the metric splits.
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+  });
+
+  it('on no-match: returns enriched_no_match_raced when the flowsheet UPDATE matches 0 rows', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    const outcome = await applyEnrichment(linkedRow, noMatchResponse);
+    expect(outcome).toBe('enriched_no_match_raced');
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
   });
 });
 

--- a/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
@@ -178,7 +178,13 @@ describe('processRow', () => {
     jest.clearAllMocks();
   });
 
-  const row = { id: 42, artist_name: 'Autechre', album_title: 'Confield', track_title: 'VI Scose Poise' };
+  const row = {
+    id: 42,
+    artist_name: 'Autechre',
+    album_title: 'Confield',
+    track_title: 'VI Scose Poise',
+    album_id: null,
+  };
 
   it('returns enriched_match and calls enrich on LML success-with-match', async () => {
     const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResponse);
@@ -217,7 +223,7 @@ describe('processRow', () => {
   it('forwards undefined for null album_title / track_title (matches lml-fetch.ts contract)', async () => {
     const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResponse);
     const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_no_match');
-    const sparseRow = { id: 1, artist_name: 'Lone Anonymous', album_title: null, track_title: null };
+    const sparseRow = { id: 1, artist_name: 'Lone Anonymous', album_title: null, track_title: null, album_id: null };
 
     await processRow(sparseRow, { lookup, enrich });
 
@@ -248,14 +254,18 @@ describe('runBackfill', () => {
     expect(sql).toMatch(/"id"\s*>/);
     expect(sql).toMatch(/ORDER BY\s+"id"\s+ASC/i);
     expect(sql).toMatch(/LIMIT/i);
+    // BS#1027: SELECT must project album_id so the enricher can branch on
+    // linked vs unlinked and UPSERT album_metadata instead of inline-writing
+    // to flowsheet.
+    expect(sql).toMatch(/"album_id"/);
   });
 
   it('advances the id-cursor across batches and terminates on empty', async () => {
     const batch1 = [
-      { id: 10, artist_name: 'a', album_title: null, track_title: null },
-      { id: 20, artist_name: 'b', album_title: null, track_title: null },
+      { id: 10, artist_name: 'a', album_title: null, track_title: null, album_id: null },
+      { id: 20, artist_name: 'b', album_title: null, track_title: null, album_id: null },
     ];
-    const batch2 = [{ id: 30, artist_name: 'c', album_title: null, track_title: null }];
+    const batch2 = [{ id: 30, artist_name: 'c', album_title: null, track_title: null, album_id: null }];
 
     (db.execute as jest.Mock).mockResolvedValueOnce(batch1).mockResolvedValueOnce(batch2).mockResolvedValueOnce([]);
 
@@ -282,9 +292,9 @@ describe('runBackfill', () => {
 
   it('counts lml_error when LML throws and continues processing', async () => {
     const batch = [
-      { id: 10, artist_name: 'a', album_title: null, track_title: null },
-      { id: 20, artist_name: 'b', album_title: null, track_title: null },
-      { id: 30, artist_name: 'c', album_title: null, track_title: null },
+      { id: 10, artist_name: 'a', album_title: null, track_title: null, album_id: null },
+      { id: 20, artist_name: 'b', album_title: null, track_title: null, album_id: null },
+      { id: 30, artist_name: 'c', album_title: null, track_title: null, album_id: null },
     ];
 
     (db.execute as jest.Mock).mockResolvedValueOnce(batch).mockResolvedValueOnce([]);
@@ -335,7 +345,7 @@ describe('runBackfill', () => {
       .mockResolvedValueOnce(false)
       .mockResolvedValue(false);
 
-    const batch = [{ id: 99, artist_name: 'a', album_title: null, track_title: null }];
+    const batch = [{ id: 99, artist_name: 'a', album_title: null, track_title: null, album_id: null }];
     (db.execute as jest.Mock).mockResolvedValueOnce(batch).mockResolvedValueOnce([]);
 
     const result = await runBackfill({
@@ -396,9 +406,9 @@ describe('runBackfill', () => {
     // *_raced variant when 0 rows updated. The orchestrator must bump
     // the matching counter rather than treating it as a regular match.
     const batch = [
-      { id: 10, artist_name: 'a', album_title: null, track_title: null },
-      { id: 20, artist_name: 'b', album_title: null, track_title: null },
-      { id: 30, artist_name: 'c', album_title: null, track_title: null },
+      { id: 10, artist_name: 'a', album_title: null, track_title: null, album_id: null },
+      { id: 20, artist_name: 'b', album_title: null, track_title: null, album_id: null },
+      { id: 30, artist_name: 'c', album_title: null, track_title: null, album_id: null },
     ];
 
     (db.execute as jest.Mock).mockResolvedValueOnce(batch).mockResolvedValueOnce([]);


### PR DESCRIPTION
## Summary

Mirrors the D3 worker pattern (`apps/enrichment-worker/enrich.ts`, BS#899) into the historical drain at `jobs/flowsheet-metadata-backfill/enrich.ts`. Closes the inline-only drift that was blocking D4 (#900): every backfill cycle was re-introducing inline rows for linked candidates that never reached `album_metadata`.

`applyEnrichment` now branches on `row.album_id`:

- **Linked + match**: UPSERT 10-column payload into `album_metadata` with `setWhere: album_metadata.updated_at < NOW()` race guard; flowsheet UPDATE stamps `metadata_attempt_at` only (no inline columns).
- **Linked + no-match**: UPSERT just the 3 synthesized search URLs into `album_metadata` (race-guarded); flowsheet UPDATE stamps marker only.
- **Unlinked + match / no-match**: existing inline-on-flowsheet behavior, verbatim — free-form rows can't enrich into `album_metadata` until linkage resolves.

The backfill keeps its own idempotency guard (`metadata_attempt_at IS NULL`). The worker's status-based guard (`metadata_status='enriching'`) deliberately does NOT apply here — the backfill operates on rows the consumer never claimed, so the marker is the right invariant. Documented inline in `enrich.ts`.

`orchestrate.ts:loadBatch` now projects `album_id` so the branch in `applyEnrichment` is decidable.

Closes #1027. Sibling D3-gap ticket: #1028 (different file path, no overlap). Unblocks D4: #900.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run test:unit -- --testPathPatterns 'flowsheet-metadata-backfill'` — 97/97 passing
- [x] Full `npm run test:unit` — 2197/2197 passing
- [ ] Integration spec at `tests/integration/flowsheet-metadata-backfill-upsert.spec.js` runs in CI against real PG (cannot reproduce locally without NPM_TOKEN for ci:env). Spec mirrors `album-metadata-upsert.spec.js`'s shape; pins the four-way (linked × match) matrix plus race-guard and marker idempotency.
- [ ] After merge + deploy: restart `flowsheet-metadata-backfill-cron` on prod EC2 (stopped 2026-05-23 ~20:25 UTC per ticket mitigation). Verify ≥100 linked drains produce matching `album_metadata` rows; confirm D4 divergence count holds at 0 for the post-fix cohort.