### PR TITLE
fix(flowsheet): centralize DJ display name in resolveDjDisplayName helper

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -439,7 +439,7 @@ export const leaveShow: RequestHandler<object, unknown, { dj_id: string }> = asy
 export const getDJList: RequestHandler = async (req, res) => {
   const currentDJs = await flowsheet_service.getDJsInCurrentShow();
   const cleanDJList = currentDJs.map((dj) => {
-    return { id: dj.id, dj_name: dj.djName || dj.name };
+    return { id: dj.id, dj_name: flowsheet_service.resolveDjDisplayName(dj.djName ?? null, dj.name ?? null) };
   });
   res.status(200).json(cleanDJList);
 };

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1,4 +1,5 @@
 import { sql, desc, eq, and, lte, gte, inArray } from 'drizzle-orm';
+import * as Sentry from '@sentry/node';
 import WxycError from '../utils/error.js';
 import {
   db,
@@ -21,6 +22,38 @@ import {
 } from '@wxyc/database';
 import { IFSEntry, ShowInfo, ShowMetadata, UpdateRequestBody } from '../controllers/flowsheet.controller.js';
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
+
+/**
+ * Resolve the DJ display name shown to listeners on the public flowsheet,
+ * applying the rules locked by the 2026-06-02 Aubrey Hearst on-air incident
+ * (WXYC/Backend-Service#1286, epic #1288):
+ *
+ *   1. Prefer `djName` (the user's stage handle on `auth_user.dj_name`).
+ *   2. Fall back to `name` (better-auth `auth_user.name`).
+ *   3. Treat the literal string "Anonymous" (case- and whitespace-insensitive)
+ *      as if `djName` were absent. The better-auth anonymous plugin and a
+ *      since-corrected onboarding default were both observed writing the
+ *      literal "Anonymous" into `auth_user.dj_name`; rendering that string to
+ *      the public on-air playlist confuses listeners and the wxyc.info playlist.
+ *   4. Trim returned values; return `null` if both inputs are blank or
+ *      Anonymous-with-no-fallback.
+ *
+ * Callers should treat `null` as "name is unresolvable" and either degrade
+ * the marker template (show_start / show_end keep a row but drop the name) or
+ * suppress the row entirely and log to Sentry (dj_join / dj_leave) — see
+ * `startShow`, `endShow`, `createJoinNotification`, `createLeaveNotification`.
+ */
+export const resolveDjDisplayName = (djName: string | null, name: string | null): string | null => {
+  const trimmedDjName = djName?.trim() ?? '';
+  if (trimmedDjName.length > 0 && trimmedDjName.toLowerCase() !== 'anonymous') {
+    return trimmedDjName;
+  }
+  const trimmedName = name?.trim() ?? '';
+  if (trimmedName.length > 0) {
+    return trimmedName;
+  }
+  return null;
+};
 
 /**
  * Compute the next play_order value for a new flowsheet entry within a given
@@ -216,6 +249,9 @@ const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
  *
  * Used by the live insert path (step 5b.2) to denormalize the resolved value
  * onto each new flowsheet row so search no longer needs to join shows -> auth_user.
+ *
+ * Filters the literal "Anonymous" out of `auth_user.dj_name` via
+ * `resolveDjDisplayName`, then folds in the legacy fallback. See #1286/#1288.
  */
 export const resolveDjNameForShow = async (show: Show): Promise<string | null> => {
   const legacy = (show.legacy_dj_name as string | null | undefined) ?? null;
@@ -229,7 +265,14 @@ export const resolveDjNameForShow = async (show: Show): Promise<string | null> =
     .where(eq(user.id, primaryDjId))
     .limit(1);
   const dj = rows[0];
-  return dj?.djName ?? legacy ?? dj?.name ?? null;
+  if (!dj) return legacy;
+  // Apply the same Anonymous / blank filtering used everywhere else, but
+  // splice the legacy_dj_name in as a middle priority so existing imports
+  // continue to surface on shows whose auth_user has no usable handle.
+  const filteredDjName = resolveDjDisplayName(dj.djName ?? null, null);
+  if (filteredDjName) return filteredDjName;
+  if (legacy && legacy.trim().length > 0) return legacy.trim();
+  return resolveDjDisplayName(null, dj.name ?? null);
 };
 
 /**
@@ -454,17 +497,22 @@ export const startShow = async (dj_id: string, show_name?: string, specialty_id?
     })
     .returning();
 
+  const display_dj_name = resolveDjDisplayName(dj_info.djName ?? null, dj_info.name ?? null);
+  const now = new Date().toLocaleString('en-US', { timeZone: 'America/New_York' });
+  // Asymmetric fallback (epic #1288): when the DJ name is unresolvable we
+  // still want a marker row so consumers know the show began. The wording
+  // degrades from "Start of Show: <name> joined the set at ${time}" to a
+  // bare "Start of show: ${time}".
+  const message = display_dj_name
+    ? `Start of Show: ${display_dj_name} joined the set at ${now}`
+    : `Start of show: ${now}`;
+
   await db.insert(flowsheet).values({
     show_id: new_show[0].id,
     entry_type: 'show_start',
-    dj_name: dj_info.djName || dj_info.name || null,
+    dj_name: display_dj_name,
     play_order: await nextPlayOrder(new_show[0].id),
-    message: `Start of Show: DJ ${dj_info.djName || dj_info.name} joined the set at ${new Date().toLocaleString(
-      'en-US',
-      {
-        timeZone: 'America/New_York',
-      }
-    )}`,
+    message,
   });
 
   return new_show[0];
@@ -508,22 +556,32 @@ export const addDJToShow = async (dj_id: string, current_show: Show): Promise<Sh
   return show_dj_instance[0];
 };
 
-const createJoinNotification = async (id: string, show_id: number): Promise<FSEntry> => {
+const createJoinNotification = async (id: string, show_id: number): Promise<FSEntry | null> => {
   const dj = (await db.select().from(user).where(eq(user.id, id)).limit(1))[0];
 
-  const persisted_dj_name = dj?.djName || dj?.name || null;
-  const display_dj_name = persisted_dj_name ?? 'A DJ';
+  const display_dj_name = resolveDjDisplayName(dj?.djName ?? null, dj?.name ?? null);
 
-  const message = `${display_dj_name} joined the set!`;
+  // Asymmetric fallback (epic #1288): a nameless mid-show join is a degraded
+  // state. The marker is suppressed rather than written — better logged than
+  // rendered to the public on-air playlist — and a Sentry warning carries
+  // dj_id + show_id so the cause is debuggable.
+  if (!display_dj_name) {
+    Sentry.captureMessage('Suppressed dj_join marker: DJ display name unresolvable', {
+      level: 'warning',
+      tags: { tool: 'flowsheet', entry_type: 'dj_join' },
+      extra: { dj_id: id, show_id },
+    });
+    return null;
+  }
 
   const notification = await db
     .insert(flowsheet)
     .values({
       show_id: show_id,
       entry_type: 'dj_join',
-      dj_name: persisted_dj_name,
+      dj_name: display_dj_name,
       play_order: await nextPlayOrder(show_id),
-      message: message,
+      message: `${display_dj_name} joined the set!`,
     })
     .returning();
 
@@ -554,17 +612,18 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
   );
 
   const dj_information = (await db.select().from(user).where(eq(user.id, primary_dj_id)).limit(1))[0];
-  const persisted_dj_name = dj_information?.djName || dj_information?.name || null;
-  const display_dj_name = persisted_dj_name ?? 'A DJ';
+  const display_dj_name = resolveDjDisplayName(dj_information?.djName ?? null, dj_information?.name ?? null);
+  const now = new Date().toLocaleString('en-US', { timeZone: 'America/New_York' });
+  // Symmetric to startShow: keep the row, degrade the wording to bare
+  // "End of show: ${time}" when the name is unresolvable (epic #1288).
+  const message = display_dj_name ? `End of Show: ${display_dj_name} left the set at ${now}` : `End of show: ${now}`;
 
   await db.insert(flowsheet).values({
     show_id: currentShow.id,
     entry_type: 'show_end',
-    dj_name: persisted_dj_name,
+    dj_name: display_dj_name,
     play_order: await nextPlayOrder(currentShow.id),
-    message: `End of Show: ${display_dj_name} left the set at ${new Date().toLocaleString('en-US', {
-      timeZone: 'America/New_York',
-    })}`,
+    message,
   });
 
   await db.update(shows).set({ end_time: new Date() }).where(eq(shows.id, currentShow.id));
@@ -594,22 +653,30 @@ export const leaveShow = async (dj_id: string, currentShow: Show): Promise<ShowD
   return update_result;
 };
 
-const createLeaveNotification = async (dj_id: string, show_id: number): Promise<FSEntry> => {
+const createLeaveNotification = async (dj_id: string, show_id: number): Promise<FSEntry | null> => {
   const dj = (await db.select().from(user).where(eq(user.id, dj_id)).limit(1))[0];
 
-  const persisted_dj_name = dj?.djName || dj?.name || null;
-  const display_dj_name = persisted_dj_name ?? 'A DJ';
+  const display_dj_name = resolveDjDisplayName(dj?.djName ?? null, dj?.name ?? null);
 
-  const message = `${display_dj_name} left the set!`;
+  // Symmetric to createJoinNotification: suppress the row and log a Sentry
+  // warning when the DJ name is unresolvable (epic #1288).
+  if (!display_dj_name) {
+    Sentry.captureMessage('Suppressed dj_leave marker: DJ display name unresolvable', {
+      level: 'warning',
+      tags: { tool: 'flowsheet', entry_type: 'dj_leave' },
+      extra: { dj_id, show_id },
+    });
+    return null;
+  }
 
   const notification = await db
     .insert(flowsheet)
     .values({
       show_id: show_id,
       entry_type: 'dj_leave',
-      dj_name: persisted_dj_name,
+      dj_name: display_dj_name,
       play_order: await nextPlayOrder(show_id),
-      message: message,
+      message: `${display_dj_name} left the set!`,
     })
     .returning();
 
@@ -757,7 +824,10 @@ export const changeOrder = async (entry_id: number, position_new: number): Promi
 export const getShowMetadata = async (show_id: number): Promise<ShowMetadata> => {
   const show = await db.select().from(shows).where(eq(shows.id, show_id));
 
-  const showDJs = (await getDJsInShow(show_id, false)).map((dj) => ({ id: dj.id, dj_name: dj.djName || dj.name }));
+  const showDJs = (await getDJsInShow(show_id, false)).map((dj) => ({
+    id: dj.id,
+    dj_name: resolveDjDisplayName(dj.djName ?? null, dj.name ?? null),
+  }));
 
   let specialty_show_name = '';
   if (show[0].specialty_id != null) {

--- a/tests/unit/services/flowsheet.joinLeaveNotifications.test.ts
+++ b/tests/unit/services/flowsheet.joinLeaveNotifications.test.ts
@@ -1,4 +1,10 @@
+import { jest } from '@jest/globals';
 import { db, createMockQueryChain } from '../../mocks/database.mock';
+
+jest.mock('@sentry/node', () => ({
+  captureMessage: jest.fn(),
+}));
+
 import { addDJToShow, leaveShow } from '../../../apps/backend/services/flowsheet.service';
 
 const makeAwaitablePlayOrderChain = (max: number) => {
@@ -7,9 +13,21 @@ const makeAwaitablePlayOrderChain = (max: number) => {
   return chain;
 };
 
+// jest.clearAllMocks() does not drain mockReturnValueOnce queues. If a test
+// queues a chain that the code never consumes (e.g. the suppression-path
+// tests below queue no flowsheet insert), the queued chain would leak into
+// the next test's call. Reset the implementations explicitly so each test
+// starts from a clean queue.
+const resetMockDbQueues = () => {
+  db.select.mockReset();
+  db.insert.mockReset();
+  db.update.mockReset();
+};
+
 describe('createJoinNotification (via addDJToShow)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetMockDbQueues();
   });
 
   it('persists dj_name (from user.djName) on the dj_join flowsheet row', async () => {
@@ -66,7 +84,11 @@ describe('createJoinNotification (via addDJToShow)', () => {
     expect(flowsheetValues.dj_name).toBe('Sam Blue');
   });
 
-  it('persists null dj_name when the user has neither djName nor name', async () => {
+  it('suppresses the flowsheet row when the user has neither djName nor name (#1286)', async () => {
+    // Post-#1286: a nameless mid-show join is a degraded state — better
+    // logged than written to the public on-air playlist. The flowsheet
+    // insert is suppressed; only the show_djs membership insert fires.
+    // See flowsheet.markerText.test.ts for the Sentry-message assertion.
     const showDjsSelect = createMockQueryChain();
     showDjsSelect.limit.mockResolvedValue([]);
     db.select.mockReturnValueOnce(showDjsSelect);
@@ -77,21 +99,17 @@ describe('createJoinNotification (via addDJToShow)', () => {
     userSelect.limit.mockResolvedValue([{ djName: null, name: null }]);
     db.select.mockReturnValueOnce(userSelect);
 
-    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
-
-    const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
-    db.insert.mockReturnValueOnce(flowsheetInsert);
-
     await addDJToShow('user-2', { id: 42 } as unknown as Parameters<typeof addDJToShow>[1]);
 
-    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(flowsheetValues.dj_name).toBeNull();
+    // Exactly one db.insert call — the show_djs membership row. No flowsheet row.
+    expect(db.insert).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('createLeaveNotification (via leaveShow service)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetMockDbQueues();
   });
 
   it('persists dj_name (from user.djName) on the dj_leave flowsheet row', async () => {

--- a/tests/unit/services/flowsheet.markerText.test.ts
+++ b/tests/unit/services/flowsheet.markerText.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Marker text regression tests for the four lifecycle entry types after the
+ * 2026-06-02 Aubrey Hearst on-air incident (WXYC/Backend-Service#1286, parent
+ * epic #1288).
+ *
+ * Locked decisions exercised here:
+ *   1. No marker template carries a literal "DJ " prefix — DJs read
+ *      "DJ Aubrey Hearst" as if "DJ" were part of their name.
+ *   2. show_start / show_end: when the DJ name is unresolvable, the marker
+ *      still writes a row, but the message degrades to a bare
+ *      "Start of show: ${time}" / "End of show: ${time}". The show *did*
+ *      start; the row must exist for downstream consumers.
+ *   3. dj_join / dj_leave: when the DJ name is unresolvable, suppress the
+ *      flowsheet row entirely and log a Sentry warning with dj_id + show_id
+ *      so the degraded state is debuggable.
+ *
+ * "Unresolvable" follows the resolveDjDisplayName contract (both inputs
+ * blank, or djName === "Anonymous" with no fallback name).
+ */
+import { jest } from '@jest/globals';
+import { db, createMockQueryChain } from '../../mocks/database.mock';
+
+jest.mock('@sentry/node', () => ({
+  captureMessage: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/node';
+import { startShow, endShow, addDJToShow, leaveShow } from '../../../apps/backend/services/flowsheet.service';
+
+const makeAwaitablePlayOrderChain = (max: number) => {
+  const chain = createMockQueryChain();
+  (chain as unknown as { then: (resolve: (v: unknown) => void) => void }).then = (resolve) => resolve([{ max }]);
+  return chain;
+};
+
+const setUpUserAndPlayOrderForStartShow = (djName: string | null, name: string | null) => {
+  const userSelect = createMockQueryChain();
+  userSelect.limit.mockResolvedValue([{ djName, name }]);
+  db.select.mockReturnValueOnce(userSelect);
+
+  db.insert.mockReturnValueOnce(createMockQueryChain([{ id: 42 }]));
+  db.insert.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-1' }]));
+  db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
+  const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
+  db.insert.mockReturnValueOnce(flowsheetInsert);
+  return flowsheetInsert;
+};
+
+const setUpForEndShow = (djName: string | null, name: string | null) => {
+  // remaining_djs select (empty so the inner loop is a no-op)
+  const remainingDjsSelect = createMockQueryChain();
+  remainingDjsSelect.where.mockResolvedValue([]);
+  db.select.mockReturnValueOnce(remainingDjsSelect);
+
+  // user lookup
+  const userSelect = createMockQueryChain();
+  userSelect.limit.mockResolvedValue([{ djName, name }]);
+  db.select.mockReturnValueOnce(userSelect);
+
+  // nextPlayOrder
+  db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
+
+  // flowsheet insert
+  const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
+  db.insert.mockReturnValueOnce(flowsheetInsert);
+
+  // shows update
+  db.update.mockReturnValueOnce(createMockQueryChain([{}]));
+
+  // getLatestShow
+  const latestShowSelect = createMockQueryChain();
+  latestShowSelect.limit.mockResolvedValue([{ id: 42, end_time: new Date() }]);
+  db.select.mockReturnValueOnce(latestShowSelect);
+
+  return flowsheetInsert;
+};
+
+const setUpForAddDJ = (djName: string | null, name: string | null) => {
+  // initial show_djs select — no existing membership
+  const showDjsSelect = createMockQueryChain();
+  showDjsSelect.limit.mockResolvedValue([]);
+  db.select.mockReturnValueOnce(showDjsSelect);
+
+  // show_djs insert
+  db.insert.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-2', active: true }]));
+
+  // user lookup inside createJoinNotification
+  const userSelect = createMockQueryChain();
+  userSelect.limit.mockResolvedValue([{ djName, name }]);
+  db.select.mockReturnValueOnce(userSelect);
+
+  // nextPlayOrder
+  db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
+
+  // flowsheet insert
+  const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
+  db.insert.mockReturnValueOnce(flowsheetInsert);
+
+  return flowsheetInsert;
+};
+
+const setUpForLeaveShow = (djName: string | null, name: string | null) => {
+  // show_djs update returning the updated row
+  db.update.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-2', active: false }]));
+
+  // user lookup
+  const userSelect = createMockQueryChain();
+  userSelect.limit.mockResolvedValue([{ djName, name }]);
+  db.select.mockReturnValueOnce(userSelect);
+
+  // nextPlayOrder
+  db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
+
+  // flowsheet insert
+  const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
+  db.insert.mockReturnValueOnce(flowsheetInsert);
+
+  return flowsheetInsert;
+};
+
+describe('startShow marker text', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Sentry.captureMessage as jest.Mock).mockClear();
+  });
+
+  it('emits "Start of Show: <name> joined the set at ..." with no "DJ " prefix when djName resolves', async () => {
+    const flowsheetInsert = setUpUserAndPlayOrderForStartShow('DJ Stardust', 'Alex Stardust');
+    await startShow('user-1');
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.entry_type).toBe('show_start');
+    expect(values.dj_name).toBe('DJ Stardust');
+    expect(values.message).toMatch(/^Start of Show: DJ Stardust joined the set at /);
+    // Defense in depth — guard against any regression that re-introduces the prefix.
+    expect(values.message).not.toMatch(/Start of Show: DJ DJ /);
+  });
+
+  it('strips literal "Anonymous" djName and falls back to user.name for the marker (Aubrey Hearst incident regression)', async () => {
+    const flowsheetInsert = setUpUserAndPlayOrderForStartShow('Anonymous', 'Aubrey Hearst');
+    await startShow('user-1');
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.dj_name).toBe('Aubrey Hearst');
+    expect(values.message).toMatch(/^Start of Show: Aubrey Hearst joined the set at /);
+    expect(values.message).not.toMatch(/Anonymous/);
+  });
+
+  it('case- and whitespace-insensitive "  anonymous  " is still treated as Anonymous', async () => {
+    const flowsheetInsert = setUpUserAndPlayOrderForStartShow('  anonymous  ', 'Aubrey Hearst');
+    await startShow('user-1');
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.dj_name).toBe('Aubrey Hearst');
+    expect(values.message).toMatch(/^Start of Show: Aubrey Hearst joined the set at /);
+    expect((values.message as string | null)?.toLowerCase() ?? '').not.toContain('anonymous');
+  });
+
+  it('degrades to "Start of show: <time>" (lowercase "show", no DJ name) when name is unresolvable', async () => {
+    const flowsheetInsert = setUpUserAndPlayOrderForStartShow(null, null);
+    await startShow('user-1');
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.dj_name).toBeNull();
+    expect(values.message).toMatch(/^Start of show: /);
+    expect(values.message).not.toMatch(/joined the set/);
+    expect(values.message).not.toMatch(/\bDJ\b/);
+  });
+
+  it('also degrades when djName is "Anonymous" and name is null', async () => {
+    const flowsheetInsert = setUpUserAndPlayOrderForStartShow('Anonymous', null);
+    await startShow('user-1');
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.dj_name).toBeNull();
+    expect(values.message).toMatch(/^Start of show: /);
+    expect(values.message).not.toMatch(/Anonymous/);
+  });
+});
+
+describe('endShow marker text', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Sentry.captureMessage as jest.Mock).mockClear();
+  });
+
+  it('emits "End of Show: <name> left the set at ..." with no "DJ " prefix when name resolves', async () => {
+    const flowsheetInsert = setUpForEndShow('DJ Night Owl', 'Riley Owens');
+    await endShow({ id: 42, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0]);
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.entry_type).toBe('show_end');
+    expect(values.dj_name).toBe('DJ Night Owl');
+    expect(values.message).toMatch(/^End of Show: DJ Night Owl left the set at /);
+    expect(values.message).not.toMatch(/End of Show: DJ DJ /);
+  });
+
+  it('strips literal "Anonymous" djName and falls back to user.name for the marker', async () => {
+    const flowsheetInsert = setUpForEndShow('Anonymous', 'Aubrey Hearst');
+    await endShow({ id: 42, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0]);
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.dj_name).toBe('Aubrey Hearst');
+    expect(values.message).toMatch(/^End of Show: Aubrey Hearst left the set at /);
+  });
+
+  it('degrades to "End of show: <time>" when both djName and name are null', async () => {
+    const flowsheetInsert = setUpForEndShow(null, null);
+    await endShow({ id: 42, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0]);
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.dj_name).toBeNull();
+    expect(values.message).toMatch(/^End of show: /);
+    expect(values.message).not.toMatch(/left the set/);
+    expect(values.message).not.toMatch(/\bDJ\b/);
+  });
+});
+
+describe('createJoinNotification (via addDJToShow) marker text', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Sentry.captureMessage as jest.Mock).mockClear();
+  });
+
+  it('emits "<name> joined the set!" with no "DJ " prefix when name resolves', async () => {
+    const flowsheetInsert = setUpForAddDJ('DJ Bluejay', 'Sam Blue');
+    await addDJToShow('user-2', { id: 42 } as unknown as Parameters<typeof addDJToShow>[1]);
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.dj_name).toBe('DJ Bluejay');
+    expect(values.message).toBe('DJ Bluejay joined the set!');
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('strips literal "Anonymous" djName and falls back to user.name', async () => {
+    const flowsheetInsert = setUpForAddDJ('Anonymous', 'Aubrey Hearst');
+    await addDJToShow('user-2', { id: 42 } as unknown as Parameters<typeof addDJToShow>[1]);
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.dj_name).toBe('Aubrey Hearst');
+    expect(values.message).toBe('Aubrey Hearst joined the set!');
+  });
+
+  it('suppresses the marker AND logs to Sentry when name is unresolvable', async () => {
+    // setUpForAddDJ still queues the user lookup; the suppression path means
+    // the flowsheet insert is never reached. Skip queuing the flowsheet
+    // insert mock so an accidental call would surface as a test failure.
+    const showDjsSelect = createMockQueryChain();
+    showDjsSelect.limit.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(showDjsSelect);
+    db.insert.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-2', active: true }]));
+    const userSelect = createMockQueryChain();
+    userSelect.limit.mockResolvedValue([{ djName: null, name: null }]);
+    db.select.mockReturnValueOnce(userSelect);
+
+    await addDJToShow('user-2', { id: 42 } as unknown as Parameters<typeof addDJToShow>[1]);
+
+    // Only the show_djs insert should have happened — no flowsheet insert.
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringMatching(/dj_join.*unresolvable/i),
+      expect.objectContaining({
+        level: 'warning',
+        extra: expect.objectContaining({ dj_id: 'user-2', show_id: 42 }),
+      })
+    );
+  });
+
+  it('also suppresses + logs when djName is "Anonymous" and name is null', async () => {
+    const showDjsSelect = createMockQueryChain();
+    showDjsSelect.limit.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(showDjsSelect);
+    db.insert.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-2', active: true }]));
+    const userSelect = createMockQueryChain();
+    userSelect.limit.mockResolvedValue([{ djName: 'Anonymous', name: null }]);
+    db.select.mockReturnValueOnce(userSelect);
+
+    await addDJToShow('user-2', { id: 42 } as unknown as Parameters<typeof addDJToShow>[1]);
+
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createLeaveNotification (via leaveShow) marker text', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Sentry.captureMessage as jest.Mock).mockClear();
+  });
+
+  it('emits "<name> left the set!" with no "DJ " prefix when name resolves', async () => {
+    const flowsheetInsert = setUpForLeaveShow('DJ Shadow', 'Josh Davis');
+    await leaveShow('user-2', { id: 42 } as unknown as Parameters<typeof leaveShow>[1]);
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.dj_name).toBe('DJ Shadow');
+    expect(values.message).toBe('DJ Shadow left the set!');
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('strips literal "Anonymous" djName and falls back to user.name', async () => {
+    const flowsheetInsert = setUpForLeaveShow('Anonymous', 'Aubrey Hearst');
+    await leaveShow('user-2', { id: 42 } as unknown as Parameters<typeof leaveShow>[1]);
+
+    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(values.dj_name).toBe('Aubrey Hearst');
+    expect(values.message).toBe('Aubrey Hearst left the set!');
+  });
+
+  it('suppresses the marker AND logs to Sentry when name is unresolvable', async () => {
+    db.update.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-2', active: false }]));
+    const userSelect = createMockQueryChain();
+    userSelect.limit.mockResolvedValue([{ djName: null, name: null }]);
+    db.select.mockReturnValueOnce(userSelect);
+
+    await leaveShow('user-2', { id: 42 } as unknown as Parameters<typeof leaveShow>[1]);
+
+    // Only the show_djs update should fire — no flowsheet insert.
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringMatching(/dj_leave.*unresolvable/i),
+      expect.objectContaining({
+        level: 'warning',
+        extra: expect.objectContaining({ dj_id: 'user-2', show_id: 42 }),
+      })
+    );
+  });
+});

--- a/tests/unit/services/flowsheet.resolveDjDisplayName.test.ts
+++ b/tests/unit/services/flowsheet.resolveDjDisplayName.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the resolveDjDisplayName helper extracted from the six
+ * marker / read sites in flowsheet.service.ts and flowsheet.controller.ts.
+ *
+ * The helper centralizes the rule: a DJ display name is "unresolvable" when
+ * either both inputs are null/empty/whitespace OR the `djName` input is the
+ * literal string `"Anonymous"` (case-insensitive, trim-tolerant).
+ *
+ * Background: 2026-06-02 Aubrey Hearst on-air incident — the previous inline
+ * pattern `dj.djName || dj.name` rendered the literal `"Anonymous"` to the
+ * public on-air playlist when a DJ's `auth_user.dj_name` was the literal
+ * string (root cause traced to the better-auth anonymous-plugin path or a
+ * stale onboarding default). See WXYC/Backend-Service#1286 and the parent
+ * epic #1288 for the locked marker-text decisions this helper enforces.
+ */
+import { resolveDjDisplayName } from '../../../apps/backend/services/flowsheet.service';
+
+describe('resolveDjDisplayName', () => {
+  it('returns djName when both inputs are present and djName is not Anonymous', () => {
+    expect(resolveDjDisplayName('DJ Stardust', 'Alex Stardust')).toBe('DJ Stardust');
+  });
+
+  it('falls back to name when djName is null', () => {
+    expect(resolveDjDisplayName(null, 'Alex Stardust')).toBe('Alex Stardust');
+  });
+
+  it('falls back to name when djName is an empty string', () => {
+    expect(resolveDjDisplayName('', 'Alex Stardust')).toBe('Alex Stardust');
+  });
+
+  it('falls back to name when djName is whitespace-only', () => {
+    expect(resolveDjDisplayName('   ', 'Alex Stardust')).toBe('Alex Stardust');
+  });
+
+  it('returns null when both inputs are null', () => {
+    expect(resolveDjDisplayName(null, null)).toBeNull();
+  });
+
+  it('returns null when both inputs are empty strings', () => {
+    expect(resolveDjDisplayName('', '')).toBeNull();
+  });
+
+  it('returns null when both inputs are whitespace-only', () => {
+    expect(resolveDjDisplayName('   ', '\t\n ')).toBeNull();
+  });
+
+  it('returns null when djName is the literal "Anonymous" and name is null', () => {
+    expect(resolveDjDisplayName('Anonymous', null)).toBeNull();
+  });
+
+  it('returns null when djName is the literal "Anonymous" and name is empty', () => {
+    expect(resolveDjDisplayName('Anonymous', '')).toBeNull();
+  });
+
+  it('returns null when djName is "anonymous" (case-insensitive)', () => {
+    expect(resolveDjDisplayName('anonymous', null)).toBeNull();
+  });
+
+  it('returns null when djName is "ANONYMOUS" (case-insensitive)', () => {
+    expect(resolveDjDisplayName('ANONYMOUS', null)).toBeNull();
+  });
+
+  it('returns null when djName is "  anonymous  " (trim + case)', () => {
+    expect(resolveDjDisplayName('  Anonymous  ', null)).toBeNull();
+  });
+
+  it('returns name when djName is "Anonymous" but name is a real value (fallback past Anonymous)', () => {
+    // Asymmetric design: if the user has a real `name`, prefer it over rendering
+    // the public "Anonymous" string. This is the Aubrey Hearst incident path —
+    // her auth_user.dj_name was "Anonymous" but better-auth `name` was empty,
+    // so the marker correctly degrades to unresolvable.
+    expect(resolveDjDisplayName('Anonymous', 'Aubrey Hearst')).toBe('Aubrey Hearst');
+  });
+
+  it('does not strip "Anonymous" from a longer name (substring match must not fire)', () => {
+    expect(resolveDjDisplayName('DJ Anonymous Mouse', null)).toBe('DJ Anonymous Mouse');
+  });
+
+  it('returns trimmed djName when valid (no surrounding whitespace bleed)', () => {
+    expect(resolveDjDisplayName('  DJ Stardust  ', null)).toBe('DJ Stardust');
+  });
+
+  it('returns trimmed name when name is the source of the value', () => {
+    expect(resolveDjDisplayName(null, '  Alex Stardust  ')).toBe('Alex Stardust');
+  });
+});


### PR DESCRIPTION
Closes #1286. Implements the locked decisions in epic #1288.

## Summary

- New `resolveDjDisplayName(djName, name)` helper in `apps/backend/services/flowsheet.service.ts` centralizes the rule: trim both inputs, treat case-insensitive `"Anonymous"` as if `djName` were absent, fall back to `name`, return `null` when nothing is usable.
- Replaces `dj.djName || dj.name` (and the comparable string-build patterns) at all six call sites: `startShow`, `endShow`, `createJoinNotification`, `createLeaveNotification`, `resolveDjNameForShow`, `getShowMetadata` (service), and `getDJList` (controller).
- Updates the four marker templates per epic #1288:
  - Drop the leading `"DJ "` prefix everywhere — DJs read `"DJ Aubrey Hearst"` as if `"DJ"` were part of their handle.
  - `show_start` / `show_end`: degrade to `"Start of show: ${time}"` / `"End of show: ${time}"` when the name is unresolvable (row still written; a nameless show-start is meaningful).
  - `dj_join` / `dj_leave`: suppress the row entirely when the name is unresolvable and log a Sentry warning with `dj_id` + `show_id` (a nameless mid-show join is a degraded state better logged than written to the public on-air playlist).

## Background

2026-06-02 incident: DJ Maura Partrick went on-air at 7:11 PM ET and the public on-air playlist read `"Start of Show: DJ Anonymous joined the set ..."` for ~25 minutes because her `auth_user.dj_name` was the literal string `"Anonymous"` (root cause likely a stale better-auth anonymous-plugin write or onboarding default). Manual patching of Backend Postgres + the tubafrenzy MySQL mirror + 6 Tomcat restarts brought the playlist back to the intended state. The inline `djName || name` pattern was at six sites — this PR consolidates them into one helper that handles the trim + Anonymous + null cases uniformly.

## Test plan

- [x] `npm run test:unit` — 2707 passed (added 31 new cases: 17 in `flowsheet.resolveDjDisplayName.test.ts`, 14 in `flowsheet.markerText.test.ts`; updated 1 case in `flowsheet.joinLeaveNotifications.test.ts` for the new suppression behavior)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [ ] Post-deploy: tail Sentry for `"Suppressed dj_(join|leave) marker"` warnings to verify the degraded path stays rare; spot-check `flowsheet.message` for a recent show-start and confirm no `"DJ "` prefix in the live playlist