### PR TITLE
fix(metadata-enrichment): widen inline synthesizeSearchUrls from 3 to 4 URLs (BS#1189)

### DIFF
--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -163,8 +163,8 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
         // render literal "0". Mirrors metadata.service.ts (#1002).
         release_year: artwork.release_year || null,
         // Prefer LML-supplied streaming URLs; fall back to synthesized.
-        // Spotify joins YT/BC/SC in BS#1189 — aligns with the canonical
-        // write path. Apple Music stays no-fallback per BS#1192.
+        // Apple Music has no fallback — null is load-bearing "no verified
+        // iTunes match" signal (BS#1192).
         spotify_url: artwork.spotify_url ?? searchUrls.spotify_url,
         apple_music_url: artwork.apple_music_url ?? null,
         youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
@@ -199,7 +199,7 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
         artwork_url: filterSpacerGif(artwork.artwork_url),
         discogs_url: artwork.release_url ?? null,
         release_year: artwork.release_year || null,
-        // Spotify joins YT/BC/SC in BS#1189; Apple stays no-fallback (BS#1192).
+        // Apple Music has no fallback — null is load-bearing (BS#1192).
         spotify_url: artwork.spotify_url ?? searchUrls.spotify_url,
         apple_music_url: artwork.apple_music_url ?? null,
         youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
@@ -220,10 +220,10 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
   // divergence from the runtime path (see backfill enrich.ts header).
   if (row.album_id !== null) {
     // Linked + no-match: UPSERT just the 4 search URLs into album_metadata
-    // (Spotify joined YT/BC/SC in BS#1189; Apple stays out per BS#1192).
-    // INSERT path leaves the other 6 columns NULL (no LML match to fill
-    // them); UPDATE path leaves them untouched on existing rows (preserves
-    // any prior out-of-band values, same semantics as the unlinked path).
+    // (Apple stays out per BS#1192). INSERT path leaves the other 6 columns
+    // NULL (no LML match to fill them); UPDATE path leaves them untouched
+    // on existing rows (preserves any prior out-of-band values, same
+    // semantics as the unlinked path).
     await db
       .insert(album_metadata)
       .values({

--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -2,7 +2,7 @@
  * Finalize UPDATE for the enrichment consumer (BS#892 / Epic C C2).
  *
  * Mirrors `jobs/flowsheet-metadata-backfill/enrich.ts` in shape — the same
- * 10-column on-match payload, the same 3-column on-no-match payload, the
+ * 10-column on-match payload, the same 4-column on-no-match payload, the
  * same spacer.gif filter, the same synthesized search URLs — but with a
  * different idempotency guard and a different terminal state.
  *
@@ -28,11 +28,13 @@
  * Build-graph isolation: the search-URL synthesis, spacer.gif filter, and bio
  * cleaner are inlined rather than imported from `apps/backend` so this package
  * can bundle independently. The canonical implementations are in
- * `apps/backend/services/metadata/metadata.service.ts` (spacer.gif filter) and
- * `apps/backend/services/metadata/providers/search-urls.provider.ts` (search
- * URLs); divergence here would be a bug. Pinned by parity tests:
+ * `apps/backend/services/metadata/metadata.service.ts` (spacer.gif filter,
+ * the 4-URL write-path shape post-BS#1192) and
+ * `apps/backend/services/metadata/providers/search-urls.provider.ts` (the
+ * per-service search-URL formulas); divergence here would be a bug. Pinned
+ * by parity tests:
  *   - tests/unit/apps/enrichment-worker/filter-spacer-gif-parity.test.ts (BS#890)
- *   - tests/unit/apps/enrichment-worker/synthesize-search-urls-parity.test.ts (BS#889)
+ *   - tests/unit/apps/enrichment-worker/synthesize-search-urls-parity.test.ts (BS#889 / BS#1189)
  * Also gated by scripts/check-spacer-gif-callsites.sh in CI.
  */
 
@@ -74,26 +76,37 @@ export const filterSpacerGif = (url: string | null | undefined): string | null =
 
 /**
  * Synthesized search URLs (per-service semantics deliberately asymmetric):
+ *   - Spotify:       trackTitle > albumTitle > artistName. Path-style URL
+ *                    matches LML's `_build_streaming_search_url` byte-for-byte
+ *                    so iOS reads back the same URL whether LML surfaced it
+ *                    or BS synthesized it (BS#1185 + LML#401).
  *   - YouTube Music: trackTitle > albumTitle > artistName
  *   - Bandcamp:      albumTitle > artistName (album-leaning)
  *   - SoundCloud:    trackTitle > artistName (NO album fallback — album-only
  *                    SoundCloud queries surface unrelated DJ mixes)
  *
- * Must match `apps/backend/services/metadata/providers/search-urls.provider.ts`
- * exactly.
+ * Apple Music is intentionally absent (BS#1192): LML's null return on
+ * `apple_music_url` is load-bearing ("no verified iTunes match"), and a
+ * keyword-search fallback would launder that signal into a clickable
+ * button. The read path proxy still fills Apple at request time.
+ *
+ * Must match the write-path shape of
+ * `apps/backend/services/metadata/metadata.service.ts#fetchMetadata`.
  */
 export const synthesizeSearchUrls = (
   row: EnrichRow
-): { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
+): { spotify_url: string; youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
   const artist = row.artist_name;
   const album = row.album_title ?? undefined;
   const track = row.track_title ?? undefined;
 
+  const spotifyQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
   const youtubeQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
   const bandcampQuery = album ? `${artist} ${album}` : artist;
   const soundcloudQuery = track ? `${artist} ${track}` : artist;
 
   return {
+    spotify_url: `https://open.spotify.com/search/${encodeURIComponent(spotifyQuery)}`,
     youtube_music_url: `https://music.youtube.com/search?q=${encodeURIComponent(youtubeQuery)}`,
     bandcamp_url: `https://bandcamp.com/search?q=${encodeURIComponent(bandcampQuery)}`,
     soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent(soundcloudQuery)}`,
@@ -149,9 +162,11 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
         // Discogs returns 0 as "year unknown"; coerce to null so iOS doesn't
         // render literal "0". Mirrors metadata.service.ts (#1002).
         release_year: artwork.release_year || null,
-        spotify_url: artwork.spotify_url ?? null,
-        apple_music_url: artwork.apple_music_url ?? null,
         // Prefer LML-supplied streaming URLs; fall back to synthesized.
+        // Spotify joins YT/BC/SC in BS#1189 — aligns with the canonical
+        // write path. Apple Music stays no-fallback per BS#1192.
+        spotify_url: artwork.spotify_url ?? searchUrls.spotify_url,
+        apple_music_url: artwork.apple_music_url ?? null,
         youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
         bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
         soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
@@ -184,7 +199,8 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
         artwork_url: filterSpacerGif(artwork.artwork_url),
         discogs_url: artwork.release_url ?? null,
         release_year: artwork.release_year || null,
-        spotify_url: artwork.spotify_url ?? null,
+        // Spotify joins YT/BC/SC in BS#1189; Apple stays no-fallback (BS#1192).
+        spotify_url: artwork.spotify_url ?? searchUrls.spotify_url,
         apple_music_url: artwork.apple_music_url ?? null,
         youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
         bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
@@ -203,14 +219,16 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
   // writes from #686-era scripts). Mirrors the backfill's deliberate
   // divergence from the runtime path (see backfill enrich.ts header).
   if (row.album_id !== null) {
-    // Linked + no-match: UPSERT just the 3 search URLs into album_metadata.
-    // INSERT path leaves the other 7 columns NULL (no LML match to fill
+    // Linked + no-match: UPSERT just the 4 search URLs into album_metadata
+    // (Spotify joined YT/BC/SC in BS#1189; Apple stays out per BS#1192).
+    // INSERT path leaves the other 6 columns NULL (no LML match to fill
     // them); UPDATE path leaves them untouched on existing rows (preserves
     // any prior out-of-band values, same semantics as the unlinked path).
     await db
       .insert(album_metadata)
       .values({
         album_id: row.album_id,
+        spotify_url: searchUrls.spotify_url,
         youtube_music_url: searchUrls.youtube_music_url,
         bandcamp_url: searchUrls.bandcamp_url,
         soundcloud_url: searchUrls.soundcloud_url,
@@ -219,6 +237,7 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
       .onConflictDoUpdate({
         target: album_metadata.album_id,
         set: {
+          spotify_url: searchUrls.spotify_url,
           youtube_music_url: searchUrls.youtube_music_url,
           bandcamp_url: searchUrls.bandcamp_url,
           soundcloud_url: searchUrls.soundcloud_url,
@@ -237,6 +256,7 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
   const updated = await db
     .update(flowsheet)
     .set({
+      spotify_url: searchUrls.spotify_url,
       youtube_music_url: searchUrls.youtube_music_url,
       bandcamp_url: searchUrls.bandcamp_url,
       soundcloud_url: searchUrls.soundcloud_url,

--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -183,8 +183,8 @@ export const applyEnrichment = async (row: EnrichRow, response: LookupResponse):
       // the runtime path in `metadata.service.ts#extractAlbumMetadata` (#1002).
       release_year: artwork.release_year || null,
       // Streaming search URLs: prefer LML's, fall back to synthesized.
-      // Spotify joins YT/BC/SC in BS#1189 — aligns with the canonical
-      // write path. Apple Music stays no-fallback per BS#1192.
+      // Apple Music has no fallback — null is load-bearing "no verified
+      // iTunes match" signal (BS#1192).
       spotify_url: artwork.spotify_url ?? searchUrls.spotify_url,
       apple_music_url: artwork.apple_music_url ?? null,
       youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
@@ -241,11 +241,10 @@ export const applyEnrichment = async (row: EnrichRow, response: LookupResponse):
   // them on a no-match would be silent data loss.
   if (row.album_id !== null) {
     // Linked + no-match: UPSERT just the 4 search URLs into album_metadata
-    // (Spotify joined YT/BC/SC in BS#1189; Apple stays out per BS#1192).
-    // INSERT path leaves the other 6 columns NULL (no LML match to fill
-    // them); UPDATE path leaves them untouched on existing rows
-    // (preserves any prior out-of-band values, matching the unlinked
-    // path's deliberate non-clobbering on no-match).
+    // (Apple stays out per BS#1192). INSERT path leaves the other 6 columns
+    // NULL (no LML match to fill them); UPDATE path leaves them untouched
+    // on existing rows (preserves any prior out-of-band values, matching
+    // the unlinked path's deliberate non-clobbering on no-match).
     await db
       .insert(album_metadata)
       .values({

--- a/jobs/flowsheet-metadata-backfill/enrich.ts
+++ b/jobs/flowsheet-metadata-backfill/enrich.ts
@@ -9,11 +9,11 @@
  *   - Linked (album_id != null) + match: UPSERT `album_metadata` with the
  *     10-column payload (race-guarded by `updated_at < NOW()`), then
  *     UPDATE `flowsheet` to stamp `metadata_attempt_at = now()` only.
- *   - Linked + no-match: UPSERT just the 3 synthesized search URLs into
+ *   - Linked + no-match: UPSERT just the 4 synthesized search URLs into
  *     `album_metadata`, then stamp the marker on `flowsheet`.
  *   - Unlinked (album_id IS NULL) + match: write the 10 metadata columns
  *     inline on `flowsheet`, stamping the marker in the same .set() block.
- *   - Unlinked + no-match: write the 3 synthesized search URLs inline on
+ *   - Unlinked + no-match: write the 4 synthesized search URLs inline on
  *     `flowsheet`, stamp the marker.
  *   - On LML throw: caller catches and DOES NOT call this. The row stays
  *     `metadata_attempt_at IS NULL` so the next sweep retries it.
@@ -86,14 +86,28 @@ export const filterSpacerGif = (url: string | null | undefined): string | null =
 };
 
 /**
- * Synthesize the three search URLs the runtime path falls back to on
- * no-match. Must match `apps/backend/services/metadata/providers/search-urls.provider.ts`
- * exactly — the inline copy is duplicated rather than imported for the same
- * build-graph isolation reason as `lml-fetch.ts`. The parity test at
+ * Synthesize the four search URLs the runtime path falls back to on
+ * no-match. Must match the write-path shape of
+ * `apps/backend/services/metadata/metadata.service.ts#fetchMetadata`
+ * exactly — the inline copy is duplicated rather than imported for the
+ * same build-graph isolation reason as `lml-fetch.ts`. The parity test at
  * `tests/unit/jobs/flowsheet-metadata-backfill/synthesize-search-urls-parity.test.ts`
- * pins the equivalence so the two cannot drift (BS#889).
+ * pins the equivalence so the two cannot drift (BS#889 / BS#1189).
+ *
+ * Apple Music is intentionally absent (BS#1192): LML's `apple_music_url`
+ * is load-bearing — null means "no verified iTunes match" — and persisting
+ * a `music.apple.com/search?term=…` URL on the write path launders that
+ * signal into a clickable button that drops users on the in-app search
+ * page. The read path (`proxy.controller.getAlbumMetadata`) still fills
+ * Apple at request time for the iOS Tragic Magic surface, where there's
+ * no persisted row to poison.
  *
  * Per-service semantics (deliberately asymmetric):
+ *   - Spotify:       trackTitle > albumTitle > artistName. Path-style URL
+ *                    (`https://open.spotify.com/search/<query>`) matches
+ *                    LML's `_build_streaming_search_url` byte-for-byte so
+ *                    iOS reads back the same URL whether LML surfaced it
+ *                    or BS synthesized it (BS#1185 + LML#401).
  *   - YouTube Music: trackTitle > albumTitle > artistName (3-tier).
  *   - Bandcamp:      albumTitle > artistName (album-leaning).
  *   - SoundCloud:    trackTitle > artistName (track-leaning, NO album
@@ -102,16 +116,18 @@ export const filterSpacerGif = (url: string | null | undefined): string | null =
  */
 export const synthesizeSearchUrls = (
   row: EnrichRow
-): { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
+): { spotify_url: string; youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
   const artist = row.artist_name;
   const album = row.album_title ?? undefined;
   const track = row.track_title ?? undefined;
 
+  const spotifyQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
   const youtubeQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
   const bandcampQuery = album ? `${artist} ${album}` : artist;
   const soundcloudQuery = track ? `${artist} ${track}` : artist;
 
   return {
+    spotify_url: `https://open.spotify.com/search/${encodeURIComponent(spotifyQuery)}`,
     youtube_music_url: `https://music.youtube.com/search?q=${encodeURIComponent(youtubeQuery)}`,
     bandcamp_url: `https://bandcamp.com/search?q=${encodeURIComponent(bandcampQuery)}`,
     soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent(soundcloudQuery)}`,
@@ -166,9 +182,11 @@ export const applyEnrichment = async (row: EnrichRow, response: LookupResponse):
       // doesn't carry a sentinel that iOS renders as literal "0". Mirrors
       // the runtime path in `metadata.service.ts#extractAlbumMetadata` (#1002).
       release_year: artwork.release_year || null,
-      spotify_url: artwork.spotify_url ?? null,
-      apple_music_url: artwork.apple_music_url ?? null,
       // Streaming search URLs: prefer LML's, fall back to synthesized.
+      // Spotify joins YT/BC/SC in BS#1189 — aligns with the canonical
+      // write path. Apple Music stays no-fallback per BS#1192.
+      spotify_url: artwork.spotify_url ?? searchUrls.spotify_url,
+      apple_music_url: artwork.apple_music_url ?? null,
       youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
       bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
       soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
@@ -222,8 +240,9 @@ export const applyEnrichment = async (row: EnrichRow, response: LookupResponse):
   // 2026-04-28 inline recovery, `scripts/backfill-metadata.ts`), so nulling
   // them on a no-match would be silent data loss.
   if (row.album_id !== null) {
-    // Linked + no-match: UPSERT just the 3 search URLs into album_metadata.
-    // INSERT path leaves the other 7 columns NULL (no LML match to fill
+    // Linked + no-match: UPSERT just the 4 search URLs into album_metadata
+    // (Spotify joined YT/BC/SC in BS#1189; Apple stays out per BS#1192).
+    // INSERT path leaves the other 6 columns NULL (no LML match to fill
     // them); UPDATE path leaves them untouched on existing rows
     // (preserves any prior out-of-band values, matching the unlinked
     // path's deliberate non-clobbering on no-match).
@@ -231,6 +250,7 @@ export const applyEnrichment = async (row: EnrichRow, response: LookupResponse):
       .insert(album_metadata)
       .values({
         album_id: row.album_id,
+        spotify_url: searchUrls.spotify_url,
         youtube_music_url: searchUrls.youtube_music_url,
         bandcamp_url: searchUrls.bandcamp_url,
         soundcloud_url: searchUrls.soundcloud_url,
@@ -239,6 +259,7 @@ export const applyEnrichment = async (row: EnrichRow, response: LookupResponse):
       .onConflictDoUpdate({
         target: album_metadata.album_id,
         set: {
+          spotify_url: searchUrls.spotify_url,
           youtube_music_url: searchUrls.youtube_music_url,
           bandcamp_url: searchUrls.bandcamp_url,
           soundcloud_url: searchUrls.soundcloud_url,
@@ -257,6 +278,7 @@ export const applyEnrichment = async (row: EnrichRow, response: LookupResponse):
   const updated = await db
     .update(flowsheet)
     .set({
+      spotify_url: searchUrls.spotify_url,
       youtube_music_url: searchUrls.youtube_music_url,
       bandcamp_url: searchUrls.bandcamp_url,
       soundcloud_url: searchUrls.soundcloud_url,

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -99,7 +99,7 @@ describe('finalizeRow (BS#892 PR-2)', () => {
     expect(setCall.artist_wikipedia_url).toBe('https://en.wikipedia.org/wiki/Juana_Molina');
   });
 
-  it('on no-match: writes 3 synthesized search URLs and flips status to enriched_no_match', async () => {
+  it('on no-match: writes 4 synthesized search URLs and flips status to enriched_no_match', async () => {
     mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
 
     const outcome = await finalizeRow(ROW, noMatchResponse);
@@ -108,12 +108,16 @@ describe('finalizeRow (BS#892 PR-2)', () => {
 
     const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(setCall.metadata_status).toBe('enriched_no_match');
-    // The 7 metadata columns are NOT in the .set() — preserves prior values.
+    // The 6 non-search-URL metadata columns are NOT in the .set() —
+    // preserves prior values. Apple Music intentionally absent (BS#1192).
     expect(setCall.artwork_url).toBeUndefined();
     expect(setCall.discogs_url).toBeUndefined();
     expect(setCall.release_year).toBeUndefined();
+    expect(setCall.apple_music_url).toBeUndefined();
     expect(setCall.artist_bio).toBeUndefined();
-    // The 3 search URLs ARE in the .set().
+    // The 4 search URLs ARE in the .set(): Spotify joined YT/BC/SC in
+    // BS#1189 to align with the canonical write-path shape.
+    expect(setCall.spotify_url).toContain('open.spotify.com/search');
     expect(setCall.youtube_music_url).toContain('music.youtube.com/search');
     expect(setCall.bandcamp_url).toContain('bandcamp.com/search');
     expect(setCall.soundcloud_url).toContain('soundcloud.com/search');
@@ -262,7 +266,7 @@ describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata
     expect(setCall.artist_wikipedia_url).toBeUndefined();
   });
 
-  it('on no-match: UPSERTs only the 3 search URLs into album_metadata', async () => {
+  it('on no-match: UPSERTs the 4 search URLs into album_metadata', async () => {
     mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
 
     const outcome = await finalizeRow(LINKED_ROW, noMatchResponse);
@@ -272,16 +276,18 @@ describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata
 
     const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(insertPayload.album_id).toBe(5678);
+    // BS#1189 widened the no-match shape to 4 URLs: Spotify joined YT/BC/SC.
+    // Apple Music intentionally absent (BS#1192).
+    expect(insertPayload.spotify_url).toContain('open.spotify.com/search');
     expect(insertPayload.youtube_music_url).toContain('music.youtube.com/search');
     expect(insertPayload.bandcamp_url).toContain('bandcamp.com/search');
     expect(insertPayload.soundcloud_url).toContain('soundcloud.com/search');
-    // Other 7 metadata fields must NOT be in the insert payload — INSERT path
-    // leaves them NULL; UPDATE path leaves existing values untouched (matches
-    // the unlinked path's deliberate non-clobbering on no-match).
+    // 6 other metadata fields must NOT be in the insert payload — INSERT
+    // path leaves them NULL; UPDATE path leaves existing values untouched
+    // (matches the unlinked path's deliberate non-clobbering on no-match).
     expect(insertPayload).not.toHaveProperty('artwork_url');
     expect(insertPayload).not.toHaveProperty('discogs_url');
     expect(insertPayload).not.toHaveProperty('release_year');
-    expect(insertPayload).not.toHaveProperty('spotify_url');
     expect(insertPayload).not.toHaveProperty('apple_music_url');
     expect(insertPayload).not.toHaveProperty('artist_bio');
     expect(insertPayload).not.toHaveProperty('artist_wikipedia_url');
@@ -291,6 +297,7 @@ describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata
     };
     expect(conflictCfg.set).not.toHaveProperty('artwork_url');
     expect(conflictCfg.set).not.toHaveProperty('artist_bio');
+    expect(conflictCfg.set.spotify_url).toContain('open.spotify.com/search');
     expect(conflictCfg.set.youtube_music_url).toContain('music.youtube.com/search');
   });
 
@@ -321,6 +328,22 @@ describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata
 });
 
 describe('synthesizeSearchUrls (per-service precedence)', () => {
+  it('Spotify prefers trackTitle over albumTitle over artistName (same selector as YT)', () => {
+    // Path-style URL (no `?q=`) — must match LML's `_build_streaming_search_url`
+    // for byte-identical alignment so iOS reads back the same URL whether LML
+    // surfaced it or BS synthesized it (BS#1185 + LML#401).
+    expect(
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C', album_id: null }).spotify_url
+    ).toBe('https://open.spotify.com/search/A%20C');
+    expect(
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: null, album_id: null }).spotify_url
+    ).toBe('https://open.spotify.com/search/A%20B');
+    expect(
+      synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: null, track_title: null, album_id: null })
+        .spotify_url
+    ).toBe('https://open.spotify.com/search/A');
+  });
+
   it('YouTube Music prefers trackTitle over albumTitle over artistName', () => {
     expect(
       synthesizeSearchUrls({ id: 1, artist_name: 'A', album_title: 'B', track_title: 'C', album_id: null })

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -115,8 +115,8 @@ describe('finalizeRow (BS#892 PR-2)', () => {
     expect(setCall.release_year).toBeUndefined();
     expect(setCall.apple_music_url).toBeUndefined();
     expect(setCall.artist_bio).toBeUndefined();
-    // The 4 search URLs ARE in the .set(): Spotify joined YT/BC/SC in
-    // BS#1189 to align with the canonical write-path shape.
+    expect(setCall.artist_wikipedia_url).toBeUndefined();
+    // The 4 search URLs ARE in the .set().
     expect(setCall.spotify_url).toContain('open.spotify.com/search');
     expect(setCall.youtube_music_url).toContain('music.youtube.com/search');
     expect(setCall.bandcamp_url).toContain('bandcamp.com/search');

--- a/tests/unit/apps/enrichment-worker/synthesize-search-urls-parity.test.ts
+++ b/tests/unit/apps/enrichment-worker/synthesize-search-urls-parity.test.ts
@@ -1,17 +1,24 @@
 /**
  * Parity test: the inline `synthesizeSearchUrls` in
- * `apps/enrichment-worker/enrich.ts` MUST produce identical output to the
- * canonical `SearchUrlProvider.getAllSearchUrls` in
+ * `apps/enrichment-worker/enrich.ts` MUST produce the same write-path-
+ * eligible search URLs as the canonical `SearchUrlProvider` in
  * `apps/backend/services/metadata/providers/search-urls.provider.ts`
- * for the same inputs (BS#889).
+ * (BS#889 / BS#1189).
  *
  * The inline copy exists for the same build-graph-isolation reason as the
  * backfill's: `apps/enrichment-worker` is bundled independently of
  * `apps/backend`. The cost of that isolation is silent drift between the
  * two implementations — historically three different services diverged
- * here, and iOS users saw different YouTube/Bandcamp/SoundCloud URLs
- * depending on which BS path enriched the row. This test pins them in
- * lockstep so the next drift fails CI loudly.
+ * here, and iOS users saw different Spotify/YouTube/Bandcamp/SoundCloud
+ * URLs depending on which BS path enriched the row. This test pins them
+ * in lockstep so the next drift fails CI loudly.
+ *
+ * Asserted shape — the **four** URLs the canonical write path
+ * (`metadata.service.fetchMetadata`) actually persists post-BS#1192:
+ * `spotify_url`, `youtube_music_url`, `bandcamp_url`, `soundcloud_url`.
+ * `appleMusicUrl` is intentionally excluded — `SearchUrlProvider` still
+ * exposes it for the read-path proxy (`proxy.controller.getAlbumMetadata`),
+ * but it does not flow to durable storage. See BS#1192 for the rationale.
  *
  * Sibling test:
  *   - `tests/unit/jobs/flowsheet-metadata-backfill/synthesize-search-urls-parity.test.ts`
@@ -43,6 +50,7 @@ describe('synthesizeSearchUrls parity (enrichment-worker inline ↔ SearchUrlPro
     });
     const canonicalOut = canonical.getAllSearchUrls(artist, album ?? undefined, track ?? undefined);
 
+    expect(inline.spotify_url).toBe(canonicalOut.spotifyUrl);
     expect(inline.youtube_music_url).toBe(canonicalOut.youtubeMusicUrl);
     expect(inline.bandcamp_url).toBe(canonicalOut.bandcampUrl);
     expect(inline.soundcloud_url).toBe(canonicalOut.soundcloudUrl);

--- a/tests/unit/jobs/flowsheet-metadata-backfill/enrich.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/enrich.test.ts
@@ -134,21 +134,25 @@ describe('applyEnrichment', () => {
     expect(renderSql(setArgs.metadata_attempt_at)).toMatch(/now\(\)/i);
   });
 
-  it('writes only synthesized search URLs and stamps on LML success-no-match (empty results)', async () => {
+  it('writes synthesized search URLs (4) and stamps on LML success-no-match (empty results)', async () => {
     const outcome = await applyEnrichment(baseRow, noMatchResponse);
     expect(outcome).toBe('enriched_no_match');
 
     const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    // BS#1189 widened the no-match shape to 4 URLs: Spotify joined YT/BC/SC
+    // as a write-path fallback. Apple Music is intentionally absent (BS#1192
+    // — null is load-bearing "no verified iTunes match" signal).
+    expect(setArgs.spotify_url).toContain('open.spotify.com/search');
     expect(setArgs.youtube_music_url).toContain('music.youtube.com/search');
     expect(setArgs.bandcamp_url).toContain('bandcamp.com/search');
     expect(setArgs.soundcloud_url).toContain('soundcloud.com/search');
     expect(renderSql(setArgs.metadata_attempt_at)).toMatch(/now\(\)/i);
-    // The 7 metadata columns should NOT be set on no-match (so they remain
-    // NULL in the DB) — the runtime path produces the same shape.
+    // The 6 non-search-URL metadata columns should NOT be set on no-match
+    // (so they remain NULL in the DB) — the runtime path produces the same
+    // shape. Apple Music is also absent (BS#1192).
     expect('artwork_url' in setArgs).toBe(false);
     expect('discogs_url' in setArgs).toBe(false);
     expect('release_year' in setArgs).toBe(false);
-    expect('spotify_url' in setArgs).toBe(false);
     expect('apple_music_url' in setArgs).toBe(false);
     expect('artist_bio' in setArgs).toBe(false);
     expect('artist_wikipedia_url' in setArgs).toBe(false);
@@ -301,22 +305,24 @@ describe('applyEnrichment (BS#1027) — linked row UPSERTs album_metadata', () =
     expect(mockDb._chain.where.mock.calls[0]?.[0]).toBeDefined();
   });
 
-  it('on no-match: UPSERTs only the 3 search URLs into album_metadata', async () => {
+  it('on no-match: UPSERTs the 4 search URLs into album_metadata', async () => {
     const outcome = await applyEnrichment(linkedRow, noMatchResponse);
     expect(outcome).toBe('enriched_no_match');
     expect(mockDb.insert).toHaveBeenCalledWith(album_metadata);
 
     const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(insertPayload.album_id).toBe(linkedRow.album_id);
+    // BS#1189 widened the no-match shape to 4 URLs: Spotify joined YT/BC/SC.
+    // Apple Music intentionally absent (BS#1192).
+    expect(insertPayload.spotify_url).toContain('open.spotify.com/search');
     expect(insertPayload.youtube_music_url).toContain('music.youtube.com/search');
     expect(insertPayload.bandcamp_url).toContain('bandcamp.com/search');
     expect(insertPayload.soundcloud_url).toContain('soundcloud.com/search');
-    // 7 other metadata fields must NOT be in the insert payload — INSERT path
+    // 6 other metadata fields must NOT be in the insert payload — INSERT path
     // leaves them NULL; UPDATE path leaves existing values untouched.
     expect(insertPayload).not.toHaveProperty('artwork_url');
     expect(insertPayload).not.toHaveProperty('discogs_url');
     expect(insertPayload).not.toHaveProperty('release_year');
-    expect(insertPayload).not.toHaveProperty('spotify_url');
     expect(insertPayload).not.toHaveProperty('apple_music_url');
     expect(insertPayload).not.toHaveProperty('artist_bio');
     expect(insertPayload).not.toHaveProperty('artist_wikipedia_url');
@@ -327,6 +333,7 @@ describe('applyEnrichment (BS#1027) — linked row UPSERTs album_metadata', () =
     };
     expect(conflictCfg.set).not.toHaveProperty('artwork_url');
     expect(conflictCfg.set).not.toHaveProperty('artist_bio');
+    expect(conflictCfg.set.spotify_url).toContain('open.spotify.com/search');
     expect(conflictCfg.set.youtube_music_url).toContain('music.youtube.com/search');
     expect(conflictCfg.setWhere).toBeDefined();
     expect(renderSql(conflictCfg.setWhere)).toMatch(/<\s*NOW\(\)/i);

--- a/tests/unit/jobs/flowsheet-metadata-backfill/synthesize-search-urls-parity.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/synthesize-search-urls-parity.test.ts
@@ -1,18 +1,25 @@
 /**
  * Parity test: the inline `synthesizeSearchUrls` in
- * `jobs/flowsheet-metadata-backfill/enrich.ts` MUST produce identical
- * output to the canonical `SearchUrlProvider.getAllSearchUrls` in
- * `apps/backend/services/metadata/providers/search-urls.provider.ts`
- * for the same inputs (BS#889).
+ * `jobs/flowsheet-metadata-backfill/enrich.ts` MUST produce the same
+ * write-path-eligible search URLs as the canonical `SearchUrlProvider`
+ * in `apps/backend/services/metadata/providers/search-urls.provider.ts`
+ * (BS#889 / BS#1189).
  *
  * The inline copy exists deliberately — the job's tsup build deliberately
  * doesn't pull in apps/backend (build-graph isolation; see the file
  * header on `enrich.ts` and on `lml-fetch.ts`). The cost of that
  * isolation is silent drift between the two implementations. Three
  * different services historically diverged here, and iOS users saw
- * different YouTube/Bandcamp/SoundCloud URLs depending on which BS path
- * enriched the row. This test pins them in lockstep so the next drift
- * fails CI loudly.
+ * different Spotify/YouTube/Bandcamp/SoundCloud URLs depending on which
+ * BS path enriched the row. This test pins them in lockstep so the next
+ * drift fails CI loudly.
+ *
+ * Asserted shape — the **four** URLs the canonical write path
+ * (`metadata.service.fetchMetadata`) actually persists post-BS#1192:
+ * `spotify_url`, `youtube_music_url`, `bandcamp_url`, `soundcloud_url`.
+ * `appleMusicUrl` is intentionally excluded — `SearchUrlProvider` still
+ * exposes it for the read-path proxy (`proxy.controller.getAlbumMetadata`),
+ * but it does not flow to durable storage. See BS#1192 for the rationale.
  */
 
 import { synthesizeSearchUrls } from '../../../../jobs/flowsheet-metadata-backfill/enrich';
@@ -41,6 +48,7 @@ describe('synthesizeSearchUrls parity with SearchUrlProvider', () => {
     });
     const canonicalOut = canonical.getAllSearchUrls(artist, album ?? undefined, track ?? undefined);
 
+    expect(inline.spotify_url).toBe(canonicalOut.spotifyUrl);
     expect(inline.youtube_music_url).toBe(canonicalOut.youtubeMusicUrl);
     expect(inline.bandcamp_url).toBe(canonicalOut.bandcampUrl);
     expect(inline.soundcloud_url).toBe(canonicalOut.soundcloudUrl);


### PR DESCRIPTION
Closes #1189.

## Summary

Widens the inline `synthesizeSearchUrls` copies in `jobs/flowsheet-metadata-backfill/enrich.ts` and `apps/enrichment-worker/enrich.ts` from 3 URLs (YT/BC/SC) to 4 URLs (Spotify + YT/BC/SC), matching the canonical write-path shape established by BS#1185 + BS#1192. Apple Music stays out of the write path per BS#1192 — null is load-bearing "no verified iTunes match" signal, and persisting a `music.apple.com/search?term=…` URL would launder that signal into a clickable button that drops users on the in-app search page.

## What was drifting

BS#1185 widened `SearchUrlProvider.getAllSearchUrls` from 3 to 5 URLs in the same PR that widened `metadata.service.fetchMetadata` (runtime path) and `proxy.controller.getAlbumMetadata` (read-path proxy). Two write-path consumers in build-isolated workspaces — the recurring drift-repair backfill and the CDC enrichment-worker — ship inline copies of the same `synthesizeSearchUrls` logic and were left at 3 URLs. The parity tests asserted only on those 3 fields, so they passed silently; the parity-test contract was narrower than the canonical contract.

The downstream cost was a read/write divergence on persisted flowsheet rows: BS's read-path proxy fed iOS a synthesized Spotify search-URL fallback while the durable `flowsheet` row was persisted with `spotify_url = NULL`, so the next read after a process restart (or a cold-cache request) would re-execute the read-path synthesis to produce a URL that the write path had already failed to persist.

## What changed

- **Both inline `synthesizeSearchUrls` copies** now return `{ spotify_url, youtube_music_url, bandcamp_url, soundcloud_url }`. Spotify URL is path-style (`https://open.spotify.com/search/<query>`) matching LML's `_build_streaming_search_url` byte-for-byte so iOS reads back the same URL whether LML surfaced it or BS synthesized it (BS#1185 + LML#401).
- **Both flowsheet match-path write sites** now consume the new Spotify fallback the same way they already consume YT/BC/SC: `spotify_url: artwork.spotify_url ?? searchUrls.spotify_url`. Apple Music write sites unchanged (`apple_music_url: artwork.apple_music_url ?? null`).
- **Both no-match paths** (linked → `album_metadata` UPSERT; unlinked → flowsheet inline UPDATE) now include `spotify_url: searchUrls.spotify_url` alongside the existing YT/BC/SC trio.
- **Both parity tests** (`tests/unit/jobs/flowsheet-metadata-backfill/synthesize-search-urls-parity.test.ts`, `tests/unit/apps/enrichment-worker/synthesize-search-urls-parity.test.ts`) now assert all 4 write-path fields. The test docs explicitly cite the BS#1192 rationale for Apple's intentional absence so the next maintainer doesn't widen the contract back to 5 URLs to "match `getAllSearchUrls`."
- **Both `enrich.test.ts` no-match assertions** flipped from `not.toHaveProperty('spotify_url')` to positive assertions on the synthesized Spotify URL. The worker's per-service-precedence describe block gains a Spotify precedence test matching the YT pattern (same query selector).
- **Header doc comments** in both `enrich.ts` files now explain the 4-URL shape, the Apple Music carve-out per BS#1192, and the byte-identical-with-LML rationale for Spotify's path-style URL.

## Pre-flight

- `npm run typecheck` — clean
- `npm run lint` — 0 errors, 466 warnings (all pre-existing baseline)
- `npm run format:check` — clean
- `npm run test:unit` — 2467/2468 pass. The single failure (`tests/unit/database/schema.flowsheet-artwork-lookup-idx.test.ts`) reproduces on `origin/main` and is out of scope.

## Cluster context

Last open child of the Tragic Magic structural-reachability cluster (BS#1184). Closing this closes BS#1184 (which closes [LML#397](https://github.com/WXYC/library-metadata-lookup/issues/397) — the cross-repo cluster tracker).

## Related

- BS#1184 (Tragic Magic parent)
- BS#1185 + BS#1188 (the predecessor PR that opened this drift)
- BS#1192 (the Apple-Music-out-of-write-path narrowing)
- BS#889 / BS#890 (canonical chokepoints: `SearchUrlProvider`, `filterSpacerGif`)
- LML#401 (the synth-shape contract this thread of work is reacting to)
