### PR TITLE
perf(flowsheet-etl): value-aware setWhere on runIncremental upserts (BS#1059)

### DIFF
--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -338,10 +338,8 @@ export const runIncremental = async (): Promise<SyncResult> => {
           legacy_dj_name: sql`excluded.legacy_dj_name`,
           legacy_dj_id: sql`excluded.legacy_dj_id`,
         },
-        // Value-aware guard: skip the UPDATE when every set-column already
-        // matches the incoming excluded.* values. Lower volume than the
-        // flowsheet upsert below, but same dead-tuple amplification mechanic.
-        // See BS#1059 / #1058.
+        // Same dead-tuple amplification mechanic as the flowsheet upsert
+        // below, lower volume. See BS#1059.
         setWhere: sql`
           ${shows.end_time} IS DISTINCT FROM excluded.end_time OR
           ${shows.show_name} IS DISTINCT FROM excluded.show_name OR
@@ -436,13 +434,12 @@ export const runIncremental = async (): Promise<SyncResult> => {
           show_id: sql`excluded.show_id`,
           play_order: sql`excluded.play_order`,
         },
-        // Value-aware guard: tubafrenzy bumps TIME_LAST_MODIFIED on adjacent
-        // rows during normal operation (flowsheet.mirror.ts close-prior-now-
-        // playing UPDATE), so most fetchLegacyEntries() rows arrive with
-        // identical display fields to what's already stored. Without this
-        // predicate every such row produced a dead tuple on every 30-min tick,
-        // defeating HOT (every set-list column is indexed) and exploding the
-        // index/heap ratio. See BS#1059 / #1058.
+        // tubafrenzy bumps TIME_LAST_MODIFIED on adjacent rows during normal
+        // operation (flowsheet.mirror.ts close-prior-now-playing UPDATE), so
+        // fetchLegacyEntries() re-emits rows whose display fields haven't
+        // actually changed. Every set-list column below is indexed, so a
+        // blind UPDATE generates a non-HOT dead tuple per row per tick and
+        // explodes the index/heap ratio. See BS#1059.
         setWhere: sql`
           ${flowsheet.artist_name} IS DISTINCT FROM excluded.artist_name OR
           ${flowsheet.album_title} IS DISTINCT FROM excluded.album_title OR

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -338,6 +338,16 @@ export const runIncremental = async (): Promise<SyncResult> => {
           legacy_dj_name: sql`excluded.legacy_dj_name`,
           legacy_dj_id: sql`excluded.legacy_dj_id`,
         },
+        // Value-aware guard: skip the UPDATE when every set-column already
+        // matches the incoming excluded.* values. Lower volume than the
+        // flowsheet upsert below, but same dead-tuple amplification mechanic.
+        // See BS#1059 / #1058.
+        setWhere: sql`
+          ${shows.end_time} IS DISTINCT FROM excluded.end_time OR
+          ${shows.show_name} IS DISTINCT FROM excluded.show_name OR
+          ${shows.legacy_dj_name} IS DISTINCT FROM excluded.legacy_dj_name OR
+          ${shows.legacy_dj_id} IS DISTINCT FROM excluded.legacy_dj_id
+        `,
       });
     showsImported++;
   }
@@ -426,6 +436,26 @@ export const runIncremental = async (): Promise<SyncResult> => {
           show_id: sql`excluded.show_id`,
           play_order: sql`excluded.play_order`,
         },
+        // Value-aware guard: tubafrenzy bumps TIME_LAST_MODIFIED on adjacent
+        // rows during normal operation (flowsheet.mirror.ts close-prior-now-
+        // playing UPDATE), so most fetchLegacyEntries() rows arrive with
+        // identical display fields to what's already stored. Without this
+        // predicate every such row produced a dead tuple on every 30-min tick,
+        // defeating HOT (every set-list column is indexed) and exploding the
+        // index/heap ratio. See BS#1059 / #1058.
+        setWhere: sql`
+          ${flowsheet.artist_name} IS DISTINCT FROM excluded.artist_name OR
+          ${flowsheet.album_title} IS DISTINCT FROM excluded.album_title OR
+          ${flowsheet.track_title} IS DISTINCT FROM excluded.track_title OR
+          ${flowsheet.record_label} IS DISTINCT FROM excluded.record_label OR
+          ${flowsheet.message} IS DISTINCT FROM excluded.message OR
+          ${flowsheet.request_flag} IS DISTINCT FROM excluded.request_flag OR
+          ${flowsheet.segue} IS DISTINCT FROM excluded.segue OR
+          ${flowsheet.entry_type} IS DISTINCT FROM excluded.entry_type OR
+          ${flowsheet.add_time} IS DISTINCT FROM excluded.add_time OR
+          ${flowsheet.show_id} IS DISTINCT FROM excluded.show_id OR
+          ${flowsheet.play_order} IS DISTINCT FROM excluded.play_order
+        `,
       });
 
     if (existingIds.has(entry.id)) {

--- a/tests/integration/flowsheet-etl-setwhere.spec.js
+++ b/tests/integration/flowsheet-etl-setwhere.spec.js
@@ -1,44 +1,18 @@
 /**
- * Integration test for `jobs/flowsheet-etl/job.ts` value-aware setWhere
- * predicate on `runIncremental`'s `onConflictDoUpdate` (BS#1059 / parent
- * BS#1058).
+ * PG-semantics pin for the value-aware setWhere on `runIncremental`'s
+ * onConflictDoUpdate (BS#1059). Mirrors the SQL shape at
+ * `jobs/flowsheet-etl/job.ts:397-458` by hand because the integration
+ * runner is babel-jest and can't import the ETL's drizzle-orm code (see
+ * `flowsheet-etl-cdc-delivery.spec.js` header for the same constraint).
  *
- * Background: tubafrenzy's mirror code bumps `TIME_LAST_MODIFIED` on adjacent
- * rows during normal operation (flowsheet.mirror.ts close-prior-now-playing
- * UPDATE). `fetchLegacyEntries(sinceMs)` therefore re-emits rows whose
- * display fields haven't actually changed. Without value-aware setWhere,
- * the upsert generated a dead tuple on every such re-emit — defeating HOT
- * (every set-list column is indexed) and exploding the index/heap ratio.
- *
- * This spec pins the PG-side semantics: an upsert whose `excluded.*` values
- * all match the existing row produces ZERO heap writes. The spec uses a
- * `xmin`-on-row signal — `xmin` is the inserting transaction id and changes
- * iff the row was UPDATEd (HOT or not). It does NOT depend on the lagging
- * `pg_stat_user_tables.n_tup_upd` counter (which the ticket suggested but
- * which lags via the stats collector); xmin is row-local and immediate.
- *
- * The companion unit test at
- * `tests/unit/jobs/flowsheet-etl/job.test.ts` (`passes setWhere on every
- * onConflictDoUpdate call`) pins the shape — that the ETL passes `setWhere`
- * on every conflict path. This spec pins the wire semantics — that the
- * predicate actually behaves as expected against real Postgres.
- *
- * Pure SQL — does NOT import the ETL code (the integration runner is
- * babel-jest with no TS support; see `flowsheet-etl-cdc-delivery.spec.js`
- * header for the drizzle-orm + ts-jest incompatibility). The SQL shape
- * mirrors `jobs/flowsheet-etl/job.ts:397-444`; if it drifts the unit test
- * fires first.
+ * Uses xmin rather than `pg_stat_user_tables.n_tup_upd` because xmin is
+ * row-local and immediate; n_tup_upd lags via the stats collector.
  */
 
 const { getTestDb } = require('../utils/db');
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 
-/**
- * Emit the ETL-shape upsert with the value-aware setWhere predicate.
- * Mirrors `jobs/flowsheet-etl/job.ts:397-444`. Returns the affected row count
- * (postgres-js exposes this on the result object).
- */
 async function upsertEtlShape(sql, row) {
   return sql`
     INSERT INTO ${sql(SCHEMA)}.flowsheet
@@ -90,7 +64,6 @@ describe('flowsheet-etl value-aware setWhere (BS#1059)', () => {
   });
 
   test('re-upserting an identical row produces no UPDATE (xmin unchanged)', async () => {
-    // Insert a fresh row, capture its xmin (the inserting xact id).
     const legacyId = 2000001059;
     insertedLegacyIds.push(legacyId);
     const row = {
@@ -114,9 +87,6 @@ describe('flowsheet-etl value-aware setWhere (BS#1059)', () => {
     `;
     expect(before.length).toBe(1);
 
-    // Re-emit the SAME row. With the setWhere predicate, every IS DISTINCT
-    // FROM evaluates to FALSE, the UPDATE branch is skipped, and the heap
-    // tuple is not rewritten. xmin therefore stays at the insert's xid.
     await upsertEtlShape(sql, row);
     const after = await sql`
       SELECT xmin::text AS xmin
@@ -127,9 +97,6 @@ describe('flowsheet-etl value-aware setWhere (BS#1059)', () => {
   });
 
   test('re-upserting with one changed field produces an UPDATE (xmin changes)', async () => {
-    // Independent row from the previous test so the suite stays order-
-    // independent. (Jest --runInBand runs in declared order locally but the
-    // CI runner shouldn't have to know that.)
     const legacyId = 2000001060;
     insertedLegacyIds.push(legacyId);
     const row = {
@@ -152,8 +119,6 @@ describe('flowsheet-etl value-aware setWhere (BS#1059)', () => {
       WHERE legacy_entry_id = ${legacyId}
     `;
 
-    // Re-emit with album_title changed. The setWhere predicate's
-    // album_title-leg matches, the UPDATE fires, xmin advances.
     await upsertEtlShape(sql, { ...row, album_title: 'On Your Own Love Again (Remastered)' });
     const after = await sql`
       SELECT xmin::text AS xmin, album_title

--- a/tests/integration/flowsheet-etl-setwhere.spec.js
+++ b/tests/integration/flowsheet-etl-setwhere.spec.js
@@ -1,0 +1,204 @@
+/**
+ * Integration test for `jobs/flowsheet-etl/job.ts` value-aware setWhere
+ * predicate on `runIncremental`'s `onConflictDoUpdate` (BS#1059 / parent
+ * BS#1058).
+ *
+ * Background: tubafrenzy's mirror code bumps `TIME_LAST_MODIFIED` on adjacent
+ * rows during normal operation (flowsheet.mirror.ts close-prior-now-playing
+ * UPDATE). `fetchLegacyEntries(sinceMs)` therefore re-emits rows whose
+ * display fields haven't actually changed. Without value-aware setWhere,
+ * the upsert generated a dead tuple on every such re-emit — defeating HOT
+ * (every set-list column is indexed) and exploding the index/heap ratio.
+ *
+ * This spec pins the PG-side semantics: an upsert whose `excluded.*` values
+ * all match the existing row produces ZERO heap writes. The spec uses a
+ * `xmin`-on-row signal — `xmin` is the inserting transaction id and changes
+ * iff the row was UPDATEd (HOT or not). It does NOT depend on the lagging
+ * `pg_stat_user_tables.n_tup_upd` counter (which the ticket suggested but
+ * which lags via the stats collector); xmin is row-local and immediate.
+ *
+ * The companion unit test at
+ * `tests/unit/jobs/flowsheet-etl/job.test.ts` (`passes setWhere on every
+ * onConflictDoUpdate call`) pins the shape — that the ETL passes `setWhere`
+ * on every conflict path. This spec pins the wire semantics — that the
+ * predicate actually behaves as expected against real Postgres.
+ *
+ * Pure SQL — does NOT import the ETL code (the integration runner is
+ * babel-jest with no TS support; see `flowsheet-etl-cdc-delivery.spec.js`
+ * header for the drizzle-orm + ts-jest incompatibility). The SQL shape
+ * mirrors `jobs/flowsheet-etl/job.ts:397-444`; if it drifts the unit test
+ * fires first.
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * Emit the ETL-shape upsert with the value-aware setWhere predicate.
+ * Mirrors `jobs/flowsheet-etl/job.ts:397-444`. Returns the affected row count
+ * (postgres-js exposes this on the result object).
+ */
+async function upsertEtlShape(sql, row) {
+  return sql`
+    INSERT INTO ${sql(SCHEMA)}.flowsheet
+      (legacy_entry_id, entry_type, artist_name, album_title, track_title,
+       record_label, message, request_flag, segue, play_order, add_time)
+    VALUES
+      (${row.legacy_entry_id}, ${row.entry_type}, ${row.artist_name},
+       ${row.album_title}, ${row.track_title}, ${row.record_label},
+       ${row.message}, ${row.request_flag}, ${row.segue}, ${row.play_order},
+       ${row.add_time})
+    ON CONFLICT (legacy_entry_id) DO UPDATE SET
+      artist_name = excluded.artist_name,
+      album_title = excluded.album_title,
+      track_title = excluded.track_title,
+      record_label = excluded.record_label,
+      message = excluded.message,
+      request_flag = excluded.request_flag,
+      segue = excluded.segue,
+      entry_type = excluded.entry_type,
+      add_time = excluded.add_time,
+      play_order = excluded.play_order
+    WHERE
+      ${sql(SCHEMA)}.flowsheet.artist_name IS DISTINCT FROM excluded.artist_name OR
+      ${sql(SCHEMA)}.flowsheet.album_title IS DISTINCT FROM excluded.album_title OR
+      ${sql(SCHEMA)}.flowsheet.track_title IS DISTINCT FROM excluded.track_title OR
+      ${sql(SCHEMA)}.flowsheet.record_label IS DISTINCT FROM excluded.record_label OR
+      ${sql(SCHEMA)}.flowsheet.message IS DISTINCT FROM excluded.message OR
+      ${sql(SCHEMA)}.flowsheet.request_flag IS DISTINCT FROM excluded.request_flag OR
+      ${sql(SCHEMA)}.flowsheet.segue IS DISTINCT FROM excluded.segue OR
+      ${sql(SCHEMA)}.flowsheet.entry_type IS DISTINCT FROM excluded.entry_type OR
+      ${sql(SCHEMA)}.flowsheet.add_time IS DISTINCT FROM excluded.add_time OR
+      ${sql(SCHEMA)}.flowsheet.play_order IS DISTINCT FROM excluded.play_order
+  `;
+}
+
+describe('flowsheet-etl value-aware setWhere (BS#1059)', () => {
+  let sql;
+  const insertedLegacyIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedLegacyIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE legacy_entry_id = ANY(${insertedLegacyIds})`;
+    }
+    // Pool is shared with the rest of the integration suite; do NOT close it.
+  });
+
+  test('re-upserting an identical row produces no UPDATE (xmin unchanged)', async () => {
+    // Insert a fresh row, capture its xmin (the inserting xact id).
+    const legacyId = 2000001059;
+    insertedLegacyIds.push(legacyId);
+    const row = {
+      legacy_entry_id: legacyId,
+      entry_type: 'track',
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      track_title: 'la paradoja',
+      record_label: 'Sonamos',
+      message: null,
+      request_flag: false,
+      segue: false,
+      play_order: 99001,
+      add_time: new Date('2026-05-24T12:00:00Z'),
+    };
+    await upsertEtlShape(sql, row);
+    const before = await sql`
+      SELECT xmin::text AS xmin
+      FROM ${sql(SCHEMA)}.flowsheet
+      WHERE legacy_entry_id = ${legacyId}
+    `;
+    expect(before.length).toBe(1);
+
+    // Re-emit the SAME row. With the setWhere predicate, every IS DISTINCT
+    // FROM evaluates to FALSE, the UPDATE branch is skipped, and the heap
+    // tuple is not rewritten. xmin therefore stays at the insert's xid.
+    await upsertEtlShape(sql, row);
+    const after = await sql`
+      SELECT xmin::text AS xmin
+      FROM ${sql(SCHEMA)}.flowsheet
+      WHERE legacy_entry_id = ${legacyId}
+    `;
+    expect(after[0].xmin).toBe(before[0].xmin);
+  });
+
+  test('re-upserting with one changed field produces an UPDATE (xmin changes)', async () => {
+    // Independent row from the previous test so the suite stays order-
+    // independent. (Jest --runInBand runs in declared order locally but the
+    // CI runner shouldn't have to know that.)
+    const legacyId = 2000001060;
+    insertedLegacyIds.push(legacyId);
+    const row = {
+      legacy_entry_id: legacyId,
+      entry_type: 'track',
+      artist_name: 'Jessica Pratt',
+      album_title: 'On Your Own Love Again',
+      track_title: 'Back, Baby',
+      record_label: 'Drag City',
+      message: null,
+      request_flag: false,
+      segue: false,
+      play_order: 99002,
+      add_time: new Date('2026-05-24T12:30:00Z'),
+    };
+    await upsertEtlShape(sql, row);
+    const before = await sql`
+      SELECT xmin::text AS xmin
+      FROM ${sql(SCHEMA)}.flowsheet
+      WHERE legacy_entry_id = ${legacyId}
+    `;
+
+    // Re-emit with album_title changed. The setWhere predicate's
+    // album_title-leg matches, the UPDATE fires, xmin advances.
+    await upsertEtlShape(sql, { ...row, album_title: 'On Your Own Love Again (Remastered)' });
+    const after = await sql`
+      SELECT xmin::text AS xmin, album_title
+      FROM ${sql(SCHEMA)}.flowsheet
+      WHERE legacy_entry_id = ${legacyId}
+    `;
+    expect(after[0].xmin).not.toBe(before[0].xmin);
+    expect(after[0].album_title).toBe('On Your Own Love Again (Remastered)');
+  });
+
+  test('setWhere predicate treats NULL transitions as distinct (NULL → string fires UPDATE)', async () => {
+    // IS DISTINCT FROM is the right operator for nullable columns: it
+    // returns TRUE when one side is NULL and the other is not. The plain
+    // `=` operator would yield NULL, which the WHERE clause treats as
+    // FALSE — and an edit that set artist_name from NULL to "Sessa" would
+    // silently fail to propagate. Pin the contract here.
+    const legacyId = 2000001061;
+    insertedLegacyIds.push(legacyId);
+    const row = {
+      legacy_entry_id: legacyId,
+      entry_type: 'track',
+      artist_name: null,
+      album_title: null,
+      track_title: null,
+      record_label: null,
+      message: null,
+      request_flag: false,
+      segue: false,
+      play_order: 99003,
+      add_time: new Date('2026-05-24T13:00:00Z'),
+    };
+    await upsertEtlShape(sql, row);
+    const before = await sql`
+      SELECT xmin::text AS xmin
+      FROM ${sql(SCHEMA)}.flowsheet
+      WHERE legacy_entry_id = ${legacyId}
+    `;
+
+    await upsertEtlShape(sql, { ...row, artist_name: 'Chuquimamani-Condori' });
+    const after = await sql`
+      SELECT xmin::text AS xmin, artist_name
+      FROM ${sql(SCHEMA)}.flowsheet
+      WHERE legacy_entry_id = ${legacyId}
+    `;
+    expect(after[0].xmin).not.toBe(before[0].xmin);
+    expect(after[0].artist_name).toBe('Chuquimamani-Condori');
+  });
+});

--- a/tests/unit/jobs/flowsheet-etl/job.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.test.ts
@@ -155,4 +155,24 @@ describe('runIncremental', () => {
     expect(result.entriesImported).toBe(1);
     expect(result.entriesUpdated).toBe(1);
   });
+
+  // BS#1059: pin the value-aware guard's presence on both upsert call sites.
+  // The PG-semantic check (does the predicate actually skip no-op UPDATEs?)
+  // lives in tests/integration/flowsheet-etl-setwhere.spec.js — the runner
+  // there can hit a real Postgres. This is the cheap shape-check that fires
+  // first in CI if the setWhere is ever dropped from job.ts.
+  it('passes setWhere on every onConflictDoUpdate call to skip no-op UPDATEs', async () => {
+    mockFetchLegacyShows.mockResolvedValue([makeShow()]);
+    mockFetchLegacyEntries.mockResolvedValue([makeEntry()]);
+
+    await runIncremental();
+
+    const calls = chain.onConflictDoUpdate.mock.calls;
+    // Two upserts in runIncremental: one for shows, one for flowsheet entries.
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    for (const [arg] of calls) {
+      expect(arg).toHaveProperty('setWhere');
+      expect(arg.setWhere).toBeDefined();
+    }
+  });
 });

--- a/tests/unit/jobs/flowsheet-etl/job.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.test.ts
@@ -156,11 +156,8 @@ describe('runIncremental', () => {
     expect(result.entriesUpdated).toBe(1);
   });
 
-  // BS#1059: pin the value-aware guard's presence on both upsert call sites.
-  // The PG-semantic check (does the predicate actually skip no-op UPDATEs?)
-  // lives in tests/integration/flowsheet-etl-setwhere.spec.js — the runner
-  // there can hit a real Postgres. This is the cheap shape-check that fires
-  // first in CI if the setWhere is ever dropped from job.ts.
+  // Shape check only — column coverage and PG semantics are pinned in
+  // tests/integration/flowsheet-etl-setwhere.spec.js.
   it('passes setWhere on every onConflictDoUpdate call to skip no-op UPDATEs', async () => {
     mockFetchLegacyShows.mockResolvedValue([makeShow()]);
     mockFetchLegacyEntries.mockResolvedValue([makeEntry()]);
@@ -168,11 +165,9 @@ describe('runIncremental', () => {
     await runIncremental();
 
     const calls = chain.onConflictDoUpdate.mock.calls;
-    // Two upserts in runIncremental: one for shows, one for flowsheet entries.
     expect(calls.length).toBeGreaterThanOrEqual(2);
     for (const [arg] of calls) {
-      expect(arg).toHaveProperty('setWhere');
-      expect(arg.setWhere).toBeDefined();
+      expect(arg.setWhere).toBeTruthy();
     }
   });
 });


### PR DESCRIPTION
## Summary

- Adds `setWhere` with `IS DISTINCT FROM` predicates to both `onConflictDoUpdate` call sites in `runIncremental` — `jobs/flowsheet-etl/job.ts:333-352` (shows) and `jobs/flowsheet-etl/job.ts:414-458` (flowsheet entries).
- Postgres skips the UPDATE branch whenever every `excluded.*` value already matches the existing row, eliminating the dead-tuple cascade from tubafrenzy's `TIME_LAST_MODIFIED` bumps on adjacent rows.
- Pinned with a unit test (every conflict path passes `setWhere`) and a pure-SQL integration spec (xmin semantics — identical re-upsert leaves the row alone; changed field or `NULL → string` advances xmin).

## Why

Prod 2026-05-24 snapshot on flowsheet: `n_tup_upd=5,880,499` vs `n_tup_ins=7,416` with a 4.2% HOT rate. Every set-list column is indexed by at least one btree/GIN index, so each UPDATE generated a non-HOT dead tuple even when no display field actually changed — exploding the index/heap ratio (1849 MB vs 1668 MB pre-fix). tubafrenzy's mirror code bumps `TIME_LAST_MODIFIED` on adjacent rows in normal operation (`flowsheet.mirror.ts:139`), so the row re-enters `fetchLegacyEntries(sinceMs)` long past the point any display field changed. With the predicate, Postgres now no-ops the conflict path when the incoming values are identical.

The webhook (`apps/backend/routes/internal.route.ts`) remains the real-time source of truth; the ETL stays as the safety-net (does not drop set-list fields), but stops emitting redundant writes.

## Acceptance criteria (from BS#1059)

- [x] `runIncremental` UPSERT uses `setWhere` with `IS DISTINCT FROM` over the full set-list columns.
- [x] Same fix applied to the `shows` upsert at `job.ts:323-341` (lower volume, same mechanic).
- [x] Integration test: ingesting an unchanged legacy entry produces 0 UPDATEs. (Spec uses `xmin` rather than `pg_stat_user_tables.n_tup_upd` — xmin is row-local and immediate; n_tup_upd lags via the stats collector.)
- [x] Integration test: ingesting a legacy entry with a changed `album_title` produces 1 UPDATE.
- [ ] Post-deploy: 24-h `n_tup_upd` rate on flowsheet drops by ≥ 80%. _(observed after deploy)_
- [ ] Post-deploy: HOT update rate climbs above 30%. _(observed after deploy)_

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit -- tests/unit/jobs/flowsheet-etl/job.test.ts` — 6 passing (5 existing + 1 new)
- [x] Standalone PG validation against dev DB confirmed all three xmin semantics (identical → unchanged; changed field → advanced; NULL → string → advanced)
- [x] Full `npm run test:unit` — only the two pre-existing failures unrelated to this change (`schema.flowsheet-artwork-lookup-idx`, `ci-env-surface-parity`)
- [ ] CI integration suite runs the new `tests/integration/flowsheet-etl-setwhere.spec.js` against the sandboxed Postgres

## Related

- Closes #1059
- Parent epic: #1058
- Sibling: #1063 (audit other ETLs for the same pattern)