### PR TITLE
fix(flowsheet): scope endShow show_djs UPDATE by (show_id, dj_id)

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -542,7 +542,10 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
 
   await Promise.all(
     remaining_djs.map(async (dj: ShowDJ) => {
-      await db.update(show_djs).set({ active: false }).where(eq(show_djs.dj_id, dj.dj_id));
+      await db
+        .update(show_djs)
+        .set({ active: false })
+        .where(and(eq(show_djs.show_id, currentShow.id), eq(show_djs.dj_id, dj.dj_id)));
       if (dj.dj_id === primary_dj_id) return;
       await createLeaveNotification(dj.dj_id, currentShow.id);
     })

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -186,7 +186,11 @@ export const shows = {
   show_name: 'show_name',
   specialty_id: 'specialty_id',
 };
-export const show_djs = {};
+export const show_djs = {
+  show_id: 'show_id',
+  dj_id: 'dj_id',
+  active: 'active',
+};
 export const user = {
   id: 'id',
   name: 'name',

--- a/tests/unit/services/flowsheet.endShow.showIdPredicate.test.ts
+++ b/tests/unit/services/flowsheet.endShow.showIdPredicate.test.ts
@@ -1,0 +1,113 @@
+import { db, createMockQueryChain, show_djs } from '../../mocks/database.mock';
+import { endShow } from '../../../apps/backend/services/flowsheet.service';
+
+/**
+ * Regression test for #1100: `endShow` must scope its `show_djs.active=false`
+ * UPDATE by `(show_id, dj_id)`, not by `dj_id` alone. Without the show_id
+ * predicate, every `show_djs` row for that DJ across all of their historical
+ * shows gets flipped to inactive. Mirrors `leaveShow`'s correctly-scoped
+ * predicate shape.
+ */
+
+const makeAwaitablePlayOrderChain = (max: number) => {
+  const chain = createMockQueryChain();
+  (chain as unknown as { then: (resolve: (v: unknown) => void) => void }).then = (resolve) => resolve([{ max }]);
+  return chain;
+};
+
+describe('endShow show_djs UPDATE predicate (#1100)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('scopes show_djs.active=false UPDATE to (show_id, dj_id), not dj_id alone', async () => {
+    const CURRENT_SHOW_ID = 2;
+    const DJ_ID = 'dj-A';
+
+    // DJ A is the remaining-active row on show 2; the mock returns this as the
+    // only row the loop will iterate over. The DJ is also the primary DJ, so
+    // the loop skips the leave-notification branch.
+    const remainingDjsSelect = createMockQueryChain();
+    remainingDjsSelect.where.mockResolvedValue([{ show_id: CURRENT_SHOW_ID, dj_id: DJ_ID, active: true }]);
+    db.select.mockReturnValueOnce(remainingDjsSelect);
+
+    // show_djs UPDATE chain — inspection target.
+    const showDjsUpdate = createMockQueryChain();
+    db.update.mockReturnValueOnce(showDjsUpdate);
+
+    // primary DJ user lookup (after the loop)
+    const userSelect = createMockQueryChain();
+    userSelect.limit.mockResolvedValue([{ djName: 'DJ A', name: 'A' }]);
+    db.select.mockReturnValueOnce(userSelect);
+
+    // nextPlayOrder for the show_end insert
+    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
+
+    // flowsheet insert (show_end)
+    db.insert.mockReturnValueOnce(createMockQueryChain([{ id: 999 }]));
+
+    // shows update (end_time)
+    db.update.mockReturnValueOnce(createMockQueryChain([{}]));
+
+    // getLatestShow() select chain
+    const latestShowSelect = createMockQueryChain();
+    latestShowSelect.limit.mockResolvedValue([{ id: CURRENT_SHOW_ID, end_time: new Date() }]);
+    db.select.mockReturnValueOnce(latestShowSelect);
+
+    await endShow({ id: CURRENT_SHOW_ID, primary_dj_id: DJ_ID } as unknown as Parameters<typeof endShow>[0]);
+
+    // The first call to showDjsUpdate.where is the per-DJ UPDATE inside the
+    // Promise.all loop. Assert it constrains both show_id and dj_id.
+    const wherePredicate = showDjsUpdate.where.mock.calls[0]?.[0] as {
+      and: Array<{ eq: [unknown, unknown] }>;
+    };
+
+    expect(wherePredicate).toEqual({
+      and: expect.arrayContaining([{ eq: [show_djs.show_id, CURRENT_SHOW_ID] }, { eq: [show_djs.dj_id, DJ_ID] }]),
+    });
+    expect(wherePredicate.and).toHaveLength(2);
+  });
+
+  it("does not flip a DJ's prior-show row when ending a later show", async () => {
+    // Sanity-check the contract from the other side: with the show_id
+    // predicate in place, a DJ who has active=true rows on shows 1 AND 2
+    // should only see show 2's row flipped when endShow(show2) runs. The
+    // UPDATE's WHERE clause carries the current show id; show 1's row is
+    // untouched because the predicate excludes it. We model that by
+    // asserting the captured predicate's show_id value equals the current
+    // show id and never the prior one.
+    const PRIOR_SHOW_ID = 1;
+    const CURRENT_SHOW_ID = 2;
+    const DJ_ID = 'dj-A';
+
+    const remainingDjsSelect = createMockQueryChain();
+    remainingDjsSelect.where.mockResolvedValue([{ show_id: CURRENT_SHOW_ID, dj_id: DJ_ID, active: true }]);
+    db.select.mockReturnValueOnce(remainingDjsSelect);
+
+    const showDjsUpdate = createMockQueryChain();
+    db.update.mockReturnValueOnce(showDjsUpdate);
+
+    const userSelect = createMockQueryChain();
+    userSelect.limit.mockResolvedValue([{ djName: 'DJ A', name: 'A' }]);
+    db.select.mockReturnValueOnce(userSelect);
+
+    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
+    db.insert.mockReturnValueOnce(createMockQueryChain([{ id: 999 }]));
+    db.update.mockReturnValueOnce(createMockQueryChain([{}]));
+
+    const latestShowSelect = createMockQueryChain();
+    latestShowSelect.limit.mockResolvedValue([{ id: CURRENT_SHOW_ID, end_time: new Date() }]);
+    db.select.mockReturnValueOnce(latestShowSelect);
+
+    await endShow({ id: CURRENT_SHOW_ID, primary_dj_id: DJ_ID } as unknown as Parameters<typeof endShow>[0]);
+
+    const wherePredicate = showDjsUpdate.where.mock.calls[0]?.[0] as {
+      and: Array<{ eq: [unknown, unknown] }>;
+    };
+    const showIdPredicate = wherePredicate.and.find(
+      (clause) => Array.isArray(clause.eq) && clause.eq[0] === show_djs.show_id
+    );
+    expect(showIdPredicate?.eq[1]).toBe(CURRENT_SHOW_ID);
+    expect(showIdPredicate?.eq[1]).not.toBe(PRIOR_SHOW_ID);
+  });
+});

--- a/tests/unit/services/flowsheet.endShow.showIdPredicate.test.ts
+++ b/tests/unit/services/flowsheet.endShow.showIdPredicate.test.ts
@@ -20,13 +20,17 @@ describe('endShow show_djs UPDATE predicate (#1100)', () => {
     jest.clearAllMocks();
   });
 
-  it('scopes show_djs.active=false UPDATE to (show_id, dj_id), not dj_id alone', async () => {
+  it('scopes show_djs.active=false UPDATE to (show_id=current, dj_id), leaving prior shows untouched', async () => {
+    const PRIOR_SHOW_ID = 1;
     const CURRENT_SHOW_ID = 2;
     const DJ_ID = 'dj-A';
 
-    // DJ A is the remaining-active row on show 2; the mock returns this as the
-    // only row the loop will iterate over. The DJ is also the primary DJ, so
-    // the loop skips the leave-notification branch.
+    // remaining_djs SELECT — DJ A is the only active member of show 2. The
+    // prior-show row (show 1) is not returned because the SELECT already
+    // filters by show_id, and isn't needed for the assertion either: the
+    // per-DJ UPDATE's predicate is derived from `currentShow.id`, so the
+    // contract we're verifying is that the captured WHERE clause carries
+    // `show_id = current` (and therefore PostgreSQL will skip show 1's row).
     const remainingDjsSelect = createMockQueryChain();
     remainingDjsSelect.where.mockResolvedValue([{ show_id: CURRENT_SHOW_ID, dj_id: DJ_ID, active: true }]);
     db.select.mockReturnValueOnce(remainingDjsSelect);
@@ -35,21 +39,19 @@ describe('endShow show_djs UPDATE predicate (#1100)', () => {
     const showDjsUpdate = createMockQueryChain();
     db.update.mockReturnValueOnce(showDjsUpdate);
 
-    // primary DJ user lookup (after the loop)
+    // primary DJ user lookup; DJ A is the primary so the loop skips
+    // createLeaveNotification.
     const userSelect = createMockQueryChain();
     userSelect.limit.mockResolvedValue([{ djName: 'DJ A', name: 'A' }]);
     db.select.mockReturnValueOnce(userSelect);
 
     // nextPlayOrder for the show_end insert
     db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
-
     // flowsheet insert (show_end)
     db.insert.mockReturnValueOnce(createMockQueryChain([{ id: 999 }]));
-
     // shows update (end_time)
     db.update.mockReturnValueOnce(createMockQueryChain([{}]));
-
-    // getLatestShow() select chain
+    // getLatestShow()
     const latestShowSelect = createMockQueryChain();
     latestShowSelect.limit.mockResolvedValue([{ id: CURRENT_SHOW_ID, end_time: new Date() }]);
     db.select.mockReturnValueOnce(latestShowSelect);
@@ -57,7 +59,8 @@ describe('endShow show_djs UPDATE predicate (#1100)', () => {
     await endShow({ id: CURRENT_SHOW_ID, primary_dj_id: DJ_ID } as unknown as Parameters<typeof endShow>[0]);
 
     // The first call to showDjsUpdate.where is the per-DJ UPDATE inside the
-    // Promise.all loop. Assert it constrains both show_id and dj_id.
+    // Promise.all loop. Assert it constrains both show_id and dj_id — and
+    // that show_id is bound to the current show, not a prior one.
     const wherePredicate = showDjsUpdate.where.mock.calls[0]?.[0] as {
       and: Array<{ eq: [unknown, unknown] }>;
     };
@@ -66,48 +69,6 @@ describe('endShow show_djs UPDATE predicate (#1100)', () => {
       and: expect.arrayContaining([{ eq: [show_djs.show_id, CURRENT_SHOW_ID] }, { eq: [show_djs.dj_id, DJ_ID] }]),
     });
     expect(wherePredicate.and).toHaveLength(2);
-  });
-
-  it("does not flip a DJ's prior-show row when ending a later show", async () => {
-    // Sanity-check the contract from the other side: with the show_id
-    // predicate in place, a DJ who has active=true rows on shows 1 AND 2
-    // should only see show 2's row flipped when endShow(show2) runs. The
-    // UPDATE's WHERE clause carries the current show id; show 1's row is
-    // untouched because the predicate excludes it. We model that by
-    // asserting the captured predicate's show_id value equals the current
-    // show id and never the prior one.
-    const PRIOR_SHOW_ID = 1;
-    const CURRENT_SHOW_ID = 2;
-    const DJ_ID = 'dj-A';
-
-    const remainingDjsSelect = createMockQueryChain();
-    remainingDjsSelect.where.mockResolvedValue([{ show_id: CURRENT_SHOW_ID, dj_id: DJ_ID, active: true }]);
-    db.select.mockReturnValueOnce(remainingDjsSelect);
-
-    const showDjsUpdate = createMockQueryChain();
-    db.update.mockReturnValueOnce(showDjsUpdate);
-
-    const userSelect = createMockQueryChain();
-    userSelect.limit.mockResolvedValue([{ djName: 'DJ A', name: 'A' }]);
-    db.select.mockReturnValueOnce(userSelect);
-
-    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
-    db.insert.mockReturnValueOnce(createMockQueryChain([{ id: 999 }]));
-    db.update.mockReturnValueOnce(createMockQueryChain([{}]));
-
-    const latestShowSelect = createMockQueryChain();
-    latestShowSelect.limit.mockResolvedValue([{ id: CURRENT_SHOW_ID, end_time: new Date() }]);
-    db.select.mockReturnValueOnce(latestShowSelect);
-
-    await endShow({ id: CURRENT_SHOW_ID, primary_dj_id: DJ_ID } as unknown as Parameters<typeof endShow>[0]);
-
-    const wherePredicate = showDjsUpdate.where.mock.calls[0]?.[0] as {
-      and: Array<{ eq: [unknown, unknown] }>;
-    };
-    const showIdPredicate = wherePredicate.and.find(
-      (clause) => Array.isArray(clause.eq) && clause.eq[0] === show_djs.show_id
-    );
-    expect(showIdPredicate?.eq[1]).toBe(CURRENT_SHOW_ID);
-    expect(showIdPredicate?.eq[1]).not.toBe(PRIOR_SHOW_ID);
+    expect(wherePredicate.and).not.toContainEqual({ eq: [show_djs.show_id, PRIOR_SHOW_ID] });
   });
 });


### PR DESCRIPTION
## Summary

- `endShow` in `apps/backend/services/flowsheet.service.ts` was updating `show_djs.active=false` keyed only on `dj_id`, flipping every prior show's row for that DJ. The peer `leaveShow` 12 lines below already scopes the predicate correctly; this PR mirrors that shape.
- Added a unit-level regression test (`tests/unit/services/flowsheet.endShow.showIdPredicate.test.ts`) that captures the UPDATE's `where()` predicate from the drizzle-orm mock and asserts both `show_id` and `dj_id` constraints are present, with `show_id` bound to the *current* show id (not a prior one). The test fails on the pre-fix line.
- Populated the `show_djs` mock-table object with column placeholders (`show_id`, `dj_id`, `active`) so the assertion can distinguish predicates by column identity, matching how other mock tables (e.g. `library`, `rotation`, `shows`) are already structured.

Latent today because read paths effectively only check the latest show's `show_djs` rows, but the corruption is real and would surface the moment any feature touches prior-show membership (overlapping live shows, multi-show DJ dashboards, retroactive show edits).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check`
- [x] `npm run test:unit` — new test passes; only pre-existing failure is `tests/unit/database/schema.flowsheet-artwork-lookup-idx.test.ts` (unrelated, fails on `main` without this change)
- [x] Verified the new test fails against the pre-fix code and passes against the fix

Closes #1100