### PR TITLE
fix(library-assertion): use Promise.allSettled so drift-check failure doesn't 503 search

### DIFF
--- a/apps/backend/services/library-artist-name-assertion.service.ts
+++ b/apps/backend/services/library-artist-name-assertion.service.ts
@@ -30,9 +30,14 @@ import { db, library, artists } from '@wxyc/database';
  *      visible before it reaches a DJ.
  *
  * Both checks are memoized so each fires at most once per process and stays
- * off the per-search hot path after the first call. Transient DB errors clear
- * the cache so the next call retries. Neither check ever throws to the
- * consumer — search continues to serve under any degraded state.
+ * off the per-search hot path after the first call. A check's outcome is
+ * cached for the lifetime of the process — success memoizes resolved,
+ * failure memoizes rejected. Operator restart is the retry mechanism. The
+ * wrapper (`checkLibraryArtistNameHealth`) uses `Promise.allSettled` so an
+ * inner check's rejection is never propagated to the caller; catalog search
+ * continues to serve under any degraded state (BS#1310, follow-up to the
+ * 2026-04-30 OPN incident BS#685 — same failure shape reintroduced via the
+ * drift leg's larger query surface).
  */
 
 let _nullCheckPromise: Promise<void> | null = null;
@@ -104,35 +109,38 @@ async function runDriftCheck(): Promise<void> {
  * Drift probe (BS#1092). Counts rows where `library.artist_name` has drifted
  * away from `artists.artist_name` and emits a Sentry warning with a sampled
  * set of `library_id`s when drift > 0. Memoized; fires at most once per
- * process. Resolves on both healthy and degraded states.
+ * process. Resolves on healthy and degraded states; if the underlying query
+ * itself rejects (e.g. `DB_STATEMENT_TIMEOUT_MS` under load — the drift
+ * query's `IS DISTINCT FROM` predicate is non-indexable), the rejection is
+ * memoized too: subsequent calls return the same rejected promise without
+ * re-running the expensive JOIN (BS#1310 storm-pattern prevention). The
+ * `checkLibraryArtistNameHealth` wrapper absorbs that rejection so search
+ * callers never observe it; direct callers see the raw outcome.
  */
 export async function checkLibraryArtistNameDrift(): Promise<void> {
   if (_driftCheckPromise === null) {
-    _driftCheckPromise = runDriftCheck().catch((err) => {
-      _driftCheckPromise = null;
-      throw err;
-    });
+    _driftCheckPromise = runDriftCheck();
   }
   return _driftCheckPromise;
 }
 
 /**
  * Run the soft data-quality assertion sweep (NULL check + drift check)
- * exactly once per process per check. Returns void on both healthy and
- * degraded states; consumers must not branch on the result. Callable from
- * any catalog-search entry point as a fire-and-observe hook.
+ * exactly once per process per check. Returns void on healthy, degraded,
+ * AND query-failure states — consumers must not branch on the result and
+ * must not see the rejection from either inner check. Callable from any
+ * catalog-search entry point as a fire-and-observe hook (BS#1310).
  */
 export async function checkLibraryArtistNameHealth(): Promise<void> {
   if (_nullCheckPromise === null) {
-    _nullCheckPromise = runNullCheck().catch((err) => {
-      _nullCheckPromise = null;
-      throw err;
-    });
+    _nullCheckPromise = runNullCheck();
   }
-  // Fan out — both checks run, both memoize independently. The drift check
-  // is cheap (single indexed JOIN, count) and doesn't block readiness; the
-  // caller awaits both because each check's failure mode is its own probe.
-  await Promise.all([_nullCheckPromise, checkLibraryArtistNameDrift()]);
+  // Fan out — both checks run, both memoize independently. `Promise.allSettled`
+  // is load-bearing: an inner-check rejection (e.g. drift query exceeding the
+  // statement timeout under load) must not propagate to catalog search.
+  // That was the 2026-04-30 OPN failure mode for the NULL check (#685), and
+  // the larger query surface of the drift leg reintroduced it (BS#1310).
+  await Promise.allSettled([_nullCheckPromise, checkLibraryArtistNameDrift()]);
 }
 
 /**

--- a/tests/unit/services/library-artist-name-assertion.test.ts
+++ b/tests/unit/services/library-artist-name-assertion.test.ts
@@ -107,17 +107,45 @@ describe('library-artist-name-assertion', () => {
       expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
     });
 
-    it('clears the cache on transient DB errors so the next call retries', async () => {
-      // The first leg (NULL check) throws; the wrapper's Promise.all rejects.
-      // The drift check still ran and its result (mocked clean) is cached.
-      // On retry, only the NULL leg re-executes.
-      db.execute.mockRejectedValueOnce(new Error('connection reset')).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
-      await expect(checkLibraryArtistNameHealth()).rejects.toThrow('connection reset');
-
-      db.execute.mockResolvedValueOnce([{ n: 0 }]);
+    it('regression (BS#1310): does not propagate inner-check rejection — drift query timing out must not 503 search', async () => {
+      // The drift query (`library × artists JOIN WHERE artist_name IS DISTINCT FROM`)
+      // has a non-indexable predicate and can exceed DB_STATEMENT_TIMEOUT_MS under
+      // load. A `Promise.all` wrapper would propagate the rejection to every
+      // catalog-search code path that awaits this assertion — the same failure
+      // shape the 2026-04-30 OPN incident (#685) closed for the NULL check.
+      // The wrapper must use Promise.allSettled and never throw.
+      db.execute.mockResolvedValueOnce([{ n: 0 }]).mockRejectedValueOnce(new Error('statement timeout'));
       await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
-      // 3 total: failed NULL, successful drift (cached), retried NULL.
-      expect(db.execute).toHaveBeenCalledTimes(3);
+    });
+
+    it('regression (BS#1310): both legs rejecting still does not propagate to caller', async () => {
+      db.execute
+        .mockRejectedValueOnce(new Error('connection reset'))
+        .mockRejectedValueOnce(new Error('statement timeout'));
+      await expect(checkLibraryArtistNameHealth()).resolves.toBeUndefined();
+    });
+
+    it('regression (BS#1310): rejected drift check stays memoized — no storm-pattern re-runs', async () => {
+      // Under a persistent timeout condition, clearing memoization on rejection
+      // would let every subsequent search call re-issue the expensive JOIN,
+      // amplifying the upstream load that caused the timeout in the first place.
+      // Operator restart is the retry mechanism; the cached rejection is the
+      // backpressure.
+      db.execute.mockResolvedValueOnce([{ n: 0 }]).mockRejectedValueOnce(new Error('statement timeout'));
+      await checkLibraryArtistNameHealth();
+      await checkLibraryArtistNameHealth();
+      await checkLibraryArtistNameHealth();
+      // First call: NULL success + drift rejected (2 db calls).
+      // Subsequent calls: both legs memoized, zero new db calls.
+      expect(db.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('regression (BS#1310): rejected NULL check stays memoized — no storm-pattern re-runs', async () => {
+      db.execute.mockRejectedValueOnce(new Error('connection reset')).mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
+      await checkLibraryArtistNameHealth();
+      await checkLibraryArtistNameHealth();
+      await checkLibraryArtistNameHealth();
+      expect(db.execute).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -180,13 +208,17 @@ describe('library-artist-name-assertion', () => {
       expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
     });
 
-    it('clears the cache on transient DB errors so the next call retries', async () => {
+    it('BS#1310: the rejected promise stays memoized — no storm-pattern re-runs of an expensive failed query', async () => {
+      // Direct invocation of the drift check (not through the wrapper) still
+      // exposes the underlying rejection — callers that opt in get the raw
+      // outcome. But the failure is memoized: a second call returns the same
+      // rejected promise without re-running the query. The wrapper
+      // (`checkLibraryArtistNameHealth`) absorbs the rejection so search
+      // callers never see it.
       db.execute.mockRejectedValueOnce(new Error('statement timeout'));
       await expect(checkLibraryArtistNameDrift()).rejects.toThrow('statement timeout');
-
-      db.execute.mockResolvedValueOnce([{ n: 0, sample_ids: [] }]);
-      await expect(checkLibraryArtistNameDrift()).resolves.toBeUndefined();
-      expect(db.execute).toHaveBeenCalledTimes(2);
+      await expect(checkLibraryArtistNameDrift()).rejects.toThrow('statement timeout');
+      expect(db.execute).toHaveBeenCalledTimes(1);
     });
 
     it('does not throw when drift is detected — degraded data must not take catalog search down', async () => {


### PR DESCRIPTION
Closes #1310. Follow-up to PR #1302 (closes BS#1092). Repeats the post-mortem of the 2026-04-30 OPN incident BS#685 for the drift leg.

## What

- `apps/backend/services/library-artist-name-assertion.service.ts` — the `checkLibraryArtistNameHealth` fan-out switches from `Promise.all` to `Promise.allSettled`. Either inner check rejecting (NULL check or drift check) no longer propagates to catalog-search callers.
- Both checks lose their `.catch(() => { _xPromise = null })` cache-clear arms. A failed check now memoizes its rejection for the lifetime of the process. Operator restart is the retry mechanism — same shape as the pre-PR #1302 behavior of the NULL check.
- Docstring rewritten to match: "memoizes outcome (resolved or rejected) for process lifetime; wrapper absorbs inner rejections."
- `checkLibraryArtistNameDrift` direct callers still observe the raw rejection (a re-await returns the same memoized rejected promise without re-running the query). Only the wrapper absorbs.

## Why

Post-hoc `/code-review max` of PR #1302 surfaced two HIGH-severity correctness issues that together repeat the OPN failure:

1. **Rejection leak**: `Promise.all` propagates either inner rejection. The drift query (`library × artists JOIN WHERE artist_name IS DISTINCT FROM` — non-indexable predicate, two scans because the inner sample subquery re-scans) can exceed `DB_STATEMENT_TIMEOUT_MS` under load or growing catalog size. Once it times out, every catalog-search code path that awaits `checkLibraryArtistNameHealth` (`fuzzySearchLibrary` / `searchLibrary` / `searchByArtist`) throws → 5xx to dj-site and iOS.
2. **Storm-pattern**: the `.catch` arms cleared `_xPromise = null` on rejection, so the next call re-ran the failed query, which fails again under the persistent condition. Every subsequent search 5xx'd until the box restarted — and every retry re-ran the expensive JOIN, amplifying the load that caused the timeout in the first place. Strictly worse than the original OPN incident.

The module's own docstring already claimed "Neither check ever throws to the consumer." The implementation contradicted it.

## Tests

Updated `tests/unit/services/library-artist-name-assertion.test.ts` to pin the new contract:

- `regression (BS#1310): does not propagate inner-check rejection — drift query timing out must not 503 search`
- `regression (BS#1310): both legs rejecting still does not propagate to caller`
- `regression (BS#1310): rejected drift check stays memoized — no storm-pattern re-runs`
- `regression (BS#1310): rejected NULL check stays memoized — no storm-pattern re-runs`
- `checkLibraryArtistNameDrift > BS#1310: the rejected promise stays memoized — no storm-pattern re-runs of an expensive failed query` — direct invocation still surfaces the rejection but memoizes it.

The previous "clears the cache on transient DB errors so the next call retries" tests for both code paths were inverted — those codified the buggy behavior. 19 tests in this file, all green; 2743 tests across the full unit suite, all green.

## Related

- PR #1302 (closes BS#1092) — introduced the drift check that has this defect.
- BS#685 — the 2026-04-30 OPN catalog-search 503 incident; same failure mode, NULL check leg, now mitigated again for the drift leg.