### PR TITLE
fix(album-level-backfill): widen BULK_PER_ITEM_TIMEOUT_MS 2_500 -> 5_000

### DIFF
--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -47,11 +47,10 @@ const JOB_NAME = 'album-level-backfill';
  * empirically-validated post-LML#370 ceiling under live `enrichment-worker`
  * contention for LML's 5-permit Discogs semaphore. The 2026-05-28 Phase 3
  * canary (BS#1078 / BS#1197) measured 38–50 % per-batch timeout at
- * `batchSize=10` vs 3–10 % at `batchSize=5` — smaller batches yield *higher*
- * net throughput because `computeBulkTimeoutMs(5)=17_500 ms` lands cascade-
- * heavy items under LML's 25 s `caller_budget_ms` window, while `(10)=30_000
- * ms` races the shared LML-client's own 30 s socket timeout. Catch-up
- * throughput comes from `BACKFILL_BULK_RATE_PER_MIN`, not this knob. */
+ * `batchSize=10` vs 3–10 % at `batchSize=5` — smaller batches keep total
+ * wall-clock inside LML's per-item 25 s `caller_budget_ms` cap (LML#370)
+ * instead of stacking cascade-bound items past it. Catch-up throughput
+ * comes from `BACKFILL_BULK_RATE_PER_MIN`, not this knob. */
 export const BULK_BATCH_SIZE_ENV = 'BACKFILL_BULK_BATCH_SIZE';
 export const BULK_BATCH_SIZE_DEFAULT = 5;
 
@@ -68,9 +67,16 @@ export const BULK_RATE_PER_MIN_DEFAULT = 1;
 export const BULK_BUDGET_MS_ENV = 'BACKFILL_BULK_BUDGET_MS';
 export const BULK_BUDGET_MS_DEFAULT = 25_000;
 
-/** Per-item slice of the bulk fetch timeout. Matches LML's amortized
- * rate: `BULK_BUDGET_MS_DEFAULT / LML_BULK_MAX_CONCURRENT = 25_000 / 10`. */
-export const BULK_PER_ITEM_TIMEOUT_MS = 2_500;
+/** Per-item slice of the bulk fetch timeout. Sized from LML's realized
+ * concurrency for cascade-bound items: `BULK_BUDGET_MS_DEFAULT` divided
+ * by LML's 5-permit Discogs semaphore, not its 10-wide bulk fan-out.
+ * The earlier `25_000 / 10 = 2_500` derivation held for warm-cache items
+ * but broke under live `enrichment-worker` contention — the 2026-05-28
+ * Phase 3 canary (BS#1078 T1) measured min elapsed 25_045 ms per batch,
+ * pinned at LML#370's per-item 25 s cap. Widening to `25_000 / 5 = 5_000`
+ * gives each cascade-bound item a full per-permit share plus the
+ * cancellation headroom from LML#372. */
+export const BULK_PER_ITEM_TIMEOUT_MS = 5_000;
 
 /** Fixed slack on top of `batchSize × BULK_PER_ITEM_TIMEOUT_MS`:
  * HTTP overhead + JSON encode/decode + safety margin. */

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -577,12 +577,26 @@ describe('computeBulkTimeoutMs', () => {
     }
   });
 
-  // Tightened from ≤30_000 (the shared-client socket ceiling) to ≤20_000 so
-  // future drift back toward batchSize=10 — which produces a 30 s budget that
-  // races the LML-client socket timeout under live contention (BS#1078 / BS#1197)
-  // — fails CI before reaching production.
-  it('keeps BULK_BATCH_SIZE_DEFAULT under the 20 s cascade-budget ceiling', () => {
-    expect(computeBulkTimeoutMs(BULK_BATCH_SIZE_DEFAULT)).toBeLessThanOrEqual(20_000);
+  // Slope-independent invariant: at the default batchSize, the client
+  // timeout should not exceed one full per-item server budget plus slack.
+  // Catches DEFAULT drift back to 10 (would give 55_000 ms at the post-#1198
+  // slope, well over the 30_000 ms ceiling) without re-baking arithmetic
+  // every time the slope or slack moves.
+  it('keeps BULK_BATCH_SIZE_DEFAULT under one per-item budget + slack', () => {
+    expect(computeBulkTimeoutMs(BULK_BATCH_SIZE_DEFAULT)).toBeLessThanOrEqual(
+      BULK_BUDGET_MS_DEFAULT + BULK_TIMEOUT_SLACK_MS
+    );
+  });
+
+  // Belt-and-suspenders cap on operator-overridden batch sizes (#1198 acceptance).
+  // BACKFILL_BULK_BATCH_SIZE up to 20 — chosen to bracket plausible catch-up
+  // overrides — must stay under 120 s of fetch budget. Above that we're outside
+  // the regime LML's per-item cap was sized for and the failure mode shifts
+  // from "slow batch" to "timeouts pile up while LML keeps doing work."
+  it('caps overridden batchSize ≤ 20 at ≤ 120 s of fetch budget', () => {
+    for (let n = 1; n <= 20; n++) {
+      expect(computeBulkTimeoutMs(n)).toBeLessThanOrEqual(120_000);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Widen `BULK_PER_ITEM_TIMEOUT_MS` from `2_500` ms to `5_000` ms. The old slope was derived from LML's bulk fan-out (`BULK_BUDGET_MS_DEFAULT / LML_BULK_MAX_CONCURRENT = 25_000 / 10`) and held for warm-cache items, but broke under live `enrichment-worker` contention. Realized concurrency for cascade-bound items is capped by LML's 5-permit Discogs semaphore, not the 10-wide fan-out, so the slope should fall out of the realized denominator: `25_000 / 5 = 5_000`.

This is the canonical interpretation of [LML#370](https://github.com/WXYC/library-metadata-lookup/issues/370)'s per-item 25 s cap plus the cancellation headroom from [LML#372](https://github.com/WXYC/library-metadata-lookup/issues/372). No change to LML server cost; only widens BS-side client-timeout headroom.

## Evidence

The 2026-05-28 Phase 3 canary at `batch=5` measured **min elapsed 25_045 ms** per batch — pinned at the LML#370 per-item cap. Successful batches took 25–28 s. The old 17.5 s ceiling for `batchSize=5` only worked because half the canary's items were warm-cache (sub-500 ms); the cascade-heavy half maxed out the budget. See [#1078's Phase 3 T1 comment](https://github.com/WXYC/Backend-Service/issues/1078#issuecomment-4569398978).

## Sequencing

Depends on `BULK_BATCH_SIZE_DEFAULT=5` ([#1197](https://github.com/WXYC/Backend-Service/pull/1197), already merged on `main` as `55111ae6`). With `DEFAULT=5` and the new slope, `computeBulkTimeoutMs(5) = 5×5_000 + 5_000 = 30_000` ms — exactly one full `BULK_BUDGET_MS_DEFAULT + BULK_TIMEOUT_SLACK_MS`, the canonical ceiling for a single LML cascade window.

## Resulting ceilings

| batchSize | timeout (ms) | Notes |
|---|---|---|
| 5 (default) | 30_000 | One full per-item budget + slack |
| 10 | 55_000 | Operator override; bounded |
| 20 | 105_000 | Operator override; under the new ≤120 s cap |

## Test changes

- **Tightened-then-replaced**: the existing `computeBulkTimeoutMs(DEFAULT) ≤ 20_000` assertion (added in #1197 as arithmetic shorthand) becomes brittle once the slope moves. Replaced with the slope-independent invariant `≤ BULK_BUDGET_MS_DEFAULT + BULK_TIMEOUT_SLACK_MS`. This still catches `DEFAULT` drift back to `10` (would give `55_000 > 30_000`) without re-baking arithmetic every time the slope or slack moves.
- **Added** (issue acceptance): for any operator-overridden `batchSize ≤ 20`, the fetch budget stays `≤ 120_000` ms.
- The linear-relationship pin (line 575-578) is unchanged and continues to catch slack/slope drift.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new errors; pre-existing warnings unchanged)
- [x] `npm run format:check`
- [x] `npx jest tests/unit/jobs/album-level-backfill/job.test.ts` — 48/48 passing

Closes #1198