### PR TITLE
chore(format): apply prettier to ADR 0005

### DIFF
--- a/docs/adr/0005-album-condition-state-machine.md
+++ b/docs/adr/0005-album-condition-state-machine.md
@@ -4,13 +4,13 @@ Replaces the current `markedMissingAt` / `markedFoundAt` two-timestamp model on 
 
 Authorization is role-gated at our boundary (iOS gates the UI based on the JWT `role` claim — see [`JWTPayload.swift`](https://github.com/WXYC/wxyc-dj-tool-ios/blob/main/Packages/WXYCAPI/Sources/WXYCAPI/JWTPayload.swift) — but we enforce):
 
-| Transition | Required role |
-|---|---|
-| `in_library` ↔ `missing` (both directions) | `dj` and above |
-| `in_library` → `damaged` | `musicDirector` and above |
-| `damaged` → `in_repair` | `musicDirector` and above |
-| `in_repair` → `in_library` | `musicDirector` and above |
-| Any other transition | Not allowed |
+| Transition                                 | Required role             |
+| ------------------------------------------ | ------------------------- |
+| `in_library` ↔ `missing` (both directions) | `dj` and above            |
+| `in_library` → `damaged`                   | `musicDirector` and above |
+| `damaged` → `in_repair`                    | `musicDirector` and above |
+| `in_repair` → `in_library`                 | `musicDirector` and above |
+| Any other transition                       | Not allowed               |
 
 Endpoint shape: replace `PATCH /library/{id}/missing` and `PATCH /library/{id}/found` with one `PATCH /library/{id}/condition` taking `{ to_state, note? }`. Server validates the transition is in the allowed set above.
 


### PR DESCRIPTION
One-line prettier normalization of `docs/adr/0005-album-condition-state-machine.md`. The file has been silently unformatted since it was committed; the local prettier cache hid it. Surfaces as a format:check failure on any CI run with a fresh cache (e.g. the venue-events-scraper PR #1345).

No semantic changes — diff is 7 lines of whitespace / list-marker normalization. Pre-merge so other in-flight PRs against main pick up a green format check.

## Test plan

- [x] Pre-push: `npm run format:check` clean
- [ ] CI green on PR