### PR TITLE
chore: remove dead registrationRateLimit

### DIFF
--- a/apps/backend/middleware/rateLimiting.ts
+++ b/apps/backend/middleware/rateLimiting.ts
@@ -6,8 +6,6 @@ const isTestEnv = process.env.NODE_ENV === 'test' || process.env.USE_MOCK_SERVIC
 const enableRateLimitInTest = process.env.TEST_RATE_LIMITING === 'true';
 
 // Configurable limits via environment variables (useful for testing)
-const REGISTRATION_WINDOW_MS = parseInt(process.env.RATE_LIMIT_REGISTRATION_WINDOW_MS || '3600000', 10); // 1 hour default
-const REGISTRATION_MAX = parseInt(process.env.RATE_LIMIT_REGISTRATION_MAX || '5', 10);
 const REQUEST_WINDOW_MS = parseInt(process.env.RATE_LIMIT_REQUEST_WINDOW_MS || '900000', 10); // 15 min default
 const REQUEST_MAX = parseInt(process.env.RATE_LIMIT_REQUEST_MAX || '10', 10);
 
@@ -15,7 +13,6 @@ const PROXY_WINDOW_MS = parseInt(process.env.RATE_LIMIT_PROXY_WINDOW_MS || '6000
 const PROXY_MAX = parseInt(process.env.RATE_LIMIT_PROXY_MAX || '120', 10);
 
 // Shared stores so we can reset them in tests
-const registrationStore = new MemoryStore();
 const songRequestStore = new MemoryStore();
 const proxyStore = new MemoryStore();
 
@@ -25,7 +22,6 @@ const proxyStore = new MemoryStore();
  */
 export const resetRateLimitStores = (): void => {
   if (isTestEnv) {
-    void registrationStore.resetAll();
     void songRequestStore.resetAll();
     void proxyStore.resetAll();
   }
@@ -36,32 +32,6 @@ const passThrough = (_req: Request, _res: Response, next: NextFunction) => next(
 
 // Determine if rate limiting should be active
 const shouldEnableRateLimiting = !isTestEnv || enableRateLimitInTest;
-
-/**
- * Rate limiter for device registration endpoint.
- * Limits registrations per IP address.
- *
- * Configurable via environment:
- * - RATE_LIMIT_REGISTRATION_WINDOW_MS (default: 3600000 = 1 hour)
- * - RATE_LIMIT_REGISTRATION_MAX (default: 5)
- *
- * Disabled in test environment unless TEST_RATE_LIMITING=true
- */
-export const registrationRateLimit = shouldEnableRateLimiting
-  ? rateLimit({
-      windowMs: REGISTRATION_WINDOW_MS,
-      max: REGISTRATION_MAX,
-      standardHeaders: true,
-      legacyHeaders: false,
-      store: registrationStore,
-      handler: (_req: Request, res: Response) => {
-        res.status(429).json({
-          message: 'Too many registration attempts. Please try again later.',
-          retryAfter: Math.ceil(REGISTRATION_WINDOW_MS / 1000),
-        });
-      },
-    })
-  : passThrough;
 
 /**
  * Rate limiter for song request endpoint.

--- a/apps/backend/routes/requestLine.route.ts
+++ b/apps/backend/routes/requestLine.route.ts
@@ -6,7 +6,6 @@ import { trackActivity } from '../middleware/trackActivity.js';
 
 export const request_line_route = Router();
 
-// Device registration - get token for anonymous requests
 request_line_route.post('/register', requestLineController.registerDevice);
 
 // Request Line - song requests from listeners (requires JWT auth)

--- a/apps/backend/routes/requestLine.route.ts
+++ b/apps/backend/routes/requestLine.route.ts
@@ -1,14 +1,13 @@
 import { requirePermissions } from '@wxyc/authentication';
 import { Router } from 'express';
 import * as requestLineController from '../controllers/requestLine.controller.js';
-import { registrationRateLimit, songRequestRateLimit } from '../middleware/rateLimiting.js';
+import { songRequestRateLimit } from '../middleware/rateLimiting.js';
 import { trackActivity } from '../middleware/trackActivity.js';
 
 export const request_line_route = Router();
 
 // Device registration - get token for anonymous requests
-// Rate limited by IP address
-request_line_route.post('/register', registrationRateLimit, requestLineController.registerDevice);
+request_line_route.post('/register', requestLineController.registerDevice);
 
 // Request Line - song requests from listeners (requires JWT auth)
 // Rate limited by device ID after authentication

--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -219,8 +219,6 @@ services:
       # Use ci:env:full and ci:test:full npm scripts to run with rate limiting enabled
       - TEST_RATE_LIMITING=${TEST_RATE_LIMITING:-false}
       # Rate limit config (only applies when TEST_RATE_LIMITING=true):
-      - RATE_LIMIT_REGISTRATION_WINDOW_MS=2000
-      - RATE_LIMIT_REGISTRATION_MAX=5
       - RATE_LIMIT_REQUEST_WINDOW_MS=2000
       - RATE_LIMIT_REQUEST_MAX=20
       # Catalog Track Search: activate both fallbacks for integration tests.

--- a/tests/integration/rateLimiting.spec.js
+++ b/tests/integration/rateLimiting.spec.js
@@ -7,16 +7,12 @@
  *
  * Environment variables for testing:
  *   TEST_RATE_LIMITING=true
- *   RATE_LIMIT_REGISTRATION_WINDOW_MS=2000   (2 seconds)
- *   RATE_LIMIT_REGISTRATION_MAX=3
  *   RATE_LIMIT_REQUEST_WINDOW_MS=2000        (2 seconds)
  *   RATE_LIMIT_REQUEST_MAX=3
  *
  * Run with:
  *   TEST_RATE_LIMITING=true \
- *   RATE_LIMIT_REGISTRATION_MAX=3 \
  *   RATE_LIMIT_REQUEST_MAX=3 \
- *   RATE_LIMIT_REGISTRATION_WINDOW_MS=2000 \
  *   RATE_LIMIT_REQUEST_WINDOW_MS=2000 \
  *   npm test -- --testPathPattern=rateLimiting
  */
@@ -42,34 +38,8 @@ const waitForWindowReset = (windowMs = 2000) => {
 
 describeOrSkip('Rate Limiting', () => {
   // Get configured limits from environment (with defaults matching test recommendations)
-  const REGISTRATION_MAX = parseInt(process.env.RATE_LIMIT_REGISTRATION_MAX || '3', 10);
   const REQUEST_MAX = parseInt(process.env.RATE_LIMIT_REQUEST_MAX || '3', 10);
   const WINDOW_MS = parseInt(process.env.RATE_LIMIT_REQUEST_WINDOW_MS || '2000', 10);
-
-  describe('Registration Rate Limiting (Legacy Endpoint)', () => {
-    it('should rate limit the legacy registration endpoint by IP', async () => {
-      // Wait for any previous window to reset
-      await waitForWindowReset(WINDOW_MS);
-
-      // Make requests up to the limit
-      const responses = [];
-      for (let i = 0; i < REGISTRATION_MAX; i++) {
-        const response = await request.post('/request/register').send({});
-        responses.push(response);
-      }
-
-      // All requests within limit should return 301 (deprecated redirect)
-      responses.forEach((response) => {
-        expect(response.status).toBe(301);
-      });
-
-      // Next request should be rate limited
-      const limitedResponse = await request.post('/request/register').send({});
-
-      expect(limitedResponse.status).toBe(429);
-      expect(limitedResponse.body.message).toMatch(/too many/i);
-    });
-  });
 
   describe('Song Request Rate Limiting', () => {
     it('should allow requests up to the limit per user', async () => {

--- a/tests/unit/scripts/ci-env-surface-parity.test.ts
+++ b/tests/unit/scripts/ci-env-surface-parity.test.ts
@@ -75,8 +75,6 @@ const EXPECTED_ONLY_IN_COMPOSE = [
   // Why: rate-limit gating. Compose exposes `TEST_RATE_LIMITING` so the
   // `ci:env:full` script can flip the cap on and exercise the rate-limit
   // middleware; the workflow doesn't run that variant.
-  'RATE_LIMIT_REGISTRATION_MAX',
-  'RATE_LIMIT_REGISTRATION_WINDOW_MS',
   'RATE_LIMIT_REQUEST_MAX',
   'RATE_LIMIT_REQUEST_WINDOW_MS',
   'SIMULATE_SLACK_FAILURE',


### PR DESCRIPTION
## Summary

- Deletes `registrationRateLimit` and its supporting state. It guards `POST /request/register`, which always returns 410 Gone with a deprecation pointer — so the limiter protects a no-op handler.
- Same XFF-spoof shape as BS#1048 fixed in the auth service (no `keyGenerator`, `req.ip` resolves from client-controlled `X-Forwarded-For` after BS#763's `trust proxy=true`), but no practical exposure because the underlying route is dead. Removing rather than re-keying.
- `songRequestRateLimit` and `proxyRateLimit` are untouched — they key on `req.auth.id` (JWT-derived) and have explicit `validate.xForwardedForHeader: false` opt-outs.

## Surfaces removed

- `apps/backend/middleware/rateLimiting.ts` — `registrationRateLimit` export, `REGISTRATION_WINDOW_MS` / `REGISTRATION_MAX`, `registrationStore`, doc-comment, the `resetAllStores` branch
- `apps/backend/routes/requestLine.route.ts` — import + middleware use on `POST /request/register`
- `dev_env/docker-compose.yml` — `RATE_LIMIT_REGISTRATION_WINDOW_MS` / `RATE_LIMIT_REGISTRATION_MAX`
- `tests/unit/scripts/ci-env-surface-parity.test.ts` — both names from `EXPECTED_ONLY_IN_COMPOSE`
- `tests/integration/rateLimiting.spec.js` — the `Registration Rate Limiting (Legacy Endpoint)` describe block (was asserting against the removed limiter)

`docs/env-vars.md` has no entry for these — nothing to remove there.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — 0 errors (449 pre-existing warnings unchanged)
- [x] `npm run format:check` — green
- [x] `npm run test:unit` — only failures are two pre-existing, unrelated tests (`ci-env-surface-parity` workflow-only allowlist drift on `DEFAULT_ORG_SLUG`; `schema.flowsheet-artwork-lookup-idx`). Both reproduce on clean `origin/main` (`8e91252b`). The compose-only parity test (the one this PR could plausibly break) passes.
- [x] Diff is delete-only (modulo one import-list shrink): `5 files changed, 2 insertions(+), 67 deletions(-)`

Closes #1050

## Related

- #1048 / PR #1049 — same vulnerability shape in `apps/auth/app.ts`, fixed there with a custom `keyGenerator` because the underlying routes are live. This ticket diverges with delete-don't-fix because the underlying route is dead.
- #763 — added `trust proxy = true` that exposed both limiters