### PR TITLE
docs(auth): rename SES from-address example from no-reply to hello@wxyc.org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,14 +48,16 @@ SENTRY_DSN=https://your-key@o123456.ingest.us.sentry.io/1234567
 # POST until it is set (no startup crash, by design).
 SES_EVENTS_SNS_TOPIC_ARN=arn:aws:sns:us-east-1:203767826763:ses-delivery-events-prod
 
-# Configuration set passed on every SendEmailCommand. Required for the
-# EventDestination on `my-first-configuration-set` to actually publish
-# events — SES picks the most-specific identity for `From:`, and the
-# `no-reply@wxyc.org` email-level identity has no config set attached, so
-# the domain-level default never applies to OTP / verification / reset
-# traffic. Passing this explicitly bypasses the identity-precedence trap.
-# Leave unset locally — when absent, no config set is passed (pre-#1070
-# behavior).
+# Configuration set passed on every SendEmailCommand. Production value:
+# my-first-configuration-set. The `wxyc.org` domain identity lists this as
+# its default, so sends from `hello@wxyc.org` (or any other *@wxyc.org
+# without its own email-level identity) pick it up automatically. Passing
+# it here explicitly is insurance against the identity-precedence trap:
+# if a future email-level identity is added for the from address without
+# the config set attached, the EventDestination would silently stop seeing
+# OTP / verification / reset traffic — the trap that BS#1070 fixed for the
+# legacy `no-reply@wxyc.org` email-level identity. Leave unset locally —
+# when absent, no config set is passed.
 SES_CONFIGURATION_SET_NAME=my-first-configuration-set
 
 ### Legacy Mirror (tubafrenzy)

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -42,7 +42,7 @@ Full reference. CLAUDE.md links here. Variables marked _required_ have no defaul
 
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`
 - `SES_FROM_EMAIL`
-- `SES_CONFIGURATION_SET_NAME` — Configuration set passed on every `SendEmailCommand`. Optional. Required in production for the event-destination on `my-first-configuration-set` to actually capture transactional sends — SES picks the most-specific identity for `From:`, and the `no-reply@wxyc.org` email-level identity has no config set attached, so the domain-level default never applies. Passing this explicitly bypasses the identity-precedence trap. Production value: `my-first-configuration-set`.
+- `SES_CONFIGURATION_SET_NAME` — Configuration set passed on every `SendEmailCommand`. Optional. Production value: `my-first-configuration-set`. The `wxyc.org` domain identity lists this as its default, so sends from `hello@wxyc.org` (or any other `*@wxyc.org` without its own email-level identity) pick it up automatically. Passing it explicitly here is belt-and-suspenders against the identity-precedence trap — if a future email-level identity for the from address is added without the config set attached, the EventDestination would silently stop seeing OTP / verification / reset traffic, the trap BS#1070 fixed for the legacy `no-reply@wxyc.org` email-level identity.
 - `PASSWORD_RESET_REDIRECT_URL`, `EMAIL_VERIFICATION_REDIRECT_URL`
 
 ### SES delivery events (`POST /internal/ses-events`)

--- a/shared/authentication/src/email.ts
+++ b/shared/authentication/src/email.ts
@@ -113,13 +113,18 @@ const buildEmailHtml = ({ title, intro, actionText, actionUrl, footer }: Omit<Em
 `.trim();
 
 /**
- * SES picks the most-specific identity for an outbound `From:`. Because
- * `no-reply@wxyc.org` is verified as an email-level identity, sends from
- * that address use the email-level identity even though `wxyc.org` (the
- * domain) has `my-first-configuration-set` set as its default. The
- * email-level identity has no `ConfigurationSetName` attached, so without
- * passing it explicitly here the EventDestination on the config set never
- * sees the OTP / verification / reset traffic (BS#1070).
+ * SES picks the most-specific identity for an outbound `From:`. The
+ * `wxyc.org` domain identity has `my-first-configuration-set` set as its
+ * default, so sends that resolve to the domain identity (e.g., the current
+ * `hello@wxyc.org` sender, which has no email-level identity) pick up the
+ * config set automatically.
+ *
+ * Passing `SES_CONFIGURATION_SET_NAME` here explicitly is belt-and-
+ * suspenders: if a future email-level identity for the from address is
+ * added without the config set attached, the EventDestination on the
+ * config set would silently stop seeing OTP / verification / reset
+ * traffic — the trap BS#1070 fixed for the legacy `no-reply@wxyc.org`
+ * email-level identity.
  *
  * `SES_CONFIGURATION_SET_NAME` is optional: when unset, no config set is
  * passed and behavior matches pre-#1070 — useful locally, where there is


### PR DESCRIPTION
## Summary

`SES_FROM_EMAIL` is moving from `no-reply@wxyc.org` to `hello@wxyc.org`. This PR is the documentation/comment side of that change — the actual switch is the env var on EC2.

Three files updated:

- `.env.example` — reframes the `SES_CONFIGURATION_SET_NAME` comment around `hello@wxyc.org` and the `wxyc.org` domain identity.
- `docs/env-vars.md` — same reframing.
- `shared/authentication/src/email.ts` — same reframing of the in-code comment above `getConfigurationSetName()`.

The BS#1070 trap (email-level identity without the config set attached → silent EventDestination dropout) is still described — now framed as the historical case for the legacy `no-reply@wxyc.org` email-level identity. The new sender (`hello@wxyc.org`) has no email-level identity, so SES uses the `wxyc.org` domain identity, which already has `my-first-configuration-set` as its default. `SES_CONFIGURATION_SET_NAME` stays as belt-and-suspenders insurance if anyone later adds an email-level identity for `hello@wxyc.org` without the config set.

Comment-only; no code paths changed. No symbols renamed.

## Out of scope (operational follow-up)

- Update `SES_FROM_EMAIL` in `/home/ec2-user/.env` on `wxyc-ec2` from `no-reply@wxyc.org` to `hello@wxyc.org`, then recreate the `auth` container (`docker restart` does not re-read env vars per the EC2 access notes).
- Confirm `wxyc.org` domain identity is verified in SES with `my-first-configuration-set` as the default.

## Test plan

- [ ] Trigger a login from a test account after the env var flip; confirm the OTP email arrives with `From: hello@wxyc.org`.
- [ ] Confirm the SES Configuration Set EventDestination still receives Send/Delivery events for the new sender (CloudWatch / SNS log, depending on the destination). Silence here = the BS#1070 trap is back.