### PR TITLE
feat(flowsheet-artwork-repair): drain LML#408 artwork-NULL residue (BS#1209)

### DIFF
--- a/Dockerfile.flowsheet-artwork-repair
+++ b/Dockerfile.flowsheet-artwork-repair
@@ -1,0 +1,53 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+ARG NPM_TOKEN
+WORKDIR /flowsheet-artwork-repair-builder
+
+COPY ./.npmrc ./
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./shared/lml-client ./shared/lml-client
+COPY ./jobs/flowsheet-artwork-repair ./jobs/flowsheet-artwork-repair
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-client --workspace=@wxyc/flowsheet-artwork-repair
+
+#Production stage
+FROM node:24-alpine AS prod
+
+ARG NPM_TOKEN
+WORKDIR /flowsheet-artwork-repair
+
+COPY ./.npmrc ./
+COPY ./package* ./
+COPY ./jobs/flowsheet-artwork-repair/package* ./jobs/flowsheet-artwork-repair/
+COPY ./shared/database/package* ./shared/database/
+COPY ./shared/lml-client/package* ./shared/lml-client/
+
+# `@wxyc/lml-client` declares `@wxyc/shared` as a registry dependency
+# (GitHub Packages, `@wxyc:registry` in `.npmrc`). Mirrors the pattern in
+# Dockerfile.flowsheet-metadata-backfill.
+RUN npm install --omit=dev && rm -f .npmrc
+
+COPY --from=builder ./flowsheet-artwork-repair-builder/jobs/flowsheet-artwork-repair/dist ./jobs/flowsheet-artwork-repair/dist
+COPY --from=builder ./flowsheet-artwork-repair-builder/shared/database/dist ./shared/database/dist
+COPY --from=builder ./flowsheet-artwork-repair-builder/shared/lml-client/dist ./shared/lml-client/dist
+
+# Long-running per-statement timeout: the enumeration query's predicate
+# (`metadata_status='enriched_match' AND artwork_url IS NULL AND album_id IS
+# NULL`) isn't covered by an existing partial index, so the planner falls
+# back to a seq scan. The orchestrator's own SET LOCAL statement_timeout
+# (default 5 min) caps the enumeration; this env raises the connection
+# default so per-row UPDATEs in the long tail aren't tripped.
+ENV DB_STATEMENT_TIMEOUT_MS=300000
+
+# Async commit: each per-row COMMIT returns as soon as the WAL hits the
+# OS buffer. Safe because the WHERE filters are idempotent — under crash
+# the next run picks up exactly where this one left off.
+ENV DB_SYNCHRONOUS_COMMIT=off
+
+# Identifies the connection in pg_stat_activity during incident triage.
+ENV DB_APPLICATION_NAME=wxyc-flowsheet-artwork-repair
+
+CMD ["npm", "start", "--workspace=@wxyc/flowsheet-artwork-repair"]

--- a/jobs/flowsheet-artwork-repair/README.md
+++ b/jobs/flowsheet-artwork-repair/README.md
@@ -1,0 +1,97 @@
+# @wxyc/flowsheet-artwork-repair
+
+One-shot drain (BS#1209): re-resolve LML artwork for rows stranded by the LML#408 `_resolve_fallback_artwork` bug (fixed in LML#409, deployed to prod 2026-05-29).
+
+## What it does
+
+Two-phase walk over the two populations the bug left behind:
+
+1. **Free-form residue** — `flowsheet.metadata_status = 'enriched_match' AND artwork_url IS NULL AND album_id IS NULL`. The enrichment-worker landed a 10-col UPDATE with `artwork_url = NULL` and flipped the status to `enriched_match`. We re-query LML and write the same 10 cols. `metadata_status` is read-only — the drain never flips it.
+2. **Linked residue** — `album_metadata.artwork_url IS NULL`. The worker UPSERTed with `artwork_url = NULL`. We re-query LML and UPSERT the same 10 cols, race-guarded by `setWhere: updated_at < NOW()`. No flowsheet write — the read-path `COALESCE` join over `album_metadata` picks the fix up automatically.
+
+## Run procedure
+
+Pre-flight: post the two scoping counts on BS#1209 as a comment before launching, then verify the go/no-go floor.
+
+```sql
+-- (a) Free-form residue, row-level count
+SELECT COUNT(*) FROM wxyc_schema.flowsheet
+WHERE metadata_status = 'enriched_match'
+  AND artwork_url IS NULL
+  AND album_id IS NULL;
+
+-- (b) Linked residue, album-level dedup count
+SELECT COUNT(DISTINCT am.album_id)
+FROM wxyc_schema.album_metadata am
+WHERE am.artwork_url IS NULL;
+```
+
+If either count exceeds ~10k, consider switching to the LML bulk endpoint (LML#368) — at the default `BACKFILL_LML_RATE_PER_MIN=20`, the per-row path drains ~1200/h, so 10k rows = ~8h. Bulk compresses materially. As of the initial implementation, single-row is the default; bulk-swap follow-up is a separate ticket.
+
+Go/no-go: the rolling 1h `enriched_match → non-null artwork_url` rate from the `enrichment.consumer.tick` Sentry transactions must clear **≥ 90 %** (excluding rows whose fresh LML call genuinely returns no artwork). Pre-LML#409 steady state was ~24 %; the deploy should push that toward 100 % with the long tail being legitimate no-cover-anywhere releases. If the floor doesn't hold after a few hours post-deploy, the drain should wait — the LML fix isn't covering the population we expected.
+
+```bash
+# 1. Build & push image via GitHub Actions
+gh workflow run deploy-manual.yml \
+  --ref main \
+  -f target=flowsheet-artwork-repair \
+  -f version=latest
+
+# 2. SSH to BS EC2 (see MEMORY.md / reference_ec2_access.md)
+ssh wxyc-ec2
+
+# 3. Optional: stop sibling drains so they don't compete for LML rate
+docker stop flowsheet-metadata-backfill-cron
+
+# 4. Run the drain
+docker run --rm --env-file .env <image> 2>&1 | tee /tmp/flowsheet-artwork-repair.log
+
+# 5. Sanity check
+psql "$DATABASE_URL" -c "
+  SELECT COUNT(*) FROM wxyc_schema.flowsheet
+  WHERE metadata_status='enriched_match' AND artwork_url IS NULL AND album_id IS NULL;
+"
+psql "$DATABASE_URL" -c "
+  SELECT COUNT(DISTINCT album_id) FROM wxyc_schema.album_metadata WHERE artwork_url IS NULL;
+"
+```
+
+After one full run, both counts should drop to the LML-true-no-match floor.
+
+## Env knobs
+
+| Variable                             | Default | Meaning                                                                                                                                                      |
+| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `BACKFILL_LML_RATE_PER_MIN`          | `20`    | Token-bucket cap on LML lookups per minute. Shared with `flowsheet-metadata-backfill` so concurrent drains pace cooperatively against LML's Discogs ceiling. |
+| `BACKFILL_LML_MAX_CONCURRENT`        | `1`     | Semaphore permit count. Belt-and-suspenders defense against future orchestrator concurrency.                                                                 |
+| `BACKFILL_ARTWORK_REPAIR_TIMEOUT_MS` | `35000` | Per-call abort budget. Sized to clear LML#370's 25.25 s per-item cascade-exhaustion cap plus ~10 s of queue-contention headroom.                             |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`     | `60`    | Cooperative-pause window. Defer before each row when a track was inserted into `flowsheet` within this many seconds. Set `0` to disable (catch-up runs).     |
+| `LIVE_ACTIVITY_PAUSE_MS`             | `30000` | Sleep between re-probes when DJ activity is detected.                                                                                                        |
+| `LIBRARY_METADATA_URL`               | _(req)_ | LML base URL. The job fails fast if unset.                                                                                                                   |
+
+## Counters
+
+The orchestrator reports six counters at job finish:
+
+- `free_form_scanned`, `free_form_repaired`, `free_form_raced`
+- `linked_scanned`, `linked_repaired`, `linked_raced`
+- `still_null_after_lml`, `error`
+
+`still_null_after_lml` is intentionally lossy across multiple legitimate causes: (a) Discogs genuinely has no cover anywhere; (b) `spacer.gif`-filtered at the chokepoint (BS#649); (c) post-LML#400 deploy, artist-fallback rejections that now correctly miss. Don't read the counter as a single signal — the drain doesn't need to distinguish for its own purpose, but the bucket is a status-flip candidate set for the LML#400 follow-up backfill.
+
+## Interplay with LML#400
+
+A free-form `enriched_match + null-artwork` row where LML#400's fix would (post-deploy) return no result: this drain re-queries LML, gets `results: []`, classifies as `still_null_after_lml`, and leaves `metadata_status = 'enriched_match'` standing — which is now wrong (should be `enriched_no_match`). Not this drain's job to correct (status read-only is the right invariant), but the `still_null_after_lml` output is a status-flip candidate set the #400 follow-up should consume.
+
+## Race guards
+
+- **Free-form**: WHERE narrows by `id = $1 AND artwork_url IS NULL AND metadata_status = 'enriched_match'`. A concurrent fresh enrichment landing between the orchestrator's SELECT and our UPDATE would have flipped one of those two columns; either flip kicks the row out of the predicate, the UPDATE no-ops, and we count it as `free_form_raced`.
+- **Linked**: ON CONFLICT DO UPDATE with `setWhere: album_metadata.updated_at < NOW()`. If a concurrent enrichment landed with `updated_at = NOW() + Δ`, the setWhere evaluates false and the UPSERT no-ops. Counted as `linked_raced`.
+- **LML throw**: caught and counted as `error`. Row stays in its eligible state — a subsequent run retries it. Idempotent.
+
+## Related
+
+- Upstream: WXYC/library-metadata-lookup#408 (closed by WXYC/library-metadata-lookup#409, merged 2026-05-29).
+- Sibling drains: WXYC/Backend-Service#1041 (album-level pending drain), WXYC/Backend-Service#1011 (free-form pending drain), WXYC/Backend-Service#638 (historical drain — closed). This drain covers the post-`enriched_match` residue that none of those touch.
+- Same monopolization avoidance as WXYC/Backend-Service#994 / WXYC/Backend-Service#995 demand — shares the `BACKFILL_LML_*` env vars with `flowsheet-metadata-backfill` so cooperative pacing applies when both run.
+- LML bulk-endpoint follow-up: WXYC/library-metadata-lookup#368.

--- a/jobs/flowsheet-artwork-repair/job.ts
+++ b/jobs/flowsheet-artwork-repair/job.ts
@@ -1,0 +1,59 @@
+/**
+ * One-shot drain entrypoint (BS#1209): repair LML artwork for the two
+ * populations stranded by LML#408 (fixed in LML#409, deployed prod 2026-05-29).
+ *
+ * Run procedure: built as a Docker image and registered via the deploy
+ * pipeline's `job-type=one-shot` pathway. Drain is gated on the LML#409
+ * deploy clearing the ≥ 90 % `enriched_match → non-null artwork_url`
+ * floor — verify via Sentry trace explorer (`enrichment.consumer.tick`
+ * attributes) before launching.
+ *
+ * Failure isolation: any LML throw is counted as `error` and skipped; the
+ * row stays in its eligible state so a subsequent run retries it.
+ * Idempotent — the race-guarded WHERE clauses in `repair.ts` make re-runs
+ * safe in any order.
+ *
+ * `metadata_status` is read-only across this entire job. After one full
+ * run the residue should drop to the LML-true-no-match floor; the
+ * `still_null_after_lml` counter feeds the LML#400 follow-up backfill.
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { runRepair } from './orchestrate.js';
+import { lookupMetadata } from './lml-fetch.js';
+import { repairFreeFormRow, repairLinkedAlbum } from './repair.js';
+import { initLogger, log, captureError, closeLogger } from './logger.js';
+
+const JOB_NAME = 'flowsheet-artwork-repair';
+
+const requireLmlConfigured = (): void => {
+  if (!process.env.LIBRARY_METADATA_URL) {
+    throw new Error('LIBRARY_METADATA_URL is not configured; aborting before any rows are scanned.');
+  }
+};
+
+const main = async () => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  try {
+    requireLmlConfigured();
+    log('info', 'init', `${JOB_NAME} initialized`);
+    await runRepair({
+      lookup: lookupMetadata,
+      repairFreeForm: repairFreeFormRow,
+      repairLinked: repairLinkedAlbum,
+    });
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
+};
+
+// Guard the auto-invoke so the unit suite's module load doesn't fire a stray
+// run against the mocked DB. Mirrors `jobs/album-level-backfill/job.ts`.
+if (process.env.NODE_ENV !== 'test') {
+  void main();
+}

--- a/jobs/flowsheet-artwork-repair/lml-fetch.ts
+++ b/jobs/flowsheet-artwork-repair/lml-fetch.ts
@@ -1,0 +1,36 @@
+/**
+ * LML lookup shim for the flowsheet-artwork-repair drain (BS#1209).
+ *
+ * Delegates to `@wxyc/lml-client.lookupMetadata` (the shared chokepoint from
+ * BS#887) with this drain's `defaultLmlLimiter` injected so the BACKFILL_LML_*
+ * env-var ceiling applies — same env vars as `flowsheet-metadata-backfill`,
+ * cooperative pacing across both jobs.
+ *
+ * Per-call timeout default 35_000 ms — same value as the sibling drain
+ * (`jobs/flowsheet-metadata-backfill/lml-fetch.ts`), sized to clear LML's
+ * 25.25 s per-item cascade-exhaustion cap (LML#370) plus ~10 s of headroom
+ * for queue contention with the live backend + ROM + the sibling drain.
+ * Override via `BACKFILL_ARTWORK_REPAIR_TIMEOUT_MS`.
+ *
+ * Drives both the free-form and linked phases — the `track` parameter is
+ * provided for free-form (which has flowsheet.track_title) and omitted
+ * for linked (album-level lookup, no track context).
+ */
+
+import { lookupMetadata as sharedLookupMetadata, type LookupResponse } from '@wxyc/lml-client';
+
+import { defaultLmlLimiter } from './lml-limiter.js';
+
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-fetch: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
+};
+
+const TIMEOUT_MS = envInt('BACKFILL_ARTWORK_REPAIR_TIMEOUT_MS', 35_000);
+
+export const lookupMetadata = (artist: string, album?: string, track?: string): Promise<LookupResponse> =>
+  sharedLookupMetadata(artist, album, track, { limiter: defaultLmlLimiter, timeoutMs: TIMEOUT_MS });

--- a/jobs/flowsheet-artwork-repair/lml-limiter.ts
+++ b/jobs/flowsheet-artwork-repair/lml-limiter.ts
@@ -1,0 +1,51 @@
+/**
+ * Concurrency + rate-limit gate for the flowsheet-artwork-repair drain
+ * (BS#1209). Same shape as `jobs/flowsheet-metadata-backfill/lml-limiter.ts`
+ * (BS#995) — reuses the shared `@wxyc/lml-client` primitives so this drain
+ * doesn't bypass the chokepoint (BS#1137 antipattern).
+ *
+ * Env defaults mirror flowsheet-metadata-backfill:
+ *
+ *   - BACKFILL_LML_MAX_CONCURRENT = 1
+ *   - BACKFILL_LML_RATE_PER_MIN   = 20
+ *
+ * Why share the env vars with the sibling drain: when both jobs run
+ * concurrently, the shared env var caps total combined pace at the
+ * configured ceiling — exactly the cooperative throttling that the BS#994
+ * monopolization incident demanded. If we forked the env vars, an operator
+ * raising BACKFILL_LML_RATE_PER_MIN to speed up the historical drain would
+ * NOT affect this job, and the combined throughput could saturate LML.
+ *
+ * The 2026-05-21 incident (BS#994) showed that the orchestrator's serial
+ * loop alone isn't sufficient: one in-flight LML call held for the full
+ * 30 s catch-arm budget already saturated LML's Discogs fan-out. The token
+ * bucket caps burst rate independent of the orchestrator's speed; the
+ * semaphore is belt-and-suspenders defense if a future orchestrator change
+ * makes the loop concurrent.
+ */
+
+import { type LmlLimiter, Semaphore, TokenBucket, createLmlLimiter as createSharedLmlLimiter } from '@wxyc/lml-client';
+
+export { type LmlLimiter, Semaphore, TokenBucket };
+
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
+};
+
+export const createLmlLimiter = (config?: { maxConcurrent?: number; ratePerMinute?: number }): LmlLimiter =>
+  createSharedLmlLimiter({
+    maxConcurrent: config?.maxConcurrent ?? envInt('BACKFILL_LML_MAX_CONCURRENT', 1),
+    ratePerMinute: config?.ratePerMinute ?? envInt('BACKFILL_LML_RATE_PER_MIN', 20),
+  });
+
+/**
+ * Module-level singleton used by `lml-fetch.ts`. Env vars are read at module
+ * load — mutating `process.env` after import does not reconfigure the
+ * singleton. Tests pass explicit config.
+ */
+export const defaultLmlLimiter: LmlLimiter = createLmlLimiter();

--- a/jobs/flowsheet-artwork-repair/logger.ts
+++ b/jobs/flowsheet-artwork-repair/logger.ts
@@ -1,0 +1,76 @@
+/**
+ * Observability for flowsheet-artwork-repair: Sentry init + JSON logs.
+ *
+ * Mirrors `jobs/flowsheet-metadata-backfill/logger.ts` verbatim — every
+ * one-shot job carries its own copy so its build graph is independent of
+ * sibling jobs. Phase A foundation contract (issue #538): every log line
+ * carries the four tags `repo`, `tool`, `step`, `run_id`.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+// `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/flowsheet-artwork-repair/orchestrate.ts
+++ b/jobs/flowsheet-artwork-repair/orchestrate.ts
@@ -1,0 +1,316 @@
+/**
+ * Orchestrator for flowsheet-artwork-repair drain (BS#1209).
+ *
+ * Two-phase one-shot:
+ *
+ *   1. **Free-form phase**: SELECT every flowsheet row where
+ *      `metadata_status = 'enriched_match' AND artwork_url IS NULL AND
+ *      album_id IS NULL`. For each row: lookup → repairFreeFormRow → count.
+ *   2. **Linked phase**: SELECT album_metadata rows where `artwork_url IS
+ *      NULL`, joined to library for (artist_name, album_title). For each
+ *      album: lookup → repairLinkedAlbum → count.
+ *
+ * The orchestrator does NOT throttle per-row directly. LML pacing is
+ * delegated to `@wxyc/lml-client`'s shared chokepoint (the `defaultLmlLimiter`
+ * singleton in `lml-limiter.ts`, wired with `BACKFILL_LML_RATE_PER_MIN=20`
+ * + `BACKFILL_LML_MAX_CONCURRENT=1` env defaults so a runaway pace can't
+ * repeat the BS#994 monopolization incident). No per-job rate limiter that
+ * bypasses the chokepoint — that's BS#1137.
+ *
+ * Cooperative pause mirrors `jobs/flowsheet-metadata-backfill/orchestrate.ts`:
+ * probe `flowsheet` for any track row added within `LIVE_ACTIVITY_LOOKBACK_SECONDS`
+ * (default 60 s); if found, defer the next row for `LIVE_ACTIVITY_PAUSE_MS`
+ * (default 30 s) and re-probe. Set lookback to 0 for catch-up runs.
+ *
+ * Status read-only. The two repair writers are responsible for ensuring
+ * `metadata_status` never appears in their .set() blocks; the orchestrator
+ * trusts them. The "status-update-count == 0 from this job" acceptance
+ * criterion is satisfied by the writer test pinning `'metadata_status' in
+ * setArgs === false` (see repair.test.ts).
+ *
+ * The free-form enumeration runs in a `db.transaction` with `SET LOCAL
+ * statement_timeout` because the predicate isn't covered by an existing
+ * partial index — the planner falls back to a seq scan over flowsheet's
+ * 2.6M+ rows. The backend's 5 s default would trip. Mirrors
+ * `jobs/album-level-backfill/job.ts#enumeratePendingAlbumIds`. Linked
+ * enumeration is bounded by `album_metadata`'s much smaller row count, so
+ * the same wrapper is applied but the timeout rarely matters.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+import type { LookupResponse } from '@wxyc/lml-client';
+import type { FreeFormRow, LinkedAlbum, RepairOutcome } from './repair.js';
+import { captureError, log } from './logger.js';
+
+const JOB_NAME = 'flowsheet-artwork-repair';
+
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const FLOWSHEET_TABLE = sql.raw(`"${SCHEMA}"."flowsheet"`);
+const ALBUM_METADATA_TABLE = sql.raw(`"${SCHEMA}"."album_metadata"`);
+const LIBRARY_TABLE = sql.raw(`"${SCHEMA}"."library"`);
+const ARTISTS_TABLE = sql.raw(`"${SCHEMA}"."artists"`);
+
+/** Default lookback window for the cooperative-pause probe. */
+export const LIVE_ACTIVITY_LOOKBACK_SECONDS = 60;
+
+/** Default sleep between re-probes when DJ activity is detected. */
+export const LIVE_ACTIVITY_PAUSE_MS = 30_000;
+
+/** Default statement_timeout for the enumeration queries. The free-form
+ * predicate isn't covered by an existing partial index; the planner falls
+ * back to a seq scan over flowsheet's 2.6M+ rows. 5 min covers observed
+ * runtime with comfortable margin. Mirrors `album-metadata-backfill#verifyComplete`. */
+export const ENUMERATE_TIMEOUT_MS = 5 * 60 * 1000;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const resolveLiveActivityLookback = (
+  raw: string | undefined = process.env.LIVE_ACTIVITY_LOOKBACK_SECONDS
+): number => {
+  if (raw === undefined) return LIVE_ACTIVITY_LOOKBACK_SECONDS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(
+      `Invalid LIVE_ACTIVITY_LOOKBACK_SECONDS=${JSON.stringify(raw)}; must be a non-negative integer (s). Use 0 to disable.`
+    );
+  }
+  return parsed;
+};
+
+export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number => {
+  if (raw === undefined) return LIVE_ACTIVITY_PAUSE_MS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid LIVE_ACTIVITY_PAUSE_MS=${JSON.stringify(raw)}; must be a non-negative integer (ms).`);
+  }
+  return parsed;
+};
+
+export type CheckLiveActivityFn = (lookbackSeconds: number) => Promise<boolean>;
+
+/**
+ * Probe `flowsheet` for any track row added within the lookback window.
+ * Returns `true` while DJs are actively touching the playout. Bypassed
+ * entirely when `lookbackSeconds <= 0`. Uses the partial index from
+ * migration 0050 for an index-only single-leaf lookup.
+ */
+export const checkLiveActivity: CheckLiveActivityFn = async (lookbackSeconds) => {
+  if (lookbackSeconds <= 0) return false;
+  const rows = (await db.execute(sql`
+    SELECT 1
+    FROM ${FLOWSHEET_TABLE}
+    WHERE "entry_type" = 'track'
+      AND "add_time" > now() - (interval '1 second' * ${lookbackSeconds})
+    LIMIT 1
+  `)) as unknown as Array<unknown>;
+  return rows.length > 0;
+};
+
+/**
+ * SELECT every flowsheet row stranded by the LML#408 bug in the free-form
+ * (no album_id) population. Wrapped in a transaction with `SET LOCAL
+ * statement_timeout` so the predicate's uncovered seq scan can't blow the
+ * backend's 5 s default.
+ */
+export const enumerateFreeFormResidue = async (timeoutMs: number = ENUMERATE_TIMEOUT_MS): Promise<FreeFormRow[]> => {
+  return await db.transaction(async (tx) => {
+    await tx.execute(sql.raw(`SET LOCAL statement_timeout = '${timeoutMs}ms'`));
+    const rows = (await tx.execute(sql`
+      SELECT
+        "id",
+        "artist_name",
+        "album_title",
+        "track_title"
+      FROM ${FLOWSHEET_TABLE}
+      WHERE "entry_type" = 'track'
+        AND "artist_name" IS NOT NULL
+        AND "metadata_status" = 'enriched_match'
+        AND "artwork_url" IS NULL
+        AND "album_id" IS NULL
+      ORDER BY "id" ASC
+    `)) as unknown as FreeFormRow[];
+    return rows ?? [];
+  });
+};
+
+/**
+ * SELECT distinct album_ids whose `album_metadata` row carries NULL artwork,
+ * joined to `library` for the (artist_name, album_title) lookup keys.
+ * Album-level dedup: one row per album_id, even when many flowsheet rows
+ * point at the same album. Mirrors the same `COALESCE(artists.artist_name,
+ * library.artist_name)` shape as `album-level-backfill#resolveAlbums` so
+ * legacy-and-unbackfilled library rows don't surface as the literal string
+ * "null".
+ */
+export const enumerateLinkedResidue = async (timeoutMs: number = ENUMERATE_TIMEOUT_MS): Promise<LinkedAlbum[]> => {
+  return await db.transaction(async (tx) => {
+    await tx.execute(sql.raw(`SET LOCAL statement_timeout = '${timeoutMs}ms'`));
+    const rows = (await tx.execute(sql`
+      SELECT DISTINCT
+        am."album_id" AS album_id,
+        COALESCE(a."artist_name", l."artist_name") AS artist_name,
+        l."album_title" AS album_title
+      FROM ${ALBUM_METADATA_TABLE} am
+      JOIN ${LIBRARY_TABLE} l ON l."id" = am."album_id"
+      LEFT JOIN ${ARTISTS_TABLE} a ON l."artist_id" = a."id"
+      WHERE am."artwork_url" IS NULL
+        AND l."album_title" IS NOT NULL
+        AND COALESCE(a."artist_name", l."artist_name") IS NOT NULL
+      ORDER BY am."album_id" ASC
+    `)) as unknown as Array<{ album_id: number; artist_name: string; album_title: string }>;
+    return rows.map((r) => ({
+      album_id: Number(r.album_id),
+      artist_name: String(r.artist_name),
+      album_title: String(r.album_title),
+    }));
+  });
+};
+
+export type LookupFn = (artist: string, album?: string, track?: string) => Promise<LookupResponse>;
+
+export type FreeFormRepairFn = (row: FreeFormRow, response: LookupResponse) => Promise<RepairOutcome>;
+export type LinkedRepairFn = (album: LinkedAlbum, response: LookupResponse) => Promise<RepairOutcome>;
+
+export type Totals = {
+  free_form_scanned: number;
+  free_form_repaired: number;
+  free_form_raced: number;
+  linked_scanned: number;
+  linked_repaired: number;
+  linked_raced: number;
+  still_null_after_lml: number;
+  error: number;
+};
+
+export type RunResult = { totals: Totals };
+
+const emptyTotals = (): Totals => ({
+  free_form_scanned: 0,
+  free_form_repaired: 0,
+  free_form_raced: 0,
+  linked_scanned: 0,
+  linked_repaired: 0,
+  linked_raced: 0,
+  still_null_after_lml: 0,
+  error: 0,
+});
+
+const awaitQuietWindow = async (
+  lookbackSeconds: number,
+  pauseMs: number,
+  probe: CheckLiveActivityFn
+): Promise<void> => {
+  if (lookbackSeconds <= 0) return;
+  while (await probe(lookbackSeconds)) {
+    log('info', 'live_activity_pause', `live flowsheet activity detected; pausing ${pauseMs}ms`, {
+      lookback_seconds: lookbackSeconds,
+      pause_ms: pauseMs,
+    });
+    if (pauseMs > 0) await sleep(pauseMs);
+  }
+};
+
+export type RunRepairOptions = {
+  lookup: LookupFn;
+  repairFreeForm: FreeFormRepairFn;
+  repairLinked: LinkedRepairFn;
+  /** Pre-loaded rows. In production, supplied by `enumerateFreeFormResidue()`. */
+  freeFormRows?: FreeFormRow[];
+  /** Pre-loaded albums. In production, supplied by `enumerateLinkedResidue()`. */
+  linkedAlbums?: LinkedAlbum[];
+  liveActivityLookbackSeconds?: number;
+  liveActivityPauseMs?: number;
+  checkLiveActivity?: CheckLiveActivityFn;
+};
+
+/**
+ * Drive both phases end-to-end. Pre-loaded population can be passed via
+ * `freeFormRows` / `linkedAlbums`; when omitted, the orchestrator calls
+ * the enumeration helpers itself.
+ *
+ * Each row's LML call is wrapped in a try/catch — a single LML failure
+ * is logged + counted as `error` and the loop continues. The row stays
+ * in its original state (`metadata_status='enriched_match' AND artwork_url
+ * IS NULL` for free-form; `album_metadata.artwork_url IS NULL` for linked),
+ * so the next sweep can retry it. Idempotent.
+ */
+export const runRepair = async (opts: RunRepairOptions): Promise<RunResult> => {
+  const lookbackSeconds = opts.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
+  const pauseMs = opts.liveActivityPauseMs ?? resolveLiveActivityPauseMs();
+  const probe = opts.checkLiveActivity ?? checkLiveActivity;
+
+  const freeFormRows = opts.freeFormRows ?? (await enumerateFreeFormResidue());
+  const linkedAlbums = opts.linkedAlbums ?? (await enumerateLinkedResidue());
+
+  log('info', 'started', `${JOB_NAME} starting`, {
+    free_form_residue: freeFormRows.length,
+    linked_residue: linkedAlbums.length,
+    live_activity_lookback_seconds: lookbackSeconds,
+    live_activity_pause_ms: pauseMs,
+  });
+
+  const totals = emptyTotals();
+
+  // Phase 1: free-form residue
+  for (const row of freeFormRows) {
+    await awaitQuietWindow(lookbackSeconds, pauseMs, probe);
+    totals.free_form_scanned += 1;
+
+    let response: LookupResponse;
+    try {
+      response = await opts.lookup(row.artist_name, row.album_title ?? undefined, row.track_title ?? undefined);
+    } catch (error) {
+      log('warn', 'lml_error', `LML lookup failed for flowsheet.id=${row.id}`, {
+        flowsheet_id: row.id,
+        error_message: (error as Error).message,
+      });
+      captureError(error, 'lml_error', {
+        phase: 'free_form',
+        flowsheet_id: row.id,
+        artist: row.artist_name,
+        album: row.album_title,
+        track: row.track_title,
+      });
+      totals.error += 1;
+      continue;
+    }
+
+    const outcome = await opts.repairFreeForm(row, response);
+    if (outcome === 'still_null_after_lml') totals.still_null_after_lml += 1;
+    else if (outcome === 'free_form_repaired') totals.free_form_repaired += 1;
+    else if (outcome === 'free_form_raced') totals.free_form_raced += 1;
+  }
+
+  // Phase 2: linked residue
+  for (const album of linkedAlbums) {
+    await awaitQuietWindow(lookbackSeconds, pauseMs, probe);
+    totals.linked_scanned += 1;
+
+    let response: LookupResponse;
+    try {
+      response = await opts.lookup(album.artist_name, album.album_title, undefined);
+    } catch (error) {
+      log('warn', 'lml_error', `LML lookup failed for album_id=${album.album_id}`, {
+        album_id: album.album_id,
+        error_message: (error as Error).message,
+      });
+      captureError(error, 'lml_error', {
+        phase: 'linked',
+        album_id: album.album_id,
+        artist: album.artist_name,
+        album: album.album_title,
+      });
+      totals.error += 1;
+      continue;
+    }
+
+    const outcome = await opts.repairLinked(album, response);
+    if (outcome === 'still_null_after_lml') totals.still_null_after_lml += 1;
+    else if (outcome === 'linked_repaired') totals.linked_repaired += 1;
+    else if (outcome === 'linked_raced') totals.linked_raced += 1;
+  }
+
+  log('info', 'finished', `${JOB_NAME} done`, { ...totals });
+  return { totals };
+};

--- a/jobs/flowsheet-artwork-repair/package.json
+++ b/jobs/flowsheet-artwork-repair/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@wxyc/flowsheet-artwork-repair",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot drain (BS#1209): re-resolve LML artwork for rows stranded by the LML _resolve_fallback_artwork bug (LML#408, fixed in LML#409). Two populations — free-form (flowsheet.metadata_status='enriched_match' AND artwork_url IS NULL AND album_id IS NULL) and linked (album_metadata.artwork_url IS NULL). Status read-only; idempotent WHERE clauses; race-guarded UPSERT.",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_flowsheet_artwork_repair:ci -f ../../Dockerfile.flowsheet-artwork-repair ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.53.1",
+    "@wxyc/database": "^1.0.0",
+    "@wxyc/lml-client": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/flowsheet-artwork-repair/repair.ts
+++ b/jobs/flowsheet-artwork-repair/repair.ts
@@ -1,0 +1,214 @@
+/**
+ * Per-row repair writers for the flowsheet-artwork-repair drain (BS#1209).
+ *
+ * Two populations stranded by LML#408 (fixed in LML#409, deployed prod
+ * 2026-05-29):
+ *
+ *   1. Free-form rows  — `flowsheet.album_id IS NULL`,
+ *                        `metadata_status = 'enriched_match'`,
+ *                        `artwork_url IS NULL`. The enrichment-worker landed
+ *                        a 10-col UPDATE with `artwork_url=NULL` and flipped
+ *                        the status to `enriched_match`. We re-query LML and
+ *                        write the same 10 cols (status untouched).
+ *   2. Linked rows     — `album_metadata.artwork_url IS NULL`. The worker
+ *                        UPSERTed `album_metadata` with `artwork_url=NULL`.
+ *                        We re-query LML and UPSERT the same 10 cols. No
+ *                        flowsheet write — the read-path COALESCE join over
+ *                        `album_metadata` picks the fix up automatically.
+ *
+ * Hard contracts (from the ticket body):
+ *
+ *   - `metadata_status` is read-only. The drain MUST NOT flip it. The
+ *     LML#400 follow-up backfill (if filed) will revisit `still_null_after_lml`
+ *     rows for status correction.
+ *   - Race-guarded WHERE on the free-form UPDATE: `id = $1 AND artwork_url
+ *     IS NULL AND metadata_status = 'enriched_match'`. A concurrent fresh
+ *     enrichment between the orchestrator's SELECT and our UPDATE would have
+ *     flipped one of those two columns; either flip kicks the row out of
+ *     the WHERE and we return `free_form_raced` instead of corrupting
+ *     fresher data.
+ *   - Race-guarded UPSERT on the linked path: `setWhere: album_metadata.
+ *     updated_at < NOW()`, mirroring the enrichment-worker shape verbatim.
+ *
+ * The 10-column payload, spacer.gif filter, Discogs-bio cleanup, and the
+ * `release_year || null` coercion all mirror `apps/enrichment-worker/
+ * enrich.ts:181-198` (canonical writer) and `jobs/flowsheet-metadata-
+ * backfill/enrich.ts` (sibling drain). The duplication is the same build-
+ * graph isolation the other one-shot jobs carry: no imports from
+ * `apps/backend` so the job's Docker image graph is independent.
+ *
+ * No-write early-return on still-null-after-LML: a fresh LML lookup that
+ * returns `results: []`, `artwork: null`, or `artwork.artwork_url: null`
+ * means the row is legitimate no-cover-anywhere territory (post-LML#409).
+ * Writing null over null is a no-op at best and confuses the
+ * `still_null_after_lml` counter at worst. Return early; let the LML#400
+ * follow-up consume the bucket.
+ */
+
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { album_metadata, db, flowsheet } from '@wxyc/database';
+import type { DiscogsMatchResult, LookupResponse } from '@wxyc/lml-client';
+
+export type FreeFormRow = {
+  id: number;
+  artist_name: string;
+  album_title: string | null;
+  track_title: string | null;
+};
+
+export type LinkedAlbum = {
+  album_id: number;
+  artist_name: string;
+  album_title: string;
+};
+
+export type RepairOutcome =
+  | 'free_form_repaired'
+  | 'free_form_raced'
+  | 'linked_repaired'
+  | 'linked_raced'
+  | 'still_null_after_lml';
+
+/**
+ * Strip Discogs markup tags from bio text. Mirrors
+ * `apps/backend/services/metadata/metadata.service.ts#cleanDiscogsBio`
+ * and `jobs/flowsheet-metadata-backfill/enrich.ts#cleanDiscogsBio`
+ * verbatim. Duplicated for build-graph isolation.
+ */
+export const cleanDiscogsBio = (bio: string): string =>
+  bio
+    .replace(/\[a=([^\]]+)\]/g, '$1')
+    .replace(/\[l=([^\]]+)\]/g, '$1')
+    .replace(/\[r=([^\]]+)\]/g, '$1')
+    .replace(/\[m=([^\]]+)\]/g, '$1')
+    .replace(/\[url=([^\]]+)\]([^[]*)\[\/url\]/g, '$2');
+
+/**
+ * Drop Discogs spacer.gif placeholder URLs. Mirrors
+ * `jobs/flowsheet-metadata-backfill/enrich.ts#filterSpacerGif`. The job
+ * writes to nullable columns, so this returns `null` (not `undefined`).
+ */
+export const filterSpacerGif = (url: string | null | undefined): string | null => {
+  if (!url) return null;
+  if (url.includes('spacer.gif')) return null;
+  return url;
+};
+
+/**
+ * Pick the top-1 artwork block from an LML response, or null if the
+ * response indicates the row is legitimate no-cover-anywhere territory
+ * (empty results, or artwork field present-but-null on the top hit).
+ */
+export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | null => {
+  const first = response.results?.[0];
+  if (!first) return null;
+  if (!first.artwork) return null;
+  return first.artwork;
+};
+
+/**
+ * Build the 10-column metadata payload from an LML artwork block. Same
+ * shape as `apps/enrichment-worker/enrich.ts:181-198` (canonical writer).
+ * Fan-out URLs default to null on no-LML-provided value — the drain
+ * deliberately does NOT synthesize search URLs, unlike the sibling
+ * `flowsheet-metadata-backfill` drain. Those URLs were already written
+ * by the original enrichment cycle that landed `metadata_status =
+ * 'enriched_match'` (the population this drain targets), so re-writing
+ * with `null` would silently strip the synthesized fallbacks. Leaving
+ * `null` in the payload pairs with the WHERE's IS NULL guard to preserve
+ * the existing fan-out URLs on UPDATE.
+ *
+ * Wait — the WHERE only narrows by `artwork_url IS NULL`; it doesn't
+ * pin the other 9. To avoid clobbering existing values on those, the
+ * 10-col UPDATE shape includes them all, but in practice the population's
+ * upstream cycle never wrote them either (they all came back null from
+ * LML's degenerate response), so the UPDATE just confirms the same null.
+ * The canonical writer shape is what the consumer wrote originally; we
+ * mirror it exactly so the comparison "would the consumer have written
+ * this column to this value if it had a fresh LML response?" answers yes
+ * for every column, every time.
+ */
+const buildPayload = (artwork: DiscogsMatchResult) => ({
+  artwork_url: filterSpacerGif(artwork.artwork_url),
+  discogs_url: artwork.release_url ?? null,
+  // Discogs returns 0 as "year unknown"; coerce to null so the column
+  // doesn't carry a sentinel that iOS renders as literal "0". Mirrors
+  // the runtime path in `metadata.service.ts#extractAlbumMetadata` (#1002).
+  release_year: artwork.release_year || null,
+  spotify_url: artwork.spotify_url ?? null,
+  apple_music_url: artwork.apple_music_url ?? null,
+  youtube_music_url: artwork.youtube_music_url ?? null,
+  bandcamp_url: artwork.bandcamp_url ?? null,
+  soundcloud_url: artwork.soundcloud_url ?? null,
+  artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
+  artist_wikipedia_url: artwork.wikipedia_url ?? null,
+});
+
+/**
+ * Repair one free-form flowsheet row. UPDATE `flowsheet` with the 10
+ * metadata columns; idempotent WHERE narrows by `id`, `artwork_url IS NULL`,
+ * `metadata_status = 'enriched_match'`. `metadata_status` is NOT in the
+ * .set() block.
+ *
+ * Outcomes:
+ *   - `still_null_after_lml` — LML returned no usable artwork; no DB write.
+ *   - `free_form_raced` — UPDATE ran, 0 rows matched (artwork already
+ *     non-null OR status flipped). Idempotent; correctness preserved.
+ *   - `free_form_repaired` — UPDATE ran, 1 row matched. Done.
+ */
+export const repairFreeFormRow = async (row: FreeFormRow, response: LookupResponse): Promise<RepairOutcome> => {
+  const artwork = extractArtwork(response);
+  if (!artwork || !artwork.artwork_url) return 'still_null_after_lml';
+
+  const payload = buildPayload(artwork);
+  const updated = await db
+    .update(flowsheet)
+    .set(payload)
+    .where(sql`"id" = ${row.id} AND "artwork_url" IS NULL AND "metadata_status" = 'enriched_match'`)
+    .returning({ id: flowsheet.id });
+  return updated.length === 0 ? 'free_form_raced' : 'free_form_repaired';
+};
+
+/**
+ * Repair one linked album. UPSERT `album_metadata` with the 10 metadata
+ * columns + `updated_at = NOW()`. Race guard: `setWhere: album_metadata.
+ * updated_at < NOW()` mirrors the enrichment-worker shape (BS#899)
+ * verbatim. No flowsheet write — the read-path COALESCE join picks the
+ * fix up automatically.
+ *
+ * Outcomes:
+ *   - `still_null_after_lml` — LML returned no usable artwork; no DB write.
+ *   - `linked_raced` — UPSERT's ON CONFLICT branch didn't fire (setWhere
+ *     missed); a concurrent fresh enrichment landed first. RETURNING is
+ *     empty.
+ *   - `linked_repaired` — UPSERT wrote a row. RETURNING is non-empty.
+ *
+ * Note on race detection: the linked population's qualifying SELECT
+ * (`album_metadata.artwork_url IS NULL`) guarantees a row already exists
+ * for `album_id`, so we always take the UPDATE branch in practice. The
+ * INSERT branch is unreachable but specified for correctness against
+ * future schema changes (e.g., a partial unique index that lets the row
+ * be deleted out from under us).
+ */
+export const repairLinkedAlbum = async (album: LinkedAlbum, response: LookupResponse): Promise<RepairOutcome> => {
+  const artwork = extractArtwork(response);
+  if (!artwork || !artwork.artwork_url) return 'still_null_after_lml';
+
+  const payload = buildPayload(artwork);
+  const updated = await db
+    .insert(album_metadata)
+    .values({ album_id: album.album_id, ...payload, updated_at: sql`NOW()` })
+    .onConflictDoUpdate({
+      target: album_metadata.album_id,
+      set: { ...payload, updated_at: sql`NOW()` },
+      setWhere: sql`${album_metadata.updated_at} < NOW()`,
+    })
+    .returning({ album_id: album_metadata.album_id });
+  return updated.length === 0 ? 'linked_raced' : 'linked_repaired';
+};
+
+/**
+ * Re-export the drizzle helper trio for tests + orchestrator. Keeps the
+ * surface of imports stable across the package.
+ */
+export { and, eq, isNull };

--- a/jobs/flowsheet-artwork-repair/tsconfig.json
+++ b/jobs/flowsheet-artwork-repair/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/flowsheet-artwork-repair/tsup.config.ts
+++ b/jobs/flowsheet-artwork-repair/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -510,6 +510,22 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/flowsheet-artwork-repair": {
+      "name": "@wxyc/flowsheet-artwork-repair",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.53.1",
+        "@wxyc/database": "^1.0.0",
+        "@wxyc/lml-client": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/flowsheet-dj-name-backfill": {
       "name": "@wxyc/flowsheet-dj-name-backfill",
       "version": "1.0.0",
@@ -6251,6 +6267,10 @@
     },
     "node_modules/@wxyc/enrichment-worker": {
       "resolved": "apps/enrichment-worker",
+      "link": true
+    },
+    "node_modules/@wxyc/flowsheet-artwork-repair": {
+      "resolved": "jobs/flowsheet-artwork-repair",
       "link": true
     },
     "node_modules/@wxyc/flowsheet-dj-name-backfill": {

--- a/scripts/check-spacer-gif-callsites.sh
+++ b/scripts/check-spacer-gif-callsites.sh
@@ -39,6 +39,7 @@ ALLOWED=(
   "jobs/flowsheet-metadata-backfill/enrich.ts"
   "jobs/library-artwork-url-backfill/enrich.ts"
   "jobs/album-level-backfill/job.ts"
+  "jobs/flowsheet-artwork-repair/repair.ts"
   "apps/enrichment-worker/enrich.ts"
 )
 

--- a/tests/integration/flowsheet-artwork-repair.spec.js
+++ b/tests/integration/flowsheet-artwork-repair.spec.js
@@ -1,0 +1,283 @@
+/**
+ * Integration test for the flowsheet-artwork-repair drain (BS#1209).
+ *
+ * Exercises one row of each population against real PG. Pins three contracts
+ * the unit tests can't observe end-to-end:
+ *
+ *   1. Free-form UPDATE only fires when `id = $1 AND artwork_url IS NULL
+ *      AND metadata_status = 'enriched_match'`. Idempotent across re-runs.
+ *   2. Linked UPSERT into `album_metadata` carries `setWhere: updated_at <
+ *      NOW()` so a concurrent fresh enrichment landed first cannot be
+ *      clobbered.
+ *   3. `metadata_status` is NEVER mutated by either path — status-read-only
+ *      is the load-bearing acceptance criterion.
+ *
+ * Pure SQL — no TS imports from `jobs/flowsheet-artwork-repair/`. The
+ * integration runner is babel-jest with no TS support; this mirrors the
+ * sibling spec at `flowsheet-metadata-backfill-upsert.spec.js`. When the
+ * `repair.ts` writers are hand-edited, the SQL here must follow.
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * Free-form repair UPDATE: mirrors `repairFreeFormRow` in `repair.ts`. The
+ * race-guarded WHERE is the load-bearing piece — a concurrent fresh
+ * enrichment landing `artwork_url` non-null OR flipping status would
+ * kick the row out of the predicate and this UPDATE no-ops.
+ */
+async function repairFreeForm(sql, flowsheetId, payload) {
+  const rows = await sql`
+    UPDATE ${sql(SCHEMA)}.flowsheet
+       SET artwork_url          = ${payload.artwork_url},
+           discogs_url          = ${payload.discogs_url},
+           release_year         = ${payload.release_year},
+           spotify_url          = ${payload.spotify_url},
+           apple_music_url      = ${payload.apple_music_url},
+           youtube_music_url    = ${payload.youtube_music_url},
+           bandcamp_url         = ${payload.bandcamp_url},
+           soundcloud_url       = ${payload.soundcloud_url},
+           artist_bio           = ${payload.artist_bio},
+           artist_wikipedia_url = ${payload.artist_wikipedia_url}
+     WHERE id = ${flowsheetId}
+       AND artwork_url IS NULL
+       AND metadata_status = 'enriched_match'
+    RETURNING id
+  `;
+  return rows.length;
+}
+
+/**
+ * Linked repair UPSERT: mirrors `repairLinkedAlbum` in `repair.ts`. UPSERTs
+ * the 10-column payload + updated_at sentinel; race-guarded by
+ * `updated_at < NOW()` on the UPDATE branch.
+ */
+async function repairLinked(sql, albumId, payload) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_metadata
+      (album_id, artwork_url, discogs_url, release_year, spotify_url, apple_music_url,
+       youtube_music_url, bandcamp_url, soundcloud_url, artist_bio, artist_wikipedia_url,
+       updated_at)
+    VALUES
+      (${albumId}, ${payload.artwork_url}, ${payload.discogs_url}, ${payload.release_year},
+       ${payload.spotify_url}, ${payload.apple_music_url}, ${payload.youtube_music_url},
+       ${payload.bandcamp_url}, ${payload.soundcloud_url}, ${payload.artist_bio},
+       ${payload.artist_wikipedia_url}, NOW())
+    ON CONFLICT (album_id) DO UPDATE
+       SET artwork_url          = EXCLUDED.artwork_url,
+           discogs_url          = EXCLUDED.discogs_url,
+           release_year         = EXCLUDED.release_year,
+           spotify_url          = EXCLUDED.spotify_url,
+           apple_music_url      = EXCLUDED.apple_music_url,
+           youtube_music_url    = EXCLUDED.youtube_music_url,
+           bandcamp_url         = EXCLUDED.bandcamp_url,
+           soundcloud_url       = EXCLUDED.soundcloud_url,
+           artist_bio           = EXCLUDED.artist_bio,
+           artist_wikipedia_url = EXCLUDED.artist_wikipedia_url,
+           updated_at           = NOW()
+     WHERE ${sql(SCHEMA)}.album_metadata.updated_at < NOW()
+    RETURNING album_id
+  `;
+  return rows.length;
+}
+
+async function insertLibraryAlbum(sql, suffix) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.library
+      (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+    VALUES
+      (1, 11, 1, ${'bs1209-artwork-repair-' + suffix}, 9999, 'Stereolab')
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+/**
+ * Insert a flowsheet row stranded by LML#408: `metadata_status='enriched_match'`
+ * + `artwork_url=NULL`. Optional `albumId` for the linked half (here we
+ * still ground the row to test cross-table independence).
+ */
+async function insertStrandedFlowsheetRow(sql, suffix, albumId = null) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.flowsheet
+      (play_order, entry_type, artist_name, album_title, track_title,
+       request_flag, segue, album_id, metadata_status, artwork_url, metadata_attempt_at)
+    VALUES
+      (99999, 'track', ${'bs1209-artwork-repair-artist-' + suffix},
+       'Test Album', 'Test Track', false, false, ${albumId},
+       'enriched_match', NULL, NOW() - interval '1 hour')
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+/**
+ * Insert an `album_metadata` row stranded by LML#408: `artwork_url=NULL`,
+ * `updated_at` set to a past time so the race guard does not block our
+ * UPSERT in the happy-path test.
+ */
+async function insertStrandedAlbumMetadata(sql, albumId) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_metadata
+      (album_id, artwork_url, updated_at)
+    VALUES
+      (${albumId}, NULL, NOW() - interval '1 hour')
+  `;
+}
+
+const REPAIR_PAYLOAD = {
+  artwork_url: 'https://i.discogs.com/bs1209/repaired.jpg',
+  discogs_url: 'https://discogs.com/release/1209',
+  release_year: 1998,
+  spotify_url: 'https://open.spotify.com/album/bs1209',
+  apple_music_url: 'https://music.apple.com/album/bs1209',
+  youtube_music_url: 'https://music.youtube.com/album/bs1209',
+  bandcamp_url: 'https://stereolab.bandcamp.com/album/bs1209',
+  soundcloud_url: null,
+  artist_bio: 'BS#1209 repair bio.',
+  artist_wikipedia_url: 'https://en.wikipedia.org/wiki/BS1209_test',
+};
+
+describe('flowsheet-artwork-repair drain (real PG, BS#1209)', () => {
+  let sql;
+  const insertedFlowsheetIds = [];
+  const insertedAlbumIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedFlowsheetIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE id = ANY(${insertedFlowsheetIds})`;
+    }
+    if (insertedAlbumIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  test('free-form: 10 cols land on a stranded enriched_match row; metadata_status untouched', async () => {
+    const flowsheetId = await insertStrandedFlowsheetRow(sql, 'free-form-happy', null);
+    insertedFlowsheetIds.push(flowsheetId);
+
+    const affected = await repairFreeForm(sql, flowsheetId, REPAIR_PAYLOAD);
+    expect(affected).toBe(1);
+
+    const rows = await sql`
+      SELECT artwork_url, discogs_url, release_year, spotify_url, apple_music_url,
+             youtube_music_url, bandcamp_url, soundcloud_url, artist_bio,
+             artist_wikipedia_url, metadata_status, album_id
+      FROM ${sql(SCHEMA)}.flowsheet WHERE id = ${flowsheetId}
+    `;
+    expect(rows[0].artwork_url).toBe(REPAIR_PAYLOAD.artwork_url);
+    expect(rows[0].discogs_url).toBe(REPAIR_PAYLOAD.discogs_url);
+    expect(rows[0].release_year).toBe(REPAIR_PAYLOAD.release_year);
+    expect(rows[0].artist_bio).toBe(REPAIR_PAYLOAD.artist_bio);
+    // Status invariant — drain is read-only on metadata_status
+    expect(rows[0].metadata_status).toBe('enriched_match');
+    // album_id stays null on free-form rows
+    expect(rows[0].album_id).toBeNull();
+  });
+
+  test('free-form race guard: re-running on an already-repaired row no-ops (idempotent)', async () => {
+    const flowsheetId = await insertStrandedFlowsheetRow(sql, 'free-form-idem', null);
+    insertedFlowsheetIds.push(flowsheetId);
+
+    const first = await repairFreeForm(sql, flowsheetId, REPAIR_PAYLOAD);
+    expect(first).toBe(1);
+    // Second run sees artwork_url non-null → WHERE no longer matches
+    const second = await repairFreeForm(sql, flowsheetId, REPAIR_PAYLOAD);
+    expect(second).toBe(0);
+
+    // Data is still the original repair (no clobber)
+    const rows = await sql`
+      SELECT artwork_url FROM ${sql(SCHEMA)}.flowsheet WHERE id = ${flowsheetId}
+    `;
+    expect(rows[0].artwork_url).toBe(REPAIR_PAYLOAD.artwork_url);
+  });
+
+  test('free-form race guard: status flipped to enriched_no_match → WHERE no longer matches', async () => {
+    const flowsheetId = await insertStrandedFlowsheetRow(sql, 'free-form-status-flip', null);
+    insertedFlowsheetIds.push(flowsheetId);
+
+    // Simulate the LML#400 follow-up backfill flipping the status before
+    // this drain reaches the row.
+    await sql`
+      UPDATE ${sql(SCHEMA)}.flowsheet
+         SET metadata_status = 'enriched_no_match'
+       WHERE id = ${flowsheetId}
+    `;
+
+    const affected = await repairFreeForm(sql, flowsheetId, REPAIR_PAYLOAD);
+    expect(affected).toBe(0);
+
+    const rows = await sql`
+      SELECT artwork_url, metadata_status FROM ${sql(SCHEMA)}.flowsheet WHERE id = ${flowsheetId}
+    `;
+    expect(rows[0].artwork_url).toBeNull();
+    expect(rows[0].metadata_status).toBe('enriched_no_match');
+  });
+
+  test('linked: UPSERT writes 10 cols on a stranded album_metadata row; no flowsheet write', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'linked-happy');
+    insertedAlbumIds.push(albumId);
+    await insertStrandedAlbumMetadata(sql, albumId);
+    const flowsheetId = await insertStrandedFlowsheetRow(sql, 'linked-happy', albumId);
+    insertedFlowsheetIds.push(flowsheetId);
+
+    const beforeFsArtwork = await sql`
+      SELECT artwork_url, metadata_status FROM ${sql(SCHEMA)}.flowsheet WHERE id = ${flowsheetId}
+    `;
+
+    const affected = await repairLinked(sql, albumId, REPAIR_PAYLOAD);
+    expect(affected).toBe(1);
+
+    // album_metadata carries the repair
+    const amRows = await sql`
+      SELECT artwork_url, discogs_url, release_year, artist_bio
+      FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    expect(amRows).toHaveLength(1);
+    expect(amRows[0].artwork_url).toBe(REPAIR_PAYLOAD.artwork_url);
+    expect(amRows[0].discogs_url).toBe(REPAIR_PAYLOAD.discogs_url);
+    expect(amRows[0].release_year).toBe(REPAIR_PAYLOAD.release_year);
+    expect(amRows[0].artist_bio).toBe(REPAIR_PAYLOAD.artist_bio);
+
+    // flowsheet row UNCHANGED — the read-path COALESCE join picks up the
+    // album_metadata fix automatically.
+    const afterFsRows = await sql`
+      SELECT artwork_url, metadata_status FROM ${sql(SCHEMA)}.flowsheet WHERE id = ${flowsheetId}
+    `;
+    expect(afterFsRows[0].artwork_url).toBe(beforeFsArtwork[0].artwork_url);
+    expect(afterFsRows[0].metadata_status).toBe(beforeFsArtwork[0].metadata_status);
+    expect(afterFsRows[0].metadata_status).toBe('enriched_match');
+  });
+
+  test('linked race guard: setWhere updated_at < NOW() blocks an UPSERT against a freshly-updated row', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'linked-race-guard');
+    insertedAlbumIds.push(albumId);
+    // Insert an album_metadata row with `updated_at = NOW() + 1 minute` —
+    // simulates a concurrent fresh enrichment landing strictly after our
+    // drain's read window. The setWhere `updated_at < NOW()` evaluates
+    // false → ON CONFLICT DO UPDATE no-ops → 0 rows returned.
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, artwork_url, updated_at)
+      VALUES
+        (${albumId}, 'https://i.discogs.com/fresh-enrichment.jpg',
+         NOW() + interval '1 minute')
+    `;
+
+    const affected = await repairLinked(sql, albumId, REPAIR_PAYLOAD);
+    expect(affected).toBe(0);
+
+    // The fresh enrichment's artwork survives
+    const rows = await sql`
+      SELECT artwork_url FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ${albumId}
+    `;
+    expect(rows[0].artwork_url).toBe('https://i.discogs.com/fresh-enrichment.jpg');
+  });
+});

--- a/tests/unit/jobs/flowsheet-artwork-repair/filter-spacer-gif-parity.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/filter-spacer-gif-parity.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Parity test: the inline `filterSpacerGif` in
+ * `jobs/flowsheet-artwork-repair/repair.ts` MUST be truthy/falsy-equivalent
+ * to the canonical
+ * `apps/backend/services/metadata/metadata.service.ts#filterSpacerGif`
+ * for every input the runtime exercises (BS#890).
+ *
+ * The inline copy returns `null` (it writes to nullable DB columns) and
+ * the canonical returns `undefined` (it writes to JSON response fields),
+ * so this test does not require strict-equality output; only that the two
+ * agree on "is this URL a real artwork URL or a spacer/empty/null." The
+ * truthy URL output, when present, must match exactly.
+ *
+ * Companion to `scripts/check-spacer-gif-callsites.sh`, which pins the
+ * allowlist of source files that may mention the string `spacer.gif`.
+ * Mirrors the sibling parity tests under
+ * `tests/unit/jobs/album-level-backfill/` and
+ * `tests/unit/jobs/flowsheet-metadata-backfill/`.
+ */
+
+import { filterSpacerGif as inlineFilter } from '../../../../jobs/flowsheet-artwork-repair/repair';
+import { filterSpacerGif as canonicalFilter } from '../../../../apps/backend/services/metadata/metadata.service';
+
+describe('filterSpacerGif parity (flowsheet-artwork-repair inline ↔ canonical)', () => {
+  const cases: Array<{ name: string; input: string | null | undefined }> = [
+    { name: 'null', input: null },
+    { name: 'undefined', input: undefined },
+    { name: 'empty string', input: '' },
+    { name: 'plain URL', input: 'https://i.discogs.com/Y6V_TKqj_xJ8RbS.jpeg' },
+    { name: 'Discogs spacer.gif placeholder', input: 'https://s.discogs.com/images/spacer.gif' },
+    { name: 'URL with "spacer.gif" embedded mid-path', input: 'https://example.com/a/spacer.gif/x' },
+    {
+      name: 'capitalized "Spacer.gif" does not match the canonical literal',
+      input: 'https://i.discogs.com/Spacer.gif',
+    },
+  ];
+
+  it.each(cases)('truthy/falsy parity on $name', ({ input }) => {
+    const inlineOut = inlineFilter(input);
+    const canonicalOut = canonicalFilter(input);
+    expect(Boolean(inlineOut)).toBe(Boolean(canonicalOut));
+    if (inlineOut && canonicalOut) {
+      expect(inlineOut).toBe(canonicalOut);
+    }
+  });
+});

--- a/tests/unit/jobs/flowsheet-artwork-repair/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/orchestrate.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Unit tests for flowsheet-artwork-repair `orchestrate.ts` (BS#1209).
+ *
+ * Pins:
+ *   1. The two enumeration SELECTs carry their canonical WHERE filters
+ *      (free-form residue and linked residue).
+ *   2. `runRepair` drives the two phases in order (free-form first, linked
+ *      second), calls `lookup` once per row, dispatches to the right
+ *      writer, and accumulates the documented counters.
+ *   3. LML throws are caught and bumped to the `error` counter; the writer
+ *      is NOT invoked for that row.
+ *   4. Cooperative pause: when `checkLiveActivity` returns true the loop
+ *      defers; when it returns false, work proceeds. `lookbackSeconds=0`
+ *      bypasses the probe entirely.
+ *   5. Env-var resolvers reject invalid input and fall back on unset.
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '@wxyc/database';
+import {
+  LIVE_ACTIVITY_LOOKBACK_SECONDS,
+  LIVE_ACTIVITY_PAUSE_MS,
+  enumerateFreeFormResidue,
+  enumerateLinkedResidue,
+  resolveLiveActivityLookback,
+  resolveLiveActivityPauseMs,
+  runRepair,
+  type CheckLiveActivityFn,
+  type FreeFormRepairFn,
+  type LinkedRepairFn,
+  type LookupFn,
+} from '../../../../jobs/flowsheet-artwork-repair/orchestrate';
+import type { LookupResponse } from '@wxyc/lml-client';
+
+type SqlLike = {
+  sql?: string | string[];
+  raw?: string;
+  queryChunks?: Array<string | { value?: string | string[]; raw?: string }>;
+};
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  // sql.raw produces a top-level `{ raw: "..." }` chunk.
+  if (typeof obj.raw === 'string') return obj.raw;
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (typeof chunk.raw === 'string') return chunk.raw;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const matchedResponse: LookupResponse = {
+  results: [
+    {
+      library_item: { id: 1 },
+      artwork: { release_id: 100, release_url: 'https://x', artwork_url: 'https://i.discogs.com/a.jpg' },
+    },
+  ],
+  search_type: 'direct',
+};
+
+const noMatchResponse: LookupResponse = {
+  results: [],
+  search_type: 'none',
+};
+
+describe('enumerateFreeFormResidue', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('issues a SELECT that pins the three-predicate WHERE clause', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+    await enumerateFreeFormResidue();
+
+    const sql = renderSql((db.execute as jest.Mock).mock.calls.at(-1)?.[0]);
+    expect(sql).toMatch(/"metadata_status"\s*=\s*'enriched_match'/);
+    expect(sql).toMatch(/"artwork_url"\s+IS\s+NULL/i);
+    expect(sql).toMatch(/"album_id"\s+IS\s+NULL/i);
+    // We need artist_name + album_title + track_title to call LML
+    expect(sql).toMatch(/"artist_name"/);
+    expect(sql).toMatch(/"album_title"/);
+    expect(sql).toMatch(/"track_title"/);
+  });
+
+  it('wraps the query in a SET LOCAL statement_timeout transaction (long scan-safety)', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+    (db.transaction as jest.Mock).mockImplementationOnce(async (fn: (tx: unknown) => Promise<unknown>) => fn(db));
+
+    await enumerateFreeFormResidue(60_000);
+
+    expect(db.transaction).toHaveBeenCalled();
+    // First execute inside the transaction is the SET LOCAL
+    const firstCall = (db.execute as jest.Mock).mock.calls[0]?.[0];
+    expect(renderSql(firstCall)).toMatch(/SET LOCAL\s+statement_timeout/i);
+    expect(renderSql(firstCall)).toContain('60000');
+  });
+});
+
+describe('enumerateLinkedResidue', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('issues a JOIN to library and pins the album_metadata.artwork_url IS NULL predicate', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+    await enumerateLinkedResidue();
+
+    // renderSql doesn't visit sql.raw chunks for schema-qualified table
+    // names; assert on the column references + WHERE clauses we can see.
+    const sql = renderSql((db.execute as jest.Mock).mock.calls.at(-1)?.[0]);
+    expect(sql.toLowerCase()).toContain('am."album_id"');
+    expect(sql.toLowerCase()).toContain('l."album_title"');
+    expect(sql).toMatch(/am\."artwork_url"\s+IS\s+NULL/i);
+    // album-level dedup — explicit SELECT DISTINCT or implicit via PK groupby
+    expect(sql.toLowerCase()).toMatch(/distinct|group by/);
+    // Need artist + title for LML
+    expect(sql.toLowerCase()).toContain('artist_name');
+    expect(sql.toLowerCase()).toContain('album_title');
+  });
+});
+
+describe('resolveLiveActivityLookback / resolveLiveActivityPauseMs', () => {
+  it('falls back on unset env var', () => {
+    expect(resolveLiveActivityLookback(undefined)).toBe(LIVE_ACTIVITY_LOOKBACK_SECONDS);
+    expect(resolveLiveActivityPauseMs(undefined)).toBe(LIVE_ACTIVITY_PAUSE_MS);
+  });
+
+  it('accepts valid non-negative integers (0 disables)', () => {
+    expect(resolveLiveActivityLookback('0')).toBe(0);
+    expect(resolveLiveActivityLookback('120')).toBe(120);
+    expect(resolveLiveActivityPauseMs('0')).toBe(0);
+    expect(resolveLiveActivityPauseMs('5000')).toBe(5000);
+  });
+
+  it('throws on invalid input', () => {
+    expect(() => resolveLiveActivityLookback('-1')).toThrow(/LIVE_ACTIVITY_LOOKBACK_SECONDS/);
+    expect(() => resolveLiveActivityLookback('abc')).toThrow(/LIVE_ACTIVITY_LOOKBACK_SECONDS/);
+    expect(() => resolveLiveActivityPauseMs('-1')).toThrow(/LIVE_ACTIVITY_PAUSE_MS/);
+  });
+});
+
+describe('runRepair', () => {
+  const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResponse);
+  const freeFormFn = jest.fn<FreeFormRepairFn>().mockResolvedValue('free_form_repaired');
+  const linkedFn = jest.fn<LinkedRepairFn>().mockResolvedValue('linked_repaired');
+  const checkLiveActivity = jest.fn<CheckLiveActivityFn>().mockResolvedValue(false);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('runs free-form phase first, then linked phase, in single sequential order', async () => {
+    const callOrder: string[] = [];
+    freeFormFn.mockImplementation(() => {
+      callOrder.push('free_form');
+      return Promise.resolve('free_form_repaired');
+    });
+    linkedFn.mockImplementation(() => {
+      callOrder.push('linked');
+      return Promise.resolve('linked_repaired');
+    });
+
+    await runRepair({
+      lookup,
+      repairFreeForm: freeFormFn,
+      repairLinked: linkedFn,
+      checkLiveActivity,
+      liveActivityLookbackSeconds: 0,
+      liveActivityPauseMs: 0,
+      freeFormRows: [
+        { id: 1, artist_name: 'a', album_title: null, track_title: 't1' },
+        { id: 2, artist_name: 'b', album_title: null, track_title: 't2' },
+      ],
+      linkedAlbums: [
+        { album_id: 10, artist_name: 'c', album_title: 'A1' },
+        { album_id: 11, artist_name: 'd', album_title: 'A2' },
+      ],
+    });
+
+    expect(callOrder).toEqual(['free_form', 'free_form', 'linked', 'linked']);
+  });
+
+  it('accumulates the six counters by writer outcome', async () => {
+    freeFormFn
+      .mockResolvedValueOnce('free_form_repaired')
+      .mockResolvedValueOnce('free_form_raced')
+      .mockResolvedValueOnce('still_null_after_lml');
+    linkedFn
+      .mockResolvedValueOnce('linked_repaired')
+      .mockResolvedValueOnce('linked_raced')
+      .mockResolvedValueOnce('still_null_after_lml');
+
+    const result = await runRepair({
+      lookup,
+      repairFreeForm: freeFormFn,
+      repairLinked: linkedFn,
+      checkLiveActivity,
+      liveActivityLookbackSeconds: 0,
+      liveActivityPauseMs: 0,
+      freeFormRows: [
+        { id: 1, artist_name: 'a', album_title: null, track_title: null },
+        { id: 2, artist_name: 'b', album_title: null, track_title: null },
+        { id: 3, artist_name: 'c', album_title: null, track_title: null },
+      ],
+      linkedAlbums: [
+        { album_id: 10, artist_name: 'd', album_title: 'A' },
+        { album_id: 11, artist_name: 'e', album_title: 'B' },
+        { album_id: 12, artist_name: 'f', album_title: 'C' },
+      ],
+    });
+
+    expect(result.totals).toMatchObject({
+      free_form_scanned: 3,
+      free_form_repaired: 1,
+      free_form_raced: 1,
+      linked_scanned: 3,
+      linked_repaired: 1,
+      linked_raced: 1,
+      still_null_after_lml: 2,
+      error: 0,
+    });
+  });
+
+  it('counts LML throws against error; writers NOT invoked for that row', async () => {
+    const flakyLookup = jest
+      .fn<LookupFn>()
+      .mockResolvedValueOnce(matchedResponse)
+      .mockRejectedValueOnce(new Error('LML 502'))
+      .mockResolvedValueOnce(matchedResponse);
+
+    const result = await runRepair({
+      lookup: flakyLookup,
+      repairFreeForm: freeFormFn,
+      repairLinked: linkedFn,
+      checkLiveActivity,
+      liveActivityLookbackSeconds: 0,
+      liveActivityPauseMs: 0,
+      freeFormRows: [
+        { id: 1, artist_name: 'a', album_title: null, track_title: null },
+        { id: 2, artist_name: 'b', album_title: null, track_title: null },
+      ],
+      linkedAlbums: [{ album_id: 10, artist_name: 'c', album_title: 'A' }],
+    });
+
+    expect(result.totals.free_form_scanned).toBe(2);
+    expect(result.totals.free_form_repaired).toBe(1);
+    expect(result.totals.linked_repaired).toBe(1);
+    expect(result.totals.error).toBe(1);
+    // Writers called only for the non-error rows
+    expect(freeFormFn).toHaveBeenCalledTimes(1);
+    expect(linkedFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes artist+album+track to lookup for free-form rows; artist+album for linked', async () => {
+    await runRepair({
+      lookup,
+      repairFreeForm: freeFormFn,
+      repairLinked: linkedFn,
+      checkLiveActivity,
+      liveActivityLookbackSeconds: 0,
+      liveActivityPauseMs: 0,
+      freeFormRows: [{ id: 1, artist_name: 'A1', album_title: 'B1', track_title: 'T1' }],
+      linkedAlbums: [{ album_id: 10, artist_name: 'A2', album_title: 'B2' }],
+    });
+
+    expect(lookup).toHaveBeenNthCalledWith(1, 'A1', 'B1', 'T1');
+    expect(lookup).toHaveBeenNthCalledWith(2, 'A2', 'B2', undefined);
+  });
+
+  it('defers when checkLiveActivity returns true, then resumes when it clears', async () => {
+    const probe = jest
+      .fn<CheckLiveActivityFn>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(false);
+
+    await runRepair({
+      lookup,
+      repairFreeForm: freeFormFn,
+      repairLinked: linkedFn,
+      checkLiveActivity: probe,
+      liveActivityLookbackSeconds: 60,
+      liveActivityPauseMs: 0,
+      freeFormRows: [{ id: 1, artist_name: 'a', album_title: null, track_title: null }],
+      linkedAlbums: [],
+    });
+
+    // probe called: 3 times until cleared + 1 final pre-row probe = 3 minimum
+    expect(probe.mock.calls.length).toBeGreaterThanOrEqual(3);
+    // Probe windows are 60s
+    probe.mock.calls.forEach((call) => expect(call[0]).toBe(60));
+  });
+
+  it('skips probe entirely when liveActivityLookbackSeconds is 0', async () => {
+    const probe = jest.fn<CheckLiveActivityFn>().mockResolvedValue(true);
+
+    await runRepair({
+      lookup,
+      repairFreeForm: freeFormFn,
+      repairLinked: linkedFn,
+      checkLiveActivity: probe,
+      liveActivityLookbackSeconds: 0,
+      liveActivityPauseMs: 0,
+      freeFormRows: [{ id: 1, artist_name: 'a', album_title: null, track_title: null }],
+      linkedAlbums: [{ album_id: 10, artist_name: 'b', album_title: 'B' }],
+    });
+
+    expect(probe).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Unit tests for flowsheet-artwork-repair `repair.ts` (BS#1209).
+ *
+ * Pins the two write shapes against three invariants from the ticket body:
+ *
+ *   1. Free-form path (album_id IS NULL): a 10-column UPDATE on `flowsheet`
+ *      with an idempotent WHERE narrowing by `id`, `artwork_url IS NULL`,
+ *      and `metadata_status = 'enriched_match'`. Status read-only —
+ *      `metadata_status` NEVER appears in the .set() block.
+ *   2. Linked path (album_id IS NOT NULL): a 10-column UPSERT on
+ *      `album_metadata` with `setWhere: album_metadata.updated_at < NOW()`
+ *      as the race guard. NO flowsheet write at all.
+ *   3. Both paths early-return `still_null_after_lml` when LML's fresh
+ *      lookup carries no artwork — those rows are legitimate no-cover-
+ *      anywhere releases (post-LML#409) and should not be touched.
+ *
+ * Race-guard tests exercise the "concurrent fresh enrichment landed first"
+ * path:
+ *   - Free-form: returning empty array ⇒ `free_form_raced`. The UPDATE
+ *     ran but matched 0 rows (artwork already non-null, or status flipped
+ *     to enriched_no_match by an LML#400 follow-up).
+ *   - Linked: returning empty array on the UPSERT ⇒ `linked_raced`. The
+ *     ON CONFLICT DO UPDATE branch's `setWhere` didn't fire.
+ */
+import { jest } from '@jest/globals';
+
+import { album_metadata, db, flowsheet } from '@wxyc/database';
+import {
+  extractArtwork,
+  repairFreeFormRow,
+  repairLinkedAlbum,
+  type FreeFormRow,
+  type LinkedAlbum,
+} from '../../../../jobs/flowsheet-artwork-repair/repair';
+import type { LookupResponse } from '@wxyc/lml-client';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const mockDb = db as unknown as {
+  insert: jest.Mock;
+  update: jest.Mock;
+  _chain: {
+    set: jest.Mock;
+    where: jest.Mock;
+    returning: jest.Mock;
+    values: jest.Mock;
+    onConflictDoUpdate: jest.Mock;
+  };
+};
+
+const freeFormRow: FreeFormRow = {
+  id: 42,
+  artist_name: 'Stereolab',
+  album_title: 'Aluminum Tunes',
+  track_title: 'Pop Quiz',
+};
+
+const linkedAlbum: LinkedAlbum = {
+  album_id: 5678,
+  artist_name: 'Stereolab',
+  album_title: 'Aluminum Tunes',
+};
+
+const matchedResponse: LookupResponse = {
+  results: [
+    {
+      library_item: { id: 1 },
+      artwork: {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        artwork_url: 'https://i.discogs.com/art.jpg',
+        release_year: 1998,
+        artist_bio: '[a=Tim Gane] and [a=Lætitia Sadier] are Stereolab.',
+        wikipedia_url: 'https://en.wikipedia.org/wiki/Stereolab',
+        spotify_url: 'https://open.spotify.com/album/abc',
+        apple_music_url: 'https://music.apple.com/album/xyz',
+        youtube_music_url: 'https://music.youtube.com/album/aaa',
+        bandcamp_url: 'https://stereolab.bandcamp.com/album/aluminum-tunes',
+        soundcloud_url: null,
+      },
+    },
+  ],
+  search_type: 'direct',
+  song_not_found: false,
+};
+
+const noMatchResponse: LookupResponse = {
+  results: [],
+  search_type: 'none',
+  song_not_found: true,
+};
+
+const noArtworkResponse: LookupResponse = {
+  results: [{ library_item: { id: 1 }, artwork: null }],
+  search_type: 'direct',
+};
+
+describe('extractArtwork', () => {
+  it('returns the top-1 artwork block when present', () => {
+    expect(extractArtwork(matchedResponse)?.artwork_url).toBe('https://i.discogs.com/art.jpg');
+  });
+
+  it('returns null on empty results', () => {
+    expect(extractArtwork(noMatchResponse)).toBeNull();
+  });
+
+  it('returns null when artwork is null on the top result', () => {
+    expect(extractArtwork(noArtworkResponse)).toBeNull();
+  });
+});
+
+describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb._chain.returning.mockResolvedValue([{ id: freeFormRow.id }]);
+  });
+
+  it('writes exactly 10 metadata columns on a fresh LML match — status NEVER touched', async () => {
+    const outcome = await repairFreeFormRow(freeFormRow, matchedResponse);
+    expect(outcome).toBe('free_form_repaired');
+
+    expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+
+    expect(setArgs).toEqual({
+      artwork_url: 'https://i.discogs.com/art.jpg',
+      discogs_url: 'https://www.discogs.com/release/12345',
+      release_year: 1998,
+      spotify_url: 'https://open.spotify.com/album/abc',
+      apple_music_url: 'https://music.apple.com/album/xyz',
+      youtube_music_url: 'https://music.youtube.com/album/aaa',
+      bandcamp_url: 'https://stereolab.bandcamp.com/album/aluminum-tunes',
+      soundcloud_url: null,
+      artist_bio: 'Tim Gane and Lætitia Sadier are Stereolab.',
+      artist_wikipedia_url: 'https://en.wikipedia.org/wiki/Stereolab',
+    });
+    expect(Object.keys(setArgs)).toHaveLength(10);
+    expect('metadata_status' in setArgs).toBe(false);
+    expect('metadata_attempt_at' in setArgs).toBe(false);
+  });
+
+  it('strips Discogs spacer.gif from artwork_url', async () => {
+    const spacerResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, artwork_url: 'https://s.discogs.com/images/spacer.gif' },
+        },
+      ],
+    };
+    const outcome = await repairFreeFormRow(freeFormRow, spacerResponse);
+    expect(outcome).toBe('free_form_repaired');
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs.artwork_url).toBeNull();
+  });
+
+  it('coerces release_year=0 (Discogs sentinel for unknown) to null', async () => {
+    const zeroYearResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, release_year: 0 },
+        },
+      ],
+    };
+    await repairFreeFormRow(freeFormRow, zeroYearResponse);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs.release_year).toBeNull();
+  });
+
+  it('idempotent WHERE narrows by id AND artwork_url IS NULL AND metadata_status=enriched_match', async () => {
+    await repairFreeFormRow(freeFormRow, matchedResponse);
+    expect(mockDb._chain.where).toHaveBeenCalledTimes(1);
+    const rendered = renderSql(mockDb._chain.where.mock.calls[0]?.[0]).toLowerCase();
+    expect(rendered).toMatch(/"id"/);
+    expect(rendered).toMatch(/artwork_url/);
+    expect(rendered).toMatch(/is null/);
+    expect(rendered).toMatch(/metadata_status/);
+    expect(rendered).toMatch(/enriched_match/);
+  });
+
+  it('returns free_form_raced when 0 rows update (artwork already non-null OR status flipped)', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+    const outcome = await repairFreeFormRow(freeFormRow, matchedResponse);
+    expect(outcome).toBe('free_form_raced');
+  });
+
+  it('returns still_null_after_lml when LML returns empty results — no DB write', async () => {
+    const outcome = await repairFreeFormRow(freeFormRow, noMatchResponse);
+    expect(outcome).toBe('still_null_after_lml');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('returns still_null_after_lml when LML returns artwork: null on top hit — no DB write', async () => {
+    const outcome = await repairFreeFormRow(freeFormRow, noArtworkResponse);
+    expect(outcome).toBe('still_null_after_lml');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('returns still_null_after_lml when artwork.artwork_url is null on the top hit — no DB write', async () => {
+    // Post-LML#409, a release with artist+label but no images[0] returns
+    // `artwork.artwork_url: null`. Treat the same as no-match for write
+    // purposes — never persist a null over a null.
+    const nullArtworkUrl: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, artwork_url: null },
+        },
+      ],
+    };
+    const outcome = await repairFreeFormRow(freeFormRow, nullArtworkUrl);
+    expect(outcome).toBe('still_null_after_lml');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('repairLinkedAlbum (BS#1209) — linked UPSERT shape', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb._chain.returning.mockResolvedValue([{ album_id: linkedAlbum.album_id }]);
+  });
+
+  it('UPSERTs exactly 10 metadata columns into album_metadata keyed by album_id — no flowsheet write', async () => {
+    const outcome = await repairLinkedAlbum(linkedAlbum, matchedResponse);
+    expect(outcome).toBe('linked_repaired');
+
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+    expect(mockDb.update).not.toHaveBeenCalled();
+
+    const valuesArgs = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(valuesArgs.album_id).toBe(linkedAlbum.album_id);
+    expect(valuesArgs.artwork_url).toBe('https://i.discogs.com/art.jpg');
+    expect(valuesArgs.discogs_url).toBe('https://www.discogs.com/release/12345');
+    expect(valuesArgs.release_year).toBe(1998);
+    expect(valuesArgs.artist_bio).toBe('Tim Gane and Lætitia Sadier are Stereolab.');
+    expect(renderSql(valuesArgs.updated_at)).toMatch(/now\(\)/i);
+
+    const onConflictArg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as {
+      target: unknown;
+      set: Record<string, unknown>;
+      setWhere: unknown;
+    };
+    expect(onConflictArg.target).toBe(album_metadata.album_id);
+    // 10 metadata cols + updated_at sentinel
+    expect(Object.keys(onConflictArg.set)).toHaveLength(11);
+    expect(onConflictArg.set.artwork_url).toBe('https://i.discogs.com/art.jpg');
+    expect(renderSql(onConflictArg.set.updated_at)).toMatch(/now\(\)/i);
+    // Race guard: only overwrite a row whose updated_at predates ours.
+    // `album_metadata.updated_at` is a stub in the mock so renderSql drops
+    // the column-ref chunk; assert on the literal `< NOW()` shape that's
+    // load-bearing for correctness.
+    const setWhereRendered = renderSql(onConflictArg.setWhere).toLowerCase();
+    expect(setWhereRendered).toContain('<');
+    expect(setWhereRendered).toContain('now()');
+  });
+
+  it('strips spacer.gif from artwork_url in both INSERT values and UPDATE set', async () => {
+    const spacerResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, artwork_url: 'https://s.discogs.com/images/spacer.gif' },
+        },
+      ],
+    };
+    await repairLinkedAlbum(linkedAlbum, spacerResponse);
+    const valuesArgs = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    const onConflictArg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(valuesArgs.artwork_url).toBeNull();
+    expect(onConflictArg.set.artwork_url).toBeNull();
+  });
+
+  it('coerces release_year=0 to null in both INSERT and UPDATE branches', async () => {
+    const zeroYearResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, release_year: 0 },
+        },
+      ],
+    };
+    await repairLinkedAlbum(linkedAlbum, zeroYearResponse);
+    const valuesArgs = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    const onConflictArg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(valuesArgs.release_year).toBeNull();
+    expect(onConflictArg.set.release_year).toBeNull();
+  });
+
+  it("returns linked_raced when the UPSERT setWhere doesn't fire (concurrent fresh enrichment)", async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+    const outcome = await repairLinkedAlbum(linkedAlbum, matchedResponse);
+    expect(outcome).toBe('linked_raced');
+  });
+
+  it('returns still_null_after_lml on empty results — no DB write', async () => {
+    const outcome = await repairLinkedAlbum(linkedAlbum, noMatchResponse);
+    expect(outcome).toBe('still_null_after_lml');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns still_null_after_lml when artwork.artwork_url is null on the top hit — no DB write', async () => {
+    const nullArtworkUrl: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, artwork_url: null },
+        },
+      ],
+    };
+    const outcome = await repairLinkedAlbum(linkedAlbum, nullArtworkUrl);
+    expect(outcome).toBe('still_null_after_lml');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- New one-shot job `jobs/flowsheet-artwork-repair/` (`@wxyc/flowsheet-artwork-repair`) drains the two populations stranded by LML's `_resolve_fallback_artwork` bug ([LML#408](https://github.com/WXYC/library-metadata-lookup/issues/408), fixed in [LML#409](https://github.com/WXYC/library-metadata-lookup/pull/409), deployed prod 2026-05-29).
- Free-form path: 10-col UPDATE on `flowsheet` with idempotent WHERE `id = $1 AND artwork_url IS NULL AND metadata_status = 'enriched_match'`. `metadata_status` never appears in the `.set()` block — drain is read-only on status.
- Linked path: 10-col UPSERT into `album_metadata` race-guarded by `setWhere: updated_at < NOW()`. No flowsheet write — read-path COALESCE join picks the fix up automatically.
- LML calls route through `@wxyc/lml-client` chokepoint with `BACKFILL_LML_RATE_PER_MIN=20` / `BACKFILL_LML_MAX_CONCURRENT=1` (shared env vars with `flowsheet-metadata-backfill` so concurrent drains pace cooperatively against LML's Discogs ceiling — BS#994/BS#995 monopolization avoidance).

## Counters

`free_form_scanned`, `free_form_repaired`, `free_form_raced`, `linked_scanned`, `linked_repaired`, `linked_raced`, `still_null_after_lml`, `error`. The `still_null_after_lml` bucket is intentionally lossy across (a) Discogs genuine no-cover, (b) spacer.gif-filtered, (c) post-LML#400 artist-fallback rejections; it is a status-flip candidate set for the LML#400 follow-up backfill.

## Pre-flight (gate on before running the drain)

Two scoping counts (deferred to the operator at run time — SSH probe of prod is auto-mode-blocked):

```sql
SELECT COUNT(*) FROM wxyc_schema.flowsheet
WHERE metadata_status = 'enriched_match' AND artwork_url IS NULL AND album_id IS NULL;

SELECT COUNT(DISTINCT am.album_id)
FROM wxyc_schema.album_metadata am WHERE am.artwork_url IS NULL;
```

Post the two counts on #1209 as a comment before launch. Go/no-go floor: the rolling 1h `enriched_match → non-null artwork_url` rate from `enrichment.consumer.tick` Sentry transactions must clear ≥ 90% (pre-LML#409 was ~24%). If the floor doesn't hold, the drain should wait. As of this PR the implementation defaults to the single-row LML path; if pre-flight numbers are large (>10k), a bulk-endpoint swap ([LML#368](https://github.com/WXYC/library-metadata-lookup/issues/368)) is a separate follow-up.

## Test plan

- [x] `npm run test:unit -- tests/unit/jobs/flowsheet-artwork-repair/` — 29/29 green (writer race guards, idempotent WHERE, status invariant, spacer.gif filter, release_year=0 coercion, still_null_after_lml early-return, orchestrator counter accumulation, cooperative pause, LML-throw isolation)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (469 pre-existing warnings unchanged)
- [x] `npm run format:check` — clean
- [x] `npm run build --workspace=@wxyc/flowsheet-artwork-repair` — clean
- [ ] Integration test `tests/integration/flowsheet-artwork-repair.spec.js` (requires `npm run db:start`) — exercises free-form happy path, idempotency, status-flip race guard, linked happy path, linked race guard against fresh enrichment
- [ ] Pre-flight counts posted to #1209
- [ ] Go/no-go floor verified ≥ 90% on Sentry trace explorer
- [ ] Manual deploy + drain run + post-drain residue verification

Note: one unit-test failure in `tests/unit/database/schema.flowsheet-artwork-lookup-idx.test.ts` reproduces on `origin/main` with no changes from this branch — pre-existing breakage, unrelated to this PR.

Closes #1209