### PR TITLE
fix(husky): skip pre-push validation on delete-only pushes; bump eslint heap

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,13 +1,13 @@
 # Skip validation if every ref being pushed is a deletion. Git signals a
-# delete by sending all-zero `local_sha` on the line for that ref. Running
-# typecheck/lint on a delete-only push wastes ~80s and (when paired with
-# the eslint heap usage) can OOM the hook even though no code is changing.
+# delete by sending an all-zero `local_sha` (40 chars for SHA-1, 64 for
+# SHA-256); the `*[!0]*` glob matches any string containing a non-zero
+# character, so the case fires only for real pushes. Running typecheck/
+# lint on a delete-only push wastes ~80s and can OOM the hook.
 has_real_push=false
 while read local_ref local_sha remote_ref remote_sha; do
-  if [ "$local_sha" != "0000000000000000000000000000000000000000" ]; then
-    has_real_push=true
-    break
-  fi
+  case "$local_sha" in
+    *[!0]*) has_real_push=true; break ;;
+  esac
 done
 
 if [ "$has_real_push" = false ]; then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,18 @@
+# Skip validation if every ref being pushed is a deletion. Git signals a
+# delete by sending all-zero `local_sha` on the line for that ref. Running
+# typecheck/lint on a delete-only push wastes ~80s and (when paired with
+# the eslint heap usage) can OOM the hook even though no code is changing.
+has_real_push=false
+while read local_ref local_sha remote_ref remote_sha; do
+  if [ "$local_sha" != "0000000000000000000000000000000000000000" ]; then
+    has_real_push=true
+    break
+  fi
+done
+
+if [ "$has_real_push" = false ]; then
+  exit 0
+fi
+
 npm run typecheck && npm run lint
 npm run check:docs || true

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "typecheck": "npm run lint:prebuild && npm run typecheck --workspace=@wxyc/database --workspace=shared/** --workspace=apps/**",
     "lint:prebuild": "npm run build --workspace=@wxyc/database --workspace=@wxyc/authentication --workspace=@wxyc/lml-client",
+    "//lint": "8192 heap: eslint holds typed AST + program graph for every workspace; OOMs at node's default ~4GB ceiling on this monorepo.",
     "lint": "npm run lint:prebuild && NODE_OPTIONS=--max-old-space-size=8192 eslint --cache --cache-strategy content --cache-location .cache/eslint/ .",
     "lint:fix": "npm run lint:prebuild && NODE_OPTIONS=--max-old-space-size=8192 eslint --cache --cache-strategy content --cache-location .cache/eslint/ . --fix",
     "lint:env": "node scripts/lint-env.js",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "typecheck": "npm run lint:prebuild && npm run typecheck --workspace=@wxyc/database --workspace=shared/** --workspace=apps/**",
     "lint:prebuild": "npm run build --workspace=@wxyc/database --workspace=@wxyc/authentication --workspace=@wxyc/lml-client",
-    "lint": "npm run lint:prebuild && eslint --cache --cache-strategy content --cache-location .cache/eslint/ .",
-    "lint:fix": "npm run lint:prebuild && eslint --cache --cache-strategy content --cache-location .cache/eslint/ . --fix",
+    "lint": "npm run lint:prebuild && NODE_OPTIONS=--max-old-space-size=8192 eslint --cache --cache-strategy content --cache-location .cache/eslint/ .",
+    "lint:fix": "npm run lint:prebuild && NODE_OPTIONS=--max-old-space-size=8192 eslint --cache --cache-strategy content --cache-location .cache/eslint/ . --fix",
     "lint:env": "node scripts/lint-env.js",
     "format": "prettier --cache --cache-location .cache/prettier/ --write .",
     "format:check": "prettier --cache --cache-location .cache/prettier/ --check .",


### PR DESCRIPTION
Closes #1045

## Summary

Two fixes to `.husky/pre-push`:

1. **Skip validation on delete-only pushes** — walk stdin (git sends `<local_ref> <local_sha> <remote_ref> <remote_sha>` per ref); if every `local_sha` is the all-zero delete marker, exit 0 immediately. No more wasted ~80s CPU on `git push --delete`.

2. **Bump eslint heap from default ~4 GB to 8 GB** — `NODE_OPTIONS=--max-old-space-size=8192` prefix on `npm run lint` and `npm run lint:fix`. Repro before fix: `FATAL ERROR: Ineffective mark-compacts near heap limit ... Abort trap: 6` (full trace in #1045). After: clean exit in ~29s user CPU (was ~83s + abort) on the same tree, 445 preexisting warnings unchanged.

## Test plan

- [x] Simulated delete push (`printf "refs/heads/foo 0000...0000 refs/heads/foo 0000...0000\n" | sh .husky/pre-push`) exits 0 with no commands run
- [x] Empty stdin exits 0
- [x] This very PR push validated the fix end-to-end: hook ran the full pipeline (typecheck + bumped lint) on the real commit and passed

## Future follow-up (not here)

The real fix is to scope lint to changed files via `git diff @{push}` (lint-staged-style for pre-push). Defers OOM by an order of magnitude. Deferring until the heap bump is no longer enough.