### PR TITLE
fix(auth): require body.dj_id = req.auth.id and per-topic role check (closes #1098, #1102, #1104)

### DIFF
--- a/apps/backend/controllers/events.controller.ts
+++ b/apps/backend/controllers/events.controller.ts
@@ -2,26 +2,33 @@ import { Request, RequestHandler } from 'express';
 import { serverEventsMgr, TestEvents, Topics, type EventData } from '../utils/serverEvents';
 import WxycError from '../utils/error.js';
 
-// Role constants for event authorization
-const ROLE_DJ = 'dj';
+// Roles permitted to subscribe to DJ-tier event topics. Matches the WXYCRoles
+// hierarchy (member < dj < musicDirector < stationManager) — any role at or
+// above the dj tier qualifies. Kept as an explicit array (rather than a
+// hierarchy lookup) so the role list lives next to the topic list — a future
+// role addition prompts a deliberate edit here (BS#1104).
+const DJ_TIER_ROLES = ['dj', 'musicDirector', 'stationManager'];
 
 // Define access levels for events
 // Empty array = public access, array with roles = requires one of those roles
 const TopicAuthz: Record<string, string[]> = {
   [Topics.test]: [],
   [Topics.liveFs]: [],
-  [Topics.showDj]: [ROLE_DJ],
-  [Topics.primaryDj]: [ROLE_DJ],
-  [Topics.mirror]: [ROLE_DJ],
+  [Topics.showDj]: DJ_TIER_ROLES,
+  [Topics.primaryDj]: DJ_TIER_ROLES,
+  [Topics.mirror]: DJ_TIER_ROLES,
 };
 
 const filterAuthorizedTopics = (req: Pick<Request, 'auth'>, topics: string[]) => {
-  const hasAuth = !!req.auth;
-
   return topics.filter((topic) => {
-    if (TopicAuthz[topic] === undefined) return false;
-    if (!TopicAuthz[topic].length) return true;
-    return hasAuth;
+    const allowedRoles = TopicAuthz[topic];
+    if (allowedRoles === undefined) return false;
+    if (allowedRoles.length === 0) return true; // public topic
+    // Per-topic authz check (BS#1104). Pre-fix this returned `!!req.auth` —
+    // any authenticated caller, including a member-role user, got every
+    // topic in TopicAuthz including the `mirror` SQL stream.
+    const role = req.auth?.role;
+    return role !== undefined && allowedRoles.includes(role);
   });
 };
 
@@ -49,7 +56,11 @@ export const subscribeToTopic: RequestHandler<object, unknown, subReqBody> = (re
     throw new WxycError('Bad Request: client_id or topics missing from request body', 400);
   }
 
-  const subbedTopics = serverEventsMgr.subscribe(topics, client_id);
+  // Per-topic authz check (BS#1104). Pre-fix this called subscribe with the
+  // raw body topics — a member-role caller could subscribe to `mirror` /
+  // `primaryDj` / `showDj` straight from the wire.
+  const authorizedTopics = filterAuthorizedTopics(req, topics);
+  const subbedTopics = serverEventsMgr.subscribe(authorizedTopics, client_id);
   res.status(200).json({ message: 'successfully subscribed', topics: subbedTopics });
 };
 

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -376,6 +376,14 @@ export const joinShow: RequestHandler = async (req: Request<object, object, Join
     throw new WxycError('Bad Request, Must include a dj_id to join show', 400);
   }
 
+  // Cross-check body.dj_id against the authenticated user (BS#1098). Pre-fix
+  // any flowsheet:write caller could pass another DJ's id and start a show
+  // attributed to the victim in shows.primary_dj_id, show_start flowsheet
+  // messages, DJ stats, and every legacy mirror push.
+  if (!req.auth?.id || req.body.dj_id !== req.auth.id) {
+    throw new WxycError('Forbidden: dj_id must match the authenticated user', 403);
+  }
+
   if (current_show?.end_time !== null) {
     const show_session: Show = await flowsheet_service.startShow(
       req.body.dj_id,
@@ -390,11 +398,18 @@ export const joinShow: RequestHandler = async (req: Request<object, object, Join
   }
 };
 
-//TODO consume JWT and ensure that jwt.dj_id = current_show.dj_id
 export const leaveShow: RequestHandler<object, unknown, { dj_id: string }> = async (req, res) => {
   const currentShow = await flowsheet_service.getLatestShow();
   if (currentShow?.end_time !== null) {
     throw new WxycError('Bad Request: No active show session found.', 400);
+  }
+
+  // Cross-check body.dj_id against the authenticated user (BS#1102). Pre-fix
+  // showMemberMiddleware only checked the caller was in the show — never
+  // that body.dj_id matched. A guest DJ could end the entire show
+  // (body.dj_id = primary_dj_id) or kick a co-host (body.dj_id = co-host id).
+  if (!req.auth?.id || req.body.dj_id !== req.auth.id) {
+    throw new WxycError('Forbidden: dj_id must match the authenticated user', 403);
   }
 
   // Show membership is verified by showMemberMiddleware on the route

--- a/tests/integration/flowsheet-linkage.spec.js
+++ b/tests/integration/flowsheet-linkage.spec.js
@@ -72,12 +72,12 @@ describe('Forward-path flowsheet linkage (B-2.1 E2E)', () => {
   beforeEach(async () => {
     if (!mockApiAvailable) return;
     await resetMockApi();
-    await fls_util.join_show(getTestDjId(), global.access_token);
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
   });
 
   afterEach(async () => {
     if (!mockApiAvailable) return;
-    await fls_util.leave_show(getTestDjId(), global.access_token);
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
   });
 
   test('free-form Autechre/Confield insert auto-links to seeded library row via LML', async () => {

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -56,9 +56,12 @@ describe('Join Show', () => {
   });
 
   test('Properly Formatted Request', async () => {
+    // BS#1098: dj_id must match the authenticated caller, so the secondary
+    // DJ joins with their own Bearer (raw user-id token, accepted by
+    // AUTH_BYPASS — see tests/setup/integration.setup.js).
     const res = await request
       .post('/flowsheet/join')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         dj_id: global.secondary_dj_id,
       })
@@ -95,9 +98,13 @@ describe('End Show', () => {
       dj_id: global.primary_dj_id,
     });
 
+    // Secondary DJ attempts to /flowsheet/end after the show is over.
+    // BS#1102: dj_id must match the authenticated caller, so the secondary
+    // DJ has to send their own Bearer to get past the auth check; the
+    // 400 then comes from "No active show".
     const res = await request
       .post('/flowsheet/end')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         dj_id: global.secondary_dj_id,
       })
@@ -114,8 +121,8 @@ describe('Leave Show', () => {
     // Start show
     await fls_util.join_show(global.primary_dj_id, global.access_token);
 
-    // Second DJ joins
-    await fls_util.join_show(global.secondary_dj_id, global.access_token);
+    // Second DJ joins under their own auth (BS#1098 cross-check).
+    await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token);
   });
 
   // Ensure that primary dj ends the show for all show djs
@@ -133,15 +140,20 @@ describe('Leave Show', () => {
       .expect(200);
   });
 
-  test('DJ not in show', async () => {
+  test('Forbidden when dj_id does not match the authenticated user (BS#1102)', async () => {
+    // Pre-fix this test passed dj_id=1000 with primary's token and expected
+    // a 400 from the downstream "DJ not in show" path. Post-fix the
+    // controller rejects the dj_id≠auth.id mismatch with 403 before that
+    // path is reached — which is the more secure outcome (the body never
+    // reaches the show-membership check).
     const res = await request
       .post('/flowsheet/end')
       .set('Authorization', global.access_token)
       .send({
         dj_id: 1000,
       })
-      .expect(400);
-    expect(res.body.message).toBeDefined();
+      .expect(403);
+    expect(res.body.error).toBeDefined();
   });
 
   test('No Active Show Session', async () => {
@@ -150,9 +162,11 @@ describe('Leave Show', () => {
       dj_id: global.primary_dj_id,
     });
 
+    // Secondary DJ attempts to /flowsheet/end the (now-ended) show. BS#1102
+    // requires the secondary's own Bearer for the dj_id=auth.id cross-check.
     const res = await request
       .post('/flowsheet/end')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         dj_id: global.secondary_dj_id,
       })
@@ -856,8 +870,8 @@ describe('On Air Status', () => {
     test('returns multiple DJs when multiple are on air', async () => {
       // Start a show with primary DJ
       await fls_util.join_show(global.primary_dj_id, global.access_token);
-      // Secondary DJ joins
-      await fls_util.join_show(global.secondary_dj_id, global.access_token);
+      // Secondary DJ joins under their own auth (BS#1098 cross-check).
+      await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token);
 
       const res = await request.get('/flowsheet/djs-on-air').set('Authorization', global.access_token).expect(200);
 
@@ -881,7 +895,8 @@ describe('Retrieve Playlist Object', () => {
     const body = await res.json();
     global.CurrentShowID = body.id;
 
-    await fls_util.join_show(global.secondary_dj_id, global.access_token);
+    // Secondary joins as themselves (BS#1098 cross-check).
+    await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token);
 
     // Insert entry to for show
     await request

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -153,7 +153,8 @@ describe('Leave Show', () => {
         dj_id: 1000,
       })
       .expect(403);
-    expect(res.body.error).toBeDefined();
+    // WxycError serializes as `{ message }` (see middleware/errorHandler.ts).
+    expect(res.body.message).toBeDefined();
   });
 
   test('No Active Show Session', async () => {

--- a/tests/integration/metadata-lml.spec.js
+++ b/tests/integration/metadata-lml.spec.js
@@ -45,12 +45,12 @@ describe('Metadata via LML (Mock API)', () => {
   beforeEach(async () => {
     if (!mockApiAvailable) return;
     await resetMockApi();
-    await fls_util.join_show(getTestDjId(), global.access_token);
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
   });
 
   afterEach(async () => {
     if (!mockApiAvailable) return;
-    await fls_util.leave_show(getTestDjId(), global.access_token);
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
   });
 
   describe('Fire-and-forget LML calls on flowsheet insert', () => {

--- a/tests/integration/metadata.spec.js
+++ b/tests/integration/metadata.spec.js
@@ -36,11 +36,11 @@ const getTestDjId = () => global.secondary_dj_id;
 
 describe('Metadata Fields in Flowsheet Response', () => {
   beforeEach(async () => {
-    await fls_util.join_show(getTestDjId(), global.access_token);
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
   });
 
   afterEach(async () => {
-    await fls_util.leave_show(getTestDjId(), global.access_token);
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
   });
 
   test('Response includes all metadata fields (even if null)', async () => {
@@ -97,11 +97,11 @@ describe('Metadata Fields in Flowsheet Response', () => {
 
 describe('Fire-and-Forget Metadata Fetch', () => {
   beforeEach(async () => {
-    await fls_util.join_show(getTestDjId(), global.access_token);
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
   });
 
   afterEach(async () => {
-    await fls_util.leave_show(getTestDjId(), global.access_token);
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
   });
 
   test('Fire-and-forget does not block track insertion for library tracks', async () => {
@@ -185,11 +185,11 @@ describe('Fire-and-Forget Metadata Fetch', () => {
 
 describe('Flowsheet CRUD with Metadata', () => {
   beforeEach(async () => {
-    await fls_util.join_show(getTestDjId(), global.access_token);
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
   });
 
   afterEach(async () => {
-    await fls_util.leave_show(getTestDjId(), global.access_token);
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
   });
 
   test('New tracks appear in subsequent queries', async () => {
@@ -280,11 +280,11 @@ describe('Flowsheet CRUD with Metadata', () => {
 
 describe('Metadata with Rotation Entries', () => {
   beforeEach(async () => {
-    await fls_util.join_show(getTestDjId(), global.access_token);
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
   });
 
   afterEach(async () => {
-    await fls_util.leave_show(getTestDjId(), global.access_token);
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
   });
 
   test('Rotation entries include rotation_bin', async () => {
@@ -353,13 +353,13 @@ describe('album_metadata COALESCE projection (BS#897)', () => {
     // the row is also auto-dropped if the library row ever goes away.
     await sql.unsafe(`DELETE FROM "${SCHEMA}".album_metadata WHERE album_id = ${SENTINEL_ALBUM_ID}`);
     if (mockApiAvailable) await resetMockApi();
-    await fls_util.join_show(getTestDjId(), global.access_token);
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
   });
 
   afterEach(async () => {
     await sql.unsafe(`DELETE FROM "${SCHEMA}".album_metadata WHERE album_id = ${SENTINEL_ALBUM_ID}`);
     if (mockApiAvailable) await resetMockApi();
-    await fls_util.leave_show(getTestDjId(), global.access_token);
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
   });
 
   test('V2 read returns album_metadata values when the row exists, regardless of flowsheet inline state', async () => {
@@ -458,11 +458,11 @@ describe('Metadata Service Initialization', () => {
 
 describe('Flowsheet Cache Behavior', () => {
   beforeEach(async () => {
-    await fls_util.join_show(getTestDjId(), global.access_token);
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
   });
 
   afterEach(async () => {
-    await fls_util.leave_show(getTestDjId(), global.access_token);
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
   });
 
   test('Repeated first-page queries return consistent results', async () => {
@@ -572,11 +572,11 @@ describe('Flowsheet Cache Behavior', () => {
 
 describe('Conditional GET (304 Not Modified)', () => {
   beforeEach(async () => {
-    await fls_util.join_show(getTestDjId(), global.access_token);
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
   });
 
   afterEach(async () => {
-    await fls_util.leave_show(getTestDjId(), global.access_token);
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
   });
 
   describe('Last-Modified header', () => {

--- a/tests/integration/mirror-http.spec.js
+++ b/tests/integration/mirror-http.spec.js
@@ -28,12 +28,12 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
   beforeEach(async () => {
     if (!mockApiAvailable) return;
     await resetMockApi();
-    await fls_util.join_show(getTestDjId(), global.access_token);
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
   });
 
   afterEach(async () => {
     if (!mockApiAvailable) return;
-    await fls_util.leave_show(getTestDjId(), global.access_token);
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
   });
 
   test('adding a flowsheet entry POSTs to mock tubafrenzy', async () => {

--- a/tests/setup/integration.setup.js
+++ b/tests/setup/integration.setup.js
@@ -8,6 +8,12 @@ process.env.USE_MOCK_SERVICES = 'true';
 global.primary_dj_id = null;
 global.secondary_dj_id = null;
 global.access_token = '';
+// Secondary DJ's token. Populated as `Bearer <secondary_dj_id>` — a raw
+// user-id Bearer that AUTH_BYPASS accepts via auth.middleware.ts's catch
+// branch (no JWT parse, req.auth.id = token). Used by integration tests
+// that need to act AS the secondary DJ (e.g. /flowsheet/join with the
+// secondary's id) under the BS#1098 / BS#1102 dj_id=auth.id cross-check.
+global.secondary_access_token = '';
 
 // DB config with defaults to avoid connecting as root when envs are missing
 const dbConfig = {
@@ -51,4 +57,9 @@ beforeAll(async () => {
   await getUserIdsFromDatabase();
   const token = await get_access_token();
   global.access_token = `Bearer ${token}`;
+  // AUTH_BYPASS accepts a raw user-id Bearer when the token doesn't parse as
+  // a JWT, populating `req.auth.id` from the token value (see
+  // shared/authentication/src/auth.middleware.ts catch branch). That gives
+  // us a per-DJ identity without needing a second better-auth sign-in.
+  global.secondary_access_token = `Bearer ${global.secondary_dj_id}`;
 });

--- a/tests/unit/controllers/events.controller.test.ts
+++ b/tests/unit/controllers/events.controller.test.ts
@@ -19,12 +19,16 @@ jest.mock('../../../apps/backend/utils/serverEvents', () => {
   };
 });
 
-import { registerEventClient } from '../../../apps/backend/controllers/events.controller';
+import { registerEventClient, subscribeToTopic } from '../../../apps/backend/controllers/events.controller';
 import { serverEventsMgr, Topics } from '../../../apps/backend/utils/serverEvents';
 
 describe('events controller', () => {
+  beforeEach(() => {
+    (serverEventsMgr.subscribe as jest.Mock).mockClear();
+  });
+
   describe('registerEventClient', () => {
-    it('includes DJ-only topics when the user is authenticated', () => {
+    it('includes DJ-only topics when the caller has the dj role', () => {
       const req = {
         auth: { id: 'user-1', role: 'dj' },
         body: { topics: [Topics.liveFs, Topics.showDj, Topics.primaryDj] },
@@ -41,6 +45,26 @@ describe('events controller', () => {
       );
     });
 
+    it('includes DJ-only topics for roles above dj (musicDirector, stationManager)', () => {
+      for (const role of ['musicDirector', 'stationManager']) {
+        (serverEventsMgr.subscribe as jest.Mock).mockClear();
+        const req = {
+          auth: { id: 'user-1', role },
+          body: { topics: [Topics.showDj, Topics.primaryDj] },
+        } as unknown as Request;
+
+        const res = {} as Response;
+        const next = jest.fn();
+
+        registerEventClient(req, res, next);
+
+        expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+          expect.arrayContaining([Topics.showDj, Topics.primaryDj]),
+          'client-1'
+        );
+      }
+    });
+
     it('excludes DJ-only topics when the user is unauthenticated', () => {
       const req = {
         body: { topics: [Topics.liveFs, Topics.showDj, Topics.primaryDj] },
@@ -53,6 +77,81 @@ describe('events controller', () => {
 
       expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
         expect.not.arrayContaining([Topics.showDj, Topics.primaryDj]),
+        'client-1'
+      );
+    });
+
+    it('excludes DJ-only topics when the caller has the member role (BS#1104)', () => {
+      // Pre-fix: filterAuthorizedTopics returned every topic in TopicAuthz as
+      // long as !!req.auth was truthy — the role list was never consulted.
+      // A member-role user could subscribe to `mirror`, `primaryDj`,
+      // `showDj`.
+      const req = {
+        auth: { id: 'user-1', role: 'member' },
+        body: { topics: [Topics.liveFs, Topics.showDj, Topics.primaryDj, Topics.mirror] },
+      } as unknown as Request;
+
+      const res = {} as Response;
+      const next = jest.fn();
+
+      registerEventClient(req, res, next);
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+        expect.not.arrayContaining([Topics.showDj, Topics.primaryDj, Topics.mirror]),
+        'client-1'
+      );
+      // Public topics still allowed.
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(expect.arrayContaining([Topics.liveFs]), 'client-1');
+    });
+  });
+
+  describe('subscribeToTopic (BS#1104)', () => {
+    function makeRes() {
+      const statusMock = jest.fn().mockReturnThis();
+      const jsonMock = jest.fn().mockReturnThis();
+      return { status: statusMock, json: jsonMock } as unknown as Response;
+    }
+
+    it('filters DJ-only topics out when the caller has the member role', () => {
+      // Pre-fix: subscribeToTopic skipped filterAuthorizedTopics entirely
+      // and called serverEventsMgr.subscribe with the raw body topics.
+      const req = {
+        auth: { id: 'user-1', role: 'member' },
+        body: { client_id: 'client-1', topics: [Topics.liveFs, Topics.mirror, Topics.primaryDj] },
+      } as unknown as Request;
+
+      subscribeToTopic(req, makeRes(), jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+        expect.not.arrayContaining([Topics.mirror, Topics.primaryDj]),
+        'client-1'
+      );
+    });
+
+    it('allows DJ-only topics when the caller has the dj role', () => {
+      const req = {
+        auth: { id: 'user-1', role: 'dj' },
+        body: { client_id: 'client-1', topics: [Topics.mirror, Topics.primaryDj, Topics.showDj] },
+      } as unknown as Request;
+
+      subscribeToTopic(req, makeRes(), jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+        expect.arrayContaining([Topics.mirror, Topics.primaryDj, Topics.showDj]),
+        'client-1'
+      );
+    });
+
+    it('still allows public topics for any authenticated caller', () => {
+      const req = {
+        auth: { id: 'user-1', role: 'member' },
+        body: { client_id: 'client-1', topics: [Topics.liveFs, Topics.test] },
+      } as unknown as Request;
+
+      subscribeToTopic(req, makeRes(), jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+        expect.arrayContaining([Topics.liveFs, Topics.test]),
         'client-1'
       );
     });

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -16,6 +16,10 @@ const mockGetLatestShow = jest.fn<() => Promise<Record<string, unknown> | null>>
 const mockGetAlbumFromDB = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockResolveDjNameForShow = jest.fn<() => Promise<string | null>>();
 const mockUpdateEntry = jest.fn<() => Promise<Record<string, unknown>>>();
+const mockStartShow = jest.fn<() => Promise<Record<string, unknown>>>();
+const mockAddDJToShow = jest.fn<() => Promise<Record<string, unknown>>>();
+const mockEndShow = jest.fn<() => Promise<Record<string, unknown>>>();
+const mockServiceLeaveShow = jest.fn<() => Promise<Record<string, unknown>>>();
 
 jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getEntriesByPage: mockGetEntriesByPage,
@@ -28,6 +32,10 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getAlbumFromDB: mockGetAlbumFromDB,
   resolveDjNameForShow: mockResolveDjNameForShow,
   updateEntry: mockUpdateEntry,
+  startShow: mockStartShow,
+  addDJToShow: mockAddDJToShow,
+  endShow: mockEndShow,
+  leaveShow: mockServiceLeaveShow,
 }));
 
 const mockFetchMetadata = jest.fn<() => Promise<void>>();
@@ -43,6 +51,8 @@ import {
   getShowInfo,
   addEntry,
   updateEntry,
+  joinShow,
+  leaveShow,
 } from '../../../apps/backend/controllers/flowsheet.controller';
 import WxycError from '../../../apps/backend/utils/error';
 
@@ -973,6 +983,129 @@ describe('flowsheet.controller', () => {
         expect(passedEntry).not.toHaveProperty(internalKey);
       }
       expect(res.status).toHaveBeenCalledWith(201);
+    });
+  });
+
+  describe('joinShow (BS#1098)', () => {
+    it('rejects when body.dj_id does not match the authenticated user', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: new Date() });
+
+      const req = {
+        auth: { id: 'caller-dj' },
+        body: { dj_id: 'victim-dj', show_name: 'taking over your show' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await expect(joinShow(req, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
+      expect(mockStartShow).not.toHaveBeenCalled();
+      expect(mockAddDJToShow).not.toHaveBeenCalled();
+    });
+
+    it('starts a new show when body.dj_id matches the caller and there is no active show', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: new Date() });
+      mockStartShow.mockResolvedValue({ id: 42, primary_dj_id: 'caller-dj' });
+
+      const req = {
+        auth: { id: 'caller-dj' },
+        body: { dj_id: 'caller-dj', show_name: 'My Show', specialty_id: 7 },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await joinShow(req, res as Response, mockNext);
+
+      expect(mockStartShow).toHaveBeenCalledWith('caller-dj', 'My Show', 7);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('adds the caller to the active show as a co-host', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: null });
+      mockAddDJToShow.mockResolvedValue({ id: 99, dj_id: 'caller-dj' });
+
+      const req = {
+        auth: { id: 'caller-dj' },
+        body: { dj_id: 'caller-dj' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await joinShow(req, res as Response, mockNext);
+
+      expect(mockAddDJToShow).toHaveBeenCalledWith('caller-dj', expect.objectContaining({ id: 1 }));
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('rejects when req.auth.id is missing entirely', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: new Date() });
+
+      const req = {
+        body: { dj_id: 'some-dj' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await expect(joinShow(req, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
+      expect(mockStartShow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('leaveShow (BS#1102)', () => {
+    it('rejects when body.dj_id does not match the authenticated user', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: null, primary_dj_id: 'victim-primary' });
+
+      const req = {
+        auth: { id: 'guest-dj' },
+        body: { dj_id: 'victim-primary' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await expect(leaveShow(req, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
+      expect(mockEndShow).not.toHaveBeenCalled();
+      expect(mockServiceLeaveShow).not.toHaveBeenCalled();
+    });
+
+    it('rejects when a guest tries to kick a co-host (body.dj_id = other co-host)', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: null, primary_dj_id: 'primary-dj' });
+
+      const req = {
+        auth: { id: 'guest-dj' },
+        body: { dj_id: 'other-cohost' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await expect(leaveShow(req, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
+      expect(mockServiceLeaveShow).not.toHaveBeenCalled();
+    });
+
+    it('ends the show when the caller is the primary DJ leaving', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: null, primary_dj_id: 'primary-dj' });
+      mockEndShow.mockResolvedValue({ id: 1, end_time: new Date() });
+
+      const req = {
+        auth: { id: 'primary-dj' },
+        body: { dj_id: 'primary-dj' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await leaveShow(req, res as Response, mockNext);
+
+      expect(mockEndShow).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+      expect(mockServiceLeaveShow).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('removes a guest DJ when the caller is the guest leaving themselves', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: null, primary_dj_id: 'primary-dj' });
+      mockServiceLeaveShow.mockResolvedValue({ id: 99, dj_id: 'guest-dj' });
+
+      const req = {
+        auth: { id: 'guest-dj' },
+        body: { dj_id: 'guest-dj' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await leaveShow(req, res as Response, mockNext);
+
+      expect(mockServiceLeaveShow).toHaveBeenCalledWith('guest-dj', expect.objectContaining({ id: 1 }));
+      expect(mockEndShow).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
     });
   });
 });


### PR DESCRIPTION
Closes #1098, #1102, #1104. Third in the P0 security sequence from #1157 (after #1097 → #1159, #1099 → #1161).

## Summary

Three call sites trusted client-provided ids without verifying against `req.auth`:

- **#1098** `joinShow` — `/flowsheet/join` read `req.body.dj_id` without comparing to `req.auth.id`, letting any `flowsheet:write` caller start a show with `primary_dj_id` set to another DJ (victim owned the `show_start` flowsheet row, every legacy mirror push, DJ stats roll-up).
- **#1102** `leaveShow` — `/flowsheet/end` decided `endShow`-vs-`leaveShow` from `body.dj_id`. Any guest in the show could pass primary's id to end everyone's show, or another co-host's id to kick them.
- **#1104** events — `filterAuthorizedTopics` only checked `!!req.auth` and never consulted `TopicAuthz[topic]` roles; a member-role caller could subscribe to `mirror`, `primaryDj`, `showDj`. `subscribeToTopic` skipped the helper entirely.

## Fix

- `joinShow` + `leaveShow`: explicit `if (!req.auth?.id || body.dj_id !== req.auth.id) throw 403`. Token-bound — `body.dj_id` remains in the wire shape but is rejected on mismatch.
- events: `TopicAuthz` now uses the DJ-tier role list (`dj`, `musicDirector`, `stationManager`); `filterAuthorizedTopics` consults it; `subscribeToTopic` funnels through the same helper before calling `serverEventsMgr.subscribe`.

## Integration test fixture

Pre-fix, several specs joined-as-secondary by passing `secondary_dj_id` with primary's token (i.e. the exact bug). They now use `global.secondary_access_token` populated as `Bearer <secondary_dj_id>` — AUTH_BYPASS's catch branch accepts a raw user-id Bearer and sets `req.auth.id` from it, so no new sign-in credentials are needed and the existing single better-auth login stays the only real sign-in in the suite.

## Test plan

- [x] `tests/unit/controllers/flowsheet.controller.test.ts` — 7 new BS#1098 / BS#1102 cases (mismatch rejected; auth missing rejected; primary-self ends show; guest-self leaves; non-primary cannot kick).
- [x] `tests/unit/controllers/events.controller.test.ts` — 7 new BS#1104 cases (member excluded, dj allowed, musicDirector/stationManager allowed, subscribeToTopic now funnels through filter, public topics still allowed).
- [x] Integration tests updated for the secondary-DJ token swap across `flowsheet.spec.js`, `metadata.spec.js`, `metadata-lml.spec.js`, `flowsheet-linkage.spec.js`, `mirror-http.spec.js`. The "Leave Show / DJ not in show" test now asserts 403 instead of 400 — the controller-level cross-check fires before the show-membership branch.
- [x] All 57 affected unit tests pass.
- [x] `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check` — green.