### PR TITLE
feat(lml): coordinator requireSearchType opt; migrate librarian writes (BS#1355)

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -100,6 +100,7 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
         budgetMs: LIBRARY_LML_BUDGET_MS,
         caller: 'library-add-album',
         warm_cache: true,
+        requireSearchType: 'direct',
       }),
     ]);
 
@@ -113,7 +114,9 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
       console.warn('Streaming check failed for new album:', streamingResult.reason);
     }
 
-    if (artworkResult.status === 'fulfilled') {
+    if (artworkResult.status === 'rejected') {
+      console.warn('Artwork fetch failed for new album:', artworkResult.reason);
+    } else if (artworkResult.value !== null) {
       const artworkUrl = filterSpacerGif(artworkResult.value.results?.[0]?.artwork?.artwork_url);
       if (artworkUrl) {
         try {
@@ -123,8 +126,6 @@ export const addAlbum: RequestHandler = async (req: Request<object, object, NewA
           console.warn('Failed to persist artwork URL:', (e as Error).message);
         }
       }
-    } else {
-      console.warn('Artwork fetch failed for new album:', artworkResult.reason);
     }
 
     // Fire-and-forget canonical-entity resolution (Epic B.1.3). The library
@@ -153,8 +154,10 @@ function fireAndForgetCanonicalEntity(libraryId: number, artistName: string | nu
       budgetMs: LIBRARY_LML_BUDGET_MS,
       caller: 'library-canonical-entity',
       warm_cache: true,
+      requireSearchType: 'direct',
     })
     .then(async (response) => {
+      if (response === null) return;
       const linkage = libraryService.mapLookupToCanonicalEntity(response);
       if (!linkage) return;
       await libraryService.updateCanonicalEntity(libraryId, linkage.id, linkage.confidence);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -629,22 +629,26 @@ async function resolveRotationDiscogsReleaseViaLml(
 
   let source: RotationPickerSource | null;
   try {
+    // BS#1351: non-direct `search_type` values surface candidates for the wrong
+    // album (Yenbett → Tzenni). The coordinator enforces the gate via
+    // `requireSearchType: 'direct'` and projects `lml.coordinator.trust_reject_reason`
+    // on the per-lookup span. LML's `fetch_one` enforces the 80/80 album-title
+    // floor for `direct` matches, so this is sufficient — the picker falls
+    // through to free-text on rejection.
     const response = await lmlLookupCoordinator.lookup(lookupArtist, albumTitle, undefined, {
       timeoutMs: ROTATION_LML_LOOKUP_TIMEOUT_MS,
       caller: 'library-rotation-picker',
+      requireSearchType: 'direct',
     });
-    // BS#1351: non-direct `search_type` values surface candidates for the wrong
-    // album (Yenbett → Tzenni). LML's `fetch_one` enforces the 80/80 album-title
-    // floor for `direct` matches, so this is sufficient — the picker falls
-    // through to free-text on rejection.
-    if (response.search_type !== 'direct') {
+    if (response === null) {
       source = null;
     } else {
       const artwork = response.results?.[0]?.artwork ?? null;
       // `release_id: 0` is LML's MusicBrainz-rescued synth sentinel
       // (orchestrator.py emits it when ARTIST_PLUS_ALBUM hits but Discogs
       // carries no artwork). Treat as "no Discogs id" so the controller
-      // doesn't follow up with `/discogs/release/0`.
+      // doesn't follow up with `/discogs/release/0`. The tracklist on the
+      // synth result is still valid and is what the picker hands to the DJ.
       const rawReleaseId = artwork?.release_id ?? null;
       const releaseId = rawReleaseId !== null && rawReleaseId > 0 ? rawReleaseId : null;
       const inlineTracklist = projectInlineTracklist(artwork?.tracklist, artistName);
@@ -829,6 +833,14 @@ export const updateArtworkUrl = async (id: number, artwork_url: string | null) =
  * so the link-time value stored on `library.canonical_entity_confidence` is
  * a coarse band kept around so future analyses can re-judge weak matches
  * once LML exposes a real signal.
+ *
+ * The non-direct rows are load-bearing for `flowsheet-linkage.service.ts`,
+ * which calls `mapLookupToCanonicalEntity` on the raw (non-gated) lookup
+ * response and uses the band to gate auto-link vs. gray-zone-review.
+ * `library.controller.fireAndForgetCanonicalEntity` gates with
+ * `requireSearchType: 'direct'` at the coordinator (BS#1355) and only
+ * reaches this map with `search_type === 'direct'`, so its caller-side
+ * behavior is unchanged.
  */
 const SEARCH_TYPE_CONFIDENCE: Record<LookupResponse['search_type'], number | null> = {
   direct: 0.9,
@@ -898,7 +910,9 @@ export async function enrichWithArtwork<T extends ArtworkEnrichable>(results: T[
       const lookupResult = await lmlLookupCoordinator.lookup(row.artist_name, row.album_title, undefined, {
         budgetMs: LIBRARY_INTERACTIVE_LML_BUDGET_MS,
         caller: 'library-enrich-artwork',
+        requireSearchType: 'direct',
       });
+      if (lookupResult === null) return;
       const artworkUrl = filterSpacerGif(lookupResult.results?.[0]?.artwork?.artwork_url);
       if (!artworkUrl) return;
       row.artwork_url = artworkUrl;

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -837,10 +837,14 @@ export const updateArtworkUrl = async (id: number, artwork_url: string | null) =
  * The non-direct rows are load-bearing for `flowsheet-linkage.service.ts`,
  * which calls `mapLookupToCanonicalEntity` on the raw (non-gated) lookup
  * response and uses the band to gate auto-link vs. gray-zone-review.
- * `library.controller.fireAndForgetCanonicalEntity` gates with
- * `requireSearchType: 'direct'` at the coordinator (BS#1355) and only
- * reaches this map with `search_type === 'direct'`, so its caller-side
- * behavior is unchanged.
+ * `library.controller.fireAndForgetCanonicalEntity` instead gates with
+ * `requireSearchType: 'direct'` at the coordinator (BS#1355) — a deliberate
+ * tightening, not a refactor: the old caller path persisted canonical
+ * entities for non-direct matches (fallback / alternative / compilation /
+ * song_as_artist) with their banded confidence; the gated path persists
+ * only `search_type === 'direct'` (band 0.9). The non-direct bands stay
+ * here for flowsheet-linkage; do not reuse them on the librarian-write
+ * path without re-opening the BS#1355 decision.
  */
 const SEARCH_TYPE_CONFIDENCE: Record<LookupResponse['search_type'], number | null> = {
   direct: 0.9,

--- a/apps/backend/services/lml/lookup-coordinator.ts
+++ b/apps/backend/services/lml/lookup-coordinator.ts
@@ -61,7 +61,18 @@ import { lookupMetadata, type LookupOptions, type LookupResponse } from '@wxyc/l
 export type CoordinatorLookupOptions = Pick<
   LookupOptions,
   'budgetMs' | 'timeoutMs' | 'caller' | 'warm_cache' | 'limiter'
->;
+> & {
+  /**
+   * When set, the coordinator returns `null` if the resolved response's
+   * `search_type` doesn't match, after projecting
+   * `lml.coordinator.trust_reject_reason` onto the per-lookup span. The
+   * raw response is still cached — the gate runs per-call so a permissive
+   * caller and a strict caller can share a cached payload and reach
+   * different verdicts. Used by librarian-typed write paths where
+   * non-direct results would persist the wrong release. BS#1355.
+   */
+  requireSearchType?: 'direct';
+};
 
 interface InFlightEntry {
   promise: Promise<LookupResponse>;
@@ -84,14 +95,28 @@ export class LmlLookupCoordinator {
   /**
    * Look up metadata for an artist/album/song triple. Coalesces concurrent
    * same-key calls; serves cached responses within TTL. Errors are not
-   * cached.
+   * cached. When `requireSearchType` is set, returns `null` on mismatch
+   * after projecting `lml.coordinator.trust_reject_reason` onto the span;
+   * otherwise the return is the raw `LookupResponse`.
    */
   async lookup(
     artist: string | undefined,
     album: string | undefined,
     song: string | undefined,
+    options: CoordinatorLookupOptions & { requireSearchType: 'direct' }
+  ): Promise<LookupResponse | null>;
+  async lookup(
+    artist: string | undefined,
+    album: string | undefined,
+    song: string | undefined,
+    options?: Omit<CoordinatorLookupOptions, 'requireSearchType'>
+  ): Promise<LookupResponse>;
+  async lookup(
+    artist: string | undefined,
+    album: string | undefined,
+    song: string | undefined,
     options?: CoordinatorLookupOptions
-  ): Promise<LookupResponse> {
+  ): Promise<LookupResponse | null> {
     const key = this.cacheKey(artist, album, song);
     const caller = options?.caller ?? 'unknown';
 
@@ -99,13 +124,13 @@ export class LmlLookupCoordinator {
       const cached = this.cache.get(key);
       if (cached) {
         this.setSpanAttrs(span, { hit: 'cache', caller });
-        return cached;
+        return this.applyTrustGate(cached, options, span);
       }
 
       const existing = this.inflight.get(key);
       if (existing) {
         this.setSpanAttrs(span, { hit: 'inflight', caller });
-        return existing.promise;
+        return this.applyTrustGate(await existing.promise, options, span);
       }
 
       // Populate cache BEFORE releasing the in-flight entry. The naive
@@ -141,8 +166,31 @@ export class LmlLookupCoordinator {
       this.inflight.set(key, { promise: settle });
       this.setSpanAttrs(span, { hit: 'miss', caller });
 
-      return settle;
+      return this.applyTrustGate(await settle, options, span);
     });
+  }
+
+  /**
+   * Per-call gate: cached responses are stored raw so a permissive caller
+   * and a strict caller can share one cached payload and reach different
+   * verdicts. The rejection attribute lands on the per-lookup span,
+   * co-located with `lml.coordinator.hit` and `.caller`.
+   */
+  private applyTrustGate(
+    response: LookupResponse,
+    options: CoordinatorLookupOptions | undefined,
+    span: ReturnType<typeof Sentry.getActiveSpan>
+  ): LookupResponse | null {
+    if (!options?.requireSearchType) return response;
+    if (response.search_type === options.requireSearchType) return response;
+    if (span) {
+      try {
+        span.setAttribute('lml.coordinator.trust_reject_reason', `search_type:${response.search_type}`);
+      } catch (err) {
+        console.warn('lml.coordinator: failed to project trust_reject_reason onto span', err);
+      }
+    }
+    return null;
   }
 
   private async fetchUncached(

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -72,8 +72,21 @@ jest.mock('@wxyc/lml-client', () => ({
 }));
 
 // Backend code paths now route through the LmlLookupCoordinator (BS#885).
+// The mock stub mirrors the real coordinator's `requireSearchType` gate
+// (BS#1355) so the addAlbum + fireAndForgetCanonicalEntity migrations are
+// validated end-to-end.
 jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
-  lmlLookupCoordinator: { lookup: mockLookupMetadata },
+  lmlLookupCoordinator: {
+    lookup: async (artist: unknown, album: unknown, song: unknown, opts: Record<string, unknown> | undefined) => {
+      const response = (await mockLookupMetadata(artist as never, album as never, song as never, opts as never)) as {
+        search_type?: string;
+      } | null;
+      if (response && opts?.requireSearchType && response.search_type !== opts.requireSearchType) {
+        return null;
+      }
+      return response;
+    },
+  },
 }));
 
 import {
@@ -411,6 +424,7 @@ describe('library.controller', () => {
           budgetMs: 5000,
           caller: 'library-canonical-entity',
           warm_cache: true,
+          requireSearchType: 'direct',
         });
       });
 

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -36,8 +36,23 @@ jest.mock('@wxyc/lml-client', () => ({
 }));
 
 // Backend code paths now route through the LmlLookupCoordinator (BS#885).
+// The mock stub mirrors the real coordinator's `requireSearchType` gate
+// (BS#1355) so per-callsite migrations are validated end-to-end: a test
+// that supplies `search_type: 'alternative'` and a caller that passes
+// `requireSearchType: 'direct'` produces the same `null` the real
+// coordinator would.
 jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
-  lmlLookupCoordinator: { lookup: mockLookupMetadata },
+  lmlLookupCoordinator: {
+    lookup: async (artist: unknown, album: unknown, song: unknown, opts: Record<string, unknown> | undefined) => {
+      const response = (await mockLookupMetadata(artist as never, album as never, song as never, opts as never)) as {
+        search_type?: string;
+      } | null;
+      if (response && opts?.requireSearchType && response.search_type !== opts.requireSearchType) {
+        return null;
+      }
+      return response;
+    },
+  },
 }));
 
 // Mock @sentry/node so we can assert that searchLibraryByTrack creates a
@@ -1905,6 +1920,7 @@ describe('library.service', () => {
       expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
         budgetMs: 5000,
         caller: 'library-enrich-artwork',
+        requireSearchType: 'direct',
       });
       expect(db.update).toHaveBeenCalled();
     });
@@ -1996,6 +2012,7 @@ describe('library.service', () => {
       expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'LP5', undefined, {
         budgetMs: 5000,
         caller: 'library-enrich-artwork',
+        requireSearchType: 'direct',
       });
     });
 
@@ -2260,6 +2277,7 @@ describe('library.service', () => {
       expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
         timeoutMs: 10000,
         caller: 'library-rotation-picker',
+        requireSearchType: 'direct',
       });
     });
 
@@ -2287,7 +2305,7 @@ describe('library.service', () => {
         undefined,
         'All the Young Droids: Junkshop Synth Pop 1978-1985',
         undefined,
-        { timeoutMs: 10000, caller: 'library-rotation-picker' }
+        { timeoutMs: 10000, caller: 'library-rotation-picker', requireSearchType: 'direct' }
       );
     });
 

--- a/tests/unit/services/lml/lookup-coordinator.test.ts
+++ b/tests/unit/services/lml/lookup-coordinator.test.ts
@@ -20,6 +20,22 @@ jest.mock('@wxyc/lml-client', () => ({
   envInt: (_name: string, fallback: number) => fallback,
 }));
 
+// Capture span attribute writes so the requireSearchType tests can assert
+// `lml.coordinator.trust_reject_reason` lands on the per-lookup span. The
+// real Sentry SDK is uninitialized in unit tests and `startSpan` would pass
+// a no-op span — useless for verifying observability output.
+const mockSpanSetAttribute = jest.fn();
+const mockSpanSetAttributes = jest.fn();
+type StartSpanCallback<T> = (span: {
+  setAttribute: typeof mockSpanSetAttribute;
+  setAttributes: typeof mockSpanSetAttributes;
+}) => T | Promise<T>;
+jest.mock('@sentry/node', () => ({
+  ...jest.requireActual<object>('@sentry/node'),
+  startSpan: <T>(_opts: unknown, cb: StartSpanCallback<T>) =>
+    cb({ setAttribute: mockSpanSetAttribute, setAttributes: mockSpanSetAttributes }),
+}));
+
 import {
   LmlLookupCoordinator,
   _resetLmlLookupCoordinatorForTest,
@@ -302,6 +318,103 @@ describe('LmlLookupCoordinator', () => {
         'Confield',
         undefined,
         expect.objectContaining({ warm_cache: true })
+      );
+    });
+  });
+
+  describe('requireSearchType gate', () => {
+    // The BS-side trust policy for librarian-typed write paths: LML's `direct`
+    // search_type is the only result shape that confirms the typed (artist,
+    // album) exists in Discogs as typed. Non-direct values (alternative,
+    // compilation, fallback, song_as_artist, none) are candidate matches LML
+    // returned when the typed album wasn't found; persisting them off a
+    // librarian-typed row writes the wrong release. Gate lives at the
+    // coordinator so the rejection attribute lands on the per-lookup span
+    // co-located with `lml.coordinator.hit` and `.caller`. BS#1355.
+
+    function withSearchType(search_type: LookupResponse['search_type']): LookupResponse {
+      return { ...fakeResponse(), search_type };
+    }
+
+    it('returns the response unchanged when requireSearchType is not set (legacy callers)', async () => {
+      mockLookupMetadata.mockResolvedValue(withSearchType('alternative'));
+
+      const result = await lmlLookupCoordinator.lookup('Noura', 'Yenbett', undefined, {
+        caller: 'metadata-service',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result?.search_type).toBe('alternative');
+    });
+
+    it('returns null and emits trust_reject_reason when search_type does not match', async () => {
+      mockLookupMetadata.mockResolvedValue(withSearchType('alternative'));
+
+      const result = await lmlLookupCoordinator.lookup('Noura', 'Yenbett', undefined, {
+        caller: 'library-rotation-picker',
+        requireSearchType: 'direct',
+      });
+
+      expect(result).toBeNull();
+      expect(mockSpanSetAttribute).toHaveBeenCalledWith(
+        'lml.coordinator.trust_reject_reason',
+        'search_type:alternative'
+      );
+    });
+
+    it('passes the response through when search_type matches and emits no reject attribute', async () => {
+      mockLookupMetadata.mockResolvedValue(withSearchType('direct'));
+
+      const result = await lmlLookupCoordinator.lookup('Autechre', 'Confield', undefined, {
+        caller: 'library-rotation-picker',
+        requireSearchType: 'direct',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result?.search_type).toBe('direct');
+      expect(mockSpanSetAttribute).not.toHaveBeenCalledWith('lml.coordinator.trust_reject_reason', expect.anything());
+    });
+
+    it.each<LookupResponse['search_type']>(['alternative', 'compilation', 'fallback', 'song_as_artist', 'none'])(
+      'rejects %s with the expected reason string',
+      async (search_type) => {
+        mockLookupMetadata.mockResolvedValue(withSearchType(search_type));
+
+        const result = await lmlLookupCoordinator.lookup('Noura', 'Yenbett', undefined, {
+          caller: 'library-rotation-picker',
+          requireSearchType: 'direct',
+        });
+
+        expect(result).toBeNull();
+        expect(mockSpanSetAttribute).toHaveBeenCalledWith(
+          'lml.coordinator.trust_reject_reason',
+          `search_type:${search_type}`
+        );
+      }
+    );
+
+    it('caches the raw response — a strict caller after a permissive caller still gates per-call', async () => {
+      mockLookupMetadata.mockResolvedValue(withSearchType('alternative'));
+
+      // First caller has no gate — receives the response.
+      const permissive = await lmlLookupCoordinator.lookup('Noura', 'Yenbett', undefined, {
+        caller: 'metadata-service',
+      });
+      expect(permissive?.search_type).toBe('alternative');
+
+      mockLookupMetadata.mockClear();
+
+      // Second caller wants direct — gets null off the cached response,
+      // without a fresh wire fetch.
+      const strict = await lmlLookupCoordinator.lookup('Noura', 'Yenbett', undefined, {
+        caller: 'library-rotation-picker',
+        requireSearchType: 'direct',
+      });
+      expect(strict).toBeNull();
+      expect(mockLookupMetadata).not.toHaveBeenCalled();
+      expect(mockSpanSetAttribute).toHaveBeenCalledWith(
+        'lml.coordinator.trust_reject_reason',
+        'search_type:alternative'
       );
     });
   });


### PR DESCRIPTION
## Summary

- Adds `requireSearchType?: 'direct'` to `CoordinatorLookupOptions`. When set and the resolved response's `search_type` doesn't match, the coordinator returns `null` after projecting `lml.coordinator.trust_reject_reason` onto the per-lookup span — co-located with the existing `lml.coordinator.hit` and `.caller` attributes. Cached responses are unaffected; the gate runs per-call.
- Overloads on `lookup()` preserve the non-null return type for callers that don't pass the opt.
- Four librarian-typed callsites migrated: picker tier-3 (collapses PR #1352's inline gate), addAlbum artwork, fireAndForgetCanonicalEntity, enrichWithArtwork.
- `SEARCH_TYPE_CONFIDENCE` stays — `flowsheet-linkage.service.ts` is a fifth, out-of-scope consumer that uses the non-direct bands for `low_confidence` review-queue routing.

## Test plan

- [x] New coordinator tests pin the gate matrix (direct passes, all five non-direct values reject with the expected reason, cached non-direct response gates per-call without a fresh fetch).
- [x] Existing picker tests pass with no behavior change (release_id=0 MusicBrainz-rescue branch still preserves tracklist).
- [x] canonicalEntity + flowsheet-linkage tests pass — `SEARCH_TYPE_CONFIDENCE` bands unchanged.
- [x] Full unit suite green except for one pre-existing flake (`library.controller searchForAlbum › does not propagate enrichment errors`, timing-sensitive, fails identically on origin/main).
- [x] `npm run typecheck`, `lint`, `format:check` all clean.
- [ ] Sentry trace explorer slice on `lml.coordinator.trust_reject_reason` after deploy to verify per-caller rejection rates land as expected.

Closes #1355