### PR TITLE
chore: bump @wxyc/shared to 1.11.0 across workspaces

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^10.53.1",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.9.0",
+    "@wxyc/shared": "^1.11.0",
     "better-auth": "^1.6.11",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -23,7 +23,7 @@
     "@wxyc/database": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^1.9.0",
+    "@wxyc/shared": "^1.11.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.16.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "@sentry/node": "^10.53.1",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.9.0",
+        "@wxyc/shared": "^1.11.0",
         "better-auth": "^1.6.11",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -121,9 +121,9 @@
       }
     },
     "apps/auth/node_modules/@wxyc/shared": {
-      "version": "1.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.9.0/8b8c1d50a1836d132b4e8e81973e932cf898814d",
-      "integrity": "sha512-5Bn/SXOjrRSupQjAfL02Dl06a5wUck5gYAfMvfjQsyxqT7104v/X9nd5kNlAPTxhczWqXRDvkgTH1yd6ExtK3Q==",
+      "version": "1.11.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.11.0/62bf03b80ede011aef90772eeb328bd954cbe83b",
+      "integrity": "sha512-vcr9ZG1KiZAFYEtjfT18mp5TdxVsPFczhuTQiNF1DRnRlEeCKiJUlRykTknfO22nyYsOr8QzT8AWTFmQk3uu4w==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -253,7 +253,7 @@
         "@wxyc/database": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^1.9.0",
+        "@wxyc/shared": "^1.11.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.16.1",
@@ -306,9 +306,9 @@
       }
     },
     "apps/backend/node_modules/@wxyc/shared": {
-      "version": "1.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.9.0/8b8c1d50a1836d132b4e8e81973e932cf898814d",
-      "integrity": "sha512-5Bn/SXOjrRSupQjAfL02Dl06a5wUck5gYAfMvfjQsyxqT7104v/X9nd5kNlAPTxhczWqXRDvkgTH1yd6ExtK3Q==",
+      "version": "1.11.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.11.0/62bf03b80ede011aef90772eeb328bd954cbe83b",
+      "integrity": "sha512-vcr9ZG1KiZAFYEtjfT18mp5TdxVsPFczhuTQiNF1DRnRlEeCKiJUlRykTknfO22nyYsOr8QzT8AWTFmQk3uu4w==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -14640,7 +14640,7 @@
         "@aws-sdk/client-ses": "^3.1053.0",
         "@sentry/node": "^10.53.1",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.9.0",
+        "@wxyc/shared": "^1.11.0",
         "better-auth": "^1.6.11",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -14676,9 +14676,9 @@
       }
     },
     "shared/authentication/node_modules/@wxyc/shared": {
-      "version": "1.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.9.0/8b8c1d50a1836d132b4e8e81973e932cf898814d",
-      "integrity": "sha512-5Bn/SXOjrRSupQjAfL02Dl06a5wUck5gYAfMvfjQsyxqT7104v/X9nd5kNlAPTxhczWqXRDvkgTH1yd6ExtK3Q==",
+      "version": "1.11.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.11.0/62bf03b80ede011aef90772eeb328bd954cbe83b",
+      "integrity": "sha512-vcr9ZG1KiZAFYEtjfT18mp5TdxVsPFczhuTQiNF1DRnRlEeCKiJUlRykTknfO22nyYsOr8QzT8AWTFmQk3uu4w==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -14816,7 +14816,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^10.53.1",
-        "@wxyc/shared": "^1.9.0"
+        "@wxyc/shared": "^1.11.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",
@@ -14850,9 +14850,9 @@
       }
     },
     "shared/lml-client/node_modules/@wxyc/shared": {
-      "version": "1.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.9.0/8b8c1d50a1836d132b4e8e81973e932cf898814d",
-      "integrity": "sha512-5Bn/SXOjrRSupQjAfL02Dl06a5wUck5gYAfMvfjQsyxqT7104v/X9nd5kNlAPTxhczWqXRDvkgTH1yd6ExtK3Q==",
+      "version": "1.11.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.11.0/62bf03b80ede011aef90772eeb328bd954cbe83b",
+      "integrity": "sha512-vcr9ZG1KiZAFYEtjfT18mp5TdxVsPFczhuTQiNF1DRnRlEeCKiJUlRykTknfO22nyYsOr8QzT8AWTFmQk3uu4w==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-ses": "^3.1053.0",
     "@sentry/node": "^10.53.1",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.9.0",
+    "@wxyc/shared": "^1.11.0",
     "better-auth": "^1.6.11",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.53.1",
-    "@wxyc/shared": "^1.9.0"
+    "@wxyc/shared": "^1.11.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",


### PR DESCRIPTION
Hygiene bump of `@wxyc/shared` from `^1.9.0` to `^1.11.0` across all four workspaces (`apps/backend`, `apps/auth`, `shared/authentication`, `shared/lml-client`). Backend-Service's `JoinRequestBody` is locally-defined in `apps/backend/controllers/flowsheet.controller.ts`, so no functional code paths change — this is purely keeping the dependency floor current behind WXYC/wxyc-shared#163.

Closes #1333.