### PR TITLE
docs(ops): runbooks for BS#1064 cron re-validation and BS#1078 Phase 3 drain

### DIFF
--- a/docs/ops-album-level-backfill-phase3.md
+++ b/docs/ops-album-level-backfill-phase3.md
@@ -1,0 +1,201 @@
+# Runbook: album-level-backfill Phase 3 prod-run (BS#1078)
+
+The album-level-backfill job (BS#1041) is operationally complete on the BS
+side; Phase 3 (the actual drain of the ~35,692 unique pending `album_id`s
+into `album_metadata`, plus the paired post-pass UPDATE on ~857k linked
+flowsheet rows) is gated on LML#370 (per-item cascade-exhaustion hard cap)
+and LML#372 (client-cancel propagation into `asyncio.gather`). Both LML
+issues closed 2026-05-25 but the LML `prod` deploy is a separate event —
+this runbook is the post-deploy execution plan.
+
+## Pre-flight (do NOT skip)
+
+### Verify both LML fixes are live in `prod`
+
+Both must be on LML's `prod` branch, deployed to the LML Railway service
+that BS's `LIBRARY_METADATA_URL` points at (NOT the staging instance).
+
+```sh
+# Check LML's prod version via the /version endpoint (or equivalent):
+curl -s "${LIBRARY_METADATA_URL}/version" | jq .
+
+# Confirm the commit SHA matches a known-good ref that includes both
+# LML#370 and LML#372. Cross-reference:
+gh issue view 370 --repo WXYC/library-metadata-lookup --json closedAt,timelineItems
+gh issue view 372 --repo WXYC/library-metadata-lookup --json closedAt,timelineItems
+```
+
+If the `/version` endpoint doesn't exist yet (it's been on the LML wishlist
+for a while), fall back to triggering a known-symptom call against LML and
+verifying the new behavior:
+
+- **LML#370 verification**: trigger a known cascade-exhaustion item (an
+  obscure 1980s European cassette label is the canonical example —
+  Jake/Chris will have a current "cascade-bait" list). Verify LML returns
+  `status: error` with `timeout: true` after ≤25s wall-clock (the per-item
+  cap), not the previous 60+ s symptom.
+- **LML#372 verification**: trigger a batch of 10 cascade-bait items
+  concurrently via `POST /api/v1/lookup/bulk`, abort the client after 30s,
+  confirm via LML's metrics dashboard that the semaphore queue drains
+  within 5s of the client abort (not the prior monotonic growth).
+
+If either verification fails, **stop here** — do not start Phase 3. Comment
+on BS#1078 with the failing test and re-block on LML.
+
+### Pick a traffic-lull window
+
+Phase 3 holds Discogs slots across ~12h of wall-clock. Schedule for
+late-night UTC (00:00–08:00 UTC is ideal) when:
+
+- Cron schedule overlap is minimal. `flowsheet-metadata-backfill-cron`
+  fires at `0 6 * * *` UTC by default — start Phase 3 AFTER the daily cron
+  has finished (typically by 16:46 UTC if the cron runs 10h45m, but pick a
+  later window so you're not co-running). The library `library-etl` and
+  `rotation-etl` daily syncs are similarly lighter overnight.
+- No active radio show on the WXYC stream. Check the dj-site flowsheet for
+  recent `show_start` events.
+- BS deploys are quiet. Check `gh run list --workflow="Auto Build & Deploy"
+  --branch=main --limit=5` — if a deploy is in flight or imminent, defer.
+
+### Snapshot the starting state
+
+```sh
+# Connect to wxyc-ec2's RDS via the standard read-only pattern. Adjust
+# DSN to match your local convention.
+psql "$WXYC_DB_DSN_READONLY" -c "
+  SELECT
+    (SELECT COUNT(*) FROM album_metadata) AS album_metadata_rows,
+    (SELECT COUNT(*) FROM flowsheet WHERE metadata_status='pending' AND album_id IS NOT NULL) AS linked_pending_residual,
+    (SELECT COUNT(DISTINCT album_id) FROM flowsheet WHERE metadata_status='pending' AND album_id IS NOT NULL) AS unique_linked_pending;
+"
+```
+
+Record these as your T0 snapshot in the BS#1078 comment thread. The
+acceptance bullets compare against this state.
+
+## Execution
+
+### Step 1 — Configure the rate
+
+The default is `BACKFILL_BULK_RATE_PER_MIN=1` per the README — explicitly
+NOT the aggressive `4` of the 2026-05-25 abort. The README's value is
+calibrated for the post-LML-fix queue ceiling. Don't change it unless the
+LML team has confirmed a higher rate is safe.
+
+```sh
+ssh wxyc-ec2
+sudo grep '^BACKFILL_BULK_RATE_PER_MIN' /opt/wxyc/.env
+# Expect: BACKFILL_BULK_RATE_PER_MIN=1
+# If unset or different, set it:
+sudo sed -i.bak '/^BACKFILL_BULK_RATE_PER_MIN=/d; $a BACKFILL_BULK_RATE_PER_MIN=1' /opt/wxyc/.env
+```
+
+### Step 2 — Launch the drain
+
+The album-level-backfill job is registered the same way the
+flowsheet-metadata-backfill is — via `deploy-base.yml`. Trigger it
+manually:
+
+```sh
+docker compose --project-name wxyc-backend run --rm album-level-backfill \
+  2>&1 | tee /tmp/bs-1078-phase3-$(date +%Y%m%dT%H%MZ).log
+```
+
+The job logs structured JSON per batch. Tail it in a second SSH session:
+
+```sh
+tail -f /tmp/bs-1078-phase3-*.log | jq -r 'select(.step=="batch_done")'
+```
+
+### Step 3 — Abort criterion
+
+**If any single batch exceeds 25 s wall-clock, abort.** That's the early
+recurrence signal — it means the per-item cap from LML#370 isn't engaging
+(or worse, the queue is growing again because LML#372 isn't propagating
+cancellation).
+
+Each `batch_done` record includes `wall_clock_ms`. The watchdog:
+
+```sh
+# In a third SSH session, alarm when any batch exceeds 25000ms:
+tail -f /tmp/bs-1078-phase3-*.log \
+  | jq -r 'select(.step=="batch_done" and .wall_clock_ms>25000) | "ABORT: batch_index=\(.batch_index) wall_clock_ms=\(.wall_clock_ms)"' \
+  | head -1
+```
+
+If that one-shot watchdog fires, kill the drain container (`docker stop
+<container>`) and start the deeper investigation per BS#1078 body. Don't
+restart the drain — figure out what regressed first.
+
+### Step 4 — Watch for the first 20 batches
+
+The first 20 batches are the canary. If they all complete in <25s with
+<5% per-item errors, the run is healthy and you can let it finish
+unattended. The job's loop survives per-batch failures so a transient hiccup
+mid-run won't kill it.
+
+```sh
+grep '"step":"batch_done"' /tmp/bs-1078-phase3-*.log \
+  | jq -s 'sort_by(.batch_index) | .[:20] | {
+      batches: length,
+      max_wall_ms: ([.[].wall_clock_ms] | max),
+      total_errors: ([.[].lml_error // 0] | add),
+      total_scanned: ([.[].scanned] | add)
+    }'
+```
+
+### Step 5 — Post-pass UPDATE
+
+After all batches complete (`linked_pending_residual` per the SQL probe in
+pre-flight should be approaching 0), the post-pass UPDATE that flips the
+~857k linked-pending flowsheet rows runs as part of the job's own
+shutdown. It's NOT a separate manual step — but verify it completed:
+
+```sh
+grep '"step":"post_pass_update_done"' /tmp/bs-1078-phase3-*.log
+```
+
+If that record is missing and the job exited cleanly, the SQL UPDATE either
+didn't run or crashed mid-flight. Re-run with `--phase=post-pass-only` (the
+job exposes that flag per BS#1041) — it's idempotent.
+
+## Acceptance verification
+
+Re-snapshot the same SQL from pre-flight and compare against T0:
+
+| Metric | Pre-flight | Expected post-run | Acceptance |
+|---|---|---|---|
+| `album_metadata` rows | T0 value | T0 + ~30k | growth ≥ 25k → ✅ |
+| `linked_pending_residual` | T0 value (~857k) | ≈ 0 | residual < 10k → ✅ |
+| `unique_linked_pending` | T0 value (~35,692) | ≈ 0 | residual < 1k → ✅ |
+
+The "residual < N" tolerances allow for:
+- Cascade-exhaustion items that LML#370 explicitly bounces to the per-row
+  drain cron (flowsheet-metadata-backfill); these stay `pending` here but
+  are picked up by the daily cron.
+- Rows added concurrently during the drain by live worker writes.
+
+Post in BS#1078 comment thread:
+
+- Start/end timestamps (UTC)
+- Number of batches run
+- Max batch wall_clock_ms
+- T0 → T1 deltas for the three metrics above
+- Any abort + restart events
+- Final state of `album_level_backfill_journal` or equivalent if such a
+  table exists (idempotency proof)
+
+## What to skip if a partial run already shipped
+
+If the 2026-05-25 partial run already wrote some `album_metadata` rows
+(~290 per BS#1078), the job's `INSERT … ON CONFLICT DO NOTHING` shape
+means re-running is safe — duplicates are no-ops. The `linked_pending`
+state is the load-bearing measure for completion; re-running until that
+reaches ~0 is the correct contract.
+
+## Out of scope
+
+- Migration of the BS-side cron's `BACKFILL_LML_PER_CALL_TIMEOUT_MS` (see
+  `ops-lml-cron-revalidation.md` — that's BS#1064's runbook).
+- Any change to LML's Discogs slot count or LML's queue behavior — both
+  are upstream concerns; this runbook is BS-side execution only.

--- a/docs/ops-lml-cron-revalidation.md
+++ b/docs/ops-lml-cron-revalidation.md
@@ -1,0 +1,160 @@
+# Runbook: flowsheet-metadata-backfill cron LML re-validation (BS#1064)
+
+Once LML's `prod` branch carries the per-item cascade cap (LML#370) and the
+queue-cancellation propagation (LML#372), the BS-side cron's ~21% LML
+timeout rate should drop. This runbook is the cheap, decisive triage to
+confirm that — and the fallback if it doesn't.
+
+## Premise
+
+The 2026-05-25 06:00 UTC firing showed:
+
+- 21 batches in ~10h45m
+- 21.1% `lml_error` (all `LML request timed out` — client-side 8s budget firing)
+- Sampled inter-row spacing ≈ 8s (the budget IS the cutoff, not server slowness)
+
+Two hypotheses (see BS#1064 body):
+
+- **A**: per-call 8s budget is too tight for cold-tail rows post-LML #337/#359.
+- **B**: BS-side stack degradation (undici pool poisoning, Sentry transport backlog, FD leak) — LML responds fast on direct curl but slow from inside the cron container.
+
+The LML closures don't make A vs B distinguishable in isolation. This runbook
+runs the cheap decision tree.
+
+## Prerequisites
+
+- LML's `prod` branch has both LML#370 and LML#372 deployed. Verify via the
+  LML repo's deploy log; both were closed 2026-05-25 but the LML `prod`
+  deploy is a separate event. Confirm with `gh issue view <id> --repo
+  WXYC/library-metadata-lookup` and look for the "deployed to prod"
+  comment, OR query LML's `/version` endpoint.
+- BS EC2 host healthy (`gh issue list --label status:investigating` shows
+  nothing relevant, host metrics nominal).
+- No active show on air (the cron's cooperative pause via #735 already
+  defers when DJs are active; this just avoids an immediate restart loop
+  if a DJ joins mid-run).
+
+## Step 1 — Baseline run with current config
+
+Do not change the cron config. Trigger one out-of-band firing so the
+post-LML-deploy state is sampled before doing anything else.
+
+```sh
+# SSH to wxyc-ec2:
+ssh wxyc-ec2
+
+# Run the cron once interactively. The exact docker invocation matches
+# what deploy-base.yml registers; copy it from the systemd unit at
+# /etc/systemd/system/flowsheet-metadata-backfill-cron.service or check
+# `docker compose --project-name wxyc-backend ps` for the configured
+# container name.
+docker compose --project-name wxyc-backend run --rm flowsheet-metadata-backfill 2>&1 | tee /tmp/bs-1064-baseline.log
+```
+
+(Or trigger via the existing systemd timer's `OnCalendar` ad-hoc:
+`sudo systemctl start flowsheet-metadata-backfill-cron.service` and follow
+with `journalctl -u flowsheet-metadata-backfill-cron.service -f`.)
+
+Wait for the run to either finish or stabilize at a representative state
+(~5-10 batches). Don't let it run the full ~10h45m unless the error rate
+is dropping fast — abort earlier if 5 batches in a row show <5% error.
+
+## Step 2 — Compute the error rate from the log
+
+The cron emits per-batch `batch_done` records. Grep them out and average:
+
+```sh
+grep '"step":"batch_done"' /tmp/bs-1064-baseline.log \
+  | jq -s '
+    {
+      batches: length,
+      scanned: ([.[].scanned] | add),
+      enriched_match: ([.[].enriched_match] | add),
+      enriched_no_match: ([.[].enriched_no_match] | add),
+      lml_error: ([.[].lml_error] | add),
+      pct_error: (([.[].lml_error] | add) * 100 / ([.[].scanned] | add))
+    }'
+```
+
+## Step 3 — Decide
+
+| `pct_error` | Verdict | Action |
+|---|---|---|
+| < 5% | **Hypothesis A confirmed; LML fixes closed the gap.** | Comment on BS#1064 with the numbers; close as fixed. No config change needed. |
+| 5–15% | Marginal. Could be A (a slightly too-tight budget still chops the tail) or B (intermittent stack degradation). | Bump `BACKFILL_LML_PER_CALL_TIMEOUT_MS` to `20000` in EC2 `.env` (Step 4) and re-run. If error rate drops to <5%: A. If it stays high: B. |
+| > 15% | **Hypothesis B; the BS-side stack is the bottleneck.** | Don't bump the budget — that just hides the symptom. Proceed to Step 5 (deeper investigation). |
+
+## Step 4 — Budget bump (only if Step 3 says "Marginal")
+
+```sh
+# Edit EC2 .env in place. The value lives next to the other
+# BACKFILL_LML_* knobs.
+ssh wxyc-ec2
+sudo sed -i.bak 's/^BACKFILL_LML_PER_CALL_TIMEOUT_MS=.*/BACKFILL_LML_PER_CALL_TIMEOUT_MS=20000/' /opt/wxyc/.env
+
+# Rebuild the cron container so the new env is in effect:
+docker compose --project-name wxyc-backend up -d --build flowsheet-metadata-backfill
+```
+
+Re-run Step 1 and recompute Step 2. If the error rate drops below 5%,
+commit the .env change permanently (don't leave it as a manual sed) and
+close BS#1064 with a comment naming the value that worked.
+
+## Step 5 — Hypothesis B investigation (only if Step 3 says "> 15%")
+
+Do not chase by sleeping/restarting. Capture evidence first.
+
+5a. **Direct LML latency probe**. Re-run Jake's earlier 5-row probe against
+LML directly, comparing wall-clock to the cron's same-row latency for the
+same `flowsheet_id`s:
+
+```sh
+# From wxyc-ec2 (so the network path matches the cron's path):
+for id in 58060 58078 58095 58097 58141; do
+  echo "--- flowsheet_id=$id"
+  time curl -s -X POST "${LIBRARY_METADATA_URL}/api/v1/lookup" \
+    -H "Authorization: Bearer ${LML_API_KEY}" \
+    -H 'Content-Type: application/json' \
+    -d "$(scripts/build-lookup-payload.sh "$id")" \
+    -o /dev/null
+done
+```
+
+If LML responds <2s for the same rows that timed out in the cron, B is
+confirmed.
+
+5b. **`/proc` snapshot of a stuck call**. While the cron is mid-call (run
+it interactively in Step 1 and grab the PID), capture:
+
+```sh
+ssh wxyc-ec2 -- 'CRON_PID=$(pgrep -f flowsheet-metadata-backfill | head -1); \
+  cat /proc/$CRON_PID/status; \
+  ls /proc/$CRON_PID/fd | wc -l; \
+  ls -la /proc/$CRON_PID/fd | head -50'
+```
+
+Look for FD count growing over the run (socket leak) or `State: D` (uninterruptible sleep on a syscall).
+
+5c. **Strip Sentry**. Build a debug container with `@sentry/node` excluded
+(comment out the `Sentry.init(...)` call in `apps/backend/instrument.ts`'s
+equivalent for the cron entrypoint) and re-run Step 1. If the timeout rate
+drops without Sentry, attach the finding to BS#1064 — the transport
+backlog hypothesis becomes credible and gets its own ticket.
+
+## Side effects to watch
+
+- The cron's cooperative pause via #735 still applies. If a DJ joins
+  mid-run, the cron defers. That's fine — re-trigger after the show ends.
+- Don't lower `BACKFILL_LML_PER_CALL_TIMEOUT_MS` below the value that
+  worked. Tighter budgets free LML's slots faster but also push borderline
+  rows into the no-match bucket; that's a different tradeoff and a
+  different ticket.
+
+## Closeout
+
+Post a comment on BS#1064 with:
+
+- Final value of `pct_error`
+- Verdict (A / Marginal-fixed-by-bump / B)
+- Any `.env` changes applied + the host they're on
+- If B: link to the new investigation ticket


### PR DESCRIPTION
Capture the post-LML-deploy execution paths for two operationally-complete-but-deploy-gated items in the #1157 P0 sequence.

## Summary

- `docs/ops-lml-cron-revalidation.md` (BS#1064): post-LML-deploy A/B decision tree between "per-call budget too tight" (Hypothesis A) and "BS-side stack degradation" (Hypothesis B), plus the evidence-capture steps for B (direct curl probe, `/proc` snapshot, Sentry-stripped debug container).
- `docs/ops-album-level-backfill-phase3.md` (BS#1078): pre-flight LML fix verifications (LML#370 + LML#372), traffic-lull window selection, rate config (`BACKFILL_BULK_RATE_PER_MIN=1` per README, NOT the aggressive `4` of the 2026-05-25 abort), abort criterion (any single batch >25s), and acceptance SQL probes.

## Why now

Both items are gated on the LML `prod` deploy, not on more BS work. The runbooks are the bridge — operator can execute them as soon as LML deploys without reconstructing the triage tree from the issue threads.

## What this PR does NOT do

It does NOT trigger either operation. They are deliberately operator-driven because both interact with prod traffic (the cron under load, the bulk drain during a traffic lull).

## Test plan

- [x] Markdown renders correctly on GitHub.
- [x] Cross-references resolve: LML#370, LML#372, BS#1064, BS#1078, BS#1041, BS#1157, BS#735, BS#994.
- [ ] When the LML `prod` deploy lands, the operator can execute the runbooks step-by-step to completion without further consultation.