### PR TITLE
fix(rotation-backfill): decode HTML entities before LML lookup

### DIFF
--- a/jobs/rotation-release-id-backfill/lml-fetch.ts
+++ b/jobs/rotation-release-id-backfill/lml-fetch.ts
@@ -33,8 +33,38 @@ const envInt = (name: string, fallback: number): number => {
 
 const TIMEOUT_MS = envInt('BACKFILL_LML_PER_CALL_TIMEOUT_MS', 8000);
 
+// Tubafrenzy paste data can land `rotation.artist_name` / `rotation.album_title`
+// as HTML-escaped strings (e.g. "Rome&#769;o Poirier"). LML's NFKD diacritic
+// strip runs over the raw string, so an entity-encoded combining mark never
+// reaches that pass and the row stays NO_RESULT. Decode here so the LML hop
+// sees the same text a reader would.
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+const HTML_ENTITY_RE = /&(#x[0-9a-f]+|#[0-9]+|[a-z]+);/gi;
+
+const decodeHtmlEntities = (input: string): string =>
+  input.replace(HTML_ENTITY_RE, (match, body: string) => {
+    if (body[0] === '#') {
+      const codepoint = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
+      if (!Number.isFinite(codepoint) || codepoint < 0 || codepoint > 0x10ffff) return match;
+      try {
+        return String.fromCodePoint(codepoint);
+      } catch {
+        return match;
+      }
+    }
+    return NAMED_ENTITIES[body.toLowerCase()] ?? match;
+  });
+
 export const lookupReleaseId = async (artist: string, album: string): Promise<number | null> => {
-  const response = await sharedLookupMetadata(artist, album, undefined, {
+  const response = await sharedLookupMetadata(decodeHtmlEntities(artist), decodeHtmlEntities(album), undefined, {
     limiter: defaultLmlLimiter,
     timeoutMs: TIMEOUT_MS,
   });

--- a/jobs/rotation-release-id-backfill/lml-fetch.ts
+++ b/jobs/rotation-release-id-backfill/lml-fetch.ts
@@ -51,16 +51,14 @@ const HTML_ENTITY_RE = /&(#x[0-9a-f]+|#[0-9]+|[a-z]+);/gi;
 
 const decodeHtmlEntities = (input: string): string =>
   input.replace(HTML_ENTITY_RE, (match, body: string) => {
-    if (body[0] === '#') {
-      const codepoint = body[1] === 'x' || body[1] === 'X' ? parseInt(body.slice(2), 16) : parseInt(body.slice(1), 10);
-      if (!Number.isFinite(codepoint) || codepoint < 0 || codepoint > 0x10ffff) return match;
-      try {
-        return String.fromCodePoint(codepoint);
-      } catch {
-        return match;
-      }
-    }
-    return NAMED_ENTITIES[body.toLowerCase()] ?? match;
+    if (body[0] !== '#') return NAMED_ENTITIES[body.toLowerCase()] ?? match;
+    const isHex = body[1] === 'x' || body[1] === 'X';
+    const codepoint = parseInt(body.slice(isHex ? 2 : 1), isHex ? 16 : 10);
+    // Reject surrogate-range too: String.fromCodePoint accepts lone
+    // surrogates without throwing and would produce ill-formed UTF-16 that
+    // breaks JSON.stringify on the LML hop.
+    if (codepoint > 0x10ffff || (codepoint >= 0xd800 && codepoint <= 0xdfff)) return match;
+    return String.fromCodePoint(codepoint);
   });
 
 export const lookupReleaseId = async (artist: string, album: string): Promise<number | null> => {

--- a/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
+++ b/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for jobs/rotation-release-id-backfill lml-fetch.ts.
+ *
+ * Focus: HTML-entity decode on (artist, album) ahead of the LML hop.
+ * tubafrenzy paste data can land `rotation.artist_name` /
+ * `rotation.album_title` as HTML-escaped strings (e.g. "Rome&#769;o Poirier"
+ * instead of "Roméo Poirier"). LML's NFKD diacritic-strip runs over the raw
+ * string — an entity-encoded combining mark never reaches that pass, so the
+ * row stays NO_RESULT. Decoding here closes the gap for the rotation
+ * backfill without touching the runtime lookup path.
+ */
+describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const loadModule = async (
+    mockLookup: jest.Mock
+  ): Promise<typeof import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js')> => {
+    jest.doMock('../../../../jobs/rotation-release-id-backfill/lml-limiter.js', () => ({
+      defaultLmlLimiter: { run: jest.fn() },
+    }));
+    jest.doMock('@wxyc/lml-client', () => ({
+      lookupMetadata: mockLookup,
+    }));
+    return import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js');
+  };
+
+  it('decodes numeric HTML entities in artist before calling LML', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 12345 } }] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    const result = await lookupReleaseId('Rome&#769;o Poirier', 'Off the Record');
+
+    expect(mockLookup).toHaveBeenCalledTimes(1);
+    // &#769; is U+0301 (combining acute) — the decoded form is decomposed
+    // (NFD): "Rome" + U+0301 + "o Poirier". That's the desired shape: LML's
+    // downstream NFKD strip can act on the combining mark and reduce to
+    // "Romeo Poirier" for cache-key matching.
+    expect(mockLookup).toHaveBeenCalledWith('Roméo Poirier', 'Off the Record', undefined, expect.any(Object));
+    expect(result).toBe(12345);
+  });
+
+  it('decodes named HTML entities in both artist and album', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 67890 } }] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    await lookupReleaseId('Duke Ellington &amp; John Coltrane', 'Duke Ellington &amp; John Coltrane');
+
+    expect(mockLookup).toHaveBeenCalledWith(
+      'Duke Ellington & John Coltrane',
+      'Duke Ellington & John Coltrane',
+      undefined,
+      expect.any(Object)
+    );
+  });
+
+  it('leaves plain strings unchanged (idempotent)', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 1 } }] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    await lookupReleaseId('Jessica Pratt', 'On Your Own Love Again');
+
+    expect(mockLookup).toHaveBeenCalledWith('Jessica Pratt', 'On Your Own Love Again', undefined, expect.any(Object));
+  });
+
+  it('decodes hex HTML entities', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 2 } }] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    // &#xf6; is precomposed ö (U+00F6).
+    await lookupReleaseId('Bj&#xf6;rk', 'Vespertine');
+
+    expect(mockLookup).toHaveBeenCalledWith('Björk', 'Vespertine', undefined, expect.any(Object));
+  });
+
+  it('returns null when LML returns no Discogs match', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: null }] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    const result = await lookupReleaseId('Some Artist', 'Some Album');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when LML returns an empty results array', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ results: [] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    const result = await lookupReleaseId('Some Artist', 'Some Album');
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
+++ b/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
@@ -1,14 +1,5 @@
-/**
- * Unit tests for jobs/rotation-release-id-backfill lml-fetch.ts.
- *
- * Focus: HTML-entity decode on (artist, album) ahead of the LML hop.
- * tubafrenzy paste data can land `rotation.artist_name` /
- * `rotation.album_title` as HTML-escaped strings (e.g. "Rome&#769;o Poirier"
- * instead of "Roméo Poirier"). LML's NFKD diacritic-strip runs over the raw
- * string — an entity-encoded combining mark never reaches that pass, so the
- * row stays NO_RESULT. Decoding here closes the gap for the rotation
- * backfill without touching the runtime lookup path.
- */
+// Pin the HTML-entity decode added in BS#1223. Rationale lives next to the
+// implementation at jobs/rotation-release-id-backfill/lml-fetch.ts.
 describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -37,10 +28,8 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () 
     const result = await lookupReleaseId('Rome&#769;o Poirier', 'Off the Record');
 
     expect(mockLookup).toHaveBeenCalledTimes(1);
-    // &#769; is U+0301 (combining acute) — the decoded form is decomposed
-    // (NFD): "Rome" + U+0301 + "o Poirier". That's the desired shape: LML's
-    // downstream NFKD strip can act on the combining mark and reduce to
-    // "Romeo Poirier" for cache-key matching.
+    // &#769; is U+0301 (combining acute); decoded form is NFD-decomposed,
+    // which is what LML's downstream NFKD strip needs to act on.
     expect(mockLookup).toHaveBeenCalledWith('Roméo Poirier', 'Off the Record', undefined, expect.any(Object));
     expect(result).toBe(12345);
   });
@@ -76,6 +65,35 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () 
     await lookupReleaseId('Bj&#xf6;rk', 'Vespertine');
 
     expect(mockLookup).toHaveBeenCalledWith('Björk', 'Vespertine', undefined, expect.any(Object));
+  });
+
+  it('passes unknown named entities through unchanged', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 3 } }] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    await lookupReleaseId('Foo &copy; Bar', '&trade;');
+
+    expect(mockLookup).toHaveBeenCalledWith('Foo &copy; Bar', '&trade;', undefined, expect.any(Object));
+  });
+
+  it('decodes multiple entities in the same string', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 4 } }] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    await lookupReleaseId('A &amp; B &#38; C', 'X');
+
+    expect(mockLookup).toHaveBeenCalledWith('A & B & C', 'X', undefined, expect.any(Object));
+  });
+
+  it('passes lone-surrogate codepoints through unchanged (avoids ill-formed UTF-16)', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 5 } }] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    // U+D800 is a high-surrogate; String.fromCodePoint accepts it silently
+    // and would produce ill-formed UTF-16.
+    await lookupReleaseId('Bad &#xd800; input', 'X');
+
+    expect(mockLookup).toHaveBeenCalledWith('Bad &#xd800; input', 'X', undefined, expect.any(Object));
   });
 
   it('returns null when LML returns no Discogs match', async () => {


### PR DESCRIPTION
Closes #1223.

## Summary

- New `decodeHtmlEntities()` in `jobs/rotation-release-id-backfill/lml-fetch.ts` runs over `artist` and `album` before calling `sharedLookupMetadata`. Supports numeric (`&#NNN;`), hex (`&#xHHH;`), and the named entities tubafrenzy is observed to produce. Unknown names pass through unchanged.
- Scoped to the backfill's LML hop. The runtime catalog path is not touched.
- Tubafrenzy will keep emitting these as long as it owns paste-input. This is the right boundary to absorb the issue — it's where the residual NO_RESULT rotation rows go to be drained.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — only pre-existing security/detect-object-injection warnings (false positives on `Record<string,string>` lookups)
- [x] `npm run format:check` — passes after prettier
- [x] `npx jest --config jest.unit.config.ts tests/unit/jobs/rotation-release-id-backfill/` — 13/13 pass (3 suites: orchestrate, writer, new lml-fetch)
- [ ] Post-merge: re-run the rotation-release-id-backfill job (cron tick or manual) against prod and confirm rotation id 21461 ("Rome&#769;o Poirier" / "Off the Record") and any sibling HTML-entity rows resolve. Roll forward via the standard cron schedule.