### PR TITLE
fix(flowsheet): block mass-assignment of internal columns on PATCH/POST (closes #1099)

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -271,8 +271,26 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
   } else if (body.album_title === undefined || body.artist_name === undefined || body.track_title === undefined) {
     throw new WxycError('Bad Request, Missing Flowsheet Parameters: album_title, artist_name, track_title', 400);
   } else {
+    // Explicit allowlist instead of `...body` spread (BS#1099). Any other
+    // body key — `metadata_status`, `legacy_entry_id`, `play_order`, etc. —
+    // would otherwise propagate verbatim into the INSERT and let a
+    // flowsheet:write caller mutate server-internal columns.
+    // `album_id` is included so explicit `null` from the snapshot branch
+    // (BS#933) still lands on the row; in this branch `body.album_id` is
+    // already constrained to null/undefined by the discriminator above.
     const fsEntry: NewFSEntry = {
-      ...body,
+      artist_name: body.artist_name,
+      album_title: body.album_title,
+      track_title: body.track_title,
+      track_position: body.track_position ?? null,
+      record_label: body.record_label,
+      label_id: body.label_id,
+      album_id: body.album_id,
+      rotation_id: body.rotation_id,
+      request_flag: body.request_flag,
+      segue: body.segue ?? false,
+      message: body.message,
+      entry_type: body.entry_type,
       show_id: latestShow.id,
       dj_name,
     };
@@ -310,6 +328,28 @@ export type UpdateRequestBody = {
   message?: string;
 };
 
+/**
+ * Pick only the fields the client is allowed to write through the public
+ * PATCH /flowsheet endpoint (BS#1099). The service-layer `updateEntry` does
+ * a passthrough `.set(entry)`, so any extra keys (`metadata_status`,
+ * `legacy_entry_id`, `show_id`, `play_order`, `linkage_*`, etc.) would land
+ * on the row. We allowlist at the controller boundary; the service also
+ * picks again for defense in depth.
+ */
+function pickUpdateEntryFields(data: UpdateRequestBody): UpdateRequestBody {
+  const picked: UpdateRequestBody = {};
+  if (data.artist_name !== undefined) picked.artist_name = data.artist_name;
+  if (data.album_title !== undefined) picked.album_title = data.album_title;
+  if (data.track_title !== undefined) picked.track_title = data.track_title;
+  if (data.track_position !== undefined) picked.track_position = data.track_position;
+  if (data.record_label !== undefined) picked.record_label = data.record_label;
+  if (data.label_id !== undefined) picked.label_id = data.label_id;
+  if (data.request_flag !== undefined) picked.request_flag = data.request_flag;
+  if (data.segue !== undefined) picked.segue = data.segue;
+  if (data.message !== undefined) picked.message = data.message;
+  return picked;
+}
+
 export const updateEntry: RequestHandler<object, unknown, { entry_id: number; data: UpdateRequestBody }> = async (
   req,
   res
@@ -319,7 +359,7 @@ export const updateEntry: RequestHandler<object, unknown, { entry_id: number; da
     throw new WxycError('Bad Request, Missing entry identifier: entry_id', 400);
   }
 
-  const updatedEntry: FSEntry = await flowsheet_service.updateEntry(entry_id, data);
+  const updatedEntry: FSEntry = await flowsheet_service.updateEntry(entry_id, pickUpdateEntryFields(data ?? {}));
   res.status(200).json(updatedEntry);
 };
 

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -402,7 +402,22 @@ function withLabel<T extends PgSelectQueryBuilder>(qb: T, label: string | null |
 }
 
 export const updateEntry = async (entry_id: number, entry: UpdateRequestBody): Promise<FSEntry> => {
-  const response = await db.update(flowsheet).set(entry).where(eq(flowsheet.id, entry_id)).returning();
+  // Defense in depth (BS#1099): construct the update object from named
+  // fields so even if a future controller starts passing the raw body,
+  // mass-assignment of internal columns (metadata_status, legacy_entry_id,
+  // show_id, play_order, linkage_*, etc.) is blocked at this boundary too.
+  const updateSet: UpdateRequestBody = {};
+  if (entry.artist_name !== undefined) updateSet.artist_name = entry.artist_name;
+  if (entry.album_title !== undefined) updateSet.album_title = entry.album_title;
+  if (entry.track_title !== undefined) updateSet.track_title = entry.track_title;
+  if (entry.track_position !== undefined) updateSet.track_position = entry.track_position;
+  if (entry.record_label !== undefined) updateSet.record_label = entry.record_label;
+  if (entry.label_id !== undefined) updateSet.label_id = entry.label_id;
+  if (entry.request_flag !== undefined) updateSet.request_flag = entry.request_flag;
+  if (entry.segue !== undefined) updateSet.segue = entry.segue;
+  if (entry.message !== undefined) updateSet.message = entry.message;
+
+  const response = await db.update(flowsheet).set(updateSet).where(eq(flowsheet.id, entry_id)).returning();
   updateLastModified();
   return response[0];
 };

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -795,5 +795,150 @@ describe('flowsheet.controller', () => {
       );
       expect(res.status).toHaveBeenCalledWith(200);
     });
+
+    it('strips internal columns from data before passing to the service (BS#1099)', async () => {
+      // Mass-assignment guard: any `flowsheet:write` caller can send arbitrary
+      // body keys today. Setting `metadata_status='enriched_match'` skips the
+      // enrichment worker forever; `legacy_entry_id` reintroduces the BS#908
+      // mirror loop; `show_id` reattaches the row to another show; `play_order`
+      // collides with the per-show sequence (#693). The controller must drop
+      // these fields before they reach `db.update().set()`.
+      mockUpdateEntry.mockResolvedValue({ id: 99, track_title: 'ok' });
+
+      const req = {
+        body: {
+          entry_id: 99,
+          data: {
+            track_title: 'ok',
+            // The following keys are server-internal and must be stripped.
+            metadata_status: 'enriched_match',
+            legacy_entry_id: 9999999,
+            legacy_release_id: 8888,
+            show_id: 1,
+            play_order: 0,
+            linkage_source: 'manual',
+            linkage_confidence: 0.99,
+            linked_at: new Date(),
+            metadata_attempt_at: new Date(),
+            enriching_since: new Date(),
+            dj_name: 'evil-dj',
+            album_id: 123,
+            artwork_url: 'https://example.com/x.jpg',
+            discogs_url: 'https://discogs.com/x',
+            release_year: 1999,
+          },
+        },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await updateEntry(req, res as Response, mockNext);
+
+      expect(mockUpdateEntry).toHaveBeenCalledTimes(1);
+      const passedData = (mockUpdateEntry as unknown as jest.Mock).mock.calls[0][1] as Record<string, unknown>;
+      // Allowed field is forwarded.
+      expect(passedData).toEqual(expect.objectContaining({ track_title: 'ok' }));
+      // Each internal key is absent from the service argument.
+      for (const internalKey of [
+        'metadata_status',
+        'legacy_entry_id',
+        'legacy_release_id',
+        'show_id',
+        'play_order',
+        'linkage_source',
+        'linkage_confidence',
+        'linked_at',
+        'metadata_attempt_at',
+        'enriching_since',
+        'dj_name',
+        'album_id',
+        'artwork_url',
+        'discogs_url',
+        'release_year',
+      ]) {
+        expect(passedData).not.toHaveProperty(internalKey);
+      }
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('addEntry free-form branch (BS#1099)', () => {
+    const activeShow = { id: 42, end_time: null };
+
+    beforeEach(() => {
+      mockGetLatestShow.mockResolvedValue(activeShow);
+      mockResolveDjNameForShow.mockResolvedValue('dj-real-name');
+    });
+
+    it('strips internal columns from body before constructing the insert payload', async () => {
+      // The free-form POST branch (no album_id, no message) used to spread
+      // `req.body` directly into the insert. A client with `flowsheet:write`
+      // could set `metadata_status`, `legacy_entry_id`, etc. The controller
+      // must construct the insert payload from named fields only.
+      // No album_id in the body — that's the discriminator that picks this
+      // branch over the (safe) album_id branch above.
+      mockAddTrack.mockResolvedValue({ id: 1, show_id: activeShow.id });
+      mockFetchMetadata.mockResolvedValue(undefined);
+
+      const req = {
+        body: {
+          // Required free-form fields:
+          artist_name: 'Juana Molina',
+          album_title: 'DOGA',
+          track_title: 'la paradoja',
+          record_label: 'Sonamos',
+          // Server-internal columns the client must not be able to set:
+          metadata_status: 'enriched_match',
+          legacy_entry_id: 9999999,
+          legacy_release_id: 8888,
+          show_id: 999,
+          play_order: 0,
+          linkage_source: 'manual',
+          linkage_confidence: 0.99,
+          linked_at: new Date(),
+          metadata_attempt_at: new Date(),
+          enriching_since: new Date(),
+          dj_name: 'evil-dj',
+          artwork_url: 'https://example.com/x.jpg',
+          discogs_url: 'https://discogs.com/x',
+          release_year: 1999,
+        },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await addEntry(req, res as Response, mockNext);
+
+      expect(mockAddTrack).toHaveBeenCalledTimes(1);
+      const passedEntry = (mockAddTrack as unknown as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
+      // The server-controlled fields are overridden by the controller.
+      expect(passedEntry.show_id).toBe(activeShow.id);
+      expect(passedEntry.dj_name).toBe('dj-real-name');
+      // Allowed fields pass through.
+      expect(passedEntry.artist_name).toBe('Juana Molina');
+      expect(passedEntry.album_title).toBe('DOGA');
+      expect(passedEntry.track_title).toBe('la paradoja');
+      expect(passedEntry.record_label).toBe('Sonamos');
+      // Internal keys are absent from the service argument. `album_id` is
+      // deliberately not in this list — in the free-form branch the
+      // discriminator `body.album_id != null` already constrains it to
+      // null/undefined, and the BS#933 snapshot path still passes
+      // `album_id: null` through to preserve that semantic.
+      for (const internalKey of [
+        'metadata_status',
+        'legacy_entry_id',
+        'legacy_release_id',
+        'play_order',
+        'linkage_source',
+        'linkage_confidence',
+        'linked_at',
+        'metadata_attempt_at',
+        'enriching_since',
+        'artwork_url',
+        'discogs_url',
+        'release_year',
+      ]) {
+        expect(passedEntry).not.toHaveProperty(internalKey);
+      }
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
   });
 });

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -859,6 +859,40 @@ describe('flowsheet.controller', () => {
       }
       expect(res.status).toHaveBeenCalledWith(200);
     });
+
+    it('forwards every UpdateRequestBody field that the client legitimately sets', async () => {
+      // Anti-drift guard: the controller's pick list and the service-layer
+      // pick list both have to stay in sync with `UpdateRequestBody`. If
+      // either drops a documented field, this test catches it.
+      mockUpdateEntry.mockResolvedValue({ id: 7 });
+
+      const data = {
+        artist_name: 'Juana Molina',
+        album_title: 'DOGA',
+        track_title: 'la paradoja',
+        track_position: 'A1',
+        record_label: 'Sonamos',
+        label_id: 99,
+        request_flag: true,
+        segue: false,
+        message: 'corrected DJ note',
+      };
+
+      const req = {
+        body: { entry_id: 7, data },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await updateEntry(req, res as Response, mockNext);
+
+      expect(mockUpdateEntry).toHaveBeenCalledTimes(1);
+      const passedData = (mockUpdateEntry as unknown as jest.Mock).mock.calls[0][1] as Record<string, unknown>;
+      // Every field in `data` (= every field in UpdateRequestBody) reaches
+      // the service. A drop here would silently break legitimate edits.
+      for (const [key, value] of Object.entries(data)) {
+        expect(passedData[key]).toEqual(value);
+      }
+    });
   });
 
   describe('addEntry free-form branch (BS#1099)', () => {


### PR DESCRIPTION
Closes #1099. Second in the P0 security sequence from #1157 (after #1097 which merged as #1159).

## Summary

- Controller-level allowlist on `updateEntry` (PATCH /flowsheet) via `pickUpdateEntryFields` — drops anything not in `UpdateRequestBody` before the service call.
- Controller-level allowlist on `addEntry`'s free-form branch — replaces `...body` spread with explicit field construction.
- Service-level defense in depth on `flowsheet_service.updateEntry` — rebuilds the update object from named fields so a future controller passing the raw body can't reintroduce the vulnerability.
- TDD: red → green for both endpoints with 15+ internal columns each.

## Why

Per #1099: today a `flowsheet:write` JWT can write to any column on `flowsheet` via the spread / `.set(entry)` paths. The blast radius covers the enrichment worker (`metadata_status='enriched_match'` permanently skips a row), the mirror loop guard (#908: setting `legacy_entry_id` reintroduces the loop), the per-show play_order invariant (#693: setting `play_order` collides with the sequence), and the streaming-URL / bio columns.

The fix shape — explicit allowlist at the route boundary, with service-layer defense in depth — matches one of the two acceptance-criteria options the issue lists. The Zod / OpenAPI cross-repo work in `wxyc-shared` is out of scope for this PR; see the issue's "Cross-repo work" section for that.

The `album_id` field is preserved in the addEntry free-form branch allowlist because the branch discriminator (`body.album_id != null`) already constrains it to null/undefined, and BS#933 introduced the explicit-`album_id: null` semantic for the snapshot-fields path.

## Test plan

- [x] `tests/unit/controllers/flowsheet.controller.test.ts` — added two TDD cases: PATCH with 15 internal columns drops all of them; POST free-form with 13 internal columns drops all of them.
- [x] All 41 flowsheet.controller tests pass.
- [x] All 142 flowsheet-related unit tests across `tests/unit/controllers/flowsheet*` and `tests/unit/services/flowsheet*` pass.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors (461 pre-existing warnings).
- [x] `npm run format:check` — clean.