### PR TITLE
fix(flowsheet-artwork-repair): synthesize streaming URL fallback on free-form path

### DIFF
--- a/jobs/flowsheet-artwork-repair/repair.ts
+++ b/jobs/flowsheet-artwork-repair/repair.ts
@@ -32,7 +32,7 @@
  *
  * The 10-column payload, spacer.gif filter, Discogs-bio cleanup, and the
  * `release_year || null` coercion all mirror `apps/enrichment-worker/
- * enrich.ts:181-198` (canonical writer) and `jobs/flowsheet-metadata-
+ * enrich.ts:159-175` (canonical writer) and `jobs/flowsheet-metadata-
  * backfill/enrich.ts` (sibling drain). The duplication is the same build-
  * graph isolation the other one-shot jobs carry: no imports from
  * `apps/backend` so the job's Docker image graph is independent.
@@ -138,7 +138,7 @@ export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | n
 type SearchUrls = ReturnType<typeof synthesizeSearchUrls>;
 
 /**
- * 10-column payload. Mirrors `apps/enrichment-worker/enrich.ts:181-198`
+ * 10-column payload. Mirrors `apps/enrichment-worker/enrich.ts:159-175`
  * (canonical writer).
  *
  * Streaming-URL fallback asymmetry:

--- a/jobs/flowsheet-artwork-repair/repair.ts
+++ b/jobs/flowsheet-artwork-repair/repair.ts
@@ -111,16 +111,18 @@ export const filterSpacerGif = (url: string | null | undefined): string | null =
  */
 export const synthesizeSearchUrls = (
   row: FreeFormRow
-): { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
+): { spotify_url: string; youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
   const artist = row.artist_name;
   const album = row.album_title ?? undefined;
   const track = row.track_title ?? undefined;
 
+  const spotifyQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
   const youtubeQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
   const bandcampQuery = album ? `${artist} ${album}` : artist;
   const soundcloudQuery = track ? `${artist} ${track}` : artist;
 
   return {
+    spotify_url: `https://open.spotify.com/search/${encodeURIComponent(spotifyQuery)}`,
     youtube_music_url: `https://music.youtube.com/search?q=${encodeURIComponent(youtubeQuery)}`,
     bandcamp_url: `https://bandcamp.com/search?q=${encodeURIComponent(bandcampQuery)}`,
     soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent(soundcloudQuery)}`,
@@ -158,7 +160,10 @@ const buildPayload = (artwork: DiscogsMatchResult, searchUrls?: SearchUrls) => (
   // Discogs returns 0 as "year unknown"; null avoids the literal "0"
   // iOS would otherwise render. Matches `metadata.service.ts#extractAlbumMetadata` (#1002).
   release_year: artwork.release_year || null,
-  spotify_url: artwork.spotify_url ?? null,
+  spotify_url: artwork.spotify_url ?? searchUrls?.spotify_url ?? null,
+  // apple_music_url stays `?? null` — null is load-bearing per BS#1192
+  // ("no verified iTunes match" signal; the read-path proxy synthesizes
+  // its own search URL when needed).
   apple_music_url: artwork.apple_music_url ?? null,
   youtube_music_url: artwork.youtube_music_url ?? searchUrls?.youtube_music_url ?? null,
   bandcamp_url: artwork.bandcamp_url ?? searchUrls?.bandcamp_url ?? null,

--- a/jobs/flowsheet-artwork-repair/repair.ts
+++ b/jobs/flowsheet-artwork-repair/repair.ts
@@ -95,51 +95,74 @@ export const filterSpacerGif = (url: string | null | undefined): string | null =
 };
 
 /**
- * Pick the top-1 artwork block from an LML response, or null if the
- * response indicates the row is legitimate no-cover-anywhere territory
- * (empty results, or artwork field present-but-null on the top hit).
+ * Synthesize the three search URLs the runtime path falls back to on
+ * no-match. Must match `apps/backend/services/metadata/providers/search-urls.provider.ts`
+ * exactly — inline copy duplicated for the same build-graph isolation
+ * reason as the rest of `repair.ts`. Parity test at
+ * `tests/unit/jobs/flowsheet-artwork-repair/synthesize-search-urls-parity.test.ts`
+ * pins the equivalence so the two cannot drift (BS#889).
+ *
+ * Per-service semantics (deliberately asymmetric):
+ *   - YouTube Music: trackTitle > albumTitle > artistName (3-tier).
+ *   - Bandcamp:      albumTitle > artistName (album-leaning).
+ *   - SoundCloud:    trackTitle > artistName (track-leaning, NO album
+ *                    fallback — album-only SoundCloud queries return
+ *                    unrelated DJ mixes more often than the album).
  */
+export const synthesizeSearchUrls = (
+  row: FreeFormRow
+): { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
+  const artist = row.artist_name;
+  const album = row.album_title ?? undefined;
+  const track = row.track_title ?? undefined;
+
+  const youtubeQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
+  const bandcampQuery = album ? `${artist} ${album}` : artist;
+  const soundcloudQuery = track ? `${artist} ${track}` : artist;
+
+  return {
+    youtube_music_url: `https://music.youtube.com/search?q=${encodeURIComponent(youtubeQuery)}`,
+    bandcamp_url: `https://bandcamp.com/search?q=${encodeURIComponent(bandcampQuery)}`,
+    soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent(soundcloudQuery)}`,
+  };
+};
+
 export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | null => {
   const first = response.results?.[0];
-  if (!first) return null;
-  if (!first.artwork) return null;
+  if (!first?.artwork) return null;
   return first.artwork;
 };
 
+type SearchUrls = { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string };
+
 /**
- * Build the 10-column metadata payload from an LML artwork block. Same
- * shape as `apps/enrichment-worker/enrich.ts:181-198` (canonical writer).
- * Fan-out URLs default to null on no-LML-provided value — the drain
- * deliberately does NOT synthesize search URLs, unlike the sibling
- * `flowsheet-metadata-backfill` drain. Those URLs were already written
- * by the original enrichment cycle that landed `metadata_status =
- * 'enriched_match'` (the population this drain targets), so re-writing
- * with `null` would silently strip the synthesized fallbacks. Leaving
- * `null` in the payload pairs with the WHERE's IS NULL guard to preserve
- * the existing fan-out URLs on UPDATE.
+ * 10-column payload. Mirrors `apps/enrichment-worker/enrich.ts:181-198`
+ * (canonical writer).
  *
- * Wait — the WHERE only narrows by `artwork_url IS NULL`; it doesn't
- * pin the other 9. To avoid clobbering existing values on those, the
- * 10-col UPDATE shape includes them all, but in practice the population's
- * upstream cycle never wrote them either (they all came back null from
- * LML's degenerate response), so the UPDATE just confirms the same null.
- * The canonical writer shape is what the consumer wrote originally; we
- * mirror it exactly so the comparison "would the consumer have written
- * this column to this value if it had a fresh LML response?" answers yes
- * for every column, every time.
+ * Streaming-URL fallback asymmetry:
+ *   - Free-form path (`searchUrls` provided): fall back to synthesized
+ *     queries via `artwork.* ?? searchUrls.*`, same shape as the
+ *     enrichment-worker (lines 171-174) + flowsheet-metadata-backfill
+ *     (enrich.ts:172-174). The drain target rows were originally enriched
+ *     by the worker, which writes synthesized URLs on null. Writing null
+ *     over those would regress dj-site + iOS streaming links — that's
+ *     what BS#1209 was about.
+ *   - Linked path (`searchUrls` omitted): fall back to `null` — no
+ *     track_title available, and SoundCloud's track-leaning query would
+ *     degrade to album-only mixes (same call as
+ *     `album-level-backfill/job.ts:294-296`).
  */
-const buildPayload = (artwork: DiscogsMatchResult) => ({
+const buildPayload = (artwork: DiscogsMatchResult, searchUrls?: SearchUrls) => ({
   artwork_url: filterSpacerGif(artwork.artwork_url),
   discogs_url: artwork.release_url ?? null,
-  // Discogs returns 0 as "year unknown"; coerce to null so the column
-  // doesn't carry a sentinel that iOS renders as literal "0". Mirrors
-  // the runtime path in `metadata.service.ts#extractAlbumMetadata` (#1002).
+  // Discogs returns 0 as "year unknown"; null avoids the literal "0"
+  // iOS would otherwise render. Matches `metadata.service.ts#extractAlbumMetadata` (#1002).
   release_year: artwork.release_year || null,
   spotify_url: artwork.spotify_url ?? null,
   apple_music_url: artwork.apple_music_url ?? null,
-  youtube_music_url: artwork.youtube_music_url ?? null,
-  bandcamp_url: artwork.bandcamp_url ?? null,
-  soundcloud_url: artwork.soundcloud_url ?? null,
+  youtube_music_url: artwork.youtube_music_url ?? searchUrls?.youtube_music_url ?? null,
+  bandcamp_url: artwork.bandcamp_url ?? searchUrls?.bandcamp_url ?? null,
+  soundcloud_url: artwork.soundcloud_url ?? searchUrls?.soundcloud_url ?? null,
   artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
   artist_wikipedia_url: artwork.wikipedia_url ?? null,
 });
@@ -160,10 +183,9 @@ export const repairFreeFormRow = async (row: FreeFormRow, response: LookupRespon
   const artwork = extractArtwork(response);
   if (!artwork || !artwork.artwork_url) return 'still_null_after_lml';
 
-  const payload = buildPayload(artwork);
   const updated = await db
     .update(flowsheet)
-    .set(payload)
+    .set(buildPayload(artwork, synthesizeSearchUrls(row)))
     .where(sql`"id" = ${row.id} AND "artwork_url" IS NULL AND "metadata_status" = 'enriched_match'`)
     .returning({ id: flowsheet.id });
   return updated.length === 0 ? 'free_form_raced' : 'free_form_repaired';

--- a/jobs/flowsheet-artwork-repair/repair.ts
+++ b/jobs/flowsheet-artwork-repair/repair.ts
@@ -133,7 +133,7 @@ export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | n
   return first.artwork;
 };
 
-type SearchUrls = { youtube_music_url: string; bandcamp_url: string; soundcloud_url: string };
+type SearchUrls = ReturnType<typeof synthesizeSearchUrls>;
 
 /**
  * 10-column payload. Mirrors `apps/enrichment-worker/enrich.ts:181-198`

--- a/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
@@ -160,7 +160,7 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
   });
 
   it('falls back to synthesized search URLs when LML returns null for streaming columns — no regression of populated columns', async () => {
-    // All three streaming URLs null on the LML response. Writer must
+    // All four streaming URLs null on the LML response. Writer must
     // synthesize instead of nulling — see `buildPayload` header for the
     // asymmetry.
     const allStreamingNullResponse: LookupResponse = {
@@ -170,6 +170,7 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
           library_item: { id: 1 },
           artwork: {
             ...matchedResponse.results[0].artwork!,
+            spotify_url: null,
             youtube_music_url: null,
             bandcamp_url: null,
             soundcloud_url: null,
@@ -180,6 +181,7 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
     await repairFreeFormRow(freeFormRow, allStreamingNullResponse);
     const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
 
+    expect(setArgs.spotify_url).toBe(`https://open.spotify.com/search/${encodeURIComponent('Stereolab Pop Quiz')}`);
     expect(setArgs.youtube_music_url).toBe(
       `https://music.youtube.com/search?q=${encodeURIComponent('Stereolab Pop Quiz')}`
     );

--- a/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
@@ -160,14 +160,9 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
   });
 
   it('falls back to synthesized search URLs when LML returns null for streaming columns — no regression of populated columns', async () => {
-    // The drain's target population is rows already enriched
-    // (`metadata_status='enriched_match'`) whose artwork is null. Those
-    // rows carry synthesized search URLs from the original enrichment
-    // write. If LML returns null for youtube/bandcamp/soundcloud, the
-    // writer must persist the synthesized URLs instead of overwriting
-    // with null. Mirrors enrichment-worker (`apps/enrichment-worker/
-    // enrich.ts:171-174`) and flowsheet-metadata-backfill (`enrich.ts:
-    // 172-174`).
+    // All three streaming URLs null on the LML response. Writer must
+    // synthesize instead of nulling — see `buildPayload` header for the
+    // asymmetry.
     const allStreamingNullResponse: LookupResponse = {
       ...matchedResponse,
       results: [

--- a/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/repair.test.ts
@@ -139,6 +139,9 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
     expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
     const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
 
+    // soundcloud_url is null on the LML response → falls back to a
+    // synthesized track-leaning query. See the streaming-URL fallback
+    // test below for the synthesis invariant.
     expect(setArgs).toEqual({
       artwork_url: 'https://i.discogs.com/art.jpg',
       discogs_url: 'https://www.discogs.com/release/12345',
@@ -147,13 +150,48 @@ describe('repairFreeFormRow (BS#1209) — free-form UPDATE shape', () => {
       apple_music_url: 'https://music.apple.com/album/xyz',
       youtube_music_url: 'https://music.youtube.com/album/aaa',
       bandcamp_url: 'https://stereolab.bandcamp.com/album/aluminum-tunes',
-      soundcloud_url: null,
+      soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent('Stereolab Pop Quiz')}`,
       artist_bio: 'Tim Gane and Lætitia Sadier are Stereolab.',
       artist_wikipedia_url: 'https://en.wikipedia.org/wiki/Stereolab',
     });
     expect(Object.keys(setArgs)).toHaveLength(10);
     expect('metadata_status' in setArgs).toBe(false);
     expect('metadata_attempt_at' in setArgs).toBe(false);
+  });
+
+  it('falls back to synthesized search URLs when LML returns null for streaming columns — no regression of populated columns', async () => {
+    // The drain's target population is rows already enriched
+    // (`metadata_status='enriched_match'`) whose artwork is null. Those
+    // rows carry synthesized search URLs from the original enrichment
+    // write. If LML returns null for youtube/bandcamp/soundcloud, the
+    // writer must persist the synthesized URLs instead of overwriting
+    // with null. Mirrors enrichment-worker (`apps/enrichment-worker/
+    // enrich.ts:171-174`) and flowsheet-metadata-backfill (`enrich.ts:
+    // 172-174`).
+    const allStreamingNullResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: {
+            ...matchedResponse.results[0].artwork!,
+            youtube_music_url: null,
+            bandcamp_url: null,
+            soundcloud_url: null,
+          },
+        },
+      ],
+    };
+    await repairFreeFormRow(freeFormRow, allStreamingNullResponse);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+
+    expect(setArgs.youtube_music_url).toBe(
+      `https://music.youtube.com/search?q=${encodeURIComponent('Stereolab Pop Quiz')}`
+    );
+    expect(setArgs.bandcamp_url).toBe(
+      `https://bandcamp.com/search?q=${encodeURIComponent('Stereolab Aluminum Tunes')}`
+    );
+    expect(setArgs.soundcloud_url).toBe(`https://soundcloud.com/search?q=${encodeURIComponent('Stereolab Pop Quiz')}`);
   });
 
   it('strips Discogs spacer.gif from artwork_url', async () => {

--- a/tests/unit/jobs/flowsheet-artwork-repair/synthesize-search-urls-parity.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/synthesize-search-urls-parity.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Parity test: the inline `synthesizeSearchUrls` in
+ * `jobs/flowsheet-artwork-repair/repair.ts` MUST produce identical
+ * output to the canonical `SearchUrlProvider.getAllSearchUrls` in
+ * `apps/backend/services/metadata/providers/search-urls.provider.ts`
+ * for the same inputs (BS#889).
+ *
+ * The inline copy exists deliberately — the job's tsup build deliberately
+ * doesn't pull in apps/backend (build-graph isolation; see the file
+ * header on `repair.ts`). The cost of that isolation is silent drift
+ * between the two implementations. This test pins them in lockstep so
+ * the next drift fails CI loudly. Mirrors the sibling parity test under
+ * `tests/unit/jobs/flowsheet-metadata-backfill/`.
+ */
+
+import { synthesizeSearchUrls } from '../../../../jobs/flowsheet-artwork-repair/repair';
+import { SearchUrlProvider } from '../../../../apps/backend/services/metadata/providers/search-urls.provider';
+
+describe('synthesizeSearchUrls parity with SearchUrlProvider', () => {
+  const canonical = new SearchUrlProvider();
+
+  type Case = { name: string; artist: string; album: string | null; track: string | null };
+  const cases: Case[] = [
+    { name: 'full track + album + artist', artist: 'Juana Molina', album: 'DOGA', track: 'la paradoja' },
+    { name: 'no track, album present', artist: 'Stereolab', album: 'Dots and Loops', track: null },
+    { name: 'no album, track present', artist: 'Autechre', album: null, track: 'VI Scose Poise' },
+    { name: 'artist only', artist: 'Chuquimamani-Condori', album: null, track: null },
+    { name: 'diacritics in artist', artist: 'Nilüfer Yanya', album: 'Painless', track: 'stabilise' },
+    { name: 'diacritics + nothing else', artist: 'Hermanos Gutiérrez', album: null, track: null },
+    { name: 'spaces + ampersand in artist', artist: 'Duke Ellington & John Coltrane', album: null, track: null },
+  ];
+
+  it.each(cases)('$name', ({ artist, album, track }) => {
+    const inline = synthesizeSearchUrls({
+      id: 0,
+      artist_name: artist,
+      album_title: album,
+      track_title: track,
+    });
+    const canonicalOut = canonical.getAllSearchUrls(artist, album ?? undefined, track ?? undefined);
+
+    expect(inline.youtube_music_url).toBe(canonicalOut.youtubeMusicUrl);
+    expect(inline.bandcamp_url).toBe(canonicalOut.bandcampUrl);
+    expect(inline.soundcloud_url).toBe(canonicalOut.soundcloudUrl);
+  });
+});

--- a/tests/unit/jobs/flowsheet-artwork-repair/synthesize-search-urls-parity.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/synthesize-search-urls-parity.test.ts
@@ -11,6 +11,12 @@
  * between the two implementations. This test pins them in lockstep so
  * the next drift fails CI loudly. Mirrors the sibling parity test under
  * `tests/unit/jobs/flowsheet-metadata-backfill/`.
+ *
+ * Asserted shape — the four URLs the canonical write path persists
+ * post-BS#1192: `spotify_url`, `youtube_music_url`, `bandcamp_url`,
+ * `soundcloud_url`. `apple_music_url` is excluded — null is load-bearing
+ * "no verified iTunes match" on the write path (the read-path proxy
+ * synthesizes a search URL when needed).
  */
 
 import { synthesizeSearchUrls } from '../../../../jobs/flowsheet-artwork-repair/repair';
@@ -39,6 +45,7 @@ describe('synthesizeSearchUrls parity with SearchUrlProvider', () => {
     });
     const canonicalOut = canonical.getAllSearchUrls(artist, album ?? undefined, track ?? undefined);
 
+    expect(inline.spotify_url).toBe(canonicalOut.spotifyUrl);
     expect(inline.youtube_music_url).toBe(canonicalOut.youtubeMusicUrl);
     expect(inline.bandcamp_url).toBe(canonicalOut.bandcampUrl);
     expect(inline.soundcloud_url).toBe(canonicalOut.soundcloudUrl);


### PR DESCRIPTION
## Summary

The BS#1209 drain's free-form writer regresses already-populated synthesized search URLs to null when LML's fresh response carries null for `youtube_music_url` / `bandcamp_url` / `soundcloud_url`. Found via `/review` while looking at the BS#1209 work that landed on `main` via #1210's commits.

## What's wrong

The drain's target population is `flowsheet` rows at `metadata_status='enriched_match' AND artwork_url IS NULL AND album_id IS NULL`. Those rows were enriched by `apps/enrichment-worker/enrich.ts`, whose write path synthesizes search URLs as fallback when LML returns null (see [`enrichment-worker/enrich.ts#L171-L174`](https://github.com/WXYC/Backend-Service/blob/main/apps/enrichment-worker/enrich.ts#L171-L174)):

```ts
youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
```

So every row in the drain's target population already carries synthesized URLs. The drain re-queries LML and writes the 10-col payload back. The current writer at [`flowsheet-artwork-repair/repair.ts#L131-L145`](https://github.com/WXYC/Backend-Service/blob/main/jobs/flowsheet-artwork-repair/repair.ts#L131-L145) does:

```ts
youtube_music_url: artwork.youtube_music_url ?? null,
bandcamp_url: artwork.bandcamp_url ?? null,
soundcloud_url: artwork.soundcloud_url ?? null,
```

When LML returns null for any of those (a not-uncommon shape — Discogs releases without Spotify/Apple/Bandcamp partners regularly come back with null streaming columns from LML), the UPDATE writes null over the previously-synthesized URL. Dj-site + iOS streaming-link affordances degrade silently for those columns.

The header comment on `buildPayload` (lines 109-129) argues this is fine because "the population's upstream cycle never wrote them either" — that's not accurate. The worker DID write them.

## What's in this PR

- New inline `synthesizeSearchUrls` helper mirroring `apps/backend/services/metadata/providers/search-urls.provider.ts` (BS#889 parity pattern).
- New parity test `tests/unit/jobs/flowsheet-artwork-repair/synthesize-search-urls-parity.test.ts` pinning truthy/falsy + URL output equivalence between the inline copy and the canonical.
- `buildPayload(artwork, searchUrls?)` now takes an optional `searchUrls` second arg. The free-form path passes synthesized URLs; the linked path omits them (linked rows have no `track_title`, and SoundCloud's track-leaning query would degrade to album-only mixes — matches `album-level-backfill/job.ts:294-296`).
- `repairFreeFormRow` calls `buildPayload(artwork, synthesizeSearchUrls(row))`.
- Updated `repair.test.ts`: the existing "writes 10 cols" test fixture had `soundcloud_url: null` on the LML response; that now expects the synthesized soundcloud URL. Added a new test that explicitly pins the synthesis-on-LML-null behavior for all three streaming columns.

## Test plan

- [x] `npm run test:unit -- tests/unit/jobs/flowsheet-artwork-repair/` — 44/44 green (was 33 before parity test + new behavioral test added)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run build --workspace=@wxyc/flowsheet-artwork-repair` — clean
- [ ] Integration check (existing `tests/integration/flowsheet-artwork-repair.spec.js` still passes against `npm run db:start`)

Refs #1209. Supersedes #1211 + #1212 (the original split, which would have been a regression vs main's current state).