### PR TITLE
fix(sse): per-client comment heartbeat instead of inactivity timeout

### DIFF
--- a/apps/backend/utils/serverEvents.ts
+++ b/apps/backend/utils/serverEvents.ts
@@ -55,28 +55,70 @@ export class ServerEventsManager {
     this.topics = new Set(topicNames);
   }
 
-  private static readonly INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000;
+  // Per-client SSE comment-heartbeat cadence (BS#1130). 30 s is the same value
+  // tubafrenzy's upstream SSE feed uses (see `playlist-proxy.service.ts` prose),
+  // and well under typical L7-proxy idle thresholds (nginx 60 s, ALB 60 s) so an
+  // idle TCP connection never silently expires between writes. SSE comments
+  // (`: …\n\n`) are invisible to `addEventListener` consumers — they keep the
+  // socket alive without surfacing as a named event.
+  private static readonly HEARTBEAT_INTERVAL_MS = 30 * 1000;
+  private static readonly HEARTBEAT_FRAME = ': keepalive\n\n';
 
   private topics: Set<string> = new Set();
   // each map key is a topic e.g. primary_dj, show_dj, live_fs,
   private clients: Map<string, EventClient> = new Map();
   private clientTopics: Map<string, Set<string>> = new Map(); // clientId -> topicIds
   private topicClients: Map<string, Set<string>> = new Map(); // topicId -> clientIds
-  private clientTimeouts: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private clientHeartbeats: Map<string, ReturnType<typeof setInterval>> = new Map();
 
-  private resetTimeout = (clientId: string) => {
-    const existing = this.clientTimeouts.get(clientId);
-    if (existing) {
-      clearTimeout(existing);
-    }
+  /**
+   * Writes a `: keepalive\n\n` SSE comment to the client every
+   * HEARTBEAT_INTERVAL_MS. The comment frame is silent to `addEventListener`
+   * consumers (per the SSE spec) but keeps the TCP connection alive and resets
+   * any intermediary idle timers.
+   *
+   * If the write fails the client's socket is half-dead (post-FIN, EPIPE,
+   * write-after-end). We capture to Sentry with the broadcast tags so the
+   * existing aggregation slot picks it up, then `unsubAll` to clean up the
+   * map entries — `res.on('close')` may already have fired but the listener
+   * is idempotent via this same path.
+   */
+  private startHeartbeat = (clientId: string) => {
+    const existing = this.clientHeartbeats.get(clientId);
+    if (existing) clearInterval(existing);
 
-    const timeoutId = setTimeout(() => {
-      if (this.clients.has(clientId)) {
-        this.disconnect(clientId, 'Connection terminated due to inactivity');
+    const intervalId = setInterval(() => {
+      const client = this.clients.get(clientId);
+      if (!client) {
+        clearInterval(intervalId);
+        this.clientHeartbeats.delete(clientId);
+        return;
       }
-    }, ServerEventsManager.INACTIVITY_TIMEOUT_MS);
+      try {
+        client.res.write(ServerEventsManager.HEARTBEAT_FRAME);
+      } catch (error) {
+        Sentry.captureException(error, {
+          tags: { subsystem: 'sse', op: 'heartbeat' },
+          extra: { client_id: clientId },
+        });
+        this.unsubAll(clientId);
+      }
+    }, ServerEventsManager.HEARTBEAT_INTERVAL_MS);
 
-    this.clientTimeouts.set(clientId, timeoutId);
+    // Don't keep the event loop alive solely for the heartbeat ticker —
+    // matches `startSseMetrics` in `sse-metrics.ts` so SIGTERM shutdown
+    // isn't blocked by idle SSE clients.
+    intervalId.unref?.();
+
+    this.clientHeartbeats.set(clientId, intervalId);
+  };
+
+  private stopHeartbeat = (clientId: string) => {
+    const intervalId = this.clientHeartbeats.get(clientId);
+    if (intervalId) {
+      clearInterval(intervalId);
+      this.clientHeartbeats.delete(clientId);
+    }
   };
 
   registerClient = (res: Response): EventClient => {
@@ -85,14 +127,10 @@ export class ServerEventsManager {
       res: res,
     };
 
-    this.resetTimeout(client.id);
+    this.startHeartbeat(client.id);
 
     client.res.on('close', () => {
-      const timeoutId = this.clientTimeouts.get(client.id);
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-        this.clientTimeouts.delete(client.id);
-      }
+      this.stopHeartbeat(client.id);
       this.unsubAll(client.id);
     });
 
@@ -200,11 +238,7 @@ export class ServerEventsManager {
     this.clientTopics.delete(clientId);
     this.clients.delete(clientId);
 
-    const timeoutId = this.clientTimeouts.get(clientId);
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-      this.clientTimeouts.delete(clientId);
-    }
+    this.stopHeartbeat(clientId);
   };
 
   broadcast = (topicId: string, data: EventData) => {
@@ -225,7 +259,6 @@ export class ServerEventsManager {
       if (client) {
         try {
           client.res.write(message);
-          this.resetTimeout(clientId);
         } catch (error) {
           // The CloudWatch counter (BS-3) makes the rate visible; Sentry
           // surfaces the exception so we can read the underlying error
@@ -257,7 +290,6 @@ export class ServerEventsManager {
     if (client) {
       try {
         client.res.write(message);
-        this.resetTimeout(clientId);
       } catch (error) {
         recordBroadcastFailure(topicId);
         Sentry.captureException(error, {

--- a/apps/backend/utils/serverEvents.ts
+++ b/apps/backend/utils/serverEvents.ts
@@ -55,12 +55,8 @@ export class ServerEventsManager {
     this.topics = new Set(topicNames);
   }
 
-  // Per-client SSE comment-heartbeat cadence (BS#1130). 30 s is the same value
-  // tubafrenzy's upstream SSE feed uses (see `playlist-proxy.service.ts` prose),
-  // and well under typical L7-proxy idle thresholds (nginx 60 s, ALB 60 s) so an
-  // idle TCP connection never silently expires between writes. SSE comments
-  // (`: …\n\n`) are invisible to `addEventListener` consumers — they keep the
-  // socket alive without surfacing as a named event.
+  // 30 s matches tubafrenzy's upstream SSE feed (see `playlist-proxy.service.ts`
+  // prose) and stays under nginx/ALB's 60 s idle defaults.
   private static readonly HEARTBEAT_INTERVAL_MS = 30 * 1000;
   private static readonly HEARTBEAT_FRAME = ': keepalive\n\n';
 
@@ -75,13 +71,9 @@ export class ServerEventsManager {
    * Writes a `: keepalive\n\n` SSE comment to the client every
    * HEARTBEAT_INTERVAL_MS. The comment frame is silent to `addEventListener`
    * consumers (per the SSE spec) but keeps the TCP connection alive and resets
-   * any intermediary idle timers.
-   *
-   * If the write fails the client's socket is half-dead (post-FIN, EPIPE,
-   * write-after-end). We capture to Sentry with the broadcast tags so the
-   * existing aggregation slot picks it up, then `unsubAll` to clean up the
-   * map entries — `res.on('close')` may already have fired but the listener
-   * is idempotent via this same path.
+   * any intermediary idle timers. On write failure (half-dead socket: EPIPE,
+   * write-after-end) we capture to Sentry under `op: 'heartbeat'` and
+   * `unsubAll` to drop the client from the maps.
    */
   private startHeartbeat = (clientId: string) => {
     const existing = this.clientHeartbeats.get(clientId);
@@ -105,9 +97,7 @@ export class ServerEventsManager {
       }
     }, ServerEventsManager.HEARTBEAT_INTERVAL_MS);
 
-    // Don't keep the event loop alive solely for the heartbeat ticker —
-    // matches `startSseMetrics` in `sse-metrics.ts` so SIGTERM shutdown
-    // isn't blocked by idle SSE clients.
+    // unref so SIGTERM isn't blocked by an idle heartbeat ticker.
     intervalId.unref?.();
 
     this.clientHeartbeats.set(clientId, intervalId);

--- a/tests/unit/utils/serverEvents.test.ts
+++ b/tests/unit/utils/serverEvents.test.ts
@@ -37,67 +37,88 @@ describe('ServerEventsManager', () => {
     jest.useRealTimers();
   });
 
-  describe('inactivity timeout', () => {
-    it('disconnects an idle client after 5 minutes', () => {
-      const mgr = new ServerEventsManager('topic-a');
-      const res = createMockResponse();
-      const _client = mgr.registerClient(res);
+  describe('heartbeat (BS#1130)', () => {
+    const HEARTBEAT_FRAME = ': keepalive\n\n';
+    const HEARTBEAT_INTERVAL_MS = 30 * 1000;
 
-      jest.advanceTimersByTime(5 * 60 * 1000);
-
-      expect(res.end).toHaveBeenCalled();
+    beforeEach(() => {
+      (Sentry.captureException as jest.Mock).mockClear();
     });
 
-    it('resets the timeout when a broadcast is sent to the client', () => {
+    it('writes a SSE comment heartbeat every 30 seconds', () => {
       const mgr = new ServerEventsManager('topic-a');
       const res = createMockResponse();
-      const client = mgr.registerClient(res);
-      mgr.subscribe(['topic-a'], client.id);
+      mgr.registerClient(res);
 
-      // Advance 4.5 minutes (not yet at 5-min threshold)
-      jest.advanceTimersByTime(4.5 * 60 * 1000);
+      const writeMock = res.write as jest.Mock;
+      // Discard the initial connection-established frame so we count only heartbeats.
+      writeMock.mockClear();
 
-      // Broadcast — this should reset the inactivity timer
-      mgr.broadcast('topic-a', { type: 'update', payload: { value: 1 } });
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+      expect(writeMock).toHaveBeenCalledWith(HEARTBEAT_FRAME);
+      expect(writeMock).toHaveBeenCalledTimes(1);
 
-      // Advance another 4.5 minutes (9 min total from registration,
-      // but only 4.5 min since last activity)
-      jest.advanceTimersByTime(4.5 * 60 * 1000);
-
-      // Client should still be connected because the timer was reset
-      expect(res.end).not.toHaveBeenCalled();
-      expect(mgr.getSubs(client.id)).toEqual(['topic-a']);
+      jest.advanceTimersByTime(2 * HEARTBEAT_INTERVAL_MS);
+      expect(writeMock).toHaveBeenCalledTimes(3);
+      expect(writeMock).toHaveBeenNthCalledWith(2, HEARTBEAT_FRAME);
+      expect(writeMock).toHaveBeenNthCalledWith(3, HEARTBEAT_FRAME);
     });
 
-    it('resets the timeout when a dispatch is sent to the client', () => {
-      const mgr = new ServerEventsManager('topic-a');
+    it('keeps a quiet-topic client connected indefinitely while heartbeats are flowing', () => {
+      // BS#1130 regression: the prior 5-minute inactivity timeout would disconnect
+      // healthy clients subscribed only to quiet topics (e.g. `mirror`, `primaryDj`).
+      const mgr = new ServerEventsManager('quiet-topic');
       const res = createMockResponse();
       const client = mgr.registerClient(res);
-      mgr.subscribe(['topic-a'], client.id);
+      mgr.subscribe(['quiet-topic'], client.id);
 
-      jest.advanceTimersByTime(4.5 * 60 * 1000);
-
-      mgr.dispatch('topic-a', client.id, { type: 'ping', payload: {} });
-
-      jest.advanceTimersByTime(4.5 * 60 * 1000);
+      // Simulate two hours of total silence on the topic — no broadcast,
+      // no dispatch — only heartbeat ticks. The old code disconnected at 5 min.
+      jest.advanceTimersByTime(2 * 60 * 60 * 1000);
 
       expect(res.end).not.toHaveBeenCalled();
-      expect(mgr.getSubs(client.id)).toEqual(['topic-a']);
+      expect(mgr.getSubs(client.id)).toEqual(['quiet-topic']);
     });
 
-    it('still disconnects if no activity occurs after the reset window', () => {
+    it('stops the heartbeat after the client disconnects', () => {
+      const mgr = new ServerEventsManager('topic-a');
+      const res = createMockResponse();
+      const client = mgr.registerClient(res);
+
+      mgr.disconnect(client.id);
+
+      const writeMock = res.write as jest.Mock;
+      writeMock.mockClear();
+
+      jest.advanceTimersByTime(5 * HEARTBEAT_INTERVAL_MS);
+
+      expect(writeMock).not.toHaveBeenCalledWith(HEARTBEAT_FRAME);
+    });
+
+    it('cleans up the client when the heartbeat write fails (half-dead socket)', () => {
       const mgr = new ServerEventsManager('topic-a');
       const res = createMockResponse();
       const client = mgr.registerClient(res);
       mgr.subscribe(['topic-a'], client.id);
 
-      jest.advanceTimersByTime(2 * 60 * 1000);
-      mgr.broadcast('topic-a', { type: 'update', payload: {} });
+      const failure = new Error('write after end');
+      (res.write as jest.Mock).mockImplementation((frame: string) => {
+        if (frame === HEARTBEAT_FRAME) throw failure;
+        return true;
+      });
 
-      // Full 5 minutes after the broadcast with no further activity
-      jest.advanceTimersByTime(5 * 60 * 1000);
+      jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
 
-      expect(res.end).toHaveBeenCalled();
+      // Captured to Sentry with the heartbeat op tag.
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        failure,
+        expect.objectContaining({
+          tags: expect.objectContaining({ subsystem: 'sse', op: 'heartbeat' }),
+          extra: expect.objectContaining({ client_id: client.id }),
+        })
+      );
+      // unsubAll fired — subscription map is empty.
+      expect(mgr.getSubs(client.id)).toEqual([]);
     });
   });
 

--- a/tests/unit/utils/serverEvents.test.ts
+++ b/tests/unit/utils/serverEvents.test.ts
@@ -65,15 +65,12 @@ describe('ServerEventsManager', () => {
     });
 
     it('keeps a quiet-topic client connected indefinitely while heartbeats are flowing', () => {
-      // BS#1130 regression: the prior 5-minute inactivity timeout would disconnect
-      // healthy clients subscribed only to quiet topics (e.g. `mirror`, `primaryDj`).
       const mgr = new ServerEventsManager('quiet-topic');
       const res = createMockResponse();
       const client = mgr.registerClient(res);
       mgr.subscribe(['quiet-topic'], client.id);
 
-      // Simulate two hours of total silence on the topic — no broadcast,
-      // no dispatch — only heartbeat ticks. The old code disconnected at 5 min.
+      // Two hours of silence on the topic — no broadcast, no dispatch.
       jest.advanceTimersByTime(2 * 60 * 60 * 1000);
 
       expect(res.end).not.toHaveBeenCalled();
@@ -109,7 +106,6 @@ describe('ServerEventsManager', () => {
 
       jest.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
 
-      // Captured to Sentry with the heartbeat op tag.
       expect(Sentry.captureException).toHaveBeenCalledWith(
         failure,
         expect.objectContaining({
@@ -117,7 +113,6 @@ describe('ServerEventsManager', () => {
           extra: expect.objectContaining({ client_id: client.id }),
         })
       );
-      // unsubAll fired — subscription map is empty.
       expect(mgr.getSubs(client.id)).toEqual([]);
     });
   });


### PR DESCRIPTION
## Summary

- Drops `ServerEventsManager`'s 5-minute `INACTIVITY_TIMEOUT_MS`, which only reset on named broadcasts/dispatches and would proactively disconnect healthy clients subscribed only to quiet topics (`mirror`, `primaryDj`, `liveFs` outside an active show).
- Adds a per-client 30 s SSE comment-heartbeat (`: keepalive\n\n`). The comment frame is silent to `addEventListener` consumers (per the SSE spec), matches the 30 s cadence tubafrenzy's upstream feed uses, and is well below typical L7-proxy idle thresholds (nginx 60 s, ALB 60 s).
- Heartbeat-only over heartbeat+raised-timeout: the comment write detects half-dead sockets (EPIPE, write-after-end) and routes through the same Sentry+`unsubAll` cleanup path as broadcast failures, and the existing `res.on('close')` listener handles TCP-level disconnects. No second timer needed.
- Reconciles the in-process SSE manager with the prose warning in `playlist-proxy.service.ts:189-200`.
- Heartbeat ticker is `.unref()`'d so idle SSE clients don't block SIGTERM, matching `startSseMetrics` in `sse-metrics.ts`.

## Test plan

- [x] `npm run test:unit -- tests/unit/utils/serverEvents.test.ts` — 15/15 pass
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- New unit tests cover: heartbeat fires at 30 s cadence and emits the `: keepalive\n\n` frame; a quiet-topic client survives 2 hours of silence (was disconnected at 5 min under the old timer); heartbeat stops after `disconnect()`; a failing heartbeat write triggers `Sentry.captureException` with the heartbeat op tag and clears the subscription map.

Closes #1130