### PR TITLE
fix(mirror): capture silent entry/update/signoff failures to Sentry

### DIFF
--- a/apps/backend/middleware/legacy/http.mirror.ts
+++ b/apps/backend/middleware/legacy/http.mirror.ts
@@ -43,6 +43,34 @@ interface MirrorEntry {
 }
 
 /**
+ * Capture a mirror call failure to Sentry. Grouping is by `operation` (in
+ * the message) and sub-tagged by `status` so a sustained outage rolls up
+ * into a single issue with an occurrence count rather than fanning out
+ * per-row. `mirrorCreateShow` had this since its 5-retry path; the entry
+ * and signoff paths previously logged to console only, which is how the
+ * 2026-06-05 tubafrenzy auth-config drift (missing `MIRROR_API_KEY` on the
+ * tubafrenzy side) ran silent through a full DJ's show.
+ */
+function captureMirrorFailure(
+  operation: 'create_entry' | 'update_entry' | 'signoff_show',
+  details: { status?: number; responseBody?: string; error?: unknown }
+): void {
+  Sentry.captureMessage(`Mirror: ${operation} failed`, {
+    level: 'error',
+    tags: {
+      subsystem: 'legacy-mirror',
+      operation,
+      ...(details.status != null ? { status: String(details.status) } : {}),
+    },
+    extra: {
+      ...(details.status != null ? { status: details.status } : {}),
+      ...(details.responseBody != null ? { responseBody: details.responseBody.slice(0, 500) } : {}),
+      ...(details.error != null ? { error: String(details.error) } : {}),
+    },
+  });
+}
+
+/**
  * POST a new entry to tubafrenzy. Returns the created entry's ID, or null on failure.
  * Never throws — errors are logged and swallowed (fire-and-forget).
  */
@@ -59,12 +87,14 @@ export async function mirrorCreateEntry(body: Record<string, unknown>): Promise<
     if (!response.ok) {
       const text = await response.text();
       console.error(`[mirror] POST failed: ${response.status} ${text}`);
+      captureMirrorFailure('create_entry', { status: response.status, responseBody: text });
       return null;
     }
     const json = (await response.json()) as { id?: number | null };
     return json.id ?? null;
   } catch (e) {
     console.error('[mirror] POST error:', e);
+    captureMirrorFailure('create_entry', { error: e });
     return null;
   }
 }
@@ -86,9 +116,11 @@ export async function mirrorUpdateEntry(tubafrenzyId: number, body: Record<strin
     if (!response.ok) {
       const text = await response.text();
       console.error(`[mirror] PATCH failed: ${response.status} ${text}`);
+      captureMirrorFailure('update_entry', { status: response.status, responseBody: text });
     }
   } catch (e) {
     console.error('[mirror] PATCH error:', e);
+    captureMirrorFailure('update_entry', { error: e });
   }
 }
 
@@ -273,9 +305,11 @@ export async function mirrorSignoffShow(radioShowId: number, signoffTime: number
     if (!response.ok) {
       const text = await response.text();
       console.error(`[mirror] POST radioShow/signoff failed: ${response.status} ${text}`);
+      captureMirrorFailure('signoff_show', { status: response.status, responseBody: text });
     }
   } catch (e) {
     console.error('[mirror] POST radioShow/signoff error:', e);
+    captureMirrorFailure('signoff_show', { error: e });
   }
 }
 

--- a/docs/adr/0005-album-condition-state-machine.md
+++ b/docs/adr/0005-album-condition-state-machine.md
@@ -4,13 +4,13 @@ Replaces the current `markedMissingAt` / `markedFoundAt` two-timestamp model on 
 
 Authorization is role-gated at our boundary (iOS gates the UI based on the JWT `role` claim — see [`JWTPayload.swift`](https://github.com/WXYC/wxyc-dj-tool-ios/blob/main/Packages/WXYCAPI/Sources/WXYCAPI/JWTPayload.swift) — but we enforce):
 
-| Transition | Required role |
-|---|---|
-| `in_library` ↔ `missing` (both directions) | `dj` and above |
-| `in_library` → `damaged` | `musicDirector` and above |
-| `damaged` → `in_repair` | `musicDirector` and above |
-| `in_repair` → `in_library` | `musicDirector` and above |
-| Any other transition | Not allowed |
+| Transition                                 | Required role             |
+| ------------------------------------------ | ------------------------- |
+| `in_library` ↔ `missing` (both directions) | `dj` and above            |
+| `in_library` → `damaged`                   | `musicDirector` and above |
+| `damaged` → `in_repair`                    | `musicDirector` and above |
+| `in_repair` → `in_library`                 | `musicDirector` and above |
+| Any other transition                       | Not allowed               |
 
 Endpoint shape: replace `PATCH /library/{id}/missing` and `PATCH /library/{id}/found` with one `PATCH /library/{id}/condition` taking `{ to_state, note? }`. Server validates the transition is in the allowed set above.
 

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -9,6 +9,9 @@
 const mockFetch = jest.fn();
 global.fetch = mockFetch as any;
 
+const mockCaptureMessage = jest.fn();
+jest.mock('@sentry/node', () => ({ captureMessage: (...args: unknown[]) => mockCaptureMessage(...args) }));
+
 import {
   mirrorCreateEntry,
   mirrorUpdateEntry,
@@ -27,6 +30,7 @@ import {
 
 beforeEach(() => {
   mockFetch.mockReset();
+  mockCaptureMessage.mockReset();
   clearEntryIdMap();
   clearShowIdMap();
 });
@@ -577,6 +581,108 @@ describe('http.mirror', () => {
       mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
 
       await expect(mirrorSignoffShow(171500, 1773799200000)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Sentry reporting on failure', () => {
+    it('mirrorCreateEntry captures HTTP error with status tag and truncated body', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve('{"error":"Invalid or missing credentials"}'),
+      });
+
+      await mirrorCreateEntry({ radioHour: 0 });
+
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        'Mirror: create_entry failed',
+        expect.objectContaining({
+          level: 'error',
+          tags: expect.objectContaining({
+            subsystem: 'legacy-mirror',
+            operation: 'create_entry',
+            status: '401',
+          }),
+          extra: expect.objectContaining({
+            status: 401,
+            responseBody: expect.stringContaining('Invalid or missing credentials'),
+          }),
+        })
+      );
+    });
+
+    it('mirrorCreateEntry captures network error without status tag', async () => {
+      const err = new Error('ECONNREFUSED');
+      mockFetch.mockRejectedValue(err);
+
+      await mirrorCreateEntry({ radioHour: 0 });
+
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        'Mirror: create_entry failed',
+        expect.objectContaining({
+          level: 'error',
+          tags: expect.objectContaining({ subsystem: 'legacy-mirror', operation: 'create_entry' }),
+          extra: expect.objectContaining({ error: expect.stringContaining('ECONNREFUSED') }),
+        })
+      );
+      const call = mockCaptureMessage.mock.calls[0][1];
+      expect(call.tags).not.toHaveProperty('status');
+    });
+
+    it('mirrorUpdateEntry captures HTTP error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('not found'),
+      });
+
+      await mirrorUpdateEntry(42, { songTitle: 'x' });
+
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        'Mirror: update_entry failed',
+        expect.objectContaining({
+          tags: expect.objectContaining({ operation: 'update_entry', status: '404' }),
+        })
+      );
+    });
+
+    it('mirrorSignoffShow captures HTTP error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 409,
+        text: () => Promise.resolve('already signed off'),
+      });
+
+      await mirrorSignoffShow(171500, 1773799200000);
+
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        'Mirror: signoff_show failed',
+        expect.objectContaining({
+          tags: expect.objectContaining({ operation: 'signoff_show', status: '409' }),
+        })
+      );
+    });
+
+    it('truncates large response bodies to 500 chars', async () => {
+      const huge = 'x'.repeat(2000);
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve(huge),
+      });
+
+      await mirrorCreateEntry({ radioHour: 0 });
+
+      const call = mockCaptureMessage.mock.calls[0][1];
+      expect(call.extra.responseBody.length).toBe(500);
+    });
+
+    it('mirrorCreateEntry does not capture on success', async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: 1 }) });
+
+      await mirrorCreateEntry({ radioHour: 0 });
+
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- `mirrorCreateEntry`, `mirrorUpdateEntry`, `mirrorSignoffShow` swallowed failures and only `console.error`ed; only `mirrorCreateShow` had Sentry alerting (5-retry exhaustion). The 2026-06-05 tubafrenzy auth-config drift incident ran silent through 52 min of track adds because of this gap.
- Add a shared `captureMirrorFailure()` helper and wire it into the three quiet paths. Issue grouping is by `operation` (in the message string) and sub-tagged by `status`, so a sustained outage rolls into one Sentry issue with an occurrence count rather than fanning out per-row.
- Response bodies are truncated to 500 chars in `extra` for quick triage.

Closes #1349

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (warnings unchanged)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 2852/2852 pass; new tests cover each capture path (HTTP error, network error, body truncation, no-capture-on-success) in `tests/unit/middleware/legacy/http.mirror.test.ts`
- [ ] Post-merge: confirm one new Sentry issue per call site when a mirror path fails; verify they group by `operation` tag