### PR TITLE
fix(album-level-backfill): resolveAlbums uses l.album_title not l.title (BS#1065)

### DIFF
--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -170,10 +170,16 @@ export interface ResolvedAlbum {
 }
 
 /** Resolve a chunk of album_ids to LML lookup keys. `library.album_title`
- * and `library.artist_name` are both NOT NULL per `shared/database/src/
- * schema.ts`; the `artists` LEFT JOIN is preferred when present (canonical
- * normalized form via the tubafrenzy ETL) and we COALESCE down to
- * `library.artist_name` for the legacy / V/A rows the join can miss.
+ * is NOT NULL per `shared/database/src/schema.ts:324`; `library.artist_name`
+ * is *nullable* (line 346, "Denormalized from artists.artist_name (Epic
+ * A.1). Nullable until A.2 backfill / A.3 live-cascade has run") with an
+ * explicit "code paths reading `artist_name` must tolerate NULL" warning
+ * on line 290. The `artists` LEFT JOIN is preferred when present (canonical
+ * normalized form via the tubafrenzy ETL); we COALESCE down to
+ * `library.artist_name`, and the `COALESCE(...) IS NOT NULL` predicate
+ * drops the legacy-and-unbackfilled rows where both sides are NULL —
+ * without it, `String(null)` would become the literal `"null"` and we'd
+ * POST it to LML as the artist name.
  *
  * Same statement-timeout wrapper as `enumeratePendingAlbumIds` — the
  * `library` table is PK-lookup-shaped via `= ANY($1)` but the `artists`
@@ -194,6 +200,7 @@ export const resolveAlbums = async (
       FROM "wxyc_schema"."library" l
       LEFT JOIN "wxyc_schema"."artists" a ON l."artist_id" = a."id"
       WHERE l."id" = ANY(${albumIds}::int[])
+        AND COALESCE(a."artist_name", l."artist_name") IS NOT NULL
     `)) as unknown as Array<{ album_id: number; artist_name: string; album_title: string }>;
     return rows.map((r) => ({
       album_id: Number(r.album_id),

--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -169,14 +169,16 @@ export interface ResolvedAlbum {
   album_title: string;
 }
 
-/** Resolve a chunk of album_ids to LML lookup keys. COALESCE preserves
- * V/A and legacy rows where the `artists` join misses; rows whose final
- * artist_name or album_title is null are dropped (the post-pass UPDATE
- * will leave their flowsheet rows pending; the per-row drain cron will
- * re-attempt). Same statement-timeout wrapper as `enumeratePendingAlbumIds`
- * — the `library` table is PK-lookup-shaped via `= ANY($1)` but the
- * `artists` LEFT JOIN can be slow if the artist row count grows; the
- * timeout caps the worst case. */
+/** Resolve a chunk of album_ids to LML lookup keys. `library.album_title`
+ * and `library.artist_name` are both NOT NULL per `shared/database/src/
+ * schema.ts`; the `artists` LEFT JOIN is preferred when present (canonical
+ * normalized form via the tubafrenzy ETL) and we COALESCE down to
+ * `library.artist_name` for the legacy / V/A rows the join can miss.
+ *
+ * Same statement-timeout wrapper as `enumeratePendingAlbumIds` — the
+ * `library` table is PK-lookup-shaped via `= ANY($1)` but the `artists`
+ * LEFT JOIN can be slow if the artist row count grows; the timeout caps
+ * the worst case. */
 export const resolveAlbums = async (
   albumIds: number[],
   timeoutMs: number = READ_TIMEOUT_DEFAULT
@@ -188,12 +190,10 @@ export const resolveAlbums = async (
       SELECT
         l."id" AS album_id,
         COALESCE(a."artist_name", l."artist_name") AS artist_name,
-        l."title" AS album_title
+        l."album_title" AS album_title
       FROM "wxyc_schema"."library" l
       LEFT JOIN "wxyc_schema"."artists" a ON l."artist_id" = a."id"
       WHERE l."id" = ANY(${albumIds}::int[])
-        AND COALESCE(a."artist_name", l."artist_name") IS NOT NULL
-        AND l."title" IS NOT NULL
     `)) as unknown as Array<{ album_id: number; artist_name: string; album_title: string }>;
     return rows.map((r) => ({
       album_id: Number(r.album_id),

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -201,7 +201,7 @@ describe('resolveAlbums', () => {
     expect(db.transaction as jest.Mock).not.toHaveBeenCalled();
   });
 
-  it('joins library + artists with COALESCE on artist_name and filters out null title', async () => {
+  it('joins library + artists with COALESCE on artist_name; selects album_title from library', async () => {
     (db.execute as jest.Mock).mockResolvedValue([{ album_id: 1, artist_name: 'Juana Molina', album_title: 'DOGA' }]);
 
     await resolveAlbums([1]);
@@ -211,7 +211,11 @@ describe('resolveAlbums', () => {
     const text = renderSql(call?.[0]);
     expect(text).toMatch(/LEFT\s+JOIN\s+"?wxyc_schema"?\."?artists"?/i);
     expect(text).toMatch(/COALESCE\s*\(\s*a\."?artist_name"?\s*,\s*l\."?artist_name"?\s*\)/i);
-    expect(text).toMatch(/l\."?title"?\s+IS\s+NOT\s+NULL/i);
+    // BS#1065 regression pin: `library.album_title` is the canonical column,
+    // not `library.title`. The 2026-05-24 prod canary failed with
+    // `column l.title does not exist` because the original SQL used `l.title`.
+    expect(text).toMatch(/l\."?album_title"?\s+AS\s+album_title/i);
+    expect(text).not.toMatch(/l\."?title"?(?!_)/i); // l."title" not l."title_…"
     expect(text).toMatch(/=\s*ANY\(/i);
   });
 

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -217,6 +217,10 @@ describe('resolveAlbums', () => {
     expect(text).toMatch(/l\."?album_title"?\s+AS\s+album_title/i);
     expect(text).not.toMatch(/l\."?title"?(?!_)/i); // l."title" not l."title_…"
     expect(text).toMatch(/=\s*ANY\(/i);
+    // `library.artist_name` is nullable (schema.ts:346, Epic A.1 backfill
+    // not yet complete); without this filter, `String(null)` would produce
+    // the literal `"null"` and we'd POST it to LML as the artist.
+    expect(text).toMatch(/COALESCE\s*\(\s*a\."?artist_name"?\s*,\s*l\."?artist_name"?\s*\)\s+IS\s+NOT\s+NULL/i);
   });
 
   it('wraps the SELECT in a transaction + SET LOCAL statement_timeout (BS#1041 dry-run regression)', async () => {


### PR DESCRIPTION
## Summary

Today's 1-batch prod canary of \`album-level-backfill:v0.1.1\` failed at the first batch's \`resolveAlbums\` call:

\`\`\`
PostgresError: column l.title does not exist
\`\`\`

The canonical column on \`wxyc_schema.library\` is \`album_title\` (per [\`shared/database/src/schema.ts\` line 322](https://github.com/WXYC/Backend-Service/blob/main/shared/database/src/schema.ts)). The query used \`l.\"title\"\`, which doesn't exist.

Closes #1065.

## Changes

- \`resolveAlbums\` SELECT now reads \`l.\"album_title\"\` (was \`l.\"title\"\`).
- Dropped the redundant \`AND COALESCE(...) IS NOT NULL\` and \`AND l.\"title\" IS NOT NULL\` predicates — both source columns (\`library.album_title\` and \`library.artist_name\`) are \`.notNull()\` per schema; the \`COALESCE\` handles the LEFT JOIN's nullable \`a.artist_name\` side, falling through to the notNull \`l.artist_name\`.
- Tightened the unit test: now asserts \`l.\"album_title\" AS album_title\` and anti-asserts bare \`l.\"title\"\` to pin the regression.

## Why the test missed it

The existing test asserted \`/l\\.\"?title\"?\\s+IS\\s+NOT\\s+NULL/i\` — a generic \`l.title\` pattern that matches \`l.title\` literally without checking it's a real column. The database mock returns arbitrary rows so there's no schema validation at unit-test time. The dry-run path doesn't exercise \`resolveAlbums\` (only enumerate runs in \`--dry-run\` mode), so the bug surfaced only on the first real-data batch.

Verified the corrected SQL against prod psql before pushing:

\`\`\`sql
SELECT l.id, COALESCE(a.artist_name, l.artist_name) AS artist_name, l.album_title
FROM wxyc_schema.library l
LEFT JOIN wxyc_schema.artists a ON l.artist_id = a.id
WHERE l.id IN (3, 4, 5);
 id |     artist_name      |         album_title          
----+----------------------+------------------------------
  3 | A Guy Called Gerald  | Humanity 12\"
  4 | A Tribe Called Quest | Left My Wallet in El Segundo
  5 | A Tribe Called Quest | People's Instinctive Travels
\`\`\`

## Follow-up captured (not in this PR)

\`--dry-run\` should exercise \`resolveAlbums\` on a small sample (e.g., the first batch's worth of album_ids) so future schema-shape bugs surface at dry-run time, not first-batch time. Would have caught this in the no-cost dry-run.

## Test plan

- [x] \`npm run test:unit -- --testPathPatterns='album-level-backfill'\` — 51/51 pass
- [x] \`npx tsc --noEmit -p jobs/album-level-backfill/tsconfig.json\` — clean
- [x] Verified SQL directly against prod psql (output above)

### Post-merge verification

Pull v0.1.2 to EC2 and re-run the 1-batch canary; expect a clean batch summary with match/no_match/error counts.

## Related

- [BS#1041](https://github.com/WXYC/Backend-Service/issues/1041) / [PR #1055](https://github.com/WXYC/Backend-Service/pull/1055) — original feature
- [BS#1056](https://github.com/WXYC/Backend-Service/issues/1056) / [PR #1057](https://github.com/WXYC/Backend-Service/pull/1057) — earlier set of dry-run bug-fixes (statement timeout + Dockerfile ENTRYPOINT)
- [BS#1064](https://github.com/WXYC/Backend-Service/issues/1064) — separate diagnostic for the cron's 21% LML timeout rate