### PR TITLE
test(flowsheet): pin rotation_id persistence on POST /flowsheet/ snapshot branch (closes #1308)

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^10.53.1",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.5.0",
+    "@wxyc/shared": "^1.9.0",
     "better-auth": "^1.6.11",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -23,7 +23,7 @@
     "@wxyc/database": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^1.6.0",
+    "@wxyc/shared": "^1.9.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "@sentry/node": "^10.53.1",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.5.0",
+        "@wxyc/shared": "^1.9.0",
         "better-auth": "^1.6.11",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -121,9 +121,9 @@
       }
     },
     "apps/auth/node_modules/@wxyc/shared": {
-      "version": "1.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.5.0/d39ca7a99054d44b105dbfc0306de1fb4b68b092",
-      "integrity": "sha512-YyCHTaSdGGwdxXbNUVQiopXyYVWZPgSoQltE6l2aDkK+SX6M9IQiikVNC0307APJc/0GVSdmxU2xhBkOtZgz8w==",
+      "version": "1.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.9.0/8b8c1d50a1836d132b4e8e81973e932cf898814d",
+      "integrity": "sha512-5Bn/SXOjrRSupQjAfL02Dl06a5wUck5gYAfMvfjQsyxqT7104v/X9nd5kNlAPTxhczWqXRDvkgTH1yd6ExtK3Q==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -253,7 +253,7 @@
         "@wxyc/database": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^1.6.0",
+        "@wxyc/shared": "^1.9.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.16.1",
@@ -306,9 +306,9 @@
       }
     },
     "apps/backend/node_modules/@wxyc/shared": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.6.0/0ac95dfea321342ddd9420ad17ce52a7e09fbdc9",
-      "integrity": "sha512-aXL5T714e7B7PYFT+s0IwBN8dh3n8QDEegwgRl7ugK3pSnmoe/tEheHgSAvmYSza+CvfoCfuApUUXPZMAOPSIw==",
+      "version": "1.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.9.0/8b8c1d50a1836d132b4e8e81973e932cf898814d",
+      "integrity": "sha512-5Bn/SXOjrRSupQjAfL02Dl06a5wUck5gYAfMvfjQsyxqT7104v/X9nd5kNlAPTxhczWqXRDvkgTH1yd6ExtK3Q==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -14640,7 +14640,7 @@
         "@aws-sdk/client-ses": "^3.1053.0",
         "@sentry/node": "^10.53.1",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.5.0",
+        "@wxyc/shared": "^1.9.0",
         "better-auth": "^1.6.11",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -14676,9 +14676,9 @@
       }
     },
     "shared/authentication/node_modules/@wxyc/shared": {
-      "version": "1.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.5.0/d39ca7a99054d44b105dbfc0306de1fb4b68b092",
-      "integrity": "sha512-YyCHTaSdGGwdxXbNUVQiopXyYVWZPgSoQltE6l2aDkK+SX6M9IQiikVNC0307APJc/0GVSdmxU2xhBkOtZgz8w==",
+      "version": "1.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.9.0/8b8c1d50a1836d132b4e8e81973e932cf898814d",
+      "integrity": "sha512-5Bn/SXOjrRSupQjAfL02Dl06a5wUck5gYAfMvfjQsyxqT7104v/X9nd5kNlAPTxhczWqXRDvkgTH1yd6ExtK3Q==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -14816,7 +14816,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^10.53.1",
-        "@wxyc/shared": "^1.5.0"
+        "@wxyc/shared": "^1.9.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",
@@ -14850,9 +14850,9 @@
       }
     },
     "shared/lml-client/node_modules/@wxyc/shared": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.6.0/0ac95dfea321342ddd9420ad17ce52a7e09fbdc9",
-      "integrity": "sha512-aXL5T714e7B7PYFT+s0IwBN8dh3n8QDEegwgRl7ugK3pSnmoe/tEheHgSAvmYSza+CvfoCfuApUUXPZMAOPSIw==",
+      "version": "1.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.9.0/8b8c1d50a1836d132b4e8e81973e932cf898814d",
+      "integrity": "sha512-5Bn/SXOjrRSupQjAfL02Dl06a5wUck5gYAfMvfjQsyxqT7104v/X9nd5kNlAPTxhczWqXRDvkgTH1yd6ExtK3Q==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-ses": "^3.1053.0",
     "@sentry/node": "^10.53.1",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.5.0",
+    "@wxyc/shared": "^1.9.0",
     "better-auth": "^1.6.11",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.53.1",
-    "@wxyc/shared": "^1.5.0"
+    "@wxyc/shared": "^1.9.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -424,6 +424,37 @@ describe('Add to Flowsheet', () => {
     expect(res.body.record_label).toEqual('Mini Records');
   });
 
+  test('With album_id null + rotation_id + snapshot fields (BS#1308)', async () => {
+    // Rotation albums that aren't in the WXYC library catalog (LEFT JOIN to
+    // library yields id: null on /library/rotation) need to preserve rotation
+    // linkage on the wire so the V2 read path can JOIN back to rotation for
+    // rotation_bin and the iOS rotation-artwork resolver can find the entry.
+    // Pre-fix, dj-site either synthesized a negative album_id (defect class
+    // #564/#608/#698/#701) or fell back to FlowsheetCreateSongFreeform and
+    // dropped rotation_id on the wire. wxyc-shared#158 added rotation_id to
+    // the freeform variant; this pins that BS persists it through the
+    // snapshot/else branch alongside album_id IS NULL.
+    const res = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: null,
+        rotation_id: 1, // Built to Spill — Keep it Like a Secret (seed rotation row)
+        artist_name: 'Noura Mint Seymali',
+        album_title: 'Tzenni',
+        track_title: 'Tzenni',
+        record_label: 'Glitterbeat',
+      })
+      .expect(201);
+
+    expect(res.body).toBeDefined();
+    expect(res.body.album_id).toBeNull();
+    expect(res.body.rotation_id).toEqual(1);
+    expect(res.body.artist_name).toEqual('Noura Mint Seymali');
+    expect(res.body.album_title).toEqual('Tzenni');
+    expect(res.body.track_title).toEqual('Tzenni');
+  });
+
   test('With track_position (BS#943, album_id branch)', async () => {
     // The dj-site flowsheet picker (E6-6) calls /proxy/library/{id}/tracks
     // after a release pick, then submits the chosen track with the library


### PR DESCRIPTION
## Summary

- Bumps `@wxyc/shared` to `^1.9.0` across `apps/auth`, `apps/backend`, `shared/authentication`, `shared/lml-client` so the new `FlowsheetCreateSongFreeform.rotation_id` wire shape from [WXYC/wxyc-shared#158](https://github.com/WXYC/wxyc-shared/pull/158) is available to consumers.
- Adds an integration regression test pinning that BS persists `rotation_id` on the snapshot/else branch when `album_id` is null.
- Pure pin: the `addEntry` handler already had this behavior (the BS#933 path); no controller, service, or migration change.

Closes #1308. Unblocks WXYC/dj-site#608 and WXYC/dj-site#701, which can now construct the new shape without synthesizing negative `album_id` values.

## Why a pin and not a behavior change

`flowsheet.album_id` and `flowsheet.rotation_id` are both nullable in `shared/database/src/schema.ts`. The else branch of `addEntry` (`apps/backend/controllers/flowsheet.controller.ts`) already constructs the insert with `rotation_id: body.rotation_id` — the BS#933 work made that branch handle explicit-null `album_id` correctly. The schema change in WXYC/wxyc-shared#158 simply declares the property on the wire so dj-site can construct it. This PR pins the persistence so a future controller refactor can't silently regress what the contract now allows.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors (487 pre-existing warnings).
- [x] `npm run format:check` — clean.
- [ ] Integration tests in CI — Docker not running locally; the new test asserts `{ album_id: null, rotation_id: 1, artist_name, album_title, track_title }` → 201 with persisted `album_id` null + `rotation_id = 1`.

## Related

- [WXYC/wxyc-shared#158](https://github.com/WXYC/wxyc-shared/pull/158) — schema-side fix that this consumes.
- [WXYC/wxyc-shared#159](https://github.com/WXYC/wxyc-shared/pull/159) — release 1.9.0.
- WXYC/dj-site#699 — Classic EntryForm fix that established the freeform-fallback shape.
- WXYC/dj-site#608, WXYC/dj-site#701 — downstream consumers next.
- BS#933 — the controller fix that made the runtime permissive ahead of the schema.