### PR TITLE
fix(rotation-webhook): partial-update SET preserves rotation_bin / kill_date

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -339,6 +339,26 @@ internal_route.post('/rotation-webhook', async (req, res) => {
       const killDate =
         release.killDate && release.killDate !== 0 ? new Date(release.killDate).toISOString().split('T')[0] : null;
 
+      // BS#1082: tubafrenzy's sendRotationLinked posts only {id,
+      // libraryReleaseId, action: 'update'} on linkage. Including rotation_bin
+      // / kill_date in SET unconditionally would clobber the existing row's
+      // values with the JS defaults ('N' / null) computed above for missing
+      // payload fields. Presence-gate the SET so partial updates leave them
+      // alone.
+      const setClause: Record<string, unknown> = {
+        album_id: sql`excluded.album_id`,
+        legacy_library_release_id: sql`excluded.legacy_library_release_id`,
+        artist_name: sql`excluded.artist_name`,
+        album_title: sql`excluded.album_title`,
+        record_label: sql`excluded.record_label`,
+      };
+      if (release.rotationType !== undefined) {
+        setClause.rotation_bin = sql`excluded.rotation_bin`;
+      }
+      if (release.killDate !== undefined) {
+        setClause.kill_date = sql`excluded.kill_date`;
+      }
+
       await db
         .insert(rotation)
         .values({
@@ -354,15 +374,7 @@ internal_route.post('/rotation-webhook', async (req, res) => {
         })
         .onConflictDoUpdate({
           target: rotation.legacy_rotation_id,
-          set: {
-            album_id: sql`excluded.album_id`,
-            legacy_library_release_id: sql`excluded.legacy_library_release_id`,
-            rotation_bin: sql`excluded.rotation_bin`,
-            kill_date: sql`excluded.kill_date`,
-            artist_name: sql`excluded.artist_name`,
-            album_title: sql`excluded.album_title`,
-            record_label: sql`excluded.record_label`,
-          },
+          set: setClause,
         });
     }
 

--- a/tests/integration/internal-rotation-webhook.spec.js
+++ b/tests/integration/internal-rotation-webhook.spec.js
@@ -1,0 +1,109 @@
+/**
+ * Integration tests for POST /internal/rotation-webhook (BS#1082).
+ *
+ * The webhook receives tubafrenzy rotation events. The acceptance criterion
+ * tested here is from #1082: when `sendRotationLinked` posts the partial
+ * shape `{id, libraryReleaseId, action: 'update'}`, the receiver must NOT
+ * clobber `rotation_bin` or `kill_date` with the JS-default values computed
+ * for missing payload fields.
+ *
+ * The companion unit test at `tests/unit/routes/internal.route.test.ts`
+ * verifies the SET-clause shape against a mocked db; this spec verifies the
+ * end-to-end behavior at the row level against real Postgres.
+ */
+
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const postgres = require('postgres');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const INTERNAL_KEY = process.env.ETL_NOTIFY_KEY || 'test-secret-key';
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 4,
+  });
+}
+
+describe('POST /internal/rotation-webhook — partial update preserves rotation_bin / kill_date (BS#1082)', () => {
+  let sql;
+
+  // Use a legacy_rotation_id deep in a range that's unlikely to collide.
+  const LEGACY_ROTATION_ID = 9_999_982;
+
+  beforeAll(() => {
+    sql = makeSql();
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end();
+  });
+
+  beforeEach(async () => {
+    await sql.unsafe(`DELETE FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`, [LEGACY_ROTATION_ID]);
+  });
+
+  afterEach(async () => {
+    await sql.unsafe(`DELETE FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`, [LEGACY_ROTATION_ID]);
+  });
+
+  async function seedHeavyRotationRow(killDate) {
+    await sql.unsafe(
+      `INSERT INTO ${SCHEMA}.rotation
+         (legacy_rotation_id, rotation_bin, add_date, kill_date, artist_name, album_title, record_label)
+       VALUES ($1, 'H', '2026-01-01', $2, 'Jessica Pratt', 'On Your Own Love Again', 'Drag City')`,
+      [LEGACY_ROTATION_ID, killDate]
+    );
+  }
+
+  test('linkage update {id, libraryReleaseId} preserves existing rotation_bin and kill_date', async () => {
+    await seedHeavyRotationRow('2026-12-31');
+
+    const res = await request
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({ action: 'update', release: { id: LEGACY_ROTATION_ID, libraryReleaseId: 0 } });
+    expect(res.status).toBe(200);
+
+    const [row] = await sql.unsafe(
+      `SELECT rotation_bin, kill_date FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`,
+      [LEGACY_ROTATION_ID]
+    );
+    expect(row.rotation_bin).toBe('H');
+    expect(row.kill_date).toEqual(new Date('2026-12-31'));
+  });
+
+  test('full-shape update {rotationType, killDate} still overwrites those fields', async () => {
+    await seedHeavyRotationRow('2026-12-31');
+
+    const res = await request
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', INTERNAL_KEY)
+      .send({
+        action: 'update',
+        release: {
+          id: LEGACY_ROTATION_ID,
+          libraryReleaseId: 0,
+          rotationType: 'M',
+          killDate: 0,
+          artistName: 'Jessica Pratt',
+          albumTitle: 'On Your Own Love Again',
+          labelName: 'Drag City',
+          addDate: 1706799600000,
+        },
+      });
+    expect(res.status).toBe(200);
+
+    const [row] = await sql.unsafe(
+      `SELECT rotation_bin, kill_date FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`,
+      [LEGACY_ROTATION_ID]
+    );
+    expect(row.rotation_bin).toBe('M');
+    expect(row.kill_date).toBeNull();
+  });
+});

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -613,6 +613,46 @@ describe('POST /internal/rotation-webhook', () => {
     expect(res.body.ok).toBe(true);
   });
 
+  // BS#1082: A `sendRotationLinked` linkage event sends only `{id,
+  // libraryReleaseId, action: 'update'}`. Prior shape unconditionally wrote
+  // defaults into rotation_bin / kill_date on every update, flipping Heavy
+  // rotation rows to 'N' and clearing kill_date until the rotation-etl cron
+  // tick repaired them.
+  it('update with partial payload omits rotation_bin and kill_date from SET clause', async () => {
+    const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
+    onConflictSpy.mockClear();
+
+    const res = await request(app)
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', release: { id: 500, libraryReleaseId: 0 } });
+
+    expect(res.status).toBe(200);
+    expect(onConflictSpy).toHaveBeenCalledTimes(1);
+    const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
+    expect(setClause).not.toHaveProperty('rotation_bin');
+    expect(setClause).not.toHaveProperty('kill_date');
+  });
+
+  // Companion to the above: when the payload DOES carry rotationType /
+  // killDate (the create path, or a full-shape update), those fields must
+  // still appear in SET so the update overwrites them.
+  it('update with full payload keeps rotation_bin and kill_date in SET clause', async () => {
+    const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
+    onConflictSpy.mockClear();
+
+    const res = await request(app)
+      .post('/internal/rotation-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', release: validRelease });
+
+    expect(res.status).toBe(200);
+    expect(onConflictSpy).toHaveBeenCalledTimes(1);
+    const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
+    expect(setClause).toHaveProperty('rotation_bin');
+    expect(setClause).toHaveProperty('kill_date');
+  });
+
   // -- Kill --
 
   it('returns 200 for valid kill', async () => {


### PR DESCRIPTION
## Summary

`sendRotationLinked` posts only `{id, libraryReleaseId, action: 'update'}` on linkage. The handler's `onConflictDoUpdate` SET unconditionally wrote `excluded.rotation_bin` / `excluded.kill_date`, both computed from JS defaults (`'N'` / `null`) for missing payload fields. Linking a Heavy rotation entry would silently flip its bin to `'N'` and clear `kill_date` until the rotation-etl cron (30m cadence) repaired it — a user-visible bug for music directors.

The fix: presence-gate the SET clause. `rotation_bin` / `kill_date` go in only when the payload actually carries the field. Symmetric to the rotation-etl `setWhere` work in #1058 / #1063 but applied at the webhook receiver instead of the ETL writer.

## Test plan

- [x] **Unit** — `tests/unit/routes/internal.route.test.ts` — two new tests pin the SET-clause shape: partial payload omits `rotation_bin` + `kill_date`; full payload keeps both. 48/48 pass.
- [x] **Integration** — `tests/integration/internal-rotation-webhook.spec.js` round-trips against real PG: seed Heavy + `kill_date`, POST partial update, assert both unchanged. Plus the inverse: full-shape update overwrites them.
- [x] **Local pre-flight** — lint 0 errors, format clean, typecheck clean, full unit suite 2676/2676 pass.
- [ ] Manual smoke after merge: send a `sendRotationLinked`-shaped linkage from tubafrenzy on a Heavy rotation row; verify `rotation_bin` stays `'H'`.

## Related

- Decision recorded on the ticket as part of #1279 Slot 2.
- Belongs in the same problem-family as the broader write-amplification refactor (#1058 / #1063); does not pre-empt it.

Closes #1082