### PR TITLE
feat(flowsheet): accept dj_name_override on joinShow (closes #1295)

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -381,7 +381,25 @@ export type JoinRequestBody = {
   dj_id: string;
   show_name?: string;
   specialty_id?: number;
+  /**
+   * Optional per-show display-name override (BS#1295, epic #1288). When
+   * non-empty after trim, takes priority over `auth_user.dj_name` for the
+   * show_start marker, `flowsheet.dj_name`, and `shows.legacy_dj_name`.
+   * Capped at 255 chars to match the `auth_user.dj_name` column. Only
+   * honored on the new-show path; ignored on the co-host /join path
+   * (`addDJToShow`) because there's no per-co-host override surface today.
+   */
+  dj_name_override?: string;
 };
+
+/**
+ * Maximum length of `dj_name_override`. Matches the `auth_user.dj_name`
+ * varchar(255) ceiling — the override is semantically a per-show stand-in
+ * for that value. `shows.legacy_dj_name` is narrower (varchar(128)); the
+ * service-side write truncates rather than rejecting so the override stays
+ * a single soft cap from the caller's point of view.
+ */
+const DJ_NAME_OVERRIDE_MAX_LENGTH = 255;
 
 //POST
 export const joinShow: RequestHandler = async (req: Request<object, object, JoinRequestBody>, res) => {
@@ -398,15 +416,38 @@ export const joinShow: RequestHandler = async (req: Request<object, object, Join
     throw new WxycError('Forbidden: dj_id must match the authenticated user', 403);
   }
 
+  // Normalize dj_name_override (BS#1295): trim, treat empty / whitespace-only
+  // as absent, reject > 255 chars at the controller boundary. Length is
+  // measured against the trimmed value so trailing whitespace can't be used
+  // to game the limit downward.
+  const raw_override = req.body.dj_name_override;
+  let dj_name_override: string | undefined;
+  if (typeof raw_override === 'string') {
+    const trimmed = raw_override.trim();
+    if (trimmed.length === 0) {
+      dj_name_override = undefined;
+    } else if (trimmed.length > DJ_NAME_OVERRIDE_MAX_LENGTH) {
+      throw new WxycError(
+        `Bad Request: dj_name_override must be ${DJ_NAME_OVERRIDE_MAX_LENGTH} characters or fewer`,
+        400
+      );
+    } else {
+      dj_name_override = trimmed;
+    }
+  }
+
   if (current_show?.end_time !== null) {
     const show_session: Show = await flowsheet_service.startShow(
       req.body.dj_id,
       req.body.show_name,
-      req.body.specialty_id
+      req.body.specialty_id,
+      dj_name_override
     );
 
     res.status(200).json(show_session);
   } else {
+    // Override is only consumed on the new-show path. Co-host join uses the
+    // auth_user.dj_name resolution unchanged.
     const show_dj_instance: ShowDJ = await flowsheet_service.addDJToShow(req.body.dj_id, current_show);
     res.status(200).json(show_dj_instance);
   }

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -473,12 +473,39 @@ export const updateEntry = async (entry_id: number, entry: UpdateRequestBody): P
   return response[0];
 };
 
-export const startShow = async (dj_id: string, show_name?: string, specialty_id?: number): Promise<Show> => {
+/**
+ * Maximum width of `shows.legacy_dj_name` (varchar(128) — see schema.ts).
+ * The override field as a whole is capped at 255 (matching `auth_user.dj_name`)
+ * at the controller boundary; the narrower legacy column gets a defensive
+ * truncate to avoid a 22001 string-too-long error when a caller sends 129-255
+ * chars. Truncation matches the flowsheet-etl pattern in jobs/flowsheet-etl.
+ */
+const SHOWS_LEGACY_DJ_NAME_MAX_LENGTH = 128;
+
+export const startShow = async (
+  dj_id: string,
+  show_name?: string,
+  specialty_id?: number,
+  dj_name_override?: string
+): Promise<Show> => {
   const dj_info = (await db.select().from(user).where(eq(user.id, dj_id)).limit(1))[0];
 
   if (!dj_info) {
     throw new WxycError(`DJ with id '${dj_id}' not found`, 404);
   }
+
+  // BS#1295: per-show display-name override. The controller already trimmed
+  // and length-checked; re-trim here as a defense-in-depth (the service is
+  // also called directly from tests / future call sites that may bypass the
+  // controller). Empty / whitespace-only override falls through to the
+  // resolveDjDisplayName path — preserving today's behavior.
+  const trimmed_override = dj_name_override?.trim() ?? '';
+  const effective_override = trimmed_override.length > 0 ? trimmed_override : null;
+
+  // Truncate to the narrower shows.legacy_dj_name column width. The
+  // marker text and flowsheet.dj_name keep the full string; only the
+  // legacy mirror column is clipped.
+  const legacy_dj_name = effective_override ? effective_override.slice(0, SHOWS_LEGACY_DJ_NAME_MAX_LENGTH) : undefined;
 
   const new_show = await db
     .insert(shows)
@@ -486,6 +513,7 @@ export const startShow = async (dj_id: string, show_name?: string, specialty_id?
       primary_dj_id: dj_id,
       specialty_id: specialty_id,
       show_name: show_name,
+      legacy_dj_name: legacy_dj_name,
     })
     .returning();
 
@@ -497,7 +525,11 @@ export const startShow = async (dj_id: string, show_name?: string, specialty_id?
     })
     .returning();
 
-  const display_dj_name = resolveDjDisplayName(dj_info.djName ?? null, dj_info.name ?? null);
+  // Override (when present) wins outright over the helper-resolved name.
+  // When the override is absent, fall back to the centralized resolution
+  // helper that handles `auth_user.dj_name`, the "Anonymous" literal, and
+  // the `auth_user.name` fallback (WXYC/Backend-Service#1286, epic #1288).
+  const display_dj_name = effective_override ?? resolveDjDisplayName(dj_info.djName ?? null, dj_info.name ?? null);
   const now = new Date().toLocaleString('en-US', { timeZone: 'America/New_York' });
   // Asymmetric fallback (epic #1288): when the DJ name is unresolvable we
   // still want a marker row so consumers know the show began. The wording

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -42,6 +42,100 @@ describe('Start Show', () => {
 });
 
 /*
+ * Start Show with dj_name_override (BS#1295 / epic #1288).
+ *
+ * Verifies the new per-show override path lands the supplied name in:
+ *   - the show_start marker `flowsheet.message` body
+ *   - the `flowsheet.dj_name` column
+ *   - the `shows.legacy_dj_name` column
+ * regardless of the caller's `auth_user.dj_name`. Also exercises the
+ * length-cap rejection and the empty-string / whitespace fallback.
+ */
+describe('Start Show with dj_name_override', () => {
+  let sql;
+
+  beforeAll(() => {
+    sql = makeSql();
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end({ timeout: 5 });
+  });
+
+  afterEach(async () => {
+    await fls_util.leave_show(global.primary_dj_id, global.access_token);
+  });
+
+  test('override populates flowsheet marker, flowsheet.dj_name, and shows.legacy_dj_name', async () => {
+    const overrideName = 'Aubrey Hearst';
+    const res = await request
+      .post('/flowsheet/join')
+      .set('Authorization', global.access_token)
+      .send({
+        dj_id: global.primary_dj_id,
+        dj_name_override: overrideName,
+      })
+      .expect(200);
+
+    expect(res.body.id).toBeDefined();
+    const showId = res.body.id;
+
+    // Pull the show row and the show_start flowsheet entry from the DB.
+    const showRows = await sql`
+      SELECT legacy_dj_name FROM ${sql(SCHEMA)}.shows WHERE id = ${showId}
+    `;
+    expect(showRows.length).toBe(1);
+    expect(showRows[0].legacy_dj_name).toEqual(overrideName);
+
+    const markerRows = await sql`
+      SELECT dj_name, message
+        FROM ${sql(SCHEMA)}.flowsheet
+       WHERE show_id = ${showId} AND entry_type = 'show_start'
+       LIMIT 1
+    `;
+    expect(markerRows.length).toBe(1);
+    expect(markerRows[0].dj_name).toEqual(overrideName);
+    expect(markerRows[0].message).toMatch(new RegExp(`^Start of Show: ${overrideName} joined the set at `));
+    expect(markerRows[0].message).not.toMatch(/\bDJ\b/); // locked decision: no "DJ" prefix
+  });
+
+  test('whitespace-only override is ignored — no regression vs baseline', async () => {
+    const res = await request
+      .post('/flowsheet/join')
+      .set('Authorization', global.access_token)
+      .send({
+        dj_id: global.primary_dj_id,
+        dj_name_override: '   ',
+      })
+      .expect(200);
+
+    const showId = res.body.id;
+
+    const showRows = await sql`
+      SELECT legacy_dj_name FROM ${sql(SCHEMA)}.shows WHERE id = ${showId}
+    `;
+    expect(showRows.length).toBe(1);
+    expect(showRows[0].legacy_dj_name).toBeNull();
+  });
+
+  test('override > 255 chars is rejected with 400', async () => {
+    const overflow = 'a'.repeat(256);
+    const res = await request
+      .post('/flowsheet/join')
+      .set('Authorization', global.access_token)
+      .send({
+        dj_id: global.primary_dj_id,
+        dj_name_override: overflow,
+      })
+      .expect(400);
+
+    expect(res.body.message).toBeDefined();
+    // No show was created — exit the afterEach cleanly. The afterEach
+    // fires leave_show, which is a no-op when there's no active show.
+  });
+});
+
+/*
  * Join Show (Secondary dj(s) hits /flowsheet/join)
  */
 describe('Join Show', () => {

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -1045,7 +1045,8 @@ describe('flowsheet.controller', () => {
 
       await joinShow(req, res as Response, mockNext);
 
-      expect(mockStartShow).toHaveBeenCalledWith('caller-dj', 'My Show', 7);
+      // 4th arg is dj_name_override (BS#1295) — undefined when absent on the body.
+      expect(mockStartShow).toHaveBeenCalledWith('caller-dj', 'My Show', 7, undefined);
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
@@ -1075,6 +1076,103 @@ describe('flowsheet.controller', () => {
 
       await expect(joinShow(req, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
       expect(mockStartShow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('joinShow dj_name_override (BS#1295)', () => {
+    it('forwards a trimmed dj_name_override to startShow when starting a new show', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: new Date() });
+      mockStartShow.mockResolvedValue({ id: 42, primary_dj_id: 'caller-dj' });
+
+      const req = {
+        auth: { id: 'caller-dj' },
+        body: { dj_id: 'caller-dj', show_name: 'My Show', specialty_id: 7, dj_name_override: 'Aubrey Hearst' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await joinShow(req, res as Response, mockNext);
+
+      expect(mockStartShow).toHaveBeenCalledWith('caller-dj', 'My Show', 7, 'Aubrey Hearst');
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('passes undefined to startShow when dj_name_override is an empty string', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: new Date() });
+      mockStartShow.mockResolvedValue({ id: 42, primary_dj_id: 'caller-dj' });
+
+      const req = {
+        auth: { id: 'caller-dj' },
+        body: { dj_id: 'caller-dj', dj_name_override: '' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await joinShow(req, res as Response, mockNext);
+
+      expect(mockStartShow).toHaveBeenCalledWith('caller-dj', undefined, undefined, undefined);
+    });
+
+    it('passes undefined to startShow when dj_name_override is whitespace-only', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: new Date() });
+      mockStartShow.mockResolvedValue({ id: 42, primary_dj_id: 'caller-dj' });
+
+      const req = {
+        auth: { id: 'caller-dj' },
+        body: { dj_id: 'caller-dj', dj_name_override: '   ' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await joinShow(req, res as Response, mockNext);
+
+      expect(mockStartShow).toHaveBeenCalledWith('caller-dj', undefined, undefined, undefined);
+    });
+
+    it('rejects with 400 when the trimmed dj_name_override exceeds 255 chars', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: new Date() });
+      const overflow = 'a'.repeat(256);
+
+      const req = {
+        auth: { id: 'caller-dj' },
+        body: { dj_id: 'caller-dj', dj_name_override: overflow },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await expect(joinShow(req, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
+      expect(mockStartShow).not.toHaveBeenCalled();
+    });
+
+    it('accepts exactly 255 chars at the boundary', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: new Date() });
+      mockStartShow.mockResolvedValue({ id: 42, primary_dj_id: 'caller-dj' });
+      const exactly255 = 'a'.repeat(255);
+
+      const req = {
+        auth: { id: 'caller-dj' },
+        body: { dj_id: 'caller-dj', dj_name_override: exactly255 },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await joinShow(req, res as Response, mockNext);
+
+      expect(mockStartShow).toHaveBeenCalledWith('caller-dj', undefined, undefined, exactly255);
+    });
+
+    it('does not forward dj_name_override when joining an existing show (co-host path)', async () => {
+      mockGetLatestShow.mockResolvedValue({ id: 1, end_time: null });
+      mockAddDJToShow.mockResolvedValue({ id: 99, dj_id: 'caller-dj' });
+
+      // Even if a client sends dj_name_override on a co-host /join, the
+      // service contract treats it as ignored — there's no per-co-host
+      // override path. Caller wired startShow only.
+      const req = {
+        auth: { id: 'caller-dj' },
+        body: { dj_id: 'caller-dj', dj_name_override: 'Aubrey Hearst' },
+      } as unknown as Request;
+      const res = createMockRes();
+
+      await joinShow(req, res as Response, mockNext);
+
+      expect(mockStartShow).not.toHaveBeenCalled();
+      expect(mockAddDJToShow).toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/services/flowsheet.startShow.test.ts
+++ b/tests/unit/services/flowsheet.startShow.test.ts
@@ -90,3 +90,113 @@ describe('startShow', () => {
     expect(flowsheetValues.dj_name).toBeNull();
   });
 });
+
+/**
+ * dj_name_override coverage for the 2026-06-02 Aubrey Hearst incident
+ * follow-up (WXYC/Backend-Service#1295, epic #1288). Override is per-call,
+ * trumps `auth_user.dj_name`/`auth_user.name` for the show_start marker text,
+ * the `flowsheet.dj_name` column, and the new `shows.legacy_dj_name` column.
+ *
+ * Empty / whitespace-only override is treated as absent — today's
+ * resolveDjDisplayName fallback path must remain the only behavior change
+ * is opt-in.
+ */
+describe('startShow dj_name_override (BS#1295)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Mocks: user lookup, shows insert (returning), show_djs insert,
+  // nextPlayOrder select, flowsheet insert. Mirrors the setUp helper in
+  // the markerText suite — duplicated here so this suite is self-contained.
+  const setUpForStartShow = (djName: string | null, name: string | null) => {
+    const userSelect = createMockQueryChain();
+    userSelect.limit.mockResolvedValue([{ djName, name }]);
+    db.select.mockReturnValueOnce(userSelect);
+
+    const showsInsert = createMockQueryChain([{ id: 42 }]);
+    db.insert.mockReturnValueOnce(showsInsert);
+    db.insert.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-1' }]));
+    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
+    const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
+    db.insert.mockReturnValueOnce(flowsheetInsert);
+
+    return { showsInsert, flowsheetInsert };
+  };
+
+  it('uses the override for marker text + flowsheet.dj_name regardless of auth_user.dj_name', async () => {
+    // auth_user holds the literal "Anonymous" from the Aubrey Hearst incident
+    // root cause; without the override this would fall back to user.name.
+    const { showsInsert, flowsheetInsert } = setUpForStartShow('Anonymous', 'maura-real-name');
+
+    await startShow('user-1', undefined, undefined, 'Aubrey Hearst');
+
+    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(flowsheetValues.dj_name).toBe('Aubrey Hearst');
+    expect(flowsheetValues.message).toMatch(/^Start of Show: Aubrey Hearst joined the set at /);
+    // AC#4: shows.legacy_dj_name populated to match the marker name when override present.
+    const showsValues = showsInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(showsValues.legacy_dj_name).toBe('Aubrey Hearst');
+  });
+
+  it('trims whitespace from the override before persisting', async () => {
+    const { showsInsert, flowsheetInsert } = setUpForStartShow('DJ Stardust', 'Alex Stardust');
+
+    await startShow('user-1', undefined, undefined, '  Aubrey Hearst  ');
+
+    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(flowsheetValues.dj_name).toBe('Aubrey Hearst');
+    expect(flowsheetValues.message).toMatch(/^Start of Show: Aubrey Hearst joined the set at /);
+    const showsValues = showsInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(showsValues.legacy_dj_name).toBe('Aubrey Hearst');
+  });
+
+  it('treats empty-string override as absent — falls back to auth_user.dj_name', async () => {
+    const { showsInsert, flowsheetInsert } = setUpForStartShow('DJ Stardust', 'Alex Stardust');
+
+    await startShow('user-1', undefined, undefined, '');
+
+    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(flowsheetValues.dj_name).toBe('DJ Stardust');
+    expect(flowsheetValues.message).toMatch(/^Start of Show: DJ Stardust joined the set at /);
+    // No override → legacy_dj_name stays null (preserves pre-#1295 shape).
+    const showsValues = showsInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(showsValues.legacy_dj_name ?? null).toBeNull();
+  });
+
+  it('treats whitespace-only override as absent — falls back to auth_user.dj_name', async () => {
+    const { showsInsert, flowsheetInsert } = setUpForStartShow('DJ Stardust', 'Alex Stardust');
+
+    await startShow('user-1', undefined, undefined, '   ');
+
+    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(flowsheetValues.dj_name).toBe('DJ Stardust');
+    const showsValues = showsInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(showsValues.legacy_dj_name ?? null).toBeNull();
+  });
+
+  it('absent override (undefined) produces the same shape as pre-#1295 — no regression', async () => {
+    const { showsInsert, flowsheetInsert } = setUpForStartShow('DJ Stardust', 'Alex Stardust');
+
+    await startShow('user-1', 'Some Show', 7);
+
+    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(flowsheetValues.dj_name).toBe('DJ Stardust');
+    expect(flowsheetValues.message).toMatch(/^Start of Show: DJ Stardust joined the set at /);
+    const showsValues = showsInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(showsValues.show_name).toBe('Some Show');
+    expect(showsValues.specialty_id).toBe(7);
+    expect(showsValues.legacy_dj_name ?? null).toBeNull();
+  });
+
+  it('does not touch show_name / specialty_id plumbing when override is present', async () => {
+    const { showsInsert } = setUpForStartShow('DJ Stardust', 'Alex Stardust');
+
+    await startShow('user-1', 'Some Show', 7, 'Aubrey Hearst');
+
+    const showsValues = showsInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(showsValues.show_name).toBe('Some Show');
+    expect(showsValues.specialty_id).toBe(7);
+    expect(showsValues.legacy_dj_name).toBe('Aubrey Hearst');
+  });
+});


### PR DESCRIPTION
## Summary

Extends `POST /flowsheet/join` to take an optional `dj_name_override` string field. When non-empty after trim, the override drives:

- the `show_start` marker text in `flowsheet.message`
- the `flowsheet.dj_name` column
- the `shows.legacy_dj_name` column

overriding the `auth_user.dj_name`-based resolution performed by the centralized `resolveDjDisplayName` helper (#1286 / #1306). Empty / whitespace-only override is treated as absent — today's behavior is preserved on the no-override path. Length cap is 255 chars at the controller boundary (matches `auth_user.dj_name`); the narrower `shows.legacy_dj_name` (varchar(128)) gets a defensive truncate at the service boundary to match the existing flowsheet-etl pattern.

Override is only honored on the new-show path; the co-host `/join` (`addDJToShow`) is unchanged because there is no per-co-host override surface today. `show_name` / `specialty_id` plumbing is unchanged.

Unblocks WXYC/dj-site#694 (re-enable the disabled Public DJ Handle input in the classic StartShow form) — Option B from the 2026-06-02 Aubrey Hearst incident triage in epic #1288.

## Acceptance criteria

- [x] `POST /flowsheet/join` with `dj_name_override: "Aubrey Hearst"` produces `flowsheet.message = "Start of Show: Aubrey Hearst joined the set at <time>"` + `dj_name = "Aubrey Hearst"`, regardless of caller's `auth_user.dj_name` (unit + integration).
- [x] `dj_name_override: ""` or `"   "` treated as absent, no regression (unit + integration).
- [x] `dj_name_override` > 255 chars rejected with 400 (unit + integration).
- [x] `shows.legacy_dj_name` populated when override present (unit + integration).
- [x] No regression on `show_name` / `specialty_id` plumbing (existing tests + new dedicated case).
- [ ] **`api.yaml` updated and types regenerated** — see follow-up note below.

## api.yaml follow-up

The BS controller defines `JoinRequestBody` locally (not imported from `@wxyc/shared`), so this commit is fully self-contained on the BS side and ships independently of the wxyc-shared spec. The wxyc-shared `api.yaml` addition (extending `/flowsheet/join` request schema with the optional `dj_name_override` field) is best landed as a separate coordinated PR so its package bump can be sequenced cleanly against the other in-flight api.yaml work in that repo. Flagging here so the contract surface stays tracked.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (warnings only, all pre-existing)
- [x] `npm run format:check` clean
- [x] `npm run build` clean
- [x] `npm run test:unit` — 2762 passed, 0 failed
- [ ] Integration tests on CI (new cases in `tests/integration/flowsheet.spec.js`)

## Related

- Closes #1295
- Parent epic: #1288
- Stacks on: #1286 (centralized `resolveDjDisplayName` helper) — landed as PR #1306 / commit `2f31a0db`
- Blocks: WXYC/dj-site#694