### PR TITLE
Warm release-tracklist LRU at boot for tier-1/2 rotation rows

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -648,6 +648,19 @@ export function __resetReleaseTracklistCacheForTests(): void {
 }
 
 /**
+ * Sizes of the per-release-id tracklist LRUs. Used by the rotation-tracks
+ * cache-warm service to classify post-`getRotationTracksFromRelease`
+ * outcomes (positive vs negative) without coupling to LRU internals.
+ * Parallel to `__rotationLmlCacheSizesForWarm`.
+ */
+export function __releaseTracklistCacheSizesForWarm(): { positive: number; negative: number } {
+  return {
+    positive: releaseTracklistPositiveCache.size,
+    negative: releaseTracklistNegativeCache.size,
+  };
+}
+
+/**
  * Fetch a Discogs release tracklist via LML and project it onto the
  * picker's `RotationTrack` wire shape. Cached per `release_id`.
  *

--- a/apps/backend/services/rotation-tracks-cache-warm.service.ts
+++ b/apps/backend/services/rotation-tracks-cache-warm.service.ts
@@ -41,7 +41,12 @@
 import * as Sentry from '@sentry/node';
 import { sql } from 'drizzle-orm';
 import { db, rotation } from '@wxyc/database';
-import { resolveRotationPickerSource, __rotationLmlCacheSizesForWarm } from './library.service.js';
+import {
+  resolveRotationPickerSource,
+  __rotationLmlCacheSizesForWarm,
+  getRotationTracksFromRelease,
+  __releaseTracklistCacheSizesForWarm,
+} from './library.service.js';
 
 const LOG_PREFIX = '[rotation-tracks-cache-warm]';
 
@@ -62,6 +67,12 @@ export interface WarmCounters {
   lmlNegative: number;
   /** Rows where `resolveRotationPickerSource` threw. */
   errors: number;
+  /** Release-fetch follow-ups that populated the release-tracklist positive LRU. */
+  releasesWarmedPositive: number;
+  /** Release-fetch follow-ups that populated the release-tracklist negative LRU (LML 404). */
+  releasesWarmedNegative: number;
+  /** Release-fetch follow-ups that threw (5xx, network, parse). */
+  releaseFetchErrors: number;
   /** Wall-clock duration of the walk in ms. */
   elapsedMs: number;
 }
@@ -96,6 +107,9 @@ export async function warmRotationTracksCache(): Promise<WarmCounters> {
     lmlPositive: 0,
     lmlNegative: 0,
     errors: 0,
+    releasesWarmedPositive: 0,
+    releasesWarmedNegative: 0,
+    releaseFetchErrors: 0,
     elapsedMs: 0,
   };
 
@@ -105,9 +119,10 @@ export async function warmRotationTracksCache(): Promise<WarmCounters> {
     const rotationId = row.id as unknown as number;
     counters.scanned += 1;
 
+    let result: Awaited<ReturnType<typeof resolveRotationPickerSource>> = null;
     try {
       const beforeSizes = __rotationLmlCacheSizesForWarm();
-      const result = await resolveRotationPickerSource(rotationId);
+      result = await resolveRotationPickerSource(rotationId);
       const afterSizes = __rotationLmlCacheSizesForWarm();
 
       // Per-row LRU-delta classifier: if a positive entry was added during
@@ -140,11 +155,42 @@ export async function warmRotationTracksCache(): Promise<WarmCounters> {
       console.warn(`${LOG_PREFIX} row ${rotationId} failed: ${(err as Error).message}`);
     }
 
+    // Follow-up release-fetch warm: mirror the picker controller's fall-through.
+    // The controller calls getRotationTracksFromRelease iff
+    // `source.inlineTracklist === null && source.releaseId !== null`. The
+    // BS#1185 sentinel (`releaseId: 0`) is always paired with an inline
+    // tracklist, so `releaseId > 0` would be equivalent; the inline-tracklist
+    // check is the contract this walks.
+    if (result && result.releaseId !== null && result.inlineTracklist === null) {
+      try {
+        const beforeReleaseSizes = __releaseTracklistCacheSizesForWarm();
+        await getRotationTracksFromRelease(result.releaseId);
+        const afterReleaseSizes = __releaseTracklistCacheSizesForWarm();
+        if (afterReleaseSizes.positive > beforeReleaseSizes.positive) {
+          counters.releasesWarmedPositive += 1;
+        } else if (afterReleaseSizes.negative > beforeReleaseSizes.negative) {
+          counters.releasesWarmedNegative += 1;
+        }
+      } catch (err) {
+        counters.releaseFetchErrors += 1;
+        Sentry.captureException(err, {
+          tags: { subsystem: 'rotation-tracks-cache-warm', phase: 'release_fetch' },
+          extra: { rotation_id: rotationId, release_id: result.releaseId },
+        });
+        console.warn(
+          `${LOG_PREFIX} row ${rotationId} release_fetch (release_id=${result.releaseId}) failed: ${(err as Error).message}`
+        );
+      }
+    }
+
     if (counters.scanned % PROGRESS_LOG_EVERY === 0) {
       console.log(
         `${LOG_PREFIX} progress: scanned=${counters.scanned}/${rows.length} ` +
           `preResolved=${counters.preResolved} lmlPositive=${counters.lmlPositive} ` +
-          `lmlNegative=${counters.lmlNegative} errors=${counters.errors}`
+          `lmlNegative=${counters.lmlNegative} ` +
+          `releasesWarmedPositive=${counters.releasesWarmedPositive} ` +
+          `releasesWarmedNegative=${counters.releasesWarmedNegative} ` +
+          `errors=${counters.errors} releaseFetchErrors=${counters.releaseFetchErrors}`
       );
     }
   }
@@ -154,7 +200,10 @@ export async function warmRotationTracksCache(): Promise<WarmCounters> {
   console.log(
     `${LOG_PREFIX} done: scanned=${counters.scanned} preResolved=${counters.preResolved} ` +
       `lmlPositive=${counters.lmlPositive} lmlNegative=${counters.lmlNegative} ` +
-      `errors=${counters.errors} elapsedMs=${counters.elapsedMs} ` +
+      `releasesWarmedPositive=${counters.releasesWarmedPositive} ` +
+      `releasesWarmedNegative=${counters.releasesWarmedNegative} ` +
+      `errors=${counters.errors} releaseFetchErrors=${counters.releaseFetchErrors} ` +
+      `elapsedMs=${counters.elapsedMs} ` +
       `(starting cache sizes positive=${startSizes.positive} negative=${startSizes.negative})`
   );
 

--- a/apps/backend/services/rotation-tracks-cache-warm.service.ts
+++ b/apps/backend/services/rotation-tracks-cache-warm.service.ts
@@ -56,6 +56,16 @@ const LOG_PREFIX = '[rotation-tracks-cache-warm]';
  */
 const PROGRESS_LOG_EVERY = 50;
 
+/**
+ * Hard wall-clock cap for the warm pass. Backstop against the LML-monopolization
+ * pattern seen in BS#995 / BS#1011 / BS#1064 — if every row falls into a
+ * 2-9 s cold-path, 310 rows × 20 s ≈ 100 min of background LML pressure. 30 min
+ * keeps the warmer well under the saturation window observed in those
+ * incidents; rows skipped by the budget get retried on the next process restart
+ * and warm progressively across the deploy cadence.
+ */
+const WARM_PASS_BUDGET_MS = 30 * 60 * 1000;
+
 export interface WarmCounters {
   /** Total rows walked. */
   scanned: number;
@@ -67,12 +77,16 @@ export interface WarmCounters {
   lmlNegative: number;
   /** Rows where `resolveRotationPickerSource` threw. */
   errors: number;
-  /** Release-fetch follow-ups that populated the release-tracklist positive LRU. */
-  releasesWarmedPositive: number;
-  /** Release-fetch follow-ups that populated the release-tracklist negative LRU (LML 404). */
-  releasesWarmedNegative: number;
+  /** Release-fetch follow-ups that grew the release-tracklist positive LRU. */
+  releaseFetchPositive: number;
+  /** Release-fetch follow-ups that grew the release-tracklist negative LRU (LML 404). */
+  releaseFetchNegative: number;
+  /** Release-fetch follow-ups that found the release already cached cross-row. */
+  releaseFetchAlreadyWarm: number;
   /** Release-fetch follow-ups that threw (5xx, network, parse). */
   releaseFetchErrors: number;
+  /** Rows skipped after the wall-clock budget elapsed. */
+  budgetSkipped: number;
   /** Wall-clock duration of the walk in ms. */
   elapsedMs: number;
 }
@@ -107,9 +121,11 @@ export async function warmRotationTracksCache(): Promise<WarmCounters> {
     lmlPositive: 0,
     lmlNegative: 0,
     errors: 0,
-    releasesWarmedPositive: 0,
-    releasesWarmedNegative: 0,
+    releaseFetchPositive: 0,
+    releaseFetchNegative: 0,
+    releaseFetchAlreadyWarm: 0,
     releaseFetchErrors: 0,
+    budgetSkipped: 0,
     elapsedMs: 0,
   };
 
@@ -117,6 +133,12 @@ export async function warmRotationTracksCache(): Promise<WarmCounters> {
 
   for (const row of rows) {
     const rotationId = row.id as unknown as number;
+
+    if (Date.now() - startTime > WARM_PASS_BUDGET_MS) {
+      counters.budgetSkipped += 1;
+      continue;
+    }
+
     counters.scanned += 1;
 
     let result: Awaited<ReturnType<typeof resolveRotationPickerSource>> = null;
@@ -155,21 +177,19 @@ export async function warmRotationTracksCache(): Promise<WarmCounters> {
       console.warn(`${LOG_PREFIX} row ${rotationId} failed: ${(err as Error).message}`);
     }
 
-    // Follow-up release-fetch warm: mirror the picker controller's fall-through.
-    // The controller calls getRotationTracksFromRelease iff
-    // `source.inlineTracklist === null && source.releaseId !== null`. The
-    // BS#1185 sentinel (`releaseId: 0`) is always paired with an inline
-    // tracklist, so `releaseId > 0` would be equivalent; the inline-tracklist
-    // check is the contract this walks.
+    // Mirror the picker controller's fall-through: getRotationTracksFromRelease
+    // iff inlineTracklist is null.
     if (result && result.releaseId !== null && result.inlineTracklist === null) {
       try {
         const beforeReleaseSizes = __releaseTracklistCacheSizesForWarm();
         await getRotationTracksFromRelease(result.releaseId);
         const afterReleaseSizes = __releaseTracklistCacheSizesForWarm();
         if (afterReleaseSizes.positive > beforeReleaseSizes.positive) {
-          counters.releasesWarmedPositive += 1;
+          counters.releaseFetchPositive += 1;
         } else if (afterReleaseSizes.negative > beforeReleaseSizes.negative) {
-          counters.releasesWarmedNegative += 1;
+          counters.releaseFetchNegative += 1;
+        } else {
+          counters.releaseFetchAlreadyWarm += 1;
         }
       } catch (err) {
         counters.releaseFetchErrors += 1;
@@ -188,8 +208,9 @@ export async function warmRotationTracksCache(): Promise<WarmCounters> {
         `${LOG_PREFIX} progress: scanned=${counters.scanned}/${rows.length} ` +
           `preResolved=${counters.preResolved} lmlPositive=${counters.lmlPositive} ` +
           `lmlNegative=${counters.lmlNegative} ` +
-          `releasesWarmedPositive=${counters.releasesWarmedPositive} ` +
-          `releasesWarmedNegative=${counters.releasesWarmedNegative} ` +
+          `releaseFetchPositive=${counters.releaseFetchPositive} ` +
+          `releaseFetchNegative=${counters.releaseFetchNegative} ` +
+          `releaseFetchAlreadyWarm=${counters.releaseFetchAlreadyWarm} ` +
           `errors=${counters.errors} releaseFetchErrors=${counters.releaseFetchErrors}`
       );
     }
@@ -200,8 +221,10 @@ export async function warmRotationTracksCache(): Promise<WarmCounters> {
   console.log(
     `${LOG_PREFIX} done: scanned=${counters.scanned} preResolved=${counters.preResolved} ` +
       `lmlPositive=${counters.lmlPositive} lmlNegative=${counters.lmlNegative} ` +
-      `releasesWarmedPositive=${counters.releasesWarmedPositive} ` +
-      `releasesWarmedNegative=${counters.releasesWarmedNegative} ` +
+      `releaseFetchPositive=${counters.releaseFetchPositive} ` +
+      `releaseFetchNegative=${counters.releaseFetchNegative} ` +
+      `releaseFetchAlreadyWarm=${counters.releaseFetchAlreadyWarm} ` +
+      `budgetSkipped=${counters.budgetSkipped} ` +
       `errors=${counters.errors} releaseFetchErrors=${counters.releaseFetchErrors} ` +
       `elapsedMs=${counters.elapsedMs} ` +
       `(starting cache sizes positive=${startSizes.positive} negative=${startSizes.negative})`

--- a/tests/unit/services/rotation-tracks-cache-warm.service.test.ts
+++ b/tests/unit/services/rotation-tracks-cache-warm.service.test.ts
@@ -23,18 +23,28 @@ import { db } from '../../mocks/database.mock';
 // `library.service` exposes both the picker resolver we drive end-to-end
 // and the LRU-sizes accessor we read for the counter classifier. Mock at
 // the module boundary so the warm service receives our test doubles.
-type PickerSource = { releaseId: number; inlineTracklist: null };
+type RotationTrack = { position: string; title: string; duration: string | null; artists: string[] };
+type PickerSource = { releaseId: number | null; inlineTracklist: RotationTrack[] | null };
 const mockResolveRotationPickerSource = jest.fn<(id: number) => Promise<PickerSource | null>>();
 type Sizes = { positive: number; negative: number };
 const sizesRef: { current: Sizes } = { current: { positive: 0, negative: 0 } };
 const mockRotationLmlCacheSizesForWarm = jest.fn<() => Sizes>(() => sizesRef.current);
+const releaseSizesRef: { current: Sizes } = { current: { positive: 0, negative: 0 } };
+const mockReleaseTracklistCacheSizesForWarm = jest.fn<() => Sizes>(() => releaseSizesRef.current);
+const mockGetRotationTracksFromRelease = jest.fn<(releaseId: number) => Promise<RotationTrack[] | null>>();
 
 jest.mock('../../../apps/backend/services/library.service', () => ({
   resolveRotationPickerSource: mockResolveRotationPickerSource,
   __rotationLmlCacheSizesForWarm: mockRotationLmlCacheSizesForWarm,
+  getRotationTracksFromRelease: mockGetRotationTracksFromRelease,
+  __releaseTracklistCacheSizesForWarm: mockReleaseTracklistCacheSizesForWarm,
 }));
 
 const source = (releaseId: number): PickerSource => ({ releaseId, inlineTracklist: null });
+const inlineSource = (releaseId: number | null, tracks: RotationTrack[]): PickerSource => ({
+  releaseId,
+  inlineTracklist: tracks,
+});
 
 const mockCaptureException = jest.fn();
 jest.mock('@sentry/node', () => ({
@@ -85,8 +95,11 @@ describe('rotation-tracks-cache-warm.service', () => {
   beforeEach(() => {
     selectMock.mockReset();
     mockResolveRotationPickerSource.mockReset();
+    mockGetRotationTracksFromRelease.mockReset();
+    mockGetRotationTracksFromRelease.mockResolvedValue([]);
     mockCaptureException.mockReset();
     sizesRef.current = { positive: 0, negative: 0 };
+    releaseSizesRef.current = { positive: 0, negative: 0 };
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
     consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -130,6 +143,97 @@ describe('rotation-tracks-cache-warm.service', () => {
       expect(counters.lmlNegative).toBe(1);
       expect(counters.errors).toBe(0);
       expect(counters.elapsedMs).toBeGreaterThanOrEqual(0);
+    });
+
+    test('warms the release-tracklist LRU for rows resolving via tier 1/2 (no inline tracklist)', async () => {
+      mockActiveRotationRows([10, 20]);
+      // Row 10: tier-1 hit (releaseId set, no inline tracklist) → must follow up.
+      // Row 20: tier-3 inline (releaseId set, inline tracklist carried) → must NOT follow up.
+      mockResolveRotationPickerSource.mockResolvedValueOnce(source(4080));
+      mockResolveRotationPickerSource.mockResolvedValueOnce(
+        inlineSource(12345, [{ position: '1', title: 'T', duration: null, artists: ['A'] }])
+      );
+
+      await warmRotationTracksCache();
+
+      expect(mockGetRotationTracksFromRelease).toHaveBeenCalledTimes(1);
+      expect(mockGetRotationTracksFromRelease).toHaveBeenCalledWith(4080);
+    });
+
+    test('does not call getRotationTracksFromRelease when the resolver returns null', async () => {
+      mockActiveRotationRows([10]);
+      mockResolveRotationPickerSource.mockResolvedValue(null);
+
+      await warmRotationTracksCache();
+
+      expect(mockGetRotationTracksFromRelease).not.toHaveBeenCalled();
+    });
+
+    test('does not call getRotationTracksFromRelease when releaseId is the BS#1185 sentinel zero with inline tracklist', async () => {
+      // MB-rescue rows carry releaseId=0 + inline tracklist; the picker
+      // short-circuits on inline tracks, so the warmer must too — calling
+      // getRotationTracksFromRelease(0) would 404 and waste a semaphore slot.
+      mockActiveRotationRows([10]);
+      mockResolveRotationPickerSource.mockResolvedValue(
+        inlineSource(0, [{ position: '1', title: 'T', duration: null, artists: ['A'] }])
+      );
+
+      await warmRotationTracksCache();
+
+      expect(mockGetRotationTracksFromRelease).not.toHaveBeenCalled();
+    });
+
+    test('release-tracklist warm counters: classifies positive vs negative cache additions per row', async () => {
+      mockActiveRotationRows([10, 20, 30]);
+      // Row 10: tier-1 hit, release-fetch warms positive LRU.
+      // Row 20: tier-1 hit, release-fetch returns null (404), warms negative LRU.
+      // Row 30: tier-3 inline, no release-fetch attempted.
+      mockResolveRotationPickerSource.mockResolvedValueOnce(source(4080));
+      mockResolveRotationPickerSource.mockResolvedValueOnce(source(9999999));
+      mockResolveRotationPickerSource.mockResolvedValueOnce(
+        inlineSource(12345, [{ position: '1', title: 'T', duration: null, artists: ['A'] }])
+      );
+      mockGetRotationTracksFromRelease.mockImplementationOnce(() => {
+        releaseSizesRef.current = { ...releaseSizesRef.current, positive: releaseSizesRef.current.positive + 1 };
+        return Promise.resolve([{ position: '1', title: 'T', duration: null, artists: ['A'] }]);
+      });
+      mockGetRotationTracksFromRelease.mockImplementationOnce(() => {
+        releaseSizesRef.current = { ...releaseSizesRef.current, negative: releaseSizesRef.current.negative + 1 };
+        return Promise.resolve(null);
+      });
+
+      const counters = await warmRotationTracksCache();
+
+      expect(counters.releasesWarmedPositive).toBe(1);
+      expect(counters.releasesWarmedNegative).toBe(1);
+      expect(counters.releaseFetchErrors).toBe(0);
+    });
+
+    test('release-fetch failure is captured to Sentry but does not halt the walk', async () => {
+      mockActiveRotationRows([10, 20]);
+      mockResolveRotationPickerSource.mockResolvedValueOnce(source(4080));
+      mockResolveRotationPickerSource.mockResolvedValueOnce(source(9999));
+      mockGetRotationTracksFromRelease.mockRejectedValueOnce(new Error('LML 504'));
+      mockGetRotationTracksFromRelease.mockResolvedValueOnce([]);
+
+      const counters = await warmRotationTracksCache();
+
+      expect(counters.scanned).toBe(2);
+      expect(counters.releaseFetchErrors).toBe(1);
+      expect(mockGetRotationTracksFromRelease).toHaveBeenCalledTimes(2);
+      // Sentry capture carries the rotation_id + release_id context.
+      const release_fetch_captures = mockCaptureException.mock.calls.filter(
+        (call) => (call[1] as { tags?: Record<string, string> })?.tags?.phase === 'release_fetch'
+      );
+      expect(release_fetch_captures).toHaveLength(1);
+      const [capturedErr, captureContext] = release_fetch_captures[0] as [
+        Error,
+        { tags?: Record<string, string>; extra?: Record<string, unknown> },
+      ];
+      expect(capturedErr.message).toBe('LML 504');
+      expect(captureContext.tags?.subsystem).toBe('rotation-tracks-cache-warm');
+      expect(captureContext.extra?.rotation_id).toBe(10);
+      expect(captureContext.extra?.release_id).toBe(4080);
     });
 
     test('does not halt when a single row throws — sibling rows still visited and captured to Sentry', async () => {

--- a/tests/unit/services/rotation-tracks-cache-warm.service.test.ts
+++ b/tests/unit/services/rotation-tracks-cache-warm.service.test.ts
@@ -204,8 +204,8 @@ describe('rotation-tracks-cache-warm.service', () => {
 
       const counters = await warmRotationTracksCache();
 
-      expect(counters.releasesWarmedPositive).toBe(1);
-      expect(counters.releasesWarmedNegative).toBe(1);
+      expect(counters.releaseFetchPositive).toBe(1);
+      expect(counters.releaseFetchNegative).toBe(1);
       expect(counters.releaseFetchErrors).toBe(0);
     });
 
@@ -234,6 +234,52 @@ describe('rotation-tracks-cache-warm.service', () => {
       expect(captureContext.tags?.subsystem).toBe('rotation-tracks-cache-warm');
       expect(captureContext.extra?.rotation_id).toBe(10);
       expect(captureContext.extra?.release_id).toBe(4080);
+    });
+
+    test('bails the loop and tallies budgetSkipped when the wall-clock budget elapses', async () => {
+      // Hard cap is 30 min (1.8e6 ms). Drive Date.now so iteration 3 fires
+      // after the cap; rows 1 and 2 should run, row 3 should be skipped.
+      mockActiveRotationRows([10, 20, 30]);
+      mockResolveRotationPickerSource.mockResolvedValue(null);
+      const BUDGET_MS = 30 * 60 * 1000;
+      const dateSpy = jest.spyOn(Date, 'now');
+      // startTime read.
+      dateSpy.mockReturnValueOnce(0);
+      // Per-iteration budget check.
+      dateSpy.mockReturnValueOnce(100); // row 10: within budget.
+      dateSpy.mockReturnValueOnce(200); // row 20: within budget.
+      dateSpy.mockReturnValueOnce(BUDGET_MS + 1); // row 30: over budget.
+      // Any further Date.now calls (final elapsedMs computation) — return a sane value.
+      dateSpy.mockReturnValue(BUDGET_MS + 100);
+
+      const counters = await warmRotationTracksCache();
+
+      expect(counters.scanned).toBe(2);
+      expect(counters.budgetSkipped).toBe(1);
+      expect(mockResolveRotationPickerSource).toHaveBeenCalledTimes(2);
+
+      dateSpy.mockRestore();
+    });
+
+    test('counts a cross-row release-fetch cache hit as releaseFetchAlreadyWarm', async () => {
+      // Two rows share the same releaseId. The first warms the LRU; the
+      // second's release-fetch returns the cached projection without
+      // growing either LRU.
+      mockActiveRotationRows([10, 20]);
+      mockResolveRotationPickerSource.mockResolvedValueOnce(source(4080));
+      mockResolveRotationPickerSource.mockResolvedValueOnce(source(4080));
+      mockGetRotationTracksFromRelease.mockImplementationOnce(() => {
+        releaseSizesRef.current = { ...releaseSizesRef.current, positive: releaseSizesRef.current.positive + 1 };
+        return Promise.resolve([]);
+      });
+      // Second call: no size change (cache hit).
+      mockGetRotationTracksFromRelease.mockResolvedValueOnce([]);
+
+      const counters = await warmRotationTracksCache();
+
+      expect(counters.releaseFetchPositive).toBe(1);
+      expect(counters.releaseFetchAlreadyWarm).toBe(1);
+      expect(counters.releaseFetchNegative).toBe(0);
     });
 
     test('does not halt when a single row throws — sibling rows still visited and captured to Sentry', async () => {


### PR DESCRIPTION
Closes #1231. Stacks on #1230 (merged).

## Summary

- `warmRotationTracksCache` now follows up each `resolveRotationPickerSource` call with `getRotationTracksFromRelease(releaseId)` when the picker controller would fall through to it (`inlineTracklist === null && releaseId !== null`).
- New counters: `releasesWarmedPositive`, `releasesWarmedNegative`, `releaseFetchErrors`.
- `__releaseTracklistCacheSizesForWarm()` added in `library.service.ts` as the parallel sizes accessor (alongside `__rotationLmlCacheSizesForWarm`).

## Why

The per-`release_id` LRU added in #1230 makes the *second* picker open instant. The *first* open still pays the 2-9 s `getRelease(id)` cold-path. Warming at boot moves that cost off the user-visible path entirely — DJs only ever see the in-process cache.

## How it shares the chokepoint

`getRotationTracksFromRelease` goes through the same `@wxyc/lml-client.getRelease` that the picker uses, so the boot walk shares the LML chokepoint (`Semaphore(5)`, `TokenBucket(50/min)`). The walk stays sequential per row to keep concurrent-LML pressure unchanged. Real user picker opens that race the warmer for the same `releaseId` coalesce on the in-flight Promise added in #1230 — they ride the warmer's `getRelease` instead of starting a second one.

## Test plan

- [ ] `npm run test:unit` — 11 warm-walker tests green (5 new for the release-fetch follow-up path).
- [ ] After deploy, watch the boot log for the `done:` summary line — should show `releasesWarmedPositive ≈ active-rotation-row count - releasesWarmedNegative` with no `releaseFetchErrors`.
- [ ] First picker open in the dj-site shortly after deploy: should be instant (LRU hit) rather than 2-9 s.

## Not included

- LML-side instrumentation of `/discogs/release/{id}` cold-path — separate LML issue.