### PR TITLE
chore(scripts): verify-rotation-release-id-backfill.sql (BS#1029 follow-up)

### DIFF
--- a/scripts/verify-rotation-release-id-backfill.sql
+++ b/scripts/verify-rotation-release-id-backfill.sql
@@ -1,0 +1,47 @@
+-- Verification SQL for jobs/rotation-release-id-backfill (BS#1029).
+--
+-- Run after a `docker run ... rotation-release-id-backfill:latest` invocation
+-- to confirm the job's counters match the database state:
+--
+--   backfill_attribution  ≈ resolved (from the job's `step: finished` log line)
+--   active_resolved       ≈ backfill_attribution + paste_verified
+--   active_rows           ≈ ticket-documented 310 (drifts as rotation pool changes)
+--
+-- The job's counters are the source of truth for what happened DURING the run;
+-- this SQL is the post-condition check for what's in the database NOW.
+--
+-- Invocation (verified working on the BS EC2 host post-2026-05-29 deploy):
+--
+--   ssh wxyc-ec2 'docker run --rm -i --env-file .env --network host \
+--     postgres:15-alpine sh -c "psql \"postgresql://\$DB_USERNAME:\$DB_PASSWORD@\$DB_HOST:\$DB_PORT/\$DB_NAME\""' \
+--     < scripts/verify-rotation-release-id-backfill.sql
+--
+-- Why the docker indirection: `source .env; psql ...` on the host fails with
+-- `password authentication failed` because shell quoting mangles the DB
+-- password during `source`. Docker's `--env-file` parser injects the value
+-- verbatim, matching what `docker run --env-file .env <backend>` already does
+-- in the deploy path. postgres:15-alpine is just an ergonomic way to ship
+-- `psql` to the host without installing it. `--network host` is required so
+-- the container can reach the RDS endpoint from inside the VPC.
+--
+-- If you have prod PG creds locally:
+--   psql "<prod-pg-url>" -f scripts/verify-rotation-release-id-backfill.sql
+--
+-- See WXYC/Backend-Service#1029 + jobs/rotation-release-id-backfill/README.md.
+
+SELECT
+  COUNT(*)
+    FILTER (WHERE kill_date IS NULL OR kill_date > CURRENT_DATE)
+    AS active_rows,
+  COUNT(*)
+    FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+            AND discogs_release_id IS NOT NULL)
+    AS active_resolved,
+  COUNT(*)
+    FILTER (WHERE discogs_release_id_source = 'lml_offline_backfill')
+    AS backfill_attribution,
+  COUNT(*)
+    FILTER (WHERE discogs_release_id_source = 'tubafrenzy_paste'
+            AND discogs_release_id IS NOT NULL)
+    AS paste_verified
+FROM wxyc_schema.rotation;


### PR DESCRIPTION
## Summary

Operator-runnable post-condition check for `jobs/rotation-release-id-backfill`. Follow-up to #1193.

Surfaces four counters from the rotation table — `active_rows`, `active_resolved`, `backfill_attribution` (rows with `discogs_release_id_source = 'lml_offline_backfill'`), and `paste_verified` (MD-verified subset with `tubafrenzy_paste` + non-NULL id). Lets a future operator confirm the post-condition matches the job's `step: finished` counters without writing the SQL from scratch.

## Why a separate PR

The verification only became necessary post-merge — first prod run finished 2026-05-29 00:19 UTC, returned `resolved=67`. Comparing that to the database steady state ran into a quoting quirk (`source .env; psql ...` fails password auth on EC2 even though `docker run --env-file .env <backend>` succeeds with the same file). The working invocation is `docker run --rm -i --env-file .env --network host postgres:15-alpine sh -c "psql ..."`, which is documented in the script header so the next operator doesn't repeat the detour.

## Verified output (production, 2026-05-29 00:35 UTC)

```
 active_rows | active_resolved | backfill_attribution | paste_verified 
-------------+-----------------+----------------------+----------------
         314 |              67 |                   67 |              0
```

- `active_rows = 314` — 4 above the ticket-stated 310 (normal pool drift)
- `active_resolved = 67` ≡ `backfill_attribution` ≡ job's `resolved` counter — all UPDATEs landed cleanly
- `paste_verified = 0` — confirms no tubafrenzy paste has populated any active row's `discogs_release_id` (consistent with #1029's baseline)

## Test plan

- [x] Hand-verified the SQL output against the job's run counters
- [x] Hand-verified the docker invocation on EC2 (returned the expected row)
- [ ] CI green

## Related

- #1029 — the backfill this verifies
- #1193 — merged 2026-05-28
- #1195 — captures the BS#1030 unblock decision (picker coverage gap)