### PR TITLE
fix(rotation-webhook): extend partial-update gate to denorm fields

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -339,24 +339,33 @@ internal_route.post('/rotation-webhook', async (req, res) => {
       const killDate =
         release.killDate && release.killDate !== 0 ? new Date(release.killDate).toISOString().split('T')[0] : null;
 
-      // BS#1082: tubafrenzy's sendRotationLinked posts only {id,
-      // libraryReleaseId, action: 'update'} on linkage. Including rotation_bin
-      // / kill_date in SET unconditionally would clobber the existing row's
-      // values with the JS defaults ('N' / null) computed above for missing
-      // payload fields. Presence-gate the SET so partial updates leave them
-      // alone.
+      // BS#1082 + BS#1312: tubafrenzy's sendRotationLinked posts only {id,
+      // libraryReleaseId, action: 'update'} on linkage. Including any of the
+      // payload-derived denorm fields in SET unconditionally would clobber
+      // the existing row's values with the JS defaults computed above for
+      // missing payload fields ('N' for rotation_bin, null for kill_date,
+      // null for artist_name / album_title / record_label when albumId is
+      // null). Presence-gate the SET so partial updates leave them alone.
+      // The INSERT path keeps the JS-default values so the create branch
+      // still populates these columns on first delivery.
       const setClause: Record<string, unknown> = {
         album_id: sql`excluded.album_id`,
         legacy_library_release_id: sql`excluded.legacy_library_release_id`,
-        artist_name: sql`excluded.artist_name`,
-        album_title: sql`excluded.album_title`,
-        record_label: sql`excluded.record_label`,
       };
       if (release.rotationType !== undefined) {
         setClause.rotation_bin = sql`excluded.rotation_bin`;
       }
       if (release.killDate !== undefined) {
         setClause.kill_date = sql`excluded.kill_date`;
+      }
+      if (release.artistName !== undefined) {
+        setClause.artist_name = sql`excluded.artist_name`;
+      }
+      if (release.albumTitle !== undefined) {
+        setClause.album_title = sql`excluded.album_title`;
+      }
+      if (release.labelName !== undefined) {
+        setClause.record_label = sql`excluded.record_label`;
       }
 
       await db

--- a/tests/integration/internal-rotation-webhook.spec.js
+++ b/tests/integration/internal-rotation-webhook.spec.js
@@ -1,11 +1,15 @@
 /**
- * Integration tests for POST /internal/rotation-webhook (BS#1082).
+ * Integration tests for POST /internal/rotation-webhook (BS#1082, BS#1312).
  *
  * The webhook receives tubafrenzy rotation events. The acceptance criterion
- * tested here is from #1082: when `sendRotationLinked` posts the partial
- * shape `{id, libraryReleaseId, action: 'update'}`, the receiver must NOT
- * clobber `rotation_bin` or `kill_date` with the JS-default values computed
- * for missing payload fields.
+ * tested here is from #1082 + #1312: when `sendRotationLinked` posts the
+ * partial shape `{id, libraryReleaseId, action: 'update'}`, the receiver
+ * must NOT clobber the existing row's `rotation_bin`, `kill_date`,
+ * `artist_name`, `album_title`, or `record_label` with the JS-default
+ * values computed for missing payload fields. The denorm trio is the
+ * surface tubafrenzy + dj-site catalog views render when `album_id IS NULL`
+ * — clobbering them turns Heavy rotation rows display-blind until the 30m
+ * rotation-etl cron repairs them.
  *
  * The companion unit test at `tests/unit/routes/internal.route.test.ts`
  * verifies the SET-clause shape against a mocked db; this spec verifies the
@@ -30,7 +34,7 @@ function makeSql() {
   });
 }
 
-describe('POST /internal/rotation-webhook — partial update preserves rotation_bin / kill_date (BS#1082)', () => {
+describe('POST /internal/rotation-webhook — partial update preserves denorm fields (BS#1082 + BS#1312)', () => {
   let sql;
 
   // Use a legacy_rotation_id deep in a range that's unlikely to collide.
@@ -61,7 +65,7 @@ describe('POST /internal/rotation-webhook — partial update preserves rotation_
     );
   }
 
-  test('linkage update {id, libraryReleaseId} preserves existing rotation_bin and kill_date', async () => {
+  test('linkage update {id, libraryReleaseId} preserves all five denorm fields (rotation_bin, kill_date, artist_name, album_title, record_label)', async () => {
     await seedHeavyRotationRow('2026-12-31');
 
     const res = await request
@@ -71,14 +75,18 @@ describe('POST /internal/rotation-webhook — partial update preserves rotation_
     expect(res.status).toBe(200);
 
     const [row] = await sql.unsafe(
-      `SELECT rotation_bin, kill_date FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`,
+      `SELECT rotation_bin, kill_date, artist_name, album_title, record_label
+         FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`,
       [LEGACY_ROTATION_ID]
     );
     expect(row.rotation_bin).toBe('H');
     expect(row.kill_date).toEqual(new Date('2026-12-31'));
+    expect(row.artist_name).toBe('Jessica Pratt');
+    expect(row.album_title).toBe('On Your Own Love Again');
+    expect(row.record_label).toBe('Drag City');
   });
 
-  test('full-shape update {rotationType, killDate} still overwrites those fields', async () => {
+  test('full-shape update {rotationType, killDate, artistName, albumTitle, labelName} overwrites all five denorm fields', async () => {
     await seedHeavyRotationRow('2026-12-31');
 
     const res = await request
@@ -91,19 +99,23 @@ describe('POST /internal/rotation-webhook — partial update preserves rotation_
           libraryReleaseId: 0,
           rotationType: 'M',
           killDate: 0,
-          artistName: 'Jessica Pratt',
-          albumTitle: 'On Your Own Love Again',
-          labelName: 'Drag City',
+          artistName: 'Juana Molina',
+          albumTitle: 'DOGA',
+          labelName: 'Sonamos',
           addDate: 1706799600000,
         },
       });
     expect(res.status).toBe(200);
 
     const [row] = await sql.unsafe(
-      `SELECT rotation_bin, kill_date FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`,
+      `SELECT rotation_bin, kill_date, artist_name, album_title, record_label
+         FROM ${SCHEMA}.rotation WHERE legacy_rotation_id = $1`,
       [LEGACY_ROTATION_ID]
     );
     expect(row.rotation_bin).toBe('M');
     expect(row.kill_date).toBeNull();
+    expect(row.artist_name).toBe('Juana Molina');
+    expect(row.album_title).toBe('DOGA');
+    expect(row.record_label).toBe('Sonamos');
   });
 });

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -613,12 +613,14 @@ describe('POST /internal/rotation-webhook', () => {
     expect(res.body.ok).toBe(true);
   });
 
-  // BS#1082: A `sendRotationLinked` linkage event sends only `{id,
-  // libraryReleaseId, action: 'update'}`. Prior shape unconditionally wrote
-  // defaults into rotation_bin / kill_date on every update, flipping Heavy
-  // rotation rows to 'N' and clearing kill_date until the rotation-etl cron
-  // tick repaired them.
-  it('update with partial payload omits rotation_bin and kill_date from SET clause', async () => {
+  // BS#1082 + BS#1312: A `sendRotationLinked` linkage event sends only
+  // `{id, libraryReleaseId, action: 'update'}`. Prior shape unconditionally
+  // wrote defaults into rotation_bin / kill_date on every update, flipping
+  // Heavy rotation rows to 'N' and clearing kill_date until the rotation-etl
+  // cron tick repaired them. BS#1312 extends the gate symmetrically to the
+  // three denorm fields (artist_name / album_title / record_label) used by
+  // tubafrenzy + dj-site catalog views when `album_id IS NULL`.
+  it('update with partial payload omits gated fields (rotation_bin, kill_date, artist_name, album_title, record_label) from SET clause', async () => {
     const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
     onConflictSpy.mockClear();
 
@@ -632,12 +634,15 @@ describe('POST /internal/rotation-webhook', () => {
     const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
     expect(setClause).not.toHaveProperty('rotation_bin');
     expect(setClause).not.toHaveProperty('kill_date');
+    expect(setClause).not.toHaveProperty('artist_name');
+    expect(setClause).not.toHaveProperty('album_title');
+    expect(setClause).not.toHaveProperty('record_label');
   });
 
-  // Companion to the above: when the payload DOES carry rotationType /
-  // killDate (the create path, or a full-shape update), those fields must
-  // still appear in SET so the update overwrites them.
-  it('update with full payload keeps rotation_bin and kill_date in SET clause', async () => {
+  // Companion to the above: when the payload DOES carry the gated fields (the
+  // create path, or a full-shape update), all five must still appear in SET
+  // so the update overwrites them.
+  it('update with full payload keeps gated fields (rotation_bin, kill_date, artist_name, album_title, record_label) in SET clause', async () => {
     const onConflictSpy = (db as unknown as { _chain: { onConflictDoUpdate: jest.Mock } })._chain.onConflictDoUpdate;
     onConflictSpy.mockClear();
 
@@ -651,6 +656,9 @@ describe('POST /internal/rotation-webhook', () => {
     const setClause = (onConflictSpy.mock.calls[0][0] as { set: Record<string, unknown> }).set;
     expect(setClause).toHaveProperty('rotation_bin');
     expect(setClause).toHaveProperty('kill_date');
+    expect(setClause).toHaveProperty('artist_name');
+    expect(setClause).toHaveProperty('album_title');
+    expect(setClause).toHaveProperty('record_label');
   });
 
   // -- Kill --


### PR DESCRIPTION
## Summary

Follow-up to PR #1301 (closes #1082). A post-hoc `/code-review max` of #1301 surfaced a CONFIRMED incomplete-fix: the presence-gate in the rotation-webhook upsert only covered `rotation_bin` and `kill_date`. The same partial-payload-clobber pattern still affected `artist_name` / `album_title` / `record_label` on the linkage-race code path.

Failure sequence (from the issue body):

1. `sendRotationLinked` posts `{id, libraryReleaseId, action: 'update'}` where `libraryReleaseId` points at a library row Backend-Service hasn't ingested yet (cross-ETL race).
2. `resolveAlbumId` returns null; INSERT values compute `artist_name = truncate(undefined, 128) = null` (and similarly for `album_title` / `record_label`).
3. SET clause unconditionally writes those nulls, clobbering the existing row's denorm values from e.g. `'Jessica Pratt' / 'On Your Own Love Again' / 'Drag City'` to null.
4. Row goes display-blind in tubafrenzy + dj-site catalog views (no `album_id` AND no denorm) until the 30m rotation-etl cron repairs it — the same user-visible failure mode #1082 described, on a different column set.

## Fix

Extend the presence-gate symmetrically. INSERT path keeps the JS-default values (so create-path inserts still populate these columns on first delivery); SET path only writes the denorm fields when the payload carries them.

```ts
if (release.artistName !== undefined) {
  setClause.artist_name = sql`excluded.artist_name`;
}
if (release.albumTitle !== undefined) {
  setClause.album_title = sql`excluded.album_title`;
}
if (release.labelName !== undefined) {
  setClause.record_label = sql`excluded.record_label`;
}
```

## Out of scope

`album_id` / `legacy_library_release_id` gating. Reviewer flagged as PLAUSIBLE — depends on whether tubafrenzy ever sends a "de-link" event with `libraryReleaseId: 0`. Per the org-wide tubafrenzy turndown tracker, that event shape doesn't exist today. Deferred.

## Test plan

- [x] `tests/unit/routes/internal.route.test.ts` — partial-payload test now asserts all five gated fields absent from SET; full-payload test asserts all five present.
- [x] `tests/integration/internal-rotation-webhook.spec.js` — partial-update test seeds Heavy/2026-12-31/Jessica Pratt/On Your Own Love Again/Drag City and asserts they survive a `{id, libraryReleaseId: 0}` update; full-shape test verifies overwrite to a different denorm trio.
- [x] `npm run lint`, `npx prettier --check`, `npm run typecheck`, `npm run test:unit` (2741/2741 pass).

## Related

- PR #1301 (the original BS#1082 fix this completes).
- BS#1082 (the symptom-class precedent).

Closes #1312.