### PR TITLE
fix(auth): key rate limiter on nginx X-Real-IP, not req.ip (BS#1048)

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -262,10 +262,6 @@ if (!isTestEnv) {
     standardHeaders: 'draft-7',
     legacyHeaders: false,
     message: { error: 'Too many requests, please try again later.' },
-    // Key by the nginx-set X-Real-IP rather than req.ip. req.ip honors the
-    // client-controlled X-Forwarded-For under `trust proxy = true`, which
-    // lets a caller rotate forged XFFs to defeat the limit and triggers
-    // express-rate-limit's ERR_ERL_PERMISSIVE_TRUST_PROXY validator. BS#1048.
     keyGenerator: rateLimitKeyFromRequest,
   });
 

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -12,6 +12,7 @@ import cors from 'cors';
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
+import { rateLimitKeyFromRequest } from './rate-limit-key';
 import { closeDatabaseConnection } from '@wxyc/database';
 import type { HealthCheckResponse } from '@wxyc/shared/dtos';
 import { lookupEmailByIdentifier } from './lookup-email';
@@ -22,12 +23,12 @@ const port = process.env.AUTH_PORT || '8082';
 
 const app = express();
 
-// Trust the reverse proxy (nginx / ALB) so req.ip resolves to the real
-// client IP from X-Forwarded-For. Without this, express-rate-limit warns
-// `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` and falls back to the direct socket
-// IP — which is the proxy itself, identical for every client. The /sign-in
-// rate limit (10 / 15 min) then becomes a single global bucket shared by
-// every caller. Mirrors the same line in apps/backend/app.ts.
+// Trust the reverse proxy so `req.ip` resolves from `X-Forwarded-For` for
+// non-rate-limit consumers (Sentry's request integration, request logging).
+// The Express rate limiter does NOT read `req.ip` — it uses an explicit
+// `keyGenerator` keyed on the nginx-set `X-Real-IP`, so XFF spoofing
+// cannot influence rate-limit bucketing (see ./rate-limit-key.ts and
+// BS#1048). Mirrors the same line in apps/backend/app.ts.
 app.set('trust proxy', true);
 
 // Parse JSON bodies first (needed for auth endpoints)
@@ -261,6 +262,11 @@ if (!isTestEnv) {
     standardHeaders: 'draft-7',
     legacyHeaders: false,
     message: { error: 'Too many requests, please try again later.' },
+    // Key by the nginx-set X-Real-IP rather than req.ip. req.ip honors the
+    // client-controlled X-Forwarded-For under `trust proxy = true`, which
+    // lets a caller rotate forged XFFs to defeat the limit and triggers
+    // express-rate-limit's ERR_ERL_PERMISSIVE_TRUST_PROXY validator. BS#1048.
+    keyGenerator: rateLimitKeyFromRequest,
   });
 
   const rateLimitedPaths = [

--- a/apps/auth/rate-limit-key.ts
+++ b/apps/auth/rate-limit-key.ts
@@ -1,16 +1,9 @@
 import type { Request } from 'express';
 
-// Derive an express-rate-limit bucket key from the nginx-terminated
-// `X-Real-IP` header. nginx is the only trusted source of client IP on
-// `/auth/*` (BS#774); `X-Forwarded-For` is client-controlled and must not
-// influence rate-limit keying. Mirrors better-auth's `ipAddressHeaders:
-// ['x-real-ip']` config in shared/authentication/src/auth.definition.ts so
-// the Express limiter and better-auth's internal limiter share one IP source.
-//
-// Reading from headers directly (instead of `req.ip`) also sidesteps
-// express-rate-limit's `ERR_ERL_PERMISSIVE_TRUST_PROXY` validator, which
-// fires when `app.set('trust proxy', true)` is combined with a default
-// keyGenerator. See BS#1048.
+// Key on the nginx-set `X-Real-IP` (the same header better-auth's getIp
+// consumes via `ipAddressHeaders: ['x-real-ip']` in
+// shared/authentication/src/auth.definition.ts). XFF is client-controlled
+// and must not influence rate-limit bucketing — see BS#774, BS#1048.
 export const rateLimitKeyFromRequest = (req: Pick<Request, 'headers' | 'socket'>): string => {
   const raw = req.headers['x-real-ip'];
   const realIp = Array.isArray(raw) ? raw[0] : raw;

--- a/apps/auth/rate-limit-key.ts
+++ b/apps/auth/rate-limit-key.ts
@@ -1,0 +1,19 @@
+import type { Request } from 'express';
+
+// Derive an express-rate-limit bucket key from the nginx-terminated
+// `X-Real-IP` header. nginx is the only trusted source of client IP on
+// `/auth/*` (BS#774); `X-Forwarded-For` is client-controlled and must not
+// influence rate-limit keying. Mirrors better-auth's `ipAddressHeaders:
+// ['x-real-ip']` config in shared/authentication/src/auth.definition.ts so
+// the Express limiter and better-auth's internal limiter share one IP source.
+//
+// Reading from headers directly (instead of `req.ip`) also sidesteps
+// express-rate-limit's `ERR_ERL_PERMISSIVE_TRUST_PROXY` validator, which
+// fires when `app.set('trust proxy', true)` is combined with a default
+// keyGenerator. See BS#1048.
+export const rateLimitKeyFromRequest = (req: Pick<Request, 'headers' | 'socket'>): string => {
+  const raw = req.headers['x-real-ip'];
+  const realIp = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof realIp === 'string' && realIp.length > 0) return realIp;
+  return req.socket.remoteAddress ?? 'unknown';
+};

--- a/tests/unit/auth/rate-limit-key.test.ts
+++ b/tests/unit/auth/rate-limit-key.test.ts
@@ -10,16 +10,7 @@ const makeReq = (overrides: {
   }) as Parameters<typeof rateLimitKeyFromRequest>[0];
 
 describe('rateLimitKeyFromRequest', () => {
-  it('prefers X-Real-IP when nginx sets it (the production path)', () => {
-    const key = rateLimitKeyFromRequest(
-      makeReq({ headers: { 'x-real-ip': '203.0.113.7' }, remoteAddress: '10.0.0.1' })
-    );
-    expect(key).toBe('203.0.113.7');
-  });
-
   it('ignores client-supplied X-Forwarded-For — only X-Real-IP is trusted', () => {
-    // The whole point of this helper: a forged XFF must NOT pick the bucket.
-    // nginx is the only trusted source; XFF is client-controlled.
     const key = rateLimitKeyFromRequest(
       makeReq({
         headers: { 'x-forwarded-for': '1.2.3.4', 'x-real-ip': '203.0.113.7' },

--- a/tests/unit/auth/rate-limit-key.test.ts
+++ b/tests/unit/auth/rate-limit-key.test.ts
@@ -1,0 +1,48 @@
+import { rateLimitKeyFromRequest } from '../../../apps/auth/rate-limit-key';
+
+const makeReq = (overrides: {
+  headers?: Record<string, string | string[] | undefined>;
+  remoteAddress?: string | undefined;
+}) =>
+  ({
+    headers: overrides.headers ?? {},
+    socket: { remoteAddress: overrides.remoteAddress },
+  }) as Parameters<typeof rateLimitKeyFromRequest>[0];
+
+describe('rateLimitKeyFromRequest', () => {
+  it('prefers X-Real-IP when nginx sets it (the production path)', () => {
+    const key = rateLimitKeyFromRequest(
+      makeReq({ headers: { 'x-real-ip': '203.0.113.7' }, remoteAddress: '10.0.0.1' })
+    );
+    expect(key).toBe('203.0.113.7');
+  });
+
+  it('ignores client-supplied X-Forwarded-For — only X-Real-IP is trusted', () => {
+    // The whole point of this helper: a forged XFF must NOT pick the bucket.
+    // nginx is the only trusted source; XFF is client-controlled.
+    const key = rateLimitKeyFromRequest(
+      makeReq({
+        headers: { 'x-forwarded-for': '1.2.3.4', 'x-real-ip': '203.0.113.7' },
+        remoteAddress: '10.0.0.1',
+      })
+    );
+    expect(key).toBe('203.0.113.7');
+  });
+
+  it('falls back to the socket address when X-Real-IP is missing', () => {
+    const key = rateLimitKeyFromRequest(makeReq({ headers: {}, remoteAddress: '10.0.0.1' }));
+    expect(key).toBe('10.0.0.1');
+  });
+
+  it('returns "unknown" when neither X-Real-IP nor a socket address is available', () => {
+    const key = rateLimitKeyFromRequest(makeReq({ headers: {}, remoteAddress: undefined }));
+    expect(key).toBe('unknown');
+  });
+
+  it('uses the first value when X-Real-IP is an array (Node header-parsing edge case)', () => {
+    const key = rateLimitKeyFromRequest(
+      makeReq({ headers: { 'x-real-ip': ['203.0.113.7', '203.0.113.8'] }, remoteAddress: '10.0.0.1' })
+    );
+    expect(key).toBe('203.0.113.7');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `apps/auth/rate-limit-key.ts` with a small `rateLimitKeyFromRequest` helper that reads `X-Real-IP` (nginx-terminated), falling back to `socket.remoteAddress` then `'unknown'`.
- Wires the helper into the existing `authMutationRateLimit` via `keyGenerator`, so the limiter stops consulting `req.ip` (and the client-controlled `X-Forwarded-For` it resolves from under `trust proxy = true`).
- Tightens the `trust proxy` comment to reflect that it's now kept for non-rate-limit consumers only (Sentry, request log).

## Why

Two settings in combination let an attacker pick their own rate-limit bucket on `/auth/sign-in`, `/auth/sign-up`, `/auth/email-otp/send-verification-otp`, `/auth/forget-password`, and `/auth/wxyc/lookup-email`:

1. `app.set('trust proxy', true)` (added in #763)
2. No `keyGenerator` → falls back to `req.ip` → reads XFF

express-rate-limit's validator detects this and throws `ERR_ERL_PERMISSIVE_TRUST_PROXY` on the first protected request. Surfaced in the post-deploy log inspection on Backend-Service 2026-05-23.

`trust proxy = false` reintroduces the #763 single-global-bucket collapse, so the fix is to stop deriving the rate-limit key from `req.ip` at all and key on `X-Real-IP` directly — the same nginx-authoritative source better-auth's internal limiter consumes via `ipAddressHeaders: ['x-real-ip']` (#774). One source of client identity, no client-controlled inputs.

## Test plan

- [x] Unit: `rateLimitKeyFromRequest` covers X-Real-IP present, XFF spoof attempt ignored, socket fallback, missing-everything sentinel, header-array edge case (5 cases, all pass)
- [x] Existing `tests/unit/auth/rate-limiting.test.ts` source-grep assertions still hold (no removed configuration)
- [x] `npm run typecheck` clean across workspaces
- [x] `npm run lint` no new warnings introduced
- [x] `npm run format:check` clean
- [ ] After deploy: tail `docker logs auth` for `/auth/sign-in` traffic — no `ERR_ERL_PERMISSIVE_TRUST_PROXY` lines

Closes #1048