### PR TITLE
refactor(enrichment-worker): suppress empty-outcome captureMessage for raced + no-match

### DIFF
--- a/apps/enrichment-worker/empty-outcome.ts
+++ b/apps/enrichment-worker/empty-outcome.ts
@@ -9,11 +9,10 @@
  * The 2026-05-19 data pull on BS#692 quantified the gap at ~50–500× undercount
  * against the actual prod degradation rate.
  *
- * This module exports a pure predicate + cause classifier so the worker can
- * fire a structured `Sentry.captureMessage('enrichment-empty-outcome', ...)`
- * on every empty outcome — caught throws AND finalized rows that landed
- * user-visibly blank — with a stable fingerprint that survives release tag
- * changes.
+ * This module exports a pure predicate + cause classifier. The handler in
+ * handler.ts uses both to decide whether to fire a structured
+ * `Sentry.captureMessage('enrichment-empty-outcome', ...)` on an empty
+ * outcome, with a stable fingerprint that survives release tag changes.
  *
  * "Empty outcome" is defined against the LML response, not the post-write
  * row state: the worker's write path always synthesizes fallback search URLs
@@ -21,6 +20,15 @@
  * columns IS NULL" predicate would never trigger after consumer writes. The
  * user-facing definition that matters is "no Discogs-derived artwork URL" —
  * that's what shows up as a blank cover tile on iOS / dj-site.
+ *
+ * Volume-control note (BS#1311): the call-site captureMessage in handler.ts
+ * fires only on `lml_degraded` outcomes this worker actually wrote. The
+ * `lml_no_match` cause is by-design Discogs miss (not a degradation) and is
+ * suppressed at the call site; `lml_timeout` lives on the catch arm and was
+ * dropped entirely (captureException there is the source of truth). The
+ * classifier here still returns `lml_no_match` so dashboard aggregation off
+ * the span attribute can split the classes; suppression is the caller's
+ * decision, not this module's.
  */
 
 import type { LookupResponse } from '@wxyc/lml-client';

--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -30,6 +30,23 @@
  * for an uncaught throw, but that log loses the row id and the LML/DB step
  * context. Catching here keeps the failure attributed to a real Sentry
  * event with the flowsheet_id + step tag instead of a noisy generic log.
+ *
+ * Sentry captureMessage volume control (BS#1311 — follow-up to BS#969 / PR
+ * #1304). captureMessage fires only on `lml_degraded` outcomes that this
+ * worker actually wrote — the LML#408 `_resolve_fallback_artwork` class
+ * BS#969 was filed to surface. Three classes are deliberately silent:
+ *   - `lml_no_match`: by-design Discogs miss, not a degradation. The
+ *     `enrichment.outcome` span attribute (still set every tick) is the
+ *     source of truth for dashboard-side rate aggregation.
+ *   - `_raced` outcomes: a sibling worker / C6 sweep wrote the user-visible
+ *     state. Firing here would cascade C6 recovery into a captureMessage
+ *     flood whose events don't correspond to actual degradation.
+ *   - The catch-arm LML throw: `captureException` already records the same
+ *     event with a stack trace. The pre-1311 paired captureMessage was a
+ *     redundant second quota slot per timeout.
+ * The Sentry org quota is per-event ingestion, not per-issue grouping —
+ * the original PR's stable-fingerprint argument did not bound burn. See
+ * BS#1291 RCA for the quota exhaustion context that motivated this trim.
  */
 
 import * as Sentry from '@sentry/node';
@@ -39,6 +56,9 @@ import type { CdcEvent } from '@wxyc/database';
 import { claimRowForEnrichment } from './claim.js';
 import { filterForEnrichment, type EnrichmentCandidate } from './cdc-subscriber.js';
 import { EMPTY_OUTCOME_FINGERPRINT, classifyEmptyCause, isEmptyOutcome } from './empty-outcome.js';
+// Suppression set for the post-finalize captureMessage block. Kept inline so
+// the BS#1311 volume-control decision is co-located with the call site.
+const SUPPRESSED_EMPTY_CAUSES: ReadonlySet<ReturnType<typeof classifyEmptyCause>> = new Set(['lml_no_match']);
 import { finalizeRow, type FinalizeOutcome } from './enrich.js';
 
 /**
@@ -115,24 +135,12 @@ async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
             tags: { component: 'enrichment-worker', step: 'lml_lookup' },
             extra: { flowsheet_id: candidate.id },
           });
-          // G7 (BS#969): also fold the throw into the aggregated
-          // enrichment-empty-outcome issue with cause=lml_timeout so the
-          // post-fix baseline + alert threshold see the throws alongside the
-          // degraded-success class. Sibling captureException above stays as
-          // the source-of-truth for the stack trace.
-          Sentry.captureMessage('enrichment-empty-outcome', {
-            level: 'warning',
-            tags: {
-              subsystem: 'metadata',
-              cause: 'lml_timeout',
-              transaction: 'enrichment.consumer.tick',
-            },
-            extra: {
-              flowsheet_id: candidate.id,
-              error_message: (err as Error).message,
-            },
-            fingerprint: EMPTY_OUTCOME_FINGERPRINT,
-          });
+          // BS#1311: the paired captureMessage on the catch arm was dropped.
+          // captureException above is the source-of-truth for the stack
+          // trace; the extra captureMessage was a redundant second quota
+          // slot per timeout (see file header for the full volume-control
+          // rationale). The `enrichment.outcome=lml_error` span attribute
+          // above keeps the throw class visible to dashboard aggregation.
           console.error('[enrichment-worker] lml error; row left in enriching state', {
             id: candidate.id,
             artist: candidate.artist_name,
@@ -143,12 +151,19 @@ async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
 
         span.setAttribute('enrichment.outcome', outcome);
 
-        // G7 (BS#969): emit the aggregated empty-outcome signal for rows that
-        // finalized with no user-visible artwork URL (the LML#408
-        // _resolve_fallback_artwork class, plus explicit no-match verdicts).
-        // Stable fingerprint so cause-tagged aggregation persists across
-        // releases.
-        if (emptyCause !== null) {
+        // G7 (BS#969): emit the aggregated empty-outcome signal for rows
+        // this worker finalized with no user-visible artwork URL — the
+        // LML#408 `_resolve_fallback_artwork` class. Stable fingerprint so
+        // cause-tagged aggregation persists across releases.
+        //
+        // BS#1311 volume control (see file header for the full rationale):
+        //   - skip when outcome ends in `_raced` — a sibling worker / C6
+        //     sweep wrote the user-visible state, not this worker
+        //   - skip when cause is `lml_no_match` — by-design Discogs miss,
+        //     not a degradation; the span attribute carries the signal
+        // Net result: captureMessage fires only on `lml_degraded` outcomes
+        // this worker wrote.
+        if (emptyCause !== null && !outcome.endsWith('_raced') && !SUPPRESSED_EMPTY_CAUSES.has(emptyCause)) {
           Sentry.captureMessage('enrichment-empty-outcome', {
             level: 'warning',
             tags: {

--- a/tests/unit/apps/enrichment-worker/handler.test.ts
+++ b/tests/unit/apps/enrichment-worker/handler.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for enrichment-worker handler.ts captureMessage volume control
+ * (BS#1311 / follow-up to BS#969).
+ *
+ * The original PR #1304 (closes #969) fired `Sentry.captureMessage` on every
+ * empty outcome — degraded LML matches, no-match verdicts, raced finalize
+ * outcomes, and the catch-arm path. Post-hoc code review surfaced two HIGH
+ * issues against the unrestored WXYC org Sentry quota (BS#1291 RCA):
+ *
+ *   1. `lml_no_match` is by-design Discogs miss, not a degradation; firing
+ *      captureMessage there inflates the rate the BS#969 alert is meant to
+ *      track.
+ *   2. `_raced` outcomes were written by a sibling worker / C6 sweep, not
+ *      by this worker; firing captureMessage cascades a C6 recovery into a
+ *      flood whose events don't correspond to actual user-visible
+ *      degradation.
+ *
+ * Plus the catch-arm captureMessage doubles every LML throw against quota
+ * (captureException already records the same event); BS#1311 drops it.
+ *
+ * Net result pinned here: captureMessage fires only on `lml_degraded`
+ * outcomes that this worker actually wrote (the LML#408 class) — the
+ * dominant case BS#969 was filed to surface. The `enrichment.outcome`
+ * span attribute (still set on every tick) remains the source of truth
+ * for dashboard-side rate aggregation of the no-match and raced classes.
+ */
+
+import { jest } from '@jest/globals';
+
+// Mock @sentry/node BEFORE importing handler.ts so the handler picks up the
+// mock at module-load time. unit.setup.ts's clearMocks: true handles per-test
+// reset; we just need the symbols to exist.
+jest.mock('@sentry/node', () => ({
+  startSpan: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+// Mock @wxyc/lml-client so we control the response shape and don't take a
+// network dependency. envInt is re-exported from the package; provide a
+// passthrough so the ENRICHMENT_LML_BUDGET_MS module-init read works.
+const mockLookupMetadata = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+jest.mock('@wxyc/lml-client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+// Mock the sibling enrichment-worker modules so the test only exercises the
+// captureMessage branching in handler.ts.
+const mockClaimRowForEnrichment =
+  jest.fn<(id: number) => Promise<{ claimed: true; id: number } | { claimed: false }>>();
+jest.mock('../../../../apps/enrichment-worker/claim.js', () => ({
+  claimRowForEnrichment: mockClaimRowForEnrichment,
+}));
+
+const mockFilterForEnrichment = jest.fn<(event: unknown) => unknown>();
+jest.mock('../../../../apps/enrichment-worker/cdc-subscriber.js', () => ({
+  filterForEnrichment: mockFilterForEnrichment,
+}));
+
+// Preserve the real `extractArtwork` (imported by empty-outcome.ts) and only
+// stub `finalizeRow`. Mocking the whole module would break the empty-outcome
+// classification path because empty-outcome.ts re-imports extractArtwork.
+const mockFinalizeRow = jest.fn<(...args: unknown[]) => Promise<string>>();
+jest.mock('../../../../apps/enrichment-worker/enrich.js', () => {
+  const actual = jest.requireActual<typeof import('../../../../apps/enrichment-worker/enrich')>(
+    '../../../../apps/enrichment-worker/enrich'
+  );
+  return {
+    ...actual,
+    finalizeRow: mockFinalizeRow,
+  };
+});
+
+import * as Sentry from '@sentry/node';
+
+import { makeEnrichmentHandler } from '../../../../apps/enrichment-worker/handler';
+
+type SpanLike = { setAttribute: jest.Mock };
+
+const makeCandidate = () => ({
+  id: 42,
+  entry_type: 'track' as const,
+  metadata_status: 'pending' as const,
+  artist_name: 'Juana Molina',
+  album_title: 'DOGA',
+  track_title: 'la paradoja',
+  album_id: null,
+});
+
+const driveOneTick = async (): Promise<SpanLike> => {
+  const span: SpanLike = { setAttribute: jest.fn() };
+  (Sentry.startSpan as jest.Mock).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (_opts: unknown, fn: any) => fn(span)
+  );
+  const candidate = makeCandidate();
+  mockFilterForEnrichment.mockReturnValueOnce(candidate);
+  mockClaimRowForEnrichment.mockResolvedValueOnce({ claimed: true, id: 42 });
+
+  const handler = makeEnrichmentHandler();
+  // The CDC handler dispatches via `void handleCandidate(...)` — fire-and-
+  // forget. Drain the microtask queue so the awaited chain inside the
+  // handler completes before our assertions.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler({} as any);
+  await new Promise((resolve) => setImmediate(resolve));
+  return span;
+};
+
+const matchResponseWithArtwork = {
+  results: [
+    {
+      artwork: {
+        artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+        release_url: 'https://discogs.com/release/123',
+      },
+    },
+  ],
+};
+
+const degradedResponse = {
+  results: [
+    {
+      artwork: {
+        artwork_url: null,
+        release_url: 'https://discogs.com/release/123',
+      },
+    },
+  ],
+};
+
+const noMatchResponse = { results: [] };
+
+describe('makeEnrichmentHandler captureMessage volume control (BS#1311)', () => {
+  it('fires captureMessage on lml_degraded — the dominant BS#969 class', async () => {
+    mockLookupMetadata.mockResolvedValueOnce(degradedResponse);
+    mockFinalizeRow.mockResolvedValueOnce('enriched_match');
+
+    const span = await driveOneTick();
+
+    expect(span.setAttribute).toHaveBeenCalledWith('enrichment.outcome', 'enriched_match');
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'enrichment-empty-outcome',
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ cause: 'lml_degraded', outcome: 'enriched_match' }),
+      })
+    );
+  });
+
+  it('does NOT fire captureMessage when outcome ends in _raced (enriched_match_raced)', async () => {
+    // A sibling worker / C6 sweep won the finalize race; the user-visible
+    // state was written by them. This worker's captureMessage would inflate
+    // the BS#969 rate against the true degradation rate.
+    mockLookupMetadata.mockResolvedValueOnce(degradedResponse);
+    mockFinalizeRow.mockResolvedValueOnce('enriched_match_raced');
+
+    const span = await driveOneTick();
+
+    expect(span.setAttribute).toHaveBeenCalledWith('enrichment.outcome', 'enriched_match_raced');
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire captureMessage when outcome ends in _raced (enriched_no_match_raced)', async () => {
+    mockLookupMetadata.mockResolvedValueOnce(noMatchResponse);
+    mockFinalizeRow.mockResolvedValueOnce('enriched_no_match_raced');
+
+    const span = await driveOneTick();
+
+    expect(span.setAttribute).toHaveBeenCalledWith('enrichment.outcome', 'enriched_no_match_raced');
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire captureMessage when cause is lml_no_match (by-design Discogs miss)', async () => {
+    // Dashboard aggregation of the no-match rate uses the
+    // `enrichment.outcome` span attribute, not per-event Sentry issues.
+    mockLookupMetadata.mockResolvedValueOnce(noMatchResponse);
+    mockFinalizeRow.mockResolvedValueOnce('enriched_no_match');
+
+    const span = await driveOneTick();
+
+    expect(span.setAttribute).toHaveBeenCalledWith('enrichment.outcome', 'enriched_no_match');
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire captureMessage on lml_match (artwork_url present)', async () => {
+    // Sanity: the happy path stays silent. extractArtwork sees a populated
+    // artwork_url so isEmptyOutcome returns false.
+    mockLookupMetadata.mockResolvedValueOnce(matchResponseWithArtwork);
+    mockFinalizeRow.mockResolvedValueOnce('enriched_match');
+
+    await driveOneTick();
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('catch arm: captureException stays, captureMessage is dropped (no double-fire on LML throw)', async () => {
+    // Pre-1311 behavior fired both captureException AND captureMessage on
+    // every LML throw — two quota slots per timeout. captureException is the
+    // source-of-truth for the stack trace; the catch-arm captureMessage was
+    // redundant and BS#1311 drops it.
+    mockLookupMetadata.mockRejectedValueOnce(new Error('LML timeout'));
+
+    const span = await driveOneTick();
+
+    expect(span.setAttribute).toHaveBeenCalledWith('enrichment.outcome', 'lml_error');
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1311.

## Summary

Post-hoc `/code-review max` of PR #1304 (closes BS#969) flagged two HIGH-severity issues against the brand-new `Sentry.captureMessage('enrichment-empty-outcome', ...)` instrumentation. The WXYC Sentry org quota is currently exhausted (BS#1291 RCA); once restored, this instrumentation as merged would dominate the burn rate at exactly the wrong moment because Sentry bills per ingested event, not per issue. Three reductions land here:

1. **Skip `_raced` outcomes.** `finalizeRow` returns `enriched_match_raced` / `enriched_no_match_raced` when a sibling worker or the C6 stranded-claim sweep won the finalize race — the user-visible state was written by them, not by this worker. Firing here cascades a C6 recovery into a captureMessage flood whose events don't correspond to actual user-visible degradation, inflating the rate the BS#969 alert threshold is meant to track.
2. **Skip `cause === 'lml_no_match'`.** By-design Discogs miss, not a degradation. The existing `enrichment.outcome` span attribute (still set every tick) carries the no-match rate for dashboard-side aggregation.
3. **Drop the catch-arm `captureMessage` entirely.** `captureException` already records the same event with a stack trace — the paired captureMessage was a redundant second quota slot per timeout.

Net result: captureMessage fires only on `lml_degraded` outcomes this worker actually wrote — the LML#408 `_resolve_fallback_artwork` class BS#969 was filed to surface.

Per-class behaviour pinned in `tests/unit/apps/enrichment-worker/handler.test.ts` (6 new tests). The pure-helper tests in `empty-outcome.test.ts` stay green unchanged — the classifier is still exported for dashboard-side use; the suppression decision lives at the call site. File headers in `handler.ts` and `empty-outcome.ts` document the volume-control decision so a future reader understands why `lml_no_match` isn't captured.

## Test plan

- [x] `npm run lint` (0 errors)
- [x] `npm run typecheck`
- [x] `npx prettier --check` on the three touched files
- [x] `npm run test:unit` — 2,746 unit tests pass, including the 6 new handler tests
- [ ] Post-merge: verify on staging that an enriched_no_match row no longer produces a Sentry event, and an LML throw no longer double-fires (captureException only)

## Related

- PR #1304 — original BS#969 instrumentation this trims
- BS#1291 — WXYC Sentry org-quota exhausted RCA (the quota context that motivated the trim)