### PR TITLE
Bump rotation negative-cache TTL 10 min → 24 h

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -346,13 +346,16 @@ export async function getDiscogsReleaseIdByLegacyId(legacyId: number): Promise<n
  * nothing) — match the artwork/negativeCache pattern in
  * `apps/backend/controllers/proxy.controller.ts`. lru-cache v11 constrains
  * value types to non-nullable, so the negative cache stores `true` and uses
- * key presence as the signal. Negative TTL is shorter so a row that becomes
- * resolvable (LML catalog improvements, Discogs additions) recovers within
- * minutes rather than waiting for the process to restart.
+ * key presence as the signal. Negative TTL is 24 h: the tier-3 cascade-
+ * exhaustion path costs the full `LML_SEARCH_HARD_TIMEOUT_MS` (~22 s)
+ * when the negative cache expires, and the rows it negatives are obscure
+ * (no Discogs release, no library_identity, no rotation.discogs_release_id —
+ * none of which flip in 10 min). Deploys re-warm the cache via the
+ * `rotation-tracks-cache-warm` walker (BS#1231), so 24 h is a soft ceiling.
  */
 const ROTATION_LML_LOOKUP_CACHE_MAX = 500;
 const ROTATION_LML_LOOKUP_TTL_POSITIVE_MS = 60 * 60 * 1000;
-const ROTATION_LML_LOOKUP_TTL_NEGATIVE_MS = 10 * 60 * 1000;
+const ROTATION_LML_LOOKUP_TTL_NEGATIVE_MS = 24 * 60 * 60 * 1000;
 /**
  * Per-call LML timeout for the picker's tier-3 lookup. 10 s matches
  * tubafrenzy's `RELEASE_LOOKUP_TIMEOUT` (`LibrarySearchClient.java:64`),


### PR DESCRIPTION
## Why

End-to-end measurement of all 201 visible rotation rows from prod dj-site (via authenticated `fetch` of the picker endpoint, sequential to share a TLS connection):

| Stat | ms |
|---|---|
| p50 | 207 |
| p90 | 432 |
| p95 | 475 |
| p99 | 521 (excl. 1 outlier) |
| max | **22 663** |

The 22.7 s outlier was `rotation_id=8207` (Heavy bin) returning `[]`. That's one of the 28 rotation rows the warm walker classified as `lmlNegative` — tier-1 + tier-2 missed, tier-3 LML cascade exhausted with no hit, capped by `LML_SEARCH_HARD_TIMEOUT_MS` (default 25 000 ms). The current 10-min negative TTL on `rotationLmlNegativeCache` means DJs re-pay this cost every ~10 min as the cache rolls over.

The rows that drive negative results are unlikely to flip in 10 min — they need a Discogs catalog addition, a library_identity hit from a future bulk-resolve, or the BS#1029 backfill writing a `rotation.discogs_release_id`. 10 min was an over-conservative TTL.

## What

`ROTATION_LML_LOOKUP_TTL_NEGATIVE_MS`: `10 * 60 * 1000` → `24 * 60 * 60 * 1000`.

The `rotation-tracks-cache-warm` walker (BS#1231) re-populates the LRU at boot so deploys re-warm naturally; 24 h is a soft ceiling against drift.

## Test plan

- [ ] `npm run test:unit -- -t "resolveRotationPickerSource"` — 33 picker tests green.
- [ ] After deploy, re-measure with the same harness: outlier count drops from 1 → 0 for at least 24 h.
- [ ] Watch warm-walker `done:` line on next restart: `lmlNegative` and `releaseFetchNegative` should populate the same as before (the TTL change doesn't affect the warm walker's behavior).

## Not included

- Persistent column for negative outcomes (BS#1234 / follow-up).
- 400–500 ms band audit (BS#1235 / follow-up).