### PR TITLE
ci(deploy-auto): serialize Auto deploys via concurrency block

### DIFF
--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -5,6 +5,18 @@ on:
     branches:
       - main
 
+# Serialize Auto deploys: when a new merge to main arrives while an
+# earlier deploy is still running, cancel the earlier run. The newer
+# commit is a superset of the older one, and the in-flight `docker stop`
+# / `docker run` sequence on EC2 would otherwise get interrupted mid-
+# startup by the next deploy's `docker stop`, leaving the healthcheck
+# polling against an unstable container. Three-PR rapid-succession
+# merges on 2026-05-30 (#1238/#1239/#1240) reported this as two failed
+# deploys for a healthy prod (#1243).
+concurrency:
+  group: deploy-auto-${{ github.workflow }}
+  cancel-in-progress: true
+
 # Caller permissions must equal or exceed the reusable workflow's
 # declared scope; deploy-base.yml requires contents:write to create
 # release tags via github-script. Granting less here makes GHA reject

--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -5,17 +5,17 @@ on:
     branches:
       - main
 
-# Serialize Auto deploys: when a new merge to main arrives while an
-# earlier deploy is still running, cancel the earlier run. The newer
-# commit is a superset of the older one, and the in-flight `docker stop`
-# / `docker run` sequence on EC2 would otherwise get interrupted mid-
-# startup by the next deploy's `docker stop`, leaving the healthcheck
-# polling against an unstable container. Three-PR rapid-succession
-# merges on 2026-05-30 (#1238/#1239/#1240) reported this as two failed
-# deploys for a healthy prod (#1243).
+# Serialize Auto deploys: queue subsequent runs instead of letting two
+# deploys race each other's `docker stop` / `docker run` sequence on EC2.
+# Three-PR rapid-succession merges on 2026-05-30 (#1238/#1239/#1240)
+# reported this as two healthcheck failures for a healthy prod (#1243).
+# `cancel-in-progress: false` is deliberate — cancellation between the
+# deploy script's `docker stop` and `docker run` would leave the service
+# down, the exact failure mode `deploy-base.yml`'s `deploy` job already
+# disables `fail-fast` to avoid (post-BS#798 comment).
 concurrency:
   group: deploy-auto-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Caller permissions must equal or exceed the reusable workflow's
 # declared scope; deploy-base.yml requires contents:write to create


### PR DESCRIPTION
Closes #1243.

## Summary

- Adds a workflow-level `concurrency:` block to `.github/workflows/deploy-auto.yml` with `cancel-in-progress: false`, scoped to the workflow name (effectively one slot for all Auto deploys, since `deploy-auto.yml` only fires on `main`).
- When a new merge to `main` arrives while an earlier Auto deploy is still running, GitHub **queues** the new run until the in-flight one finishes. The newer commit then deploys cleanly on top — each deploy completes its full `docker stop` / `docker run` sequence without interruption.

## Background

Three PRs (#1238 / #1239 / #1240) merged within 19 seconds on 2026-05-30 (16:36:59 → 16:37:18 UTC). Each triggered an Auto deploy. The first two reported `Confirm server is up` healthcheck failures because the next deploy's `docker stop <container>; docker run <container>` sequence interrupted the previous deploy's startup before the healthcheck poll fired. Prod was actually healthy (`7cd37f33` from #1240 contains all three changes), but the deploy logs and canary signals looked like two failed deploys.

## Why not `cancel-in-progress: true`

The original ticket and the first revision of this PR proposed `cancel-in-progress: true`. Code review surfaced that workflow-level cancellation would re-introduce the failure mode `deploy-base.yml`'s `deploy` job already disables `fail-fast` to avoid:

```yaml
# One target's deploy failure must not cancel sibling deploys mid-flight.
# The deploy script does `docker stop && docker rm && docker run`, so a
# cancellation between stop and run leaves the service down — turning a
# transient ETL pull error into a public-facing outage.
fail-fast: false
```

That comment was added in the BS#798 post-mortem to stop matrix-internal cancellation. The same failure mode applies at the cross-run scope: a workflow-level cancel could land between `docker stop` and `docker run`, taking the service down until the next deploy's full build cycle (~5 min) reaches the deploy step. Queueing avoids that risk entirely while still solving the racing-deploys problem.

The cost of queueing: 3 rapid-succession merges now take ~3× deploy wall-clock instead of ~1×. Acceptable for the safety guarantee.

## Test plan

- [x] YAML lints (visible in this PR's diff)
- [ ] After merge: next set of rapid-succession merges shows the second Auto deploy entering `pending → queued → in_progress` instead of running in parallel. (Backfill: confirm by merging at least two PRs within ~60 s and checking the runs.)