### PR TITLE
fix(auth): positive-list AUTH_BYPASS guard and pin NODE_ENV (closes #1097)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,10 @@ DJ_APP_CLIENT_ID=your_client_id
 
 ### Testing Env Variables
 TEST_HOST=http://localhost
-AUTH_BYPASS=true
+# AUTH_BYPASS skips JWT verification — useful for tests only. Honored ONLY
+# when NODE_ENV is explicitly "development" or "test" (positive-list guard,
+# BS#1097). Do NOT enable in this file by default — opt in per-environment.
+# AUTH_BYPASS=true
 AUTH_USERNAME=test_user
 AUTH_PASSWORD=your_test_password
 

--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -36,4 +36,9 @@ COPY --from=builder ./auth-builder/shared/authentication/dist ./shared/authentic
 # shared/database/src/client.ts.
 ENV DB_APPLICATION_NAME=wxyc-auth
 
+# Pin NODE_ENV=production so AUTH_BYPASS and the /auth/test/* endpoints
+# stay closed even if the operator's .env omits NODE_ENV. Defense in depth
+# alongside the positive-list guard in auth.middleware.ts (BS#1097).
+ENV NODE_ENV=production
+
 CMD ["npm", "start", "--workspace=@wxyc/auth-service"]

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -39,4 +39,9 @@ COPY --from=builder ./builder/shared/lml-client/dist ./shared/lml-client/dist
 # obvious during incident triage.
 ENV DB_APPLICATION_NAME=wxyc-backend
 
+# Pin NODE_ENV=production so AUTH_BYPASS-gated paths stay closed even if the
+# operator's .env omits NODE_ENV. Defense in depth alongside the positive-list
+# guards in auth.middleware.ts and checkShowMember.ts (BS#1097).
+ENV NODE_ENV=production
+
 CMD ["npm", "start", "--workspace=@wxyc/backend"]

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -45,9 +45,11 @@ app.use(
   })
 );
 
-// Test helper endpoints (must be registered BEFORE Better Auth handler)
-// Disabled in production
-if (process.env.NODE_ENV !== 'production') {
+// Test helper endpoints (must be registered BEFORE Better Auth handler).
+// Positive-list gate (BS#1097): enable only in explicit dev/test. A negative
+// check (`!== 'production'`) exposed these to staging or any host where
+// NODE_ENV happened to be unset.
+if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
   // Get verification token for testing password reset flow
   // Better Auth stores password reset tokens with:
   //   identifier: "reset-password:<token>" or "email-verification:<token>"
@@ -250,8 +252,13 @@ const lookupEmailHandler = async (req: Request, res: Response) => {
 
 // Disable rate limiting in test environments to avoid flaky integration tests.
 // This matches the pattern used by the backend's rateLimiting middleware.
+// Positive-list gate (BS#1097): the AUTH_BYPASS / USE_MOCK_SERVICES escape
+// hatches are honored only when NODE_ENV is explicitly development or test.
+// In any other environment (production, staging, or unset) rate limits hold.
+const isDevOrTest = process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
 const isTestEnv =
-  process.env.NODE_ENV === 'test' || process.env.USE_MOCK_SERVICES === 'true' || process.env.AUTH_BYPASS === 'true';
+  process.env.NODE_ENV === 'test' ||
+  (isDevOrTest && (process.env.USE_MOCK_SERVICES === 'true' || process.env.AUTH_BYPASS === 'true'));
 
 if (!isTestEnv) {
   // Strict limit for auth mutations vulnerable to brute-force attacks.

--- a/apps/backend/middleware/checkShowMember.ts
+++ b/apps/backend/middleware/checkShowMember.ts
@@ -2,7 +2,13 @@ import { RequestHandler } from 'express';
 import { getDJsInCurrentShow } from '../services/flowsheet.service.js';
 
 export const showMemberMiddleware: RequestHandler = async (req, res, next) => {
-  if (process.env.AUTH_BYPASS === 'true') {
+  // Positive-list gate (BS#1097): bypass requires explicit dev/test NODE_ENV.
+  // Previously this middleware had no NODE_ENV gate at all, so a stray
+  // `AUTH_BYPASS=true` in any environment would skip show-membership checks.
+  if (
+    process.env.AUTH_BYPASS === 'true' &&
+    (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test')
+  ) {
     return next();
   }
 

--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -167,6 +167,10 @@ services:
         NPM_TOKEN: ${NPM_TOKEN:-}
     profiles: [ci]
     environment:
+      # Override the Dockerfile's `ENV NODE_ENV=production` pin (BS#1097) so
+      # the positive-list AUTH_BYPASS guard engages for the integration suite.
+      # Matches the auth service's `NODE_ENV=test` above.
+      - NODE_ENV=test
       - DB_HOST=ci-db
       # In-container port: hardcoded to match what postgres listens on
       # inside the docker network. Host-side `DB_PORT` (e.g. the dev

--- a/shared/authentication/src/auth.middleware.ts
+++ b/shared/authentication/src/auth.middleware.ts
@@ -63,7 +63,15 @@ export type RequiredPermissions = {
 
 export function requirePermissions(required: RequiredPermissions) {
   return async (req: Request, res: Response, next: NextFunction) => {
-    if (process.env.AUTH_BYPASS === 'true' && process.env.NODE_ENV !== 'production') {
+    // Positive-list gate (BS#1097): bypass requires explicit dev/test NODE_ENV.
+    // A negative check (`!== 'production'`) was unsafe — any operator who
+    // forgot to set NODE_ENV on EC2 (`.env.example` shipped `AUTH_BYPASS=true`,
+    // no Dockerfile pinned NODE_ENV) chained into account takeover via
+    // BS#1112/#1115. Keep this safe-by-default.
+    if (
+      process.env.AUTH_BYPASS === 'true' &&
+      (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test')
+    ) {
       // In bypass mode, skip JWKS signature verification but still enforce
       // the same request structure as production: require a Bearer token.
       const authHeader = req.headers.authorization;

--- a/tests/unit/authentication/auth-bypass.test.ts
+++ b/tests/unit/authentication/auth-bypass.test.ts
@@ -60,7 +60,7 @@ describe('AUTH_BYPASS environment variable', () => {
     expect(mockRes.status).toHaveBeenCalledWith(401);
   });
 
-  it('should allow bypass in non-production when AUTH_BYPASS is true', async () => {
+  it('should allow bypass in NODE_ENV=test when AUTH_BYPASS is true', async () => {
     process.env.AUTH_BYPASS = 'true';
     process.env.NODE_ENV = 'test';
     mockReq.headers = { authorization: 'Bearer test-user-id' };
@@ -71,7 +71,18 @@ describe('AUTH_BYPASS environment variable', () => {
     expect(mockNext).toHaveBeenCalled();
   });
 
-  it('should allow bypass when NODE_ENV is not set and AUTH_BYPASS is true', async () => {
+  it('should allow bypass in NODE_ENV=development when AUTH_BYPASS is true', async () => {
+    process.env.AUTH_BYPASS = 'true';
+    process.env.NODE_ENV = 'development';
+    mockReq.headers = { authorization: 'Bearer test-user-id' };
+
+    const middleware = requirePermissions({ flowsheet: ['read'] });
+    await middleware(mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+    expect(mockNext).toHaveBeenCalled();
+  });
+
+  it('should NOT bypass when NODE_ENV is unset (default-safe)', async () => {
     process.env.AUTH_BYPASS = 'true';
     delete process.env.NODE_ENV;
     mockReq.headers = { authorization: 'Bearer test-user-id' };
@@ -79,7 +90,22 @@ describe('AUTH_BYPASS environment variable', () => {
     const middleware = requirePermissions({ flowsheet: ['read'] });
     await middleware(mockReq as Request, mockRes as Response, mockNext as NextFunction);
 
-    expect(mockNext).toHaveBeenCalled();
+    expect(mockNext).not.toHaveBeenCalled();
+    // Bypass declined → falls through to JWKS verify, which fails on the
+    // raw "test-user-id" token (not a JWT) and returns 401.
+    expect(mockRes.status).toHaveBeenCalledWith(401);
+  });
+
+  it('should NOT bypass when NODE_ENV is a non-allowed value (e.g. "staging")', async () => {
+    process.env.AUTH_BYPASS = 'true';
+    process.env.NODE_ENV = 'staging';
+    mockReq.headers = { authorization: 'Bearer test-user-id' };
+
+    const middleware = requirePermissions({ flowsheet: ['read'] });
+    await middleware(mockReq as Request, mockRes as Response, mockNext as NextFunction);
+
+    expect(mockNext).not.toHaveBeenCalled();
+    expect(mockRes.status).toHaveBeenCalledWith(401);
   });
 
   it('should reject requests without auth header even in bypass mode', async () => {

--- a/tests/unit/middleware/checkShowMember.test.ts
+++ b/tests/unit/middleware/checkShowMember.test.ts
@@ -29,15 +29,77 @@ function createMockReqResNext(userId: string) {
 
 describe('showMemberMiddleware', () => {
   const originalAuthBypass = process.env.AUTH_BYPASS;
+  const originalNodeEnv = process.env.NODE_ENV;
 
   beforeEach(() => {
     delete process.env.AUTH_BYPASS;
+    delete process.env.NODE_ENV;
   });
 
   afterAll(() => {
     if (originalAuthBypass !== undefined) {
       process.env.AUTH_BYPASS = originalAuthBypass;
+    } else {
+      delete process.env.AUTH_BYPASS;
     }
+    if (originalNodeEnv !== undefined) {
+      process.env.NODE_ENV = originalNodeEnv;
+    } else {
+      delete process.env.NODE_ENV;
+    }
+  });
+
+  describe('AUTH_BYPASS gating (BS#1097)', () => {
+    it('does NOT short-circuit when AUTH_BYPASS=true but NODE_ENV is unset', async () => {
+      process.env.AUTH_BYPASS = 'true';
+      delete process.env.NODE_ENV;
+      mockGetDJsInCurrentShow.mockResolvedValue([{ id: 'dj-alice' }]);
+
+      const { req, res, next, statusMock } = createMockReqResNext('dj-charlie');
+
+      await showMemberMiddleware(req, res, next);
+
+      // Bypass must not engage outside dev/test — the real authz check runs.
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('does NOT short-circuit when AUTH_BYPASS=true and NODE_ENV=production', async () => {
+      process.env.AUTH_BYPASS = 'true';
+      process.env.NODE_ENV = 'production';
+      mockGetDJsInCurrentShow.mockResolvedValue([{ id: 'dj-alice' }]);
+
+      const { req, res, next, statusMock } = createMockReqResNext('dj-charlie');
+
+      await showMemberMiddleware(req, res, next);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits when AUTH_BYPASS=true and NODE_ENV=test', async () => {
+      process.env.AUTH_BYPASS = 'true';
+      process.env.NODE_ENV = 'test';
+
+      const { req, res, next, statusMock } = createMockReqResNext('dj-charlie');
+
+      await showMemberMiddleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(statusMock).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits when AUTH_BYPASS=true and NODE_ENV=development', async () => {
+      process.env.AUTH_BYPASS = 'true';
+      process.env.NODE_ENV = 'development';
+
+      const { req, res, next, statusMock } = createMockReqResNext('dj-charlie');
+
+      await showMemberMiddleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(statusMock).not.toHaveBeenCalled();
+    });
   });
 
   it('rejects a DJ who is not in the current show', async () => {

--- a/tests/unit/scripts/ci-env-surface-parity.test.ts
+++ b/tests/unit/scripts/ci-env-surface-parity.test.ts
@@ -115,20 +115,19 @@ const EXPECTED_ONLY_IN_WORKFLOW = [
   'CI_DB_PORT',
   'CI_PORT',
 
+  // Why: auth-service auto-membership / org-sync hooks read this from env
+  // and no-op (with a warning) when unset. Compose sets it on the `auth`
+  // service env block; the backend service doesn't need it. In GHA CI's
+  // host-process model both services share workflow-level env, so it
+  // appears here. Mirroring it into the compose `backend` env would be
+  // harmless but pointless — the backend code never reads it.
+  'DEFAULT_ORG_SLUG',
+
   // Why: mock-api server addressing. Backend reads LIBRARY_METADATA_URL
   // (mirrored). MOCK_API_PORT + MOCK_API_URL exist for the harness side
   // (mock-server start command, test assertions about response bodies).
   'MOCK_API_PORT',
   'MOCK_API_URL',
-
-  // Why: test-mode signal needed on the workflow's host-process model
-  // (gates rate-limit middleware bypass, etc.). The compose backend
-  // container doesn't set NODE_ENV but its test-mode behaviors are reached
-  // via parallel gates (`TEST_RATE_LIMITING=false`, `AUTH_BYPASS=true`).
-  // If a code path appears that requires NODE_ENV=test specifically and
-  // can't reach it via those gates, this entry should move to "mirror in
-  // both" — but that's a backend change, not a CI-env one.
-  'NODE_ENV',
 
   // Why: workflow-level alias for CI_PORT used by certain non-test scripts
   // that read PORT (e.g. drizzle-kit migrations); harness-side.


### PR DESCRIPTION
Closes #1097.

## Summary

- Bypass guards across `auth.middleware.ts`, `checkShowMember.ts`, and `apps/auth/app.ts` now use a **positive list** (`NODE_ENV === 'development' || === 'test'`) instead of `!== 'production'`. Any environment that isn't explicitly dev/test fails safe.
- `Dockerfile.auth` and `Dockerfile.backend` pin `ENV NODE_ENV=production` so the runtime default is safe even if the middleware guard regressed.
- `.env.example` no longer ships `AUTH_BYPASS=true`; documented and commented.
- `dev_env/docker-compose.yml`'s `backend` ci-profile block now sets `NODE_ENV=test` so `npm run ci:testmock` keeps the integration suite's bypass working under the new pin. (The auth service block already did this.)
- The `ci-env-surface-parity` allowlist is updated for the mirrored `NODE_ENV` and folds in the pre-existing `DEFAULT_ORG_SLUG` workflow-only entry that was added 2026-05-23.

## Why

Per #1097 triage: neither Dockerfile pinned `NODE_ENV=production` and `.env.example` shipped `AUTH_BYPASS=true`, so one missing line in EC2's `.env` chained into account takeover via #1115. `checkShowMember` had no `NODE_ENV` check at all — only `AUTH_BYPASS === 'true'`.

The positive-list shape is intrinsically safe: misspellings, unset values, and unanticipated environments (staging, preview) all decline the bypass without anyone having to remember to set `NODE_ENV=production`. The Dockerfile pin is the secondary defense.

## Sequencing

This is the head of the P0 sequence in #1157. Closing this narrowly mitigates #1112, #1115, and the previously-unguarded show-member bypass at `checkShowMember.ts:5`. #1099 (mass-assignment) and the #1098 / #1102 / #1104 trio follow next.

## Test plan

- [x] `tests/unit/authentication/auth-bypass.test.ts` — flipped the "NODE_ENV unset → bypass" assertion; added a staging-case assertion.
- [x] `tests/unit/middleware/checkShowMember.test.ts` — added a BS#1097 describe block covering unset, production, test, development.
- [x] `tests/unit/scripts/ci-env-surface-parity.test.ts` — green.
- [x] `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check` — green.
- [x] Full `npm run test:unit` — only pre-existing failure unrelated to this PR (`schema.flowsheet-artwork-lookup-idx.test.ts`, also red on main).