### PR TITLE
refactor(db): lift requireNonNegativeInt to @wxyc/database; collapse live-activity resolvers

### DIFF
--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -35,7 +35,7 @@
  */
 
 import { sql } from 'drizzle-orm';
-import { album_metadata, db, closeDatabaseConnection } from '@wxyc/database';
+import { album_metadata, db, closeDatabaseConnection, requireNonNegativeInt, requirePositiveInt } from '@wxyc/database';
 import { bulkLookupMetadata, type BulkLookupItem, type LookupResponse } from '@wxyc/lml-client';
 import { captureError, closeLogger, initLogger, log } from './logger.js';
 
@@ -113,26 +113,6 @@ export const LIVE_ACTIVITY_LOOKBACK_DEFAULT = 300;
 
 /** Sleep between re-probes when DJ activity is detected. */
 export const LIVE_ACTIVITY_PAUSE_MS_DEFAULT = 30_000;
-
-// -- Env parsing -------------------------------------------------------------
-
-const requirePositiveInt = (raw: string | undefined, envName: string, fallback: number): number => {
-  if (raw === undefined || raw === '') return fallback;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
-    throw new Error(`[${JOB_NAME}] Invalid ${envName}=${raw}: must be a positive integer.`);
-  }
-  return n;
-};
-
-const requireNonNegativeInt = (raw: string | undefined, envName: string, fallback: number): number => {
-  if (raw === undefined || raw === '') return fallback;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
-    throw new Error(`[${JOB_NAME}] Invalid ${envName}=${raw}: must be a non-negative integer.`);
-  }
-  return n;
-};
 
 // -- Inlined helpers ---------------------------------------------------------
 //
@@ -503,16 +483,23 @@ export const resolveOptions = (
   env: NodeJS.ProcessEnv = process.env,
   args: string[] = process.argv
 ): BackfillOptions => {
+  const ctx = { context: JOB_NAME };
   return {
-    batchSize: requirePositiveInt(env[BULK_BATCH_SIZE_ENV], BULK_BATCH_SIZE_ENV, BULK_BATCH_SIZE_DEFAULT),
-    ratePerMin: requirePositiveInt(env[BULK_RATE_PER_MIN_ENV], BULK_RATE_PER_MIN_ENV, BULK_RATE_PER_MIN_DEFAULT),
-    budgetMs: requirePositiveInt(env[BULK_BUDGET_MS_ENV], BULK_BUDGET_MS_ENV, BULK_BUDGET_MS_DEFAULT),
-    postPassTimeoutMs: requirePositiveInt(env[POST_PASS_TIMEOUT_ENV], POST_PASS_TIMEOUT_ENV, POST_PASS_TIMEOUT_DEFAULT),
-    readTimeoutMs: requirePositiveInt(env[READ_TIMEOUT_ENV], READ_TIMEOUT_ENV, READ_TIMEOUT_DEFAULT),
+    batchSize: requirePositiveInt(env[BULK_BATCH_SIZE_ENV], BULK_BATCH_SIZE_ENV, BULK_BATCH_SIZE_DEFAULT, ctx),
+    ratePerMin: requirePositiveInt(env[BULK_RATE_PER_MIN_ENV], BULK_RATE_PER_MIN_ENV, BULK_RATE_PER_MIN_DEFAULT, ctx),
+    budgetMs: requirePositiveInt(env[BULK_BUDGET_MS_ENV], BULK_BUDGET_MS_ENV, BULK_BUDGET_MS_DEFAULT, ctx),
+    postPassTimeoutMs: requirePositiveInt(
+      env[POST_PASS_TIMEOUT_ENV],
+      POST_PASS_TIMEOUT_ENV,
+      POST_PASS_TIMEOUT_DEFAULT,
+      ctx
+    ),
+    readTimeoutMs: requirePositiveInt(env[READ_TIMEOUT_ENV], READ_TIMEOUT_ENV, READ_TIMEOUT_DEFAULT, ctx),
     liveActivityLookbackSeconds: requireNonNegativeInt(
       env[LIVE_ACTIVITY_LOOKBACK_ENV],
       LIVE_ACTIVITY_LOOKBACK_ENV,
-      LIVE_ACTIVITY_LOOKBACK_DEFAULT
+      LIVE_ACTIVITY_LOOKBACK_DEFAULT,
+      ctx
     ),
     liveActivityPauseMs: LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
     dryRun: args.includes('--dry-run'),

--- a/jobs/flowsheet-artwork-repair/orchestrate.ts
+++ b/jobs/flowsheet-artwork-repair/orchestrate.ts
@@ -43,6 +43,7 @@ import {
   checkLiveActivity as defaultCheckLiveActivity,
   LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
   LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+  requireNonNegativeInt,
   type CheckLiveActivityFn,
 } from '@wxyc/database';
 import type { LookupResponse } from '@wxyc/lml-client';
@@ -67,25 +68,14 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 
 export const resolveLiveActivityLookback = (
   raw: string | undefined = process.env.LIVE_ACTIVITY_LOOKBACK_SECONDS
-): number => {
-  if (raw === undefined) return LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT;
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new Error(
-      `Invalid LIVE_ACTIVITY_LOOKBACK_SECONDS=${JSON.stringify(raw)}; must be a non-negative integer (s). Use 0 to disable.`
-    );
-  }
-  return parsed;
-};
+): number =>
+  requireNonNegativeInt(raw, 'LIVE_ACTIVITY_LOOKBACK_SECONDS', LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT, {
+    unit: 's',
+    note: 'Use 0 to disable.',
+  });
 
-export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number => {
-  if (raw === undefined) return LIVE_ACTIVITY_PAUSE_MS_DEFAULT;
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new Error(`Invalid LIVE_ACTIVITY_PAUSE_MS=${JSON.stringify(raw)}; must be a non-negative integer (ms).`);
-  }
-  return parsed;
-};
+export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number =>
+  requireNonNegativeInt(raw, 'LIVE_ACTIVITY_PAUSE_MS', LIVE_ACTIVITY_PAUSE_MS_DEFAULT, { unit: 'ms' });
 
 /**
  * SELECT every flowsheet row stranded by the LML#408 bug in the free-form

--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -49,6 +49,7 @@ import {
   checkLiveActivity as defaultCheckLiveActivity,
   LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
   LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+  requireNonNegativeInt,
   type CheckLiveActivityFn,
 } from '@wxyc/database';
 import type { LookupResponse } from '@wxyc/lml-client';
@@ -119,25 +120,14 @@ export const resolveThrottleMs = (raw: string | undefined = process.env.BACKFILL
  */
 export const resolveLiveActivityLookback = (
   raw: string | undefined = process.env.LIVE_ACTIVITY_LOOKBACK_SECONDS
-): number => {
-  if (raw === undefined) return LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT;
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new Error(
-      `Invalid LIVE_ACTIVITY_LOOKBACK_SECONDS=${JSON.stringify(raw)}; must be a non-negative integer (s). Use 0 to disable the cooperative pause.`
-    );
-  }
-  return parsed;
-};
+): number =>
+  requireNonNegativeInt(raw, 'LIVE_ACTIVITY_LOOKBACK_SECONDS', LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT, {
+    unit: 's',
+    note: 'Use 0 to disable the cooperative pause.',
+  });
 
-export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number => {
-  if (raw === undefined) return LIVE_ACTIVITY_PAUSE_MS_DEFAULT;
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new Error(`Invalid LIVE_ACTIVITY_PAUSE_MS=${JSON.stringify(raw)}; must be a non-negative integer (ms).`);
-  }
-  return parsed;
-};
+export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number =>
+  requireNonNegativeInt(raw, 'LIVE_ACTIVITY_PAUSE_MS', LIVE_ACTIVITY_PAUSE_MS_DEFAULT, { unit: 'ms' });
 
 /**
  * Resolve PARTITION_INDEX / PARTITION_COUNT env vars into a SQL fragment that

--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -50,6 +50,7 @@ import {
   LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
   LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
   requireNonNegativeInt,
+  requirePositiveInt,
   type CheckLiveActivityFn,
 } from '@wxyc/database';
 import type { LookupResponse } from '@wxyc/lml-client';
@@ -88,14 +89,8 @@ const FLOWSHEET_TABLE = sql.raw(`"${SCHEMA}"."flowsheet"`);
  *
  * Exported so unit tests can drive it without mucking with process.env.
  */
-export const resolveBatchSize = (raw: string | undefined = process.env.BACKFILL_BATCH_SIZE): number => {
-  if (raw === undefined) return BATCH_SIZE;
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 1) {
-    throw new Error(`Invalid BACKFILL_BATCH_SIZE=${JSON.stringify(raw)}; must be a positive integer.`);
-  }
-  return parsed;
-};
+export const resolveBatchSize = (raw: string | undefined = process.env.BACKFILL_BATCH_SIZE): number =>
+  requirePositiveInt(raw, 'BACKFILL_BATCH_SIZE', BATCH_SIZE);
 
 /**
  * Resolve `BACKFILL_THROTTLE_MS` from the environment, falling back to
@@ -105,14 +100,8 @@ export const resolveBatchSize = (raw: string | undefined = process.env.BACKFILL_
  *
  * Exported so unit tests can drive it without mucking with process.env.
  */
-export const resolveThrottleMs = (raw: string | undefined = process.env.BACKFILL_THROTTLE_MS): number => {
-  if (raw === undefined) return THROTTLE_MS;
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 0) {
-    throw new Error(`Invalid BACKFILL_THROTTLE_MS=${JSON.stringify(raw)}; must be a non-negative integer.`);
-  }
-  return parsed;
-};
+export const resolveThrottleMs = (raw: string | undefined = process.env.BACKFILL_THROTTLE_MS): number =>
+  requireNonNegativeInt(raw, 'BACKFILL_THROTTLE_MS', THROTTLE_MS);
 
 /**
  * Throws on misconfig — this is a cron-driven job; loud failure is

--- a/shared/database/src/env-parsers.ts
+++ b/shared/database/src/env-parsers.ts
@@ -36,7 +36,7 @@ export const requirePositiveInt = (
   fallback: number,
   opts: IntParserOptions = {}
 ): number => {
-  if (raw === undefined || raw === '') return fallback;
+  if (raw === undefined || raw.trim() === '') return fallback;
   const n = Number(raw);
   if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
     throw new Error(formatIntError(envName, raw, 'positive', opts));
@@ -50,7 +50,7 @@ export const requireNonNegativeInt = (
   fallback: number,
   opts: IntParserOptions = {}
 ): number => {
-  if (raw === undefined || raw === '') return fallback;
+  if (raw === undefined || raw.trim() === '') return fallback;
   const n = Number(raw);
   if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
     throw new Error(formatIntError(envName, raw, 'non-negative', opts));

--- a/shared/database/src/env-parsers.ts
+++ b/shared/database/src/env-parsers.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared integer-env parsers for jobs and services. Lifted from
+ * `jobs/album-level-backfill/job.ts` so the throw-variant pattern
+ * duplicated across `flowsheet-metadata-backfill` and
+ * `flowsheet-artwork-repair` resolvers can collapse to one-liners.
+ *
+ * Both helpers treat `undefined` and the empty string as "unset" and
+ * return the caller-supplied fallback. Anything else is validated as
+ * an integer and either returned or thrown.
+ */
+
+export interface IntParserOptions {
+  /** Bracketed context prepended to the error: `[ctx] Invalid ...`. */
+  context?: string;
+  /** Parenthesized unit appended after `integer`: `... integer (ms).`. */
+  unit?: string;
+  /** Trailing note appended after the period: `... integer. Use 0 to disable.`. */
+  note?: string;
+}
+
+const formatIntError = (
+  envName: string,
+  raw: string,
+  kind: 'positive' | 'non-negative',
+  { context, unit, note }: IntParserOptions
+): string => {
+  const prefix = context ? `[${context}] ` : '';
+  const unitPart = unit ? ` (${unit})` : '';
+  const notePart = note ? ` ${note}` : '';
+  return `${prefix}Invalid ${envName}=${JSON.stringify(raw)}: must be a ${kind} integer${unitPart}.${notePart}`;
+};
+
+export const requirePositiveInt = (
+  raw: string | undefined,
+  envName: string,
+  fallback: number,
+  opts: IntParserOptions = {}
+): number => {
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+    throw new Error(formatIntError(envName, raw, 'positive', opts));
+  }
+  return n;
+};
+
+export const requireNonNegativeInt = (
+  raw: string | undefined,
+  envName: string,
+  fallback: number,
+  opts: IntParserOptions = {}
+): number => {
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    throw new Error(formatIntError(envName, raw, 'non-negative', opts));
+  }
+  return n;
+};

--- a/shared/database/src/index.ts
+++ b/shared/database/src/index.ts
@@ -6,3 +6,4 @@ export * from './legacy/etl-utils.js';
 export * from './cdc-listener.js';
 export * from './library-tiebreak.js';
 export * from './live-activity.js';
+export * from './env-parsers.js';

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -274,6 +274,9 @@ export const LIVE_ACTIVITY_PAUSE_MS_DEFAULT = 30_000;
 export type CheckLiveActivityFn = (lookbackSeconds: number) => Promise<boolean>;
 export const checkLiveActivity = jest.fn<CheckLiveActivityFn>().mockResolvedValue(false);
 
+export { requirePositiveInt, requireNonNegativeInt } from '../../shared/database/src/env-parsers.js';
+export type { IntParserOptions } from '../../shared/database/src/env-parsers.js';
+
 // Mock types
 export type AnonymousDevice = {
   id: number;

--- a/tests/unit/database/env-parsers.test.ts
+++ b/tests/unit/database/env-parsers.test.ts
@@ -1,0 +1,65 @@
+import { requireNonNegativeInt, requirePositiveInt } from '../../../shared/database/src/env-parsers';
+
+describe('requirePositiveInt', () => {
+  it('returns fallback when raw is undefined or empty', () => {
+    expect(requirePositiveInt(undefined, 'X', 42)).toBe(42);
+    expect(requirePositiveInt('', 'X', 42)).toBe(42);
+  });
+
+  it('returns the parsed integer when valid', () => {
+    expect(requirePositiveInt('1', 'X', 42)).toBe(1);
+    expect(requirePositiveInt('100', 'X', 42)).toBe(100);
+  });
+
+  it('throws on zero, negative, non-integer, or non-numeric input', () => {
+    expect(() => requirePositiveInt('0', 'X', 42)).toThrow(/X.*positive integer/);
+    expect(() => requirePositiveInt('-1', 'X', 42)).toThrow(/X.*positive integer/);
+    expect(() => requirePositiveInt('1.5', 'X', 42)).toThrow(/X.*positive integer/);
+    expect(() => requirePositiveInt('abc', 'X', 42)).toThrow(/X.*positive integer/);
+    expect(() => requirePositiveInt('Infinity', 'X', 42)).toThrow(/X.*positive integer/);
+  });
+});
+
+describe('requireNonNegativeInt', () => {
+  it('returns fallback when raw is undefined or empty', () => {
+    expect(requireNonNegativeInt(undefined, 'X', 42)).toBe(42);
+    expect(requireNonNegativeInt('', 'X', 42)).toBe(42);
+  });
+
+  it('returns the parsed integer when valid (including zero)', () => {
+    expect(requireNonNegativeInt('0', 'X', 42)).toBe(0);
+    expect(requireNonNegativeInt('1', 'X', 42)).toBe(1);
+    expect(requireNonNegativeInt('100', 'X', 42)).toBe(100);
+  });
+
+  it('throws on negative, non-integer, or non-numeric input', () => {
+    expect(() => requireNonNegativeInt('-1', 'X', 42)).toThrow(/X.*non-negative integer/);
+    expect(() => requireNonNegativeInt('1.5', 'X', 42)).toThrow(/X.*non-negative integer/);
+    expect(() => requireNonNegativeInt('abc', 'X', 42)).toThrow(/X.*non-negative integer/);
+    expect(() => requireNonNegativeInt('Infinity', 'X', 42)).toThrow(/X.*non-negative integer/);
+  });
+});
+
+describe('error formatting options', () => {
+  it('prepends bracketed context when provided', () => {
+    expect(() => requirePositiveInt('0', 'X', 42, { context: 'my-job' })).toThrow(
+      /^\[my-job\] Invalid X="0": must be a positive integer\.$/
+    );
+  });
+
+  it('appends parenthesized unit when provided', () => {
+    expect(() => requireNonNegativeInt('-1', 'PAUSE', 30, { unit: 'ms' })).toThrow(
+      /Invalid PAUSE="-1": must be a non-negative integer \(ms\)\.$/
+    );
+  });
+
+  it('appends trailing note when provided', () => {
+    expect(() => requireNonNegativeInt('-1', 'LOOKBACK', 60, { unit: 's', note: 'Use 0 to disable.' })).toThrow(
+      /Invalid LOOKBACK="-1": must be a non-negative integer \(s\)\. Use 0 to disable\.$/
+    );
+  });
+
+  it('JSON-stringifies the raw value in the error message', () => {
+    expect(() => requirePositiveInt('not-a-number', 'X', 1)).toThrow(/X="not-a-number"/);
+  });
+});

--- a/tests/unit/database/env-parsers.test.ts
+++ b/tests/unit/database/env-parsers.test.ts
@@ -1,9 +1,11 @@
 import { requireNonNegativeInt, requirePositiveInt } from '../../../shared/database/src/env-parsers';
 
 describe('requirePositiveInt', () => {
-  it('returns fallback when raw is undefined or empty', () => {
+  it('returns fallback when raw is undefined, empty, or whitespace-only', () => {
     expect(requirePositiveInt(undefined, 'X', 42)).toBe(42);
     expect(requirePositiveInt('', 'X', 42)).toBe(42);
+    expect(requirePositiveInt('   ', 'X', 42)).toBe(42);
+    expect(requirePositiveInt('\t\n', 'X', 42)).toBe(42);
   });
 
   it('returns the parsed integer when valid', () => {
@@ -21,9 +23,11 @@ describe('requirePositiveInt', () => {
 });
 
 describe('requireNonNegativeInt', () => {
-  it('returns fallback when raw is undefined or empty', () => {
+  it('returns fallback when raw is undefined, empty, or whitespace-only', () => {
     expect(requireNonNegativeInt(undefined, 'X', 42)).toBe(42);
     expect(requireNonNegativeInt('', 'X', 42)).toBe(42);
+    expect(requireNonNegativeInt('   ', 'X', 42)).toBe(42);
+    expect(requireNonNegativeInt('\t\n', 'X', 42)).toBe(42);
   });
 
   it('returns the parsed integer when valid (including zero)', () => {

--- a/tests/unit/jobs/flowsheet-artwork-repair/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-artwork-repair/orchestrate.test.ts
@@ -128,6 +128,13 @@ describe('resolveLiveActivityLookback / resolveLiveActivityPauseMs', () => {
     expect(resolveLiveActivityPauseMs(undefined)).toBe(30_000);
   });
 
+  it('falls back to the default when env var is empty or whitespace-only', () => {
+    expect(resolveLiveActivityLookback('')).toBe(60);
+    expect(resolveLiveActivityLookback('   ')).toBe(60);
+    expect(resolveLiveActivityPauseMs('')).toBe(30_000);
+    expect(resolveLiveActivityPauseMs('   ')).toBe(30_000);
+  });
+
   it('accepts valid non-negative integers (0 disables)', () => {
     expect(resolveLiveActivityLookback('0')).toBe(0);
     expect(resolveLiveActivityLookback('120')).toBe(120);

--- a/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
@@ -135,6 +135,11 @@ describe('resolveLiveActivityLookback', () => {
     expect(resolveLiveActivityLookback(undefined)).toBe(60);
   });
 
+  it('falls back to the default when env var is empty or whitespace-only', () => {
+    expect(resolveLiveActivityLookback('')).toBe(60);
+    expect(resolveLiveActivityLookback('   ')).toBe(60);
+  });
+
   it('accepts 0 (operators can disable the cooperative pause for catch-up runs)', () => {
     expect(resolveLiveActivityLookback('0')).toBe(0);
   });
@@ -153,6 +158,11 @@ describe('resolveLiveActivityLookback', () => {
 describe('resolveLiveActivityPauseMs', () => {
   it('falls back to the shared 30s default when env var is unset', () => {
     expect(resolveLiveActivityPauseMs(undefined)).toBe(30_000);
+  });
+
+  it('falls back to the default when env var is empty or whitespace-only', () => {
+    expect(resolveLiveActivityPauseMs('')).toBe(30_000);
+    expect(resolveLiveActivityPauseMs('   ')).toBe(30_000);
   });
 
   it('accepts 0 (tests may want no pause)', () => {


### PR DESCRIPTION
Closes #1249. Follow-up from /simplify Agent 1 during the PR #1244 review loop.

## Summary

- New `shared/database/src/env-parsers.ts` exports `requirePositiveInt` and `requireNonNegativeInt` with optional `context` / `unit` / `note` formatting hooks. Both re-export through the `@wxyc/database` barrel and the unit-test mock.
- `flowsheet-metadata-backfill/orchestrate.ts` and `flowsheet-artwork-repair/orchestrate.ts` collapse each `resolveLiveActivityLookback` / `resolveLiveActivityPauseMs` to a single `requireNonNegativeInt(...)` call that preserves the existing unit (`s` / `ms`) and disable-note copy.
- `album-level-backfill/job.ts` drops its private `requirePositiveInt` / `requireNonNegativeInt` and uses the shared pair with `{ context: 'album-level-backfill' }` so the `[album-level-backfill]` log prefix survives.
- New `tests/unit/database/env-parsers.test.ts` covers happy paths, fallback paths, every rejection class (negative, zero, fractional, NaN, Infinity), and every formatting option.

## Behavior notes

- Existing resolver tests use `.toThrow(/ENV_NAME/)` regex matching, so the unified `Invalid X="…": must be a non-negative integer (unit). Note.` shape ships safely.
- Empty-string env values now fall back to the default (matching the album-level-backfill behavior). The previous orchestrate.ts resolvers resolved `LIVE_ACTIVITY_LOOKBACK_SECONDS=` to `0` (because `Number('') === 0`). Empty env vars are misconfig in practice and falling back to the default is the safer outcome.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (existing warnings only)
- [x] `npm run format:check` clean
- [x] `npm run test:unit` — all 2,599 tests pass (4 affected suites: env-parsers, both orchestrate.ts suites, album-level-backfill job)
- [x] `npm run build --workspace=@wxyc/database` clean; both helpers + `IntParserOptions` appear in `dist/index.d.ts`