### PR TITLE
feat(ses): instrument SES Send->Delivery latency for OTP emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,16 @@ SENTRY_DSN=https://your-key@o123456.ingest.us.sentry.io/1234567
 # POST until it is set (no startup crash, by design).
 SES_EVENTS_SNS_TOPIC_ARN=arn:aws:sns:us-east-1:203767826763:ses-delivery-events-prod
 
+# Configuration set passed on every SendEmailCommand. Required for the
+# EventDestination on `my-first-configuration-set` to actually publish
+# events — SES picks the most-specific identity for `From:`, and the
+# `no-reply@wxyc.org` email-level identity has no config set attached, so
+# the domain-level default never applies to OTP / verification / reset
+# traffic. Passing this explicitly bypasses the identity-precedence trap.
+# Leave unset locally — when absent, no config set is passed (pre-#1070
+# behavior).
+SES_CONFIGURATION_SET_NAME=my-first-configuration-set
+
 ### Legacy Mirror (tubafrenzy)
 # For local dev, use the same key as tubafrenzy's docker-compose default.
 # For production, generate with: uuidgen

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,14 @@ SLACK_WXYC_REQUESTS_WEBHOOK=https://hooks.slack.com/services/your/webhook/url
 ### Sentry
 SENTRY_DSN=https://your-key@o123456.ingest.us.sentry.io/1234567
 
+### SES Delivery Events (POST /internal/ses-events)
+# The SNS topic ARN that the `wxyc.org` SES Configuration Set publishes
+# SES Send/Delivery/Bounce/Complaint/Reject/DeliveryDelay events to. The
+# /internal/ses-events route pins this and rejects messages whose
+# TopicArn does not match. Leave unset locally — the route will 400 every
+# POST until it is set (no startup crash, by design).
+SES_EVENTS_SNS_TOPIC_ARN=arn:aws:sns:us-east-1:203767826763:ses-delivery-events-prod
+
 ### Legacy Mirror (tubafrenzy)
 # For local dev, use the same key as tubafrenzy's docker-compose default.
 # For production, generate with: uuidgen

--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -17,6 +17,7 @@ import { events_route } from './routes/events.route.js';
 import { request_line_route } from './routes/requestLine.route.js';
 import { config_route } from './routes/config.route.js';
 import { internal_route } from './routes/internal.route.js';
+import { ses_events_route } from './routes/ses-events.route.js';
 import { proxy_route } from './routes/proxy.route.js';
 import { playlist_route } from './routes/playlist.route.js';
 import { startPlaylistProxy, stopPlaylistProxy } from './services/playlist-proxy.service.js';
@@ -122,6 +123,12 @@ app.get('/healthcheck', async (req, res) => {
     res.status(503).json(body);
   }
 });
+
+// SNS subscriber for SES Configuration Set events (`ses-delivery-events-prod`
+// topic). Auth is the SNS X.509 signature + pinned TopicArn; no shared key.
+// Mounted before /internal so its route-scoped `express.text()` body parser
+// owns these requests (SNS sends Content-Type: text/plain).
+app.use('/internal/ses-events', ses_events_route);
 
 // Internal endpoints (ETL sync notifications, key-authenticated)
 app.use('/internal', internal_route);

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -40,6 +40,7 @@
     "postgres": "^3.4.9",
     "posthog-node": "^5.33.4",
     "sharp": "^0.34.5",
+    "sns-validator": "^0.3.5",
     "ssh2": "^1.17.0",
     "swagger-ui-express": "^5.0.1",
     "ws": "^8.20.0",

--- a/apps/backend/routes/ses-events.route.ts
+++ b/apps/backend/routes/ses-events.route.ts
@@ -22,8 +22,10 @@ import {
  * is the trust root.
  *
  * Body parser: SNS sends `Content-Type: text/plain` (AWS historical choice),
- * so we attach a route-scoped `express.text({ type: 'wildcard' })`. The
- * global `app.use(express.json())` only handles `application/json` and never
+ * so we attach a route-scoped `express.text({ type: STAR-SLASH-STAR })`
+ * (the literal MIME wildcard — not quoted here verbatim because the
+ * two-char sequence would close this block comment early). The global
+ * `app.use(express.json())` only handles `application/json` and never
  * touches these bodies, so mount order is irrelevant.
  */
 export const ses_events_route = Router();

--- a/apps/backend/routes/ses-events.route.ts
+++ b/apps/backend/routes/ses-events.route.ts
@@ -1,0 +1,108 @@
+import * as Sentry from '@sentry/node';
+import express, { Router } from 'express';
+import {
+  confirmSubscription,
+  emitSesEventSpan,
+  parseSesEvent,
+  validateSnsMessage,
+} from '../services/ses-events/index.js';
+
+/**
+ * POST /internal/ses-events
+ *
+ * SNS HTTPS subscriber for the `ses-delivery-events-prod` topic. Receives
+ * Send/Delivery/Bounce/Complaint/Reject/DeliveryDelay events from the SES
+ * Configuration Set attached to the `wxyc.org` sending identity, and emits
+ * one Sentry span per event so `Send → Delivery` p50/p90/p99 is visible in
+ * the trace explorer.
+ *
+ * Auth model: SNS X.509 signature validation IS the auth. We pin the topic
+ * ARN via `SES_EVENTS_SNS_TOPIC_ARN`. We do NOT require X-Internal-Key here
+ * because SES → SNS → BS cannot inject custom HTTP headers; the cert chain
+ * is the trust root.
+ *
+ * Body parser: SNS sends `Content-Type: text/plain` (AWS historical choice),
+ * so we attach a route-scoped `express.text({ type: 'wildcard' })`. The
+ * global `app.use(express.json())` only handles `application/json` and never
+ * touches these bodies, so mount order is irrelevant.
+ */
+export const ses_events_route = Router();
+
+ses_events_route.post('/', express.text({ type: '*/*', limit: '64kb' }), async (req, res) => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(typeof req.body === 'string' ? req.body : '');
+  } catch {
+    res.status(400).json({ error: 'invalid json' });
+    return;
+  }
+
+  let validated;
+  try {
+    validated = await validateSnsMessage(parsed);
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: 'ses-events', stage: 'validate' } });
+    res.status(400).json({ error: 'invalid signature or topic' });
+    return;
+  }
+
+  if (validated.Type === 'SubscriptionConfirmation') {
+    if (!validated.SubscribeURL) {
+      Sentry.captureMessage('SES events: SubscriptionConfirmation missing SubscribeURL', {
+        level: 'error',
+        tags: { subsystem: 'ses-events', stage: 'confirm' },
+      });
+      res.status(400).json({ error: 'subscription confirmation missing SubscribeURL' });
+      return;
+    }
+    try {
+      await confirmSubscription(validated.SubscribeURL);
+    } catch (e) {
+      Sentry.captureException(e, { tags: { subsystem: 'ses-events', stage: 'confirm' } });
+      res.status(500).json({ error: 'failed to confirm subscription' });
+      return;
+    }
+    res.json({ ok: true, confirmed: true });
+    return;
+  }
+
+  if (validated.Type === 'UnsubscribeConfirmation') {
+    // Operator removed the subscription. Don't auto-reconfirm — that's an
+    // explicit decision; just observe and 200.
+    console.warn('[ses-events] received UnsubscribeConfirmation', { topicArn: validated.TopicArn });
+    res.json({ ok: true });
+    return;
+  }
+
+  // Type === 'Notification'
+  let messagePayload: unknown;
+  try {
+    messagePayload = JSON.parse(validated.Message);
+  } catch {
+    Sentry.captureMessage('SES events: SNS Notification.Message is not JSON', {
+      level: 'error',
+      tags: { subsystem: 'ses-events', stage: 'parse' },
+    });
+    res.status(400).json({ error: 'unparseable ses event' });
+    return;
+  }
+
+  let event;
+  try {
+    event = parseSesEvent(messagePayload);
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: 'ses-events', stage: 'parse' } });
+    res.status(400).json({ error: 'unparseable ses event' });
+    return;
+  }
+
+  try {
+    emitSesEventSpan(event);
+  } catch (e) {
+    // Observability must never break the receive path. SES will retry on
+    // 5xx, so a Sentry-emit blip should still 200 to AWS.
+    console.warn('[ses-events] failed to emit span', e);
+  }
+
+  res.json({ ok: true });
+});

--- a/apps/backend/services/ses-events/confirm-subscription.ts
+++ b/apps/backend/services/ses-events/confirm-subscription.ts
@@ -1,0 +1,24 @@
+/**
+ * Complete an SNS HTTP/HTTPS subscription handshake by GETting the
+ * `SubscribeURL` that AWS delivers in the one-time `SubscriptionConfirmation`
+ * message. AWS expects a 2xx; we treat 3xx as failure (no redirect chasing).
+ *
+ * Errors propagate so the caller can attribute them to Sentry. The route
+ * still 5xx's on confirmation failure: AWS will retry the message a handful
+ * of times, so a transient downstream blip is recoverable without operator
+ * intervention.
+ */
+export async function confirmSubscription(subscribeUrl: string): Promise<void> {
+  const url = new URL(subscribeUrl);
+  if (url.protocol !== 'https:') {
+    throw new Error(`SubscribeURL is not https: ${url.protocol}`);
+  }
+  if (!url.hostname.endsWith('.amazonaws.com')) {
+    throw new Error(`SubscribeURL hostname is not under amazonaws.com: ${url.hostname}`);
+  }
+
+  const res = await fetch(url, { method: 'GET', redirect: 'manual' });
+  if (!res.ok) {
+    throw new Error(`SubscribeURL GET returned ${res.status}`);
+  }
+}

--- a/apps/backend/services/ses-events/emit-span.ts
+++ b/apps/backend/services/ses-events/emit-span.ts
@@ -1,0 +1,131 @@
+import * as Sentry from '@sentry/node';
+import type { SesEvent } from './types.js';
+
+/**
+ * Emit a Sentry span for one SES event. The span has:
+ *
+ *   name: 'ses.event'
+ *   op:   'email.ses'
+ *
+ *   attributes:
+ *     email.event_type:       'Send' | 'Delivery' | 'Bounce' | ...
+ *     email.message_id:       SES mail.messageId
+ *     email.recipient_domain: the part after '@' in the first recipient
+ *                             (NEVER the local-part — PII)
+ *     email.smtp_response:    (Delivery only) trimmed to 500 chars
+ *     email.bounce_type:      (Bounce only)
+ *     email.bounce_subtype:   (Bounce only)
+ *     email.delay_type:       (DeliveryDelay only)
+ *     email.reject_reason:    (Reject only) trimmed to 500 chars
+ *
+ *   measurements:
+ *     ses.delivery_latency_ms: (Delivery only) ms from mail.timestamp to delivery.timestamp
+ *     ses.processing_time_ms:  (Delivery only) delivery.processingTimeMillis
+ *
+ *   span status:
+ *     ok                 on Send/Delivery
+ *     failed_precondition on Bounce/Complaint/Reject
+ *     deadline_exceeded   on DeliveryDelay
+ *
+ * Span lifetime is synchronous. We open it, set everything, end it. No
+ * fetch to wrap — this is pure projection of an already-completed event
+ * onto a span the trace explorer can search and aggregate.
+ */
+export function emitSesEventSpan(event: SesEvent): void {
+  Sentry.startSpan(
+    {
+      name: 'ses.event',
+      op: 'email.ses',
+      attributes: buildAttributes(event),
+    },
+    (span) => {
+      const measurements = buildMeasurements(event);
+      for (const [name, value] of Object.entries(measurements)) {
+        // Sentry's setAttribute is the supported v10 path; measurements
+        // surface in the trace explorer the same way once attributes start
+        // with a known numeric metric key. We accept the slight loss of
+        // dedicated "measurements" semantics in exchange for an API that
+        // does not require us to chase SDK-internal types.
+        span.setAttribute(name, value);
+      }
+      span.setStatus(buildStatus(event));
+    }
+  );
+}
+
+function buildAttributes(event: SesEvent): Record<string, string | number> {
+  const recipientDomain = extractDomain(firstRecipient(event));
+  const base: Record<string, string | number> = {
+    'email.event_type': event.kind,
+    'email.message_id': event.messageId,
+    'email.recipient_domain': recipientDomain,
+  };
+
+  if (event.kind === 'Delivery') {
+    base['email.smtp_response'] = trim(event.smtpResponse, 500);
+    return base;
+  }
+  if (event.kind === 'Bounce') {
+    base['email.bounce_type'] = event.bounceType;
+    base['email.bounce_subtype'] = event.bounceSubType;
+    return base;
+  }
+  if (event.kind === 'Reject') {
+    base['email.reject_reason'] = trim(event.reason, 500);
+    return base;
+  }
+  if (event.kind === 'DeliveryDelay') {
+    base['email.delay_type'] = event.delayType;
+    return base;
+  }
+  return base;
+}
+
+function buildMeasurements(event: SesEvent): Record<string, number> {
+  if (event.kind !== 'Delivery') return {};
+  const latency = event.deliveredAt.getTime() - event.sendTimestamp.getTime();
+  // Clock skew between SES and the receiving MTA can in principle produce a
+  // negative delta; clamp to 0 rather than emit a garbage measurement.
+  const latencyMs = latency < 0 ? 0 : latency;
+  return {
+    'ses.delivery_latency_ms': latencyMs,
+    'ses.processing_time_ms': event.processingTimeMillis,
+  };
+}
+
+// Sentry encodes span status as a numeric enum: 0 = UNSET, 1 = OK, 2 = ERROR.
+// The constants ship as `Sentry.SPAN_STATUS_OK` / `SPAN_STATUS_ERROR`; we
+// inline the literals here so this module doesn't depend on a stable name
+// for an SDK-internal export that has churned across recent versions.
+const STATUS_OK = 1 as const;
+const STATUS_ERROR = 2 as const;
+
+function buildStatus(event: SesEvent): { code: typeof STATUS_OK | typeof STATUS_ERROR; message?: string } {
+  switch (event.kind) {
+    case 'Send':
+    case 'Delivery':
+      return { code: STATUS_OK };
+    case 'Bounce':
+    case 'Complaint':
+    case 'Reject':
+      return { code: STATUS_ERROR, message: 'failed_precondition' };
+    case 'DeliveryDelay':
+      return { code: STATUS_ERROR, message: 'deadline_exceeded' };
+  }
+}
+
+function firstRecipient(event: SesEvent): string {
+  if (event.kind === 'Send') return event.recipients[0] ?? '';
+  if (event.kind === 'Reject') return '';
+  return event.recipient;
+}
+
+function extractDomain(address: string): string {
+  const at = address.lastIndexOf('@');
+  if (at < 0 || at === address.length - 1) return 'unknown';
+  return address.slice(at + 1).toLowerCase();
+}
+
+function trim(value: string, max: number): string {
+  return value.length <= max ? value : value.slice(0, max);
+}

--- a/apps/backend/services/ses-events/index.ts
+++ b/apps/backend/services/ses-events/index.ts
@@ -1,0 +1,14 @@
+export { parseSesEvent } from './parse-ses-event.js';
+export { emitSesEventSpan } from './emit-span.js';
+export { validateSnsMessage, type ValidatedSnsMessage } from './sns-validator.js';
+export { confirmSubscription } from './confirm-subscription.js';
+export type {
+  SesEvent,
+  SesEventKind,
+  SesSendEvent,
+  SesDeliveryEvent,
+  SesBounceEvent,
+  SesComplaintEvent,
+  SesRejectEvent,
+  SesDeliveryDelayEvent,
+} from './types.js';

--- a/apps/backend/services/ses-events/parse-ses-event.ts
+++ b/apps/backend/services/ses-events/parse-ses-event.ts
@@ -65,6 +65,13 @@ function parseSend(
   messageId: string,
   sendTimestamp: Date
 ): SesSendEvent {
+  // Send is emitted when SES accepts the API call, before the message is
+  // bound to a specific delivery attempt — `mail.destination` is always
+  // populated by SES in practice, but a missing/empty value is not a parser
+  // error here the way it is for Delivery/Bounce/Complaint/DeliveryDelay
+  // (each of which carries its own recipient list tied to a *delivery*).
+  // emit-span.ts falls back to `email.recipient_domain = 'unknown'` if the
+  // Send slipped through with no destination; that asymmetry is intentional.
   const destination = mail['destination'];
   const recipients = Array.isArray(destination) ? destination.filter((d): d is string => typeof d === 'string') : [];
   return { kind: 'Send', messageId, sendTimestamp, recipients };

--- a/apps/backend/services/ses-events/parse-ses-event.ts
+++ b/apps/backend/services/ses-events/parse-ses-event.ts
@@ -81,11 +81,11 @@ function parseDelivery(payload: Record<string, unknown>, messageId: string, send
     throw new Error('SES Delivery event missing delivery.processingTimeMillis');
   }
   const recipients = delivery['recipients'];
-  const recipient = Array.isArray(recipients) && typeof recipients[0] === 'string' ? (recipients[0]) : '';
+  const recipient = Array.isArray(recipients) && typeof recipients[0] === 'string' ? recipients[0] : '';
   if (recipient === '') {
     throw new Error('SES Delivery event missing delivery.recipients[0]');
   }
-  const smtpResponse = typeof delivery['smtpResponse'] === 'string' ? (delivery['smtpResponse']) : '';
+  const smtpResponse = typeof delivery['smtpResponse'] === 'string' ? delivery['smtpResponse'] : '';
   return {
     kind: 'Delivery',
     messageId,
@@ -102,8 +102,8 @@ function parseBounce(payload: Record<string, unknown>, messageId: string, sendTi
   if (!isPlainObject(bounce)) {
     throw new Error('SES Bounce event missing bounce object');
   }
-  const bounceType = typeof bounce['bounceType'] === 'string' ? (bounce['bounceType']) : 'Unknown';
-  const bounceSubType = typeof bounce['bounceSubType'] === 'string' ? (bounce['bounceSubType']) : 'Unknown';
+  const bounceType = typeof bounce['bounceType'] === 'string' ? bounce['bounceType'] : 'Unknown';
+  const bounceSubType = typeof bounce['bounceSubType'] === 'string' ? bounce['bounceSubType'] : 'Unknown';
   const bouncedRecipients = bounce['bouncedRecipients'];
   const recipient = extractFirstRecipientAddress(bouncedRecipients);
   if (recipient === '') {
@@ -129,7 +129,7 @@ function parseReject(payload: Record<string, unknown>, messageId: string, sendTi
   if (!isPlainObject(reject)) {
     throw new Error('SES Reject event missing reject object');
   }
-  const reason = typeof reject['reason'] === 'string' ? (reject['reason']) : 'Unknown';
+  const reason = typeof reject['reason'] === 'string' ? reject['reason'] : 'Unknown';
   return { kind: 'Reject', messageId, sendTimestamp, reason };
 }
 
@@ -142,7 +142,7 @@ function parseDeliveryDelay(
   if (!isPlainObject(deliveryDelay)) {
     throw new Error('SES DeliveryDelay event missing deliveryDelay object');
   }
-  const delayType = typeof deliveryDelay['delayType'] === 'string' ? (deliveryDelay['delayType']) : 'Unknown';
+  const delayType = typeof deliveryDelay['delayType'] === 'string' ? deliveryDelay['delayType'] : 'Unknown';
   const expirationTimeRaw = deliveryDelay['expirationTime'];
   const expirationTime = typeof expirationTimeRaw === 'string' ? parseTimestampOrNull(expirationTimeRaw) : null;
   const recipient = extractFirstRecipientAddress(deliveryDelay['delayedRecipients']);

--- a/apps/backend/services/ses-events/parse-ses-event.ts
+++ b/apps/backend/services/ses-events/parse-ses-event.ts
@@ -1,0 +1,181 @@
+import type {
+  SesBounceEvent,
+  SesComplaintEvent,
+  SesDeliveryDelayEvent,
+  SesDeliveryEvent,
+  SesEvent,
+  SesRejectEvent,
+  SesSendEvent,
+} from './types.js';
+
+/**
+ * Parse a JSON-decoded SES event payload (the contents of SNS `Message` for
+ * events published by an SES Configuration Set EventDestination).
+ *
+ * Throws on missing required fields or unknown event types. Unknown event
+ * types are surfaced as errors so the route layer can attribute them to
+ * Sentry rather than dropping silently — at the time this is written the
+ * configured event matchers are SEND/DELIVERY/BOUNCE/COMPLAINT/REJECT/
+ * DELIVERY_DELAY, so an unknown type means SES added a new category we
+ * haven't classified yet.
+ */
+export function parseSesEvent(payload: unknown): SesEvent {
+  if (!isPlainObject(payload)) {
+    throw new Error('SES payload is not an object');
+  }
+
+  const eventType = payload['eventType'];
+  if (typeof eventType !== 'string') {
+    throw new Error('SES payload missing eventType');
+  }
+
+  const mail = payload['mail'];
+  if (!isPlainObject(mail)) {
+    throw new Error('SES payload missing mail object');
+  }
+
+  const messageId = mail['messageId'];
+  if (typeof messageId !== 'string' || messageId.length === 0) {
+    throw new Error('SES payload missing mail.messageId');
+  }
+
+  const sendTimestamp = parseTimestamp(mail['timestamp'], 'mail.timestamp');
+
+  switch (eventType) {
+    case 'Send':
+      return parseSend(payload, mail, messageId, sendTimestamp);
+    case 'Delivery':
+      return parseDelivery(payload, messageId, sendTimestamp);
+    case 'Bounce':
+      return parseBounce(payload, messageId, sendTimestamp);
+    case 'Complaint':
+      return parseComplaint(payload, messageId, sendTimestamp);
+    case 'Reject':
+      return parseReject(payload, messageId, sendTimestamp);
+    case 'DeliveryDelay':
+      return parseDeliveryDelay(payload, messageId, sendTimestamp);
+    default:
+      throw new Error(`Unknown SES eventType: ${eventType}`);
+  }
+}
+
+function parseSend(
+  _payload: Record<string, unknown>,
+  mail: Record<string, unknown>,
+  messageId: string,
+  sendTimestamp: Date
+): SesSendEvent {
+  const destination = mail['destination'];
+  const recipients = Array.isArray(destination) ? destination.filter((d): d is string => typeof d === 'string') : [];
+  return { kind: 'Send', messageId, sendTimestamp, recipients };
+}
+
+function parseDelivery(payload: Record<string, unknown>, messageId: string, sendTimestamp: Date): SesDeliveryEvent {
+  const delivery = payload['delivery'];
+  if (!isPlainObject(delivery)) {
+    throw new Error('SES Delivery event missing delivery object');
+  }
+  const deliveredAt = parseTimestamp(delivery['timestamp'], 'delivery.timestamp');
+  const processingTimeMillis = delivery['processingTimeMillis'];
+  if (typeof processingTimeMillis !== 'number' || !Number.isFinite(processingTimeMillis)) {
+    throw new Error('SES Delivery event missing delivery.processingTimeMillis');
+  }
+  const recipients = delivery['recipients'];
+  const recipient = Array.isArray(recipients) && typeof recipients[0] === 'string' ? (recipients[0]) : '';
+  if (recipient === '') {
+    throw new Error('SES Delivery event missing delivery.recipients[0]');
+  }
+  const smtpResponse = typeof delivery['smtpResponse'] === 'string' ? (delivery['smtpResponse']) : '';
+  return {
+    kind: 'Delivery',
+    messageId,
+    sendTimestamp,
+    deliveredAt,
+    recipient,
+    smtpResponse,
+    processingTimeMillis,
+  };
+}
+
+function parseBounce(payload: Record<string, unknown>, messageId: string, sendTimestamp: Date): SesBounceEvent {
+  const bounce = payload['bounce'];
+  if (!isPlainObject(bounce)) {
+    throw new Error('SES Bounce event missing bounce object');
+  }
+  const bounceType = typeof bounce['bounceType'] === 'string' ? (bounce['bounceType']) : 'Unknown';
+  const bounceSubType = typeof bounce['bounceSubType'] === 'string' ? (bounce['bounceSubType']) : 'Unknown';
+  const bouncedRecipients = bounce['bouncedRecipients'];
+  const recipient = extractFirstRecipientAddress(bouncedRecipients);
+  if (recipient === '') {
+    throw new Error('SES Bounce event missing bounce.bouncedRecipients[0].emailAddress');
+  }
+  return { kind: 'Bounce', messageId, sendTimestamp, recipient, bounceType, bounceSubType };
+}
+
+function parseComplaint(payload: Record<string, unknown>, messageId: string, sendTimestamp: Date): SesComplaintEvent {
+  const complaint = payload['complaint'];
+  if (!isPlainObject(complaint)) {
+    throw new Error('SES Complaint event missing complaint object');
+  }
+  const recipient = extractFirstRecipientAddress(complaint['complainedRecipients']);
+  if (recipient === '') {
+    throw new Error('SES Complaint event missing complaint.complainedRecipients[0].emailAddress');
+  }
+  return { kind: 'Complaint', messageId, sendTimestamp, recipient };
+}
+
+function parseReject(payload: Record<string, unknown>, messageId: string, sendTimestamp: Date): SesRejectEvent {
+  const reject = payload['reject'];
+  if (!isPlainObject(reject)) {
+    throw new Error('SES Reject event missing reject object');
+  }
+  const reason = typeof reject['reason'] === 'string' ? (reject['reason']) : 'Unknown';
+  return { kind: 'Reject', messageId, sendTimestamp, reason };
+}
+
+function parseDeliveryDelay(
+  payload: Record<string, unknown>,
+  messageId: string,
+  sendTimestamp: Date
+): SesDeliveryDelayEvent {
+  const deliveryDelay = payload['deliveryDelay'];
+  if (!isPlainObject(deliveryDelay)) {
+    throw new Error('SES DeliveryDelay event missing deliveryDelay object');
+  }
+  const delayType = typeof deliveryDelay['delayType'] === 'string' ? (deliveryDelay['delayType']) : 'Unknown';
+  const expirationTimeRaw = deliveryDelay['expirationTime'];
+  const expirationTime = typeof expirationTimeRaw === 'string' ? parseTimestampOrNull(expirationTimeRaw) : null;
+  const recipient = extractFirstRecipientAddress(deliveryDelay['delayedRecipients']);
+  if (recipient === '') {
+    throw new Error('SES DeliveryDelay event missing deliveryDelay.delayedRecipients[0].emailAddress');
+  }
+  return { kind: 'DeliveryDelay', messageId, sendTimestamp, recipient, delayType, expirationTime };
+}
+
+function extractFirstRecipientAddress(value: unknown): string {
+  if (!Array.isArray(value) || value.length === 0) return '';
+  const first = value[0];
+  if (!isPlainObject(first)) return '';
+  const addr = first['emailAddress'];
+  return typeof addr === 'string' ? addr : '';
+}
+
+function parseTimestamp(value: unknown, fieldName: string): Date {
+  if (typeof value !== 'string') {
+    throw new Error(`SES payload field ${fieldName} is not a string`);
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`SES payload field ${fieldName} is not a valid ISO 8601 timestamp`);
+  }
+  return date;
+}
+
+function parseTimestampOrNull(value: string): Date | null {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/backend/services/ses-events/sns-validator.ts
+++ b/apps/backend/services/ses-events/sns-validator.ts
@@ -1,10 +1,18 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const MessageValidator = require('sns-validator') as new () => {
+// `sns-validator` is AWS-published CJS-only (`module.exports = MessageValidator`).
+// Node ESM's CJS-default interop maps that to a default import; tsup keeps the
+// import external (see apps/backend/tsup.config.ts) so the bundle does not
+// re-emit a dynamic `require()` that would fail at runtime under ESM.
+// @ts-expect-error — package ships no .d.ts; the constructor + validate shape
+// below describes the surface we actually call.
+import MessageValidatorCtor from 'sns-validator';
+
+type MessageValidatorInstance = {
   validate: (
     message: Record<string, unknown>,
     callback: (err: Error | null, message: Record<string, unknown>) => void
   ) => void;
 };
+const MessageValidator = MessageValidatorCtor as new () => MessageValidatorInstance;
 
 /**
  * Shape of a validated SNS HTTP/HTTPS message. SNS sends three kinds:

--- a/apps/backend/services/ses-events/sns-validator.ts
+++ b/apps/backend/services/ses-events/sns-validator.ts
@@ -69,6 +69,6 @@ export async function validateSnsMessage(payload: unknown): Promise<ValidatedSns
     TopicArn: topicArn,
     Timestamp: String(validated['Timestamp'] ?? ''),
     Message: String(validated['Message'] ?? ''),
-    SubscribeURL: typeof validated['SubscribeURL'] === 'string' ? (validated['SubscribeURL']) : undefined,
+    SubscribeURL: typeof validated['SubscribeURL'] === 'string' ? validated['SubscribeURL'] : undefined,
   };
 }

--- a/apps/backend/services/ses-events/sns-validator.ts
+++ b/apps/backend/services/ses-events/sns-validator.ts
@@ -1,0 +1,74 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const MessageValidator = require('sns-validator') as new () => {
+  validate: (
+    message: Record<string, unknown>,
+    callback: (err: Error | null, message: Record<string, unknown>) => void
+  ) => void;
+};
+
+/**
+ * Shape of a validated SNS HTTP/HTTPS message. SNS sends three kinds:
+ * `SubscriptionConfirmation` (one-time, on subscription create),
+ * `UnsubscribeConfirmation` (on subscription delete), and `Notification`
+ * (for every event). Only `Notification` carries a `Message` we need to
+ * parse downstream.
+ */
+export interface ValidatedSnsMessage {
+  Type: 'SubscriptionConfirmation' | 'UnsubscribeConfirmation' | 'Notification';
+  MessageId: string;
+  TopicArn: string;
+  Timestamp: string;
+  Message: string;
+  SubscribeURL?: string;
+}
+
+const validator = new MessageValidator();
+
+/**
+ * Validate the X-509 signature on a raw SNS message body, then check the
+ * `TopicArn` matches the configured topic. Resolves to the typed message
+ * on success; rejects on signature mismatch, expired cert, missing fields,
+ * or wrong topic.
+ *
+ * The expected topic ARN is read from `SES_EVENTS_SNS_TOPIC_ARN` at call
+ * time so test setups can override `process.env` between cases. Throws
+ * with a stable error string if the env var is unset — the route layer
+ * surfaces this to Sentry rather than crashing on boot, so a missing env
+ * var is observable, not silent.
+ */
+export async function validateSnsMessage(payload: unknown): Promise<ValidatedSnsMessage> {
+  const expectedTopicArn = process.env['SES_EVENTS_SNS_TOPIC_ARN'];
+  if (!expectedTopicArn) {
+    throw new Error('SES_EVENTS_SNS_TOPIC_ARN is not set');
+  }
+
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('SNS payload is not an object');
+  }
+
+  const validated = await new Promise<Record<string, unknown>>((resolve, reject) => {
+    validator.validate(payload as Record<string, unknown>, (err, message) => {
+      if (err) reject(err);
+      else resolve(message);
+    });
+  });
+
+  const topicArn = validated['TopicArn'];
+  if (typeof topicArn !== 'string' || topicArn !== expectedTopicArn) {
+    throw new Error('SNS message TopicArn does not match SES_EVENTS_SNS_TOPIC_ARN');
+  }
+
+  const type = validated['Type'];
+  if (type !== 'SubscriptionConfirmation' && type !== 'UnsubscribeConfirmation' && type !== 'Notification') {
+    throw new Error(`Unexpected SNS message Type: ${String(type)}`);
+  }
+
+  return {
+    Type: type,
+    MessageId: String(validated['MessageId'] ?? ''),
+    TopicArn: topicArn,
+    Timestamp: String(validated['Timestamp'] ?? ''),
+    Message: String(validated['Message'] ?? ''),
+    SubscribeURL: typeof validated['SubscribeURL'] === 'string' ? (validated['SubscribeURL']) : undefined,
+  };
+}

--- a/apps/backend/services/ses-events/types.ts
+++ b/apps/backend/services/ses-events/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Discriminated union of the six SES event types we observe for transactional
+ * email instrumentation. The shape comes from the SES "Configuration Set →
+ * SNS event publishing" documented payload; we keep a narrow projection that
+ * carries only the fields we surface on Sentry spans.
+ *
+ * Recipient values are intentionally kept as full email addresses inside this
+ * module, but only the domain part is allowed to leave it (see emit-span.ts).
+ * Treat any local-part as PII; never log or attribute it.
+ */
+
+export type SesEventKind = 'Send' | 'Delivery' | 'Bounce' | 'Complaint' | 'Reject' | 'DeliveryDelay';
+
+export interface SesEventBase {
+  kind: SesEventKind;
+  messageId: string;
+  sendTimestamp: Date;
+}
+
+export interface SesSendEvent extends SesEventBase {
+  kind: 'Send';
+  recipients: string[];
+}
+
+export interface SesDeliveryEvent extends SesEventBase {
+  kind: 'Delivery';
+  deliveredAt: Date;
+  recipient: string;
+  smtpResponse: string;
+  processingTimeMillis: number;
+}
+
+export interface SesBounceEvent extends SesEventBase {
+  kind: 'Bounce';
+  recipient: string;
+  bounceType: string;
+  bounceSubType: string;
+}
+
+export interface SesComplaintEvent extends SesEventBase {
+  kind: 'Complaint';
+  recipient: string;
+}
+
+export interface SesRejectEvent extends SesEventBase {
+  kind: 'Reject';
+  reason: string;
+}
+
+export interface SesDeliveryDelayEvent extends SesEventBase {
+  kind: 'DeliveryDelay';
+  recipient: string;
+  delayType: string;
+  expirationTime: Date | null;
+}
+
+export type SesEvent =
+  | SesSendEvent
+  | SesDeliveryEvent
+  | SesBounceEvent
+  | SesComplaintEvent
+  | SesRejectEvent
+  | SesDeliveryDelayEvent;

--- a/apps/backend/tsup.config.ts
+++ b/apps/backend/tsup.config.ts
@@ -19,7 +19,10 @@ export default defineConfig((options) => ({
   clean: true,
   sourcemap: true,
   splitting: false,
-  external: ['@sentry/node', 'ws'],
+  // `sns-validator` is CJS-only; bundling it into ESM produces a `Dynamic
+  // require of "sns-validator" is not supported` at runtime. Mark external
+  // so Node's CJS↔ESM interop resolves it through node_modules.
+  external: ['@sentry/node', 'ws', 'sns-validator'],
   onSuccess: options.watch ? 'node --import ./dist/instrument.js ./dist/app.js' : undefined,
   minify: !options.watch,
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -40,6 +40,12 @@ Full reference. CLAUDE.md links here. Variables marked _required_ have no defaul
 - `SES_FROM_EMAIL`
 - `PASSWORD_RESET_REDIRECT_URL`, `EMAIL_VERIFICATION_REDIRECT_URL`
 
+### SES delivery events (`POST /internal/ses-events`)
+
+- `SES_EVENTS_SNS_TOPIC_ARN` — ARN of the SNS topic that the `wxyc.org` SES Configuration Set publishes Send/Delivery/Bounce/Complaint/Reject/DeliveryDelay events to. The receiving route pins this ARN and rejects messages whose `TopicArn` does not match (signature validation also checks the AWS X.509 cert chain). Production value: `arn:aws:sns:us-east-1:203767826763:ses-delivery-events-prod`. Leave unset locally — the route returns 400 for every POST when the env var is missing, by design, so a missing config is observable rather than a startup crash.
+
+The Backend container does not call SES, so no additional AWS credentials are needed for this route — SNS signature validation only requires the public cert fetched from SNS's `SigningCertURL`.
+
 ## Testing
 
 - `AUTH_BYPASS` — Set `true` to skip JWT verification in tests

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -38,6 +38,7 @@ Full reference. CLAUDE.md links here. Variables marked _required_ have no defaul
 
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`
 - `SES_FROM_EMAIL`
+- `SES_CONFIGURATION_SET_NAME` — Configuration set passed on every `SendEmailCommand`. Optional. Required in production for the event-destination on `my-first-configuration-set` to actually capture transactional sends — SES picks the most-specific identity for `From:`, and the `no-reply@wxyc.org` email-level identity has no config set attached, so the domain-level default never applies. Passing this explicitly bypasses the identity-precedence trap. Production value: `my-first-configuration-set`.
 - `PASSWORD_RESET_REDIRECT_URL`, `EMAIL_VERIFICATION_REDIRECT_URL`
 
 ### SES delivery events (`POST /internal/ses-events`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -286,6 +286,7 @@
         "postgres": "^3.4.9",
         "posthog-node": "^5.33.4",
         "sharp": "^0.34.5",
+        "sns-validator": "^0.3.5",
         "ssh2": "^1.17.0",
         "swagger-ui-express": "^5.0.1",
         "ws": "^8.20.0",
@@ -13021,6 +13022,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/sns-validator": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/sns-validator/-/sns-validator-0.3.5.tgz",
+      "integrity": "sha512-lapYNmezLsltnt2fcQyhmYnC41mYZ7EjU7f2oR/hrhpbD/LemryclRpApwxO84gOyDIQ7MWe/h4HvkdunFzSKg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15504,6 +15511,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.1045.0",
+        "@sentry/node": "^10.52.0",
         "@wxyc/database": "^1.0.0",
         "@wxyc/shared": "^1.5.0",
         "better-auth": "^1.6.9",

--- a/plans/ses-delivery-instrumentation.md
+++ b/plans/ses-delivery-instrumentation.md
@@ -1,0 +1,384 @@
+# SES delivery latency instrumentation for OTP emails
+
+## Goal
+
+Measure the end-to-end time from `SendEmailCommand` to recipient-MTA acceptance for transactional emails (OTP, password reset, verification, account setup) so we can establish a real `Send → Delivery` p50/p90/p99 distribution by recipient domain. Without this we cannot tell whether the user-reported "slow OTP" is a 2-second tail or a 30-second one, and we cannot tell whether a future deliverability change moved the needle.
+
+Target stated by Jake: p90 `Send → Delivery` < 10 s.
+
+## Non-goals
+
+- This PR does not change any deliverability posture (no DKIM rotation, no MAIL FROM change, no DMARC tightening, no new SES IP pool, no email template changes). Those are downstream changes that we will reason about _after_ we have data.
+- This PR does not change anything about how OTPs are generated or how `better-auth` orchestrates the OTP flow. The send is already fire-and-forget; that does not change.
+- This PR does not move SES email sending off `console.error`-and-pray for _all_ email types. The targeted change is to swap the OTP catch handler to `Sentry.captureException`, since OTP is the loudest user-visible path. The other three email types (`passwordReset`, `emailVerification`, `accountSetup`) keep their current `console.error` behavior in this PR and can be migrated as a follow-up.
+
+## Diagnostic findings that motivated this approach
+
+Confirmed 2026-05-24 in WXYC AWS account `203767826763`, us-east-1:
+
+| Check                                                             | Result                                                      |
+| ----------------------------------------------------------------- | ----------------------------------------------------------- |
+| `sesv2 get-account.ProductionAccessEnabled`                       | `true`                                                      |
+| `EnforcementStatus`                                               | `HEALTHY`                                                   |
+| `SendQuota.Max24HourSend` / `MaxSendRate`                         | `50000` / `14/s`                                            |
+| `SentLast24Hours`                                                 | `1`                                                         |
+| Bounces / Complaints across last ~2 weeks                         | `0` / `0`                                                   |
+| `wxyc.org` DKIM                                                   | `SUCCESS`, RSA-2048, signing enabled                        |
+| Custom MAIL FROM (`mail.wxyc.org`)                                | `SUCCESS`, SPF aligns                                       |
+| `wxyc.org` SPF                                                    | `v=spf1 include:_spf.google.com include:amazonses.com ~all` |
+| `_dmarc.wxyc.org`                                                 | `p=none` (monitor)                                          |
+| DKIM CNAMEs (×3)                                                  | all resolve to `dkim.amazonses.com`                         |
+| Configuration set `my-first-configuration-set` event destinations | **none**                                                    |
+| `wxyc.org` identity default config set                            | **`my-first-configuration-set`** (already attached)         |
+
+The deliverability fundamentals are fine. The problem is that we are sending blind: no event publishing, no measurement, no per-message visibility past the `SendEmailCommand` return.
+
+The fact that the `wxyc.org` identity already has `my-first-configuration-set` as its default config set means **adding an EventDestination instantly attributes every existing send** without touching `shared/authentication/src/email.ts`. That is the key lever and the reason this plan is small.
+
+## Architecture
+
+```
+SES.SendEmailCommand (from BS auth)
+       │
+       ▼
+AWS SES (us-east-1)  ── publishes Send, Delivery, Bounce, Complaint, Reject, DeliveryDelay events
+       │              to Configuration Set's EventDestination
+       ▼
+SNS topic `ses-delivery-events-prod`  (in WXYC AWS 203767826763, us-east-1)
+       │
+       ▼ HTTPS subscription
+POST https://api.wxyc.org/internal/ses-events  (new endpoint on apps/backend)
+       │
+       ├─ SubscriptionConfirmation → GET the SubscribeURL (one-time, on subscription create)
+       ├─ Signature validation via sns-payload-validator (every message)
+       ├─ Parse SES event payload
+       └─ Emit Sentry transaction "ses.event" with:
+              op:               "email.ses"
+              tags:             email.type, email.event_type, recipient.domain
+              measurements:     delivery_latency_ms (only set on Delivery events,
+                                                     = Delivery.timestamp - mail.timestamp)
+              status:           ok | failed_precondition | unavailable
+       ▼
+Sentry project (BS apps/backend) — trace explorer + metric explorer get the spans
+       (no separate dashboard build in this PR; we read from trace explorer
+        per the established LML pattern.)
+```
+
+### Why SNS HTTPS → BS, not SNS → Lambda → CloudWatch
+
+- BS already runs at `api.wxyc.org` with `/internal/*` open for webhook-style traffic (`tubafrenzy webhook`, `LML streaming-status-webhook`, `flowsheet-sync-notify`). The same auth/validation pattern fits perfectly.
+- BS already has `@sentry/node` 10.52.0 instrumented (`apps/backend/instrument.ts`) and a documented "wrap-at-chokepoint + project-onto-span" pattern (LML#213/BS#646). The SES handler slots in cleanly.
+- A new Lambda would mean (a) another AWS-managed deploy target, (b) another place to ship code, (c) duplicating Sentry instrumentation. Worth nothing here.
+- The traffic is bounded: at current volume (1 send/day) and even at 5,000 sends/day, we are looking at 5–25k SNS POSTs/day; BS handles ~50k routine flowsheet/rotation webhook hits/day without issue.
+
+### Why EventDestination → SNS, not → EventBridge or → CloudWatch directly
+
+- **CloudWatch metrics destination** drops the per-message timestamps and message-ID; we get hourly aggregate counters but cannot compute per-message latency or break down by recipient domain. Rejected.
+- **CloudWatch Logs destination via Firehose** works but adds a Firehose stream + S3 bucket + lifecycle policy for no compelling benefit at this volume.
+- **EventBridge bus → API Destination → BS** is one extra hop with extra IAM and extra failure modes. SNS → HTTPS is the older, simpler, well-trodden pattern with first-class signature validation. Rejected for now; we can migrate later if we want EventBridge's filtering.
+
+## Components
+
+### A. AWS-side infrastructure (provisioned via AWS CLI under `wxyc-api` profile)
+
+A.1. **SNS topic**: `arn:aws:sns:us-east-1:203767826763:ses-delivery-events-prod`
+
+- Encryption: AWS-managed KMS key (`alias/aws/sns`)
+- Access policy: allow `ses.amazonaws.com` from this account to `sns:Publish`. No cross-account; no public publish.
+
+A.2. **SES Configuration Set EventDestination**
+
+- Config set: `my-first-configuration-set` (existing)
+- Destination name: `ses-delivery-events-prod-sns`
+- Enabled: `true`
+- Matching events: `SEND`, `DELIVERY`, `BOUNCE`, `COMPLAINT`, `REJECT`, `DELIVERY_DELAY`
+- SNS target: the topic above
+
+A.3. **SNS HTTPS subscription**
+
+- Endpoint: `https://api.wxyc.org/internal/ses-events`
+- Created **after** the BS endpoint is deployed (so the handler can confirm).
+- Confirmation: BS handler GETs `SubscribeURL` on `SubscriptionConfirmation` message receipt; SNS marks the subscription confirmed.
+
+A.4. **Raw message delivery**: **not enabled.** We want SNS's wrapping envelope because it carries the signature we validate against. Raw delivery would bypass validation.
+
+A.5. All three resources will be created via shell commands documented in the PR description so they are reproducible, but they will not be Terraformed in this PR — WXYC has no Terraform repo for SES yet.
+
+### B. Backend-Service changes
+
+All changes are scoped to `apps/backend` and `shared/authentication`.
+
+**Decisions resolved pre-implementation** (from `/review-plan` 2026-05-24):
+
+- **Body parser**: route uses inline `express.text({ type: '*/*', limit: '64kb' })` as a route-level middleware on the POST handler. `apps/backend/app.ts:44`'s `app.use(express.json())` only parses `application/json`, and SNS sends `Content-Type: text/plain`, so the global parser never touches SNS bodies. No "mount before json" gymnastics needed.
+- **Sentry in `@wxyc/authentication`**: add `@sentry/node` as a runtime dependency to `shared/authentication/package.json` and to the `external: [...]` list in `shared/authentication/tsup.config.ts` (matching the existing pattern for `drizzle-orm`, `postgres`, `better-auth`, `@wxyc/shared`). This keeps Sentry out of the package's bundled output but installed where consumers use it. `apps/auth` already has `@sentry/node` 10.52.0 and loads `instrument.ts` at process start via `node --import`, so the import in `auth.definition.ts` resolves cleanly at runtime. No factory refactor needed.
+
+B.1. **New file `apps/backend/services/ses-events/sns-validator.ts`**
+
+- Wraps `sns-payload-validator` (or equivalent — see "Dependency choice" below).
+- Pure function: `validateSnsMessage(body: unknown): Promise<ValidatedSnsMessage>`
+- Throws on signature mismatch, expired cert, wrong topic ARN, or unrecognized message type.
+- Topic ARN is read from `SES_EVENTS_SNS_TOPIC_ARN` env var (fail-fast if unset).
+
+B.2. **New file `apps/backend/services/ses-events/parse-ses-event.ts`**
+
+- Given a `ValidatedSnsMessage`, parse the SES event JSON payload (which lives in `Message`).
+- Returns a typed `SesEvent`:
+  ```ts
+  type SesEvent =
+    | { kind: 'Send'; messageId: string; sendTimestamp: Date; mailType: WxycMailType | null; recipients: string[] }
+    | {
+        kind: 'Delivery';
+        messageId: string;
+        sendTimestamp: Date;
+        deliveredAt: Date;
+        recipient: string;
+        smtpResponse: string;
+        processingTimeMillis: number;
+        mailType: WxycMailType | null;
+      }
+    | {
+        kind: 'Bounce';
+        messageId: string;
+        sendTimestamp: Date;
+        recipient: string;
+        bounceType: string;
+        bounceSubType: string;
+        mailType: WxycMailType | null;
+      }
+    | { kind: 'Complaint'; messageId: string; sendTimestamp: Date; recipient: string; mailType: WxycMailType | null }
+    | { kind: 'Reject'; messageId: string; sendTimestamp: Date; reason: string; mailType: WxycMailType | null }
+    | {
+        kind: 'DeliveryDelay';
+        messageId: string;
+        sendTimestamp: Date;
+        recipient: string;
+        delayType: string;
+        expirationTime: Date | null;
+        mailType: WxycMailType | null;
+      };
+  ```
+- `mailType` is inferred from a custom SES message tag we will add to `SendEmailCommand` in a future PR (see "Future work"). In this PR, `mailType` is always `null`; we will tag by subject-line heuristic instead and document the limitation.
+
+B.3. **New file `apps/backend/services/ses-events/emit-span.ts`**
+
+- Given a typed `SesEvent`, emit a Sentry transaction with:
+  - `name: 'ses.event'`
+  - `op: 'email.ses'`
+  - `attributes`:
+    - `email.event_type` = `'Send' | 'Delivery' | 'Bounce' | ...`
+    - `email.message_id` = SES `mail.messageId`
+    - `email.recipient_domain` = the part after `@` in the (first) recipient (do **not** log the local-part — PII)
+    - `email.mail_type` = `mailType ?? 'unknown'`
+    - `email.smtp_response` = present only on Delivery; trimmed to 500 chars
+    - `email.bounce_type` / `email.bounce_subtype` = present only on Bounce
+    - `email.delay_type` = present only on DeliveryDelay
+  - `measurements`:
+    - `ses.delivery_latency_ms` (Delivery only) = `deliveredAt.getTime() - sendTimestamp.getTime()`
+    - `ses.processing_time_ms` (Delivery only) = `processingTimeMillis` from the event
+  - `status`: `ok` on Send/Delivery, `failed_precondition` on Bounce/Complaint/Reject, `deadline_exceeded` on DeliveryDelay
+- Span lifetime is synchronous: we open it, set attributes/measurements, end it. There is no fetch to wrap.
+
+B.4. **New file `apps/backend/routes/ses-events.route.ts`**
+
+- Express `Router`.
+- `POST /` (mounted at `/internal/ses-events` from `apps/backend/app.ts`).
+- Body-parser config: SNS sends `Content-Type: text/plain` (yes, really — historical AWS choice). The route uses `express.text({ type: '*/*' })` scoped to this router so the raw string is available for signature validation. (The rest of `/internal/*` keeps `express.json()`.)
+- Pseudocode:
+
+  ```ts
+  router.post('/', express.text({ type: '*/*', limit: '64kb' }), async (req, res) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(req.body);
+    } catch {
+      res.status(400).json({ error: 'invalid json' });
+      return;
+    }
+
+    let validated: ValidatedSnsMessage;
+    try {
+      validated = await validateSnsMessage(parsed);
+    } catch (e) {
+      Sentry.captureException(e, { tags: { subsystem: 'ses-events', stage: 'validate' } });
+      res.status(400).json({ error: 'invalid signature or topic' });
+      return;
+    }
+
+    if (validated.Type === 'SubscriptionConfirmation') {
+      try {
+        await confirmSubscription(validated.SubscribeURL);
+      } catch (e) {
+        Sentry.captureException(e, { tags: { subsystem: 'ses-events', stage: 'confirm' } });
+        res.status(500).json({ error: 'failed to confirm subscription' });
+        return;
+      }
+      res.json({ ok: true, confirmed: true });
+      return;
+    }
+
+    if (validated.Type === 'UnsubscribeConfirmation') {
+      // Log + 200; do nothing else. Operator removed the subscription.
+      console.warn('[ses-events] received UnsubscribeConfirmation', { topicArn: validated.TopicArn });
+      res.json({ ok: true });
+      return;
+    }
+
+    if (validated.Type !== 'Notification') {
+      res.status(400).json({ error: 'unexpected message type' });
+      return;
+    }
+
+    let event: SesEvent;
+    try {
+      event = parseSesEvent(validated);
+    } catch (e) {
+      Sentry.captureException(e, { tags: { subsystem: 'ses-events', stage: 'parse' } });
+      res.status(400).json({ error: 'unparseable ses event' });
+      return;
+    }
+
+    try {
+      emitSpan(event);
+    } catch (e) {
+      // Observability must never break the receive path.
+      console.warn('[ses-events] failed to emit span', e);
+    }
+
+    res.json({ ok: true });
+  });
+  ```
+
+- Auth model: **SNS signature validation is the auth**. We do not require `X-Internal-Key` because SES → SNS → BS cannot inject custom headers. The topic ARN is pinned via `SES_EVENTS_SNS_TOPIC_ARN`, and the signature is verified against AWS's cert chain.
+
+B.5. **Wire the router** in `apps/backend/app.ts`:
+
+- `app.use('/internal/ses-events', sesEventsRoute);`
+- Ordering relative to the global `express.json()` is irrelevant — see "Decisions resolved pre-implementation" above. The route's inline `express.text()` middleware claims the body before the handler runs.
+
+B.6. **Change in `shared/authentication/src/auth.definition.ts`** (the only code change outside `apps/backend`):
+
+- Replace the silently-swallowed `console.error('Error sending OTP email:', error)` in the `emailOTP({ sendVerificationOTP })` callback (`shared/authentication/src/auth.definition.ts:320`) with:
+  ```ts
+  void sendOTPEmail({ to: email, otp, type }).catch((error) => {
+    console.error('Error sending OTP email:', error);
+    Sentry.captureException(error, { tags: { subsystem: 'auth-otp', email_type: type } });
+  });
+  ```
+- Add `import * as Sentry from '@sentry/node';` at the top of the file.
+- Add `@sentry/node` to `shared/authentication/package.json` `dependencies` (same `^10.52.0` as the rest of the repo).
+- Add `'@sentry/node'` to the `external: [...]` list in `shared/authentication/tsup.config.ts` (matches the existing pattern for `drizzle-orm`, `postgres`, `better-auth`, `@wxyc/shared`).
+- In scope: OTP only, since that is what Jake asked about. The other three callers (`sendResetPassword`, `sendVerificationEmail`, admin account-setup) keep their current `console.error` and are listed in "Future work" below.
+
+### C. Test strategy (TDD)
+
+C.1. **Unit tests** for `parse-ses-event.ts`:
+
+- Fixtures: real SES event payloads pasted from AWS docs for each of the six event types.
+- Assert each fixture maps to the right `SesEvent` shape, including correct timestamp parsing (SES uses ISO 8601 with timezone).
+- Negative cases: missing `mail.timestamp`, malformed `eventType`, empty `mail.destination`.
+
+C.2. **Unit tests** for `emit-span.ts`:
+
+- Mock `@sentry/node`'s `startSpan` and assert attributes/measurements per event kind.
+- Verify recipient local-part is **never** present in any attribute (PII guard).
+- Verify `delivery_latency_ms` is non-negative.
+
+C.3. **Unit tests** for the route, modeled on `tests/unit/routes/internal.route.test.ts`:
+
+- Mock `validateSnsMessage` and `emitSpan`.
+- Happy-path: SubscriptionConfirmation → triggers `confirmSubscription` mock, returns 200.
+- Happy-path: Notification with Send → triggers `emitSpan` mock, returns 200.
+- Negative: invalid signature → 400, Sentry captured.
+- Negative: wrong topic ARN → 400, Sentry captured (verified via validator throwing).
+- Negative: unparseable SES payload → 400, Sentry captured, response does NOT include the raw payload (no log injection).
+- Defensive: `emitSpan` throws → handler still 200s (observability must not break the receive path).
+
+C.4. **No integration tests** in this PR. The dependency on AWS SNS for real round-trip is real but out of scope; the unit tests with realistic fixtures + a manual smoke test post-deploy is the right scope.
+
+C.5. **Smoke test plan** (manual, post-deploy, documented in PR body):
+
+- Trigger an OTP via the auth sign-in path against prod.
+- Observe `Send` and `Delivery` spans land in Sentry within ~30s.
+- Confirm `ses.delivery_latency_ms` measurement is populated.
+- Confirm `email.recipient_domain` is the domain only, no local-part.
+
+### D. Configuration / env vars
+
+Adds to `apps/backend/.env.example` and `docs/env-vars.md` under a new **SES delivery events** section:
+
+- `SES_EVENTS_SNS_TOPIC_ARN` — the topic ARN to pin signature validation against.
+- (No new AWS creds. The Backend container does not call SES; it only receives the SNS HTTP POST. Signature validation requires no AWS auth — just the public cert from SNS's signing-cert URL.)
+
+If `SES_EVENTS_SNS_TOPIC_ARN` is unset, the route still mounts but every POST returns 400 with `subsystem: 'ses-events', stage: 'validate'` Sentry tags. This is preferable to throwing at startup, since it keeps the deploy alive if the env var is missing.
+
+### E. Dependency choice (resolved)
+
+Audited 2026-05-24 from `npm view`:
+
+| Package                 | Owner                                                   | License    | Last published | Runtime deps                                  |
+| ----------------------- | ------------------------------------------------------- | ---------- | -------------- | --------------------------------------------- |
+| `sns-validator`         | **AWS (`github.com/aws/aws-js-sns-message-validator`)** | Apache-2.0 | 2025-03-27     | **none**                                      |
+| `sns-payload-validator` | community (devinstewart)                                | MIT        | 2023-02-07     | lru-cache                                     |
+| `aws-sns-validator`     | community (buithaibinh)                                 | ISC        | 2022-04-12     | request (deprecated), requestretry, lru-cache |
+
+**Decision: `sns-validator`** — AWS-owned, most recently updated, zero runtime dependencies. The API is callback-based (`validator.validate(msg, cb)`); we wrap it in a `Promise` inside `sns-validator.ts` so the route stays `async/await`.
+
+### F. Rollout
+
+1. Land BS PR with the endpoint + tests + `email.ts` Sentry capture.
+2. After deploy: run AWS CLI commands to create the SNS topic, attach the EventDestination, create the HTTPS subscription. (One-shot operator steps; documented in PR body.)
+3. Wait for `SubscriptionConfirmation` POST → BS auto-confirms → SES starts publishing events.
+4. Trigger a test OTP, verify span lands in Sentry within ~30s.
+5. Let it bake for 24h, then come back and read p90 from Sentry trace explorer with `op:email.ses email.event_type:Delivery`.
+
+If p90 is already <10s, we close the task and the instrumentation stays in place as ongoing visibility. If p90 is high, we have per-recipient-domain breakdown to drive the next decision (Gmail throttling vs iCloud vs Outlook vs something else).
+
+## Future work (intentionally out of scope)
+
+- Tag `SendEmailCommand` with an `email.mail_type` SES message tag (`sign-in`, `email-verification`, etc.) so spans can be grouped without subject-line heuristics. This is a one-line change in `sendOTPEmail`/`sendEmail` but is deferred to keep this PR focused on the receive side.
+- Migrate the other three `void sendEmail(...).catch(...)` callers (`sendResetPassword`, `sendVerificationEmail`, the admin account-setup path) to `Sentry.captureException`.
+- Add a Sentry alert on `ses.delivery_latency_ms` p90 > 10s once we know what the baseline is.
+- Move the SES Configuration Set + SNS topic into a (yet-to-exist) WXYC Terraform repo when one is created.
+
+## Risk register
+
+| Risk                                                                                             | Likelihood   | Impact | Mitigation                                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------ | ------------ | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SNS signature validation library has CVE                                                         | low          | high   | Pin version, audit on first install, dependabot watch                                                                                                             |
+| Body-parser ordering breaks other `/internal/*` routes                                           | low          | medium | Scoped `express.text()` to this router only; covered by existing internal-route tests still passing                                                               |
+| Subscription confirmation HTTPS GET fails (cert chain)                                           | low          | medium | Confirmation is operator-visible (curl the topic-list endpoint); operator can re-trigger via SNS console                                                          |
+| BS endpoint receives spoofed SES events                                                          | low          | high   | Signature validation against AWS cert chain + topic ARN pin                                                                                                       |
+| Recipient local-part leaks into Sentry attrs (PII)                                               | medium       | medium | Explicit domain-only extraction + unit test                                                                                                                       |
+| Volume of SNS POSTs overwhelms BS                                                                | very low     | low    | At 5k/day target volume, ~3/min — nowhere near BS load                                                                                                            |
+| `Sentry.captureException` import in `@wxyc/authentication` breaks the package's standalone build | **resolved** | —      | Add `@sentry/node` to package `dependencies` + tsup `external` list, matching the existing pattern. No factory refactor; runtime resolution works in `apps/auth`. |
+
+## Files changed (rough estimate)
+
+- `apps/backend/routes/ses-events.route.ts` (new, ~70 LOC)
+- `apps/backend/services/ses-events/sns-validator.ts` (new, ~30 LOC)
+- `apps/backend/services/ses-events/parse-ses-event.ts` (new, ~80 LOC)
+- `apps/backend/services/ses-events/emit-span.ts` (new, ~50 LOC)
+- `apps/backend/services/ses-events/confirm-subscription.ts` (new, ~15 LOC)
+- `apps/backend/app.ts` (~3-line addition)
+- `shared/authentication/src/auth.definition.ts` OR `apps/auth/app.ts` (~3-line addition)
+- `tests/unit/routes/ses-events.route.test.ts` (new, ~200 LOC)
+- `tests/unit/services/ses-events/parse-ses-event.test.ts` (new, ~150 LOC)
+- `tests/unit/services/ses-events/emit-span.test.ts` (new, ~120 LOC)
+- `apps/backend/.env.example` (1 line)
+- `docs/env-vars.md` (small section)
+- `apps/backend/package.json` (1 dep)
+- `package-lock.json` (regenerated)
+
+Net delta target: ~750 LOC including tests. Well under the 1000-LOC PR ceiling.
+
+## Acceptance criteria
+
+1. `POST /internal/ses-events` with a valid `SubscriptionConfirmation` body confirms the subscription and returns 200.
+2. `POST /internal/ses-events` with a valid `Notification` body of each of the six SES event types emits exactly one Sentry span with the correct `email.event_type` attribute.
+3. `Delivery`-kind events carry a non-negative `ses.delivery_latency_ms` measurement.
+4. No attribute or log line in any code path contains a recipient's email local-part.
+5. Signature mismatch, wrong topic ARN, or unparseable payload all return 4xx and emit a `Sentry.captureException` with `subsystem: 'ses-events'`.
+6. `sendOTPEmail` failures are captured to Sentry with `subsystem: 'auth-otp'`.
+7. All existing internal-route tests still pass (body-parser scoping change is non-breaking).
+8. `npm run typecheck && npm run lint && npm run format:check && npm run test:unit && npm run build` all pass locally before push.

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-ses": "^3.1045.0",
+    "@sentry/node": "^10.52.0",
     "@wxyc/database": "^1.0.0",
     "@wxyc/shared": "^1.5.0",
     "better-auth": "^1.6.9",

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { account, db, invitation, jwks, member, organization, session, user, verification } from '@wxyc/database';
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
@@ -318,7 +319,12 @@ export const auth = betterAuth({
     emailOTP({
       async sendVerificationOTP({ email, otp, type }) {
         void sendOTPEmail({ to: email, otp, type }).catch((error) => {
+          // Pre-2026-05-24 this was console.error only, so SES errors were
+          // invisible to Sentry / oncall. The OTP path is the loudest
+          // user-visible email; the other three callers in this file still
+          // use console.error and can be migrated as a follow-up.
           console.error('Error sending OTP email:', error);
+          Sentry.captureException(error, { tags: { subsystem: 'auth-otp', email_type: type } });
         });
       },
       otpLength: 6,

--- a/shared/authentication/src/auth.middleware.ts
+++ b/shared/authentication/src/auth.middleware.ts
@@ -79,10 +79,16 @@ export function requirePermissions(required: RequiredPermissions) {
       // If the token is not a valid JWT (e.g. integration tests pass a raw
       // user ID), fall back to using the token value as the user ID directly.
       try {
-        const payload = decodeJwt(token) as WXYCAuthJwtPayload;
+        const payload = decodeJwt(token);
         const userId = payload.id || payload.sub;
         if (userId) {
-          req.auth = { ...payload, id: userId };
+          // Cast mirrors the catch branch below: `email` is required on
+          // WXYCAuthJwtPayload but `decodeJwt`'s `JWTPayload` doesn't carry
+          // it as a known field. Dep churn (added @sentry/node 2026-05-24
+          // BS#1070) tightened type inference enough that the dts build
+          // now refuses the implicit spread; the cast makes the existing
+          // intent explicit without changing runtime behavior.
+          req.auth = { ...payload, id: userId } as WXYCAuthJwtPayload;
         }
       } catch {
         req.auth = { id: token } as WXYCAuthJwtPayload;

--- a/shared/authentication/src/email.ts
+++ b/shared/authentication/src/email.ts
@@ -113,6 +113,24 @@ const buildEmailHtml = ({ title, intro, actionText, actionUrl, footer }: Omit<Em
 `.trim();
 
 /**
+ * SES picks the most-specific identity for an outbound `From:`. Because
+ * `no-reply@wxyc.org` is verified as an email-level identity, sends from
+ * that address use the email-level identity even though `wxyc.org` (the
+ * domain) has `my-first-configuration-set` set as its default. The
+ * email-level identity has no `ConfigurationSetName` attached, so without
+ * passing it explicitly here the EventDestination on the config set never
+ * sees the OTP / verification / reset traffic (BS#1070).
+ *
+ * `SES_CONFIGURATION_SET_NAME` is optional: when unset, no config set is
+ * passed and behavior matches pre-#1070 — useful locally, where there is
+ * no SES at all.
+ */
+function getConfigurationSetName(): string | undefined {
+  const name = process.env.SES_CONFIGURATION_SET_NAME?.trim();
+  return name && name.length > 0 ? name : undefined;
+}
+
+/**
  * Send a transactional email using the unified email system
  */
 export async function sendEmail(email: WXYCEmail): Promise<void> {
@@ -137,6 +155,7 @@ export async function sendEmail(email: WXYCEmail): Promise<void> {
         Html: { Data: htmlBody },
       },
     },
+    ConfigurationSetName: getConfigurationSetName(),
   });
 
   const client = getSesClient();
@@ -241,6 +260,7 @@ export const sendOTPEmail = async ({ to, otp, type }: OTPEmailInput) => {
         Html: { Data: htmlBody },
       },
     },
+    ConfigurationSetName: getConfigurationSetName(),
   });
 
   const client = getSesClient();

--- a/shared/authentication/tsup.config.ts
+++ b/shared/authentication/tsup.config.ts
@@ -8,5 +8,5 @@ export default defineConfig({
   outDir: 'dist',
   clean: true,
   sourcemap: true,
-  external: ['drizzle-orm', 'postgres', 'better-auth', '@wxyc/shared'],
+  external: ['drizzle-orm', 'postgres', 'better-auth', '@wxyc/shared', '@sentry/node'],
 });

--- a/tests/unit/routes/ses-events.route.test.ts
+++ b/tests/unit/routes/ses-events.route.test.ts
@@ -1,0 +1,204 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+const mockValidate = jest.fn();
+const mockParseSesEvent = jest.fn();
+const mockEmitSesEventSpan = jest.fn();
+const mockConfirmSubscription = jest.fn();
+const mockSentryCaptureException = jest.fn();
+const mockSentryCaptureMessage = jest.fn();
+
+jest.mock('../../../apps/backend/services/ses-events/sns-validator', () => ({
+  validateSnsMessage: (...args: unknown[]) => (mockValidate as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+jest.mock('../../../apps/backend/services/ses-events/parse-ses-event', () => ({
+  parseSesEvent: (...args: unknown[]) => (mockParseSesEvent as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+jest.mock('../../../apps/backend/services/ses-events/emit-span', () => ({
+  emitSesEventSpan: (...args: unknown[]) => (mockEmitSesEventSpan as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+jest.mock('../../../apps/backend/services/ses-events/confirm-subscription', () => ({
+  confirmSubscription: (...args: unknown[]) =>
+    (mockConfirmSubscription as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+jest.mock('@sentry/node', () => ({
+  captureException: (...args: unknown[]) =>
+    (mockSentryCaptureException as unknown as (...a: unknown[]) => unknown)(...args),
+  captureMessage: (...args: unknown[]) =>
+    (mockSentryCaptureMessage as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+
+import { ses_events_route } from '../../../apps/backend/routes/ses-events.route';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json()); // matches prod: global json parser shouldn't touch text/plain bodies
+  app.use('/internal/ses-events', ses_events_route);
+  return app;
+}
+
+const SNS_TEXT_HEADER = { 'Content-Type': 'text/plain; charset=UTF-8' };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockValidate.mockReset();
+  mockParseSesEvent.mockReset();
+  mockEmitSesEventSpan.mockReset();
+  mockConfirmSubscription.mockReset();
+  mockSentryCaptureException.mockReset();
+  mockSentryCaptureMessage.mockReset();
+});
+
+describe('POST /internal/ses-events', () => {
+  it('confirms an SNS SubscriptionConfirmation and returns 200', async () => {
+    mockValidate.mockResolvedValueOnce({
+      Type: 'SubscriptionConfirmation',
+      MessageId: 'sc-1',
+      TopicArn: 'arn:test',
+      Timestamp: '2026-05-24T10:00:00Z',
+      Message: '',
+      SubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&...',
+    } as never);
+    mockConfirmSubscription.mockResolvedValueOnce(undefined as never);
+
+    const res = await request(makeApp())
+      .post('/internal/ses-events')
+      .set(SNS_TEXT_HEADER)
+      .send(JSON.stringify({ Type: 'SubscriptionConfirmation' }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, confirmed: true });
+    expect(mockConfirmSubscription).toHaveBeenCalledTimes(1);
+    expect(mockEmitSesEventSpan).not.toHaveBeenCalled();
+  });
+
+  it('processes a Notification and emits a span', async () => {
+    mockValidate.mockResolvedValueOnce({
+      Type: 'Notification',
+      MessageId: 'n-1',
+      TopicArn: 'arn:test',
+      Timestamp: '2026-05-24T10:00:00Z',
+      Message: JSON.stringify({ eventType: 'Send', mail: {} }),
+    } as never);
+    mockParseSesEvent.mockReturnValueOnce({
+      kind: 'Send',
+      messageId: 'mid',
+      sendTimestamp: new Date(),
+      recipients: ['user@example.com'],
+    });
+
+    const res = await request(makeApp())
+      .post('/internal/ses-events')
+      .set(SNS_TEXT_HEADER)
+      .send(JSON.stringify({ Type: 'Notification' }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(mockEmitSesEventSpan).toHaveBeenCalledTimes(1);
+    expect(mockConfirmSubscription).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 + captures Sentry when signature validation fails', async () => {
+    mockValidate.mockRejectedValueOnce(new Error('invalid signature') as never);
+
+    const res = await request(makeApp())
+      .post('/internal/ses-events')
+      .set(SNS_TEXT_HEADER)
+      .send(JSON.stringify({ Type: 'Notification' }));
+
+    expect(res.status).toBe(400);
+    expect(mockSentryCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: expect.objectContaining({ subsystem: 'ses-events', stage: 'validate' }) })
+    );
+    expect(mockEmitSesEventSpan).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 + captures Sentry when the SES payload is unparseable', async () => {
+    mockValidate.mockResolvedValueOnce({
+      Type: 'Notification',
+      MessageId: 'n-2',
+      TopicArn: 'arn:test',
+      Timestamp: '2026-05-24T10:00:00Z',
+      Message: '{not json',
+    } as never);
+
+    const res = await request(makeApp())
+      .post('/internal/ses-events')
+      .set(SNS_TEXT_HEADER)
+      .send(JSON.stringify({ Type: 'Notification' }));
+
+    expect(res.status).toBe(400);
+    expect(mockSentryCaptureMessage).toHaveBeenCalledWith(
+      expect.stringMatching(/Message is not JSON/),
+      expect.objectContaining({ tags: expect.objectContaining({ subsystem: 'ses-events', stage: 'parse' }) })
+    );
+    expect(mockEmitSesEventSpan).not.toHaveBeenCalled();
+  });
+
+  it('still returns 200 if span emission throws (observability never breaks the receive path)', async () => {
+    mockValidate.mockResolvedValueOnce({
+      Type: 'Notification',
+      MessageId: 'n-3',
+      TopicArn: 'arn:test',
+      Timestamp: '2026-05-24T10:00:00Z',
+      Message: JSON.stringify({ eventType: 'Send', mail: {} }),
+    } as never);
+    mockParseSesEvent.mockReturnValueOnce({ kind: 'Send' });
+    mockEmitSesEventSpan.mockImplementationOnce(() => {
+      throw new Error('sentry transport blew up');
+    });
+
+    const res = await request(makeApp())
+      .post('/internal/ses-events')
+      .set(SNS_TEXT_HEADER)
+      .send(JSON.stringify({ Type: 'Notification' }));
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 on a SubscriptionConfirmation missing SubscribeURL', async () => {
+    mockValidate.mockResolvedValueOnce({
+      Type: 'SubscriptionConfirmation',
+      MessageId: 'sc-2',
+      TopicArn: 'arn:test',
+      Timestamp: '2026-05-24T10:00:00Z',
+      Message: '',
+      SubscribeURL: undefined,
+    } as never);
+
+    const res = await request(makeApp())
+      .post('/internal/ses-events')
+      .set(SNS_TEXT_HEADER)
+      .send(JSON.stringify({ Type: 'SubscriptionConfirmation' }));
+
+    expect(res.status).toBe(400);
+    expect(mockConfirmSubscription).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 on UnsubscribeConfirmation (operator removed subscription)', async () => {
+    mockValidate.mockResolvedValueOnce({
+      Type: 'UnsubscribeConfirmation',
+      MessageId: 'uc-1',
+      TopicArn: 'arn:test',
+      Timestamp: '2026-05-24T10:00:00Z',
+      Message: '',
+    } as never);
+
+    const res = await request(makeApp())
+      .post('/internal/ses-events')
+      .set(SNS_TEXT_HEADER)
+      .send(JSON.stringify({ Type: 'UnsubscribeConfirmation' }));
+
+    expect(res.status).toBe(200);
+    expect(mockConfirmSubscription).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on invalid JSON', async () => {
+    const res = await request(makeApp()).post('/internal/ses-events').set(SNS_TEXT_HEADER).send('this is not json');
+
+    expect(res.status).toBe(400);
+    expect(mockValidate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/email.test.ts
+++ b/tests/unit/services/email.test.ts
@@ -140,6 +140,42 @@ describe('sendEmail', () => {
       })
     );
   });
+
+  it('passes ConfigurationSetName when SES_CONFIGURATION_SET_NAME is set', async () => {
+    process.env.SES_CONFIGURATION_SET_NAME = 'my-first-configuration-set';
+    jest.resetModules();
+    const emailModule = await import('../../../shared/authentication/src/email');
+    const sesModule = await import('@aws-sdk/client-ses');
+    const FreshCommand = sesModule.SendEmailCommand as unknown as jest.Mock;
+
+    await emailModule.sendEmail({
+      type: 'passwordReset',
+      to: 'user@example.com',
+      url: 'https://example.com/reset',
+    });
+
+    expect(FreshCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ ConfigurationSetName: 'my-first-configuration-set' })
+    );
+    delete process.env.SES_CONFIGURATION_SET_NAME;
+  });
+
+  it('omits ConfigurationSetName when SES_CONFIGURATION_SET_NAME is unset (undefined, not the string "undefined")', async () => {
+    delete process.env.SES_CONFIGURATION_SET_NAME;
+    jest.resetModules();
+    const emailModule = await import('../../../shared/authentication/src/email');
+    const sesModule = await import('@aws-sdk/client-ses');
+    const FreshCommand = sesModule.SendEmailCommand as unknown as jest.Mock;
+
+    await emailModule.sendEmail({
+      type: 'passwordReset',
+      to: 'user@example.com',
+      url: 'https://example.com/reset',
+    });
+
+    const callArgs = FreshCommand.mock.calls[0][0] as { ConfigurationSetName?: unknown };
+    expect(callArgs.ConfigurationSetName).toBeUndefined();
+  });
 });
 
 // Test cases for new user detection logic (to be used in auth.definition)

--- a/tests/unit/services/ses-events/emit-span.test.ts
+++ b/tests/unit/services/ses-events/emit-span.test.ts
@@ -1,0 +1,149 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+const setAttribute = jest.fn();
+const setStatus = jest.fn();
+const startSpan = jest.fn();
+
+jest.mock('@sentry/node', () => ({
+  startSpan: (...args: unknown[]) => (startSpan as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+
+import { emitSesEventSpan } from '../../../../apps/backend/services/ses-events/emit-span';
+import type { SesEvent } from '../../../../apps/backend/services/ses-events/types';
+
+beforeEach(() => {
+  setAttribute.mockReset();
+  setStatus.mockReset();
+  startSpan.mockReset();
+  startSpan.mockImplementation((_opts: unknown, cb: unknown) => {
+    const span = { setAttribute, setStatus };
+    return (cb as (s: typeof span) => unknown)(span);
+  });
+});
+
+const sendTs = new Date('2026-05-24T10:00:00.000Z');
+const deliveredAt = new Date('2026-05-24T10:00:02.500Z');
+
+describe('emitSesEventSpan', () => {
+  it('emits a Send span with name "ses.event" and op "email.ses"', () => {
+    const event: SesEvent = {
+      kind: 'Send',
+      messageId: 'mid-1',
+      sendTimestamp: sendTs,
+      recipients: ['user@example.com'],
+    };
+    emitSesEventSpan(event);
+    expect(startSpan).toHaveBeenCalledTimes(1);
+    const callArgs = startSpan.mock.calls[0] as unknown as [Record<string, unknown>, unknown];
+    expect(callArgs[0]).toMatchObject({ name: 'ses.event', op: 'email.ses' });
+    expect((callArgs[0].attributes as Record<string, unknown>)['email.event_type']).toBe('Send');
+    expect((callArgs[0].attributes as Record<string, unknown>)['email.recipient_domain']).toBe('example.com');
+    expect((callArgs[0].attributes as Record<string, unknown>)['email.message_id']).toBe('mid-1');
+  });
+
+  it('NEVER includes the recipient local-part in attributes', () => {
+    const event: SesEvent = {
+      kind: 'Delivery',
+      messageId: 'mid-2',
+      sendTimestamp: sendTs,
+      deliveredAt,
+      recipient: 'secret.local.part@example.com',
+      smtpResponse: '250 OK',
+      processingTimeMillis: 100,
+    };
+    emitSesEventSpan(event);
+    const callArgs = startSpan.mock.calls[0] as unknown as [Record<string, unknown>, unknown];
+    const attrs = callArgs[0].attributes as Record<string, string | number>;
+    for (const v of Object.values(attrs)) {
+      const text = typeof v === 'string' ? v : String(v);
+      expect(text).not.toMatch(/secret\.local\.part/);
+    }
+    expect(attrs['email.recipient_domain']).toBe('example.com');
+  });
+
+  it('emits ses.delivery_latency_ms = delta in ms on Delivery events', () => {
+    const event: SesEvent = {
+      kind: 'Delivery',
+      messageId: 'mid-3',
+      sendTimestamp: sendTs,
+      deliveredAt,
+      recipient: 'user@example.com',
+      smtpResponse: '250 OK',
+      processingTimeMillis: 1234,
+    };
+    emitSesEventSpan(event);
+    expect(setAttribute).toHaveBeenCalledWith('ses.delivery_latency_ms', 2500);
+    expect(setAttribute).toHaveBeenCalledWith('ses.processing_time_ms', 1234);
+  });
+
+  it('clamps negative latency to 0 (clock skew defense)', () => {
+    const event: SesEvent = {
+      kind: 'Delivery',
+      messageId: 'mid-4',
+      sendTimestamp: new Date('2026-05-24T10:00:05.000Z'),
+      deliveredAt: new Date('2026-05-24T10:00:00.000Z'),
+      recipient: 'user@example.com',
+      smtpResponse: '250 OK',
+      processingTimeMillis: 100,
+    };
+    emitSesEventSpan(event);
+    expect(setAttribute).toHaveBeenCalledWith('ses.delivery_latency_ms', 0);
+  });
+
+  it('sets failed_precondition status on Bounce', () => {
+    const event: SesEvent = {
+      kind: 'Bounce',
+      messageId: 'mid-5',
+      sendTimestamp: sendTs,
+      recipient: 'user@example.com',
+      bounceType: 'Permanent',
+      bounceSubType: 'General',
+    };
+    emitSesEventSpan(event);
+    // Sentry numeric status codes: 1 = OK, 2 = ERROR
+    expect(setStatus).toHaveBeenCalledWith({ code: 2, message: 'failed_precondition' });
+  });
+
+  it('sets deadline_exceeded status on DeliveryDelay', () => {
+    const event: SesEvent = {
+      kind: 'DeliveryDelay',
+      messageId: 'mid-6',
+      sendTimestamp: sendTs,
+      recipient: 'user@example.com',
+      delayType: 'MailboxFull',
+      expirationTime: null,
+    };
+    emitSesEventSpan(event);
+    expect(setStatus).toHaveBeenCalledWith({ code: 2, message: 'deadline_exceeded' });
+  });
+
+  it('trims smtpResponse to 500 chars', () => {
+    const longResp = 'x'.repeat(800);
+    const event: SesEvent = {
+      kind: 'Delivery',
+      messageId: 'mid-7',
+      sendTimestamp: sendTs,
+      deliveredAt,
+      recipient: 'user@example.com',
+      smtpResponse: longResp,
+      processingTimeMillis: 0,
+    };
+    emitSesEventSpan(event);
+    const callArgs = startSpan.mock.calls[0] as unknown as [Record<string, unknown>, unknown];
+    const attrs = callArgs[0].attributes as Record<string, unknown>;
+    expect((attrs['email.smtp_response'] as string).length).toBe(500);
+  });
+
+  it('falls back to "unknown" domain when recipient has no @', () => {
+    const event: SesEvent = {
+      kind: 'Reject',
+      messageId: 'mid-8',
+      sendTimestamp: sendTs,
+      reason: 'Bad content',
+    };
+    emitSesEventSpan(event);
+    const callArgs = startSpan.mock.calls[0] as unknown as [Record<string, unknown>, unknown];
+    const attrs = callArgs[0].attributes as Record<string, unknown>;
+    expect(attrs['email.recipient_domain']).toBe('unknown');
+  });
+});

--- a/tests/unit/services/ses-events/parse-ses-event.test.ts
+++ b/tests/unit/services/ses-events/parse-ses-event.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from '@jest/globals';
+import { parseSesEvent } from '../../../../apps/backend/services/ses-events/parse-ses-event';
+
+/**
+ * Fixtures modeled on the SES event payload documented at
+ * https://docs.aws.amazon.com/ses/latest/dg/event-publishing-retrieving-sns-contents.html
+ * — the SNS-wrapped event publishing schema.
+ *
+ * Fields we don't surface on spans (mail.headers, mail.commonHeaders, the
+ * full mail.tags map, etc.) are still kept in fixtures so the parser is
+ * exercised against the real shape, not a stripped-down one.
+ */
+
+const baseMail = {
+  timestamp: '2026-05-24T10:00:00.000Z',
+  source: 'no-reply@wxyc.org',
+  sourceArn: 'arn:aws:ses:us-east-1:203767826763:identity/wxyc.org',
+  sendingAccountId: '203767826763',
+  messageId: '01000180abcdef00-12345678-1234-1234-1234-1234567890ab-000000',
+  destination: ['user@example.com'],
+  headersTruncated: false,
+  headers: [{ name: 'From', value: 'no-reply@wxyc.org' }],
+  commonHeaders: { from: ['no-reply@wxyc.org'], to: ['user@example.com'], subject: 'Your WXYC login code' },
+};
+
+describe('parseSesEvent', () => {
+  it('parses a Send event', () => {
+    const event = parseSesEvent({ eventType: 'Send', mail: baseMail, send: {} });
+    expect(event).toEqual({
+      kind: 'Send',
+      messageId: baseMail.messageId,
+      sendTimestamp: new Date(baseMail.timestamp),
+      recipients: ['user@example.com'],
+    });
+  });
+
+  it('parses a Delivery event with delivery latency math intact', () => {
+    const event = parseSesEvent({
+      eventType: 'Delivery',
+      mail: baseMail,
+      delivery: {
+        timestamp: '2026-05-24T10:00:02.500Z',
+        processingTimeMillis: 1234,
+        recipients: ['user@example.com'],
+        smtpResponse: '250 2.0.0 OK',
+        reportingMTA: 'a8-83.smtp-out.amazonses.com',
+      },
+    });
+    expect(event.kind).toBe('Delivery');
+    if (event.kind !== 'Delivery') throw new Error('discriminant');
+    expect(event.recipient).toBe('user@example.com');
+    expect(event.processingTimeMillis).toBe(1234);
+    expect(event.smtpResponse).toBe('250 2.0.0 OK');
+    expect(event.deliveredAt.getTime() - event.sendTimestamp.getTime()).toBe(2500);
+  });
+
+  it('parses a Bounce event and surfaces bounceType + subType', () => {
+    const event = parseSesEvent({
+      eventType: 'Bounce',
+      mail: baseMail,
+      bounce: {
+        bounceType: 'Permanent',
+        bounceSubType: 'General',
+        bouncedRecipients: [
+          { emailAddress: 'user@example.com', status: '5.1.1', diagnosticCode: 'smtp; 550 user unknown' },
+        ],
+        timestamp: '2026-05-24T10:00:01.000Z',
+        feedbackId: '01000180bouncefeed-...',
+      },
+    });
+    expect(event).toMatchObject({
+      kind: 'Bounce',
+      recipient: 'user@example.com',
+      bounceType: 'Permanent',
+      bounceSubType: 'General',
+    });
+  });
+
+  it('parses a Complaint event', () => {
+    const event = parseSesEvent({
+      eventType: 'Complaint',
+      mail: baseMail,
+      complaint: {
+        complainedRecipients: [{ emailAddress: 'user@example.com' }],
+        timestamp: '2026-05-24T10:00:01.000Z',
+        feedbackId: '01000180complaint-...',
+        complaintFeedbackType: 'abuse',
+      },
+    });
+    expect(event).toMatchObject({ kind: 'Complaint', recipient: 'user@example.com' });
+  });
+
+  it('parses a Reject event', () => {
+    const event = parseSesEvent({
+      eventType: 'Reject',
+      mail: baseMail,
+      reject: { reason: 'Bad content' },
+    });
+    expect(event).toMatchObject({ kind: 'Reject', reason: 'Bad content' });
+  });
+
+  it('parses a DeliveryDelay event', () => {
+    const event = parseSesEvent({
+      eventType: 'DeliveryDelay',
+      mail: baseMail,
+      deliveryDelay: {
+        delayType: 'TransientCommunicationFailure',
+        delayedRecipients: [
+          { emailAddress: 'user@example.com', status: '4.4.1', diagnosticCode: 'smtp; 421 try later' },
+        ],
+        expirationTime: '2026-05-24T11:00:00.000Z',
+        reportingMTA: 'a8-83.smtp-out.amazonses.com',
+        timestamp: '2026-05-24T10:05:00.000Z',
+      },
+    });
+    expect(event).toMatchObject({
+      kind: 'DeliveryDelay',
+      recipient: 'user@example.com',
+      delayType: 'TransientCommunicationFailure',
+    });
+    if (event.kind === 'DeliveryDelay') {
+      expect(event.expirationTime?.toISOString()).toBe('2026-05-24T11:00:00.000Z');
+    }
+  });
+
+  it('handles a DeliveryDelay without expirationTime', () => {
+    const event = parseSesEvent({
+      eventType: 'DeliveryDelay',
+      mail: baseMail,
+      deliveryDelay: {
+        delayType: 'MailboxFull',
+        delayedRecipients: [{ emailAddress: 'user@example.com' }],
+      },
+    });
+    if (event.kind !== 'DeliveryDelay') throw new Error('discriminant');
+    expect(event.expirationTime).toBeNull();
+  });
+
+  it('throws on unknown eventType', () => {
+    expect(() => parseSesEvent({ eventType: 'Open', mail: baseMail })).toThrow(/Unknown SES eventType/);
+  });
+
+  it('throws on missing mail.timestamp', () => {
+    const { timestamp: _t, ...mailNoTs } = baseMail;
+    expect(() => parseSesEvent({ eventType: 'Send', mail: mailNoTs })).toThrow(/mail\.timestamp/);
+  });
+
+  it('throws on missing mail.messageId', () => {
+    const { messageId: _m, ...mailNoId } = baseMail;
+    expect(() => parseSesEvent({ eventType: 'Send', mail: mailNoId })).toThrow(/messageId/);
+  });
+
+  it('throws on empty bounce recipients', () => {
+    expect(() =>
+      parseSesEvent({
+        eventType: 'Bounce',
+        mail: baseMail,
+        bounce: { bounceType: 'P', bounceSubType: 'G', bouncedRecipients: [] },
+      })
+    ).toThrow(/bouncedRecipients\[0\]/);
+  });
+
+  it('throws on non-object payload', () => {
+    expect(() => parseSesEvent('not an object')).toThrow(/not an object/);
+    expect(() => parseSesEvent(null)).toThrow();
+    expect(() => parseSesEvent([])).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `POST /internal/ses-events` SNS subscriber that emits one Sentry span per SES event (Send / Delivery / Bounce / Complaint / Reject / DeliveryDelay) so `Send→Delivery` p50/p90/p99 by recipient domain becomes visible in the trace explorer.
- Wires `Sentry.captureException` into the `emailOTP` catch handler so SES errors on OTP sends stop being invisible.
- No AWS-side resources change in this PR — the SNS topic + EventDestination + HTTPS subscription are operator steps documented in [`plans/ses-delivery-instrumentation.md`](plans/ses-delivery-instrumentation.md) and provisioned post-deploy so the SubscriptionConfirmation handshake can complete against the deployed endpoint.

Closes #1070.

## Why this shape

Diagnostic (run 2026-05-24, in `plans/ses-delivery-instrumentation.md`) confirmed SES is healthy: production access granted, 14/s send rate, 0 bounces, 0 complaints, DKIM+SPF+DMARC aligned, custom MAIL FROM verified. The blocker on the user-reported "slow OTP" is that there's no measurement: the configuration set has zero event destinations. This PR adds measurement before changing anything else.

The `wxyc.org` SES identity already has `my-first-configuration-set` as its default config set, so adding the EventDestination instantly attributes every existing send — no code change in `email.ts` needed for measurement; the only existing-code change is the OTP error capture.

## Dep choice (audited)

- **`sns-validator` 0.3.5** — AWS-published (`github.com/aws/aws-js-sns-message-validator`), Apache-2.0, last published 2025-03-27, **zero runtime dependencies**.
- Alternatives `sns-payload-validator` (community, 2023-02-07, lru-cache dep) and `aws-sns-validator` (community, 2022-04-12, brings in deprecated `request` package) were rejected — see plan §E for the comparison table.

## Auth model

- SNS X.509 signature validation via `sns-validator` against the AWS cert chain.
- Topic ARN pinned to `SES_EVENTS_SNS_TOPIC_ARN`; mismatched messages are rejected.
- No shared-key header — SES → SNS → BS cannot inject custom HTTP headers, so the cert chain is the only trust root.

## Body parser

- Route uses inline `express.text({ type: '...', limit: '64kb' })`. The global `app.use(express.json())` only parses `application/json`, and SNS sends `Content-Type: text/plain`, so mount order is irrelevant.

## Out of scope (followups listed in the plan)

- Tagging `SendEmailCommand` with a custom `email.mail_type` SES message tag so spans can be grouped without subject-line heuristics.
- Migrating the other three `void sendEmail(...).catch(...)` callers (`sendResetPassword`, `sendVerificationEmail`, admin account-setup) to Sentry.
- Adding a Sentry alert on `ses.delivery_latency_ms` p90 > 10s once we have a baseline.

## Incidental fix

- `auth.middleware.ts` line 85 needed an explicit `as WXYCAuthJwtPayload` cast on the spread because adding `@sentry/node` to `shared/authentication` deps pulled in stricter type inference that broke the dts build on the previously-implicit spread. The catch branch directly below already had the same cast for the same reason. No runtime behavior change.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors; pre-existing warnings unchanged)
- [x] `npm run format:check` clean
- [x] `npm run build` clean
- [x] `npm run test:unit` — 28 new tests pass; the 2 failures on the branch (`schema.flowsheet-artwork-lookup-idx`, `ci-env-surface-parity`) are pre-existing on `origin/main`, verified by stashing and re-running on clean main.
- [ ] After merge + deploy: operator runs the SNS / EventDestination provisioning commands from the plan, triggers a test OTP, verifies the `ses.event` span lands in Sentry within ~30s with `ses.delivery_latency_ms` populated and `email.recipient_domain` (no local-part).