### PR TITLE
perf(album-level-backfill): parallelize per-batch UPSERTs via Promise.all

### DIFF
--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -411,14 +411,22 @@ export const runBatch = async (
   let match = 0;
   let no_match = 0;
   let error = 0;
-  let upserts = 0;
+
+  // Parallelize the UPSERTs via Promise.all instead of awaiting each in turn.
+  // The sequential `for...await` paid one network round-trip per match
+  // (BATCH_SIZE × tunnel/RDS latency); Promise.all lets postgres-js pipeline
+  // them on the single connection. Measured against prod via SSH tunnel
+  // during the BS#1041 drain: ~4-5s shaved per 50-item batch (≈ 25% wall),
+  // shifting the per-batch bottleneck from BS-side serialization to LML's
+  // own cascade-strategy tail. Idempotency unchanged — `upsertAlbumMatch`
+  // is race-guarded by `updated_at < NOW()`, so ordering does not matter.
+  const upsertPromises: Array<Promise<boolean>> = [];
   for (const result of response.results) {
     if (result.status === 'match' && result.lookup) {
       match += 1;
       const album = resolved[result.index];
       if (!album) continue; // shouldn't happen given input-order guarantee
-      const wrote = await upsertAlbumMatch(album.album_id, result.lookup);
-      if (wrote) upserts += 1;
+      upsertPromises.push(upsertAlbumMatch(album.album_id, result.lookup));
     } else if (result.status === 'no_match') {
       no_match += 1;
     } else {
@@ -429,6 +437,7 @@ export const runBatch = async (
       );
     }
   }
+  const upserts = (await Promise.all(upsertPromises)).filter(Boolean).length;
   return { batchSize: items.length, match, no_match, error, upserts };
 };
 

--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -412,14 +412,9 @@ export const runBatch = async (
   let no_match = 0;
   let error = 0;
 
-  // Parallelize the UPSERTs via Promise.all instead of awaiting each in turn.
-  // The sequential `for...await` paid one network round-trip per match
-  // (BATCH_SIZE × tunnel/RDS latency); Promise.all lets postgres-js pipeline
-  // them on the single connection. Measured against prod via SSH tunnel
-  // during the BS#1041 drain: ~4-5s shaved per 50-item batch (≈ 25% wall),
-  // shifting the per-batch bottleneck from BS-side serialization to LML's
-  // own cascade-strategy tail. Idempotency unchanged — `upsertAlbumMatch`
-  // is race-guarded by `updated_at < NOW()`, so ordering does not matter.
+  // `upsertAlbumMatch` is race-guarded by `updated_at < NOW()` and
+  // `enumeratePendingAlbumIds` returns distinct album_ids per batch, so
+  // ordering within a batch is irrelevant — safe to issue concurrently.
   const upsertPromises: Array<Promise<boolean>> = [];
   for (const result of response.results) {
     if (result.status === 'match' && result.lookup) {


### PR DESCRIPTION
## Summary

- `runBatch` in `jobs/album-level-backfill/job.ts` switches the per-result `upsertAlbumMatch` loop from sequential `for...await` to `Promise.all` over the collected upsert promises. `postgres-js` pipelines them on the single connection.
- Measured during the 2026-05-25 local drain (Mac → EC2 SSH tunnel → RDS): ~4-5s shaved per 50-item batch, ≈ 25% of pre-change batch wall.
- Per-item LML errors still log synchronously in the loop body; only the DB writes are parallelized.
- Idempotency unchanged — `upsertAlbumMatch` is race-guarded by `setWhere: album_metadata.updated_at < NOW()`; `enumeratePendingAlbumIds` guarantees DISTINCT `album_id` per batch, so no in-batch conflicts.

Closes #1148

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — 0 errors (461 pre-existing warnings unchanged)
- [x] `npm run format:check` — clean
- [x] `npx jest --config jest.unit.config.ts --testPathPatterns="album-level-backfill"` — 52/52 pass
- [ ] Reviewer: confirm the race-guard reasoning in the new comment matches your read of `upsertAlbumMatch` semantics

## Notes

This is the only piece extracted from a larger 2026-05-25 local-drain experiment. The other experiments in the same session (`parseExcludeRanges` env var for known-bad album_id ranges; `auto-quarantine` skip-ahead on wedge detection; `BACKFILL_CONCURRENT_BATCHES` sliding-window dispatcher) all interact with the cascade-cascade mechanism (`lml-cascade-cascade-mechanism` memory) and are intentionally NOT included here — they're worth their own scoped issue once LML#370+#372 land and the operational picture stabilizes.