### PR TITLE
feat(lml-client): forward budgetMs on single-lookup paths

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -23,6 +23,17 @@ import {
 import { filterSpacerGif } from '../services/metadata/metadata.service.js';
 import WxycError from '../utils/error.js';
 
+/**
+ * Caller-honored LML budget forwarded as `X-Caller-Budget-Ms`
+ * (WXYC/library-metadata-lookup#345). Used by both the add-album insert
+ * (which blocks the 201 response on the LML enrichment) and the
+ * fire-and-forget canonical-entity resolution. 5 s matches the
+ * runtime-interactive class — the row is already persisted by the time
+ * either call fires, so the budget is about freeing LML's Discogs quota
+ * for an obscure-artist cascade, not about user-facing latency on the 201.
+ */
+const LIBRARY_LML_BUDGET_MS = Number(process.env.LIBRARY_LML_BUDGET_MS ?? 5000);
+
 type NewAlbumRequest = {
   album_title: string;
   artist_name?: string;
@@ -93,7 +104,7 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
     const artistName = body.alternate_artist_name || body.artist_name || '';
     const [streamingResult, artworkResult] = await Promise.allSettled([
       checkStreamingAvailability(artistName, body.album_title),
-      lookupMetadata(artistName, body.album_title),
+      lookupMetadata(artistName, body.album_title, undefined, { budgetMs: LIBRARY_LML_BUDGET_MS }),
     ]);
 
     if (streamingResult.status === 'fulfilled' && streamingResult.value.on_streaming !== null) {
@@ -141,7 +152,7 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
 function fireAndForgetCanonicalEntity(libraryId: number, artistName: string | null, albumTitle: string): void {
   if (!artistName) return;
 
-  lookupMetadata(artistName, albumTitle)
+  lookupMetadata(artistName, albumTitle, undefined, { budgetMs: LIBRARY_LML_BUDGET_MS })
     .then(async (response) => {
       const linkage = libraryService.mapLookupToCanonicalEntity(response);
       if (!linkage) return;

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -18,21 +18,19 @@ import {
   lookupMetadata,
   isLmlConfigured,
   getRelease,
+  envInt,
   LmlClientError,
 } from '@wxyc/lml-client';
 import { filterSpacerGif } from '../services/metadata/metadata.service.js';
 import WxycError from '../utils/error.js';
 
 /**
- * Caller-honored LML budget forwarded as `X-Caller-Budget-Ms`
- * (WXYC/library-metadata-lookup#345). Used by both the add-album insert
- * (which blocks the 201 response on the LML enrichment) and the
- * fire-and-forget canonical-entity resolution. 5 s matches the
- * runtime-interactive class — the row is already persisted by the time
- * either call fires, so the budget is about freeing LML's Discogs quota
- * for an obscure-artist cascade, not about user-facing latency on the 201.
+ * Budget for the add-album insert + fire-and-forget canonical-entity paths.
+ * The row is already persisted before either call fires, so the budget is
+ * about freeing LML's Discogs quota — not about 201 latency. 5 s matches the
+ * other runtime-interactive sites. See `LookupOptions.budgetMs` for mechanics.
  */
-const LIBRARY_LML_BUDGET_MS = Number(process.env.LIBRARY_LML_BUDGET_MS ?? 5000);
+const LIBRARY_LML_BUDGET_MS = envInt('LIBRARY_LML_BUDGET_MS', 5000);
 
 type NewAlbumRequest = {
   album_title: string;

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -19,6 +19,7 @@ import {
   getArtistDetails,
   resolveEntity as lmlResolveEntity,
   searchLibrary,
+  envInt,
   LmlClientError,
 } from '@wxyc/lml-client';
 import type { DiscogsMatchResult, DiscogsReleaseMetadata, DiscogsTrackItem, LookupResponse } from '@wxyc/lml-client';
@@ -57,15 +58,13 @@ function singleLookupEnabled(): boolean {
 }
 
 /**
- * Caller-honored LML budget forwarded as `X-Caller-Budget-Ms`
- * (WXYC/library-metadata-lookup#345). Set tightly because the proxy path is
- * user-visible (iOS playlist + dj-site cover-art); we'd rather degrade to
- * synthesized fallback URLs than hold the response on an obscure-artist
- * cascade burning Discogs quota for a response we'll discard. Matches the
- * 5 s deadline used by the rotation picker (BS#992) and the
- * WXYC/library-metadata-lookup#337 re-measurement target.
+ * Budget for the user-visible iOS playlist + dj-site cover-art path. Tight
+ * because the controller would rather degrade to synthesized fallback URLs
+ * than hold the response on an obscure-artist cascade. Matches the 5 s
+ * deadline used by the rotation picker (BS#992). See `LookupOptions.budgetMs`
+ * for the mechanics.
  */
-const PROXY_LML_BUDGET_MS = Number(process.env.PROXY_LML_BUDGET_MS ?? 5000);
+const PROXY_LML_BUDGET_MS = envInt('PROXY_LML_BUDGET_MS', 5000);
 
 /** Spotify OAuth2 token response. */
 interface SpotifyTokenResponse {

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -56,6 +56,17 @@ function singleLookupEnabled(): boolean {
   return process.env.PROXY_METADATA_SINGLE_LOOKUP === 'true';
 }
 
+/**
+ * Caller-honored LML budget forwarded as `X-Caller-Budget-Ms`
+ * (WXYC/library-metadata-lookup#345). Set tightly because the proxy path is
+ * user-visible (iOS playlist + dj-site cover-art); we'd rather degrade to
+ * synthesized fallback URLs than hold the response on an obscure-artist
+ * cascade burning Discogs quota for a response we'll discard. Matches the
+ * 5 s deadline used by the rotation picker (BS#992) and the
+ * WXYC/library-metadata-lookup#337 re-measurement target.
+ */
+const PROXY_LML_BUDGET_MS = Number(process.env.PROXY_LML_BUDGET_MS ?? 5000);
+
 /** Spotify OAuth2 token response. */
 interface SpotifyTokenResponse {
   access_token: string;
@@ -309,9 +320,14 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   try {
     let lookupResponse: LookupResponse;
     if (useSingleLookup) {
-      lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle, { extended: true });
+      lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle, {
+        extended: true,
+        budgetMs: PROXY_LML_BUDGET_MS,
+      });
     } else {
-      lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle);
+      lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle, {
+        budgetMs: PROXY_LML_BUDGET_MS,
+      });
     }
     upstreamCalls += 1;
     artwork = lookupResponse.results?.[0]?.artwork;

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -354,6 +354,25 @@ const ROTATION_LML_LOOKUP_TTL_NEGATIVE_MS = 10 * 60 * 1000;
  */
 const ROTATION_LML_LOOKUP_TIMEOUT_MS = 5000;
 
+/**
+ * Caller-honored budget forwarded to LML as `X-Caller-Budget-Ms`
+ * (WXYC/library-metadata-lookup#345). Set ~1 s tighter than
+ * `ROTATION_LML_LOOKUP_TIMEOUT_MS` so LML's A10 cutoff
+ * (WXYC/library-metadata-lookup#403/#404) fires before the local
+ * `AbortController` aborts the fetch — leaves room for the LML response
+ * envelope on the wire when LML decides to short-circuit.
+ */
+const ROTATION_LML_LOOKUP_BUDGET_MS = 4000;
+
+/**
+ * Interactive (user-visible) LML budget for search-result artwork enrichment
+ * and the catalog Track 2 lookup-by-song path. Matches the rotation-picker
+ * deadline class (BS#992) — both are user-visible and would rather degrade
+ * to no-artwork / shorter-list than hold the response on an obscure-artist
+ * cascade burning Discogs quota for an answer BS won't render.
+ */
+const LIBRARY_INTERACTIVE_LML_BUDGET_MS = Number(process.env.LIBRARY_INTERACTIVE_LML_BUDGET_MS ?? 5000);
+
 const rotationLmlPositiveCache = new LRUCache<number, number>({
   max: ROTATION_LML_LOOKUP_CACHE_MAX,
   ttl: ROTATION_LML_LOOKUP_TTL_POSITIVE_MS,
@@ -472,6 +491,7 @@ async function resolveRotationDiscogsReleaseViaLml(
   try {
     const response = await lookupMetadata(artistName, albumTitle, undefined, {
       timeoutMs: ROTATION_LML_LOOKUP_TIMEOUT_MS,
+      budgetMs: ROTATION_LML_LOOKUP_BUDGET_MS,
     });
     releaseId = response.results?.[0]?.artwork?.release_id ?? null;
   } catch (err) {
@@ -591,7 +611,9 @@ export async function enrichWithArtwork<T extends ArtworkEnrichable>(results: T[
 
   const settlements = await Promise.allSettled(
     uncached.map(async (row) => {
-      const lookupResult = await lookupMetadata(row.artist_name, row.album_title);
+      const lookupResult = await lookupMetadata(row.artist_name, row.album_title, undefined, {
+        budgetMs: LIBRARY_INTERACTIVE_LML_BUDGET_MS,
+      });
       const artworkUrl = filterSpacerGif(lookupResult.results?.[0]?.artwork?.artwork_url);
       if (!artworkUrl) return;
       row.artwork_url = artworkUrl;
@@ -1205,7 +1227,7 @@ export async function searchAlbumsByTitle(albumTitle: string, limit = 5): Promis
  */
 async function searchLibraryByTrackUncachedOrThrow(query: string): Promise<TaggedLibraryViewEntry[]> {
   const lookupStart = performance.now();
-  const response: LookupResponse = await lookupBySong(query);
+  const response: LookupResponse = await lookupBySong(query, { budgetMs: LIBRARY_INTERACTIVE_LML_BUDGET_MS });
   try {
     Sentry.getActiveSpan()?.setAttributes({
       'track_search.master_lookup_ms': performance.now() - lookupStart,

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -23,7 +23,7 @@ import {
   LibraryArtistViewEntry,
 } from '@wxyc/database';
 import { LibraryResult, EnrichedLibraryResult, enrichLibraryResult } from './requestLine/types.js';
-import { lookupBySong, lookupMetadata, isLmlConfigured, type LookupResponse } from '@wxyc/lml-client';
+import { lookupBySong, lookupMetadata, isLmlConfigured, envInt, type LookupResponse } from '@wxyc/lml-client';
 import { filterSpacerGif } from './metadata/metadata.service.js';
 import { checkLibraryArtistNameHealth } from './library-artist-name-assertion.service.js';
 import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrackSearch.js';
@@ -355,23 +355,19 @@ const ROTATION_LML_LOOKUP_TTL_NEGATIVE_MS = 10 * 60 * 1000;
 const ROTATION_LML_LOOKUP_TIMEOUT_MS = 5000;
 
 /**
- * Caller-honored budget forwarded to LML as `X-Caller-Budget-Ms`
- * (WXYC/library-metadata-lookup#345). Set ~1 s tighter than
- * `ROTATION_LML_LOOKUP_TIMEOUT_MS` so LML's A10 cutoff
- * (WXYC/library-metadata-lookup#403/#404) fires before the local
- * `AbortController` aborts the fetch — leaves room for the LML response
- * envelope on the wire when LML decides to short-circuit.
+ * Picker budget. Pinned ~1 s tighter than `ROTATION_LML_LOOKUP_TIMEOUT_MS`
+ * so LML's A10 cutoff fires before the local `AbortController` aborts the
+ * fetch. Hardcoded because the two constants are paired (changing one without
+ * the other breaks the timing). See `LookupOptions.budgetMs` for mechanics.
  */
 const ROTATION_LML_LOOKUP_BUDGET_MS = 4000;
 
 /**
- * Interactive (user-visible) LML budget for search-result artwork enrichment
- * and the catalog Track 2 lookup-by-song path. Matches the rotation-picker
- * deadline class (BS#992) — both are user-visible and would rather degrade
- * to no-artwork / shorter-list than hold the response on an obscure-artist
- * cascade burning Discogs quota for an answer BS won't render.
+ * Budget for `enrichWithArtwork` and `searchLibraryByTrack` — both user-visible
+ * read paths that would rather degrade than hold the response on an obscure-
+ * artist cascade. See `LookupOptions.budgetMs` for mechanics.
  */
-const LIBRARY_INTERACTIVE_LML_BUDGET_MS = Number(process.env.LIBRARY_INTERACTIVE_LML_BUDGET_MS ?? 5000);
+const LIBRARY_INTERACTIVE_LML_BUDGET_MS = envInt('LIBRARY_INTERACTIVE_LML_BUDGET_MS', 5000);
 
 const rotationLmlPositiveCache = new LRUCache<number, number>({
   max: ROTATION_LML_LOOKUP_CACHE_MAX,

--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -41,6 +41,19 @@ import { filterForEnrichment, type EnrichmentCandidate } from './cdc-subscriber.
 import { finalizeRow, type FinalizeOutcome } from './enrich.js';
 
 /**
+ * Caller-honored LML budget forwarded as `X-Caller-Budget-Ms`
+ * (WXYC/library-metadata-lookup#345). The CDC consumer is fire-and-forget,
+ * but a slow lookup holds the row in `enriching` state until the C6
+ * stranded-claim sweep (#895) reverts it past `enriching_since + 60s`.
+ * Tracking the shared LML client's 30 s fetch timeout with 1 s of slack
+ * lets LML's A10 cutoff (WXYC/library-metadata-lookup#403/#404) abandon an
+ * obscure-artist cascade just before the BS `AbortController` would, so the
+ * row gets reclaimed by C6 sooner rather than burning Discogs quota on an
+ * answer the worker won't render.
+ */
+const ENRICHMENT_LML_BUDGET_MS = Number(process.env.ENRICHMENT_LML_BUDGET_MS ?? 29000);
+
+/**
  * Build a CDC event handler that runs the full enrichment chain.
  *
  * The returned function is the long-lived handler that
@@ -83,7 +96,8 @@ async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
           const response = await lookupMetadata(
             candidate.artist_name,
             candidate.album_title ?? undefined,
-            candidate.track_title ?? undefined
+            candidate.track_title ?? undefined,
+            { budgetMs: ENRICHMENT_LML_BUDGET_MS }
           );
           outcome = await finalizeRow(candidate, response);
         } catch (err) {

--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -33,7 +33,7 @@
  */
 
 import * as Sentry from '@sentry/node';
-import { lookupMetadata } from '@wxyc/lml-client';
+import { lookupMetadata, envInt } from '@wxyc/lml-client';
 import type { CdcEvent } from '@wxyc/database';
 
 import { claimRowForEnrichment } from './claim.js';
@@ -41,17 +41,12 @@ import { filterForEnrichment, type EnrichmentCandidate } from './cdc-subscriber.
 import { finalizeRow, type FinalizeOutcome } from './enrich.js';
 
 /**
- * Caller-honored LML budget forwarded as `X-Caller-Budget-Ms`
- * (WXYC/library-metadata-lookup#345). The CDC consumer is fire-and-forget,
- * but a slow lookup holds the row in `enriching` state until the C6
- * stranded-claim sweep (#895) reverts it past `enriching_since + 60s`.
- * Tracking the shared LML client's 30 s fetch timeout with 1 s of slack
- * lets LML's A10 cutoff (WXYC/library-metadata-lookup#403/#404) abandon an
- * obscure-artist cascade just before the BS `AbortController` would, so the
- * row gets reclaimed by C6 sooner rather than burning Discogs quota on an
- * answer the worker won't render.
+ * Budget for the CDC consumer's lookup. Tracks the shared client's 30 s
+ * fetch timeout with 1 s of slack so LML cuts off just before the
+ * `AbortController` would — frees the row's `enriching` claim for C6 sweep
+ * recovery (#895) sooner. See `LookupOptions.budgetMs` for mechanics.
  */
-const ENRICHMENT_LML_BUDGET_MS = Number(process.env.ENRICHMENT_LML_BUDGET_MS ?? 29000);
+const ENRICHMENT_LML_BUDGET_MS = envInt('ENRICHMENT_LML_BUDGET_MS', 29000);
 
 /**
  * Build a CDC event handler that runs the full enrichment chain.

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -84,15 +84,18 @@ const TIMEOUT_MS = 30000;
  * with the client and stays the chokepoint for every consumer.
  */
 
-function envInt(name: string, fallback: number): number {
+/**
+ * Read a positive-integer env var with a fallback. Empty string and undefined
+ * map to the fallback; `0`, negative, and non-numeric values trigger a startup
+ * warn and also fall back — silently shipping `NaN`/`0` to downstream consumers
+ * (a semaphore-permit count, a budget header, etc.) is the failure mode this
+ * guards against.
+ */
+export function envInt(name: string, fallback: number): number {
   const raw = process.env[name];
   if (raw === undefined || raw === '') return fallback;
   const parsed = Number(raw);
   if (Number.isFinite(parsed) && parsed > 0) return parsed;
-  // Surface misconfigurations at startup so an operator who set `=0`
-  // intending to disable the limiter sees their value was rejected
-  // instead of silently falling back. A 0-permit semaphore would
-  // deadlock, which is why we don't accept it.
   console.warn(`lml.client: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
   return fallback;
 }
@@ -283,6 +286,28 @@ function getBaseUrl(): string {
   return url.replace(/\/api\/v1\/?$/, '').replace(/\/$/, '');
 }
 
+/**
+ * Caller-honored LML budget header (WXYC/library-metadata-lookup#345). When
+ * present, LML short-circuits its empty-results cascade once the budget
+ * elapses (WXYC/library-metadata-lookup#403/#404). Emitted by `postLookup`
+ * and `bulkLookupMetadata` when the caller sets `options.budgetMs`.
+ */
+const CALLER_BUDGET_HEADER = 'X-Caller-Budget-Ms';
+
+/**
+ * Build the request headers for a `/lookup` or `/lookup/bulk` POST. Returns a
+ * fresh object so callers can safely mutate. `budgetMs` becomes the
+ * `CALLER_BUDGET_HEADER` value when set; absent budget means no header (LML
+ * keeps the pre-A10 safety branch).
+ */
+function buildLookupHeaders(budgetMs?: number): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (budgetMs !== undefined) {
+    headers[CALLER_BUDGET_HEADER] = String(budgetMs);
+  }
+  return headers;
+}
+
 async function lmlFetch(path: string, init?: RequestInit, timeoutMs?: number): Promise<Response> {
   const url = `${getBaseUrl()}${path}`;
   const controller = new AbortController();
@@ -464,20 +489,11 @@ async function postLookup(
         console.warn('lml.client: failed to project queue_depth onto span', err);
       }
 
-      // Only emit X-Caller-Budget-Ms when the caller set budgetMs — absent
-      // header means LML keeps the pre-A10 safety branch for warm-cache /
-      // write-path callers (WXYC/library-metadata-lookup#403/#404). Same
-      // header-forwarding shape as `bulkLookupMetadata`.
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (options?.budgetMs !== undefined) {
-        headers['X-Caller-Budget-Ms'] = String(options.budgetMs);
-      }
-
       const response = await lmlFetch(
         '/api/v1/lookup',
         {
           method: 'POST',
-          headers,
+          headers: buildLookupHeaders(options?.budgetMs),
           body: JSON.stringify(body),
         },
         options?.timeoutMs
@@ -601,16 +617,11 @@ export async function bulkLookupMetadata(
         console.warn('lml.client: failed to project queue_depth + bulk.size onto span', err);
       }
 
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (options?.budgetMs !== undefined) {
-        headers['X-Caller-Budget-Ms'] = String(options.budgetMs);
-      }
-
       const response = await lmlFetch(
         '/api/v1/lookup/bulk',
         {
           method: 'POST',
-          headers,
+          headers: buildLookupHeaders(options?.budgetMs),
           body: JSON.stringify({ items }),
         },
         options?.timeoutMs

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -364,6 +364,19 @@ export interface LookupOptions {
    * defaults from BS#995) to keep accounting separated and tunable per caller.
    */
   limiter?: LmlLimiter;
+  /**
+   * Caller-honored budget (ms) forwarded to LML as `X-Caller-Budget-Ms`
+   * (WXYC/library-metadata-lookup#345). When set, LML short-circuits its
+   * empty-results cascade once the budget elapses
+   * (WXYC/library-metadata-lookup#403/#404) instead of burning Discogs quota
+   * on a response the caller has already abandoned. Pair with `timeoutMs`:
+   * set `budgetMs ~= timeoutMs - 1000` so LML's cutoff fires before the
+   * fetch aborts, leaving room for transport + the LML response slack.
+   * Omit to inherit LML's env soft budget (`LML_SEARCH_BUDGET_MS`, default
+   * 4 s) which only fires when at least one prior strategy returned results
+   * — the no-header path keeps the pre-A10 warm-cache / write-path semantics.
+   */
+  budgetMs?: number;
 }
 
 type LookupBody = {
@@ -402,7 +415,11 @@ export async function lookupMetadata(
   if (song) body.song = song;
   if (options?.extended) body.extended = true;
   if (options?.warm_cache) body.warm_cache = true;
-  return postLookup(body, { timeoutMs: options?.timeoutMs, limiter: options?.limiter });
+  return postLookup(body, {
+    timeoutMs: options?.timeoutMs,
+    limiter: options?.limiter,
+    budgetMs: options?.budgetMs,
+  });
 }
 
 /**
@@ -413,8 +430,11 @@ export async function lookupMetadata(
  * (BS#823) — Backend-Service is a thin proxy here; LML does all the ranking
  * and the response's `matched_via` carries the per-result evidence.
  */
-export async function lookupBySong(song: string, options?: Pick<LookupOptions, 'limiter'>): Promise<LookupResponse> {
-  return postLookup({ song, raw_message: song }, { limiter: options?.limiter });
+export async function lookupBySong(
+  song: string,
+  options?: Pick<LookupOptions, 'limiter' | 'budgetMs'>
+): Promise<LookupResponse> {
+  return postLookup({ song, raw_message: song }, { limiter: options?.limiter, budgetMs: options?.budgetMs });
 }
 
 /**
@@ -428,7 +448,7 @@ export async function lookupBySong(song: string, options?: Pick<LookupOptions, '
  */
 async function postLookup(
   body: LookupBody,
-  options?: { timeoutMs?: number; limiter?: LmlLimiter }
+  options?: { timeoutMs?: number; limiter?: LmlLimiter; budgetMs?: number }
 ): Promise<LookupResponse> {
   // BS#906 / G4: Mirror LML's Discogs ceilings on the client so back-pressure
   // surfaces at the BS chokepoint, not as queueing inside LML. The limiter
@@ -443,11 +463,21 @@ async function postLookup(
       } catch (err) {
         console.warn('lml.client: failed to project queue_depth onto span', err);
       }
+
+      // Only emit X-Caller-Budget-Ms when the caller set budgetMs — absent
+      // header means LML keeps the pre-A10 safety branch for warm-cache /
+      // write-path callers (WXYC/library-metadata-lookup#403/#404). Same
+      // header-forwarding shape as `bulkLookupMetadata`.
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (options?.budgetMs !== undefined) {
+        headers['X-Caller-Budget-Ms'] = String(options.budgetMs);
+      }
+
       const response = await lmlFetch(
         '/api/v1/lookup',
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers,
           body: JSON.stringify(body),
         },
         options?.timeoutMs

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -75,6 +75,7 @@ jest.mock('@wxyc/lml-client', () => ({
   lookupMetadata: mockLookupMetadata,
   isLmlConfigured: mockIsLmlConfigured,
   getRelease: mockGetRelease,
+  envInt: (_name: string, fallback: number) => fallback,
   LmlClientError: MockLmlClientError,
 }));
 

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -409,7 +409,7 @@ describe('library.controller', () => {
 
         // Controller returns 201 immediately, before fire-and-forget completes.
         expect(res.status).toHaveBeenCalledWith(201);
-        expect(mockLookupMetadata).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+        expect(mockLookupMetadata).toHaveBeenCalledWith('Juana Molina', 'DOGA', undefined, { budgetMs: 5000 });
       });
 
       it('writes canonical_entity_id back to the inserted row when the lookup yields a match', async () => {

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -31,6 +31,7 @@ jest.mock('@wxyc/lml-client', () => ({
   getArtistDetails: mockGetArtistDetails,
   resolveEntity: mockResolveEntity,
   searchLibrary: mockSearchLibrary,
+  envInt: (_name: string, fallback: number) => fallback,
   LmlClientError: MockLmlClientError,
 }));
 

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -647,6 +647,7 @@ describe('proxy.controller', () => {
         // the new fields.
         expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
           extended: true,
+          budgetMs: 5000,
         });
       });
 

--- a/tests/unit/services/flowsheet-linkage.metrics.test.ts
+++ b/tests/unit/services/flowsheet-linkage.metrics.test.ts
@@ -17,6 +17,7 @@ const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
 jest.mock('@wxyc/lml-client', () => ({
   lookupMetadata: mockLookupMetadata,
   isLmlConfigured: jest.fn().mockReturnValue(true),
+  envInt: (_name: string, fallback: number) => fallback,
 }));
 
 import { runLmlLinkage } from '../../../apps/backend/services/flowsheet-linkage.service';

--- a/tests/unit/services/flowsheet-linkage.service.test.ts
+++ b/tests/unit/services/flowsheet-linkage.service.test.ts
@@ -15,6 +15,7 @@ const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
 jest.mock('@wxyc/lml-client', () => ({
   lookupMetadata: mockLookupMetadata,
   isLmlConfigured: jest.fn().mockReturnValue(true),
+  envInt: (_name: string, fallback: number) => fallback,
 }));
 
 import { runLmlLinkage } from '../../../apps/backend/services/flowsheet-linkage.service';

--- a/tests/unit/services/library.canonicalEntity.test.ts
+++ b/tests/unit/services/library.canonicalEntity.test.ts
@@ -7,6 +7,7 @@ const mockIsLmlConfigured = jest.fn<() => boolean>();
 jest.mock('@wxyc/lml-client', () => ({
   lookupMetadata: mockLookupMetadata,
   isLmlConfigured: mockIsLmlConfigured,
+  envInt: (_name: string, fallback: number) => fallback,
 }));
 
 import { mapLookupToCanonicalEntity, updateCanonicalEntity } from '../../../apps/backend/services/library.service';

--- a/tests/unit/services/library.reconciledIdentity.test.ts
+++ b/tests/unit/services/library.reconciledIdentity.test.ts
@@ -20,6 +20,7 @@ jest.mock('@wxyc/database', () => ({
 jest.mock('@wxyc/lml-client', () => ({
   lookupMetadata: jest.fn(),
   isLmlConfigured: jest.fn().mockReturnValue(false),
+  envInt: (_name: string, fallback: number) => fallback,
 }));
 
 jest.mock('../../../apps/backend/services/requestLine/types', () => ({

--- a/tests/unit/services/library.rotation.test.ts
+++ b/tests/unit/services/library.rotation.test.ts
@@ -35,6 +35,7 @@ const mockIsLmlConfigured = jest.fn<() => boolean>();
 jest.mock('@wxyc/lml-client', () => ({
   lookupMetadata: mockLookupMetadata,
   isLmlConfigured: mockIsLmlConfigured,
+  envInt: (_name: string, fallback: number) => fallback,
 }));
 
 import { getRotationFromDB } from '../../../apps/backend/services/library.service';

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -9,6 +9,7 @@ jest.mock('@wxyc/lml-client', () => ({
   lookupMetadata: mockLookupMetadata,
   lookupBySong: mockLookupBySong,
   isLmlConfigured: mockIsLmlConfigured,
+  envInt: (_name: string, fallback: number) => fallback,
 }));
 
 // Mock @sentry/node so we can assert that searchLibraryByTrack creates a

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -1038,7 +1038,7 @@ describe('library.service', () => {
       const results = await searchLibraryByTrack('Back, Baby', 10);
 
       expect(mockLookupBySong).toHaveBeenCalledTimes(1);
-      expect(mockLookupBySong).toHaveBeenCalledWith('Back, Baby');
+      expect(mockLookupBySong).toHaveBeenCalledWith('Back, Baby', { budgetMs: 5000 });
       // Bridge query reads from `library` (with joins) so the unique index
       // on legacy_release_id is reachable.
       expect(libraryChain.from).toHaveBeenCalledWith(library);
@@ -1451,7 +1451,7 @@ describe('library.service', () => {
       await searchLibraryByTrack('Different Song', 10);
 
       expect(mockLookupBySong.mock.calls.length).toBe(callsAfterFirst + 1);
-      expect(mockLookupBySong).toHaveBeenLastCalledWith('Different Song');
+      expect(mockLookupBySong).toHaveBeenLastCalledWith('Different Song', { budgetMs: 5000 });
     });
 
     it('trim + lowercase: variations of the same query share one cache entry', async () => {
@@ -1864,7 +1864,7 @@ describe('library.service', () => {
       const enriched = await enrichWithArtwork(results);
 
       expect(enriched[0].artwork_url).toBe('https://i.discogs.com/confield.jpg');
-      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield');
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, { budgetMs: 5000 });
       expect(db.update).toHaveBeenCalled();
     });
 
@@ -1952,7 +1952,7 @@ describe('library.service', () => {
       expect(enriched[1].artwork_url).toBe('https://i.discogs.com/lp5.jpg');
       // Only one LML call (for LP5, not Confield)
       expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
-      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'LP5');
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'LP5', undefined, { budgetMs: 5000 });
     });
 
     it('handles LML returning no results', async () => {
@@ -2202,9 +2202,15 @@ describe('library.service', () => {
       const result = await getDiscogsReleaseIdByRotationId(42);
 
       expect(result).toBe(4080);
-      // The picker passes a 5 s budget so a hung LML call doesn't stall the
-      // dropdown for 30 s and tie up the shared LML semaphore permit (BS#992).
-      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, { timeoutMs: 5000 });
+      // The picker passes a 5 s fetch timeout so a hung LML call doesn't stall
+      // the dropdown for 30 s and tie up the shared LML semaphore permit
+      // (BS#992). The 4 s budgetMs forwards as X-Caller-Budget-Ms so LML's A10
+      // cutoff abandons its empty-results cascade ~1 s before BS aborts the
+      // fetch (WXYC/library-metadata-lookup#403/#404).
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
+        timeoutMs: 5000,
+        budgetMs: 4000,
+      });
     });
 
     it('does not call LML when the direct column has a value', async () => {

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -201,6 +201,38 @@ describe('lml.client', () => {
       expect(callBody.warm_cache).toBeUndefined();
     });
 
+    it('forwards X-Caller-Budget-Ms when budgetMs is provided', async () => {
+      // Mirrors bulkLookupMetadata's header-forwarding contract so the LML
+      // A10 caller-budget cutoff (WXYC/library-metadata-lookup#403/#404)
+      // fires for single-lookup callers too — without the header, LML's
+      // empty-results cascade grinds past the caller's deadline.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Stereolab', 'Aluminum Tunes', undefined, { budgetMs: 5000 });
+
+      const init = mockFetch.mock.calls[0][1];
+      if (!init) throw new Error('mockFetch was not called with init args');
+      expect(init.headers).toMatchObject({ 'X-Caller-Budget-Ms': '5000' });
+    });
+
+    it('omits X-Caller-Budget-Ms when budgetMs is not provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Stereolab', 'Aluminum Tunes');
+
+      const init = mockFetch.mock.calls[0][1];
+      if (!init) throw new Error('mockFetch was not called with init args');
+      expect(Object.keys((init.headers as Record<string, string>) ?? {})).not.toContain('X-Caller-Budget-Ms');
+    });
+
     it('wraps the call in a Sentry span and projects cache_stats onto it', async () => {
       const cache_stats = {
         memory_hits: 1,
@@ -415,6 +447,34 @@ describe('lml.client', () => {
         'lml.cache.pg_misses': 1,
         'lml.cache.api_calls': 1,
       });
+    });
+
+    it('forwards X-Caller-Budget-Ms when budgetMs is provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupBySong('Back, Baby', { budgetMs: 5000 });
+
+      const init = mockFetch.mock.calls[0][1];
+      if (!init) throw new Error('mockFetch was not called with init args');
+      expect(init.headers).toMatchObject({ 'X-Caller-Budget-Ms': '5000' });
+    });
+
+    it('omits X-Caller-Budget-Ms when budgetMs is not provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupBySong('Back, Baby');
+
+      const init = mockFetch.mock.calls[0][1];
+      if (!init) throw new Error('mockFetch was not called with init args');
+      expect(Object.keys((init.headers as Record<string, string>) ?? {})).not.toContain('X-Caller-Budget-Ms');
     });
 
     it('throws LmlClientError on non-2xx response', async () => {

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -202,10 +202,6 @@ describe('lml.client', () => {
     });
 
     it('forwards X-Caller-Budget-Ms when budgetMs is provided', async () => {
-      // Mirrors bulkLookupMetadata's header-forwarding contract so the LML
-      // A10 caller-budget cutoff (WXYC/library-metadata-lookup#403/#404)
-      // fires for single-lookup callers too — without the header, LML's
-      // empty-results cascade grinds past the caller's deadline.
       mockFetch.mockResolvedValue({
         ok: true,
         json: () =>


### PR DESCRIPTION
## Summary

- `lookupMetadata` and `lookupBySong` now accept `options.budgetMs` and forward it to LML as `X-Caller-Budget-Ms`. Mirrors the header-forwarding shape `bulkLookupMetadata` already uses, so the WXYC/library-metadata-lookup#403/#404 A10 cutoff fires for single-lookup callers too.
- Hot-path callers set tight budgets: proxy controller (5 s), library controller add-album + fire-and-forget canonical entity (5 s), library service rotation picker (4 s — `timeoutMs - 1000`), library service interactive lookups (5 s), enrichment-worker CDC consumer (29 s — `timeoutMs - 1000`).
- Four env knobs follow the `BACKFILL_BULK_BUDGET_MS` precedent of one per caller type, each defaulting to the value the caller actually wants: `PROXY_LML_BUDGET_MS`, `LIBRARY_LML_BUDGET_MS`, `LIBRARY_INTERACTIVE_LML_BUDGET_MS`, `ENRICHMENT_LML_BUDGET_MS`. The rotation picker keeps its existing inline 5 s timeout + new 4 s budget as module constants alongside the existing `ROTATION_LML_LOOKUP_TIMEOUT_MS`.

## Why

Without the header, LML's `state.results`-empty cascade burns Discogs quota for an answer BS won't render — the WXYC/library-metadata-lookup#337 symptoms-table queries (Rita Villa / Czardas, The Fly Girlz / Born 2 Be Fly) measured at 19–24 s on production with `api_time_ms ≈ 18-22 s`, where each API call sits on the Discogs rate limiter for ~9-11 s. Forwarding `X-Caller-Budget-Ms` lets LML short-circuit the cascade once the caller's deadline elapses (verified: same six queries finish under 1.3 s with the header set).

This unblocks the Epic A acceptance (`library-metadata-lookup#338`) p99 ≤ 8 s on the BS proxy path.

## Test plan

- [x] `npm run test:unit -- tests/unit/services/lml.client.test.ts` — new tests assert header forwarding on `lookupMetadata` + `lookupBySong`, mirroring the existing `bulkLookupMetadata` assertion (`tests/unit/services/lml.client.test.ts:496`)
- [x] `npm run test:unit` — 2432/2433 passing; the one failure is the pre-existing `schema.flowsheet-artwork-lookup-idx.test.ts` regression on origin/main, unrelated to this PR
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (warnings pre-existing)
- [x] `npm run format:check` — clean
- [ ] Re-measure the six WXYC/library-metadata-lookup#337 symptoms-table queries through the BS proxy path after staging deploy; epic acceptance p99 ≤ 8 s

Closes #1186

## Related

- WXYC/library-metadata-lookup#338 (Epic A) — gated on this for the p99 acceptance
- WXYC/library-metadata-lookup#403 / #404 — LML side of the gate
- WXYC/Backend-Service#873 — the 30 s runtime-timeout mitigation, which this lets us scale back to 5 s once staging measurement confirms