### PR TITLE
fix(flowsheet): guard not-found album lookup with 404 (closes BS#1271)

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -195,6 +195,18 @@ export const addEntry: RequestHandler = async (req: Request<object, object, FSEn
     //backfill album info from library before adding to flowsheet
     const albumInfo = await flowsheet_service.getAlbumFromDB(body.album_id);
 
+    // `getAlbumFromDB` returns undefined when `body.album_id` points to a row
+    // that doesn't exist in `library` — possible when the dj-site picker
+    // payload references a library row that's been deleted, or when a
+    // rotation→library FK has desynced. BS#933 covered the explicit-null
+    // case; this guards the equally-reachable not-found case. Without it the
+    // following `albumInfo.record_label = ...` / `...albumInfo` spread throws
+    // a bare TypeError that the centralized errorHandler maps to 500 — the
+    // signal at the root of BS#1271's POST /flowsheet internal_error bursts.
+    if (!albumInfo) {
+      throw new WxycError(`Album ${body.album_id} not found in library`, 404);
+    }
+
     if (body.record_label !== undefined) {
       albumInfo.record_label = body.record_label;
     }

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -462,6 +462,36 @@ describe('flowsheet.controller', () => {
       );
     });
 
+    it('throws WxycError 404 when a positive album_id is not found in library (BS#1271)', async () => {
+      // BS#933 narrowed the lookup-branch predicate from `!== undefined` to
+      // `!= null`, fixing the explicit-null case. A positive `album_id` that
+      // doesn't match any `library.id` (deleted between dj-site picker fetch
+      // and POST, or rotation→library FK desync) still slipped through and
+      // produced a bare TypeError on the next line — captured as a 500 with
+      // no Sentry exception, the signal at the root of BS#1271's POST
+      // /flowsheet internal_error bursts. The guard now turns the not-found
+      // case into a clean 404 WxycError.
+      // Mock the not-found case explicitly: real `getAlbumFromDB` returns
+      // `undefined` on no match (see library.service.test.ts:1759).
+      mockGetAlbumFromDB.mockResolvedValue(undefined);
+
+      const req = createMockBodyReq({
+        album_id: 9999,
+        track_title: 'Crispy Duck',
+        record_label: 'Duophonic',
+      });
+      const res = createMockRes();
+
+      await expect(addEntry(req as Request, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
+      await expect(addEntry(req as Request, res as Response, mockNext)).rejects.toMatchObject({
+        statusCode: 404,
+        message: expect.stringContaining('9999'),
+      });
+      expect(mockGetAlbumFromDB).toHaveBeenCalledWith(9999);
+      // INSERT must not run when the album lookup misses.
+      expect(mockAddTrack).not.toHaveBeenCalled();
+    });
+
     it('passes segue field through for library-linked tracks (album_id provided)', async () => {
       const albumInfo = {
         artist_name: 'Stereolab',


### PR DESCRIPTION
## Summary

Adds a not-found guard at `apps/backend/controllers/flowsheet.controller.ts:198` so a POST /flowsheet with an `album_id` that doesn't match any `library` row returns a clean **404 WxycError** instead of TypeError-ing on `albumInfo.record_label = …` / `…albumInfo` (lines 199 / 204).

## Background

BS#1271 captured a recurring burst of internal_error spans on `POST /flowsheet` with no matching captured exception. The 24h re-check on 2026-06-04 classified it as RECURRED at ~35% magnitude post-Track-1, with a new cluster at 2026-06-03 ~16:00 UTC.

The investigation (full evidence in the BS#1271 thread) confirmed:

- `http.response.status_code: 500` on all 8 post-deploy traces — kills the original 4xx-misclassify hypothesis.
- Trace shape exactly walks the controller through `getAlbumFromDB` (6 db SELECTs, then nothing — no `nextPlayOrder`, no INSERT).
- Existing regression tests (`flowsheet.controller.test.ts:412`, `library.service.test.ts:1759`, `flowsheet.spec.js:484`) already document the TypeError when `getAlbumFromDB` returns undefined.
- BS#933 narrowed the lookup-branch predicate from `!== undefined` to `!= null`, fixing the explicit-null case but leaving the positive-but-not-found case unguarded.

Failure mode in production: dj-site `RotationEntryFields.tsx:71` sends `album_id: release.id` from a rotation row. When the underlying library row has been deleted or the rotation→library FK has desynced, `getAlbumFromDB` returns undefined and the next line throws `TypeError`.

## Change

Single-file controller fix + matching unit test. Turns the not-found case into a 404 WxycError. This:

- Eliminates the bare TypeError → 500 (closes the root cause).
- Makes `shouldCaptureExpressError` correctly skip Sentry capture (4xx is a legitimate client error, not a server bug).
- Means the span no longer carries `span.status: internal_error` per OTel HTTP semconv.

## What this PR does NOT do

- Doesn't try to make Sentry's `setupExpressErrorHandler` capture the bare-TypeError case. That's a separate observability gap (no caught exception was emitted by the SDK even though the filter says it should have captured) — worth a follow-up issue rather than bundling here.
- Doesn't change the dj-site picker contract. Backend hardening only.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 2868 / 2868 passed; new test covers the not-found case
- [ ] Integration test pass on CI