### PR TITLE
feat(events): Sentry capture on SSE broadcast write failures (BS-4)

### DIFF
--- a/apps/backend/utils/serverEvents.ts
+++ b/apps/backend/utils/serverEvents.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import WxycError from '../utils/error.js';
 import { Response } from 'express';
 import { recordBroadcast, recordBroadcastFailure } from '../services/sse/sse-metrics.js';
@@ -227,7 +228,14 @@ export class ServerEventsManager {
           client.res.write(message);
           this.resetTimeout(clientId);
         } catch (error) {
+          // The CloudWatch counter (BS-3) makes the rate visible; Sentry
+          // surfaces the exception so we can read the underlying error
+          // (write-after-end, EPIPE, etc.) when the rate spikes.
           recordBroadcastFailure(topicId);
+          Sentry.captureException(error, {
+            tags: { subsystem: 'sse', op: 'broadcast', topic: topicId },
+            extra: { client_id: client.id },
+          });
           this.unsubAll(client.id);
         }
       }
@@ -253,6 +261,10 @@ export class ServerEventsManager {
         this.resetTimeout(clientId);
       } catch (error) {
         recordBroadcastFailure(topicId);
+        Sentry.captureException(error, {
+          tags: { subsystem: 'sse', op: 'dispatch', topic: topicId },
+          extra: { client_id: client.id },
+        });
         this.unsubAll(client.id);
       }
     }

--- a/tests/unit/utils/serverEvents.test.ts
+++ b/tests/unit/utils/serverEvents.test.ts
@@ -7,6 +7,11 @@ jest.mock('../../../apps/backend/services/sse/sse-metrics', () => ({
   recordBroadcastFailure: jest.fn(),
 }));
 
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/node';
 import { ServerEventsManager } from '../../../apps/backend/utils/serverEvents';
 import { recordBroadcast, recordBroadcastFailure } from '../../../apps/backend/services/sse/sse-metrics';
 import { Response } from 'express';
@@ -165,6 +170,82 @@ describe('ServerEventsManager', () => {
       expect(recordBroadcastFailure).toHaveBeenCalledWith('topic-a');
       // dispatch() is single-client; it does not count as an EventsBroadcast.
       expect(recordBroadcast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Sentry capture on write failure (BS-4)', () => {
+    beforeEach(() => {
+      (Sentry.captureException as jest.Mock).mockClear();
+      (recordBroadcastFailure as jest.Mock).mockClear();
+    });
+
+    it('captures broadcast write exceptions to Sentry with topic + client_id', () => {
+      const mgr = new ServerEventsManager('topic-a');
+      const res = createMockResponse();
+      const client = mgr.registerClient(res);
+      mgr.subscribe(['topic-a'], client.id);
+
+      const failure = new Error('socket closed');
+      (res.write as jest.Mock).mockImplementation(() => {
+        throw failure;
+      });
+
+      mgr.broadcast('topic-a', { type: 'update', payload: {} });
+
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      const [err, context] = (Sentry.captureException as jest.Mock).mock.calls[0];
+      expect(err).toBe(failure);
+      expect(context).toMatchObject({
+        tags: expect.objectContaining({ subsystem: 'sse', op: 'broadcast', topic: 'topic-a' }),
+        extra: expect.objectContaining({ client_id: client.id }),
+      });
+    });
+
+    it('captures dispatch write exceptions to Sentry with topic + client_id', () => {
+      const mgr = new ServerEventsManager('topic-a');
+      const res = createMockResponse();
+      const client = mgr.registerClient(res);
+      mgr.subscribe(['topic-a'], client.id);
+
+      (res.write as jest.Mock).mockImplementation(() => {
+        throw new Error('EPIPE');
+      });
+
+      mgr.dispatch('topic-a', client.id, { type: 'ping', payload: {} });
+
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      const [, context] = (Sentry.captureException as jest.Mock).mock.calls[0];
+      expect(context).toMatchObject({
+        tags: expect.objectContaining({ subsystem: 'sse', op: 'dispatch', topic: 'topic-a' }),
+        extra: expect.objectContaining({ client_id: client.id }),
+      });
+    });
+
+    it('does not capture anything on a successful broadcast', () => {
+      const mgr = new ServerEventsManager('topic-a');
+      const res = createMockResponse();
+      const client = mgr.registerClient(res);
+      mgr.subscribe(['topic-a'], client.id);
+
+      mgr.broadcast('topic-a', { type: 'update', payload: {} });
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('Sentry capture and the CloudWatch counter both fire on the same write failure', () => {
+      const mgr = new ServerEventsManager('topic-a');
+      const res = createMockResponse();
+      const client = mgr.registerClient(res);
+      mgr.subscribe(['topic-a'], client.id);
+
+      (res.write as jest.Mock).mockImplementation(() => {
+        throw new Error('write after end');
+      });
+
+      mgr.broadcast('topic-a', { type: 'update', payload: {} });
+
+      expect(recordBroadcastFailure).toHaveBeenCalledTimes(1);
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `Sentry.captureException` to the silent unsub-on-write-failure path in `serverEvents.ts:broadcast` / `dispatch`. Tagged `subsystem: sse, op: (broadcast|dispatch), topic: <topic>` with `client_id` in `extra`.
- Paired with BS-3's CloudWatch counter (`WXYC/BackendService/SSE/BroadcastFailures`): the counter shows the rate, Sentry shows the underlying exception. A rate spike becomes diagnosable from the issue queue.

Closes #1173. Last of four sequenced Backend-Service PRs landing the [dj-site live-updates SSE plan](https://github.com/WXYC/dj-site/blob/main/docs/live-updates-sse.md). **Branched from #1172 (BS-3)** because both touch the same `catch` blocks — the PR base is `feature/sse-cloudwatch-metrics` and will rebase clean onto `main` once BS-3 merges.

## Test plan

- [x] 4 new cases in `tests/unit/utils/serverEvents.test.ts` pinning the broadcast tag, dispatch tag, no-capture-on-success, and capture-plus-counter-fire shapes.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` clean.