### PR TITLE
fix(album-level-backfill): isolate HTTP-level bulkLookupMetadata throws per batch (BS#1076)

### DIFF
--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -389,7 +389,23 @@ export const runBatch = async (
     return { batchSize: 0, match: 0, no_match: 0, error: 0, upserts: 0 };
   }
 
-  const response = await bulkLookupMetadata(items, { budgetMs: options.budgetMs });
+  // Isolate HTTP-level failures (timeout, 5xx, network) so a single bad
+  // batch can't abort the whole run. LML's bulk endpoint already
+  // isolates per-item failures via `status: 'error'` in its response —
+  // but if the HTTP call itself throws (LmlClientError on 30s timeout,
+  // BS#1076), the loop dies without try/catch. Treat a thrown batch as
+  // "all N items errored"; the per-row drain cron picks those album_ids
+  // up on its next sweep. Idempotency holds: nothing was UPSERTed.
+  let response;
+  try {
+    response = await bulkLookupMetadata(items, { budgetMs: options.budgetMs });
+  } catch (err) {
+    const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    console.warn(
+      `[${JOB_NAME}] lml.batch_failed size=${items.length} first_album_id=${resolved[0]?.album_id ?? '?'} last_album_id=${resolved[resolved.length - 1]?.album_id ?? '?'} error=${JSON.stringify(msg)}`
+    );
+    return { batchSize: items.length, match: 0, no_match: 0, error: items.length, upserts: 0 };
+  }
   // resolved[i] corresponds to items[i] which corresponds to response.results[i].
   // LML guarantees input-order results.
   let match = 0;

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -540,6 +540,24 @@ describe('runBatch', () => {
     expect(mockBulkLookupMetadata).not.toHaveBeenCalled();
     expect(out).toMatchObject({ batchSize: 0, match: 0 });
   });
+
+  it('BS#1076: HTTP-level bulkLookupMetadata throw is isolated; batch reports error=N and run continues', async () => {
+    // Reproduces the 2026-05-24 prod failure: batch 2 hit a 30s LML
+    // timeout (LmlClientError statusCode 504), which an uncaught throw
+    // would propagate up and abort the entire run mid-stream. With
+    // per-batch try/catch, the batch reports `error=N` and the loop
+    // continues. UPSERTs from prior successful batches stay intact
+    // (idempotent), and the per-row drain cron retries the failed
+    // album_ids on its next sweep.
+    mockBulkLookupMetadata.mockRejectedValueOnce(
+      Object.assign(new Error('LML request timed out'), { name: 'LmlClientError', statusCode: 504 })
+    );
+
+    const out = await runBatch([1, 2], { budgetMs: 25000, dryRun: false });
+
+    expect(out).toMatchObject({ batchSize: 2, match: 0, no_match: 0, error: 2, upserts: 0 });
+    expect(db.insert as jest.Mock).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The 2026-05-24 Phase-3 prod run of \`album-level-backfill:v0.1.4\` died after 2 batches:

\`\`\`
[album-level-backfill] start batchSize=50 ratePerMin=4 budgetMs=25000 dryRun=false
[album-level-backfill] enumerated scanned=35692 unique album_ids
[album-level-backfill] batch=1/714 size=50 match=50 no_match=0 error=0 upserts=48 elapsed_ms=904
[album-level-backfill] FAILED: LmlClientError: LML request timed out
    statusCode: 504
\`\`\`

Batch 2 hit the 30s lml-client \`AbortController\` timeout (cold-cache item in the batch). \`bulkLookupMetadata\` threw \`LmlClientError\`; \`runBatch\` had no try/catch; exception propagated to \`main()\`; entire run aborted with 99.9% of the work remaining. The 48 \`album_metadata\` rows from batch 1 stayed (idempotent), but 35,642 album_ids skipped.

LML's bulk endpoint isolates per-item failures **inside** its response (\`status: 'error'\` per item) but if the HTTP call itself throws, the job had no handling.

Closes #1076.

## Fix

Wrap the \`bulkLookupMetadata\` call in \`runBatch\` with try/catch. On throw, the batch returns \`BatchResult { batchSize: N, match: 0, no_match: 0, error: N, upserts: 0 }\`; the loop continues. The per-row drain cron picks up the failed album_ids on its next sweep.

Logged warning includes batch size + first/last \`album_id\` so the operator can correlate which range of the alphabet failed.

## Test

\`tests/unit/jobs/album-level-backfill/job.test.ts\` adds a new \`runBatch\` case: mocks \`bulkLookupMetadata\` with \`mockRejectedValueOnce\` throwing a 504 \`LmlClientError\`, asserts \`runBatch\` returns the expected error-N shape and never touches \`db.insert\`. 52/52 pass locally.

## Why prior tests missed it

The mock-only unit suite used \`.mockResolvedValue()\` everywhere — happy path only. No test exercised the throw path. Same theme as the prior BS#1056/#1065/#1068/#1071: the test surface can't catch what the mocks don't simulate. Tracked as the recurring \"add CI Docker-postgres integration test\" follow-up.

## Test plan

- [x] \`npm run test:unit -- --testPathPatterns='album-level-backfill'\` — 52/52 pass
- [x] \`npx tsc --noEmit -p jobs/album-level-backfill/tsconfig.json\` — clean
- [x] \`npx prettier --check\` — clean

### Post-merge verification

Pull v0.1.5 to EC2 and retry the Phase-3 run with the aggressive knobs. Expect: most batches succeed; occasional cold-cache batches log \`lml.batch_failed size=50 ...\` and report \`error=50\`; the loop continues; eventual exit with a non-zero \`error\` count is now expected (and acceptable — those album_ids re-attempt on next cron sweep).

## Related

- [BS#1041](https://github.com/WXYC/Backend-Service/issues/1041) / [PR #1055](https://github.com/WXYC/Backend-Service/pull/1055) — feature
- [BS#1056](https://github.com/WXYC/Backend-Service/issues/1056), [BS#1065](https://github.com/WXYC/Backend-Service/issues/1065), [BS#1068](https://github.com/WXYC/Backend-Service/issues/1068), [BS#1071](https://github.com/WXYC/Backend-Service/issues/1071) — earlier prod-discovered execution-time bugs
- [BS#1064](https://github.com/WXYC/Backend-Service/issues/1064) — same root cause class (LML 30s timeout); the per-row cron has it at 21% rate