### PR TITLE
Drop rotation-picker budgetMs + bump timeoutMs to restore tubafrenzy parity

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -344,23 +344,24 @@ const ROTATION_LML_LOOKUP_CACHE_MAX = 500;
 const ROTATION_LML_LOOKUP_TTL_POSITIVE_MS = 60 * 60 * 1000;
 const ROTATION_LML_LOOKUP_TTL_NEGATIVE_MS = 10 * 60 * 1000;
 /**
- * Per-call LML timeout for the picker's tier-3 lookup (BS#992). The default
- * `TIMEOUT_MS` in the LML client is 30 s — appropriate for fire-and-forget
- * enrichment paths but unacceptable for a user-visible dropdown that's
- * already a degrades-to-free-text flow. The shorter budget also frees the
- * shared LML semaphore permit ~6× sooner so other concurrent callers
- * (`/proxy/metadata/album`, `/library/query`) aren't queued behind a
- * single hung tier-3 lookup.
+ * Per-call LML timeout for the picker's tier-3 lookup. 10 s matches
+ * tubafrenzy's `RELEASE_LOOKUP_TIMEOUT` (`LibrarySearchClient.java:64`),
+ * which is the parity bar we measure picker coverage against. Shorter
+ * timeouts cut off LML's cascade before the later strategies that find
+ * obscure college-rotation releases get to run — the source of the
+ * coverage regression that motivated dropping the BS#1186 budget.
+ *
+ * Intentionally no `budgetMs` companion: BS#1186 added a 4 s
+ * `X-Caller-Budget-Ms` header to short-circuit LML's empty-results
+ * cascade. That cap was justified by malformed-query examples
+ * (track-titles-as-album-names) and applied uniformly across callers,
+ * including this one. For the picker — which always passes real
+ * `(artist_name, album_title)` pairs from rotation rows — the cascade's
+ * later strategies are exactly where matches come from, so capping at
+ * 4 s collapsed picker coverage to ~23 %. The iOS proxy/artwork hot-path
+ * callers keep their budgets; only this call site opts out.
  */
-const ROTATION_LML_LOOKUP_TIMEOUT_MS = 5000;
-
-/**
- * Picker budget. Pinned ~1 s tighter than `ROTATION_LML_LOOKUP_TIMEOUT_MS`
- * so LML's A10 cutoff fires before the local `AbortController` aborts the
- * fetch. Hardcoded because the two constants are paired (changing one without
- * the other breaks the timing). See `LookupOptions.budgetMs` for mechanics.
- */
-const ROTATION_LML_LOOKUP_BUDGET_MS = 4000;
+const ROTATION_LML_LOOKUP_TIMEOUT_MS = 10000;
 
 /**
  * Budget for `enrichWithArtwork` and `searchLibraryByTrack` — both user-visible
@@ -471,6 +472,26 @@ export async function getDiscogsReleaseIdByRotationId(rotationId: number): Promi
  * already wraps the call in a Sentry span carrying `lml.cache.*` and
  * `lml.queue_depth` attributes for trace-explorer drill-down.
  */
+/**
+ * Detect Various-Artists artist-name variants the picker should omit from
+ * the LML lookup. Mirrors tubafrenzy's `LibrarySearchClient.isVariousArtistsName`
+ * (`LibrarySearchClient.java:429`): passing "Various Artists" pollutes
+ * LML's fuzzy matching and surfaces unrelated compilations instead of the
+ * actual release. LML's /lookup orchestrator supports the album-only path.
+ *
+ * Exported for the unit-test parity matrix; not part of the public service
+ * surface.
+ */
+export function isVariousArtistsName(name: string): boolean {
+  const trimmed = name.trim().toLowerCase();
+  if (trimmed.length === 0) return false;
+  if (/^v[\s./]*a\.?$/.test(trimmed)) return true;
+  if (trimmed === 'various') return true;
+  if (/^various\s+art/.test(trimmed)) return true;
+  if (/^var\.?\s+art/.test(trimmed)) return true;
+  return false;
+}
+
 async function resolveRotationDiscogsReleaseViaLml(
   rotationId: number,
   artistName: string | null,
@@ -483,11 +504,12 @@ async function resolveRotationDiscogsReleaseViaLml(
   if (cachedPositive !== undefined) return cachedPositive;
   if (rotationLmlNegativeCache.has(rotationId)) return null;
 
+  const lookupArtist = isVariousArtistsName(artistName) ? undefined : artistName;
+
   let releaseId: number | null;
   try {
-    const response = await lookupMetadata(artistName, albumTitle, undefined, {
+    const response = await lookupMetadata(lookupArtist, albumTitle, undefined, {
       timeoutMs: ROTATION_LML_LOOKUP_TIMEOUT_MS,
-      budgetMs: ROTATION_LML_LOOKUP_BUDGET_MS,
     });
     releaseId = response.results?.[0]?.artwork?.release_id ?? null;
   } catch (err) {

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -426,7 +426,7 @@ type LookupBody = {
  * @returns Lookup results with library items and enriched artwork metadata
  */
 export async function lookupMetadata(
-  artist: string,
+  artist: string | undefined,
   album?: string,
   song?: string,
   options?: LookupOptions
@@ -435,7 +435,12 @@ export async function lookupMetadata(
   // are already structured. Synthesize a free-form description that the LML
   // parser would have produced — matches the e2e fixtures in LML's repo.
   const rawMessage = [artist, album, song].filter(Boolean).join(' - ');
-  const body: LookupBody = { artist, raw_message: rawMessage };
+  // `artist` is optional so callers can opt out of artist-side disambiguation
+  // when they know the artist field would poison the match (e.g. the rotation
+  // picker for Various-Artists releases — LML's parser does better with the
+  // album-only path than with "Various Artists" as a literal artist).
+  const body: LookupBody = { raw_message: rawMessage };
+  if (artist) body.artist = artist;
   if (album) body.album = album;
   if (song) body.song = song;
   if (options?.extended) body.extended = true;

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -51,6 +51,7 @@ import {
   updateArtworkUrl,
   getDiscogsReleaseIdByRotationId,
   __resetRotationLmlLookupCacheForTests,
+  isVariousArtistsName,
 } from '../../../apps/backend/services/library.service';
 import { resetConfig as resetCatalogTrackSearchConfig } from '../../../apps/backend/config/catalogTrackSearch';
 
@@ -2203,15 +2204,63 @@ describe('library.service', () => {
       const result = await getDiscogsReleaseIdByRotationId(42);
 
       expect(result).toBe(4080);
-      // The picker passes a 5 s fetch timeout so a hung LML call doesn't stall
-      // the dropdown for 30 s and tie up the shared LML semaphore permit
-      // (BS#992). The 4 s budgetMs forwards as X-Caller-Budget-Ms so LML's A10
-      // cutoff abandons its empty-results cascade ~1 s before BS aborts the
-      // fetch (WXYC/library-metadata-lookup#403/#404).
+      // 10 s timeout matches tubafrenzy's `RELEASE_LOOKUP_TIMEOUT` so picker
+      // coverage on long-tail rotation rows parity-matches the legacy system.
+      // No `budgetMs` here on purpose: BS#1186's cutoff was justified by
+      // malformed-query examples (track-titles-as-album-names) — for the
+      // picker, which always passes real `(artist_name, album_title)` pairs
+      // from rotation, the cascade's later strategies are exactly where the
+      // match for obscure college rotation comes from.
       expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
-        timeoutMs: 5000,
-        budgetMs: 4000,
+        timeoutMs: 10000,
       });
+    });
+
+    it("omits the artist field when the rotation row's artist_name is a Various-Artists variant", async () => {
+      // Mirrors tubafrenzy's `LibrarySearchClient.searchDiscogsRelease`
+      // carve-out (`LibrarySearchClient.java:283,429`): passing
+      // "Various Artists" pollutes LML's fuzzy matching and surfaces
+      // unrelated compilations instead of the actual release. LML's
+      // /lookup orchestrator supports the album-only path natively.
+      mockRow({
+        direct: null,
+        fallback: null,
+        artist_name: 'Various Artists',
+        album_title: 'All the Young Droids: Junkshop Synth Pop 1978-1985',
+      });
+      mockLookupMetadata.mockResolvedValue({
+        results: [{ artwork: { release_id: 26538110 } }],
+        search_type: 'direct',
+      });
+
+      const result = await getDiscogsReleaseIdByRotationId(42);
+
+      expect(result).toBe(26538110);
+      expect(mockLookupMetadata).toHaveBeenCalledWith(
+        undefined,
+        'All the Young Droids: Junkshop Synth Pop 1978-1985',
+        undefined,
+        { timeoutMs: 10000 }
+      );
+    });
+
+    it.each([
+      ['Various Artists', true],
+      ['various artists', true],
+      ['VARIOUS ARTISTS', true],
+      ['Various Artist', true],
+      ['various', true],
+      ['V/A', true],
+      ['V.A.', true],
+      ['v a', true],
+      ['Var Artists', true],
+      ['Var. Artists', true],
+      ['Variety Pack', false],
+      ['Variations', false],
+      ['Autechre', false],
+      ['', false],
+    ])('isVariousArtistsName(%p) === %p', (input, expected) => {
+      expect(isVariousArtistsName(input)).toBe(expected);
     });
 
     it('does not call LML when the direct column has a value', async () => {

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -66,8 +66,8 @@ describe('lml.client', () => {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            artist: 'Autechre',
             raw_message: 'Autechre - Confield - VI Scose Poise',
+            artist: 'Autechre',
             album: 'Confield',
             song: 'VI Scose Poise',
           }),
@@ -87,7 +87,7 @@ describe('lml.client', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         'http://lml.test:8000/api/v1/lookup',
         expect.objectContaining({
-          body: JSON.stringify({ artist: 'Autechre', raw_message: 'Autechre' }),
+          body: JSON.stringify({ raw_message: 'Autechre', artist: 'Autechre' }),
         })
       );
     });


### PR DESCRIPTION
Closes #1207.

## Summary

- Drop \`budgetMs: 4000\` from the rotation picker's tier-3 LML lookup. BS#1186's cap was justified by malformed-query examples and applied uniformly to a call site where the cascade's later strategies are exactly where matches come from.
- Bump \`ROTATION_LML_LOOKUP_TIMEOUT_MS\` from 5 s to 10 s to match tubafrenzy's \`RELEASE_LOOKUP_TIMEOUT\`.
- Mirror tubafrenzy's V/A carve-out: \`isVariousArtistsName\` helper covers \`V/A\`, \`V.A.\`, \`various\`, \`Various Artists\`, \`Var. Artists\`, etc.; when matched, the picker omits the artist field on the LML call (LML's parser handles the album-only path natively).
- \`lookupMetadata\`'s \`artist\` param becomes \`string | undefined\` to support the V/A opt-out. \`LookupBody.artist\` was already optional, so the wire shape only changes when callers pass undefined intentionally.

Other LML callers (proxy.controller, library.controller, enrichWithArtwork, searchLibraryByTrack, enrichment-worker) keep their budgets — BS#1186 stays in place for the iOS-playlist artwork hot path.

## Why

Live coverage probe tonight against authenticated Safari → BS direct, 30 rotation rows sampled across all bins:

- Heavy: 1/9 (11%)
- Specialty: 0/6 (0%)
- Light: 3/9 (33%)
- Medium: 3/6 (50%)
- **Total: 7/30 (23%)**

23% is exactly BS#1029's tier-1 backfill coverage — meaning tiers 2 + 3 are adding ~0 because the 4 s cap kills LML's cascade before the long-tail-matching strategies fire. Tubafrenzy on the same call path gets near-100%.

## Test plan

- [x] \`npm run test:unit\` — 2466/2467 pass (1 pre-existing schema test failure unrelated, fails identically on origin/main).
- [x] Picker tests pin the new behavior: no \`budgetMs\`, 10 s timeout, V/A artist-omission.
- [x] 14-case parametric pin for \`isVariousArtistsName\` (true positives + true negatives).
- [x] \`npm run typecheck && npm run format:check\` clean.
- [ ] Post-deploy: re-run the live coverage probe; expect ≥ 70% hit rate (vs current 23%, vs tubafrenzy ≈ 100%).