### PR TITLE
fix(catalog): widen modern Card Catalog cascade gate to multi-word (BS#1146)

### DIFF
--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { sql, type SQL } from 'drizzle-orm';
 import { db, library_artist_view, genres, format as formatTable } from '@wxyc/database';
 import type { TrackMatchHint } from '@wxyc/shared/dtos';
@@ -120,25 +121,57 @@ export async function searchLibrary(
 
   if (results.length > 0 || total > 0) return { results, total };
 
-  // Catalog-track-search cascade (BS#977). When the primary query returns no
-  // rows AND the user typed a single bareword (no field qualifiers, exact
-  // match, or negation), fall through to Track 1 (CTA) + Track 2 (LML
-  // `/lookup`). The cascade is single-page: pagination beyond page 0 stays
-  // empty so the client doesn't keep scrolling into a bounded fallback list.
+  // Catalog-track-search cascade (BS#977, multi-word relaxation BS#1146). When
+  // the primary query returns no rows AND the user typed plain text (no field
+  // qualifiers, exact match, NOT, or OR), fall through to Track 1 (CTA) +
+  // Track 2 (LML `/lookup`). The cascade is single-page: pagination beyond
+  // page 0 stays empty so the client doesn't keep scrolling into a bounded
+  // fallback list.
+  //
+  // Two cheap defensive guards keep cascade-entry traffic bounded against
+  // typo storms and pathological inputs: `MIN_CASCADE_QUERY_LENGTH` rules out
+  // 1-3-char-per-word noise; the conditions cap inside `isPlainTextQuery`
+  // rules out long pasted lyrics / query-builder abuse. The downstream LML
+  // chokepoint (`Semaphore(5) + TokenBucket(50/min)` in `@wxyc/lml-client`)
+  // is the hard cap on fan-out; these guards just trim the worst inputs
+  // before they reach it.
   if (params.page !== 0) return { results, total };
-  if (!isSingleBareword(conditions)) return { results, total };
+  if (params.q.trim().length < MIN_CASCADE_QUERY_LENGTH) return { results, total };
+  if (!isPlainTextQuery(conditions)) return { results, total };
 
-  const cascadeResults = await runCascade(params);
+  const cascadeResults = await runCascade(params, conditions.length);
   return { results: cascadeResults, total: cascadeResults.length };
 }
 
-function isSingleBareword(conditions: SearchCondition<CatalogField>[]): boolean {
-  if (conditions.length !== 1) return false;
-  const [c] = conditions;
-  return c.field === 'all' && !c.exact && !c.negated;
+export const MIN_CASCADE_QUERY_LENGTH = 4;
+export const MAX_CASCADE_CONDITIONS = 6;
+
+export function isPlainTextQuery(conditions: SearchCondition<CatalogField>[]): boolean {
+  if (conditions.length === 0 || conditions.length > MAX_CASCADE_CONDITIONS) return false;
+  return conditions.every((c) => c.field === 'all' && !c.exact && !c.negated && c.operator === 'AND');
 }
 
-async function runCascade(params: LibraryQueryParams): Promise<AlbumSearchResultRow[]> {
+/**
+ * Wraps the cascade in a `catalog.cascade` span that carries the numeric
+ * `cascade.query_word_count` attribute set at creation time — pass attrs at
+ * `startSpan` rather than `setAttribute(name, number)` after creation so Sentry
+ * indexes the value as numeric and not as a string (the avg/p50/p90
+ * aggregation trap from BS#1081). Lets post-deploy dashboards split widened
+ * traffic (≥2 conditions) from baseline (1 condition) without renaming any
+ * existing `track_search.*` attributes.
+ */
+async function runCascade(params: LibraryQueryParams, conditionCount: number): Promise<AlbumSearchResultRow[]> {
+  return Sentry.startSpan(
+    {
+      name: 'catalog.cascade',
+      op: 'catalog.cascade',
+      attributes: { 'cascade.query_word_count': conditionCount },
+    },
+    () => runCascadeUnwrapped(params)
+  );
+}
+
+async function runCascadeUnwrapped(params: LibraryQueryParams): Promise<AlbumSearchResultRow[]> {
   const q = params.q.trim();
   if (q.length === 0) return [];
 

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -72,6 +72,11 @@ export function isPlainTextQuery(conditions: SearchCondition<CatalogField>[]): b
   return conditions.every((c) => c.field === 'all' && !c.exact && !c.negated && c.operator === 'AND');
 }
 
+export function passesCascadeGate(trimmedQ: string, conditions: SearchCondition<CatalogField>[]): boolean {
+  if (trimmedQ.length < MIN_CASCADE_QUERY_LENGTH) return false;
+  return isPlainTextQuery(conditions);
+}
+
 /**
  * Search the catalog with parsed query conditions, enum filters, sort,
  * and offset pagination. Reads `library_artist_view` so callers get the
@@ -135,8 +140,7 @@ export async function searchLibrary(
   // page 0 stays empty so clients don't scroll a bounded fallback list.
   if (params.page !== 0) return { results, total };
   const trimmed = params.q.trim();
-  if (trimmed.length < MIN_CASCADE_QUERY_LENGTH) return { results, total };
-  if (!isPlainTextQuery(conditions)) return { results, total };
+  if (!passesCascadeGate(trimmed, conditions)) return { results, total };
 
   // Attribute set at startSpan creation so Sentry indexes it numerically
   // (avoids the BS#1081 string-typing trap that breaks avg/p50/p90).

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -64,6 +64,14 @@ const SECONDARY_SORT: Record<CatalogSort, SQL> = {
   date: sql`${library_artist_view.artist_name}`,
 };
 
+export const MIN_CASCADE_QUERY_LENGTH = 4;
+export const MAX_CASCADE_CONDITIONS = 6;
+
+export function isPlainTextQuery(conditions: SearchCondition<CatalogField>[]): boolean {
+  if (conditions.length === 0 || conditions.length > MAX_CASCADE_CONDITIONS) return false;
+  return conditions.every((c) => c.field === 'all' && !c.exact && !c.negated && c.operator === 'AND');
+}
+
 /**
  * Search the catalog with parsed query conditions, enum filters, sort,
  * and offset pagination. Reads `library_artist_view` so callers get the
@@ -121,60 +129,29 @@ export async function searchLibrary(
 
   if (results.length > 0 || total > 0) return { results, total };
 
-  // Catalog-track-search cascade (BS#977, multi-word relaxation BS#1146). When
-  // the primary query returns no rows AND the user typed plain text (no field
-  // qualifiers, exact match, NOT, or OR), fall through to Track 1 (CTA) +
-  // Track 2 (LML `/lookup`). The cascade is single-page: pagination beyond
-  // page 0 stays empty so the client doesn't keep scrolling into a bounded
-  // fallback list.
-  //
-  // Two cheap defensive guards keep cascade-entry traffic bounded against
-  // typo storms and pathological inputs: `MIN_CASCADE_QUERY_LENGTH` rules out
-  // 1-3-char-per-word noise; the conditions cap inside `isPlainTextQuery`
-  // rules out long pasted lyrics / query-builder abuse. The downstream LML
-  // chokepoint (`Semaphore(5) + TokenBucket(50/min)` in `@wxyc/lml-client`)
-  // is the hard cap on fan-out; these guards just trim the worst inputs
-  // before they reach it.
+  // Catalog-track-search cascade (BS#977, multi-word relaxation BS#1146).
+  // Guards trim worst-case inputs (typo storms, query-builder abuse) before
+  // LML's `Semaphore(5) + TokenBucket(50/min)` chokepoint; pagination beyond
+  // page 0 stays empty so clients don't scroll a bounded fallback list.
   if (params.page !== 0) return { results, total };
-  if (params.q.trim().length < MIN_CASCADE_QUERY_LENGTH) return { results, total };
+  const trimmed = params.q.trim();
+  if (trimmed.length < MIN_CASCADE_QUERY_LENGTH) return { results, total };
   if (!isPlainTextQuery(conditions)) return { results, total };
 
-  const cascadeResults = await runCascade(params, conditions.length);
-  return { results: cascadeResults, total: cascadeResults.length };
-}
-
-export const MIN_CASCADE_QUERY_LENGTH = 4;
-export const MAX_CASCADE_CONDITIONS = 6;
-
-export function isPlainTextQuery(conditions: SearchCondition<CatalogField>[]): boolean {
-  if (conditions.length === 0 || conditions.length > MAX_CASCADE_CONDITIONS) return false;
-  return conditions.every((c) => c.field === 'all' && !c.exact && !c.negated && c.operator === 'AND');
-}
-
-/**
- * Wraps the cascade in a `catalog.cascade` span that carries the numeric
- * `cascade.query_word_count` attribute set at creation time — pass attrs at
- * `startSpan` rather than `setAttribute(name, number)` after creation so Sentry
- * indexes the value as numeric and not as a string (the avg/p50/p90
- * aggregation trap from BS#1081). Lets post-deploy dashboards split widened
- * traffic (≥2 conditions) from baseline (1 condition) without renaming any
- * existing `track_search.*` attributes.
- */
-async function runCascade(params: LibraryQueryParams, conditionCount: number): Promise<AlbumSearchResultRow[]> {
-  return Sentry.startSpan(
+  // Attribute set at startSpan creation so Sentry indexes it numerically
+  // (avoids the BS#1081 string-typing trap that breaks avg/p50/p90).
+  const cascadeResults = await Sentry.startSpan(
     {
       name: 'catalog.cascade',
       op: 'catalog.cascade',
-      attributes: { 'cascade.query_word_count': conditionCount },
+      attributes: { 'cascade.query_word_count': conditions.length },
     },
-    () => runCascadeUnwrapped(params)
+    () => runCascade(params, trimmed)
   );
+  return { results: cascadeResults, total: cascadeResults.length };
 }
 
-async function runCascadeUnwrapped(params: LibraryQueryParams): Promise<AlbumSearchResultRow[]> {
-  const q = params.q.trim();
-  if (q.length === 0) return [];
-
+async function runCascade(params: LibraryQueryParams, q: string): Promise<AlbumSearchResultRow[]> {
   const cascade: TaggedLibraryViewEntry[] = await runCatalogTrackSearchCascade(q, params.limit, params.on_streaming);
   if (cascade.length === 0) return [];
 

--- a/tests/integration/library-query.spec.js
+++ b/tests/integration/library-query.spec.js
@@ -223,7 +223,11 @@ describe('GET /library/query cascade — modern Card Catalog serves matched_via 
     expect(res.body.totalPages).toBe(1);
   });
 
-  test('single-bareword Track 2 query ("vi scose poise") returns Confield via LML fallback', async () => {
+  test('multi-word Track 2 query ("vi scose poise") returns Confield via LML fallback', async () => {
+    // CONFIELD_TRACK_QUERY tokenizes into 3 plain-text conditions. The cascade
+    // gate accepts AND-only plain-text queries of any length (BS#1146); pre-fix
+    // the gate rejected anything where `conditions.length !== 1`, so this
+    // assertion path was silently warn-skipping.
     const res = await auth
       .get('/library/query')
       .query({ q: CONFIELD_TRACK_QUERY, sort: 'artist', order: 'asc', limit: 20 })
@@ -233,7 +237,7 @@ describe('GET /library/query cascade — modern Card Catalog serves matched_via 
     expect(Array.isArray(res.body.results)).toBe(true);
     if (res.body.results.length === 0) {
       console.warn(
-        '[BS#977] /library/query cascade returned no Track 2 results. Likely the backend is running ' +
+        '[BS#977/#1146] /library/query cascade returned no Track 2 results. Likely the backend is running ' +
           'without CATALOG_TRACK_SEARCH_DISCOGS_ENABLED=true. Set it in .env and restart `npm run dev`.'
       );
       return;
@@ -247,6 +251,21 @@ describe('GET /library/query cascade — modern Card Catalog serves matched_via 
     // Mock LML's songLookup map returns matched_via.source = 'discogs_master'
     // for the Confield row; bridged via library.legacy_release_id back to BS.
     expect(hit.matched_via.some((m) => m.source && m.source.startsWith('discogs'))).toBe(true);
+  });
+
+  test('multi-word query mixed with field qualifier skips the cascade', async () => {
+    // 'vi scose artist:NonexistentArtistFoo' parses to 2 bareword + 1
+    // field-qualified condition. Even with the relaxed multi-word gate
+    // (BS#1146), the presence of a field-qualified condition disqualifies the
+    // query from cascade entry. Primary returns 0 → no cascade → no results.
+    const res = await auth
+      .get('/library/query')
+      .query({ q: 'vi scose artist:NonexistentArtistFoo', limit: 10 })
+      .expect(200);
+
+    expect(Array.isArray(res.body.results)).toBe(true);
+    expect(res.body.results.length).toBe(0);
+    expect(res.body.total).toBe(0);
   });
 
   test('primary tsvector/ILIKE hit never carries matched_via (cascade only fires on primary 0-hit)', async () => {

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -297,11 +297,14 @@ describe('library.controller', () => {
       // Reject *after* the budget would naturally fire — the budget should win
       // and the rejection should be swallowed.
       mockEnrichWithArtwork.mockReturnValue(
-        new Promise<unknown[]>((_, reject) => setTimeout(() => reject(enrichError), 50))
+        new Promise<unknown[]>((_, reject) => setTimeout(() => reject(enrichError), 500))
       );
 
       const previous = process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
-      process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = '5';
+      // Budget << reject delay; 50/500/750ms gives ~10x headroom over the
+      // previous 5/50/75ms shape so CI runners under load don't race-invert
+      // and resolve the rejection before the budget fires.
+      process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = '50';
       jest.resetModules();
       const { searchForAlbum: searchWithTightBudget } =
         await import('../../../apps/backend/controllers/library.controller');
@@ -315,7 +318,7 @@ describe('library.controller', () => {
         expect(res.json).toHaveBeenCalledWith(searchResults);
         // Give the late rejection time to settle into the catch handler so the
         // assertion below isn't subject to a process-level unhandledRejection.
-        await new Promise((resolve) => setTimeout(resolve, 75));
+        await new Promise((resolve) => setTimeout(resolve, 750));
       } finally {
         if (previous === undefined) delete process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
         else process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = previous;

--- a/tests/unit/services/library-search.cascade-gate.test.ts
+++ b/tests/unit/services/library-search.cascade-gate.test.ts
@@ -1,0 +1,56 @@
+import { parseSearchQuery, CATALOG_PARSER_CONFIG } from '../../../apps/backend/services/search-parser.service';
+import { isPlainTextQuery, MAX_CASCADE_CONDITIONS } from '../../../apps/backend/services/library-search.service';
+
+const parse = (q: string) => parseSearchQuery(q, CATALOG_PARSER_CONFIG);
+
+describe('isPlainTextQuery (catalog cascade gate)', () => {
+  describe('accepts', () => {
+    it('single bareword', () => {
+      expect(isPlainTextQuery(parse('autechre'))).toBe(true);
+    });
+
+    it('multi-bareword AND-joined (the bug fix case)', () => {
+      expect(isPlainTextQuery(parse('vi scose poise'))).toBe(true);
+    });
+
+    it('multi-bareword with explicit AND', () => {
+      expect(isPlainTextQuery(parse('vi AND scose AND poise'))).toBe(true);
+    });
+  });
+
+  describe('rejects', () => {
+    it('empty conditions', () => {
+      expect(isPlainTextQuery(parse(''))).toBe(false);
+    });
+
+    it('field-prefixed query', () => {
+      expect(isPlainTextQuery(parse('artist:autechre'))).toBe(false);
+    });
+
+    it('mixed bareword + field-prefixed', () => {
+      expect(isPlainTextQuery(parse('vi scose artist:autechre'))).toBe(false);
+    });
+
+    it('exact-match (quoted)', () => {
+      expect(isPlainTextQuery(parse('"vi scose poise"'))).toBe(false);
+    });
+
+    it('NOT-negated condition', () => {
+      expect(isPlainTextQuery(parse('vi NOT scose'))).toBe(false);
+    });
+
+    it('OR-joined conditions', () => {
+      expect(isPlainTextQuery(parse('vi OR scose'))).toBe(false);
+    });
+
+    it('more than MAX_CASCADE_CONDITIONS conditions (pathological multi-word)', () => {
+      const tooMany = Array.from({ length: MAX_CASCADE_CONDITIONS + 1 }, (_, i) => `w${i}`).join(' ');
+      expect(isPlainTextQuery(parse(tooMany))).toBe(false);
+    });
+
+    it('exactly MAX_CASCADE_CONDITIONS conditions still accepted', () => {
+      const atCap = Array.from({ length: MAX_CASCADE_CONDITIONS }, (_, i) => `w${i}`).join(' ');
+      expect(isPlainTextQuery(parse(atCap))).toBe(true);
+    });
+  });
+});

--- a/tests/unit/services/library-search.cascade-gate.test.ts
+++ b/tests/unit/services/library-search.cascade-gate.test.ts
@@ -1,5 +1,10 @@
 import { parseSearchQuery, CATALOG_PARSER_CONFIG } from '../../../apps/backend/services/search-parser.service';
-import { isPlainTextQuery, MAX_CASCADE_CONDITIONS } from '../../../apps/backend/services/library-search.service';
+import {
+  isPlainTextQuery,
+  passesCascadeGate,
+  MAX_CASCADE_CONDITIONS,
+  MIN_CASCADE_QUERY_LENGTH,
+} from '../../../apps/backend/services/library-search.service';
 
 const parse = (q: string) => parseSearchQuery(q, CATALOG_PARSER_CONFIG);
 
@@ -52,5 +57,29 @@ describe('isPlainTextQuery (catalog cascade gate)', () => {
       const atCap = Array.from({ length: MAX_CASCADE_CONDITIONS }, (_, i) => `w${i}`).join(' ');
       expect(isPlainTextQuery(parse(atCap))).toBe(true);
     });
+  });
+});
+
+describe('passesCascadeGate (catalog cascade entry predicate)', () => {
+  it('rejects queries shorter than MIN_CASCADE_QUERY_LENGTH', () => {
+    const short = 'a'.repeat(MIN_CASCADE_QUERY_LENGTH - 1);
+    expect(passesCascadeGate(short, parse(short))).toBe(false);
+  });
+
+  it('accepts queries at exactly MIN_CASCADE_QUERY_LENGTH with plain text', () => {
+    const atFloor = 'a'.repeat(MIN_CASCADE_QUERY_LENGTH);
+    expect(passesCascadeGate(atFloor, parse(atFloor))).toBe(true);
+  });
+
+  it('accepts multi-word plain text above the floor (the bug fix case)', () => {
+    expect(passesCascadeGate('vi scose poise', parse('vi scose poise'))).toBe(true);
+  });
+
+  it('rejects long queries with field qualifiers (gate composition)', () => {
+    expect(passesCascadeGate('artist:autechre', parse('artist:autechre'))).toBe(false);
+  });
+
+  it('rejects an empty trimmed query', () => {
+    expect(passesCascadeGate('', parse(''))).toBe(false);
   });
 });

--- a/tests/unit/services/library-search.cascade-span.test.ts
+++ b/tests/unit/services/library-search.cascade-span.test.ts
@@ -1,0 +1,104 @@
+import { jest } from '@jest/globals';
+import { db } from '../../mocks/database.mock';
+
+// Pin the BS#1081 numeric-typing fix: the `cascade.query_word_count` attribute
+// must be set at `Sentry.startSpan` creation time (via `attributes: {...}`)
+// rather than via `setAttribute` after the span exists. If a future refactor
+// regresses to `span.setAttribute('cascade.query_word_count', n)`, Sentry
+// indexes the value as a string and breaks avg/p50/p90 aggregation on the
+// post-deploy dashboards.
+
+const mockRunCatalogTrackSearchCascade = jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]);
+
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  runCatalogTrackSearchCascade: mockRunCatalogTrackSearchCascade,
+}));
+
+type SpanLike = { setAttribute: jest.Mock; setAttributes: jest.Mock };
+type SpanOpts = { name: string; op: string; attributes?: Record<string, unknown> };
+const spanInstance: SpanLike = { setAttribute: jest.fn(), setAttributes: jest.fn() };
+const mockStartSpan = jest.fn(
+  <T>(_opts: SpanOpts, callback: (span: SpanLike) => T | Promise<T>): Promise<T> =>
+    Promise.resolve(callback(spanInstance))
+);
+jest.mock('@sentry/node', () => ({
+  startSpan: <T>(opts: SpanOpts, callback: (span: SpanLike) => T | Promise<T>): Promise<T> =>
+    mockStartSpan(opts, callback),
+  getActiveSpan: () => spanInstance,
+}));
+
+import { searchLibrary } from '../../../apps/backend/services/library-search.service';
+
+const PARAMS = {
+  page: 0,
+  limit: 20,
+  sort: 'artist' as const,
+  order: 'asc' as const,
+};
+
+function primeEmptyPrimary(): void {
+  // Two `db.execute` calls in `searchLibrary` (data + count via Promise.all).
+  // Empty data + total=0 forces the post-empty branch where the cascade gate
+  // is consulted.
+  db.execute.mockReset();
+  db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0 }]);
+}
+
+describe('searchLibrary catalog.cascade Sentry span (BS#1081 regression pin)', () => {
+  beforeEach(() => {
+    mockStartSpan.mockClear();
+    mockRunCatalogTrackSearchCascade.mockClear();
+  });
+
+  it('passes cascade.query_word_count as numeric at startSpan creation', async () => {
+    primeEmptyPrimary();
+
+    await searchLibrary({ ...PARAMS, q: 'vi scose poise' });
+
+    expect(mockStartSpan).toHaveBeenCalledTimes(1);
+    const opts = mockStartSpan.mock.calls[0][0];
+    expect(opts.name).toBe('catalog.cascade');
+    expect(opts.op).toBe('catalog.cascade');
+    const attrs = opts.attributes ?? {};
+    expect(attrs).toEqual({ 'cascade.query_word_count': 3 });
+    expect(typeof attrs['cascade.query_word_count']).toBe('number');
+  });
+
+  it('does not invoke startSpan or the cascade when the gate rejects (short query)', async () => {
+    primeEmptyPrimary();
+
+    await searchLibrary({ ...PARAMS, q: 'vi' });
+
+    expect(mockStartSpan).not.toHaveBeenCalled();
+    expect(mockRunCatalogTrackSearchCascade).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke startSpan when the gate rejects (field-qualified)', async () => {
+    primeEmptyPrimary();
+
+    await searchLibrary({ ...PARAMS, q: 'artist:NonexistentArtistFoo' });
+
+    expect(mockStartSpan).not.toHaveBeenCalled();
+    expect(mockRunCatalogTrackSearchCascade).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke startSpan on paginated requests (page > 0)', async () => {
+    primeEmptyPrimary();
+
+    await searchLibrary({ ...PARAMS, page: 1, q: 'vi scose poise' });
+
+    expect(mockStartSpan).not.toHaveBeenCalled();
+    expect(mockRunCatalogTrackSearchCascade).not.toHaveBeenCalled();
+  });
+
+  it('never falls back to setAttribute for the word-count attribute', async () => {
+    primeEmptyPrimary();
+
+    await searchLibrary({ ...PARAMS, q: 'vi scose poise' });
+
+    const setAttributeKeys = spanInstance.setAttribute.mock.calls.map((c) => c[0]);
+    const setAttributesKeys = spanInstance.setAttributes.mock.calls.flatMap((c) => Object.keys(c[0] as object));
+    expect(setAttributeKeys).not.toContain('cascade.query_word_count');
+    expect(setAttributesKeys).not.toContain('cascade.query_word_count');
+  });
+});


### PR DESCRIPTION
## Summary

- Relax the `/library/query` cascade gate so multi-word plain-text queries (e.g. "vi scose poise") reach Track 1 (CTA) and Track 2 (LML `/lookup`). Pre-fix it required `conditions.length === 1`, so the cascade was unreachable for any tokenized song title.
- Add two cheap defensive guards before cascade entry: a `MIN_CASCADE_QUERY_LENGTH = 4` floor on the trimmed query and a `MAX_CASCADE_CONDITIONS = 6` cap. Bounds typo-storm and pathological-input traffic before it reaches the LML chokepoint.
- Wrap the cascade in a `catalog.cascade` Sentry span carrying `cascade.query_word_count` set at `startSpan` creation time so the attribute is indexed numerically (avoiding the string-typing trap from BS#1081). Lets post-deploy dashboards split widened traffic (≥2 conditions) from baseline (1 condition) in trace explorer.

## Why this is safe to widen

- Cascade is sequential, short-circuiting: CTA (~50ms ILIKE+DENSE_RANK over ~2.6k-row table) runs first; LML only runs if CTA returns 0.
- BS-side LML chokepoint is `Semaphore(5) + TokenBucket(50/min)` in `shared/lml-client/src/index.ts:221-222` — worst-case sustained cold-lookup throughput stays bounded at ~0.83/sec per BS process regardless of how many requests pass the gate.
- LML lookup has 30s `AbortController` timeout; BS Express timeout 35s; both flags (`CATALOG_TRACK_SEARCH_DISCOGS_ENABLED`, `CATALOG_TRACK_SEARCH_CTA_ENABLED`) remain kill switches.
- E2-8 Sentry instrumentation (`track_search.cache_hit`, `track_search.master_lookup_ms`, `track_search.latency_ms`) lights up on every cascade entry; combined with the new `cascade.query_word_count` we can measure widened vs baseline behavior post-deploy without renaming anything.

## Test plan

- [x] Unit: `tests/unit/services/library-search.cascade-gate.test.ts` — truth table for `isPlainTextQuery` (single bareword ✓; multi-bareword ✓; field-prefixed ✗; quoted exact ✗; NOT ✗; OR ✗; > `MAX_CASCADE_CONDITIONS` ✗; empty ✗; exactly `MAX_CASCADE_CONDITIONS` ✓).
- [x] Integration: `tests/integration/library-query.spec.js` — `vi scose poise` → Confield with `matched_via[0].source` starting `discogs`; new field-mixed test asserts `vi scose artist:NonexistentArtistFoo` skips the cascade.
- [x] Local: `npm run typecheck` (clean); `npm run lint` (0 errors, 462 pre-existing warnings); `npm run format:check` (clean); related unit tests 60/60.
- [ ] CI: docker integration test exercises the multi-word cascade end-to-end against the mock LML (`CATALOG_TRACK_SEARCH_DISCOGS_ENABLED=true` already set in `dev_env/docker-compose.yml`).
- [ ] Prod smoke after deploy: `https://dj.wxyc.org/dashboard/catalog?q=vi+scose+poise` returns Confield with the `matched_via` chip.

## Post-deploy monitoring

Watch the `catalog.cascade` span split by `cascade.query_word_count` in Sentry trace explorer:

| Metric | Threshold | Action |
|---|---|---|
| `track_search.cache_hit` rate on `cascade.query_word_count ≥ 2` | ≥ 50% | ship as-is |
| `track_search.cache_hit` rate | 30-50% | file follow-up: negative-cache LML 0-result responses |
| `track_search.cache_hit` rate <30% OR `lml.queue_depth` sustained ≥5 | flag-flip `CATALOG_TRACK_SEARCH_DISCOGS_ENABLED=false` | reconsider; likely the gate is still too loose or LML's `SONG_AS_TRACK` strategy needs upstream work |

Closes #1146