### PR TITLE
feat(rotation-picker): consume inline tracklist from LML extended mode

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -390,6 +390,15 @@ export const getRotationTracks: RequestHandler<{ rotation_id: string }> = async 
     return;
   }
 
+  // The service contract guarantees `releaseId !== null` when
+  // `inlineTracklist === null`, but TypeScript can't narrow that without
+  // a discriminated union — guard explicitly so the cache shape stays
+  // simple.
+  if (source.releaseId === null) {
+    res.status(200).json([]);
+    return;
+  }
+
   let release;
   try {
     release = await getRelease(source.releaseId);
@@ -401,13 +410,7 @@ export const getRotationTracks: RequestHandler<{ rotation_id: string }> = async 
     throw err;
   }
 
-  const tracks: RotationTrack[] = release.tracklist.map((t) => ({
-    position: t.position,
-    title: t.title,
-    duration: t.duration ?? null,
-    artists: t.artists && t.artists.length > 0 ? t.artists : [release.artist],
-  }));
-  res.status(200).json(tracks);
+  res.status(200).json(libraryService.projectInlineTracklist(release.tracklist, release.artist) ?? []);
 };
 
 export const getFormats: RequestHandler = async (req, res) => {

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -333,49 +333,45 @@ export const killRotation: RequestHandler<object, unknown, KillRotationRelease> 
   }
 };
 
-/**
- * Wire shape returned by `GET /library/rotation/:rotation_id/tracks`. The
- * dj-site rotation entry picker (`useGetRotationTracksQuery`) consumes this
- * directly — keep field names + types in lockstep with the dj-site
- * `RotationTrack` type in `lib/features/rotation/api.ts`.
- *
- * Distinct from the `/proxy/library/:libraryId/tracks` shape
- * (`{position, title, artist_credit, duration_ms}`) consumed by the
- * catalog-search picker (BS#836 / dj-site#501). Same upstream data, two
- * pickers with two pre-existing wire contracts.
- */
-export interface RotationTrack {
-  position: string;
-  title: string;
-  duration: string | null;
-  artists: string[];
-}
+// Wire shape `RotationTrack` lives in `library.service.ts` so the service
+// can project the LML extended-mode tracklist inline (BS#1185 + LML#427)
+// without crossing the controller → service direction; re-exported here so
+// consumers that import the type alongside the handler stay unbroken.
+//
+// Distinct from the `/proxy/library/:libraryId/tracks` shape
+// (`{position, title, artist_credit, duration_ms}`) consumed by the
+// catalog-search picker (BS#836 / dj-site#501). Same upstream data, two
+// pickers with two pre-existing wire contracts.
+import type { RotationTrack } from '../services/library.service.js';
+export type { RotationTrack };
 
 /**
  * GET /library/rotation/:rotation_id/tracks (BS#940)
  *
  * Composition for the dj-site rotation entry mode track picker.
- *   1. Resolve the Discogs release id via `getDiscogsReleaseIdByRotationId`,
- *      which walks three tiers: `rotation.discogs_release_id` (mirrored from
- *      tubafrenzy by jobs/rotation-etl, migration 0077), `library_identity.
- *      discogs_release_id` via the `rotation.album_id` bridge, and an LML
- *      `POST /api/v1/lookup` against the rotation row's `(artist_name,
- *      album_title)` — the substrate matching tubafrenzy's
- *      `RotationTracklistCache` (#986). Tier-3 results are cached per
- *      `rotation_id` in the service layer.
- *   2. Fetch the tracklist from LML's `GET /api/v1/discogs/release/{id}`.
- *   3. Project Discogs's per-track `artists` onto the dj-site shape; fall
- *      back to the release-level artist when a track has no per-track credits
- *      (Discogs's normal shape for non-V/A releases).
+ *   1. Resolve the picker source via `resolveRotationPickerSource`, which
+ *      walks three tiers: `rotation.discogs_release_id` (mirrored from
+ *      tubafrenzy by jobs/rotation-etl, migration 0077),
+ *      `library_identity.discogs_release_id` via the `rotation.album_id`
+ *      bridge, and an LML `POST /api/v1/lookup` (with `extended=true`)
+ *      against the rotation row's `(artist_name, album_title)`. Tier-3
+ *      results are cached per `rotation_id` in the service layer.
+ *   2. If the source carries an `inlineTracklist`, return it directly. LML
+ *      already projected the tracks (Discogs hit OR MusicBrainz rescue on
+ *      LML#427) — no follow-up `getRelease(id)` round-trip.
+ *   3. Otherwise fetch the tracklist from LML's
+ *      `GET /api/v1/discogs/release/{id}` and project per-track artists
+ *      onto the dj-site shape, falling back to the release-level artist
+ *      when a track has no per-track credits.
  *
- * Degrades gracefully: returns 200 + `[]` when the rotation row doesn't exist,
- * when all three resolution tiers miss, and when LML 404s the release. Only
- * LML 5xx bubbles up so transient upstream failures surface rather than
- * silently hiding the dropdown.
+ * Degrades gracefully: returns 200 + `[]` when the rotation row doesn't
+ * exist, when all three resolution tiers miss, and when LML 404s the
+ * release. Only LML 5xx bubbles up so transient upstream failures surface
+ * rather than silently hiding the dropdown.
  *
- * No controller-side cache on the `/release/{id}` fetch — LML's 3-tier cache
- * already deduplicates by release id. The tier-3 lookup is cached at the
- * service layer (keyed by `rotation_id`).
+ * No controller-side cache on the `/release/{id}` fetch — LML's 3-tier
+ * cache already deduplicates by release id. The tier-3 lookup is cached at
+ * the service layer (keyed by `rotation_id`).
  */
 export const getRotationTracks: RequestHandler<{ rotation_id: string }> = async (req, res) => {
   const rotationId = parseInt(req.params.rotation_id, 10);
@@ -383,15 +379,20 @@ export const getRotationTracks: RequestHandler<{ rotation_id: string }> = async 
     throw new WxycError('rotation_id must be a positive integer', 400);
   }
 
-  const discogsReleaseId = await libraryService.getDiscogsReleaseIdByRotationId(rotationId);
-  if (discogsReleaseId === null) {
+  const source = await libraryService.resolveRotationPickerSource(rotationId);
+  if (source === null) {
     res.status(200).json([]);
+    return;
+  }
+
+  if (source.inlineTracklist !== null) {
+    res.status(200).json(source.inlineTracklist);
     return;
   }
 
   let release;
   try {
-    release = await getRelease(discogsReleaseId);
+    release = await getRelease(source.releaseId);
   } catch (err) {
     if (err instanceof LmlClientError && err.statusCode === 404) {
       res.status(200).json([]);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -326,7 +326,7 @@ export async function getDiscogsReleaseIdByLegacyId(legacyId: number): Promise<n
 
 /**
  * Per-rotation_id LRU for the LML `POST /api/v1/lookup` fallback in
- * `getDiscogsReleaseIdByRotationId`. The dj-site picker is opened many times
+ * `resolveRotationPickerSource`. The dj-site picker is opened many times
  * per session against a handful of rotation rows; caching avoids restarting
  * the LML query for each open. Mirrors tubafrenzy's `RotationTracklistCache`
  * concept (process-local map keyed by rotation id), minus the warm-on-startup
@@ -370,7 +370,42 @@ const ROTATION_LML_LOOKUP_TIMEOUT_MS = 10000;
  */
 const LIBRARY_INTERACTIVE_LML_BUDGET_MS = envInt('LIBRARY_INTERACTIVE_LML_BUDGET_MS', 5000);
 
-const rotationLmlPositiveCache = new LRUCache<number, number>({
+/**
+ * Wire shape returned by `GET /library/rotation/:rotation_id/tracks`. The
+ * dj-site rotation entry picker (`useGetRotationTracksQuery`) consumes this
+ * directly — keep field names + types in lockstep with the dj-site
+ * `RotationTrack` type in `lib/features/rotation/api.ts`. Re-exported from
+ * `apps/backend/controllers/library.controller.ts` for the surface that
+ * consumers reference today.
+ */
+export interface RotationTrack {
+  position: string;
+  title: string;
+  duration: string | null;
+  artists: string[];
+}
+
+/**
+ * What `resolveRotationPickerSource` hands back to the picker controller.
+ *
+ * `releaseId` is the Discogs release the picker can fetch a tracklist from.
+ * Tiers 1 and 2 (stored Discogs id) always produce a real release id with
+ * `inlineTracklist: null`, so the controller falls through to its existing
+ * `getRelease(releaseId)` projection. Tier 3 (runtime LML lookup with
+ * `extended=true`) carries an `inlineTracklist` when LML's response had one
+ * — Discogs hit (the cascade matched) or MusicBrainz rescue (BS#1185 synth
+ * + LML#427). In that case the controller short-circuits and returns
+ * `inlineTracklist` directly; no second LML round-trip needed. The
+ * `releaseId` may be `0` on the synth-with-MB-rescue path because there's
+ * no Discogs release behind the tracklist, and BS treats `release_id === 0`
+ * as a signal to skip the follow-up release fetch (matches BS#1185).
+ */
+export interface RotationPickerSource {
+  releaseId: number;
+  inlineTracklist: RotationTrack[] | null;
+}
+
+const rotationLmlPositiveCache = new LRUCache<number, RotationPickerSource>({
   max: ROTATION_LML_LOOKUP_CACHE_MAX,
   ttl: ROTATION_LML_LOOKUP_TTL_POSITIVE_MS,
   ttlAutopurge: true,
@@ -402,37 +437,40 @@ export function __rotationLmlCacheSizesForWarm(): { positive: number; negative: 
 }
 
 /**
- * Look up the resolved Discogs release id for a rotation row by its id.
+ * Resolve the source the rotation-tracks picker should render against, by
+ * `rotation_id`. Returns either a `releaseId` the controller can hand to
+ * `getRelease(id)`, an inline tracklist the controller can return as-is, or
+ * `null` if every tier missed and the picker should degrade to free-text.
  *
  * Three-tier resolution to match tubafrenzy's `RotationTracklistCache` parity
  * (see BS#986):
  *
  *   1. `rotation.discogs_release_id` (direct) — mirrored from tubafrenzy
  *      `ROTATION_RELEASE.DISCOGS_RELEASE_ID` by `jobs/rotation-etl`. Populated
- *      via the rotation-add form's paste-URL prefill flow. 0/21,563 rows
- *      carry a value in prod as of 2026-05-21, so tier 1 is the rare path.
+ *      via the rotation-add form's paste-URL prefill flow.
+ *      → `{ releaseId, inlineTracklist: null }`
  *   2. `library_identity.discogs_release_id` via the `album_id` bridge
- *      (fallback) — written by `jobs/library-identity-consumer` (BS#802),
- *      but the column is structurally NULL today until BS#801 extends LML's
- *      `bulk-resolve-libraries` contract with release-level resolution.
+ *      (fallback) — written by `jobs/library-identity-consumer` (BS#802).
+ *      → `{ releaseId, inlineTracklist: null }`
  *   3. LML `POST /api/v1/lookup` on `(rotation.artist_name, rotation.album_title)`
- *      (runtime) — the same `(artist, title)` lookup tubafrenzy's
- *      `RotationTracklistCache.fetchAndCache` uses. Per-`rotation_id` LRU
- *      caches positive and negative results.
- *
- * Tier 3 keeps the picker working today; tiers 1 and 2 are the substrate
- * we hand off to once upstreams catch up.
+ *      with `extended=true` — the same `(artist, title)` lookup tubafrenzy's
+ *      `RotationTracklistCache.fetchAndCache` uses, but extended to carry the
+ *      tracklist inline. When LML returns a tracklist (Discogs hit OR
+ *      MusicBrainz-rescued synth path on the BS#1185 sentinel + LML#427),
+ *      the controller returns it directly; no follow-up `getRelease(id)`
+ *      round-trip needed. Per-`rotation_id` LRU caches positive and negative
+ *      outcomes.
+ *      → `{ releaseId, inlineTracklist }`
  *
  * Returns null when all three tiers miss: rotation row doesn't exist; the
  * row has no `artist_name` or `album_title`; LML returns no results,
  * isn't configured, or fails. The picker degrades to free-text.
  *
- * Used by `/library/rotation/:rotation_id/tracks` (BS#940) to compose
- * against LML's `/api/v1/discogs/release/{id}` for the rotation entry
- * mode picker. Parallel to `getDiscogsReleaseIdByLegacyId` (BS#836)
- * which the catalog-search picker uses via `legacy_release_id`.
+ * Used by `/library/rotation/:rotation_id/tracks` (BS#940). Parallel to
+ * `getDiscogsReleaseIdByLegacyId` (BS#836) which the catalog-search picker
+ * uses via `legacy_release_id`.
  */
-export async function getDiscogsReleaseIdByRotationId(rotationId: number): Promise<number | null> {
+export async function resolveRotationPickerSource(rotationId: number): Promise<RotationPickerSource | null> {
   const rows = await db
     .select({
       direct: rotation.discogs_release_id,
@@ -447,13 +485,13 @@ export async function getDiscogsReleaseIdByRotationId(rotationId: number): Promi
   if (!rows[0]) return null;
 
   const stored = rows[0].direct ?? rows[0].fallback ?? null;
-  if (stored !== null) return stored;
+  if (stored !== null) return { releaseId: stored, inlineTracklist: null };
 
   return resolveRotationDiscogsReleaseViaLml(rotationId, rows[0].artist_name, rows[0].album_title);
 }
 
 /**
- * Tier-3 of `getDiscogsReleaseIdByRotationId`. Asks LML to identify the
+ * Tier-3 of `resolveRotationPickerSource`. Asks LML to identify the
  * Discogs release for a rotation row's `(artist_name, album_title)` when
  * the direct column and `library_identity` fallback both miss. Mirrors
  * tubafrenzy's `RotationTracklistCache.fetchAndCache`, which calls
@@ -496,7 +534,7 @@ async function resolveRotationDiscogsReleaseViaLml(
   rotationId: number,
   artistName: string | null,
   albumTitle: string | null
-): Promise<number | null> {
+): Promise<RotationPickerSource | null> {
   if (!artistName || !albumTitle) return null;
   if (!isLmlConfigured()) return null;
 
@@ -506,12 +544,23 @@ async function resolveRotationDiscogsReleaseViaLml(
 
   const lookupArtist = isVariousArtistsName(artistName) ? undefined : artistName;
 
-  let releaseId: number | null;
+  let source: RotationPickerSource | null;
   try {
+    // `extended: true` opts the top-1 result's `artwork` block into the
+    // extra payload LML already has during enrichment (LML#414) — including
+    // `tracklist`, which lets the picker skip the follow-up
+    // `getRelease(id)` round-trip and (for the MusicBrainz-rescued
+    // synth-result path on LML#427) get a tracklist for releases Discogs
+    // doesn't carry. Same `(artist, album)` call as before; the request body
+    // only gains the `extended` flag.
     const response = await lookupMetadata(lookupArtist, albumTitle, undefined, {
       timeoutMs: ROTATION_LML_LOOKUP_TIMEOUT_MS,
+      extended: true,
     });
-    releaseId = response.results?.[0]?.artwork?.release_id ?? null;
+    const artwork = response.results?.[0]?.artwork ?? null;
+    const releaseId = artwork?.release_id ?? null;
+    const inlineTracklist = projectInlineTracklist(artwork?.tracklist, artistName);
+    source = releaseId !== null || inlineTracklist !== null ? { releaseId: releaseId ?? 0, inlineTracklist } : null;
   } catch (err) {
     console.warn(
       '[library.service] LML /lookup for rotation_id=%d failed; degrading picker to free-text: %s',
@@ -521,13 +570,44 @@ async function resolveRotationDiscogsReleaseViaLml(
     return null;
   }
 
-  if (releaseId !== null) {
-    rotationLmlPositiveCache.set(rotationId, releaseId);
+  if (source !== null) {
+    rotationLmlPositiveCache.set(rotationId, source);
   } else {
     rotationLmlNegativeCache.set(rotationId, true);
   }
 
-  return releaseId;
+  return source;
+}
+
+/**
+ * Project the LML `extended=true` `artwork.tracklist` shape onto the picker's
+ * wire shape (`RotationTrack[]`). Mirrors the projection the controller does
+ * on `release.tracklist` from `getRelease(id)`, but on the inline-tracklist
+ * surface introduced by BS#1185 + LML#427.
+ *
+ * `artistFallback` is the rotation row's `artist_name` — used when a track
+ * has no per-track artist credits (Discogs's normal shape for non-V/A
+ * releases; MusicBrainz's normal shape for almost everything). The picker
+ * always wants at least one artist name to render against the track row.
+ *
+ * Returns `null` (not `[]`) when the tracklist is absent, so the caller can
+ * distinguish "LML returned a tracklist" from "LML didn't carry one and the
+ * controller should fall through to the release fetch".
+ */
+function projectInlineTracklist(
+  tracklist:
+    | ReadonlyArray<{ position: string; title: string; duration?: string | null; artists?: readonly string[] | null }>
+    | null
+    | undefined,
+  artistFallback: string
+): RotationTrack[] | null {
+  if (!tracklist || tracklist.length === 0) return null;
+  return tracklist.map((t) => ({
+    position: t.position,
+    title: t.title,
+    duration: t.duration ?? null,
+    artists: t.artists && t.artists.length > 0 ? Array.from(t.artists) : [artistFallback],
+  }));
 }
 
 export const updateOnStreaming = async (id: number, on_streaming: boolean | null) => {

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -23,7 +23,14 @@ import {
   LibraryArtistViewEntry,
 } from '@wxyc/database';
 import { LibraryResult, EnrichedLibraryResult, enrichLibraryResult } from './requestLine/types.js';
-import { lookupBySong, lookupMetadata, isLmlConfigured, envInt, type LookupResponse } from '@wxyc/lml-client';
+import {
+  lookupBySong,
+  lookupMetadata,
+  isLmlConfigured,
+  envInt,
+  type LookupResponse,
+  type DiscogsTrackItem,
+} from '@wxyc/lml-client';
 import { filterSpacerGif } from './metadata/metadata.service.js';
 import { checkLibraryArtistNameHealth } from './library-artist-name-assertion.service.js';
 import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrackSearch.js';
@@ -388,20 +395,20 @@ export interface RotationTrack {
 /**
  * What `resolveRotationPickerSource` hands back to the picker controller.
  *
- * `releaseId` is the Discogs release the picker can fetch a tracklist from.
- * Tiers 1 and 2 (stored Discogs id) always produce a real release id with
- * `inlineTracklist: null`, so the controller falls through to its existing
- * `getRelease(releaseId)` projection. Tier 3 (runtime LML lookup with
- * `extended=true`) carries an `inlineTracklist` when LML's response had one
- * — Discogs hit (the cascade matched) or MusicBrainz rescue (BS#1185 synth
- * + LML#427). In that case the controller short-circuits and returns
- * `inlineTracklist` directly; no second LML round-trip needed. The
- * `releaseId` may be `0` on the synth-with-MB-rescue path because there's
- * no Discogs release behind the tracklist, and BS treats `release_id === 0`
- * as a signal to skip the follow-up release fetch (matches BS#1185).
+ * The controller short-circuits whenever `inlineTracklist !== null` and
+ * returns it as the response. That covers both:
+ *   - tier 3 Discogs hit with `extended=true` (LML returned the tracklist
+ *     in the same response we asked for the release id), and
+ *   - tier 3 MusicBrainz rescue (LML synthesized the result; `releaseId`
+ *     is `null` because there's no Discogs release behind it — BS#1185).
+ *
+ * When `inlineTracklist === null` the controller calls `getRelease(releaseId)`
+ * and projects its tracklist. That path is taken for tiers 1 and 2 (stored
+ * id, no LML round-trip) and for tier-3 responses that LML couldn't extend
+ * with a tracklist (e.g. extended-mode payload was suppressed upstream).
  */
 export interface RotationPickerSource {
-  releaseId: number;
+  releaseId: number | null;
   inlineTracklist: RotationTrack[] | null;
 }
 
@@ -560,7 +567,7 @@ async function resolveRotationDiscogsReleaseViaLml(
     const artwork = response.results?.[0]?.artwork ?? null;
     const releaseId = artwork?.release_id ?? null;
     const inlineTracklist = projectInlineTracklist(artwork?.tracklist, artistName);
-    source = releaseId !== null || inlineTracklist !== null ? { releaseId: releaseId ?? 0, inlineTracklist } : null;
+    source = releaseId !== null || inlineTracklist !== null ? { releaseId, inlineTracklist } : null;
   } catch (err) {
     console.warn(
       '[library.service] LML /lookup for rotation_id=%d failed; degrading picker to free-text: %s',
@@ -580,25 +587,16 @@ async function resolveRotationDiscogsReleaseViaLml(
 }
 
 /**
- * Project the LML `extended=true` `artwork.tracklist` shape onto the picker's
- * wire shape (`RotationTrack[]`). Mirrors the projection the controller does
- * on `release.tracklist` from `getRelease(id)`, but on the inline-tracklist
- * surface introduced by BS#1185 + LML#427.
- *
- * `artistFallback` is the rotation row's `artist_name` — used when a track
- * has no per-track artist credits (Discogs's normal shape for non-V/A
- * releases; MusicBrainz's normal shape for almost everything). The picker
- * always wants at least one artist name to render against the track row.
- *
- * Returns `null` (not `[]`) when the tracklist is absent, so the caller can
- * distinguish "LML returned a tracklist" from "LML didn't carry one and the
- * controller should fall through to the release fetch".
+ * Project the LML tracklist shape onto the picker's wire shape. Shared
+ * between the service's `extended=true` inline path (BS#1185 + LML#427)
+ * and the controller's follow-up `getRelease(id)` path so the two surfaces
+ * can't drift. Returns `null` (not `[]`) when the tracklist is absent so
+ * the caller can distinguish "LML carried tracks" from "fall through to
+ * the release fetch". `artistFallback` is rendered against any track whose
+ * per-track `artists[]` is empty.
  */
-function projectInlineTracklist(
-  tracklist:
-    | ReadonlyArray<{ position: string; title: string; duration?: string | null; artists?: readonly string[] | null }>
-    | null
-    | undefined,
+export function projectInlineTracklist(
+  tracklist: ReadonlyArray<DiscogsTrackItem> | null | undefined,
   artistFallback: string
 ): RotationTrack[] | null {
   if (!tracklist || tracklist.length === 0) return null;

--- a/apps/backend/services/rotation-tracks-cache-warm.service.ts
+++ b/apps/backend/services/rotation-tracks-cache-warm.service.ts
@@ -13,7 +13,7 @@
  * What gets warmed:
  *   For every active rotation row (`kill_date IS NULL OR kill_date >
  *   CURRENT_DATE` — the same predicate `getRotationFromDB` uses), the warmer
- *   calls `getDiscogsReleaseIdByRotationId` end-to-end so it goes through
+ *   calls `resolveRotationPickerSource` end-to-end so it goes through
  *   the same three-tier resolver real picker opens take. That means the
  *   warm walk shares the LML chokepoint with concurrent user traffic —
  *   `lookupSemaphore` (5 permits) and the rate-limit token bucket throttle
@@ -41,7 +41,7 @@
 import * as Sentry from '@sentry/node';
 import { sql } from 'drizzle-orm';
 import { db, rotation } from '@wxyc/database';
-import { getDiscogsReleaseIdByRotationId, __rotationLmlCacheSizesForWarm } from './library.service.js';
+import { resolveRotationPickerSource, __rotationLmlCacheSizesForWarm } from './library.service.js';
 
 const LOG_PREFIX = '[rotation-tracks-cache-warm]';
 
@@ -60,17 +60,17 @@ export interface WarmCounters {
   lmlPositive: number;
   /** Rows that hit LML and got nothing (negative cache populated). */
   lmlNegative: number;
-  /** Rows where `getDiscogsReleaseIdByRotationId` threw. */
+  /** Rows where `resolveRotationPickerSource` threw. */
   errors: number;
   /** Wall-clock duration of the walk in ms. */
   elapsedMs: number;
 }
 
 /**
- * Walk every active rotation row, calling `getDiscogsReleaseIdByRotationId`
+ * Walk every active rotation row, calling `resolveRotationPickerSource`
  * for each so the per-`rotation_id` LRUs in `library.service.ts` are populated.
  *
- * Sequential by design — `getDiscogsReleaseIdByRotationId` itself acquires
+ * Sequential by design — `resolveRotationPickerSource` itself acquires
  * the `lookupSemaphore` permit when it falls through to LML, so the upper
  * bound on outstanding LML calls remains 5. Driving extra concurrency here
  * would only deepen the semaphore queue without raising throughput, while
@@ -107,7 +107,7 @@ export async function warmRotationTracksCache(): Promise<WarmCounters> {
 
     try {
       const beforeSizes = __rotationLmlCacheSizesForWarm();
-      const result = await getDiscogsReleaseIdByRotationId(rotationId);
+      const result = await resolveRotationPickerSource(rotationId);
       const afterSizes = __rotationLmlCacheSizesForWarm();
 
       // Per-row LRU-delta classifier: if a positive entry was added during

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -13,7 +13,11 @@ const mockGenerateAlbumCodeNumber = jest.fn<(artistId: number) => Promise<number
 const mockCreateLabel = jest.fn<(label: string) => Promise<{ id: number }>>();
 const mockUpdateCanonicalEntity = jest.fn<(id: number, entityId: string, confidence: number) => Promise<unknown>>();
 const mockMapLookupToCanonicalEntity = jest.fn<(response: unknown) => { id: string; confidence: number } | null>();
-const mockGetDiscogsReleaseIdByRotationId = jest.fn<(rotationId: number) => Promise<number | null>>();
+type PickerSourceMock = {
+  releaseId: number;
+  inlineTracklist: Array<{ position: string; title: string; duration: string | null; artists: string[] }> | null;
+};
+const mockResolveRotationPickerSource = jest.fn<(rotationId: number) => Promise<PickerSourceMock | null>>();
 
 jest.mock('../../../apps/backend/services/library.service', () => ({
   getAlbumFromDB: mockGetAlbumFromDB,
@@ -46,7 +50,7 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   insertGenre: jest.fn(),
   insertFormat: jest.fn(),
   isISODate: jest.fn(),
-  getDiscogsReleaseIdByRotationId: mockGetDiscogsReleaseIdByRotationId,
+  resolveRotationPickerSource: mockResolveRotationPickerSource,
 }));
 
 jest.mock('../../../apps/backend/services/labels.service', () => ({
@@ -471,7 +475,7 @@ describe('library.controller', () => {
     };
 
     beforeEach(() => {
-      mockGetDiscogsReleaseIdByRotationId.mockReset();
+      mockResolveRotationPickerSource.mockReset();
       mockGetRelease.mockReset();
     });
 
@@ -480,7 +484,7 @@ describe('library.controller', () => {
       const res = mockResponse();
 
       await expect(getRotationTracks(req, res, next)).rejects.toThrow('positive integer');
-      expect(mockGetDiscogsReleaseIdByRotationId).not.toHaveBeenCalled();
+      expect(mockResolveRotationPickerSource).not.toHaveBeenCalled();
     });
 
     it('returns 400 for non-positive rotation_id', async () => {
@@ -491,20 +495,20 @@ describe('library.controller', () => {
     });
 
     it('returns 200 + empty array when no identity resolves (rotation missing, no album_id, or no library_identity row)', async () => {
-      mockGetDiscogsReleaseIdByRotationId.mockResolvedValue(null);
+      mockResolveRotationPickerSource.mockResolvedValue(null);
       const req = { params: { rotation_id: '42' } } as unknown as Request;
       const res = mockResponse();
 
       await getRotationTracks(req, res, next);
 
-      expect(mockGetDiscogsReleaseIdByRotationId).toHaveBeenCalledWith(42);
+      expect(mockResolveRotationPickerSource).toHaveBeenCalledWith(42);
       expect(mockGetRelease).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith([]);
     });
 
-    it('projects Discogs tracklist into RotationTrack shape when identity resolves', async () => {
-      mockGetDiscogsReleaseIdByRotationId.mockResolvedValue(4080);
+    it('projects Discogs tracklist into RotationTrack shape when identity resolves and inline tracklist is absent', async () => {
+      mockResolveRotationPickerSource.mockResolvedValue({ releaseId: 4080, inlineTracklist: null });
       mockGetRelease.mockResolvedValue(sampleRelease);
       const req = { params: { rotation_id: '42' } } as unknown as Request;
       const res = mockResponse();
@@ -521,8 +525,28 @@ describe('library.controller', () => {
       ]);
     });
 
+    it('short-circuits to the inline tracklist when the resolver carries one (no getRelease call)', async () => {
+      // BS#1185 + LML#427: when the tier-3 LML lookup returns an extended
+      // result with a tracklist (Discogs hit OR MusicBrainz rescue), the
+      // service projects it inline and the controller returns it directly.
+      // No second LML round-trip via `getRelease`.
+      const inlineTracklist = [
+        { position: '1', title: 'Tragic Magic', duration: '6:01', artists: ['Julianna Barwick & Mary Lattimore'] },
+        { position: '2', title: 'For Mariko', duration: '4:18', artists: ['Julianna Barwick & Mary Lattimore'] },
+      ];
+      mockResolveRotationPickerSource.mockResolvedValue({ releaseId: 0, inlineTracklist });
+      const req = { params: { rotation_id: '42' } } as unknown as Request;
+      const res = mockResponse();
+
+      await getRotationTracks(req, res, next);
+
+      expect(mockGetRelease).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(inlineTracklist);
+    });
+
     it('returns 200 + empty array on LML 404 (release unknown to Discogs)', async () => {
-      mockGetDiscogsReleaseIdByRotationId.mockResolvedValue(9999999);
+      mockResolveRotationPickerSource.mockResolvedValue({ releaseId: 9999999, inlineTracklist: null });
       mockGetRelease.mockRejectedValue(new MockLmlClientError('not found', 404));
       const req = { params: { rotation_id: '42' } } as unknown as Request;
       const res = mockResponse();
@@ -534,7 +558,7 @@ describe('library.controller', () => {
     });
 
     it('bubbles LML 5xx errors so transient failures surface rather than silently degrading', async () => {
-      mockGetDiscogsReleaseIdByRotationId.mockResolvedValue(4080);
+      mockResolveRotationPickerSource.mockResolvedValue({ releaseId: 4080, inlineTracklist: null });
       mockGetRelease.mockRejectedValue(new MockLmlClientError('upstream timeout', 504));
       const req = { params: { rotation_id: '42' } } as unknown as Request;
       const res = mockResponse();

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -14,7 +14,7 @@ const mockCreateLabel = jest.fn<(label: string) => Promise<{ id: number }>>();
 const mockUpdateCanonicalEntity = jest.fn<(id: number, entityId: string, confidence: number) => Promise<unknown>>();
 const mockMapLookupToCanonicalEntity = jest.fn<(response: unknown) => { id: string; confidence: number } | null>();
 type PickerSourceMock = {
-  releaseId: number;
+  releaseId: number | null;
   inlineTracklist: Array<{ position: string; title: string; duration: string | null; artists: string[] }> | null;
 };
 const mockResolveRotationPickerSource = jest.fn<(rotationId: number) => Promise<PickerSourceMock | null>>();
@@ -51,6 +51,24 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   insertFormat: jest.fn(),
   isISODate: jest.fn(),
   resolveRotationPickerSource: mockResolveRotationPickerSource,
+  // Real implementation lifted to the service so the controller's release-fetch
+  // path and the service's inline path share one projection. Pass through;
+  // assertions below pin the wire shape.
+  projectInlineTracklist: (
+    tracks:
+      | ReadonlyArray<{ position: string; title: string; duration?: string | null; artists?: readonly string[] | null }>
+      | null
+      | undefined,
+    artistFallback: string
+  ) =>
+    !tracks || tracks.length === 0
+      ? null
+      : tracks.map((t) => ({
+          position: t.position,
+          title: t.title,
+          duration: t.duration ?? null,
+          artists: t.artists && t.artists.length > 0 ? Array.from(t.artists) : [artistFallback],
+        })),
 }));
 
 jest.mock('../../../apps/backend/services/labels.service', () => ({

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -49,7 +49,7 @@ import {
   markAlbumFound,
   enrichWithArtwork,
   updateArtworkUrl,
-  getDiscogsReleaseIdByRotationId,
+  resolveRotationPickerSource,
   __resetRotationLmlLookupCacheForTests,
   isVariousArtistsName,
 } from '../../../apps/backend/services/library.service';
@@ -2102,7 +2102,7 @@ describe('library.service', () => {
     });
   });
 
-  describe('getDiscogsReleaseIdByRotationId', () => {
+  describe('resolveRotationPickerSource', () => {
     // Pins the direct + fallback precedence of the simplified read path
     // (post-tubafrenzy-parity migration 0077). The tubafrenzy-sourced
     // `rotation.discogs_release_id` wins when present; the library_identity
@@ -2119,8 +2119,8 @@ describe('library.service', () => {
       db.select.mockReturnValue(chain);
       chain.limit = jest.fn().mockResolvedValue([{ direct: 12345, fallback: null }]);
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
-      expect(result).toBe(12345);
+      const result = await resolveRotationPickerSource(42);
+      expect(result).toEqual({ releaseId: 12345, inlineTracklist: null });
     });
 
     it('falls back to library_identity.discogs_release_id when the direct column is NULL', async () => {
@@ -2128,8 +2128,8 @@ describe('library.service', () => {
       db.select.mockReturnValue(chain);
       chain.limit = jest.fn().mockResolvedValue([{ direct: null, fallback: 99 }]);
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
-      expect(result).toBe(99);
+      const result = await resolveRotationPickerSource(42);
+      expect(result).toEqual({ releaseId: 99, inlineTracklist: null });
     });
 
     it('prefers the direct column over the fallback when both are present', async () => {
@@ -2140,8 +2140,8 @@ describe('library.service', () => {
       db.select.mockReturnValue(chain);
       chain.limit = jest.fn().mockResolvedValue([{ direct: 12345, fallback: 99 }]);
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
-      expect(result).toBe(12345);
+      const result = await resolveRotationPickerSource(42);
+      expect(result).toEqual({ releaseId: 12345, inlineTracklist: null });
     });
 
     it('returns null when both sources are NULL', async () => {
@@ -2149,7 +2149,7 @@ describe('library.service', () => {
       db.select.mockReturnValue(chain);
       chain.limit = jest.fn().mockResolvedValue([{ direct: null, fallback: null }]);
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
+      const result = await resolveRotationPickerSource(42);
       expect(result).toBeNull();
     });
 
@@ -2158,12 +2158,12 @@ describe('library.service', () => {
       db.select.mockReturnValue(chain);
       chain.limit = jest.fn().mockResolvedValue([]);
 
-      const result = await getDiscogsReleaseIdByRotationId(404);
+      const result = await resolveRotationPickerSource(404);
       expect(result).toBeNull();
     });
   });
 
-  describe('getDiscogsReleaseIdByRotationId — tier-3 LML fallback', () => {
+  describe('resolveRotationPickerSource — tier-3 LML fallback', () => {
     // Tier 3 mirrors tubafrenzy's RotationTracklistCache parity (BS#986):
     // when direct + fallback both miss, ask LML `POST /api/v1/lookup` to
     // identify the release from (artist_name, album_title). Per-rotation_id
@@ -2201,9 +2201,9 @@ describe('library.service', () => {
         search_type: 'direct',
       });
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
+      const result = await resolveRotationPickerSource(42);
 
-      expect(result).toBe(4080);
+      expect(result).toEqual({ releaseId: 4080, inlineTracklist: null });
       // 10 s timeout matches tubafrenzy's `RELEASE_LOOKUP_TIMEOUT` so picker
       // coverage on long-tail rotation rows parity-matches the legacy system.
       // No `budgetMs` here on purpose: BS#1186's cutoff was justified by
@@ -2213,6 +2213,7 @@ describe('library.service', () => {
       // match for obscure college rotation comes from.
       expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
         timeoutMs: 10000,
+        extended: true,
       });
     });
 
@@ -2233,14 +2234,14 @@ describe('library.service', () => {
         search_type: 'direct',
       });
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
+      const result = await resolveRotationPickerSource(42);
 
-      expect(result).toBe(26538110);
+      expect(result).toEqual({ releaseId: 26538110, inlineTracklist: null });
       expect(mockLookupMetadata).toHaveBeenCalledWith(
         undefined,
         'All the Young Droids: Junkshop Synth Pop 1978-1985',
         undefined,
-        { timeoutMs: 10000 }
+        { timeoutMs: 10000, extended: true }
       );
     });
 
@@ -2266,25 +2267,25 @@ describe('library.service', () => {
     it('does not call LML when the direct column has a value', async () => {
       mockRow({ direct: 12345, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
+      const result = await resolveRotationPickerSource(42);
 
-      expect(result).toBe(12345);
+      expect(result).toEqual({ releaseId: 12345, inlineTracklist: null });
       expect(mockLookupMetadata).not.toHaveBeenCalled();
     });
 
     it('does not call LML when the fallback has a value', async () => {
       mockRow({ direct: null, fallback: 99, artist_name: 'Autechre', album_title: 'Confield' });
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
+      const result = await resolveRotationPickerSource(42);
 
-      expect(result).toBe(99);
+      expect(result).toEqual({ releaseId: 99, inlineTracklist: null });
       expect(mockLookupMetadata).not.toHaveBeenCalled();
     });
 
     it('returns null and does not call LML when artist_name is NULL', async () => {
       mockRow({ direct: null, fallback: null, artist_name: null, album_title: 'Confield' });
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
+      const result = await resolveRotationPickerSource(42);
 
       expect(result).toBeNull();
       expect(mockLookupMetadata).not.toHaveBeenCalled();
@@ -2293,7 +2294,7 @@ describe('library.service', () => {
     it('returns null and does not call LML when album_title is NULL', async () => {
       mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: null });
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
+      const result = await resolveRotationPickerSource(42);
 
       expect(result).toBeNull();
       expect(mockLookupMetadata).not.toHaveBeenCalled();
@@ -2303,7 +2304,7 @@ describe('library.service', () => {
       mockIsLmlConfigured.mockReturnValue(false);
       mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
+      const result = await resolveRotationPickerSource(42);
 
       expect(result).toBeNull();
       expect(mockLookupMetadata).not.toHaveBeenCalled();
@@ -2314,7 +2315,7 @@ describe('library.service', () => {
       mockLookupMetadata.mockRejectedValue(new Error('LML 504'));
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
+      const result = await resolveRotationPickerSource(42);
 
       expect(result).toBeNull();
       expect(consoleSpy).toHaveBeenCalled();
@@ -2325,7 +2326,7 @@ describe('library.service', () => {
       mockRow({ direct: null, fallback: null, artist_name: 'Mystery Artist', album_title: 'Unknown' });
       mockLookupMetadata.mockResolvedValue({ results: [], search_type: 'none' });
 
-      const result = await getDiscogsReleaseIdByRotationId(42);
+      const result = await resolveRotationPickerSource(42);
 
       expect(result).toBeNull();
     });
@@ -2337,15 +2338,15 @@ describe('library.service', () => {
         search_type: 'direct',
       });
 
-      const first = await getDiscogsReleaseIdByRotationId(42);
-      expect(first).toBe(4080);
+      const first = await resolveRotationPickerSource(42);
+      expect(first).toEqual({ releaseId: 4080, inlineTracklist: null });
 
       // The DB read still happens on every call (this is by design — the LRU
       // only short-circuits the LML query, which is the expensive bit). The
       // second call reaches the resolver but hits the cache before LML.
       mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
-      const second = await getDiscogsReleaseIdByRotationId(42);
-      expect(second).toBe(4080);
+      const second = await resolveRotationPickerSource(42);
+      expect(second).toEqual({ releaseId: 4080, inlineTracklist: null });
 
       expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
     });
@@ -2354,11 +2355,11 @@ describe('library.service', () => {
       mockRow({ direct: null, fallback: null, artist_name: 'Mystery Artist', album_title: 'Unknown' });
       mockLookupMetadata.mockResolvedValue({ results: [], search_type: 'none' });
 
-      const first = await getDiscogsReleaseIdByRotationId(42);
+      const first = await resolveRotationPickerSource(42);
       expect(first).toBeNull();
 
       mockRow({ direct: null, fallback: null, artist_name: 'Mystery Artist', album_title: 'Unknown' });
-      const second = await getDiscogsReleaseIdByRotationId(42);
+      const second = await resolveRotationPickerSource(42);
       expect(second).toBeNull();
 
       expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
@@ -2373,7 +2374,7 @@ describe('library.service', () => {
       mockLookupMetadata.mockRejectedValueOnce(new Error('LML timeout'));
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-      const first = await getDiscogsReleaseIdByRotationId(42);
+      const first = await resolveRotationPickerSource(42);
       expect(first).toBeNull();
 
       mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
@@ -2381,11 +2382,84 @@ describe('library.service', () => {
         results: [{ artwork: { release_id: 4080 } }],
         search_type: 'direct',
       });
-      const second = await getDiscogsReleaseIdByRotationId(42);
-      expect(second).toBe(4080);
+      const second = await resolveRotationPickerSource(42);
+      expect(second).toEqual({ releaseId: 4080, inlineTracklist: null });
 
       expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
       consoleSpy.mockRestore();
+    });
+
+    it('carries an inline tracklist when LML returns extended-mode tracks', async () => {
+      // BS#1185 + LML#427: `extended=true` opts the top-1 result into a
+      // tracklist on `artwork.tracklist`. The picker controller short-circuits
+      // on that, avoiding the follow-up `getRelease(id)` round-trip. Empty
+      // per-track artists fall back to the rotation row's artist_name so the
+      // dj-site picker always has at least one name to render.
+      mockRow({ direct: null, fallback: null, artist_name: 'Autechre', album_title: 'Confield' });
+      mockLookupMetadata.mockResolvedValue({
+        results: [
+          {
+            artwork: {
+              release_id: 4080,
+              tracklist: [
+                { position: 'A1', title: 'VI Scose Poise', duration: '5:30', artists: ['Autechre'] },
+                { position: 'A2', title: 'Cfern', duration: '5:11', artists: [] },
+                { position: 'A3', title: 'Pen Expers', duration: null, artists: null },
+              ],
+            },
+          },
+        ],
+        search_type: 'direct',
+      });
+
+      const result = await resolveRotationPickerSource(42);
+
+      expect(result).toEqual({
+        releaseId: 4080,
+        inlineTracklist: [
+          { position: 'A1', title: 'VI Scose Poise', duration: '5:30', artists: ['Autechre'] },
+          { position: 'A2', title: 'Cfern', duration: '5:11', artists: ['Autechre'] },
+          { position: 'A3', title: 'Pen Expers', duration: null, artists: ['Autechre'] },
+        ],
+      });
+    });
+
+    it('carries an inline tracklist when LML synth-rescues with release_id=0 (MB rescue)', async () => {
+      // LML#427 MusicBrainz rescue: when Discogs misses, LML synthesizes a
+      // result with `release_id: 0` (the BS#1185 sentinel) and a tracklist
+      // sourced from musicbrainz-cache. The picker still gets a tracklist
+      // and skips `getRelease(0)` (which would 404). releaseId=0 short-circuits
+      // the controller via `inlineTracklist !== null`.
+      mockRow({
+        direct: null,
+        fallback: null,
+        artist_name: 'Julianna Barwick & Mary Lattimore',
+        album_title: 'Tragic Magic',
+      });
+      mockLookupMetadata.mockResolvedValue({
+        results: [
+          {
+            artwork: {
+              release_id: 0,
+              tracklist: [
+                { position: '1', title: 'Tragic Magic', duration: '6:01', artists: [] },
+                { position: '2', title: 'For Mariko', duration: '4:18', artists: [] },
+              ],
+            },
+          },
+        ],
+        search_type: 'direct',
+      });
+
+      const result = await resolveRotationPickerSource(42);
+
+      expect(result).toEqual({
+        releaseId: 0,
+        inlineTracklist: [
+          { position: '1', title: 'Tragic Magic', duration: '6:01', artists: ['Julianna Barwick & Mary Lattimore'] },
+          { position: '2', title: 'For Mariko', duration: '4:18', artists: ['Julianna Barwick & Mary Lattimore'] },
+        ],
+      });
     });
   });
 });

--- a/tests/unit/services/rotation-tracks-cache-warm.service.test.ts
+++ b/tests/unit/services/rotation-tracks-cache-warm.service.test.ts
@@ -3,7 +3,7 @@
  *
  * Coverage:
  *  1. The walk fetches active rotation rows (kill_date IS NULL OR > today),
- *     calls `getDiscogsReleaseIdByRotationId` for each, and emits a final
+ *     calls `resolveRotationPickerSource` for each, and emits a final
  *     summary log line with the expected counters.
  *  2. A single row's failure is captured to Sentry and does not halt the
  *     walk; subsequent rows are still visited.
@@ -13,7 +13,7 @@
  *     the top-level walk is caught and Sentry-captured rather than escaping
  *     to the caller (which would be `app.listen`'s callback).
  *
- * The shared `db` and `getDiscogsReleaseIdByRotationId` (via library.service)
+ * The shared `db` and `resolveRotationPickerSource` (via library.service)
  * are mocked. We hold the LRU-sizes accessor stub so we can simulate
  * positive/negative cache growth.
  */
@@ -23,15 +23,18 @@ import { db } from '../../mocks/database.mock';
 // `library.service` exposes both the picker resolver we drive end-to-end
 // and the LRU-sizes accessor we read for the counter classifier. Mock at
 // the module boundary so the warm service receives our test doubles.
-const mockGetDiscogsReleaseIdByRotationId = jest.fn<(id: number) => Promise<number | null>>();
+type PickerSource = { releaseId: number; inlineTracklist: null };
+const mockResolveRotationPickerSource = jest.fn<(id: number) => Promise<PickerSource | null>>();
 type Sizes = { positive: number; negative: number };
 const sizesRef: { current: Sizes } = { current: { positive: 0, negative: 0 } };
 const mockRotationLmlCacheSizesForWarm = jest.fn<() => Sizes>(() => sizesRef.current);
 
 jest.mock('../../../apps/backend/services/library.service', () => ({
-  getDiscogsReleaseIdByRotationId: mockGetDiscogsReleaseIdByRotationId,
+  resolveRotationPickerSource: mockResolveRotationPickerSource,
   __rotationLmlCacheSizesForWarm: mockRotationLmlCacheSizesForWarm,
 }));
+
+const source = (releaseId: number): PickerSource => ({ releaseId, inlineTracklist: null });
 
 const mockCaptureException = jest.fn();
 jest.mock('@sentry/node', () => ({
@@ -60,17 +63,17 @@ function mockActiveRotationRows(ids: number[]): void {
 }
 
 /**
- * Make `getDiscogsReleaseIdByRotationId` advance the LRU sizes accessor as
+ * Make `resolveRotationPickerSource` advance the LRU sizes accessor as
  * the real resolver would. Used by the tier-3 classification test.
  */
 function resolverSideEffect(grow: 'positive' | 'negative' | 'none', returnValue: number | null): void {
-  mockGetDiscogsReleaseIdByRotationId.mockImplementationOnce(() => {
+  mockResolveRotationPickerSource.mockImplementationOnce(() => {
     if (grow === 'positive') {
       sizesRef.current = { ...sizesRef.current, positive: sizesRef.current.positive + 1 };
     } else if (grow === 'negative') {
       sizesRef.current = { ...sizesRef.current, negative: sizesRef.current.negative + 1 };
     }
-    return Promise.resolve(returnValue);
+    return Promise.resolve(returnValue === null ? null : source(returnValue));
   });
 }
 
@@ -81,7 +84,7 @@ describe('rotation-tracks-cache-warm.service', () => {
 
   beforeEach(() => {
     selectMock.mockReset();
-    mockGetDiscogsReleaseIdByRotationId.mockReset();
+    mockResolveRotationPickerSource.mockReset();
     mockCaptureException.mockReset();
     sizesRef.current = { positive: 0, negative: 0 };
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -98,14 +101,14 @@ describe('rotation-tracks-cache-warm.service', () => {
   describe('warmRotationTracksCache', () => {
     test('visits every active rotation row in id order', async () => {
       mockActiveRotationRows([10, 20, 30]);
-      mockGetDiscogsReleaseIdByRotationId.mockResolvedValue(null);
+      mockResolveRotationPickerSource.mockResolvedValue(null);
 
       await warmRotationTracksCache();
 
-      expect(mockGetDiscogsReleaseIdByRotationId).toHaveBeenCalledTimes(3);
-      expect(mockGetDiscogsReleaseIdByRotationId).toHaveBeenNthCalledWith(1, 10);
-      expect(mockGetDiscogsReleaseIdByRotationId).toHaveBeenNthCalledWith(2, 20);
-      expect(mockGetDiscogsReleaseIdByRotationId).toHaveBeenNthCalledWith(3, 30);
+      expect(mockResolveRotationPickerSource).toHaveBeenCalledTimes(3);
+      expect(mockResolveRotationPickerSource).toHaveBeenNthCalledWith(1, 10);
+      expect(mockResolveRotationPickerSource).toHaveBeenNthCalledWith(2, 20);
+      expect(mockResolveRotationPickerSource).toHaveBeenNthCalledWith(3, 30);
     });
 
     test('summary counters: classifies tier-3 positive vs negative vs pre-resolved per row', async () => {
@@ -131,14 +134,14 @@ describe('rotation-tracks-cache-warm.service', () => {
 
     test('does not halt when a single row throws — sibling rows still visited and captured to Sentry', async () => {
       mockActiveRotationRows([10, 20, 30]);
-      mockGetDiscogsReleaseIdByRotationId.mockResolvedValueOnce(123);
-      mockGetDiscogsReleaseIdByRotationId.mockRejectedValueOnce(new Error('LML timeout'));
-      mockGetDiscogsReleaseIdByRotationId.mockResolvedValueOnce(null);
+      mockResolveRotationPickerSource.mockResolvedValueOnce(source(123));
+      mockResolveRotationPickerSource.mockRejectedValueOnce(new Error('LML timeout'));
+      mockResolveRotationPickerSource.mockResolvedValueOnce(null);
 
       const counters = await warmRotationTracksCache();
 
       // Walk visited all three rows despite the middle row throwing.
-      expect(mockGetDiscogsReleaseIdByRotationId).toHaveBeenCalledTimes(3);
+      expect(mockResolveRotationPickerSource).toHaveBeenCalledTimes(3);
       expect(counters.scanned).toBe(3);
       expect(counters.errors).toBe(1);
       expect(mockCaptureException).toHaveBeenCalledTimes(1);
@@ -180,7 +183,7 @@ describe('rotation-tracks-cache-warm.service', () => {
 
       const counters = await warmRotationTracksCache();
 
-      expect(mockGetDiscogsReleaseIdByRotationId).not.toHaveBeenCalled();
+      expect(mockResolveRotationPickerSource).not.toHaveBeenCalled();
       expect(counters.scanned).toBe(0);
       expect(counters.errors).toBe(0);
     });


### PR DESCRIPTION
Closes #1226.

## Summary

- Rename `getDiscogsReleaseIdByRotationId` → `resolveRotationPickerSource`. Return widens from `Promise<number | null>` to `Promise<RotationPickerSource | null>` where `RotationPickerSource = { releaseId: number; inlineTracklist: RotationTrack[] | null }`.
- Tier 3 now passes `extended: true` to `lookupMetadata`, pulls `tracklist` off `results[0].artwork`, and projects to `RotationTrack[]` inline. Per-track artist fallback to the rotation row's `artist_name`.
- Controller short-circuits when `inlineTracklist !== null`. No follow-up `getRelease(releaseId)` round-trip on the extended-mode hit path. `releaseId === 0` (BS#1185 MB-rescue synth) is handled by the same short-circuit, so we never 404 on `getRelease(0)`.
- LRU widened from `LRUCache<number, number>` to `LRUCache<number, RotationPickerSource>`. Negative cache unchanged. Cache-warm service adapted to the new return type without behavior change.
- `RotationTrack` interface moves from the controller to `library.service.ts` so the service can project to the wire shape without a controller → service direction violation; re-exported from the controller via `import type { RotationTrack } from '../services/library.service.js'; export type { RotationTrack };` so existing import sites stay unbroken.

## Test plan

- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run lint` — only pre-existing warnings (0 errors)
- [x] `npm run format:check` — clean after prettier
- [x] `npx jest --config jest.unit.config.ts tests/unit/services/library.service.test.ts tests/unit/services/rotation-tracks-cache-warm.service.test.ts tests/unit/controllers/library.controller.test.ts` — 158/158 pass
- [ ] Post-merge: open the rotation picker on dj-site for a row known to be MB-resolvable but Discogs-missing (Tragic-Magic-class). Confirm the dropdown populates without a follow-up `/release/{id}` Discogs round-trip.