### PR TITLE
feat(enrichment-worker): empty-outcome capture with stable Sentry fingerprint

### DIFF
--- a/apps/enrichment-worker/empty-outcome.ts
+++ b/apps/enrichment-worker/empty-outcome.ts
@@ -1,0 +1,67 @@
+/**
+ * Empty-outcome classification for enrichment-worker Sentry observability
+ * (BS#969 / Epic G G7).
+ *
+ * The legacy `Sentry.captureException` path in `apps/backend/services/metadata`
+ * only fires when `lookupMetadata` throws — it catches LML timeouts but misses
+ * the dominant failure mode: LML responds inside its budget with a degraded
+ * result (artwork object present but `artwork_url` null, the LML#408 class).
+ * The 2026-05-19 data pull on BS#692 quantified the gap at ~50–500× undercount
+ * against the actual prod degradation rate.
+ *
+ * This module exports a pure predicate + cause classifier so the worker can
+ * fire a structured `Sentry.captureMessage('enrichment-empty-outcome', ...)`
+ * on every empty outcome — caught throws AND finalized rows that landed
+ * user-visibly blank — with a stable fingerprint that survives release tag
+ * changes.
+ *
+ * "Empty outcome" is defined against the LML response, not the post-write
+ * row state: the worker's write path always synthesizes fallback search URLs
+ * (spotify/youtube/bandcamp/soundcloud), so the BS#969-original "all five row
+ * columns IS NULL" predicate would never trigger after consumer writes. The
+ * user-facing definition that matters is "no Discogs-derived artwork URL" —
+ * that's what shows up as a blank cover tile on iOS / dj-site.
+ */
+
+import type { LookupResponse } from '@wxyc/lml-client';
+
+import { extractArtwork } from './enrich.js';
+
+export type EmptyOutcomeCause = 'lml_degraded' | 'lml_no_match' | 'lml_timeout' | 'unknown';
+
+/**
+ * True if the LML response will produce a user-visibly blank artwork tile:
+ * either no Discogs match at all (artwork === null) or a match whose
+ * `artwork_url` is missing (the LML#408 `_resolve_fallback_artwork` class).
+ *
+ * Does NOT cover the LML-threw path; the caller in handler.ts fires the
+ * `lml_timeout` cause separately from its catch arm.
+ */
+export const isEmptyOutcome = (response: LookupResponse): boolean => {
+  const artwork = extractArtwork(response);
+  if (!artwork) return true;
+  return !artwork.artwork_url;
+};
+
+/**
+ * Classify an empty-outcome response into the cause tag that distinguishes
+ * LML-side failure modes on the aggregated Sentry issue. Caller should only
+ * invoke this when `isEmptyOutcome(response)` is true.
+ *
+ * The `lml_timeout` cause is unreachable from this function (the LML throw
+ * path lives in handler.ts's catch arm); it exists in `EmptyOutcomeCause`
+ * because the catch arm uses it as a tag value on its own captureMessage.
+ */
+export const classifyEmptyCause = (response: LookupResponse): Exclude<EmptyOutcomeCause, 'lml_timeout'> => {
+  const artwork = extractArtwork(response);
+  if (!artwork) return 'lml_no_match';
+  if (!artwork.artwork_url) return 'lml_degraded';
+  return 'unknown';
+};
+
+/**
+ * Stable Sentry fingerprint so all four `cause` classifications group onto
+ * a single long-lived issue that survives release tag changes. Tag-filter
+ * within Sentry to split causes when triaging.
+ */
+export const EMPTY_OUTCOME_FINGERPRINT = ['enrichment-empty-outcome', 'subsystem-metadata'];

--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -38,6 +38,7 @@ import type { CdcEvent } from '@wxyc/database';
 
 import { claimRowForEnrichment } from './claim.js';
 import { filterForEnrichment, type EnrichmentCandidate } from './cdc-subscriber.js';
+import { EMPTY_OUTCOME_FINGERPRINT, classifyEmptyCause, isEmptyOutcome } from './empty-outcome.js';
 import { finalizeRow, type FinalizeOutcome } from './enrich.js';
 
 /**
@@ -87,6 +88,7 @@ async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
         }
 
         let outcome: FinalizeOutcome;
+        let emptyCause: ReturnType<typeof classifyEmptyCause> | null = null;
         try {
           const response = await lookupMetadata(
             candidate.artist_name,
@@ -95,6 +97,13 @@ async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
             { budgetMs: ENRICHMENT_LML_BUDGET_MS, caller: 'enrichment-worker' }
           );
           outcome = await finalizeRow(candidate, response);
+          // G7 (BS#969): defer the captureMessage until after the
+          // span.setAttribute below, but compute the classification while the
+          // response is still in scope. `null` means the response was a real
+          // user-visible match; non-null means we need to fire.
+          if (isEmptyOutcome(response)) {
+            emptyCause = classifyEmptyCause(response);
+          }
         } catch (err) {
           // Row stays `enriching`. C6 stranded-claim sweep recovers it past
           // `enriching_since + 60s`. We do NOT revert to `pending` here —
@@ -106,6 +115,24 @@ async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
             tags: { component: 'enrichment-worker', step: 'lml_lookup' },
             extra: { flowsheet_id: candidate.id },
           });
+          // G7 (BS#969): also fold the throw into the aggregated
+          // enrichment-empty-outcome issue with cause=lml_timeout so the
+          // post-fix baseline + alert threshold see the throws alongside the
+          // degraded-success class. Sibling captureException above stays as
+          // the source-of-truth for the stack trace.
+          Sentry.captureMessage('enrichment-empty-outcome', {
+            level: 'warning',
+            tags: {
+              subsystem: 'metadata',
+              cause: 'lml_timeout',
+              transaction: 'enrichment.consumer.tick',
+            },
+            extra: {
+              flowsheet_id: candidate.id,
+              error_message: (err as Error).message,
+            },
+            fingerprint: EMPTY_OUTCOME_FINGERPRINT,
+          });
           console.error('[enrichment-worker] lml error; row left in enriching state', {
             id: candidate.id,
             artist: candidate.artist_name,
@@ -115,6 +142,28 @@ async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
         }
 
         span.setAttribute('enrichment.outcome', outcome);
+
+        // G7 (BS#969): emit the aggregated empty-outcome signal for rows that
+        // finalized with no user-visible artwork URL (the LML#408
+        // _resolve_fallback_artwork class, plus explicit no-match verdicts).
+        // Stable fingerprint so cause-tagged aggregation persists across
+        // releases.
+        if (emptyCause !== null) {
+          Sentry.captureMessage('enrichment-empty-outcome', {
+            level: 'warning',
+            tags: {
+              subsystem: 'metadata',
+              cause: emptyCause,
+              transaction: 'enrichment.consumer.tick',
+              outcome,
+            },
+            extra: {
+              flowsheet_id: candidate.id,
+              artist: candidate.artist_name,
+            },
+            fingerprint: EMPTY_OUTCOME_FINGERPRINT,
+          });
+        }
       } catch (err) {
         // DB error during claim or finalize. Same defensive posture: capture
         // + log, row state is whatever PG ended up with. C6 sweep handles

--- a/tests/unit/apps/enrichment-worker/empty-outcome.test.ts
+++ b/tests/unit/apps/enrichment-worker/empty-outcome.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for empty-outcome predicate + cause classifier (BS#969 / Epic G G7).
+ *
+ * The predicate is pure — wraps `extractArtwork` and looks at `artwork_url`.
+ * These tests pin the failure-mode taxonomy from BS#969:
+ *
+ *   - `lml_no_match`  — `results: []` from LML (artwork === null after extract)
+ *   - `lml_degraded`  — artwork object returned but `artwork_url` missing/null
+ *                       (the LML#408 `_resolve_fallback_artwork` class)
+ *   - `unknown`       — shouldn't be reachable if isEmptyOutcome() is true
+ *
+ * Plus regression-pinning for the "non-empty" cases (proper match, artwork_url
+ * present) so a future change to extractArtwork doesn't silently start firing
+ * the Sentry alert for every successful enrichment.
+ */
+
+import type { LookupResponse } from '@wxyc/lml-client';
+
+import { classifyEmptyCause, isEmptyOutcome } from '../../../../apps/enrichment-worker/empty-outcome';
+
+const makeMatchResponse = (artworkOverrides: Record<string, unknown> = {}) =>
+  ({
+    results: [
+      {
+        artwork: {
+          artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+          release_url: 'https://discogs.com/release/123',
+          release_year: 2022,
+          spotify_url: 'https://open.spotify.com/album/x',
+          apple_music_url: 'https://music.apple.com/album/y',
+          ...artworkOverrides,
+        },
+      },
+    ],
+  }) as unknown as LookupResponse;
+
+const NO_MATCH_RESPONSE = { results: [] } as unknown as LookupResponse;
+
+describe('isEmptyOutcome (BS#969 G7)', () => {
+  it('returns true for explicit no-match response (results: [])', () => {
+    expect(isEmptyOutcome(NO_MATCH_RESPONSE)).toBe(true);
+  });
+
+  it('returns true when artwork object is returned but artwork_url is null', () => {
+    expect(isEmptyOutcome(makeMatchResponse({ artwork_url: null }))).toBe(true);
+  });
+
+  it('returns true when artwork object is returned but artwork_url is undefined', () => {
+    expect(isEmptyOutcome(makeMatchResponse({ artwork_url: undefined }))).toBe(true);
+  });
+
+  it('returns true when artwork object is returned but artwork_url is empty string', () => {
+    // Empty string is the falsy edge — same user-facing blank tile.
+    expect(isEmptyOutcome(makeMatchResponse({ artwork_url: '' }))).toBe(true);
+  });
+
+  it('returns false when artwork_url is populated (even if other fields are null)', () => {
+    expect(
+      isEmptyOutcome(
+        makeMatchResponse({
+          artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+          release_year: null,
+          apple_music_url: null,
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+describe('classifyEmptyCause (BS#969 G7)', () => {
+  it('returns lml_no_match for an explicit no-match response', () => {
+    expect(classifyEmptyCause(NO_MATCH_RESPONSE)).toBe('lml_no_match');
+  });
+
+  it('returns lml_degraded when artwork is returned but artwork_url is null', () => {
+    expect(classifyEmptyCause(makeMatchResponse({ artwork_url: null }))).toBe('lml_degraded');
+  });
+
+  it('returns lml_degraded when artwork is returned but artwork_url is undefined', () => {
+    expect(classifyEmptyCause(makeMatchResponse({ artwork_url: undefined }))).toBe('lml_degraded');
+  });
+
+  it('returns lml_degraded when artwork_url is empty string', () => {
+    expect(classifyEmptyCause(makeMatchResponse({ artwork_url: '' }))).toBe('lml_degraded');
+  });
+
+  it('returns unknown when artwork_url is present (defensive fallback)', () => {
+    // Caller should only invoke classify after isEmptyOutcome returns true,
+    // but the function is defensive — if invoked on a non-empty response, the
+    // 'unknown' tag surfaces the misuse without crashing.
+    expect(classifyEmptyCause(makeMatchResponse())).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary

The legacy `Sentry.captureException` in `apps/backend/services/metadata/` only fires on LML throws — it catches the timeout class but misses the dominant degradation mode (LML responds inside budget with `artwork.artwork_url=null`, the LML#408 class). Today's prod corroborates: 24.6% artwork-fill rate among `enriched_match` rows in the last 24h, matching the pre-LML#409 baseline, with zero Sentry signal pointing at it.

This wires `Sentry.captureMessage('enrichment-empty-outcome', ...)` into the consumer's `handler.ts` at both branches:

- LML catch arm → cause `lml_timeout`
- After successful `finalizeRow` whose response yields no user-visible artwork URL → cause `lml_degraded` (artwork object returned with `artwork_url` null) or `lml_no_match` (explicit no-match verdict)

Stable fingerprint `['enrichment-empty-outcome', 'subsystem-metadata']` so the cause-tagged aggregation persists across release tags. Pure-function helpers in `empty-outcome.ts`; 10 unit tests cover each cause + non-empty negative case + falsy-edge `artwork_url=''`.

The predicate runs against the LML response, not the post-write row. The worker's write path always synthesizes fallback search URLs, so the ticket's original "all five row columns IS NULL" predicate would never trigger after consumer writes. Reduced to the user-facing definition: "no Discogs-derived artwork URL".

Worker-only scope. The legacy `apps/backend/services/metadata/enrichment.service.ts` fire-and-forget path is being deleted in #894 (Slot 4 of #1279); duplicating instrumentation there would be wasted work.

## Test plan

- [x] 10 new unit tests in `tests/unit/apps/enrichment-worker/empty-outcome.test.ts` cover each cause classification + the non-empty regression-pin
- [x] Full worker suite still 69/69 pass (was 59 + 10 new)
- [x] Full unit suite 2686/2686 pass
- [x] Lint 0 errors, format clean, typecheck clean
- [ ] Post-deploy: verify `enrichment-empty-outcome` events land in Sentry with `cause` tag distinguishing the four classes; tune alert threshold against first week's baseline
- [ ] Resolve `BACKEND-SERVICE-1` + `BACKEND-SERVICE-B` as superseded after the new path has accrued a week of prod data

## Related

- Diagnostic for the #1209 decision blocker (#1279 Slot 2 surfaced the 24.6% rate; this is the visibility that would have caught the LML#409 prod regression in real time)
- Supersedes #692 and re-scopes #904 (per ticket body)
- Adjacent to #907 (G5 test gaps) — these helpers' tests cover similar ground

Closes #969