### PR TITLE
fix(album-level-backfill): revert ::int[] drop; restore PG-array-literal binding (BS#1071)

### DIFF
--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -190,14 +190,24 @@ export const resolveAlbums = async (
   timeoutMs: number = READ_TIMEOUT_DEFAULT
 ): Promise<ResolvedAlbum[]> => {
   if (albumIds.length === 0) return [];
+  // Bind as a single PG-array-literal string param (`'{1,2,3}'::int[]`).
+  // Verified against prod psql via PREPARE q(text) AS ... ANY($1::int[]).
+  //
+  // Drizzle/postgres-js splats a JS array into N positional placeholders
+  // here — both `ANY(${array}::int[])` and the bare `ANY(${array})` send
+  // `ANY(($1, $2, …, $50))` over the wire, which PG rejects with
+  // `cannot cast type record to integer[]` (cast form, BS#1068) or
+  // `op ANY/ALL (array) requires array on right side` (bare form,
+  // BS#1071, 2026-05-24 second prod canary). The two callsites at
+  // `shared/database/src/library-tiebreak.ts:47` and
+  // `jobs/flowsheet-etl/job.ts:102` likely have the same latent bug at
+  // arity ≥ 2 — see BS#1072 follow-up.
+  //
+  // Safe by construction: TypeScript types `albumIds: number[]`, so the
+  // join contains only numeric literals — no injection surface.
+  const idArrayLiteral = `{${albumIds.join(',')}}`;
   return await db.transaction(async (tx) => {
     await tx.execute(sql.raw(`SET LOCAL statement_timeout = '${timeoutMs}ms'`));
-    // No `::int[]` cast on `${albumIds}` — postgres-js binds JS arrays
-    // natively to PG arrays, and the explicit cast forces a text-protocol
-    // splat (`ANY(($1, $2, …, $50)::int[])`) that PG rejects with
-    // `cannot cast type record to integer[]` (BS#1068, 2026-05-24 prod
-    // canary). Matches the pattern in `library-tiebreak.ts` and
-    // `flowsheet-etl/job.ts` that have run safely in prod for months.
     const rows = (await tx.execute(sql`
       SELECT
         l."id" AS album_id,
@@ -205,7 +215,7 @@ export const resolveAlbums = async (
         l."album_title" AS album_title
       FROM "wxyc_schema"."library" l
       LEFT JOIN "wxyc_schema"."artists" a ON l."artist_id" = a."id"
-      WHERE l."id" = ANY(${albumIds})
+      WHERE l."id" = ANY(${idArrayLiteral}::int[])
         AND COALESCE(a."artist_name", l."artist_name") IS NOT NULL
     `)) as unknown as Array<{ album_id: number; artist_name: string; album_title: string }>;
     return rows.map((r) => ({

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -222,18 +222,21 @@ describe('resolveAlbums', () => {
     // the literal `"null"` and we'd POST it to LML as the artist.
     expect(text).toMatch(/COALESCE\s*\(\s*a\."?artist_name"?\s*,\s*l\."?artist_name"?\s*\)\s+IS\s+NOT\s+NULL/i);
 
-    // BS#1068 regression pin: anti-assert the `::int[]` cast that
-    // triggered the prod canary's `cannot cast type record to integer[]`.
-    // Drizzle/postgres-js binds JS arrays natively; the explicit cast
-    // forces a text-protocol splat. Matches the safe-binding pattern in
-    // `shared/database/src/library-tiebreak.ts:47` (which has its own
-    // parameterization-pin test at `tests/unit/database/library-tiebreak.test.ts:128`).
-    expect(text).not.toMatch(/::int\[\]/i);
-    // Sanity: the IDs make it into the bound params (mirrors library-tiebreak's pin).
-    const serialized = JSON.stringify(call?.[0]);
-    expect(serialized).toContain('1');
-    expect(serialized).toContain('2');
-    expect(serialized).toContain('3');
+    // BS#1068 + BS#1071 regression pin: positive-assert the
+    // `'{1,2,3}'::int[]` array-literal binding shape. Drizzle/postgres-js
+    // splats `${jsArray}` into N positional placeholders for BOTH
+    // `ANY(${array}::int[])` (BS#1068, cast collides with splat) and
+    // bare `ANY(${array})` (BS#1071, splat produces `ANY((p1, p2, ...))` —
+    // PG rejects: "op ANY/ALL (array) requires array on right side").
+    // The only shape that survives is `ANY('{1,2,3}'::int[])` — a single
+    // bound text param cast to int[] inside PG.
+    const values = (call?.[0] as { values?: unknown[] } | undefined)?.values ?? [];
+    expect(values).toContain('{1,2,3}');
+    // Anti-assert the broken shapes: no individual numeric param values
+    // from a splat (the BS#1068/BS#1071 symptom).
+    expect(values).not.toContain(1);
+    expect(values).not.toContain(2);
+    expect(values).not.toContain(3);
   });
 
   it('wraps the SELECT in a transaction + SET LOCAL statement_timeout (BS#1041 dry-run regression)', async () => {


### PR DESCRIPTION
## Summary

The 2026-05-24 v0.1.3 prod canary (post-[PR #1069](https://github.com/WXYC/Backend-Service/pull/1069)) failed at first batch:

\`\`\`
PostgresError: op ANY/ALL (array) requires array on right side
  position: 273
  WHERE l.\"id\" = ANY((\$1, \$2, ..., \$50))
  params: 3, 4, 5, ..., 115
\`\`\`

The \`/simplify\` reviewer's hypothesis on PR #1069 (\"Drizzle/postgres-js binds JS number arrays natively as PG arrays — the cast was the only problem\") was wrong. **Drizzle's sql tag splats primitive arrays into N positional placeholders regardless of whether the explicit \`::int[]\` cast is present.** Both shapes fail in prod:

| Shape | Symptom | Issue |
|---|---|---|
| \`ANY(\${array}::int[])\` | \`cannot cast type record to integer[]\` | BS#1068 |
| \`ANY(\${array})\` | \`op ANY/ALL (array) requires array on right side\` | BS#1071 (this) |

Closes #1071.

## Fix

Restore the manual PG-array-literal pattern from PR #1069 v1, which **I had verified against prod psql** with \`PREPARE q(text) AS … ANY(\$1::int[])\` before the simplify pass talked me out of it.

\`\`\`ts
const idArrayLiteral = \`{\${albumIds.join(',')}}\`;
... WHERE l.\"id\" = ANY(\${idArrayLiteral}::int[]) ...
\`\`\`

postgres-js sends the literal as one bound text param; PG natively casts text to \`int[]\`. TypeScript-typed \`number[]\` input ensures no injection.

## Latent sibling bug

The two \"prior art\" callsites \`/simplify\` cited:

- \`shared/database/src/library-tiebreak.ts:47\` — has an explicit \`if (libraryIds.length === 1) return libraryIds[0]\` short-circuit, so it would crash at arity ≥ 2.
- \`jobs/flowsheet-etl/job.ts:102\` — \`legacyEntryIds\` may typically arrive 1 element at a time.

Filed as [BS#1072](https://github.com/WXYC/Backend-Service/issues/1072) with a Sentry-check action item. Out of scope for this PR.

## Tests

- Positive-assert: the bound \`.values\` array contains \`'{1,2,3}'\` (single string param).
- Anti-assert: \`.values\` does NOT contain individual numeric splats (the BS#1068 + BS#1071 symptom).
- Existing BS#1065 \`l.\"title\"\` anti-pin retained.

## Process retro

I should have verified the simplified form against prod psql before merging PR #1069. The text-pattern assertion in \`library-tiebreak\`'s test only checks the IDs serialize into the bound payload — not that the resulting SQL works against real PG. The reviewer's \"prior art runs in prod\" claim was extrapolated from those tests, not from prod execution. Captured for retro: add a CI Docker-postgres integration test for the read queries — same theme as the prior three execution-time bugs in this job.

## Test plan

- [x] \`npm run test:unit -- --testPathPatterns='album-level-backfill'\` — 51/51 pass
- [x] \`npx tsc --noEmit -p jobs/album-level-backfill/tsconfig.json\` — clean
- [x] \`npx prettier --check\` on touched files — clean
- [x] PG-array-literal pattern verified against prod psql before merging PR #1069 v1 (re-applied here)

### Post-merge verification

Pull v0.1.4 to EC2; re-run the 1-batch canary. Expect a clean per-status summary log line this time.

## Related

- [BS#1041](https://github.com/WXYC/Backend-Service/issues/1041) / [PR #1055](https://github.com/WXYC/Backend-Service/pull/1055) — feature
- [BS#1056](https://github.com/WXYC/Backend-Service/issues/1056) / [PR #1057](https://github.com/WXYC/Backend-Service/pull/1057)
- [BS#1065](https://github.com/WXYC/Backend-Service/issues/1065) / [PR #1066](https://github.com/WXYC/Backend-Service/pull/1066)
- [BS#1068](https://github.com/WXYC/Backend-Service/issues/1068) / [PR #1069](https://github.com/WXYC/Backend-Service/pull/1069) — first binding-shape fix, incorrectly simplified
- [BS#1072](https://github.com/WXYC/Backend-Service/issues/1072) — latent sibling bug
- [BS#1064](https://github.com/WXYC/Backend-Service/issues/1064)