### PR TITLE
fix(album-level-backfill): pin LML result.index invariant (closes BS#1088)

### DIFF
--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -38,6 +38,7 @@ import { sql } from 'drizzle-orm';
 import { album_metadata, db, closeDatabaseConnection, requireNonNegativeInt, requirePositiveInt } from '@wxyc/database';
 import { bulkLookupMetadata, type BulkLookupItem, type LookupResponse } from '@wxyc/lml-client';
 import { cleanDiscogsBio, filterSpacerGif } from '@wxyc/metadata';
+import * as Sentry from '@sentry/node';
 import { captureError, closeLogger, initLogger, log } from './logger.js';
 
 const JOB_NAME = 'album-level-backfill';
@@ -346,6 +347,13 @@ export interface BatchResult {
   no_match: number;
   error: number;
   upserts: number;
+  /** Count of per-result rows where LML's `result.index` did not equal the
+   * position we sent in `items[i]`. LML's bulk handler honors the input-
+   * order contract today (`asyncio.gather` over `_run_one(index=i)`), so a
+   * non-zero value here means a future LML refactor silently dropped that
+   * invariant — we skip the write rather than UPSERT against the wrong
+   * `album_id`. Regression-pin for BS#1088. */
+  unexpected_index: number;
 }
 
 /** Run one chunk end-to-end: resolve → bulk call → UPSERT matches. The
@@ -368,11 +376,11 @@ export const runBatch = async (
       resolved: resolved.length,
       items: items.length,
     });
-    return { batchSize: items.length, match: 0, no_match: 0, error: 0, upserts: 0 };
+    return { batchSize: items.length, match: 0, no_match: 0, error: 0, upserts: 0, unexpected_index: 0 };
   }
 
   if (items.length === 0) {
-    return { batchSize: 0, match: 0, no_match: 0, error: 0, upserts: 0 };
+    return { batchSize: 0, match: 0, no_match: 0, error: 0, upserts: 0, unexpected_index: 0 };
   }
 
   // Isolate HTTP-level failures (timeout, 5xx, network) so a single bad
@@ -399,29 +407,54 @@ export const runBatch = async (
       error_message: errorMessage,
     });
     captureError(err, 'lml_batch_failed', extra);
-    return { batchSize: items.length, match: 0, no_match: 0, error: items.length, upserts: 0 };
+    return { batchSize: items.length, match: 0, no_match: 0, error: items.length, upserts: 0, unexpected_index: 0 };
   }
-  // resolved[i] corresponds to items[i] which corresponds to response.results[i].
-  // LML guarantees input-order results.
-  let match = 0;
-  let no_match = 0;
-  let error = 0;
-
+  // Iterate by *position* and assert `result.index === i`. LML's bulk
+  // handler honors the input-order contract today (`asyncio.gather` over
+  // `_run_one(index=i)`), so this is a regression-pin (BS#1088) — a future
+  // partial-failure isolation change that filters mid-batch (`try/except`
+  // skip) would cause `resolved[result.index]` to look up the *wrong*
+  // album_id and silently UPSERT `album_metadata` against it (same failure
+  // class as BS#1051 in a different code path). Position lookup is O(1);
+  // `find()` would be O(N²) over the batch and the ticket flags that
+  // explicitly.
+  //
   // `upsertAlbumMatch` is race-guarded by `updated_at < NOW()` and
   // `enumeratePendingAlbumIds` returns distinct album_ids per batch, so
   // ordering within a batch is irrelevant — safe to issue concurrently.
+  let match = 0;
+  let no_match = 0;
+  let error = 0;
+  let unexpected_index = 0;
   const upsertPromises: Array<Promise<boolean>> = [];
-  for (const result of response.results) {
+  for (let i = 0; i < items.length; i++) {
+    const result = response.results[i];
+    if (!result || result.index !== i) {
+      unexpected_index += 1;
+      const album = resolved[i];
+      Sentry.addBreadcrumb({
+        category: 'album-level-backfill',
+        message: 'unexpected_result_index',
+        level: 'warning',
+        data: { expected: i, got: result?.index ?? null, album_id: album?.album_id ?? null },
+      });
+      log('warn', 'unexpected_result_index', `LML result.index mismatch at position ${i}; skipping write`, {
+        expected_index: i,
+        got_index: result?.index ?? null,
+        album_id: album?.album_id ?? null,
+      });
+      continue;
+    }
     if (result.status === 'match' && result.lookup) {
       match += 1;
-      const album = resolved[result.index];
+      const album = resolved[i];
       if (!album) continue; // shouldn't happen given input-order guarantee
       upsertPromises.push(upsertAlbumMatch(album.album_id, result.lookup));
     } else if (result.status === 'no_match') {
       no_match += 1;
     } else {
       error += 1;
-      const album = resolved[result.index];
+      const album = resolved[i];
       log('warn', 'lml_error', `LML per-item error for album_id=${album?.album_id ?? '?'}`, {
         album_id: album?.album_id ?? null,
         error_message: result.message ?? null,
@@ -429,7 +462,7 @@ export const runBatch = async (
     }
   }
   const upserts = (await Promise.all(upsertPromises)).filter(Boolean).length;
-  return { batchSize: items.length, match, no_match, error, upserts };
+  return { batchSize: items.length, match, no_match, error, upserts, unexpected_index };
 };
 
 // -- Top-level orchestration -------------------------------------------------
@@ -442,6 +475,10 @@ export interface BackfillSummary {
   error: number;
   upserts: number;
   flipped: number;
+  /** Aggregate of `BatchResult.unexpected_index` across all batches. The
+   * BS#1088 acceptance bar is 0 on a 24-h prod run; non-zero means a
+   * future LML refactor dropped the input-order contract. */
+  unexpected_index: number;
 }
 
 export interface BackfillOptions {
@@ -515,6 +552,7 @@ export const runBackfill = async (options: BackfillOptions): Promise<BackfillSum
       error: 0,
       upserts: 0,
       flipped: 0,
+      unexpected_index: 0,
     };
   }
 
@@ -525,6 +563,7 @@ export const runBackfill = async (options: BackfillOptions): Promise<BackfillSum
   let totalNoMatch = 0;
   let totalError = 0;
   let totalUpserts = 0;
+  let totalUnexpectedIndex = 0;
 
   for (let i = 0; i < batches.length; i += 1) {
     await awaitQuietWindow(options.liveActivityLookbackSeconds, options.liveActivityPauseMs);
@@ -541,6 +580,7 @@ export const runBackfill = async (options: BackfillOptions): Promise<BackfillSum
     totalNoMatch += result.no_match;
     totalError += result.error;
     totalUpserts += result.upserts;
+    totalUnexpectedIndex += result.unexpected_index;
 
     // Field names are pinned to the BS#1078 Phase 3 runbook's `jq` watchdog
     // (`docs/ops-album-level-backfill-phase3.md`). The watchdog filters on
@@ -548,6 +588,9 @@ export const runBackfill = async (options: BackfillOptions): Promise<BackfillSum
     // probe sums `.scanned` and `.lml_error`. Don't rename these without
     // updating the runbook in lockstep — silent rename will leave the
     // watchdog matching nothing again (BS#1179).
+    // `unexpected_index` is the BS#1088 acceptance signal; the runbook
+    // grep adds it as a new aggregate field, so the log shape stays
+    // backward-compatible with the existing `jq` watchdog.
     log('info', 'batch_done', `batch ${i + 1}/${batches.length} done`, {
       batch_index: i + 1,
       batches: batches.length,
@@ -556,6 +599,7 @@ export const runBackfill = async (options: BackfillOptions): Promise<BackfillSum
       no_match: result.no_match,
       lml_error: result.error,
       upserts: result.upserts,
+      unexpected_index: result.unexpected_index,
       wall_clock_ms: wallClockMs,
     });
 
@@ -591,6 +635,7 @@ export const runBackfill = async (options: BackfillOptions): Promise<BackfillSum
     error: totalError,
     upserts: totalUpserts,
     flipped,
+    unexpected_index: totalUnexpectedIndex,
   };
 };
 

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -19,6 +19,24 @@ jest.mock('@wxyc/lml-client', () => ({
   bulkLookupMetadata: mockBulkLookupMetadata,
 }));
 
+// Spyable Sentry mock so the BS#1088 breadcrumb test can assert call shape
+// without depending on a live Sentry transport. Mirrors the established
+// `mockBulkLookupMetadata` pattern above. `@sentry/node`'s ESM exports are
+// non-configurable, so `jest.spyOn(Sentry, 'addBreadcrumb')` throws — we
+// have to replace the surface at module-mock time.
+const mockSentryAddBreadcrumb = jest.fn<(b: unknown) => void>();
+jest.mock('@sentry/node', () => ({
+  __esModule: true,
+  addBreadcrumb: mockSentryAddBreadcrumb,
+  // The job's logger.ts module also imports @sentry/node; preserve the
+  // surface it touches so `initLogger()` (not called in unit tests) and
+  // `captureError()` (called by BS#1076 path) don't crash if exercised.
+  init: jest.fn(),
+  setTag: jest.fn(),
+  captureException: jest.fn(),
+  close: jest.fn(() => Promise.resolve(true)),
+}));
+
 import { db, album_metadata } from '@wxyc/database';
 import type { LookupResponse } from '@wxyc/lml-client';
 import {
@@ -502,6 +520,97 @@ describe('runBatch', () => {
     expect(out).toMatchObject({ batchSize: 0, match: 0 });
   });
 
+  // BS#1088: defensive pin against a future LML refactor that drops the
+  // input-order `result.index === i` invariant. LML's current bulk handler
+  // honors `index=i` via asyncio.gather, but a partial-failure isolation
+  // change (try/except skip mid-batch) would silently UPSERT
+  // `album_metadata` for the wrong album_id — same failure class as
+  // BS#1051 in a different code path. Per-row assert with O(1) lookup;
+  // mismatch is logged, counted to `unexpected_index`, breadcrumbed to
+  // Sentry, and skipped.
+  describe('BS#1088 result.index defense', () => {
+    it.each([
+      {
+        name: 'in-order',
+        results: [
+          { index: 0, status: 'match' as const, lookup: lookupWithArtwork() },
+          { index: 1, status: 'match' as const, lookup: lookupWithArtwork() },
+        ],
+        expect: { match: 2, upserts: 2, unexpected_index: 0 },
+      },
+      {
+        name: 'out-of-order (swap)',
+        results: [
+          { index: 1, status: 'match' as const, lookup: lookupWithArtwork() },
+          { index: 0, status: 'match' as const, lookup: lookupWithArtwork() },
+        ],
+        // Both results land on the mismatch branch: position 0 carries
+        // index=1, position 1 carries index=0. Neither writes; both count.
+        expect: { match: 0, upserts: 0, unexpected_index: 2 },
+      },
+      {
+        name: 'missing-index (LML returns N-1 results)',
+        results: [{ index: 0, status: 'match' as const, lookup: lookupWithArtwork() }],
+        // Position 0 matches; position 1 is missing entirely (undefined
+        // pulled from response.results, which has no entry there).
+        expect: { match: 1, upserts: 1, unexpected_index: 1 },
+      },
+    ])('parameterized: $name', async ({ results, expect: expected }) => {
+      mockBulkLookupMetadata.mockResolvedValue({ results });
+
+      const out = await runBatch([1, 2], { budgetMs: 25000, dryRun: false });
+
+      expect(out.match).toBe(expected.match);
+      expect(out.upserts).toBe(expected.upserts);
+      expect(out.unexpected_index).toBe(expected.unexpected_index);
+      expect((db.insert as jest.Mock).mock.calls.length).toBe(expected.upserts);
+    });
+
+    it('emits a Sentry breadcrumb on mismatch (category album-level-backfill, expected vs got)', async () => {
+      mockSentryAddBreadcrumb.mockClear();
+      mockBulkLookupMetadata.mockResolvedValue({
+        results: [
+          { index: 5, status: 'match' as const, lookup: lookupWithArtwork() },
+          { index: 0, status: 'match' as const, lookup: lookupWithArtwork() },
+        ],
+      });
+
+      await runBatch([1, 2], { budgetMs: 25000, dryRun: false });
+
+      expect(mockSentryAddBreadcrumb).toHaveBeenCalledTimes(2);
+      expect(mockSentryAddBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'album-level-backfill',
+          message: 'unexpected_result_index',
+          data: expect.objectContaining({ expected: 0, got: 5 }),
+        })
+      );
+      expect(mockSentryAddBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'album-level-backfill',
+          message: 'unexpected_result_index',
+          data: expect.objectContaining({ expected: 1, got: 0 }),
+        })
+      );
+    });
+
+    it('mismatch does not abort the batch: sibling in-order matches still write', async () => {
+      mockBulkLookupMetadata.mockResolvedValue({
+        results: [
+          { index: 0, status: 'match' as const, lookup: lookupWithArtwork() },
+          { index: 0, status: 'match' as const, lookup: lookupWithArtwork() }, // duplicate index at position 1
+        ],
+      });
+
+      const out = await runBatch([1, 2], { budgetMs: 25000, dryRun: false });
+
+      expect(out.match).toBe(1);
+      expect(out.upserts).toBe(1);
+      expect(out.unexpected_index).toBe(1);
+      expect((db.insert as jest.Mock).mock.calls.length).toBe(1);
+    });
+  });
+
   it('BS#1076: HTTP-level bulkLookupMetadata throw is isolated; batch reports error=N and run continues', async () => {
     // Reproduces the 2026-05-24 prod failure: batch 2 hit a 30s LML
     // timeout (LmlClientError statusCode 504), which an uncaught throw
@@ -644,6 +753,7 @@ describe('runBackfill', () => {
       error: 0,
       upserts: 0,
       flipped: 0,
+      unexpected_index: 0,
     });
     expect(mockBulkLookupMetadata).not.toHaveBeenCalled();
     expect(db.insert as jest.Mock).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #1088. Slot 3 of close-out tracker BS#1279.

## Problem

`album-level-backfill`'s `runBatch` does `resolved[result.index]` with no per-row check that the index LML returned actually matches the position BS sent. LML's bulk handler honors the input-order contract today (`asyncio.gather` over `_run_one(index=i)`), but a future partial-failure isolation change — a `try/except` skip mid-batch, or a re-ordering for streaming — would cause BS to silently UPSERT `album_metadata` against the wrong `album_id`. Same failure class as BS#1051 in a different code path; the existing `if (!album) continue` guard handles index-past-end, not index-mismatch.

## Change

Iterate by position with an O(1) assert. On `result.index !== i`:

- count to a new `unexpected_index` bucket on `BatchResult` + `BackfillSummary`
- log a structured warn (`step: unexpected_result_index`, `expected_index`, `got_index`, `album_id`)
- emit a Sentry breadcrumb (`category: album-level-backfill`, `message: unexpected_result_index`, `data: { expected, got, album_id }`)
- skip the write and continue

Position lookup is O(1); the ticket flags `find()` (O(N^2) over the batch) as the wrong shape. The existing `batch_done` log fields are unchanged — `unexpected_index` is additive so the BS#1078 Phase 3 runbook's `jq` watchdog stays valid.

## Acceptance signal

`unexpected_index = 0` on a 24-h prod run confirms LML's current contract; any non-zero value flags a silent LML behavior change before it corrupts `album_metadata`.

## Tests

Parameterized unit test over LML response shapes: in-order, out-of-order swap, missing-index (LML returns N-1 results). Plus a Sentry-breadcrumb shape assertion and a sibling-isolation test (one bad result, one good result -> one UPSERT, `unexpected_index=1`). 47 tests in the file, 2681 across the unit suite, all green locally.