### PR TITLE
fix(album-level-backfill): scale bulk-fetch timeout to batch size; lower default to 10

### DIFF
--- a/jobs/album-level-backfill/README.md
+++ b/jobs/album-level-backfill/README.md
@@ -24,7 +24,7 @@ If `linked_pending / unique_album_ids > 5`, the dedup payoff justifies the run.
 
 1. `SELECT DISTINCT album_id` from pending flowsheet rows with non-null `album_id`.
 2. Resolve each chunk of album_ids to `(artist_name, album_title)` via `library` + `artists` join.
-3. Call LML `POST /api/v1/lookup/bulk` with batches of `BACKFILL_BULK_BATCH_SIZE` items (default 50).
+3. Call LML `POST /api/v1/lookup/bulk` with batches of `BACKFILL_BULK_BATCH_SIZE` items (default 10). The per-batch fetch timeout scales with this value (`batchSize × 2.5 s + 5 s` slack) so a cascade-heavy batch can't exhaust the shared LML-client's 30 s default (BS#1178).
 4. For each `match` result, UPSERT into `album_metadata` with the same race-guarded `setWhere: updated_at < NOW()` shape the enrichment-worker uses.
 5. After all bulk calls complete, ANALYZE `album_metadata`.
 6. Cooperative pause until quiet, then post-pass UPDATE: `WITH matched AS (UPDATE flowsheet ... FROM album_metadata) SELECT count(*)`. Scoped inside `db.transaction` + `SET LOCAL statement_timeout`.
@@ -49,7 +49,10 @@ docker stop flowsheet-metadata-backfill-cron
 # 4. Run a dry-run first to verify env + scope
 docker run --rm --env-file .env <image> --dry-run
 
-# 5. Run for real (expected wall-clock: ~12 hours at default 1 batch/min)
+# 5. Run for real. At post-BS#1178 defaults (batch=10, rate=1/min ≈ 10 items/min)
+#    a full 35,692-album drain takes ~60 h. For catch-up runs, bump
+#    BACKFILL_BULK_RATE_PER_MIN (e.g. 3 → ~20 h) — keep BATCH_SIZE at 10
+#    so the per-batch fetch-timeout headroom stays intact.
 docker run --rm --env-file .env <image> 2>&1 | tee /tmp/album-level-backfill.log
 
 # 6. Sanity check
@@ -70,17 +73,17 @@ psql "$DATABASE_URL" -c "
 
 ## Env knobs
 
-| Variable                                    | Default            | Meaning                                                                                |
-| ------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------- |
-| `BACKFILL_BULK_BATCH_SIZE`                  | `50`               | Items per LML bulk request. LML caps at 100.                                           |
-| `BACKFILL_BULK_RATE_PER_MIN`                | `1`                | Batches per minute. 1/min ≈ 50 items/min sustained.                                    |
-| `BACKFILL_BULK_BUDGET_MS`                   | `25000`            | Forwarded to LML as `X-Caller-Budget-Ms`.                                              |
-| `ALBUM_LEVEL_BACKFILL_POST_PASS_TIMEOUT_MS` | `14400000` (4h)    | `SET LOCAL statement_timeout` for the post-pass UPDATE.                                |
-| `ALBUM_LEVEL_BACKFILL_READ_TIMEOUT_MS`      | `300000` (5min)    | `SET LOCAL statement_timeout` for the enumerate scan + per-batch resolveAlbums lookup. |
-| `LIVE_ACTIVITY_LOOKBACK_SECONDS`            | `300`              | Cooperative-pause lookback window; `0` disables.                                       |
-| `LIBRARY_METADATA_URL`                      | (required)         | LML base URL.                                                                          |
-| `LML_API_KEY`                               | (required in prod) | LML bearer token.                                                                      |
-| `DATABASE_URL`                              | (required)         | Postgres connection string.                                                            |
+| Variable                                    | Default            | Meaning                                                                                       |
+| ------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------- |
+| `BACKFILL_BULK_BATCH_SIZE`                  | `10`               | Items per LML bulk request. LML caps at 100. Raising this scales the fetch timeout (BS#1178). |
+| `BACKFILL_BULK_RATE_PER_MIN`                | `1`                | Batches per minute. At the default batch size, 1/min ≈ 10 items/min sustained.                |
+| `BACKFILL_BULK_BUDGET_MS`                   | `25000`            | Per-item budget forwarded to LML as `X-Caller-Budget-Ms`. NOT the batch fetch timeout.        |
+| `ALBUM_LEVEL_BACKFILL_POST_PASS_TIMEOUT_MS` | `14400000` (4h)    | `SET LOCAL statement_timeout` for the post-pass UPDATE.                                       |
+| `ALBUM_LEVEL_BACKFILL_READ_TIMEOUT_MS`      | `300000` (5min)    | `SET LOCAL statement_timeout` for the enumerate scan + per-batch resolveAlbums lookup.        |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`            | `300`              | Cooperative-pause lookback window; `0` disables.                                              |
+| `LIBRARY_METADATA_URL`                      | (required)         | LML base URL.                                                                                 |
+| `LML_API_KEY`                               | (required in prod) | LML bearer token.                                                                             |
+| `DATABASE_URL`                              | (required)         | Postgres connection string.                                                                   |
 
 ## Acceptance verification
 

--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -43,66 +43,39 @@ const JOB_NAME = 'album-level-backfill';
 
 // -- Env knobs ---------------------------------------------------------------
 
-/** Items per bulk-lookup request. LML's hard cap is 100; default 10 is
+/** Items per bulk-lookup request. LML hard cap is 100; default 10 is
  * sized so one wave of LML's internal `LML_BULK_MAX_CONCURRENT=10`
- * fan-out fits inside a single per-item `caller_budget_ms` window —
- * keeping the worst-case wall-clock under the shared LML-client fetch
- * ceiling. Prior default of 50 (BS#1178) produced
- * `error=50 elapsed_ms=30016` on every batch because cascade-bait items
- * amortize at ~2.1 s each (LML#370 per-item cap is 25 s) and 50 × 2.1 s
- * blows past the 30 s shared-client timeout, so every call hit
- * `LmlClientError: LML request timed out` before any per-item verdict
- * was returned. The dynamic timeout in `computeBulkTimeoutMs` scales
- * with this value; raising it without raising the slack reintroduces
- * the same failure mode. */
+ * fan-out fits inside a single per-item `caller_budget_ms` window.
+ * `computeBulkTimeoutMs` scales the fetch timeout with this value;
+ * raising the env override without paired slack reintroduces the
+ * 30 s shared-client timeout. */
 export const BULK_BATCH_SIZE_ENV = 'BACKFILL_BULK_BATCH_SIZE';
 export const BULK_BATCH_SIZE_DEFAULT = 10;
 
 /** Batches per minute. Bound the bulk caller so it can run concurrently
  * with the per-row drain cron (BS#995, 4 items/min) without saturating
- * LML's serial Discogs fan-out. At the post-BS#1178 default
- * `BULK_BATCH_SIZE_DEFAULT=10`, 1 batch/min ≈ 10 items/min sustained;
- * operators tuning for catch-up should raise `BACKFILL_BULK_RATE_PER_MIN`
- * (not `BACKFILL_BULK_BATCH_SIZE`) to scale throughput without
- * regressing the per-batch fetch-timeout headroom. */
+ * LML's serial Discogs fan-out. Catch-up throughput should come from
+ * raising this knob, not `BACKFILL_BULK_BATCH_SIZE` — see README. */
 export const BULK_RATE_PER_MIN_ENV = 'BACKFILL_BULK_RATE_PER_MIN';
 export const BULK_RATE_PER_MIN_DEFAULT = 1;
 
-/** Per-ITEM wall-clock budget forwarded to LML as `X-Caller-Budget-Ms`.
- * LML's per-item `perform_lookup` uses this as `min(header, env default)`
- * (A8 / LML#345); it caps each individual cascade, not the whole batch.
- * 25 s matches LML's own ceiling. The fetch-level timeout that wraps
- * the entire bulk call is computed dynamically by `computeBulkTimeoutMs`
- * — do not interpret this as a batch budget. */
+/** Per-ITEM budget forwarded to LML as `X-Caller-Budget-Ms` (A8 / LML#345).
+ * Caps each individual cascade inside the bulk call, NOT the whole batch.
+ * The fetch-level timeout is computed dynamically by `computeBulkTimeoutMs`. */
 export const BULK_BUDGET_MS_ENV = 'BACKFILL_BULK_BUDGET_MS';
 export const BULK_BUDGET_MS_DEFAULT = 25_000;
 
-/** Per-item slice of the bulk fetch timeout. Cascade-bait items
- * empirically amortize at ~2.1 s server-side (LML#370 cap is 25 s;
- * cache-warm items resolve in 100–500 ms but the cascade-heavy ones
- * dominate the per-batch wall-clock). 2.5 s matches LML's amortized
- * rate (`BULK_BUDGET_MS_DEFAULT / LML_BULK_MAX_CONCURRENT = 25_000 /
- * 10`) so the linear formula in `computeBulkTimeoutMs` agrees with
- * the wave-based worst case for sizes that fall on a 10-item boundary
- * and stays conservative in between. Pinned by unit test. */
+/** Per-item slice of the bulk fetch timeout. Matches LML's amortized
+ * rate: `BULK_BUDGET_MS_DEFAULT / LML_BULK_MAX_CONCURRENT = 25_000 / 10`. */
 export const BULK_PER_ITEM_TIMEOUT_MS = 2_500;
 
-/** Fixed slack added on top of `batchSize × BULK_PER_ITEM_TIMEOUT_MS`.
- * Covers HTTP overhead, JSON encode/decode, and a small safety margin
- * for the case where every item in the batch happens to hit LML's
- * per-item cap. Pinned by unit test. */
+/** Fixed slack on top of `batchSize × BULK_PER_ITEM_TIMEOUT_MS`:
+ * HTTP overhead + JSON encode/decode + safety margin. */
 export const BULK_TIMEOUT_SLACK_MS = 5_000;
 
-/** Compute the client-side fetch timeout for one bulk call.
- *
- * BS#1178: the shared `lmlFetch` defaults `TIMEOUT_MS = 30_000`, sized
- * against the single-item `/api/v1/lookup` endpoint. The bulk endpoint's
- * wall-clock scales with batch size, so callers must override it. This
- * helper keeps the relationship explicit — change `BULK_BATCH_SIZE_*`,
- * and the fetch timeout follows automatically; the unit test in
- * `tests/unit/jobs/album-level-backfill/job.test.ts` pins it so a
- * future bump to either knob without the matching slack regresses
- * loudly. */
+/** Scale the LML-client fetch timeout to batch size. The shared
+ * `lmlFetch` default (30 s) is sized against the single-item endpoint;
+ * bulk wall-clock scales with batch size, so callers must override. */
 export const computeBulkTimeoutMs = (batchSize: number): number =>
   batchSize * BULK_PER_ITEM_TIMEOUT_MS + BULK_TIMEOUT_SLACK_MS;
 
@@ -435,16 +408,10 @@ export const runBatch = async (
 
   // Isolate HTTP-level failures (timeout, 5xx, network) so a single bad
   // batch can't abort the whole run. LML's bulk endpoint already
-  // isolates per-item failures via `status: 'error'` in its response —
-  // but if the HTTP call itself throws (LmlClientError on the fetch
-  // timeout, BS#1076 / BS#1178), the loop dies without try/catch.
-  // Treat a thrown batch as "all N items errored"; the per-row drain
-  // cron picks those album_ids up on its next sweep. Idempotency holds:
-  // nothing was UPSERTed.
-  //
-  // The fetch-level timeout is scaled to batch size (BS#1178) so the
-  // 30 s shared-client default doesn't fire mid-cascade — see
-  // `computeBulkTimeoutMs` above.
+  // isolates per-item failures via `status: 'error'`; if the HTTP call
+  // itself throws (LmlClientError on the fetch timeout, BS#1076), treat
+  // the whole batch as N errors and let the per-row drain cron retry on
+  // its next sweep. Idempotency holds: nothing was UPSERTed.
   const timeoutMs = computeBulkTimeoutMs(items.length);
   let response;
   try {

--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -43,24 +43,68 @@ const JOB_NAME = 'album-level-backfill';
 
 // -- Env knobs ---------------------------------------------------------------
 
-/** Items per bulk-lookup request. LML's hard cap is 100; default 50 is a
- * conservative compromise between roundtrip amortization and per-batch
- * blast radius if a single Discogs cascade goes pathological. */
+/** Items per bulk-lookup request. LML's hard cap is 100; default 10 is
+ * sized so one wave of LML's internal `LML_BULK_MAX_CONCURRENT=10`
+ * fan-out fits inside a single per-item `caller_budget_ms` window —
+ * keeping the worst-case wall-clock under the shared LML-client fetch
+ * ceiling. Prior default of 50 (BS#1178) produced
+ * `error=50 elapsed_ms=30016` on every batch because cascade-bait items
+ * amortize at ~2.1 s each (LML#370 per-item cap is 25 s) and 50 × 2.1 s
+ * blows past the 30 s shared-client timeout, so every call hit
+ * `LmlClientError: LML request timed out` before any per-item verdict
+ * was returned. The dynamic timeout in `computeBulkTimeoutMs` scales
+ * with this value; raising it without raising the slack reintroduces
+ * the same failure mode. */
 export const BULK_BATCH_SIZE_ENV = 'BACKFILL_BULK_BATCH_SIZE';
-export const BULK_BATCH_SIZE_DEFAULT = 50;
+export const BULK_BATCH_SIZE_DEFAULT = 10;
 
 /** Batches per minute. Bound the bulk caller so it can run concurrently
  * with the per-row drain cron (BS#995, 4 items/min) without saturating
- * LML's serial Discogs fan-out. 1 batch/min ≈ 50 items/min sustained. */
+ * LML's serial Discogs fan-out. At the post-BS#1178 default
+ * `BULK_BATCH_SIZE_DEFAULT=10`, 1 batch/min ≈ 10 items/min sustained;
+ * operators tuning for catch-up should raise `BACKFILL_BULK_RATE_PER_MIN`
+ * (not `BACKFILL_BULK_BATCH_SIZE`) to scale throughput without
+ * regressing the per-batch fetch-timeout headroom. */
 export const BULK_RATE_PER_MIN_ENV = 'BACKFILL_BULK_RATE_PER_MIN';
 export const BULK_RATE_PER_MIN_DEFAULT = 1;
 
-/** Per-batch wall-clock budget forwarded to LML as `X-Caller-Budget-Ms`.
- * LML's per-item perform_lookup uses this as min(header, env default)
- * (A8 / LML#345). 25s leaves headroom under the 30s LML-client timeout
- * for HTTP overhead + JSON encode/decode of a 50-item batch. */
+/** Per-ITEM wall-clock budget forwarded to LML as `X-Caller-Budget-Ms`.
+ * LML's per-item `perform_lookup` uses this as `min(header, env default)`
+ * (A8 / LML#345); it caps each individual cascade, not the whole batch.
+ * 25 s matches LML's own ceiling. The fetch-level timeout that wraps
+ * the entire bulk call is computed dynamically by `computeBulkTimeoutMs`
+ * — do not interpret this as a batch budget. */
 export const BULK_BUDGET_MS_ENV = 'BACKFILL_BULK_BUDGET_MS';
 export const BULK_BUDGET_MS_DEFAULT = 25_000;
+
+/** Per-item slice of the bulk fetch timeout. Cascade-bait items
+ * empirically amortize at ~2.1 s server-side (LML#370 cap is 25 s;
+ * cache-warm items resolve in 100–500 ms but the cascade-heavy ones
+ * dominate the per-batch wall-clock). 2.5 s matches LML's amortized
+ * rate (`BULK_BUDGET_MS_DEFAULT / LML_BULK_MAX_CONCURRENT = 25_000 /
+ * 10`) so the linear formula in `computeBulkTimeoutMs` agrees with
+ * the wave-based worst case for sizes that fall on a 10-item boundary
+ * and stays conservative in between. Pinned by unit test. */
+export const BULK_PER_ITEM_TIMEOUT_MS = 2_500;
+
+/** Fixed slack added on top of `batchSize × BULK_PER_ITEM_TIMEOUT_MS`.
+ * Covers HTTP overhead, JSON encode/decode, and a small safety margin
+ * for the case where every item in the batch happens to hit LML's
+ * per-item cap. Pinned by unit test. */
+export const BULK_TIMEOUT_SLACK_MS = 5_000;
+
+/** Compute the client-side fetch timeout for one bulk call.
+ *
+ * BS#1178: the shared `lmlFetch` defaults `TIMEOUT_MS = 30_000`, sized
+ * against the single-item `/api/v1/lookup` endpoint. The bulk endpoint's
+ * wall-clock scales with batch size, so callers must override it. This
+ * helper keeps the relationship explicit — change `BULK_BATCH_SIZE_*`,
+ * and the fetch timeout follows automatically; the unit test in
+ * `tests/unit/jobs/album-level-backfill/job.test.ts` pins it so a
+ * future bump to either knob without the matching slack regresses
+ * loudly. */
+export const computeBulkTimeoutMs = (batchSize: number): number =>
+  batchSize * BULK_PER_ITEM_TIMEOUT_MS + BULK_TIMEOUT_SLACK_MS;
 
 /** Statement timeout for the post-pass UPDATE. The 2026-05-23 drain-accel
  * flipped 309k rows in 80 min; 857k is ~3h; 4h gives a 30% margin. */
@@ -392,13 +436,19 @@ export const runBatch = async (
   // Isolate HTTP-level failures (timeout, 5xx, network) so a single bad
   // batch can't abort the whole run. LML's bulk endpoint already
   // isolates per-item failures via `status: 'error'` in its response —
-  // but if the HTTP call itself throws (LmlClientError on 30s timeout,
-  // BS#1076), the loop dies without try/catch. Treat a thrown batch as
-  // "all N items errored"; the per-row drain cron picks those album_ids
-  // up on its next sweep. Idempotency holds: nothing was UPSERTed.
+  // but if the HTTP call itself throws (LmlClientError on the fetch
+  // timeout, BS#1076 / BS#1178), the loop dies without try/catch.
+  // Treat a thrown batch as "all N items errored"; the per-row drain
+  // cron picks those album_ids up on its next sweep. Idempotency holds:
+  // nothing was UPSERTed.
+  //
+  // The fetch-level timeout is scaled to batch size (BS#1178) so the
+  // 30 s shared-client default doesn't fire mid-cascade — see
+  // `computeBulkTimeoutMs` above.
+  const timeoutMs = computeBulkTimeoutMs(items.length);
   let response;
   try {
-    response = await bulkLookupMetadata(items, { budgetMs: options.budgetMs });
+    response = await bulkLookupMetadata(items, { budgetMs: options.budgetMs, timeoutMs });
   } catch (err) {
     const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
     console.warn(

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -42,6 +42,9 @@ import {
   BULK_RATE_PER_MIN_DEFAULT,
   BULK_RATE_PER_MIN_ENV,
   BULK_BUDGET_MS_DEFAULT,
+  BULK_PER_ITEM_TIMEOUT_MS,
+  BULK_TIMEOUT_SLACK_MS,
+  computeBulkTimeoutMs,
   POST_PASS_TIMEOUT_DEFAULT,
   POST_PASS_TIMEOUT_ENV,
   READ_TIMEOUT_DEFAULT,
@@ -481,7 +484,7 @@ describe('runBatch', () => {
     expect(out).toMatchObject({ match: 0, no_match: 0, error: 0, upserts: 0 });
   });
 
-  it('forwards the resolved items + budgetMs to bulkLookupMetadata', async () => {
+  it('forwards the resolved items + budgetMs + dynamic timeoutMs to bulkLookupMetadata (BS#1178)', async () => {
     mockBulkLookupMetadata.mockResolvedValue({
       results: [
         { index: 0, status: 'no_match', lookup: { results: [] } },
@@ -497,7 +500,11 @@ describe('runBatch', () => {
       { artist: 'Juana Molina', album: 'DOGA', raw_message: 'Juana Molina - DOGA' },
       { artist: 'Jessica Pratt', album: 'OYOLA', raw_message: 'Jessica Pratt - OYOLA' },
     ]);
-    expect(opts).toEqual({ budgetMs: 25000 });
+    // BS#1178: `bulkLookupMetadata` MUST receive an explicit `timeoutMs`
+    // override so the 30 s shared-client default doesn't fire mid-batch
+    // for cascade-heavy items. The value is derived from batch size by
+    // `computeBulkTimeoutMs` and pinned independently below.
+    expect(opts).toEqual({ budgetMs: 25000, timeoutMs: computeBulkTimeoutMs(2) });
   });
 
   it('counts match / no_match / error per response and UPSERTs only matches', async () => {
@@ -557,6 +564,38 @@ describe('runBatch', () => {
 
     expect(out).toMatchObject({ batchSize: 2, match: 0, no_match: 0, error: 2, upserts: 0 });
     expect(db.insert as jest.Mock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bulk-fetch timeout sizing (BS#1178).
+// ---------------------------------------------------------------------------
+
+describe('computeBulkTimeoutMs (BS#1178)', () => {
+  // Pin the linear relationship so a future bump to BULK_BATCH_SIZE_DEFAULT
+  // without a paired slack bump fails loudly here, not in production as
+  // `LmlClientError: LML request timed out`.
+  it('is linear in batchSize: timeoutMs === batchSize × per_item + slack', () => {
+    for (const n of [1, 5, 10, 15, 50, 100]) {
+      expect(computeBulkTimeoutMs(n)).toBe(n * BULK_PER_ITEM_TIMEOUT_MS + BULK_TIMEOUT_SLACK_MS);
+    }
+  });
+
+  // The acceptance bullet on BS#1178 ("Unit test pinning the relationship
+  // `timeoutMs ≥ batchSize × <per_item_estimate>`"). Slack is non-negative
+  // by construction, so the lower bound holds for any batchSize ≥ 0.
+  it('is at least batchSize × BULK_PER_ITEM_TIMEOUT_MS for every supported size', () => {
+    for (const n of [1, 5, 10, 15, 50, 100]) {
+      expect(computeBulkTimeoutMs(n)).toBeGreaterThanOrEqual(n * BULK_PER_ITEM_TIMEOUT_MS);
+    }
+  });
+
+  // The default batch size MUST fit under the shared-client 30 s ceiling
+  // with non-zero slack, otherwise BS#1178's regression reappears the
+  // moment the dynamic override is removed or the default is raised.
+  it('keeps the post-fix BULK_BATCH_SIZE_DEFAULT comfortably under any plausible LML-client ceiling', () => {
+    expect(BULK_BATCH_SIZE_DEFAULT).toBe(10);
+    expect(computeBulkTimeoutMs(BULK_BATCH_SIZE_DEFAULT)).toBe(30_000);
   });
 });
 

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -484,7 +484,7 @@ describe('runBatch', () => {
     expect(out).toMatchObject({ match: 0, no_match: 0, error: 0, upserts: 0 });
   });
 
-  it('forwards the resolved items + budgetMs + dynamic timeoutMs to bulkLookupMetadata (BS#1178)', async () => {
+  it('forwards the resolved items + budgetMs + dynamic timeoutMs to bulkLookupMetadata', async () => {
     mockBulkLookupMetadata.mockResolvedValue({
       results: [
         { index: 0, status: 'no_match', lookup: { results: [] } },
@@ -500,10 +500,6 @@ describe('runBatch', () => {
       { artist: 'Juana Molina', album: 'DOGA', raw_message: 'Juana Molina - DOGA' },
       { artist: 'Jessica Pratt', album: 'OYOLA', raw_message: 'Jessica Pratt - OYOLA' },
     ]);
-    // BS#1178: `bulkLookupMetadata` MUST receive an explicit `timeoutMs`
-    // override so the 30 s shared-client default doesn't fire mid-batch
-    // for cascade-heavy items. The value is derived from batch size by
-    // `computeBulkTimeoutMs` and pinned independently below.
     expect(opts).toEqual({ budgetMs: 25000, timeoutMs: computeBulkTimeoutMs(2) });
   });
 
@@ -568,10 +564,10 @@ describe('runBatch', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Bulk-fetch timeout sizing (BS#1178).
+// Bulk-fetch timeout sizing.
 // ---------------------------------------------------------------------------
 
-describe('computeBulkTimeoutMs (BS#1178)', () => {
+describe('computeBulkTimeoutMs', () => {
   // Pin the linear relationship so a future bump to BULK_BATCH_SIZE_DEFAULT
   // without a paired slack bump fails loudly here, not in production as
   // `LmlClientError: LML request timed out`.
@@ -581,21 +577,8 @@ describe('computeBulkTimeoutMs (BS#1178)', () => {
     }
   });
 
-  // The acceptance bullet on BS#1178 ("Unit test pinning the relationship
-  // `timeoutMs ≥ batchSize × <per_item_estimate>`"). Slack is non-negative
-  // by construction, so the lower bound holds for any batchSize ≥ 0.
-  it('is at least batchSize × BULK_PER_ITEM_TIMEOUT_MS for every supported size', () => {
-    for (const n of [1, 5, 10, 15, 50, 100]) {
-      expect(computeBulkTimeoutMs(n)).toBeGreaterThanOrEqual(n * BULK_PER_ITEM_TIMEOUT_MS);
-    }
-  });
-
-  // The default batch size MUST fit under the shared-client 30 s ceiling
-  // with non-zero slack, otherwise BS#1178's regression reappears the
-  // moment the dynamic override is removed or the default is raised.
-  it('keeps the post-fix BULK_BATCH_SIZE_DEFAULT comfortably under any plausible LML-client ceiling', () => {
-    expect(BULK_BATCH_SIZE_DEFAULT).toBe(10);
-    expect(computeBulkTimeoutMs(BULK_BATCH_SIZE_DEFAULT)).toBe(30_000);
+  it('keeps BULK_BATCH_SIZE_DEFAULT under the 30 s shared LML-client ceiling', () => {
+    expect(computeBulkTimeoutMs(BULK_BATCH_SIZE_DEFAULT)).toBeLessThanOrEqual(30_000);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1178.

The album-level-backfill drain's `bulkLookupMetadata` call inherited the shared LML-client's 30 s default `TIMEOUT_MS`, which was sized against the single-item `/api/v1/lookup` endpoint. With LML's post-#370 per-item cap (~25 s) and `BULK_BATCH_SIZE_DEFAULT=50`, every cascade-heavy bulk request hit the abort before any per-item verdict came back — the 2026-05-27 00:00 UTC drain ran for 14.5 h logging `match=0 no_match=0 error=50 upserts=0 elapsed_ms=30016` on every batch and produced zero upserts.

Two complementary fixes:

1. **Lower `BULK_BATCH_SIZE_DEFAULT` 50 → 10** so one wave of LML's internal `LML_BULK_MAX_CONCURRENT=10` fan-out fits inside a single per-item `caller_budget_ms`.
2. **Compute the fetch timeout dynamically from batch size** (`computeBulkTimeoutMs = batchSize × 2500 + 5000`) and pass it explicitly to `bulkLookupMetadata`. Raising `BACKFILL_BULK_BATCH_SIZE` in env now scales the timeout in lockstep instead of silently regressing to today's failure mode.

The 2.5 s/item rate matches LML's amortized ceiling (`BULK_BUDGET_MS_DEFAULT / LML_BULK_MAX_CONCURRENT = 25_000 / 10`), so the linear formula agrees with the wave-based worst case at 10-item boundaries and stays conservative in between. The 5 s slack covers HTTP overhead + JSON encode/decode + a safety margin for the case where every item in the batch hits LML's per-item cap.

## What changed

- `jobs/album-level-backfill/job.ts`
  - `BULK_BATCH_SIZE_DEFAULT`: 50 → 10
  - New: `BULK_PER_ITEM_TIMEOUT_MS = 2_500`, `BULK_TIMEOUT_SLACK_MS = 5_000`, `computeBulkTimeoutMs(batchSize)` helper.
  - `runBatch` now passes `timeoutMs: computeBulkTimeoutMs(items.length)` into `bulkLookupMetadata`.
  - Refreshed comments on `BULK_BATCH_SIZE_DEFAULT`, `BULK_RATE_PER_MIN_DEFAULT`, `BULK_BUDGET_MS_DEFAULT` to reflect the new relationship between batch size and fetch timeout.
- `tests/unit/jobs/album-level-backfill/job.test.ts`
  - Existing "forwards budgetMs" test now also asserts the explicit `timeoutMs`.
  - New `describe('computeBulkTimeoutMs (BS#1178)')` block pins: the linear formula, the lower-bound invariant `timeoutMs ≥ batchSize × BULK_PER_ITEM_TIMEOUT_MS`, and that the post-fix default fits the LML-client ceiling.
- `jobs/album-level-backfill/README.md`
  - New default in env-knobs table, new wall-clock note, BS#1178 cross-references.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (462 warnings, 0 errors — pre-existing, unchanged)
- [x] `npm run format:check`
- [x] `npx jest tests/unit/jobs/album-level-backfill` — 55/55 passing
- [x] `npx jest tests/unit/services/lml.client.test.ts` — 52/52 passing (verifies the `timeoutMs` override I'm now exercising)
- [x] Full `npm run test:unit` — 2423/2424 passing (one pre-existing failure in `schema.flowsheet-artwork-lookup-idx.test.ts`, unrelated)
- [ ] Integration regression on a real cascade-heavy drain (acceptance bullet 4 from #1178). Will be exercised on the next prod re-run; the runbook update is tracked separately per the issue body.

## Related

- BS#1078 (Phase 3 prod re-validation that surfaced this)
- LML#370 (per-item cascade-exhaustion cap)
- BS#1076 (HTTP-level throw isolation; same try/catch path)
- BS#1064 (per-row cron's parallel pathology — same root-cause class, separate fix)