### PR TITLE
fix(library): short-circuit fuzzySearchLibrary on V/A artist names (#1158)

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -27,6 +27,7 @@ import { lookupBySong, lookupMetadata, isLmlConfigured, type LookupResponse } fr
 import { filterSpacerGif } from './metadata/metadata.service.js';
 import { checkLibraryArtistNameHealth } from './library-artist-name-assertion.service.js';
 import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrackSearch.js';
+import { isCompilationArtist } from './requestLine/matching/index.js';
 
 /**
  * Source columns on `artists` (and any joined / view-projected row) that
@@ -795,6 +796,12 @@ export const fuzzySearchLibrary = async (
   n = 5,
   on_streaming?: boolean
 ): Promise<TaggedLibraryViewEntry[]> => {
+  // Skip only the trigram-OR branches; the both-same tsvector path handles
+  // V/A queries cheaply via the search_doc GIN index.
+  if (artist_name !== album_title && isCompilationArtist(artist_name)) {
+    return [];
+  }
+
   await checkLibraryArtistNameHealth();
 
   // Both-mode default (dj-site sends the same string as artist and title).

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -124,6 +124,57 @@ describe('library.service', () => {
     });
   });
 
+  describe('fuzzySearchLibrary compilation-indicator short-circuit', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it.each<[string, string | undefined]>([
+      ['Various Artists', 'In-Correcto 15-25'],
+      ['V/A', 'Some Album'],
+      ['v.a.', 'Some Album'],
+      ['Soundtrack', 'Movie Title'],
+      ['Compilation', 'Best Of 2025'],
+      ['Various Artists', undefined],
+      ['V/A', undefined],
+    ])('returns [] without DB calls for artist=%s album=%s', async (artist, title) => {
+      const result = await fuzzySearchLibrary(artist, title, 10);
+      expect(result).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+      expect(db.execute).not.toHaveBeenCalled();
+    });
+
+    it('does NOT short-circuit when artist===album (both-mode cascade still runs)', async () => {
+      const chain = createMockQueryChain([]);
+      db.select.mockReturnValue(chain);
+      chain.limit = jest.fn().mockResolvedValue([]);
+
+      await fuzzySearchLibrary('Various Artists', 'Various Artists', 5);
+
+      expect(db.select).toHaveBeenCalled();
+    });
+
+    it('does NOT short-circuit for legitimate artist names', async () => {
+      const chain = createMockQueryChain([]);
+      db.select.mockReturnValue(chain);
+      chain.limit = jest.fn().mockResolvedValue([]);
+
+      await fuzzySearchLibrary('Stereolab', 'Dots and Loops', 5);
+
+      expect(db.select).toHaveBeenCalled();
+    });
+
+    it('does NOT short-circuit album-only queries (predicate checks artist field)', async () => {
+      const chain = createMockQueryChain([]);
+      db.select.mockReturnValue(chain);
+      chain.limit = jest.fn().mockResolvedValue([]);
+
+      await fuzzySearchLibrary(undefined, 'Various Artists Compilation Vol 5', 5);
+
+      expect(db.select).toHaveBeenCalled();
+    });
+  });
+
   // Shared mock view row for search function tests
   const mockViewRow = {
     id: 1,


### PR DESCRIPTION
## Summary

- Short-circuit `fuzzySearchLibrary` to return `[]` when the `artist_name` argument matches a compilation indicator (`Various Artists`, `V/A`, `V.A.`, `Soundtrack`, `Compilation`, case-insensitive) — but only on the two trigram-OR branches that choke, not the both-same cascade.
- Reuses the existing `isCompilationArtist` predicate from `services/requestLine/matching/compilation.ts` (already in this repo, no new helper).
- 10 new parameterized unit tests covering positive paths (all keywords × both-different and single-field), negative controls (real artists still hit DB, album-only queries still hit DB), and the carve-out that artist===album still runs the cascade.

## The bug

DJ-site freezes when a DJ picks a Various Artists release in the rotation picker. Repro (Playwright headless, local stack, 2026-05-25):

```
+103ms  GET /library/?artist_name=Various+Artists&album_title=In-Correcto+15-25&n=10
+30s    (never returned within 30s capture window)
```

Root cause is in `apps/backend/services/library.service.ts:812-818` — the both-different branch:

```ts
const trigramPredicate = sql`(${library.artist_name} % ${artist_name} OR ${library.album_title} % ${album_title})`;
return libraryViewQuery(false)
  .where(...)
  .orderBy(asc(sql`${library.artist_name} <-> ${artist_name}`), asc(sql`${library.album_title} <-> ${album_title}`))
  .limit(n);
```

With `artist_name = 'Various Artists'`, the `%` trigram match overlaps a huge slice of `library` (every row whose artist or title shares a trigram with `various` / `artists` / `art` / `var`). The `<->` similarity-distance ORDER BY then materializes that candidate set and sorts it. Should be killed by the 5s `statement_timeout` (shared/database/src/client.ts:42-53) but apparently isn't terminating cleanly enough to return inside 30s — separate follow-up to verify the timeout path.

## Scope

Only the two trigram-OR branches in `fuzzySearchLibrary` get the early return:

| Branch | Trigger | New behavior |
|---|---|---|
| Both fields, artist ≠ album | `?artist_name=Various+Artists&album_title=...` | returns `[]` |
| Single-field artist | `?artist_name=Various+Artists` | returns `[]` |
| Both fields, artist === album | `?artist_name=Various+Artists&album_title=Various+Artists` | **unchanged** — runs existing tsvector + CTA cascade |
| Album-only | `?album_title=Various+Artists+Compilation+Vol+5` | **unchanged** — predicate only checks `artist_name` |

The both-same path is unaffected: `searchLibraryBothMode` opens with `tsvector` against `library.search_doc`, which uses `websearch_to_tsquery` + a GIN index — bounded and fast even for V/A queries — and the CTA cascade behind it has its own value for compilation lookups.

## Test plan

- [x] `npx jest --config jest.unit.config.ts tests/unit/services/library.service.test.ts` — 110/110 passing
- [x] `npx jest --config jest.unit.config.ts tests/unit/controllers/library.controller.test.ts` — 27/27 passing
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (461 pre-existing warnings)
- [x] Full unit suite (`npm run test:unit`): 2 pre-existing failures unrelated to this change (verified by stashing this branch's changes and re-running): `ci-env-surface-parity.test.ts` (DEFAULT_ORG_SLUG drift in test.yml) and `schema.flowsheet-artwork-lookup-idx.test.ts` (missing `flowsheet_artwork_lookup_idx` in schema source)
- [ ] After merge: spot-check `/library/?artist_name=Various+Artists&album_title=X` in staging returns `200 + []` in <100ms

## Related

- Sibling: WXYC/dj-site#653 (skip the four-request fan-out at the source)
- Investigation blocked-by both: WXYC/dj-site#654 (renderer crash root-cause)
- Same predicate used in: WXYC/library-metadata-lookup writeback guard `46c0c5f`
- Original report: PR #650 (dj-site frontend dedupe + (N) strip, landed earlier today)

Closes #1158