### PR TITLE
fix(artist-search-alias-consumer): coerce nullable binds to null (closes BS#1300)

### DIFF
--- a/jobs/artist-search-alias-consumer/writer.ts
+++ b/jobs/artist-search-alias-consumer/writer.ts
@@ -18,7 +18,7 @@
  *      `INSERT … ON CONFLICT (artist_id, source, variant) DO UPDATE` per
  *      variant.
  *
- * Two BS-incident-driven invariants:
+ * Three BS-incident-driven invariants:
  *   - **No `'{...}'::text[]` literals.** Variant strings can carry commas,
  *     apostrophes, and Unicode ("Earth, Wind & Fire" / "Sinéad O'Connor").
  *     The Drizzle/postgres-js array-literal pattern silently corrupts
@@ -32,6 +32,14 @@
  *     returns it unchanged, and `Buffer.byteLength()` inside `b.str()`
  *     throws ERR_INVALID_ARG_TYPE (BS#802 cost 14,405 UPSERTs in prod).
  *     Use `new Date().toISOString()` to defeat the override.
+ *   - **Coerce nullable interpolations to `null` (not `undefined`).**
+ *     Drizzle's `sql` tag interpolates `undefined` as an empty parameter
+ *     position, producing invalid `VALUES (…, , …)` syntax. LML can emit
+ *     sparse JSON for `discogs_name_variation` rows (all relationship
+ *     columns missing), which `JSON.parse` materialises as `undefined`
+ *     rather than `null`. Use `${v.field ?? null}` on every nullable
+ *     column (BS#1300 cost 899 writer_errors on the 2026-06-03 first
+ *     prod run — ~20% of substrate rows).
  */
 
 import { sql } from 'drizzle-orm';
@@ -109,8 +117,8 @@ export const writeArtistVariants = async (
            "external_subject_id", "external_object_id", "active",
            "method", "confidence", "last_verified_at")
         VALUES
-          (${artist_id}, ${v.source}, ${v.variant}, ${v.related_artist_id},
-           ${v.external_subject_id}, ${v.external_object_id}, ${v.active},
+          (${artist_id}, ${v.source}, ${v.variant}, ${v.related_artist_id ?? null},
+           ${v.external_subject_id ?? null}, ${v.external_object_id ?? null}, ${v.active ?? null},
            ${v.method}, ${v.confidence}, ${lastVerifiedAt})
         ON CONFLICT ("artist_id", "source", "variant") DO UPDATE SET
           "related_artist_id"   = EXCLUDED."related_artist_id",

--- a/tests/unit/jobs/artist-search-alias-consumer/writer.test.ts
+++ b/tests/unit/jobs/artist-search-alias-consumer/writer.test.ts
@@ -195,6 +195,41 @@ describe('writeArtistVariants', () => {
     expect(allBinds).not.toContain('\t\n  ');
   });
 
+  it('coerces missing nullable fields (undefined) to SQL null — BS#1300 sparse-JSON regression', async () => {
+    // LML emits sparse JSON for `discogs_name_variation` rows: the
+    // upstream Discogs payload lacks the relationship columns
+    // (`related_artist_id`, `external_subject_id`, `external_object_id`)
+    // and the composer doesn't materialise them. `JSON.parse` of a
+    // missing key produces `undefined`, not `null`. Drizzle's `sql` tag
+    // interpolates `undefined` as an empty positional bind, producing
+    // `VALUES (…, , …)` which Postgres rejects with a syntax error and
+    // rolls the per-artist transaction back. Cost: 899 writer_errors
+    // (~20%) on the 2026-06-03 first prod run.
+    //
+    // The writer must coerce every nullable interpolation through
+    // `?? null` so the bind arrives at postgres-js as a JS `null`,
+    // which binds to SQL NULL.
+    const sparseVariant = {
+      source: 'discogs_name_variation',
+      variant: 'Sonic Yoof',
+      method: 'name_variation',
+      confidence: 0.95,
+      // related_artist_id / external_subject_id / external_object_id / active
+      // are absent — `v.x` is `undefined` at runtime.
+    } as unknown as ArtistSearchAliasVariant;
+
+    await writeArtistVariants(42, [sparseVariant], ['discogs_name_variation']);
+
+    const allBinds = sqlTagCalls.flatMap((c) => c.values);
+    // No `undefined` binds anywhere — every nullable slot must coerce
+    // through `?? null` before reaching the sql tag.
+    expect(allBinds).not.toContain(undefined);
+    // The coerced nullable slots show up as `null` binds (one per
+    // missing column).
+    const nullBindCount = allBinds.filter((v) => v === null).length;
+    expect(nullBindCount).toBeGreaterThanOrEqual(4);
+  });
+
   it('falls back to DELETE-only when every variant is blank-after-trim (treats filtered-out as variants=[])', async () => {
     // If the only variants supplied are all blank, the writer should
     // behave as if variants=[] was passed: scoped DELETE, no INSERT.


### PR DESCRIPTION
## Summary

Drizzle's `sql` tag interpolates `undefined` as an empty parameter position, producing invalid `VALUES (…, , …)` syntax. LML's bulk endpoint emits sparse JSON for `discogs_name_variation` rows (relationship columns absent), which `JSON.parse` materialises as `undefined` rather than `null`. Cost on the 2026-06-03 first prod run: **899 writer_errors (~20% of the 23,736-row substrate)**.

## Change

`jobs/artist-search-alias-consumer/writer.ts:112-114` — coerce each nullable interpolation through `?? null` (`related_artist_id`, `external_subject_id`, `external_object_id`, `active`). Postgres-js binds JS `null` to SQL NULL; the empty-position bug goes away.

Adds a third "BS-incident-driven invariant" block to the writer docstring so future authors don't re-introduce the pattern, and a regression test that mocks LML's sparse-JSON shape and asserts no `undefined` binds reach the `sql` tag.

## Test plan

- [x] `npm run test:unit -- tests/unit/jobs/artist-search-alias-consumer/writer.test.ts` — 12/12 pass (was 11, +1 regression)
- [x] Regression test fails without the fix (4 `undefined` binds captured) and passes with it — verified via `git stash` round-trip
- [x] `npm run format:check` clean
- [x] Workspace typecheck clean (`tsc --noEmit` in `jobs/artist-search-alias-consumer/`)
- [x] ESLint clean on changed files
- [ ] Post-deploy: manual prod re-run of the consumer should report `writer_errors=0` and `source_rows_written` should increase by >=899 (the previously-failed rows are eligible for re-write — their `last_verified_at` from today's partial run is fresh, but the failed rows never got inserted at all)

## Unblocks

- BS#1274 (PR 6 env flip) — substrate needs 100% population before `CATALOG_SEARCH_ALIAS_ENABLED=true`

Closes #1300