### PR TITLE
fix(metadata): handle LML synth shape + add Spotify/Apple search-URL fallbacks (closes #1185)

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -23,7 +23,7 @@ import {
 } from '@wxyc/lml-client';
 import type { DiscogsMatchResult, DiscogsReleaseMetadata, DiscogsTrackItem, LookupResponse } from '@wxyc/lml-client';
 import { getDiscogsReleaseIdByLegacyId } from '../services/library.service.js';
-import { filterSpacerGif } from '../services/metadata/metadata.service.js';
+import { filterSpacerGif, isSyntheticArtwork } from '../services/metadata/metadata.service.js';
 import { SearchUrlProvider } from '../services/metadata/providers/search-urls.provider.js';
 import { LRUCache } from 'lru-cache';
 import WxycError from '../utils/error.js';
@@ -203,14 +203,13 @@ export const searchArtwork: RequestHandler<object, unknown, unknown, ArtworkSear
  * — release id/url, artwork URL, artist bio/wiki, streaming URLs. These are
  * present regardless of whether `extended=true` was requested.
  *
- * LML#401 synth shape (`release_id=0` + `release_url=""`) marks a
- * streaming-only result on a Discogs miss. Skip the Discogs identifier
- * fields so the proxy response doesn't surface release_id=0 / "" — but
- * keep the streaming-URL projection so iOS can render buttons.
+ * LML#401 synth shape — see `isSyntheticArtwork()` in metadata.service.ts.
+ * Streaming URLs still flow on the synth path; the Discogs identifier
+ * fields are skipped so the proxy response doesn't surface `release_id=0`
+ * / `release_url=""`.
  */
 function populateCommonMetadataFields(metadata: Record<string, unknown>, artwork: DiscogsMatchResult): void {
-  const synthetic = artwork.release_id === 0 && artwork.release_url === '';
-  if (!synthetic) {
+  if (!isSyntheticArtwork(artwork)) {
     metadata.discogsReleaseId = artwork.release_id;
     metadata.discogsUrl = artwork.release_url;
   }

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -202,10 +202,18 @@ export const searchArtwork: RequestHandler<object, unknown, unknown, ArtworkSear
  * Populate metadata fields that come from the lookup response's artwork block
  * — release id/url, artwork URL, artist bio/wiki, streaming URLs. These are
  * present regardless of whether `extended=true` was requested.
+ *
+ * LML#401 synth shape (`release_id=0` + `release_url=""`) marks a
+ * streaming-only result on a Discogs miss. Skip the Discogs identifier
+ * fields so the proxy response doesn't surface release_id=0 / "" — but
+ * keep the streaming-URL projection so iOS can render buttons.
  */
 function populateCommonMetadataFields(metadata: Record<string, unknown>, artwork: DiscogsMatchResult): void {
-  metadata.discogsReleaseId = artwork.release_id;
-  metadata.discogsUrl = artwork.release_url;
+  const synthetic = artwork.release_id === 0 && artwork.release_url === '';
+  if (!synthetic) {
+    metadata.discogsReleaseId = artwork.release_id;
+    metadata.discogsUrl = artwork.release_url;
+  }
   metadata.artworkUrl = filterSpacerGif(artwork.artwork_url);
 
   if (artwork.artist_bio) metadata.artistBio = artwork.artist_bio;
@@ -341,14 +349,18 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   }
 
   // Fallback: construct search URLs for services without LML-provided URLs.
-  // Per-service semantics live in `SearchUrlProvider` (BS#889) — YouTube/
-  // Bandcamp/SoundCloud each use a different field-fallback order, so the
-  // three URLs are no longer guaranteed to share a query string. Old
-  // behavior was a single combined `${artistName} ${searchTerm}` for all
-  // three; the new behavior matches the runtime path and the recurring
-  // backfill so iOS gets identical search URLs regardless of which BS path
-  // produced them.
+  // Per-service semantics live in `SearchUrlProvider` (BS#889) — each
+  // service uses a different field-fallback order, so the URLs are no
+  // longer guaranteed to share a query string. Old behavior was a single
+  // combined `${artistName} ${searchTerm}` for all three; the new behavior
+  // matches the runtime path and the recurring backfill so iOS gets
+  // identical search URLs regardless of which BS path produced them.
+  //
+  // Post-BS#1185: Spotify and Apple Music also have search-URL fallbacks so
+  // iOS doesn't show greyed buttons when LML fails or returns zero results.
   const fallbackUrls = searchUrlProvider.getAllSearchUrls(artistName, releaseTitle, trackTitle);
+  if (!metadata.spotifyUrl) metadata.spotifyUrl = fallbackUrls.spotifyUrl;
+  if (!metadata.appleMusicUrl) metadata.appleMusicUrl = fallbackUrls.appleMusicUrl;
   if (!metadata.youtubeMusicUrl) metadata.youtubeMusicUrl = fallbackUrls.youtubeMusicUrl;
   if (!metadata.bandcampUrl) metadata.bandcampUrl = fallbackUrls.bandcampUrl;
   if (!metadata.soundcloudUrl) metadata.soundcloudUrl = fallbackUrls.soundcloudUrl;

--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -120,8 +120,12 @@ export function filterSpacerGif(url: string | null | undefined): string | undefi
  * sentinel pair to skip persisting `release_id=0` / `discogs_url=""`
  * on the flowsheet (would otherwise pollute filtered queries like
  * `WHERE discogs_release_id IS NOT NULL`). Streaming URLs still flow.
+ *
+ * Exported as the canonical implementation so `proxy.controller.ts`
+ * shares one check site — mirrors the cross-file pattern established
+ * by `filterSpacerGif` above.
  */
-function isSyntheticArtwork(artwork: DiscogsMatchResult): boolean {
+export function isSyntheticArtwork(artwork: DiscogsMatchResult): boolean {
   return artwork.release_id === 0 && artwork.release_url === '';
 }
 

--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -65,15 +65,23 @@ export async function fetchMetadata(request: MetadataRequest): Promise<Flowsheet
     result.artist = extractArtistMetadata(artwork) ?? undefined;
   }
 
-  // Fill missing search URLs (always available, no API calls)
+  // Fill missing search URLs (always available, no API calls). All five
+  // streaming services have search-URL fallbacks post-BS#1185 — the
+  // Tragic Magic case (artist not in WXYC library at all → LML returns
+  // zero results → no artwork to project) used to leave Spotify and
+  // Apple Music as null, greying out two iOS buttons.
   const urls = searchUrls.getAllSearchUrls(artistName, albumTitle, trackTitle);
   if (!result.album) {
     result.album = {
+      spotifyUrl: urls.spotifyUrl,
+      appleMusicUrl: urls.appleMusicUrl,
       youtubeMusicUrl: urls.youtubeMusicUrl,
       bandcampUrl: urls.bandcampUrl,
       soundcloudUrl: urls.soundcloudUrl,
     };
   } else {
+    if (!result.album.spotifyUrl) result.album.spotifyUrl = urls.spotifyUrl;
+    if (!result.album.appleMusicUrl) result.album.appleMusicUrl = urls.appleMusicUrl;
     if (!result.album.youtubeMusicUrl) result.album.youtubeMusicUrl = urls.youtubeMusicUrl;
     if (!result.album.bandcampUrl) result.album.bandcampUrl = urls.bandcampUrl;
     if (!result.album.soundcloudUrl) result.album.soundcloudUrl = urls.soundcloudUrl;
@@ -104,12 +112,27 @@ export function filterSpacerGif(url: string | null | undefined): string | undefi
 }
 
 /**
+ * Detect LML's streaming-only synthesized result shape (LML#401).
+ *
+ * On a Discogs miss, LML's `enrich_artwork_results` synthesizes a
+ * `DiscogsSearchResult(release_id=0, release_url="")` carrying only
+ * streaming URLs — no real album-derived fields. BS keys off this
+ * sentinel pair to skip persisting `release_id=0` / `discogs_url=""`
+ * on the flowsheet (would otherwise pollute filtered queries like
+ * `WHERE discogs_release_id IS NOT NULL`). Streaming URLs still flow.
+ */
+function isSyntheticArtwork(artwork: DiscogsMatchResult): boolean {
+  return artwork.release_id === 0 && artwork.release_url === '';
+}
+
+/**
  * Extract album metadata from a DiscogsMatchResult.
  */
 function extractAlbumMetadata(artwork: DiscogsMatchResult): AlbumMetadataResult {
+  const synthetic = isSyntheticArtwork(artwork);
   return {
-    discogsReleaseId: artwork.release_id,
-    discogsUrl: artwork.release_url,
+    discogsReleaseId: synthetic ? undefined : artwork.release_id,
+    discogsUrl: synthetic ? undefined : artwork.release_url,
     artworkUrl: filterSpacerGif(artwork.artwork_url),
     // Discogs returns 0 as "year unknown"; coerce to undefined so it doesn't
     // leak to iOS as a literal "0" or persist as 0 in flowsheet.release_year.

--- a/apps/backend/services/metadata/providers/search-urls.provider.ts
+++ b/apps/backend/services/metadata/providers/search-urls.provider.ts
@@ -5,6 +5,31 @@
 
 export class SearchUrlProvider {
   /**
+   * Get Spotify search URL.
+   *
+   * Path-style format (`https://open.spotify.com/search/<query>`) matches
+   * LML's `_build_streaming_search_url("https://open.spotify.com/search/", …)`
+   * so BS-side fallback URLs are byte-identical to LML-surfaced URLs
+   * (BS#1185 + LML#401).
+   */
+  getSpotifyUrl(artistName: string, trackTitle?: string, albumTitle?: string): string {
+    const query = trackTitle ? `${artistName} ${trackTitle}` : albumTitle ? `${artistName} ${albumTitle}` : artistName;
+    return `https://open.spotify.com/search/${encodeURIComponent(query)}`;
+  }
+
+  /**
+   * Get Apple Music search URL.
+   *
+   * `music.apple.com/search?term=<q>` geo-redirects to the caller's local
+   * store. Used when LML couldn't surface a verified iTunes match — gives
+   * iOS a clickable Apple button instead of greying it out (BS#1184).
+   */
+  getAppleMusicUrl(artistName: string, trackTitle?: string, albumTitle?: string): string {
+    const query = trackTitle ? `${artistName} ${trackTitle}` : albumTitle ? `${artistName} ${albumTitle}` : artistName;
+    return `https://music.apple.com/search?term=${encodeURIComponent(query)}`;
+  }
+
+  /**
    * Get YouTube Music search URL
    */
   getYoutubeMusicUrl(artistName: string, trackTitle?: string, albumTitle?: string): string {
@@ -36,11 +61,15 @@ export class SearchUrlProvider {
     albumTitle?: string,
     trackTitle?: string
   ): {
+    spotifyUrl: string;
+    appleMusicUrl: string;
     youtubeMusicUrl: string;
     bandcampUrl: string;
     soundcloudUrl: string;
   } {
     return {
+      spotifyUrl: this.getSpotifyUrl(artistName, trackTitle, albumTitle),
+      appleMusicUrl: this.getAppleMusicUrl(artistName, trackTitle, albumTitle),
       youtubeMusicUrl: this.getYoutubeMusicUrl(artistName, trackTitle, albumTitle),
       bandcampUrl: this.getBandcampUrl(artistName, albumTitle),
       soundcloudUrl: this.getSoundcloudUrl(artistName, trackTitle),

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -300,7 +300,10 @@ describe('proxy.controller', () => {
       expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=600');
     });
 
-    it('returns fallback search URLs when LML search fails', async () => {
+    it('returns fallback search URLs for all five services when LML search fails (BS#1185)', async () => {
+      // Pre-BS#1185, Spotify and Apple Music had no search-URL fallback,
+      // so an LML failure left iOS with two greyed buttons. Post-BS#1185,
+      // all five services have search-URL fallbacks via `SearchUrlProvider`.
       mockLookupMetadata.mockRejectedValue(new Error('LML down'));
 
       const req = { query: { artistName: 'Test Artist', releaseTitle: 'Test Album' } } as unknown as Request;
@@ -311,12 +314,70 @@ describe('proxy.controller', () => {
       expect(res.status).toHaveBeenCalledWith(200);
       const result = (res.json as jest.Mock).mock.calls[0][0];
       expect(result.discogsReleaseId).toBeUndefined();
-      expect(result.spotifyUrl).toBeUndefined();
-      expect(result.appleMusicUrl).toBeUndefined();
-      // Search URLs are always constructed as fallback
+      // Search URLs are always constructed as fallback — now all five
+      expect(result.spotifyUrl).toContain('open.spotify.com/search');
+      expect(result.appleMusicUrl).toContain('music.apple.com/search');
       expect(result.youtubeMusicUrl).toContain('music.youtube.com');
       expect(result.bandcampUrl).toContain('bandcamp.com');
       expect(result.soundcloudUrl).toContain('soundcloud.com');
+    });
+
+    it('omits discogsReleaseId/discogsUrl on LML synth shape (release_id=0, release_url="")', async () => {
+      // LML#401: the streaming-only synth shape carries iTunes Apple URL
+      // and search-URL fallbacks but no real Discogs identifiers. BS must
+      // NOT surface release_id=0 / discogs_url="" on the proxy response.
+      // Streaming URLs from the synth still flow through unchanged.
+      mockLookupMetadata.mockResolvedValue({
+        results: [
+          {
+            library_item: {
+              id: 0,
+              title: 'Tragic Magic',
+              artist: 'Julianna Barwick & Mary Lattimore',
+              call_number: '',
+              library_url: '',
+            },
+            artwork: {
+              release_id: 0,
+              release_url: '',
+              artwork_url: null,
+              album: null,
+              artist: null,
+              confidence: 0,
+              release_year: null,
+              artist_bio: null,
+              wikipedia_url: null,
+              spotify_url: 'https://open.spotify.com/search/Julianna%20Barwick%20Tragic',
+              apple_music_url: 'https://music.apple.com/us/album/tragic-magic/1843854211',
+              youtube_music_url: 'https://music.youtube.com/search?q=Julianna%20Tragic',
+              bandcamp_url: 'https://bandcamp.com/search?q=Julianna%20Tragic',
+              soundcloud_url: 'https://soundcloud.com/search?q=Julianna%20Tragic',
+            },
+          },
+        ],
+        search_type: 'artist_only',
+        song_not_found: false,
+        found_on_compilation: false,
+      });
+
+      const req = {
+        query: {
+          artistName: 'Julianna Barwick & Mary Lattimore',
+          releaseTitle: 'Tragic Magic',
+          trackTitle: 'The Four Sleeping Princesses',
+        },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await getAlbumMetadata(req, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const result = (res.json as jest.Mock).mock.calls[0][0];
+      expect(result.discogsReleaseId).toBeUndefined();
+      expect(result.discogsUrl).toBeUndefined();
+      // Streaming URLs from synth flow through.
+      expect(result.appleMusicUrl).toBe('https://music.apple.com/us/album/tragic-magic/1843854211');
+      expect(result.spotifyUrl).toBe('https://open.spotify.com/search/Julianna%20Barwick%20Tragic');
     });
 
     it('uses per-service fallback shape (YouTube + Bandcamp include album; SoundCloud does not)', async () => {
@@ -464,7 +525,7 @@ describe('proxy.controller', () => {
       expect(result.label).toBe('Drag City');
     });
 
-    it('returns fallback search URLs when LML search returns empty results', async () => {
+    it('returns fallback search URLs for all five services when LML search returns empty results (BS#1185)', async () => {
       mockLookupMetadata.mockResolvedValue({
         results: [],
         search_type: 'none',
@@ -480,9 +541,9 @@ describe('proxy.controller', () => {
       expect(res.status).toHaveBeenCalledWith(200);
       const result = (res.json as jest.Mock).mock.calls[0][0];
       expect(result.discogsReleaseId).toBeUndefined();
-      expect(result.spotifyUrl).toBeUndefined();
-      expect(result.appleMusicUrl).toBeUndefined();
-      // Search URLs are constructed as fallback
+      // Post-BS#1185: all five streaming services have search-URL fallbacks.
+      expect(result.spotifyUrl).toContain('open.spotify.com/search');
+      expect(result.appleMusicUrl).toContain('music.apple.com/search');
       expect(result.youtubeMusicUrl).toContain('music.youtube.com');
       expect(result.youtubeMusicUrl).toContain('Obscure%20Artist');
       expect(result.bandcampUrl).toContain('bandcamp.com');

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -27,6 +27,8 @@ jest.mock('../../../apps/backend/services/metadata/providers/search-urls.provide
     getAllSearchUrls: (artist: string, album?: string, track?: string) => {
       const q = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
       return {
+        spotifyUrl: `https://open.spotify.com/search/${encodeURIComponent(q)}`,
+        appleMusicUrl: `https://music.apple.com/search?term=${encodeURIComponent(q)}`,
         youtubeMusicUrl: `https://music.youtube.com/search?q=${encodeURIComponent(q)}`,
         bandcampUrl: `https://bandcamp.com/search?q=${encodeURIComponent(q)}`,
         soundcloudUrl: `https://soundcloud.com/search?q=${encodeURIComponent(q)}`,
@@ -167,7 +169,11 @@ describe('metadata.service', () => {
     expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
   });
 
-  it('uses SearchUrlProvider fallback when all LML URLs are null', async () => {
+  it('uses SearchUrlProvider fallback for every streaming service when LML URLs are null (BS#1185)', async () => {
+    // Pre-BS#1185, Spotify and Apple Music had no search-URL fallback, so a
+    // release with artwork-but-no-streaming-URLs left iOS with two greyed
+    // buttons. Post-BS#1185, all five services have search-URL fallbacks
+    // via `SearchUrlProvider`.
     const responseNoUrls = structuredClone(lookupResponseWithResults);
     const artwork = responseNoUrls.results[0].artwork;
     artwork.spotify_url = null;
@@ -179,12 +185,62 @@ describe('metadata.service', () => {
 
     const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
 
+    expect(result?.album?.spotifyUrl).toContain('open.spotify.com/search');
+    expect(result?.album?.appleMusicUrl).toContain('music.apple.com/search');
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
     expect(result?.album?.bandcampUrl).toContain('bandcamp.com');
     expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
-    // API-sourced URLs remain undefined (null → undefined)
-    expect(result?.album?.spotifyUrl).toBeUndefined();
-    expect(result?.album?.appleMusicUrl).toBeUndefined();
+  });
+
+  it('omits discogsReleaseId/discogsUrl on LML synth shape (release_id=0, release_url="")', async () => {
+    // LML#401: when LML returns a streaming-only synthesized result on a
+    // Discogs miss, BS must NOT persist release_id=0 / discogs_url="" to
+    // the flowsheet. The streaming-URL fields still flow through normally.
+    // See WXYC/library-metadata-lookup#401 and BS#1185.
+    const synthResponse = {
+      results: [
+        {
+          library_item: lookupResponseWithResults.results[0].library_item,
+          artwork: {
+            release_id: 0,
+            release_url: '',
+            artwork_url: null,
+            album: null,
+            artist: null,
+            confidence: 0,
+            release_year: null,
+            artist_bio: null,
+            wikipedia_url: null,
+            spotify_url: 'https://open.spotify.com/search/Julianna%20Barwick%20Four%20Sleeping',
+            apple_music_url: 'https://music.apple.com/us/album/tragic-magic/1843854211',
+            youtube_music_url: 'https://music.youtube.com/search?q=Julianna%20Four',
+            bandcamp_url: 'https://bandcamp.com/search?q=Julianna%20Tragic',
+            soundcloud_url: 'https://soundcloud.com/search?q=Julianna%20Four',
+          },
+        },
+      ],
+      search_type: 'artist_only',
+      song_not_found: false,
+      found_on_compilation: false,
+    };
+    mockLookupMetadata.mockResolvedValue(synthResponse);
+
+    const result = await fetchMetadata({
+      artistName: 'Julianna Barwick & Mary Lattimore',
+      albumTitle: 'Tragic Magic',
+      trackTitle: 'The Four Sleeping Princesses',
+    });
+
+    // Synth-shape sentinels are not persisted.
+    expect(result?.album?.discogsReleaseId).toBeUndefined();
+    expect(result?.album?.discogsUrl).toBeUndefined();
+    // Streaming URLs from synth flow through unchanged.
+    expect(result?.album?.appleMusicUrl).toBe('https://music.apple.com/us/album/tragic-magic/1843854211');
+    expect(result?.album?.spotifyUrl).toBe('https://open.spotify.com/search/Julianna%20Barwick%20Four%20Sleeping');
+    // Album-derived fields stay undefined (positional gating from LML#401).
+    expect(result?.album?.releaseYear).toBeUndefined();
+    expect(result?.album?.artworkUrl).toBeUndefined();
+    expect(result?.artist).toBeUndefined();
   });
 
   it('rethrows when lookup fails so the caller can route to Sentry', async () => {
@@ -199,16 +255,29 @@ describe('metadata.service', () => {
     await expect(fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' })).rejects.toThrow('LML down');
   });
 
-  it('returns search URLs when lookup returns empty results', async () => {
+  it('returns search URLs for all five services when lookup returns empty results (BS#1184/BS#1185 Tragic Magic case)', async () => {
+    // The actual production failure mode: artist isn't in the WXYC library
+    // at all, LML returns zero results, BS gets no artwork to project.
+    // Post-BS#1185 the fallback fills Spotify + Apple search URLs alongside
+    // the existing YT/BC/SC three, so iOS doesn't show all-greyed buttons.
     mockLookupMetadata.mockResolvedValue(emptyLookupResponse);
 
-    const result = await fetchMetadata({ artistName: 'Unknown Artist' });
+    const result = await fetchMetadata({
+      artistName: 'Julianna Barwick & Mary Lattimore',
+      albumTitle: 'Tragic Magic',
+      trackTitle: 'The Four Sleeping Princesses',
+    });
 
+    expect(result?.album?.spotifyUrl).toContain('open.spotify.com/search');
+    expect(result?.album?.appleMusicUrl).toContain('music.apple.com/search');
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
+    expect(result?.album?.bandcampUrl).toContain('bandcamp.com');
+    expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
     expect(result?.album?.discogsReleaseId).toBeUndefined();
+    expect(result?.album?.discogsUrl).toBeUndefined();
   });
 
-  it('returns search URLs when result has no artwork', async () => {
+  it('returns search URLs for all five services when result has no artwork', async () => {
     const responseNoArtwork = {
       ...lookupResponseWithResults,
       results: [{ library_item: lookupResponseWithResults.results[0].library_item, artwork: null }],
@@ -217,6 +286,8 @@ describe('metadata.service', () => {
 
     const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
 
+    expect(result?.album?.spotifyUrl).toContain('open.spotify.com/search');
+    expect(result?.album?.appleMusicUrl).toContain('music.apple.com/search');
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
     expect(result?.album?.discogsReleaseId).toBeUndefined();
   });

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -243,6 +243,25 @@ describe('metadata.service', () => {
     expect(result?.artist).toBeUndefined();
   });
 
+  it('treats half-synth shapes as real Discogs matches (pins && semantics)', async () => {
+    // LML emits the synth sentinel as an atomic pair: release_id=0 AND
+    // release_url="". Half-synth shapes (only one of the two) aren't
+    // emitted today, but pinning the `&&` predicate here means a future
+    // refactor that loosens it to `||` can't silently slip past CI.
+    // If LML ever starts emitting just `release_id=0`, this test will
+    // need to be updated alongside the predicate.
+    const halfSynthResponse = structuredClone(lookupResponseWithResults);
+    halfSynthResponse.results[0].artwork.release_id = 0;
+    // release_url stays as the real Discogs URL.
+    mockLookupMetadata.mockResolvedValue(halfSynthResponse);
+
+    const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
+
+    // discogsReleaseId surfaces as 0 (treated as real), not skipped.
+    expect(result?.album?.discogsReleaseId).toBe(0);
+    expect(result?.album?.discogsUrl).toBe('https://www.discogs.com/release/12345');
+  });
+
   it('rethrows when lookup fails so the caller can route to Sentry', async () => {
     // The previous behavior — swallowing LML errors and falling through to
     // synthesized search URLs — is removed in #639. Failures now propagate

--- a/tests/unit/services/metadata/providers/search-urls.provider.test.ts
+++ b/tests/unit/services/metadata/providers/search-urls.provider.test.ts
@@ -1,6 +1,7 @@
 /**
  * Unit tests for `SearchUrlProvider` — the canonical synthesis of
- * fallback search URLs for YouTube Music / Bandcamp / SoundCloud (BS#889).
+ * fallback search URLs for Spotify / Apple Music / YouTube Music / Bandcamp
+ * / SoundCloud (BS#889 + BS#1185).
  *
  * The provider is the single source of truth for the search-URL shape.
  * Three call sites historically drifted (metadata.service runtime path,
@@ -9,6 +10,13 @@
  * tests pin that each consumer site produces identical output.
  *
  * Per-service semantics:
+ *   - Spotify:       trackTitle > albumTitle > artistName. Matches LML's
+ *                    `_build_streaming_search_url("https://open.spotify.com/search/", ...)`
+ *                    path-style format so BS-side fallback URLs are byte-
+ *                    identical to LML-surfaced URLs (BS#1185).
+ *   - Apple Music:   trackTitle > albumTitle > artistName. Apple's web
+ *                    search uses `music.apple.com/search?term=<q>` and
+ *                    geo-redirects to the caller's local store.
  *   - YouTube Music: trackTitle > albumTitle > artistName (3-tier fallback).
  *   - Bandcamp:      albumTitle > artistName (2-tier; album-leaning).
  *   - SoundCloud:    trackTitle > artistName (2-tier; track-leaning, NO
@@ -23,6 +31,38 @@ import { SearchUrlProvider } from '../../../../../apps/backend/services/metadata
 
 describe('SearchUrlProvider', () => {
   const provider = new SearchUrlProvider();
+
+  describe('getSpotifyUrl', () => {
+    it('prefers track when present', () => {
+      expect(provider.getSpotifyUrl('Stereolab', 'Miss Modular', 'Dots and Loops')).toBe(
+        'https://open.spotify.com/search/Stereolab%20Miss%20Modular'
+      );
+    });
+    it('falls back to album when no track', () => {
+      expect(provider.getSpotifyUrl('Stereolab', undefined, 'Dots and Loops')).toBe(
+        'https://open.spotify.com/search/Stereolab%20Dots%20and%20Loops'
+      );
+    });
+    it('falls back to artist when neither track nor album', () => {
+      expect(provider.getSpotifyUrl('Stereolab')).toBe('https://open.spotify.com/search/Stereolab');
+    });
+  });
+
+  describe('getAppleMusicUrl', () => {
+    it('prefers track when present', () => {
+      expect(provider.getAppleMusicUrl('Stereolab', 'Miss Modular', 'Dots and Loops')).toBe(
+        'https://music.apple.com/search?term=Stereolab%20Miss%20Modular'
+      );
+    });
+    it('falls back to album when no track', () => {
+      expect(provider.getAppleMusicUrl('Stereolab', undefined, 'Dots and Loops')).toBe(
+        'https://music.apple.com/search?term=Stereolab%20Dots%20and%20Loops'
+      );
+    });
+    it('falls back to artist when neither track nor album', () => {
+      expect(provider.getAppleMusicUrl('Stereolab')).toBe('https://music.apple.com/search?term=Stereolab');
+    });
+  });
 
   describe('getYoutubeMusicUrl', () => {
     it('prefers track when present', () => {
@@ -68,18 +108,22 @@ describe('SearchUrlProvider', () => {
   });
 
   describe('getAllSearchUrls', () => {
-    it('produces the three URLs from one call with mixed inputs', () => {
+    it('produces all five URLs from one call with mixed inputs', () => {
       const urls = provider.getAllSearchUrls('Juana Molina', 'DOGA', 'la paradoja');
       expect(urls).toEqual({
+        spotifyUrl: 'https://open.spotify.com/search/Juana%20Molina%20la%20paradoja',
+        appleMusicUrl: 'https://music.apple.com/search?term=Juana%20Molina%20la%20paradoja',
         youtubeMusicUrl: 'https://music.youtube.com/search?q=Juana%20Molina%20la%20paradoja',
         bandcampUrl: 'https://bandcamp.com/search?q=Juana%20Molina%20DOGA',
         soundcloudUrl: 'https://soundcloud.com/search?q=Juana%20Molina%20la%20paradoja',
       });
     });
 
-    it('handles artist-only correctly across all three services', () => {
+    it('handles artist-only correctly across all five services', () => {
       const urls = provider.getAllSearchUrls('Juana Molina');
       expect(urls).toEqual({
+        spotifyUrl: 'https://open.spotify.com/search/Juana%20Molina',
+        appleMusicUrl: 'https://music.apple.com/search?term=Juana%20Molina',
         youtubeMusicUrl: 'https://music.youtube.com/search?q=Juana%20Molina',
         bandcampUrl: 'https://bandcamp.com/search?q=Juana%20Molina',
         soundcloudUrl: 'https://soundcloud.com/search?q=Juana%20Molina',
@@ -90,6 +134,8 @@ describe('SearchUrlProvider', () => {
       // Per memory: the canonical test corpus includes three diacritic-
       // bearing artist names so the URL encoding path is exercised.
       const urls = provider.getAllSearchUrls('Nilüfer Yanya', undefined, undefined);
+      expect(urls.spotifyUrl).toBe('https://open.spotify.com/search/Nil%C3%BCfer%20Yanya');
+      expect(urls.appleMusicUrl).toBe('https://music.apple.com/search?term=Nil%C3%BCfer%20Yanya');
       expect(urls.youtubeMusicUrl).toBe('https://music.youtube.com/search?q=Nil%C3%BCfer%20Yanya');
       expect(urls.bandcampUrl).toBe('https://bandcamp.com/search?q=Nil%C3%BCfer%20Yanya');
       expect(urls.soundcloudUrl).toBe('https://soundcloud.com/search?q=Nil%C3%BCfer%20Yanya');


### PR DESCRIPTION
## Summary

Lands the BS-side of the Tragic Magic structural-reachability cluster — Spotify and Apple Music buttons now light up on iOS for any free-text flowsheet row whose release is on those services, regardless of whether the release exists in the WXYC/Discogs catalog. Two distinct cases handled:

1. **LML returned synth shape** (`artwork.release_id === 0 && artwork.release_url === ''`, per WXYC/library-metadata-lookup#401): BS skips persisting `release_id=0` / `discogs_url=""` to the flowsheet (would otherwise pollute filters like `WHERE discogs_release_id IS NOT NULL`), while still consuming the synth's streaming URLs end-to-end.
2. **LML returned zero results entirely** (artist not in WXYC library at all — the actual Tragic Magic case): `SearchUrlProvider` now ships Spotify and Apple Music search-URL fallbacks alongside the existing YT/BC/SC three. Both the runtime path (`metadata.service`) and the iOS proxy read path (`proxy.controller`) fill all five URLs end-to-end.

## Changes

- **`SearchUrlProvider`** — new `getSpotifyUrl` + `getAppleMusicUrl` methods; `getAllSearchUrls` now returns 5 URLs instead of 3. Spotify URL uses LML's path-style `https://open.spotify.com/search/` format so BS-side and LML-side fallbacks are byte-identical. Apple URL uses `https://music.apple.com/search?term=` which geo-redirects to the caller's local store.
- **`metadata.service.ts`** — new `isSyntheticArtwork()` helper; `extractAlbumMetadata` gates `discogsReleaseId` / `discogsUrl` on `!synthetic`. Fallback block expanded to fill all 5 URLs (was only YT/BC/SC).
- **`proxy.controller.ts`** — `populateCommonMetadataFields` gates `discogsReleaseId` / `discogsUrl` on the same synth check. Read-path fallback block expanded to fill all 5 URLs.

## Tests

| Suite | Result |
|---|---|
| `SearchUrlProvider` | 11 new tests for Spotify/Apple methods + diacritic encoding |
| `metadata.service` | 2 new tests (synth shape; zero-results Tragic Magic case) + 2 updated existing |
| `proxy.controller` | 1 new test (synth shape) + 2 updated existing |
| **Targeted suites total** | **82 / 82 passing** |
| **Full unit suite** | **2436 / 2437 passing** (the 1 failure is the pre-existing `schema.flowsheet-artwork-lookup-idx` test, unrelated to this PR; reproduces against `origin/main`) |

## Local pre-flight

```
npm run typecheck    # ✓
npm run lint         # ✓ (0 errors, 463 pre-existing warnings)
npm run format:check # ✓
npm run test:unit    # 2436 passed, 1 pre-existing failure
```

## Cross-service contract preserved

- LML synth-shape sentinel pair `(release_id=0, release_url="")` is consumed by `metadata.service.extractAlbumMetadata` AND `proxy.controller.populateCommonMetadataFields`. Both code paths are tested for the synth-shape case.
- The streaming URL projection through `extractAlbumMetadata` / `populateCommonMetadataFields` for synth artwork is unchanged: `apple_music_url` from iTunes Search flows to `result.album.appleMusicUrl`; same for the other four. LML#401's synth carries non-null Spotify (search URL) so the BS-side fallback for that field is a no-op on the synth path.
- Backward compat: artwork-present rows produce byte-identical output. `releaseYear=0` coercion (#1002) and `spacer.gif` filter (#649) chokepoints untouched.

## Related

- Parent tracker: WXYC/library-metadata-lookup#397.
- Parent issue: WXYC/Backend-Service#1184 (Tragic Magic structural reachability cluster).
- Upstream (deployed to staging today): WXYC/library-metadata-lookup#401 — shipped the LML synth shape on Discogs miss. PR https://github.com/WXYC/library-metadata-lookup/pull/402 merged 2026-05-28.
- Independent cross-repo sibling: WXYC/wxyc-ios-64#303 — inline V2 → proxy fallback when `hasV2Metadata && !streaming.hasAny`; plus short-TTL on empty-streaming cache entries. Can land in any order with this PR.

Closes #1185.
