### PR TITLE
feat(album-level-backfill): surface unexpected_index via captureMessage + cap breadcrumbs

### DIFF
--- a/docs/ops-album-level-backfill-phase3.md
+++ b/docs/ops-album-level-backfill-phase3.md
@@ -140,9 +140,17 @@ grep '"step":"batch_done"' /tmp/bs-1078-phase3-*.log \
       batches: length,
       max_wall_ms: ([.[].wall_clock_ms] | max),
       total_errors: ([.[].lml_error // 0] | add),
-      total_scanned: ([.[].scanned] | add)
+      total_scanned: ([.[].scanned] | add),
+      total_unexpected_index: ([.[].unexpected_index // 0] | add)
     }'
 ```
+
+`total_unexpected_index` is the BS#1088 / BS#1316 acceptance signal: a
+non-zero value means LML silently dropped its bulk input-order contract
+and the job skipped the affected writes. Also watch the new
+`album-level-backfill.unexpected_index` Sentry issue — the job fires
+`captureMessage` with a stable fingerprint per non-zero batch, so the
+issue persists across deploys and you can hang an alert rule off it.
 
 ### Step 5 — Post-pass UPDATE
 

--- a/jobs/album-level-backfill/job.ts
+++ b/jobs/album-level-backfill/job.ts
@@ -426,18 +426,25 @@ export const runBatch = async (
   let no_match = 0;
   let error = 0;
   let unexpected_index = 0;
+  // BS#1316 gap 3: accumulate first-mismatch context inside the loop and
+  // emit ONE breadcrumb per batch after, instead of one per row. Sentry's
+  // default `maxBreadcrumbs` is 100 FIFO; per-row emission under a full
+  // contract break would evict legitimate upstream context (LML HTTP span,
+  // DB query trail) before the NEXT captured event could attach to them.
+  let firstMismatchIndex: number | null = null;
+  let firstMismatchGot: number | null = null;
+  let firstMismatchAlbumId: number | null = null;
   const upsertPromises: Array<Promise<boolean>> = [];
   for (let i = 0; i < items.length; i++) {
     const result = response.results[i];
     if (!result || result.index !== i) {
       unexpected_index += 1;
       const album = resolved[i];
-      Sentry.addBreadcrumb({
-        category: 'album-level-backfill',
-        message: 'unexpected_result_index',
-        level: 'warning',
-        data: { expected: i, got: result?.index ?? null, album_id: album?.album_id ?? null },
-      });
+      if (firstMismatchIndex === null) {
+        firstMismatchIndex = i;
+        firstMismatchGot = result?.index ?? null;
+        firstMismatchAlbumId = album?.album_id ?? null;
+      }
       log('warn', 'unexpected_result_index', `LML result.index mismatch at position ${i}; skipping write`, {
         expected_index: i,
         got_index: result?.index ?? null,
@@ -462,6 +469,39 @@ export const runBatch = async (
     }
   }
   const upserts = (await Promise.all(upsertPromises)).filter(Boolean).length;
+
+  // BS#1316 gaps 2 + 3: surface the non-zero `unexpected_index` signal.
+  // Without this, the per-row counter aggregates correctly in the
+  // `batch_done` log + `BackfillSummary` but evaporates from the Sentry
+  // Issues view at process exit (no captured event → orphaned breadcrumbs).
+  // One breadcrumb per batch caps FIFO pressure; one `captureMessage` per
+  // non-zero batch surfaces the signal with a stable fingerprint so an
+  // alert rule can hang off the issue and cause-aggregation persists across
+  // deploys.
+  if (unexpected_index > 0) {
+    Sentry.addBreadcrumb({
+      category: 'album-level-backfill',
+      message: 'unexpected_result_index',
+      level: 'warning',
+      data: {
+        mismatch_count: unexpected_index,
+        first_mismatch_index: firstMismatchIndex,
+        first_mismatch_got: firstMismatchGot,
+        first_mismatch_album_id: firstMismatchAlbumId,
+      },
+    });
+    Sentry.captureMessage('album-level-backfill.unexpected_index', {
+      level: 'warning',
+      tags: { source: 'album-level-backfill' },
+      extra: {
+        unexpected_index,
+        scanned: items.length,
+        batch_first_id: resolved[0]?.album_id ?? null,
+      },
+      fingerprint: ['album-level-backfill', 'unexpected_index'],
+    });
+  }
+
   return { batchSize: items.length, match, no_match, error, upserts, unexpected_index };
 };
 

--- a/tests/unit/jobs/album-level-backfill/job.test.ts
+++ b/tests/unit/jobs/album-level-backfill/job.test.ts
@@ -25,9 +25,11 @@ jest.mock('@wxyc/lml-client', () => ({
 // non-configurable, so `jest.spyOn(Sentry, 'addBreadcrumb')` throws — we
 // have to replace the surface at module-mock time.
 const mockSentryAddBreadcrumb = jest.fn<(b: unknown) => void>();
+const mockSentryCaptureMessage = jest.fn<(msg: string, ctx?: unknown) => void>();
 jest.mock('@sentry/node', () => ({
   __esModule: true,
   addBreadcrumb: mockSentryAddBreadcrumb,
+  captureMessage: mockSentryCaptureMessage,
   // The job's logger.ts module also imports @sentry/node; preserve the
   // surface it touches so `initLogger()` (not called in unit tests) and
   // `captureError()` (called by BS#1076 path) don't crash if exercised.
@@ -566,7 +568,12 @@ describe('runBatch', () => {
       expect((db.insert as jest.Mock).mock.calls.length).toBe(expected.upserts);
     });
 
-    it('emits a Sentry breadcrumb on mismatch (category album-level-backfill, expected vs got)', async () => {
+    // BS#1316 gap 3: per-row breadcrumbs blow the 100-entry FIFO when every
+    // row mismatches. Cap at one breadcrumb per batch carrying the
+    // `first_mismatch_*` + `mismatch_count` payload so legitimate upstream
+    // breadcrumbs (LML HTTP span, DB query trail) survive into the NEXT
+    // captured event.
+    it('BS#1316: emits at most one breadcrumb per batch carrying first_mismatch + mismatch_count', async () => {
       mockSentryAddBreadcrumb.mockClear();
       mockBulkLookupMetadata.mockResolvedValue({
         results: [
@@ -577,21 +584,105 @@ describe('runBatch', () => {
 
       await runBatch([1, 2], { budgetMs: 25000, dryRun: false });
 
-      expect(mockSentryAddBreadcrumb).toHaveBeenCalledTimes(2);
+      expect(mockSentryAddBreadcrumb).toHaveBeenCalledTimes(1);
       expect(mockSentryAddBreadcrumb).toHaveBeenCalledWith(
         expect.objectContaining({
           category: 'album-level-backfill',
           message: 'unexpected_result_index',
-          data: expect.objectContaining({ expected: 0, got: 5 }),
+          level: 'warning',
+          data: expect.objectContaining({
+            first_mismatch_index: 0,
+            first_mismatch_got: 5,
+            mismatch_count: 2,
+          }),
         })
       );
-      expect(mockSentryAddBreadcrumb).toHaveBeenCalledWith(
+    });
+
+    // BS#1316 gap 3 continued: even at the worst case (every row in a batch
+    // mismatches), exactly one breadcrumb fires. This is the FIFO-protection
+    // invariant — at default batchSize=5 the prior shape could emit 5
+    // breadcrumbs per batch; with one-per-batch the cap is bounded.
+    it('BS#1316: a fully-mismatched batch still produces one breadcrumb', async () => {
+      mockSentryAddBreadcrumb.mockClear();
+      mockBulkLookupMetadata.mockResolvedValue({
+        results: [
+          { index: 9, status: 'match' as const, lookup: lookupWithArtwork() },
+          { index: 8, status: 'match' as const, lookup: lookupWithArtwork() },
+        ],
+      });
+
+      await runBatch([1, 2], { budgetMs: 25000, dryRun: false });
+
+      expect(mockSentryAddBreadcrumb).toHaveBeenCalledTimes(1);
+      const breadcrumb = mockSentryAddBreadcrumb.mock.calls[0]?.[0] as {
+        data?: { mismatch_count?: number; first_mismatch_index?: number; first_mismatch_got?: number };
+      };
+      expect(breadcrumb?.data?.mismatch_count).toBe(2);
+      expect(breadcrumb?.data?.first_mismatch_index).toBe(0);
+      expect(breadcrumb?.data?.first_mismatch_got).toBe(9);
+    });
+
+    // BS#1316 gap 3: when the batch is healthy, no breadcrumb fires.
+    it('BS#1316: no breadcrumb when the batch has zero mismatches', async () => {
+      mockSentryAddBreadcrumb.mockClear();
+      mockBulkLookupMetadata.mockResolvedValue({
+        results: [
+          { index: 0, status: 'match' as const, lookup: lookupWithArtwork() },
+          { index: 1, status: 'match' as const, lookup: lookupWithArtwork() },
+        ],
+      });
+
+      await runBatch([1, 2], { budgetMs: 25000, dryRun: false });
+
+      expect(mockSentryAddBreadcrumb).not.toHaveBeenCalled();
+    });
+
+    // BS#1316 gap 2: breadcrumbs evaporate at process exit unless an event
+    // is captured. Fire `Sentry.captureMessage` per non-zero batch so the
+    // Sentry Issues view surfaces it with a stable fingerprint that an
+    // alert rule can hang off.
+    it('BS#1316: fires Sentry.captureMessage with stable fingerprint when unexpected_index > 0', async () => {
+      mockSentryCaptureMessage.mockClear();
+      mockBulkLookupMetadata.mockResolvedValue({
+        results: [
+          { index: 5, status: 'match' as const, lookup: lookupWithArtwork() },
+          { index: 1, status: 'match' as const, lookup: lookupWithArtwork() },
+        ],
+      });
+
+      await runBatch([1, 2], { budgetMs: 25000, dryRun: false });
+
+      expect(mockSentryCaptureMessage).toHaveBeenCalledTimes(1);
+      expect(mockSentryCaptureMessage).toHaveBeenCalledWith(
+        'album-level-backfill.unexpected_index',
         expect.objectContaining({
-          category: 'album-level-backfill',
-          message: 'unexpected_result_index',
-          data: expect.objectContaining({ expected: 1, got: 0 }),
+          level: 'warning',
+          tags: expect.objectContaining({ source: 'album-level-backfill' }),
+          extra: expect.objectContaining({
+            unexpected_index: 1,
+            scanned: 2,
+            batch_first_id: 1,
+          }),
+          fingerprint: ['album-level-backfill', 'unexpected_index'],
         })
       );
+    });
+
+    // BS#1316 gap 2: healthy batches stay silent — captureMessage only fires
+    // on the signal, not on every successful batch.
+    it('BS#1316: does NOT fire captureMessage when the batch has zero mismatches', async () => {
+      mockSentryCaptureMessage.mockClear();
+      mockBulkLookupMetadata.mockResolvedValue({
+        results: [
+          { index: 0, status: 'match' as const, lookup: lookupWithArtwork() },
+          { index: 1, status: 'match' as const, lookup: lookupWithArtwork() },
+        ],
+      });
+
+      await runBatch([1, 2], { budgetMs: 25000, dryRun: false });
+
+      expect(mockSentryCaptureMessage).not.toHaveBeenCalled();
     });
 
     it('mismatch does not abort the batch: sibling in-order matches still write', async () => {


### PR DESCRIPTION
Closes #1316. Follow-up to PR #1303 / BS#1088.

## Summary

- Cap per-batch breadcrumbs to one — accumulate `mismatch_count` + `first_mismatch_index` + `first_mismatch_got` inside the loop and emit a single `Sentry.addBreadcrumb` after, so a full LML contract break can't blow the 100-entry FIFO and evict legitimate upstream context (LML HTTP span, DB query trail) before the next real error attaches to them.
- Fire `Sentry.captureMessage('album-level-backfill.unexpected_index', ...)` per non-zero batch with `fingerprint: ['album-level-backfill', 'unexpected_index']`. Without this, the breadcrumbs evaporate at process exit on healthy-shaped runs that still see a non-zero `unexpected_index`, leaving the Sentry Issues view clean while the signal is silently dropped. The stable fingerprint lets cause-aggregation persist across deploys and gives an alert rule something durable to hang off.
- Extend the runbook's jq aggregator at `docs/ops-album-level-backfill-phase3.md` to include `.unexpected_index` alongside `.scanned` and `.lml_error`, and add a one-line note pointing the operator at the new Sentry issue.

The `unexpected_index` counter on `BatchResult` + `BackfillSummary` is untouched — the existing aggregation through the `batch_done` log line and the final summary still carries the same shape.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npx prettier --check` on touched files — clean
- [x] `npm run typecheck` — clean across all workspaces
- [x] `npm run test:unit` — 2754/2754 pass, including new BS#1316 assertions on the cap-at-one-per-batch breadcrumb shape and the fire-on-non-zero / silent-on-zero `captureMessage` invariants