### PR TITLE
refactor(live-activity): extract checkLiveActivity probe into @wxyc/database

### DIFF
--- a/apps/backend/services/rotation-tracks-cache-warm.service.ts
+++ b/apps/backend/services/rotation-tracks-cache-warm.service.ts
@@ -85,11 +85,9 @@ const PER_ROW_PAUSE_BUDGET_MS = 10 * 60 * 1000;
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * Env-driven knob for `WARM_LIVE_ACTIVITY_LOOKBACK_SECONDS`. Operators set
- * 0 to disable the cooperative-pause probe entirely (BS#1237). Invalid
- * values fall back to the default with a console.warn — boot must succeed
- * even with a misconfigured env var, since the warmer is a best-effort
- * optimization and the API needs to start serving traffic.
+ * Warn-and-default on misconfig: boot must succeed even with a bad env var,
+ * since the warmer is a best-effort optimization and the API needs to start
+ * serving traffic. `0` disables the probe.
  */
 const resolveLiveActivityLookback = (
   raw: string | undefined = process.env.WARM_LIVE_ACTIVITY_LOOKBACK_SECONDS

--- a/apps/backend/services/rotation-tracks-cache-warm.service.ts
+++ b/apps/backend/services/rotation-tracks-cache-warm.service.ts
@@ -40,7 +40,14 @@
  */
 import * as Sentry from '@sentry/node';
 import { sql } from 'drizzle-orm';
-import { db, rotation } from '@wxyc/database';
+import {
+  db,
+  rotation,
+  checkLiveActivity as defaultCheckLiveActivity,
+  LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
+  LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+  type CheckLiveActivityFn,
+} from '@wxyc/database';
 import {
   resolveRotationPickerSource,
   __rotationLmlCacheSizesForWarm,
@@ -67,14 +74,6 @@ const PROGRESS_LOG_EVERY = 50;
 const WARM_PASS_BUDGET_MS = 30 * 60 * 1000;
 
 /**
- * Cooperative-pause lookback / pause / per-row cap (BS#1237, mirrors
- * `jobs/flowsheet-metadata-backfill`'s #735 pattern). Set
- * `WARM_LIVE_ACTIVITY_LOOKBACK_SECONDS=0` to disable.
- */
-const LIVE_ACTIVITY_LOOKBACK_SECONDS = 60;
-const LIVE_ACTIVITY_PAUSE_MS = 30_000;
-
-/**
  * Per-row pause cap: any single rotation row can hold up the walker for
  * at most this long before we count it as `budgetSkipped` and move on.
  * Prevents a row whose probe-window never clears (long continuous show)
@@ -83,45 +82,25 @@ const LIVE_ACTIVITY_PAUSE_MS = 30_000;
  */
 const PER_ROW_PAUSE_BUDGET_MS = 10 * 60 * 1000;
 
-const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
-const FLOWSHEET_TABLE = sql.raw(`"${SCHEMA}"."flowsheet"`);
-
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * Probe `flowsheet` for any track insert within the lookback window.
- * Uses the `flowsheet_track_add_time_idx` partial index (migration 0050)
- * for an index-only check; cost is negligible.
- *
- * Exported so tests can stub it.
- */
-export const checkLiveActivity = async (lookbackSeconds: number): Promise<boolean> => {
-  if (lookbackSeconds <= 0) return false;
-  const rows = (await db.execute(sql`
-    SELECT 1
-    FROM ${FLOWSHEET_TABLE}
-    WHERE "entry_type" = 'track'
-      AND "add_time" > now() - (interval '1 second' * ${lookbackSeconds})
-    LIMIT 1
-  `)) as unknown as Array<unknown>;
-  return rows.length > 0;
-};
-
-/**
- * Env-driven knob for `LIVE_ACTIVITY_LOOKBACK_SECONDS`. Operators set 0 to
- * disable the probe entirely. Invalid values fall back to the default with
- * a console.warn.
+ * Env-driven knob for `WARM_LIVE_ACTIVITY_LOOKBACK_SECONDS`. Operators set
+ * 0 to disable the cooperative-pause probe entirely (BS#1237). Invalid
+ * values fall back to the default with a console.warn — boot must succeed
+ * even with a misconfigured env var, since the warmer is a best-effort
+ * optimization and the API needs to start serving traffic.
  */
 const resolveLiveActivityLookback = (
   raw: string | undefined = process.env.WARM_LIVE_ACTIVITY_LOOKBACK_SECONDS
 ): number => {
-  if (raw === undefined) return LIVE_ACTIVITY_LOOKBACK_SECONDS;
+  if (raw === undefined) return LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT;
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed < 0) {
     console.warn(
-      `${LOG_PREFIX} invalid WARM_LIVE_ACTIVITY_LOOKBACK_SECONDS=${JSON.stringify(raw)}; using default ${LIVE_ACTIVITY_LOOKBACK_SECONDS}`
+      `${LOG_PREFIX} invalid WARM_LIVE_ACTIVITY_LOOKBACK_SECONDS=${JSON.stringify(raw)}; using default ${LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT}`
     );
-    return LIVE_ACTIVITY_LOOKBACK_SECONDS;
+    return LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT;
   }
   return parsed;
 };
@@ -160,7 +139,7 @@ export interface WarmCounters {
  * `checkLiveActivity` probe + a 0 `pauseMs` to skip the real-time `setTimeout`.
  */
 export interface WarmOptions {
-  checkLiveActivity?: (lookbackSeconds: number) => Promise<boolean>;
+  checkLiveActivity?: CheckLiveActivityFn;
   liveActivityLookbackSeconds?: number;
   liveActivityPauseMs?: number;
 }
@@ -183,9 +162,9 @@ export interface WarmOptions {
 export async function warmRotationTracksCache(opts: WarmOptions = {}): Promise<WarmCounters> {
   const startTime = Date.now();
   const startSizes = __rotationLmlCacheSizesForWarm();
-  const probe = opts.checkLiveActivity ?? checkLiveActivity;
+  const probe = opts.checkLiveActivity ?? defaultCheckLiveActivity;
   const lookbackSeconds = opts.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
-  const pauseMs = opts.liveActivityPauseMs ?? LIVE_ACTIVITY_PAUSE_MS;
+  const pauseMs = opts.liveActivityPauseMs ?? LIVE_ACTIVITY_PAUSE_MS_DEFAULT;
 
   const rows = await db
     .select({ id: rotation.id })

--- a/jobs/flowsheet-artwork-repair/orchestrate.ts
+++ b/jobs/flowsheet-artwork-repair/orchestrate.ts
@@ -38,7 +38,13 @@
  */
 
 import { sql } from 'drizzle-orm';
-import { db } from '@wxyc/database';
+import {
+  db,
+  checkLiveActivity as defaultCheckLiveActivity,
+  LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
+  LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+  type CheckLiveActivityFn,
+} from '@wxyc/database';
 import type { LookupResponse } from '@wxyc/lml-client';
 import type { FreeFormRow, LinkedAlbum, RepairOutcome } from './repair.js';
 import { captureError, log } from './logger.js';
@@ -51,12 +57,6 @@ const ALBUM_METADATA_TABLE = sql.raw(`"${SCHEMA}"."album_metadata"`);
 const LIBRARY_TABLE = sql.raw(`"${SCHEMA}"."library"`);
 const ARTISTS_TABLE = sql.raw(`"${SCHEMA}"."artists"`);
 
-/** Default lookback window for the cooperative-pause probe. */
-export const LIVE_ACTIVITY_LOOKBACK_SECONDS = 60;
-
-/** Default sleep between re-probes when DJ activity is detected. */
-export const LIVE_ACTIVITY_PAUSE_MS = 30_000;
-
 /** Default statement_timeout for the enumeration queries. The free-form
  * predicate isn't covered by an existing partial index; the planner falls
  * back to a seq scan over flowsheet's 2.6M+ rows. 5 min covers observed
@@ -68,7 +68,7 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 export const resolveLiveActivityLookback = (
   raw: string | undefined = process.env.LIVE_ACTIVITY_LOOKBACK_SECONDS
 ): number => {
-  if (raw === undefined) return LIVE_ACTIVITY_LOOKBACK_SECONDS;
+  if (raw === undefined) return LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT;
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed < 0) {
     throw new Error(
@@ -79,32 +79,12 @@ export const resolveLiveActivityLookback = (
 };
 
 export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number => {
-  if (raw === undefined) return LIVE_ACTIVITY_PAUSE_MS;
+  if (raw === undefined) return LIVE_ACTIVITY_PAUSE_MS_DEFAULT;
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed < 0) {
     throw new Error(`Invalid LIVE_ACTIVITY_PAUSE_MS=${JSON.stringify(raw)}; must be a non-negative integer (ms).`);
   }
   return parsed;
-};
-
-export type CheckLiveActivityFn = (lookbackSeconds: number) => Promise<boolean>;
-
-/**
- * Probe `flowsheet` for any track row added within the lookback window.
- * Returns `true` while DJs are actively touching the playout. Bypassed
- * entirely when `lookbackSeconds <= 0`. Uses the partial index from
- * migration 0050 for an index-only single-leaf lookup.
- */
-export const checkLiveActivity: CheckLiveActivityFn = async (lookbackSeconds) => {
-  if (lookbackSeconds <= 0) return false;
-  const rows = (await db.execute(sql`
-    SELECT 1
-    FROM ${FLOWSHEET_TABLE}
-    WHERE "entry_type" = 'track'
-      AND "add_time" > now() - (interval '1 second' * ${lookbackSeconds})
-    LIMIT 1
-  `)) as unknown as Array<unknown>;
-  return rows.length > 0;
 };
 
 /**
@@ -238,7 +218,7 @@ export type RunRepairOptions = {
 export const runRepair = async (opts: RunRepairOptions): Promise<RunResult> => {
   const lookbackSeconds = opts.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
   const pauseMs = opts.liveActivityPauseMs ?? resolveLiveActivityPauseMs();
-  const probe = opts.checkLiveActivity ?? checkLiveActivity;
+  const probe = opts.checkLiveActivity ?? defaultCheckLiveActivity;
 
   const freeFormRows = opts.freeFormRows ?? (await enumerateFreeFormResidue());
   const linkedAlbums = opts.linkedAlbums ?? (await enumerateLinkedResidue());

--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -44,7 +44,13 @@
  */
 
 import { sql, type SQL } from 'drizzle-orm';
-import { db } from '@wxyc/database';
+import {
+  db,
+  checkLiveActivity as defaultCheckLiveActivity,
+  LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
+  LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+  type CheckLiveActivityFn,
+} from '@wxyc/database';
 import type { LookupResponse } from '@wxyc/lml-client';
 import type { EnrichRow, EnrichOutcome } from './enrich.js';
 import { captureError, log } from './logger.js';
@@ -63,24 +69,6 @@ export const BATCH_SIZE = 500;
  * override to 0.
  */
 export const THROTTLE_MS = 100;
-
-/**
- * Default cooperative-pause lookback window, in seconds. Before each batch
- * the orchestrator probes `flowsheet` for any track inserts within this
- * window; if found, a DJ is actively managing the playout and the batch is
- * deferred until the window clears. This keeps the backfill out of the way
- * during exactly the moments when UX matters most. Set
- * `LIVE_ACTIVITY_LOOKBACK_SECONDS=0` to disable the probe (catch-up runs).
- */
-export const LIVE_ACTIVITY_LOOKBACK_SECONDS = 60;
-
-/**
- * Default sleep between cooperative-pause re-probes, in ms. After a deferral
- * the loop sleeps this long, then re-checks. If activity persists, defer
- * again. There is no defer cap — the cron's outer `timeout 14400` is the
- * effective ceiling, and the next run picks up where this one left off.
- */
-export const LIVE_ACTIVITY_PAUSE_MS = 30_000;
 
 /**
  * Schema-qualified table reference, honoring `WXYC_SCHEMA_NAME` so parallel
@@ -127,15 +115,17 @@ export const resolveThrottleMs = (raw: string | undefined = process.env.BACKFILL
 
 /**
  * Resolve `LIVE_ACTIVITY_LOOKBACK_SECONDS` from the environment, falling
- * back to `LIVE_ACTIVITY_LOOKBACK_SECONDS`. Operators set `0` to disable
- * the cooperative-pause probe entirely (e.g., emergency catch-up runs).
+ * back to `LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT`. Operators set `0` to
+ * disable the cooperative-pause probe entirely (e.g., emergency catch-up
+ * runs). Throws on misconfig — this is a cron-driven job; loud failure is
+ * preferred so an operator notices.
  *
  * Exported so unit tests can drive it without mucking with process.env.
  */
 export const resolveLiveActivityLookback = (
   raw: string | undefined = process.env.LIVE_ACTIVITY_LOOKBACK_SECONDS
 ): number => {
-  if (raw === undefined) return LIVE_ACTIVITY_LOOKBACK_SECONDS;
+  if (raw === undefined) return LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT;
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed < 0) {
     throw new Error(
@@ -147,42 +137,18 @@ export const resolveLiveActivityLookback = (
 
 /**
  * Resolve `LIVE_ACTIVITY_PAUSE_MS` from the environment, falling back to
- * `LIVE_ACTIVITY_PAUSE_MS`. Tests pass `0` to keep the deferral loop tight.
+ * `LIVE_ACTIVITY_PAUSE_MS_DEFAULT`. Tests pass `0` to keep the deferral
+ * loop tight.
  *
  * Exported so unit tests can drive it without mucking with process.env.
  */
 export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number => {
-  if (raw === undefined) return LIVE_ACTIVITY_PAUSE_MS;
+  if (raw === undefined) return LIVE_ACTIVITY_PAUSE_MS_DEFAULT;
   const parsed = Number(raw);
   if (!Number.isInteger(parsed) || parsed < 0) {
     throw new Error(`Invalid LIVE_ACTIVITY_PAUSE_MS=${JSON.stringify(raw)}; must be a non-negative integer (ms).`);
   }
   return parsed;
-};
-
-export type CheckLiveActivityFn = (lookbackSeconds: number) => Promise<boolean>;
-
-/**
- * Probe `flowsheet` for any track row inserted within the lookback window.
- * Returns true when a DJ is actively adding tracks (the highest UX-sensitivity
- * moment); returns false otherwise. Bypassed entirely when lookbackSeconds is
- * zero or negative.
- *
- * Uses the partial index from migration 0050
- * (`flowsheet_track_add_time_idx ON (add_time DESC) WHERE entry_type='track'`)
- * for an index-only check. Cost is negligible — single buffer read of the
- * leftmost leaf page.
- */
-export const checkLiveActivity: CheckLiveActivityFn = async (lookbackSeconds) => {
-  if (lookbackSeconds <= 0) return false;
-  const rows = (await db.execute(sql`
-    SELECT 1
-    FROM ${FLOWSHEET_TABLE}
-    WHERE "entry_type" = 'track'
-      AND "add_time" > now() - (interval '1 second' * ${lookbackSeconds})
-    LIMIT 1
-  `)) as unknown as Array<unknown>;
-  return rows.length > 0;
 };
 
 /**
@@ -328,7 +294,7 @@ export const runBackfill = async (opts: {
   const partition = opts.partition ?? resolvePartitionFilter();
   const liveActivityLookbackSeconds = opts.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
   const liveActivityPauseMs = opts.liveActivityPauseMs ?? resolveLiveActivityPauseMs();
-  const probe = opts.checkLiveActivity ?? checkLiveActivity;
+  const probe = opts.checkLiveActivity ?? defaultCheckLiveActivity;
 
   log('info', 'started', `${JOB_NAME} starting`, {
     batch_size: batchSize,

--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -114,13 +114,8 @@ export const resolveThrottleMs = (raw: string | undefined = process.env.BACKFILL
 };
 
 /**
- * Resolve `LIVE_ACTIVITY_LOOKBACK_SECONDS` from the environment, falling
- * back to `LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT`. Operators set `0` to
- * disable the cooperative-pause probe entirely (e.g., emergency catch-up
- * runs). Throws on misconfig — this is a cron-driven job; loud failure is
- * preferred so an operator notices.
- *
- * Exported so unit tests can drive it without mucking with process.env.
+ * Throws on misconfig — this is a cron-driven job; loud failure is
+ * preferred so an operator notices. `0` disables the probe (catch-up runs).
  */
 export const resolveLiveActivityLookback = (
   raw: string | undefined = process.env.LIVE_ACTIVITY_LOOKBACK_SECONDS
@@ -135,13 +130,6 @@ export const resolveLiveActivityLookback = (
   return parsed;
 };
 
-/**
- * Resolve `LIVE_ACTIVITY_PAUSE_MS` from the environment, falling back to
- * `LIVE_ACTIVITY_PAUSE_MS_DEFAULT`. Tests pass `0` to keep the deferral
- * loop tight.
- *
- * Exported so unit tests can drive it without mucking with process.env.
- */
 export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number => {
   if (raw === undefined) return LIVE_ACTIVITY_PAUSE_MS_DEFAULT;
   const parsed = Number(raw);

--- a/shared/database/src/index.ts
+++ b/shared/database/src/index.ts
@@ -5,3 +5,4 @@ export * from './legacy/sql.mirror.js';
 export * from './legacy/etl-utils.js';
 export * from './cdc-listener.js';
 export * from './library-tiebreak.js';
+export * from './live-activity.js';

--- a/shared/database/src/live-activity.ts
+++ b/shared/database/src/live-activity.ts
@@ -1,33 +1,15 @@
 /**
- * Cooperative-pause primitives shared by jobs and the rotation-tracks-cache
- * warm walker (BS#1241).
- *
- * `checkLiveActivity` probes `flowsheet` for any track row inserted within
- * the lookback window. Returns `true` while a DJ is actively adding tracks
- * — the highest UX-sensitivity moment, when backfills / boot warmers should
- * yield. Uses the partial index from migration 0050
- * (`flowsheet_track_add_time_idx ON (add_time DESC) WHERE
- * entry_type='track'`) for an index-only single-leaf-page check. Cost is
- * negligible.
- *
- * `LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT` and `LIVE_ACTIVITY_PAUSE_MS_DEFAULT`
- * are the canonical defaults; callers that need a stricter window (e.g.,
- * `jobs/album-level-backfill`'s long-transaction post-pass at 300 s) override
- * locally.
- *
- * Resolver functions stay per-caller because the throw-vs-warn policy is
- * legitimately different: jobs throw on misconfig (cron exits, operator
- * notices); the API-boot warm walker warns and defaults (boot must succeed
- * for the API to serve traffic). Both shapes are visible in the call sites
- * for that reason.
+ * Probe `flowsheet` for any track row inserted within the lookback window
+ * — `true` while a DJ is actively adding tracks. Backed by migration 0050's
+ * partial index `flowsheet_track_add_time_idx ON (add_time DESC) WHERE
+ * entry_type='track'` for an index-only single-leaf-page read. The literal
+ * `'track'` predicate is what lets the planner match the partial index;
+ * keep it inline rather than parameterised.
  */
 import { sql } from 'drizzle-orm';
 import { db } from './client.js';
 
-/** Default lookback window (seconds) for the cooperative-pause probe. */
 export const LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT = 60;
-
-/** Default sleep (ms) between re-probes when DJ activity is detected. */
 export const LIVE_ACTIVITY_PAUSE_MS_DEFAULT = 30_000;
 
 export type CheckLiveActivityFn = (lookbackSeconds: number) => Promise<boolean>;

--- a/shared/database/src/live-activity.ts
+++ b/shared/database/src/live-activity.ts
@@ -1,0 +1,48 @@
+/**
+ * Cooperative-pause primitives shared by jobs and the rotation-tracks-cache
+ * warm walker (BS#1241).
+ *
+ * `checkLiveActivity` probes `flowsheet` for any track row inserted within
+ * the lookback window. Returns `true` while a DJ is actively adding tracks
+ * — the highest UX-sensitivity moment, when backfills / boot warmers should
+ * yield. Uses the partial index from migration 0050
+ * (`flowsheet_track_add_time_idx ON (add_time DESC) WHERE
+ * entry_type='track'`) for an index-only single-leaf-page check. Cost is
+ * negligible.
+ *
+ * `LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT` and `LIVE_ACTIVITY_PAUSE_MS_DEFAULT`
+ * are the canonical defaults; callers that need a stricter window (e.g.,
+ * `jobs/album-level-backfill`'s long-transaction post-pass at 300 s) override
+ * locally.
+ *
+ * Resolver functions stay per-caller because the throw-vs-warn policy is
+ * legitimately different: jobs throw on misconfig (cron exits, operator
+ * notices); the API-boot warm walker warns and defaults (boot must succeed
+ * for the API to serve traffic). Both shapes are visible in the call sites
+ * for that reason.
+ */
+import { sql } from 'drizzle-orm';
+import { db } from './client.js';
+
+/** Default lookback window (seconds) for the cooperative-pause probe. */
+export const LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT = 60;
+
+/** Default sleep (ms) between re-probes when DJ activity is detected. */
+export const LIVE_ACTIVITY_PAUSE_MS_DEFAULT = 30_000;
+
+export type CheckLiveActivityFn = (lookbackSeconds: number) => Promise<boolean>;
+
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const FLOWSHEET_TABLE = sql.raw(`"${SCHEMA}"."flowsheet"`);
+
+export const checkLiveActivity: CheckLiveActivityFn = async (lookbackSeconds) => {
+  if (lookbackSeconds <= 0) return false;
+  const rows = (await db.execute(sql`
+    SELECT 1
+    FROM ${FLOWSHEET_TABLE}
+    WHERE "entry_type" = 'track'
+      AND "add_time" > now() - (interval '1 second' * ${lookbackSeconds})
+    LIMIT 1
+  `)) as unknown as Array<unknown>;
+  return rows.length > 0;
+};

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -267,9 +267,8 @@ export const flowsheetEntryTypeEnum = () => ({});
 // which library_id the tie-break "picks".
 export const pickPrimaryLibraryRow = jest.fn<(libraryIds: number[]) => Promise<number | null>>();
 
-// Cooperative-pause primitives (BS#1241). Mirrored from shared/database/src/live-activity.ts
-// so consumer unit tests that import them via `@wxyc/database` get the real default values
-// rather than `undefined`.
+// Mirror the real defaults so resolvers fall back to numbers, not undefined.
+// Drift is pinned by `tests/unit/database/live-activity.test.ts`.
 export const LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT = 60;
 export const LIVE_ACTIVITY_PAUSE_MS_DEFAULT = 30_000;
 export type CheckLiveActivityFn = (lookbackSeconds: number) => Promise<boolean>;

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -267,6 +267,14 @@ export const flowsheetEntryTypeEnum = () => ({});
 // which library_id the tie-break "picks".
 export const pickPrimaryLibraryRow = jest.fn<(libraryIds: number[]) => Promise<number | null>>();
 
+// Cooperative-pause primitives (BS#1241). Mirrored from shared/database/src/live-activity.ts
+// so consumer unit tests that import them via `@wxyc/database` get the real default values
+// rather than `undefined`.
+export const LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT = 60;
+export const LIVE_ACTIVITY_PAUSE_MS_DEFAULT = 30_000;
+export type CheckLiveActivityFn = (lookbackSeconds: number) => Promise<boolean>;
+export const checkLiveActivity = jest.fn<CheckLiveActivityFn>().mockResolvedValue(false);
+
 // Mock types
 export type AnonymousDevice = {
   id: number;

--- a/tests/unit/database/live-activity.test.ts
+++ b/tests/unit/database/live-activity.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Pin the cooperative-pause defaults so the values in `tests/mocks/database.mock.ts`
+ * (which consumer unit tests import via `@wxyc/database`) can't drift from the
+ * real values silently.
+ */
+jest.mock('../../../shared/database/src/client.js', () => jest.requireActual('../../mocks/database.mock'), {
+  virtual: true,
+});
+
+import {
+  LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
+  LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+} from '../../../shared/database/src/live-activity';
+import {
+  LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT as MOCK_LOOKBACK,
+  LIVE_ACTIVITY_PAUSE_MS_DEFAULT as MOCK_PAUSE,
+} from '../../mocks/database.mock';
+
+describe('live-activity defaults', () => {
+  it('shared/database default matches database mock', () => {
+    expect(MOCK_LOOKBACK).toBe(LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT);
+    expect(MOCK_PAUSE).toBe(LIVE_ACTIVITY_PAUSE_MS_DEFAULT);
+  });
+});

--- a/tests/unit/jobs/flowsheet-artwork-repair/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/orchestrate.test.ts
@@ -16,16 +16,13 @@
  */
 import { jest } from '@jest/globals';
 
-import { db } from '@wxyc/database';
+import { db, type CheckLiveActivityFn } from '@wxyc/database';
 import {
-  LIVE_ACTIVITY_LOOKBACK_SECONDS,
-  LIVE_ACTIVITY_PAUSE_MS,
   enumerateFreeFormResidue,
   enumerateLinkedResidue,
   resolveLiveActivityLookback,
   resolveLiveActivityPauseMs,
   runRepair,
-  type CheckLiveActivityFn,
   type FreeFormRepairFn,
   type LinkedRepairFn,
   type LookupFn,
@@ -126,9 +123,9 @@ describe('enumerateLinkedResidue', () => {
 });
 
 describe('resolveLiveActivityLookback / resolveLiveActivityPauseMs', () => {
-  it('falls back on unset env var', () => {
-    expect(resolveLiveActivityLookback(undefined)).toBe(LIVE_ACTIVITY_LOOKBACK_SECONDS);
-    expect(resolveLiveActivityPauseMs(undefined)).toBe(LIVE_ACTIVITY_PAUSE_MS);
+  it('falls back to the shared 60s / 30s defaults when env var is unset', () => {
+    expect(resolveLiveActivityLookback(undefined)).toBe(60);
+    expect(resolveLiveActivityPauseMs(undefined)).toBe(30_000);
   });
 
   it('accepts valid non-negative integers (0 disables)', () => {

--- a/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
@@ -17,11 +17,9 @@
  */
 import { jest } from '@jest/globals';
 
-import { db } from '@wxyc/database';
+import { db, type CheckLiveActivityFn } from '@wxyc/database';
 import {
   BATCH_SIZE,
-  LIVE_ACTIVITY_LOOKBACK_SECONDS,
-  LIVE_ACTIVITY_PAUSE_MS,
   THROTTLE_MS,
   processRow,
   resolveBatchSize,
@@ -30,7 +28,6 @@ import {
   resolvePartitionFilter,
   resolveThrottleMs,
   runBackfill,
-  type CheckLiveActivityFn,
   type EnrichFn,
   type LookupFn,
 } from '../../../../jobs/flowsheet-metadata-backfill/orchestrate';
@@ -134,8 +131,8 @@ describe('resolveThrottleMs', () => {
 });
 
 describe('resolveLiveActivityLookback', () => {
-  it('falls back to LIVE_ACTIVITY_LOOKBACK_SECONDS when env var is unset', () => {
-    expect(resolveLiveActivityLookback(undefined)).toBe(LIVE_ACTIVITY_LOOKBACK_SECONDS);
+  it('falls back to the shared 60s default when env var is unset', () => {
+    expect(resolveLiveActivityLookback(undefined)).toBe(60);
   });
 
   it('accepts 0 (operators can disable the cooperative pause for catch-up runs)', () => {
@@ -154,8 +151,8 @@ describe('resolveLiveActivityLookback', () => {
 });
 
 describe('resolveLiveActivityPauseMs', () => {
-  it('falls back to LIVE_ACTIVITY_PAUSE_MS when env var is unset', () => {
-    expect(resolveLiveActivityPauseMs(undefined)).toBe(LIVE_ACTIVITY_PAUSE_MS);
+  it('falls back to the shared 30s default when env var is unset', () => {
+    expect(resolveLiveActivityPauseMs(undefined)).toBe(30_000);
   });
 
   it('accepts 0 (tests may want no pause)', () => {
@@ -330,9 +327,9 @@ describe('runBackfill', () => {
     expect(THROTTLE_MS).toBe(100);
   });
 
-  it('exposes LIVE_ACTIVITY_LOOKBACK_SECONDS and LIVE_ACTIVITY_PAUSE_MS for ops tuning', () => {
-    expect(LIVE_ACTIVITY_LOOKBACK_SECONDS).toBe(60);
-    expect(LIVE_ACTIVITY_PAUSE_MS).toBe(30_000);
+  it('default resolvers produce the shared 60s lookback / 30s pause', () => {
+    expect(resolveLiveActivityLookback(undefined)).toBe(60);
+    expect(resolveLiveActivityPauseMs(undefined)).toBe(30_000);
   });
 
   it('defers a batch when checkLiveActivity returns true, then proceeds when it clears', async () => {


### PR DESCRIPTION
## Summary

Three callers of the cooperative-pause probe — `apps/backend/services/rotation-tracks-cache-warm.service.ts`, `jobs/flowsheet-metadata-backfill/orchestrate.ts`, and `jobs/flowsheet-artwork-repair/orchestrate.ts` — had byte-equivalent copies of:

- `checkLiveActivity(lookbackSeconds)` SQL (`SELECT 1 FROM flowsheet WHERE entry_type='track' AND add_time > now() - …`)
- `SCHEMA` / `FLOWSHEET_TABLE` `sql.raw` sanitization helper
- `LIVE_ACTIVITY_LOOKBACK_SECONDS = 60` / `LIVE_ACTIVITY_PAUSE_MS = 30_000` default constants
- `CheckLiveActivityFn` type signature

Move them all to `shared/database/src/live-activity.ts` (canonical name `LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT` / `LIVE_ACTIVITY_PAUSE_MS_DEFAULT`) and export via `@wxyc/database`. Each caller imports the probe + defaults + type; per-caller env resolvers stay local because the policy is legitimately different (warn-on-invalid at API boot vs throw-on-invalid in a one-shot job).

`tests/mocks/database.mock.ts` mirrors the new exports so consumer unit tests that import the type/defaults via `@wxyc/database` get the real values rather than `undefined`.

Net **-72 lines** across the four production files; **+24** in the new shared module + mock.

## Scope deviation from the issue body

#1241 named two callers (warm.service + flowsheet-metadata-backfill). `flowsheet-artwork-repair` had the same duplication so I migrated all three together — single PR is cleaner than a follow-up that touches the shared module just to delete one more inline copy.

`jobs/album-level-backfill/job.ts` is deliberately left out. Its inline comment documents the divergence:

> Cooperative pause is inlined (not imported from `jobs/flowsheet-metadata-backfill/orchestrate.ts`) because this job's operation envelope is a single 3-hour post-pass transaction, distinct from the cron's 60-second per-row batch loop. Sharing the helper would couple two lifecycles whose pause semantics diverge.

Its `awaitQuietWindow` wraps the probe in a loop+log+sleep loop different from the other three callers' inline pattern, and its lookback default is **300 s** (5×) vs 60 s. Migrating it would either ignore that comment or force the shared module to grow knobs it doesn't need yet.

`sleep` is also deliberately left out — the issue body's "separate, larger sweep" framing for the ~8 inline copies still holds.

## Test plan

- [x] `npm run typecheck` — all workspaces clean
- [x] `npm run lint` — 0 errors (pre-existing 471 warnings)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` for the three touched test files — 62/62 pass
- [x] Full `npm run test:unit` — 2566/2567 pass; sole failure (`tests/unit/database/schema.flowsheet-artwork-lookup-idx.test.ts`) is pre-existing on `origin/main` and unrelated (the schema test wasn't updated when migration 0082 dropped the index it's checking for)

Closes #1241