### PR TITLE
fix(metadata.service): wire budgetMs into LML lookup

### DIFF
--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -28,12 +28,10 @@ export { filterSpacerGif, isSyntheticArtwork } from '@wxyc/metadata';
 const searchUrls = new SearchUrlProvider();
 
 /**
- * Budget for the metadata-service LML lookup. Honest scope oversight from
- * BS#1186 (which listed four files but missed this one); without it, LML's
- * empty-cascade safety branch kept the lookup grinding to the 30 s
- * `AbortController` ceiling — measured at 30,002 ms p95 on 2026-05-31. 5 s
- * matches the other runtime callers in the same deadline class.
- * See `LookupOptions.budgetMs` for mechanics.
+ * Budget for the metadata-service fire-and-forget LML lookup on flowsheet
+ * insert. 5 s matches the other runtime callers — short enough that LML
+ * cuts off well before the BS-side 30 s `AbortController` ceiling. See
+ * `LookupOptions.budgetMs` for mechanics.
  */
 const METADATA_SERVICE_LML_BUDGET_MS = envInt('METADATA_SERVICE_LML_BUDGET_MS', 5000);
 

--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -18,7 +18,7 @@
  *      in `@wxyc/metadata`.
  */
 import { MetadataRequest, AlbumMetadataResult, ArtistMetadataResult, FlowsheetMetadata } from './metadata.types.js';
-import { lookupMetadata } from '@wxyc/lml-client';
+import { lookupMetadata, envInt } from '@wxyc/lml-client';
 import type { DiscogsMatchResult } from '@wxyc/lml-client';
 import { cleanDiscogsBio, filterSpacerGif, isSyntheticArtwork } from '@wxyc/metadata';
 import { SearchUrlProvider } from './providers/search-urls.provider.js';
@@ -26,6 +26,16 @@ import { SearchUrlProvider } from './providers/search-urls.provider.js';
 export { filterSpacerGif, isSyntheticArtwork } from '@wxyc/metadata';
 
 const searchUrls = new SearchUrlProvider();
+
+/**
+ * Budget for the metadata-service LML lookup. Honest scope oversight from
+ * BS#1186 (which listed four files but missed this one); without it, LML's
+ * empty-cascade safety branch kept the lookup grinding to the 30 s
+ * `AbortController` ceiling — measured at 30,002 ms p95 on 2026-05-31. 5 s
+ * matches the other runtime callers in the same deadline class.
+ * See `LookupOptions.budgetMs` for mechanics.
+ */
+const METADATA_SERVICE_LML_BUDGET_MS = envInt('METADATA_SERVICE_LML_BUDGET_MS', 5000);
 
 /**
  * Check whether the LML service is configured.
@@ -56,7 +66,10 @@ export async function fetchMetadata(request: MetadataRequest): Promise<Flowsheet
   const { artistName, albumTitle, trackTitle } = request;
   const result: FlowsheetMetadata = {};
 
-  const lookupResponse = await lookupMetadata(artistName, albumTitle, trackTitle, { caller: 'metadata-service' });
+  const lookupResponse = await lookupMetadata(artistName, albumTitle, trackTitle, {
+    caller: 'metadata-service',
+    budgetMs: METADATA_SERVICE_LML_BUDGET_MS,
+  });
   const artwork: DiscogsMatchResult | null = lookupResponse.results?.[0]?.artwork ?? null;
 
   if (artwork) {

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -12,6 +12,7 @@ const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
 
 jest.mock('@wxyc/lml-client', () => ({
   lookupMetadata: mockLookupMetadata,
+  envInt: (_name: string, fallback: number) => fallback,
   LmlClientError: class LmlClientError extends Error {
     statusCode: number;
     constructor(message: string, statusCode: number) {
@@ -115,6 +116,7 @@ describe('metadata.service', () => {
 
     expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', 'VI Scose Poise', {
       caller: 'metadata-service',
+      budgetMs: 5000,
     });
   });
 


### PR DESCRIPTION
## Summary

`metadata.service.ts:fetchMetadata` was missing from BS#1186's scope and never got the `budgetMs` wiring that BS#1190 added to the other four runtime callers. Without the `X-Caller-Budget-Ms` header, LML's empty-cascade safety branch kept these lookups grinding to the BS-side 30 s `AbortController` ceiling.

The [2026-05-31 Epic A p95 daily check](https://github.com/WXYC/library-metadata-lookup/issues/338#issuecomment-4585603040) measured `metadata-service` at exactly **30,002 ms p95 over 148 spans** — that's the wall, not bad luck.

This adds a new `METADATA_SERVICE_LML_BUDGET_MS` env-tunable constant (default 5000) and threads it into the existing options bag at the single call site. 5 s matches the other runtime callers' deadline class.

## Why this matters

`fetchMetadata` is called fire-and-forget on every flowsheet insert. Each call holding the BS process for 30 s ties up an LML semaphore permit ~6× longer than necessary, causing head-of-line blocking on the shared chokepoint (BS#906). Closing this puts the runtime metadata path back inside its expected deadline class.

## Test plan

- [x] Existing call-shape assertion in `tests/unit/services/metadata.service.test.ts:116` updated to assert the new `budgetMs: 5000` field
- [x] Test's `jest.mock('@wxyc/lml-client', ...)` factory updated to mock `envInt` (since the SUT now imports it)
- [x] `npm run test:unit` — 2531/2531 in the touched paths; full suite same pre-existing schema test failure as before, unrelated
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [ ] Post-deploy: the WXYC/library-metadata-lookup#338 daily check shows `metadata-service` p95 substantially below 30 s

Closes #1258

## Related

- WXYC/Backend-Service#1186 — original budget-wiring scope (missed this file)
- WXYC/Backend-Service#1190 — implementation of the 4 listed files
- WXYC/Backend-Service#1236 — added `lml.caller` projection that surfaced this gap
- WXYC/library-metadata-lookup#338 — Epic A acceptance still gated by this