### PR TITLE
fix(library): reject non-direct LML search_type in rotation picker tier-3

### DIFF
--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -640,10 +640,24 @@ async function resolveRotationDiscogsReleaseViaLml(
       timeoutMs: ROTATION_LML_LOOKUP_TIMEOUT_MS,
       caller: 'library-rotation-picker',
     });
-    const artwork = response.results?.[0]?.artwork ?? null;
-    const releaseId = artwork?.release_id ?? null;
-    const inlineTracklist = projectInlineTracklist(artwork?.tracklist, artistName);
-    source = releaseId !== null || inlineTracklist !== null ? { releaseId, inlineTracklist } : null;
+    // BS#1351: only trust `search_type === "direct"`. Everything else
+    // (`alternative`, `compilation`, `fallback`, `song_as_artist`, `none`)
+    // is LML signalling a non-album-match — including artist-fallback
+    // candidates whose `artwork` carries a different release than the
+    // typed album. Accepting those handed the rotation picker the wrong
+    // tracklist (the Yenbett → Tzenni regression). LML's `fetch_one`
+    // already enforces the 80/80 album-title floor for direct matches
+    // (LML PR #483), so this check is sufficient — no additional
+    // normalize/compare needed on the BS side. Falling through to null
+    // degrades the picker to free-text, which is the correct UX.
+    if (response.search_type !== 'direct') {
+      source = null;
+    } else {
+      const artwork = response.results?.[0]?.artwork ?? null;
+      const releaseId = artwork?.release_id ?? null;
+      const inlineTracklist = projectInlineTracklist(artwork?.tracklist, artistName);
+      source = releaseId !== null || inlineTracklist !== null ? { releaseId, inlineTracklist } : null;
+    }
   } catch (err) {
     console.warn(
       '[library.service] LML /lookup for rotation_id=%d failed; degrading picker to free-text: %s',

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -629,32 +629,24 @@ async function resolveRotationDiscogsReleaseViaLml(
 
   let source: RotationPickerSource | null;
   try {
-    // `extended: true` opts the top-1 result's `artwork` block into the
-    // extra payload LML already has during enrichment (LML#414) — including
-    // `tracklist`, which lets the picker skip the follow-up
-    // `getRelease(id)` round-trip and (for the MusicBrainz-rescued
-    // synth-result path on LML#427) get a tracklist for releases Discogs
-    // doesn't carry. Same `(artist, album)` call as before; the request body
-    // only gains the `extended` flag.
     const response = await lmlLookupCoordinator.lookup(lookupArtist, albumTitle, undefined, {
       timeoutMs: ROTATION_LML_LOOKUP_TIMEOUT_MS,
       caller: 'library-rotation-picker',
     });
-    // BS#1351: only trust `search_type === "direct"`. Everything else
-    // (`alternative`, `compilation`, `fallback`, `song_as_artist`, `none`)
-    // is LML signalling a non-album-match — including artist-fallback
-    // candidates whose `artwork` carries a different release than the
-    // typed album. Accepting those handed the rotation picker the wrong
-    // tracklist (the Yenbett → Tzenni regression). LML's `fetch_one`
-    // already enforces the 80/80 album-title floor for direct matches
-    // (LML PR #483), so this check is sufficient — no additional
-    // normalize/compare needed on the BS side. Falling through to null
-    // degrades the picker to free-text, which is the correct UX.
+    // BS#1351: non-direct `search_type` values surface candidates for the wrong
+    // album (Yenbett → Tzenni). LML's `fetch_one` enforces the 80/80 album-title
+    // floor for `direct` matches, so this is sufficient — the picker falls
+    // through to free-text on rejection.
     if (response.search_type !== 'direct') {
       source = null;
     } else {
       const artwork = response.results?.[0]?.artwork ?? null;
-      const releaseId = artwork?.release_id ?? null;
+      // `release_id: 0` is LML's MusicBrainz-rescued synth sentinel
+      // (orchestrator.py emits it when ARTIST_PLUS_ALBUM hits but Discogs
+      // carries no artwork). Treat as "no Discogs id" so the controller
+      // doesn't follow up with `/discogs/release/0`.
+      const rawReleaseId = artwork?.release_id ?? null;
+      const releaseId = rawReleaseId !== null && rawReleaseId > 0 ? rawReleaseId : null;
       const inlineTracklist = projectInlineTracklist(artwork?.tracklist, artistName);
       source = releaseId !== null || inlineTracklist !== null ? { releaseId, inlineTracklist } : null;
     }

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -518,7 +518,7 @@ describe('library.controller', () => {
         { position: '1', title: 'Tragic Magic', duration: '6:01', artists: ['Julianna Barwick & Mary Lattimore'] },
         { position: '2', title: 'For Mariko', duration: '4:18', artists: ['Julianna Barwick & Mary Lattimore'] },
       ];
-      mockResolveRotationPickerSource.mockResolvedValue({ releaseId: 0, inlineTracklist });
+      mockResolveRotationPickerSource.mockResolvedValue({ releaseId: null, inlineTracklist });
       const req = { params: { rotation_id: '42' } } as unknown as Request;
       const res = mockResponse();
 

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -2624,7 +2624,7 @@ describe('library.service', () => {
       // Yenbett's. The happy path (`search_type: "direct"`) is already pinned by
       // the test above; this block pins the rejection of every non-direct value.
       it.each(['alternative', 'compilation', 'fallback', 'song_as_artist', 'none'] as const)(
-        'rejects search_type=%s even with non-empty artwork',
+        'rejects search_type=%s even with non-empty artwork and stamps the persistent negative marker',
         async (searchType) => {
           mockRow({
             direct: null,
@@ -2645,6 +2645,12 @@ describe('library.service', () => {
           await new Promise((r) => setImmediate(r));
 
           expect(result).toBeNull();
+          // The persistent stamp is what feeds the 7-day skip on cold cache —
+          // a refactor that moves the stamp into the LML-error branch only
+          // would silently re-introduce cascade-exhaustion on the Yenbett
+          // cohort.
+          expect(db.update).toHaveBeenCalledWith(rotation);
+          expect(updateSetMock).toHaveBeenCalled();
         }
       );
 

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -2473,9 +2473,10 @@ describe('library.service', () => {
     it('carries an inline tracklist when LML synth-rescues with release_id=0 (MB rescue)', async () => {
       // LML#427 MusicBrainz rescue: when Discogs misses, LML synthesizes a
       // result with `release_id: 0` (the BS#1185 sentinel) and a tracklist
-      // sourced from musicbrainz-cache. The picker still gets a tracklist
-      // and skips `getRelease(0)` (which would 404). releaseId=0 short-circuits
-      // the controller via `inlineTracklist !== null`.
+      // sourced from musicbrainz-cache. The picker still gets a tracklist;
+      // BS#1351 normalizes the sentinel id to `null` so the controller's
+      // follow-up release fetch is skipped via `releaseId === null` rather
+      // than racing the inline-tracklist short-circuit.
       mockRow({
         direct: null,
         fallback: null,
@@ -2500,7 +2501,7 @@ describe('library.service', () => {
       const result = await resolveRotationPickerSource(42);
 
       expect(result).toEqual({
-        releaseId: 0,
+        releaseId: null,
         inlineTracklist: [
           { position: '1', title: 'Tragic Magic', duration: '6:01', artists: ['Julianna Barwick & Mary Lattimore'] },
           { position: '2', title: 'For Mariko', duration: '4:18', artists: ['Julianna Barwick & Mary Lattimore'] },
@@ -2618,81 +2619,52 @@ describe('library.service', () => {
     });
 
     describe('search_type gate (BS#1351)', () => {
-      // Pre-fix behaviour blindly trusted `results[0].artwork` regardless of
-      // `search_type`. For the Yenbett rotation row LML returned a
-      // `search_type: "alternative"` artist-fallback response whose top
-      // result was Tzenni — and the picker happily handed Tzenni's
-      // tracklist back as if it belonged to Yenbett. The fix gates the
-      // tier-3 acceptance on `search_type === "direct"`; everything else
-      // returns null so the picker degrades to free-text. The full LML
-      // enum is `{direct, compilation, none, fallback, alternative,
-      // song_as_artist}`; we already pin `direct` (happy path) and `none`
-      // (empty results) above — the remaining four must reject even when
-      // `results[0].artwork.release_id` is set.
-
-      it('rejects search_type=alternative even with a non-empty artwork (the Yenbett bug-pin)', async () => {
-        mockRow({
-          direct: null,
-          fallback: null,
-          artist_name: 'Noura Mint Seymali',
-          album_title: 'Yenbett',
-        });
-        // The actual prod response that caused the bug: top result is
-        // Tzenni (a different album by the same artist), surfaced as an
-        // artist-fallback after LML's album-match floor dropped both
-        // candidates.
-        mockLookupMetadata.mockResolvedValue({
-          results: [
-            { artwork: { release_id: 7727849, album: 'Tzenni' } },
-            { artwork: { release_id: 9239170, album: 'Arbina' } },
-          ],
-          search_type: 'alternative',
-        });
-
-        const result = await resolveRotationPickerSource(42);
-
-        expect(result).toBeNull();
-      });
-
-      it.each([['compilation'], ['fallback'], ['song_as_artist']] as const)(
-        'rejects search_type=%s even with a non-empty artwork',
+      // The Yenbett rotation row repro: LML returned `search_type: "alternative"`
+      // with Tzenni at results[0]. Pre-fix BS handed Tzenni's tracklist back as
+      // Yenbett's. The happy path (`search_type: "direct"`) is already pinned by
+      // the test above; this block pins the rejection of every non-direct value.
+      it.each(['alternative', 'compilation', 'fallback', 'song_as_artist', 'none'] as const)(
+        'rejects search_type=%s even with non-empty artwork',
         async (searchType) => {
           mockRow({
             direct: null,
             fallback: null,
-            artist_name: 'Some Artist',
-            album_title: 'Some Album',
+            artist_name: 'Noura Mint Seymali',
+            album_title: 'Yenbett',
           });
           mockLookupMetadata.mockResolvedValue({
-            results: [{ artwork: { release_id: 12345, album: 'Some Other Album' } }],
+            results: [{ artwork: { release_id: 7727849, album: 'Tzenni' } }],
             search_type: searchType,
           });
+          const updateSetMock = jest.fn().mockReturnThis();
+          const updateWhereMock = jest.fn().mockResolvedValue(undefined);
+          db.update.mockReturnValue({ set: updateSetMock, where: updateWhereMock });
+          updateSetMock.mockReturnValue({ where: updateWhereMock });
 
           const result = await resolveRotationPickerSource(42);
+          await new Promise((r) => setImmediate(r));
 
           expect(result).toBeNull();
         }
       );
 
-      it('accepts search_type=direct (happy-path regression pin)', async () => {
-        // LML already enforces the 80/80 album-title floor inside
-        // `fetch_one` (LML PR #483), so every `direct` response carries
-        // artwork that has already cleared the album-title check. BS can
-        // therefore trust `direct` without re-doing the comparison.
-        mockRow({
-          direct: null,
-          fallback: null,
-          artist_name: 'Autechre',
-          album_title: 'Confield',
-        });
+      it('treats LML release_id=0 (MusicBrainz-synth sentinel) as no Discogs id', async () => {
+        mockRow({ direct: null, fallback: null, artist_name: 'Some Artist', album_title: 'Some Album' });
         mockLookupMetadata.mockResolvedValue({
-          results: [{ artwork: { release_id: 4080, album: 'Confield' } }],
+          results: [{ artwork: { release_id: 0, album: 'Some Album' } }],
           search_type: 'direct',
         });
+        const updateSetMock = jest.fn().mockReturnThis();
+        const updateWhereMock = jest.fn().mockResolvedValue(undefined);
+        db.update.mockReturnValue({ set: updateSetMock, where: updateWhereMock });
+        updateSetMock.mockReturnValue({ where: updateWhereMock });
 
         const result = await resolveRotationPickerSource(42);
+        await new Promise((r) => setImmediate(r));
 
-        expect(result).toEqual({ releaseId: 4080, inlineTracklist: null });
+        // No tracklist and no real release id → degrades to free-text. The
+        // controller never calls `/discogs/release/0`.
+        expect(result).toBeNull();
       });
     });
   });

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -2616,6 +2616,85 @@ describe('library.service', () => {
         expect(db.update).not.toHaveBeenCalled();
       });
     });
+
+    describe('search_type gate (BS#1351)', () => {
+      // Pre-fix behaviour blindly trusted `results[0].artwork` regardless of
+      // `search_type`. For the Yenbett rotation row LML returned a
+      // `search_type: "alternative"` artist-fallback response whose top
+      // result was Tzenni — and the picker happily handed Tzenni's
+      // tracklist back as if it belonged to Yenbett. The fix gates the
+      // tier-3 acceptance on `search_type === "direct"`; everything else
+      // returns null so the picker degrades to free-text. The full LML
+      // enum is `{direct, compilation, none, fallback, alternative,
+      // song_as_artist}`; we already pin `direct` (happy path) and `none`
+      // (empty results) above — the remaining four must reject even when
+      // `results[0].artwork.release_id` is set.
+
+      it('rejects search_type=alternative even with a non-empty artwork (the Yenbett bug-pin)', async () => {
+        mockRow({
+          direct: null,
+          fallback: null,
+          artist_name: 'Noura Mint Seymali',
+          album_title: 'Yenbett',
+        });
+        // The actual prod response that caused the bug: top result is
+        // Tzenni (a different album by the same artist), surfaced as an
+        // artist-fallback after LML's album-match floor dropped both
+        // candidates.
+        mockLookupMetadata.mockResolvedValue({
+          results: [
+            { artwork: { release_id: 7727849, album: 'Tzenni' } },
+            { artwork: { release_id: 9239170, album: 'Arbina' } },
+          ],
+          search_type: 'alternative',
+        });
+
+        const result = await resolveRotationPickerSource(42);
+
+        expect(result).toBeNull();
+      });
+
+      it.each([['compilation'], ['fallback'], ['song_as_artist']] as const)(
+        'rejects search_type=%s even with a non-empty artwork',
+        async (searchType) => {
+          mockRow({
+            direct: null,
+            fallback: null,
+            artist_name: 'Some Artist',
+            album_title: 'Some Album',
+          });
+          mockLookupMetadata.mockResolvedValue({
+            results: [{ artwork: { release_id: 12345, album: 'Some Other Album' } }],
+            search_type: searchType,
+          });
+
+          const result = await resolveRotationPickerSource(42);
+
+          expect(result).toBeNull();
+        }
+      );
+
+      it('accepts search_type=direct (happy-path regression pin)', async () => {
+        // LML already enforces the 80/80 album-title floor inside
+        // `fetch_one` (LML PR #483), so every `direct` response carries
+        // artwork that has already cleared the album-title check. BS can
+        // therefore trust `direct` without re-doing the comparison.
+        mockRow({
+          direct: null,
+          fallback: null,
+          artist_name: 'Autechre',
+          album_title: 'Confield',
+        });
+        mockLookupMetadata.mockResolvedValue({
+          results: [{ artwork: { release_id: 4080, album: 'Confield' } }],
+          search_type: 'direct',
+        });
+
+        const result = await resolveRotationPickerSource(42);
+
+        expect(result).toEqual({ releaseId: 4080, inlineTracklist: null });
+      });
+    });
   });
 
   describe('getRotationTracksFromRelease', () => {

--- a/tests/unit/services/rotation-tracks-cache-warm.service.test.ts
+++ b/tests/unit/services/rotation-tracks-cache-warm.service.test.ts
@@ -169,13 +169,15 @@ describe('rotation-tracks-cache-warm.service', () => {
       expect(mockGetRotationTracksFromRelease).not.toHaveBeenCalled();
     });
 
-    test('does not call getRotationTracksFromRelease when releaseId is the BS#1185 sentinel zero with inline tracklist', async () => {
-      // MB-rescue rows carry releaseId=0 + inline tracklist; the picker
-      // short-circuits on inline tracks, so the warmer must too — calling
-      // getRotationTracksFromRelease(0) would 404 and waste a semaphore slot.
+    test('does not call getRotationTracksFromRelease when the resolver returns a null releaseId with inline tracklist', async () => {
+      // MB-rescue rows project to `releaseId: null` (BS#1351 normalizes the
+      // LML sentinel `release_id: 0`) and carry the inline tracklist. The
+      // warmer must skip the release fetch in this shape — a fetch with a
+      // null id is a no-op and a fetch with 0 would 404, in either case
+      // wasting a semaphore slot.
       mockActiveRotationRows([10]);
       mockResolveRotationPickerSource.mockResolvedValue(
-        inlineSource(0, [{ position: '1', title: 'T', duration: null, artists: ['A'] }])
+        inlineSource(null, [{ position: '1', title: 'T', duration: null, artists: ['A'] }])
       );
 
       await warmRotationTracksCache();


### PR DESCRIPTION
## Symptom

DJ reported via the dj-site rotation picker: selecting "Noura Mint Seymali — Yenbett" populates the track combobox with Tzenni's tracklist (Eguetmar / Tzenni / El Barm / El Madi / …) instead of Yenbett's tracks. A picker that confidently shows the wrong tracklist is worse than one that shows none — the DJ has no signal anything is wrong, picks a track, hits submit, and the flowsheet now claims they played the wrong song off the wrong album.

## Root cause

`resolveRotationDiscogsReleaseViaLml` in `apps/backend/services/library.service.ts` blindly trusted `results[0].artwork` regardless of `response.search_type`. For rotation rows whose albums are not in WXYC's library catalog, LML falls back to artist-match candidates and signals this via `search_type: "alternative"` (or `compilation` / `fallback` / `song_as_artist`). LML's own log for the Yenbett row even says `Album-match floor dropped 2 of 2 artist-fallback candidates against typed album 'Yenbett'`, but the response still carries the candidates and BS was treating them as authoritative.

## Fix

Gate the tier-3 acceptance on `search_type === 'direct'`. Everything else returns null so the picker falls through to free-text degradation, which is the correct UX. LML's `fetch_one` already enforces the 80/80 album-title floor for direct matches (LML PR #483), so this check is sufficient — no additional normalize/compare on the BS side, and no new helper needed.

## Tests

- Bug-pin: `search_type=alternative` with the actual prod-shaped response (top result is Tzenni, second is Arbina) returns null.
- Happy-path regression pin: `search_type=direct` still returns the projected source.
- Parameterized rejection for the remaining non-direct enum values: `compilation`, `fallback`, `song_as_artist`. (`none` was already covered by an existing test.)

All 2857 unit tests pass; lint, typecheck, format:check, and build are clean.

## Cohort follow-up

Posting the `tubafrenzy_paste` cohort numbers (21,325 rows total, 70 player-facing active) and a targeted re-attempt suggestion as a comment on #1351 once CI is green — operator tooling, not in this PR's scope.

Closes #1351