### PR TITLE
feat(flowsheet-artwork-repair): writers + workspace scaffold (BS#1209, 1/2)

### DIFF
--- a/jobs/flowsheet-artwork-repair/package.json
+++ b/jobs/flowsheet-artwork-repair/package.json
@@ -2,7 +2,7 @@
   "name": "@wxyc/flowsheet-artwork-repair",
   "job-type": "one-shot",
   "version": "1.0.0",
-  "description": "WXYC one-shot drain (BS#1209) — writers scaffold. Re-resolve LML artwork for rows stranded by the LML _resolve_fallback_artwork bug (LML#408, fixed in LML#409). Two write paths: free-form UPDATE on flowsheet (idempotent WHERE) and linked UPSERT on album_metadata (race-guarded). Orchestrator + entrypoint land in a follow-up PR (#1209 split).",
+  "description": "WXYC one-shot drain (BS#1209): re-resolve LML artwork for rows stranded by the LML _resolve_fallback_artwork bug. Free-form UPDATE on flowsheet (idempotent WHERE) and linked UPSERT on album_metadata (race-guarded).",
   "type": "module",
   "main": "./dist/repair.js",
   "scripts": {

--- a/jobs/flowsheet-artwork-repair/package.json
+++ b/jobs/flowsheet-artwork-repair/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@wxyc/flowsheet-artwork-repair",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "WXYC one-shot drain (BS#1209) — writers scaffold. Re-resolve LML artwork for rows stranded by the LML _resolve_fallback_artwork bug (LML#408, fixed in LML#409). Two write paths: free-form UPDATE on flowsheet (idempotent WHERE) and linked UPSERT on album_metadata (race-guarded). Orchestrator + entrypoint land in a follow-up PR (#1209 split).",
+  "type": "module",
+  "main": "./dist/repair.js",
+  "scripts": {
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.53.1",
+    "@wxyc/database": "^1.0.0",
+    "@wxyc/lml-client": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/flowsheet-artwork-repair/repair.ts
+++ b/jobs/flowsheet-artwork-repair/repair.ts
@@ -1,51 +1,20 @@
 /**
- * Per-row repair writers for the flowsheet-artwork-repair drain (BS#1209).
+ * Per-row repair writers for the BS#1209 drain.
  *
- * Two populations stranded by LML#408 (fixed in LML#409, deployed prod
- * 2026-05-29):
+ * Free-form path UPDATEs `flowsheet` under an idempotent WHERE; linked
+ * path UPSERTs `album_metadata` under `setWhere: updated_at < NOW()`.
+ * `metadata_status` is read-only on both paths — the LML#400 follow-up
+ * backfill (if filed) will revisit `still_null_after_lml` rows for
+ * status correction.
  *
- *   1. Free-form rows  — `flowsheet.album_id IS NULL`,
- *                        `metadata_status = 'enriched_match'`,
- *                        `artwork_url IS NULL`. The enrichment-worker landed
- *                        a 10-col UPDATE with `artwork_url=NULL` and flipped
- *                        the status to `enriched_match`. We re-query LML and
- *                        write the same 10 cols (status untouched).
- *   2. Linked rows     — `album_metadata.artwork_url IS NULL`. The worker
- *                        UPSERTed `album_metadata` with `artwork_url=NULL`.
- *                        We re-query LML and UPSERT the same 10 cols. No
- *                        flowsheet write — the read-path COALESCE join over
- *                        `album_metadata` picks the fix up automatically.
- *
- * Hard contracts (from the ticket body):
- *
- *   - `metadata_status` is read-only. The drain MUST NOT flip it. The
- *     LML#400 follow-up backfill (if filed) will revisit `still_null_after_lml`
- *     rows for status correction.
- *   - Race-guarded WHERE on the free-form UPDATE: `id = $1 AND artwork_url
- *     IS NULL AND metadata_status = 'enriched_match'`. A concurrent fresh
- *     enrichment between the orchestrator's SELECT and our UPDATE would have
- *     flipped one of those two columns; either flip kicks the row out of
- *     the WHERE and we return `free_form_raced` instead of corrupting
- *     fresher data.
- *   - Race-guarded UPSERT on the linked path: `setWhere: album_metadata.
- *     updated_at < NOW()`, mirroring the enrichment-worker shape verbatim.
- *
- * The 10-column payload, spacer.gif filter, Discogs-bio cleanup, and the
- * `release_year || null` coercion all mirror `apps/enrichment-worker/
- * enrich.ts:181-198` (canonical writer) and `jobs/flowsheet-metadata-
- * backfill/enrich.ts` (sibling drain). The duplication is the same build-
- * graph isolation the other one-shot jobs carry: no imports from
- * `apps/backend` so the job's Docker image graph is independent.
- *
- * No-write early-return on still-null-after-LML: a fresh LML lookup that
- * returns `results: []`, `artwork: null`, or `artwork.artwork_url: null`
- * means the row is legitimate no-cover-anywhere territory (post-LML#409).
- * Writing null over null is a no-op at best and confuses the
- * `still_null_after_lml` counter at worst. Return early; let the LML#400
- * follow-up consume the bucket.
+ * The 10-column payload, spacer.gif filter, and Discogs-bio cleanup
+ * mirror `apps/enrichment-worker/enrich.ts:181-198`. Inlined for the
+ * same build-graph isolation the sibling drains carry (no imports from
+ * `apps/backend`); parity pinned via
+ * `tests/unit/jobs/flowsheet-artwork-repair/filter-spacer-gif-parity.test.ts`.
  */
 
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import { album_metadata, db, flowsheet } from '@wxyc/database';
 import type { DiscogsMatchResult, LookupResponse } from '@wxyc/lml-client';
 
@@ -62,19 +31,15 @@ export type LinkedAlbum = {
   album_title: string;
 };
 
-export type RepairOutcome =
-  | 'free_form_repaired'
-  | 'free_form_raced'
-  | 'linked_repaired'
-  | 'linked_raced'
-  | 'still_null_after_lml';
-
 /**
- * Strip Discogs markup tags from bio text. Mirrors
- * `apps/backend/services/metadata/metadata.service.ts#cleanDiscogsBio`
- * and `jobs/flowsheet-metadata-backfill/enrich.ts#cleanDiscogsBio`
- * verbatim. Duplicated for build-graph isolation.
+ * `still_null_after_lml` covers all three "no usable artwork from LML"
+ * shapes (empty results, `artwork: null`, `artwork.artwork_url: null`).
+ * `raced` means the row was eligible at SELECT time but a concurrent
+ * fresh enrichment landed first; the WHERE / setWhere correctly no-ops.
+ * The orchestrator buckets `repaired` / `raced` per population.
  */
+export type RepairOutcome = 'repaired' | 'raced' | 'still_null_after_lml';
+
 export const cleanDiscogsBio = (bio: string): string =>
   bio
     .replace(/\[a=([^\]]+)\]/g, '$1')
@@ -84,9 +49,7 @@ export const cleanDiscogsBio = (bio: string): string =>
     .replace(/\[url=([^\]]+)\]([^[]*)\[\/url\]/g, '$2');
 
 /**
- * Drop Discogs spacer.gif placeholder URLs. Mirrors
- * `jobs/flowsheet-metadata-backfill/enrich.ts#filterSpacerGif`. The job
- * writes to nullable columns, so this returns `null` (not `undefined`).
+ * Returns `null` (not `undefined`) — repair writes to nullable DB columns.
  */
 export const filterSpacerGif = (url: string | null | undefined): string | null => {
   if (!url) return null;
@@ -94,46 +57,17 @@ export const filterSpacerGif = (url: string | null | undefined): string | null =
   return url;
 };
 
-/**
- * Pick the top-1 artwork block from an LML response, or null if the
- * response indicates the row is legitimate no-cover-anywhere territory
- * (empty results, or artwork field present-but-null on the top hit).
- */
 export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | null => {
   const first = response.results?.[0];
-  if (!first) return null;
-  if (!first.artwork) return null;
+  if (!first?.artwork) return null;
   return first.artwork;
 };
 
-/**
- * Build the 10-column metadata payload from an LML artwork block. Same
- * shape as `apps/enrichment-worker/enrich.ts:181-198` (canonical writer).
- * Fan-out URLs default to null on no-LML-provided value — the drain
- * deliberately does NOT synthesize search URLs, unlike the sibling
- * `flowsheet-metadata-backfill` drain. Those URLs were already written
- * by the original enrichment cycle that landed `metadata_status =
- * 'enriched_match'` (the population this drain targets), so re-writing
- * with `null` would silently strip the synthesized fallbacks. Leaving
- * `null` in the payload pairs with the WHERE's IS NULL guard to preserve
- * the existing fan-out URLs on UPDATE.
- *
- * Wait — the WHERE only narrows by `artwork_url IS NULL`; it doesn't
- * pin the other 9. To avoid clobbering existing values on those, the
- * 10-col UPDATE shape includes them all, but in practice the population's
- * upstream cycle never wrote them either (they all came back null from
- * LML's degenerate response), so the UPDATE just confirms the same null.
- * The canonical writer shape is what the consumer wrote originally; we
- * mirror it exactly so the comparison "would the consumer have written
- * this column to this value if it had a fresh LML response?" answers yes
- * for every column, every time.
- */
 const buildPayload = (artwork: DiscogsMatchResult) => ({
   artwork_url: filterSpacerGif(artwork.artwork_url),
   discogs_url: artwork.release_url ?? null,
-  // Discogs returns 0 as "year unknown"; coerce to null so the column
-  // doesn't carry a sentinel that iOS renders as literal "0". Mirrors
-  // the runtime path in `metadata.service.ts#extractAlbumMetadata` (#1002).
+  // Discogs returns 0 as "year unknown"; null avoids the literal "0"
+  // iOS would otherwise render. Matches `metadata.service.ts#extractAlbumMetadata` (#1002).
   release_year: artwork.release_year || null,
   spotify_url: artwork.spotify_url ?? null,
   apple_music_url: artwork.apple_music_url ?? null,
@@ -144,52 +78,18 @@ const buildPayload = (artwork: DiscogsMatchResult) => ({
   artist_wikipedia_url: artwork.wikipedia_url ?? null,
 });
 
-/**
- * Repair one free-form flowsheet row. UPDATE `flowsheet` with the 10
- * metadata columns; idempotent WHERE narrows by `id`, `artwork_url IS NULL`,
- * `metadata_status = 'enriched_match'`. `metadata_status` is NOT in the
- * .set() block.
- *
- * Outcomes:
- *   - `still_null_after_lml` — LML returned no usable artwork; no DB write.
- *   - `free_form_raced` — UPDATE ran, 0 rows matched (artwork already
- *     non-null OR status flipped). Idempotent; correctness preserved.
- *   - `free_form_repaired` — UPDATE ran, 1 row matched. Done.
- */
 export const repairFreeFormRow = async (row: FreeFormRow, response: LookupResponse): Promise<RepairOutcome> => {
   const artwork = extractArtwork(response);
   if (!artwork || !artwork.artwork_url) return 'still_null_after_lml';
 
-  const payload = buildPayload(artwork);
   const updated = await db
     .update(flowsheet)
-    .set(payload)
+    .set(buildPayload(artwork))
     .where(sql`"id" = ${row.id} AND "artwork_url" IS NULL AND "metadata_status" = 'enriched_match'`)
     .returning({ id: flowsheet.id });
-  return updated.length === 0 ? 'free_form_raced' : 'free_form_repaired';
+  return updated.length === 0 ? 'raced' : 'repaired';
 };
 
-/**
- * Repair one linked album. UPSERT `album_metadata` with the 10 metadata
- * columns + `updated_at = NOW()`. Race guard: `setWhere: album_metadata.
- * updated_at < NOW()` mirrors the enrichment-worker shape (BS#899)
- * verbatim. No flowsheet write — the read-path COALESCE join picks the
- * fix up automatically.
- *
- * Outcomes:
- *   - `still_null_after_lml` — LML returned no usable artwork; no DB write.
- *   - `linked_raced` — UPSERT's ON CONFLICT branch didn't fire (setWhere
- *     missed); a concurrent fresh enrichment landed first. RETURNING is
- *     empty.
- *   - `linked_repaired` — UPSERT wrote a row. RETURNING is non-empty.
- *
- * Note on race detection: the linked population's qualifying SELECT
- * (`album_metadata.artwork_url IS NULL`) guarantees a row already exists
- * for `album_id`, so we always take the UPDATE branch in practice. The
- * INSERT branch is unreachable but specified for correctness against
- * future schema changes (e.g., a partial unique index that lets the row
- * be deleted out from under us).
- */
 export const repairLinkedAlbum = async (album: LinkedAlbum, response: LookupResponse): Promise<RepairOutcome> => {
   const artwork = extractArtwork(response);
   if (!artwork || !artwork.artwork_url) return 'still_null_after_lml';
@@ -204,11 +104,5 @@ export const repairLinkedAlbum = async (album: LinkedAlbum, response: LookupResp
       setWhere: sql`${album_metadata.updated_at} < NOW()`,
     })
     .returning({ album_id: album_metadata.album_id });
-  return updated.length === 0 ? 'linked_raced' : 'linked_repaired';
+  return updated.length === 0 ? 'raced' : 'repaired';
 };
-
-/**
- * Re-export the drizzle helper trio for tests + orchestrator. Keeps the
- * surface of imports stable across the package.
- */
-export { and, eq, isNull };

--- a/jobs/flowsheet-artwork-repair/repair.ts
+++ b/jobs/flowsheet-artwork-repair/repair.ts
@@ -1,0 +1,214 @@
+/**
+ * Per-row repair writers for the flowsheet-artwork-repair drain (BS#1209).
+ *
+ * Two populations stranded by LML#408 (fixed in LML#409, deployed prod
+ * 2026-05-29):
+ *
+ *   1. Free-form rows  — `flowsheet.album_id IS NULL`,
+ *                        `metadata_status = 'enriched_match'`,
+ *                        `artwork_url IS NULL`. The enrichment-worker landed
+ *                        a 10-col UPDATE with `artwork_url=NULL` and flipped
+ *                        the status to `enriched_match`. We re-query LML and
+ *                        write the same 10 cols (status untouched).
+ *   2. Linked rows     — `album_metadata.artwork_url IS NULL`. The worker
+ *                        UPSERTed `album_metadata` with `artwork_url=NULL`.
+ *                        We re-query LML and UPSERT the same 10 cols. No
+ *                        flowsheet write — the read-path COALESCE join over
+ *                        `album_metadata` picks the fix up automatically.
+ *
+ * Hard contracts (from the ticket body):
+ *
+ *   - `metadata_status` is read-only. The drain MUST NOT flip it. The
+ *     LML#400 follow-up backfill (if filed) will revisit `still_null_after_lml`
+ *     rows for status correction.
+ *   - Race-guarded WHERE on the free-form UPDATE: `id = $1 AND artwork_url
+ *     IS NULL AND metadata_status = 'enriched_match'`. A concurrent fresh
+ *     enrichment between the orchestrator's SELECT and our UPDATE would have
+ *     flipped one of those two columns; either flip kicks the row out of
+ *     the WHERE and we return `free_form_raced` instead of corrupting
+ *     fresher data.
+ *   - Race-guarded UPSERT on the linked path: `setWhere: album_metadata.
+ *     updated_at < NOW()`, mirroring the enrichment-worker shape verbatim.
+ *
+ * The 10-column payload, spacer.gif filter, Discogs-bio cleanup, and the
+ * `release_year || null` coercion all mirror `apps/enrichment-worker/
+ * enrich.ts:181-198` (canonical writer) and `jobs/flowsheet-metadata-
+ * backfill/enrich.ts` (sibling drain). The duplication is the same build-
+ * graph isolation the other one-shot jobs carry: no imports from
+ * `apps/backend` so the job's Docker image graph is independent.
+ *
+ * No-write early-return on still-null-after-LML: a fresh LML lookup that
+ * returns `results: []`, `artwork: null`, or `artwork.artwork_url: null`
+ * means the row is legitimate no-cover-anywhere territory (post-LML#409).
+ * Writing null over null is a no-op at best and confuses the
+ * `still_null_after_lml` counter at worst. Return early; let the LML#400
+ * follow-up consume the bucket.
+ */
+
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { album_metadata, db, flowsheet } from '@wxyc/database';
+import type { DiscogsMatchResult, LookupResponse } from '@wxyc/lml-client';
+
+export type FreeFormRow = {
+  id: number;
+  artist_name: string;
+  album_title: string | null;
+  track_title: string | null;
+};
+
+export type LinkedAlbum = {
+  album_id: number;
+  artist_name: string;
+  album_title: string;
+};
+
+export type RepairOutcome =
+  | 'free_form_repaired'
+  | 'free_form_raced'
+  | 'linked_repaired'
+  | 'linked_raced'
+  | 'still_null_after_lml';
+
+/**
+ * Strip Discogs markup tags from bio text. Mirrors
+ * `apps/backend/services/metadata/metadata.service.ts#cleanDiscogsBio`
+ * and `jobs/flowsheet-metadata-backfill/enrich.ts#cleanDiscogsBio`
+ * verbatim. Duplicated for build-graph isolation.
+ */
+export const cleanDiscogsBio = (bio: string): string =>
+  bio
+    .replace(/\[a=([^\]]+)\]/g, '$1')
+    .replace(/\[l=([^\]]+)\]/g, '$1')
+    .replace(/\[r=([^\]]+)\]/g, '$1')
+    .replace(/\[m=([^\]]+)\]/g, '$1')
+    .replace(/\[url=([^\]]+)\]([^[]*)\[\/url\]/g, '$2');
+
+/**
+ * Drop Discogs spacer.gif placeholder URLs. Mirrors
+ * `jobs/flowsheet-metadata-backfill/enrich.ts#filterSpacerGif`. The job
+ * writes to nullable columns, so this returns `null` (not `undefined`).
+ */
+export const filterSpacerGif = (url: string | null | undefined): string | null => {
+  if (!url) return null;
+  if (url.includes('spacer.gif')) return null;
+  return url;
+};
+
+/**
+ * Pick the top-1 artwork block from an LML response, or null if the
+ * response indicates the row is legitimate no-cover-anywhere territory
+ * (empty results, or artwork field present-but-null on the top hit).
+ */
+export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | null => {
+  const first = response.results?.[0];
+  if (!first) return null;
+  if (!first.artwork) return null;
+  return first.artwork;
+};
+
+/**
+ * Build the 10-column metadata payload from an LML artwork block. Same
+ * shape as `apps/enrichment-worker/enrich.ts:181-198` (canonical writer).
+ * Fan-out URLs default to null on no-LML-provided value — the drain
+ * deliberately does NOT synthesize search URLs, unlike the sibling
+ * `flowsheet-metadata-backfill` drain. Those URLs were already written
+ * by the original enrichment cycle that landed `metadata_status =
+ * 'enriched_match'` (the population this drain targets), so re-writing
+ * with `null` would silently strip the synthesized fallbacks. Leaving
+ * `null` in the payload pairs with the WHERE's IS NULL guard to preserve
+ * the existing fan-out URLs on UPDATE.
+ *
+ * Wait — the WHERE only narrows by `artwork_url IS NULL`; it doesn't
+ * pin the other 9. To avoid clobbering existing values on those, the
+ * 10-col UPDATE shape includes them all, but in practice the population's
+ * upstream cycle never wrote them either (they all came back null from
+ * LML's degenerate response), so the UPDATE just confirms the same null.
+ * The canonical writer shape is what the consumer wrote originally; we
+ * mirror it exactly so the comparison "would the consumer have written
+ * this column to this value if it had a fresh LML response?" answers yes
+ * for every column, every time.
+ */
+const buildPayload = (artwork: DiscogsMatchResult) => ({
+  artwork_url: filterSpacerGif(artwork.artwork_url),
+  discogs_url: artwork.release_url ?? null,
+  // Discogs returns 0 as "year unknown"; coerce to null so the column
+  // doesn't carry a sentinel that iOS renders as literal "0". Mirrors
+  // the runtime path in `metadata.service.ts#extractAlbumMetadata` (#1002).
+  release_year: artwork.release_year || null,
+  spotify_url: artwork.spotify_url ?? null,
+  apple_music_url: artwork.apple_music_url ?? null,
+  youtube_music_url: artwork.youtube_music_url ?? null,
+  bandcamp_url: artwork.bandcamp_url ?? null,
+  soundcloud_url: artwork.soundcloud_url ?? null,
+  artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
+  artist_wikipedia_url: artwork.wikipedia_url ?? null,
+});
+
+/**
+ * Repair one free-form flowsheet row. UPDATE `flowsheet` with the 10
+ * metadata columns; idempotent WHERE narrows by `id`, `artwork_url IS NULL`,
+ * `metadata_status = 'enriched_match'`. `metadata_status` is NOT in the
+ * .set() block.
+ *
+ * Outcomes:
+ *   - `still_null_after_lml` — LML returned no usable artwork; no DB write.
+ *   - `free_form_raced` — UPDATE ran, 0 rows matched (artwork already
+ *     non-null OR status flipped). Idempotent; correctness preserved.
+ *   - `free_form_repaired` — UPDATE ran, 1 row matched. Done.
+ */
+export const repairFreeFormRow = async (row: FreeFormRow, response: LookupResponse): Promise<RepairOutcome> => {
+  const artwork = extractArtwork(response);
+  if (!artwork || !artwork.artwork_url) return 'still_null_after_lml';
+
+  const payload = buildPayload(artwork);
+  const updated = await db
+    .update(flowsheet)
+    .set(payload)
+    .where(sql`"id" = ${row.id} AND "artwork_url" IS NULL AND "metadata_status" = 'enriched_match'`)
+    .returning({ id: flowsheet.id });
+  return updated.length === 0 ? 'free_form_raced' : 'free_form_repaired';
+};
+
+/**
+ * Repair one linked album. UPSERT `album_metadata` with the 10 metadata
+ * columns + `updated_at = NOW()`. Race guard: `setWhere: album_metadata.
+ * updated_at < NOW()` mirrors the enrichment-worker shape (BS#899)
+ * verbatim. No flowsheet write — the read-path COALESCE join picks the
+ * fix up automatically.
+ *
+ * Outcomes:
+ *   - `still_null_after_lml` — LML returned no usable artwork; no DB write.
+ *   - `linked_raced` — UPSERT's ON CONFLICT branch didn't fire (setWhere
+ *     missed); a concurrent fresh enrichment landed first. RETURNING is
+ *     empty.
+ *   - `linked_repaired` — UPSERT wrote a row. RETURNING is non-empty.
+ *
+ * Note on race detection: the linked population's qualifying SELECT
+ * (`album_metadata.artwork_url IS NULL`) guarantees a row already exists
+ * for `album_id`, so we always take the UPDATE branch in practice. The
+ * INSERT branch is unreachable but specified for correctness against
+ * future schema changes (e.g., a partial unique index that lets the row
+ * be deleted out from under us).
+ */
+export const repairLinkedAlbum = async (album: LinkedAlbum, response: LookupResponse): Promise<RepairOutcome> => {
+  const artwork = extractArtwork(response);
+  if (!artwork || !artwork.artwork_url) return 'still_null_after_lml';
+
+  const payload = buildPayload(artwork);
+  const updated = await db
+    .insert(album_metadata)
+    .values({ album_id: album.album_id, ...payload, updated_at: sql`NOW()` })
+    .onConflictDoUpdate({
+      target: album_metadata.album_id,
+      set: { ...payload, updated_at: sql`NOW()` },
+      setWhere: sql`${album_metadata.updated_at} < NOW()`,
+    })
+    .returning({ album_id: album_metadata.album_id });
+  return updated.length === 0 ? 'linked_raced' : 'linked_repaired';
+};
+
+/**
+ * Re-export the drizzle helper trio for tests + orchestrator. Keeps the
+ * surface of imports stable across the package.
+ */
+export { and, eq, isNull };

--- a/jobs/flowsheet-artwork-repair/repair.ts
+++ b/jobs/flowsheet-artwork-repair/repair.ts
@@ -11,7 +11,20 @@
  * mirror `apps/enrichment-worker/enrich.ts:181-198`. Inlined for the
  * same build-graph isolation the sibling drains carry (no imports from
  * `apps/backend`); parity pinned via
- * `tests/unit/jobs/flowsheet-artwork-repair/filter-spacer-gif-parity.test.ts`.
+ * `tests/unit/jobs/flowsheet-artwork-repair/filter-spacer-gif-parity.test.ts`
+ * and `tests/unit/jobs/flowsheet-artwork-repair/synthesize-search-urls-parity.test.ts`.
+ *
+ * Streaming-URL fallback asymmetry (mirrors the canonical writers):
+ *   - Free-form path has track_title available → synthesize search URLs
+ *     and use `artwork.* ?? searchUrls.*` for youtube / bandcamp /
+ *     soundcloud (same shape as enrichment-worker:171-174 and
+ *     flowsheet-metadata-backfill/enrich.ts:172-174). Avoids regressing
+ *     existing synthesized URLs when LML returns null on those columns.
+ *   - Linked path has no track_title → fall back to `?? null` (same as
+ *     album-level-backfill/job.ts:294-296). SoundCloud's track-leaning
+ *     query would degrade to an album-only search that returns unrelated
+ *     DJ mixes, so leave the column null rather than synthesizing
+ *     against insufficient inputs.
  */
 
 import { sql } from 'drizzle-orm';
@@ -57,13 +70,56 @@ export const filterSpacerGif = (url: string | null | undefined): string | null =
   return url;
 };
 
+/**
+ * Synthesize the three search URLs the runtime path falls back to on
+ * no-match. Must match `apps/backend/services/metadata/providers/search-urls.provider.ts`
+ * exactly — the inline copy is duplicated rather than imported for the same
+ * build-graph isolation reason as the rest of `repair.ts`. Parity test at
+ * `tests/unit/jobs/flowsheet-artwork-repair/synthesize-search-urls-parity.test.ts`
+ * pins the equivalence so the two cannot drift (BS#889).
+ *
+ * Per-service semantics (deliberately asymmetric):
+ *   - YouTube Music: trackTitle > albumTitle > artistName (3-tier).
+ *   - Bandcamp:      albumTitle > artistName (album-leaning).
+ *   - SoundCloud:    trackTitle > artistName (track-leaning, NO album
+ *                    fallback — album-only SoundCloud queries return
+ *                    unrelated DJ mixes more often than the album).
+ */
+export const synthesizeSearchUrls = (
+  row: FreeFormRow
+): { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
+  const artist = row.artist_name;
+  const album = row.album_title ?? undefined;
+  const track = row.track_title ?? undefined;
+
+  const youtubeQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
+  const bandcampQuery = album ? `${artist} ${album}` : artist;
+  const soundcloudQuery = track ? `${artist} ${track}` : artist;
+
+  return {
+    youtube_music_url: `https://music.youtube.com/search?q=${encodeURIComponent(youtubeQuery)}`,
+    bandcamp_url: `https://bandcamp.com/search?q=${encodeURIComponent(bandcampQuery)}`,
+    soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent(soundcloudQuery)}`,
+  };
+};
+
 export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | null => {
   const first = response.results?.[0];
   if (!first?.artwork) return null;
   return first.artwork;
 };
 
-const buildPayload = (artwork: DiscogsMatchResult) => ({
+type SearchUrls = { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string };
+
+/**
+ * Free-form variant: streaming URLs fall back to synthesized queries so
+ * we never regress a populated column to null. `searchUrls` is required.
+ *
+ * Linked-album variant (`searchUrls` omitted): streaming URLs fall back
+ * to null — track_title isn't available, and SoundCloud's track-leaning
+ * query would degrade poorly on artist+album only inputs.
+ */
+const buildPayload = (artwork: DiscogsMatchResult, searchUrls?: SearchUrls) => ({
   artwork_url: filterSpacerGif(artwork.artwork_url),
   discogs_url: artwork.release_url ?? null,
   // Discogs returns 0 as "year unknown"; null avoids the literal "0"
@@ -71,9 +127,9 @@ const buildPayload = (artwork: DiscogsMatchResult) => ({
   release_year: artwork.release_year || null,
   spotify_url: artwork.spotify_url ?? null,
   apple_music_url: artwork.apple_music_url ?? null,
-  youtube_music_url: artwork.youtube_music_url ?? null,
-  bandcamp_url: artwork.bandcamp_url ?? null,
-  soundcloud_url: artwork.soundcloud_url ?? null,
+  youtube_music_url: artwork.youtube_music_url ?? searchUrls?.youtube_music_url ?? null,
+  bandcamp_url: artwork.bandcamp_url ?? searchUrls?.bandcamp_url ?? null,
+  soundcloud_url: artwork.soundcloud_url ?? searchUrls?.soundcloud_url ?? null,
   artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
   artist_wikipedia_url: artwork.wikipedia_url ?? null,
 });
@@ -84,7 +140,7 @@ export const repairFreeFormRow = async (row: FreeFormRow, response: LookupRespon
 
   const updated = await db
     .update(flowsheet)
-    .set(buildPayload(artwork))
+    .set(buildPayload(artwork, synthesizeSearchUrls(row)))
     .where(sql`"id" = ${row.id} AND "artwork_url" IS NULL AND "metadata_status" = 'enriched_match'`)
     .returning({ id: flowsheet.id });
   return updated.length === 0 ? 'raced' : 'repaired';

--- a/jobs/flowsheet-artwork-repair/tsconfig.json
+++ b/jobs/flowsheet-artwork-repair/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/flowsheet-artwork-repair/tsup.config.ts
+++ b/jobs/flowsheet-artwork-repair/tsup.config.ts
@@ -5,10 +5,6 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// PR1 of the BS#1209 split: only the writers ship in this PR. The entry
-// is `repair.ts` so the workspace builds standalone (no `job.ts` yet).
-// The follow-up PR adds `job.ts` (entrypoint) + `orchestrate.ts` and
-// re-points this config back to `job.ts`.
 export default defineConfig(() => ({
   entry: ['repair.ts'],
   format: ['esm'],

--- a/jobs/flowsheet-artwork-repair/tsup.config.ts
+++ b/jobs/flowsheet-artwork-repair/tsup.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// PR1 of the BS#1209 split: only the writers ship in this PR. The entry
+// is `repair.ts` so the workspace builds standalone (no `job.ts` yet).
+// The follow-up PR adds `job.ts` (entrypoint) + `orchestrate.ts` and
+// re-points this config back to `job.ts`.
+export default defineConfig(() => ({
+  entry: ['repair.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  minify: true,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -510,6 +510,22 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/flowsheet-artwork-repair": {
+      "name": "@wxyc/flowsheet-artwork-repair",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.53.1",
+        "@wxyc/database": "^1.0.0",
+        "@wxyc/lml-client": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/flowsheet-dj-name-backfill": {
       "name": "@wxyc/flowsheet-dj-name-backfill",
       "version": "1.0.0",
@@ -6251,6 +6267,10 @@
     },
     "node_modules/@wxyc/enrichment-worker": {
       "resolved": "apps/enrichment-worker",
+      "link": true
+    },
+    "node_modules/@wxyc/flowsheet-artwork-repair": {
+      "resolved": "jobs/flowsheet-artwork-repair",
       "link": true
     },
     "node_modules/@wxyc/flowsheet-dj-name-backfill": {

--- a/scripts/check-spacer-gif-callsites.sh
+++ b/scripts/check-spacer-gif-callsites.sh
@@ -39,6 +39,7 @@ ALLOWED=(
   "jobs/flowsheet-metadata-backfill/enrich.ts"
   "jobs/library-artwork-url-backfill/enrich.ts"
   "jobs/album-level-backfill/job.ts"
+  "jobs/flowsheet-artwork-repair/repair.ts"
   "apps/enrichment-worker/enrich.ts"
 )
 

--- a/tests/unit/jobs/flowsheet-artwork-repair/filter-spacer-gif-parity.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/filter-spacer-gif-parity.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Parity test: the inline `filterSpacerGif` in
+ * `jobs/flowsheet-artwork-repair/repair.ts` MUST be truthy/falsy-equivalent
+ * to the canonical
+ * `apps/backend/services/metadata/metadata.service.ts#filterSpacerGif`
+ * for every input the runtime exercises (BS#890).
+ *
+ * The inline copy returns `null` (it writes to nullable DB columns) and
+ * the canonical returns `undefined` (it writes to JSON response fields),
+ * so this test does not require strict-equality output; only that the two
+ * agree on "is this URL a real artwork URL or a spacer/empty/null." The
+ * truthy URL output, when present, must match exactly.
+ *
+ * Companion to `scripts/check-spacer-gif-callsites.sh`, which pins the
+ * allowlist of source files that may mention the string `spacer.gif`.
+ * Mirrors the sibling parity tests under
+ * `tests/unit/jobs/album-level-backfill/` and
+ * `tests/unit/jobs/flowsheet-metadata-backfill/`.
+ */
+
+import { filterSpacerGif as inlineFilter } from '../../../../jobs/flowsheet-artwork-repair/repair';
+import { filterSpacerGif as canonicalFilter } from '../../../../apps/backend/services/metadata/metadata.service';
+
+describe('filterSpacerGif parity (flowsheet-artwork-repair inline ↔ canonical)', () => {
+  const cases: Array<{ name: string; input: string | null | undefined }> = [
+    { name: 'null', input: null },
+    { name: 'undefined', input: undefined },
+    { name: 'empty string', input: '' },
+    { name: 'plain URL', input: 'https://i.discogs.com/Y6V_TKqj_xJ8RbS.jpeg' },
+    { name: 'Discogs spacer.gif placeholder', input: 'https://s.discogs.com/images/spacer.gif' },
+    { name: 'URL with "spacer.gif" embedded mid-path', input: 'https://example.com/a/spacer.gif/x' },
+    {
+      name: 'capitalized "Spacer.gif" does not match the canonical literal',
+      input: 'https://i.discogs.com/Spacer.gif',
+    },
+  ];
+
+  it.each(cases)('truthy/falsy parity on $name', ({ input }) => {
+    const inlineOut = inlineFilter(input);
+    const canonicalOut = canonicalFilter(input);
+    expect(Boolean(inlineOut)).toBe(Boolean(canonicalOut));
+    if (inlineOut && canonicalOut) {
+      expect(inlineOut).toBe(canonicalOut);
+    }
+  });
+});

--- a/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Unit tests for flowsheet-artwork-repair `repair.ts` (BS#1209).
+ *
+ * Pins the two write shapes against three invariants from the ticket body:
+ *
+ *   1. Free-form path (album_id IS NULL): a 10-column UPDATE on `flowsheet`
+ *      with an idempotent WHERE narrowing by `id`, `artwork_url IS NULL`,
+ *      and `metadata_status = 'enriched_match'`. Status read-only —
+ *      `metadata_status` NEVER appears in the .set() block.
+ *   2. Linked path (album_id IS NOT NULL): a 10-column UPSERT on
+ *      `album_metadata` with `setWhere: album_metadata.updated_at < NOW()`
+ *      as the race guard. NO flowsheet write at all.
+ *   3. Both paths early-return `still_null_after_lml` when LML's fresh
+ *      lookup carries no artwork — those rows are legitimate no-cover-
+ *      anywhere releases (post-LML#409) and should not be touched.
+ *
+ * Race-guard tests exercise the "concurrent fresh enrichment landed first"
+ * path:
+ *   - Free-form: returning empty array ⇒ `free_form_raced`. The UPDATE
+ *     ran but matched 0 rows (artwork already non-null, or status flipped
+ *     to enriched_no_match by an LML#400 follow-up).
+ *   - Linked: returning empty array on the UPSERT ⇒ `linked_raced`. The
+ *     ON CONFLICT DO UPDATE branch's `setWhere` didn't fire.
+ */
+import { jest } from '@jest/globals';
+
+import { album_metadata, db, flowsheet } from '@wxyc/database';
+import {
+  extractArtwork,
+  repairFreeFormRow,
+  repairLinkedAlbum,
+  type FreeFormRow,
+  type LinkedAlbum,
+} from '../../../../jobs/flowsheet-artwork-repair/repair';
+import type { LookupResponse } from '@wxyc/lml-client';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const mockDb = db as unknown as {
+  insert: jest.Mock;
+  update: jest.Mock;
+  _chain: {
+    set: jest.Mock;
+    where: jest.Mock;
+    returning: jest.Mock;
+    values: jest.Mock;
+    onConflictDoUpdate: jest.Mock;
+  };
+};
+
+const freeFormRow: FreeFormRow = {
+  id: 42,
+  artist_name: 'Stereolab',
+  album_title: 'Aluminum Tunes',
+  track_title: 'Pop Quiz',
+};
+
+const linkedAlbum: LinkedAlbum = {
+  album_id: 5678,
+  artist_name: 'Stereolab',
+  album_title: 'Aluminum Tunes',
+};
+
+const matchedResponse: LookupResponse = {
+  results: [
+    {
+      library_item: { id: 1 },
+      artwork: {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        artwork_url: 'https://i.discogs.com/art.jpg',
+        release_year: 1998,
+        artist_bio: '[a=Tim Gane] and [a=Lætitia Sadier] are Stereolab.',
+        wikipedia_url: 'https://en.wikipedia.org/wiki/Stereolab',
+        spotify_url: 'https://open.spotify.com/album/abc',
+        apple_music_url: 'https://music.apple.com/album/xyz',
+        youtube_music_url: 'https://music.youtube.com/album/aaa',
+        bandcamp_url: 'https://stereolab.bandcamp.com/album/aluminum-tunes',
+        soundcloud_url: null,
+      },
+    },
+  ],
+  search_type: 'direct',
+  song_not_found: false,
+};
+
+const noMatchResponse: LookupResponse = {
+  results: [],
+  search_type: 'none',
+  song_not_found: true,
+};
+
+const noArtworkResponse: LookupResponse = {
+  results: [{ library_item: { id: 1 }, artwork: null }],
+  search_type: 'direct',
+};
+
+describe('extractArtwork', () => {
+  it('returns the top-1 artwork block when present', () => {
+    expect(extractArtwork(matchedResponse)?.artwork_url).toBe('https://i.discogs.com/art.jpg');
+  });
+
+  it('returns null on empty results', () => {
+    expect(extractArtwork(noMatchResponse)).toBeNull();
+  });
+
+  it('returns null when artwork is null on the top result', () => {
+    expect(extractArtwork(noArtworkResponse)).toBeNull();
+  });
+});
+
+describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb._chain.returning.mockResolvedValue([{ id: freeFormRow.id }]);
+  });
+
+  it('writes exactly 10 metadata columns on a fresh LML match — status NEVER touched', async () => {
+    const outcome = await repairFreeFormRow(freeFormRow, matchedResponse);
+    expect(outcome).toBe('free_form_repaired');
+
+    expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+
+    expect(setArgs).toEqual({
+      artwork_url: 'https://i.discogs.com/art.jpg',
+      discogs_url: 'https://www.discogs.com/release/12345',
+      release_year: 1998,
+      spotify_url: 'https://open.spotify.com/album/abc',
+      apple_music_url: 'https://music.apple.com/album/xyz',
+      youtube_music_url: 'https://music.youtube.com/album/aaa',
+      bandcamp_url: 'https://stereolab.bandcamp.com/album/aluminum-tunes',
+      soundcloud_url: null,
+      artist_bio: 'Tim Gane and Lætitia Sadier are Stereolab.',
+      artist_wikipedia_url: 'https://en.wikipedia.org/wiki/Stereolab',
+    });
+    expect(Object.keys(setArgs)).toHaveLength(10);
+    expect('metadata_status' in setArgs).toBe(false);
+    expect('metadata_attempt_at' in setArgs).toBe(false);
+  });
+
+  it('strips Discogs spacer.gif from artwork_url', async () => {
+    const spacerResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, artwork_url: 'https://s.discogs.com/images/spacer.gif' },
+        },
+      ],
+    };
+    const outcome = await repairFreeFormRow(freeFormRow, spacerResponse);
+    expect(outcome).toBe('free_form_repaired');
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs.artwork_url).toBeNull();
+  });
+
+  it('coerces release_year=0 (Discogs sentinel for unknown) to null', async () => {
+    const zeroYearResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, release_year: 0 },
+        },
+      ],
+    };
+    await repairFreeFormRow(freeFormRow, zeroYearResponse);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs.release_year).toBeNull();
+  });
+
+  it('idempotent WHERE narrows by id AND artwork_url IS NULL AND metadata_status=enriched_match', async () => {
+    await repairFreeFormRow(freeFormRow, matchedResponse);
+    expect(mockDb._chain.where).toHaveBeenCalledTimes(1);
+    const rendered = renderSql(mockDb._chain.where.mock.calls[0]?.[0]).toLowerCase();
+    expect(rendered).toMatch(/"id"/);
+    expect(rendered).toMatch(/artwork_url/);
+    expect(rendered).toMatch(/is null/);
+    expect(rendered).toMatch(/metadata_status/);
+    expect(rendered).toMatch(/enriched_match/);
+  });
+
+  it('returns free_form_raced when 0 rows update (artwork already non-null OR status flipped)', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+    const outcome = await repairFreeFormRow(freeFormRow, matchedResponse);
+    expect(outcome).toBe('free_form_raced');
+  });
+
+  it('returns still_null_after_lml when LML returns empty results — no DB write', async () => {
+    const outcome = await repairFreeFormRow(freeFormRow, noMatchResponse);
+    expect(outcome).toBe('still_null_after_lml');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('returns still_null_after_lml when LML returns artwork: null on top hit — no DB write', async () => {
+    const outcome = await repairFreeFormRow(freeFormRow, noArtworkResponse);
+    expect(outcome).toBe('still_null_after_lml');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('returns still_null_after_lml when artwork.artwork_url is null on the top hit — no DB write', async () => {
+    // Post-LML#409, a release with artist+label but no images[0] returns
+    // `artwork.artwork_url: null`. Treat the same as no-match for write
+    // purposes — never persist a null over a null.
+    const nullArtworkUrl: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, artwork_url: null },
+        },
+      ],
+    };
+    const outcome = await repairFreeFormRow(freeFormRow, nullArtworkUrl);
+    expect(outcome).toBe('still_null_after_lml');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('repairLinkedAlbum (BS#1209) — linked UPSERT shape', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb._chain.returning.mockResolvedValue([{ album_id: linkedAlbum.album_id }]);
+  });
+
+  it('UPSERTs exactly 10 metadata columns into album_metadata keyed by album_id — no flowsheet write', async () => {
+    const outcome = await repairLinkedAlbum(linkedAlbum, matchedResponse);
+    expect(outcome).toBe('linked_repaired');
+
+    expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
+    expect(mockDb.update).not.toHaveBeenCalled();
+
+    const valuesArgs = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(valuesArgs.album_id).toBe(linkedAlbum.album_id);
+    expect(valuesArgs.artwork_url).toBe('https://i.discogs.com/art.jpg');
+    expect(valuesArgs.discogs_url).toBe('https://www.discogs.com/release/12345');
+    expect(valuesArgs.release_year).toBe(1998);
+    expect(valuesArgs.artist_bio).toBe('Tim Gane and Lætitia Sadier are Stereolab.');
+    expect(renderSql(valuesArgs.updated_at)).toMatch(/now\(\)/i);
+
+    const onConflictArg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as {
+      target: unknown;
+      set: Record<string, unknown>;
+      setWhere: unknown;
+    };
+    expect(onConflictArg.target).toBe(album_metadata.album_id);
+    // 10 metadata cols + updated_at sentinel
+    expect(Object.keys(onConflictArg.set)).toHaveLength(11);
+    expect(onConflictArg.set.artwork_url).toBe('https://i.discogs.com/art.jpg');
+    expect(renderSql(onConflictArg.set.updated_at)).toMatch(/now\(\)/i);
+    // Race guard: only overwrite a row whose updated_at predates ours.
+    // `album_metadata.updated_at` is a stub in the mock so renderSql drops
+    // the column-ref chunk; assert on the literal `< NOW()` shape that's
+    // load-bearing for correctness.
+    const setWhereRendered = renderSql(onConflictArg.setWhere).toLowerCase();
+    expect(setWhereRendered).toContain('<');
+    expect(setWhereRendered).toContain('now()');
+  });
+
+  it('strips spacer.gif from artwork_url in both INSERT values and UPDATE set', async () => {
+    const spacerResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, artwork_url: 'https://s.discogs.com/images/spacer.gif' },
+        },
+      ],
+    };
+    await repairLinkedAlbum(linkedAlbum, spacerResponse);
+    const valuesArgs = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    const onConflictArg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(valuesArgs.artwork_url).toBeNull();
+    expect(onConflictArg.set.artwork_url).toBeNull();
+  });
+
+  it('coerces release_year=0 to null in both INSERT and UPDATE branches', async () => {
+    const zeroYearResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, release_year: 0 },
+        },
+      ],
+    };
+    await repairLinkedAlbum(linkedAlbum, zeroYearResponse);
+    const valuesArgs = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    const onConflictArg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(valuesArgs.release_year).toBeNull();
+    expect(onConflictArg.set.release_year).toBeNull();
+  });
+
+  it("returns linked_raced when the UPSERT setWhere doesn't fire (concurrent fresh enrichment)", async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+    const outcome = await repairLinkedAlbum(linkedAlbum, matchedResponse);
+    expect(outcome).toBe('linked_raced');
+  });
+
+  it('returns still_null_after_lml on empty results — no DB write', async () => {
+    const outcome = await repairLinkedAlbum(linkedAlbum, noMatchResponse);
+    expect(outcome).toBe('still_null_after_lml');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns still_null_after_lml when artwork.artwork_url is null on the top hit — no DB write', async () => {
+    const nullArtworkUrl: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, artwork_url: null },
+        },
+      ],
+    };
+    const outcome = await repairLinkedAlbum(linkedAlbum, nullArtworkUrl);
+    expect(outcome).toBe('still_null_after_lml');
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
@@ -15,12 +15,7 @@
  *      anywhere releases (post-LML#409) and should not be touched.
  *
  * Race-guard tests exercise the "concurrent fresh enrichment landed first"
- * path:
- *   - Free-form: returning empty array ⇒ `free_form_raced`. The UPDATE
- *     ran but matched 0 rows (artwork already non-null, or status flipped
- *     to enriched_no_match by an LML#400 follow-up).
- *   - Linked: returning empty array on the UPSERT ⇒ `linked_raced`. The
- *     ON CONFLICT DO UPDATE branch's `setWhere` didn't fire.
+ * path: empty `returning()` array ⇒ `raced` for either writer.
  */
 import { jest } from '@jest/globals';
 
@@ -134,7 +129,7 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
 
   it('writes exactly 10 metadata columns on a fresh LML match — status NEVER touched', async () => {
     const outcome = await repairFreeFormRow(freeFormRow, matchedResponse);
-    expect(outcome).toBe('free_form_repaired');
+    expect(outcome).toBe('repaired');
 
     expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
     const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
@@ -167,7 +162,7 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
       ],
     };
     const outcome = await repairFreeFormRow(freeFormRow, spacerResponse);
-    expect(outcome).toBe('free_form_repaired');
+    expect(outcome).toBe('repaired');
     const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(setArgs.artwork_url).toBeNull();
   });
@@ -198,10 +193,10 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
     expect(rendered).toMatch(/enriched_match/);
   });
 
-  it('returns free_form_raced when 0 rows update (artwork already non-null OR status flipped)', async () => {
+  it('returns raced when 0 rows update (artwork already non-null OR status flipped)', async () => {
     mockDb._chain.returning.mockResolvedValueOnce([]);
     const outcome = await repairFreeFormRow(freeFormRow, matchedResponse);
-    expect(outcome).toBe('free_form_raced');
+    expect(outcome).toBe('raced');
   });
 
   it('returns still_null_after_lml when LML returns empty results — no DB write', async () => {
@@ -243,7 +238,7 @@ describe('repairLinkedAlbum (BS#1209) — linked UPSERT shape', () => {
 
   it('UPSERTs exactly 10 metadata columns into album_metadata keyed by album_id — no flowsheet write', async () => {
     const outcome = await repairLinkedAlbum(linkedAlbum, matchedResponse);
-    expect(outcome).toBe('linked_repaired');
+    expect(outcome).toBe('repaired');
 
     expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
     expect(mockDb.update).not.toHaveBeenCalled();
@@ -309,10 +304,10 @@ describe('repairLinkedAlbum (BS#1209) — linked UPSERT shape', () => {
     expect(onConflictArg.set.release_year).toBeNull();
   });
 
-  it("returns linked_raced when the UPSERT setWhere doesn't fire (concurrent fresh enrichment)", async () => {
+  it("returns raced when the UPSERT setWhere doesn't fire (concurrent fresh enrichment)", async () => {
     mockDb._chain.returning.mockResolvedValueOnce([]);
     const outcome = await repairLinkedAlbum(linkedAlbum, matchedResponse);
-    expect(outcome).toBe('linked_raced');
+    expect(outcome).toBe('raced');
   });
 
   it('returns still_null_after_lml on empty results — no DB write', async () => {

--- a/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
@@ -134,6 +134,9 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
     expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
     const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
 
+    // soundcloud_url is null in the fixture; the writer falls back to a
+    // synthesized search URL (track-leaning). See the streaming-URL
+    // fallback test below for the synthesis invariant.
     expect(setArgs).toEqual({
       artwork_url: 'https://i.discogs.com/art.jpg',
       discogs_url: 'https://www.discogs.com/release/12345',
@@ -142,13 +145,49 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
       apple_music_url: 'https://music.apple.com/album/xyz',
       youtube_music_url: 'https://music.youtube.com/album/aaa',
       bandcamp_url: 'https://stereolab.bandcamp.com/album/aluminum-tunes',
-      soundcloud_url: null,
+      soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent('Stereolab Pop Quiz')}`,
       artist_bio: 'Tim Gane and Lætitia Sadier are Stereolab.',
       artist_wikipedia_url: 'https://en.wikipedia.org/wiki/Stereolab',
     });
     expect(Object.keys(setArgs)).toHaveLength(10);
     expect('metadata_status' in setArgs).toBe(false);
     expect('metadata_attempt_at' in setArgs).toBe(false);
+  });
+
+  it('falls back to synthesized search URLs when LML returns null for youtube / bandcamp / soundcloud — no regression of populated columns', async () => {
+    // Target population for the BS#1209 drain is rows already enriched
+    // (`metadata_status='enriched_match'`) whose artwork is null. Those
+    // rows likely already carry synthesized search URLs from the original
+    // enrichment write. If LML's fresh lookup returns null for any of the
+    // three streaming columns, the writer must NOT overwrite the existing
+    // value with null — it must instead persist the same synthesized URL
+    // shape the original enrichment used. Mirrors enrichment-worker
+    // (apps/enrichment-worker/enrich.ts:171-174) + flowsheet-metadata-backfill
+    // (jobs/flowsheet-metadata-backfill/enrich.ts:172-174).
+    const allStreamingNullResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: {
+            ...matchedResponse.results[0].artwork!,
+            youtube_music_url: null,
+            bandcamp_url: null,
+            soundcloud_url: null,
+          },
+        },
+      ],
+    };
+    await repairFreeFormRow(freeFormRow, allStreamingNullResponse);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+
+    expect(setArgs.youtube_music_url).toBe(
+      `https://music.youtube.com/search?q=${encodeURIComponent('Stereolab Pop Quiz')}`
+    );
+    expect(setArgs.bandcamp_url).toBe(
+      `https://bandcamp.com/search?q=${encodeURIComponent('Stereolab Aluminum Tunes')}`
+    );
+    expect(setArgs.soundcloud_url).toBe(`https://soundcloud.com/search?q=${encodeURIComponent('Stereolab Pop Quiz')}`);
   });
 
   it('strips Discogs spacer.gif from artwork_url', async () => {
@@ -302,6 +341,39 @@ describe('repairLinkedAlbum (BS#1209) — linked UPSERT shape', () => {
     const onConflictArg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
     expect(valuesArgs.release_year).toBeNull();
     expect(onConflictArg.set.release_year).toBeNull();
+  });
+
+  it('does NOT synthesize streaming search URLs when LML returns null — track_title unavailable in LinkedAlbum (mirrors album-level-backfill)', async () => {
+    // Linked path has only artist + album, no track. SoundCloud's
+    // track-leaning fallback would degrade to album-only queries that
+    // surface unrelated DJ mixes, so the convention (same as
+    // album-level-backfill/job.ts:294-296) is `?? null` — leave the
+    // column null rather than synthesize against insufficient inputs.
+    // The runtime read path COALESCEs over album_metadata + flowsheet, so
+    // a null here preserves whatever the flowsheet row already carries.
+    const allStreamingNullResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: {
+            ...matchedResponse.results[0].artwork!,
+            youtube_music_url: null,
+            bandcamp_url: null,
+            soundcloud_url: null,
+          },
+        },
+      ],
+    };
+    await repairLinkedAlbum(linkedAlbum, allStreamingNullResponse);
+    const valuesArgs = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    const onConflictArg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(valuesArgs.youtube_music_url).toBeNull();
+    expect(valuesArgs.bandcamp_url).toBeNull();
+    expect(valuesArgs.soundcloud_url).toBeNull();
+    expect(onConflictArg.set.youtube_music_url).toBeNull();
+    expect(onConflictArg.set.bandcamp_url).toBeNull();
+    expect(onConflictArg.set.soundcloud_url).toBeNull();
   });
 
   it("returns raced when the UPSERT setWhere doesn't fire (concurrent fresh enrichment)", async () => {

--- a/tests/unit/jobs/flowsheet-artwork-repair/synthesize-search-urls-parity.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/synthesize-search-urls-parity.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Parity test: the inline `synthesizeSearchUrls` in
+ * `jobs/flowsheet-artwork-repair/repair.ts` MUST produce identical
+ * output to the canonical `SearchUrlProvider.getAllSearchUrls` in
+ * `apps/backend/services/metadata/providers/search-urls.provider.ts`
+ * for the same inputs (BS#889).
+ *
+ * The inline copy exists deliberately — the job's tsup build deliberately
+ * doesn't pull in apps/backend (build-graph isolation; see the file
+ * header on `repair.ts`). The cost of that isolation is silent drift
+ * between the two implementations. This test pins them in lockstep so
+ * the next drift fails CI loudly. Mirrors the sibling parity test under
+ * `tests/unit/jobs/flowsheet-metadata-backfill/`.
+ */
+
+import { synthesizeSearchUrls } from '../../../../jobs/flowsheet-artwork-repair/repair';
+import { SearchUrlProvider } from '../../../../apps/backend/services/metadata/providers/search-urls.provider';
+
+describe('synthesizeSearchUrls parity with SearchUrlProvider', () => {
+  const canonical = new SearchUrlProvider();
+
+  type Case = { name: string; artist: string; album: string | null; track: string | null };
+  const cases: Case[] = [
+    { name: 'full track + album + artist', artist: 'Juana Molina', album: 'DOGA', track: 'la paradoja' },
+    { name: 'no track, album present', artist: 'Stereolab', album: 'Dots and Loops', track: null },
+    { name: 'no album, track present', artist: 'Autechre', album: null, track: 'VI Scose Poise' },
+    { name: 'artist only', artist: 'Chuquimamani-Condori', album: null, track: null },
+    { name: 'diacritics in artist', artist: 'Nilüfer Yanya', album: 'Painless', track: 'stabilise' },
+    { name: 'diacritics + nothing else', artist: 'Hermanos Gutiérrez', album: null, track: null },
+    { name: 'spaces + ampersand in artist', artist: 'Duke Ellington & John Coltrane', album: null, track: null },
+  ];
+
+  it.each(cases)('$name', ({ artist, album, track }) => {
+    const inline = synthesizeSearchUrls({
+      id: 0,
+      artist_name: artist,
+      album_title: album,
+      track_title: track,
+    });
+    const canonicalOut = canonical.getAllSearchUrls(artist, album ?? undefined, track ?? undefined);
+
+    expect(inline.youtube_music_url).toBe(canonicalOut.youtubeMusicUrl);
+    expect(inline.bandcamp_url).toBe(canonicalOut.bandcampUrl);
+    expect(inline.soundcloud_url).toBe(canonicalOut.soundcloudUrl);
+  });
+});


### PR DESCRIPTION
## Summary

First of two stacked PRs splitting [#1210](https://github.com/WXYC/Backend-Service/pull/1210) into a reviewable pair. Ships **just the SQL write shapes** the BS#1209 drain needs, fully unit-tested in isolation. Orchestrator, LML wiring, entrypoint, Dockerfile, README, and integration spec land in PR2 (stacked on this branch).

**Reviewer question for this PR**: Are the two write SQL shapes correct?

- **Free-form `repairFreeFormRow`** — 10-col UPDATE on `flowsheet` under idempotent WHERE `id = $1 AND artwork_url IS NULL AND metadata_status = 'enriched_match'`. Race-guarded against concurrent fresh enrichment (artwork flipped non-null OR status flipped to `enriched_no_match`).
- **Linked `repairLinkedAlbum`** — 10-col UPSERT on `album_metadata` with `setWhere: album_metadata.updated_at < NOW()` mirroring the enrichment-worker shape verbatim. No flowsheet write — read-path COALESCE join over `album_metadata` surfaces the fix automatically.
- **Status invariant** — `metadata_status` NEVER appears in either path's `.set()`. The drain is read-only on status; the LML#400 follow-up backfill will revisit `still_null_after_lml` rows for status correction.
- **`filterSpacerGif`** — inline copy added to the BS#890 allowlist (`scripts/check-spacer-gif-callsites.sh`) + parity test pinning truthy/falsy equivalence to the canonical filter in `apps/backend/services/metadata/metadata.service.ts`.

## What this PR does NOT have

The workspace builds and lints but is not yet runnable. `tsup` temporarily targets `repair.ts` as the entry — PR2 re-points to `job.ts` once the entrypoint lands. The package.json deliberately omits a `start` script for the same reason; running this workspace from main today produces no useful output.

This is what makes the split safe: PR1 alone has no Docker image, no cron registration, no runtime path touches.

## Test plan

- [x] `npm run test:unit -- tests/unit/jobs/flowsheet-artwork-repair/` — 24/24 green (17 writer tests + 7 parity tests)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run build --workspace=@wxyc/flowsheet-artwork-repair` — builds to dist/repair.js
- [x] `bash scripts/check-spacer-gif-callsites.sh` — PASS
- [ ] PR2 lands behind this one with the orchestrator + entrypoint

Refs #1209