### PR TITLE
refactor(cdc): split dispatcher from CDC_SECRET-gated WebSocket exposure

### DIFF
--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -22,7 +22,12 @@ import { proxy_route } from './routes/proxy.route.js';
 import { playlist_route } from './routes/playlist.route.js';
 import { startPlaylistProxy, stopPlaylistProxy } from './services/playlist-proxy.service.js';
 import { startAlbumPlaysRefresh, stopAlbumPlaysRefresh } from './services/album-plays-refresh.service.js';
-import { setupCdcWebSocket, shutdownCdcWebSocket } from './services/cdc/index.js';
+import {
+  setupCdcWebSocket,
+  shutdownCdcWebSocket,
+  startCdcDispatcher,
+  shutdownCdcDispatcher,
+} from './services/cdc/index.js';
 import { setupMetadataBroadcast } from './services/metadata-broadcast/index.js';
 import { startSseMetrics, stopSseMetrics } from './services/sse/sse-metrics.js';
 import { serverEventsMgr } from './utils/serverEvents.js';
@@ -143,13 +148,22 @@ const server = app.listen(port, () => {
   startPlaylistProxy();
   startAlbumPlaysRefresh();
   startSseMetrics(() => serverEventsMgr.getClientCountByTopic());
-  void setupCdcWebSocket(server);
+  // BS#1187: start the per-process CDC LISTEN unconditionally so in-process
+  // subscribers (`setupMetadataBroadcast()`, future consumers) work in
+  // environments that don't configure CDC_SECRET. The websocket fan-out
+  // remains hard-gated on the secret — it's the external exposure, not the
+  // listener owner.
+  void startCdcDispatcher();
   // Second CDC handler: rebroadcasts terminal metadata UPDATEs as SSE
   // `liveFs:update` so dj-site stays in sync after the enrichment-worker
   // (BS#892) finalizes a row. Closes BS#893 + BS#628. Registers a handler
   // on the same per-process LISTEN connection — independent of the
   // websocket handler, both fire on every event.
   setupMetadataBroadcast();
+  // The websocket exposure remains hard-gated on CDC_SECRET; the call is
+  // unconditional because `setupCdcWebSocket` self-no-ops (with the
+  // [cdc-ws] disabled log) when the secret is unset.
+  void setupCdcWebSocket(server);
   // One-shot warm of the rotation-tracks picker LRUs in
   // `library.service.ts`. Fire-and-forget — the walk shares the LML
   // semaphore with concurrent traffic, and the LRUs are process-local so
@@ -189,6 +203,7 @@ function shutdown(signal: string): void {
   stopAlbumPlaysRefresh();
   stopSseMetrics();
   void shutdownCdcWebSocket();
+  void shutdownCdcDispatcher();
   // BS#905: observe enrichments abandoned mid-flight. Sentry captureMessage
   // fires only when at least one promise is still pending after the deadline,
   // so a clean shutdown stays silent. Drain happens in parallel with

--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -148,11 +148,10 @@ const server = app.listen(port, () => {
   startPlaylistProxy();
   startAlbumPlaysRefresh();
   startSseMetrics(() => serverEventsMgr.getClientCountByTopic());
-  // BS#1187: start the per-process CDC LISTEN unconditionally so in-process
-  // subscribers (`setupMetadataBroadcast()`, future consumers) work in
-  // environments that don't configure CDC_SECRET. The websocket fan-out
-  // remains hard-gated on the secret — it's the external exposure, not the
-  // listener owner.
+  // LISTEN startup runs unconditionally so in-process subscribers
+  // (`setupMetadataBroadcast`, future consumers) fire whether or not
+  // CDC_SECRET is set (BS#1187). The websocket call below self-no-ops
+  // when the secret is unset.
   void startCdcDispatcher();
   // Second CDC handler: rebroadcasts terminal metadata UPDATEs as SSE
   // `liveFs:update` so dj-site stays in sync after the enrichment-worker
@@ -160,9 +159,6 @@ const server = app.listen(port, () => {
   // on the same per-process LISTEN connection — independent of the
   // websocket handler, both fire on every event.
   setupMetadataBroadcast();
-  // The websocket exposure remains hard-gated on CDC_SECRET; the call is
-  // unconditional because `setupCdcWebSocket` self-no-ops (with the
-  // [cdc-ws] disabled log) when the secret is unset.
   void setupCdcWebSocket(server);
   // One-shot warm of the rotation-tracks picker LRUs in
   // `library.service.ts`. Fire-and-forget — the walk shares the LML

--- a/apps/backend/services/cdc/cdc-websocket.ts
+++ b/apps/backend/services/cdc/cdc-websocket.ts
@@ -29,11 +29,8 @@ let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
  * Sets up the CDC WebSocket server on the given HTTP server.
  * Handles upgrade requests to /cdc, authenticates via query parameter,
  * and registers a fan-out handler against the shared CDC dispatcher.
- *
- * Caller is responsible for the `CDC_SECRET` gate at the call site
- * (see `apps/backend/app.ts`). The secret is re-read here only to defend
- * against an accidental direct call; the canonical "WS disabled" log lives
- * here so deploy verification still sees the same `[cdc-ws]` line.
+ * No-ops (with the canonical `[cdc-ws]` disabled log) when CDC_SECRET
+ * is unset — deploy verification matches the same log line.
  */
 export async function setupCdcWebSocket(server: HttpServer): Promise<void> {
   const secret = process.env.CDC_SECRET;
@@ -96,9 +93,7 @@ export async function setupCdcWebSocket(server: HttpServer): Promise<void> {
   }, HEARTBEAT_INTERVAL_MS);
   heartbeatTimer.unref();
 
-  // Register CDC event handler — fan out to the WebSocket clients only.
-  // The dispatcher's LISTEN is already running (see `app.ts` startup),
-  // so this is a pure subscription with no side effects on the listener.
+  // Per-event fan-out to connected WebSocket clients.
   onCdcEvent((event: CdcEvent) => {
     if (!wss || wss.clients.size === 0) return;
     const msg = JSON.stringify(event);

--- a/apps/backend/services/cdc/cdc-websocket.ts
+++ b/apps/backend/services/cdc/cdc-websocket.ts
@@ -3,14 +3,20 @@
  *
  * Attaches to the existing Express HTTP server via the 'upgrade' event,
  * filtered to the /cdc path. Authenticates connections via CDC_SECRET
- * query parameter. Broadcasts PostgreSQL CDC events (from LISTEN/NOTIFY)
- * to all connected clients.
+ * query parameter. Fans out PostgreSQL CDC events (received via the shared
+ * dispatcher's `onCdcEvent`) to all connected WebSocket clients.
+ *
+ * The LISTEN startup itself lives in `dispatcher.ts` (BS#1187): the
+ * dispatcher always runs so in-process subscribers like
+ * `setupMetadataBroadcast()` work whether or not `CDC_SECRET` is configured.
+ * This module owns only the external WebSocket exposure and remains
+ * hard-gated on `CDC_SECRET`.
  */
 
 import { Server as HttpServer, IncomingMessage } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { URL } from 'url';
-import { onCdcEvent, startCdcListener, stopCdcListener } from '@wxyc/database';
+import { onCdcEvent } from '@wxyc/database';
 import type { CdcEvent } from '@wxyc/database';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -22,7 +28,12 @@ let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 /**
  * Sets up the CDC WebSocket server on the given HTTP server.
  * Handles upgrade requests to /cdc, authenticates via query parameter,
- * and starts the PostgreSQL CDC listener.
+ * and registers a fan-out handler against the shared CDC dispatcher.
+ *
+ * Caller is responsible for the `CDC_SECRET` gate at the call site
+ * (see `apps/backend/app.ts`). The secret is re-read here only to defend
+ * against an accidental direct call; the canonical "WS disabled" log lives
+ * here so deploy verification still sees the same `[cdc-ws]` line.
  */
 export async function setupCdcWebSocket(server: HttpServer): Promise<void> {
   const secret = process.env.CDC_SECRET;
@@ -85,7 +96,9 @@ export async function setupCdcWebSocket(server: HttpServer): Promise<void> {
   }, HEARTBEAT_INTERVAL_MS);
   heartbeatTimer.unref();
 
-  // Register CDC event handler
+  // Register CDC event handler — fan out to the WebSocket clients only.
+  // The dispatcher's LISTEN is already running (see `app.ts` startup),
+  // so this is a pure subscription with no side effects on the listener.
   onCdcEvent((event: CdcEvent) => {
     if (!wss || wss.clients.size === 0) return;
     const msg = JSON.stringify(event);
@@ -98,13 +111,14 @@ export async function setupCdcWebSocket(server: HttpServer): Promise<void> {
     }
   });
 
-  // Start listening for PostgreSQL notifications
-  await startCdcListener();
   console.log(`[cdc-ws] CDC WebSocket ready at ${CDC_PATH}`);
 }
 
 /**
- * Shuts down the CDC WebSocket server and stops the PostgreSQL listener.
+ * Shuts down the CDC WebSocket server. Safe to call unconditionally —
+ * a no-op when the WebSocket was never set up (e.g. `CDC_SECRET` unset).
+ * The CDC LISTEN connection is owned by the dispatcher and torn down
+ * separately via `shutdownCdcDispatcher()`.
  */
 export async function shutdownCdcWebSocket(): Promise<void> {
   if (heartbeatTimer) {
@@ -120,6 +134,5 @@ export async function shutdownCdcWebSocket(): Promise<void> {
     wss = null;
   }
 
-  await stopCdcListener();
   console.log('[cdc-ws] CDC WebSocket shut down');
 }

--- a/apps/backend/services/cdc/dispatcher.ts
+++ b/apps/backend/services/cdc/dispatcher.ts
@@ -1,0 +1,31 @@
+/**
+ * CDC dispatcher: owns the per-process LISTEN connection.
+ *
+ * Split out from `cdc-websocket.ts` (BS#1187): the LISTEN startup must run
+ * independently of the WebSocket exposure so that in-process CDC subscribers
+ * (`setupMetadataBroadcast()`, future consumers) keep working in environments
+ * that don't configure `CDC_SECRET`. The websocket fan-out is one consumer of
+ * the dispatcher, not its owner.
+ *
+ * Wire format and `onCdcEvent` API are unchanged — both still come from
+ * `@wxyc/database` and remain the cross-consumer contract.
+ */
+
+import { startCdcListener, stopCdcListener } from '@wxyc/database';
+
+/**
+ * Starts the per-process CDC LISTEN connection. Idempotent at the listener
+ * layer (`startCdcListener` warns and returns on a second call). Call once
+ * at startup, before any consumer that registers via `onCdcEvent`.
+ */
+export async function startCdcDispatcher(): Promise<void> {
+  await startCdcListener();
+}
+
+/**
+ * Stops the per-process CDC LISTEN connection and clears registered
+ * callbacks. Safe to call unconditionally during shutdown.
+ */
+export async function shutdownCdcDispatcher(): Promise<void> {
+  await stopCdcListener();
+}

--- a/apps/backend/services/cdc/index.ts
+++ b/apps/backend/services/cdc/index.ts
@@ -1,1 +1,2 @@
 export { setupCdcWebSocket, shutdownCdcWebSocket } from './cdc-websocket.js';
+export { startCdcDispatcher, shutdownCdcDispatcher } from './dispatcher.js';

--- a/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
+++ b/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
@@ -79,9 +79,12 @@ export function filterMetadataUpdate(event: CdcEvent): LiveFsUpdatePayload | nul
 
 /**
  * Register the metadata-broadcast CDC handler. Call once at startup, after
- * `serverEventsMgr` is ready and alongside `setupCdcWebSocket()` — both
- * register independent `onCdcEvent` handlers against the same per-process
- * LISTEN connection (see `apps/backend/services/cdc/cdc-websocket.ts:89`).
+ * `serverEventsMgr` is ready. Sits alongside `setupCdcWebSocket()` — both
+ * register independent `onCdcEvent` handlers against the per-process LISTEN
+ * connection owned by `startCdcDispatcher()` (see
+ * `apps/backend/services/cdc/dispatcher.ts`). The dispatcher runs whether
+ * or not the websocket is configured (BS#1187), so this handler fires in
+ * environments without `CDC_SECRET`.
  */
 export function setupMetadataBroadcast(): void {
   onCdcEvent((event) => {

--- a/docs/cdc.md
+++ b/docs/cdc.md
@@ -28,7 +28,8 @@ PostgreSQL triggers (`cdc_notify()`) fire `pg_notify('cdc', payload)` on every I
 
 - `shared/database/src/migrations/0045_cdc_notify_triggers.sql` — trigger function + per-table triggers
 - `shared/database/src/cdc-listener.ts` — dedicated LISTEN connection and event dispatch
-- `apps/backend/services/cdc/cdc-websocket.ts` — WebSocket server with auth and heartbeat
+- `apps/backend/services/cdc/dispatcher.ts` — per-process LISTEN startup/shutdown. Runs unconditionally so in-process consumers (`metadata-broadcast`) work regardless of `CDC_SECRET` (BS#1187)
+- `apps/backend/services/cdc/cdc-websocket.ts` — WebSocket server with auth and heartbeat; gated on `CDC_SECRET` (external-listener channel only)
 
 ## Reconciliation monitor
 

--- a/tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts
+++ b/tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts
@@ -54,6 +54,19 @@ const makeServer = (): HttpServer => {
   return server as unknown as HttpServer;
 };
 
+/** Run `fn` with CDC_SECRET pinned to `value` (or unset when `null`) and restore the prior value afterwards. */
+async function withCdcSecret(value: string | null, fn: () => Promise<void>): Promise<void> {
+  const prev = process.env.CDC_SECRET;
+  if (value === null) delete process.env.CDC_SECRET;
+  else process.env.CDC_SECRET = value;
+  try {
+    await fn();
+  } finally {
+    if (prev === undefined) delete process.env.CDC_SECRET;
+    else process.env.CDC_SECRET = prev;
+  }
+}
+
 describe('startCdcDispatcher (BS#1187)', () => {
   // The dispatcher must own LISTEN startup so in-process subscribers
   // (`setupMetadataBroadcast`, future consumers) work whether or not the
@@ -64,14 +77,10 @@ describe('startCdcDispatcher (BS#1187)', () => {
   });
 
   it('calls startCdcListener regardless of CDC_SECRET', async () => {
-    const prev = process.env.CDC_SECRET;
-    delete process.env.CDC_SECRET;
-    try {
+    await withCdcSecret(null, async () => {
       await startCdcDispatcher();
       expect(startCdcListener).toHaveBeenCalledTimes(1);
-    } finally {
-      if (prev !== undefined) process.env.CDC_SECRET = prev;
-    }
+    });
   });
 
   it('does not register an onCdcEvent handler itself — that is the consumers job', async () => {
@@ -109,9 +118,7 @@ describe('setupCdcWebSocket (BS#1187)', () => {
   });
 
   it('no-ops with the [cdc-ws] disabled log when CDC_SECRET is unset', async () => {
-    const prev = process.env.CDC_SECRET;
-    delete process.env.CDC_SECRET;
-    try {
+    await withCdcSecret(null, async () => {
       await setupCdcWebSocket(makeServer());
 
       // Deploy-verification contract: this exact line was preserved across
@@ -119,37 +126,27 @@ describe('setupCdcWebSocket (BS#1187)', () => {
       expect(consoleLogSpy).toHaveBeenCalledWith('[cdc-ws] CDC_SECRET not set, CDC WebSocket disabled');
       expect(WebSocketServer).not.toHaveBeenCalled();
       // The decoupling guarantee: the websocket path no longer touches the
-      // listener. If this assertion regresses, in-process subscribers will
-      // silently lose events in CDC_SECRET-less environments — the exact
-      // bug BS#1187 fixed.
+      // listener. Regressing this would silently disable in-process
+      // subscribers in CDC_SECRET-less environments (the BS#1187 bug).
       expect(startCdcListener).not.toHaveBeenCalled();
       expect(onCdcEvent).not.toHaveBeenCalled();
-    } finally {
-      if (prev !== undefined) process.env.CDC_SECRET = prev;
-    }
+    });
   });
 
   it('binds the WebSocketServer and registers a fan-out handler when CDC_SECRET is set', async () => {
-    const prev = process.env.CDC_SECRET;
-    process.env.CDC_SECRET = 'test-secret';
-    try {
+    await withCdcSecret('test-secret', async () => {
       const server = makeServer();
-      await setupCdcWebSocket(server);
+      try {
+        await setupCdcWebSocket(server);
 
-      expect(WebSocketServer).toHaveBeenCalledTimes(1);
-      expect(server.on).toHaveBeenCalledWith('upgrade', expect.any(Function));
-      // The fan-out handler — the websocket's only consumer of the shared
-      // dispatcher. LISTEN startup itself stays in the dispatcher.
-      expect(onCdcEvent).toHaveBeenCalledTimes(1);
-      expect(startCdcListener).not.toHaveBeenCalled();
-    } finally {
-      if (prev !== undefined) {
-        process.env.CDC_SECRET = prev;
-      } else {
-        delete process.env.CDC_SECRET;
+        expect(WebSocketServer).toHaveBeenCalledTimes(1);
+        expect(server.on).toHaveBeenCalledWith('upgrade', expect.any(Function));
+        expect(onCdcEvent).toHaveBeenCalledTimes(1);
+        expect(startCdcListener).not.toHaveBeenCalled();
+      } finally {
+        await shutdownCdcWebSocket();
       }
-      await shutdownCdcWebSocket();
-    }
+    });
   });
 });
 

--- a/tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts
+++ b/tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the CDC dispatcher / websocket split (BS#1187).
+ *
+ * Pre-BS#1187, `setupCdcWebSocket` owned both the WebSocket exposure AND
+ * the per-process `startCdcListener()` call. A missing `CDC_SECRET` short-
+ * circuited the function before the LISTEN ever started, which silently
+ * disabled every in-process subscriber that registered via `onCdcEvent`
+ * — most importantly `setupMetadataBroadcast()`, the dj-site
+ * `liveFs:update` SSE bridge.
+ *
+ * Pin the new shape:
+ *   1. `startCdcDispatcher()` calls `startCdcListener()` unconditionally.
+ *   2. `setupCdcWebSocket()` is still secret-gated; no LISTEN side effect.
+ *   3. With `CDC_SECRET` unset: dispatcher started, log emitted, no LISTEN
+ *      call from the websocket path, no WebSocketServer bound.
+ *   4. With `CDC_SECRET` set: dispatcher started, websocket fan-out
+ *      handler registered, no second LISTEN start.
+ *
+ * The metadata-broadcast subscriber's actual filtering is covered in
+ * `metadata-broadcast.test.ts`; this file pins the wiring contract that
+ * lets it fire in the first place.
+ */
+
+jest.mock('@wxyc/database', () => ({
+  onCdcEvent: jest.fn(),
+  startCdcListener: jest.fn().mockResolvedValue(undefined),
+  stopCdcListener: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('ws', () => {
+  const onMock = jest.fn();
+  const closeMock = jest.fn();
+  const WebSocketServer = jest.fn().mockImplementation(() => ({
+    on: onMock,
+    close: closeMock,
+    clients: new Set(),
+    handleUpgrade: jest.fn(),
+    emit: jest.fn(),
+  }));
+  return {
+    WebSocketServer,
+    WebSocket: { OPEN: 1 },
+  };
+});
+
+import type { Server as HttpServer } from 'http';
+import { onCdcEvent, startCdcListener, stopCdcListener } from '@wxyc/database';
+import { WebSocketServer } from 'ws';
+import { setupCdcWebSocket, shutdownCdcWebSocket } from '../../../../../../apps/backend/services/cdc/cdc-websocket';
+import { startCdcDispatcher, shutdownCdcDispatcher } from '../../../../../../apps/backend/services/cdc/dispatcher';
+
+const makeServer = (): HttpServer => {
+  const server = { on: jest.fn(), setTimeout: jest.fn() };
+  return server as unknown as HttpServer;
+};
+
+describe('startCdcDispatcher (BS#1187)', () => {
+  // The dispatcher must own LISTEN startup so in-process subscribers
+  // (`setupMetadataBroadcast`, future consumers) work whether or not the
+  // websocket is configured. This was the silent-failure mode pre-#1187.
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls startCdcListener regardless of CDC_SECRET', async () => {
+    const prev = process.env.CDC_SECRET;
+    delete process.env.CDC_SECRET;
+    try {
+      await startCdcDispatcher();
+      expect(startCdcListener).toHaveBeenCalledTimes(1);
+    } finally {
+      if (prev !== undefined) process.env.CDC_SECRET = prev;
+    }
+  });
+
+  it('does not register an onCdcEvent handler itself — that is the consumers job', async () => {
+    await startCdcDispatcher();
+    expect(onCdcEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not start a WebSocketServer', async () => {
+    await startCdcDispatcher();
+    expect(WebSocketServer).not.toHaveBeenCalled();
+  });
+});
+
+describe('shutdownCdcDispatcher (BS#1187)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls stopCdcListener', async () => {
+    await shutdownCdcDispatcher();
+    expect(stopCdcListener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('setupCdcWebSocket (BS#1187)', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('no-ops with the [cdc-ws] disabled log when CDC_SECRET is unset', async () => {
+    const prev = process.env.CDC_SECRET;
+    delete process.env.CDC_SECRET;
+    try {
+      await setupCdcWebSocket(makeServer());
+
+      // Deploy-verification contract: this exact line was preserved across
+      // the BS#1187 split so log-tail dashboards keep matching.
+      expect(consoleLogSpy).toHaveBeenCalledWith('[cdc-ws] CDC_SECRET not set, CDC WebSocket disabled');
+      expect(WebSocketServer).not.toHaveBeenCalled();
+      // The decoupling guarantee: the websocket path no longer touches the
+      // listener. If this assertion regresses, in-process subscribers will
+      // silently lose events in CDC_SECRET-less environments — the exact
+      // bug BS#1187 fixed.
+      expect(startCdcListener).not.toHaveBeenCalled();
+      expect(onCdcEvent).not.toHaveBeenCalled();
+    } finally {
+      if (prev !== undefined) process.env.CDC_SECRET = prev;
+    }
+  });
+
+  it('binds the WebSocketServer and registers a fan-out handler when CDC_SECRET is set', async () => {
+    const prev = process.env.CDC_SECRET;
+    process.env.CDC_SECRET = 'test-secret';
+    try {
+      const server = makeServer();
+      await setupCdcWebSocket(server);
+
+      expect(WebSocketServer).toHaveBeenCalledTimes(1);
+      expect(server.on).toHaveBeenCalledWith('upgrade', expect.any(Function));
+      // The fan-out handler — the websocket's only consumer of the shared
+      // dispatcher. LISTEN startup itself stays in the dispatcher.
+      expect(onCdcEvent).toHaveBeenCalledTimes(1);
+      expect(startCdcListener).not.toHaveBeenCalled();
+    } finally {
+      if (prev !== undefined) {
+        process.env.CDC_SECRET = prev;
+      } else {
+        delete process.env.CDC_SECRET;
+      }
+      await shutdownCdcWebSocket();
+    }
+  });
+});
+
+describe('shutdownCdcWebSocket (BS#1187)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not call stopCdcListener — the dispatcher owns the LISTEN lifecycle', async () => {
+    await shutdownCdcWebSocket();
+    expect(stopCdcListener).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted `startCdcDispatcher()` / `shutdownCdcDispatcher()` into a sibling `apps/backend/services/cdc/dispatcher.ts`. The per-process LISTEN now starts unconditionally so `setupMetadataBroadcast()` (and any future in-process `onCdcEvent` consumer) fires whether or not `CDC_SECRET` is configured.
- `setupCdcWebSocket(server)` keeps the `CDC_SECRET` gate, the `WebSocketServer` setup, the upgrade handler, the heartbeat, and the per-client fan-out. It no longer owns the LISTEN. The `[cdc-ws] CDC_SECRET not set, CDC WebSocket disabled` log is preserved so deploy verification still matches.
- `app.ts` calls `startCdcDispatcher()` before `setupMetadataBroadcast()`; `setupCdcWebSocket()` stays self-no-opping when the secret is unset (single source for the deploy log).
- New `tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts` pins the split: dispatcher starts LISTEN regardless of secret; websocket path no longer touches the listener; secret-set path still binds the WebSocketServer + registers exactly one fan-out handler.
- `docs/cdc.md` and the metadata-broadcast doc-comment updated to reflect the new owner of the LISTEN lifecycle.

Once this lands, the placeholder `CDC_SECRET=e2e-cdc-secret-not-used-by-tests` exports in dj-site's E2E infra can be removed in a follow-up dj-site PR.

Closes #1187