### PR TITLE
fix(internal-route): resolve libraryReleaseId at INSERT (BS#1028)

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -102,6 +102,21 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       const albumTitle = truncate(entry.releaseTitle, 128);
       const trackTitle = truncate(entry.songTitle, 128);
 
+      // Resolve tubafrenzy's libraryReleaseId to a Backend-Service album_id at
+      // INSERT time. The payload always carries this field (BackendServiceWebhookClient
+      // .buildPayload at tubafrenzy/libs/core/src/main/java/org/wxyc/flowsheet/
+      // BackendServiceWebhookClient.java); the BS handler used to ignore it,
+      // so tubafrenzy-driven rows arrived with album_id NULL and were linked
+      // later by jobs/flowsheet-etl's resolveAlbumIds (30-min cadence). That
+      // window was wide enough for D3's in-process writer to take the unlinked
+      // branch and write inline metadata that never reached album_metadata
+      // (BS#1028). Resolving here closes the window: enrichment fires in the
+      // same request as the link, so D3's linked branch UPSERTs album_metadata.
+      //
+      // Mirrors the sibling rotation-webhook resolution at line ~298.
+      const rawLibraryId = entry.libraryReleaseId ?? 0;
+      const albumId = await resolveAlbumId(rawLibraryId);
+
       // INSERT ... ON CONFLICT DO NOTHING RETURNING { id }: either we win
       // the insert and PG hands back exactly one row, or a concurrent
       // INSERT / prior webhook delivery already claimed the
@@ -114,6 +129,8 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
         .insert(flowsheet)
         .values({
           legacy_entry_id: entry.id,
+          legacy_release_id: rawLibraryId || null,
+          album_id: albumId,
           show_id: showId,
           entry_type: entryType,
           artist_name: artistName,
@@ -161,9 +178,15 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // CDC/index churn on every duplicate webhook delivery. The historical
       // drain at jobs/flowsheet-metadata-backfill/ is the safety net for
       // rows whose first INSERT enrichment returned null.
+      //
+      // `albumId` comes from the libraryReleaseId resolution above. When set,
+      // D3's writer (apps/backend/services/metadata/enrichment.service.ts)
+      // takes the linked branch and UPSERTs album_metadata; when null, it
+      // writes inline (preserves free-form / unresolved-link behavior).
       if (created && upsertedRow && entryType === 'track' && artistName) {
         fireAndForgetMetadataForRow({
           flowsheetId: upsertedRow.id,
+          albumId: albumId ?? undefined,
           artistName,
           albumTitle,
           trackTitle,

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -96,26 +96,17 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       }
 
       const entryType = mapProdEntryType(entry.flowsheetEntryType ?? 0);
-      const showId = await resolveShowId(entry.radioShowId);
       const isMsgType = isMessageEntryType(entryType);
       const artistName = isMsgType ? null : truncate(entry.artistName, 128);
       const albumTitle = truncate(entry.releaseTitle, 128);
       const trackTitle = truncate(entry.songTitle, 128);
 
-      // Resolve tubafrenzy's libraryReleaseId to a Backend-Service album_id at
-      // INSERT time. The payload always carries this field (BackendServiceWebhookClient
-      // .buildPayload at tubafrenzy/libs/core/src/main/java/org/wxyc/flowsheet/
-      // BackendServiceWebhookClient.java); the BS handler used to ignore it,
-      // so tubafrenzy-driven rows arrived with album_id NULL and were linked
-      // later by jobs/flowsheet-etl's resolveAlbumIds (30-min cadence). That
-      // window was wide enough for D3's in-process writer to take the unlinked
-      // branch and write inline metadata that never reached album_metadata
-      // (BS#1028). Resolving here closes the window: enrichment fires in the
-      // same request as the link, so D3's linked branch UPSERTs album_metadata.
-      //
-      // Mirrors the sibling rotation-webhook resolution at line ~298.
+      // Resolve linkage at INSERT so enrichment fires with album_id already
+      // set; without this, D3's writer takes the unlinked branch and writes
+      // inline metadata that never reaches album_metadata until the next
+      // flowsheet-etl cycle (#1028).
       const rawLibraryId = entry.libraryReleaseId ?? 0;
-      const albumId = await resolveAlbumId(rawLibraryId);
+      const [showId, albumId] = await Promise.all([resolveShowId(entry.radioShowId), resolveAlbumId(rawLibraryId)]);
 
       // INSERT ... ON CONFLICT DO NOTHING RETURNING { id }: either we win
       // the insert and PG hands back exactly one row, or a concurrent
@@ -178,11 +169,6 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // CDC/index churn on every duplicate webhook delivery. The historical
       // drain at jobs/flowsheet-metadata-backfill/ is the safety net for
       // rows whose first INSERT enrichment returned null.
-      //
-      // `albumId` comes from the libraryReleaseId resolution above. When set,
-      // D3's writer (apps/backend/services/metadata/enrichment.service.ts)
-      // takes the linked branch and UPSERTs album_metadata; when null, it
-      // writes inline (preserves free-form / unresolved-link behavior).
       if (created && upsertedRow && entryType === 'track' && artistName) {
         fireAndForgetMetadataForRow({
           flowsheetId: upsertedRow.id,

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -120,13 +120,26 @@ describe('POST /internal/flowsheet-webhook', () => {
     // values. Reset both mocks fully so per-test queues don't bleed across
     // tests. Default `mockReturning` to a fresh-INSERT response (one row);
     // tests that need a conflict response queue `[]` first, then a
-    // separate update-branch row. `mockLimit` covers the show-resolution
-    // SELECT (returns [] = no existing show, fall through to the inline
-    // INSERT ... ON CONFLICT DO NOTHING + re-SELECT chain in resolveShowId).
+    // separate update-branch row.
+    //
+    // Each webhook call issues two .limit(1) SELECTs:
+    //   1. resolveShowId — looks up the show by legacy_show_id; the queued
+    //      `[{ id: 9999 }]` short-circuits so we don't need to model the
+    //      INSERT-then-re-SELECT fallback.
+    //   2. resolveAlbumId — looks up library by legacy_release_id; default
+    //      queues empty so BS#1028's libraryReleaseId resolution returns
+    //      null and the row is treated as unlinked. Tests that want a
+    //      resolved album_id queue their own mockResolvedValueOnce values
+    //      before triggering the request.
+    // Trailing `mockResolvedValue([])` is the safety net once the
+    // per-call queue is drained.
     mockReturning.mockReset();
     mockReturning.mockResolvedValue([{ id: 5555 }]);
     mockLimit.mockReset();
-    mockLimit.mockResolvedValue([{ id: 9999 }]);
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999 }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([]);
   });
 
   // -- Auth --
@@ -228,6 +241,10 @@ describe('POST /internal/flowsheet-webhook', () => {
     // NOTHING RETURNING { id } either returns one row (we won the insert
     // race and the row is fresh) or an empty array (someone else inserted
     // first; we should UPDATE without firing enrichment).
+    //
+    // Default beforeEach queues an empty album lookup → albumId resolves to
+    // undefined here, exercising the unlinked branch. Linked-branch shape
+    // is covered by the BS#1028 tests below.
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
 
     const res = await request(app)
@@ -238,6 +255,7 @@ describe('POST /internal/flowsheet-webhook', () => {
     expect(res.status).toBe(200);
     expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledWith({
       flowsheetId: 5555,
+      albumId: undefined,
       artistName: 'Autechre',
       albumTitle: 'Confield',
       trackTitle: 'VI Scose Poise',
@@ -323,6 +341,90 @@ describe('POST /internal/flowsheet-webhook', () => {
 
     expect(res.status).toBe(200);
     expect(mockFireAndForgetMetadataForRow).not.toHaveBeenCalled();
+  });
+
+  // -- libraryReleaseId → album_id resolution (BS#1028) --
+  //
+  // The tubafrenzy webhook payload always carries `libraryReleaseId`
+  // (BackendServiceWebhookClient.buildPayload, tubafrenzy/libs/core/...).
+  // The handler resolves it to a Backend-Service `album_id` at INSERT time
+  // and forwards the resolved id to `fireAndForgetMetadataForRow` so D3's
+  // in-process writer takes the linked branch and UPSERTs `album_metadata`.
+  //
+  // Three cases:
+  //   1. libraryReleaseId resolves to a library row → albumId forwarded.
+  //   2. libraryReleaseId is 0 (sentinel for "no library link") → albumId
+  //      undefined; resolveAlbumId short-circuits without a SELECT.
+  //   3. libraryReleaseId is non-zero but no matching library row →
+  //      albumId undefined; row is unlinked until flowsheet-etl resolves
+  //      a future linkage (rare but possible if the library ETL hasn't
+  //      caught up to a brand-new release yet).
+
+  it('forwards the resolved album_id when libraryReleaseId matches a library row (BS#1028)', async () => {
+    // Override mockLimit queue: show lookup → 9999, album lookup → 7777
+    // (mirrors a tubafrenzy entry whose libraryReleaseId already corresponds
+    // to a library row).
+    mockLimit.mockReset();
+    mockLimit.mockResolvedValueOnce([{ id: 9999 }]).mockResolvedValueOnce([{ id: 7777 }]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry });
+
+    expect(res.status).toBe(200);
+    expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledWith({
+      flowsheetId: 5555,
+      albumId: 7777,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+      trackTitle: 'VI Scose Poise',
+    });
+  });
+
+  it('forwards albumId: undefined when libraryReleaseId is 0 (no library link)', async () => {
+    // resolveAlbumId short-circuits on 0 — no album SELECT is issued. The
+    // beforeEach queue still satisfies the show lookup; the album lookup
+    // never fires, so the queue's empty-album slot goes unused.
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, libraryReleaseId: 0 } });
+
+    expect(res.status).toBe(200);
+    expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledWith({
+      flowsheetId: 5555,
+      albumId: undefined,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+      trackTitle: 'VI Scose Poise',
+    });
+  });
+
+  it('forwards albumId: undefined when libraryReleaseId does not match any library row', async () => {
+    // libraryReleaseId is non-zero but the library SELECT returns empty —
+    // e.g. a brand-new release the library ETL hasn't synced yet, or an
+    // orphaned legacy id. resolveAlbumId returns null; enrichment fires
+    // with albumId: undefined and D3 takes the unlinked-inline branch.
+    // Default beforeEach queue (album lookup → []) already models this.
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, libraryReleaseId: 999_999 } });
+
+    expect(res.status).toBe(200);
+    expect(mockFireAndForgetMetadataForRow).toHaveBeenCalledWith({
+      flowsheetId: 5555,
+      albumId: undefined,
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+      trackTitle: 'VI Scose Poise',
+    });
   });
 
   // -- Delete --

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -116,23 +116,10 @@ describe('POST /internal/flowsheet-webhook', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // jest.clearAllMocks() does not drain queued mockResolvedValueOnce
-    // values. Reset both mocks fully so per-test queues don't bleed across
-    // tests. Default `mockReturning` to a fresh-INSERT response (one row);
-    // tests that need a conflict response queue `[]` first, then a
-    // separate update-branch row.
-    //
-    // Each webhook call issues two .limit(1) SELECTs:
-    //   1. resolveShowId — looks up the show by legacy_show_id; the queued
-    //      `[{ id: 9999 }]` short-circuits so we don't need to model the
-    //      INSERT-then-re-SELECT fallback.
-    //   2. resolveAlbumId — looks up library by legacy_release_id; default
-    //      queues empty so BS#1028's libraryReleaseId resolution returns
-    //      null and the row is treated as unlinked. Tests that want a
-    //      resolved album_id queue their own mockResolvedValueOnce values
-    //      before triggering the request.
-    // Trailing `mockResolvedValue([])` is the safety net once the
-    // per-call queue is drained.
+    // Each webhook call issues two .limit(1) SELECTs in order: resolveShowId
+    // then resolveAlbumId. Default queue resolves the show but not the album
+    // (unlinked path); tests that need a resolved album_id queue their own
+    // values before triggering the request.
     mockReturning.mockReset();
     mockReturning.mockResolvedValue([{ id: 5555 }]);
     mockLimit.mockReset();
@@ -241,10 +228,6 @@ describe('POST /internal/flowsheet-webhook', () => {
     // NOTHING RETURNING { id } either returns one row (we won the insert
     // race and the row is fresh) or an empty array (someone else inserted
     // first; we should UPDATE without firing enrichment).
-    //
-    // Default beforeEach queues an empty album lookup → albumId resolves to
-    // undefined here, exercising the unlinked branch. Linked-branch shape
-    // is covered by the BS#1028 tests below.
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
 
     const res = await request(app)
@@ -344,26 +327,8 @@ describe('POST /internal/flowsheet-webhook', () => {
   });
 
   // -- libraryReleaseId → album_id resolution (BS#1028) --
-  //
-  // The tubafrenzy webhook payload always carries `libraryReleaseId`
-  // (BackendServiceWebhookClient.buildPayload, tubafrenzy/libs/core/...).
-  // The handler resolves it to a Backend-Service `album_id` at INSERT time
-  // and forwards the resolved id to `fireAndForgetMetadataForRow` so D3's
-  // in-process writer takes the linked branch and UPSERTs `album_metadata`.
-  //
-  // Three cases:
-  //   1. libraryReleaseId resolves to a library row → albumId forwarded.
-  //   2. libraryReleaseId is 0 (sentinel for "no library link") → albumId
-  //      undefined; resolveAlbumId short-circuits without a SELECT.
-  //   3. libraryReleaseId is non-zero but no matching library row →
-  //      albumId undefined; row is unlinked until flowsheet-etl resolves
-  //      a future linkage (rare but possible if the library ETL hasn't
-  //      caught up to a brand-new release yet).
 
-  it('forwards the resolved album_id when libraryReleaseId matches a library row (BS#1028)', async () => {
-    // Override mockLimit queue: show lookup → 9999, album lookup → 7777
-    // (mirrors a tubafrenzy entry whose libraryReleaseId already corresponds
-    // to a library row).
+  it('forwards the resolved album_id when libraryReleaseId matches a library row', async () => {
     mockLimit.mockReset();
     mockLimit.mockResolvedValueOnce([{ id: 9999 }]).mockResolvedValueOnce([{ id: 7777 }]);
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
@@ -384,9 +349,7 @@ describe('POST /internal/flowsheet-webhook', () => {
   });
 
   it('forwards albumId: undefined when libraryReleaseId is 0 (no library link)', async () => {
-    // resolveAlbumId short-circuits on 0 — no album SELECT is issued. The
-    // beforeEach queue still satisfies the show lookup; the album lookup
-    // never fires, so the queue's empty-album slot goes unused.
+    // libraryReleaseId=0 short-circuits resolveAlbumId — no album SELECT issued.
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
 
     const res = await request(app)
@@ -405,11 +368,6 @@ describe('POST /internal/flowsheet-webhook', () => {
   });
 
   it('forwards albumId: undefined when libraryReleaseId does not match any library row', async () => {
-    // libraryReleaseId is non-zero but the library SELECT returns empty —
-    // e.g. a brand-new release the library ETL hasn't synced yet, or an
-    // orphaned legacy id. resolveAlbumId returns null; enrichment fires
-    // with albumId: undefined and D3 takes the unlinked-inline branch.
-    // Default beforeEach queue (album lookup → []) already models this.
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
 
     const res = await request(app)


### PR DESCRIPTION
## Summary

Replaces #1035. That PR forwarded `RETURNING album_id` through to enrichment, but the INSERT never sets `album_id` in the first place — so the value was always NULL on the fresh-INSERT branch (the only branch that fires enrichment). Functionally inert in prod.

The actual gap: the tubafrenzy webhook payload always carries `libraryReleaseId` (`BackendServiceWebhookClient.buildPayload` in the tubafrenzy repo, line ~218), but the BS handler ignored it. Tubafrenzy-driven rows arrived with `album_id` NULL and were linked later by `jobs/flowsheet-etl`'s `resolveAlbumIds` step on a 30-min cadence. That window was wide enough for D3's in-process writer to take the unlinked branch and write inline metadata that never reached `album_metadata` — same shape of D3 gap as #1027.

This PR resolves `libraryReleaseId` at INSERT via the existing `resolveAlbumId` helper (the sibling `rotation-webhook` handler in the same file already does this), includes `album_id` + `legacy_release_id` in the INSERT VALUES, and forwards the resolved id to `fireAndForgetMetadataForRow`. Enrichment now fires in the same request as the link, so D3's linked branch UPSERTs `album_metadata` for tubafrenzy-driven track rows.

The UPDATE-on-conflict branch is intentionally unchanged — `flowsheet-etl` still owns post-hoc linkage for rows that pre-date a libraryReleaseId-aware webhook, and the conflict branch doesn't fire enrichment anyway.

## Test plan

Three scenarios on the fresh-INSERT branch:

- [x] `libraryReleaseId` resolves to a library row → `albumId` forwarded.
- [x] `libraryReleaseId` is 0 (no-link sentinel) → `albumId: undefined`; `resolveAlbumId` short-circuits without a SELECT.
- [x] `libraryReleaseId` is non-zero but no library row → `albumId: undefined`.

Locally:

- [x] `npm run test:unit -- --testPathPatterns 'internal\.route\.test'` — 42/42 passing
- [x] Full `npm run test:unit` — 2200/2200 passing
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (440 pre-existing warnings)
- [x] `npm run format:check` — clean
- [ ] CI green
- [ ] Post-deploy: confirm a tubafrenzy-webhook-driven linked row produces an `album_metadata` UPSERT via Sentry span query.

## Related

- Closes #1028.
- Supersedes #1035 (close after this lands).
- Sibling D3-gap ticket / PR: #1027 / #1036 (merged).
- D3 origin: #899.
- Sibling pattern this mirrors: `internal.route.ts:298` (rotation-webhook).