### PR TITLE
fix(album-level-backfill): lower BULK_BATCH_SIZE_DEFAULT 10 -> 5

### DIFF
--- a/jobs/album-level-backfill/README.md
+++ b/jobs/album-level-backfill/README.md
@@ -24,7 +24,7 @@ If `linked_pending / unique_album_ids > 5`, the dedup payoff justifies the run.
 
 1. `SELECT DISTINCT album_id` from pending flowsheet rows with non-null `album_id`.
 2. Resolve each chunk of album_ids to `(artist_name, album_title)` via `library` + `artists` join.
-3. Call LML `POST /api/v1/lookup/bulk` with batches of `BACKFILL_BULK_BATCH_SIZE` items (default 10). The per-batch fetch timeout scales with this value (`batchSize × 2.5 s + 5 s` slack) so a cascade-heavy batch can't exhaust the shared LML-client's 30 s default (BS#1178).
+3. Call LML `POST /api/v1/lookup/bulk` with batches of `BACKFILL_BULK_BATCH_SIZE` items (default 5, lowered from 10 in BS#1197). The per-batch fetch timeout scales with this value (`batchSize × 2.5 s + 5 s` slack) so a cascade-heavy batch can't exhaust the shared LML-client's 30 s default (BS#1178). The 2026-05-28 Phase 3 canary measured 38–50 % per-batch timeouts at `batchSize=10` vs 3–10 % at `batchSize=5` under live `enrichment-worker` contention, so smaller batches yield _higher_ net throughput.
 4. For each `match` result, UPSERT into `album_metadata` with the same race-guarded `setWhere: updated_at < NOW()` shape the enrichment-worker uses.
 5. After all bulk calls complete, ANALYZE `album_metadata`.
 6. Cooperative pause until quiet, then post-pass UPDATE: `WITH matched AS (UPDATE flowsheet ... FROM album_metadata) SELECT count(*)`. Scoped inside `db.transaction` + `SET LOCAL statement_timeout`.
@@ -49,10 +49,11 @@ docker stop flowsheet-metadata-backfill-cron
 # 4. Run a dry-run first to verify env + scope
 docker run --rm --env-file .env <image> --dry-run
 
-# 5. Run for real. At post-BS#1178 defaults (batch=10, rate=1/min ≈ 10 items/min)
-#    a full 35,692-album drain takes ~60 h. For catch-up runs, bump
-#    BACKFILL_BULK_RATE_PER_MIN (e.g. 3 → ~20 h) — keep BATCH_SIZE at 10
-#    so the per-batch fetch-timeout headroom stays intact.
+# 5. Run for real. At post-BS#1197 defaults (batch=5, rate=1/min ≈ 5 items/min)
+#    a full 35,692-album drain takes ~120 h. For catch-up runs, bump
+#    BACKFILL_BULK_RATE_PER_MIN (e.g. 6 → ~20 h) — keep BATCH_SIZE at 5
+#    so the per-batch fetch-timeout headroom stays intact under live
+#    enrichment-worker contention (see BS#1078 Phase 3 evidence).
 docker run --rm --env-file .env <image> 2>&1 | tee /tmp/album-level-backfill.log
 
 # 6. Sanity check
@@ -73,17 +74,17 @@ psql "$DATABASE_URL" -c "
 
 ## Env knobs
 
-| Variable                                    | Default            | Meaning                                                                                       |
-| ------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------- |
-| `BACKFILL_BULK_BATCH_SIZE`                  | `10`               | Items per LML bulk request. LML caps at 100. Raising this scales the fetch timeout (BS#1178). |
-| `BACKFILL_BULK_RATE_PER_MIN`                | `1`                | Batches per minute. At the default batch size, 1/min ≈ 10 items/min sustained.                |
-| `BACKFILL_BULK_BUDGET_MS`                   | `25000`            | Per-item budget forwarded to LML as `X-Caller-Budget-Ms`. NOT the batch fetch timeout.        |
-| `ALBUM_LEVEL_BACKFILL_POST_PASS_TIMEOUT_MS` | `14400000` (4h)    | `SET LOCAL statement_timeout` for the post-pass UPDATE.                                       |
-| `ALBUM_LEVEL_BACKFILL_READ_TIMEOUT_MS`      | `300000` (5min)    | `SET LOCAL statement_timeout` for the enumerate scan + per-batch resolveAlbums lookup.        |
-| `LIVE_ACTIVITY_LOOKBACK_SECONDS`            | `300`              | Cooperative-pause lookback window; `0` disables.                                              |
-| `LIBRARY_METADATA_URL`                      | (required)         | LML base URL.                                                                                 |
-| `LML_API_KEY`                               | (required in prod) | LML bearer token.                                                                             |
-| `DATABASE_URL`                              | (required)         | Postgres connection string.                                                                   |
+| Variable                                    | Default            | Meaning                                                                                                                                                                   |
+| ------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BACKFILL_BULK_BATCH_SIZE`                  | `5`                | Items per LML bulk request. LML caps at 100. Raising this scales the fetch timeout (BS#1178); empirical post-LML#370 ceiling under live worker contention is 5 (BS#1197). |
+| `BACKFILL_BULK_RATE_PER_MIN`                | `1`                | Batches per minute. At the default batch size, 1/min ≈ 5 items/min sustained.                                                                                             |
+| `BACKFILL_BULK_BUDGET_MS`                   | `25000`            | Per-item budget forwarded to LML as `X-Caller-Budget-Ms`. NOT the batch fetch timeout.                                                                                    |
+| `ALBUM_LEVEL_BACKFILL_POST_PASS_TIMEOUT_MS` | `14400000` (4h)    | `SET LOCAL statement_timeout` for the post-pass UPDATE.                                                                                                                   |
+| `ALBUM_LEVEL_BACKFILL_READ_TIMEOUT_MS`      | `300000` (5min)    | `SET LOCAL statement_timeout` for the enumerate scan + per-batch resolveAlbums lookup.                                                                                    |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`            | `300`              | Cooperative-pause lookback window; `0` disables.                                                                                                                          |
+| `LIBRARY_METADATA_URL`                      | (required)         | LML base URL.                                                                                                                                                             |
+| `LML_API_KEY`                               | (required in prod) | LML bearer token.                                                                                                                                                         |
+| `DATABASE_URL`                              | (required)         | Postgres connection string.                                                                                                                                               |
 
 ## Acceptance verification
 

--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -43,14 +43,17 @@ const JOB_NAME = 'album-level-backfill';
 
 // -- Env knobs ---------------------------------------------------------------
 
-/** Items per bulk-lookup request. LML hard cap is 100; default 10 is
- * sized so one wave of LML's internal `LML_BULK_MAX_CONCURRENT=10`
- * fan-out fits inside a single per-item `caller_budget_ms` window.
- * `computeBulkTimeoutMs` scales the fetch timeout with this value;
- * raising the env override without paired slack reintroduces the
- * 30 s shared-client timeout. */
+/** Items per bulk-lookup request. LML hard cap is 100; default 5 is the
+ * empirically-validated post-LML#370 ceiling under live `enrichment-worker`
+ * contention for LML's 5-permit Discogs semaphore. The 2026-05-28 Phase 3
+ * canary (BS#1078 / BS#1197) measured 38–50 % per-batch timeout at
+ * `batchSize=10` vs 3–10 % at `batchSize=5` — smaller batches yield *higher*
+ * net throughput because `computeBulkTimeoutMs(5)=17_500 ms` lands cascade-
+ * heavy items under LML's 25 s `caller_budget_ms` window, while `(10)=30_000
+ * ms` races the shared LML-client's own 30 s socket timeout. Catch-up
+ * throughput comes from `BACKFILL_BULK_RATE_PER_MIN`, not this knob. */
 export const BULK_BATCH_SIZE_ENV = 'BACKFILL_BULK_BATCH_SIZE';
-export const BULK_BATCH_SIZE_DEFAULT = 10;
+export const BULK_BATCH_SIZE_DEFAULT = 5;
 
 /** Batches per minute. Bound the bulk caller so it can run concurrently
  * with the per-row drain cron (BS#995, 4 items/min) without saturating

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -577,8 +577,12 @@ describe('computeBulkTimeoutMs', () => {
     }
   });
 
-  it('keeps BULK_BATCH_SIZE_DEFAULT under the 30 s shared LML-client ceiling', () => {
-    expect(computeBulkTimeoutMs(BULK_BATCH_SIZE_DEFAULT)).toBeLessThanOrEqual(30_000);
+  // Tightened from ≤30_000 (the shared-client socket ceiling) to ≤20_000 so
+  // future drift back toward batchSize=10 — which produces a 30 s budget that
+  // races the LML-client socket timeout under live contention (BS#1078 / BS#1197)
+  // — fails CI before reaching production.
+  it('keeps BULK_BATCH_SIZE_DEFAULT under the 20 s cascade-budget ceiling', () => {
+    expect(computeBulkTimeoutMs(BULK_BATCH_SIZE_DEFAULT)).toBeLessThanOrEqual(20_000);
   });
 });
 


### PR DESCRIPTION
## Summary

- Empirically-validated post-LML#370 default under live `enrichment-worker` contention for LML's 5-permit Discogs semaphore.
- Refresh the env-knob comment + tighten the pin-test from ≤30_000 ms to ≤20_000 ms so any future drift back to `batchSize=10` fails CI before reaching production.
- README "How it works" + Run procedure + Env knobs updated for the new default and the ~5 items/min sustained throughput.

The 2026-05-28 Phase 3 canary measured 38–50 % per-batch timeouts at `batchSize=10` vs 3–10 % at `batchSize=5`: `computeBulkTimeoutMs(10)=30_000 ms` races the shared LML-client socket timeout, while `(5)=17_500 ms` lands cascade-heavy items under LML's 25 s `caller_budget_ms` window. Net throughput is *higher* with the smaller batch (see issue body for the canary table).

Closes #1197.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` (0 errors; only pre-existing warnings)
- [x] `npm run format:check` clean
- [x] `npm run test:unit -- tests/unit/jobs/album-level-backfill/` — 60/60 pass, including the tightened `computeBulkTimeoutMs(BULK_BATCH_SIZE_DEFAULT) ≤ 20_000` pin-test
- [x] `npm run build` clean
- [ ] CI green