### PR TITLE
fix(flowsheet): rotation_bin (artist, album) read-path fallback

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -125,6 +125,14 @@ const FSEntryFieldsRaw = {
   // status is preserved — mirrors how tubafrenzy classifies at mirror time (WXYC/dj-site#750).
   // Subquery only fires per-row on a missed FK join; on rows with a populated rotation_id
   // COALESCE short-circuits and the subquery is not evaluated.
+  //
+  // Tie-break (`ORDER BY r2.id`): the schema source comment at `rotation` explicitly
+  // permits multiple active rows per (album_id, rotation_bin) over an album's lifecycle
+  // (re-bins, re-adds, label-driven re-promotes). Picking the lowest `id` (oldest active
+  // row) is a deliberate, stable choice for the badge UX — when an album has been re-binned
+  // L → M, the badge reports its original cohort rather than flipping retroactively. This
+  // matches the historical-correctness story above (kill_date filtering against add_time).
+  // The primary FK join via flowsheet.rotation_id remains canonical when present.
   rotation_bin: sql<string | null>`
     COALESCE(
       ${rotation.rotation_bin},

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -113,7 +113,47 @@ const FSEntryFieldsRaw = {
   record_label: flowsheet.record_label,
   label_id: flowsheet.label_id,
   rotation_id: flowsheet.rotation_id,
-  rotation_bin: rotation.rotation_bin,
+  // Primary source is the FK join (`leftJoin(rotation, rotation.id = flowsheet.rotation_id)`).
+  // Fallback fires only when that join misses (rotation.rotation_bin IS NULL) and the entry
+  // looks like a real track with non-empty artist+album. Three match cohorts:
+  //   (a) flowsheet.album_id matches an active rotation.album_id (library-linked rotation rows);
+  //   (b) (artist, album) snapshot matches active rotation row's denormalized fields
+  //       (library-unlinked rotation rows hold the snapshot directly);
+  //   (c) (artist, album) matches the library+artists join on an active rotation row's
+  //       album_id (library-linked rows whose denorm fields are NULL).
+  // kill_date is compared against the flowsheet entry's add_time so historical rotation
+  // status is preserved — mirrors how tubafrenzy classifies at mirror time (WXYC/dj-site#750).
+  // Subquery only fires per-row on a missed FK join; on rows with a populated rotation_id
+  // COALESCE short-circuits and the subquery is not evaluated.
+  rotation_bin: sql<string | null>`
+    COALESCE(
+      ${rotation.rotation_bin},
+      CASE WHEN ${flowsheet.rotation_id} IS NULL
+        AND coalesce(${flowsheet.artist_name}, '') <> ''
+        AND coalesce(${flowsheet.album_title}, '') <> ''
+      THEN (
+        SELECT r2.rotation_bin
+        FROM ${rotation} r2
+        LEFT JOIN ${library} l2 ON l2.id = r2.album_id
+        LEFT JOIN ${artists} a2 ON a2.id = l2.artist_id
+        WHERE (r2.kill_date IS NULL OR r2.kill_date > ${flowsheet.add_time}::date)
+          AND (
+            (${flowsheet.album_id} IS NOT NULL AND r2.album_id = ${flowsheet.album_id})
+            OR (
+              lower(trim(coalesce(r2.artist_name, ''))) = lower(trim(${flowsheet.artist_name}))
+              AND lower(trim(coalesce(r2.album_title, ''))) = lower(trim(${flowsheet.album_title}))
+            )
+            OR (
+              lower(trim(coalesce(a2.artist_name, ''))) = lower(trim(${flowsheet.artist_name}))
+              AND lower(trim(coalesce(l2.album_title, ''))) = lower(trim(${flowsheet.album_title}))
+            )
+          )
+        ORDER BY r2.id
+        LIMIT 1
+      )
+      END
+    )
+  `,
   request_flag: flowsheet.request_flag,
   segue: flowsheet.segue,
   message: flowsheet.message,

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -802,9 +802,29 @@ describe('rotation_bin read-path fallback (dj-site#750)', () => {
   // When the picker emit path doesn't persist flowsheet.rotation_id (the
   // 2026-06-04 regression cohort), the primary FK join leaves rotation_bin
   // NULL and dj-site's badge disappears. The read path's COALESCE fallback
-  // recovers the bin via (a) album_id match, (b) denorm artist/album match,
-  // or (c) library+artists JOIN match. Seed has rotation row 1 = album_id 1
-  // (Built to Spill — Keep it Like a Secret) in bin 'L'.
+  // recovers the bin via (a) album_id match, (b) denorm artist/album match
+  // on the rotation row itself (NULL album_id, library-unlinked snapshot),
+  // or (c) library+artists JOIN match via the rotation row's album_id.
+  // Seed has rotation row 1 = album_id 1 (Built to Spill — Keep it Like a
+  // Secret) in bin 'L'. The cohort-(b) test below provisions an extra
+  // library-unlinked rotation row inline; the kill_date test provisions a
+  // killed rotation row. Both are torn down in afterAll.
+
+  let sql;
+  const extraRotationIds = [];
+
+  beforeAll(() => {
+    sql = makeSql();
+  });
+
+  afterAll(async () => {
+    if (extraRotationIds.length > 0) {
+      await sql`
+        DELETE FROM ${sql(SCHEMA)}.rotation WHERE id IN ${sql(extraRotationIds)}
+      `;
+    }
+    if (sql) await sql.end({ timeout: 5 });
+  });
 
   beforeEach(async () => {
     await fls_util.join_show(global.primary_dj_id, global.access_token);
@@ -887,6 +907,68 @@ describe('rotation_bin read-path fallback (dj-site#750)', () => {
 
     const res = await request.get('/flowsheet').query({ limit: 5 }).send().expect(200);
     const track = res.body.entries.find((e) => e.entry_type === 'track' && e.track_title === 'Venom');
+    expect(track).toBeDefined();
+    expect(track.rotation_id).toBeNull();
+    expect(track.rotation_bin).toBeNull();
+  });
+
+  test('rotation_bin populated via cohort (b): rotation row with NULL album_id + denorm artist/album snapshot', async () => {
+    // Cohort (b) per the SQL: library-unlinked rotation rows (NULL album_id)
+    // that hold the (artist_name, album_title) snapshot directly. The
+    // schema's source-shape comment explicitly permits NULL album_id on
+    // rotation. Provision such a row inline so the (b) OR-arm is exercised
+    // — the seeded fixture only covers album_id-bearing rows ((a)/(c)).
+    const inserted = await sql`
+      INSERT INTO ${sql(SCHEMA)}.rotation (album_id, rotation_bin, artist_name, album_title)
+      VALUES (NULL, 'H', 'Phantom Artist', 'Phantom Album')
+      RETURNING id
+    `;
+    extraRotationIds.push(inserted[0].id);
+
+    await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: null,
+        artist_name: 'Phantom Artist',
+        album_title: 'Phantom Album',
+        track_title: 'Ghost Track',
+      })
+      .expect(201);
+
+    const res = await request.get('/flowsheet').query({ limit: 5 }).send().expect(200);
+    const track = res.body.entries.find((e) => e.entry_type === 'track' && e.track_title === 'Ghost Track');
+    expect(track).toBeDefined();
+    expect(track.album_id).toBeNull();
+    expect(track.rotation_id).toBeNull();
+    expect(track.rotation_bin).toEqual('H');
+  });
+
+  test('rotation_bin stays NULL when rotation row was killed before flowsheet add_time', async () => {
+    // Regression pin: kill_date filter must exclude rotation rows whose
+    // kill_date is on/before the flowsheet entry's add_time. Provision a
+    // killed library-unlinked rotation row dated well in the past so the
+    // freshly-added flowsheet row falls strictly after kill_date.
+    const inserted = await sql`
+      INSERT INTO ${sql(SCHEMA)}.rotation (album_id, rotation_bin, artist_name, album_title, add_date, kill_date)
+      VALUES (NULL, 'H', 'Killed Artist', 'Killed Album', '2024-01-01', '2024-02-01')
+      RETURNING id
+    `;
+    extraRotationIds.push(inserted[0].id);
+
+    await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: null,
+        artist_name: 'Killed Artist',
+        album_title: 'Killed Album',
+        track_title: 'Posthumous Track',
+      })
+      .expect(201);
+
+    const res = await request.get('/flowsheet').query({ limit: 5 }).send().expect(200);
+    const track = res.body.entries.find((e) => e.entry_type === 'track' && e.track_title === 'Posthumous Track');
     expect(track).toBeDefined();
     expect(track.rotation_id).toBeNull();
     expect(track.rotation_bin).toBeNull();

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -798,6 +798,101 @@ describe('Retrieve Flowsheet Entries', () => {
   });
 });
 
+describe('rotation_bin read-path fallback (dj-site#750)', () => {
+  // When the picker emit path doesn't persist flowsheet.rotation_id (the
+  // 2026-06-04 regression cohort), the primary FK join leaves rotation_bin
+  // NULL and dj-site's badge disappears. The read path's COALESCE fallback
+  // recovers the bin via (a) album_id match, (b) denorm artist/album match,
+  // or (c) library+artists JOIN match. Seed has rotation row 1 = album_id 1
+  // (Built to Spill — Keep it Like a Secret) in bin 'L'.
+
+  beforeEach(async () => {
+    await fls_util.join_show(global.primary_dj_id, global.access_token);
+  });
+
+  afterEach(async () => {
+    await fls_util.leave_show(global.primary_dj_id, global.access_token);
+  });
+
+  test('rotation_bin populated via primary FK join when rotation_id is set (baseline)', async () => {
+    await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: 1,
+        rotation_id: 1,
+        track_title: 'Carry the Zero',
+      })
+      .expect(201);
+
+    const res = await request.get('/flowsheet').query({ limit: 5 }).send().expect(200);
+    const track = res.body.entries.find((e) => e.entry_type === 'track' && e.track_title === 'Carry the Zero');
+    expect(track).toBeDefined();
+    expect(track.rotation_id).toEqual(1);
+    expect(track.rotation_bin).toEqual('L');
+  });
+
+  test('rotation_bin populated via album_id fallback when rotation_id is NULL', async () => {
+    // Simulates the regression cohort: picker preserved album_id but lost rotation_id.
+    await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: 1,
+        track_title: 'Carry the Zero',
+      })
+      .expect(201);
+
+    const res = await request.get('/flowsheet').query({ limit: 5 }).send().expect(200);
+    const track = res.body.entries.find((e) => e.entry_type === 'track' && e.track_title === 'Carry the Zero');
+    expect(track).toBeDefined();
+    expect(track.rotation_id).toBeNull();
+    expect(track.rotation_bin).toEqual('L');
+  });
+
+  test('rotation_bin populated via library+artists denorm fallback when album_id and rotation_id are both NULL', async () => {
+    // Simulates the worst case: snapshot branch wrote no album_id and no rotation_id,
+    // only the typed/picker-seeded artist+album strings.
+    await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: null,
+        artist_name: 'Built to Spill',
+        album_title: 'Keep it Like a Secret',
+        track_title: 'Carry the Zero',
+      })
+      .expect(201);
+
+    const res = await request.get('/flowsheet').query({ limit: 5 }).send().expect(200);
+    const track = res.body.entries.find((e) => e.entry_type === 'track' && e.track_title === 'Carry the Zero');
+    expect(track).toBeDefined();
+    expect(track.album_id).toBeNull();
+    expect(track.rotation_id).toBeNull();
+    expect(track.rotation_bin).toEqual('L');
+  });
+
+  test('rotation_bin stays NULL when (artist, album) does not match any active rotation row', async () => {
+    // Regression pin: fallback must not match on artist alone or album alone, and
+    // must not silently classify random tracks as rotation. "Ravyn Lenae — Crush"
+    // is in the library (album_id 2) but is NOT in the seeded rotation set.
+    await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: 2,
+        track_title: 'Venom',
+      })
+      .expect(201);
+
+    const res = await request.get('/flowsheet').query({ limit: 5 }).send().expect(200);
+    const track = res.body.entries.find((e) => e.entry_type === 'track' && e.track_title === 'Venom');
+    expect(track).toBeDefined();
+    expect(track.rotation_id).toBeNull();
+    expect(track.rotation_bin).toBeNull();
+  });
+});
+
 describe('Delete Flowsheet Entries', () => {
   beforeEach(async () => {
     await fls_util.join_show(global.primary_dj_id, global.access_token);


### PR DESCRIPTION
## Summary

- Adds a `COALESCE` fallback to `FSEntryFieldsRaw.rotation_bin` in `apps/backend/services/flowsheet.service.ts` that resolves rotation bin via `album_id`, denormalized `(artist, album)`, or `library`+`artists` JOIN when the primary `rotation.id = flowsheet.rotation_id` join misses.
- Subquery only fires on rows where the primary join returned NULL (short-circuited by COALESCE) and the entry has non-empty artist+album. Historical correctness preserved by comparing `rotation.kill_date` against `flowsheet.add_time`.
- Restores dj-site's ROTATION badge for the [WXYC/dj-site#750](https://github.com/WXYC/dj-site/issues/750) regression cohort (every rotation play since 2026-06-04 20:00 UTC has `flowsheet.rotation_id` NULL).

## Why this and not the picker fix

The picker-emit root cause is still unidentified — [WXYC/dj-site#750](https://github.com/WXYC/dj-site/issues/750) tracks the investigation. This patch is the small, low-risk read-path counterpart: makes the user-visible badge correct (matches tubafrenzy/wxyc.info classification) regardless of whether `rotation_id` makes it into the DB or not. It does **not** replace the picker root-cause work — `flowsheet.rotation_id` is still the canonical link and is still NULL on the regression cohort; clients that depend directly on `rotation_id` (iOS rotation-artwork resolver, BS internal queries) aren't helped by this. But the badge UX is.

## Tests

`tests/integration/flowsheet.spec.js` adds 4 cases under `describe('rotation_bin read-path fallback (dj-site#750)')`:

- baseline: `rotation_id` set → primary FK join, `rotation_bin = 'L'`
- fallback (a): `album_id` set, `rotation_id` NULL → `rotation_bin = 'L'`
- fallback (c): both `album_id` and `rotation_id` NULL, denorm artist/album match → `rotation_bin = 'L'`
- regression pin: an in-library album NOT in rotation stays NULL (Ravyn Lenae — Crush)

Local: `npm run typecheck`, `npm run lint`, `npm run format:check`, and unit-test pattern for `flowsheet.service` all green. `npm run ci:testmock` hits a pre-existing missing-script on the enrichment-worker workspace (unrelated); CI will exercise the integration suite.

## Test plan

- [ ] CI integration tests green for `flowsheet.spec.js` (the 4 new cases land in the existing GET-flowsheet section)
- [ ] Manual smoke after deploy: confirm dj-site flowsheet view re-renders ROTATION badges on existing entries from the regression window (no backfill needed — read-path computes at request time)
- [ ] Verify no perf regression on `/flowsheet` paginated GET (the subquery only fires on rows where the primary join missed; on a fully-badged cohort it's a no-op)

## Out of scope

- Picker write-path root cause for the 2026-06-04 cliff — tracked in [WXYC/dj-site#750](https://github.com/WXYC/dj-site/issues/750), still open.
- Jack Baker "(2)" Discogs disambig leak — separate bug filed as [WXYC/dj-site#751](https://github.com/WXYC/dj-site/issues/751).
- Backfilling `flowsheet.rotation_id` on existing rows — historical state stays as written; the read-path computes on the fly.

Refs WXYC/dj-site#750.