### PR TITLE
[B2] LmlLookupCoordinator: single chokepoint + in-flight coalescing

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -13,7 +13,8 @@ import * as libraryService from '../services/library.service.js';
 import * as labelsService from '../services/labels.service.js';
 import * as librarySearchService from '../services/library-search.service.js';
 import type { CatalogSort, CatalogOrder } from '../services/library-search.service.js';
-import { checkStreamingAvailability, lookupMetadata, isLmlConfigured, envInt } from '@wxyc/lml-client';
+import { checkStreamingAvailability, isLmlConfigured, envInt } from '@wxyc/lml-client';
+import { lmlLookupCoordinator } from '../services/lml/index.js';
 import { filterSpacerGif } from '../services/metadata/metadata.service.js';
 import WxycError from '../utils/error.js';
 
@@ -95,9 +96,10 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
     const artistName = body.alternate_artist_name || body.artist_name || '';
     const [streamingResult, artworkResult] = await Promise.allSettled([
       checkStreamingAvailability(artistName, body.album_title),
-      lookupMetadata(artistName, body.album_title, undefined, {
+      lmlLookupCoordinator.lookup(artistName, body.album_title, undefined, {
         budgetMs: LIBRARY_LML_BUDGET_MS,
         caller: 'library-add-album',
+        warm_cache: true,
       }),
     ]);
 
@@ -146,10 +148,12 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
 function fireAndForgetCanonicalEntity(libraryId: number, artistName: string | null, albumTitle: string): void {
   if (!artistName) return;
 
-  lookupMetadata(artistName, albumTitle, undefined, {
-    budgetMs: LIBRARY_LML_BUDGET_MS,
-    caller: 'library-canonical-entity',
-  })
+  lmlLookupCoordinator
+    .lookup(artistName, albumTitle, undefined, {
+      budgetMs: LIBRARY_LML_BUDGET_MS,
+      caller: 'library-canonical-entity',
+      warm_cache: true,
+    })
     .then(async (response) => {
       const linkage = libraryService.mapLookupToCanonicalEntity(response);
       if (!linkage) return;

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -213,8 +213,11 @@ function populateCommonMetadataFields(metadata: Record<string, unknown>, artwork
   // Empty `profile_tokens` arrays are truthy in JS; omit the field
   // entirely to match the codebase's "omit when empty" wire convention
   // (cf. `populateReleaseMetadata`'s `genres.length > 0 ? ... : undefined`).
+  // Defensive copy: `artwork` may be the coordinator's cached LookupResponse;
+  // assigning the array by reference would let any downstream mutation of
+  // `metadata.bioTokens` poison the cache.
   if (artwork.profile_tokens && artwork.profile_tokens.length > 0) {
-    metadata.bioTokens = artwork.profile_tokens;
+    metadata.bioTokens = [...artwork.profile_tokens];
   }
 
   if (artwork.spotify_url) metadata.spotifyUrl = artwork.spotify_url;
@@ -229,9 +232,16 @@ function populateCommonMetadataFields(metadata: Record<string, unknown>, artwork
  * full release date, discogs artist id, release year) from the
  * `DiscogsMatchResult.artwork` block — the coordinator forces `extended:
  * true` on every lookup, so these fields are always present when LML
- * matches a release. Shape kept generic so the `libraryTracks` path can
- * reuse it with a `DiscogsReleaseMetadata` from a direct `getRelease()`
- * call.
+ * matches a release.
+ *
+ * Sole caller is `getAlbumMetadata` (the `libraryTracks` path projects
+ * tracks via `projectTracks` directly from a `getRelease()` result).
+ * The genres/styles/tracklist arrays are defensively copied before
+ * being assigned onto `metadata` because the source object can be the
+ * coordinator's cached `LookupResponse` — a downstream mutation of
+ * `metadata.genres` would otherwise poison the cache for every
+ * subsequent same-key reader within the 5-min TTL (cf. the coordinator's
+ * read-only contract).
  */
 function populateReleaseMetadata(
   metadata: Record<string, unknown>,
@@ -250,8 +260,8 @@ function populateReleaseMetadata(
   // leak to iOS as a literal "0" on the playcut detail view. Mirrors the
   // chokepoint in `metadata.service.ts#extractAlbumMetadata`. #1002.
   metadata.releaseYear = release.year || undefined;
-  metadata.genres = release.genres && release.genres.length > 0 ? release.genres : undefined;
-  metadata.styles = release.styles && release.styles.length > 0 ? release.styles : undefined;
+  metadata.genres = release.genres && release.genres.length > 0 ? [...release.genres] : undefined;
+  metadata.styles = release.styles && release.styles.length > 0 ? [...release.styles] : undefined;
   metadata.label = release.label ?? undefined;
   metadata.discogsArtistId = release.artist_id ?? null;
   metadata.fullReleaseDate = release.released ?? undefined;
@@ -264,10 +274,7 @@ function populateReleaseMetadata(
   }
   // Filter spacer.gif placeholders (#649) and surface the artwork URL.
   // On the extended-lookup path this is the same value already set by
-  // `populateCommonMetadataFields`; the assignment is idempotent. Kept
-  // distinct so the `libraryTracks` path (which calls
-  // `populateReleaseMetadata` from a `getRelease()` result) still gets
-  // the URL when populateCommonMetadataFields wasn't called.
+  // `populateCommonMetadataFields`; the assignment is idempotent.
   const releaseArtwork = filterSpacerGif(release.artwork_url);
   if (releaseArtwork) metadata.artworkUrl = releaseArtwork;
 }

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -210,7 +210,12 @@ function populateCommonMetadataFields(metadata: Record<string, unknown>, artwork
   if (artwork.artist_bio) metadata.artistBio = artwork.artist_bio;
   if (artwork.wikipedia_url) metadata.artistWikipediaUrl = artwork.wikipedia_url;
   if (artwork.artist_image_url) metadata.artistImageUrl = artwork.artist_image_url;
-  if (artwork.profile_tokens) metadata.bioTokens = artwork.profile_tokens;
+  // Empty `profile_tokens` arrays are truthy in JS; omit the field
+  // entirely to match the codebase's "omit when empty" wire convention
+  // (cf. `populateReleaseMetadata`'s `genres.length > 0 ? ... : undefined`).
+  if (artwork.profile_tokens && artwork.profile_tokens.length > 0) {
+    metadata.bioTokens = artwork.profile_tokens;
+  }
 
   if (artwork.spotify_url) metadata.spotifyUrl = artwork.spotify_url;
   if (artwork.apple_music_url) metadata.appleMusicUrl = artwork.apple_music_url;
@@ -257,10 +262,12 @@ function populateReleaseMetadata(
       duration: t.duration ?? undefined,
     }));
   }
-  // Prefer release artwork over lookup artwork — but still filter out
-  // spacer.gif placeholders (see #649). On the extended path the values
-  // are typically identical; on the legacy path the release fetch can
-  // surface a higher-quality image.
+  // Filter spacer.gif placeholders (#649) and surface the artwork URL.
+  // On the extended-lookup path this is the same value already set by
+  // `populateCommonMetadataFields`; the assignment is idempotent. Kept
+  // distinct so the `libraryTracks` path (which calls
+  // `populateReleaseMetadata` from a `getRelease()` result) still gets
+  // the URL when populateCommonMetadataFields wasn't called.
   const releaseArtwork = filterSpacerGif(release.artwork_url);
   if (releaseArtwork) metadata.artworkUrl = releaseArtwork;
 }

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -14,7 +14,6 @@ import * as Sentry from '@sentry/node';
 import { getArtworkFinder } from '../services/artwork/finder.js';
 import { classify as classifyNSFW } from '../services/artwork/nsfw.js';
 import {
-  lookupMetadata,
   getRelease,
   getArtistDetails,
   resolveEntity as lmlResolveEntity,
@@ -23,6 +22,7 @@ import {
   LmlClientError,
 } from '@wxyc/lml-client';
 import type { DiscogsMatchResult, DiscogsReleaseMetadata, DiscogsTrackItem, LookupResponse } from '@wxyc/lml-client';
+import { lmlLookupCoordinator } from '../services/lml/index.js';
 import { getDiscogsReleaseIdByLegacyId } from '../services/library.service.js';
 import { filterSpacerGif, isSyntheticArtwork } from '../services/metadata/metadata.service.js';
 import { SearchUrlProvider } from '../services/metadata/providers/search-urls.provider.js';
@@ -34,28 +34,6 @@ import WxycError from '../utils/error.js';
 // and the flowsheet-metadata-backfill job all produce identical URLs for
 // the same inputs (BS#889).
 const searchUrlProvider = new SearchUrlProvider();
-
-/**
- * Toggle the single-call /proxy/metadata/album path.
- *
- * When `'true'`, we pass `extended: true` to LML's `/api/v1/lookup` and read
- * the tracklist/genres/styles/label/full_release_date/discogs_artist_id off
- * the lookup response's `artwork` block directly — no follow-up
- * `/api/v1/discogs/release/{id}` call. Available since `@wxyc/shared@1.5.0`
- * + LML#335.
- *
- * Defaults off so the flag can ship before production traffic is cut over.
- * Flip in Railway env (`PROXY_METADATA_SINGLE_LOOKUP=true`) once staging
- * smoke-tests confirm response parity. Matches the env-var pattern used
- * for AUTH_BYPASS / TEST_RATE_LIMITING — there's no centralized
- * feature-flag module in this repo.
- *
- * After the cutover is stable, the flag and the legacy two-call branch get
- * deleted together (separate cleanup PR).
- */
-function singleLookupEnabled(): boolean {
-  return process.env.PROXY_METADATA_SINGLE_LOOKUP === 'true';
-}
 
 /**
  * Budget for the user-visible iOS playlist + dj-site cover-art path. Tight
@@ -231,6 +209,8 @@ function populateCommonMetadataFields(metadata: Record<string, unknown>, artwork
 
   if (artwork.artist_bio) metadata.artistBio = artwork.artist_bio;
   if (artwork.wikipedia_url) metadata.artistWikipediaUrl = artwork.wikipedia_url;
+  if (artwork.artist_image_url) metadata.artistImageUrl = artwork.artist_image_url;
+  if (artwork.profile_tokens) metadata.bioTokens = artwork.profile_tokens;
 
   if (artwork.spotify_url) metadata.spotifyUrl = artwork.spotify_url;
   if (artwork.apple_music_url) metadata.appleMusicUrl = artwork.apple_music_url;
@@ -241,14 +221,12 @@ function populateCommonMetadataFields(metadata: Record<string, unknown>, artwork
 
 /**
  * Populate the release-detail fields (tracklist, genres, styles, label,
- * full release date, discogs artist id, release year). Source-agnostic:
- * works the same on a `DiscogsMatchResult` with `extended=true` (new path)
- * or on a `DiscogsReleaseMetadata` from a separate `getRelease()` call
- * (legacy two-call path).
- *
- * On the extended path the release artwork URL is the same as the lookup
- * artwork URL, so the `prefer release artwork over lookup` logic is a no-op
- * but kept for symmetry with the legacy path.
+ * full release date, discogs artist id, release year) from the
+ * `DiscogsMatchResult.artwork` block — the coordinator forces `extended:
+ * true` on every lookup, so these fields are always present when LML
+ * matches a release. Shape kept generic so the `libraryTracks` path can
+ * reuse it with a `DiscogsReleaseMetadata` from a direct `getRelease()`
+ * call.
  */
 function populateReleaseMetadata(
   metadata: Record<string, unknown>,
@@ -294,46 +272,26 @@ function populateReleaseMetadata(
  * enriched streaming URLs (Spotify, Apple Music, YouTube Music, Bandcamp,
  * SoundCloud), so no direct calls to those APIs are needed.
  *
- * Two code paths, selected by `PROXY_METADATA_SINGLE_LOOKUP`:
- *
- * - **Single-call** (flag on, future default): LML `/api/v1/lookup` with
- *   `extended: true` returns release details inline on the top-1 artwork
- *   block. One round-trip iOS → BS → LML; the LML pipeline runs its release
- *   and artist fetches concurrently server-side. Subsecond p50 target.
- *
- * - **Legacy two-call** (flag off, current default): one lookup followed
- *   by a separate `/api/v1/discogs/release/{id}` for the release details
- *   we want to surface. Two LML round-trips, the second one re-fetching
- *   release data LML already loaded ~100ms earlier during enrichment.
- *
- * Sentry annotates the active span with
- * `proxy.metadata.album.upstream_calls` so the cutover can be graphed by
- * cohort in the trace explorer.
+ * Single-call path: the coordinator forces `extended: true`, so LML returns
+ * release details (tracklist/genres/styles/label/full_release_date/
+ * discogs_artist_id) inline on the top-1 artwork block. One round-trip
+ * iOS → BS → LML; LML runs its release + artist fetches concurrently
+ * server-side.
  */
 export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMetadataQuery> = async (req, res) => {
   const { artistName, releaseTitle, trackTitle } = req.query;
 
   if (!artistName) throw new WxycError('artistName query parameter is required', 400);
 
-  const useSingleLookup = singleLookupEnabled();
   const metadata: Record<string, unknown> = {};
   let upstreamCalls = 0;
 
   let artwork: DiscogsMatchResult | undefined;
   try {
-    let lookupResponse: LookupResponse;
-    if (useSingleLookup) {
-      lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle, {
-        extended: true,
-        budgetMs: PROXY_LML_BUDGET_MS,
-        caller: 'proxy-album-metadata',
-      });
-    } else {
-      lookupResponse = await lookupMetadata(artistName, releaseTitle, trackTitle, {
-        budgetMs: PROXY_LML_BUDGET_MS,
-        caller: 'proxy-album-metadata',
-      });
-    }
+    const lookupResponse: LookupResponse = await lmlLookupCoordinator.lookup(artistName, releaseTitle, trackTitle, {
+      budgetMs: PROXY_LML_BUDGET_MS,
+      caller: 'proxy-album-metadata',
+    });
     upstreamCalls += 1;
     artwork = lookupResponse.results?.[0]?.artwork;
   } catch (searchError) {
@@ -342,30 +300,16 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
 
   if (artwork) {
     populateCommonMetadataFields(metadata, artwork);
-
-    if (useSingleLookup) {
-      // The lookup response already carries the release-detail fields
-      // (`extended: true`); no follow-up call needed.
-      populateReleaseMetadata(metadata, {
-        year: artwork.release_year,
-        genres: artwork.genres,
-        styles: artwork.styles,
-        label: artwork.label,
-        artist_id: artwork.discogs_artist_id,
-        released: artwork.full_release_date,
-        tracklist: artwork.tracklist,
-        artwork_url: artwork.artwork_url,
-      });
-    } else {
-      // Legacy path: fetch enriched release details with a second LML call.
-      try {
-        const release = await getRelease(artwork.release_id);
-        upstreamCalls += 1;
-        populateReleaseMetadata(metadata, release);
-      } catch (releaseError) {
-        console.warn('[ProxyController] Failed to fetch release details from LML:', releaseError);
-      }
-    }
+    populateReleaseMetadata(metadata, {
+      year: artwork.release_year,
+      genres: artwork.genres,
+      styles: artwork.styles,
+      label: artwork.label,
+      artist_id: artwork.discogs_artist_id,
+      released: artwork.full_release_date,
+      tracklist: artwork.tracklist,
+      artwork_url: artwork.artwork_url,
+    });
   }
 
   // Fallback: construct search URLs for services without LML-provided URLs.
@@ -385,13 +329,12 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   if (!metadata.bandcampUrl) metadata.bandcampUrl = fallbackUrls.bandcampUrl;
   if (!metadata.soundcloudUrl) metadata.soundcloudUrl = fallbackUrls.soundcloudUrl;
 
-  // Project the upstream-call count + mode onto the active Sentry span so
-  // we can split p50/p95 by cohort in the trace explorer. Wrap in a
-  // try/except — observability must never break the request path.
+  // Project the upstream-call count onto the active Sentry span so we can
+  // split p50/p95 by cohort in the trace explorer. Wrap in a try/except —
+  // observability must never break the request path.
   try {
     Sentry.getActiveSpan()?.setAttributes({
       'proxy.metadata.album.upstream_calls': upstreamCalls,
-      'proxy.metadata.album.single_lookup': useSingleLookup,
     });
   } catch (err) {
     console.warn('[ProxyController] failed to project Sentry attrs', err);

--- a/apps/backend/services/artwork/providers/discogs.ts
+++ b/apps/backend/services/artwork/providers/discogs.ts
@@ -6,7 +6,8 @@
 
 import { ArtworkProvider } from './base.js';
 import { ArtworkRequest, ArtworkSearchResult } from '../../requestLine/types.js';
-import { lookupMetadata, searchTrackReleases, validateTrackOnRelease, isLmlConfigured } from '@wxyc/lml-client';
+import { searchTrackReleases, validateTrackOnRelease, isLmlConfigured } from '@wxyc/lml-client';
+import { lmlLookupCoordinator } from '../../lml/index.js';
 import { filterSpacerGif } from '../../metadata/metadata.service.js';
 
 /**
@@ -31,7 +32,7 @@ export class DiscogsProvider implements ArtworkProvider {
 
     let lookupResponse;
     try {
-      lookupResponse = await lookupMetadata(request.artist || '', request.album, request.song, {
+      lookupResponse = await lmlLookupCoordinator.lookup(request.artist || '', request.album, request.song, {
         caller: 'artwork-discogs-fallback',
       });
     } catch (error) {

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -587,7 +587,7 @@ export async function resolveRotationPickerSource(rotationId: number): Promise<R
  * isn't a write target on this path either, and a column-mix between
  * paste-URL-prefilled and LML-resolved values would muddy provenance.
  *
- * Bounded at `ROTATION_LML_LOOKUP_TIMEOUT_MS` (5 s) per call — fast-fail
+ * Bounded at `ROTATION_LML_LOOKUP_TIMEOUT_MS` (10 s) per call — fast-fail
  * for the user-visible picker (BS#992). Caller errors are swallowed so
  * the picker degrades to free-text rather than 500ing; the LML client
  * already wraps the call in a Sentry span carrying `lml.cache.*` and

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -33,7 +33,6 @@ import {
 import {
   getRelease,
   lookupBySong,
-  lookupMetadata,
   isLmlConfigured,
   envInt,
   LmlClientError,
@@ -41,6 +40,7 @@ import {
   type DiscogsTrackItem,
   type DiscogsReleaseMetadata,
 } from '@wxyc/lml-client';
+import { lmlLookupCoordinator } from './lml/index.js';
 import { filterSpacerGif } from './metadata/metadata.service.js';
 import { checkLibraryArtistNameHealth } from './library-artist-name-assertion.service.js';
 import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrackSearch.js';
@@ -636,9 +636,8 @@ async function resolveRotationDiscogsReleaseViaLml(
     // synth-result path on LML#427) get a tracklist for releases Discogs
     // doesn't carry. Same `(artist, album)` call as before; the request body
     // only gains the `extended` flag.
-    const response = await lookupMetadata(lookupArtist, albumTitle, undefined, {
+    const response = await lmlLookupCoordinator.lookup(lookupArtist, albumTitle, undefined, {
       timeoutMs: ROTATION_LML_LOOKUP_TIMEOUT_MS,
-      extended: true,
       caller: 'library-rotation-picker',
     });
     const artwork = response.results?.[0]?.artwork ?? null;
@@ -890,7 +889,7 @@ export async function enrichWithArtwork<T extends ArtworkEnrichable>(results: T[
 
   const settlements = await Promise.allSettled(
     uncached.map(async (row) => {
-      const lookupResult = await lookupMetadata(row.artist_name, row.album_title, undefined, {
+      const lookupResult = await lmlLookupCoordinator.lookup(row.artist_name, row.album_title, undefined, {
         budgetMs: LIBRARY_INTERACTIVE_LML_BUDGET_MS,
         caller: 'library-enrich-artwork',
       });

--- a/apps/backend/services/lml/index.ts
+++ b/apps/backend/services/lml/index.ts
@@ -1,0 +1,2 @@
+export { LmlLookupCoordinator, lmlLookupCoordinator, _resetLmlLookupCoordinatorForTest } from './lookup-coordinator';
+export type { CoordinatorLookupOptions } from './lookup-coordinator';

--- a/apps/backend/services/lml/lookup-coordinator.ts
+++ b/apps/backend/services/lml/lookup-coordinator.ts
@@ -23,12 +23,16 @@
  * driven by `extended`.
  *
  * **First-caller-wins on the wire** for `caller`, `budgetMs`, `timeoutMs`,
- * `limiter`. Subsequent coalescers await the in-flight promise as-is. The
- * `warm_cache` flag accumulates — if ANY in-flight caller asks for it the
- * wire call carries `warm_cache: true` (write-path callers opt in; read-
- * path callers don't). On error the in-flight entry is discarded along
- * with the accumulated `warm_cache` flag — a subsequent retry rebuilds
- * the flag from the new coalescing population.
+ * `limiter`, and `warm_cache`. Subsequent coalescers await the in-flight
+ * promise as-is — the wire request body is already serialized and in
+ * flight by the time a coalescing caller arrives, so there is no
+ * opportunity to union flags onto it. Write-path callers (`library-add-
+ * album`, `library-canonical-entity`) set `warm_cache: true`; whether a
+ * coalesced burst warms the LML PG cache is decided entirely by which
+ * caller arrived first. Acceptable in practice: write-path callers
+ * dominate same-key bursts that originate from a single user action, and
+ * the warm-cache effect is a side benefit (LML's PG cache stays warm),
+ * not a correctness invariant.
  *
  * **No error caching.** Throws propagate to all waiters; the next request
  * for the same key issues a fresh wire call. LML's own short cache TTL
@@ -51,10 +55,6 @@ export type CoordinatorLookupOptions = Pick<
 
 interface InFlightEntry {
   promise: Promise<LookupResponse>;
-  /** Caller tags collected from the originating call and every coalescer; surfaced on the span. */
-  callers: Set<string>;
-  /** Union across coalesced callers: any `warm_cache: true` sets this true. Discarded on error. */
-  warmCacheRequested: boolean;
 }
 
 const DEFAULT_MAX_ENTRIES = 1000;
@@ -94,8 +94,6 @@ export class LmlLookupCoordinator {
 
       const existing = this.inflight.get(key);
       if (existing) {
-        existing.callers.add(caller);
-        if (options?.warm_cache) existing.warmCacheRequested = true;
         this.setSpanAttrs(span, { hit: 'inflight', caller });
         return existing.promise;
       }
@@ -103,13 +101,7 @@ export class LmlLookupCoordinator {
       const promise = this.fetchUncached(artist, album, song, options).finally(() => {
         this.inflight.delete(key);
       });
-
-      const entry: InFlightEntry = {
-        promise,
-        callers: new Set([caller]),
-        warmCacheRequested: !!options?.warm_cache,
-      };
-      this.inflight.set(key, entry);
+      this.inflight.set(key, { promise });
       this.setSpanAttrs(span, { hit: 'miss', caller });
 
       const result = await promise;

--- a/apps/backend/services/lml/lookup-coordinator.ts
+++ b/apps/backend/services/lml/lookup-coordinator.ts
@@ -1,0 +1,183 @@
+/**
+ * Single chokepoint that fronts every `lookupMetadata` call from the
+ * `@wxyc/backend` API process (BS#885 / Epic B / B2).
+ *
+ * Two collapsing strategies, both per-process:
+ *
+ *   1. **In-flight coalescing.** Concurrent callers asking for the same
+ *      `(artist, album, song)` await one Promise; the first caller's wire
+ *      call services every coalescer.
+ *   2. **Short-TTL response cache.** Successful `LookupResponse` payloads
+ *      memoize for 5 min in a process-local LRU. LML's PG cache remains
+ *      the source of truth; this is "we asked LML 30 s ago, the answer
+ *      hasn't changed yet."
+ *
+ * Cross-instance coalescing (Redis / PG advisory locks) is out of scope —
+ * dj-site session stickiness collapses most same-key bursts onto one
+ * replica.
+ *
+ * **`extended: true` is forced** on every wire call so cached responses
+ * are usable by any caller regardless of which extended fields they
+ * actually consume (BS#885 mandate). Cost: ~1 KB payload growth per
+ * response; LML's downstream work is unchanged because it's already
+ * driven by `extended`.
+ *
+ * **First-caller-wins on the wire** for `caller`, `budgetMs`, `timeoutMs`,
+ * `limiter`. Subsequent coalescers await the in-flight promise as-is. The
+ * `warm_cache` flag accumulates — if ANY in-flight caller asks for it the
+ * wire call carries `warm_cache: true` (write-path callers opt in; read-
+ * path callers don't). On error the in-flight entry is discarded along
+ * with the accumulated `warm_cache` flag — a subsequent retry rebuilds
+ * the flag from the new coalescing population.
+ *
+ * **No error caching.** Throws propagate to all waiters; the next request
+ * for the same key issues a fresh wire call. LML's own short cache TTL
+ * on errors handles avalanche.
+ */
+import * as Sentry from '@sentry/node';
+import { LRUCache } from 'lru-cache';
+
+import { lookupMetadata, type LookupOptions, type LookupResponse } from '@wxyc/lml-client';
+
+/**
+ * Options accepted by `LmlLookupCoordinator.lookup`. Mirrors `LookupOptions`
+ * except `extended` is intentionally omitted — the coordinator always passes
+ * `extended: true` so cached responses are valid for every caller.
+ */
+export type CoordinatorLookupOptions = Pick<
+  LookupOptions,
+  'budgetMs' | 'timeoutMs' | 'caller' | 'warm_cache' | 'limiter'
+>;
+
+interface InFlightEntry {
+  promise: Promise<LookupResponse>;
+  /** Caller tags collected from the originating call and every coalescer; surfaced on the span. */
+  callers: Set<string>;
+  /** Union across coalesced callers: any `warm_cache: true` sets this true. Discarded on error. */
+  warmCacheRequested: boolean;
+}
+
+const DEFAULT_MAX_ENTRIES = 1000;
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+export class LmlLookupCoordinator {
+  private readonly inflight = new Map<string, InFlightEntry>();
+  private readonly cache: LRUCache<string, LookupResponse>;
+
+  constructor(opts?: { maxEntries?: number; ttlMs?: number }) {
+    this.cache = new LRUCache({
+      max: opts?.maxEntries ?? DEFAULT_MAX_ENTRIES,
+      ttl: opts?.ttlMs ?? DEFAULT_TTL_MS,
+    });
+  }
+
+  /**
+   * Look up metadata for an artist/album/song triple. Coalesces concurrent
+   * same-key calls; serves cached responses within TTL. Errors are not
+   * cached.
+   */
+  async lookup(
+    artist: string | undefined,
+    album: string | undefined,
+    song: string | undefined,
+    options?: CoordinatorLookupOptions
+  ): Promise<LookupResponse> {
+    const key = this.cacheKey(artist, album, song);
+    const caller = options?.caller ?? 'unknown';
+
+    return Sentry.startSpan({ name: 'lml.coordinator.lookup', op: 'function' }, async (span) => {
+      const cached = this.cache.get(key);
+      if (cached) {
+        this.setSpanAttrs(span, { hit: 'cache', caller });
+        return cached;
+      }
+
+      const existing = this.inflight.get(key);
+      if (existing) {
+        existing.callers.add(caller);
+        if (options?.warm_cache) existing.warmCacheRequested = true;
+        this.setSpanAttrs(span, { hit: 'inflight', caller });
+        return existing.promise;
+      }
+
+      const promise = this.fetchUncached(artist, album, song, options).finally(() => {
+        this.inflight.delete(key);
+      });
+
+      const entry: InFlightEntry = {
+        promise,
+        callers: new Set([caller]),
+        warmCacheRequested: !!options?.warm_cache,
+      };
+      this.inflight.set(key, entry);
+      this.setSpanAttrs(span, { hit: 'miss', caller });
+
+      const result = await promise;
+      this.cache.set(key, result);
+      return result;
+    });
+  }
+
+  private async fetchUncached(
+    artist: string | undefined,
+    album: string | undefined,
+    song: string | undefined,
+    options: CoordinatorLookupOptions | undefined
+  ): Promise<LookupResponse> {
+    return lookupMetadata(artist, album, song, {
+      extended: true,
+      warm_cache: options?.warm_cache,
+      budgetMs: options?.budgetMs,
+      timeoutMs: options?.timeoutMs,
+      caller: options?.caller,
+      limiter: options?.limiter,
+    });
+  }
+
+  /**
+   * `undefined` and `''` both normalize to `∅` — both express "no value for
+   * this field." Whitespace is trimmed, internal runs collapse to a single
+   * space, casing is folded. No diacritic folding — LML's parser handles
+   * fuzzy matching.
+   */
+  private cacheKey(artist: string | undefined, album: string | undefined, song: string | undefined): string {
+    return [normalize(artist), normalize(album), normalize(song)].join('|');
+  }
+
+  private setSpanAttrs(
+    span: ReturnType<typeof Sentry.getActiveSpan>,
+    attrs: { hit: 'cache' | 'inflight' | 'miss'; caller: string }
+  ): void {
+    if (!span) return;
+    try {
+      span.setAttributes({
+        'lml.coordinator.hit': attrs.hit,
+        'lml.coordinator.caller': attrs.caller,
+      });
+    } catch (err) {
+      console.warn('lml.coordinator: failed to project attrs onto span', err);
+    }
+  }
+}
+
+function normalize(s: string | undefined): string {
+  if (!s) return '∅';
+  const trimmed = s.trim();
+  if (trimmed === '') return '∅';
+  return trimmed.toLowerCase().replace(/\s+/g, ' ');
+}
+
+/** Process-wide singleton. Module-load shape mirrors `defaultLimiter` in `@wxyc/lml-client`. */
+export const lmlLookupCoordinator = new LmlLookupCoordinator();
+
+/**
+ * Test-only — clears the singleton's in-flight + cache maps so tests don't
+ * leak state across cases. Mirrors `_resetLmlClientLimitersForTest()` in
+ * `@wxyc/lml-client`.
+ */
+export function _resetLmlLookupCoordinatorForTest(): void {
+  // eslint-disable-next-line @typescript-eslint/dot-notation
+  (lmlLookupCoordinator['inflight'] as Map<string, InFlightEntry>).clear();
+  // eslint-disable-next-line @typescript-eslint/dot-notation
+  (lmlLookupCoordinator['cache'] as LRUCache<string, LookupResponse>).clear();
+}

--- a/apps/backend/services/lml/lookup-coordinator.ts
+++ b/apps/backend/services/lml/lookup-coordinator.ts
@@ -98,15 +98,36 @@ export class LmlLookupCoordinator {
         return existing.promise;
       }
 
-      const promise = this.fetchUncached(artist, album, song, options).finally(() => {
-        this.inflight.delete(key);
-      });
-      this.inflight.set(key, { promise });
+      // Populate cache BEFORE releasing the in-flight entry. The naive
+      // `.finally(() => inflight.delete(key))` runs *before* the outer
+      // `await promise` resumes to set the cache, opening a microtask
+      // gap where a same-key caller arriving in the gap sees neither
+      // cache nor inflight and issues a redundant wire call. Sequencing
+      // cache.set → inflight.delete inside the settle chain itself
+      // closes the gap — an arriving caller always sees the cache hit
+      // by the next event-loop turn. Rejections skip the success arm
+      // and propagate through `.finally`; the in-flight entry is then
+      // cleared without caching the error, so the next request retries.
+      //
+      // **Read-only contract**: the cached `LookupResponse` is returned
+      // by reference to every coalesced + cache-hit caller for up to 5
+      // min. Callsites must NOT mutate the response or any nested field
+      // (`results`, `artwork`, etc.) — doing so poisons subsequent reads.
+      // All current callsites read-only; a deep freeze would be safer
+      // but costs O(n) per cache-set on every response. Tracked as a
+      // follow-up if mutation footguns appear.
+      const settle = this.fetchUncached(artist, album, song, options)
+        .then((result) => {
+          this.cache.set(key, result);
+          return result;
+        })
+        .finally(() => {
+          this.inflight.delete(key);
+        });
+      this.inflight.set(key, { promise: settle });
       this.setSpanAttrs(span, { hit: 'miss', caller });
 
-      const result = await promise;
-      this.cache.set(key, result);
-      return result;
+      return settle;
     });
   }
 

--- a/apps/backend/services/lml/lookup-coordinator.ts
+++ b/apps/backend/services/lml/lookup-coordinator.ts
@@ -34,6 +34,16 @@
  * the warm-cache effect is a side benefit (LML's PG cache stays warm),
  * not a correctness invariant.
  *
+ * **`warm_cache` on cache hits is a no-op.** When a cached response is
+ * served (no wire call fires), the `warm_cache: true` flag the caller
+ * passed never reaches LML — the PG cache is not warmed even when
+ * explicitly requested. This is the same trade-off as first-caller-wins
+ * extended to the cache layer: a read-path caller filling the LRU at T=0
+ * locks out warm-cache effects for write-path callers arriving within
+ * the 5-min TTL. `warm_cache` remains best-effort across both paths;
+ * the LML PG cache has its own (longer) TTL and is repopulated by
+ * subsequent reads regardless.
+ *
  * **No error caching.** Throws propagate to all waiters; the next request
  * for the same key issues a fresh wire call. LML's own short cache TTL
  * on errors handles avalanche.
@@ -116,7 +126,11 @@ export class LmlLookupCoordinator {
       // All current callsites read-only; a deep freeze would be safer
       // but costs O(n) per cache-set on every response. Tracked as a
       // follow-up if mutation footguns appear.
-      const settle = this.fetchUncached(artist, album, song, options)
+      // Pass the resolved `caller` (not the raw `options?.caller`) so the
+      // wire span's `lml.caller` attribute matches what we projected onto
+      // the coordinator span — single source of truth for the "unknown"
+      // default. The other options forward as-is.
+      const settle = this.fetchUncached(artist, album, song, { ...options, caller })
         .then((result) => {
           this.cache.set(key, result);
           return result;

--- a/apps/backend/services/metadata/metadata.service.ts
+++ b/apps/backend/services/metadata/metadata.service.ts
@@ -18,9 +18,10 @@
  *      in `@wxyc/metadata`.
  */
 import { MetadataRequest, AlbumMetadataResult, ArtistMetadataResult, FlowsheetMetadata } from './metadata.types.js';
-import { lookupMetadata, envInt } from '@wxyc/lml-client';
+import { envInt } from '@wxyc/lml-client';
 import type { DiscogsMatchResult } from '@wxyc/lml-client';
 import { cleanDiscogsBio, filterSpacerGif, isSyntheticArtwork } from '@wxyc/metadata';
+import { lmlLookupCoordinator } from '../lml/index.js';
 import { SearchUrlProvider } from './providers/search-urls.provider.js';
 
 export { filterSpacerGif, isSyntheticArtwork } from '@wxyc/metadata';
@@ -64,7 +65,7 @@ export async function fetchMetadata(request: MetadataRequest): Promise<Flowsheet
   const { artistName, albumTitle, trackTitle } = request;
   const result: FlowsheetMetadata = {};
 
-  const lookupResponse = await lookupMetadata(artistName, albumTitle, trackTitle, {
+  const lookupResponse = await lmlLookupCoordinator.lookup(artistName, albumTitle, trackTitle, {
     caller: 'metadata-service',
     budgetMs: METADATA_SERVICE_LML_BUDGET_MS,
   });

--- a/apps/backend/services/requestLine/requestLine.enhanced.service.ts
+++ b/apps/backend/services/requestLine/requestLine.enhanced.service.ts
@@ -22,7 +22,8 @@ import { getConfig, isParsingEnabled } from './config.js';
 import { parseRequest, isParserAvailable } from '../ai/index.js';
 import { executeSearchPipeline, getSearchTypeFromState } from './search/index.js';
 import { findSimilarArtist } from '../library.service.js';
-import { searchTrackReleases, lookupMetadata, validateTrackOnRelease, isLmlConfigured } from '@wxyc/lml-client';
+import { searchTrackReleases, validateTrackOnRelease, isLmlConfigured } from '@wxyc/lml-client';
+import { lmlLookupCoordinator } from '../lml/index.js';
 import { fetchArtworkForItems } from '../artwork/index.js';
 import {
   buildSlackBlocks,
@@ -229,7 +230,9 @@ export async function processRequest(body: RequestLineRequestBody): Promise<Unif
               }));
             },
             searchReleasesByArtist: async (artist: string, limit = 10) => {
-              const response = await lookupMetadata(artist, undefined, undefined, { caller: 'request-line' });
+              const response = await lmlLookupCoordinator.lookup(artist, undefined, undefined, {
+                caller: 'request-line',
+              });
               return (response.results ?? [])
                 .filter((r) => r.library_item?.title)
                 .slice(0, limit)

--- a/plans/bs885-lml-lookup-coordinator.md
+++ b/plans/bs885-lml-lookup-coordinator.md
@@ -15,16 +15,16 @@ LML's PG cache remains the source of truth; this is "we asked LML 30 s ago, the 
 
 Identified by `grep -n 'lookupMetadata(' apps/backend/{controllers,services}/**/*.ts`, after BS#894 (orphan callers removed) and the BS#918 follow-up cleanup folded into this PR (removes the `PROXY_METADATA_SINGLE_LOOKUP=false` legacy `else` branch at `proxy.controller.ts:332`).
 
-| # | File:line | Function | Path class | `extended` today | Budget/timeout today | Existing `caller` tag |
-|---|---|---|---|---|---|---|
-| 1 | `apps/backend/controllers/proxy.controller.ts:326` | `getAlbumMetadata` | iOS read | `true` | `PROXY_LML_BUDGET_MS=5000` | `proxy-album-metadata` |
-| 2 | `apps/backend/controllers/library.controller.ts:98` | `addAlbum` (artwork+streaming) | DJ write | — | `LIBRARY_LML_BUDGET_MS=5000` | `library-add-album` |
-| 3 | `apps/backend/controllers/library.controller.ts:149` | `fireAndForgetCanonicalEntity` | DJ write | — | `LIBRARY_LML_BUDGET_MS=5000` | `library-canonical-entity` |
-| 4 | `apps/backend/services/library.service.ts:639` | rotation picker `resolveRotationLmlSource` | DJ read | `true` | `ROTATION_LML_LOOKUP_TIMEOUT_MS=10000` | `library-rotation-picker` |
-| 5 | `apps/backend/services/library.service.ts:893` | `enrichWithArtwork` | DJ read | — | `LIBRARY_INTERACTIVE_LML_BUDGET_MS=5000` | `library-enrich-artwork` |
-| 6 | `apps/backend/services/artwork/providers/discogs.ts:34` | Discogs artwork provider `search` | proxy read | — | (none) | `artwork-discogs-fallback` |
-| 7 | `apps/backend/services/requestLine/requestLine.enhanced.service.ts:232` | `searchReleasesByArtist` | anonymous read | — | (none) | `request-line` |
-| 8 | `apps/backend/services/metadata/metadata.service.ts:67` | `fetchMetadata` | various | — | `METADATA_SERVICE_LML_BUDGET_MS=5000` | `metadata-service` |
+| #   | File:line                                                               | Function                                   | Path class     | `extended` today | Budget/timeout today                     | Existing `caller` tag      |
+| --- | ----------------------------------------------------------------------- | ------------------------------------------ | -------------- | ---------------- | ---------------------------------------- | -------------------------- |
+| 1   | `apps/backend/controllers/proxy.controller.ts:326`                      | `getAlbumMetadata`                         | iOS read       | `true`           | `PROXY_LML_BUDGET_MS=5000`               | `proxy-album-metadata`     |
+| 2   | `apps/backend/controllers/library.controller.ts:98`                     | `addAlbum` (artwork+streaming)             | DJ write       | —                | `LIBRARY_LML_BUDGET_MS=5000`             | `library-add-album`        |
+| 3   | `apps/backend/controllers/library.controller.ts:149`                    | `fireAndForgetCanonicalEntity`             | DJ write       | —                | `LIBRARY_LML_BUDGET_MS=5000`             | `library-canonical-entity` |
+| 4   | `apps/backend/services/library.service.ts:639`                          | rotation picker `resolveRotationLmlSource` | DJ read        | `true`           | `ROTATION_LML_LOOKUP_TIMEOUT_MS=10000`   | `library-rotation-picker`  |
+| 5   | `apps/backend/services/library.service.ts:893`                          | `enrichWithArtwork`                        | DJ read        | —                | `LIBRARY_INTERACTIVE_LML_BUDGET_MS=5000` | `library-enrich-artwork`   |
+| 6   | `apps/backend/services/artwork/providers/discogs.ts:34`                 | Discogs artwork provider `search`          | proxy read     | —                | (none)                                   | `artwork-discogs-fallback` |
+| 7   | `apps/backend/services/requestLine/requestLine.enhanced.service.ts:232` | `searchReleasesByArtist`                   | anonymous read | —                | (none)                                   | `request-line`             |
+| 8   | `apps/backend/services/metadata/metadata.service.ts:67`                 | `fetchMetadata`                            | various        | —                | `METADATA_SERVICE_LML_BUDGET_MS=5000`    | `metadata-service`         |
 
 The `proxy.controller.ts:332` legacy `else` branch is deleted as part of this PR — see Cleanups below.
 
@@ -55,15 +55,16 @@ import { LRUCache } from 'lru-cache';
 import { lookupMetadata, type LookupOptions, type LookupResponse } from '@wxyc/lml-client';
 import * as Sentry from '@sentry/node';
 
-export interface CoordinatorLookupOptions extends Pick<LookupOptions, 'budgetMs' | 'timeoutMs' | 'caller' | 'warm_cache' | 'limiter'> {
+export interface CoordinatorLookupOptions extends Pick<
+  LookupOptions,
+  'budgetMs' | 'timeoutMs' | 'caller' | 'warm_cache' | 'limiter'
+> {
   // `extended` is intentionally NOT exposed — the coordinator forces `true`
   // so cached responses are valid for any caller (BS#885's "passes `extended: true` explicitly").
 }
 
 interface InFlightEntry {
   promise: Promise<LookupResponse>;
-  callers: Set<string>;
-  warmCacheRequested: boolean;
 }
 
 export class LmlLookupCoordinator {
@@ -85,38 +86,29 @@ export class LmlLookupCoordinator {
   ): Promise<LookupResponse> {
     const key = this.cacheKey(artist, album, song);
 
-    return Sentry.startSpan(
-      { name: 'lml.coordinator.lookup', op: 'function' },
-      async (span) => {
-        const cached = this.cache.get(key);
-        if (cached) {
-          this.setSpanAttrs(span, { hit: 'cache', caller: options?.caller });
-          return cached;
-        }
-
-        const existing = this.inflight.get(key);
-        if (existing) {
-          existing.callers.add(options?.caller ?? 'unknown');
-          if (options?.warm_cache) existing.warmCacheRequested = true;
-          this.setSpanAttrs(span, { hit: 'inflight', caller: options?.caller });
-          return existing.promise;
-        }
-
-        const entry: InFlightEntry = {
-          callers: new Set([options?.caller ?? 'unknown']),
-          warmCacheRequested: !!options?.warm_cache,
-          promise: this.fetchUncached(artist, album, song, options).finally(() => {
-            this.inflight.delete(key);
-          }),
-        };
-        this.inflight.set(key, entry);
-        this.setSpanAttrs(span, { hit: 'miss', caller: options?.caller });
-
-        const result = await entry.promise;
-        this.cache.set(key, result);
-        return result;
+    return Sentry.startSpan({ name: 'lml.coordinator.lookup', op: 'function' }, async (span) => {
+      const cached = this.cache.get(key);
+      if (cached) {
+        this.setSpanAttrs(span, { hit: 'cache', caller: options?.caller });
+        return cached;
       }
-    );
+
+      const existing = this.inflight.get(key);
+      if (existing) {
+        this.setSpanAttrs(span, { hit: 'inflight', caller: options?.caller });
+        return existing.promise;
+      }
+
+      const promise = this.fetchUncached(artist, album, song, options).finally(() => {
+        this.inflight.delete(key);
+      });
+      this.inflight.set(key, { promise });
+      this.setSpanAttrs(span, { hit: 'miss', caller: options?.caller });
+
+      const result = await promise;
+      this.cache.set(key, result);
+      return result;
+    });
   }
 
   private async fetchUncached(
@@ -173,7 +165,7 @@ export function _resetLmlLookupCoordinatorForTest(): void {
 
 1. **`extended: true` is forced.** Some callers don't need the extra fields; passing them harmlessly inflates payload size by ~1 KB. The win — every cached entry is usable by every caller, no shape mismatch — outweighs the per-call cost. This is the issue's stated mandate.
 
-2. **`warm_cache` unions across coalesced callers.** If any in-flight caller asks for `warm_cache: true`, the wire call carries it. Write-path callers (`library-add-album`, `library-canonical-entity`) opt in by setting `warm_cache: true` at their call site. Read-path callers leave it absent. **Error path**: on rejection, the in-flight entry is cleared (the `finally` block); the accumulated `warmCacheRequested` flag is discarded with it. A subsequent retry for the same key re-accumulates from the new coalescing population — the flag never persists across error/retry boundaries.
+2. **`warm_cache` follows first-caller-wins like every other LookupOption.** Whether the wire call carries `warm_cache: true` is decided by whichever caller arrived first. Subsequent coalescers don't union onto the in-flight request — the wire body is already serialized and in flight by the time they arrive. Write-path callers (`library-add-album`, `library-canonical-entity`) set `warm_cache: true` at their call site; whether a coalesced burst warms LML's PG cache is decided entirely by which caller arrived first. Acceptable in practice because (a) write-path callers dominate same-key bursts originating from a single user action, and (b) warm-cache is a best-effort side benefit, not a correctness invariant.
 
 3. **First-caller-wins for budget/timeout/limiter/caller-tag on the wire.** Subsequent coalescers wait on the in-flight promise. Each caller wraps its own deadline locally via `Promise.race` against an `AbortSignal.timeout` if they need stricter semantics — out of scope for the coordinator itself; the read paths that have tight budgets (proxy, library) already handle their own catch arms. **This is documented behavior**: the coordinator does not honor per-caller timeoutMs after coalescing.
 
@@ -187,10 +179,10 @@ export function _resetLmlLookupCoordinatorForTest(): void {
 
 ### Span instrumentation
 
-| Attribute | Values | Purpose |
-|---|---|---|
-| `lml.coordinator.hit` | `cache` \| `inflight` \| `miss` | Outcome class — drives the "did coalescing/caching collapse a call?" Sentry query |
-| `lml.coordinator.caller` | the caller tag of THIS invocation | Per-call attribution even when underlying wire call inherited a different tag |
+| Attribute                | Values                            | Purpose                                                                           |
+| ------------------------ | --------------------------------- | --------------------------------------------------------------------------------- |
+| `lml.coordinator.hit`    | `cache` \| `inflight` \| `miss`   | Outcome class — drives the "did coalescing/caching collapse a call?" Sentry query |
+| `lml.coordinator.caller` | the caller tag of THIS invocation | Per-call attribution even when underlying wire call inherited a different tag     |
 
 The underlying `lml.lookup` span continues to fire on wire-call misses (existing chokepoint instrumentation in `@wxyc/lml-client`). Cache hits and in-flight coalesces produce only the `lml.coordinator.lookup` span — by construction, that's the observability win.
 
@@ -199,6 +191,7 @@ The underlying `lml.lookup` span continues to fire on wire-call misses (existing
 8 callsite changes, each: replace `lookupMetadata(...)` with `lmlLookupCoordinator.lookup(...)`; drop the `extended` flag (coordinator forces it); keep `budgetMs`/`timeoutMs`/`caller`/`warm_cache`/`limiter`.
 
 Write-path additions:
+
 - `library.controller.ts:98` (`addAlbum`) → add `warm_cache: true`
 - `library.controller.ts:149` (`fireAndForgetCanonicalEntity`) → add `warm_cache: true`
 
@@ -239,7 +232,7 @@ Consumed by `wxyc-ios-64#270`'s fallback path. The parallel `metadata.service.ts
 - **TTL expiry**: `lookup()` after the TTL elapses → fresh `lookupMetadata` invocation (use jest fake timers + injected `ttlMs`).
 - **Error propagation, no cache poisoning**: a throwing `lookupMetadata` rejects all coalescing waiters; the next call issues a fresh wire request.
 - **Cache key normalization**: `("Beatles", "Abbey Road", undefined)` and `("BEATLES ", " abbey  road", "")` map to the same cache entry.
-- **`warm_cache` union**: two concurrent callers — one with `warm_cache: true`, one without — produce one wire call with `warm_cache: true`.
+- **`warm_cache` passthrough (first-caller-wins)**: two concurrent callers where the first sets `warm_cache: false` and the second sets `warm_cache: true` produce one wire call with `warm_cache: false`. The reverse ordering produces `warm_cache: true`. (Documents the actual semantics — the wire body is in flight before coalescers arrive.)
 - **First-caller-wins on caller tag**: the wire call's `caller` field matches the first caller in.
 
 ### Existing callsite unit tests
@@ -258,19 +251,20 @@ The mock LML server already exists in `dev_env/mock-lml/` per `metadata-lml.spec
 ### Sentry acceptance (post-deploy)
 
 Per BS#885 acceptance criteria:
+
 - A single dj-site addEntry that previously produced two `lml.lookup` spans (one from `fireAndForgetMetadata`, one from `fireAndForgetLinkage`) produces… well, the two-call pattern was already eliminated by BS#894, so this criterion is **already satisfied at the trace-shape level**. The coordinator's narrower acceptance is the next bullet:
 - Two concurrent intra-instance calls for the same `(artist, album, song)` produce one outbound `lml.lookup` span (one coordinator-miss, one coordinator-inflight-hit). Verifiable in the Sentry trace explorer within 24h of deploy.
 
 ## Risks + mitigations
 
-| Risk | Mitigation |
-|---|---|
-| Forcing `extended: true` for callers that don't read those fields incurs LML cost. | LML's response shape already populates the fields on cache hit; on cache miss, the existing `extended` flag triggers the same downstream work. No new LML compute. Payload size grows by ~1 KB per response. Acceptable. |
-| First-caller-wins for budget means a tight-deadline second caller waits for a longer-deadline first caller. | Documented. Callers with hard deadlines (proxy) wrap with their own catch arm — the existing `try/catch` patterns in proxy.controller already do this. |
-| The new module-level singleton's state isn't reset between Jest test suites, leaking cache hits across tests. | Provide `_resetLmlLookupCoordinatorForTest()`; call from each callsite test's `beforeEach`. |
-| `warm_cache: true` union could amplify LML background fan-out if many read-path callers coalesce with one write-path caller. | LML's `warm_cache` is idempotent — duplicate background tasks are deduplicated server-side. The amplification is theoretical, not measured. |
-| Stale cached response (5 min TTL) returned after an artwork was updated in LML. | Cached response is the *prior* LookupResponse; LML's own writes don't propagate through BS's cache. Acceptable for ~5 min UI staleness. If real, this becomes a TTL tuning ticket post-launch. |
-| Per-instance singleton means N BS replicas have N independent caches; same-key bursts hitting different replicas still produce N wire calls. | Documented as "intra-instance only" — the issue's explicit out-of-scope. dj-site session stickiness collapses most bursts onto one replica. |
+| Risk                                                                                                                                         | Mitigation                                                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Forcing `extended: true` for callers that don't read those fields incurs LML cost.                                                           | LML's response shape already populates the fields on cache hit; on cache miss, the existing `extended` flag triggers the same downstream work. No new LML compute. Payload size grows by ~1 KB per response. Acceptable.                                                                                                                                                                |
+| First-caller-wins for budget means a tight-deadline second caller waits for a longer-deadline first caller.                                  | Documented. Callers with hard deadlines (proxy) wrap with their own catch arm — the existing `try/catch` patterns in proxy.controller already do this.                                                                                                                                                                                                                                  |
+| The new module-level singleton's state isn't reset between Jest test suites, leaking cache hits across tests.                                | Provide `_resetLmlLookupCoordinatorForTest()`; call from each callsite test's `beforeEach`.                                                                                                                                                                                                                                                                                             |
+| `warm_cache` first-caller-wins means a read-path caller arriving first can prevent a coalescing write-path caller's PG cache warm.           | Warm-cache is a best-effort side benefit, not a correctness invariant. Same-key bursts that originate from a single DJ action almost always have the write-path caller arrive first because the write-path is what _triggers_ the burst (`library.controller.addAlbum` fires both the artwork lookup and the canonical-entity lookup before any downstream read paths see the new row). |
+| Stale cached response (5 min TTL) returned after an artwork was updated in LML.                                                              | Cached response is the _prior_ LookupResponse; LML's own writes don't propagate through BS's cache. Acceptable for ~5 min UI staleness. If real, this becomes a TTL tuning ticket post-launch.                                                                                                                                                                                          |
+| Per-instance singleton means N BS replicas have N independent caches; same-key bursts hitting different replicas still produce N wire calls. | Documented as "intra-instance only" — the issue's explicit out-of-scope. dj-site session stickiness collapses most bursts onto one replica.                                                                                                                                                                                                                                             |
 
 ## PR delta estimate
 

--- a/plans/bs885-lml-lookup-coordinator.md
+++ b/plans/bs885-lml-lookup-coordinator.md
@@ -1,0 +1,311 @@
+> Plan for [BS#885 — B2 LmlLookupCoordinator: single chokepoint with in-flight coalescing](https://github.com/WXYC/Backend-Service/issues/885). Closes the last open child of [Epic B (BS#876)](https://github.com/WXYC/Backend-Service/issues/876). Slot 5 of [tracker BS#1279](https://github.com/WXYC/Backend-Service/issues/1279).
+
+## Goal
+
+Front every `lookupMetadata` call inside the `@wxyc/backend` API process with a single process-wide `LmlLookupCoordinator` that does two things and only two things:
+
+1. **In-flight coalescing.** When two callers ask for the same `(artist, album, song)` while the first wire call is still in flight, the second caller awaits the first call's Promise instead of issuing its own LML request.
+2. **Short-TTL response cache.** Successful `LookupResponse` payloads are memoized in a process-local LRU (~1000 entries, 5 min TTL) so a second request for the same key arriving 30 s after the first one's wire call resolves serves from cache.
+
+LML's PG cache remains the source of truth; this is "we asked LML 30 s ago, the answer hasn't changed yet."
+
+## Scope
+
+### In scope (8 live callsites, all in `apps/backend`)
+
+Identified by `grep -n 'lookupMetadata(' apps/backend/{controllers,services}/**/*.ts`, after BS#894 (orphan callers removed) and the BS#918 follow-up cleanup folded into this PR (removes the `PROXY_METADATA_SINGLE_LOOKUP=false` legacy `else` branch at `proxy.controller.ts:332`).
+
+| # | File:line | Function | Path class | `extended` today | Budget/timeout today | Existing `caller` tag |
+|---|---|---|---|---|---|---|
+| 1 | `apps/backend/controllers/proxy.controller.ts:326` | `getAlbumMetadata` | iOS read | `true` | `PROXY_LML_BUDGET_MS=5000` | `proxy-album-metadata` |
+| 2 | `apps/backend/controllers/library.controller.ts:98` | `addAlbum` (artwork+streaming) | DJ write | — | `LIBRARY_LML_BUDGET_MS=5000` | `library-add-album` |
+| 3 | `apps/backend/controllers/library.controller.ts:149` | `fireAndForgetCanonicalEntity` | DJ write | — | `LIBRARY_LML_BUDGET_MS=5000` | `library-canonical-entity` |
+| 4 | `apps/backend/services/library.service.ts:639` | rotation picker `resolveRotationLmlSource` | DJ read | `true` | `ROTATION_LML_LOOKUP_TIMEOUT_MS=10000` | `library-rotation-picker` |
+| 5 | `apps/backend/services/library.service.ts:893` | `enrichWithArtwork` | DJ read | — | `LIBRARY_INTERACTIVE_LML_BUDGET_MS=5000` | `library-enrich-artwork` |
+| 6 | `apps/backend/services/artwork/providers/discogs.ts:34` | Discogs artwork provider `search` | proxy read | — | (none) | `artwork-discogs-fallback` |
+| 7 | `apps/backend/services/requestLine/requestLine.enhanced.service.ts:232` | `searchReleasesByArtist` | anonymous read | — | (none) | `request-line` |
+| 8 | `apps/backend/services/metadata/metadata.service.ts:67` | `fetchMetadata` | various | — | `METADATA_SERVICE_LML_BUDGET_MS=5000` | `metadata-service` |
+
+The `proxy.controller.ts:332` legacy `else` branch is deleted as part of this PR — see Cleanups below.
+
+### Out of scope
+
+- **`apps/enrichment-worker/handler.ts:113`** — separate Docker container, separate Node process. Intra-instance coalescing in the API server cannot help a worker process; coordinating across processes is BS#885's explicit "out of scope" line (Redis Lua locks / PG advisory locks / sticky LB) and remains so. The worker keeps importing `lookupMetadata` directly from `@wxyc/lml-client`.
+- **`lookupBySong`** at `library.service.ts:1620` (track-search) — different `/lookup` request body shape, already wrapped in its own well-tuned LRU at `searchLibraryByTrack`. A future iteration could fold both `lookupMetadata` and `lookupBySong` into one coordinator surface; out of scope here to keep the PR scoped.
+- **Cross-instance coalescing.** Five BS instances each getting one user request for the same `(artist, album)` produces five LML calls; acceptable because dj-site session-stickiness collapses most same-key bursts onto one instance.
+- **Coordinator-side field mapping** (the second cleanup item in BS#885's comment). Moves the duplicate `populateCommonMetadataFields` / `extractAlbumMetadata` maps into one place — worth doing but expands the PR significantly. Filed as follow-up. The narrow extended-field gap (`artist_image_url`, `profile_tokens`) is closed in this PR at the existing map sites.
+
+## Design
+
+### File layout
+
+```
+apps/backend/services/lml/
+  lookup-coordinator.ts        # new — coordinator class + module-level singleton
+  index.ts                     # new — re-exports `lmlLookupCoordinator`
+
+tests/unit/services/lml/
+  lookup-coordinator.test.ts   # new — unit tests for coalescing, caching, error semantics
+```
+
+### Coordinator shape
+
+```typescript
+import { LRUCache } from 'lru-cache';
+import { lookupMetadata, type LookupOptions, type LookupResponse } from '@wxyc/lml-client';
+import * as Sentry from '@sentry/node';
+
+export interface CoordinatorLookupOptions extends Pick<LookupOptions, 'budgetMs' | 'timeoutMs' | 'caller' | 'warm_cache' | 'limiter'> {
+  // `extended` is intentionally NOT exposed — the coordinator forces `true`
+  // so cached responses are valid for any caller (BS#885's "passes `extended: true` explicitly").
+}
+
+interface InFlightEntry {
+  promise: Promise<LookupResponse>;
+  callers: Set<string>;
+  warmCacheRequested: boolean;
+}
+
+export class LmlLookupCoordinator {
+  private readonly inflight = new Map<string, InFlightEntry>();
+  private readonly cache: LRUCache<string, LookupResponse>;
+
+  constructor(opts?: { maxEntries?: number; ttlMs?: number }) {
+    this.cache = new LRUCache({
+      max: opts?.maxEntries ?? 1000,
+      ttl: opts?.ttlMs ?? 5 * 60 * 1000,
+    });
+  }
+
+  async lookup(
+    artist: string | undefined,
+    album: string | undefined,
+    song: string | undefined,
+    options?: CoordinatorLookupOptions
+  ): Promise<LookupResponse> {
+    const key = this.cacheKey(artist, album, song);
+
+    return Sentry.startSpan(
+      { name: 'lml.coordinator.lookup', op: 'function' },
+      async (span) => {
+        const cached = this.cache.get(key);
+        if (cached) {
+          this.setSpanAttrs(span, { hit: 'cache', caller: options?.caller });
+          return cached;
+        }
+
+        const existing = this.inflight.get(key);
+        if (existing) {
+          existing.callers.add(options?.caller ?? 'unknown');
+          if (options?.warm_cache) existing.warmCacheRequested = true;
+          this.setSpanAttrs(span, { hit: 'inflight', caller: options?.caller });
+          return existing.promise;
+        }
+
+        const entry: InFlightEntry = {
+          callers: new Set([options?.caller ?? 'unknown']),
+          warmCacheRequested: !!options?.warm_cache,
+          promise: this.fetchUncached(artist, album, song, options).finally(() => {
+            this.inflight.delete(key);
+          }),
+        };
+        this.inflight.set(key, entry);
+        this.setSpanAttrs(span, { hit: 'miss', caller: options?.caller });
+
+        const result = await entry.promise;
+        this.cache.set(key, result);
+        return result;
+      }
+    );
+  }
+
+  private async fetchUncached(
+    artist: string | undefined,
+    album: string | undefined,
+    song: string | undefined,
+    options?: CoordinatorLookupOptions
+  ): Promise<LookupResponse> {
+    return lookupMetadata(artist, album, song, {
+      extended: true,
+      warm_cache: options?.warm_cache,
+      budgetMs: options?.budgetMs,
+      timeoutMs: options?.timeoutMs,
+      caller: options?.caller,
+      limiter: options?.limiter,
+    });
+  }
+
+  private cacheKey(artist?: string, album?: string, song?: string): string {
+    return [normalize(artist), normalize(album), normalize(song)].join('|');
+  }
+
+  private setSpanAttrs(
+    span: ReturnType<typeof Sentry.getActiveSpan>,
+    attrs: { hit: 'cache' | 'inflight' | 'miss'; caller?: string }
+  ): void {
+    try {
+      span?.setAttributes({
+        'lml.coordinator.hit': attrs.hit,
+        'lml.coordinator.caller': attrs.caller ?? 'unknown',
+      });
+    } catch (err) {
+      console.warn('lml.coordinator: failed to project attrs onto span', err);
+    }
+  }
+}
+
+function normalize(s?: string): string {
+  if (!s) return '∅';
+  return s.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+export const lmlLookupCoordinator = new LmlLookupCoordinator();
+
+// Test-only — lets a test exercise eviction/coalescing without leaking state.
+// Mirrors `_resetLmlClientLimitersForTest()` in `@wxyc/lml-client`.
+export function _resetLmlLookupCoordinatorForTest(): void {
+  lmlLookupCoordinator['inflight'].clear();
+  lmlLookupCoordinator['cache'].clear();
+}
+```
+
+### Key semantic decisions
+
+1. **`extended: true` is forced.** Some callers don't need the extra fields; passing them harmlessly inflates payload size by ~1 KB. The win — every cached entry is usable by every caller, no shape mismatch — outweighs the per-call cost. This is the issue's stated mandate.
+
+2. **`warm_cache` unions across coalesced callers.** If any in-flight caller asks for `warm_cache: true`, the wire call carries it. Write-path callers (`library-add-album`, `library-canonical-entity`) opt in by setting `warm_cache: true` at their call site. Read-path callers leave it absent. **Error path**: on rejection, the in-flight entry is cleared (the `finally` block); the accumulated `warmCacheRequested` flag is discarded with it. A subsequent retry for the same key re-accumulates from the new coalescing population — the flag never persists across error/retry boundaries.
+
+3. **First-caller-wins for budget/timeout/limiter/caller-tag on the wire.** Subsequent coalescers wait on the in-flight promise. Each caller wraps its own deadline locally via `Promise.race` against an `AbortSignal.timeout` if they need stricter semantics — out of scope for the coordinator itself; the read paths that have tight budgets (proxy, library) already handle their own catch arms. **This is documented behavior**: the coordinator does not honor per-caller timeoutMs after coalescing.
+
+4. **No error caching.** Throws propagate to all coalescing waiters; the in-flight entry is cleared in `finally`. The next request for the same key issues a fresh wire call. LML's own short cache TTL on errors handles avalanche.
+
+5. **5 min TTL** matches the issue's spec. Stale-but-fresh-enough for the typical "DJ adds a track, three downstream queries fire within seconds" pattern. LML's PG cache is the source of truth — for content changes (new artwork, corrected tracklist), the 5-min staleness window is acceptable.
+
+6. **Cache key normalization** is conservative: trim, lowercase, collapse internal whitespace. No diacritic folding, no fuzzy normalization — that's LML's parser's job, not the coordinator's.
+
+7. **Per-instance singleton.** Module-level instance like the existing `defaultLimiter`. Tests use `_resetLmlLookupCoordinatorForTest()` between cases.
+
+### Span instrumentation
+
+| Attribute | Values | Purpose |
+|---|---|---|
+| `lml.coordinator.hit` | `cache` \| `inflight` \| `miss` | Outcome class — drives the "did coalescing/caching collapse a call?" Sentry query |
+| `lml.coordinator.caller` | the caller tag of THIS invocation | Per-call attribution even when underlying wire call inherited a different tag |
+
+The underlying `lml.lookup` span continues to fire on wire-call misses (existing chokepoint instrumentation in `@wxyc/lml-client`). Cache hits and in-flight coalesces produce only the `lml.coordinator.lookup` span — by construction, that's the observability win.
+
+## Migration
+
+8 callsite changes, each: replace `lookupMetadata(...)` with `lmlLookupCoordinator.lookup(...)`; drop the `extended` flag (coordinator forces it); keep `budgetMs`/`timeoutMs`/`caller`/`warm_cache`/`limiter`.
+
+Write-path additions:
+- `library.controller.ts:98` (`addAlbum`) → add `warm_cache: true`
+- `library.controller.ts:149` (`fireAndForgetCanonicalEntity`) → add `warm_cache: true`
+
+This replaces the orphan `flowsheet-linkage.service.ts` warm-cache opt-in that BS#1322 removes.
+
+Test-side: 8 callsite test files (mostly proxy.controller.test.ts, library.controller.test.ts, library.service.test.ts, metadata.service.test.ts, requestLine.enhanced.service.test.ts, artwork providers tests) each swap `jest.mock('@wxyc/lml-client')` for `jest.mock('../../services/lml/lookup-coordinator')` and assert on the coordinator instead. Most are one-line mock target swaps.
+
+## Cleanups folded into this PR (per BS#885 comment)
+
+### 1. Delete `PROXY_METADATA_SINGLE_LOOKUP` machinery (per BS#918)
+
+Since the coordinator forces `extended: true`, the flag becomes dead code. In the same PR:
+
+- Delete `singleLookupEnabled()` in `apps/backend/controllers/proxy.controller.ts`
+- Delete the legacy `else` branch in `getAlbumMetadata` (the `getRelease()` follow-up call)
+- Delete the `describe('PROXY_METADATA_SINGLE_LOOKUP=true', ...)` block in `tests/unit/controllers/proxy.controller.test.ts`
+- Remove `PROXY_METADATA_SINGLE_LOOKUP` from `.env.example` and `docs/env-vars.md`
+- Note in PR body: Railway prod env should drop `PROXY_METADATA_SINGLE_LOOKUP` (no-op since the code path is gone, but env cleanup)
+
+### 2. Forward `artist_image_url` + `profile_tokens` on the proxy response
+
+`populateCommonMetadataFields` (`apps/backend/controllers/proxy.controller.ts:205-218`) maps `artistBio` and `artistWikipediaUrl` off the artwork block but stops there. Two-line addition:
+
+```typescript
+if (artwork.artist_image_url) metadata.artistImageUrl = artwork.artist_image_url;
+if (artwork.profile_tokens) metadata.bioTokens = artwork.profile_tokens;
+```
+
+Consumed by `wxyc-ios-64#270`'s fallback path. The parallel `metadata.service.ts:extractAlbumMetadata` is intentionally NOT modified: its result shape (`AlbumMetadataResult`, `ArtistMetadataResult`) feeds persistence (flowsheet metadata columns), not the proxy response, and adding the fields there would require schema additions out of scope for B2. The persistence-side fix is filed as follow-up.
+
+## Test plan
+
+### Unit tests (`tests/unit/services/lml/lookup-coordinator.test.ts`)
+
+- **Single call**: one `lookup()` → one `lookupMetadata` invocation.
+- **In-flight coalescing**: two concurrent `lookup()` calls for the same key → one `lookupMetadata` invocation, both Promises resolve to the same response object.
+- **Cache hit**: `lookup()` after a settled prior `lookup()` for the same key → zero `lookupMetadata` invocations, returns cached value.
+- **TTL expiry**: `lookup()` after the TTL elapses → fresh `lookupMetadata` invocation (use jest fake timers + injected `ttlMs`).
+- **Error propagation, no cache poisoning**: a throwing `lookupMetadata` rejects all coalescing waiters; the next call issues a fresh wire request.
+- **Cache key normalization**: `("Beatles", "Abbey Road", undefined)` and `("BEATLES ", " abbey  road", "")` map to the same cache entry.
+- **`warm_cache` union**: two concurrent callers — one with `warm_cache: true`, one without — produce one wire call with `warm_cache: true`.
+- **First-caller-wins on caller tag**: the wire call's `caller` field matches the first caller in.
+
+### Existing callsite unit tests
+
+Each of the 8 callsite tests updates its mock target from `@wxyc/lml-client` to `../../services/lml/lookup-coordinator`. Assertions on the arguments passed are updated to match the new shape (drop `extended` from expectations; assert `warm_cache` on the two write-path callers).
+
+### Integration test
+
+Add `tests/integration/lml-coordinator.spec.js`:
+
+- Submit two concurrent `/proxy/metadata/album?artistName=X&releaseTitle=Y` requests for the same key.
+- Assert the mock LML server received exactly **one** `POST /api/v1/lookup`.
+
+The mock LML server already exists in `dev_env/mock-lml/` per `metadata-lml.spec.js`; this just wires a call-counter assertion (existing pattern). Sentry span-tree assertions are deliberately NOT in the integration test — `getActiveSpan()` returns the active span at assertion time, not a historical trace, and the Sentry test SDK setup isn't worth the complexity. Span-tree shape is verified post-deploy via the Sentry trace explorer (see "Sentry acceptance" below).
+
+### Sentry acceptance (post-deploy)
+
+Per BS#885 acceptance criteria:
+- A single dj-site addEntry that previously produced two `lml.lookup` spans (one from `fireAndForgetMetadata`, one from `fireAndForgetLinkage`) produces… well, the two-call pattern was already eliminated by BS#894, so this criterion is **already satisfied at the trace-shape level**. The coordinator's narrower acceptance is the next bullet:
+- Two concurrent intra-instance calls for the same `(artist, album, song)` produce one outbound `lml.lookup` span (one coordinator-miss, one coordinator-inflight-hit). Verifiable in the Sentry trace explorer within 24h of deploy.
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Forcing `extended: true` for callers that don't read those fields incurs LML cost. | LML's response shape already populates the fields on cache hit; on cache miss, the existing `extended` flag triggers the same downstream work. No new LML compute. Payload size grows by ~1 KB per response. Acceptable. |
+| First-caller-wins for budget means a tight-deadline second caller waits for a longer-deadline first caller. | Documented. Callers with hard deadlines (proxy) wrap with their own catch arm — the existing `try/catch` patterns in proxy.controller already do this. |
+| The new module-level singleton's state isn't reset between Jest test suites, leaking cache hits across tests. | Provide `_resetLmlLookupCoordinatorForTest()`; call from each callsite test's `beforeEach`. |
+| `warm_cache: true` union could amplify LML background fan-out if many read-path callers coalesce with one write-path caller. | LML's `warm_cache` is idempotent — duplicate background tasks are deduplicated server-side. The amplification is theoretical, not measured. |
+| Stale cached response (5 min TTL) returned after an artwork was updated in LML. | Cached response is the *prior* LookupResponse; LML's own writes don't propagate through BS's cache. Acceptable for ~5 min UI staleness. If real, this becomes a TTL tuning ticket post-launch. |
+| Per-instance singleton means N BS replicas have N independent caches; same-key bursts hitting different replicas still produce N wire calls. | Documented as "intra-instance only" — the issue's explicit out-of-scope. dj-site session stickiness collapses most bursts onto one replica. |
+
+## PR delta estimate
+
+- New: `apps/backend/services/lml/lookup-coordinator.ts` (~150 lines), `apps/backend/services/lml/index.ts` (~5 lines)
+- New: `tests/unit/services/lml/lookup-coordinator.test.ts` (~250 lines)
+- 8 callsite migrations: 1-3 lines each (~20 lines total)
+- 8 callsite test mock-target swaps + assertion updates: ~15 lines each (~120 lines)
+- New: `tests/integration/lml-coordinator.spec.js` (~80 lines)
+- `proxy.controller.ts` cleanup (delete `singleLookupEnabled` + legacy else branch + 2 forwarded fields): ~-40 / +4 lines
+- `metadata.service.ts` cleanup (2 forwarded fields): +2 lines
+- `proxy.controller.test.ts` cleanup (delete legacy describe): ~-60 lines
+- `.env.example` + `docs/env-vars.md` (remove `PROXY_METADATA_SINGLE_LOOKUP`): ~-5 lines
+
+**Net: ~+550 / -110, ~660 lines across ~18 files.** Comfortably under 1000.
+
+## Sequencing relative to BS#1322 (orphan cleanup)
+
+BS#1322 deletes `enrichment.service.ts` + `flowsheet-linkage.service.ts` + `linkage-metrics.service.ts` (the C5 cleanup). It is independent of this PR — neither blocks the other:
+
+- BS#1322 can ship before this PR: removes already-orphan code; no LML callsite impact.
+- This PR can ship before BS#1322: the orphan modules still call `lookupMetadata` directly, but they're not invoked from any live path, so the coordinator simply has no coalescing opportunity with them.
+
+I'll let BS#1322 ship first if convenient (mechanical, low-risk); otherwise this PR proceeds independently.
+
+## Rollout
+
+1. Worktree off `main`. TDD: unit test for coalescing → coordinator skeleton → pass → migrate one caller (`metadata.service.ts` — simplest) → unit tests pass → migrate remaining 7 → unit tests pass → integration tests pass → cleanups (#918 dead code + extended fields).
+2. Local `npm run typecheck && npm run lint && npm run format:check && npm run test:unit && npm run ci:testmock` before push.
+3. Open PR; close BS#885 via `Closes #885` in PR body.
+4. `/review-loop` to converge on substantive findings.
+5. Rebase-and-merge to main (use `--admin` if needed for branch protection).
+6. Post-merge: watch the 24h Sentry trace for the acceptance criterion (one wire call from two concurrent intra-instance lookups). If the rate isn't measurably collapsing, the LRU TTL or cache-key normalization may need tuning — file a follow-up.
+
+## Open questions for review
+
+1. **Should `library-rotation-picker`'s 10 s `ROTATION_LML_LOOKUP_TIMEOUT_MS` win over a competing proxy caller's 5 s `PROXY_LML_BUDGET_MS` when they coalesce?** Current plan: first-caller-wins on the wire. Alternative: max-wins (be patient enough for the slowest caller). I lean first-caller-wins because it's simpler and the worst case (longer-budget caller coalesces with shorter-budget first caller) gets a faster answer than it would have alone.
+2. **Should the `lml.coordinator.lookup` span suppress the inner `lml.lookup` span on cache-hit / in-flight-hit?** Plan: no — Sentry handles span nesting; the absence of a child `lml.lookup` span on hits is itself the observability signal (verifiable in the trace tree). **Implementation verification step**: after wiring the coordinator + the first migrated caller, hit `/proxy/metadata/album` twice locally with the dev DB and inspect the local Sentry trace tree to confirm (a) the miss path produces `lml.coordinator.lookup` → `lml.lookup` as parent → child, and (b) the second-call cache hit produces only `lml.coordinator.lookup` with no inner `lml.lookup` child. If the trace shape is wrong (e.g., orphan inner span on cache hit), add an explicit no-op span context on hit paths.
+3. **Test-only `_resetLmlLookupCoordinatorForTest()` — leak risk?** Plan: ship it as a named export with the `_` prefix convention. Mirrors `_resetLmlClientLimitersForTest()` in `@wxyc/lml-client`. Eslint already allows underscore-prefixed test-only exports here.

--- a/tests/integration/lml-coordinator.spec.js
+++ b/tests/integration/lml-coordinator.spec.js
@@ -11,12 +11,27 @@ const { isMockApiAvailable, resetMockApi, getMockRequests } = require('../utils/
  * call, not two. The coordinator's in-flight coalescing makes the second
  * request piggyback on the first request's wire call.
  *
+ * **Test isolation**: the coordinator's process-local LRU lives in the
+ * running BS process across all integration tests, and `resetMockApi()`
+ * only clears the mock-LML request log, not the coordinator's cache.
+ * Each test uses uniquely-named artist keys (no overlap with other
+ * integration specs that hit `/proxy/metadata/album`) so the assertions
+ * on wire-call count aren't poisoned by earlier-test cache state.
+ *
  * Sentry span-tree shape (one `lml.lookup` span where there used to be N
  * for N coalescing callers) is verified post-deploy via the trace explorer
  * — `getActiveSpan()` returns the active span at assertion time, not a
  * historical trace, so an automated assert here would require setting up
  * the Sentry test SDK. Not worth the complexity for one acceptance test.
  */
+
+// Unique per-test artists. The mock LML responds with `results: []` for any
+// unknown artist (still a 200 LookupResponse), which is exactly what we
+// want — the test counts wire calls, not response content.
+const COALESCE_ARTIST = 'BS885 Coalesce Test Artist';
+const DIFFKEY_ARTIST_A = 'BS885 Diff Key Artist A';
+const DIFFKEY_ARTIST_B = 'BS885 Diff Key Artist B';
+const CACHE_ARTIST = 'BS885 Cache Hit Test Artist';
 
 let mockApiAvailable = false;
 
@@ -55,17 +70,15 @@ describe('LmlLookupCoordinator end-to-end (Mock API)', () => {
       request
         .get('/proxy/metadata/album')
         .set('Authorization', `Bearer ${anonToken}`)
-        .query({ artistName: 'Autechre', releaseTitle: 'Confield' }),
+        .query({ artistName: COALESCE_ARTIST, releaseTitle: 'Test Album' }),
       request
         .get('/proxy/metadata/album')
         .set('Authorization', `Bearer ${anonToken}`)
-        .query({ artistName: 'Autechre', releaseTitle: 'Confield' }),
+        .query({ artistName: COALESCE_ARTIST, releaseTitle: 'Test Album' }),
     ]);
 
     expect(res1.status).toBe(200);
     expect(res2.status).toBe(200);
-    // Same response from both — coalesced into one wire call.
-    expect(res1.body.discogsReleaseId).toBe(res2.body.discogsReleaseId);
 
     // The whole point: one outbound LML lookup despite two concurrent
     // backend requests for the same (artist, album, song) key.
@@ -81,11 +94,11 @@ describe('LmlLookupCoordinator end-to-end (Mock API)', () => {
       request
         .get('/proxy/metadata/album')
         .set('Authorization', `Bearer ${anonToken}`)
-        .query({ artistName: 'Autechre', releaseTitle: 'Confield' }),
+        .query({ artistName: DIFFKEY_ARTIST_A, releaseTitle: 'Album A' }),
       request
         .get('/proxy/metadata/album')
         .set('Authorization', `Bearer ${anonToken}`)
-        .query({ artistName: 'Beatles', releaseTitle: 'Abbey Road' }),
+        .query({ artistName: DIFFKEY_ARTIST_B, releaseTitle: 'Album B' }),
     ]);
 
     expect(res1.status).toBe(200);
@@ -100,20 +113,18 @@ describe('LmlLookupCoordinator end-to-end (Mock API)', () => {
     if (!mockApiAvailable || !anonToken) return;
 
     // First call: warms the cache.
-    const res1 = await request
+    await request
       .get('/proxy/metadata/album')
       .set('Authorization', `Bearer ${anonToken}`)
-      .query({ artistName: 'Autechre', releaseTitle: 'Confield' })
+      .query({ artistName: CACHE_ARTIST, releaseTitle: 'Cache Album' })
       .expect(200);
 
     // Second call after the first settles: should hit the LRU cache.
-    const res2 = await request
+    await request
       .get('/proxy/metadata/album')
       .set('Authorization', `Bearer ${anonToken}`)
-      .query({ artistName: 'Autechre', releaseTitle: 'Confield' })
+      .query({ artistName: CACHE_ARTIST, releaseTitle: 'Cache Album' })
       .expect(200);
-
-    expect(res2.body.discogsReleaseId).toBe(res1.body.discogsReleaseId);
 
     const lmlRequests = await getMockRequests('lml');
     const lookupCalls = lmlRequests.filter((r) => r.path === '/api/v1/lookup');

--- a/tests/integration/lml-coordinator.spec.js
+++ b/tests/integration/lml-coordinator.spec.js
@@ -1,0 +1,122 @@
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { signInAnonymous } = require('../utils/anonymous_auth');
+const { isMockApiAvailable, resetMockApi, getMockRequests } = require('../utils/mock_api');
+
+/**
+ * LmlLookupCoordinator integration test (BS#885).
+ *
+ * Pins the central behavior of the coordinator end-to-end against the
+ * backend's running API + the mock LML server: two concurrent same-key
+ * `/proxy/metadata/album` requests produce ONE outbound `POST /api/v1/lookup`
+ * call, not two. The coordinator's in-flight coalescing makes the second
+ * request piggyback on the first request's wire call.
+ *
+ * Sentry span-tree shape (one `lml.lookup` span where there used to be N
+ * for N coalescing callers) is verified post-deploy via the trace explorer
+ * — `getActiveSpan()` returns the active span at assertion time, not a
+ * historical trace, so an automated assert here would require setting up
+ * the Sentry test SDK. Not worth the complexity for one acceptance test.
+ */
+
+let mockApiAvailable = false;
+
+beforeAll(async () => {
+  mockApiAvailable = await isMockApiAvailable();
+  if (!mockApiAvailable) {
+    console.warn('Skipping lml-coordinator tests: mock API server not available');
+  }
+});
+
+describe('LmlLookupCoordinator end-to-end (Mock API)', () => {
+  let anonToken;
+
+  beforeAll(async () => {
+    if (!mockApiAvailable) return;
+    try {
+      const { token } = await signInAnonymous();
+      anonToken = token;
+    } catch {
+      console.warn('Could not obtain anonymous token, coordinator tests will skip');
+    }
+  });
+
+  beforeEach(async () => {
+    if (!mockApiAvailable) return;
+    await resetMockApi();
+  });
+
+  test('two concurrent same-key /proxy/metadata/album requests coalesce to one LML lookup', async () => {
+    if (!mockApiAvailable || !anonToken) return;
+
+    // Concurrent: kick off both before awaiting either. The coordinator's
+    // in-flight Map should hold both Promises before the first wire call
+    // resolves.
+    const [res1, res2] = await Promise.all([
+      request
+        .get('/proxy/metadata/album')
+        .set('Authorization', `Bearer ${anonToken}`)
+        .query({ artistName: 'Autechre', releaseTitle: 'Confield' }),
+      request
+        .get('/proxy/metadata/album')
+        .set('Authorization', `Bearer ${anonToken}`)
+        .query({ artistName: 'Autechre', releaseTitle: 'Confield' }),
+    ]);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    // Same response from both — coalesced into one wire call.
+    expect(res1.body.discogsReleaseId).toBe(res2.body.discogsReleaseId);
+
+    // The whole point: one outbound LML lookup despite two concurrent
+    // backend requests for the same (artist, album, song) key.
+    const lmlRequests = await getMockRequests('lml');
+    const lookupCalls = lmlRequests.filter((r) => r.path === '/api/v1/lookup');
+    expect(lookupCalls.length).toBe(1);
+  });
+
+  test('different-key concurrent requests do NOT coalesce', async () => {
+    if (!mockApiAvailable || !anonToken) return;
+
+    const [res1, res2] = await Promise.all([
+      request
+        .get('/proxy/metadata/album')
+        .set('Authorization', `Bearer ${anonToken}`)
+        .query({ artistName: 'Autechre', releaseTitle: 'Confield' }),
+      request
+        .get('/proxy/metadata/album')
+        .set('Authorization', `Bearer ${anonToken}`)
+        .query({ artistName: 'Beatles', releaseTitle: 'Abbey Road' }),
+    ]);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+
+    const lmlRequests = await getMockRequests('lml');
+    const lookupCalls = lmlRequests.filter((r) => r.path === '/api/v1/lookup');
+    expect(lookupCalls.length).toBe(2);
+  });
+
+  test('a settled lookup serves the next same-key request from cache (no second wire call)', async () => {
+    if (!mockApiAvailable || !anonToken) return;
+
+    // First call: warms the cache.
+    const res1 = await request
+      .get('/proxy/metadata/album')
+      .set('Authorization', `Bearer ${anonToken}`)
+      .query({ artistName: 'Autechre', releaseTitle: 'Confield' })
+      .expect(200);
+
+    // Second call after the first settles: should hit the LRU cache.
+    const res2 = await request
+      .get('/proxy/metadata/album')
+      .set('Authorization', `Bearer ${anonToken}`)
+      .query({ artistName: 'Autechre', releaseTitle: 'Confield' })
+      .expect(200);
+
+    expect(res2.body.discogsReleaseId).toBe(res1.body.discogsReleaseId);
+
+    const lmlRequests = await getMockRequests('lml');
+    const lookupCalls = lmlRequests.filter((r) => r.path === '/api/v1/lookup');
+    expect(lookupCalls.length).toBe(1);
+  });
+});

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -71,6 +71,11 @@ jest.mock('@wxyc/lml-client', () => ({
   envInt: (_name: string, fallback: number) => fallback,
 }));
 
+// Backend code paths now route through the LmlLookupCoordinator (BS#885).
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: mockLookupMetadata },
+}));
+
 import {
   markMissing,
   markFound,
@@ -405,6 +410,7 @@ describe('library.controller', () => {
         expect(mockLookupMetadata).toHaveBeenCalledWith('Juana Molina', 'DOGA', undefined, {
           budgetMs: 5000,
           caller: 'library-canonical-entity',
+          warm_cache: true,
         });
       });
 

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -35,6 +35,11 @@ jest.mock('@wxyc/lml-client', () => ({
   LmlClientError: MockLmlClientError,
 }));
 
+// Backend code paths now route through the LmlLookupCoordinator (BS#885).
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: mockLookupMetadata },
+}));
+
 // library.service mock — only the helper libraryTracks consumes.
 const mockGetDiscogsReleaseIdByLegacyId = jest.fn<(legacyId: number) => Promise<number | null>>();
 
@@ -220,6 +225,10 @@ describe('proxy.controller', () => {
     });
 
     it('returns merged metadata from LML lookup + release details', async () => {
+      // Post-BS#885: the coordinator forces `extended: true` on every
+      // lookup, so the artwork block carries the release-detail fields
+      // (year/label/genres/styles/tracklist/discogs_artist_id/released)
+      // inline. No separate `getRelease()` call.
       mockLookupMetadata.mockResolvedValue({
         results: [
           {
@@ -242,32 +251,22 @@ describe('proxy.controller', () => {
               youtube_music_url: 'https://music.youtube.com/search?q=Autechre+Confield',
               bandcamp_url: 'https://bandcamp.com/search?q=Autechre+Confield',
               soundcloud_url: 'https://soundcloud.com/search?q=Autechre+Confield',
+              release_year: 2001,
+              label: 'Warp',
+              discogs_artist_id: 3840,
+              genres: ['Electronic'],
+              styles: ['IDM', 'Abstract'],
+              tracklist: [
+                { position: '1', title: 'VI Scose Poise', duration: '6:45' },
+                { position: '2', title: 'Cfern', duration: '7:01' },
+              ],
+              full_release_date: '2001-04-30',
             },
           },
         ],
         search_type: 'direct',
         song_not_found: false,
         found_on_compilation: false,
-      });
-
-      mockGetRelease.mockResolvedValue({
-        release_id: 12345,
-        title: 'Confield',
-        artist: 'Autechre',
-        year: 2001,
-        label: 'Warp',
-        artist_id: 3840,
-        genres: ['Electronic'],
-        styles: ['IDM', 'Abstract'],
-        tracklist: [
-          { position: '1', title: 'VI Scose Poise', duration: '6:45', artists: [] },
-          { position: '2', title: 'Cfern', duration: '7:01', artists: [] },
-        ],
-        artwork_url: 'https://i.discogs.com/art.jpg',
-        release_url: 'https://www.discogs.com/release/12345',
-        released: '2001-04-30',
-        cached: false,
-        artists: [{ artist_id: 3840, name: 'Autechre', join: '', role: null }],
       });
 
       const req = {
@@ -462,6 +461,8 @@ describe('proxy.controller', () => {
       // release has no real cover art; passing that through results in a
       // broken/blank image on iOS. Drop it at this callsite the same way
       // metadata.service.ts does.
+      // Post-BS#885: release-detail fields come back inline on the
+      // artwork block (coordinator forces `extended: true`).
       mockLookupMetadata.mockResolvedValue({
         results: [
           {
@@ -484,29 +485,19 @@ describe('proxy.controller', () => {
               youtube_music_url: null,
               bandcamp_url: null,
               soundcloud_url: null,
+              release_year: 2015,
+              label: 'Drag City',
+              discogs_artist_id: 5555,
+              genres: ['Rock'],
+              styles: [],
+              tracklist: [],
+              full_release_date: '2015-02-03',
             },
           },
         ],
         search_type: 'direct',
         song_not_found: false,
         found_on_compilation: false,
-      });
-
-      mockGetRelease.mockResolvedValue({
-        release_id: 7777,
-        title: 'On Your Own Love Again',
-        artist: 'Jessica Pratt',
-        year: 2015,
-        label: 'Drag City',
-        artist_id: 5555,
-        genres: ['Rock'],
-        styles: [],
-        tracklist: [],
-        artwork_url: 'https://s.discogs.com/images/spacer.gif',
-        release_url: 'https://www.discogs.com/release/7777',
-        released: '2015-02-03',
-        cached: false,
-        artists: [{ artist_id: 5555, name: 'Jessica Pratt', join: '', role: null }],
       });
 
       const req = {
@@ -552,26 +543,15 @@ describe('proxy.controller', () => {
       expect(mockGetRelease).not.toHaveBeenCalled();
     });
 
-    // --- Single-call path (PROXY_METADATA_SINGLE_LOOKUP=true) ---
+    // --- Single-call path (the only path post-BS#885) ---
     //
-    // When the flag is on, `getAlbumMetadata` calls LML once with
-    // `extended: true` and reads the release-detail fields off the lookup
-    // response's `artwork` block. The follow-up `getRelease()` call goes
-    // away. These tests pin the new path's contract; the legacy path's
-    // tests above remain to cover the pre-cutover behavior.
+    // The coordinator forces `extended: true`, so LML returns the
+    // release-detail fields inline on the lookup response's `artwork`
+    // block. No follow-up `getRelease()` call. (The `PROXY_METADATA_SINGLE_LOOKUP`
+    // env flag and its legacy two-call branch were removed when this
+    // coordinator landed; BS#918 cleanup folded here.)
 
-    describe('PROXY_METADATA_SINGLE_LOOKUP=true', () => {
-      const originalFlag = process.env.PROXY_METADATA_SINGLE_LOOKUP;
-
-      beforeEach(() => {
-        process.env.PROXY_METADATA_SINGLE_LOOKUP = 'true';
-      });
-
-      afterEach(() => {
-        if (originalFlag === undefined) delete process.env.PROXY_METADATA_SINGLE_LOOKUP;
-        else process.env.PROXY_METADATA_SINGLE_LOOKUP = originalFlag;
-      });
-
+    describe('extended-mode response shape', () => {
       it('reads release-detail fields off the lookup artwork and skips getRelease', async () => {
         mockLookupMetadata.mockResolvedValue({
           results: [
@@ -644,10 +624,11 @@ describe('proxy.controller', () => {
         // The whole point of this PR: no follow-up LML call.
         expect(mockGetRelease).not.toHaveBeenCalled();
 
-        // Lookup was called with `extended: true` so LML knows to populate
-        // the new fields.
+        // Post-BS#885: callsite no longer passes `extended` — the
+        // LmlLookupCoordinator forces it on the wire. The coordinator
+        // mock receives the callsite args; `extended` is applied inside
+        // the (real) coordinator's fetchUncached path.
         expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
-          extended: true,
           budgetMs: 5000,
           caller: 'proxy-album-metadata',
         });

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -404,7 +404,16 @@ describe('proxy.controller', () => {
       expect(result.soundcloudUrl).toBe('https://soundcloud.com/search?q=Stereolab');
     });
 
-    it('returns search-only metadata when release fetch fails', async () => {
+    it('omits enriched fields when the lookup artwork has no extended metadata', async () => {
+      // The artwork block carries release-detail fields when LML's
+      // extended pipeline finds them (`release_year`, `genres`, `styles`,
+      // `tracklist`, `discogs_artist_id`, `full_release_date`). When the
+      // artwork lacks those fields (LML matched the release but the
+      // extended pipeline returned no enrichment), the proxy response
+      // surfaces the search-only metadata (Discogs IDs + streaming URLs)
+      // and omits the missing enriched fields rather than fabricating
+      // them. No follow-up `getRelease()` call happens — the coordinator
+      // forces `extended: true` on the single lookup.
       mockLookupMetadata.mockResolvedValue({
         results: [
           {
@@ -435,8 +444,6 @@ describe('proxy.controller', () => {
         found_on_compilation: false,
       });
 
-      mockGetRelease.mockRejectedValue(new Error('Release fetch failed'));
-
       const req = {
         query: { artistName: 'Cat Power', releaseTitle: 'Moon Pix' },
       } as unknown as Request;
@@ -448,11 +455,13 @@ describe('proxy.controller', () => {
       const result = (res.json as jest.Mock).mock.calls[0][0];
       expect(result.discogsReleaseId).toBe(99999);
       expect(result.artworkUrl).toBe('https://i.discogs.com/art.jpg');
-      // Streaming URLs from search result still present
+      // Streaming URLs from search result still present.
       expect(result.spotifyUrl).toBe('https://open.spotify.com/album/moonpix');
-      // No enriched fields since release fetch failed
+      // Enriched fields are omitted when the artwork doesn't carry them.
       expect(result.genres).toBeUndefined();
       expect(result.tracklist).toBeUndefined();
+      // getRelease is never called on the album path post-BS#885.
+      expect(mockGetRelease).not.toHaveBeenCalled();
     });
 
     it('strips Discogs spacer.gif placeholder from artworkUrl (#649)', async () => {

--- a/tests/unit/services/artwork.discogs-provider.test.ts
+++ b/tests/unit/services/artwork.discogs-provider.test.ts
@@ -22,6 +22,11 @@ jest.mock('@wxyc/lml-client', () => ({
   envInt: (_name: string, fallback: number) => fallback,
 }));
 
+// Backend code paths now route through the LmlLookupCoordinator (BS#885).
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: mockLookupMetadata },
+}));
+
 import { DiscogsProvider } from '../../../apps/backend/services/artwork/providers/discogs';
 
 describe('artwork DiscogsProvider', () => {

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -35,6 +35,11 @@ jest.mock('@wxyc/lml-client', () => ({
   LmlClientError: MockLmlClientError,
 }));
 
+// Backend code paths now route through the LmlLookupCoordinator (BS#885).
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: mockLookupMetadata },
+}));
+
 // Mock @sentry/node so we can assert that searchLibraryByTrack creates a
 // catalog.track_search span and projects per-search measurements onto it
 // without initializing Sentry. startSpan(opts, callback) wraps a span mock
@@ -2249,9 +2254,11 @@ describe('library.service', () => {
       // picker, which always passes real `(artist_name, album_title)` pairs
       // from rotation, the cascade's later strategies are exactly where the
       // match for obscure college rotation comes from.
+      // `extended: true` is no longer passed at the callsite — the
+      // LmlLookupCoordinator (BS#885) forces it on the wire. Coordinator
+      // mock receives the callsite args without it.
       expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
         timeoutMs: 10000,
-        extended: true,
         caller: 'library-rotation-picker',
       });
     });
@@ -2280,7 +2287,7 @@ describe('library.service', () => {
         undefined,
         'All the Young Droids: Junkshop Synth Pop 1978-1985',
         undefined,
-        { timeoutMs: 10000, extended: true, caller: 'library-rotation-picker' }
+        { timeoutMs: 10000, caller: 'library-rotation-picker' }
       );
     });
 

--- a/tests/unit/services/lml/lookup-coordinator.test.ts
+++ b/tests/unit/services/lml/lookup-coordinator.test.ts
@@ -238,8 +238,13 @@ describe('LmlLookupCoordinator', () => {
     });
   });
 
-  describe('warm_cache union across coalesced callers', () => {
-    it('passes warm_cache=true on wire when any in-flight caller requested it', async () => {
+  describe('warm_cache passthrough (first-caller-wins)', () => {
+    // The wire request body is serialized and in flight by the time a
+    // coalescing caller arrives — there's no opportunity to union flags
+    // onto it. So warm_cache, like every other LookupOptions field, is
+    // decided by whichever caller arrived first.
+
+    it('passes warm_cache=false on the wire when the first caller did not request it', async () => {
       let resolveFn: (r: LookupResponse) => void = () => {};
       mockLookupMetadata.mockImplementation(
         () =>
@@ -252,16 +257,12 @@ describe('LmlLookupCoordinator', () => {
         caller: 'read-path',
         warm_cache: false,
       });
-      const _p2 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
+      const p2 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
         caller: 'write-path',
         warm_cache: true,
       });
 
-      // First wire call already issued (warm_cache=false from p1, the first caller).
-      // The union behavior is asserted by the issued wire call carrying warm_cache=true
-      // only when the FIRST caller asked for it — this test sets read-path FIRST.
-      // For the dominant semantics we want, the wire call should reflect what the
-      // first caller asked. (Documented in the plan: first-caller-wins.)
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
       expect(mockLookupMetadata).toHaveBeenCalledWith(
         'Autechre',
         'Confield',
@@ -270,7 +271,7 @@ describe('LmlLookupCoordinator', () => {
       );
 
       resolveFn(fakeResponse());
-      await p1;
+      await Promise.all([p1, p2]);
     });
 
     it('passes warm_cache=true when the first caller is the write-path caller', async () => {
@@ -305,7 +306,7 @@ describe('LmlLookupCoordinator', () => {
         budgetMs: 3000,
         timeoutMs: 5000,
       });
-      const _p2 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
+      const p2 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
         caller: 'second-caller',
         budgetMs: 10000,
         timeoutMs: 15000,
@@ -320,7 +321,7 @@ describe('LmlLookupCoordinator', () => {
       );
 
       resolveFn(fakeResponse());
-      await p1;
+      await Promise.all([p1, p2]);
     });
   });
 });

--- a/tests/unit/services/lml/lookup-coordinator.test.ts
+++ b/tests/unit/services/lml/lookup-coordinator.test.ts
@@ -158,6 +158,25 @@ describe('LmlLookupCoordinator', () => {
       await coord.lookup('Autechre', 'Confield', undefined, { caller: 'b' });
       expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
     });
+
+    it('a same-key caller arriving immediately after the wire settles hits cache (no race window)', async () => {
+      // Regression test for the cache-set vs inflight-delete ordering race.
+      // A naive `.finally(() => inflight.delete(key))` runs *before* the
+      // outer `await promise` resumes to set the cache, so a same-key
+      // caller arriving in the microtask gap would miss both cache and
+      // inflight and issue a redundant wire call. The coordinator's
+      // `.then(setCache).finally(deleteInflight)` ordering closes the gap.
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      const firstSettle = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'a' });
+      await firstSettle;
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+
+      // Immediately after `await firstSettle` resumes, the cache must
+      // already contain the result. A second call must not issue a wire.
+      await lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'b' });
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('cache key normalization', () => {

--- a/tests/unit/services/lml/lookup-coordinator.test.ts
+++ b/tests/unit/services/lml/lookup-coordinator.test.ts
@@ -194,7 +194,7 @@ describe('LmlLookupCoordinator', () => {
       expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
     });
 
-    it('undefined fields key distinctly from empty strings', async () => {
+    it('undefined and empty string normalize to the same key (both map to the ∅ sentinel)', async () => {
       mockLookupMetadata.mockResolvedValue(fakeResponse());
 
       await lmlLookupCoordinator.lookup(undefined, 'Album', undefined, { caller: 'a' });

--- a/tests/unit/services/lml/lookup-coordinator.test.ts
+++ b/tests/unit/services/lml/lookup-coordinator.test.ts
@@ -159,24 +159,20 @@ describe('LmlLookupCoordinator', () => {
       expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
     });
 
-    it('a same-key caller arriving immediately after the wire settles hits cache (no race window)', async () => {
-      // Regression test for the cache-set vs inflight-delete ordering race.
-      // A naive `.finally(() => inflight.delete(key))` runs *before* the
-      // outer `await promise` resumes to set the cache, so a same-key
-      // caller arriving in the microtask gap would miss both cache and
-      // inflight and issue a redundant wire call. The coordinator's
-      // `.then(setCache).finally(deleteInflight)` ordering closes the gap.
-      mockLookupMetadata.mockResolvedValue(fakeResponse());
-
-      const firstSettle = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'a' });
-      await firstSettle;
-      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
-
-      // Immediately after `await firstSettle` resumes, the cache must
-      // already contain the result. A second call must not issue a wire.
-      await lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'b' });
-      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
-    });
+    // Note on the cache-set vs inflight-delete race window: the bug was a
+    // microtask-ordering hazard between `.finally(deleteInflight)` and
+    // `cache.set`; the fix sequences them inside one `.then(cacheSet)
+    // .finally(deleteInflight)` chain so an arriving same-key caller
+    // always sees either inflight (before fetchUncached resolves) or
+    // cache (after). The race is documented in source at
+    // `lookup-coordinator.ts:lookup()`. A faithful regression test
+    // would need to inject a caller in the microtask gap between
+    // `fetchUncached` resolving and the coordinator's chained handlers
+    // firing — the test scaffold for that is fragile (depends on Jest's
+    // microtask scheduling and breaks if the SDK changes how spans
+    // wrap async). The cache-hit test above (`serves a settled prior
+    // call from cache`) pins the post-settle invariant the fix
+    // delivers; that is the load-bearing check.
   });
 
   describe('cache key normalization', () => {

--- a/tests/unit/services/lml/lookup-coordinator.test.ts
+++ b/tests/unit/services/lml/lookup-coordinator.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Unit tests for LmlLookupCoordinator.
+ *
+ * Verifies the three coordinator behaviors that matter:
+ *   1. In-flight coalescing — two concurrent same-key calls hit the wire once.
+ *   2. Response caching — settled calls within TTL serve from cache.
+ *   3. Error propagation — throws reach all waiters; no cache poisoning.
+ *
+ * Plus the supporting semantics: cache-key normalization, `warm_cache` union,
+ * `extended: true` forced on the wire call.
+ */
+import { jest } from '@jest/globals';
+
+import type { LookupResponse } from '@wxyc/lml-client';
+
+const mockLookupMetadata = jest.fn<(...args: unknown[]) => Promise<LookupResponse>>();
+
+jest.mock('@wxyc/lml-client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+import {
+  LmlLookupCoordinator,
+  _resetLmlLookupCoordinatorForTest,
+  lmlLookupCoordinator,
+} from '../../../../apps/backend/services/lml/lookup-coordinator';
+
+function fakeResponse(artwork_url = 'https://i.discogs.com/a.jpg'): LookupResponse {
+  return {
+    results: [
+      {
+        library_item: { id: 1, title: 'Confield', artist: 'Autechre' },
+        artwork: {
+          release_id: 1,
+          release_url: '',
+          artwork_url,
+          album: 'Confield',
+          artist: 'Autechre',
+          confidence: 0.9,
+        },
+      },
+    ],
+    search_type: 'direct',
+    song_not_found: false,
+    found_on_compilation: false,
+  } as LookupResponse;
+}
+
+describe('LmlLookupCoordinator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    _resetLmlLookupCoordinatorForTest();
+  });
+
+  describe('basic delegation', () => {
+    it('forwards a single call to lookupMetadata with extended=true forced', async () => {
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      const result = await lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
+        caller: 'test',
+        budgetMs: 5000,
+      });
+
+      expect(result).toBeDefined();
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+      expect(mockLookupMetadata).toHaveBeenCalledWith(
+        'Autechre',
+        'Confield',
+        undefined,
+        expect.objectContaining({ extended: true, caller: 'test', budgetMs: 5000 })
+      );
+    });
+
+    it('propagates undefined artist (Various-Artists convention)', async () => {
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      await lmlLookupCoordinator.lookup(undefined, 'Soul Jazz Comp', undefined, { caller: 'test' });
+
+      expect(mockLookupMetadata).toHaveBeenCalledWith(
+        undefined,
+        'Soul Jazz Comp',
+        undefined,
+        expect.objectContaining({ extended: true })
+      );
+    });
+  });
+
+  describe('in-flight coalescing', () => {
+    it('two concurrent same-key calls produce one outbound fetch', async () => {
+      let resolveFn: (r: LookupResponse) => void = () => {};
+      mockLookupMetadata.mockImplementation(
+        () =>
+          new Promise<LookupResponse>((resolve) => {
+            resolveFn = resolve;
+          })
+      );
+
+      const p1 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'a' });
+      const p2 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'b' });
+
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+
+      resolveFn(fakeResponse());
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1).toBe(r2);
+    });
+
+    it('three concurrent same-key calls all receive the same response object', async () => {
+      const response = fakeResponse();
+      mockLookupMetadata.mockImplementation(() => Promise.resolve(response));
+
+      const results = await Promise.all([
+        lmlLookupCoordinator.lookup('Beatles', 'Abbey Road', undefined, { caller: 'a' }),
+        lmlLookupCoordinator.lookup('Beatles', 'Abbey Road', undefined, { caller: 'b' }),
+        lmlLookupCoordinator.lookup('Beatles', 'Abbey Road', undefined, { caller: 'c' }),
+      ]);
+
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+      expect(results[0]).toBe(response);
+      expect(results[1]).toBe(response);
+      expect(results[2]).toBe(response);
+    });
+
+    it('different keys do not coalesce', async () => {
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      await Promise.all([
+        lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'a' }),
+        lmlLookupCoordinator.lookup('Beatles', 'Abbey Road', undefined, { caller: 'b' }),
+      ]);
+
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('response caching', () => {
+    it('serves a settled prior call from cache (zero outbound fetches)', async () => {
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      await lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'a' });
+      mockLookupMetadata.mockClear();
+
+      await lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'b' });
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
+    });
+
+    it('re-fetches after TTL elapses', async () => {
+      const coord = new LmlLookupCoordinator({ ttlMs: 50 });
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      await coord.lookup('Autechre', 'Confield', undefined, { caller: 'a' });
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+
+      await new Promise((r) => setTimeout(r, 80));
+
+      await coord.lookup('Autechre', 'Confield', undefined, { caller: 'b' });
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('cache key normalization', () => {
+    it('treats case + leading/trailing whitespace as the same key', async () => {
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      await lmlLookupCoordinator.lookup('Beatles', 'Abbey Road', undefined, { caller: 'a' });
+      await lmlLookupCoordinator.lookup('  BEATLES ', 'abbey road  ', undefined, { caller: 'b' });
+
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    });
+
+    it('collapses internal whitespace runs', async () => {
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      await lmlLookupCoordinator.lookup('The   Beatles', 'Abbey  Road', undefined, { caller: 'a' });
+      await lmlLookupCoordinator.lookup('The Beatles', 'Abbey Road', undefined, { caller: 'b' });
+
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    });
+
+    it('undefined fields key distinctly from empty strings', async () => {
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      await lmlLookupCoordinator.lookup(undefined, 'Album', undefined, { caller: 'a' });
+      await lmlLookupCoordinator.lookup('', 'Album', undefined, { caller: 'b' });
+
+      // Both should map to the same key — undefined and empty string both
+      // normalize to the empty sentinel. This is the conservative call;
+      // if a caller passes '' they almost certainly meant "no artist."
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('error semantics', () => {
+    it('propagates throws to all coalescing waiters', async () => {
+      const err = new Error('LML 502');
+      let rejectFn: (e: Error) => void = () => {};
+      mockLookupMetadata.mockImplementation(
+        () =>
+          new Promise<LookupResponse>((_, reject) => {
+            rejectFn = reject;
+          })
+      );
+
+      const p1 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'a' });
+      const p2 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'b' });
+
+      rejectFn(err);
+
+      await expect(p1).rejects.toThrow('LML 502');
+      await expect(p2).rejects.toThrow('LML 502');
+    });
+
+    it('does not cache errors — retry issues a fresh wire call', async () => {
+      mockLookupMetadata.mockRejectedValueOnce(new Error('LML 502')).mockResolvedValueOnce(fakeResponse());
+
+      await expect(lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'a' })).rejects.toThrow(
+        'LML 502'
+      );
+
+      const result = await lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'b' });
+      expect(result).toBeDefined();
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(2);
+    });
+
+    it('after error, in-flight entry is cleared (next call is not coalesced into a dead Promise)', async () => {
+      mockLookupMetadata.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(fakeResponse());
+
+      await expect(lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'a' })).rejects.toThrow(
+        'boom'
+      );
+
+      // Should succeed (not coalesce into the dead Promise).
+      await expect(
+        lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, { caller: 'b' })
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('warm_cache union across coalesced callers', () => {
+    it('passes warm_cache=true on wire when any in-flight caller requested it', async () => {
+      let resolveFn: (r: LookupResponse) => void = () => {};
+      mockLookupMetadata.mockImplementation(
+        () =>
+          new Promise<LookupResponse>((resolve) => {
+            resolveFn = resolve;
+          })
+      );
+
+      const p1 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
+        caller: 'read-path',
+        warm_cache: false,
+      });
+      const _p2 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
+        caller: 'write-path',
+        warm_cache: true,
+      });
+
+      // First wire call already issued (warm_cache=false from p1, the first caller).
+      // The union behavior is asserted by the issued wire call carrying warm_cache=true
+      // only when the FIRST caller asked for it — this test sets read-path FIRST.
+      // For the dominant semantics we want, the wire call should reflect what the
+      // first caller asked. (Documented in the plan: first-caller-wins.)
+      expect(mockLookupMetadata).toHaveBeenCalledWith(
+        'Autechre',
+        'Confield',
+        undefined,
+        expect.objectContaining({ warm_cache: false })
+      );
+
+      resolveFn(fakeResponse());
+      await p1;
+    });
+
+    it('passes warm_cache=true when the first caller is the write-path caller', async () => {
+      mockLookupMetadata.mockResolvedValue(fakeResponse());
+
+      await lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
+        caller: 'write-path',
+        warm_cache: true,
+      });
+
+      expect(mockLookupMetadata).toHaveBeenCalledWith(
+        'Autechre',
+        'Confield',
+        undefined,
+        expect.objectContaining({ warm_cache: true })
+      );
+    });
+  });
+
+  describe('first-caller-wins on the wire', () => {
+    it('the wire call inherits the first caller tag, budget, and timeout', async () => {
+      let resolveFn: (r: LookupResponse) => void = () => {};
+      mockLookupMetadata.mockImplementation(
+        () =>
+          new Promise<LookupResponse>((resolve) => {
+            resolveFn = resolve;
+          })
+      );
+
+      const p1 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
+        caller: 'first-caller',
+        budgetMs: 3000,
+        timeoutMs: 5000,
+      });
+      const _p2 = lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
+        caller: 'second-caller',
+        budgetMs: 10000,
+        timeoutMs: 15000,
+      });
+
+      expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+      expect(mockLookupMetadata).toHaveBeenCalledWith(
+        'Autechre',
+        'Confield',
+        undefined,
+        expect.objectContaining({ caller: 'first-caller', budgetMs: 3000, timeoutMs: 5000 })
+      );
+
+      resolveFn(fakeResponse());
+      await p1;
+    });
+  });
+});

--- a/tests/unit/services/metadata.service.test.ts
+++ b/tests/unit/services/metadata.service.test.ts
@@ -23,6 +23,14 @@ jest.mock('@wxyc/lml-client', () => ({
   },
 }));
 
+// Backend code paths now route through the LmlLookupCoordinator (BS#885).
+// The coordinator's `lookup` method is what callsite tests assert on; mock
+// it to the same fn the previous `@wxyc/lml-client` mock served so existing
+// `mockResolvedValue` setups continue to work.
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: mockLookupMetadata },
+}));
+
 jest.mock('../../../apps/backend/services/metadata/providers/search-urls.provider', () => ({
   SearchUrlProvider: jest.fn().mockImplementation(() => ({
     getAllSearchUrls: (artist: string, album?: string, track?: string) => {


### PR DESCRIPTION
Closes #885. Closes the last open child of Epic B (#876).

## Summary

Front every `lookupMetadata` call inside the `@wxyc/backend` API process with a single `LmlLookupCoordinator` that does two things and only two things:

1. **In-flight coalescing.** When two callers ask for the same `(artist, album, song)` while the first wire call is still in flight, the second caller awaits the first call's Promise instead of issuing its own LML request.
2. **Short-TTL response cache.** Successful `LookupResponse` payloads are memoized in a process-local LRU (~1000 entries, 5 min TTL) so a second request for the same key arriving 30 s after the first one's wire call resolves serves from cache.

LML's PG cache remains the source of truth; this is "we asked LML 30 s ago, the answer hasn't changed yet."

## Callsites migrated (8)

- `apps/backend/controllers/proxy.controller.ts:getAlbumMetadata` (iOS read, `proxy-album-metadata`)
- `apps/backend/controllers/library.controller.ts:addAlbum` (DJ write, `library-add-album`, **warm_cache: true**)
- `apps/backend/controllers/library.controller.ts:fireAndForgetCanonicalEntity` (DJ write, `library-canonical-entity`, **warm_cache: true**)
- `apps/backend/services/library.service.ts:resolveRotationLmlSource` (DJ read, `library-rotation-picker`)
- `apps/backend/services/library.service.ts:enrichWithArtwork` (DJ read, `library-enrich-artwork`)
- `apps/backend/services/artwork/providers/discogs.ts:DiscogsProvider.search` (proxy read, `artwork-discogs-fallback`)
- `apps/backend/services/requestLine/requestLine.enhanced.service.ts:searchReleasesByArtist` (anonymous read, `request-line`)
- `apps/backend/services/metadata/metadata.service.ts:fetchMetadata` (`metadata-service`)

Out of scope: `apps/enrichment-worker/handler.ts` runs in a separate Node process and continues to import `lookupMetadata` directly (intra-instance coalescing in the API server cannot help a separate worker process). `lookupBySong` at `library.service.ts:searchLibraryByTrack` already has its own well-tuned LRU and remains untouched.

## Key semantics

- **`extended: true` is forced** on every wire call (BS#885 mandate). Every cached entry is usable by every caller.
- **First-caller-wins on the wire** for `caller`, `budgetMs`, `timeoutMs`, `limiter`, and `warm_cache`. Subsequent coalescers await the in-flight promise as-is — the wire request body is already serialized and in flight by the time a coalescing caller arrives. Write-path callers set `warm_cache: true` at the call site; whether a coalesced burst warms LML's PG cache is decided entirely by which caller arrived first. Acceptable because (a) write-path callers dominate same-key bursts originating from a single user action, and (b) warm-cache is a best-effort side benefit.
- **No error caching.** Throws propagate to all coalescing waiters; the in-flight entry clears in `finally`. LML's own short cache TTL on errors handles avalanche.
- **5 min LRU TTL, 1000 entries** matches BS#885's spec.
- **Cache key normalization** is conservative: trim, lowercase, collapse internal whitespace. No diacritic folding (LML's parser handles that). `undefined` and `''` both normalize to the empty sentinel `∅`.

## Span instrumentation

The coordinator wraps every call in a `lml.coordinator.lookup` span with two attributes:

- `lml.coordinator.hit`: `cache` | `inflight` | `miss`
- `lml.coordinator.caller`: the caller tag of THIS invocation

The underlying `@wxyc/lml-client` `lml.lookup` span continues to fire on wire-call misses. On `cache` / `inflight` hits only the coordinator span fires — that's the observability win, queryable in Sentry trace explorer.

## Cleanups folded into this PR

### #918 (`PROXY_METADATA_SINGLE_LOOKUP` cutover follow-up)

The coordinator's forced `extended: true` makes the flag dead code. In this PR:

- Removed `singleLookupEnabled()` helper from `proxy.controller.ts`
- Removed the legacy two-call `else` branch in `getAlbumMetadata` (deleted the `getRelease()` follow-up call entirely)
- Removed `proxy.metadata.album.single_lookup` span attribute (now meaningless)
- Removed the `describe('PROXY_METADATA_SINGLE_LOOKUP=true', ...)` test block; renamed to `describe('extended-mode response shape', ...)` since it's the only path now
- Updated legacy-path tests to put release-detail fields on the artwork mock (parity with single-call path)

Railway prod env should drop the `PROXY_METADATA_SINGLE_LOOKUP` env var (no-op since the code path is gone, but env cleanup).

### #885 comment item 2 (forwarded extended fields)

`populateCommonMetadataFields` now maps two additional extended-mode fields onto the proxy response:

- `artwork.artist_image_url` → `metadata.artistImageUrl`
- `artwork.profile_tokens` → `metadata.bioTokens`

Consumed by `wxyc-ios-64#270`'s fallback path. The parallel `metadata.service.ts:extractAlbumMetadata` is intentionally NOT modified — its result shape feeds DB persistence and adding the fields would require schema additions out of scope for B2 (filed separately).

## Test plan

- [x] 16 new unit tests in `tests/unit/services/lml/lookup-coordinator.test.ts` cover: basic delegation, in-flight coalescing (2 + 3 concurrent + different-key), response caching (hit + TTL expiry), cache-key normalization (case/whitespace/internal-runs/empty-string), error propagation + no cache poisoning + post-error retry, warm_cache first-caller-wins, first-caller-wins on caller tag / budget / timeout
- [x] 8 callsite test files updated: added the coordinator mock alongside the existing `@wxyc/lml-client` mock so existing `mockResolvedValue` setups continue to work; assertions updated where callsite args changed (write-path `warm_cache: true`, no callsite `extended`)
- [x] New `tests/integration/lml-coordinator.spec.js` asserts two concurrent `/proxy/metadata/album` requests collapse to one mock-LML wire call; different-key requests don't coalesce; settled cache serves the next same-key request from cache
- [x] All local checks: `typecheck`, `lint` (0 errors), `format:check`, `npm run test:unit` (2771/2771 pass across 211 suites)
- [ ] Integration tests via `ci:testmock` will run in CI (Docker daemon not available locally)
- [ ] Post-deploy Sentry acceptance: two concurrent intra-instance lookups for the same `(artist, album, song)` produce one outbound `lml.lookup` span (one coordinator-miss, one coordinator-inflight-hit). Verifiable in Sentry trace explorer within 24h of deploy.

## Risks + mitigations

- **Forcing `extended: true`**: ~1 KB payload growth per response; LML's downstream work is unchanged because it's already driven by `extended`. Net cost negligible; cache key uniformity wins.
- **First-caller-wins for budget**: tight-deadline second caller waits for a longer-deadline first caller. The existing catch arms in proxy.controller / library.service handle their own degradation. Documented.
- **Stale cached response (5 min TTL)** after a Discogs/LML write: cached LookupResponse is the *prior* one; LML's own cache invalidation doesn't propagate through BS's process-local LRU. Acceptable for typical use; TTL tuning is a follow-up if real.
- **Per-instance singleton** means N BS replicas have N independent caches; same-key bursts hitting different replicas still produce N wire calls. Documented as "intra-instance only" — dj-site session stickiness collapses most bursts onto one replica.

## Related

- Parent: #876 (Epic B)
- Sibling closed earlier: #886 (B3, superseded by C5 / #894), #887 (B4, `@wxyc/lml-client` extracted), #888 (B5), #889 (B6), #890 (B7)
- Cleanup folded: #918 (`PROXY_METADATA_SINGLE_LOOKUP` cutover)
- Orphan cleanup (independent): #1322 (delete `enrichment.service.ts`, `flowsheet-linkage.service.ts`, `linkage-metrics.service.ts` — the C5 cleanup)
- Tracker: #1279 (Slot 5)