### PR TITLE
feat(assertion): detect library/artists artist_name drift

### DIFF
--- a/apps/backend/services/library-artist-name-assertion.service.ts
+++ b/apps/backend/services/library-artist-name-assertion.service.ts
@@ -1,33 +1,46 @@
 import { sql } from 'drizzle-orm';
 import * as Sentry from '@sentry/node';
-import { db, library } from '@wxyc/database';
+import { db, library, artists } from '@wxyc/database';
 
 /**
- * Soft data-quality check for the denormalized `library.artist_name` column.
+ * Soft data-quality checks for the denormalized `library.artist_name` column.
  *
- * Originally a hard precondition that 503'd catalog search whenever any row
- * carried NULL `artist_name`. That fired in prod 2026-04-30: a single ETL row
- * (Oneohtrix Point Never, "Tranquilizer", added 2026-04-28) was inserted by
- * `jobs/library-etl/job.ts` without `artist_name` set, and the next backend
- * restart cached a process-wide 503 — DJs locked out of the flowsheet for the
- * lifetime of the box.
+ * Two independent observability probes share this module:
  *
- * The denormalization is non-essential at the read path: search results
- * project `artists.artist_name` from the JOIN, and trigram predicates that
- * touch `library.artist_name` can't match a NULL via `%`, so degraded rows
- * silently drop out of search instead of poisoning it. The remaining role of
- * this check is observability — one Sentry warning per process when the
- * column is degraded, so the leak path is visible without taking the station
- * down.
+ *   1. NULL check (`checkLibraryArtistNameNull`) — was the original 2026-04-30
+ *      precondition that 503'd catalog search whenever any row carried NULL
+ *      `artist_name`. A single ETL row (Oneohtrix Point Never, "Tranquilizer",
+ *      added 2026-04-28) was inserted by `jobs/library-etl/job.ts` without
+ *      `artist_name` set, and the next backend restart cached a process-wide
+ *      503 — DJs locked out of the flowsheet for the lifetime of the box. The
+ *      precondition was downgraded to a soft warning; trigram and tsvector
+ *      predicates can't match a NULL with `%` or `@@`, so degraded rows fall
+ *      out of search organically.
  *
- * The result is memoized so the warning fires at most once per process and
- * the check stays off the per-search hot path after the first call.
- * Transient DB errors clear the cache so the next call retries.
+ *   2. Drift check (`checkLibraryArtistNameDrift`, BS#1092) — detects value
+ *      drift between `library.artist_name` (denorm, what trigram search reads)
+ *      and `artists.artist_name` (canonical, what the catalog list view
+ *      projects through `library_artist_view`'s INNER JOIN). Migration 0060's
+ *      cascade trigger keeps them in sync on `UPDATE OF artist_name ON artists`,
+ *      but ad-hoc admin SQL or future write paths (logical replication, a
+ *      future admin UI touching `artists` directly) can bypass it. The latent
+ *      symptom is invisible: the catalog list shows the new name; typing it
+ *      into search returns nothing. The drift check surfaces a Sentry warning
+ *      with a sampled set of offending `library_id`s so the leak path becomes
+ *      visible before it reaches a DJ.
+ *
+ * Both checks are memoized so each fires at most once per process and stays
+ * off the per-search hot path after the first call. Transient DB errors clear
+ * the cache so the next call retries. Neither check ever throws to the
+ * consumer — search continues to serve under any degraded state.
  */
 
-let _checkPromise: Promise<void> | null = null;
+let _nullCheckPromise: Promise<void> | null = null;
+let _driftCheckPromise: Promise<void> | null = null;
 
-async function runCheck(): Promise<void> {
+const DRIFT_SAMPLE_SIZE = 10;
+
+async function runNullCheck(): Promise<void> {
   const result = await db.execute(
     sql`SELECT count(*)::int AS n FROM ${library} WHERE ${library.artist_name} IS NULL LIMIT 1`
   );
@@ -46,24 +59,92 @@ async function runCheck(): Promise<void> {
   }
 }
 
-/**
- * Run the soft data-quality check exactly once per process. Returns void on
- * both healthy and degraded states; consumers must not branch on the result.
- * Callable from any catalog-search entry point as a fire-and-observe hook.
- */
-export async function checkLibraryArtistNameHealth(): Promise<void> {
-  if (_checkPromise === null) {
-    _checkPromise = runCheck().catch((err) => {
-      _checkPromise = null;
-      throw err;
-    });
+async function runDriftCheck(): Promise<void> {
+  // IS DISTINCT FROM treats NULLs symmetrically: a NULL `library.artist_name`
+  // against a non-NULL `artists.artist_name` counts as drift. The NULL check
+  // above already surfaces the NULL case under a different tag/step; both
+  // surfacing it is intentional — different leak paths, same row.
+  const result = await db.execute(
+    sql`SELECT count(*)::int AS n,
+               (SELECT array_agg(l2.id) FROM (
+                  SELECT l.id FROM ${library} l
+                  JOIN ${artists} a ON a.id = l.artist_id
+                  WHERE l.artist_name IS DISTINCT FROM a.artist_name
+                  ORDER BY l.id
+                  LIMIT ${DRIFT_SAMPLE_SIZE}
+                ) l2) AS sample_ids
+        FROM ${library} l
+        JOIN ${artists} a ON a.id = l.artist_id
+        WHERE l.artist_name IS DISTINCT FROM a.artist_name`
+  );
+  const rows = result as unknown as Array<{
+    n: number | string | null;
+    sample_ids: Array<number | string> | null;
+  }>;
+  const n = Number(rows[0]?.n ?? 0);
+  if (n > 0) {
+    const sampleIds = (rows[0]?.sample_ids ?? []).map((id) => Number(id));
+    Sentry.captureMessage(
+      `library.artist_name has ${n} row(s) drift from artists.artist_name — denormalization is stale`,
+      {
+        level: 'warning',
+        tags: { tool: 'library-search', step: 'drift-check' },
+        extra: { count: n, sample_library_ids: sampleIds },
+      }
+    );
+    console.warn(
+      `[library] library.artist_name drift detected on ${n} row(s); ` +
+        `catalog list shows the joined value but trigram search returns nothing. ` +
+        `Sample library_ids: ${sampleIds.join(', ') || '(none)'}.`
+    );
   }
-  return _checkPromise;
 }
 
 /**
- * Test-only: reset the cached check state so the next call re-queries.
+ * Drift probe (BS#1092). Counts rows where `library.artist_name` has drifted
+ * away from `artists.artist_name` and emits a Sentry warning with a sampled
+ * set of `library_id`s when drift > 0. Memoized; fires at most once per
+ * process. Resolves on both healthy and degraded states.
+ */
+export async function checkLibraryArtistNameDrift(): Promise<void> {
+  if (_driftCheckPromise === null) {
+    _driftCheckPromise = runDriftCheck().catch((err) => {
+      _driftCheckPromise = null;
+      throw err;
+    });
+  }
+  return _driftCheckPromise;
+}
+
+/**
+ * Run the soft data-quality assertion sweep (NULL check + drift check)
+ * exactly once per process per check. Returns void on both healthy and
+ * degraded states; consumers must not branch on the result. Callable from
+ * any catalog-search entry point as a fire-and-observe hook.
+ */
+export async function checkLibraryArtistNameHealth(): Promise<void> {
+  if (_nullCheckPromise === null) {
+    _nullCheckPromise = runNullCheck().catch((err) => {
+      _nullCheckPromise = null;
+      throw err;
+    });
+  }
+  // Fan out — both checks run, both memoize independently. The drift check
+  // is cheap (single indexed JOIN, count) and doesn't block readiness; the
+  // caller awaits both because each check's failure mode is its own probe.
+  await Promise.all([_nullCheckPromise, checkLibraryArtistNameDrift()]);
+}
+
+/**
+ * Test-only: reset the cached NULL-check state so the next call re-queries.
  */
 export function _resetLibraryArtistNameHealthCheckForTests(): void {
-  _checkPromise = null;
+  _nullCheckPromise = null;
+}
+
+/**
+ * Test-only: reset the cached drift-check state so the next call re-queries.
+ */
+export function _resetLibraryArtistNameDriftCheckForTests(): void {
+  _driftCheckPromise = null;
 }

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -80,7 +80,10 @@ export const library = {
   canonical_entity_confidence: 'canonical_entity_confidence',
   canonical_entity_resolved_at: 'canonical_entity_resolved_at',
 };
-export const artists = {};
+export const artists = {
+  id: 'id',
+  artist_name: 'artist_name',
+};
 export const genres = {};
 export const format = {};
 export const rotation = {

--- a/tests/unit/services/library-artist-name-assertion.test.ts
+++ b/tests/unit/services/library-artist-name-assertion.test.ts
@@ -16,18 +16,26 @@ import * as Sentry from '@sentry/node';
 
 import {
   checkLibraryArtistNameHealth,
+  checkLibraryArtistNameDrift,
   _resetLibraryArtistNameHealthCheckForTests,
+  _resetLibraryArtistNameDriftCheckForTests,
 } from '../../../apps/backend/services/library-artist-name-assertion.service';
 
 describe('library-artist-name-assertion', () => {
   beforeEach(() => {
     _resetLibraryArtistNameHealthCheckForTests();
+    _resetLibraryArtistNameDriftCheckForTests();
     (Sentry.captureMessage as jest.Mock).mockClear();
   });
 
   describe('checkLibraryArtistNameHealth', () => {
+    // The wrapper fans out to BOTH the NULL check and the drift check
+    // (BS#1092). Each first-call invocation issues two db.execute calls —
+    // one per check. Tests that only care about the NULL-check behavior
+    // mock the drift-check result as the second response.
+
     it('passes silently when count is 0', async () => {
-      db.execute.mockResolvedValueOnce([{ n: 0 }]);
+      db.execute.mockResolvedValueOnce([{ n: 0 }]).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
       await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
       expect(Sentry.captureMessage).not.toHaveBeenCalled();
     });
@@ -47,7 +55,7 @@ describe('library-artist-name-assertion', () => {
       // to serve. Trigram and tsvector predicates can't match a NULL with `%`
       // or `@@`, so degraded rows fall out of search organically — no need
       // to refuse service.
-      db.execute.mockResolvedValueOnce([{ n: 1 }]);
+      db.execute.mockResolvedValueOnce([{ n: 1 }]).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
       await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
     });
 
@@ -56,12 +64,12 @@ describe('library-artist-name-assertion', () => {
       // built for. With the soft-check pattern, even a fully-degraded column
       // doesn't throw — the column is denormalized from `artists.artist_name`
       // anyway, so search results stay correct via the JOIN projection.
-      db.execute.mockResolvedValueOnce([{ n: 64163 }]);
+      db.execute.mockResolvedValueOnce([{ n: 64163 }]).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
       await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
     });
 
     it('emits a Sentry warning with tool/step/count tags when the column is degraded', async () => {
-      db.execute.mockResolvedValueOnce([{ n: 42 }]);
+      db.execute.mockResolvedValueOnce([{ n: 42 }]).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
       await checkLibraryArtistNameHealth();
 
       expect(Sentry.captureMessage).toHaveBeenCalledWith(
@@ -76,34 +84,126 @@ describe('library-artist-name-assertion', () => {
 
     it('treats string count from Postgres as numeric', async () => {
       // postgres-js sometimes returns count(*) as a stringified bigint.
-      db.execute.mockResolvedValueOnce([{ n: '7' }]);
+      db.execute.mockResolvedValueOnce([{ n: '7' }]).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
       await checkLibraryArtistNameHealth();
+      // Sentry fires for the NULL leg only; drift leg is clean.
       expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
     });
 
-    it('caches across multiple invocations — only one db call', async () => {
-      db.execute.mockResolvedValueOnce([{ n: 0 }]);
+    it('caches across multiple invocations — two db calls (one per check), no repeats', async () => {
+      db.execute.mockResolvedValueOnce([{ n: 0 }]).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
       await checkLibraryArtistNameHealth();
       await checkLibraryArtistNameHealth();
       await checkLibraryArtistNameHealth();
-      expect(db.execute).toHaveBeenCalledTimes(1);
+      expect(db.execute).toHaveBeenCalledTimes(2);
     });
 
-    it('caches the degraded state — only one Sentry warning per process', async () => {
-      db.execute.mockResolvedValueOnce([{ n: 100 }]);
+    it('caches the degraded state — only one Sentry warning per process for the NULL leg', async () => {
+      db.execute.mockResolvedValueOnce([{ n: 100 }]).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
       await checkLibraryArtistNameHealth();
       await checkLibraryArtistNameHealth();
       await checkLibraryArtistNameHealth();
+      expect(db.execute).toHaveBeenCalledTimes(2);
+      expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the cache on transient DB errors so the next call retries', async () => {
+      // The first leg (NULL check) throws; the wrapper's Promise.all rejects.
+      // The drift check still ran and its result (mocked clean) is cached.
+      // On retry, only the NULL leg re-executes.
+      db.execute.mockRejectedValueOnce(new Error('connection reset')).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
+      await expect(checkLibraryArtistNameHealth()).rejects.toThrow('connection reset');
+
+      db.execute.mockResolvedValueOnce([{ n: 0 }]);
+      await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
+      // 3 total: failed NULL, successful drift (cached), retried NULL.
+      expect(db.execute).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('checkLibraryArtistNameDrift', () => {
+    // Drift detection (BS#1092): `library.artist_name` is denormalized from
+    // `artists.artist_name` and kept in sync via a cascade trigger (migration
+    // 0060). The trigger fires on `UPDATE OF artist_name ON artists`, but
+    // ad-hoc admin SQL or future write paths that bypass the trigger leave
+    // the denorm stale. Catalog list views (joined through `library_artist_view`)
+    // show the new name while trigram search (which reads the denorm) returns
+    // nothing — the search-not-found case is silent and user-invisible.
+    // The drift check is a soft observability signal.
+
+    it('passes silently when no rows drift', async () => {
+      db.execute.mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
+      await expect(checkLibraryArtistNameDrift()).resolves.toBeUndefined();
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    });
+
+    it('emits a Sentry warning with count, sample library_ids, and the canonical tags when drift is detected', async () => {
+      db.execute.mockResolvedValueOnce([{ n: 3, sample_ids: [101, 202, 303] }]);
+      await checkLibraryArtistNameDrift();
+
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('3 row(s) drift'),
+        expect.objectContaining({
+          level: 'warning',
+          tags: expect.objectContaining({ tool: 'library-search', step: 'drift-check' }),
+          extra: expect.objectContaining({
+            count: 3,
+            sample_library_ids: [101, 202, 303],
+          }),
+        })
+      );
+    });
+
+    it('treats string count from Postgres as numeric', async () => {
+      db.execute.mockResolvedValueOnce([{ n: '5', sample_ids: [1, 2, 3, 4, 5] }]);
+      await checkLibraryArtistNameDrift();
+      expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('tolerates a missing sample_ids field (null or undefined)', async () => {
+      db.execute.mockResolvedValueOnce([{ n: 4, sample_ids: null }]);
+      await checkLibraryArtistNameDrift();
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          extra: expect.objectContaining({ count: 4, sample_library_ids: [] }),
+        })
+      );
+    });
+
+    it('caches across multiple invocations — only one db call, one Sentry warning per process', async () => {
+      db.execute.mockResolvedValueOnce([{ n: 12, sample_ids: [1, 2] }]);
+      await checkLibraryArtistNameDrift();
+      await checkLibraryArtistNameDrift();
+      await checkLibraryArtistNameDrift();
       expect(db.execute).toHaveBeenCalledTimes(1);
       expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
     });
 
     it('clears the cache on transient DB errors so the next call retries', async () => {
-      db.execute.mockRejectedValueOnce(new Error('connection reset'));
-      await expect(checkLibraryArtistNameHealth()).rejects.toThrow('connection reset');
+      db.execute.mockRejectedValueOnce(new Error('statement timeout'));
+      await expect(checkLibraryArtistNameDrift()).rejects.toThrow('statement timeout');
 
-      db.execute.mockResolvedValueOnce([{ n: 0 }]);
-      await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
+      db.execute.mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
+      await expect(checkLibraryArtistNameDrift()).resolves.toBeUndefined();
+      expect(db.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not throw when drift is detected — degraded data must not take catalog search down', async () => {
+      // Mirrors the NULL-check post-mortem contract: this is observability,
+      // not a hard gate. A future write path that bypasses the cascade trigger
+      // must not be allowed to 503 the catalog.
+      db.execute.mockResolvedValueOnce([{ n: 9999, sample_ids: [1, 2, 3] }]);
+      await expect(checkLibraryArtistNameDrift()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('checkLibraryArtistNameHealth — sweep wiring', () => {
+    it('runs both the NULL check and the drift check', async () => {
+      // Both checks share `db.execute`. The wrapper fans out so a single
+      // post-startup call exercises both observability paths.
+      db.execute.mockResolvedValueOnce([{ n: 0 }]).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
+      await checkLibraryArtistNameHealth();
       expect(db.execute).toHaveBeenCalledTimes(2);
     });
   });


### PR DESCRIPTION
Closes #1092. Slot 3 of #1279.

## Summary

The existing soft-warning assertion on the catalog-search path covered the NULL leak path that 503'd catalog search on 2026-04-30, but only the NULL case. The same denormalization can drift quietly: any write to `artists.artist_name` that bypasses migration 0060's cascade trigger (ad-hoc admin SQL, a future logical-replication consumer, an admin UI touching `artists` directly) leaves `library.artist_name` stale. The catalog list view (`library_artist_view`'s INNER JOIN) shows the new name; trigram search reads the denorm and silently returns nothing — invisible from Sentry until a DJ surfaces it.

This adds `checkLibraryArtistNameDrift`, a cheap indexed JOIN with `IS DISTINCT FROM`, memoized once per process, that surfaces a Sentry warning (tags `tool=library-search`, `step=drift-check`) with a sampled set of offending `library_id`s when drift > 0. Same soft-warning contract as the NULL check — never throws to the consumer; search continues to serve under any degraded state. The wrapper `checkLibraryArtistNameHealth` fans out to both checks via `Promise.all` so the existing fire-and-observe call sites in `library.service.ts` exercise both observability paths post-startup.

## Files

- `apps/backend/services/library-artist-name-assertion.service.ts` — add `checkLibraryArtistNameDrift`, fan out from the existing `checkLibraryArtistNameHealth` wrapper, extract `runNullCheck` from the prior monolithic `runCheck`. Module-level doc updated to describe the two-probe shape.
- `tests/unit/services/library-artist-name-assertion.test.ts` — new `checkLibraryArtistNameDrift` describe (7 cases: clean, dirty with sample IDs, string-bigint coercion, missing sample_ids, memoization, cache-on-error, soft-warning contract); existing `checkLibraryArtistNameHealth` cases updated to mock both legs.
- `tests/mocks/database.mock.ts` — expose `artists.id` and `artists.artist_name` for the JOIN in the new query.

## Test plan

- [x] `npm run test:unit` — 2684 pass (16 in this file, up from 8)
- [x] `npm run lint` — 0 errors (478 pre-existing warnings unchanged)
- [x] `npm run typecheck` — clean
- [x] `npx prettier --check <touched files>` — clean
- [ ] Remote CI green