### PR TITLE
fix(auth): sanitize fallback 500 handler so internals never reach the response body

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -10,11 +10,12 @@ import { auth } from '@wxyc/authentication';
 import { fromNodeHeaders, toNodeHandler } from 'better-auth/node';
 import cors from 'cors';
 import express from 'express';
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
 import { rateLimitKeyFromRequest } from './rate-limit-key';
 import { closeDatabaseConnection } from '@wxyc/database';
 import type { HealthCheckResponse } from '@wxyc/shared/dtos';
+import { fallbackErrorHandler } from './fallback-error-handler';
 import { lookupEmailByIdentifier } from './lookup-email';
 import { provisionUser, ProvisionError } from './provision-user';
 import { resolveOrganization } from './resolve-organization';
@@ -332,11 +333,9 @@ app.get('/healthcheck', async (req, res) => {
 
 Sentry.setupExpressErrorHandler(app);
 
-// Fallback error handler
-app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
-  const message = err instanceof Error ? err.message : String(err);
-  res.status(500).json({ error: message });
-});
+// Fallback error handler — sanitises response body, forwards full error to
+// Sentry. See `./fallback-error-handler.ts` for rationale (BS#1109).
+app.use(fallbackErrorHandler);
 
 // Create default user if needed
 const createDefaultUser = async () => {

--- a/apps/auth/fallback-error-handler.ts
+++ b/apps/auth/fallback-error-handler.ts
@@ -12,8 +12,7 @@ import type { Request, Response, NextFunction } from 'express';
 export function fallbackErrorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction): void {
   Sentry.captureException(err);
 
-  const isProduction = process.env.NODE_ENV === 'production';
-  if (isProduction) {
+  if (process.env.NODE_ENV === 'production') {
     res.status(500).json({ error: 'Internal server error' });
     return;
   }

--- a/apps/auth/fallback-error-handler.ts
+++ b/apps/auth/fallback-error-handler.ts
@@ -1,0 +1,23 @@
+// Fallback Express error handler for the auth service. Sanitises the response
+// body so an unhandled error never leaks SQL fragments, bind values, table or
+// column names back to the caller (BS#1109).
+//
+// The full error is always forwarded to Sentry — only the response body is
+// stripped. In non-production environments the detailed message is preserved
+// to aid dev debugging, mirroring the pattern in
+// `apps/backend/middleware/errorHandler.ts`.
+import * as Sentry from '@sentry/node';
+import type { Request, Response, NextFunction } from 'express';
+
+export function fallbackErrorHandler(err: unknown, _req: Request, res: Response, _next: NextFunction): void {
+  Sentry.captureException(err);
+
+  const isProduction = process.env.NODE_ENV === 'production';
+  if (isProduction) {
+    res.status(500).json({ error: 'Internal server error' });
+    return;
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  res.status(500).json({ error: message });
+}

--- a/tests/unit/auth/fallback-error-handler.test.ts
+++ b/tests/unit/auth/fallback-error-handler.test.ts
@@ -85,17 +85,18 @@ describe('fallbackErrorHandler (BS#1109 sanitisation)', () => {
     expect(jsonMock).toHaveBeenCalledWith({ error: 'test-env message' });
   });
 
-  it('sanitises in production when NODE_ENV is unset (defensive default would leak — so we explicitly only relax for non-production)', () => {
+  it('treats unset NODE_ENV as non-production (dev-server convenience)', () => {
+    // The sanitisation gate is positive-list on `=== 'production'`, so an
+    // unset NODE_ENV falls into the dev branch and returns the detailed
+    // message. Production deploys always set NODE_ENV, so this only matters
+    // for local `node app.js` invocations. The acceptance criterion (no
+    // leak when NODE_ENV === 'production') is covered above.
     delete process.env.NODE_ENV;
     const { res, jsonMock } = mockResponse();
     const error = new Error('would-be-leaky message');
 
     fallbackErrorHandler(error, mockReq, res, mockNext);
 
-    // NODE_ENV unset is treated as "not production" by the current branch,
-    // so the detailed message is returned. This matches the dev-server case
-    // where NODE_ENV isn't always set. The acceptance criterion (no leak in
-    // production) is covered by the production-mode test above.
     expect(jsonMock).toHaveBeenCalledWith({ error: 'would-be-leaky message' });
   });
 

--- a/tests/unit/auth/fallback-error-handler.test.ts
+++ b/tests/unit/auth/fallback-error-handler.test.ts
@@ -1,0 +1,111 @@
+import { jest } from '@jest/globals';
+import type { Request, Response, NextFunction } from 'express';
+
+// Mock Sentry so we can assert on captureException invocations without booting
+// the SDK. Keep the mock factory variable name prefixed with `mock` so Jest's
+// out-of-band hoisting allows the reference (see provision-user.test.ts).
+const mockSentryCaptureException = jest.fn();
+jest.mock('@sentry/node', () => ({
+  captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
+}));
+
+import { fallbackErrorHandler } from '../../../apps/auth/fallback-error-handler';
+
+function mockResponse() {
+  const statusMock = jest.fn().mockReturnThis();
+  const jsonMock = jest.fn().mockReturnThis();
+  const res = {
+    status: statusMock,
+    json: jsonMock,
+  } as unknown as Response;
+  return { res, statusMock, jsonMock };
+}
+
+const mockReq = { method: 'POST', url: '/auth/sign-in/username' } as Request;
+const mockNext = jest.fn() as NextFunction;
+
+describe('fallbackErrorHandler (BS#1109 sanitisation)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    mockSentryCaptureException.mockClear();
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('does not leak SQL fragments in production response body', () => {
+    process.env.NODE_ENV = 'production';
+    const { res, statusMock, jsonMock } = mockResponse();
+    const leakyError = new Error('select * from foo where x = $1 failed: connection refused');
+
+    fallbackErrorHandler(leakyError, mockReq, res, mockNext);
+
+    expect(statusMock).toHaveBeenCalledWith(500);
+    expect(jsonMock).toHaveBeenCalledWith({ error: 'Internal server error' });
+
+    const body = jsonMock.mock.calls[0]?.[0] as { error: string };
+    expect(body.error).not.toMatch(/select/i);
+    expect(body.error).not.toContain('foo');
+    expect(body.error).not.toContain('$1');
+    expect(body.error).not.toContain('connection refused');
+  });
+
+  it('always forwards the full error to Sentry, even in production', () => {
+    process.env.NODE_ENV = 'production';
+    const { res } = mockResponse();
+    const leakyError = new Error('select * from foo where x = $1 failed: connection refused');
+
+    fallbackErrorHandler(leakyError, mockReq, res, mockNext);
+
+    expect(mockSentryCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockSentryCaptureException).toHaveBeenCalledWith(leakyError);
+  });
+
+  it('preserves the detailed message in development for debugging', () => {
+    process.env.NODE_ENV = 'development';
+    const { res, statusMock, jsonMock } = mockResponse();
+    const error = new Error('detailed dev message');
+
+    fallbackErrorHandler(error, mockReq, res, mockNext);
+
+    expect(statusMock).toHaveBeenCalledWith(500);
+    expect(jsonMock).toHaveBeenCalledWith({ error: 'detailed dev message' });
+    expect(mockSentryCaptureException).toHaveBeenCalledWith(error);
+  });
+
+  it('preserves the detailed message in test environment', () => {
+    process.env.NODE_ENV = 'test';
+    const { res, jsonMock } = mockResponse();
+    const error = new Error('test-env message');
+
+    fallbackErrorHandler(error, mockReq, res, mockNext);
+
+    expect(jsonMock).toHaveBeenCalledWith({ error: 'test-env message' });
+  });
+
+  it('sanitises in production when NODE_ENV is unset (defensive default would leak — so we explicitly only relax for non-production)', () => {
+    delete process.env.NODE_ENV;
+    const { res, jsonMock } = mockResponse();
+    const error = new Error('would-be-leaky message');
+
+    fallbackErrorHandler(error, mockReq, res, mockNext);
+
+    // NODE_ENV unset is treated as "not production" by the current branch,
+    // so the detailed message is returned. This matches the dev-server case
+    // where NODE_ENV isn't always set. The acceptance criterion (no leak in
+    // production) is covered by the production-mode test above.
+    expect(jsonMock).toHaveBeenCalledWith({ error: 'would-be-leaky message' });
+  });
+
+  it('handles non-Error throws (string, undefined) without crashing', () => {
+    process.env.NODE_ENV = 'production';
+    const { res, jsonMock } = mockResponse();
+
+    fallbackErrorHandler('something broke', mockReq, res, mockNext);
+
+    expect(jsonMock).toHaveBeenCalledWith({ error: 'Internal server error' });
+    expect(mockSentryCaptureException).toHaveBeenCalledWith('something broke');
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts the auth service's fallback Express error handler into `apps/auth/fallback-error-handler.ts` so it is directly unit-testable, matching the layout of `lookup-email`, `provision-user`, `resolve-organization`.
- In production, the handler returns a generic `{ error: 'Internal server error' }` body — `Error.message` is no longer reflected back to the caller, so postgres-js / better-auth messages containing SQL fragments, table/column names, and bind values no longer leak.
- In non-production (`NODE_ENV !== 'production'`), the detailed message is preserved to aid dev/test debugging.
- `Sentry.captureException(err)` is called unconditionally so the full error reaches Sentry regardless of the response body — fixing the implicit-only forwarding that the issue called out.
- Mirrors the sanitisation pattern already used in `apps/backend/middleware/errorHandler.ts`.

## Test plan

- New unit test `tests/unit/auth/fallback-error-handler.test.ts` covers:
  - Production: SQL fragment `select * from foo where x = $1 failed: ...` does NOT appear in the response body.
  - Production: `Sentry.captureException` is invoked with the original error.
  - Development and test: detailed message preserved.
  - Non-Error throws (string, etc.) are handled without crashing and still trigger Sentry.
- `npm run typecheck` clean across all workspaces.
- `npm run lint` clean (0 errors).
- `npm run format:check` clean.
- `npm run test:unit -- tests/unit/auth/` — 97 / 97 pass.

Closes #1109