### PR TITLE
fix(metadata): strip Discogs numeric-id entity tokens in cleanDiscogsBio

### DIFF
--- a/shared/metadata/src/helpers/clean-discogs-bio.ts
+++ b/shared/metadata/src/helpers/clean-discogs-bio.ts
@@ -1,10 +1,16 @@
 /**
  * Strip Discogs markup tags from bio text.
  *
- * Discogs profiles use custom markup like `[a=Artist]`, `[l=Label]`,
- * `[r=Release]`, `[m=Master]`, `[url=...]...[/url]`. This converts them
- * to plain text so the iOS playcut detail view doesn't render the raw
- * tags.
+ * Discogs profiles use two flavours of entity markup:
+ *   - Named: `[a=Artist]`, `[l=Label]`, `[r=Release]`, `[m=Master]` — Discogs
+ *     renders these as the inline name, so we keep the inner text.
+ *   - Numeric-id: `[a8390436]`, `[l123]`, `[r45]`, `[m999]` — Discogs resolves
+ *     these to the entity name in its own UI. LML hands them through verbatim,
+ *     so we drop the token (a name-resolving round-trip is out of scope for a
+ *     string helper) and clean up the punctuation left behind.
+ * Plus `[url=...]text[/url]` which collapses to the visible text.
+ *
+ * Without this, iOS's playcut detail view renders the raw tokens.
  */
 export const cleanDiscogsBio = (bio: string): string =>
   bio
@@ -12,4 +18,7 @@ export const cleanDiscogsBio = (bio: string): string =>
     .replace(/\[l=([^\]]+)\]/g, '$1')
     .replace(/\[r=([^\]]+)\]/g, '$1')
     .replace(/\[m=([^\]]+)\]/g, '$1')
-    .replace(/\[url=([^\]]+)\]([^[]*)\[\/url\]/g, '$2');
+    .replace(/\[url=([^\]]+)\]([^[]*)\[\/url\]/g, '$2')
+    .replace(/,?\s*\[(?:a|l|r|m)\d+\]/g, '')
+    .replace(/ +/g, ' ')
+    .trim();

--- a/shared/metadata/src/helpers/clean-discogs-bio.ts
+++ b/shared/metadata/src/helpers/clean-discogs-bio.ts
@@ -19,6 +19,6 @@ export const cleanDiscogsBio = (bio: string): string =>
     .replace(/\[r=([^\]]+)\]/g, '$1')
     .replace(/\[m=([^\]]+)\]/g, '$1')
     .replace(/\[url=([^\]]+)\]([^[]*)\[\/url\]/g, '$2')
-    .replace(/,?\s*\[(?:a|l|r|m)\d+\]/g, '')
+    .replace(/[,:;]?\s*\[(?:a|l|r|m)\d+\]/g, '')
     .replace(/ +/g, ' ')
     .trim();

--- a/tests/unit/shared/metadata/clean-discogs-bio.test.ts
+++ b/tests/unit/shared/metadata/clean-discogs-bio.test.ts
@@ -31,4 +31,35 @@ describe('cleanDiscogsBio', () => {
   it('returns the input unchanged when there is no markup', () => {
     expect(cleanDiscogsBio('A plain bio with no tags.')).toBe('A plain bio with no tags.');
   });
+
+  describe('numeric-id entity references', () => {
+    it.each([
+      ['a', 'Co-founder of duo, [a8390436].', 'Co-founder of duo.'],
+      ['l', 'Released on [l123] in 2003.', 'Released on in 2003.'],
+      ['r', 'See [r45] for details.', 'See for details.'],
+      ['m', 'Master release: [m999].', 'Master release:.'],
+    ])('strips [%s<id>] numeric-id references', (_letter, input, expected) => {
+      expect(cleanDiscogsBio(input)).toBe(expected);
+    });
+
+    it('matches the acceptance example from issue #1354', () => {
+      expect(
+        cleanDiscogsBio(
+          'Seoul-based producer and DJ. Co-founder of Computer Music Club and half of leftfield ambient duo, [a8390436].'
+        )
+      ).toBe('Seoul-based producer and DJ. Co-founder of Computer Music Club and half of leftfield ambient duo.');
+    });
+
+    it('squashes the double-space left when a token sits between words', () => {
+      expect(cleanDiscogsBio('Member of [a8390436] and other groups.')).toBe('Member of and other groups.');
+    });
+
+    it('trims leading whitespace when a token starts the bio', () => {
+      expect(cleanDiscogsBio('[a8390436] is the producer.')).toBe('is the producer.');
+    });
+
+    it('leaves [a=Name] and other named-reference behaviour unchanged', () => {
+      expect(cleanDiscogsBio('Member of [a=Stereolab] and [r=12345].')).toBe('Member of Stereolab and 12345.');
+    });
+  });
 });

--- a/tests/unit/shared/metadata/clean-discogs-bio.test.ts
+++ b/tests/unit/shared/metadata/clean-discogs-bio.test.ts
@@ -37,8 +37,15 @@ describe('cleanDiscogsBio', () => {
       ['a', 'Co-founder of duo, [a8390436].', 'Co-founder of duo.'],
       ['l', 'Released on [l123] in 2003.', 'Released on in 2003.'],
       ['r', 'See [r45] for details.', 'See for details.'],
-      ['m', 'Master release: [m999].', 'Master release:.'],
+      ['m', 'Master release: [m999].', 'Master release.'],
     ])('strips [%s<id>] numeric-id references', (_letter, input, expected) => {
+      expect(cleanDiscogsBio(input)).toBe(expected);
+    });
+
+    it.each([
+      [':', 'Producer: [a8390436].', 'Producer.'],
+      [';', 'duo; [l123].', 'duo.'],
+    ])('eats leading "%s" punctuation along with the numeric-id token', (_punct, input, expected) => {
       expect(cleanDiscogsBio(input)).toBe(expected);
     });
 


### PR DESCRIPTION
## Summary

- Extend `cleanDiscogsBio` to drop the numeric-id form of Discogs entity tokens (`[a8390436]`, `[l123]`, `[r45]`, `[m999]`) on top of the existing named-form (`[a=Name]`) and `[url=...][/url]` handling.
- Eat a comma + whitespace immediately preceding the token so `"ambient duo, [a8390436]."` becomes `"ambient duo."`. Squash multi-space runs and trim to mop up tokens that sat mid-sentence or at the start of the bio.
- Named-form and `[url=...][/url]` behaviour is unchanged — verified by leaving the existing tests untouched and adding the new cases under a nested `describe`.

## Context

LML hands the numeric-id tokens through verbatim, so the iOS playcut detail view rendered the raw `[a8390436]`. Surfaced by the Yetsuby re-enrichment in #1353. Resolving the id to the entity name would require an LML/Discogs round-trip from a string helper, which the issue ruled out of scope.

No data migration: newly-enriched rows pick up the cleaner output; historical rows will only update on next re-enrichment. Acceptable slow drift per the issue.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors)
- [x] `npm run format:check` clean
- [x] `npm run test:unit` — 213 suites / 2854 tests pass (15 in `clean-discogs-bio.test.ts`, 7 of which are new)
- [x] All four prefixes (`a`/`l`/`r`/`m`) covered by a parameterized `it.each`
- [x] Issue #1354 acceptance example (`"ambient duo, [a8390436]."` → `"ambient duo."`) covered by a dedicated test
- [x] Mid-sentence, leading-position, and existing `[a=Name]` regression cases covered

Closes #1354.