### PR TITLE
fix(metadata): drop write-path Apple Music search-URL fallback (BS#1192)

### DIFF
--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -65,23 +65,28 @@ export async function fetchMetadata(request: MetadataRequest): Promise<Flowsheet
     result.artist = extractArtistMetadata(artwork) ?? undefined;
   }
 
-  // Fill missing search URLs (always available, no API calls). All five
-  // streaming services have search-URL fallbacks post-BS#1185 — the
-  // Tragic Magic case (artist not in WXYC library at all → LML returns
-  // zero results → no artwork to project) used to leave Spotify and
-  // Apple Music as null, greying out two iOS buttons.
+  // Fill missing search URLs (always available, no API calls). Four
+  // streaming services have write-path search-URL fallbacks: Spotify,
+  // YouTube Music, Bandcamp, SoundCloud. Apple Music is intentionally
+  // omitted from the WRITE path (BS#1192) — LML's `apple_music_url=null`
+  // is load-bearing signal that iTunes Search was either queried-and-empty
+  // or queried-and-rejected by LML#390/#398's artist/album/track-floor
+  // verification. Persisting a fabricated `music.apple.com/search?term=`
+  // URL onto `flowsheet`/`album_metadata` reverses LML's `42a6c5d`
+  // "missing-link strictly better than wrong-link" contract. The READ
+  // path in `proxy.controller.ts` still mints the Apple search URL at
+  // iOS runtime — that's where the BS#1184 Tragic Magic case lands
+  // (no V2 metadata → proxy.getAlbumMetadata fallback).
   const urls = searchUrls.getAllSearchUrls(artistName, albumTitle, trackTitle);
   if (!result.album) {
     result.album = {
       spotifyUrl: urls.spotifyUrl,
-      appleMusicUrl: urls.appleMusicUrl,
       youtubeMusicUrl: urls.youtubeMusicUrl,
       bandcampUrl: urls.bandcampUrl,
       soundcloudUrl: urls.soundcloudUrl,
     };
   } else {
     if (!result.album.spotifyUrl) result.album.spotifyUrl = urls.spotifyUrl;
-    if (!result.album.appleMusicUrl) result.album.appleMusicUrl = urls.appleMusicUrl;
     if (!result.album.youtubeMusicUrl) result.album.youtubeMusicUrl = urls.youtubeMusicUrl;
     if (!result.album.bandcampUrl) result.album.bandcampUrl = urls.bandcampUrl;
     if (!result.album.soundcloudUrl) result.album.soundcloudUrl = urls.soundcloudUrl;

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -169,11 +169,18 @@ describe('metadata.service', () => {
     expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
   });
 
-  it('uses SearchUrlProvider fallback for every streaming service when LML URLs are null (BS#1185)', async () => {
+  it('uses SearchUrlProvider fallback for Spotify + YT/BC/SC, leaves appleMusicUrl undefined (BS#1185 + BS#1192)', async () => {
     // Pre-BS#1185, Spotify and Apple Music had no search-URL fallback, so a
     // release with artwork-but-no-streaming-URLs left iOS with two greyed
-    // buttons. Post-BS#1185, all five services have search-URL fallbacks
-    // via `SearchUrlProvider`.
+    // buttons. BS#1185 added fallbacks for all five services. BS#1192 then
+    // pulled the Apple Music fallback back out of the WRITE path: LML's
+    // `apple_music_url=null` is load-bearing signal that iTunes was either
+    // queried-and-empty or queried-and-rejected by LML#390/#398's
+    // artist/album/track-floor verification. Synthesizing a search URL on
+    // the durable row reverses LML's `42a6c5d` "missing-link strictly
+    // better than wrong-link" contract. The read-path (proxy.controller)
+    // still fills it for iOS runtime requests — that's where the Tragic
+    // Magic case lands.
     const responseNoUrls = structuredClone(lookupResponseWithResults);
     const artwork = responseNoUrls.results[0].artwork;
     artwork.spotify_url = null;
@@ -186,10 +193,23 @@ describe('metadata.service', () => {
     const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
 
     expect(result?.album?.spotifyUrl).toContain('open.spotify.com/search');
-    expect(result?.album?.appleMusicUrl).toContain('music.apple.com/search');
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
     expect(result?.album?.bandcampUrl).toContain('bandcamp.com');
     expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
+    // BS#1192: write-path drops the Apple fallback. LML's null stays null.
+    expect(result?.album?.appleMusicUrl).toBeUndefined();
+  });
+
+  it('preserves LML-provided apple_music_url when present (BS#1192 negative case)', async () => {
+    // The write-path drop only suppresses fabricated search URLs. When LML
+    // returns a real Apple Music URL — direct match or post-verification
+    // synth-shape pass-through (LML#401) — it must still flow to the
+    // durable row.
+    mockLookupMetadata.mockResolvedValue(lookupResponseWithResults);
+
+    const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
+
+    expect(result?.album?.appleMusicUrl).toBe('https://music.apple.com/album/xyz');
   });
 
   it('omits discogsReleaseId/discogsUrl on LML synth shape (release_id=0, release_url="")', async () => {
@@ -274,11 +294,15 @@ describe('metadata.service', () => {
     await expect(fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' })).rejects.toThrow('LML down');
   });
 
-  it('returns search URLs for all five services when lookup returns empty results (BS#1184/BS#1185 Tragic Magic case)', async () => {
+  it('returns Spotify + YT/BC/SC search URLs when lookup returns empty results (BS#1184 Tragic Magic case, post-BS#1192)', async () => {
     // The actual production failure mode: artist isn't in the WXYC library
     // at all, LML returns zero results, BS gets no artwork to project.
-    // Post-BS#1185 the fallback fills Spotify + Apple search URLs alongside
-    // the existing YT/BC/SC three, so iOS doesn't show all-greyed buttons.
+    // BS#1185 added Spotify + Apple fallbacks for this case; BS#1192 pulled
+    // Apple back out of the write-path because iTunes wasn't queried at all
+    // (no LML lookup means no album-verified Apple link). The READ path
+    // (proxy.controller) still mints the Apple search URL when iOS asks at
+    // runtime; that's the Tragic Magic surface for the no-V2-metadata
+    // branch. See `proxy.controller.test.ts` for the read-path coverage.
     mockLookupMetadata.mockResolvedValue(emptyLookupResponse);
 
     const result = await fetchMetadata({
@@ -288,15 +312,15 @@ describe('metadata.service', () => {
     });
 
     expect(result?.album?.spotifyUrl).toContain('open.spotify.com/search');
-    expect(result?.album?.appleMusicUrl).toContain('music.apple.com/search');
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
     expect(result?.album?.bandcampUrl).toContain('bandcamp.com');
     expect(result?.album?.soundcloudUrl).toContain('soundcloud.com');
+    expect(result?.album?.appleMusicUrl).toBeUndefined();
     expect(result?.album?.discogsReleaseId).toBeUndefined();
     expect(result?.album?.discogsUrl).toBeUndefined();
   });
 
-  it('returns search URLs for all five services when result has no artwork', async () => {
+  it('returns Spotify + YT/BC/SC search URLs (no Apple) when result has no artwork', async () => {
     const responseNoArtwork = {
       ...lookupResponseWithResults,
       results: [{ library_item: lookupResponseWithResults.results[0].library_item, artwork: null }],
@@ -306,8 +330,8 @@ describe('metadata.service', () => {
     const result = await fetchMetadata({ artistName: 'Autechre', albumTitle: 'Confield' });
 
     expect(result?.album?.spotifyUrl).toContain('open.spotify.com/search');
-    expect(result?.album?.appleMusicUrl).toContain('music.apple.com/search');
     expect(result?.album?.youtubeMusicUrl).toContain('music.youtube.com');
+    expect(result?.album?.appleMusicUrl).toBeUndefined();
     expect(result?.album?.discogsReleaseId).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

Drops the write-path Apple Music search-URL fallback introduced by #1188 (BS#1185). LML's `apple_music_url=null` carries verification semantics — it's the signal that iTunes Search was either queried-and-empty OR queried-and-rejected by LML#390/#398's artist/album/track-floor verification. Synthesizing `music.apple.com/search?term=<typed-query>` and persisting it onto the durable `flowsheet`/`album_metadata` row reverses LML's `42a6c5d` "missing-link strictly better than wrong-link" contract: an iOS button that opens an in-app search for the DJ's typed string is the wrong-link experience, not the missing-link one. The user clicks expecting playback, lands on a search result page (potentially with no matches), and reads it as a broken iOS button.

The read path stays intact. `proxy.controller.populateCommonMetadataFields` at `apps/backend/controllers/proxy.controller.ts:377` still mints `music.apple.com/search?term=` when LML returns no Apple URL — that's the iOS no-V2-metadata branch that lands on the BS#1184 Tragic Magic case at runtime (artist not in WXYC library at all, LML returns `results: []`, nothing to inherit from). The read-path runtime fill happens at the (artist, album, track) tuple iOS just requested, so the scope-mismatch doesn't apply there.

## Why now

The Tamaryn / "Love Fade" / "The Waves" flowsheet row surfaced after #1188 deployed at 18:15 UTC on 2026-05-28. Apple Music in-app opened on a keyword search for `Tamaryn Love Fade` instead of the album. Three album_metadata rows have known confirmed poison (album_id 45717, 27150, 51321) and the count grows on every flowsheet add + every recurring backfill tick until this lands.

## Changes

- **`apps/backend/services/metadata/metadata.service.ts`** — drop `appleMusicUrl: urls.appleMusicUrl` from the no-album-yet branch (line 77, pre-change) and `if (!result.album.appleMusicUrl) result.album.appleMusicUrl = urls.appleMusicUrl;` from the merge branch (line 84, pre-change). Comment expanded to document the write-path/read-path split.
- `SearchUrlProvider.getAppleMusicUrl` and `getAllSearchUrls`'s `appleMusicUrl` field stay — `proxy.controller.ts:375-377` still consumes them.
- `extractAlbumMetadata` at line 146 still copies LML's `artwork.apple_music_url ?? undefined` through unchanged: a real LML-provided Apple URL (direct match or LML#401 synth-shape pass-through) still flows to the durable row.

## Why not also drop the read-path fallback?

The Tragic Magic case (BS#1184) is the iOS no-V2-metadata branch: iOS's catalog cache misses, iOS calls `/proxy/album/<artist>/<album>/<track>`, BS calls LML, LML returns no results, BS's read-path fallback fills the search URL so iOS shows a button instead of grey. There's no persistence; the next request that hits a real catalog match supersedes it. That trade — runtime search URL beats grey button when there's no persistent state to corrupt — is still correct.

## Tests

| Suite | Result |
|---|---|
| `metadata.service` (updated 3 + new 1) | **16 / 16 passing** |
| `proxy.controller` (untouched) | **all passing** |
| `search-urls.provider` (untouched) | **all passing** |
| **Targeted suites total** | **84 / 84 passing** |
| **Full unit suite** | **2449 / 2450 passing** (1 pre-existing `schema.flowsheet-artwork-lookup-idx` failure, unrelated; reproduces against `origin/main`) |

## Local pre-flight

```
npm run typecheck    # ✓
npm run lint         # ✓ (0 errors, 466 pre-existing warnings)
npm run format:check # ✓
npm run test:unit    # 2449 passed, 1 pre-existing failure
```

## Follow-up work (filed separately)

- **Three poisoned `album_metadata` rows** (`album_id` 45717, 27150, 51321) need a one-shot `UPDATE album_metadata SET apple_music_url = NULL WHERE album_id IN (...) AND apple_music_url LIKE '%music.apple.com/search%'` after this lands. Filed as a follow-up ticket (see below).
- **BS#1189 scope narrowing**: the inline `synthesizeSearchUrls` write-path copies in `jobs/flowsheet-metadata-backfill/enrich.ts` + `apps/enrichment-worker/enrich.ts` were going to widen from 3 → 5 URLs. With this PR, they widen from 3 → 4 (Spotify only; Apple drops out of the write-path entirely). Comment on #1189 to follow.
- **LML#400 — systemic upstream wrong-album fallback** — separate, deeper fix. Not blocked by this PR.

Closes #1192.

Refs: WXYC/Backend-Service#1184 (Tragic Magic parent), WXYC/Backend-Service#1185 (predecessor that introduced the now-dropped write-path Apple fallback via #1188), WXYC/Backend-Service#1189 (sibling write-path drift, scope narrows), WXYC/library-metadata-lookup#390, WXYC/library-metadata-lookup#398, WXYC/library-metadata-lookup#401.
