### PR TITLE
fix(flowsheet-etl): preserve verbatim ARTIST_NAME for show_start/show_end

### DIFF
--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -29,7 +29,7 @@ import {
   truncate,
 } from '@wxyc/database';
 import { parseInsertLine } from './parse-dump.js';
-import { mapProdEntryType, resolveEntryTimestamp, parseShowEntryDJName } from './transform.js';
+import { mapProdEntryType, resolveEntryTimestamp } from './transform.js';
 import { fetchLegacyShows, fetchLegacyEntries, closeLegacyConnection } from './fetch-legacy.js';
 import { initLogger, log, captureError, closeLogger } from './logger.js';
 
@@ -113,16 +113,24 @@ const isMessageEntryType = (entryType: string): boolean =>
   entryType === 'breakpoint' || entryType === 'talkset' || entryType === 'message';
 
 /**
- * Resolve the artist_name for a flowsheet entry. For show_start/show_end entries,
- * parse the DJ name from the structured ARTIST_NAME text. For message-bearing types
- * (breakpoint, talkset, message), the text belongs in the message field instead.
+ * Resolve the artist_name for a flowsheet entry.
+ *
+ * For message-bearing types (breakpoint, talkset, message), the text belongs in
+ * the message field instead — return null here.
+ *
+ * For show_start / show_end markers, the ARTIST_NAME column in tubafrenzy holds
+ * the full marker text (e.g. "START OF SHOW: DJ Aubrey Hearst SIGNED ON at
+ * 7:43 PM (6/2/26)"). Preserve it verbatim — V1 surfaces (dj-site flowsheet,
+ * wxyc.info) render `artist_name` directly, and reducing it to the bare DJ
+ * name strips information the writer put there on purpose. The ETL stays
+ * shape-agnostic about marker templates; whatever TF holds is what BS persists,
+ * truncated to the 128-char column limit. See #1287 and epic #1288.
+ *
+ * Exported for unit testing.
  */
-const resolveArtistName = (rawArtistName: string | null, entryType: string): string | null => {
+export const resolveArtistName = (rawArtistName: string | null, entryType: string): string | null => {
   if (!rawArtistName) return null;
   if (isMessageEntryType(entryType)) return null;
-  if (entryType === 'show_start' || entryType === 'show_end') {
-    return truncate(parseShowEntryDJName(rawArtistName), 128) ?? truncate(rawArtistName, 128);
-  }
   return truncate(rawArtistName, 128);
 };
 

--- a/jobs/flowsheet-etl/transform.ts
+++ b/jobs/flowsheet-etl/transform.ts
@@ -133,18 +133,6 @@ export const resolveEntryTimestamp = (
   return epochMsToDate(startTime) ?? epochMsToDate(timeCreated) ?? epochMsToDate(timeLastModified);
 };
 
-/**
- * Extract the DJ name from a START/END OF SHOW message in FLOWSHEET_ENTRY_PROD.
- * These entries store structured text in the ARTIST_NAME column:
- *   "START OF SHOW: DJ Bluejay SIGNED ON at 12:03 PM (4/4/26)"
- *   "END OF SHOW: dj wilde SIGNED OFF at 12:03 PM (4/4/26)"
- * Returns the DJ name or null if the text doesn't match the pattern.
- */
-export const parseShowEntryDJName = (artistName: string): string | null => {
-  const match = artistName.match(/^(?:START|END) OF SHOW: (.+?) SIGNED (?:ON|OFF)/);
-  return match ? match[1] : null;
-};
-
 // truncate is re-exported from @wxyc/database above
 
 export type TransformedShow = {

--- a/tests/unit/jobs/flowsheet-etl/job.resolveArtistName.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.resolveArtistName.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for resolveArtistName.
+ *
+ * Regression cover for #1287: the flowsheet ETL must preserve the verbatim
+ * ARTIST_NAME text that tubafrenzy holds for show_start / show_end markers
+ * (e.g. "START OF SHOW: DJ Aubrey Hearst SIGNED ON at 7:43 PM (6/2/26)")
+ * rather than reducing it to the bare DJ name.
+ *
+ * Marker text shape is owned by the writer (see epic #1288). This ETL stays
+ * shape-agnostic: whatever marker text TF holds is what BS persists, up to
+ * the 128-char artist_name column limit.
+ */
+
+// Mock fetch-legacy so importing job.ts doesn't try to open a MirrorSQL
+// connection during module evaluation.
+jest.mock('../../../../jobs/flowsheet-etl/fetch-legacy', () => ({
+  fetchLegacyShows: jest.fn(),
+  fetchLegacyEntries: jest.fn(),
+  closeLegacyConnection: jest.fn(),
+}));
+
+import { resolveArtistName } from '../../../../jobs/flowsheet-etl/job';
+
+describe('resolveArtistName', () => {
+  describe('show_start / show_end markers — verbatim', () => {
+    it('preserves a START OF SHOW marker verbatim', () => {
+      const marker = 'START OF SHOW: DJ Aubrey Hearst SIGNED ON at 7:43 PM (6/2/26)';
+      expect(resolveArtistName(marker, 'show_start')).toBe(marker);
+    });
+
+    it('preserves an END OF SHOW marker verbatim', () => {
+      const marker = 'END OF SHOW: Aubrey Hearst SIGNED OFF at 7:43 PM (6/2/26)';
+      expect(resolveArtistName(marker, 'show_end')).toBe(marker);
+    });
+
+    it('preserves a mixed-case BS-mirror marker verbatim', () => {
+      // BS writer-side template (post-#1286) emits "Start of Show: <name> joined the set at <time>".
+      // The ETL must persist whatever shape TF mirrors back.
+      const marker = 'Start of Show: Aubrey Hearst joined the set at 7:11 PM';
+      expect(resolveArtistName(marker, 'show_start')).toBe(marker);
+    });
+
+    it('truncates a marker longer than 128 chars', () => {
+      const long = 'START OF SHOW: ' + 'A'.repeat(200) + ' SIGNED ON at 7:43 PM (6/2/26)';
+      const result = resolveArtistName(long, 'show_start');
+      expect(result).toHaveLength(128);
+      expect(result?.startsWith('START OF SHOW: ')).toBe(true);
+    });
+  });
+
+  describe('null guards', () => {
+    it('returns null for null input (show_start)', () => {
+      expect(resolveArtistName(null, 'show_start')).toBeNull();
+    });
+
+    it('returns null for null input (show_end)', () => {
+      expect(resolveArtistName(null, 'show_end')).toBeNull();
+    });
+
+    it('returns null for null input (track)', () => {
+      expect(resolveArtistName(null, 'track')).toBeNull();
+    });
+  });
+
+  describe('track entries — unchanged behavior', () => {
+    it('returns a plain artist name truncated to 128', () => {
+      expect(resolveArtistName('Stereolab', 'track')).toBe('Stereolab');
+    });
+
+    it('truncates an overlong track artist_name to 128', () => {
+      const long = 'A'.repeat(200);
+      expect(resolveArtistName(long, 'track')).toHaveLength(128);
+    });
+  });
+
+  describe('message-bearing types — NULL (routed to message column)', () => {
+    it('returns null for breakpoint (text routed to message)', () => {
+      expect(resolveArtistName('--- 7:00 PM BREAKPOINT ---', 'breakpoint')).toBeNull();
+    });
+
+    it('returns null for talkset (text routed to message)', () => {
+      expect(resolveArtistName('TALKSET', 'talkset')).toBeNull();
+    });
+
+    it('returns null for message (text routed to message)', () => {
+      expect(resolveArtistName('PSA: pledge drive starts Monday', 'message')).toBeNull();
+    });
+  });
+});

--- a/tests/unit/jobs/flowsheet-etl/job.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.test.ts
@@ -156,6 +156,46 @@ describe('runIncremental', () => {
     expect(result.entriesUpdated).toBe(1);
   });
 
+  it('persists verbatim ARTIST_NAME for show_start markers (regression #1287)', async () => {
+    const marker = 'START OF SHOW: DJ Aubrey Hearst SIGNED ON at 7:43 PM (6/2/26)';
+    mockFetchLegacyShows.mockResolvedValue([makeShow()]);
+    mockFetchLegacyEntries.mockResolvedValue([
+      makeEntry({ id: 2003, entryTypeCode: 9, artistName: marker }), // 9 = START_OF_SHOW
+    ]);
+
+    await runIncremental();
+
+    const insertCalls = chain.values.mock.calls;
+    const showStartInsert = insertCalls.find(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).legacy_entry_id === 2003
+    );
+    expect(showStartInsert).toBeDefined();
+    const values = showStartInsert![0] as Record<string, unknown>;
+    expect(values.entry_type).toBe('show_start');
+    expect(values.artist_name).toBe(marker);
+    expect(values.message).toBeNull();
+  });
+
+  it('persists verbatim ARTIST_NAME for show_end markers (regression #1287)', async () => {
+    const marker = 'END OF SHOW: Aubrey Hearst SIGNED OFF at 7:43 PM (6/2/26)';
+    mockFetchLegacyShows.mockResolvedValue([makeShow()]);
+    mockFetchLegacyEntries.mockResolvedValue([
+      makeEntry({ id: 2004, entryTypeCode: 10, artistName: marker }), // 10 = END_OF_SHOW
+    ]);
+
+    await runIncremental();
+
+    const insertCalls = chain.values.mock.calls;
+    const showEndInsert = insertCalls.find(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).legacy_entry_id === 2004
+    );
+    expect(showEndInsert).toBeDefined();
+    const values = showEndInsert![0] as Record<string, unknown>;
+    expect(values.entry_type).toBe('show_end');
+    expect(values.artist_name).toBe(marker);
+    expect(values.message).toBeNull();
+  });
+
   // Shape check only — column coverage and PG semantics are pinned in
   // tests/integration/flowsheet-etl-setwhere.spec.js.
   it('passes setWhere on every onConflictDoUpdate call to skip no-op UPDATEs', async () => {

--- a/tests/unit/jobs/flowsheet-etl/transform.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/transform.test.ts
@@ -3,7 +3,6 @@ import {
   mapProdEntryType,
   epochMsToDate,
   resolveEntryTimestamp,
-  parseShowEntryDJName,
   parseMySQLDatetime,
   truncate,
   transformShow,
@@ -104,32 +103,6 @@ describe('flowsheet-etl transform', () => {
 
     it('returns null when all timestamps are null', () => {
       expect(resolveEntryTimestamp(null, null, null)).toBeNull();
-    });
-  });
-
-  describe('parseShowEntryDJName', () => {
-    it('extracts DJ name from START OF SHOW message', () => {
-      expect(parseShowEntryDJName('START OF SHOW: DJ Bluejay SIGNED ON at 12:03 PM (4/4/26)')).toBe('DJ Bluejay');
-    });
-
-    it('extracts DJ name from END OF SHOW message', () => {
-      expect(parseShowEntryDJName('END OF SHOW: dj wilde SIGNED OFF at 12:03 PM (4/4/26)')).toBe('dj wilde');
-    });
-
-    it('handles anonymous DJ (just "DJ")', () => {
-      expect(parseShowEntryDJName('END OF SHOW: DJ SIGNED OFF at 11:54 PM (4/3/26)')).toBe('DJ');
-    });
-
-    it('handles multi-word DJ names', () => {
-      expect(parseShowEntryDJName('START OF SHOW: Xx_CoolSocc3r101_xX SIGNED ON at 9:02 PM (4/1/26)')).toBe(
-        'Xx_CoolSocc3r101_xX'
-      );
-    });
-
-    it('returns null for non-show entries', () => {
-      expect(parseShowEntryDJName('TALKSET')).toBeNull();
-      expect(parseShowEntryDJName('--- 1:00 PM BREAKPOINT ---')).toBeNull();
-      expect(parseShowEntryDJName('Autechre')).toBeNull();
     });
   });
 


### PR DESCRIPTION
Closes #1287. Part of epic #1288 (Aubrey Hearst on-air incident follow-ups).

## Summary

The flowsheet ETL's `resolveArtistName` was special-casing `show_start` / `show_end` rows: it ran them through `parseShowEntryDJName` and reduced tubafrenzy's full marker text (e.g. `"START OF SHOW: DJ Aubrey Hearst SIGNED ON at 7:43 PM (6/2/26)"`) to the bare DJ name (`"DJ Aubrey Hearst"`) in BS `artist_name`. dj-site flowsheet (a V1 surface) reads `artist_name` verbatim, so it displayed the stripped name where the full marker text should have appeared. Surfaced during the 2026-06-02 Aubrey Hearst incident when manual `artist_name` patches were silently overwritten back to bare names by the next ETL tick.

## Change

Drop the `show_start` / `show_end` branch in `resolveArtistName` at `jobs/flowsheet-etl/job.ts`. Those entry types now fall through to the same `truncate(rawArtistName, 128)` behavior as plain tracks, so whatever marker text TF holds is what BS persists.

`parseShowEntryDJName` in `jobs/flowsheet-etl/transform.ts` had no other callers and has been removed along with its unit tests. `resolveArtistName` is now exported so it can be unit-tested directly.

The ETL stays shape-agnostic about marker templates — the writer (BS via the helper introduced in #1286, or tubafrenzy on classic-mode sign-on) owns that shape. No coupling to the new "DJ"-less template from epic #1288; this fix preserves whatever wrapper text the writer chooses, today or after #1286 lands.

## Forward-only

No historical backfill. Historical rows in `wxyc_schema.flowsheet` that the ETL already stamped with the bare DJ name will continue to display that way on V1 surfaces (dj-site flowsheet). V2 surfaces derive the display name from the dedicated `dj_name` column and are unaffected. Backfilling ~2M legacy rows for a cosmetic V1 cleanup isn't worth the lock / CDC churn — revisit only if a V1 surface surfaces a complaint.

## Tests

- New `tests/unit/jobs/flowsheet-etl/job.resolveArtistName.test.ts` covers the verbatim invariant for `show_start` / `show_end` (both `START OF SHOW: ...` and mixed-case `Start of Show: ...` shapes), the null guard, the truncation-at-128 case, the unchanged track behavior, and the message-routing nulls for `breakpoint` / `talkset` / `message`.
- Extended `tests/unit/jobs/flowsheet-etl/job.test.ts` with two `runIncremental` regressions that assert verbatim persistence end-to-end for `show_start` (TF type code 9) and `show_end` (TF type code 10) rows.
- Removed the now-orphaned `parseShowEntryDJName` describe block from `transform.test.ts`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 2685 / 2685 pass
- [x] `npm run build` — all workspaces build
- [ ] CI green on this PR
- [ ] Post-deploy: confirm next ETL tick after a fresh `show_start` / `show_end` marker leaves the BS `artist_name` matching TF `ARTIST_NAME` verbatim