### PR TITLE
docs(album-level-backfill): drop "restart cron" guidance until BS#1064 resolves

### DIFF
--- a/jobs/album-level-backfill/README.md
+++ b/jobs/album-level-backfill/README.md
@@ -59,8 +59,13 @@ psql "$DATABASE_URL" -c "
   WHERE entry_type='track' AND metadata_status='pending' AND album_id IS NOT NULL;
 "
 
-# 7. Restart the per-row drain cron to handle the album_id IS NULL residual
-docker start flowsheet-metadata-backfill-cron
+# 7. Do NOT restart the per-row drain cron yet. The 2026-05-24 firing
+#    showed a 21% LML timeout rate (~2,200 of 10,500 rows). Investigation
+#    in BS#1064 must finish before resuming the cron — otherwise it will
+#    burn LML quota at a steady error rate for no net progress. The 744k
+#    `album_id IS NULL` residual stays pending until then.
+#
+# docker start flowsheet-metadata-backfill-cron
 ```
 
 ## Env knobs


### PR DESCRIPTION
## Summary

- README's step 7 currently tells operators to `docker start flowsheet-metadata-backfill-cron` after the album-level run completes.
- The 2026-05-24 cron firing showed a 21% LML timeout rate (`2,220 of 10,500` rows; verified post-SIGTERM). Restarting the cron resumes that error rate against LML for no net forward progress until BS#1064's triage finishes.
- Comment out the `docker start` and inline the rationale + cross-link to BS#1064 so the next operator doesn't undo BS#1064's intent by following the README literally.

## Why now

Surfaced during the album-level-backfill operational plan (Q5 in `/tmp/album-bulk-drain-plan.md`, plan-reviewer-approved). One-line behavioral risk hidden in a doc; cheaper to ship the fix in parallel with the canary run than to wait.

## What this doesn't change

- The 744k `album_id IS NULL` residual stays pending until BS#1064 resolves and the cron is restarted.
- The job itself, its env knobs, the run procedure for the album-level drain — all unchanged.
- No code changes; README only.

## Test plan

- [x] `npx prettier --check jobs/album-level-backfill/README.md` clean
- [x] Diff is 1 file, +7/-2 lines
- [ ] After merge: operator running step 7 sees the gate and stops

Refs:
- BS#1064 (cron timeout-rate investigation)
- BS#1041 (this job's parent, merged in #1055)
- BS#1011 (historical drain completion, blocked on BS#1064)