### PR TITLE
fix(jest): also ignore .worktrees/ in unit haste map

### DIFF
--- a/jest.unit.config.ts
+++ b/jest.unit.config.ts
@@ -40,7 +40,14 @@ const config: Config = {
   // resolver finds it.
   moduleDirectories: ['node_modules', 'apps/backend/node_modules', 'shared/authentication/node_modules'],
   collectCoverageFrom: ['apps/backend/**/*.ts', 'jobs/**/*.ts', '!**/*.d.ts', '!**/dist/**'],
-  modulePathIgnorePatterns: ['<rootDir>/.claude/worktrees'],
+  // Ignore worktree paths so Jest's haste map doesn't collide on duplicate
+  // workspace `package.json` files (e.g. `@wxyc/database`, `@wxyc/lml-client`)
+  // when multiple worktrees are active. Patterns are `<rootDir>`-anchored so a
+  // jest run from inside a worktree (where rootDir resolves to the worktree
+  // itself) doesn't accidentally exclude its own files. From the parent repo
+  // these patterns match both worktree conventions; from inside a worktree,
+  // siblings aren't under rootDir and therefore aren't haste-mapped anyway.
+  modulePathIgnorePatterns: ['<rootDir>/.claude/worktrees/', '<rootDir>/.worktrees/'],
   clearMocks: true,
 };
 


### PR DESCRIPTION
Closes #1340

## Problem

`jest.unit.config.ts` ignored only `<rootDir>/.claude/worktrees` in `modulePathIgnorePatterns`. The standard `git worktree add` convention used by the review-loop skill puts worktrees at `.worktrees/<branch>/` — no `.claude/` prefix. When two or more sibling worktrees existed under `.worktrees/`, Jest's haste map collided on duplicate `package.json` files for `@wxyc/database`, `@wxyc/lml-client`, `@wxyc/authentication`, etc., and refused to start with the standard "looked up in the Haste module map ... several different files" error. CI is unaffected (no sibling worktrees), so the bug only bit local runs.

## Fix

Add `<rootDir>/.worktrees/` alongside the existing `<rootDir>/.claude/worktrees/` entry. Both patterns stay `<rootDir>`-anchored on purpose: when jest runs from inside a worktree, `<rootDir>` resolves to the worktree itself, and an un-anchored pattern would match the worktree's own absolute path and exclude all of its test files. Anchoring keeps the agent's own files visible while still hiding sibling worktree trees walked via symlinked workspace packages.

`jest.config.json` (integration) doesn't use `modulePathIgnorePatterns` and resolves workspace packages via path mappers, so it isn't affected by the same collision pattern.

## Verification

- `npm run test:unit` — 213 suites, 2834 tests passing from inside a worktree directory.
- `npm run lint` — 0 errors.
- `npm run format:check` — clean.
- `npm run typecheck` — clean.