### PR TITLE
feat(lml-client): add lml.caller Sentry attribute for per-caller-class slicing

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -95,7 +95,10 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
     const artistName = body.alternate_artist_name || body.artist_name || '';
     const [streamingResult, artworkResult] = await Promise.allSettled([
       checkStreamingAvailability(artistName, body.album_title),
-      lookupMetadata(artistName, body.album_title, undefined, { budgetMs: LIBRARY_LML_BUDGET_MS }),
+      lookupMetadata(artistName, body.album_title, undefined, {
+        budgetMs: LIBRARY_LML_BUDGET_MS,
+        caller: 'library-add-album',
+      }),
     ]);
 
     if (streamingResult.status === 'fulfilled' && streamingResult.value.on_streaming !== null) {
@@ -143,7 +146,10 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
 function fireAndForgetCanonicalEntity(libraryId: number, artistName: string | null, albumTitle: string): void {
   if (!artistName) return;
 
-  lookupMetadata(artistName, albumTitle, undefined, { budgetMs: LIBRARY_LML_BUDGET_MS })
+  lookupMetadata(artistName, albumTitle, undefined, {
+    budgetMs: LIBRARY_LML_BUDGET_MS,
+    caller: 'library-canonical-entity',
+  })
     .then(async (response) => {
       const linkage = libraryService.mapLookupToCanonicalEntity(response);
       if (!linkage) return;

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -322,10 +322,12 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
       lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle, {
         extended: true,
         budgetMs: PROXY_LML_BUDGET_MS,
+        caller: 'proxy-album-metadata',
       });
     } else {
       lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle, {
         budgetMs: PROXY_LML_BUDGET_MS,
+        caller: 'proxy-album-metadata',
       });
     }
     upstreamCalls += 1;

--- a/apps/backend/services/artwork/providers/discogs.ts
+++ b/apps/backend/services/artwork/providers/discogs.ts
@@ -31,7 +31,9 @@ export class DiscogsProvider implements ArtworkProvider {
 
     let lookupResponse;
     try {
-      lookupResponse = await lookupMetadata(request.artist || '', request.album, request.song);
+      lookupResponse = await lookupMetadata(request.artist || '', request.album, request.song, {
+        caller: 'artwork-discogs-fallback',
+      });
     } catch (error) {
       console.warn('[DiscogsProvider] LML lookup failed:', error);
       return [];

--- a/apps/backend/services/flowsheet-linkage.service.ts
+++ b/apps/backend/services/flowsheet-linkage.service.ts
@@ -75,6 +75,7 @@ export async function runLmlLinkage(args: {
     // LML bounds concurrent warm tasks process-wide to cap Discogs amplification.
     response = await lookupMetadata(artistName, albumTitle ?? undefined, undefined, {
       warm_cache: true,
+      caller: 'flowsheet-linkage',
     });
   } catch (error) {
     // The forward path is fire-and-forget — we own error reporting here so

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -587,6 +587,7 @@ async function resolveRotationDiscogsReleaseViaLml(
     const response = await lookupMetadata(lookupArtist, albumTitle, undefined, {
       timeoutMs: ROTATION_LML_LOOKUP_TIMEOUT_MS,
       extended: true,
+      caller: 'library-rotation-picker',
     });
     const artwork = response.results?.[0]?.artwork ?? null;
     const releaseId = artwork?.release_id ?? null;
@@ -839,6 +840,7 @@ export async function enrichWithArtwork<T extends ArtworkEnrichable>(results: T[
     uncached.map(async (row) => {
       const lookupResult = await lookupMetadata(row.artist_name, row.album_title, undefined, {
         budgetMs: LIBRARY_INTERACTIVE_LML_BUDGET_MS,
+        caller: 'library-enrich-artwork',
       });
       const artworkUrl = filterSpacerGif(lookupResult.results?.[0]?.artwork?.artwork_url);
       if (!artworkUrl) return;
@@ -1453,7 +1455,10 @@ export async function searchAlbumsByTitle(albumTitle: string, limit = 5): Promis
  */
 async function searchLibraryByTrackUncachedOrThrow(query: string): Promise<TaggedLibraryViewEntry[]> {
   const lookupStart = performance.now();
-  const response: LookupResponse = await lookupBySong(query, { budgetMs: LIBRARY_INTERACTIVE_LML_BUDGET_MS });
+  const response: LookupResponse = await lookupBySong(query, {
+    budgetMs: LIBRARY_INTERACTIVE_LML_BUDGET_MS,
+    caller: 'library-track-search',
+  });
   try {
     Sentry.getActiveSpan()?.setAttributes({
       'track_search.master_lookup_ms': performance.now() - lookupStart,

--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -57,7 +57,7 @@ export async function fetchMetadata(request: MetadataRequest): Promise<Flowsheet
   const { artistName, albumTitle, trackTitle } = request;
   const result: FlowsheetMetadata = {};
 
-  const lookupResponse = await lookupMetadata(artistName, albumTitle, trackTitle);
+  const lookupResponse = await lookupMetadata(artistName, albumTitle, trackTitle, { caller: 'metadata-service' });
   const artwork: DiscogsMatchResult | null = lookupResponse.results?.[0]?.artwork ?? null;
 
   if (artwork) {

--- a/apps/backend/services/requestLine/requestLine.enhanced.service.ts
+++ b/apps/backend/services/requestLine/requestLine.enhanced.service.ts
@@ -229,7 +229,7 @@ export async function processRequest(body: RequestLineRequestBody): Promise<Unif
               }));
             },
             searchReleasesByArtist: async (artist: string, limit = 10) => {
-              const response = await lookupMetadata(artist);
+              const response = await lookupMetadata(artist, undefined, undefined, { caller: 'request-line' });
               return (response.results ?? [])
                 .filter((r) => r.library_item?.title)
                 .slice(0, limit)

--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -92,7 +92,7 @@ async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
             candidate.artist_name,
             candidate.album_title ?? undefined,
             candidate.track_title ?? undefined,
-            { budgetMs: ENRICHMENT_LML_BUDGET_MS }
+            { budgetMs: ENRICHMENT_LML_BUDGET_MS, caller: 'enrichment-worker' }
           );
           outcome = await finalizeRow(candidate, response);
         } catch (err) {

--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -428,7 +428,11 @@ export const runBatch = async (
   const timeoutMs = computeBulkTimeoutMs(items.length);
   let response;
   try {
-    response = await bulkLookupMetadata(items, { budgetMs: options.budgetMs, timeoutMs });
+    response = await bulkLookupMetadata(items, {
+      budgetMs: options.budgetMs,
+      timeoutMs,
+      caller: 'album-level-backfill',
+    });
   } catch (err) {
     const firstAlbumId = resolved[0]?.album_id ?? null;
     const lastAlbumId = resolved[resolved.length - 1]?.album_id ?? null;

--- a/jobs/flowsheet-artwork-repair/lml-fetch.ts
+++ b/jobs/flowsheet-artwork-repair/lml-fetch.ts
@@ -33,4 +33,8 @@ const envInt = (name: string, fallback: number): number => {
 const TIMEOUT_MS = envInt('BACKFILL_ARTWORK_REPAIR_TIMEOUT_MS', 35_000);
 
 export const lookupMetadata = (artist: string, album?: string, track?: string): Promise<LookupResponse> =>
-  sharedLookupMetadata(artist, album, track, { limiter: defaultLmlLimiter, timeoutMs: TIMEOUT_MS });
+  sharedLookupMetadata(artist, album, track, {
+    limiter: defaultLmlLimiter,
+    timeoutMs: TIMEOUT_MS,
+    caller: 'flowsheet-artwork-repair',
+  });

--- a/jobs/flowsheet-metadata-backfill/lml-fetch.ts
+++ b/jobs/flowsheet-metadata-backfill/lml-fetch.ts
@@ -48,4 +48,8 @@ const envInt = (name: string, fallback: number): number => {
 const TIMEOUT_MS = envInt('BACKFILL_LML_PER_CALL_TIMEOUT_MS', 35_000);
 
 export const lookupMetadata = (artist: string, album?: string, track?: string): Promise<LookupResponse> =>
-  sharedLookupMetadata(artist, album, track, { limiter: defaultLmlLimiter, timeoutMs: TIMEOUT_MS });
+  sharedLookupMetadata(artist, album, track, {
+    limiter: defaultLmlLimiter,
+    timeoutMs: TIMEOUT_MS,
+    caller: 'flowsheet-metadata-backfill',
+  });

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -402,6 +402,19 @@ export interface LookupOptions {
    * — the no-header path keeps the pre-A10 warm-cache / write-path semantics.
    */
   budgetMs?: number;
+  /**
+   * Caller-class label projected onto the Sentry `lml.lookup` span as the
+   * `lml.caller` attribute (BS#1235). Used to slice the rolled-up p95 in
+   * Sentry's trace explorer (and the Epic A acceptance routine at
+   * WXYC/library-metadata-lookup#338) so interactive paths
+   * (proxy/library/rotation, ~5 s budget) and background paths
+   * (enrichment-worker, ~29 s budget) don't fight each other in the rollup.
+   * Lowercase kebab-case scoped to the call site (e.g. `proxy-album-metadata`,
+   * `enrichment-worker`, `library-track-search`). Omit at your peril — missing
+   * callers project as `lml.caller=unknown`, which is meant as a Sentry
+   * flag-of-shame so untracked call sites surface in queries.
+   */
+  caller?: string;
 }
 
 type LookupBody = {
@@ -449,6 +462,7 @@ export async function lookupMetadata(
     timeoutMs: options?.timeoutMs,
     limiter: options?.limiter,
     budgetMs: options?.budgetMs,
+    caller: options?.caller,
   });
 }
 
@@ -462,9 +476,12 @@ export async function lookupMetadata(
  */
 export async function lookupBySong(
   song: string,
-  options?: Pick<LookupOptions, 'limiter' | 'budgetMs'>
+  options?: Pick<LookupOptions, 'limiter' | 'budgetMs' | 'caller'>
 ): Promise<LookupResponse> {
-  return postLookup({ song, raw_message: song }, { limiter: options?.limiter, budgetMs: options?.budgetMs });
+  return postLookup(
+    { song, raw_message: song },
+    { limiter: options?.limiter, budgetMs: options?.budgetMs, caller: options?.caller }
+  );
 }
 
 /**
@@ -478,7 +495,7 @@ export async function lookupBySong(
  */
 async function postLookup(
   body: LookupBody,
-  options?: { timeoutMs?: number; limiter?: LmlLimiter; budgetMs?: number }
+  options?: { timeoutMs?: number; limiter?: LmlLimiter; budgetMs?: number; caller?: string }
 ): Promise<LookupResponse> {
   // BS#906 / G4: Mirror LML's Discogs ceilings on the client so back-pressure
   // surfaces at the BS chokepoint, not as queueing inside LML. The limiter
@@ -489,9 +506,12 @@ async function postLookup(
   return activeLimiter.run(async () => {
     return await Sentry.startSpan({ name: 'lml.lookup', op: 'http.client' }, async (span) => {
       try {
-        span.setAttributes({ 'lml.queue_depth': activeLimiter.state().queueDepth });
+        span.setAttributes({
+          'lml.queue_depth': activeLimiter.state().queueDepth,
+          'lml.caller': options?.caller ?? 'unknown',
+        });
       } catch (err) {
-        console.warn('lml.client: failed to project queue_depth onto span', err);
+        console.warn('lml.client: failed to project queue_depth + caller onto span', err);
       }
 
       const response = await lmlFetch(
@@ -598,7 +618,7 @@ const BULK_LOOKUP_INPUT_CAP = 100;
  */
 export async function bulkLookupMetadata(
   items: BulkLookupItem[],
-  options?: { timeoutMs?: number; limiter?: LmlLimiter; budgetMs?: number }
+  options?: { timeoutMs?: number; limiter?: LmlLimiter; budgetMs?: number; caller?: string }
 ): Promise<BulkLookupResponse> {
   if (items.length === 0) {
     throw new LmlClientError('bulkLookupMetadata requires at least 1 item.', 400);
@@ -617,9 +637,10 @@ export async function bulkLookupMetadata(
         span.setAttributes({
           'lml.queue_depth': activeLimiter.state().queueDepth,
           'lml.bulk.size': items.length,
+          'lml.caller': options?.caller ?? 'unknown',
         });
       } catch (err) {
-        console.warn('lml.client: failed to project queue_depth + bulk.size onto span', err);
+        console.warn('lml.client: failed to project queue_depth + bulk.size + caller onto span', err);
       }
 
       const response = await lmlFetch(

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -402,7 +402,10 @@ describe('library.controller', () => {
 
         // Controller returns 201 immediately, before fire-and-forget completes.
         expect(res.status).toHaveBeenCalledWith(201);
-        expect(mockLookupMetadata).toHaveBeenCalledWith('Juana Molina', 'DOGA', undefined, { budgetMs: 5000 });
+        expect(mockLookupMetadata).toHaveBeenCalledWith('Juana Molina', 'DOGA', undefined, {
+          budgetMs: 5000,
+          caller: 'library-canonical-entity',
+        });
       });
 
       it('writes canonical_entity_id back to the inserted row when the lookup yields a match', async () => {

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -649,6 +649,7 @@ describe('proxy.controller', () => {
         expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
           extended: true,
           budgetMs: 5000,
+          caller: 'proxy-album-metadata',
         });
       });
 

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -500,7 +500,7 @@ describe('runBatch', () => {
       { artist: 'Juana Molina', album: 'DOGA', raw_message: 'Juana Molina - DOGA' },
       { artist: 'Jessica Pratt', album: 'OYOLA', raw_message: 'Jessica Pratt - OYOLA' },
     ]);
-    expect(opts).toEqual({ budgetMs: 25000, timeoutMs: computeBulkTimeoutMs(2) });
+    expect(opts).toEqual({ budgetMs: 25000, timeoutMs: computeBulkTimeoutMs(2), caller: 'album-level-backfill' });
   });
 
   it('counts match / no_match / error per response and UPSERTs only matches', async () => {

--- a/tests/unit/services/artwork.discogs-provider.test.ts
+++ b/tests/unit/services/artwork.discogs-provider.test.ts
@@ -75,7 +75,9 @@ describe('artwork DiscogsProvider', () => {
 
       const results = await provider.search({ artist: 'Autechre', album: 'Confield' });
 
-      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined);
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
+        caller: 'artwork-discogs-fallback',
+      });
       expect(results).toHaveLength(1);
       expect(results[0]).toEqual({
         artworkUrl: 'https://i.discogs.com/confield.jpg',
@@ -144,7 +146,9 @@ describe('artwork DiscogsProvider', () => {
 
       await provider.search({ artist: 'Autechre', song: 'VI Scose Poise' });
 
-      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', undefined, 'VI Scose Poise');
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', undefined, 'VI Scose Poise', {
+        caller: 'artwork-discogs-fallback',
+      });
     });
   });
 

--- a/tests/unit/services/flowsheet-linkage.service.test.ts
+++ b/tests/unit/services/flowsheet-linkage.service.test.ts
@@ -69,6 +69,7 @@ describe('runLmlLinkage (B-2.1)', () => {
     // lookup for the same artist renders richer profile_tokens for free.
     expect(mockLookupMetadata).toHaveBeenCalledWith('Juana Molina', 'DOGA', undefined, {
       warm_cache: true,
+      caller: 'flowsheet-linkage',
     });
     expect(outcome).toEqual({
       status: 'linked',

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -1065,7 +1065,10 @@ describe('library.service', () => {
       const results = await searchLibraryByTrack('Back, Baby', 10);
 
       expect(mockLookupBySong).toHaveBeenCalledTimes(1);
-      expect(mockLookupBySong).toHaveBeenCalledWith('Back, Baby', { budgetMs: 5000 });
+      expect(mockLookupBySong).toHaveBeenCalledWith('Back, Baby', {
+        budgetMs: 5000,
+        caller: 'library-track-search',
+      });
       // Bridge query reads from `library` (with joins) so the unique index
       // on legacy_release_id is reachable.
       expect(libraryChain.from).toHaveBeenCalledWith(library);
@@ -1478,7 +1481,10 @@ describe('library.service', () => {
       await searchLibraryByTrack('Different Song', 10);
 
       expect(mockLookupBySong.mock.calls.length).toBe(callsAfterFirst + 1);
-      expect(mockLookupBySong).toHaveBeenLastCalledWith('Different Song', { budgetMs: 5000 });
+      expect(mockLookupBySong).toHaveBeenLastCalledWith('Different Song', {
+        budgetMs: 5000,
+        caller: 'library-track-search',
+      });
     });
 
     it('trim + lowercase: variations of the same query share one cache entry', async () => {
@@ -1891,7 +1897,10 @@ describe('library.service', () => {
       const enriched = await enrichWithArtwork(results);
 
       expect(enriched[0].artwork_url).toBe('https://i.discogs.com/confield.jpg');
-      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, { budgetMs: 5000 });
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
+        budgetMs: 5000,
+        caller: 'library-enrich-artwork',
+      });
       expect(db.update).toHaveBeenCalled();
     });
 
@@ -1979,7 +1988,10 @@ describe('library.service', () => {
       expect(enriched[1].artwork_url).toBe('https://i.discogs.com/lp5.jpg');
       // Only one LML call (for LP5, not Confield)
       expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
-      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'LP5', undefined, { budgetMs: 5000 });
+      expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'LP5', undefined, {
+        budgetMs: 5000,
+        caller: 'library-enrich-artwork',
+      });
     });
 
     it('handles LML returning no results', async () => {
@@ -2240,6 +2252,7 @@ describe('library.service', () => {
       expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
         timeoutMs: 10000,
         extended: true,
+        caller: 'library-rotation-picker',
       });
     });
 
@@ -2267,7 +2280,7 @@ describe('library.service', () => {
         undefined,
         'All the Young Droids: Junkshop Synth Pop 1978-1985',
         undefined,
-        { timeoutMs: 10000, extended: true }
+        { timeoutMs: 10000, extended: true, caller: 'library-rotation-picker' }
       );
     });
 

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -229,6 +229,36 @@ describe('lml.client', () => {
       expect(Object.keys((init.headers as Record<string, string>) ?? {})).not.toContain('X-Caller-Budget-Ms');
     });
 
+    it('projects lml.caller onto the Sentry span when caller is provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Stereolab', 'Aluminum Tunes', undefined, { caller: 'proxy-album-metadata' });
+
+      const callerCalls = mockSpanSetAttributes.mock.calls.filter(
+        (args) => (args[0] as Record<string, unknown>)?.['lml.caller'] === 'proxy-album-metadata'
+      );
+      expect(callerCalls).toHaveLength(1);
+    });
+
+    it("projects lml.caller='unknown' when caller is not provided (flag-of-shame)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupMetadata('Stereolab', 'Aluminum Tunes');
+
+      const callerCalls = mockSpanSetAttributes.mock.calls.filter(
+        (args) => (args[0] as Record<string, unknown>)?.['lml.caller'] === 'unknown'
+      );
+      expect(callerCalls).toHaveLength(1);
+    });
+
     it('wraps the call in a Sentry span and projects cache_stats onto it', async () => {
       const cache_stats = {
         memory_hits: 1,
@@ -473,6 +503,21 @@ describe('lml.client', () => {
       expect(Object.keys((init.headers as Record<string, string>) ?? {})).not.toContain('X-Caller-Budget-Ms');
     });
 
+    it('projects lml.caller onto the Sentry span when caller is provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      await lookupBySong('Back, Baby', { caller: 'library-track-search' });
+
+      const callerCalls = mockSpanSetAttributes.mock.calls.filter(
+        (args) => (args[0] as Record<string, unknown>)?.['lml.caller'] === 'library-track-search'
+      );
+      expect(callerCalls).toHaveLength(1);
+    });
+
     it('throws LmlClientError on non-2xx response', async () => {
       mockFetch.mockResolvedValue({
         ok: false,
@@ -573,6 +618,20 @@ describe('lml.client', () => {
       const init = mockFetch.mock.calls[0][1];
       if (!init) throw new Error('mockFetch was not called with init args');
       expect(Object.keys((init.headers as Record<string, string>) ?? {})).not.toContain('X-Caller-Budget-Ms');
+    });
+
+    it('projects lml.caller onto the bulk Sentry span when caller is provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await bulkLookupMetadata([itemFor('A', 'X')], { caller: 'album-level-backfill' });
+
+      const callerCalls = mockSpanSetAttributes.mock.calls.filter(
+        (args) => (args[0] as Record<string, unknown>)?.['lml.caller'] === 'album-level-backfill'
+      );
+      expect(callerCalls).toHaveLength(1);
     });
 
     it('consumes exactly one limiter token per batch (not one per item)', async () => {

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -113,7 +113,9 @@ describe('metadata.service', () => {
       trackTitle: 'VI Scose Poise',
     });
 
-    expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', 'VI Scose Poise');
+    expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', 'VI Scose Poise', {
+      caller: 'metadata-service',
+    });
   });
 
   it('makes a single LML call instead of three', async () => {


### PR DESCRIPTION
## Summary

- `@wxyc/lml-client` projects a new `lml.caller` Sentry attribute on the `lml.lookup` and `lml.lookup.bulk` spans. Defaults to `'unknown'` so untracked call sites surface in Sentry queries (flag-of-shame).
- All 11 shared-client call sites + the bulk caller + the two job wrappers that go through the shared client get caller labels.
- Two job wrappers that bypass the shared client and call `fetch` directly (`library-artwork-url-backfill`, `library-canonical-entity-backfill`) don't emit `lml.lookup` spans at all — no tagging needed there, noted in the issue as out of scope.

## Why

The rolled-up Epic A acceptance metric (Sentry `lml.lookup` span p95 ≤ 5 s over 24h) conflates three deadline classes — user-visible interactive (~5 s budget), fire-and-forget runtime (~5 s budget), and background CDC/backfill (~29 s budget). When CDC volume dominates, its legitimate ~25 s empty-cascade tail pins the rollup p95 to the 30 s `AbortController` ceiling even though interactive paths comfortably meet the contract.

The [2026-05-30 daily check on WXYC/library-metadata-lookup#338](https://github.com/WXYC/library-metadata-lookup/issues/338#issuecomment-4581866506) showed this exactly:

| Metric | Value | Count | Verdict |
|---|---|---|---|
| `lml.lookup` p95 (BS client, `op:http.client`) | **30,001 ms** | 1,880 spans | FAIL |
| `/api/v1/lookup` p95 (LML server, `op:http.server`) | 3,792 ms | 19,394 spans | PASS |

Slicing by `lml.caller` lets the routine and Sentry's trace explorer query each caller-class independently. The Epic A acceptance refines to "p95 ≤ 5000 ms for user-visible callers" instead of the bundled rollup.

## Caller-name table

| Caller | Site | Deadline class |
|---|---|---|
| `proxy-album-metadata` | `apps/backend/controllers/proxy.controller.ts:getAlbumMetadata` | user-visible 5 s |
| `library-add-album` | `apps/backend/controllers/library.controller.ts:addAlbum` | user-visible 5 s |
| `library-canonical-entity` | `apps/backend/controllers/library.controller.ts:fireAndForgetCanonicalEntity` | fire-and-forget 5 s |
| `library-rotation-picker` | `apps/backend/services/library.service.ts:resolveRotationPickerSource` | user-visible 10 s timeout |
| `library-enrich-artwork` | `apps/backend/services/library.service.ts:enrichWithArtwork` | user-visible 5 s |
| `library-track-search` | `apps/backend/services/library.service.ts:searchLibraryByTrackUncachedOrThrow` | user-visible 5 s |
| `enrichment-worker` | `apps/enrichment-worker/handler.ts` | background 29 s |
| `flowsheet-linkage` | `apps/backend/services/flowsheet-linkage.service.ts` | write-path warm |
| `artwork-discogs-fallback` | `apps/backend/services/artwork/providers/discogs.ts` | fire-and-forget |
| `request-line` | `apps/backend/services/requestLine/requestLine.enhanced.service.ts` | user-visible |
| `metadata-service` | `apps/backend/services/metadata/metadata.service.ts` | runtime |
| `album-level-backfill` | `jobs/album-level-backfill/job.ts` (bulk) | backfill ~25 s |
| `flowsheet-metadata-backfill` | `jobs/flowsheet-metadata-backfill/lml-fetch.ts` | backfill ~30 s |
| `flowsheet-artwork-repair` | `jobs/flowsheet-artwork-repair/lml-fetch.ts` | backfill ~30 s |

## Test plan

- [x] New `lml.client.test.ts` tests assert `lml.caller` projection on both `lookupMetadata`+`lookupBySong` (single) and `bulkLookupMetadata` (bulk) paths; also tests the `'unknown'` fallback for untracked callers
- [x] All 14 existing call-shape assertions updated for the new options field
- [x] `npm run test:unit` — 2562/2563 passing; the one failure is `schema.flowsheet-artwork-lookup-idx.test.ts`, pre-existing on origin/main, unrelated
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (warnings pre-existing)
- [x] `npm run format:check` — clean
- [ ] Post-deploy: update the WXYC/library-metadata-lookup#338 daily check routine to query per-caller p95; refine Epic A acceptance to user-visible callers only

Closes #1235

## Related

- WXYC/library-metadata-lookup#338 (Epic A) — closure gated on this for a meaningful per-caller p95 acceptance
- WXYC/Backend-Service#1190 — the `budgetMs` forwarding that surfaced the rollup-p95 problem in the daily check
- WXYC/library-metadata-lookup#403 / #404 — LML A10 cutoff