### PR TITLE
fix(metadata): drop write-path Apple Music search-URL fallback (BS#1192)

### DIFF
--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -65,23 +65,33 @@ export async function fetchMetadata(request: MetadataRequest): Promise<Flowsheet
     result.artist = extractArtistMetadata(artwork) ?? undefined;
   }
 
-  // Fill missing search URLs (always available, no API calls). All five
-  // streaming services have search-URL fallbacks post-BS#1185 — the
-  // Tragic Magic case (artist not in WXYC library at all → LML returns
-  // zero results → no artwork to project) used to leave Spotify and
-  // Apple Music as null, greying out two iOS buttons.
+  // Fill missing search URLs (always available, no API calls). Four of the
+  // five streaming services have search-URL fallbacks here: Spotify, YT,
+  // Bandcamp, SoundCloud. Apple Music is intentionally absent (BS#1192).
+  //
+  // LML's `_fetch_apple_music_url` enforces a verified iTunes match (80/80
+  // fuzzy floor + album-collection check). A null return is load-bearing
+  // signal — "we couldn't verify this release exists on Apple Music" —
+  // and persisting a keyword-search URL on the write path launders that
+  // signal into a clickable button that drops users on the in-app search
+  // page. Worse, `album_metadata` is keyed by `album_id` but the search
+  // query uses the enrichment-triggering `trackTitle`, so every linked
+  // flowsheet row for that album reads back the same track-scoped URL —
+  // wrong scope independent of the LML-signal issue.
+  //
+  // The read path (`proxy.controller.getAlbumMetadata`) still fills Apple
+  // at request time for the iOS Tragic Magic surface, where there's no
+  // persisted row to poison.
   const urls = searchUrls.getAllSearchUrls(artistName, albumTitle, trackTitle);
   if (!result.album) {
     result.album = {
       spotifyUrl: urls.spotifyUrl,
-      appleMusicUrl: urls.appleMusicUrl,
       youtubeMusicUrl: urls.youtubeMusicUrl,
       bandcampUrl: urls.bandcampUrl,
       soundcloudUrl: urls.soundcloudUrl,
     };
   } else {
     if (!result.album.spotifyUrl) result.album.spotifyUrl = urls.spotifyUrl;
-    if (!result.album.appleMusicUrl) result.album.appleMusicUrl = urls.appleMusicUrl;
     if (!result.album.youtubeMusicUrl) result.album.youtubeMusicUrl = urls.youtubeMusicUrl;
     if (!result.album.bandcampUrl) result.album.bandcampUrl = urls.bandcampUrl;
     if (!result.album.soundcloudUrl) result.album.soundcloudUrl = urls.soundcloudUrl;

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -169,11 +169,24 @@ describe('metadata.service', () => {
     expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
   });
 
-  it('uses SearchUrlProvider fallback for every streaming service when LML URLs are null (BS#1185)', async () => {
+  it('uses SearchUrlProvider fallback for streaming services other than Apple Music when LML URLs are null (BS#1185 + BS#1192)', async () => {
     // Pre-BS#1185, Spotify and Apple Music had no search-URL fallback, so a
     // release with artwork-but-no-streaming-URLs left iOS with two greyed
-    // buttons. Post-BS#1185, all five services have search-URL fallbacks
-    // via `SearchUrlProvider`.
+    // buttons. BS#1185 added fallbacks for both.
+    //
+    // BS#1192: the Apple Music write-path fallback is removed. LML's
+    // `_fetch_apple_music_url` enforces a verified iTunes match (80/80
+    // fuzzy floor + album-collection check). When it returns null, that's
+    // load-bearing signal — "we couldn't verify this release exists on
+    // Apple Music" — and persisting a keyword-search URL launders that
+    // signal into a clickable button that drops the user on the in-app
+    // search page. Leave Apple null on write so iOS greys the button
+    // (correctly indicating "we don't know"). The read path
+    // (`proxy.controller`) still fills Apple at request time for the iOS
+    // Tragic Magic surface, where there's no persisted row to poison.
+    //
+    // Spotify has no LML-side verification floor to preserve, so its
+    // write-path fallback stays.
     const responseNoUrls = structuredClone(lookupResponseWithResults);
     const artwork = responseNoUrls.results[0].artwork;
     artwork.spotify_url = null;
@@ -186,10 +199,21 @@ describe('metadata.service', () => {
     const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
 
     expect(result?.album?.spotifyUrl).toContain('open.spotify.com/search');
-    expect(result?.album?.appleMusicUrl).toContain('music.apple.com/search');
+    expect(result?.album?.appleMusicUrl).toBeUndefined();
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
     expect(result?.album?.bandcampUrl).toContain('bandcamp.com');
     expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
+  });
+
+  it('does not override a present LML-surfaced apple_music_url on the write path (BS#1192)', async () => {
+    // When LML successfully verifies an Apple Music match, the URL flows
+    // through unchanged — BS#1192 only removes the *fallback* fill, not
+    // any real LML-surfaced URL.
+    mockLookupMetadata.mockResolvedValue(lookupResponseWithResults);
+
+    const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
+
+    expect(result?.album?.appleMusicUrl).toBe('https://music.apple.com/album/xyz');
   });
 
   it('omits discogsReleaseId/discogsUrl on LML synth shape (release_id=0, release_url="")', async () => {
@@ -274,11 +298,13 @@ describe('metadata.service', () => {
     await expect(fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' })).rejects.toThrow('LML down');
   });
 
-  it('returns search URLs for all five services when lookup returns empty results (BS#1184/BS#1185 Tragic Magic case)', async () => {
+  it('returns search URLs for non-Apple services when lookup returns empty results (BS#1184/BS#1185/BS#1192 Tragic Magic case)', async () => {
     // The actual production failure mode: artist isn't in the WXYC library
     // at all, LML returns zero results, BS gets no artwork to project.
-    // Post-BS#1185 the fallback fills Spotify + Apple search URLs alongside
-    // the existing YT/BC/SC three, so iOS doesn't show all-greyed buttons.
+    // BS#1185 added Spotify + Apple search-URL fallbacks alongside YT/BC/SC.
+    // BS#1192 removes the Apple fallback (write-path only) — see the
+    // BS#1192 test above for the rationale. Apple stays undefined here;
+    // the read path fills it at request time for iOS.
     mockLookupMetadata.mockResolvedValue(emptyLookupResponse);
 
     const result = await fetchMetadata({
@@ -288,7 +314,7 @@ describe('metadata.service', () => {
     });
 
     expect(result?.album?.spotifyUrl).toContain('open.spotify.com/search');
-    expect(result?.album?.appleMusicUrl).toContain('music.apple.com/search');
+    expect(result?.album?.appleMusicUrl).toBeUndefined();
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
     expect(result?.album?.bandcampUrl).toContain('bandcamp.com');
     expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
@@ -296,7 +322,7 @@ describe('metadata.service', () => {
     expect(result?.album?.discogsUrl).toBeUndefined();
   });
 
-  it('returns search URLs for all five services when result has no artwork', async () => {
+  it('returns search URLs for non-Apple services when result has no artwork (BS#1192)', async () => {
     const responseNoArtwork = {
       ...lookupResponseWithResults,
       results: [{ library_item: lookupResponseWithResults.results[0].library_item, artwork: null }],
@@ -306,7 +332,7 @@ describe('metadata.service', () => {
     const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
 
     expect(result?.album?.spotifyUrl).toContain('open.spotify.com/search');
-    expect(result?.album?.appleMusicUrl).toContain('music.apple.com/search');
+    expect(result?.album?.appleMusicUrl).toBeUndefined();
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
     expect(result?.album?.discogsReleaseId).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- Drop `appleMusicUrl` from both branches of the search-URL fallback fill in `metadata.service.fetchMetadata`. Spotify, YT Music, Bandcamp, SoundCloud still get filled.
- Real LML-surfaced `apple_music_url` values still flow through `extractAlbumMetadata` unchanged — this PR removes only the *fallback* when LML returned `null`.
- `SearchUrlProvider.getAppleMusicUrl` and `appleMusicUrl` in `getAllSearchUrls`'s return type are preserved — `proxy.controller.getAlbumMetadata` still consumes them on the iOS read path.

## Why

[`_fetch_apple_music_url`](https://github.com/WXYC/library-metadata-lookup/blob/main/lookup/itunes.py) enforces a verified iTunes Search match (80/80 fuzzy floor + album-collection check). A `null` return is load-bearing signal — "we couldn't verify this release exists on Apple Music" — and persisting `music.apple.com/search?term=…` on the write path launders that signal into a clickable button that drops users on the in-app search page (today's Tamaryn "Love Fade" report). The "missing > wrong" invariant LML enforces ([`42a6c5d`](https://github.com/WXYC/library-metadata-lookup/commit/42a6c5d)) belongs on the write path too.

Compounding scope problem: `album_metadata` is keyed by `album_id`, but the search query uses the enrichment-triggering `trackTitle`. Every linked flowsheet row for that album then reads the same track-scoped URL — wrong scope independent of the LML-signal issue.

Spotify has no LML-side verification floor analogous to `_fetch_apple_music_url`, so its write-path fallback stays (`open.spotify.com/search/…` is functionally correct for any artist+album combination).

## Test plan

- [x] `npx jest tests/unit/services/metadata.service.test.ts` — 16/16 (was 13/13 on origin/main + 3 modified + 1 net new = 16).
- [x] Existing BS#1185 write-path Apple assertions flipped from `toContain('music.apple.com/search')` to `toBeUndefined()`.
- [x] New pin asserts a real LML-surfaced `apple_music_url` value flows through unchanged.
- [x] Read-path proxy.controller Apple assertions kept untouched (lines 320, 547 — both still pass).
- [x] `SearchUrlProvider` unit tests unchanged (helper is preserved).
- [x] Full unit suite: 0 new failures vs. `origin/main` baseline (same 10 pre-existing failures in `flowsheet-linkage`, `library.service`, `proxy.controller.libraryTracks`, etc. — all unrelated, none touch metadata.service).
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean (0 errors, pre-existing warnings only).
- [x] `npm run format:check` clean.

## Related

- BS#1185 — original Spotify+Apple fallback addition (this PR removes the Apple half).
- BS#1189 — inline `synthesizeSearchUrls` drift in `apps/enrichment-worker/enrich.ts` + `jobs/flowsheet-metadata-backfill/enrich.ts`; narrowed to Spotify only ([comment](https://github.com/WXYC/Backend-Service/issues/1189#issuecomment-4568954786)). The parity-test asymmetry against the canonical's 5-key return is settled by this PR — land this first.
- LML#401 — synth-shape contract that this PR's tests pin.
- LML "missing > wrong" invariant: [`42a6c5d`](https://github.com/WXYC/library-metadata-lookup/commit/42a6c5d).

## Follow-up

Prod cleanup (separate, surgical): null 3 poisoned `album_metadata.apple_music_url` rows (album_ids 51321, 27150, 45717) + check `flowsheet.apple_music_url` for inline matches. Will be done after this PR merges so the write path stops re-poisoning.

Closes #1192