### PR TITLE
fix(playlist-proxy): COALESCE album_metadata + flowsheet.artwork_url (BS#1042 mitigation)

### DIFF
--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -3,7 +3,12 @@
  *
  * Subscribes to tubafrenzy's SSE stream at /playlists/recentStream, maintains
  * an in-memory copy of the current playlist, and enriches playcuts with
- * artwork URLs by joining flowsheet to album_metadata via flowsheet.album_id.
+ * artwork URLs. During Epic D's dual-source transition, the enrichment uses
+ * `COALESCE(album_metadata.artwork_url, flowsheet.artwork_url)` over a
+ * LEFT JOIN — preferring the newer `album_metadata` table when populated,
+ * falling back to the legacy inline column when it isn't. D4 (#900) will
+ * drop the column and collapse the COALESCE; until then the dual-read
+ * preserves the pre-D5 coverage. See BS#1012, BS#1038.
  * Client requests are served instantly from memory via getRecentEntries().
  *
  * Exported API:
@@ -307,9 +312,22 @@ export function processDeletedEvent(data: string): void {
 
 // --- Enrichment ---
 
+/** COALESCE(album_metadata.artwork_url, flowsheet.artwork_url) — Epic D dual-source read. */
+const coalescedArtworkUrl = sql<string>`coalesce(${album_metadata.artwork_url}, ${flowsheet.artwork_url})`;
+
 /**
- * Batch-enrich all playcut entries with artwork URLs from album_metadata,
- * joined via flowsheet.album_id (BS#1012 / D5).
+ * Batch-enrich all playcut entries with artwork URLs.
+ *
+ * Reads `COALESCE(album_metadata.artwork_url, flowsheet.artwork_url)` over a
+ * LEFT JOIN — prefers the newer album_metadata source when populated, falls
+ * back to flowsheet's inline column during the Epic D transition (BS#1038).
+ *
+ * The WHERE filters on `f.artwork_url IS NOT NULL` so the planner can use
+ * the existing partial index `flowsheet_artwork_lookup_idx` (migration 0057)
+ * for the lookup-key probe. That set is a strict subset of the OLD path's
+ * coverage, so no pre-D5 keys are lost. Once album_metadata reaches parity
+ * with flowsheet.artwork_url (BS#1038), D5's INNER-JOIN-only shape can
+ * return and D4 (#900) can drop the column.
  */
 async function enrichPlaycuts(): Promise<void> {
   const playcutEntries = entries.filter((e) => e.entryType === 'playcut' && e.playcut);
@@ -329,18 +347,12 @@ async function enrichPlaycuts(): Promise<void> {
     const rows = await db
       .select({
         key: flowsheetLookupKey,
-        artwork_url: album_metadata.artwork_url,
+        artwork_url: coalescedArtworkUrl,
       })
       .from(flowsheet)
-      // INNER JOIN to album_metadata drops `flowsheet.album_id IS NULL` rows
-      // naturally (the FK can't match NULL). That matches the partial-index
-      // predicate `flowsheet_album_link_lookup_idx ... WHERE album_id IS NOT
-      // NULL` (migration 0081) so the planner indexes the lookup_key probe
-      // instead of seq-scanning the 2.6M-row flowsheet table. See incident
-      // #511 for what happens when the planner falls off the index.
-      .innerJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
-      .where(and(inArray(flowsheetLookupKey, keys), isNotNull(album_metadata.artwork_url)))
-      .groupBy(flowsheetLookupKey, album_metadata.artwork_url);
+      .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
+      .where(and(inArray(flowsheetLookupKey, keys), isNotNull(flowsheet.artwork_url)))
+      .groupBy(flowsheetLookupKey, coalescedArtworkUrl);
 
     // Build new map and only swap on success — preserves existing artwork on DB failure
     const newMap = new Map<number, string>();
@@ -363,7 +375,8 @@ async function enrichPlaycuts(): Promise<void> {
 }
 
 /**
- * Enrich a single playcut entry with artwork from album_metadata (BS#1012 / D5).
+ * Enrich a single playcut entry with artwork. Same COALESCE + LEFT JOIN +
+ * partial-index alignment as enrichPlaycuts — see comment there.
  */
 async function enrichSinglePlaycut(entry: TubafrenzyEntry): Promise<void> {
   if (!entry.playcut) return;
@@ -372,11 +385,10 @@ async function enrichSinglePlaycut(entry: TubafrenzyEntry): Promise<void> {
 
   try {
     const rows = await db
-      .select({ artwork_url: album_metadata.artwork_url })
+      .select({ artwork_url: coalescedArtworkUrl })
       .from(flowsheet)
-      // Same JOIN + partial-index alignment as enrichPlaycuts — see comment there.
-      .innerJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
-      .where(and(inArray(flowsheetLookupKey, [key]), isNotNull(album_metadata.artwork_url)))
+      .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
+      .where(and(inArray(flowsheetLookupKey, [key]), isNotNull(flowsheet.artwork_url)))
       .limit(1);
 
     if (rows.length > 0 && rows[0].artwork_url) {

--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -8,7 +8,7 @@
  * LEFT JOIN — preferring the newer `album_metadata` table when populated,
  * falling back to the legacy inline column when it isn't. D4 (#900) will
  * drop the column and collapse the COALESCE; until then the dual-read
- * preserves the pre-D5 coverage. See BS#1012, BS#1038.
+ * preserves the pre-D5 coverage. See BS#1012, BS#1042.
  * Client requests are served instantly from memory via getRecentEntries().
  *
  * Exported API:
@@ -320,13 +320,13 @@ const coalescedArtworkUrl = sql<string>`coalesce(${album_metadata.artwork_url}, 
  *
  * Reads `COALESCE(album_metadata.artwork_url, flowsheet.artwork_url)` over a
  * LEFT JOIN — prefers the newer album_metadata source when populated, falls
- * back to flowsheet's inline column during the Epic D transition (BS#1038).
+ * back to flowsheet's inline column during the Epic D transition (BS#1042).
  *
  * The WHERE filters on `f.artwork_url IS NOT NULL` so the planner can use
  * the existing partial index `flowsheet_artwork_lookup_idx` (migration 0057)
  * for the lookup-key probe. That set is a strict subset of the OLD path's
  * coverage, so no pre-D5 keys are lost. Once album_metadata reaches parity
- * with flowsheet.artwork_url (BS#1038), D5's INNER-JOIN-only shape can
+ * with flowsheet.artwork_url (BS#1042), D5's INNER-JOIN-only shape can
  * return and D4 (#900) can drop the column.
  */
 async function enrichPlaycuts(): Promise<void> {

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -20,7 +20,7 @@ const mockLimit = jest.fn();
 const mockDbChain = {
   select: mockSelect,
   from: mockFrom,
-  innerJoin: mockInnerJoin,
+  leftJoin: mockInnerJoin,
   where: mockWhere,
   groupBy: mockGroupBy,
   limit: mockLimit,
@@ -36,7 +36,7 @@ jest.mock('@wxyc/database', () => ({
   db: {
     select: (...args: unknown[]) => mockSelect(...args),
     from: (...args: unknown[]) => mockFrom(...args),
-    innerJoin: (...args: unknown[]) => mockInnerJoin(...args),
+    leftJoin: (...args: unknown[]) => mockInnerJoin(...args),
     where: (...args: unknown[]) => mockWhere(...args),
     groupBy: (...args: unknown[]) => mockGroupBy(...args),
     limit: (...args: unknown[]) => mockLimit(...args),
@@ -411,18 +411,19 @@ describe('playlist-proxy.service', () => {
     });
   });
 
-  describe('artwork query: partial-index alignment (regression for #511, BS#1012)', () => {
-    // The post-D5 partial functional index `flowsheet_album_link_lookup_idx`
-    // (migration 0081) only covers rows where `album_id IS NOT NULL`. The
-    // playlist-proxy queries an INNER JOIN of flowsheet ⨝ album_metadata,
-    // which drops `flowsheet.album_id IS NULL` rows naturally and therefore
-    // matches the partial-index predicate so the lookup_key probe is an
-    // index scan instead of a 2.6M-row seq scan (incident #511).
+  describe('artwork query: dual-source COALESCE + partial-index alignment (regression for #511, BS#1038)', () => {
+    // The playlist-proxy reads `COALESCE(album_metadata.artwork_url,
+    // flowsheet.artwork_url)` over a LEFT JOIN during the Epic D transition
+    // (BS#1038). The WHERE filter on `f.artwork_url IS NOT NULL` aligns with
+    // the OLD partial index `flowsheet_artwork_lookup_idx` (migration 0057)
+    // so the lookup-key probe is an index scan, not a 2.6M-row seq scan
+    // (incident #511). Once album_metadata reaches parity (BS#1038) the
+    // INNER-JOIN-only shape can return and D4 (#900) can drop the column;
+    // until then, the COALESCE preserves pre-D5 artwork coverage.
     //
-    // Source-grep over the deployed file is the right shape because the
-    // bug class is a *missing* clause in the SQL builder. A behavioural test
-    // wouldn't catch a future regression where someone adds a new query
-    // path without the join + filter; the source-grep does.
+    // Source-grep is the right shape: the bug class is a *missing* clause
+    // in the SQL builder, which behavioural tests wouldn't catch when a
+    // future change adds a new query path without the join + filter.
     const fs = jest.requireActual<typeof import('fs')>('fs');
     const path = jest.requireActual<typeof import('path')>('path');
 
@@ -443,30 +444,34 @@ describe('playlist-proxy.service', () => {
       expect(proxySource).toMatch(/\balbum_metadata\b/);
     });
 
-    it('every flowsheet artwork SELECT inner-joins album_metadata on album_id and filters isNotNull(album_metadata.artwork_url)', () => {
-      // Find every WHERE that targets the flowsheetLookupKey-on-flowsheet
-      // pattern. Each must be paired with an `.innerJoin(album_metadata, ...)`
-      // upstream in the same chain and combined with
-      // `isNotNull(album_metadata.artwork_url)` so the partial index fires.
-      // Two call sites exist today (enrichPlaycuts, enrichSinglePlaycut); any
-      // future addition should match the same shape.
+    it('defines a COALESCE(album_metadata.artwork_url, flowsheet.artwork_url) expression', () => {
+      // The dual-source read MUST prefer album_metadata over the legacy
+      // flowsheet column — argument order in COALESCE is the contract.
+      // Flipping it would inverse the preference and stale album_metadata
+      // values would be hidden behind fresher inline writes.
+      expect(proxySource).toMatch(
+        /coalesce\(\s*\$\{album_metadata\.artwork_url\}\s*,\s*\$\{flowsheet\.artwork_url\}\s*\)/i
+      );
+    });
+
+    it('every flowsheet artwork SELECT left-joins album_metadata on album_id and filters isNotNull(flowsheet.artwork_url)', () => {
+      // Find every chain that targets the flowsheetLookupKey-on-flowsheet
+      // pattern. Each must:
+      //  - LEFT JOIN album_metadata on album_id (preserves rows where the
+      //    new table has no entry yet — BS#1038 coverage)
+      //  - filter on isNotNull(flowsheet.artwork_url) so the planner uses
+      //    `flowsheet_artwork_lookup_idx` (migration 0057), not a seq scan
+      // Two call sites exist today (enrichPlaycuts, enrichSinglePlaycut);
+      // any future addition should match the same shape.
       const chains = proxySource.match(/db\s*\.\s*select[\s\S]*?\.\s*(?:groupBy|limit)\([\s\S]*?\)\s*;/g) ?? [];
       const artworkChains = chains.filter((c) => /flowsheetLookupKey/.test(c));
       expect(artworkChains.length).toBeGreaterThanOrEqual(2);
       for (const chain of artworkChains) {
         expect(chain).toMatch(
-          /\.innerJoin\(\s*album_metadata\s*,\s*eq\(\s*album_metadata\.album_id\s*,\s*flowsheet\.album_id\s*\)\s*\)/
+          /\.leftJoin\(\s*album_metadata\s*,\s*eq\(\s*album_metadata\.album_id\s*,\s*flowsheet\.album_id\s*\)\s*\)/
         );
-        expect(chain).toMatch(/isNotNull\s*\(\s*album_metadata\.artwork_url\s*\)/);
+        expect(chain).toMatch(/isNotNull\s*\(\s*flowsheet\.artwork_url\s*\)/);
       }
-    });
-
-    it('does not read flowsheet.artwork_url (D4 column-drop safety)', () => {
-      // BS#1012 / D5 cut the proxy off `flowsheet.artwork_url` so D4 (#900)
-      // can drop the column. If someone re-adds a read of it, this test
-      // catches the regression at PR time before the next D4 attempt wedges
-      // on a missing column.
-      expect(proxySource).not.toMatch(/flowsheet\.artwork_url/);
     });
   });
 });

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -411,13 +411,13 @@ describe('playlist-proxy.service', () => {
     });
   });
 
-  describe('artwork query: dual-source COALESCE + partial-index alignment (regression for #511, BS#1038)', () => {
+  describe('artwork query: dual-source COALESCE + partial-index alignment (regression for #511, BS#1042)', () => {
     // The playlist-proxy reads `COALESCE(album_metadata.artwork_url,
     // flowsheet.artwork_url)` over a LEFT JOIN during the Epic D transition
-    // (BS#1038). The WHERE filter on `f.artwork_url IS NOT NULL` aligns with
+    // (BS#1042). The WHERE filter on `f.artwork_url IS NOT NULL` aligns with
     // the OLD partial index `flowsheet_artwork_lookup_idx` (migration 0057)
     // so the lookup-key probe is an index scan, not a 2.6M-row seq scan
-    // (incident #511). Once album_metadata reaches parity (BS#1038) the
+    // (incident #511). Once album_metadata reaches parity (BS#1042) the
     // INNER-JOIN-only shape can return and D4 (#900) can drop the column;
     // until then, the COALESCE preserves pre-D5 artwork coverage.
     //
@@ -458,7 +458,7 @@ describe('playlist-proxy.service', () => {
       // Find every chain that targets the flowsheetLookupKey-on-flowsheet
       // pattern. Each must:
       //  - LEFT JOIN album_metadata on album_id (preserves rows where the
-      //    new table has no entry yet — BS#1038 coverage)
+      //    new table has no entry yet — BS#1042 coverage)
       //  - filter on isNotNull(flowsheet.artwork_url) so the planner uses
       //    `flowsheet_artwork_lookup_idx` (migration 0057), not a seq scan
       // Two call sites exist today (enrichPlaycuts, enrichSinglePlaycut);


### PR DESCRIPTION
Mitigates [#1042](https://github.com/WXYC/Backend-Service/issues/1042) — coverage regression surfaced by [#1037](https://github.com/WXYC/Backend-Service/pull/1037) (D5).

## Why

Post-deploy smoke of D5 (#1037) found a 5x coverage cliff: 73,096 distinct `(artist+album)` keys resolvable via the pre-D5 `flowsheet.artwork_url` path, only 14,222 via the new `album_metadata`-only path. `album_metadata` isn't yet at parity with `flowsheet.artwork_url` because D2's historical backfill ([#1021](https://github.com/WXYC/Backend-Service/pull/1021)) missed at least 20K linked rows. Live impact: 200-entry SSE init enriched only ~10 entries (single digits where pre-D5 had ~40-80).

The durable fix is to bring `album_metadata` to parity ([#1042](https://github.com/WXYC/Backend-Service/issues/1042)). That's a multi-step job (investigate D2's miss, run a fill, verify). In the meantime, this PR restores pre-D5 coverage by adopting the canonical Epic D dual-source transition pattern that [#897](https://github.com/WXYC/Backend-Service/issues/897) (D1) already established for the V2 read path: `LEFT JOIN album_metadata` + `COALESCE(am.artwork_url, f.artwork_url)`.

## What this PR does

- **`apps/backend/services/playlist-proxy.service.ts`** — Both query chains switch from `INNER JOIN` to `LEFT JOIN album_metadata`, projection becomes `COALESCE(album_metadata.artwork_url, flowsheet.artwork_url)`. The WHERE filter switches to `isNotNull(flowsheet.artwork_url)` so the planner uses the old `flowsheet_artwork_lookup_idx` (migration 0057) — which is still alive — instead of the new `flowsheet_album_link_lookup_idx` (migration 0081). The new index goes idle until #1042 closes; it stays in place for the eventual cutover.
- **`tests/unit/services/playlist-proxy.service.test.ts`** — Regression-pin block retargeted: pins the LEFT JOIN + `isNotNull(flowsheet.artwork_url)` shape; new pin on the COALESCE argument order (album_metadata first — preferring stale-inline-over-fresh would defeat the point). The negative pin against `flowsheet.artwork_url` reads is removed; the column is read again by design.

## Why COALESCE order matters

`COALESCE(album_metadata.artwork_url, flowsheet.artwork_url)` — `album_metadata` is the newer, post-D3 source and reflects the latest enrichment writes. Flipping the argument order would hide fresh `album_metadata` updates behind stale legacy values. The test pins the order so a future refactor can't accidentally invert it.

## Pre-flight

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (445 warnings, pre-existing)
- [x] `npm run format:check` — clean
- [x] `npm run lint:migrations` — clean (no migrations added)
- [x] `npm run build` — all workspaces succeed
- [x] `npm run test:unit` — 2213/2214 pass. **One pre-existing failure** in `tests/unit/scripts/ci-env-surface-parity.test.ts` from BS#1033's f3a16782 (`DEFAULT_ORG_SLUG` added to the workflow but not the allowlist). Out of scope; verified the failure also reproduces on `origin/main` without this PR's changes.

## Production rollout

No DDL — just a code change. Standard Manual Build & Deploy after merge. The OLD index (`flowsheet_artwork_lookup_idx`) is already in production, so the new query plan picks it up immediately.

Post-deploy smoke: restart backend, confirm `[playlist-proxy] Enriched <N>` log message shows a count comparable to pre-D5 baseline (target: ~40-80 per 200-entry init batch, not single digits).

## Sequencing

1. Merge + deploy this PR — restores iOS playlist artwork coverage now.
2. Work on [#1042](https://github.com/WXYC/Backend-Service/issues/1042) — investigate + run the `album_metadata` backfill.
3. After parity, revert this PR's COALESCE back to D5's INNER-JOIN-only shape (one-liner).
4. Unblock [#900](https://github.com/WXYC/Backend-Service/issues/900) (D4 — DROP COLUMN).

## Related

- Surfaced by: [#1037](https://github.com/WXYC/Backend-Service/pull/1037) (D5 merge, this same day)
- Hard depends on: [#1042](https://github.com/WXYC/Backend-Service/issues/1042) for eventual revert + D4 unblock
- Parent: [#878](https://github.com/WXYC/Backend-Service/issues/878) (Epic D)
- Project: [#32](https://github.com/orgs/WXYC/projects/32) (post-launch service hardening)