### PR TITLE
Revert playlist-proxy COALESCE fallback now that BS#1042 parity reached

### DIFF
--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -3,12 +3,7 @@
  *
  * Subscribes to tubafrenzy's SSE stream at /playlists/recentStream, maintains
  * an in-memory copy of the current playlist, and enriches playcuts with
- * artwork URLs. During Epic D's dual-source transition, the enrichment uses
- * `COALESCE(album_metadata.artwork_url, flowsheet.artwork_url)` over a
- * LEFT JOIN — preferring the newer `album_metadata` table when populated,
- * falling back to the legacy inline column when it isn't. D4 (#900) will
- * drop the column and collapse the COALESCE; until then the dual-read
- * preserves the pre-D5 coverage. See BS#1012, BS#1042.
+ * artwork URLs by joining flowsheet to album_metadata via flowsheet.album_id.
  * Client requests are served instantly from memory via getRecentEntries().
  *
  * Exported API:
@@ -312,22 +307,9 @@ export function processDeletedEvent(data: string): void {
 
 // --- Enrichment ---
 
-/** COALESCE(album_metadata.artwork_url, flowsheet.artwork_url) — Epic D dual-source read. */
-const coalescedArtworkUrl = sql<string>`coalesce(${album_metadata.artwork_url}, ${flowsheet.artwork_url})`;
-
 /**
- * Batch-enrich all playcut entries with artwork URLs.
- *
- * Reads `COALESCE(album_metadata.artwork_url, flowsheet.artwork_url)` over a
- * LEFT JOIN — prefers the newer album_metadata source when populated, falls
- * back to flowsheet's inline column during the Epic D transition (BS#1042).
- *
- * The WHERE filters on `f.artwork_url IS NOT NULL` so the planner can use
- * the existing partial index `flowsheet_artwork_lookup_idx` (migration 0057)
- * for the lookup-key probe. That set is a strict subset of the OLD path's
- * coverage, so no pre-D5 keys are lost. Once album_metadata reaches parity
- * with flowsheet.artwork_url (BS#1042), D5's INNER-JOIN-only shape can
- * return and D4 (#900) can drop the column.
+ * Batch-enrich all playcut entries with artwork URLs from album_metadata,
+ * joined via flowsheet.album_id (BS#1012 / D5).
  */
 async function enrichPlaycuts(): Promise<void> {
   const playcutEntries = entries.filter((e) => e.entryType === 'playcut' && e.playcut);
@@ -347,12 +329,18 @@ async function enrichPlaycuts(): Promise<void> {
     const rows = await db
       .select({
         key: flowsheetLookupKey,
-        artwork_url: coalescedArtworkUrl,
+        artwork_url: album_metadata.artwork_url,
       })
       .from(flowsheet)
-      .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
-      .where(and(inArray(flowsheetLookupKey, keys), isNotNull(flowsheet.artwork_url)))
-      .groupBy(flowsheetLookupKey, coalescedArtworkUrl);
+      // INNER JOIN to album_metadata drops `flowsheet.album_id IS NULL` rows
+      // naturally (the FK can't match NULL). That matches the partial-index
+      // predicate `flowsheet_album_link_lookup_idx ... WHERE album_id IS NOT
+      // NULL` (migration 0081) so the planner indexes the lookup_key probe
+      // instead of seq-scanning the 2.6M-row flowsheet table. See incident
+      // #511 for what happens when the planner falls off the index.
+      .innerJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
+      .where(and(inArray(flowsheetLookupKey, keys), isNotNull(album_metadata.artwork_url)))
+      .groupBy(flowsheetLookupKey, album_metadata.artwork_url);
 
     // Build new map and only swap on success — preserves existing artwork on DB failure
     const newMap = new Map<number, string>();
@@ -375,8 +363,7 @@ async function enrichPlaycuts(): Promise<void> {
 }
 
 /**
- * Enrich a single playcut entry with artwork. Same COALESCE + LEFT JOIN +
- * partial-index alignment as enrichPlaycuts — see comment there.
+ * Enrich a single playcut entry with artwork from album_metadata (BS#1012 / D5).
  */
 async function enrichSinglePlaycut(entry: TubafrenzyEntry): Promise<void> {
   if (!entry.playcut) return;
@@ -385,10 +372,11 @@ async function enrichSinglePlaycut(entry: TubafrenzyEntry): Promise<void> {
 
   try {
     const rows = await db
-      .select({ artwork_url: coalescedArtworkUrl })
+      .select({ artwork_url: album_metadata.artwork_url })
       .from(flowsheet)
-      .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
-      .where(and(inArray(flowsheetLookupKey, [key]), isNotNull(flowsheet.artwork_url)))
+      // Same JOIN + partial-index alignment as enrichPlaycuts — see comment there.
+      .innerJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
+      .where(and(inArray(flowsheetLookupKey, [key]), isNotNull(album_metadata.artwork_url)))
       .limit(1);
 
     if (rows.length > 0 && rows[0].artwork_url) {

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -20,7 +20,7 @@ const mockLimit = jest.fn();
 const mockDbChain = {
   select: mockSelect,
   from: mockFrom,
-  leftJoin: mockInnerJoin,
+  innerJoin: mockInnerJoin,
   where: mockWhere,
   groupBy: mockGroupBy,
   limit: mockLimit,
@@ -36,7 +36,7 @@ jest.mock('@wxyc/database', () => ({
   db: {
     select: (...args: unknown[]) => mockSelect(...args),
     from: (...args: unknown[]) => mockFrom(...args),
-    leftJoin: (...args: unknown[]) => mockInnerJoin(...args),
+    innerJoin: (...args: unknown[]) => mockInnerJoin(...args),
     where: (...args: unknown[]) => mockWhere(...args),
     groupBy: (...args: unknown[]) => mockGroupBy(...args),
     limit: (...args: unknown[]) => mockLimit(...args),
@@ -411,19 +411,18 @@ describe('playlist-proxy.service', () => {
     });
   });
 
-  describe('artwork query: dual-source COALESCE + partial-index alignment (regression for #511, BS#1042)', () => {
-    // The playlist-proxy reads `COALESCE(album_metadata.artwork_url,
-    // flowsheet.artwork_url)` over a LEFT JOIN during the Epic D transition
-    // (BS#1042). The WHERE filter on `f.artwork_url IS NOT NULL` aligns with
-    // the OLD partial index `flowsheet_artwork_lookup_idx` (migration 0057)
-    // so the lookup-key probe is an index scan, not a 2.6M-row seq scan
-    // (incident #511). Once album_metadata reaches parity (BS#1042) the
-    // INNER-JOIN-only shape can return and D4 (#900) can drop the column;
-    // until then, the COALESCE preserves pre-D5 artwork coverage.
+  describe('artwork query: partial-index alignment (regression for #511, BS#1012)', () => {
+    // The post-D5 partial functional index `flowsheet_album_link_lookup_idx`
+    // (migration 0081) only covers rows where `album_id IS NOT NULL`. The
+    // playlist-proxy queries an INNER JOIN of flowsheet ⨝ album_metadata,
+    // which drops `flowsheet.album_id IS NULL` rows naturally and therefore
+    // matches the partial-index predicate so the lookup_key probe is an
+    // index scan instead of a 2.6M-row seq scan (incident #511).
     //
-    // Source-grep is the right shape: the bug class is a *missing* clause
-    // in the SQL builder, which behavioural tests wouldn't catch when a
-    // future change adds a new query path without the join + filter.
+    // Source-grep over the deployed file is the right shape because the
+    // bug class is a *missing* clause in the SQL builder. A behavioural test
+    // wouldn't catch a future regression where someone adds a new query
+    // path without the join + filter; the source-grep does.
     const fs = jest.requireActual<typeof import('fs')>('fs');
     const path = jest.requireActual<typeof import('path')>('path');
 
@@ -444,34 +443,30 @@ describe('playlist-proxy.service', () => {
       expect(proxySource).toMatch(/\balbum_metadata\b/);
     });
 
-    it('defines a COALESCE(album_metadata.artwork_url, flowsheet.artwork_url) expression', () => {
-      // The dual-source read MUST prefer album_metadata over the legacy
-      // flowsheet column — argument order in COALESCE is the contract.
-      // Flipping it would inverse the preference and stale album_metadata
-      // values would be hidden behind fresher inline writes.
-      expect(proxySource).toMatch(
-        /coalesce\(\s*\$\{album_metadata\.artwork_url\}\s*,\s*\$\{flowsheet\.artwork_url\}\s*\)/i
-      );
-    });
-
-    it('every flowsheet artwork SELECT left-joins album_metadata on album_id and filters isNotNull(flowsheet.artwork_url)', () => {
-      // Find every chain that targets the flowsheetLookupKey-on-flowsheet
-      // pattern. Each must:
-      //  - LEFT JOIN album_metadata on album_id (preserves rows where the
-      //    new table has no entry yet — BS#1042 coverage)
-      //  - filter on isNotNull(flowsheet.artwork_url) so the planner uses
-      //    `flowsheet_artwork_lookup_idx` (migration 0057), not a seq scan
-      // Two call sites exist today (enrichPlaycuts, enrichSinglePlaycut);
-      // any future addition should match the same shape.
+    it('every flowsheet artwork SELECT inner-joins album_metadata on album_id and filters isNotNull(album_metadata.artwork_url)', () => {
+      // Find every WHERE that targets the flowsheetLookupKey-on-flowsheet
+      // pattern. Each must be paired with an `.innerJoin(album_metadata, ...)`
+      // upstream in the same chain and combined with
+      // `isNotNull(album_metadata.artwork_url)` so the partial index fires.
+      // Two call sites exist today (enrichPlaycuts, enrichSinglePlaycut); any
+      // future addition should match the same shape.
       const chains = proxySource.match(/db\s*\.\s*select[\s\S]*?\.\s*(?:groupBy|limit)\([\s\S]*?\)\s*;/g) ?? [];
       const artworkChains = chains.filter((c) => /flowsheetLookupKey/.test(c));
       expect(artworkChains.length).toBeGreaterThanOrEqual(2);
       for (const chain of artworkChains) {
         expect(chain).toMatch(
-          /\.leftJoin\(\s*album_metadata\s*,\s*eq\(\s*album_metadata\.album_id\s*,\s*flowsheet\.album_id\s*\)\s*\)/
+          /\.innerJoin\(\s*album_metadata\s*,\s*eq\(\s*album_metadata\.album_id\s*,\s*flowsheet\.album_id\s*\)\s*\)/
         );
-        expect(chain).toMatch(/isNotNull\s*\(\s*flowsheet\.artwork_url\s*\)/);
+        expect(chain).toMatch(/isNotNull\s*\(\s*album_metadata\.artwork_url\s*\)/);
       }
+    });
+
+    it('does not read flowsheet.artwork_url (D4 column-drop safety)', () => {
+      // BS#1012 / D5 cut the proxy off `flowsheet.artwork_url` so D4 (#900)
+      // can drop the column. If someone re-adds a read of it, this test
+      // catches the regression at PR time before the next D4 attempt wedges
+      // on a missing column.
+      expect(proxySource).not.toMatch(/flowsheet\.artwork_url/);
     });
   });
 });


### PR DESCRIPTION
## Summary

Reverts PR #1043's dual-source COALESCE shape back to D5's INNER-JOIN-only artwork read. The fallback to `flowsheet.artwork_url` was a safety net for the ~15K albums that `album_metadata` didn't have rows for; the targeted bridge UPSERT in #1042 closed the gap to zero, so the fallback is no longer needed.

## Why now

#1042's D2 coverage miss was diagnosed: the original D2 backfill (#898) predicated on `metadata_attempt_at IS NOT NULL`, which excluded ~13,981 legacy tubafrenzy-mirrored albums plus 1,212 albums where `album_metadata.artwork_url` was NULL despite an `flowsheet.artwork_url` value. The bridge UPSERT (idempotent `ON CONFLICT (album_id) DO UPDATE … WHERE album_metadata.artwork_url IS NULL`) inserted 15,193 rows in a single transaction — preserving D3's live-writer state untouched by virtue of the `IS NULL` filter on the conflict path.

Post-backfill parity verification:

| metric | value |
|---|---|
| `album_metadata.album_id` ∩ `flowsheet.album_id` with non-null artwork | 20,371 |
| `album_metadata` rows with non-null artwork | 20,371 |
| coverage gap | 0 |

## What this PR changes

- **`apps/backend/services/playlist-proxy.service.ts`** — drops `coalescedArtworkUrl` sql expr; changes `leftJoin` back to `innerJoin`; projects `album_metadata.artwork_url` directly; filters `isNotNull(album_metadata.artwork_url)`; groups by `album_metadata.artwork_url`. Header doc + inline comments reflect D5 shape.
- **`tests/unit/services/playlist-proxy.service.test.ts`** — restores `innerJoin` mock; restores the D5 partial-index-alignment pin block targeting the JOIN + `album_metadata.artwork_url` filter; restores the negative pin that catches any future read of `flowsheet.artwork_url` (D4 column-drop safety).

The diff is byte-identical to D5 (commit `67ad805f`) for both files — confirmed via `git diff 67ad805f -- <files>` returning empty.

## Index transition

With this PR in production:

- The `flowsheet_album_link_lookup_idx` partial index (migration 0081, `WHERE album_id IS NOT NULL`) becomes the active path again.
- The `flowsheet_artwork_lookup_idx` partial index (migration 0057, `WHERE artwork_url IS NOT NULL`) goes idle, awaiting D4's `DROP COLUMN` cascade.

## Unblocks

- #900 (D4 — `DROP COLUMN flowsheet.artwork_url`). After this PR deploys, the next migration can drop the column and cascade the OLD index without any read-path regression.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — 445 pre-existing warnings, 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run test:unit -- tests/unit/services/playlist-proxy.service.test.ts` — 26/26 pass
- [x] Full `npm run test:unit` — 2213/2214 pass; the one failure (`tests/unit/scripts/ci-env-surface-parity.test.ts` complaining about `DEFAULT_ORG_SLUG`) is pre-existing on `origin/main` and unrelated to this revert
- [ ] After Auto Build & Deploy: confirm `[playlist-proxy] Enriched N playcuts with artwork` log count holds at pre-revert levels (parity check)

Closes #1042