### PR TITLE
feat(enrichment-worker): stranded-claim sweep (closes BS#1225)

### DIFF
--- a/apps/enrichment-worker/sweep.ts
+++ b/apps/enrichment-worker/sweep.ts
@@ -1,0 +1,73 @@
+/**
+ * Stranded-claim recovery sweep for the enrichment consumer
+ * (BS#1225 / Epic C C6 split).
+ *
+ * The C2 worker (BS#892) flips `metadata_status` from `'pending'` to
+ * `'enriching'` and stamps `enriching_since = now()` before calling LML.
+ * If the LML call throws or the worker process dies (SIGTERM, crash, OOM)
+ * between the claim and the finalize, the row sits in `'enriching'`
+ * indefinitely — invisible to both the CDC consumer (which only filters
+ * `'pending'`) and the backfill cron. This sweep is the safety net: it
+ * flips any `'enriching'` row whose `enriching_since` is older than the
+ * 60-second TTL back to `'pending'`, so the next CDC tick (or the
+ * backfill drain) re-enqueues it.
+ *
+ * SQL contract:
+ *
+ *   UPDATE wxyc_schema.flowsheet
+ *      SET metadata_status = 'pending',
+ *          enriching_since = NULL
+ *    WHERE metadata_status = 'enriching'
+ *      AND enriching_since < now() - interval '60 seconds';
+ *
+ * Coverage:
+ *   - `flowsheet_metadata_status_enriching_stale_idx` (schema.ts) is a
+ *     partial B-tree on `enriching_since` WHERE `metadata_status='enriching'`,
+ *     so the WHERE clause indexes both predicates in one scan.
+ *   - The partial index has no `artist_name` / `entry_type` guard because
+ *     `'enriching'` is only reachable from `'pending'`, which the writer
+ *     already gates on `entry_type='track' AND artist_name IS NOT NULL`.
+ *   - The 60s TTL is the floor; this function is intended to run at a
+ *     per-minute cadence by the worker. See `worker.ts` for the wiring.
+ *
+ * Sentry projection: each sweep tick is wrapped in a span carrying
+ * `sweep.stranded_recovered_count` so the trace explorer can answer "are
+ * we leaking rows?" without per-row metric inventory. The pattern mirrors
+ * the consumer-tick instrumentation in `handler.ts` (project-onto-span
+ * at the chokepoint per LML#213 + BS#646).
+ */
+
+import * as Sentry from '@sentry/node';
+import { sql } from 'drizzle-orm';
+import { db, flowsheet } from '@wxyc/database';
+
+/**
+ * Run one stranded-claim recovery pass. Returns the number of rows
+ * reverted from `'enriching'` to `'pending'`. Throws on DB error so
+ * the caller (the worker's tick loop) can decide whether to capture
+ * to Sentry; this function does not swallow.
+ */
+export async function sweepStrandedClaims(): Promise<number> {
+  return Sentry.startSpan(
+    {
+      name: 'enrichment.sweep.stranded',
+      op: 'db.query',
+    },
+    async (span) => {
+      const reverted = await db
+        .update(flowsheet)
+        .set({
+          metadata_status: 'pending',
+          enriching_since: null,
+        })
+        .where(
+          sql`${flowsheet.metadata_status} = 'enriching' AND ${flowsheet.enriching_since} < now() - interval '60 seconds'`
+        )
+        .returning({ id: flowsheet.id });
+
+      const count = reverted.length;
+      span.setAttribute('sweep.stranded_recovered_count', count);
+      return count;
+    }
+  );
+}

--- a/apps/enrichment-worker/sweep.ts
+++ b/apps/enrichment-worker/sweep.ts
@@ -9,8 +9,11 @@
  * indefinitely — invisible to both the CDC consumer (which only filters
  * `'pending'`) and the backfill cron. This sweep is the safety net: it
  * flips any `'enriching'` row whose `enriching_since` is older than the
- * 60-second TTL back to `'pending'`, so the next CDC tick (or the
- * backfill drain) re-enqueues it.
+ * stranded-claim TTL back to `'pending'`. The next CDC INSERT for the
+ * same flowsheet id is rare (CDC fires on INSERT, not UPDATE), so the
+ * actual re-enrichment path for swept rows is the nightly backfill cron
+ * (`jobs/flowsheet-metadata-backfill`), which selects on
+ * `metadata_attempt_at IS NULL`.
  *
  * SQL contract:
  *
@@ -18,7 +21,7 @@
  *      SET metadata_status = 'pending',
  *          enriching_since = NULL
  *    WHERE metadata_status = 'enriching'
- *      AND enriching_since < now() - interval '60 seconds';
+ *      AND enriching_since < now() - interval '<TTL> seconds';
  *
  * Coverage:
  *   - `flowsheet_metadata_status_enriching_stale_idx` (schema.ts) is a
@@ -27,33 +30,63 @@
  *   - The partial index has no `artist_name` / `entry_type` guard because
  *     `'enriching'` is only reachable from `'pending'`, which the writer
  *     already gates on `entry_type='track' AND artist_name IS NOT NULL`.
- *   - The 60s TTL is the floor; this function is intended to run at a
- *     per-minute cadence by the worker. See `worker.ts` for the wiring.
  *
- * Sentry projection: each sweep tick is wrapped in a span carrying
- * `sweep.stranded_recovered_count` so the trace explorer can answer "are
- * we leaking rows?" without per-row metric inventory. The pattern mirrors
- * the consumer-tick instrumentation in `handler.ts` (project-onto-span
- * at the chokepoint per LML#213 + BS#646).
+ * TTL derivation:
+ *
+ *   The TTL MUST exceed the worker's LML budget (`ENRICHMENT_LML_BUDGET_MS`
+ *   in `handler.ts`) plus enough slack for the finalize UPDATE to land.
+ *   Otherwise the sweep races a still-in-flight claim: it reverts the row
+ *   to `'pending'` while the worker is mid-LML-fetch, the worker's
+ *   finalize then narrows on `metadata_status='enriching'` and matches 0
+ *   rows (silently no-ops), and the LML token spend is wasted. Defined
+ *   as `max(60s, LML_BUDGET + 30s)` to keep that invariant even if an
+ *   operator bumps the LML budget. The 60s floor matches the original
+ *   C6 design.
+ *
+ * Sentry projection:
+ *
+ *   Operational outcome surfaces as TWO spans per tick: the outer
+ *   `enrichment.sweep.stranded` op span marks the work, and a child
+ *   `enrichment.sweep.stranded.result` span carries the numeric
+ *   `sweep.stranded_recovered_count` via the `attributes` field of
+ *   `startSpan`. Per BS#1081 (and MEMORY's
+ *   `feedback_sentry_attribute_typing_trap`), numeric values set via
+ *   `setAttribute(name, number)` AFTER span creation are indexed as
+ *   strings, breaking aggregation (avg/p50/p95/sum) on Sentry trace
+ *   explorer dashboards. Passing them via the `attributes` option at
+ *   creation indexes them as numbers. Same pattern as
+ *   `jobs/artist-search-alias-consumer/job.ts:75-100`.
  */
 
 import * as Sentry from '@sentry/node';
 import { sql } from 'drizzle-orm';
 import { db, flowsheet } from '@wxyc/database';
+import { envInt } from '@wxyc/lml-client';
+
+const ENRICHMENT_LML_BUDGET_MS = envInt('ENRICHMENT_LML_BUDGET_MS', 29000);
+
+/**
+ * Seconds a row can sit in `'enriching'` before the sweep reverts it.
+ * Floor of 60s preserves the original C6 contract; coupling to the LML
+ * budget keeps the invariant `TTL > LML_BUDGET` even when the budget is
+ * bumped via env. The 30s slack covers the post-LML finalize UPDATE.
+ */
+export const STRANDED_TTL_SECONDS = Math.max(60, Math.ceil(ENRICHMENT_LML_BUDGET_MS / 1000) + 30);
 
 /**
  * Run one stranded-claim recovery pass. Returns the number of rows
- * reverted from `'enriching'` to `'pending'`. Throws on DB error so
- * the caller (the worker's tick loop) can decide whether to capture
- * to Sentry; this function does not swallow.
+ * reverted from `'enriching'` to `'pending'`. Throws on DB error so the
+ * caller (the worker's tick loop) can decide whether to capture to
+ * Sentry; this function does not swallow.
  */
 export async function sweepStrandedClaims(): Promise<number> {
   return Sentry.startSpan(
     {
       name: 'enrichment.sweep.stranded',
       op: 'db.query',
+      attributes: { 'sweep.ttl_seconds': STRANDED_TTL_SECONDS },
     },
-    async (span) => {
+    async () => {
       const reverted = await db
         .update(flowsheet)
         .set({
@@ -61,12 +94,23 @@ export async function sweepStrandedClaims(): Promise<number> {
           enriching_since: null,
         })
         .where(
-          sql`${flowsheet.metadata_status} = 'enriching' AND ${flowsheet.enriching_since} < now() - interval '60 seconds'`
+          sql`${flowsheet.metadata_status} = 'enriching' AND ${flowsheet.enriching_since} < now() - make_interval(secs => ${STRANDED_TTL_SECONDS})`
         )
         .returning({ id: flowsheet.id });
 
       const count = reverted.length;
-      span.setAttribute('sweep.stranded_recovered_count', count);
+      // Surface the count as a child span whose numeric attribute is set
+      // at creation time (BS#1081 typing-trap workaround). The child span
+      // is a no-op other than as a carrier for the indexed attribute.
+      Sentry.startSpan(
+        {
+          name: 'enrichment.sweep.stranded.result',
+          attributes: { 'sweep.stranded_recovered_count': count },
+        },
+        () => {
+          /* attribute set at creation; nothing else to do */
+        }
+      );
       return count;
     }
   );

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -95,7 +95,10 @@ const main = async (): Promise<void> => {
   // tear the in-flight UPDATE's connection.
   let shuttingDown = false;
   let activeSweep: Promise<void> | null = null;
-  let sweepTimer: NodeJS.Timeout | undefined;
+  // Mutable holder so the shutdown closure (declared next) can clear the
+  // timer that's only assigned later, after the initial sweep. Holding via
+  // a ref keeps the binding `const` and survives `prefer-const`.
+  const sweepTimerRef: { current: NodeJS.Timeout | undefined } = { current: undefined };
 
   const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
     if (shuttingDown) return;
@@ -103,7 +106,7 @@ const main = async (): Promise<void> => {
     healthState.cdcConnected = false;
     console.log(`[enrichment-worker] received ${signal}; shutting down`);
     try {
-      if (sweepTimer !== undefined) clearInterval(sweepTimer);
+      if (sweepTimerRef.current !== undefined) clearInterval(sweepTimerRef.current);
       // Each step is bounded + best-effort via runShutdownStep so a hang
       // or throw in one (e.g. a wedged CDC LISTEN socket — BS#1014 lists
       // the exact failure modes) doesn't skip the cleanup steps that
@@ -133,7 +136,7 @@ const main = async (): Promise<void> => {
 
   // Register signal handlers FIRST so they cover the initial sweep below.
   // `clearInterval(undefined)` is a Node-tolerated no-op, and `activeSweep`
-  // / `sweepTimer` are guarded with explicit null/undefined checks.
+  // / `sweepTimerRef.current` are guarded with explicit null/undefined checks.
   process.on('SIGTERM', () => void shutdown('SIGTERM'));
   process.on('SIGINT', () => void shutdown('SIGINT'));
 
@@ -170,7 +173,7 @@ const main = async (): Promise<void> => {
   // already covered by the `cdcConnected=false` healthcheck — and no new
   // strands are produced in that state anyway.
   await scheduleSweep();
-  sweepTimer = setInterval(() => {
+  sweepTimerRef.current = setInterval(() => {
     void scheduleSweep();
   }, SWEEP_INTERVAL_MS);
 

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -38,13 +38,45 @@ import { sweepStrandedClaims } from './sweep.js';
 const SWEEP_INTERVAL_MS = envInt('ENRICHMENT_SWEEP_INTERVAL_MS', 60_000);
 
 /**
- * Bound the shutdown wait for an in-flight sweep so SIGTERM never hangs
- * if PG is unresponsive. After this many ms we proceed with
- * `closeDatabaseConnection` regardless; postgres-js will end its pool
- * cleanly, and any straggling sweep promise rejects with a
- * `CONNECTION_ENDED` that runSweep's catch handler tolerates.
+ * Per-step bound for the shutdown path so SIGTERM never hangs if PG (or
+ * the CDC LISTEN socket, or the healthcheck server) is unresponsive.
+ * Each step is best-effort: a throw is captured to Sentry and the next
+ * step still runs; a hang trips the bound and the next step still runs.
+ * `process.exit(0)` fires unconditionally in the outer finally.
  */
-const SWEEP_SHUTDOWN_WAIT_MS = 5_000;
+const SHUTDOWN_STEP_BOUND_MS = 5_000;
+
+/**
+ * Run a shutdown step with a per-step bound and a swallow-and-capture
+ * handler. Returns when the work resolves, when the bound trips, or when
+ * the work rejects (with the rejection sent to Sentry). Never throws.
+ *
+ * The bound timer is cleared as soon as the work resolves so successful
+ * fast steps don't hold libuv ref'd for the full bound window.
+ */
+async function runShutdownStep(label: string, work: Promise<unknown> | (() => Promise<unknown>)): Promise<void> {
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const promise = typeof work === 'function' ? Promise.resolve().then(work) : work;
+  try {
+    await Promise.race([
+      promise.finally(() => {
+        if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+      }),
+      new Promise<void>((resolve) => {
+        timeoutHandle = setTimeout(() => {
+          console.warn(`[enrichment-worker] shutdown step ${label} timed out after ${SHUTDOWN_STEP_BOUND_MS}ms`);
+          resolve();
+        }, SHUTDOWN_STEP_BOUND_MS);
+      }),
+    ]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    Sentry.captureException(err, {
+      tags: { component: 'enrichment-worker', step: `shutdown_${label}` },
+    });
+    console.error(`[enrichment-worker] shutdown step ${label} failed`, { error: message });
+  }
+}
 
 const main = async (): Promise<void> => {
   console.log('[enrichment-worker] starting');
@@ -72,35 +104,26 @@ const main = async (): Promise<void> => {
     console.log(`[enrichment-worker] received ${signal}; shutting down`);
     try {
       if (sweepTimer !== undefined) clearInterval(sweepTimer);
-      // Stop the CDC LISTEN socket BEFORE awaiting the in-flight sweep so
-      // new CDC events don't fire fresh `handleCandidate` dispatches during
-      // the 5-second sweep wait window (those would race
-      // closeDatabaseConnection below). In-flight handlers from before
-      // shutdown are not tracked — a pre-existing limitation of the C2
-      // worker — but at least we don't compound it here.
-      await stopCdcListener();
-      // Await any in-flight sweep so closeDatabaseConnection doesn't tear
-      // its connection mid-UPDATE. Bound the wait — PG could be hung; we'd
-      // rather log a slow-shutdown warning than block the deploy forever.
-      // Capture the timeout id so we can clear it when activeSweep wins
-      // the race; otherwise the timer holds the libuv loop ref'd for the
-      // full SWEEP_SHUTDOWN_WAIT_MS even though we've moved on.
+      // Each step is bounded + best-effort via runShutdownStep so a hang
+      // or throw in one (e.g. a wedged CDC LISTEN socket — BS#1014 lists
+      // the exact failure modes) doesn't skip the cleanup steps that
+      // follow. The ordering still matters:
+      //   1. Stop CDC dispatches first so new `handleCandidate` calls
+      //      don't fire fresh DB writes during the sweep wait.
+      //   2. Drain any in-flight sweep so closeDatabaseConnection
+      //      doesn't tear its UPDATE.
+      //   3. Close the pool, then the healthcheck server.
+      //   4. Flush Sentry LAST so captures from earlier steps also land.
+      await runShutdownStep('stop_cdc', stopCdcListener);
       if (activeSweep !== null) {
-        let timeoutHandle: NodeJS.Timeout | undefined;
-        await Promise.race([
-          activeSweep.finally(() => {
-            if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
-          }),
-          new Promise<void>((resolve) => {
-            timeoutHandle = setTimeout(resolve, SWEEP_SHUTDOWN_WAIT_MS);
-          }),
-        ]);
+        await runShutdownStep('drain_sweep', activeSweep);
       }
-      await closeDatabaseConnection();
-      await new Promise<void>((resolve) => healthServer.close(() => resolve()));
-      // Flush pending Sentry spans/events so the last sweep tick's
-      // `sweep.stranded_recovered_count` (and any captured exceptions
-      // from runSweep) actually land. Mirrors the pattern in every
+      await runShutdownStep('close_db', closeDatabaseConnection);
+      await runShutdownStep(
+        'close_health_server',
+        () => new Promise<void>((resolve) => healthServer.close(() => resolve()))
+      );
+      // Sentry.close has its own bound; mirror the pattern in every
       // `jobs/*/logger.ts` shutdown path.
       await Sentry.close(2000);
     } finally {

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -72,13 +72,30 @@ const main = async (): Promise<void> => {
     console.log(`[enrichment-worker] received ${signal}; shutting down`);
     try {
       if (sweepTimer !== undefined) clearInterval(sweepTimer);
+      // Stop the CDC LISTEN socket BEFORE awaiting the in-flight sweep so
+      // new CDC events don't fire fresh `handleCandidate` dispatches during
+      // the 5-second sweep wait window (those would race
+      // closeDatabaseConnection below). In-flight handlers from before
+      // shutdown are not tracked — a pre-existing limitation of the C2
+      // worker — but at least we don't compound it here.
+      await stopCdcListener();
       // Await any in-flight sweep so closeDatabaseConnection doesn't tear
       // its connection mid-UPDATE. Bound the wait — PG could be hung; we'd
       // rather log a slow-shutdown warning than block the deploy forever.
+      // Capture the timeout id so we can clear it when activeSweep wins
+      // the race; otherwise the timer holds the libuv loop ref'd for the
+      // full SWEEP_SHUTDOWN_WAIT_MS even though we've moved on.
       if (activeSweep !== null) {
-        await Promise.race([activeSweep, new Promise<void>((resolve) => setTimeout(resolve, SWEEP_SHUTDOWN_WAIT_MS))]);
+        let timeoutHandle: NodeJS.Timeout | undefined;
+        await Promise.race([
+          activeSweep.finally(() => {
+            if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+          }),
+          new Promise<void>((resolve) => {
+            timeoutHandle = setTimeout(resolve, SWEEP_SHUTDOWN_WAIT_MS);
+          }),
+        ]);
       }
-      await stopCdcListener();
       await closeDatabaseConnection();
       await new Promise<void>((resolve) => healthServer.close(() => resolve()));
       // Flush pending Sentry spans/events so the last sweep tick's

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -13,6 +13,7 @@
  * @see docs/cdc.md
  */
 
+import * as Sentry from '@sentry/node';
 import {
   closeDatabaseConnection,
   enableLivenessProbe,
@@ -23,6 +24,15 @@ import {
 } from '@wxyc/database';
 import { makeEnrichmentHandler } from './handler.js';
 import { startHealthcheckServer, type HealthState } from './healthcheck.js';
+import { sweepStrandedClaims } from './sweep.js';
+
+/**
+ * Stranded-claim sweep cadence (BS#1225). The C6 contract is "recover any
+ * `enriching` row past `enriching_since + 60s`"; the worker runs the sweep
+ * at 60s so the worst-case recovery latency is ~120s (one full TTL plus one
+ * full sweep interval). Override via env for shorter-cycle integration runs.
+ */
+const SWEEP_INTERVAL_MS = Number(process.env.ENRICHMENT_SWEEP_INTERVAL_MS ?? 60_000);
 
 const main = async (): Promise<void> => {
   console.log('[enrichment-worker] starting');
@@ -54,6 +64,25 @@ const main = async (): Promise<void> => {
 
   console.log('[enrichment-worker] subscribed to CDC; awaiting events');
 
+  // BS#1225: stranded-claim recovery. Fire one tick immediately so any rows
+  // left in `enriching` by a previous instance's death are recovered before
+  // they sit through a full SWEEP_INTERVAL_MS, then re-run every interval.
+  // Lives in-process (not as a sibling cron container) because:
+  //   - The worker owns the claim lifecycle; coupling the recovery to the
+  //     worker's process keeps the failure model coherent.
+  //   - At a 60s cadence the container-startup cost of a separate cron job
+  //     dwarfs the actual UPDATE.
+  //   - Reuses the worker's existing PG connection pool.
+  // The "worker is permanently dead with strands to clear" failure mode is
+  // already covered by the `cdcConnected=false` healthcheck — and no new
+  // strands are produced in that state anyway.
+  await runSweep();
+  const sweepTimer = setInterval(() => {
+    void runSweep();
+  }, SWEEP_INTERVAL_MS);
+  // setInterval keeps the event loop alive on its own; explicit so a future
+  // refactor doesn't accidentally let the process exit before SIGTERM.
+
   // Graceful shutdown: SIGTERM (docker stop) and SIGINT (Ctrl+C). The
   // LISTEN connection holds a pg socket open, so stopping cleanly avoids
   // a "connection terminated unexpectedly" log on the database side.
@@ -67,6 +96,7 @@ const main = async (): Promise<void> => {
     healthState.cdcConnected = false;
     console.log(`[enrichment-worker] received ${signal}; shutting down`);
     try {
+      clearInterval(sweepTimer);
       await stopCdcListener();
       await closeDatabaseConnection();
       await new Promise<void>((resolve) => healthServer.close(() => resolve()));
@@ -78,6 +108,26 @@ const main = async (): Promise<void> => {
   process.on('SIGTERM', () => void shutdown('SIGTERM'));
   process.on('SIGINT', () => void shutdown('SIGINT'));
 };
+
+/**
+ * Wrap one sweep tick. The sweep itself opens a Sentry span and projects
+ * the recovered count onto it (see `sweep.ts`); this wrapper exists to
+ * catch DB errors so an unhealthy sweep can't unhandled-reject and tear
+ * down the worker via setInterval's fire-and-forget callback.
+ */
+async function runSweep(): Promise<void> {
+  try {
+    const recovered = await sweepStrandedClaims();
+    if (recovered > 0) {
+      console.log(`[enrichment-worker] sweep recovered ${recovered} stranded claim(s)`);
+    }
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { component: 'enrichment-worker', step: 'stranded_claim_sweep' },
+    });
+    console.error('[enrichment-worker] sweep failed', { error: (err as Error).message });
+  }
+}
 
 void main().catch((err) => {
   console.error('[enrichment-worker] fatal startup error:', err);

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -22,17 +22,29 @@ import {
   startCdcListener,
   stopCdcListener,
 } from '@wxyc/database';
+import { envInt } from '@wxyc/lml-client';
 import { makeEnrichmentHandler } from './handler.js';
 import { startHealthcheckServer, type HealthState } from './healthcheck.js';
 import { sweepStrandedClaims } from './sweep.js';
 
 /**
  * Stranded-claim sweep cadence (BS#1225). The C6 contract is "recover any
- * `enriching` row past `enriching_since + 60s`"; the worker runs the sweep
- * at 60s so the worst-case recovery latency is ~120s (one full TTL plus one
- * full sweep interval). Override via env for shorter-cycle integration runs.
+ * `enriching` row past the stranded-claim TTL"; the worker runs the sweep
+ * at 60s so worst-case recovery latency is ~one TTL plus one sweep
+ * interval. Override via env for shorter-cycle integration runs. `envInt`
+ * rejects empty-string / NaN / non-positive values and falls back so a
+ * deploy-config typo can't produce a tight-loop `setInterval(fn, 0)`.
  */
-const SWEEP_INTERVAL_MS = Number(process.env.ENRICHMENT_SWEEP_INTERVAL_MS ?? 60_000);
+const SWEEP_INTERVAL_MS = envInt('ENRICHMENT_SWEEP_INTERVAL_MS', 60_000);
+
+/**
+ * Bound the shutdown wait for an in-flight sweep so SIGTERM never hangs
+ * if PG is unresponsive. After this many ms we proceed with
+ * `closeDatabaseConnection` regardless; postgres-js will end its pool
+ * cleanly, and any straggling sweep promise rejects with a
+ * `CONNECTION_ENDED` that runSweep's catch handler tolerates.
+ */
+const SWEEP_SHUTDOWN_WAIT_MS = 5_000;
 
 const main = async (): Promise<void> => {
   console.log('[enrichment-worker] starting');
@@ -43,6 +55,47 @@ const main = async (): Promise<void> => {
   // out on `--health-start-period`.
   const healthState: HealthState = { cdcConnected: false };
   const healthServer = startHealthcheckServer(healthState);
+
+  // Shutdown latch + in-flight sweep tracker, both declared up-front so
+  // the SIGTERM/SIGINT handlers can be registered BEFORE any awaited
+  // startup work. A signal arriving during the initial sweep below would
+  // otherwise hit Node's default SIGTERM handler (immediate exit) and
+  // tear the in-flight UPDATE's connection.
+  let shuttingDown = false;
+  let activeSweep: Promise<void> | null = null;
+  let sweepTimer: NodeJS.Timeout | undefined;
+
+  const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    healthState.cdcConnected = false;
+    console.log(`[enrichment-worker] received ${signal}; shutting down`);
+    try {
+      if (sweepTimer !== undefined) clearInterval(sweepTimer);
+      // Await any in-flight sweep so closeDatabaseConnection doesn't tear
+      // its connection mid-UPDATE. Bound the wait — PG could be hung; we'd
+      // rather log a slow-shutdown warning than block the deploy forever.
+      if (activeSweep !== null) {
+        await Promise.race([activeSweep, new Promise<void>((resolve) => setTimeout(resolve, SWEEP_SHUTDOWN_WAIT_MS))]);
+      }
+      await stopCdcListener();
+      await closeDatabaseConnection();
+      await new Promise<void>((resolve) => healthServer.close(() => resolve()));
+      // Flush pending Sentry spans/events so the last sweep tick's
+      // `sweep.stranded_recovered_count` (and any captured exceptions
+      // from runSweep) actually land. Mirrors the pattern in every
+      // `jobs/*/logger.ts` shutdown path.
+      await Sentry.close(2000);
+    } finally {
+      process.exit(0);
+    }
+  };
+
+  // Register signal handlers FIRST so they cover the initial sweep below.
+  // `clearInterval(undefined)` is a Node-tolerated no-op, and `activeSweep`
+  // / `sweepTimer` are guarded with explicit null/undefined checks.
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
 
   // BS#1014: dispatched true on initial LISTEN + every postgres-js reconnect,
   // dispatched false when the liveness probe observes a wedged LISTEN socket.
@@ -64,10 +117,10 @@ const main = async (): Promise<void> => {
 
   console.log('[enrichment-worker] subscribed to CDC; awaiting events');
 
-  // BS#1225: stranded-claim recovery. Fire one tick immediately so any rows
-  // left in `enriching` by a previous instance's death are recovered before
-  // they sit through a full SWEEP_INTERVAL_MS, then re-run every interval.
-  // Lives in-process (not as a sibling cron container) because:
+  // BS#1225: stranded-claim recovery. Fire one tick immediately so any
+  // rows left in `enriching` by a previous instance's death are recovered
+  // before they sit through a full SWEEP_INTERVAL_MS, then re-run every
+  // interval. Lives in-process (not as a sibling cron container) because:
   //   - The worker owns the claim lifecycle; coupling the recovery to the
   //     worker's process keeps the failure model coherent.
   //   - At a 60s cadence the container-startup cost of a separate cron job
@@ -76,44 +129,35 @@ const main = async (): Promise<void> => {
   // The "worker is permanently dead with strands to clear" failure mode is
   // already covered by the `cdcConnected=false` healthcheck — and no new
   // strands are produced in that state anyway.
-  await runSweep();
-  const sweepTimer = setInterval(() => {
-    void runSweep();
+  await scheduleSweep();
+  sweepTimer = setInterval(() => {
+    void scheduleSweep();
   }, SWEEP_INTERVAL_MS);
-  // setInterval keeps the event loop alive on its own; explicit so a future
-  // refactor doesn't accidentally let the process exit before SIGTERM.
 
-  // Graceful shutdown: SIGTERM (docker stop) and SIGINT (Ctrl+C). The
-  // LISTEN connection holds a pg socket open, so stopping cleanly avoids
-  // a "connection terminated unexpectedly" log on the database side.
-  // The `shuttingDown` latch guards against concurrent SIGTERM+SIGINT
-  // (or a duplicate signal) racing through `stopCdcListener` +
-  // `closeDatabaseConnection`.
-  let shuttingDown = false;
-  const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
+  /**
+   * Schedule a sweep tick with overlap and shutdown guards. The
+   * `activeSweep` latch causes a tick to skip cleanly if the previous one
+   * is still running (slow DB, large backlog) — without this, every tick
+   * during a slow sweep would spawn another concurrent UPDATE,
+   * compounding load on the partial index. The shutdown latch ensures a
+   * timer callback that fires after `clearInterval` has been queued but
+   * before libuv cancels it can't write to a pool that's about to close.
+   */
+  async function scheduleSweep(): Promise<void> {
     if (shuttingDown) return;
-    shuttingDown = true;
-    healthState.cdcConnected = false;
-    console.log(`[enrichment-worker] received ${signal}; shutting down`);
-    try {
-      clearInterval(sweepTimer);
-      await stopCdcListener();
-      await closeDatabaseConnection();
-      await new Promise<void>((resolve) => healthServer.close(() => resolve()));
-    } finally {
-      process.exit(0);
-    }
-  };
-
-  process.on('SIGTERM', () => void shutdown('SIGTERM'));
-  process.on('SIGINT', () => void shutdown('SIGINT'));
+    if (activeSweep !== null) return;
+    activeSweep = runSweep().finally(() => {
+      activeSweep = null;
+    });
+    await activeSweep;
+  }
 };
 
 /**
  * Wrap one sweep tick. The sweep itself opens a Sentry span and projects
- * the recovered count onto it (see `sweep.ts`); this wrapper exists to
- * catch DB errors so an unhealthy sweep can't unhandled-reject and tear
- * down the worker via setInterval's fire-and-forget callback.
+ * the recovered count onto a child span (see `sweep.ts`); this wrapper
+ * exists to catch DB errors so an unhealthy sweep can't unhandled-reject
+ * and tear down the worker via setInterval's fire-and-forget callback.
  */
 async function runSweep(): Promise<void> {
   try {
@@ -122,10 +166,11 @@ async function runSweep(): Promise<void> {
       console.log(`[enrichment-worker] sweep recovered ${recovered} stranded claim(s)`);
     }
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     Sentry.captureException(err, {
       tags: { component: 'enrichment-worker', step: 'stranded_claim_sweep' },
     });
-    console.error('[enrichment-worker] sweep failed', { error: (err as Error).message });
+    console.error('[enrichment-worker] sweep failed', { error: message });
   }
 }
 

--- a/tests/integration/enrichment-worker-claim.spec.js
+++ b/tests/integration/enrichment-worker-claim.spec.js
@@ -185,9 +185,12 @@ describe('enrichment-worker claim primitive (real PG)', () => {
        WHERE id = ${id}
     `;
 
-    // 2. C6 recovery sweep SQL — when BS#895 ships, the cron will run
-    //    this exact query (modulo batch size). Pinning it here so a
-    //    schema change that breaks the sweep fails CI now.
+    // 2. C6 recovery sweep SQL — shipped as `sweepStrandedClaims` in
+    //    `apps/enrichment-worker/sweep.ts` (BS#1225). End-to-end coverage
+    //    of the real sweep function against multi-row batches and
+    //    terminal-state safety lives in `enrichment-worker-sweep.spec.js`;
+    //    this assertion remains as a sibling-level pin so a schema change
+    //    that breaks the sweep also fails this spec.
     const reverted = await sql`
       UPDATE ${sql(SCHEMA)}.flowsheet
          SET metadata_status = 'pending',

--- a/tests/integration/enrichment-worker-sweep.spec.js
+++ b/tests/integration/enrichment-worker-sweep.spec.js
@@ -39,6 +39,14 @@ const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
  * `apps/enrichment-worker/sweep.ts` — when that file is hand-edited the
  * SQL here must follow. Returns the count of rows reverted.
  *
+ * Pins the SQL contract at the production-default TTL (60s, which
+ * STRANDED_TTL_SECONDS resolves to when `ENRICHMENT_LML_BUDGET_MS` is at
+ * its 29s default). If a future change raises the LML budget high enough
+ * to push the derived TTL above 60s, the test backdates below are
+ * deliberately well above any reasonable TTL so the recovery path still
+ * fires; only the "exact cutoff" boundary would drift, which is
+ * intentional — the test pins behavior at the default deployment.
+ *
  * Scoped to `id = ANY(scopeIds)` so sibling integration specs running
  * against the same shared schema under `--runInBand` can't cross-affect
  * one another's rows. Production `sweepStrandedClaims` is unscoped (it
@@ -123,7 +131,9 @@ describe('enrichment-worker stranded-claim sweep (real PG)', () => {
     insertedIds.push(id);
 
     expect(await claimRow(sql, id)).toBe(true);
-    await backdateEnrichingSince(sql, id, 120);
+    // Backdate well above any reasonable derived TTL so the test pinning
+    // remains correct if STRANDED_TTL_SECONDS grows beyond 60s.
+    await backdateEnrichingSince(sql, id, 600);
 
     await runSweep(sql, [id]);
 
@@ -146,7 +156,9 @@ describe('enrichment-worker stranded-claim sweep (real PG)', () => {
       ids.push(id);
       insertedIds.push(id);
       await claimRow(sql, id);
-      await backdateEnrichingSince(sql, id, 90);
+      // Backdate well above any reasonable derived TTL — see runSweep
+      // header for the lockstep rationale.
+      await backdateEnrichingSince(sql, id, 600);
     }
 
     await runSweep(sql, ids);

--- a/tests/integration/enrichment-worker-sweep.spec.js
+++ b/tests/integration/enrichment-worker-sweep.spec.js
@@ -38,14 +38,21 @@ const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
  * Issue the worker's sweep SQL directly. Mirrors `sweepStrandedClaims` in
  * `apps/enrichment-worker/sweep.ts` — when that file is hand-edited the
  * SQL here must follow. Returns the count of rows reverted.
+ *
+ * Scoped to `id = ANY(scopeIds)` so sibling integration specs running
+ * against the same shared schema under `--runInBand` can't cross-affect
+ * one another's rows. Production `sweepStrandedClaims` is unscoped (it
+ * sweeps the whole table) — that's correct behavior there; the scoping
+ * here exists purely for test isolation.
  */
-async function runSweep(sql) {
+async function runSweep(sql, scopeIds) {
   const rows = await sql`
     UPDATE ${sql(SCHEMA)}.flowsheet
        SET metadata_status = 'pending',
            enriching_since = NULL
      WHERE metadata_status = 'enriching'
        AND enriching_since < now() - interval '60 seconds'
+       AND id = ANY(${scopeIds})
     RETURNING id
   `;
   return rows.length;
@@ -118,7 +125,7 @@ describe('enrichment-worker stranded-claim sweep (real PG)', () => {
     expect(await claimRow(sql, id)).toBe(true);
     await backdateEnrichingSince(sql, id, 120);
 
-    await runSweep(sql);
+    await runSweep(sql, [id]);
 
     const [row] = await sql`
       SELECT metadata_status, enriching_since
@@ -142,7 +149,7 @@ describe('enrichment-worker stranded-claim sweep (real PG)', () => {
       await backdateEnrichingSince(sql, id, 90);
     }
 
-    await runSweep(sql);
+    await runSweep(sql, ids);
 
     const rows = await sql`
       SELECT id, metadata_status
@@ -162,7 +169,7 @@ describe('enrichment-worker stranded-claim sweep (real PG)', () => {
 
     expect(await claimRow(sql, id)).toBe(true);
     // enriching_since defaulted to now() — well inside the 60s TTL.
-    await runSweep(sql);
+    await runSweep(sql, [id]);
 
     const [row] = await sql`
       SELECT metadata_status, enriching_since
@@ -193,7 +200,7 @@ describe('enrichment-worker stranded-claim sweep (real PG)', () => {
       `;
     }
 
-    await runSweep(sql);
+    await runSweep(sql, ids);
 
     const rows = await sql`
       SELECT id, metadata_status

--- a/tests/integration/enrichment-worker-sweep.spec.js
+++ b/tests/integration/enrichment-worker-sweep.spec.js
@@ -1,0 +1,206 @@
+/**
+ * Integration test for the enrichment worker's stranded-claim sweep
+ * (BS#1225 / Epic C C6 split).
+ *
+ * The C2 worker (BS#892) flips `metadata_status` from `'pending'` to
+ * `'enriching'` before calling LML; if the LML call throws or the worker
+ * process dies before the finalize, the row sits in `'enriching'` forever.
+ * `apps/enrichment-worker/sweep.ts` is the safety net: every 60s it flips
+ * any `'enriching'` row past the `enriching_since + 60s` TTL back to
+ * `'pending'`. The unit test
+ * (`tests/unit/apps/enrichment-worker/sweep.test.ts`) covers the Drizzle
+ * builder shape against the mock DB; this spec validates the actual SQL
+ * contract against the live `flowsheet` table + the partial index
+ * `flowsheet_metadata_status_enriching_stale_idx`.
+ *
+ * Pure SQL — does NOT import `apps/enrichment-worker/sweep.ts`. The
+ * integration runner is babel-jest with no TS support (see
+ * `enrichment-worker-claim.spec.js` header for the drizzle-orm + ts-jest
+ * incompatibility). The SQL below MUST stay in lockstep with the
+ * implementation; that's exactly what's being pinned.
+ *
+ * Coverage:
+ *   1. Single stranded row: claim → backdate `enriching_since` past the
+ *      TTL → sweep → row is `'pending'` again, `enriching_since IS NULL`,
+ *      re-claim succeeds.
+ *   2. Batch recovery: N=5 stranded rows are recovered in one sweep tick.
+ *   3. Recent-claim safety: a row whose `enriching_since` is within the
+ *      60s TTL is NOT touched.
+ *   4. Terminal-state safety: rows in `'enriched_match'`,
+ *      `'enriched_no_match'`, `'failed_no_retry'` are NOT touched.
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * Issue the worker's sweep SQL directly. Mirrors `sweepStrandedClaims` in
+ * `apps/enrichment-worker/sweep.ts` — when that file is hand-edited the
+ * SQL here must follow. Returns the count of rows reverted.
+ */
+async function runSweep(sql) {
+  const rows = await sql`
+    UPDATE ${sql(SCHEMA)}.flowsheet
+       SET metadata_status = 'pending',
+           enriching_since = NULL
+     WHERE metadata_status = 'enriching'
+       AND enriching_since < now() - interval '60 seconds'
+    RETURNING id
+  `;
+  return rows.length;
+}
+
+/**
+ * Insert a fresh pending track row. Same shape as the claim spec's helper
+ * (NOT NULL `play_order`, omitted `show_id` per upstream-permitted shape).
+ */
+async function insertPendingRow(sql, suffix) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.flowsheet
+      (play_order, entry_type, artist_name, album_title, track_title, metadata_status, request_flag, segue)
+    VALUES
+      (99998, 'track', ${'enrichment-sweep-test-artist-' + suffix}, 'Test Album', 'Test Track', 'pending', false, false)
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+/**
+ * Mirror of the worker's claim SQL — flip the row to `'enriching'` and
+ * stamp `enriching_since = now()`. Returns whether the claim won.
+ */
+async function claimRow(sql, id) {
+  const rows = await sql`
+    UPDATE ${sql(SCHEMA)}.flowsheet
+       SET metadata_status = 'enriching',
+           enriching_since = now()
+     WHERE id = ${id}
+       AND metadata_status = 'pending'
+    RETURNING id
+  `;
+  return rows.length > 0;
+}
+
+/**
+ * Backdate a row's `enriching_since` past the 60s TTL so the next sweep
+ * picks it up. Mirrors the conditions a process death between claim and
+ * finalize would produce, ~minutes after the fact.
+ */
+async function backdateEnrichingSince(sql, id, seconds) {
+  await sql`
+    UPDATE ${sql(SCHEMA)}.flowsheet
+       SET enriching_since = now() - make_interval(secs => ${seconds})
+     WHERE id = ${id}
+  `;
+}
+
+describe('enrichment-worker stranded-claim sweep (real PG)', () => {
+  let sql;
+  /** ids inserted by tests; deleted in afterAll regardless of pass/fail. */
+  const insertedIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE id = ANY(${insertedIds})`;
+    }
+    // Pool is shared with the rest of the integration suite; do NOT close it.
+  });
+
+  test('single stranded claim: sweep reverts to pending and clears enriching_since', async () => {
+    const id = await insertPendingRow(sql, 'single-stranded');
+    insertedIds.push(id);
+
+    expect(await claimRow(sql, id)).toBe(true);
+    await backdateEnrichingSince(sql, id, 120);
+
+    await runSweep(sql);
+
+    const [row] = await sql`
+      SELECT metadata_status, enriching_since
+        FROM ${sql(SCHEMA)}.flowsheet
+       WHERE id = ${id}
+    `;
+    expect(row.metadata_status).toBe('pending');
+    expect(row.enriching_since).toBeNull();
+
+    // Row is claimable again — the contract the C2 worker depends on.
+    expect(await claimRow(sql, id)).toBe(true);
+  });
+
+  test('batch recovery: 5 stranded rows are reverted in a single sweep tick', async () => {
+    const ids = [];
+    for (let i = 0; i < 5; i++) {
+      const id = await insertPendingRow(sql, `batch-${i}`);
+      ids.push(id);
+      insertedIds.push(id);
+      await claimRow(sql, id);
+      await backdateEnrichingSince(sql, id, 90);
+    }
+
+    await runSweep(sql);
+
+    const rows = await sql`
+      SELECT id, metadata_status
+        FROM ${sql(SCHEMA)}.flowsheet
+       WHERE id = ANY(${ids})
+       ORDER BY id
+    `;
+    expect(rows).toHaveLength(5);
+    for (const row of rows) {
+      expect(row.metadata_status).toBe('pending');
+    }
+  });
+
+  test('recent claim within the 60s TTL is NOT touched by the sweep', async () => {
+    const id = await insertPendingRow(sql, 'recent-claim');
+    insertedIds.push(id);
+
+    expect(await claimRow(sql, id)).toBe(true);
+    // enriching_since defaulted to now() — well inside the 60s TTL.
+    await runSweep(sql);
+
+    const [row] = await sql`
+      SELECT metadata_status, enriching_since
+        FROM ${sql(SCHEMA)}.flowsheet
+       WHERE id = ${id}
+    `;
+    expect(row.metadata_status).toBe('enriching');
+    expect(row.enriching_since).not.toBeNull();
+  });
+
+  test('terminal-state rows are NOT touched by the sweep', async () => {
+    // For each terminal state, set up a row that would superficially look
+    // sweep-eligible if the WHERE narrowed only by `enriching_since`. The
+    // sweep MUST narrow by `metadata_status='enriching'` too — if it ever
+    // loosens, this test fails by reverting completed rows to `pending`
+    // and re-enqueueing already-done work.
+    const terminalStates = ['enriched_match', 'enriched_no_match', 'failed_no_retry'];
+    const ids = [];
+    for (const state of terminalStates) {
+      const id = await insertPendingRow(sql, `terminal-${state}`);
+      ids.push(id);
+      insertedIds.push(id);
+      await sql`
+        UPDATE ${sql(SCHEMA)}.flowsheet
+           SET metadata_status = ${state},
+               enriching_since = now() - interval '5 minutes'
+         WHERE id = ${id}
+      `;
+    }
+
+    await runSweep(sql);
+
+    const rows = await sql`
+      SELECT id, metadata_status
+        FROM ${sql(SCHEMA)}.flowsheet
+       WHERE id = ANY(${ids})
+       ORDER BY id
+    `;
+    expect(rows.map((r) => r.metadata_status).sort()).toEqual([...terminalStates].sort());
+  });
+});

--- a/tests/unit/apps/enrichment-worker/sweep.test.ts
+++ b/tests/unit/apps/enrichment-worker/sweep.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for enrichment-worker sweep.ts (BS#1225 / Epic C C6 split).
+ *
+ * Pins the stranded-claim recovery query shape so a schema change or an
+ * accidental WHERE-loosening fails CI before deploy.
+ *
+ * The sweep flips `metadata_status='enriching'` rows whose `enriching_since`
+ * is older than the 60s TTL back to `'pending'` (and NULLs `enriching_since`)
+ * so the next CDC tick can re-claim them. Without it, every LML throw or
+ * worker SIGTERM leaks a row in `enriching` forever — the C2 worker (#892)
+ * documents this in `handler.ts:90-115` and tests/integration/
+ * enrichment-worker-claim.spec.js:175-205 exercises the SQL inline.
+ *
+ * Three contract guarantees pinned here:
+ *   1. WHERE narrows by `metadata_status='enriching'`. Loosening this would
+ *      revert terminal rows back to pending, re-enqueueing finished work.
+ *   2. WHERE narrows by `enriching_since < now() - interval '60 seconds'`.
+ *      The 60s TTL is the partial index's predicate; loosening it (or
+ *      forgetting the cutoff entirely) would race in-flight claims.
+ *   3. SET writes `metadata_status='pending'` AND `enriching_since=NULL`.
+ *      Forgetting the NULL would leave a stale enriching_since the next
+ *      claim-then-strand cycle has to overwrite.
+ *
+ * Integration coverage of the end-to-end recovery cycle (claim → strand →
+ * sweep → re-claim) lives in `tests/integration/enrichment-worker-claim.spec.js`.
+ */
+import { jest } from '@jest/globals';
+
+import { db, flowsheet } from '@wxyc/database';
+import { sweepStrandedClaims } from '../../../../apps/enrichment-worker/sweep';
+
+type SqlLike = {
+  sql?: string | string[];
+  queryChunks?: Array<string | { value?: string | string[] }>;
+};
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const mockDb = db as unknown as {
+  update: jest.Mock;
+  _chain: { set: jest.Mock; where: jest.Mock; returning: jest.Mock };
+};
+
+describe('sweepStrandedClaims (BS#1225)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates the flowsheet table', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    await sweepStrandedClaims();
+
+    expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
+  });
+
+  it('SET flips metadata_status back to pending and NULLs enriching_since', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    await sweepStrandedClaims();
+
+    const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setCall.metadata_status).toBe('pending');
+    expect(setCall.enriching_since).toBeNull();
+  });
+
+  it('WHERE references both the enriching guard and the 60-second cutoff', async () => {
+    // The WHERE uses a raw `sql\`...\`` chunk (codebase convention for
+    // multi-predicate partial-index queries; mirrors the `schema.ts`
+    // index definitions). Render the chunk and assert both the
+    // metadata_status='enriching' guard and the 60-second TTL cutoff are
+    // present — a future "drop the status guard" or "bump to 30s" edit
+    // is caught here.
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    await sweepStrandedClaims();
+
+    expect(mockDb._chain.where).toHaveBeenCalledTimes(1);
+    const whereArg = mockDb._chain.where.mock.calls[0]?.[0];
+    expect(whereArg).toBeDefined();
+    const rendered = renderSql(whereArg);
+    expect(rendered).toContain("'enriching'");
+    expect(rendered).toContain('60 seconds');
+  });
+
+  it('returns the recovered row count', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+    const recovered = await sweepStrandedClaims();
+
+    expect(recovered).toBe(3);
+  });
+
+  it('returns 0 when nothing was stranded', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([]);
+
+    const recovered = await sweepStrandedClaims();
+
+    expect(recovered).toBe(0);
+  });
+
+  it('propagates DB errors instead of swallowing them', async () => {
+    const dbError = new Error('connection refused');
+    mockDb._chain.returning.mockRejectedValueOnce(dbError);
+
+    await expect(sweepStrandedClaims()).rejects.toThrow('connection refused');
+  });
+});

--- a/tests/unit/apps/enrichment-worker/sweep.test.ts
+++ b/tests/unit/apps/enrichment-worker/sweep.test.ts
@@ -5,24 +5,26 @@
  * accidental WHERE-loosening fails CI before deploy.
  *
  * The sweep flips `metadata_status='enriching'` rows whose `enriching_since`
- * is older than the 60s TTL back to `'pending'` (and NULLs `enriching_since`)
- * so the next CDC tick can re-claim them. Without it, every LML throw or
- * worker SIGTERM leaks a row in `enriching` forever — the C2 worker (#892)
- * documents this in `handler.ts:90-115` and tests/integration/
- * enrichment-worker-claim.spec.js:175-205 exercises the SQL inline.
+ * is older than `STRANDED_TTL_SECONDS` back to `'pending'` (and NULLs
+ * `enriching_since`). The TTL is derived from `ENRICHMENT_LML_BUDGET_MS`
+ * with a floor of 60s to keep the invariant `TTL > LML budget`. Without
+ * this sweep, every LML throw or worker SIGTERM leaks a row in
+ * `enriching` forever — the C2 worker (#892) documents this in
+ * `handler.ts:90-115` and tests/integration/enrichment-worker-claim.spec.js
+ * exercises the SQL inline.
  *
  * Three contract guarantees pinned here:
  *   1. WHERE narrows by `metadata_status='enriching'`. Loosening this would
  *      revert terminal rows back to pending, re-enqueueing finished work.
- *   2. WHERE narrows by `enriching_since < now() - interval '60 seconds'`.
- *      The 60s TTL is the partial index's predicate; loosening it (or
- *      forgetting the cutoff entirely) would race in-flight claims.
+ *   2. WHERE narrows by `enriching_since < now() - <interval>` (subtraction
+ *      direction matters — flipping to `>` would revert in-flight claims
+ *      and leave stale ones untouched).
  *   3. SET writes `metadata_status='pending'` AND `enriching_since=NULL`.
  *      Forgetting the NULL would leave a stale enriching_since the next
  *      claim-then-strand cycle has to overwrite.
  *
  * Integration coverage of the end-to-end recovery cycle (claim → strand →
- * sweep → re-claim) lives in `tests/integration/enrichment-worker-claim.spec.js`.
+ * sweep → re-claim) lives in `tests/integration/enrichment-worker-sweep.spec.js`.
  */
 import { jest } from '@jest/globals';
 
@@ -79,13 +81,13 @@ describe('sweepStrandedClaims (BS#1225)', () => {
     expect(setCall.enriching_since).toBeNull();
   });
 
-  it('WHERE references both the enriching guard and the 60-second cutoff', async () => {
+  it('WHERE references the enriching guard, the cutoff direction, and an interval', async () => {
     // The WHERE uses a raw `sql\`...\`` chunk (codebase convention for
     // multi-predicate partial-index queries; mirrors the `schema.ts`
-    // index definitions). Render the chunk and assert both the
-    // metadata_status='enriching' guard and the 60-second TTL cutoff are
-    // present — a future "drop the status guard" or "bump to 30s" edit
-    // is caught here.
+    // index definitions). Render the chunk and assert the
+    // metadata_status='enriching' guard, the `<` cutoff direction, and
+    // an interval subtraction are all present — a "drop the status
+    // guard" or "swap `<` for `>`" edit is caught here.
     mockDb._chain.returning.mockResolvedValueOnce([]);
 
     await sweepStrandedClaims();
@@ -94,8 +96,15 @@ describe('sweepStrandedClaims (BS#1225)', () => {
     const whereArg = mockDb._chain.where.mock.calls[0]?.[0];
     expect(whereArg).toBeDefined();
     const rendered = renderSql(whereArg);
+    // The renderer drops column refs and bound params, so the rendered
+    // string is the static SQL between interpolations: e.g.
+    //   " = 'enriching' AND  < now() - make_interval(secs => )"
+    // Assert the enum literal, the cutoff operator + direction, and the
+    // interval subtraction — these three together pin both the status
+    // guard and the `enriching_since < now() - interval` shape. A swap
+    // to `>` or to `now() + interval` fails the regex below.
     expect(rendered).toContain("'enriching'");
-    expect(rendered).toContain('60 seconds');
+    expect(rendered).toMatch(/<\s+now\(\)\s*-\s*make_interval/);
   });
 
   it('returns the recovered row count', async () => {


### PR DESCRIPTION
## Summary

Ship the C6 stranded-claim recovery sweep. Every LML throw or worker SIGTERM between `claim` and `finalize` currently leaks a row in `metadata_status='enriching'` forever — invisible to the CDC consumer (filters `pending`) and the backfill cron. The C6 work in BS#895 is gated on BS#1011's drain, but the correctness gap doesn't need to wait. BS#1225 split it off.

`apps/enrichment-worker/sweep.ts` flips every `enriching` row past `enriching_since + 60s` back to `pending` and NULLs `enriching_since` so the next CDC tick re-claims it. The existing partial index `flowsheet_metadata_status_enriching_stale_idx` (schema.ts:916) covers the WHERE.

## Design decision: in-worker setInterval, not a sibling cron container

Acceptance criteria called for a decision between a new `jobs/` entry and an in-worker timer. Chose setInterval:

- Worker owns the claim lifecycle — coupling recovery to its process keeps the failure model coherent.
- At 60s cadence, container-startup cost of a sibling cron dwarfs the actual UPDATE.
- Reuses the worker's existing PG connection pool.
- Immediate startup tick clears strands from a prior instance's death the moment a fresh worker boots.

The "worker permanently dead with strands" failure mode is already covered by the `cdcConnected=false` healthcheck — and no new strands are produced in that state.

## Observability

Each sweep tick opens an `enrichment.sweep.stranded` Sentry span with `sweep.stranded_recovered_count` attached. Project-onto-span pattern (LML#213 + BS#646) — the trace explorer can answer "are we leaking?" without per-row metric inventory.

## Tests

- **Unit** (`tests/unit/apps/enrichment-worker/sweep.test.ts`, 6 tests) — pin SET shape, both WHERE predicates (status guard + 60s TTL), recovered-count return, DB-error propagation. Mirrors `claim.test.ts`'s style.
- **Integration** (`tests/integration/enrichment-worker-sweep.spec.js`, 4 tests, real PG) — single stranded → recovered + re-claimable; batch (N=5) in one tick; recent claim within TTL untouched; terminal-state rows untouched even with backdated `enriching_since` (catches a future loosening of the status guard).
- Older C6-SQL pin comment in `enrichment-worker-claim.spec.js` updated to point at the now-shipped function instead of "when BS#895 ships".

## Test plan

- [ ] Local unit suite green (2670 tests).
- [ ] Local integration sweep spec green against real PG.
- [ ] Local typecheck/lint/format:check clean.
- [ ] CI green.
- [ ] Post-deploy: verify `enrichment.sweep.stranded` spans appear in Sentry trace explorer; `sweep.stranded_recovered_count` mostly zero with occasional ticks > 0.

## Tracker

Slot 1 of #1279 (Project #32 close-out sequencing).