### PR TITLE
Cache rotation-picker tracklist BS-side keyed by release_id

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -13,14 +13,7 @@ import * as libraryService from '../services/library.service.js';
 import * as labelsService from '../services/labels.service.js';
 import * as librarySearchService from '../services/library-search.service.js';
 import type { CatalogSort, CatalogOrder } from '../services/library-search.service.js';
-import {
-  checkStreamingAvailability,
-  lookupMetadata,
-  isLmlConfigured,
-  getRelease,
-  envInt,
-  LmlClientError,
-} from '@wxyc/lml-client';
+import { checkStreamingAvailability, lookupMetadata, isLmlConfigured, envInt } from '@wxyc/lml-client';
 import { filterSpacerGif } from '../services/metadata/metadata.service.js';
 import WxycError from '../utils/error.js';
 
@@ -399,18 +392,8 @@ export const getRotationTracks: RequestHandler<{ rotation_id: string }> = async 
     return;
   }
 
-  let release;
-  try {
-    release = await getRelease(source.releaseId);
-  } catch (err) {
-    if (err instanceof LmlClientError && err.statusCode === 404) {
-      res.status(200).json([]);
-      return;
-    }
-    throw err;
-  }
-
-  res.status(200).json(libraryService.projectInlineTracklist(release.tracklist, release.artist) ?? []);
+  const tracks = await libraryService.getRotationTracksFromRelease(source.releaseId);
+  res.status(200).json(tracks ?? []);
 };
 
 export const getFormats: RequestHandler = async (req, res) => {

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -32,6 +32,7 @@ import {
   LmlClientError,
   type LookupResponse,
   type DiscogsTrackItem,
+  type DiscogsReleaseMetadata,
 } from '@wxyc/lml-client';
 import { filterSpacerGif } from './metadata/metadata.service.js';
 import { checkLibraryArtistNameHealth } from './library-artist-name-assertion.service.js';
@@ -613,20 +614,14 @@ export function projectInlineTracklist(
 /**
  * Per-`release_id` LRU on the projected `RotationTrack[]` from LML's
  * `GET /api/v1/discogs/release/{id}`. Absorbs the dominant cost on the
- * rotation-tracks picker: the LML release-fetch endpoint takes 2-9 s on
- * Discogs cache miss (78 ms warm). This cache covers both the
- * second-open-on-same-row case and the cross-row case where two rotation_ids
- * resolve to the same release_id.
+ * rotation-tracks picker — the LML release-fetch endpoint takes 2-9 s on
+ * Discogs cache miss vs. 78 ms warm.
  *
  * Positive TTL is long (24 h) because Discogs release tracklists are
- * effectively immutable — editorial corrections are rare and the picker
- * tolerates staleness. Negative TTL is short so a release that becomes
- * known to Discogs recovers quickly.
- *
- * Parity-aware with the upstream LML cache and the tier-3
- * `rotationLmlPositiveCache` (per-`rotation_id` LRU). Nothing flushes this
- * on rotation row edits — the read paths feeding it are picker-only and a
- * 24 h TTL is the right blast radius for an immutable Discogs payload.
+ * effectively immutable. Negative TTL is short so a release that becomes
+ * known to Discogs recovers quickly. In-flight map coalesces concurrent
+ * dropdown opens on the same release so a cold-deploy burst pays the
+ * cold-path once across DJs, not once per DJ.
  */
 const RELEASE_TRACKLIST_CACHE_MAX = 500;
 const RELEASE_TRACKLIST_TTL_POSITIVE_MS = 24 * 60 * 60 * 1000;
@@ -644,49 +639,52 @@ const releaseTracklistNegativeCache = new LRUCache<number, true>({
   ttlAutopurge: true,
 });
 
+const releaseTracklistInflight = new Map<number, Promise<RotationTrack[] | null>>();
+
 export function __resetReleaseTracklistCacheForTests(): void {
   releaseTracklistPositiveCache.clear();
   releaseTracklistNegativeCache.clear();
+  releaseTracklistInflight.clear();
 }
 
 /**
  * Fetch a Discogs release tracklist via LML and project it onto the
- * picker's `RotationTrack` wire shape. Results are cached per `release_id`
- * (see `releaseTracklistPositiveCache` / `releaseTracklistNegativeCache`).
+ * picker's `RotationTrack` wire shape. Cached per `release_id`.
  *
  * Returns:
- *   - `RotationTrack[]` — projected tracklist (possibly empty if the release
- *     itself has no tracks); positive-cached.
- *   - `null` — LML returned 404 for the release id; negative-cached so the
- *     picker doesn't re-ask on every dropdown open. The controller maps
- *     `null` → 200 + `[]`.
+ *   - `RotationTrack[]` — positive-cached projection.
+ *   - `null` — LML returned 404; negative-cached. Controller maps to 200 + `[]`.
  *
  * Other LML errors (5xx, network, parse) bubble so transient upstream
  * failures surface rather than silently degrading the picker.
- *
- * Used by `getRotationTracks` controller (BS#940) when
- * `resolveRotationPickerSource` returns a `releaseId` with no inline
- * tracklist (tier 1 / tier 2 hits).
  */
 export async function getRotationTracksFromRelease(releaseId: number): Promise<RotationTrack[] | null> {
   const cachedPositive = releaseTracklistPositiveCache.get(releaseId);
   if (cachedPositive !== undefined) return cachedPositive;
   if (releaseTracklistNegativeCache.has(releaseId)) return null;
 
-  let release: Awaited<ReturnType<typeof getRelease>>;
-  try {
-    release = await getRelease(releaseId);
-  } catch (err) {
-    if (err instanceof LmlClientError && err.statusCode === 404) {
-      releaseTracklistNegativeCache.set(releaseId, true);
-      return null;
-    }
-    throw err;
-  }
+  const inflight = releaseTracklistInflight.get(releaseId);
+  if (inflight) return inflight;
 
-  const tracks = projectInlineTracklist(release.tracklist, release.artist) ?? [];
-  releaseTracklistPositiveCache.set(releaseId, tracks);
-  return tracks;
+  const pending = (async () => {
+    let release: DiscogsReleaseMetadata;
+    try {
+      release = await getRelease(releaseId);
+    } catch (err) {
+      if (err instanceof LmlClientError && err.statusCode === 404) {
+        releaseTracklistNegativeCache.set(releaseId, true);
+        return null;
+      }
+      throw err;
+    }
+    const tracks = projectInlineTracklist(release.tracklist, release.artist) ?? [];
+    releaseTracklistPositiveCache.set(releaseId, tracks);
+    return tracks;
+  })().finally(() => {
+    releaseTracklistInflight.delete(releaseId);
+  });
+  releaseTracklistInflight.set(releaseId, pending);
+  return pending;
 }
 
 export const updateOnStreaming = async (id: number, on_streaming: boolean | null) => {

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -24,10 +24,12 @@ import {
 } from '@wxyc/database';
 import { LibraryResult, EnrichedLibraryResult, enrichLibraryResult } from './requestLine/types.js';
 import {
+  getRelease,
   lookupBySong,
   lookupMetadata,
   isLmlConfigured,
   envInt,
+  LmlClientError,
   type LookupResponse,
   type DiscogsTrackItem,
 } from '@wxyc/lml-client';
@@ -606,6 +608,85 @@ export function projectInlineTracklist(
     duration: t.duration ?? null,
     artists: t.artists && t.artists.length > 0 ? Array.from(t.artists) : [artistFallback],
   }));
+}
+
+/**
+ * Per-`release_id` LRU on the projected `RotationTrack[]` from LML's
+ * `GET /api/v1/discogs/release/{id}`. Absorbs the dominant cost on the
+ * rotation-tracks picker: the LML release-fetch endpoint takes 2-9 s on
+ * Discogs cache miss (78 ms warm). This cache covers both the
+ * second-open-on-same-row case and the cross-row case where two rotation_ids
+ * resolve to the same release_id.
+ *
+ * Positive TTL is long (24 h) because Discogs release tracklists are
+ * effectively immutable — editorial corrections are rare and the picker
+ * tolerates staleness. Negative TTL is short so a release that becomes
+ * known to Discogs recovers quickly.
+ *
+ * Parity-aware with the upstream LML cache and the tier-3
+ * `rotationLmlPositiveCache` (per-`rotation_id` LRU). Nothing flushes this
+ * on rotation row edits — the read paths feeding it are picker-only and a
+ * 24 h TTL is the right blast radius for an immutable Discogs payload.
+ */
+const RELEASE_TRACKLIST_CACHE_MAX = 500;
+const RELEASE_TRACKLIST_TTL_POSITIVE_MS = 24 * 60 * 60 * 1000;
+const RELEASE_TRACKLIST_TTL_NEGATIVE_MS = 10 * 60 * 1000;
+
+const releaseTracklistPositiveCache = new LRUCache<number, RotationTrack[]>({
+  max: RELEASE_TRACKLIST_CACHE_MAX,
+  ttl: RELEASE_TRACKLIST_TTL_POSITIVE_MS,
+  ttlAutopurge: true,
+});
+
+const releaseTracklistNegativeCache = new LRUCache<number, true>({
+  max: RELEASE_TRACKLIST_CACHE_MAX,
+  ttl: RELEASE_TRACKLIST_TTL_NEGATIVE_MS,
+  ttlAutopurge: true,
+});
+
+export function __resetReleaseTracklistCacheForTests(): void {
+  releaseTracklistPositiveCache.clear();
+  releaseTracklistNegativeCache.clear();
+}
+
+/**
+ * Fetch a Discogs release tracklist via LML and project it onto the
+ * picker's `RotationTrack` wire shape. Results are cached per `release_id`
+ * (see `releaseTracklistPositiveCache` / `releaseTracklistNegativeCache`).
+ *
+ * Returns:
+ *   - `RotationTrack[]` — projected tracklist (possibly empty if the release
+ *     itself has no tracks); positive-cached.
+ *   - `null` — LML returned 404 for the release id; negative-cached so the
+ *     picker doesn't re-ask on every dropdown open. The controller maps
+ *     `null` → 200 + `[]`.
+ *
+ * Other LML errors (5xx, network, parse) bubble so transient upstream
+ * failures surface rather than silently degrading the picker.
+ *
+ * Used by `getRotationTracks` controller (BS#940) when
+ * `resolveRotationPickerSource` returns a `releaseId` with no inline
+ * tracklist (tier 1 / tier 2 hits).
+ */
+export async function getRotationTracksFromRelease(releaseId: number): Promise<RotationTrack[] | null> {
+  const cachedPositive = releaseTracklistPositiveCache.get(releaseId);
+  if (cachedPositive !== undefined) return cachedPositive;
+  if (releaseTracklistNegativeCache.has(releaseId)) return null;
+
+  let release: Awaited<ReturnType<typeof getRelease>>;
+  try {
+    release = await getRelease(releaseId);
+  } catch (err) {
+    if (err instanceof LmlClientError && err.statusCode === 404) {
+      releaseTracklistNegativeCache.set(releaseId, true);
+      return null;
+    }
+    throw err;
+  }
+
+  const tracks = projectInlineTracklist(release.tracklist, release.artist) ?? [];
+  releaseTracklistPositiveCache.set(releaseId, tracks);
+  return tracks;
 }
 
 export const updateOnStreaming = async (id: number, on_streaming: boolean | null) => {

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -18,6 +18,8 @@ type PickerSourceMock = {
   inlineTracklist: Array<{ position: string; title: string; duration: string | null; artists: string[] }> | null;
 };
 const mockResolveRotationPickerSource = jest.fn<(rotationId: number) => Promise<PickerSourceMock | null>>();
+type RotationTrackMock = { position: string; title: string; duration: string | null; artists: string[] };
+const mockGetRotationTracksFromRelease = jest.fn<(releaseId: number) => Promise<RotationTrackMock[] | null>>();
 
 jest.mock('../../../apps/backend/services/library.service', () => ({
   getAlbumFromDB: mockGetAlbumFromDB,
@@ -51,24 +53,7 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   insertFormat: jest.fn(),
   isISODate: jest.fn(),
   resolveRotationPickerSource: mockResolveRotationPickerSource,
-  // Real implementation lifted to the service so the controller's release-fetch
-  // path and the service's inline path share one projection. Pass through;
-  // assertions below pin the wire shape.
-  projectInlineTracklist: (
-    tracks:
-      | ReadonlyArray<{ position: string; title: string; duration?: string | null; artists?: readonly string[] | null }>
-      | null
-      | undefined,
-    artistFallback: string
-  ) =>
-    !tracks || tracks.length === 0
-      ? null
-      : tracks.map((t) => ({
-          position: t.position,
-          title: t.title,
-          duration: t.duration ?? null,
-          artists: t.artists && t.artists.length > 0 ? Array.from(t.artists) : [artistFallback],
-        })),
+  getRotationTracksFromRelease: mockGetRotationTracksFromRelease,
 }));
 
 jest.mock('../../../apps/backend/services/labels.service', () => ({
@@ -78,27 +63,12 @@ jest.mock('../../../apps/backend/services/labels.service', () => ({
 const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
 const mockCheckStreamingAvailability = jest.fn<() => Promise<unknown>>();
 const mockIsLmlConfigured = jest.fn<() => boolean>().mockReturnValue(false);
-const mockGetRelease = jest.fn<(releaseId: number) => Promise<unknown>>();
-
-// LmlClientError needs to be a real class so `err instanceof LmlClientError`
-// in the controller works after mocking. Mirrors the real shape in
-// shared/lml-client/src/index.ts (@wxyc/lml-client).
-class MockLmlClientError extends Error {
-  statusCode: number;
-  constructor(message: string, statusCode: number) {
-    super(message);
-    this.name = 'LmlClientError';
-    this.statusCode = statusCode;
-  }
-}
 
 jest.mock('@wxyc/lml-client', () => ({
   checkStreamingAvailability: mockCheckStreamingAvailability,
   lookupMetadata: mockLookupMetadata,
   isLmlConfigured: mockIsLmlConfigured,
-  getRelease: mockGetRelease,
   envInt: (_name: string, fallback: number) => fallback,
-  LmlClientError: MockLmlClientError,
 }));
 
 import {
@@ -479,22 +449,14 @@ describe('library.controller', () => {
   });
 
   describe('getRotationTracks', () => {
-    // Minimal Discogs release shape needed by the projection. The real
-    // DiscogsReleaseMetadata has more fields; we provide only what the
-    // controller reads.
-    const sampleRelease = {
-      release_id: 4080,
-      title: 'Confield',
-      artist: 'Autechre',
-      tracklist: [
-        { position: 'A1', title: 'VI Scose Poise', duration: '5:30', artists: ['Autechre'] },
-        { position: 'A2', title: 'Cfern', duration: '5:11', artists: [] },
-      ],
-    };
+    const sampleProjection: RotationTrackMock[] = [
+      { position: 'A1', title: 'VI Scose Poise', duration: '5:30', artists: ['Autechre'] },
+      { position: 'A2', title: 'Cfern', duration: '5:11', artists: ['Autechre'] },
+    ];
 
     beforeEach(() => {
       mockResolveRotationPickerSource.mockReset();
-      mockGetRelease.mockReset();
+      mockGetRotationTracksFromRelease.mockReset();
     });
 
     it('returns 400 for non-numeric rotation_id', async () => {
@@ -520,34 +482,29 @@ describe('library.controller', () => {
       await getRotationTracks(req, res, next);
 
       expect(mockResolveRotationPickerSource).toHaveBeenCalledWith(42);
-      expect(mockGetRelease).not.toHaveBeenCalled();
+      expect(mockGetRotationTracksFromRelease).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith([]);
     });
 
-    it('projects Discogs tracklist into RotationTrack shape when identity resolves and inline tracklist is absent', async () => {
+    it('delegates to getRotationTracksFromRelease when identity resolves and inline tracklist is absent', async () => {
       mockResolveRotationPickerSource.mockResolvedValue({ releaseId: 4080, inlineTracklist: null });
-      mockGetRelease.mockResolvedValue(sampleRelease);
+      mockGetRotationTracksFromRelease.mockResolvedValue(sampleProjection);
       const req = { params: { rotation_id: '42' } } as unknown as Request;
       const res = mockResponse();
 
       await getRotationTracks(req, res, next);
 
-      expect(mockGetRelease).toHaveBeenCalledWith(4080);
+      expect(mockGetRotationTracksFromRelease).toHaveBeenCalledWith(4080);
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith([
-        { position: 'A1', title: 'VI Scose Poise', duration: '5:30', artists: ['Autechre'] },
-        // Empty Discogs track.artists falls back to the release artist so the
-        // dj-site picker always has at least one artist name to render.
-        { position: 'A2', title: 'Cfern', duration: '5:11', artists: ['Autechre'] },
-      ]);
+      expect(res.json).toHaveBeenCalledWith(sampleProjection);
     });
 
-    it('short-circuits to the inline tracklist when the resolver carries one (no getRelease call)', async () => {
+    it('short-circuits to the inline tracklist when the resolver carries one (no release fetch)', async () => {
       // BS#1185 + LML#427: when the tier-3 LML lookup returns an extended
       // result with a tracklist (Discogs hit OR MusicBrainz rescue), the
       // service projects it inline and the controller returns it directly.
-      // No second LML round-trip via `getRelease`.
+      // No second LML round-trip.
       const inlineTracklist = [
         { position: '1', title: 'Tragic Magic', duration: '6:01', artists: ['Julianna Barwick & Mary Lattimore'] },
         { position: '2', title: 'For Mariko', duration: '4:18', artists: ['Julianna Barwick & Mary Lattimore'] },
@@ -558,14 +515,14 @@ describe('library.controller', () => {
 
       await getRotationTracks(req, res, next);
 
-      expect(mockGetRelease).not.toHaveBeenCalled();
+      expect(mockGetRotationTracksFromRelease).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(inlineTracklist);
     });
 
-    it('returns 200 + empty array on LML 404 (release unknown to Discogs)', async () => {
+    it('returns 200 + empty array when the service returns null (LML 404 negative-cached)', async () => {
       mockResolveRotationPickerSource.mockResolvedValue({ releaseId: 9999999, inlineTracklist: null });
-      mockGetRelease.mockRejectedValue(new MockLmlClientError('not found', 404));
+      mockGetRotationTracksFromRelease.mockResolvedValue(null);
       const req = { params: { rotation_id: '42' } } as unknown as Request;
       const res = mockResponse();
 
@@ -575,9 +532,9 @@ describe('library.controller', () => {
       expect(res.json).toHaveBeenCalledWith([]);
     });
 
-    it('bubbles LML 5xx errors so transient failures surface rather than silently degrading', async () => {
+    it('bubbles service errors (LML 5xx, network) so transient failures surface rather than silently degrading', async () => {
       mockResolveRotationPickerSource.mockResolvedValue({ releaseId: 4080, inlineTracklist: null });
-      mockGetRelease.mockRejectedValue(new MockLmlClientError('upstream timeout', 504));
+      mockGetRotationTracksFromRelease.mockRejectedValue(new Error('upstream timeout'));
       const req = { params: { rotation_id: '42' } } as unknown as Request;
       const res = mockResponse();
 

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -4,12 +4,28 @@ import { db, createMockQueryChain, library, library_artist_view, album_plays } f
 const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
 const mockLookupBySong = jest.fn<() => Promise<unknown>>();
 const mockIsLmlConfigured = jest.fn<() => boolean>();
+const mockGetRelease = jest.fn<(releaseId: number) => Promise<unknown>>();
+
+// Mirror the real `LmlClientError` shape so the service's
+// `err instanceof LmlClientError` branch picks up the mocked rejection
+// (BS#1185 / LML#427 negative-cache test). The real class lives in
+// `shared/lml-client/src/index.ts`.
+class MockLmlClientError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = 'LmlClientError';
+    this.statusCode = statusCode;
+  }
+}
 
 jest.mock('@wxyc/lml-client', () => ({
   lookupMetadata: mockLookupMetadata,
   lookupBySong: mockLookupBySong,
   isLmlConfigured: mockIsLmlConfigured,
+  getRelease: mockGetRelease,
   envInt: (_name: string, fallback: number) => fallback,
+  LmlClientError: MockLmlClientError,
 }));
 
 // Mock @sentry/node so we can assert that searchLibraryByTrack creates a
@@ -52,6 +68,8 @@ import {
   resolveRotationPickerSource,
   __resetRotationLmlLookupCacheForTests,
   isVariousArtistsName,
+  getRotationTracksFromRelease,
+  __resetReleaseTracklistCacheForTests,
 } from '../../../apps/backend/services/library.service';
 import { resetConfig as resetCatalogTrackSearchConfig } from '../../../apps/backend/config/catalogTrackSearch';
 
@@ -2460,6 +2478,101 @@ describe('library.service', () => {
           { position: '2', title: 'For Mariko', duration: '4:18', artists: ['Julianna Barwick & Mary Lattimore'] },
         ],
       });
+    });
+  });
+
+  describe('getRotationTracksFromRelease', () => {
+    // BS-side LRU on the projected RotationTrack[] keyed by Discogs release_id.
+    // The picker's dominant cost in prod is `GET /api/v1/discogs/release/{id}`
+    // (2-9s on LML cache miss; 78ms warm). This cache absorbs both the
+    // second-open-on-same-row case and the cross-rotation-row case where two
+    // rotation_ids resolve to the same release_id.
+
+    const sampleRelease = {
+      artist: 'Autechre',
+      title: 'Confield',
+      tracklist: [
+        { position: 'A1', title: 'VI Scose Poise', duration: '5:30', artists: ['Autechre'] },
+        { position: 'A2', title: 'Cfern', duration: '5:11', artists: [] },
+      ],
+    };
+
+    beforeEach(() => {
+      __resetReleaseTracklistCacheForTests();
+      mockGetRelease.mockReset();
+    });
+
+    it('fetches the release, projects to RotationTrack shape, returns the array', async () => {
+      mockGetRelease.mockResolvedValue(sampleRelease);
+
+      const tracks = await getRotationTracksFromRelease(4080);
+
+      expect(mockGetRelease).toHaveBeenCalledWith(4080);
+      expect(tracks).toEqual([
+        { position: 'A1', title: 'VI Scose Poise', duration: '5:30', artists: ['Autechre'] },
+        // Empty per-track artists fall back to the release-level artist so the
+        // dj-site picker always has at least one name to render.
+        { position: 'A2', title: 'Cfern', duration: '5:11', artists: ['Autechre'] },
+      ]);
+    });
+
+    it('caches positive results so subsequent calls do not hit getRelease within TTL', async () => {
+      mockGetRelease.mockResolvedValue(sampleRelease);
+
+      const first = await getRotationTracksFromRelease(4080);
+      const second = await getRotationTracksFromRelease(4080);
+
+      expect(first).toEqual(second);
+      expect(mockGetRelease).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the cached projection by reference (same array identity)', async () => {
+      // Subsequent picker opens should not re-allocate the projection — the
+      // LRU value is the array itself.
+      mockGetRelease.mockResolvedValue(sampleRelease);
+
+      const first = await getRotationTracksFromRelease(4080);
+      const second = await getRotationTracksFromRelease(4080);
+
+      expect(second).toBe(first);
+    });
+
+    it('returns null on LML 404 and negative-caches so subsequent calls skip getRelease', async () => {
+      mockGetRelease.mockRejectedValue(new MockLmlClientError('not found', 404));
+
+      const first = await getRotationTracksFromRelease(9999999);
+      const second = await getRotationTracksFromRelease(9999999);
+
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+      expect(mockGetRelease).toHaveBeenCalledTimes(1);
+    });
+
+    it('rethrows non-404 LmlClientError (e.g. 5xx) so transient failures surface', async () => {
+      mockGetRelease.mockRejectedValue(new MockLmlClientError('upstream timeout', 504));
+
+      await expect(getRotationTracksFromRelease(4080)).rejects.toThrow('upstream timeout');
+    });
+
+    it('rethrows non-LmlClientError errors (network, JSON parse, etc.) without caching', async () => {
+      mockGetRelease.mockRejectedValueOnce(new Error('socket hang up'));
+
+      await expect(getRotationTracksFromRelease(4080)).rejects.toThrow('socket hang up');
+
+      // Next call should retry (no cached null), to give the picker a chance
+      // to recover when the upstream blip clears.
+      mockGetRelease.mockResolvedValueOnce(sampleRelease);
+      const second = await getRotationTracksFromRelease(4080);
+      expect(second).not.toBeNull();
+      expect(mockGetRelease).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns an empty array (not null) when the release has an empty tracklist', async () => {
+      mockGetRelease.mockResolvedValue({ artist: 'Autechre', title: 'Untitled', tracklist: [] });
+
+      const tracks = await getRotationTracksFromRelease(4080);
+
+      expect(tracks).toEqual([]);
     });
   });
 });

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -2482,12 +2482,6 @@ describe('library.service', () => {
   });
 
   describe('getRotationTracksFromRelease', () => {
-    // BS-side LRU on the projected RotationTrack[] keyed by Discogs release_id.
-    // The picker's dominant cost in prod is `GET /api/v1/discogs/release/{id}`
-    // (2-9s on LML cache miss; 78ms warm). This cache absorbs both the
-    // second-open-on-same-row case and the cross-rotation-row case where two
-    // rotation_ids resolve to the same release_id.
-
     const sampleRelease = {
       artist: 'Autechre',
       title: 'Confield',
@@ -2573,6 +2567,30 @@ describe('library.service', () => {
       const tracks = await getRotationTracksFromRelease(4080);
 
       expect(tracks).toEqual([]);
+    });
+
+    it('coalesces concurrent calls for the same release_id into a single getRelease call', async () => {
+      // A cold-cache deploy followed by a burst of DJs opening the same picker
+      // row should pay the 2-9 s cold-path once across all of them, not once
+      // per DJ. The in-flight Promise map is the single-flight guard.
+      let resolveRelease: (value: unknown) => void = () => undefined;
+      mockGetRelease.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRelease = resolve;
+        })
+      );
+
+      const first = getRotationTracksFromRelease(4080);
+      const second = getRotationTracksFromRelease(4080);
+      const third = getRotationTracksFromRelease(4080);
+
+      resolveRelease(sampleRelease);
+      const [a, b, c] = await Promise.all([first, second, third]);
+
+      expect(mockGetRelease).toHaveBeenCalledTimes(1);
+      // All three callers see the same projected array (cache identity).
+      expect(b).toBe(a);
+      expect(c).toBe(a);
     });
   });
 });


### PR DESCRIPTION
Closes #1229.

## Summary

- New `library.service.getRotationTracksFromRelease(releaseId): Promise<RotationTrack[] | null>` wrapping `getRelease(id)` + `projectInlineTracklist` in a positive/negative LRU keyed by `release_id`.
- `getRotationTracks` controller delegates the tier-1/2 release-fetch path to it and drops its own `getRelease` + `LmlClientError` imports.
- Cache parameters: 500 entries, 24 h positive TTL (Discogs tracklists are effectively immutable), 10 min negative TTL on LML 404.

## Why this and not LML's own cache

LML's 3-tier cache already deduplicates by release_id on the upstream side. But each cache hit still costs a 78 ms LML round-trip across the network from BS. The first miss is 2-9 s. Sentry traces (last 2h, n=5) show p95 = 9.2 s, p50 = 8.3 s for the picker — every tier-1/2 open paid the cold-path cost. With this LRU, the second open of any rotation row (or any other rotation row pointing at the same release) is in-process.

## Test plan

- [ ] `npm run test:unit` — 159 picker-related unit tests green (7 new for `getRotationTracksFromRelease`).
- [ ] Open the rotation-tracks picker for the same rotation row twice in prod. First open: 2-9 s. Second open: instant.
- [ ] Open the picker for two rotation rows that share a `discogs_release_id` (rare but exists). Second open: instant.
- [ ] Sentry: confirm the second open's trace has no `http.client GET .../discogs/release/{id}` span.

## Not included

- Pre-warming LML's release cache at boot — separate issue.
- Instrumenting LML's `/discogs/release/{id}` cold-path — separate LML-side issue.