### PR TITLE
fix(album-level-backfill): emit structured JSON logs the runbook watchdog can consume

### DIFF
--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -404,18 +404,15 @@ export const runBatch = async (
   try {
     response = await bulkLookupMetadata(items, { budgetMs: options.budgetMs });
   } catch (err) {
+    const firstAlbumId = resolved[0]?.album_id ?? null;
+    const lastAlbumId = resolved[resolved.length - 1]?.album_id ?? null;
     const errorMessage = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    const extra = { size: items.length, first_album_id: firstAlbumId, last_album_id: lastAlbumId };
     log('warn', 'lml_batch_failed', 'bulkLookupMetadata threw; entire batch counted as error', {
-      size: items.length,
-      first_album_id: resolved[0]?.album_id ?? null,
-      last_album_id: resolved[resolved.length - 1]?.album_id ?? null,
+      ...extra,
       error_message: errorMessage,
     });
-    captureError(err, 'lml_batch_failed', {
-      size: items.length,
-      first_album_id: resolved[0]?.album_id ?? null,
-      last_album_id: resolved[resolved.length - 1]?.album_id ?? null,
-    });
+    captureError(err, 'lml_batch_failed', extra);
     return { batchSize: items.length, match: 0, no_match: 0, error: items.length, upserts: 0 };
   }
   // resolved[i] corresponds to items[i] which corresponds to response.results[i].
@@ -605,12 +602,12 @@ export const runBackfill = async (options: BackfillOptions): Promise<BackfillSum
 };
 
 const main = async (): Promise<void> => {
-  const runId = initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
 
   try {
     const options = resolveOptions();
     const summary = await runBackfill(options);
-    log('info', 'finished', `${JOB_NAME} done`, { run_id: runId, ...summary });
+    log('info', 'finished', `${JOB_NAME} done`, { ...summary });
   } catch (err) {
     captureError(err, 'main');
     log('error', 'failed', `${JOB_NAME} failed: ${err instanceof Error ? err.message : String(err)}`, {

--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -34,10 +34,10 @@
  * Run procedure: see jobs/album-level-backfill/README.md.
  */
 
-import * as Sentry from '@sentry/node';
 import { sql } from 'drizzle-orm';
 import { album_metadata, db, closeDatabaseConnection } from '@wxyc/database';
 import { bulkLookupMetadata, type BulkLookupItem, type LookupResponse } from '@wxyc/lml-client';
+import { captureError, closeLogger, initLogger, log } from './logger.js';
 
 const JOB_NAME = 'album-level-backfill';
 
@@ -309,7 +309,10 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
  * lookback window is quiet (no track within `lookbackSeconds`). */
 export const awaitQuietWindow = async (lookbackSeconds: number, pauseMs: number): Promise<void> => {
   while (await checkLiveActivity(lookbackSeconds)) {
-    console.log(`[${JOB_NAME}] live DJ activity within ${lookbackSeconds}s; deferring ${Math.round(pauseMs / 1000)}s.`);
+    log('info', 'live_activity_pause', `live DJ activity within ${lookbackSeconds}s; deferring ${pauseMs}ms`, {
+      lookback_seconds: lookbackSeconds,
+      pause_ms: pauseMs,
+    });
     await sleep(pauseMs);
   }
 };
@@ -349,7 +352,7 @@ export const runPostPassUpdate = async (timeoutMs: number): Promise<number> => {
  * statistics before the post-pass UPDATE's JOIN. Paired-bulk rule from
  * docs/bulk-update-playbook.md. */
 export const analyzeAlbumMetadata = async (): Promise<void> => {
-  console.log(`[${JOB_NAME}] ANALYZE album_metadata.`);
+  log('info', 'analyze_started', 'ANALYZE album_metadata');
   await db.execute(sql`ANALYZE "wxyc_schema"."album_metadata"`);
 };
 
@@ -379,9 +382,10 @@ export const runBatch = async (
   const items = buildBulkItems(resolved);
 
   if (options.dryRun) {
-    console.log(
-      `[${JOB_NAME}] (dry-run) batch resolved=${resolved.length} would-call bulkLookup with ${items.length} items.`
-    );
+    log('info', 'batch_dry_run', `dry-run: would call bulkLookup with ${items.length} items`, {
+      resolved: resolved.length,
+      items: items.length,
+    });
     return { batchSize: items.length, match: 0, no_match: 0, error: 0, upserts: 0 };
   }
 
@@ -400,10 +404,18 @@ export const runBatch = async (
   try {
     response = await bulkLookupMetadata(items, { budgetMs: options.budgetMs });
   } catch (err) {
-    const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-    console.warn(
-      `[${JOB_NAME}] lml.batch_failed size=${items.length} first_album_id=${resolved[0]?.album_id ?? '?'} last_album_id=${resolved[resolved.length - 1]?.album_id ?? '?'} error=${JSON.stringify(msg)}`
-    );
+    const errorMessage = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    log('warn', 'lml_batch_failed', 'bulkLookupMetadata threw; entire batch counted as error', {
+      size: items.length,
+      first_album_id: resolved[0]?.album_id ?? null,
+      last_album_id: resolved[resolved.length - 1]?.album_id ?? null,
+      error_message: errorMessage,
+    });
+    captureError(err, 'lml_batch_failed', {
+      size: items.length,
+      first_album_id: resolved[0]?.album_id ?? null,
+      last_album_id: resolved[resolved.length - 1]?.album_id ?? null,
+    });
     return { batchSize: items.length, match: 0, no_match: 0, error: items.length, upserts: 0 };
   }
   // resolved[i] corresponds to items[i] which corresponds to response.results[i].
@@ -427,9 +439,10 @@ export const runBatch = async (
     } else {
       error += 1;
       const album = resolved[result.index];
-      console.warn(
-        `[${JOB_NAME}] lml.error album_id=${album?.album_id ?? '?'} message=${JSON.stringify(result.message ?? null)}`
-      );
+      log('warn', 'lml_error', `LML per-item error for album_id=${album?.album_id ?? '?'}`, {
+        album_id: album?.album_id ?? null,
+        error_message: result.message ?? null,
+      });
     }
   }
   const upserts = (await Promise.all(upsertPromises)).filter(Boolean).length;
@@ -486,16 +499,24 @@ const chunk = <T>(arr: T[], size: number): T[][] => {
 };
 
 export const runBackfill = async (options: BackfillOptions): Promise<BackfillSummary> => {
-  console.log(
-    `[${JOB_NAME}] start batchSize=${options.batchSize} ratePerMin=${options.ratePerMin} budgetMs=${options.budgetMs} dryRun=${options.dryRun}`
-  );
+  log('info', 'started', `${JOB_NAME} starting`, {
+    batch_size: options.batchSize,
+    rate_per_min: options.ratePerMin,
+    budget_ms: options.budgetMs,
+    dry_run: options.dryRun,
+  });
 
   const albumIds = await enumeratePendingAlbumIds(options.readTimeoutMs);
-  console.log(`[${JOB_NAME}] enumerated scanned=${albumIds.length} unique album_ids`);
+  log('info', 'enumerated', `enumerated ${albumIds.length} unique album_ids`, {
+    scanned: albumIds.length,
+  });
 
   if (options.dryRun) {
     const batches = chunk(albumIds, options.batchSize);
-    console.log(`[${JOB_NAME}] (dry-run) would run ${batches.length} batches of up to ${options.batchSize} items.`);
+    log('info', 'dry_run_plan', `(dry-run) would run ${batches.length} batches of up to ${options.batchSize} items`, {
+      batches: batches.length,
+      batch_size: options.batchSize,
+    });
     return {
       scanned: albumIds.length,
       batches: batches.length,
@@ -524,16 +545,29 @@ export const runBackfill = async (options: BackfillOptions): Promise<BackfillSum
       dryRun: false,
       readTimeoutMs: options.readTimeoutMs,
     });
-    const elapsedMs = Date.now() - t0;
+    const wallClockMs = Date.now() - t0;
 
     totalMatch += result.match;
     totalNoMatch += result.no_match;
     totalError += result.error;
     totalUpserts += result.upserts;
 
-    console.log(
-      `[${JOB_NAME}] batch=${i + 1}/${batches.length} size=${result.batchSize} match=${result.match} no_match=${result.no_match} error=${result.error} upserts=${result.upserts} elapsed_ms=${elapsedMs}`
-    );
+    // Field names are pinned to the BS#1078 Phase 3 runbook's `jq` watchdog
+    // (`docs/ops-album-level-backfill-phase3.md`). The watchdog filters on
+    // `.step=="batch_done" and .wall_clock_ms>25000`; the aggregate-first-20
+    // probe sums `.scanned` and `.lml_error`. Don't rename these without
+    // updating the runbook in lockstep — silent rename will leave the
+    // watchdog matching nothing again (BS#1179).
+    log('info', 'batch_done', `batch ${i + 1}/${batches.length} done`, {
+      batch_index: i + 1,
+      batches: batches.length,
+      scanned: result.batchSize,
+      match: result.match,
+      no_match: result.no_match,
+      lml_error: result.error,
+      upserts: result.upserts,
+      wall_clock_ms: wallClockMs,
+    });
 
     if (i < batches.length - 1 && interBatchSleepMs > 0) {
       await sleep(interBatchSleepMs);
@@ -546,11 +580,18 @@ export const runBackfill = async (options: BackfillOptions): Promise<BackfillSum
   // doesn't enter a 3-hour write window. Probe-and-defer happens BEFORE
   // opening the transaction, never inside it.
   await awaitQuietWindow(options.liveActivityLookbackSeconds, options.liveActivityPauseMs);
-  console.log(`[${JOB_NAME}] starting post-pass UPDATE (statement_timeout=${options.postPassTimeoutMs}ms)`);
+  log('info', 'post_pass_started', `starting post-pass UPDATE`, {
+    statement_timeout_ms: options.postPassTimeoutMs,
+  });
   const t0 = Date.now();
   const flipped = await runPostPassUpdate(options.postPassTimeoutMs);
-  const elapsedMs = Date.now() - t0;
-  console.log(`[${JOB_NAME}] post-pass UPDATE flipped=${flipped} elapsed_ms=${elapsedMs}`);
+  const wallClockMs = Date.now() - t0;
+  // `post_pass_update_done` is the literal grep target in the runbook's
+  // Step 5 ("verify it completed"). Keep this step name stable.
+  log('info', 'post_pass_update_done', `post-pass UPDATE flipped=${flipped}`, {
+    flipped,
+    wall_clock_ms: wallClockMs,
+  });
 
   return {
     scanned: albumIds.length,
@@ -563,33 +604,22 @@ export const runBackfill = async (options: BackfillOptions): Promise<BackfillSum
   };
 };
 
-const resolveTracesSampleRate = (raw: string | undefined): number => {
-  if (raw === undefined) return 0;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
-  return parsed;
-};
-
 const main = async (): Promise<void> => {
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    release: process.env.SENTRY_RELEASE,
-    environment: process.env.NODE_ENV || 'production',
-    tracesSampleRate: resolveTracesSampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE),
-  });
-  Sentry.setTag('repo', 'Backend-Service');
-  Sentry.setTag('tool', JOB_NAME);
+  const runId = initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
 
   try {
     const options = resolveOptions();
     const summary = await runBackfill(options);
-    console.log(`[${JOB_NAME}] DONE ${JSON.stringify(summary)}`);
+    log('info', 'finished', `${JOB_NAME} done`, { run_id: runId, ...summary });
   } catch (err) {
-    Sentry.captureException(err, { tags: { step: 'main' } });
-    console.error(`[${JOB_NAME}] FAILED:`, err);
+    captureError(err, 'main');
+    log('error', 'failed', `${JOB_NAME} failed: ${err instanceof Error ? err.message : String(err)}`, {
+      error_message: err instanceof Error ? err.message : String(err),
+      error_name: err instanceof Error ? err.name : null,
+    });
     process.exitCode = 1;
   } finally {
-    await Sentry.close(2000);
+    await closeLogger();
     await closeDatabaseConnection();
   }
 };

--- a/jobs/album-level-backfill/logger.ts
+++ b/jobs/album-level-backfill/logger.ts
@@ -1,0 +1,97 @@
+/**
+ * Observability for album-level-backfill: Sentry init + JSON logs.
+ *
+ * Every log line carries the four tags `repo`, `tool`, `step`, `run_id` so
+ * downstream consumers (the BS#1078 Phase 3 runbook's `jq` watchdog, the
+ * Loki/CloudWatch pipeline) can filter by step without a regex over
+ * free-form prose. Sentry stays inactive when SENTRY_DSN is unset (the
+ * @sentry/node SDK silently no-ops in that case), so this module is safe to
+ * call from any environment.
+ *
+ * Mirrors `jobs/flowsheet-metadata-backfill/logger.ts` verbatim — the
+ * contract is identical, the duplication is the established pattern for
+ * keeping each one-shot job's build graph independent of the others.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+// `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+/**
+ * Initialize Sentry and the structured logger. Call once at the top of the
+ * entrypoint, before any other logic. Returns the resolved `run_id` so the
+ * caller can pass it to subprocesses or persist it for cross-system tracing.
+ */
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+/**
+ * Emit a JSON log line. `info`/`warn` go to stdout, `error` goes to stderr
+ * so container log shippers can split streams by severity.
+ *
+ * Silently no-ops when called before `initLogger()` so unit tests that
+ * exercise library functions directly (without invoking the entrypoint)
+ * don't have to thread an init call through every fixture.
+ */
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+/** Capture an exception to Sentry with the current run's tags + an extra `step`. */
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+/** Flush pending Sentry events. Call from the entrypoint's `finally`. */
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/tests/unit/jobs/album-level-backfill/logger.test.ts
+++ b/tests/unit/jobs/album-level-backfill/logger.test.ts
@@ -1,9 +1,9 @@
 /**
  * Tests for the album-level-backfill observability logger's pure helpers.
- * The init / JSON-line behavior mirrors `jobs/flowsheet-etl/logger.ts`
- * verbatim and is exercised by that job's smoke tests; the duplicated
- * resolveTracesSampleRate is re-asserted here so the duplication doesn't
- * drift silently.
+ * The init / JSON-line behavior mirrors `jobs/flowsheet-metadata-backfill/logger.ts`
+ * verbatim and is exercised by `tests/unit/jobs/flowsheet-etl/logger.test.ts`;
+ * the duplicated resolveTracesSampleRate is re-asserted here so the
+ * per-job duplication doesn't drift silently.
  */
 
 import { resolveTracesSampleRate } from '../../../../jobs/album-level-backfill/logger';

--- a/tests/unit/jobs/album-level-backfill/logger.test.ts
+++ b/tests/unit/jobs/album-level-backfill/logger.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Tests for the album-level-backfill observability logger's pure helpers.
+ * The init / JSON-line behavior mirrors `jobs/flowsheet-etl/logger.ts`
+ * verbatim and is exercised by that job's smoke tests; the duplicated
+ * resolveTracesSampleRate is re-asserted here so the duplication doesn't
+ * drift silently.
+ */
+
+import { resolveTracesSampleRate } from '../../../../jobs/album-level-backfill/logger';
+
+describe('resolveTracesSampleRate', () => {
+  it('defaults to 0 when env var is unset', () => {
+    expect(resolveTracesSampleRate(undefined)).toBe(0);
+  });
+
+  it('parses valid values in [0, 1]', () => {
+    expect(resolveTracesSampleRate('0')).toBe(0);
+    expect(resolveTracesSampleRate('0.5')).toBe(0.5);
+    expect(resolveTracesSampleRate('1')).toBe(1);
+    expect(resolveTracesSampleRate('1.0')).toBe(1);
+  });
+
+  it('falls back to 0 on malformed or out-of-range values', () => {
+    expect(resolveTracesSampleRate('abc')).toBe(0);
+    expect(resolveTracesSampleRate('-0.5')).toBe(0);
+    expect(resolveTracesSampleRate('1.5')).toBe(0);
+    expect(resolveTracesSampleRate('NaN')).toBe(0);
+    expect(resolveTracesSampleRate('Infinity')).toBe(0);
+  });
+});

--- a/tests/unit/jobs/album-level-backfill/runbook-log-contract.test.ts
+++ b/tests/unit/jobs/album-level-backfill/runbook-log-contract.test.ts
@@ -1,0 +1,209 @@
+/**
+ * BS#1179 regression pin: the album-level-backfill drain log shape MUST stay
+ * in lockstep with the BS#1078 Phase 3 runbook's `jq` watchdog and grep
+ * probes (`docs/ops-album-level-backfill-phase3.md`).
+ *
+ * The 2026-05-27 incident: the runbook's `jq -r 'select(.step=="batch_done"
+ * and .wall_clock_ms>25000) ...'` watchdog was wired into a launcher script
+ * but the job emitted plain text with `elapsed_ms`, so the filter never
+ * matched. A fully-failing 14.5h drain ran unnoticed.
+ *
+ * These tests assert the structural contract the runbook reads:
+ *   - `step: 'batch_done'` per batch with `wall_clock_ms`, `batch_index`,
+ *     `scanned`, `lml_error` keys
+ *   - `step: 'lml_batch_failed'` when bulkLookupMetadata throws, with
+ *     `size`, `first_album_id`, `last_album_id`, `error_message` keys
+ *   - `step: 'post_pass_update_done'` after the post-pass UPDATE (Step 5
+ *     grep target in the runbook)
+ *
+ * Renaming any of these keys (or the step names) without updating the
+ * runbook in lockstep will break the watchdog silently. Don't.
+ */
+
+import { jest } from '@jest/globals';
+
+const mockBulkLookupMetadata = jest.fn<(items: unknown, opts?: unknown) => Promise<unknown>>();
+jest.mock('@wxyc/lml-client', () => ({
+  __esModule: true,
+  bulkLookupMetadata: mockBulkLookupMetadata,
+}));
+
+import { db } from '@wxyc/database';
+import { runBackfill, type BackfillOptions } from '../../../../jobs/album-level-backfill/job';
+import { initLogger, closeLogger } from '../../../../jobs/album-level-backfill/logger';
+
+type JsonLine = Record<string, unknown>;
+
+const baseOptions = (over: Partial<BackfillOptions> = {}): BackfillOptions => ({
+  batchSize: 2,
+  ratePerMin: 60_000, // sleep ≈ 1ms between batches; keeps tests fast
+  budgetMs: 25_000,
+  postPassTimeoutMs: 60_000,
+  readTimeoutMs: 300_000,
+  liveActivityLookbackSeconds: 0,
+  liveActivityPauseMs: 1,
+  dryRun: false,
+  ...over,
+});
+
+const captureStdoutJson = (): JsonLine[] => {
+  const lines: JsonLine[] = [];
+  jest.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    const text = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString();
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        lines.push(JSON.parse(line) as JsonLine);
+      } catch {
+        // Non-JSON stdout (jest worker chatter etc.) is ignored.
+      }
+    }
+    return true;
+  });
+  return lines;
+};
+
+const captureStderrJson = (): JsonLine[] => {
+  const lines: JsonLine[] = [];
+  jest.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    const text = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString();
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        lines.push(JSON.parse(line) as JsonLine);
+      } catch {
+        // Non-JSON stderr (e.g. Sentry's own warnings) is ignored.
+      }
+    }
+    return true;
+  });
+  return lines;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.SENTRY_DSN;
+  initLogger({ repo: 'Backend-Service', tool: 'album-level-backfill', runId: 'test-run' });
+});
+
+afterEach(async () => {
+  jest.restoreAllMocks();
+  await closeLogger();
+});
+
+const wrappedSelect = (rows: unknown[]): [unknown, unknown] => [{}, rows];
+
+describe('runbook log contract — batch_done', () => {
+  it('emits one batch_done JSON record per batch with wall_clock_ms / batch_index / scanned / lml_error', async () => {
+    const resolved = [
+      { album_id: 1, artist_name: 'A', album_title: 'X' },
+      { album_id: 2, artist_name: 'B', album_title: 'Y' },
+    ];
+    const mock = db.execute as jest.Mock;
+    for (const v of [
+      ...wrappedSelect([{ album_id: 1 }, { album_id: 2 }, { album_id: 3 }, { album_id: 4 }]),
+      ...wrappedSelect(resolved),
+      ...wrappedSelect(resolved),
+      ...wrappedSelect([{ flipped: 0 }]),
+    ]) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mockBulkLookupMetadata.mockResolvedValue({
+      results: [
+        { index: 0, status: 'no_match', lookup: { results: [] } },
+        { index: 1, status: 'error', lookup: null, message: 'Boom' },
+      ],
+    });
+
+    const stdoutLines = captureStdoutJson();
+    await runBackfill(baseOptions({ batchSize: 2 }));
+
+    const batchDone = stdoutLines.filter((l) => l.step === 'batch_done');
+    // BS#1078 runbook watchdog (line 122 of ops-album-level-backfill-phase3.md):
+    //   jq -r 'select(.step=="batch_done" and .wall_clock_ms>25000) | "...batch_index=\(.batch_index)..."'
+    // Both `step==='batch_done'` and the `wall_clock_ms` + `batch_index` keys
+    // MUST exist or the watchdog stays silent.
+    expect(batchDone.length).toBe(2);
+    for (const rec of batchDone) {
+      expect(typeof rec.wall_clock_ms).toBe('number');
+      expect(typeof rec.batch_index).toBe('number');
+      // Step-4 aggregate (line 138-145 of the runbook) sums `.scanned` and
+      // `.lml_error // 0`. Both keys must be numeric.
+      expect(typeof rec.scanned).toBe('number');
+      expect(typeof rec.lml_error).toBe('number');
+      // Spot-check the other accounting keys we emit alongside.
+      expect(rec).toHaveProperty('match');
+      expect(rec).toHaveProperty('no_match');
+      expect(rec).toHaveProperty('upserts');
+      expect(rec).toHaveProperty('batches');
+      // Tag bundle from the base logger.
+      expect(rec.repo).toBe('Backend-Service');
+      expect(rec.tool).toBe('album-level-backfill');
+      expect(rec.run_id).toBe('test-run');
+    }
+    // Per-batch lml_error reflects the LML per-item error.
+    expect(batchDone[0].lml_error).toBe(1);
+    expect(batchDone[1].lml_error).toBe(1);
+  });
+});
+
+describe('runbook log contract — lml_batch_failed', () => {
+  it('emits structured lml_batch_failed on bulkLookupMetadata throw (replaces the BS#1179 plain-text line)', async () => {
+    const resolved = [
+      { album_id: 100, artist_name: 'A', album_title: 'X' },
+      { album_id: 200, artist_name: 'B', album_title: 'Y' },
+    ];
+    const mock = db.execute as jest.Mock;
+    for (const v of [
+      ...wrappedSelect([{ album_id: 100 }, { album_id: 200 }]),
+      ...wrappedSelect(resolved),
+      ...wrappedSelect([{ flipped: 0 }]),
+    ]) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mockBulkLookupMetadata.mockRejectedValueOnce(
+      Object.assign(new Error('LML request timed out'), { name: 'LmlClientError' })
+    );
+
+    const stdoutLines = captureStdoutJson();
+    const stderrLines = captureStderrJson();
+    await runBackfill(baseOptions({ batchSize: 2 }));
+
+    const failed = [...stdoutLines, ...stderrLines].find((l) => l.step === 'lml_batch_failed');
+    expect(failed).toBeDefined();
+    // The plain-text line at jobs/album-level-backfill/job.ts (pre-#1179)
+    // packed first/last_album_id + error into a flat string; the runbook
+    // can't tail-and-filter it. Now structured so `jq` can.
+    expect(failed?.size).toBe(2);
+    expect(failed?.first_album_id).toBe(100);
+    expect(failed?.last_album_id).toBe(200);
+    expect(failed?.error_message).toMatch(/LmlClientError: LML request timed out/);
+    expect(failed?.level).toBe('warn');
+  });
+});
+
+describe('runbook log contract — post_pass_update_done', () => {
+  it('emits post_pass_update_done after the post-pass UPDATE (Step 5 grep target)', async () => {
+    const resolved = [{ album_id: 1, artist_name: 'A', album_title: 'X' }];
+    const mock = db.execute as jest.Mock;
+    for (const v of [
+      ...wrappedSelect([{ album_id: 1 }]),
+      ...wrappedSelect(resolved),
+      ...wrappedSelect([{ flipped: 42 }]),
+    ]) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mockBulkLookupMetadata.mockResolvedValue({
+      results: [{ index: 0, status: 'no_match', lookup: { results: [] } }],
+    });
+
+    const stdoutLines = captureStdoutJson();
+    await runBackfill(baseOptions({ batchSize: 1 }));
+
+    // Runbook Step 5 (line 155): grep '"step":"post_pass_update_done"' /tmp/...
+    const done = stdoutLines.find((l) => l.step === 'post_pass_update_done');
+    expect(done).toBeDefined();
+    expect(done?.flipped).toBe(42);
+    expect(typeof done?.wall_clock_ms).toBe('number');
+  });
+});

--- a/tests/unit/jobs/album-level-backfill/runbook-log-contract.test.ts
+++ b/tests/unit/jobs/album-level-backfill/runbook-log-contract.test.ts
@@ -46,33 +46,16 @@ const baseOptions = (over: Partial<BackfillOptions> = {}): BackfillOptions => ({
   ...over,
 });
 
-const captureStdoutJson = (): JsonLine[] => {
+const captureJson = (stream: 'stdout' | 'stderr'): JsonLine[] => {
   const lines: JsonLine[] = [];
-  jest.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+  jest.spyOn(process[stream], 'write').mockImplementation((chunk: unknown) => {
     const text = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString();
     for (const line of text.split('\n')) {
       if (!line.trim()) continue;
       try {
         lines.push(JSON.parse(line) as JsonLine);
       } catch {
-        // Non-JSON stdout (jest worker chatter etc.) is ignored.
-      }
-    }
-    return true;
-  });
-  return lines;
-};
-
-const captureStderrJson = (): JsonLine[] => {
-  const lines: JsonLine[] = [];
-  jest.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
-    const text = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString();
-    for (const line of text.split('\n')) {
-      if (!line.trim()) continue;
-      try {
-        lines.push(JSON.parse(line) as JsonLine);
-      } catch {
-        // Non-JSON stderr (e.g. Sentry's own warnings) is ignored.
+        // Non-JSON output (jest worker chatter, Sentry's own warnings) is ignored.
       }
     }
     return true;
@@ -115,33 +98,29 @@ describe('runbook log contract — batch_done', () => {
       ],
     });
 
-    const stdoutLines = captureStdoutJson();
+    const stdoutLines = captureJson('stdout');
     await runBackfill(baseOptions({ batchSize: 2 }));
 
-    const batchDone = stdoutLines.filter((l) => l.step === 'batch_done');
     // BS#1078 runbook watchdog (line 122 of ops-album-level-backfill-phase3.md):
     //   jq -r 'select(.step=="batch_done" and .wall_clock_ms>25000) | "...batch_index=\(.batch_index)..."'
-    // Both `step==='batch_done'` and the `wall_clock_ms` + `batch_index` keys
-    // MUST exist or the watchdog stays silent.
+    // Step-4 aggregate (lines 138-145) sums `.scanned` and `.lml_error // 0`.
+    // Renaming any of these keys without updating the runbook will silently
+    // re-break the watchdog (BS#1179).
+    const batchDone = stdoutLines.filter((l) => l.step === 'batch_done');
     expect(batchDone.length).toBe(2);
     for (const rec of batchDone) {
       expect(typeof rec.wall_clock_ms).toBe('number');
       expect(typeof rec.batch_index).toBe('number');
-      // Step-4 aggregate (line 138-145 of the runbook) sums `.scanned` and
-      // `.lml_error // 0`. Both keys must be numeric.
       expect(typeof rec.scanned).toBe('number');
       expect(typeof rec.lml_error).toBe('number');
-      // Spot-check the other accounting keys we emit alongside.
       expect(rec).toHaveProperty('match');
       expect(rec).toHaveProperty('no_match');
       expect(rec).toHaveProperty('upserts');
       expect(rec).toHaveProperty('batches');
-      // Tag bundle from the base logger.
       expect(rec.repo).toBe('Backend-Service');
       expect(rec.tool).toBe('album-level-backfill');
       expect(rec.run_id).toBe('test-run');
     }
-    // Per-batch lml_error reflects the LML per-item error.
     expect(batchDone[0].lml_error).toBe(1);
     expect(batchDone[1].lml_error).toBe(1);
   });
@@ -165,15 +144,15 @@ describe('runbook log contract — lml_batch_failed', () => {
       Object.assign(new Error('LML request timed out'), { name: 'LmlClientError' })
     );
 
-    const stdoutLines = captureStdoutJson();
-    const stderrLines = captureStderrJson();
+    // Pre-#1179 the plain-text line packed first/last_album_id + error into
+    // a flat string; the runbook can't tail-and-filter it. Now structured
+    // so `jq` can.
+    const stdoutLines = captureJson('stdout');
+    const stderrLines = captureJson('stderr');
     await runBackfill(baseOptions({ batchSize: 2 }));
 
     const failed = [...stdoutLines, ...stderrLines].find((l) => l.step === 'lml_batch_failed');
     expect(failed).toBeDefined();
-    // The plain-text line at jobs/album-level-backfill/job.ts (pre-#1179)
-    // packed first/last_album_id + error into a flat string; the runbook
-    // can't tail-and-filter it. Now structured so `jq` can.
     expect(failed?.size).toBe(2);
     expect(failed?.first_album_id).toBe(100);
     expect(failed?.last_album_id).toBe(200);
@@ -197,7 +176,7 @@ describe('runbook log contract — post_pass_update_done', () => {
       results: [{ index: 0, status: 'no_match', lookup: { results: [] } }],
     });
 
-    const stdoutLines = captureStdoutJson();
+    const stdoutLines = captureJson('stdout');
     await runBackfill(baseOptions({ batchSize: 1 }));
 
     // Runbook Step 5 (line 155): grep '"step":"post_pass_update_done"' /tmp/...


### PR DESCRIPTION
## Problem

The BS#1078 Phase 3 runbook (`docs/ops-album-level-backfill-phase3.md`) wires a `jq`-based abort watchdog onto the drain log:

```sh
tail -f /tmp/bs-1078-phase3-*.log \
  | jq -r 'select(.step=="batch_done" and .wall_clock_ms>25000) | "ABORT: batch_index=\(.batch_index) wall_clock_ms=\(.wall_clock_ms)"' \
  | head -1
```

The job was emitting plain text with `elapsed_ms`:

```
[album-level-backfill] batch=182/374 size=50 ... elapsed_ms=30016
[album-level-backfill] lml.batch_failed size=50 first_album_id=40028 ...
```

Field names disagree (`wall_clock_ms` vs `elapsed_ms`); shape disagrees (JSON object per line vs plain text). The watchdog matched nothing, so the 2026-05-27 14.5h all-error drain (BS#1178) ran unnoticed.

## Fix

Option 1 from #1179 (preferred): align the drain to JSON logging.

- New `jobs/album-level-backfill/logger.ts`, mirroring `jobs/flowsheet-metadata-backfill/logger.ts` (intentional per-job duplication for build-graph isolation, per the comment in the sibling file).
- `runBackfill` now emits one `step:'batch_done'` JSON record per batch with `wall_clock_ms`, `batch_index`, `batches`, `scanned`, `match`, `no_match`, `lml_error`, `upserts` — exactly the keys the runbook's `jq` filters (lines 107/122/138) consume.
- HTTP-level bulk-call throws emit `step:'lml_batch_failed'` as a structured record with `size`, `first_album_id`, `last_album_id`, `error_message`, and `Sentry.captureException` with the same tag (no longer silent past the warn line).
- Other top-level emissions (`started`, `enumerated`, `analyze_started`, `live_activity_pause`, `post_pass_started`, `post_pass_update_done`, `finished`, `failed`) get matching step names. `post_pass_update_done` is the literal grep target in the runbook's Step 5.
- `main()` initializes via `initLogger` and flushes via `closeLogger` — same shape as `flowsheet-metadata-backfill`.

The runbook itself needed no edits — it was written against this contract; only the job had drifted.

## Pin against silent rename

`tests/unit/jobs/album-level-backfill/runbook-log-contract.test.ts` runs `runBackfill` with mocked LML + DB, captures `process.stdout/stderr`, parses each JSON line, and asserts the runbook's load-bearing keys (`step`, `wall_clock_ms`, `batch_index`, `scanned`, `lml_error` on `batch_done`; `size`, `first_album_id`, `last_album_id`, `error_message` on `lml_batch_failed`; `flipped`, `wall_clock_ms` on `post_pass_update_done`). A future PR that renames any of these without updating the runbook will fail this test.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (only pre-existing warnings in unrelated files)
- [x] `npm run format:check` — clean
- [x] `npx jest --config jest.unit.config.ts tests/unit/jobs/album-level-backfill/` — 58/58 pass (4 suites, including the 3 new contract tests)
- [x] Full `npm run test:unit` — 2426/2427 pass; the 1 failure (`schema.flowsheet-artwork-lookup-idx.test.ts`) reproduces on `main` and is unrelated
- [ ] Next prod Phase 3 attempt verifies the runbook's `jq` watchdog actually fires when a synthetic >25 000 ms batch is injected (per #1179 acceptance bullet 2)

Closes #1179

## Related

- BS#1078 — Phase 3 runbook
- BS#1178 — the 2026-05-27 silent drain that surfaced this gap
- BS#1041 — album-level-backfill job