### PR TITLE
feat(events): inline full row in liveFs:update payload (BS-2)

### DIFF
--- a/apps/backend/services/metadata-broadcast/index.ts
+++ b/apps/backend/services/metadata-broadcast/index.ts
@@ -1,2 +1,2 @@
 export { setupMetadataBroadcast, filterMetadataUpdate } from './metadata-broadcast.js';
-export type { MetadataBroadcastPayload } from './metadata-broadcast.js';
+export type { LiveFsUpdatePayload } from './metadata-broadcast.js';

--- a/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
+++ b/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
@@ -16,10 +16,12 @@
  *   - data.metadata_status is a terminal state
  *     ('enriched_match' | 'enriched_no_match' | 'failed_no_retry')
  *
- * Per-row payload includes `id` and `metadata_status` so dj-site can scope
- * a refetch to just the changed row instead of paying for a list refetch.
- * Today's dj-site treats this as a generic update signal; the per-row
- * payload is forward-compat for finer-grained handling.
+ * Payload is the full flowsheet row from `event.data` (BS-2). dj-site's
+ * listener middleware patches the row into its RTK Query cache directly —
+ * a /live viewer that just opened the page sees post-enrichment fields
+ * (`artwork_url`, `release_year`, etc.) without a follow-up GET.
+ * `wxyc-shared`'s `LiveFsUpdateEvent` is the canonical cross-language
+ * shape; this file's `LiveFsUpdatePayload` mirrors that contract.
  *
  * False positives: the filter matches any flowsheet UPDATE that lands in
  * a terminal metadata_status. The historical `flowsheet-metadata-backfill`
@@ -33,19 +35,30 @@
  * so there's no per-client duplication.
  */
 
+import * as Sentry from '@sentry/node';
 import type { CdcEvent } from '@wxyc/database';
 import { onCdcEvent } from '@wxyc/database';
 import { serverEventsMgr, Topics, FsEvents } from '../../utils/serverEvents.js';
 
 const TERMINAL_STATUSES = new Set(['enriched_match', 'enriched_no_match', 'failed_no_retry']);
 
-export type MetadataBroadcastPayload = {
+/**
+ * Wire shape of the `liveFs:update` payload. Mirrors `LiveFsUpdateEvent` in
+ * `wxyc-shared/api.yaml`. The two required fields (`id`, `metadata_status`)
+ * are pinned because we assert them at the filter boundary; the rest of the
+ * flowsheet columns (`artist_name`, `album_title`, `artwork_url`, ...) ride
+ * along untyped at this seam — dj-site / iOS receive them via the typed
+ * `FlowsheetSongEntry` schema generated from `@wxyc/shared`, which is the
+ * cross-language source of truth.
+ */
+export type LiveFsUpdatePayload = {
   id: number;
   metadata_status: 'enriched_match' | 'enriched_no_match' | 'failed_no_retry';
+  [key: string]: unknown;
 };
 
 /** Pure filter for testability — returns the broadcast payload on match, null on skip. */
-export function filterMetadataUpdate(event: CdcEvent): MetadataBroadcastPayload | null {
+export function filterMetadataUpdate(event: CdcEvent): LiveFsUpdatePayload | null {
   if (event.table !== 'flowsheet') return null;
   if (event.action !== 'UPDATE') return null;
   if (!event.data) return null;
@@ -57,7 +70,11 @@ export function filterMetadataUpdate(event: CdcEvent): MetadataBroadcastPayload 
   const id = data.id;
   if (typeof id !== 'number') return null;
 
-  return { id, metadata_status: status as MetadataBroadcastPayload['metadata_status'] };
+  return {
+    ...data,
+    id,
+    metadata_status: status as LiveFsUpdatePayload['metadata_status'],
+  };
 }
 
 /**
@@ -80,8 +97,11 @@ export function setupMetadataBroadcast(): void {
       // serverEventsMgr.broadcast already swallows per-client errors
       // (unsubAll on write failure); this guard catches anything else
       // (e.g. an empty topic set wouldn't throw, but a future change
-      // might).
-      console.error('[metadata-broadcast] broadcast failed:', (err as Error).message);
+      // might). Surface to Sentry so a sudden rate spike isn't invisible.
+      Sentry.captureException(err, {
+        tags: { module: 'metadata-broadcast', subsystem: 'sse' },
+        extra: { id: payload.id, metadata_status: payload.metadata_status },
+      });
     }
   });
 }

--- a/tests/unit/apps/backend/services/metadata-broadcast.test.ts
+++ b/tests/unit/apps/backend/services/metadata-broadcast.test.ts
@@ -12,7 +12,28 @@
  */
 
 import type { CdcEvent } from '@wxyc/database';
-import { filterMetadataUpdate } from '../../../../../apps/backend/services/metadata-broadcast/metadata-broadcast';
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('../../../../../apps/backend/utils/serverEvents.js', () => ({
+  Topics: { liveFs: 'live-fs-topic' },
+  FsEvents: { update: 'update' },
+  serverEventsMgr: { broadcast: jest.fn() },
+}));
+
+jest.mock('@wxyc/database', () => ({
+  onCdcEvent: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/node';
+import {
+  filterMetadataUpdate,
+  setupMetadataBroadcast,
+} from '../../../../../apps/backend/services/metadata-broadcast/metadata-broadcast';
+import { onCdcEvent } from '@wxyc/database';
+import { serverEventsMgr } from '../../../../../apps/backend/utils/serverEvents.js';
 
 const flowsheetUpdate = (overrides: Partial<Record<string, unknown>> = {}): CdcEvent => ({
   table: 'flowsheet',
@@ -27,25 +48,46 @@ const flowsheetUpdate = (overrides: Partial<Record<string, unknown>> = {}): CdcE
 });
 
 describe('filterMetadataUpdate (BS#892 PR-2)', () => {
-  it('returns payload for an enriched_match UPDATE', () => {
-    expect(filterMetadataUpdate(flowsheetUpdate())).toEqual({
+  // Pre-BS-2 payload was `{id, metadata_status}` — dj-site's listener
+  // middleware would patch only those two fields and rely on the rest
+  // already being in the local cache. BS-2 inlines the full row so
+  // newly-mounted clients (a /live viewer that just opened the page) can
+  // surface metadata-enriched fields like `artwork_url` without a follow-up
+  // GET. The wxyc-shared `LiveFsUpdateEvent` contract pins this shape.
+
+  it('returns the full row data as the payload (BS-2)', () => {
+    const event = flowsheetUpdate({
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      track_title: 'la paradoja',
+      record_label: 'Sonamos',
+      artwork_url: 'https://example.com/doga.jpg',
+    });
+    expect(filterMetadataUpdate(event)).toEqual({
       id: 42,
       metadata_status: 'enriched_match',
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      track_title: 'la paradoja',
+      record_label: 'Sonamos',
+      artwork_url: 'https://example.com/doga.jpg',
     });
   });
 
-  it('returns payload for an enriched_no_match UPDATE', () => {
-    expect(filterMetadataUpdate(flowsheetUpdate({ metadata_status: 'enriched_no_match' }))).toEqual({
-      id: 42,
-      metadata_status: 'enriched_no_match',
-    });
+  it('still returns payload for an enriched_match UPDATE (id + status guaranteed)', () => {
+    const payload = filterMetadataUpdate(flowsheetUpdate());
+    expect(payload).not.toBeNull();
+    expect(payload).toMatchObject({ id: 42, metadata_status: 'enriched_match' });
   });
 
-  it('returns payload for a failed_no_retry UPDATE', () => {
-    expect(filterMetadataUpdate(flowsheetUpdate({ metadata_status: 'failed_no_retry' }))).toEqual({
-      id: 42,
-      metadata_status: 'failed_no_retry',
-    });
+  it('still returns payload for an enriched_no_match UPDATE', () => {
+    const payload = filterMetadataUpdate(flowsheetUpdate({ metadata_status: 'enriched_no_match' }));
+    expect(payload).toMatchObject({ id: 42, metadata_status: 'enriched_no_match' });
+  });
+
+  it('still returns payload for a failed_no_retry UPDATE', () => {
+    const payload = filterMetadataUpdate(flowsheetUpdate({ metadata_status: 'failed_no_retry' }));
+    expect(payload).toMatchObject({ id: 42, metadata_status: 'failed_no_retry' });
   });
 
   it('skips UPDATE to enriching (claim-time, not user-visible)', () => {
@@ -83,5 +125,47 @@ describe('filterMetadataUpdate (BS#892 PR-2)', () => {
 
   it('skips when metadata_status is some other string (defensive against schema drift)', () => {
     expect(filterMetadataUpdate(flowsheetUpdate({ metadata_status: 'unknown_status' }))).toBeNull();
+  });
+});
+
+describe('setupMetadataBroadcast Sentry path (BS-2)', () => {
+  // Pre-BS-2 a broadcast throw was logged to console.error and lost in CW
+  // tail noise. BS-2 routes the exception through Sentry so a rate spike
+  // becomes visible.
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('captures broadcast exceptions to Sentry with module + payload tags', () => {
+    (serverEventsMgr.broadcast as jest.Mock).mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    setupMetadataBroadcast();
+
+    const cb = (onCdcEvent as jest.Mock).mock.calls[0][0] as (event: CdcEvent) => void;
+    cb(flowsheetUpdate());
+
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    const [err, context] = (Sentry.captureException as jest.Mock).mock.calls[0];
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe('boom');
+    expect(context).toMatchObject({
+      tags: expect.objectContaining({ module: 'metadata-broadcast' }),
+      extra: expect.objectContaining({ id: 42, metadata_status: 'enriched_match' }),
+    });
+  });
+
+  it('does not call Sentry on a normal broadcast', () => {
+    (serverEventsMgr.broadcast as jest.Mock).mockImplementation(() => undefined);
+
+    setupMetadataBroadcast();
+
+    const cb = (onCdcEvent as jest.Mock).mock.calls[0][0] as (event: CdcEvent) => void;
+    cb(flowsheetUpdate());
+
+    expect(serverEventsMgr.broadcast).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- `filterMetadataUpdate` now returns the full flowsheet row from `event.data`, not just `{id, metadata_status}`. A /live viewer that just opened the page sees post-enrichment fields (`artwork_url`, `release_year`, ...) on the first SSE event without a follow-up GET.
- Rename `MetadataBroadcastPayload` → `LiveFsUpdatePayload` to match the `wxyc-shared` `LiveFsUpdateEvent` schema (next PR in the sequence).
- Replace `console.error` on broadcast failure with `Sentry.captureException(err, { tags: { module: 'metadata-broadcast', subsystem: 'sse' }, extra: { id, metadata_status } })` so a rate spike is visible in the Sentry issue stream.

Closes #1169. Second of four sequenced Backend-Service PRs landing the [dj-site live-updates SSE plan](https://github.com/WXYC/dj-site/blob/main/docs/live-updates-sse.md); sits behind #1168 (BS-1).

## Test plan

- [x] `tests/unit/apps/backend/services/metadata-broadcast.test.ts` — new full-row pass-through case + 2 Sentry-path cases. Existing filter tests use `toMatchObject` so they still pin `id`/`metadata_status` without over-pinning the payload shape.
- [x] `npm run typecheck` (all workspaces), `npm run lint` (no new errors — 464 pre-existing warnings unchanged), `npm run format:check` clean.
- [x] Full unit suite: 2380/2381 pass (the one failure in `schema.flowsheet-artwork-lookup-idx.test.ts` is pre-existing on origin/main).