### PR TITLE
feat(events): add GET /events/stream for EventSource clients (BS-1)

### DIFF
--- a/apps/backend/controllers/events.controller.ts
+++ b/apps/backend/controllers/events.controller.ts
@@ -44,6 +44,50 @@ export const registerEventClient: RequestHandler<object, unknown, regReqBody> = 
   serverEventsMgr.subscribe(topics, client.id);
 };
 
+/**
+ * Parse the `?topics=` query parameter into a topic-string array.
+ *
+ * Contract: a single comma-separated string. Anything else (missing, array
+ * from repeated `?topics=&topics=`, non-string) collapses to `[]`. Tolerates
+ * whitespace around each value so a hand-typed `?topics=live-fs-topic, test-topic`
+ * still works.
+ *
+ * Unknown topic strings are passed through to `filterAuthorizedTopics`, which
+ * drops them silently — matching the existing `POST /events/register` behavior
+ * where `topics` not in `TopicAuthz` are filtered out before `subscribe`.
+ */
+const parseTopicsQuery = (raw: unknown): string[] => {
+  if (typeof raw !== 'string' || raw.length === 0) return [];
+  return raw
+    .split(',')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+};
+
+/**
+ * EventSource-friendly counterpart to `POST /events/register`.
+ *
+ * Native browser EventSource is GET-only and can't attach an `Authorization`
+ * header or a JSON body, so dj-site's listener middleware opens
+ * `EventSource('${BACKEND_URL}/events/stream?topics=live-fs-topic')`. The
+ * subscription pipeline is otherwise identical: `registerClient` →
+ * `filterAuthorizedTopics` → `subscribe`.
+ *
+ * No `requirePermissions` guard at the route level — see comment on the
+ * route definition. Authorization is per-topic via `TopicAuthz`: public
+ * topics (`liveFs`, `test`) succeed without `req.auth`; DJ-tier topics
+ * (`showDj`, `primaryDj`, `mirror`) are filtered out when the caller's
+ * role isn't in `DJ_TIER_ROLES`.
+ */
+export const streamEventClient: RequestHandler = (req, res) => {
+  const client = serverEventsMgr.registerClient(res);
+
+  const requested = parseTopicsQuery(req.query.topics);
+  const topics = filterAuthorizedTopics(req, requested);
+
+  serverEventsMgr.subscribe(topics, client.id);
+};
+
 type subReqBody = {
   client_id: string;
   topics: string[];

--- a/apps/backend/controllers/events.controller.ts
+++ b/apps/backend/controllers/events.controller.ts
@@ -44,18 +44,10 @@ export const registerEventClient: RequestHandler<object, unknown, regReqBody> = 
   serverEventsMgr.subscribe(topics, client.id);
 };
 
-/**
- * Parse the `?topics=` query parameter into a topic-string array.
- *
- * Contract: a single comma-separated string. Anything else (missing, array
- * from repeated `?topics=&topics=`, non-string) collapses to `[]`. Tolerates
- * whitespace around each value so a hand-typed `?topics=live-fs-topic, test-topic`
- * still works.
- *
- * Unknown topic strings are passed through to `filterAuthorizedTopics`, which
- * drops them silently — matching the existing `POST /events/register` behavior
- * where `topics` not in `TopicAuthz` are filtered out before `subscribe`.
- */
+// Contract: a single comma-separated string. Repeated `?topics=&topics=`
+// (Express parses to array), missing, or non-string collapse to `[]`.
+// Unknown topic strings pass through to filterAuthorizedTopics, which drops
+// them silently — same shape as POST /events/register.
 const parseTopicsQuery = (raw: unknown): string[] => {
   if (typeof raw !== 'string' || raw.length === 0) return [];
   return raw
@@ -65,19 +57,15 @@ const parseTopicsQuery = (raw: unknown): string[] => {
 };
 
 /**
- * EventSource-friendly counterpart to `POST /events/register`.
+ * EventSource-friendly counterpart to `POST /events/register`. Native browser
+ * EventSource is GET-only and can't attach an `Authorization` header or a
+ * JSON body, so dj-site's listener middleware opens
+ * `EventSource('${BACKEND_URL}/events/stream?topics=live-fs-topic')`.
  *
- * Native browser EventSource is GET-only and can't attach an `Authorization`
- * header or a JSON body, so dj-site's listener middleware opens
- * `EventSource('${BACKEND_URL}/events/stream?topics=live-fs-topic')`. The
- * subscription pipeline is otherwise identical: `registerClient` →
- * `filterAuthorizedTopics` → `subscribe`.
- *
- * No `requirePermissions` guard at the route level — see comment on the
- * route definition. Authorization is per-topic via `TopicAuthz`: public
- * topics (`liveFs`, `test`) succeed without `req.auth`; DJ-tier topics
- * (`showDj`, `primaryDj`, `mirror`) are filtered out when the caller's
- * role isn't in `DJ_TIER_ROLES`.
+ * No `requirePermissions` guard at the route level — authorization is
+ * per-topic via `TopicAuthz` inside `filterAuthorizedTopics`. Public topics
+ * (`liveFs`, `test`) succeed without `req.auth`; DJ-tier topics filter out
+ * when the caller's role isn't in `DJ_TIER_ROLES`.
  */
 export const streamEventClient: RequestHandler = (req, res) => {
   const client = serverEventsMgr.registerClient(res);

--- a/apps/backend/routes/events.route.ts
+++ b/apps/backend/routes/events.route.ts
@@ -11,12 +11,9 @@ events_route.post('/register', requirePermissions({ flowsheet: ['read'] }), serv
 //TODO: You shouldn't have to be authenticated to subscribe to a topic
 events_route.put('/subscribe', requirePermissions({ flowsheet: ['read'] }), serverEvents.subscribeToTopic);
 
-// EventSource-friendly GET counterpart to POST /events/register. No
-// route-level auth guard: native browser EventSource can't send an
-// Authorization header, and authorization is already per-topic via
-// TopicAuthz inside filterAuthorizedTopics — public topics (liveFs,
-// test) accept anonymous callers; DJ-tier topics filter out without a
-// role match. See docs/live-updates-sse.md.
+// Anonymous on purpose: browser EventSource can't send an Authorization
+// header. Per-topic authz happens in filterAuthorizedTopics — see the
+// JSDoc on streamEventClient.
 events_route.get('/stream', serverEvents.streamEventClient);
 
 events_route.get('/test', serverEvents.testTrigger);

--- a/apps/backend/routes/events.route.ts
+++ b/apps/backend/routes/events.route.ts
@@ -11,4 +11,12 @@ events_route.post('/register', requirePermissions({ flowsheet: ['read'] }), serv
 //TODO: You shouldn't have to be authenticated to subscribe to a topic
 events_route.put('/subscribe', requirePermissions({ flowsheet: ['read'] }), serverEvents.subscribeToTopic);
 
+// EventSource-friendly GET counterpart to POST /events/register. No
+// route-level auth guard: native browser EventSource can't send an
+// Authorization header, and authorization is already per-topic via
+// TopicAuthz inside filterAuthorizedTopics — public topics (liveFs,
+// test) accept anonymous callers; DJ-tier topics filter out without a
+// role match. See docs/live-updates-sse.md.
+events_route.get('/stream', serverEvents.streamEventClient);
+
 events_route.get('/test', serverEvents.testTrigger);

--- a/tests/integration/events.spec.js
+++ b/tests/integration/events.spec.js
@@ -8,7 +8,8 @@ const { createAuthRequest, expectErrorContains, expectFields } = require('../uti
  * Tests for:
  * - POST /events/register - Register an SSE client (opens persistent connection)
  * - PUT /events/subscribe - Subscribe to event topics
- * - GET /events/test - Trigger a test broadcast event
+ * - GET /events/stream  - EventSource-friendly counterpart to /events/register (no auth required)
+ * - GET /events/test    - Trigger a test broadcast event
  */
 
 /**
@@ -105,6 +106,92 @@ const connectSSE = (authToken, topics = [], timeoutMs = 2000) => {
   });
 };
 
+/**
+ * GET /events/stream counterpart of `connectSSE`. Native EventSource is
+ * GET-only and can't send a JSON body, so topics ride in the query string
+ * as a comma-separated list. Auth is optional — omit `authToken` to exercise
+ * the public-topic path that browser EventSource clients walk.
+ */
+const connectSSEStream = (topics = [], authToken = undefined, timeoutMs = 2000) => {
+  return new Promise((resolve, reject) => {
+    const query = topics.length ? `?topics=${encodeURIComponent(topics.join(','))}` : '';
+    const url = new URL(`${process.env.TEST_HOST}:${process.env.PORT}/events/stream${query}`);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    const headers = {};
+    if (authToken) headers.Authorization = authToken;
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port,
+      path: `${url.pathname}${url.search}`,
+      method: 'GET',
+      headers,
+      signal: controller.signal,
+    };
+
+    let receivedData = '';
+    const events = [];
+
+    const req = http.request(options, (res) => {
+      if (res.statusCode !== 200) {
+        clearTimeout(timeout);
+        reject(new Error(`Unexpected status code: ${res.statusCode}`));
+        return;
+      }
+
+      const contentType = res.headers['content-type'];
+      if (!contentType || !contentType.includes('text/event-stream')) {
+        clearTimeout(timeout);
+        reject(new Error(`Expected text/event-stream, got: ${contentType}`));
+        return;
+      }
+
+      res.on('data', (chunk) => {
+        receivedData += chunk.toString();
+        const lines = receivedData.split('\n\n');
+        for (let i = 0; i < lines.length - 1; i++) {
+          const line = lines[i];
+          if (line.startsWith('data: ')) {
+            try {
+              events.push(JSON.parse(line.slice(6)));
+            } catch (e) {
+              // Ignore parse errors for partial data
+            }
+          }
+        }
+        receivedData = lines[lines.length - 1];
+
+        if (events.length > 0 && events[0].type === 'connection-established') {
+          clearTimeout(timeout);
+          controller.abort();
+          resolve({ events, headers: res.headers });
+        }
+      });
+
+      res.on('error', (err) => {
+        if (err.name !== 'AbortError') {
+          clearTimeout(timeout);
+          reject(err);
+        }
+      });
+    });
+
+    req.on('error', (err) => {
+      clearTimeout(timeout);
+      if (err.name === 'AbortError' && events.length > 0) {
+        resolve({ events, headers: {} });
+      } else if (err.name !== 'AbortError') {
+        reject(err);
+      }
+    });
+
+    req.end();
+  });
+};
+
 describe('Server-Sent Events', () => {
   let auth;
 
@@ -179,6 +266,26 @@ describe('Server-Sent Events', () => {
 
       expectFields(res.body, 'message');
       expect(res.body.message).toBe('event triggered');
+    });
+  });
+
+  describe('GET /events/stream', () => {
+    test('opens an SSE connection without an Authorization header', async () => {
+      // The whole point of this endpoint: native browser EventSource has no
+      // way to attach a Bearer token, so the route must succeed anonymously.
+      const { events, headers } = await connectSSEStream(['live-fs-topic']);
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[0].type).toBe('connection-established');
+      expectFields(events[0].payload, 'clientId');
+      expect(headers['content-type']).toContain('text/event-stream');
+    });
+
+    test('opens an SSE connection with no topics query parameter', async () => {
+      const { events } = await connectSSEStream();
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[0].type).toBe('connection-established');
     });
   });
 });

--- a/tests/integration/events.spec.js
+++ b/tests/integration/events.spec.js
@@ -13,129 +13,24 @@ const { createAuthRequest, expectErrorContains, expectFields } = require('../uti
  */
 
 /**
- * Helper to make an SSE connection and collect the initial events.
- * Uses native http module with AbortController for proper stream handling.
+ * Open an SSE connection with the given http.request options and resolve
+ * once the initial `connection-established` event arrives (or `timeoutMs`
+ * elapses, which aborts the request). `writeBody` is invoked once the
+ * request is open so callers can attach a JSON body before `req.end()`.
+ *
+ * Used by both helpers below — POST /events/register (with body) and GET
+ * /events/stream (no body) share the same SSE-framing parser; only the
+ * request shape differs.
  */
-const connectSSE = (authToken, topics = [], timeoutMs = 2000) => {
+const openSSE = (options, timeoutMs, writeBody) => {
   return new Promise((resolve, reject) => {
-    const url = new URL(`${process.env.TEST_HOST}:${process.env.PORT}/events/register`);
-    const body = JSON.stringify({ topics });
-
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-    const options = {
-      hostname: url.hostname,
-      port: url.port,
-      path: url.pathname,
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(body),
-        Authorization: authToken,
-      },
-      signal: controller.signal,
-    };
 
     let receivedData = '';
     const events = [];
 
-    const req = http.request(options, (res) => {
-      if (res.statusCode !== 200) {
-        clearTimeout(timeout);
-        reject(new Error(`Unexpected status code: ${res.statusCode}`));
-        return;
-      }
-
-      // Verify SSE headers
-      const contentType = res.headers['content-type'];
-      if (!contentType || !contentType.includes('text/event-stream')) {
-        clearTimeout(timeout);
-        reject(new Error(`Expected text/event-stream, got: ${contentType}`));
-        return;
-      }
-
-      res.on('data', (chunk) => {
-        receivedData += chunk.toString();
-
-        // Parse SSE data format (data: {...}\n\n)
-        const lines = receivedData.split('\n\n');
-        for (let i = 0; i < lines.length - 1; i++) {
-          const line = lines[i];
-          if (line.startsWith('data: ')) {
-            try {
-              const eventData = JSON.parse(line.slice(6));
-              events.push(eventData);
-            } catch (e) {
-              // Ignore parse errors for partial data
-            }
-          }
-        }
-        // Keep the last incomplete chunk
-        receivedData = lines[lines.length - 1];
-
-        // Once we have the connection event, we can resolve
-        if (events.length > 0 && events[0].type === 'connection-established') {
-          clearTimeout(timeout);
-          controller.abort();
-          resolve({ events, headers: res.headers });
-        }
-      });
-
-      res.on('error', (err) => {
-        // AbortError is expected when we call controller.abort()
-        if (err.name !== 'AbortError') {
-          clearTimeout(timeout);
-          reject(err);
-        }
-      });
-    });
-
-    req.on('error', (err) => {
-      clearTimeout(timeout);
-      // AbortError is expected
-      if (err.name === 'AbortError' && events.length > 0) {
-        resolve({ events, headers: {} });
-      } else if (err.name !== 'AbortError') {
-        reject(err);
-      }
-    });
-
-    req.write(body);
-    req.end();
-  });
-};
-
-/**
- * GET /events/stream counterpart of `connectSSE`. Native EventSource is
- * GET-only and can't send a JSON body, so topics ride in the query string
- * as a comma-separated list. Auth is optional — omit `authToken` to exercise
- * the public-topic path that browser EventSource clients walk.
- */
-const connectSSEStream = (topics = [], authToken = undefined, timeoutMs = 2000) => {
-  return new Promise((resolve, reject) => {
-    const query = topics.length ? `?topics=${encodeURIComponent(topics.join(','))}` : '';
-    const url = new URL(`${process.env.TEST_HOST}:${process.env.PORT}/events/stream${query}`);
-
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-    const headers = {};
-    if (authToken) headers.Authorization = authToken;
-
-    const options = {
-      hostname: url.hostname,
-      port: url.port,
-      path: `${url.pathname}${url.search}`,
-      method: 'GET',
-      headers,
-      signal: controller.signal,
-    };
-
-    let receivedData = '';
-    const events = [];
-
-    const req = http.request(options, (res) => {
+    const req = http.request({ ...options, signal: controller.signal }, (res) => {
       if (res.statusCode !== 200) {
         clearTimeout(timeout);
         reject(new Error(`Unexpected status code: ${res.statusCode}`));
@@ -151,6 +46,7 @@ const connectSSEStream = (topics = [], authToken = undefined, timeoutMs = 2000) 
 
       res.on('data', (chunk) => {
         receivedData += chunk.toString();
+        // Parse SSE data format (data: {...}\n\n). Keep the last incomplete chunk.
         const lines = receivedData.split('\n\n');
         for (let i = 0; i < lines.length - 1; i++) {
           const line = lines[i];
@@ -172,6 +68,7 @@ const connectSSEStream = (topics = [], authToken = undefined, timeoutMs = 2000) 
       });
 
       res.on('error', (err) => {
+        // AbortError is expected when we call controller.abort()
         if (err.name !== 'AbortError') {
           clearTimeout(timeout);
           reject(err);
@@ -188,8 +85,55 @@ const connectSSEStream = (topics = [], authToken = undefined, timeoutMs = 2000) 
       }
     });
 
+    if (writeBody) writeBody(req);
     req.end();
   });
+};
+
+const connectSSE = (authToken, topics = [], timeoutMs = 2000) => {
+  const url = new URL(`${process.env.TEST_HOST}:${process.env.PORT}/events/register`);
+  const body = JSON.stringify({ topics });
+
+  return openSSE(
+    {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        Authorization: authToken,
+      },
+    },
+    timeoutMs,
+    (req) => req.write(body)
+  );
+};
+
+/**
+ * GET /events/stream counterpart of `connectSSE`. Native EventSource is
+ * GET-only and can't send a JSON body, so topics ride in the query string
+ * as a comma-separated list. Auth is optional — omit `authToken` to exercise
+ * the public-topic path that browser EventSource clients walk.
+ */
+const connectSSEStream = (topics = [], authToken = undefined, timeoutMs = 2000) => {
+  const query = topics.length ? `?topics=${encodeURIComponent(topics.join(','))}` : '';
+  const url = new URL(`${process.env.TEST_HOST}:${process.env.PORT}/events/stream${query}`);
+
+  const headers = {};
+  if (authToken) headers.Authorization = authToken;
+
+  return openSSE(
+    {
+      hostname: url.hostname,
+      port: url.port,
+      path: `${url.pathname}${url.search}`,
+      method: 'GET',
+      headers,
+    },
+    timeoutMs
+  );
 };
 
 describe('Server-Sent Events', () => {

--- a/tests/unit/controllers/events.controller.test.ts
+++ b/tests/unit/controllers/events.controller.test.ts
@@ -19,7 +19,11 @@ jest.mock('../../../apps/backend/utils/serverEvents', () => {
   };
 });
 
-import { registerEventClient, subscribeToTopic } from '../../../apps/backend/controllers/events.controller';
+import {
+  registerEventClient,
+  subscribeToTopic,
+  streamEventClient,
+} from '../../../apps/backend/controllers/events.controller';
 import { serverEventsMgr, Topics } from '../../../apps/backend/utils/serverEvents';
 
 describe('events controller', () => {
@@ -154,6 +158,132 @@ describe('events controller', () => {
         expect.arrayContaining([Topics.liveFs, Topics.test]),
         'client-1'
       );
+    });
+  });
+
+  describe('streamEventClient (GET /events/stream)', () => {
+    // GET /events/stream is the EventSource-friendly counterpart to POST
+    // /events/register: same registerClient + filterAuthorizedTopics +
+    // subscribe pipeline, but topics arrive as a comma-separated `?topics=`
+    // query string instead of a JSON body. Browsers' native EventSource
+    // can't set custom headers or send a body — the GET-with-query shape
+    // is what dj-site's listener middleware speaks.
+
+    it('parses comma-separated topics from the query string and subscribes', () => {
+      const req = {
+        query: { topics: `${Topics.liveFs},${Topics.test}` },
+      } as unknown as Request;
+
+      const res = {} as Response;
+      const next = jest.fn();
+
+      streamEventClient(req, res, next);
+
+      expect(serverEventsMgr.registerClient).toHaveBeenCalledWith(res);
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+        expect.arrayContaining([Topics.liveFs, Topics.test]),
+        'client-1'
+      );
+    });
+
+    it('subscribes to no topics when the query is missing', () => {
+      const req = { query: {} } as unknown as Request;
+
+      streamEventClient(req, {} as Response, jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith([], 'client-1');
+    });
+
+    it('allows public topics for unauthenticated callers (the liveFs path)', () => {
+      const req = {
+        query: { topics: Topics.liveFs },
+      } as unknown as Request;
+
+      streamEventClient(req, {} as Response, jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(expect.arrayContaining([Topics.liveFs]), 'client-1');
+    });
+
+    it('drops DJ-tier topics for unauthenticated callers (the EventSource path has no Authorization header)', () => {
+      const req = {
+        query: { topics: `${Topics.liveFs},${Topics.showDj},${Topics.mirror}` },
+      } as unknown as Request;
+
+      streamEventClient(req, {} as Response, jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+        expect.not.arrayContaining([Topics.showDj, Topics.mirror]),
+        'client-1'
+      );
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(expect.arrayContaining([Topics.liveFs]), 'client-1');
+    });
+
+    it('drops DJ-tier topics when the caller has the member role (parity with POST /register)', () => {
+      const req = {
+        auth: { id: 'user-1', role: 'member' },
+        query: { topics: `${Topics.liveFs},${Topics.showDj},${Topics.mirror}` },
+      } as unknown as Request;
+
+      streamEventClient(req, {} as Response, jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+        expect.not.arrayContaining([Topics.showDj, Topics.mirror]),
+        'client-1'
+      );
+    });
+
+    it('includes DJ-tier topics when the caller has the dj role (still works for authenticated EventSource clients)', () => {
+      const req = {
+        auth: { id: 'user-1', role: 'dj' },
+        query: { topics: `${Topics.liveFs},${Topics.showDj}` },
+      } as unknown as Request;
+
+      streamEventClient(req, {} as Response, jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+        expect.arrayContaining([Topics.liveFs, Topics.showDj]),
+        'client-1'
+      );
+    });
+
+    it('silently drops topic strings that are not in TopicAuthz', () => {
+      const req = {
+        query: { topics: `${Topics.liveFs},does-not-exist` },
+      } as unknown as Request;
+
+      streamEventClient(req, {} as Response, jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+        expect.not.arrayContaining(['does-not-exist']),
+        'client-1'
+      );
+    });
+
+    it('trims whitespace around comma-separated topic values', () => {
+      // Tolerate `?topics=live-fs-topic, test-topic` from hand-typed URLs.
+      const req = {
+        query: { topics: ` ${Topics.liveFs} , ${Topics.test} ` },
+      } as unknown as Request;
+
+      streamEventClient(req, {} as Response, jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith(
+        expect.arrayContaining([Topics.liveFs, Topics.test]),
+        'client-1'
+      );
+    });
+
+    it('ignores a non-string topics query parameter (e.g. repeated ?topics=&topics= produces an array)', () => {
+      // Express parses repeated query params into an array. The contract
+      // is a single comma-separated string, so anything else short-circuits
+      // to an empty subscription rather than crashing.
+      const req = {
+        query: { topics: [Topics.liveFs, Topics.test] },
+      } as unknown as Request;
+
+      streamEventClient(req, {} as Response, jest.fn());
+
+      expect(serverEventsMgr.subscribe).toHaveBeenCalledWith([], 'client-1');
     });
   });
 });

--- a/tests/unit/controllers/events.controller.test.ts
+++ b/tests/unit/controllers/events.controller.test.ts
@@ -162,13 +162,6 @@ describe('events controller', () => {
   });
 
   describe('streamEventClient (GET /events/stream)', () => {
-    // GET /events/stream is the EventSource-friendly counterpart to POST
-    // /events/register: same registerClient + filterAuthorizedTopics +
-    // subscribe pipeline, but topics arrive as a comma-separated `?topics=`
-    // query string instead of a JSON body. Browsers' native EventSource
-    // can't set custom headers or send a body — the GET-with-query shape
-    // is what dj-site's listener middleware speaks.
-
     it('parses comma-separated topics from the query string and subscribes', () => {
       const req = {
         query: { topics: `${Topics.liveFs},${Topics.test}` },
@@ -260,7 +253,6 @@ describe('events controller', () => {
     });
 
     it('trims whitespace around comma-separated topic values', () => {
-      // Tolerate `?topics=live-fs-topic, test-topic` from hand-typed URLs.
       const req = {
         query: { topics: ` ${Topics.liveFs} , ${Topics.test} ` },
       } as unknown as Request;


### PR DESCRIPTION
## Summary

- Add `GET /events/stream?topics=<csv>` as the EventSource-friendly counterpart to `POST /events/register`. No route-level auth guard — browsers' native EventSource can't attach an Authorization header.
- Authorization stays per-topic via `TopicAuthz` + `filterAuthorizedTopics`. Public topics (`liveFs`, `test`) accept anonymous callers; DJ-tier topics (`showDj`, `primaryDj`, `mirror`) filter out without a role match. POST /events/register stays for non-browser consumers.
- Parse `?topics=` as comma-separated wire-format strings (`live-fs-topic`), tolerant of whitespace, collapse non-string to `[]`.

Closes #1167. First of four sequenced Backend-Service PRs landing the [dj-site live-updates SSE plan](https://github.com/WXYC/dj-site/blob/main/docs/live-updates-sse.md) (companion to [WXYC/dj-site#659](https://github.com/WXYC/dj-site/pull/659), which is already merged with both feature flags OFF — flipping them requires this endpoint to ship).

## Test plan

- [x] `tests/unit/controllers/events.controller.test.ts` — 9 new cases covering query parsing, auth-role filtering, and the unknown-topic / non-string-query edge cases.
- [x] `tests/integration/events.spec.js` — `connectSSEStream` helper + scenarios for anonymous subscription with topics and with no topics.
- [x] `npm run typecheck` (all workspaces), `npm run lint` (no new errors — 464 pre-existing warnings unchanged), `npm run format:check` clean.
- [x] Full unit suite: 2386/2387 pass (the one failure in `schema.flowsheet-artwork-lookup-idx.test.ts` is pre-existing on origin/main, unrelated to events).