### PR TITLE
feat(auth): add lookup-email endpoint for unified username-or-email login

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -14,6 +14,7 @@ import type { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
 import { closeDatabaseConnection } from '@wxyc/database';
 import type { HealthCheckResponse } from '@wxyc/shared/dtos';
+import { lookupEmailByIdentifier } from './lookup-email';
 import { provisionUser, ProvisionError } from './provision-user';
 import { resolveOrganization } from './resolve-organization';
 
@@ -223,14 +224,35 @@ app.post('/auth/admin/provision-user', async (req, res) => {
   }
 });
 
+// Resolve a login identifier (username or email) to a verification email.
+// Public — rate-limited below alongside the other brute-force-sensitive
+// endpoints. The login UI accepts a single "Username or email" field and
+// calls this only when the identifier contains no '@'. Returning the email
+// for a known username is a mild enumeration vector that matches the
+// existing leak surface of /auth/sign-in/username (which already reveals
+// "user exists" via its error responses). Rate limiting bounds it.
+const lookupEmailHandler = async (req: Request, res: Response) => {
+  try {
+    const identifier = (req.body as { identifier?: unknown })?.identifier;
+    if (!identifier || typeof identifier !== 'string') {
+      return res.status(400).json({ error: 'identifier required' });
+    }
+
+    const email = await lookupEmailByIdentifier(identifier);
+    return res.json({ email });
+  } catch (error) {
+    console.error('[LOOKUP EMAIL] Unexpected error:', error);
+    Sentry.captureException(error, { tags: { subsystem: 'lookup-email' } });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
 // Disable rate limiting in test environments to avoid flaky integration tests.
 // This matches the pattern used by the backend's rateLimiting middleware.
 const isTestEnv =
   process.env.NODE_ENV === 'test' || process.env.USE_MOCK_SERVICES === 'true' || process.env.AUTH_BYPASS === 'true';
 
-if (isTestEnv) {
-  app.use('/auth', toNodeHandler(auth));
-} else {
+if (!isTestEnv) {
   // Strict limit for auth mutations vulnerable to brute-force attacks.
   // These are the only endpoints that need tight rate limiting.
   const authMutationRateLimit = rateLimit({
@@ -246,14 +268,16 @@ if (isTestEnv) {
     '/auth/sign-up',
     '/auth/email-otp/send-verification-otp',
     '/auth/forget-password',
+    '/auth/wxyc/lookup-email',
   ];
 
   for (const path of rateLimitedPaths) {
     app.use(path, authMutationRateLimit);
   }
-
-  app.use('/auth', toNodeHandler(auth));
 }
+
+app.post('/auth/wxyc/lookup-email', lookupEmailHandler);
+app.use('/auth', toNodeHandler(auth));
 
 // Liveness/readiness endpoint. Body conforms to HealthCheckResponse from
 // @wxyc/shared (api.yaml v1.3.0 / @wxyc/shared v0.13.0); the shape is the

--- a/apps/auth/lookup-email.ts
+++ b/apps/auth/lookup-email.ts
@@ -1,0 +1,25 @@
+/**
+ * Resolve a login identifier to a verification email address.
+ *
+ * The login UI accepts either a username or an email in a single field.
+ * Email-keyed flows (OTP send/verify) need the email, so the client calls
+ * this resolver when the identifier contains no '@'. Identifiers that
+ * already look like emails are echoed back unchanged — the OTP send will
+ * silently no-op for unknown emails (better-auth `disableSignUp: true`).
+ */
+
+import { auth } from '@wxyc/authentication';
+
+export async function lookupEmailByIdentifier(identifier: string): Promise<string | null> {
+  if (identifier.includes('@')) {
+    return identifier;
+  }
+
+  const context = await auth.$context;
+  const user = await context.adapter.findOne<{ email: string }>({
+    model: 'user',
+    where: [{ field: 'username', value: identifier }],
+  });
+
+  return user?.email ?? null;
+}

--- a/tests/unit/auth/lookup-email.test.ts
+++ b/tests/unit/auth/lookup-email.test.ts
@@ -1,0 +1,96 @@
+import { jest } from '@jest/globals';
+
+jest.mock('better-auth/plugins/access', () => ({
+  createAccessControl: () => ({
+    newRole: (statements: any) => ({
+      authorize: () => ({ success: true }),
+      statements,
+    }),
+  }),
+}));
+
+jest.mock('better-auth/plugins/organization/access', () => ({
+  adminAc: { statements: {} },
+  defaultStatements: {},
+}));
+
+jest.mock('@wxyc/database', () => ({
+  db: {},
+  user: { id: 'id' },
+}));
+
+jest.mock('drizzle-orm', () => ({
+  eq: jest.fn((a: unknown, b: unknown) => ({ field: a, value: b })),
+}));
+
+const mockAdapterFindOne = jest.fn();
+
+jest.mock('@wxyc/authentication', () => ({
+  auth: {
+    $context: Promise.resolve({
+      adapter: {
+        findOne: mockAdapterFindOne,
+      },
+    }),
+  },
+  WXYCRoles: {
+    member: {},
+    dj: {},
+    musicDirector: {},
+    stationManager: {},
+  },
+}));
+
+import { lookupEmailByIdentifier } from '../../../apps/auth/lookup-email';
+
+describe('lookupEmailByIdentifier', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('identifier contains "@"', () => {
+    it('echoes the identifier back without hitting the adapter', async () => {
+      const result = await lookupEmailByIdentifier('dj@wxyc.org');
+
+      expect(result).toBe('dj@wxyc.org');
+      expect(mockAdapterFindOne).not.toHaveBeenCalled();
+    });
+
+    it('does not validate that the email belongs to a real user', async () => {
+      const result = await lookupEmailByIdentifier('nobody@example.com');
+
+      expect(result).toBe('nobody@example.com');
+      expect(mockAdapterFindOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('identifier is a username', () => {
+    it('returns the email for a known username', async () => {
+      mockAdapterFindOne.mockResolvedValue({ email: 'jbromberg@wxyc.org' });
+
+      const result = await lookupEmailByIdentifier('jbromberg');
+
+      expect(result).toBe('jbromberg@wxyc.org');
+      expect(mockAdapterFindOne).toHaveBeenCalledWith({
+        model: 'user',
+        where: [{ field: 'username', value: 'jbromberg' }],
+      });
+    });
+
+    it('returns null when no user matches the username', async () => {
+      mockAdapterFindOne.mockResolvedValue(null);
+
+      const result = await lookupEmailByIdentifier('notarealdj');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the user row has no email', async () => {
+      mockAdapterFindOne.mockResolvedValue({ email: undefined });
+
+      const result = await lookupEmailByIdentifier('jbromberg');
+
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Closes #1038

## Summary

Adds `POST /auth/wxyc/lookup-email` so the dj-site login UI can accept either a username or an email in a single field. The endpoint echoes `@`-containing identifiers back unchanged and resolves usernames to their email via the better-auth adapter; rate-limited at 10/15min per IP alongside the other brute-force-sensitive auth mutations.

## Test plan

- [x] Five new unit tests in `tests/unit/auth/lookup-email.test.ts` (@-passthrough, known username, unknown username, missing-email, adapter call shape)
- [x] `npm run test:unit` — 2194/2194 green
- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors (preexisting warnings unchanged)
- [x] `npm run format:check` clean
- [x] Curl-verified against running auth server: 4/4 cases (email passthrough, missing body 400, unknown username returns null, known username returns email)

## Related

- Frontend consumer: WXYC/dj-site#592 (depends on this PR)