### PR TITLE
test(metadata): pin LML-provided apple_music_url end-to-end (BS#1192 negative case)

### DIFF
--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -156,6 +156,24 @@ describe('metadata.service', () => {
     expect(result?.artist?.wikipediaUrl).toBe('https://en.wikipedia.org/wiki/Autechre');
   });
 
+  it('preserves LML-provided apple_music_url end-to-end (BS#1192 negative case)', async () => {
+    // BS#1192 dropped the write-path Apple Music fallback so iTunes Search
+    // rejections (LML#390/#398 floor) stay null on the durable row. This
+    // pins the OTHER direction: when LML returns a real, verified
+    // `apple_music_url` (direct iTunes Search match OR LML#401 synth-shape
+    // pass-through), it must still flow to `result.album.appleMusicUrl`
+    // unchanged. A future refactor that broadens the BS#1192 drop into
+    // "strip Apple from the write path" would break this assertion.
+    mockLookupMetadata.mockResolvedValue(lookupResponseWithResults);
+
+    const result = await fetchMetadata({
+      artistName: 'Autechre',
+      albumTitle: 'Confield',
+    });
+
+    expect(result?.album?.appleMusicUrl).toBe('https://music.apple.com/album/xyz');
+  });
+
   it('fills missing streaming URLs with search URL fallbacks', async () => {
     mockLookupMetadata.mockResolvedValue(lookupResponseWithResults);
 


### PR DESCRIPTION
## Summary

Adds a one-test pin to `tests/unit/services/metadata.service.test.ts` complementing the BS#1192 write-path Apple Music search-URL fallback drop (commit [`7bb2a239`](https://github.com/WXYC/Backend-Service/commit/7bb2a239)).

BS#1192's drop only suppresses the **synthesized** `music.apple.com/search?term=…` URL. When LML returns a **real, verified** `apple_music_url` — either a direct iTunes Search match that cleared LML#390/#398's 80/80 artist+track+album floor, or the LML#401 synth-shape pass-through that carries a verified iTunes URL alongside a Discogs miss — that URL must still flow to `result.album.appleMusicUrl` unchanged so the durable row preserves it.

The existing tests cover the **null-in / undefined-out** direction (`uses SearchUrlProvider fallback for Spotify + YT/BC/SC, leaves appleMusicUrl undefined`, `returns Spotify + YT/BC/SC search URLs when lookup returns empty results`, `returns Spotify + YT/BC/SC search URLs (no Apple) when result has no artwork`). None of them cover the **URL-in / URL-out** direction. Without the new test, a future refactor that broadens BS#1192's drop into "strip Apple from the write path entirely" would silently null `result.album.appleMusicUrl` and only get caught by a production incident.

## Changes

- **`tests/unit/services/metadata.service.test.ts`** — adds `preserves LML-provided apple_music_url end-to-end (BS#1192 negative case)` after the existing `extracts artist metadata from lookup response artwork` test. Same fixture as the album-extraction test; asserts `appleMusicUrl === 'https://music.apple.com/album/xyz'` from the LML-provided artwork.

## Tests

| Suite | Result |
|---|---|
| `metadata.service` | **17 / 17 passing** (16 pre-existing + new) |
| **Full unit suite** | **2450 / 2451 passing** (1 pre-existing `schema.flowsheet-artwork-lookup-idx` failure, unrelated to this PR; reproduces against `origin/main`) |

## Local pre-flight

```
npm run typecheck    # ✓
npm run lint         # ✓ (0 errors, 466 pre-existing warnings)
npm run format:check # ✓
npm run test:unit    # 2450 passed, 1 pre-existing failure
```

## Related

- BS#1192 (commit [`7bb2a239`](https://github.com/WXYC/Backend-Service/commit/7bb2a239)) — write-path Apple Music fallback drop this PR pins the inverse of.
- BS#1185 / PR #1188 — original write-path Apple fallback this PR's existing-coverage gap traces back to.
- WXYC/library-metadata-lookup#390 / #398 / #401 — upstream iTunes-result verification + synth-shape contract that BS#1192's null-respecting behavior keys off.