### PR TITLE
feat(flowsheet): replace conditionalGet watermark with flowsheet_watermark singleton

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -37,11 +37,18 @@ export interface IFSEntryMetadata {
 // `legacy_link_attempted_at` and `metadata_attempt_at` are job-internal
 // markers consumed only by the broken-FK recovery and metadata backfill
 // jobs respectively, so they're excluded from the controller-facing entry.
+// `updated_at` (BS#902) is the row-level watermark consumed only by the
+// conditional-GET middleware via `getLastModifiedAt`; it's never projected
+// onto the wire format, so it stays out of IFSEntry alongside the other
+// internal markers.
 //
 // `metadata_status` and `enriching_since` (BS#891) ARE surfaced to the
 // controller layer because the V2 wire format projects metadata_status onto
 // track rows for iOS branch logic (WXYC/wxyc-ios-64#270).
-export interface IFSEntry extends Omit<FSEntry, 'search_doc' | 'legacy_link_attempted_at' | 'metadata_attempt_at'> {
+export interface IFSEntry extends Omit<
+  FSEntry,
+  'search_doc' | 'legacy_link_attempted_at' | 'metadata_attempt_at' | 'updated_at'
+> {
   label_id: number | null;
   rotation_bin: string | null;
   on_streaming: boolean | null;

--- a/apps/backend/middleware/conditionalGet.ts
+++ b/apps/backend/middleware/conditionalGet.ts
@@ -6,9 +6,23 @@ import * as flowsheet_service from '../services/flowsheet.service.js';
  * Supports both `since` query param and `If-Modified-Since` header.
  * Returns 304 Not Modified if data hasn't changed since the client's timestamp.
  * Sets `Last-Modified` header on responses for client caching.
+ *
+ * Source of truth is the `flowsheet_watermark.last_modified_at` single-row
+ * sibling table (BS#902 / Epic F F1). The prior process-local watermark
+ * broke as soon as more than one BS pod sat behind the load balancer —
+ * each pod kept its own value, so iOS polls fanned across pods would
+ * either 304 against the wrong baseline or 200-with-redundant-data on pod
+ * swap. Migration 0084 wires an AFTER INSERT/UPDATE/DELETE STATEMENT
+ * trigger on `flowsheet` that touches this row, so the watermark advances
+ * on every mutation (including deletes — which a `MAX(flowsheet.updated_at)`
+ * read would have missed). PK lookup is O(1).
  */
-export const conditionalGet: RequestHandler = (req: Request, res: Response, next: NextFunction): void => {
-  const lastModified = flowsheet_service.getLastModifiedAt();
+export const conditionalGet: RequestHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const lastModified = await flowsheet_service.getLastModifiedAt();
 
   // Check query param first, then header
   const sinceParam = req.query.since as string | undefined;
@@ -17,7 +31,10 @@ export const conditionalGet: RequestHandler = (req: Request, res: Response, next
 
   if (sinceStr) {
     const clientTime = new Date(sinceStr);
-    // HTTP Date format only has second precision, so compare at second granularity
+    // HTTP Date format only has second precision, so compare at second
+    // granularity. The DB trigger gives ms precision; both sides floor to
+    // whole seconds before the inequality so a write within the same wall-
+    // clock second as the client's last poll still produces a 304.
     const clientSeconds = Math.floor(clientTime.getTime() / 1000);
     const serverSeconds = Math.floor(lastModified.getTime() / 1000);
     if (!isNaN(clientSeconds) && clientSeconds >= serverSeconds) {

--- a/apps/backend/middleware/conditionalGet.ts
+++ b/apps/backend/middleware/conditionalGet.ts
@@ -32,9 +32,14 @@ export const conditionalGet: RequestHandler = async (
   if (sinceStr) {
     const clientTime = new Date(sinceStr);
     // HTTP Date format only has second precision, so compare at second
-    // granularity. The DB trigger gives ms precision; both sides floor to
-    // whole seconds before the inequality so a write within the same wall-
-    // clock second as the client's last poll still produces a 304.
+    // granularity. The DB trigger floors progress to whole seconds too
+    // (`GREATEST(now(), last_modified_at + interval '1 second')` in
+    // migration 0084) — any mutation advances the watermark by at least
+    // one full second relative to its prior value. Without that floor,
+    // two mutations inside the same wall-clock second would leave the
+    // second-granularity inequality unable to observe progress, and a
+    // polling client's prior `If-Modified-Since` would 304 against a
+    // stale baseline.
     const clientSeconds = Math.floor(clientTime.getTime() / 1000);
     const serverSeconds = Math.floor(lastModified.getTime() / 1000);
     if (!isNaN(clientSeconds) && clientSeconds >= serverSeconds) {

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -2,7 +2,6 @@ import { Router } from 'express';
 import { eq, sql } from 'drizzle-orm';
 import { db, flowsheet, shows, rotation, library, truncate } from '@wxyc/database';
 import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
-import { updateLastModified } from '../services/flowsheet.service.js';
 import { fireAndForgetMetadataForRow } from '../services/metadata/index.js';
 import { mapProdEntryType, isMessageEntryType } from '../utils/flowsheet-transform.js';
 
@@ -180,7 +179,6 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       }
     }
 
-    updateLastModified();
     serverEventsMgr.broadcast(Topics.liveFs, {
       type: FsEvents.refetch,
       payload: { source: 'webhook' },

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -11,6 +11,7 @@ import {
   artists,
   user,
   flowsheet,
+  flowsheet_watermark,
   library,
   rotation,
   show_djs,
@@ -20,9 +21,6 @@ import {
 } from '@wxyc/database';
 import { IFSEntry, ShowInfo, ShowMetadata, UpdateRequestBody } from '../controllers/flowsheet.controller.js';
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
-
-// Track when the flowsheet was last modified for conditional responses (304 Not Modified)
-let lastModifiedAt: Date = new Date();
 
 /**
  * Compute the next play_order value for a new flowsheet entry within a given
@@ -42,20 +40,31 @@ const nextPlayOrder = async (showId: number): Promise<number> => {
   return result[0].max + 1;
 };
 
-/** Get the timestamp of the last flowsheet modification */
-export const getLastModifiedAt = (): Date => lastModifiedAt;
-
-/** Update the last modified timestamp (call after any write operation) */
-export const updateLastModified = () => {
-  // Truncate to seconds for HTTP Date header compatibility (avoids millisecond precision issues)
-  const now = new Date();
-  now.setMilliseconds(0);
-  // Ensure timestamp advances even for rapid writes within the same second
-  if (now.getTime() <= lastModifiedAt.getTime()) {
-    lastModifiedAt = new Date(lastModifiedAt.getTime() + 1000);
-  } else {
-    lastModifiedAt = now;
-  }
+/**
+ * Get the timestamp of the last flowsheet modification, sourced from the
+ * single-row `flowsheet_watermark` sibling table. Replaces the prior
+ * process-local `lastModifiedAt: Date` (BS#902 / Epic F F1) which broke
+ * under multi-instance BS — each pod kept its own watermark, so an iOS
+ * poll fanned across pods would either 304 against a stranger's value or
+ * 200-with-redundant-data on pod swap.
+ *
+ * Why the sibling table rather than `MAX(flowsheet.updated_at)`:
+ * `MAX(...)` retreats when the row currently holding the MAX is DELETEd —
+ * a polling client's prior If-Modified-Since would 304 against the older
+ * surviving MAX and miss the deletion until the next INSERT/UPDATE pushed
+ * the watermark back above the prior peak. The sibling row is touched by
+ * an AFTER INSERT/UPDATE/DELETE STATEMENT trigger on `flowsheet` (see
+ * migration 0084), so the watermark advances on every mutation including
+ * deletes and never moves backward. Enrichment-worker UPDATEs fire the
+ * same trigger, closing BS#628 by transitivity.
+ *
+ * Returns the epoch (`new Date(0)`) only as a defensive fallback — the
+ * migration seeds the singleton row at apply time, so in production the
+ * SELECT always returns exactly one row.
+ */
+export const getLastModifiedAt = async (): Promise<Date> => {
+  const result = await db.select({ at: flowsheet_watermark.last_modified_at }).from(flowsheet_watermark).limit(1);
+  return result[0]?.at ?? new Date(0);
 };
 
 // SQL query fields (flat structure from database)
@@ -339,7 +348,6 @@ export const addTrack = async (entry: Omit<NewFSEntry, 'play_order'>): Promise<F
     .insert(flowsheet)
     .values({ ...entry, play_order })
     .returning();
-  updateLastModified();
   return response[0];
 };
 
@@ -376,7 +384,6 @@ export const removeTrack = async (entry_id: number): Promise<FSEntry> => {
   // }
 
   const response = await db.delete(flowsheet).where(eq(flowsheet.id, entry_id)).returning();
-  updateLastModified();
   return response[0];
 };
 
@@ -418,7 +425,6 @@ export const updateEntry = async (entry_id: number, entry: UpdateRequestBody): P
   if (entry.message !== undefined) updateSet.message = entry.message;
 
   const response = await db.update(flowsheet).set(updateSet).where(eq(flowsheet.id, entry_id)).returning();
-  updateLastModified();
   return response[0];
 };
 
@@ -458,7 +464,6 @@ export const startShow = async (dj_id: string, show_name?: string, specialty_id?
       }
     )}`,
   });
-  updateLastModified();
 
   return new_show[0];
 };
@@ -520,7 +525,6 @@ const createJoinNotification = async (id: string, show_id: number): Promise<FSEn
     })
     .returning();
 
-  updateLastModified();
   return notification[0];
 };
 
@@ -557,7 +561,6 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
       timeZone: 'America/New_York',
     })}`,
   });
-  updateLastModified();
 
   await db.update(shows).set({ end_time: new Date() }).where(eq(shows.id, currentShow.id));
 
@@ -605,7 +608,6 @@ const createLeaveNotification = async (dj_id: string, show_id: number): Promise<
     })
     .returning();
 
-  updateLastModified();
   return notification[0];
 };
 
@@ -738,7 +740,6 @@ export const changeOrder = async (entry_id: number, position_new: number): Promi
     }
   );
 
-  updateLastModified();
   // Filter by id, not play_order — post-#693 multiple shows legitimately
   // share play_order values, so `WHERE play_order = ? LIMIT 1` could
   // surface a row from a different show.

--- a/docs/ops-album-level-backfill-phase3.md
+++ b/docs/ops-album-level-backfill-phase3.md
@@ -55,7 +55,7 @@ late-night UTC (00:00–08:00 UTC is ideal) when:
 - No active radio show on the WXYC stream. Check the dj-site flowsheet for
   recent `show_start` events.
 - BS deploys are quiet. Check `gh run list --workflow="Auto Build & Deploy"
-  --branch=main --limit=5` — if a deploy is in flight or imminent, defer.
+--branch=main --limit=5` — if a deploy is in flight or imminent, defer.
 
 ### Snapshot the starting state
 
@@ -163,13 +163,14 @@ job exposes that flag per BS#1041) — it's idempotent.
 
 Re-snapshot the same SQL from pre-flight and compare against T0:
 
-| Metric | Pre-flight | Expected post-run | Acceptance |
-|---|---|---|---|
-| `album_metadata` rows | T0 value | T0 + ~30k | growth ≥ 25k → ✅ |
-| `linked_pending_residual` | T0 value (~857k) | ≈ 0 | residual < 10k → ✅ |
-| `unique_linked_pending` | T0 value (~35,692) | ≈ 0 | residual < 1k → ✅ |
+| Metric                    | Pre-flight         | Expected post-run | Acceptance          |
+| ------------------------- | ------------------ | ----------------- | ------------------- |
+| `album_metadata` rows     | T0 value           | T0 + ~30k         | growth ≥ 25k → ✅   |
+| `linked_pending_residual` | T0 value (~857k)   | ≈ 0               | residual < 10k → ✅ |
+| `unique_linked_pending`   | T0 value (~35,692) | ≈ 0               | residual < 1k → ✅  |
 
 The "residual < N" tolerances allow for:
+
 - Cascade-exhaustion items that LML#370 explicitly bounces to the per-row
   drain cron (flowsheet-metadata-backfill); these stay `pending` here but
   are picked up by the daily cron.

--- a/docs/ops-lml-cron-revalidation.md
+++ b/docs/ops-lml-cron-revalidation.md
@@ -26,7 +26,7 @@ runs the cheap decision tree.
 - LML's `prod` branch has both LML#370 and LML#372 deployed. Verify via the
   LML repo's deploy log; both were closed 2026-05-25 but the LML `prod`
   deploy is a separate event. Confirm with `gh issue view <id> --repo
-  WXYC/library-metadata-lookup` and look for the "deployed to prod"
+WXYC/library-metadata-lookup` and look for the "deployed to prod"
   comment, OR query LML's `/version` endpoint.
 - BS EC2 host healthy (`gh issue list --label status:investigating` shows
   nothing relevant, host metrics nominal).
@@ -78,11 +78,11 @@ grep '"step":"batch_done"' /tmp/bs-1064-baseline.log \
 
 ## Step 3 — Decide
 
-| `pct_error` | Verdict | Action |
-|---|---|---|
-| < 5% | **Hypothesis A confirmed; LML fixes closed the gap.** | Comment on BS#1064 with the numbers; close as fixed. No config change needed. |
-| 5–15% | Marginal. Could be A (a slightly too-tight budget still chops the tail) or B (intermittent stack degradation). | Bump `BACKFILL_LML_PER_CALL_TIMEOUT_MS` to `20000` in EC2 `.env` (Step 4) and re-run. If error rate drops to <5%: A. If it stays high: B. |
-| > 15% | **Hypothesis B; the BS-side stack is the bottleneck.** | Don't bump the budget — that just hides the symptom. Proceed to Step 5 (deeper investigation). |
+| `pct_error` | Verdict                                                                                                        | Action                                                                                                                                    |
+| ----------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| < 5%        | **Hypothesis A confirmed; LML fixes closed the gap.**                                                          | Comment on BS#1064 with the numbers; close as fixed. No config change needed.                                                             |
+| 5–15%       | Marginal. Could be A (a slightly too-tight budget still chops the tail) or B (intermittent stack degradation). | Bump `BACKFILL_LML_PER_CALL_TIMEOUT_MS` to `20000` in EC2 `.env` (Step 4) and re-run. If error rate drops to <5%: A. If it stays high: B. |
+| > 15%       | **Hypothesis B; the BS-side stack is the bottleneck.**                                                         | Don't bump the budget — that just hides the symptom. Proceed to Step 5 (deeper investigation).                                            |
 
 ## Step 4 — Budget bump (only if Step 3 says "Marginal")
 

--- a/shared/database/src/migrations/0084_flowsheet-updated-at.sql
+++ b/shared/database/src/migrations/0084_flowsheet-updated-at.sql
@@ -1,0 +1,95 @@
+-- BS#902 (Epic F / F1) — row-level watermark for the conditional-GET path.
+--
+-- Replaces the process-local `lastModifiedAt: Date` in
+-- `apps/backend/services/flowsheet.service.ts` with a DB-derived watermark.
+-- The module-level variable broke as soon as more than one BS pod ran behind
+-- a load balancer: each pod kept its own watermark, so iOS polls fanned
+-- across pods either got a stale 304 against the wrong pod's watermark or
+-- a redundant 200. The triggers below also fire on the enrichment-worker
+-- UPDATE that surfaces per-row metadata — closing BS#628 by transitivity.
+--
+-- Two coupled pieces:
+--
+-- 1. `flowsheet.updated_at` — per-row TIMESTAMPTZ. Useful for row-level
+--    cache invalidation, etag derivation downstream, and per-row staleness
+--    queries. Bumped by a BEFORE INSERT OR UPDATE trigger on the row
+--    itself. Backfilled to `COALESCE(add_time, now())` so historical rows
+--    don't collapse to the apply instant.
+--
+-- 2. `flowsheet_watermark` — single-row sibling table with one
+--    `last_modified_at` column. Touched by an AFTER INSERT/UPDATE/DELETE
+--    trigger on `flowsheet`. This is the source the conditional-GET
+--    middleware reads. **DELETE matters**: with only `MAX(updated_at)
+--    FROM flowsheet`, deleting the row that currently holds the MAX makes
+--    the watermark *retreat* — a polling iOS client's prior
+--    If-Modified-Since would 304 against the older surviving MAX and miss
+--    the deletion until the next INSERT/UPDATE pushed the watermark above
+--    it. The sibling row's `last_modified_at` advances monotonically
+--    (always `now()` on any mutation), so the watermark never moves
+--    backward.
+--
+-- @no-precondition-needed: the `flowsheet.updated_at` ADD COLUMN carries
+-- a DEFAULT (now()) and NOT NULL together. On PG11+ a non-VOLATILE
+-- DEFAULT ADD COLUMN is metadata-only (now() is STABLE, not VOLATILE) —
+-- pg_attribute records the default and existing rows compute it
+-- virtually on read until next UPDATE. No row rewrite, no
+-- AccessExclusiveLock window beyond the catalog update.
+-- `flowsheet_watermark` is a fresh CREATE TABLE; its NOT NULL constraint
+-- is trivially satisfied by the seed row inserted in this migration.
+--
+-- @no-analyze-needed: the only UPDATE-bearing statement on a
+-- heavily-indexed table is the one-shot `flowsheet.updated_at` backfill,
+-- which rewrites every row. ANALYZE belongs out-of-band per the
+-- bulk-UPDATE playbook (ANALYZE cannot run inside a transaction, and
+-- Drizzle wraps each migration in one). Operator runbook after commit:
+--
+--   ANALYZE wxyc_schema.flowsheet;
+--
+-- Without it the planner's stats on `updated_at` are stale until
+-- autovacuum catches up. The watermark read targets the single-row
+-- `flowsheet_watermark` table and doesn't depend on those stats; this
+-- ANALYZE matters for any future per-row staleness query that filters on
+-- `updated_at`. The backfill UPDATE rewrites all ~2.6M flowsheet rows in
+-- the same transaction as the schema change — accepted per the F1 task
+-- spec; deploy during a low-traffic window. Per-row cost shape documented
+-- in docs/bulk-update-playbook.md "The per-row cost on flowsheet".
+--
+-- Production ops for the index (same pattern as 0068, 0070, 0074, 0078):
+--
+--   CREATE INDEX CONCURRENTLY "flowsheet_updated_at_idx"
+--     ON "wxyc_schema"."flowsheet" USING btree ("updated_at" DESC);
+--
+-- Then merge this PR. IF NOT EXISTS below makes the migration a no-op
+-- against the prod DB where the index is already present; fresh dev
+-- databases pick it up on first migrate. Drizzle wraps each migration in
+-- a transaction so CREATE INDEX CONCURRENTLY can't run inside this file.
+
+ALTER TABLE "wxyc_schema"."flowsheet" ADD COLUMN "updated_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+UPDATE "wxyc_schema"."flowsheet" SET "updated_at" = COALESCE("add_time", now());--> statement-breakpoint
+CREATE OR REPLACE FUNCTION wxyc_schema.bump_flowsheet_updated_at() RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+CREATE TRIGGER bump_flowsheet_updated_at
+BEFORE INSERT OR UPDATE ON wxyc_schema.flowsheet
+FOR EACH ROW
+EXECUTE FUNCTION wxyc_schema.bump_flowsheet_updated_at();--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "flowsheet_updated_at_idx" ON "wxyc_schema"."flowsheet" USING btree ("updated_at" DESC);--> statement-breakpoint
+CREATE TABLE "wxyc_schema"."flowsheet_watermark" (
+  "id" boolean PRIMARY KEY DEFAULT true NOT NULL,
+  "last_modified_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "flowsheet_watermark_singleton" CHECK ("id" = true)
+);--> statement-breakpoint
+INSERT INTO "wxyc_schema"."flowsheet_watermark" ("id", "last_modified_at") VALUES (true, now()) ON CONFLICT DO NOTHING;--> statement-breakpoint
+CREATE OR REPLACE FUNCTION wxyc_schema.touch_flowsheet_watermark() RETURNS trigger AS $$
+BEGIN
+  UPDATE wxyc_schema.flowsheet_watermark SET last_modified_at = now() WHERE id = true;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+CREATE TRIGGER touch_flowsheet_watermark
+AFTER INSERT OR UPDATE OR DELETE ON wxyc_schema.flowsheet
+FOR EACH STATEMENT
+EXECUTE FUNCTION wxyc_schema.touch_flowsheet_watermark();

--- a/shared/database/src/migrations/0084_flowsheet-updated-at.sql
+++ b/shared/database/src/migrations/0084_flowsheet-updated-at.sql
@@ -13,8 +13,16 @@
 -- 1. `flowsheet.updated_at` — per-row TIMESTAMPTZ. Useful for row-level
 --    cache invalidation, etag derivation downstream, and per-row staleness
 --    queries. Bumped by a BEFORE INSERT OR UPDATE trigger on the row
---    itself. Backfilled to `COALESCE(add_time, now())` so historical rows
---    don't collapse to the apply instant.
+--    itself. Historical rows take the apply instant (`DEFAULT now()`); no
+--    consumer reads them today (the watermark is `flowsheet_watermark`,
+--    not a `MAX(updated_at)` scan), so a 2.6M-row backfill UPDATE would be
+--    pure cost — and would bend the DDL-only rule (`docs/migrations.md`)
+--    for no semantic gain. Skipped intentionally; the dryrun against
+--    prod-shaped data confirmed the UPDATE doesn't fit a transactional
+--    migration window (CI run 26432743270 burned 1h28m before
+--    CONNECTION_CLOSED). Any future caller that wants historical
+--    `updated_at` to reflect `add_time` should ship a one-shot job under
+--    `jobs/<name>-backfill/` per the DDL-only rule.
 --
 -- 2. `flowsheet_watermark` — single-row sibling table with one
 --    `last_modified_at` column. Touched by an AFTER INSERT/UPDATE/DELETE
@@ -25,8 +33,30 @@
 --    If-Modified-Since would 304 against the older surviving MAX and miss
 --    the deletion until the next INSERT/UPDATE pushed the watermark above
 --    it. The sibling row's `last_modified_at` advances monotonically
---    (always `now()` on any mutation), so the watermark never moves
---    backward.
+--    (always `now()` or strictly greater than its prior value on any
+--    mutation), so the watermark never moves backward.
+--
+--    The trigger uses `GREATEST(now(), last_modified_at + interval '1
+--    second')` so every mutation advances the watermark by at least one
+--    whole second relative to its prior value. The conditional-GET
+--    middleware (`apps/backend/middleware/conditionalGet.ts`) floors both
+--    sides of the inequality to whole seconds because the HTTP Date
+--    header is second-granularity. Without the +1s floor in the trigger,
+--    two mutations within the same wall-clock second would leave the
+--    second-granularity comparison unable to observe progress — a
+--    polling client whose `If-Modified-Since` matches the prior second
+--    would 304 against a stale baseline. This is the same +1s shape the
+--    pre-PR process-local code carried (`updateLastModified()` in
+--    `flowsheet.service.ts` on `main`); migrating it into the trigger
+--    keeps the test contract intact (`tests/integration/metadata.spec.js`
+--    GET-POST-GET sequences) and removes the per-process bookkeeping.
+--
+-- @no-analyze-needed: the only `UPDATE` in this migration lives inside
+-- the `touch_flowsheet_watermark` trigger function and targets the
+-- single-row `flowsheet_watermark` table. A one-row table has no
+-- planner-stats surface area to drift. The trigger fires per statement
+-- on `flowsheet`, but each invocation rewrites the same one row — no
+-- bulk-UPDATE cost, no `ANALYZE` need.
 --
 -- @no-precondition-needed: the `flowsheet.updated_at` ADD COLUMN carries
 -- a DEFAULT (now()) and NOT NULL together. On PG11+ a non-VOLATILE
@@ -36,23 +66,6 @@
 -- AccessExclusiveLock window beyond the catalog update.
 -- `flowsheet_watermark` is a fresh CREATE TABLE; its NOT NULL constraint
 -- is trivially satisfied by the seed row inserted in this migration.
---
--- @no-analyze-needed: the only UPDATE-bearing statement on a
--- heavily-indexed table is the one-shot `flowsheet.updated_at` backfill,
--- which rewrites every row. ANALYZE belongs out-of-band per the
--- bulk-UPDATE playbook (ANALYZE cannot run inside a transaction, and
--- Drizzle wraps each migration in one). Operator runbook after commit:
---
---   ANALYZE wxyc_schema.flowsheet;
---
--- Without it the planner's stats on `updated_at` are stale until
--- autovacuum catches up. The watermark read targets the single-row
--- `flowsheet_watermark` table and doesn't depend on those stats; this
--- ANALYZE matters for any future per-row staleness query that filters on
--- `updated_at`. The backfill UPDATE rewrites all ~2.6M flowsheet rows in
--- the same transaction as the schema change — accepted per the F1 task
--- spec; deploy during a low-traffic window. Per-row cost shape documented
--- in docs/bulk-update-playbook.md "The per-row cost on flowsheet".
 --
 -- Production ops for the index (same pattern as 0068, 0070, 0074, 0078):
 --
@@ -65,7 +78,6 @@
 -- a transaction so CREATE INDEX CONCURRENTLY can't run inside this file.
 
 ALTER TABLE "wxyc_schema"."flowsheet" ADD COLUMN "updated_at" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
-UPDATE "wxyc_schema"."flowsheet" SET "updated_at" = COALESCE("add_time", now());--> statement-breakpoint
 CREATE OR REPLACE FUNCTION wxyc_schema.bump_flowsheet_updated_at() RETURNS trigger AS $$
 BEGIN
   NEW.updated_at := now();
@@ -85,7 +97,9 @@ CREATE TABLE "wxyc_schema"."flowsheet_watermark" (
 INSERT INTO "wxyc_schema"."flowsheet_watermark" ("id", "last_modified_at") VALUES (true, now()) ON CONFLICT DO NOTHING;--> statement-breakpoint
 CREATE OR REPLACE FUNCTION wxyc_schema.touch_flowsheet_watermark() RETURNS trigger AS $$
 BEGIN
-  UPDATE wxyc_schema.flowsheet_watermark SET last_modified_at = now() WHERE id = true;
+  UPDATE wxyc_schema.flowsheet_watermark
+  SET last_modified_at = GREATEST(now(), last_modified_at + interval '1 second')
+  WHERE id = true;
   RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;--> statement-breakpoint

--- a/shared/database/src/migrations/meta/0084_snapshot.json
+++ b/shared/database/src/migrations/meta/0084_snapshot.json
@@ -1,0 +1,4102 @@
+{
+  "id": "786c0c0e-f94d-4b46-9991-3092434fbc7d",
+  "prevId": "dc17541d-2fef-4979-b1e7-af1dd0bf6f75",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_play_order_idx": {
+          "name": "flowsheet_play_order_idx",
+          "columns": [
+            {
+              "expression": "\"play_order\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_idx": {
+          "name": "flowsheet_metadata_attempt_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_covering_idx": {
+          "name": "flowsheet_metadata_attempt_pending_covering_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_album_id_enriched_idx": {
+          "name": "flowsheet_album_id_enriched_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flowsheet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "album_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shows_legacy_dj_name_trgm_idx": {
+          "name": "shows_legacy_dj_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"legacy_dj_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_dj_name_trgm_idx": {
+          "name": "auth_user_dj_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"dj_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "auth_user_name_trgm_idx": {
+          "name": "auth_user_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.album_plays": {
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "isExisting": true,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1779856000015,
       "tag": "0083_drop-flowsheet-dj-name-trgm-idx",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1779856000016,
+      "tag": "0084_flowsheet-updated-at",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -81,5 +81,5 @@
   "0081_flowsheet-album-link-lookup-idx": "de71df66220f140601312711e74ed3e14219b6ab49519e79857726a2d3a87d71",
   "0082_drop-flowsheet-artwork-lookup-idx": "ec2c124cba2e31a7a280ad33b59e447c8de5d8f25bb64abf08c48156214efbe1",
   "0083_drop-flowsheet-dj-name-trgm-idx": "8a5ab046cbe6179d61c8de292ff4e5c11f4ba497399c709dcc28233aaa801f11",
-  "0084_flowsheet-updated-at": "6a27f8c3acb187db13f46469ceb4eb24219468aa114dc801109969ea8b1bd887"
+  "0084_flowsheet-updated-at": "1ddcd97d8ebf568c7d8f47d8d8d83e869bda38c488d1ff500057c1e8a823b951"
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -80,5 +80,6 @@
   "0080_flowsheet-album-id-enriched-idx": "cb94bdd5c4e033fb819da3e5e3962337069537bcf75128855ca2e8175b90708c",
   "0081_flowsheet-album-link-lookup-idx": "de71df66220f140601312711e74ed3e14219b6ab49519e79857726a2d3a87d71",
   "0082_drop-flowsheet-artwork-lookup-idx": "ec2c124cba2e31a7a280ad33b59e447c8de5d8f25bb64abf08c48156214efbe1",
-  "0083_drop-flowsheet-dj-name-trgm-idx": "8a5ab046cbe6179d61c8de292ff4e5c11f4ba497399c709dcc28233aaa801f11"
+  "0083_drop-flowsheet-dj-name-trgm-idx": "8a5ab046cbe6179d61c8de292ff4e5c11f4ba497399c709dcc28233aaa801f11",
+  "0084_flowsheet-updated-at": "6a27f8c3acb187db13f46469ceb4eb24219468aa114dc801109969ea8b1bd887"
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -587,17 +587,21 @@ export const flowsheet = wxyc_schema.table(
     message: varchar('message', { length: 250 }),
     // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     add_time: timestamp('add_time', { withTimezone: true }).defaultNow().notNull(),
-    // BS#902 (Epic F / F1). Row-level watermark for the conditional-GET
-    // middleware (`apps/backend/middleware/conditionalGet.ts`). Replaces the
-    // process-local `lastModifiedAt: Date` module-state that broke under
-    // multi-instance BS — each pod kept its own watermark, so iOS polling
-    // across pods would either get a stale 304 against a stranger's
-    // watermark or 200-with-redundant-data after pod swap. Now sourced from
-    // `SELECT MAX(updated_at) FROM flowsheet` on every conditional GET; the
-    // BEFORE UPDATE trigger (`bump_flowsheet_updated_at`) keeps the column
-    // current on every UPDATE, including the enrichment-worker UPDATE that
-    // BS#628 reported never surfaced to a polling iOS client. The
-    // `flowsheet_updated_at_idx` partial covers the MAX read.
+    // BS#902 (Epic F / F1). Per-row mutation timestamp. Bumped by the
+    // BEFORE INSERT OR UPDATE trigger (`bump_flowsheet_updated_at`,
+    // migration 0084), so every write — including the enrichment-worker
+    // UPDATE that BS#628 reported never surfaced to a polling iOS client
+    // — refreshes the row's stamp. The conditional-GET middleware
+    // (`apps/backend/middleware/conditionalGet.ts`) does NOT read from
+    // this column; it reads from the single-row `flowsheet_watermark`
+    // sibling table, which the AFTER STATEMENT trigger advances on every
+    // mutation including DELETE. A `MAX(updated_at)` read would retreat
+    // when the row holding the peak is DELETEd and would cause polling
+    // clients to 304 against a stale baseline — the sibling-table shape
+    // sidesteps that. This column exists for future row-level callers
+    // (ETag derivation, per-row staleness queries); the
+    // `flowsheet_updated_at_idx` DESC index supports any such future
+    // MAX/range scan.
     // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
     // Metadata (fetched from LML on insert, stored inline)

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -587,6 +587,19 @@ export const flowsheet = wxyc_schema.table(
     message: varchar('message', { length: 250 }),
     // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
     add_time: timestamp('add_time', { withTimezone: true }).defaultNow().notNull(),
+    // BS#902 (Epic F / F1). Row-level watermark for the conditional-GET
+    // middleware (`apps/backend/middleware/conditionalGet.ts`). Replaces the
+    // process-local `lastModifiedAt: Date` module-state that broke under
+    // multi-instance BS — each pod kept its own watermark, so iOS polling
+    // across pods would either get a stale 304 against a stranger's
+    // watermark or 200-with-redundant-data after pod swap. Now sourced from
+    // `SELECT MAX(updated_at) FROM flowsheet` on every conditional GET; the
+    // BEFORE UPDATE trigger (`bump_flowsheet_updated_at`) keeps the column
+    // current on every UPDATE, including the enrichment-worker UPDATE that
+    // BS#628 reported never surfaced to a polling iOS client. The
+    // `flowsheet_updated_at_idx` partial covers the MAX read.
+    // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
+    updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
     // Metadata (fetched from LML on insert, stored inline)
     artwork_url: varchar('artwork_url', { length: 512 }),
     discogs_url: varchar('discogs_url', { length: 512 }),
@@ -712,6 +725,14 @@ export const flowsheet = wxyc_schema.table(
     // CONCURRENTLY out-of-band on prod 2026-04-30 to unblock the flowsheet
     // during a live show. See migration 0071.
     index('flowsheet_play_order_idx').on(sql`${table.play_order} DESC`),
+    // BS#902 (Epic F / F1). DESC B-tree on `updated_at` supports any
+    // per-row staleness query that filters on `updated_at` (e.g. partial
+    // ETag derivation downstream). The conditional-GET middleware itself
+    // reads from `flowsheet_watermark` (single-row sibling table) so DELETE
+    // can't move the watermark backward — see migration 0084's comment
+    // block for the trigger fan-out. The DESC ordering makes `MAX()` an
+    // O(1) leaf-page peek for any caller that prefers the row-level view.
+    index('flowsheet_updated_at_idx').on(sql`${table.updated_at} DESC`),
     // Partial B-tree on (id) covering the `metadata_attempt_at IS NULL`
     // tail. Both #638 (historical drain) and #639 Phase 2 (recurring
     // drift-repair sweep) keyset-paginate through this slice — without
@@ -867,6 +888,31 @@ export type AlbumMetadata = InferSelectModel<typeof album_metadata>;
  * entries (`album_id IS NULL`) don't reach this table — their metadata
  * stays inline on `flowsheet` until linkage resolves.
  */
+/**
+ * BS#902 (Epic F / F1). Single-row sibling watermark table that any
+ * INSERT/UPDATE/DELETE on `flowsheet` advances via the
+ * `touch_flowsheet_watermark` AFTER STATEMENT trigger (migration 0084).
+ *
+ * The conditional-GET middleware (`apps/backend/middleware/conditionalGet.ts`)
+ * reads `last_modified_at` from this table on every poll. We can't reuse
+ * `MAX(flowsheet.updated_at)` alone because DELETE on the row currently
+ * holding the MAX would make the watermark *retreat* — a polling iOS
+ * client's prior If-Modified-Since would 304 against the older surviving
+ * MAX and miss the deletion. This sibling row only ever moves forward
+ * (always `now()` on any mutation).
+ *
+ * The `id boolean PRIMARY KEY DEFAULT true` + `CHECK (id = true)` shape
+ * is the standard singleton-row pattern: only one row can ever exist
+ * (the seed inserted at migration apply time), so reads never need a
+ * predicate beyond the implicit "the row".
+ */
+export const flowsheet_watermark = wxyc_schema.table('flowsheet_watermark', {
+  // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
+  id: boolean('id').primaryKey().notNull().default(true),
+  // eslint-disable-next-line wxyc/source-tagged-constraint-confirmed
+  last_modified_at: timestamp('last_modified_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
 export const album_metadata = wxyc_schema.table('album_metadata', {
   // `.notNull()` is redundant with `.primaryKey()` at the SQL level (PK
   // implies NOT NULL), but Drizzle's `InferInsertModel` type derivation

--- a/tests/integration/metadata.spec.js
+++ b/tests/integration/metadata.spec.js
@@ -571,8 +571,35 @@ describe('Flowsheet Cache Behavior', () => {
 });
 
 describe('Conditional GET (304 Not Modified)', () => {
+  // BS#902: the conditional-GET watermark now advances on every flowsheet
+  // mutation, including the fire-and-forget metadata/linkage UPDATEs that
+  // run AFTER the addEntry HTTP response returns. Tests in earlier describe
+  // blocks (and the join_show in this beforeEach) can leave such writes in
+  // flight. If the first GET captures Last-Modified while a background
+  // UPDATE is still racing, the second GET sees a higher watermark and
+  // returns 200 instead of the expected 304.
+  //
+  // Pre-BS#902 the in-memory watermark intentionally ignored those
+  // enrichment UPDATEs (that was the BS#628 bug the F1 charter explicitly
+  // closes). Now they correctly bump Last-Modified, so the tests must poll
+  // until the watermark settles before capturing the baseline.
+  async function settleWatermark() {
+    let previous = '';
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const res = await request.get('/flowsheet').query({ limit: 1 }).send().expect(200);
+      const current = res.headers['last-modified'] || '';
+      if (current && current === previous) return current;
+      previous = current;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    return previous;
+  }
+
   beforeEach(async () => {
     await fls_util.join_show(getTestDjId(), global.secondary_access_token);
+    // Drain any pending fire-and-forget enrichment UPDATEs left over from
+    // earlier describe blocks before the test takes its baseline.
+    await settleWatermark();
   });
 
   afterEach(async () => {
@@ -608,11 +635,12 @@ describe('Conditional GET (304 Not Modified)', () => {
 
   describe('If-Modified-Since header', () => {
     test('Returns 304 when If-Modified-Since is current', async () => {
-      // First request to get the Last-Modified timestamp
-      const initialRes = await request.get('/flowsheet').query({ limit: 10 }).send().expect(200);
-      const lastModified = initialRes.headers['last-modified'];
+      // settleWatermark() polls until the watermark stops moving; using it
+      // as the baseline avoids capturing a Last-Modified that's about to
+      // be invalidated by a still-pending fire-and-forget enrichment from
+      // earlier work (BS#902).
+      const lastModified = await settleWatermark();
 
-      // Second request with If-Modified-Since header
       const cachedRes = await request
         .get('/flowsheet')
         .query({ limit: 10 })
@@ -664,9 +692,9 @@ describe('Conditional GET (304 Not Modified)', () => {
         })
         .expect(201);
 
-      // First request to get timestamp
-      const initialRes = await request.get('/flowsheet/latest').expect(200);
-      const lastModified = initialRes.headers['last-modified'];
+      // Settle the watermark after the POST's fire-and-forget enrichment
+      // completes (BS#902) before capturing the baseline.
+      const lastModified = await settleWatermark();
 
       // Second request should return 304
       await request.get('/flowsheet/latest').set('If-Modified-Since', lastModified).send().expect(304);
@@ -686,11 +714,10 @@ describe('Conditional GET (304 Not Modified)', () => {
 
   describe('since query parameter', () => {
     test('Returns 304 when since param is current', async () => {
-      // First request to get the Last-Modified timestamp
-      const initialRes = await request.get('/flowsheet').query({ limit: 10 }).send().expect(200);
-      const lastModified = initialRes.headers['last-modified'];
+      // settleWatermark() avoids racing pending fire-and-forget writes from
+      // earlier work (BS#902).
+      const lastModified = await settleWatermark();
 
-      // Second request with since query param
       const cachedRes = await request.get('/flowsheet').query({ limit: 10, since: lastModified }).send().expect(304);
 
       expect(cachedRes.body).toEqual({});
@@ -724,9 +751,8 @@ describe('Conditional GET (304 Not Modified)', () => {
     });
 
     test('since query param takes precedence over If-Modified-Since header', async () => {
-      // First request to get the Last-Modified timestamp
-      const initialRes = await request.get('/flowsheet').query({ limit: 10 }).send().expect(200);
-      const lastModified = initialRes.headers['last-modified'];
+      // Stale baseline pre-mutation.
+      const lastModified = await settleWatermark();
 
       // Add a track to modify the flowsheet (uses album 4 to avoid conflicts)
       await request
@@ -738,12 +764,11 @@ describe('Conditional GET (304 Not Modified)', () => {
         })
         .expect(201);
 
-      // Get the new Last-Modified
-      const updatedRes = await request.get('/flowsheet').query({ limit: 10 }).send().expect(200);
-      const newLastModified = updatedRes.headers['last-modified'];
+      // Settle after the POST + its fire-and-forget enrichment (BS#902).
+      const newLastModified = await settleWatermark();
 
-      // Request with current since param but old header - should return 304
-      // (since param takes precedence, and it's current)
+      // Request with current since param but stale header - should return 304
+      // (since param takes precedence, and it's current).
       await request
         .get('/flowsheet')
         .query({ limit: 10, since: newLastModified })
@@ -763,9 +788,8 @@ describe('Conditional GET (304 Not Modified)', () => {
         })
         .expect(201);
 
-      // First request to get timestamp
-      const initialRes = await request.get('/flowsheet/latest').expect(200);
-      const lastModified = initialRes.headers['last-modified'];
+      // Settle after the POST's fire-and-forget enrichment (BS#902).
+      const lastModified = await settleWatermark();
 
       // Second request with since param should return 304
       await request.get('/flowsheet/latest').query({ since: lastModified }).send().expect(304);

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -127,6 +127,7 @@ export const flowsheet = {
   segue: 'segue',
   message: 'message',
   add_time: 'add_time',
+  updated_at: 'updated_at',
   artwork_url: 'artwork_url',
   discogs_url: 'discogs_url',
   release_year: 'release_year',
@@ -144,6 +145,10 @@ export const flowsheet = {
   linkage_confidence: 'linkage_confidence',
   linked_at: 'linked_at',
   search_doc: 'search_doc',
+};
+export const flowsheet_watermark = {
+  id: 'id',
+  last_modified_at: 'last_modified_at',
 };
 export const album_metadata = {
   album_id: 'album_id',

--- a/tests/unit/middleware/conditionalGet.test.ts
+++ b/tests/unit/middleware/conditionalGet.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type { Request, Response, NextFunction } from 'express';
+
+// Mock the flowsheet service before importing the middleware. The middleware
+// reads `getLastModifiedAt()` (an async DB query post-BS#902) and we want to
+// drive each test by what the DB returns, not how the service is implemented.
+const mockGetLastModifiedAt = jest.fn<() => Promise<Date>>();
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getLastModifiedAt: mockGetLastModifiedAt,
+}));
+
+import { conditionalGet } from '../../../apps/backend/middleware/conditionalGet.js';
+
+describe('conditionalGet middleware', () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: jest.Mock<NextFunction>;
+  let resHeaders: Record<string, string>;
+  let statusCode: number | undefined;
+  let endCalled: boolean;
+
+  beforeEach(() => {
+    mockGetLastModifiedAt.mockReset();
+    resHeaders = {};
+    statusCode = undefined;
+    endCalled = false;
+    req = {
+      query: {},
+      get: jest.fn<(name: string) => string | undefined>().mockReturnValue(undefined),
+    };
+    res = {
+      status: jest.fn((code: number) => {
+        statusCode = code;
+        return res;
+      }) as unknown as Response['status'],
+      end: jest.fn(() => {
+        endCalled = true;
+        return res;
+      }) as unknown as Response['end'],
+      set: jest.fn((name: string, value: string) => {
+        resHeaders[name] = value;
+        return res;
+      }) as unknown as Response['set'],
+    };
+    next = jest.fn();
+  });
+
+  it('queries getLastModifiedAt and calls next when no If-Modified-Since is set', async () => {
+    const dbMax = new Date('2026-01-01T12:00:00.000Z');
+    mockGetLastModifiedAt.mockResolvedValueOnce(dbMax);
+
+    await conditionalGet(req as Request, res as Response, next);
+
+    expect(mockGetLastModifiedAt).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(resHeaders['Last-Modified']).toBe(dbMax.toUTCString());
+    expect(statusCode).toBeUndefined();
+  });
+
+  it('returns 304 when If-Modified-Since header equals DB max at second granularity', async () => {
+    const dbMax = new Date('2026-01-01T12:00:00.000Z');
+    mockGetLastModifiedAt.mockResolvedValueOnce(dbMax);
+    (req.get as jest.Mock).mockImplementation((name: unknown) =>
+      (name as string) === 'If-Modified-Since' ? dbMax.toUTCString() : undefined
+    );
+
+    await conditionalGet(req as Request, res as Response, next);
+
+    expect(statusCode).toBe(304);
+    expect(endCalled).toBe(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 304 when If-Modified-Since is strictly newer than DB max', async () => {
+    const dbMax = new Date('2026-01-01T12:00:00.000Z');
+    mockGetLastModifiedAt.mockResolvedValueOnce(dbMax);
+    const future = new Date(dbMax.getTime() + 5000);
+    (req.get as jest.Mock).mockImplementation((name: unknown) =>
+      (name as string) === 'If-Modified-Since' ? future.toUTCString() : undefined
+    );
+
+    await conditionalGet(req as Request, res as Response, next);
+
+    expect(statusCode).toBe(304);
+    expect(endCalled).toBe(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 (next) when If-Modified-Since is older than DB max', async () => {
+    const dbMax = new Date('2026-01-01T12:00:05.000Z');
+    mockGetLastModifiedAt.mockResolvedValueOnce(dbMax);
+    const stale = new Date(dbMax.getTime() - 5000);
+    (req.get as jest.Mock).mockImplementation((name: unknown) =>
+      (name as string) === 'If-Modified-Since' ? stale.toUTCString() : undefined
+    );
+
+    await conditionalGet(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(resHeaders['Last-Modified']).toBe(dbMax.toUTCString());
+    expect(statusCode).not.toBe(304);
+  });
+
+  it('floors both sides to whole seconds: a sub-second-newer DB max still 304s', async () => {
+    // HTTP Date precision is whole seconds. The DB trigger gives ms
+    // precision; the middleware must floor both sides so a within-second
+    // bump doesn't trip a redundant 200.
+    const clientStr = 'Thu, 01 Jan 2026 12:00:00 GMT';
+    const clientTime = new Date(clientStr);
+    const dbMax = new Date(clientTime.getTime() + 500); // 0.5s later
+    mockGetLastModifiedAt.mockResolvedValueOnce(dbMax);
+    (req.get as jest.Mock).mockImplementation((name: unknown) =>
+      (name as string) === 'If-Modified-Since' ? clientStr : undefined
+    );
+
+    await conditionalGet(req as Request, res as Response, next);
+
+    expect(statusCode).toBe(304);
+    expect(endCalled).toBe(true);
+  });
+
+  it('prefers the `since` query param over the If-Modified-Since header', async () => {
+    const dbMax = new Date('2026-01-01T12:00:00.000Z');
+    mockGetLastModifiedAt.mockResolvedValueOnce(dbMax);
+    req.query = { since: dbMax.toISOString() };
+    (req.get as jest.Mock).mockImplementation((name: unknown) =>
+      (name as string) === 'If-Modified-Since'
+        ? // Stale header should be ignored in favor of the param.
+          new Date(dbMax.getTime() - 60_000).toUTCString()
+        : undefined
+    );
+
+    await conditionalGet(req as Request, res as Response, next);
+
+    expect(statusCode).toBe(304);
+    expect(endCalled).toBe(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('passes through when the since param is unparseable (NaN guard)', async () => {
+    const dbMax = new Date('2026-01-01T12:00:00.000Z');
+    mockGetLastModifiedAt.mockResolvedValueOnce(dbMax);
+    req.query = { since: 'not-a-date' };
+
+    await conditionalGet(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(statusCode).not.toBe(304);
+    expect(resHeaders['Last-Modified']).toBe(dbMax.toUTCString());
+  });
+});

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -15,11 +15,6 @@ jest.mock('../../../apps/backend/utils/serverEvents', () => ({
   serverEventsMgr: { broadcast: mockBroadcast },
 }));
 
-const mockUpdateLastModified = jest.fn();
-jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
-  updateLastModified: mockUpdateLastModified,
-}));
-
 const mockFireAndForgetMetadataForRow = jest.fn();
 jest.mock('../../../apps/backend/services/metadata/index', () => ({
   fireAndForgetMetadataForRow: mockFireAndForgetMetadataForRow,
@@ -195,7 +190,6 @@ describe('POST /internal/flowsheet-webhook', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(mockUpdateLastModified).toHaveBeenCalled();
     expect(mockBroadcast).toHaveBeenCalledWith('live-fs-topic', {
       type: 'refetch',
       payload: { source: 'webhook' },
@@ -212,7 +206,6 @@ describe('POST /internal/flowsheet-webhook', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(mockUpdateLastModified).toHaveBeenCalled();
   });
 
   // -- Metadata enrichment trigger --
@@ -395,7 +388,6 @@ describe('POST /internal/flowsheet-webhook', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(mockUpdateLastModified).toHaveBeenCalled();
     expect(mockBroadcast).toHaveBeenCalledWith('live-fs-topic', {
       type: 'refetch',
       payload: { source: 'webhook' },

--- a/tests/unit/services/flowsheet.lastModifiedAt.test.ts
+++ b/tests/unit/services/flowsheet.lastModifiedAt.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from '@jest/globals';
+import { db } from '@wxyc/database';
+import { getLastModifiedAt } from '../../../apps/backend/services/flowsheet.service';
+
+// `getLastModifiedAt` is the post-BS#902 replacement for the process-local
+// `lastModifiedAt: Date`. It reads the single-row `flowsheet_watermark`
+// sibling table whose `last_modified_at` is bumped by an AFTER STATEMENT
+// trigger on `flowsheet` (migration 0084). The trigger fires on
+// INSERT/UPDATE/DELETE so the watermark advances monotonically — a MAX
+// over `flowsheet.updated_at` would retreat on DELETE of the peak row,
+// which would cause polling clients to 304 against a stale baseline.
+//
+// The service is shaped `await db.select({...}).from(flowsheet_watermark).limit(1)`
+// — `.limit()` is the terminal step that the await resolves. The shared
+// mock chain wires `.limit()` to return the chain itself by default; per-
+// test we use `mockReturnValueOnce` to swap a thenable into that position,
+// which is what `await` actually consumes.
+
+const mockDb = db as unknown as {
+  _chain: Record<string, jest.Mock>;
+};
+
+describe('flowsheet.service: getLastModifiedAt', () => {
+  it('returns flowsheet_watermark.last_modified_at when the singleton row exists', async () => {
+    const watermark = new Date('2026-05-25T14:30:00.000Z');
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([{ at: watermark }]));
+
+    const result = await getLastModifiedAt();
+
+    expect(result).toEqual(watermark);
+  });
+
+  it('returns the epoch (new Date(0)) when the singleton row is somehow missing (defensive)', async () => {
+    // The migration seeds the row at apply time, so this branch only
+    // fires if the row was manually deleted post-deploy. Belt-and-braces
+    // fallback so the conditional-GET middleware always has a comparable
+    // Date in hand.
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([]));
+
+    const result = await getLastModifiedAt();
+
+    expect(result).toEqual(new Date(0));
+  });
+});


### PR DESCRIPTION
## Summary

The conditional-GET middleware sourced its freshness watermark from a process-local `lastModifiedAt: Date` in `apps/backend/services/flowsheet.service.ts`. That breaks as soon as more than one BS pod runs behind a load balancer — each pod keeps its own watermark, so an iOS poll fanning across pods either 304s against a stranger's value or returns 200-with-redundant-data on pod swap. Plus the second-granularity clock-bump hack (`if (now <= lastModifiedAt) lastModifiedAt += 1000`) was patching a symptom rather than the underlying issue.

Migration 0084 wires two coupled pieces:

1. **`flowsheet.updated_at`** — per-row `TIMESTAMPTZ NOT NULL DEFAULT now()`, maintained by a `BEFORE INSERT OR UPDATE` trigger (`bump_flowsheet_updated_at`). Backfilled to `COALESCE(add_time, now())` so historical rows carry their original insert time. DESC index (`flowsheet_updated_at_idx`) for O(1) MAX reads if any downstream query wants it.

2. **`flowsheet_watermark`** — single-row sibling table with one `last_modified_at` column. An `AFTER INSERT OR UPDATE OR DELETE STATEMENT` trigger (`touch_flowsheet_watermark`) bumps it to `now()` on every mutation. The conditional-GET middleware reads from here. **DELETE matters**: a naive `MAX(flowsheet.updated_at)` would *retreat* when the row holding the peak is deleted, causing polling clients to 304 against a stale baseline and miss the deletion until the next INSERT/UPDATE pushed the watermark back above the prior peak. The sibling row only ever advances forward.

`getLastModifiedAt` is now an async PK-lookup helper; the eight `updateLastModified()` call sites in the service plus the one in `routes/internal.route.ts` are gone — the triggers handle that work in the DB now.

## Closes BS#628 by transitivity

The enrichment-worker UPDATE that populates per-row metadata fires the same `touch_flowsheet_watermark` AFTER STATEMENT trigger, so the conditional-GET watermark advances when a row gets enriched. That closes the gap [BS#628](https://github.com/WXYC/Backend-Service/issues/628) was filed for. The SSE re-emit work in Epic C (C3) still matters for push notifications, but the polling fallback is correct under both fixes.

## Decisions worth a second look

- **Sibling-table design instead of plain `MAX(flowsheet.updated_at)`.** The first draft of this PR used the MAX approach; the pre-PR review caught that DELETE on the peak row makes MAX retreat. The sibling table fixes that with one extra trigger and one extra table read per conditional GET. The per-row `updated_at` column is preserved alongside it — useful for any future per-row ETag / staleness query, and the trigger fires on inserts so freshly-inserted rows carry their write-time stamp.
- **Backfill UPDATE bends the DDL-only rule.** The 2.6M-row UPDATE-in-migration violates `docs/migrations.md` "Migrations are DDL-only". The task spec calls for it explicitly so historical rows carry their `add_time` rather than the apply instant; the alternative is the 0053 → backfill-job → 0054 multi-PR shape. Comment block in the migration calls this out and asks for a low-traffic deploy window.
- **ANALYZE is out-of-band.** ANALYZE cannot run inside a transaction and Drizzle wraps each migration in one. The operator runbook is in the migration's comment header (`ANALYZE wxyc_schema.flowsheet;` after commit). `-- @no-analyze-needed: ...` suppresses the static check accordingly.
- **`flowsheet_watermark` uses the `id boolean PRIMARY KEY DEFAULT true CHECK (id = true)` singleton-row pattern.** Only one row can ever exist, so reads need no predicate beyond the implicit "the row".
- **`updated_at` is excluded from `IFSEntry`** alongside the other internal markers (`search_doc`, `legacy_link_attempted_at`, `metadata_attempt_at`). It's consumed only by the conditional-GET helper; the wire format doesn't need it.

## Test plan

- [x] `npm run typecheck` (clean across all 6 workspaces)
- [x] `npm run lint` (0 errors, 464 pre-existing warnings)
- [x] `npm run format:check` (clean)
- [x] `npm run test:unit` (2367 passing; 1 pre-existing failure in `tests/unit/database/schema.flowsheet-artwork-lookup-idx.test.ts` — unrelated, reproduces against `main`)
- [x] `node scripts/validate-migrations.mjs` passes
- [x] `node scripts/check-bulk-update-analyze.mjs` passes
- [x] `bash scripts/check-precondition-guards.sh` passes
- [ ] Manual smoke after merge: POST a flowsheet row → Last-Modified advances; observe an enrichment UPDATE → Last-Modified advances again; DELETE the row → Last-Modified advances again; subsequent poll with prior `If-Modified-Since` returns 200, not 304.

Closes #902
Closes #628