### PR TITLE
fix(flowsheet-webhook): consume rotationReleaseId and write rotation_id

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -105,7 +105,12 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // inline metadata that never reaches album_metadata until the next
       // flowsheet-etl cycle (#1028).
       const rawLibraryId = entry.libraryReleaseId ?? 0;
-      const [showId, albumId] = await Promise.all([resolveShowId(entry.radioShowId), resolveAlbumId(rawLibraryId)]);
+      const rawRotationId = entry.rotationReleaseId ?? 0;
+      const [showId, albumId, rotationId] = await Promise.all([
+        resolveShowId(entry.radioShowId),
+        resolveAlbumId(rawLibraryId),
+        resolveRotationId(rawRotationId),
+      ]);
 
       // INSERT ... ON CONFLICT DO NOTHING RETURNING { id }: either we win
       // the insert and PG hands back exactly one row, or a concurrent
@@ -115,12 +120,19 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // (BS#909): same correctness, no MVCC-internal dependency, race-
       // safe under concurrent webhook delivery (acceptance criterion (c)
       // — exactly one delivery fires enrichment per legacy_entry_id).
+      //
+      // `rotation_id` (BS#1268) is set on INSERT only — like `album_id`,
+      // linkage is anchored to the first delivery and not refreshed on
+      // ON CONFLICT updates. Tubafrenzy is the source of truth for the
+      // linkage; if the operator re-binds a flowsheet entry to a different
+      // rotation row, that's a new legacy_entry_id, not an UPDATE.
       const inserted = await db
         .insert(flowsheet)
         .values({
           legacy_entry_id: entry.id,
           legacy_release_id: rawLibraryId || null,
           album_id: albumId,
+          rotation_id: rotationId,
           show_id: showId,
           entry_type: entryType,
           artist_name: artistName,
@@ -245,6 +257,26 @@ async function resolveAlbumId(legacyLibraryReleaseId: number): Promise<number | 
     .select({ id: library.id })
     .from(library)
     .where(eq(library.legacy_release_id, legacyLibraryReleaseId))
+    .limit(1);
+  return row?.id ?? null;
+}
+
+/**
+ * Resolve a Backend-Service rotation_id from a tubafrenzy ROTATION_RELEASE_ID
+ * (the `entry.rotationReleaseId` field on the flowsheet webhook payload, set
+ * by tubafrenzy's `FlowsheetEntryAddServlet.populateRotationRelease()`).
+ * Returns null if the legacy id is 0 / unset or no rotation row matches.
+ *
+ * Single indexed SELECT via `rotation_legacy_rotation_id_idx` (unique by the
+ * tubafrenzy invariant — one rotation row per legacy_rotation_id). BS#1268.
+ */
+async function resolveRotationId(legacyRotationId: number): Promise<number | null> {
+  if (!legacyRotationId) return null;
+
+  const [row] = await db
+    .select({ id: rotation.id })
+    .from(rotation)
+    .where(eq(rotation.legacy_rotation_id, legacyRotationId))
     .limit(1);
   return row?.id ?? null;
 }

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -111,15 +111,18 @@ describe('POST /internal/flowsheet-webhook', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Each webhook call issues two .limit(1) SELECTs in order: resolveShowId
-    // then resolveAlbumId. Default queue resolves the show but not the album
-    // (unlinked path); tests that need a resolved album_id queue their own
-    // values before triggering the request.
+    // Each webhook call issues three .limit(1) SELECTs in `Promise.all`:
+    // resolveShowId, resolveAlbumId, resolveRotationId. They dispatch in
+    // declaration order and the mocked driver resolves them FIFO. Default
+    // queue resolves the show but not the album or rotation (unlinked
+    // path); tests that need a resolved album_id or rotation_id queue
+    // their own values before triggering the request.
     mockReturning.mockReset();
     mockReturning.mockResolvedValue([{ id: 5555 }]);
     mockLimit.mockReset();
     mockLimit
       .mockResolvedValueOnce([{ id: 9999 }])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValue([]);
   });
@@ -323,7 +326,10 @@ describe('POST /internal/flowsheet-webhook', () => {
 
   it('forwards the resolved album_id when libraryReleaseId matches a library row', async () => {
     mockLimit.mockReset();
-    mockLimit.mockResolvedValueOnce([{ id: 9999 }]).mockResolvedValueOnce([{ id: 7777 }]);
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999 }])
+      .mockResolvedValueOnce([{ id: 7777 }])
+      .mockResolvedValueOnce([]);
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
 
     const res = await request(app)
@@ -376,6 +382,81 @@ describe('POST /internal/flowsheet-webhook', () => {
       albumTitle: 'Confield',
       trackTitle: 'VI Scose Poise',
     });
+  });
+
+  // -- rotationReleaseId → rotation_id resolution (BS#1268) --
+  //
+  // Sibling of BS#1028's library-side path: tubafrenzy sends
+  // `entry.rotationReleaseId` on every flowsheet webhook (set by
+  // `FlowsheetEntryAddServlet.populateRotationRelease()`). BS resolves it via
+  // `rotation_legacy_rotation_id_idx` (unique) and writes the BS-side
+  // `rotation.id` into `flowsheet.rotation_id` on the fresh-INSERT branch.
+  // The conflict-UPDATE path doesn't refresh linkage — anchored to the
+  // first delivery.
+
+  const mockValues = (mockChain as unknown as { values: jest.Mock }).values;
+  const lastInsertValues = (): Record<string, unknown> => mockValues.mock.calls[0]![0] as Record<string, unknown>;
+
+  it('forwards the resolved rotation_id when rotationReleaseId matches a rotation row', async () => {
+    // resolveShowId → 9999, resolveAlbumId → unlinked, resolveRotationId → 4242.
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999 }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 4242 }]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, rotationReleaseId: 12345 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ rotation_id: 4242 }));
+  });
+
+  it('inserts rotation_id: null when rotationReleaseId is 0 (no rotation context)', async () => {
+    // rotationReleaseId=0 short-circuits resolveRotationId — no rotation
+    // SELECT issued. Default beforeEach queue handles this implicitly, but
+    // we pin the contract explicitly here.
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, rotationReleaseId: 0 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ rotation_id: null }));
+  });
+
+  it('inserts rotation_id: null when rotationReleaseId does not match any rotation row', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, rotationReleaseId: 999_999 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ rotation_id: null }));
+  });
+
+  it('coexists with libraryReleaseId — both album_id and rotation_id are populated when both resolve', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999 }])
+      .mockResolvedValueOnce([{ id: 7777 }])
+      .mockResolvedValueOnce([{ id: 4242 }]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, rotationReleaseId: 12345 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ album_id: 7777, rotation_id: 4242 }));
   });
 
   // -- Delete --


### PR DESCRIPTION
## Summary

BS's flowsheet webhook handler in `internal.route.ts` already receives `entry.rotationReleaseId` on every tubafrenzy delivery — but reads only `entry.libraryReleaseId` and silently discards the rotation context. Result: `flowsheet.rotation_id` is null on 100% of recent webhook-origin track entries (743 sampled across 6 weeks). User-visible: iOS / dj-site flowsheet display shows blank cards for rotation-listed albums that aren't in the WXYC library catalog (Yenbett-class case).

This PR mirrors the BS#1028 library-shaped resolution path on the rotation side:

- New `resolveRotationId(legacyRotationId)` helper — single indexed SELECT via `rotation_legacy_rotation_id_idx` (unique by tubafrenzy invariant).
- Parallelized in the existing `Promise.all` alongside `resolveShowId` + `resolveAlbumId`.
- `rotation_id` included in the INSERT VALUES on the fresh-INSERT branch only. Linkage anchored to the first delivery, matching `album_id`'s policy.

Sibling fixes that complete the rotation-artwork pipeline:
- WXYC/Backend-Service#1270 (PATCH allowlist for dj-site write path)
- WXYC/dj-site#691 (`convertToAlbumEntry` discriminator)

Closes #1268.

## Notes on issue-body scope

The original ticket body suggested an `(artist_name, album_title)` fallback path. The investigation found that wasn't necessary — tubafrenzy already sends `rotationReleaseId` on the wire and `rotation.legacy_rotation_id` is unique-indexed. Single indexed SELECT, no heuristic. The helper name is `resolveRotationId` (matching the existing `resolveAlbumId` shape) rather than `resolveRotationIdByLegacyId`.

## Tests

Four new tests under the `// -- rotationReleaseId → rotation_id resolution (BS#1268) --` band:

1. **Forwards resolved rotation_id** when `rotationReleaseId` matches a rotation row.
2. **Inserts rotation_id: null** when `rotationReleaseId` is 0 (no rotation context).
3. **Inserts rotation_id: null** when `rotationReleaseId` doesn't match any rotation row.
4. **Coexists with libraryReleaseId** — both `album_id` and `rotation_id` populate when both resolve.

INSERT VALUES asserted via `mockChain.values.mock.calls`. The default `beforeEach` mock-limit queue gained a third entry for the new third `.limit(1)` call. The existing BS#1028 forwards-resolved-album_id test gained the corresponding third queued value.

## Acceptance criteria

- [x] `internal.route.ts` reads `entry.rotationReleaseId`; on non-zero, resolves via new helper; includes resolved `rotation_id` (or null) in INSERT VALUES.
- [x] Unit test: webhook with resolving `rotationReleaseId` → INSERT carries `rotation_id`.
- [x] Unit test: `rotationReleaseId=0` or unresolved → INSERT carries `rotation_id: null`.
- [x] Unit test: both `libraryReleaseId` and `rotationReleaseId` populate when both resolve.
- [x] `npm run test:unit` → 2667 tests green (was 2664; +3 new + 1 split for the coexist case).
- [x] `npm run typecheck` → green.
- [x] `npm run lint` → no new errors.
- [x] `npm run format:check` → green.
- [ ] Post-deploy: a new tubafrenzy webhook entry for "Hebebeb (Zrag)" / "Yenbett" produces a flowsheet row with non-null `rotation_id`.

## Constraints honored

- BS#1028 pattern mirrored: same `resolveX` shape, same `Promise.all` site, same INSERT-only-on-fresh policy.
- ON CONFLICT UPDATE path unchanged: `rotation_id` is anchored at first delivery, like `album_id`. Operator re-bind to a different rotation row arrives as a new `legacy_entry_id`, not an UPDATE — per tubafrenzy's contract.
- Webhook handler is fast-path: single indexed SELECT, parallelized with show/album lookups, no N+1.
- `internal.route.ts` is on the post-launch service hardening project (#32) critical-surface list. No behavior change in the no-rotation case; additive only.

## Test plan

- [x] Worktree off `origin/main`
- [x] Unit suite: 2667 / 2667 passing
- [x] `typecheck`, `lint`, `format:check`
- [ ] CI on push
- [ ] Live webhook delivery for Yenbett-class row post-deploy