### PR TITLE
fix(internal-webhook): resolve dj_name on tubafrenzy marker rows

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -425,7 +425,7 @@ export const leaveShow: RequestHandler<object, unknown, { dj_id: string }> = asy
 export const getDJList: RequestHandler = async (req, res) => {
   const currentDJs = await flowsheet_service.getDJsInCurrentShow();
   const cleanDJList = currentDJs.map((dj) => {
-    return { id: dj.id, dj_name: flowsheet_service.resolveDjDisplayName(dj.djName ?? null, dj.name ?? null) };
+    return { id: dj.id, dj_name: flowsheet_service.resolveDjDisplayName(dj.djName ?? null) };
   });
   res.status(200).json(cleanDJList);
 };

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -57,21 +57,28 @@ internal_route.post('/flowsheet-sync-notify', (req, res) => {
 interface ResolvedShow {
   id: number;
   /**
-   * COALESCE(auth_user.dj_name, shows.legacy_dj_name, auth_user.name) —
-   * matches the ETL / dj-name-backfill SQL. The `resolveDjDisplayName`
-   * helper (services/flowsheet.service.ts) can't be reused here because
-   * its signature is `(djName, name) => string | null` — it has no
-   * `legacy_dj_name` parameter. Picking the same 3-column COALESCE the
+   * COALESCE(auth_user.dj_name, shows.legacy_dj_name) — matches the
+   * ETL / dj-name-backfill SQL. The `resolveDjDisplayName` helper
+   * (services/flowsheet.service.ts) can't be reused here because its
+   * signature is `(djName) => string | null` — it has no
+   * `legacy_dj_name` parameter. Picking the same 2-column COALESCE the
    * ETL (jobs/flowsheet-etl/job.ts:97) and backfill
-   * (jobs/flowsheet-dj-name-backfill/job.ts:66) already use means a row
-   * later re-resolved by either job lands the identical value — no
-   * writer drift. The known consequence — neither writer filters the
-   * literal 'Anonymous' the live path strips — is shared with both
-   * jobs by design (BS#1371 spec).
+   * (jobs/flowsheet-dj-name-backfill/job.ts:66) use means a row later
+   * re-resolved by either job lands the identical value — no writer
+   * drift. The known consequence — neither writer filters the literal
+   * 'Anonymous' the live path strips — is shared with both jobs by
+   * design (BS#1371 spec).
    *
-   * Null when the show has no resolvable name from any of the three
-   * sources (stub shows pre-ETL-fill; legacy rows with no primary_dj_id
-   * and no legacy_dj_name).
+   * `auth_user.name` is intentionally NOT in the chain — dj-site
+   * provisioning writes the user's real name into that column
+   * (`name: realName || username` in the roster UI), and surfacing real
+   * names on the public v2 wire would be PII exposure. The live path's
+   * asymmetric-fallback policy already handles null gracefully
+   * (degraded `Start of show: ${time}` instead of leaking a real name).
+   *
+   * Null when the show has no resolvable name from either source
+   * (stub shows pre-ETL-fill; legacy rows with no primary_dj_id and no
+   * legacy_dj_name).
    */
   dj_name: string | null;
 }
@@ -92,7 +99,7 @@ async function resolveShow(legacyShowId: number): Promise<ResolvedShow | null> {
     db
       .select({
         id: shows.id,
-        dj_name: sql<string | null>`COALESCE(${user.djName}, ${shows.legacy_dj_name}, ${user.name})`,
+        dj_name: sql<string | null>`COALESCE(${user.djName}, ${shows.legacy_dj_name})`,
       })
       .from(shows)
       .leftJoin(user, eq(user.id, shows.primary_dj_id))

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -1,10 +1,15 @@
 import { Router } from 'express';
 import { eq, sql } from 'drizzle-orm';
-import { db, flowsheet, shows, rotation, library, truncate } from '@wxyc/database';
+import { db, flowsheet, shows, rotation, library, truncate, user } from '@wxyc/database';
 import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
 import { mapProdEntryType, isMessageEntryType } from '../utils/flowsheet-transform.js';
 
 const ETL_NOTIFY_KEY = process.env.ETL_NOTIFY_KEY ?? '';
+
+// Marker entry types that surface `dj_name` on the v2 wire (and so must be
+// resolved on the webhook insert path — BS#1371). Track + message-typed rows
+// follow other rules and are intentionally excluded.
+const MARKER_ENTRY_TYPES = new Set(['show_start', 'show_end', 'dj_join', 'dj_leave']);
 
 export const internal_route = Router();
 
@@ -37,21 +42,56 @@ internal_route.post('/flowsheet-sync-notify', (req, res) => {
   res.json({ ok: true });
 });
 
+interface ResolvedShow {
+  id: number;
+  /**
+   * COALESCE(auth_user.dj_name, shows.legacy_dj_name, auth_user.name) —
+   * matches the ETL / dj-name-backfill convention. Raw COALESCE (not the
+   * `resolveDjDisplayName` helper) on purpose: the live `startShow` /
+   * `endShow` path filters the literal 'Anonymous'; the ETL + backfill
+   * jobs do not. If the webhook used the helper and the same row were
+   * later re-resolved by the ETL or backfill, the two writers would
+   * disagree — drift instead of fix. See jobs/flowsheet-etl/job.ts:84-86
+   * and jobs/flowsheet-dj-name-backfill/job.ts for the convention.
+   *
+   * Null when the show has no resolvable name from any of the three
+   * sources (stub shows pre-ETL-fill; legacy rows with no primary_dj_id
+   * and no legacy_dj_name).
+   */
+  dj_name: string | null;
+}
+
 /**
  * Look up a show by legacy_show_id, creating a stub if it doesn't exist.
  * Uses onConflictDoNothing + re-select for concurrent-insert safety.
+ *
+ * Also resolves the show's display dj_name via a LEFT JOIN to auth_user on
+ * `shows.primary_dj_id` — same query path, no extra round-trip. The webhook
+ * INSERT writes this onto marker rows so the v2 wire honours the
+ * FLOWSHEET_DJ_NAME_NON_NULL contract (BS#1371).
  */
-async function resolveShowId(legacyShowId: number): Promise<number | null> {
+async function resolveShow(legacyShowId: number): Promise<ResolvedShow | null> {
   if (!legacyShowId) return null;
 
-  const existing = await db.select({ id: shows.id }).from(shows).where(eq(shows.legacy_show_id, legacyShowId)).limit(1);
-  if (existing.length > 0) return existing[0].id;
+  const selectShow = () =>
+    db
+      .select({
+        id: shows.id,
+        dj_name: sql<string | null>`COALESCE(${user.djName}, ${shows.legacy_dj_name}, ${user.name})`,
+      })
+      .from(shows)
+      .leftJoin(user, eq(user.id, shows.primary_dj_id))
+      .where(eq(shows.legacy_show_id, legacyShowId))
+      .limit(1);
+
+  const existing = await selectShow();
+  if (existing.length > 0) return { id: existing[0].id, dj_name: existing[0].dj_name };
 
   // Create a stub show — the ETL will fill in details (end_time, show_name) later.
   await db.insert(shows).values({ legacy_show_id: legacyShowId, start_time: new Date() }).onConflictDoNothing();
 
-  const [row] = await db.select({ id: shows.id }).from(shows).where(eq(shows.legacy_show_id, legacyShowId)).limit(1);
-  return row?.id ?? null;
+  const [row] = await selectShow();
+  return row ? { id: row.id, dj_name: row.dj_name } : null;
 }
 
 const VALID_ACTIONS = new Set(['create', 'update', 'delete']);
@@ -107,11 +147,25 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // fires from this route — CDC drives the consumer.
       const rawLibraryId = entry.libraryReleaseId ?? 0;
       const rawRotationId = entry.rotationReleaseId ?? 0;
-      const [showId, albumId, rotationId] = await Promise.all([
-        resolveShowId(entry.radioShowId),
+      const [show, albumId, rotationId] = await Promise.all([
+        resolveShow(entry.radioShowId),
         resolveAlbumId(rawLibraryId),
         resolveRotationId(rawRotationId),
       ]);
+      const showId = show?.id ?? null;
+      // For show_start / show_end / dj_join / dj_leave the v2 wire surfaces
+      // dj_name (FLOWSHEET_DJ_NAME_NON_NULL contract). Other entry types
+      // either denormalize dj_name differently (track) or don't surface it
+      // (talkset, breakpoint, message), so we leave them null and let the
+      // existing population paths handle them.
+      //
+      // dj_join / dj_leave caveat (BS#1371): the webhook payload has no
+      // per-event DJ id, only radioShowId — so guest-join markers attribute
+      // to shows.primary_dj_id, not the joining guest. Same known limitation
+      // as flowsheet-dj-name-backfill (`jobs/flowsheet-dj-name-backfill/job.ts`);
+      // the live createJoinNotification path is the only one that gets guest
+      // attribution right.
+      const markerDjName = MARKER_ENTRY_TYPES.has(entryType) ? (show?.dj_name ?? null) : null;
 
       // INSERT ... ON CONFLICT DO NOTHING RETURNING { id }: either we win
       // the insert and PG hands back exactly one row, or a concurrent
@@ -142,6 +196,7 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
           track_title: trackTitle,
           record_label: truncate(entry.labelName, 128),
           message: isMsgType ? truncate(entry.artistName, 250) : null,
+          dj_name: markerDjName,
           request_flag: !!entry.requestFlag,
           segue: false,
           play_order: entry.sequenceWithinShow ?? 0,

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -2,14 +2,26 @@ import { Router } from 'express';
 import { eq, sql } from 'drizzle-orm';
 import { db, flowsheet, shows, rotation, library, truncate, user } from '@wxyc/database';
 import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
-import { mapProdEntryType, isMessageEntryType } from '../utils/flowsheet-transform.js';
+import { mapProdEntryType, isMessageEntryType, type BackendEntryType } from '../utils/flowsheet-transform.js';
 
 const ETL_NOTIFY_KEY = process.env.ETL_NOTIFY_KEY ?? '';
 
 // Marker entry types that surface `dj_name` on the v2 wire (and so must be
 // resolved on the webhook insert path — BS#1371). Track + message-typed rows
 // follow other rules and are intentionally excluded.
-const MARKER_ENTRY_TYPES = new Set(['show_start', 'show_end', 'dj_join', 'dj_leave']);
+//
+// `dj_join` / `dj_leave` are kept defensively even though `mapProdEntryType`
+// currently doesn't emit them (the tubafrenzy PROD code map covers 0-10 only,
+// none of which resolve to join/leave). If tubafrenzy ever extends the PROD
+// table with join/leave codes, the gate is ready and the attribution caveat
+// below applies. Typed as `Set<BackendEntryType>` so a typo'd literal would
+// fail to compile rather than silently match no entry at runtime.
+const MARKER_ENTRY_TYPES: ReadonlySet<BackendEntryType> = new Set<BackendEntryType>([
+  'show_start',
+  'show_end',
+  'dj_join',
+  'dj_leave',
+]);
 
 export const internal_route = Router();
 
@@ -46,13 +58,16 @@ interface ResolvedShow {
   id: number;
   /**
    * COALESCE(auth_user.dj_name, shows.legacy_dj_name, auth_user.name) —
-   * matches the ETL / dj-name-backfill convention. Raw COALESCE (not the
-   * `resolveDjDisplayName` helper) on purpose: the live `startShow` /
-   * `endShow` path filters the literal 'Anonymous'; the ETL + backfill
-   * jobs do not. If the webhook used the helper and the same row were
-   * later re-resolved by the ETL or backfill, the two writers would
-   * disagree — drift instead of fix. See jobs/flowsheet-etl/job.ts:84-86
-   * and jobs/flowsheet-dj-name-backfill/job.ts for the convention.
+   * matches the ETL / dj-name-backfill SQL. The `resolveDjDisplayName`
+   * helper (services/flowsheet.service.ts) can't be reused here because
+   * its signature is `(djName, name) => string | null` — it has no
+   * `legacy_dj_name` parameter. Picking the same 3-column COALESCE the
+   * ETL (jobs/flowsheet-etl/job.ts:97) and backfill
+   * (jobs/flowsheet-dj-name-backfill/job.ts:66) already use means a row
+   * later re-resolved by either job lands the identical value — no
+   * writer drift. The known consequence — neither writer filters the
+   * literal 'Anonymous' the live path strips — is shared with both
+   * jobs by design (BS#1371 spec).
    *
    * Null when the show has no resolvable name from any of the three
    * sources (stub shows pre-ETL-fill; legacy rows with no primary_dj_id
@@ -92,6 +107,18 @@ async function resolveShow(legacyShowId: number): Promise<ResolvedShow | null> {
 
   const [row] = await selectShow();
   return row ? { id: row.id, dj_name: row.dj_name } : null;
+}
+
+/**
+ * Trim a COALESCE-resolved dj_name and coerce blank/whitespace to null so
+ * the v2 wire never serves a string of spaces. Mirrors the live writer's
+ * `resolveDjDisplayName` shape — same input, same null normalization —
+ * minus the 'Anonymous' literal filter (kept consistent with the ETL +
+ * backfill convention; see ResolvedShow.dj_name docstring).
+ */
+function normalizeMarkerName(raw: string | null | undefined): string | null {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : null;
 }
 
 const VALID_ACTIONS = new Set(['create', 'update', 'delete']);
@@ -159,13 +186,21 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // (talkset, breakpoint, message), so we leave them null and let the
       // existing population paths handle them.
       //
-      // dj_join / dj_leave caveat (BS#1371): the webhook payload has no
-      // per-event DJ id, only radioShowId — so guest-join markers attribute
-      // to shows.primary_dj_id, not the joining guest. Same known limitation
-      // as flowsheet-dj-name-backfill (`jobs/flowsheet-dj-name-backfill/job.ts`);
-      // the live createJoinNotification path is the only one that gets guest
-      // attribution right.
-      const markerDjName = MARKER_ENTRY_TYPES.has(entryType) ? (show?.dj_name ?? null) : null;
+      // Trim whitespace and treat blank as null so the wire doesn't surface
+      // a string of spaces (the live writer's `resolveDjDisplayName` does
+      // the same — without it, a `shows.legacy_dj_name='   '` from a
+      // tubafrenzy edit would persist into flowsheet.dj_name and the v2
+      // wire would emit whitespace, defeating the BS#1371 fix via a
+      // different path).
+      //
+      // dj_join / dj_leave caveat (BS#1371): when those codes do enter via
+      // the webhook path (currently they don't — see MARKER_ENTRY_TYPES
+      // above), the payload has no per-event DJ id, only radioShowId — so
+      // guest-join markers would attribute to shows.primary_dj_id, not the
+      // joining guest. Same known limitation as flowsheet-dj-name-backfill;
+      // the live createJoinNotification path is the only one that gets
+      // guest attribution right today.
+      const markerDjName = MARKER_ENTRY_TYPES.has(entryType) ? normalizeMarkerName(show?.dj_name) : null;
 
       // INSERT ... ON CONFLICT DO NOTHING RETURNING { id }: either we win
       // the insert and PG hands back exactly one row, or a concurrent
@@ -213,18 +248,28 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
         // UPDATE set-list — show_id / play_order / segue / add_time stay
         // anchored to the first INSERT's values, mutable metadata-ish
         // fields move with the latest webhook payload.
-        await db
-          .update(flowsheet)
-          .set({
-            artist_name: artistName,
-            album_title: albumTitle,
-            track_title: trackTitle,
-            record_label: truncate(entry.labelName, 128),
-            message: isMsgType ? truncate(entry.artistName, 250) : null,
-            request_flag: !!entry.requestFlag,
-            entry_type: entryType,
-          })
-          .where(eq(flowsheet.legacy_entry_id, entry.id));
+        //
+        // `dj_name` is conditionally refreshed only when the resolver
+        // produced a non-null value (defense-in-depth for the stub-then-
+        // fill race: webhook may have inserted with dj_name=NULL when the
+        // stub `shows` row had no resolvable name yet; a later redelivery
+        // after the ETL fills shows.legacy_dj_name will heal the row).
+        // We never overwrite a non-NULL stored value with NULL — that
+        // would regress a row the live path or a prior delivery already
+        // resolved.
+        const refresh: Record<string, unknown> = {
+          artist_name: artistName,
+          album_title: albumTitle,
+          track_title: trackTitle,
+          record_label: truncate(entry.labelName, 128),
+          message: isMsgType ? truncate(entry.artistName, 250) : null,
+          request_flag: !!entry.requestFlag,
+          entry_type: entryType,
+        };
+        if (markerDjName !== null) {
+          refresh.dj_name = markerDjName;
+        }
+        await db.update(flowsheet).set(refresh).where(eq(flowsheet.legacy_entry_id, entry.id));
       }
     }
 

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -24,33 +24,37 @@ import { IFSEntry, ShowInfo, ShowMetadata, UpdateRequestBody } from '../controll
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
 
 /**
- * Resolve the DJ display name shown to listeners on the public flowsheet,
- * applying the rules locked by the 2026-06-02 Aubrey Hearst on-air incident
- * (WXYC/Backend-Service#1286, epic #1288):
+ * Resolve the DJ display name shown to listeners on the public flowsheet.
  *
- *   1. Prefer `djName` (the user's stage handle on `auth_user.dj_name`).
- *   2. Fall back to `name` (better-auth `auth_user.name`).
- *   3. Treat the literal string "Anonymous" (case- and whitespace-insensitive)
+ * Rules:
+ *   1. Use `djName` (the user's stage handle on `auth_user.dj_name`).
+ *   2. Treat the literal string "Anonymous" (case- and whitespace-insensitive)
  *      as if `djName` were absent. The better-auth anonymous plugin and a
  *      since-corrected onboarding default were both observed writing the
- *      literal "Anonymous" into `auth_user.dj_name`; rendering that string to
- *      the public on-air playlist confuses listeners and the wxyc.info playlist.
- *   4. Trim returned values; return `null` if both inputs are blank or
- *      Anonymous-with-no-fallback.
+ *      literal "Anonymous" into `auth_user.dj_name`; rendering that string
+ *      to the public on-air playlist confused listeners and the wxyc.info
+ *      playlist (BS#1286, epic #1288, 2026-06-02 Aubrey Hearst on-air
+ *      incident).
+ *   3. Trim the returned value; return `null` if blank or Anonymous.
+ *
+ * Why this no longer falls back to `auth_user.name`: dj-site's admin
+ * provisioning flow writes the user's real name into `auth_user.name`
+ * (`name: newAccount.realName || newAccount.username` in roster UI), so
+ * surfacing `name` on the public v2 flowsheet wire would leak PII —
+ * exactly the same class of incident BS#1286 fixed for the 'Anonymous'
+ * literal. Real names are appropriate for DJ-to-DJ internal views; they
+ * are not appropriate for the public on-air playlist.
  *
  * Callers should treat `null` as "name is unresolvable" and either degrade
- * the marker template (show_start / show_end keep a row but drop the name) or
- * suppress the row entirely and log to Sentry (dj_join / dj_leave) — see
- * `startShow`, `endShow`, `createJoinNotification`, `createLeaveNotification`.
+ * the marker template (show_start / show_end keep a row but drop the name)
+ * or suppress the row entirely and log to Sentry (dj_join / dj_leave) —
+ * see `startShow`, `endShow`, `createJoinNotification`,
+ * `createLeaveNotification`.
  */
-export const resolveDjDisplayName = (djName: string | null, name: string | null): string | null => {
+export const resolveDjDisplayName = (djName: string | null): string | null => {
   const trimmedDjName = djName?.trim() ?? '';
   if (trimmedDjName.length > 0 && trimmedDjName.toLowerCase() !== 'anonymous') {
     return trimmedDjName;
-  }
-  const trimmedName = name?.trim() ?? '';
-  if (trimmedName.length > 0) {
-    return trimmedName;
   }
   return null;
 };
@@ -297,7 +301,6 @@ const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
  *      `resolveDjDisplayName`)
  *   3. `shows.legacy_dj_name` (tubafrenzy-owned; "DJ name at time of the
  *      show for shows whose primary_dj_id couldn't be resolved")
- *   4. `auth_user.name`
  *
  * Used by the live insert path (step 5b.2) to denormalize the resolved value
  * onto each new flowsheet row so search no longer needs to join shows -> auth_user.
@@ -319,6 +322,11 @@ const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
  * on purpose. The pre-existing `auth_user.dj_name` filter was a workaround
  * for an upstream onboarding bug that wrote "Anonymous" automatically;
  * the override is operator-supplied, so we trust it verbatim.
+ *
+ * `auth_user.name` is intentionally NOT in the chain — it typically stores
+ * the user's real name (set from realName at provision time), which is PII
+ * and must not leak onto the public on-air playlist. See
+ * `resolveDjDisplayName`'s docstring.
  */
 export const resolveDjNameForShow = async (show: Show): Promise<string | null> => {
   const override = ((show.dj_name_override as string | null | undefined) ?? '').trim();
@@ -329,20 +337,13 @@ export const resolveDjNameForShow = async (show: Show): Promise<string | null> =
 
   if (primaryDjId == null) return legacy;
 
-  const rows = await db
-    .select({ djName: user.djName, name: user.name })
-    .from(user)
-    .where(eq(user.id, primaryDjId))
-    .limit(1);
+  const rows = await db.select({ djName: user.djName }).from(user).where(eq(user.id, primaryDjId)).limit(1);
   const dj = rows[0];
   if (!dj) return legacy;
-  // Apply the same Anonymous / blank filtering used everywhere else, but
-  // splice the legacy_dj_name in as a middle priority so existing imports
-  // continue to surface on shows whose auth_user has no usable handle.
-  const filteredDjName = resolveDjDisplayName(dj.djName ?? null, null);
+  const filteredDjName = resolveDjDisplayName(dj.djName ?? null);
   if (filteredDjName) return filteredDjName;
   if (legacy && legacy.trim().length > 0) return legacy.trim();
-  return resolveDjDisplayName(null, dj.name ?? null);
+  return null;
 };
 
 /**
@@ -595,7 +596,7 @@ export const startShow = async (
   // When the override is absent, fall back to the centralized resolution
   // helper that handles `auth_user.dj_name`, the "Anonymous" literal, and
   // the `auth_user.name` fallback (WXYC/Backend-Service#1286, epic #1288).
-  const display_dj_name = effective_override ?? resolveDjDisplayName(dj_info.djName ?? null, dj_info.name ?? null);
+  const display_dj_name = effective_override ?? resolveDjDisplayName(dj_info.djName ?? null);
   const now = new Date().toLocaleString('en-US', { timeZone: 'America/New_York' });
   // Asymmetric fallback (epic #1288): when the DJ name is unresolvable we
   // still want a marker row so consumers know the show began. The wording
@@ -657,7 +658,7 @@ export const addDJToShow = async (dj_id: string, current_show: Show): Promise<Sh
 const createJoinNotification = async (id: string, show_id: number): Promise<FSEntry | null> => {
   const dj = (await db.select().from(user).where(eq(user.id, id)).limit(1))[0];
 
-  const display_dj_name = resolveDjDisplayName(dj?.djName ?? null, dj?.name ?? null);
+  const display_dj_name = resolveDjDisplayName(dj?.djName ?? null);
 
   // Asymmetric fallback (epic #1288): a nameless mid-show join is a degraded
   // state. The marker is suppressed rather than written — better logged than
@@ -710,7 +711,7 @@ export const endShow = async (currentShow: Show): Promise<Show> => {
   );
 
   const dj_information = (await db.select().from(user).where(eq(user.id, primary_dj_id)).limit(1))[0];
-  const display_dj_name = resolveDjDisplayName(dj_information?.djName ?? null, dj_information?.name ?? null);
+  const display_dj_name = resolveDjDisplayName(dj_information?.djName ?? null);
   const now = new Date().toLocaleString('en-US', { timeZone: 'America/New_York' });
   // Symmetric to startShow: keep the row, degrade the wording to bare
   // "End of show: ${time}" when the name is unresolvable (epic #1288).
@@ -754,7 +755,7 @@ export const leaveShow = async (dj_id: string, currentShow: Show): Promise<ShowD
 const createLeaveNotification = async (dj_id: string, show_id: number): Promise<FSEntry | null> => {
   const dj = (await db.select().from(user).where(eq(user.id, dj_id)).limit(1))[0];
 
-  const display_dj_name = resolveDjDisplayName(dj?.djName ?? null, dj?.name ?? null);
+  const display_dj_name = resolveDjDisplayName(dj?.djName ?? null);
 
   // Symmetric to createJoinNotification: suppress the row and log a Sentry
   // warning when the DJ name is unresolvable (epic #1288).
@@ -924,7 +925,7 @@ export const getShowMetadata = async (show_id: number): Promise<ShowMetadata> =>
 
   const showDJs = (await getDJsInShow(show_id, false)).map((dj) => ({
     id: dj.id,
-    dj_name: resolveDjDisplayName(dj.djName ?? null, dj.name ?? null),
+    dj_name: resolveDjDisplayName(dj.djName ?? null),
   }));
 
   let specialty_show_name = '';

--- a/apps/backend/utils/flowsheet-transform.ts
+++ b/apps/backend/utils/flowsheet-transform.ts
@@ -5,7 +5,7 @@
  * entry type codes or truncation rules change.
  */
 
-type BackendEntryType =
+export type BackendEntryType =
   | 'track'
   | 'show_start'
   | 'show_end'

--- a/jobs/flowsheet-dj-name-backfill/job.ts
+++ b/jobs/flowsheet-dj-name-backfill/job.ts
@@ -8,9 +8,12 @@
  * `dj_name IS NULL` filter (re-running picks up exactly the rows the previous
  * run did not finish).
  *
- * The COALESCE order matches the search service's DJ_NAME_EXPR and the live
- * insert path, so every row carries the same resolved name regardless of
- * which subsystem populated it.
+ * The COALESCE chain — `auth_user.dj_name` then `shows.legacy_dj_name` —
+ * matches the webhook + live insert path. `auth_user.name` is intentionally
+ * NOT in the chain: dj-site provisioning writes the user's real name into
+ * that column, and surfacing real names on the public v2 wire would be PII
+ * exposure. Rows where neither source resolves stay NULL; the live path's
+ * asymmetric-fallback policy degrades gracefully.
  *
  * Covered entry types (#952): track (search hot path) plus the four marker
  * types — show_start, show_end, dj_join, dj_leave — which surface dj_name in
@@ -63,7 +66,7 @@ const PROGRESS_LOG_EVERY = 1; // every batch; the operation is rare enough that 
 const applyBatch = async (batchSize: number): Promise<number> => {
   const result = await db.execute(sql`
     UPDATE "wxyc_schema"."flowsheet" AS f
-    SET "dj_name" = COALESCE(u."dj_name", s."legacy_dj_name", u."name")
+    SET "dj_name" = COALESCE(u."dj_name", s."legacy_dj_name")
     FROM "wxyc_schema"."shows" AS s
     LEFT JOIN "auth_user" AS u ON u."id" = s."primary_dj_id"
     WHERE f."show_id" = s."id"

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -82,8 +82,11 @@ const resolveAlbumIds = async () => {
  * cron's `docker rm -f` killed the container the orphaned PostgreSQL backend
  * kept holding row locks, blocking the next tick. See issue #511.
  *
- * The COALESCE order matches the search service's DJ_NAME_EXPR so future
- * modern-DJ ETL imports pick up auth_user.dj_name automatically.
+ * The COALESCE chain — `auth_user.dj_name` then `shows.legacy_dj_name` —
+ * matches the webhook, backfill, and live insert path. `auth_user.name`
+ * is intentionally NOT in the chain: dj-site provisioning writes the
+ * user's real name into that column, and surfacing real names on the
+ * public v2 wire would be PII exposure.
  */
 const resolveDjNames = async (legacyEntryIds: number[]) => {
   if (legacyEntryIds.length === 0) return;
@@ -94,7 +97,7 @@ const resolveDjNames = async (legacyEntryIds: number[]) => {
   // get populated for the row I just inserted?" steady-state questions.
   const result = await db.execute(sql`
     UPDATE "wxyc_schema"."flowsheet" AS f
-    SET "dj_name" = COALESCE(u."dj_name", s."legacy_dj_name", u."name")
+    SET "dj_name" = COALESCE(u."dj_name", s."legacy_dj_name")
     FROM "wxyc_schema"."shows" AS s
     LEFT JOIN "auth_user" AS u ON u."id" = s."primary_dj_id"
     WHERE f."show_id" = s."id"

--- a/tests/integration/internal-flowsheet-webhook.spec.js
+++ b/tests/integration/internal-flowsheet-webhook.spec.js
@@ -137,14 +137,29 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
     }
   });
 
-  // Highest-priority COALESCE arm. Seeds an auth_user, points shows.primary_dj_id
-  // at it, and asserts the resolver picked user.dj_name over legacy_dj_name.
-  // Without this case the LEFT JOIN to auth_user is never exercised against real
-  // Postgres; a schema rename of auth_user.dj_name would leave the legacy_dj_name
-  // case (above) green while production silently regressed on the primary arm.
+  // Highest-priority COALESCE arm. Points shows.primary_dj_id at a seeded
+  // auth_user and asserts the resolver picked auth_user.dj_name over
+  // legacy_dj_name. Without this case the LEFT JOIN to auth_user is never
+  // exercised against real Postgres; a schema rename of auth_user.dj_name
+  // would leave the legacy_dj_name case (above) green while production
+  // silently regressed on the primary arm.
+  //
+  // The expected name is fetched at runtime from the seed row rather than
+  // hardcoded, so a future rename of the seeded dj_name in dev_env/seed_db.sql
+  // doesn't break this test for an unrelated reason. We do hard-code the
+  // user id (a stable seed key) — if the row itself is removed from the
+  // seed the upfront SELECT throws with a clear "seeded user missing"
+  // message instead of a confusing equality failure on the dj_name.
   test('show_start webhook prefers auth_user.dj_name over legacy_dj_name (BS#1371)', async () => {
     const LEGACY_SHOW_ID = 9_999_988;
-    const PRIMARY_DJ_ID = 'test-dj1-id-00000000000000000001'; // seeded in dev_env/seed_db.sql with dj_name='Test dj1'
+    const PRIMARY_DJ_ID = 'test-dj1-id-00000000000000000001'; // seeded in dev_env/seed_db.sql
+    const [seededUser] = await sql.unsafe(`SELECT dj_name FROM auth_user WHERE id = $1`, [PRIMARY_DJ_ID]);
+    if (!seededUser?.dj_name) {
+      throw new Error(
+        `Seeded auth_user ${PRIMARY_DJ_ID} is missing or has no dj_name; cannot run BS#1371 auth_user-arm test`
+      );
+    }
+    const expectedDjName = seededUser.dj_name;
     await seedShow(LEGACY_SHOW_ID, { legacyDjName: 'Legacy Override Loser', primaryDjId: PRIMARY_DJ_ID });
 
     try {
@@ -160,7 +175,9 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
       ]);
       expect(rows.length).toBe(1);
       expect(rows[0].entry_type).toBe('show_start');
-      expect(rows[0].dj_name).toBe('Test dj1');
+      expect(rows[0].dj_name).toBe(expectedDjName);
+      // Negative assertion: the lower-priority legacy_dj_name must NOT win.
+      expect(rows[0].dj_name).not.toBe('Legacy Override Loser');
     } finally {
       await clearShow(LEGACY_SHOW_ID);
     }

--- a/tests/integration/internal-flowsheet-webhook.spec.js
+++ b/tests/integration/internal-flowsheet-webhook.spec.js
@@ -91,16 +91,32 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
   // auth_user.name). Pre-fix, every webhook-delivered show_start /
   // show_end / dj_join / dj_leave row landed with dj_name=NULL and the v2
   // wire emitted '' (iOS rendered an empty handle for ~119k historical
-  // rows). This test seeds a stub show with a `legacy_dj_name`, delivers a
-  // show_start (flowsheetEntryType=9) for it, and asserts the inserted row
-  // picked the legacy_dj_name from the COALESCE.
+  // rows). The three cases below cover the three resolution arms.
+  //
+  // `seedShow` pre-DELETEs (defensive against a prior crashed test leaving
+  // a polluted row that would otherwise survive a naive INSERT...ON
+  // CONFLICT DO NOTHING and produce a confusing false pass/fail). `clearShow`
+  // clears the flowsheet row before the show (FK ordering — shows is not
+  // ON DELETE CASCADE).
+  const seedShow = async (legacyShowId, { legacyDjName = null, primaryDjId = null } = {}) => {
+    await sql.unsafe(
+      `DELETE FROM ${SCHEMA}.flowsheet WHERE show_id IN (SELECT id FROM ${SCHEMA}.shows WHERE legacy_show_id = $1)`,
+      [legacyShowId]
+    );
+    await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [legacyShowId]);
+    await sql.unsafe(
+      `INSERT INTO ${SCHEMA}.shows (legacy_show_id, legacy_dj_name, primary_dj_id, start_time) VALUES ($1, $2, $3, NOW())`,
+      [legacyShowId, legacyDjName, primaryDjId]
+    );
+  };
+  const clearShow = async (legacyShowId) => {
+    await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [LEGACY_ENTRY_ID]);
+    await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [legacyShowId]);
+  };
+
   test('show_start webhook resolves dj_name from shows.legacy_dj_name (BS#1371)', async () => {
     const LEGACY_SHOW_ID = 9_999_990;
-    await sql.unsafe(
-      `INSERT INTO ${SCHEMA}.shows (legacy_show_id, legacy_dj_name, start_time) VALUES ($1, $2, NOW())
-       ON CONFLICT DO NOTHING`,
-      [LEGACY_SHOW_ID, "T'mia Powell"]
-    );
+    await seedShow(LEGACY_SHOW_ID, { legacyDjName: "T'mia Powell" });
 
     try {
       const entry = buildEntry({ flowsheetEntryType: 9, radioShowId: LEGACY_SHOW_ID });
@@ -117,12 +133,36 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
       expect(rows[0].entry_type).toBe('show_start');
       expect(rows[0].dj_name).toBe("T'mia Powell");
     } finally {
-      // Clear the flowsheet row before the show — flowsheet.show_id is an
-      // FK to shows.id and not ON DELETE CASCADE, so the show DELETE would
-      // otherwise fail. afterEach also clears the flowsheet row by
-      // legacy_entry_id (idempotent), but it runs after this finally.
-      await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [LEGACY_ENTRY_ID]);
-      await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
+      await clearShow(LEGACY_SHOW_ID);
+    }
+  });
+
+  // Highest-priority COALESCE arm. Seeds an auth_user, points shows.primary_dj_id
+  // at it, and asserts the resolver picked user.dj_name over legacy_dj_name.
+  // Without this case the LEFT JOIN to auth_user is never exercised against real
+  // Postgres; a schema rename of auth_user.dj_name would leave the legacy_dj_name
+  // case (above) green while production silently regressed on the primary arm.
+  test('show_start webhook prefers auth_user.dj_name over legacy_dj_name (BS#1371)', async () => {
+    const LEGACY_SHOW_ID = 9_999_988;
+    const PRIMARY_DJ_ID = 'test-dj1-id-00000000000000000001'; // seeded in dev_env/seed_db.sql with dj_name='Test dj1'
+    await seedShow(LEGACY_SHOW_ID, { legacyDjName: 'Legacy Override Loser', primaryDjId: PRIMARY_DJ_ID });
+
+    try {
+      const entry = buildEntry({ flowsheetEntryType: 9, radioShowId: LEGACY_SHOW_ID });
+      const res = await request
+        .post('/internal/flowsheet-webhook')
+        .set('X-Internal-Key', INTERNAL_KEY)
+        .send({ action: 'create', entry });
+      expect(res.status).toBe(200);
+
+      const rows = await sql.unsafe(`SELECT entry_type, dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+        LEGACY_ENTRY_ID,
+      ]);
+      expect(rows.length).toBe(1);
+      expect(rows[0].entry_type).toBe('show_start');
+      expect(rows[0].dj_name).toBe('Test dj1');
+    } finally {
+      await clearShow(LEGACY_SHOW_ID);
     }
   });
 
@@ -131,11 +171,7 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
     // The webhook must NOT write dj_name on track rows so we don't double-
     // write and risk drift between the webhook and the ETL writer.
     const LEGACY_SHOW_ID = 9_999_989;
-    await sql.unsafe(
-      `INSERT INTO ${SCHEMA}.shows (legacy_show_id, legacy_dj_name, start_time) VALUES ($1, $2, NOW())
-       ON CONFLICT DO NOTHING`,
-      [LEGACY_SHOW_ID, 'Some Resolvable Name']
-    );
+    await seedShow(LEGACY_SHOW_ID, { legacyDjName: 'Some Resolvable Name' });
 
     try {
       const entry = buildEntry({ flowsheetEntryType: 6, radioShowId: LEGACY_SHOW_ID });
@@ -152,8 +188,7 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
       expect(rows[0].entry_type).toBe('track');
       expect(rows[0].dj_name).toBeNull();
     } finally {
-      await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [LEGACY_ENTRY_ID]);
-      await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
+      await clearShow(LEGACY_SHOW_ID);
     }
   });
 

--- a/tests/integration/internal-flowsheet-webhook.spec.js
+++ b/tests/integration/internal-flowsheet-webhook.spec.js
@@ -86,6 +86,72 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
     expect(rows[0].artist_name).toBe('Chuquimamani-Condori');
   });
 
+  // BS#1371: marker entry types delivered via the webhook must carry
+  // `dj_name` resolved via COALESCE(auth_user.dj_name, shows.legacy_dj_name,
+  // auth_user.name). Pre-fix, every webhook-delivered show_start /
+  // show_end / dj_join / dj_leave row landed with dj_name=NULL and the v2
+  // wire emitted '' (iOS rendered an empty handle for ~119k historical
+  // rows). This test seeds a stub show with a `legacy_dj_name`, delivers a
+  // show_start (flowsheetEntryType=9) for it, and asserts the inserted row
+  // picked the legacy_dj_name from the COALESCE.
+  test('show_start webhook resolves dj_name from shows.legacy_dj_name (BS#1371)', async () => {
+    const LEGACY_SHOW_ID = 9_999_990;
+    await sql.unsafe(
+      `INSERT INTO ${SCHEMA}.shows (legacy_show_id, legacy_dj_name, start_time) VALUES ($1, $2, NOW())
+       ON CONFLICT DO NOTHING`,
+      [LEGACY_SHOW_ID, "T'mia Powell"]
+    );
+
+    try {
+      const entry = buildEntry({ flowsheetEntryType: 9, radioShowId: LEGACY_SHOW_ID });
+      const res = await request
+        .post('/internal/flowsheet-webhook')
+        .set('X-Internal-Key', INTERNAL_KEY)
+        .send({ action: 'create', entry });
+      expect(res.status).toBe(200);
+
+      const rows = await sql.unsafe(`SELECT entry_type, dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+        LEGACY_ENTRY_ID,
+      ]);
+      expect(rows.length).toBe(1);
+      expect(rows[0].entry_type).toBe('show_start');
+      expect(rows[0].dj_name).toBe("T'mia Powell");
+    } finally {
+      // Clean up the stub show only — the flowsheet row is cleared by afterEach.
+      await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
+    }
+  });
+
+  test('track webhook leaves dj_name NULL even when the show has a resolved name (BS#1371)', async () => {
+    // Track rows have their own dj_name population path (ETL + live insert).
+    // The webhook must NOT write dj_name on track rows so we don't double-
+    // write and risk drift between the webhook and the ETL writer.
+    const LEGACY_SHOW_ID = 9_999_989;
+    await sql.unsafe(
+      `INSERT INTO ${SCHEMA}.shows (legacy_show_id, legacy_dj_name, start_time) VALUES ($1, $2, NOW())
+       ON CONFLICT DO NOTHING`,
+      [LEGACY_SHOW_ID, 'Some Resolvable Name']
+    );
+
+    try {
+      const entry = buildEntry({ flowsheetEntryType: 6, radioShowId: LEGACY_SHOW_ID });
+      const res = await request
+        .post('/internal/flowsheet-webhook')
+        .set('X-Internal-Key', INTERNAL_KEY)
+        .send({ action: 'create', entry });
+      expect(res.status).toBe(200);
+
+      const rows = await sql.unsafe(`SELECT entry_type, dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+        LEGACY_ENTRY_ID,
+      ]);
+      expect(rows.length).toBe(1);
+      expect(rows[0].entry_type).toBe('track');
+      expect(rows[0].dj_name).toBeNull();
+    } finally {
+      await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
+    }
+  });
+
   test('a second delivery with different mutable fields refreshes those fields', async () => {
     // First delivery: fresh INSERT — the row carries the initial payload.
     const initial = buildEntry({ artistName: 'Juana Molina', songTitle: 'la paradoja', releaseTitle: 'DOGA' });

--- a/tests/integration/internal-flowsheet-webhook.spec.js
+++ b/tests/integration/internal-flowsheet-webhook.spec.js
@@ -117,7 +117,11 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
       expect(rows[0].entry_type).toBe('show_start');
       expect(rows[0].dj_name).toBe("T'mia Powell");
     } finally {
-      // Clean up the stub show only — the flowsheet row is cleared by afterEach.
+      // Clear the flowsheet row before the show — flowsheet.show_id is an
+      // FK to shows.id and not ON DELETE CASCADE, so the show DELETE would
+      // otherwise fail. afterEach also clears the flowsheet row by
+      // legacy_entry_id (idempotent), but it runs after this finally.
+      await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [LEGACY_ENTRY_ID]);
       await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
     }
   });
@@ -148,6 +152,7 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
       expect(rows[0].entry_type).toBe('track');
       expect(rows[0].dj_name).toBeNull();
     } finally {
+      await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [LEGACY_ENTRY_ID]);
       await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
     }
   });

--- a/tests/unit/jobs/flowsheet-dj-name-backfill/job.test.ts
+++ b/tests/unit/jobs/flowsheet-dj-name-backfill/job.test.ts
@@ -46,9 +46,13 @@ describe('flowsheet-dj-name-backfill: applyBatch', () => {
     jest.clearAllMocks();
   });
 
-  it('builds an UPDATE that COALESCEs auth_user.dj_name → shows.legacy_dj_name → auth_user.name', async () => {
-    // Match the same precedence the search service and live insert path use.
-    // Drift here would silently change which name appears for legacy rows.
+  it('builds an UPDATE that COALESCEs auth_user.dj_name → shows.legacy_dj_name (and does NOT fall back to auth_user.name)', async () => {
+    // Match the same precedence the webhook and live insert path use. The
+    // chain stops at shows.legacy_dj_name on purpose — `auth_user.name`
+    // stores the user's real name (dj-site admin provisioning writes
+    // `name: realName || username`), so surfacing it on the public v2 wire
+    // would be PII exposure. Drift here would re-introduce the leak BS#1371
+    // closed.
     (db.execute as jest.Mock).mockResolvedValueOnce({ count: 5000 });
 
     await applyBatch(5000);
@@ -56,7 +60,9 @@ describe('flowsheet-dj-name-backfill: applyBatch', () => {
     const call = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*dj_name[\s\S]*COALESCE/i);
     expect(call).toBeDefined();
     const sqlText = renderSql(call?.[0]);
-    expect(sqlText).toMatch(/COALESCE\(\s*u\."dj_name",\s*s\."legacy_dj_name",\s*u\."name"\s*\)/);
+    expect(sqlText).toMatch(/COALESCE\(\s*u\."dj_name",\s*s\."legacy_dj_name"\s*\)/);
+    // Negative assertion: u."name" must NOT appear in the SET expression.
+    expect(sqlText).not.toMatch(/u\."name"/);
   });
 
   it('restricts the UPDATE to track + marker rows with NULL dj_name within a bounded batch', async () => {

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -26,7 +26,8 @@ import { internal_route } from '../../../apps/backend/routes/internal.route';
 
 // Make the DB mock chain's terminal methods resolve appropriately for the
 // webhook handler. Three chain shapes feed through `mockReturning`:
-//   1. Show resolution `select.from.where.limit` → returns [{ id }] or [].
+//   1. Show resolution `select.from.leftJoin.where.limit` → returns
+//      [{ id, dj_name }] (dj_name resolved via the COALESCE expression) or [].
 //   2. Flowsheet INSERT ... ON CONFLICT DO NOTHING RETURNING { id }
 //      → returns [{ id }] when a fresh row was inserted, [] on conflict.
 //   3. Flowsheet UPDATE ... WHERE ... RETURNING { id } (taken only after a
@@ -107,16 +108,19 @@ describe('POST /internal/flowsheet-webhook', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Each webhook call issues three .limit(1) SELECTs in `Promise.all`:
-    // resolveShowId, resolveAlbumId, resolveRotationId. They dispatch in
+    // resolveShow, resolveAlbumId, resolveRotationId. They dispatch in
     // declaration order and the mocked driver resolves them FIFO. Default
-    // queue resolves the show but not the album or rotation (unlinked
-    // path); tests that need a resolved album_id or rotation_id queue
-    // their own values before triggering the request.
+    // queue resolves the show (with a resolved dj_name) but not the album
+    // or rotation (unlinked path); tests that need a resolved album_id or
+    // rotation_id queue their own values before triggering the request.
+    // The show row's `dj_name` is the COALESCE expression evaluated by the
+    // mocked driver; tests covering BS#1371 marker-name resolution control
+    // it by queuing their own values.
     mockReturning.mockReset();
     mockReturning.mockResolvedValue([{ id: 5555 }]);
     mockLimit.mockReset();
     mockLimit
-      .mockResolvedValueOnce([{ id: 9999 }])
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Default Test DJ' }])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValue([]);
@@ -222,7 +226,7 @@ describe('POST /internal/flowsheet-webhook', () => {
   it('writes the resolved album_id into the row when libraryReleaseId matches a library row', async () => {
     mockLimit.mockReset();
     mockLimit
-      .mockResolvedValueOnce([{ id: 9999 }])
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Default Test DJ' }])
       .mockResolvedValueOnce([{ id: 7777 }])
       .mockResolvedValueOnce([]);
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
@@ -262,10 +266,10 @@ describe('POST /internal/flowsheet-webhook', () => {
   });
 
   it('forwards the resolved rotation_id when rotationReleaseId matches a rotation row', async () => {
-    // resolveShowId → 9999, resolveAlbumId → unlinked, resolveRotationId → 4242.
+    // resolveShow → 9999, resolveAlbumId → unlinked, resolveRotationId → 4242.
     mockLimit.mockReset();
     mockLimit
-      .mockResolvedValueOnce([{ id: 9999 }])
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Default Test DJ' }])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ id: 4242 }]);
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
@@ -309,7 +313,7 @@ describe('POST /internal/flowsheet-webhook', () => {
   it('coexists with libraryReleaseId — both album_id and rotation_id are populated when both resolve', async () => {
     mockLimit.mockReset();
     mockLimit
-      .mockResolvedValueOnce([{ id: 9999 }])
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Default Test DJ' }])
       .mockResolvedValueOnce([{ id: 7777 }])
       .mockResolvedValueOnce([{ id: 4242 }]);
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
@@ -321,6 +325,122 @@ describe('POST /internal/flowsheet-webhook', () => {
 
     expect(res.status).toBe(200);
     expect(lastInsertValues()).toEqual(expect.objectContaining({ album_id: 7777, rotation_id: 4242 }));
+  });
+
+  // -- dj_name resolution on marker entry types (BS#1371) --
+  //
+  // The v2 wire surfaces dj_name on show_start / show_end / dj_join / dj_leave
+  // (FLOWSHEET_DJ_NAME_NON_NULL contract in wxyc-shared). Pre-#1371 the
+  // webhook handler wrote dj_name=NULL on every row regardless of entry type,
+  // leaving the v2 endpoint to emit `''` and iOS to render an empty handle.
+  // The fix: resolve dj_name via the same COALESCE expression the ETL +
+  // flowsheet-dj-name-backfill use and write it on marker INSERTs.
+
+  it('writes resolved dj_name on a show_start INSERT (flowsheetEntryType=9)', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: "T'mia Powell" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'show_start', dj_name: "T'mia Powell" }));
+  });
+
+  it('writes resolved dj_name on a show_end INSERT (flowsheetEntryType=10)', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Iman Amadou' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 10 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'show_end', dj_name: 'Iman Amadou' }));
+  });
+
+  it('writes dj_name: null on a show_start INSERT when the show has no resolvable name', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: null }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'show_start', dj_name: null }));
+  });
+
+  it('writes dj_name: null on a track INSERT even when the show has a resolved dj_name', async () => {
+    // Track rows have their own dj_name population path (search hot path,
+    // populated by the flowsheet ETL + live insert). The webhook leaves
+    // dj_name null on track INSERTs so the ETL / backfill stays the single
+    // writer for that column on track rows.
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: "T'mia Powell" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'track', dj_name: null }));
+  });
+
+  it('writes dj_name: null on a talkset INSERT (flowsheetEntryType=7) regardless of show name', async () => {
+    // talkset / breakpoint / message rows aren't attributed to a DJ. The
+    // webhook leaves dj_name null so the v2 wire emits the message body.
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: "T'mia Powell" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 7 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'talkset', dj_name: null }));
+  });
+
+  it('writes dj_name: null on a marker INSERT when radioShowId is 0 (no show)', async () => {
+    // radioShowId=0 short-circuits resolveShow, mirroring resolveAlbumId.
+    // The marker row lands without a show or a dj_name; no SELECT issued.
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9, radioShowId: 0 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(
+      expect.objectContaining({ entry_type: 'show_start', show_id: null, dj_name: null })
+    );
   });
 
   // -- Delete --

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -428,19 +428,36 @@ describe('POST /internal/flowsheet-webhook', () => {
   });
 
   it('writes dj_name: null on a marker INSERT when radioShowId is 0 (no show)', async () => {
-    // radioShowId=0 short-circuits resolveShow, mirroring resolveAlbumId.
-    // The marker row lands without a show or a dj_name; no SELECT issued.
+    // All three resolvers short-circuit: radioShowId=0 → resolveShow returns
+    // null without a SELECT; libraryReleaseId=0 → resolveAlbumId same;
+    // rotationReleaseId=0 → resolveRotationId same. Pin all three explicitly
+    // (vs. inheriting the beforeEach default queue, which would survive only
+    // because none of the limits are consumed) so a future regression that
+    // restored the SELECT call would fail loudly rather than silently consume
+    // the wrong mock entry.
+    mockLimit.mockReset();
+    mockReturning.mockReset();
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
 
     const res = await request(app)
       .post('/internal/flowsheet-webhook')
       .set('X-Internal-Key', 'test-secret-key')
-      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9, radioShowId: 0 } });
+      .send({
+        action: 'create',
+        entry: { ...validEntry, flowsheetEntryType: 9, radioShowId: 0, libraryReleaseId: 0, rotationReleaseId: 0 },
+      });
 
     expect(res.status).toBe(200);
     expect(lastInsertValues()).toEqual(
-      expect.objectContaining({ entry_type: 'show_start', show_id: null, dj_name: null })
+      expect.objectContaining({
+        entry_type: 'show_start',
+        show_id: null,
+        album_id: null,
+        rotation_id: null,
+        dj_name: null,
+      })
     );
+    expect(mockLimit).not.toHaveBeenCalled();
   });
 
   // -- ON CONFLICT UPDATE dj_name refresh (BS#1371 defense-in-depth) --

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -443,6 +443,113 @@ describe('POST /internal/flowsheet-webhook', () => {
     );
   });
 
+  // -- ON CONFLICT UPDATE dj_name refresh (BS#1371 defense-in-depth) --
+  //
+  // The fresh-INSERT path writes `dj_name` for marker entry types. The
+  // conflict-UPDATE path now refreshes it when the resolver returned a
+  // non-null value, so a stub-show first-delivery that landed dj_name=NULL
+  // can heal on a later redelivery once the ETL has filled
+  // shows.legacy_dj_name. We never overwrite a non-NULL stored value with
+  // NULL — that would regress rows the live path or a prior delivery
+  // already resolved.
+
+  const mockUpdate = (db as unknown as { update: jest.Mock }).update;
+  const lastUpdateSet = (): Record<string, unknown> => {
+    const setMock = (mockChain as unknown as { set: jest.Mock }).set;
+    return setMock.mock.calls[0]![0] as Record<string, unknown>;
+  };
+
+  it('UPDATE on conflict refreshes dj_name for a marker entry when the show resolves to a non-null name', async () => {
+    // resolveShow → {id:9999, dj_name:'Aubrey'}; INSERT conflict (empty
+    // returning); handler falls through to UPDATE.
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Aubrey' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockReturning.mockResolvedValueOnce([]); // conflict signal
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9 } });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(lastUpdateSet()).toEqual(expect.objectContaining({ entry_type: 'show_start', dj_name: 'Aubrey' }));
+  });
+
+  it('UPDATE on conflict OMITS dj_name when the show resolves to null (never overwrite non-NULL with NULL)', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: null }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockReturning.mockResolvedValueOnce([]); // conflict signal
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9 } });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+    const setClause = lastUpdateSet();
+    expect(setClause).not.toHaveProperty('dj_name');
+    expect(setClause).toEqual(expect.objectContaining({ entry_type: 'show_start' }));
+  });
+
+  it('UPDATE on conflict OMITS dj_name on a track entry (non-marker entry types never set dj_name)', async () => {
+    mockReturning.mockResolvedValueOnce([]); // conflict signal
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', entry: validEntry });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+    const setClause = lastUpdateSet();
+    expect(setClause).not.toHaveProperty('dj_name');
+    expect(setClause).toEqual(expect.objectContaining({ entry_type: 'track' }));
+  });
+
+  it('INSERT trims whitespace-only resolved dj_name to null on a marker entry', async () => {
+    // shows.legacy_dj_name='   ' (whitespace) — without normalizeMarkerName
+    // this would persist as '   ' and v2 wire would emit whitespace.
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: '   ' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'show_start', dj_name: null }));
+  });
+
+  it('INSERT trims surrounding whitespace from resolved dj_name on a marker entry', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: '  Aubrey  ' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'show_start', dj_name: 'Aubrey' }));
+  });
+
   // -- Delete --
 
   it('returns 200 for valid delete', async () => {

--- a/tests/unit/services/flowsheet.endShow.test.ts
+++ b/tests/unit/services/flowsheet.endShow.test.ts
@@ -49,13 +49,13 @@ describe('endShow', () => {
     );
   });
 
-  it('falls back to user.name when djName is null', async () => {
+  it('persists null dj_name when djName is null — never leaks auth_user.name (BS#1371 PII)', async () => {
     const remainingDjsSelect = createMockQueryChain();
     remainingDjsSelect.where.mockResolvedValue([]);
     db.select.mockReturnValueOnce(remainingDjsSelect);
 
     const userSelect = createMockQueryChain();
-    userSelect.limit.mockResolvedValue([{ djName: null, name: 'Riley Owens' }]);
+    userSelect.limit.mockResolvedValue([{ djName: null, name: 'Riley Owens (real name)' }]);
     db.select.mockReturnValueOnce(userSelect);
 
     db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
@@ -71,6 +71,8 @@ describe('endShow', () => {
     await endShow({ id: 42, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0]);
 
     const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(flowsheetValues.dj_name).toBe('Riley Owens');
+    // show_end row is kept (the show ended) but dj_name is null; endShow's
+    // asymmetric-fallback emits the degraded message body.
+    expect(flowsheetValues.dj_name).toBeNull();
   });
 });

--- a/tests/unit/services/flowsheet.joinLeaveNotifications.test.ts
+++ b/tests/unit/services/flowsheet.joinLeaveNotifications.test.ts
@@ -62,7 +62,12 @@ describe('createJoinNotification (via addDJToShow)', () => {
     );
   });
 
-  it('falls back to user.name when djName is null', async () => {
+  it('suppresses the flowsheet row when djName is null — never leaks auth_user.name (BS#1371 PII)', async () => {
+    // Pre-BS#1371 PII fix: the resolver fell back to auth_user.name and the
+    // join marker landed with the user's real name on the public wire.
+    // Post-fix: a null djName is unresolvable; the marker is suppressed
+    // (Sentry warning fires; see flowsheet.markerText.test.ts) regardless
+    // of what auth_user.name holds.
     const showDjsSelect = createMockQueryChain();
     showDjsSelect.limit.mockResolvedValue([]);
     db.select.mockReturnValueOnce(showDjsSelect);
@@ -70,18 +75,13 @@ describe('createJoinNotification (via addDJToShow)', () => {
     db.insert.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-2', active: true }]));
 
     const userSelect = createMockQueryChain();
-    userSelect.limit.mockResolvedValue([{ djName: null, name: 'Sam Blue' }]);
+    userSelect.limit.mockResolvedValue([{ djName: null, name: 'Sam Blue (real name)' }]);
     db.select.mockReturnValueOnce(userSelect);
-
-    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
-
-    const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
-    db.insert.mockReturnValueOnce(flowsheetInsert);
 
     await addDJToShow('user-2', { id: 42 } as unknown as Parameters<typeof addDJToShow>[1]);
 
-    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(flowsheetValues.dj_name).toBe('Sam Blue');
+    // Exactly one db.insert call — the show_djs membership row. No flowsheet row.
+    expect(db.insert).toHaveBeenCalledTimes(1);
   });
 
   it('suppresses the flowsheet row when the user has neither djName nor name (#1286)', async () => {
@@ -139,21 +139,18 @@ describe('createLeaveNotification (via leaveShow service)', () => {
     );
   });
 
-  it('falls back to user.name when djName is null', async () => {
+  it('suppresses the flowsheet row when djName is null — never leaks auth_user.name (BS#1371 PII)', async () => {
     db.update.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-2', active: false }]));
 
     const userSelect = createMockQueryChain();
-    userSelect.limit.mockResolvedValue([{ djName: null, name: 'Josh Davis' }]);
+    userSelect.limit.mockResolvedValue([{ djName: null, name: 'Josh Davis (real name)' }]);
     db.select.mockReturnValueOnce(userSelect);
-
-    db.select.mockReturnValueOnce(makeAwaitablePlayOrderChain(0));
-
-    const flowsheetInsert = createMockQueryChain([{ id: 999 }]);
-    db.insert.mockReturnValueOnce(flowsheetInsert);
 
     await leaveShow('user-2', { id: 42 } as unknown as Parameters<typeof leaveShow>[1]);
 
-    const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(flowsheetValues.dj_name).toBe('Josh Davis');
+    // No flowsheet INSERT — the createLeaveNotification path suppresses the
+    // marker when the resolved name is null instead of falling back to the
+    // user's real name.
+    expect(db.insert).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/flowsheet.markerText.test.ts
+++ b/tests/unit/services/flowsheet.markerText.test.ts
@@ -136,24 +136,29 @@ describe('startShow marker text', () => {
     expect(values.message).not.toMatch(/Start of Show: DJ DJ /);
   });
 
-  it('strips literal "Anonymous" djName and falls back to user.name for the marker (Aubrey Hearst incident regression)', async () => {
-    const flowsheetInsert = setUpUserAndPlayOrderForStartShow('Anonymous', 'Aubrey Hearst');
+  it('strips literal "Anonymous" djName and degrades the marker — never leaks auth_user.name (BS#1371 PII)', async () => {
+    const flowsheetInsert = setUpUserAndPlayOrderForStartShow('Anonymous', 'Aubrey Hearst (real name)');
     await startShow('user-1');
 
     const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(values.dj_name).toBe('Aubrey Hearst');
-    expect(values.message).toMatch(/^Start of Show: Aubrey Hearst joined the set at /);
+    // Pre-#1371 the marker fell back to auth_user.name and rendered the real
+    // name on the public on-air playlist. Now: dj_name is null and the message
+    // degrades to bare "Start of show: ${time}". No leak of 'Aubrey Hearst'.
+    expect(values.dj_name).toBeNull();
+    expect(values.message).toMatch(/^Start of show: /);
     expect(values.message).not.toMatch(/Anonymous/);
+    expect(values.message).not.toMatch(/Aubrey Hearst/);
   });
 
-  it('case- and whitespace-insensitive "  anonymous  " is still treated as Anonymous', async () => {
-    const flowsheetInsert = setUpUserAndPlayOrderForStartShow('  anonymous  ', 'Aubrey Hearst');
+  it('case- and whitespace-insensitive "  anonymous  " is still treated as Anonymous and degrades the marker', async () => {
+    const flowsheetInsert = setUpUserAndPlayOrderForStartShow('  anonymous  ', 'Aubrey Hearst (real name)');
     await startShow('user-1');
 
     const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(values.dj_name).toBe('Aubrey Hearst');
-    expect(values.message).toMatch(/^Start of Show: Aubrey Hearst joined the set at /);
+    expect(values.dj_name).toBeNull();
+    expect(values.message).toMatch(/^Start of show: /);
     expect((values.message as string | null)?.toLowerCase() ?? '').not.toContain('anonymous');
+    expect(values.message).not.toMatch(/Aubrey Hearst/);
   });
 
   it('degrades to "Start of show: <time>" (lowercase "show", no DJ name) when name is unresolvable', async () => {
@@ -195,13 +200,15 @@ describe('endShow marker text', () => {
     expect(values.message).not.toMatch(/End of Show: DJ DJ /);
   });
 
-  it('strips literal "Anonymous" djName and falls back to user.name for the marker', async () => {
-    const flowsheetInsert = setUpForEndShow('Anonymous', 'Aubrey Hearst');
+  it('strips literal "Anonymous" djName and degrades the marker — never leaks auth_user.name (BS#1371 PII)', async () => {
+    const flowsheetInsert = setUpForEndShow('Anonymous', 'Aubrey Hearst (real name)');
     await endShow({ id: 42, primary_dj_id: 'user-1' } as unknown as Parameters<typeof endShow>[0]);
 
     const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(values.dj_name).toBe('Aubrey Hearst');
-    expect(values.message).toMatch(/^End of Show: Aubrey Hearst left the set at /);
+    expect(values.dj_name).toBeNull();
+    expect(values.message).toMatch(/^End of show: /);
+    expect(values.message).not.toMatch(/Anonymous/);
+    expect(values.message).not.toMatch(/Aubrey Hearst/);
   });
 
   it('degrades to "End of show: <time>" when both djName and name are null', async () => {
@@ -232,13 +239,21 @@ describe('createJoinNotification (via addDJToShow) marker text', () => {
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 
-  it('strips literal "Anonymous" djName and falls back to user.name', async () => {
-    const flowsheetInsert = setUpForAddDJ('Anonymous', 'Aubrey Hearst');
+  it('suppresses the marker when djName is "Anonymous" — never leaks auth_user.name (BS#1371 PII)', async () => {
+    // Suppression path takes the same shape as the "neither djName nor name"
+    // case below — no flowsheet INSERT mock queued, since none should fire.
+    const showDjsSelect = createMockQueryChain();
+    showDjsSelect.limit.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(showDjsSelect);
+    db.insert.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-2', active: true }]));
+    const userSelect = createMockQueryChain();
+    userSelect.limit.mockResolvedValue([{ djName: 'Anonymous', name: 'Aubrey Hearst (real name)' }]);
+    db.select.mockReturnValueOnce(userSelect);
+
     await addDJToShow('user-2', { id: 42 } as unknown as Parameters<typeof addDJToShow>[1]);
 
-    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(values.dj_name).toBe('Aubrey Hearst');
-    expect(values.message).toBe('Aubrey Hearst joined the set!');
+    expect(db.insert).toHaveBeenCalledTimes(1); // show_djs membership only
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
   });
 
   it('suppresses the marker AND logs to Sentry when name is unresolvable', async () => {
@@ -298,13 +313,16 @@ describe('createLeaveNotification (via leaveShow) marker text', () => {
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 
-  it('strips literal "Anonymous" djName and falls back to user.name', async () => {
-    const flowsheetInsert = setUpForLeaveShow('Anonymous', 'Aubrey Hearst');
+  it('suppresses the marker when djName is "Anonymous" — never leaks auth_user.name (BS#1371 PII)', async () => {
+    db.update.mockReturnValueOnce(createMockQueryChain([{ show_id: 42, dj_id: 'user-2', active: false }]));
+    const userSelect = createMockQueryChain();
+    userSelect.limit.mockResolvedValue([{ djName: 'Anonymous', name: 'Aubrey Hearst (real name)' }]);
+    db.select.mockReturnValueOnce(userSelect);
+
     await leaveShow('user-2', { id: 42 } as unknown as Parameters<typeof leaveShow>[1]);
 
-    const values = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(values.dj_name).toBe('Aubrey Hearst');
-    expect(values.message).toBe('Aubrey Hearst left the set!');
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
   });
 
   it('suppresses the marker AND logs to Sentry when name is unresolvable', async () => {

--- a/tests/unit/services/flowsheet.resolveDjDisplayName.test.ts
+++ b/tests/unit/services/flowsheet.resolveDjDisplayName.test.ts
@@ -1,86 +1,65 @@
 /**
- * Unit tests for the resolveDjDisplayName helper extracted from the six
- * marker / read sites in flowsheet.service.ts and flowsheet.controller.ts.
+ * Unit tests for the resolveDjDisplayName helper extracted from the marker /
+ * read sites in flowsheet.service.ts and flowsheet.controller.ts.
  *
  * The helper centralizes the rule: a DJ display name is "unresolvable" when
- * either both inputs are null/empty/whitespace OR the `djName` input is the
- * literal string `"Anonymous"` (case-insensitive, trim-tolerant).
+ * either the `djName` input is null/empty/whitespace, OR it's the literal
+ * string `"Anonymous"` (case-insensitive, trim-tolerant).
  *
- * Background: 2026-06-02 Aubrey Hearst on-air incident — the previous inline
- * pattern `dj.djName || dj.name` rendered the literal `"Anonymous"` to the
- * public on-air playlist when a DJ's `auth_user.dj_name` was the literal
- * string (root cause traced to the better-auth anonymous-plugin path or a
- * stale onboarding default). See WXYC/Backend-Service#1286 and the parent
- * epic #1288 for the locked marker-text decisions this helper enforces.
+ * Background:
+ *   - 2026-06-02 Aubrey Hearst on-air incident — the previous inline pattern
+ *     `dj.djName || dj.name` rendered the literal `"Anonymous"` to the public
+ *     on-air playlist when a DJ's `auth_user.dj_name` was the literal string
+ *     (root cause traced to the better-auth anonymous-plugin path or a stale
+ *     onboarding default). See WXYC/Backend-Service#1286 and the parent epic
+ *     #1288 for the locked marker-text decisions this helper enforces.
+ *   - BS#1371 follow-up — the prior signature `(djName, name) => string | null`
+ *     fell back to `auth_user.name` when djName was unresolvable. But dj-site
+ *     admin provisioning writes the user's real name into `auth_user.name`
+ *     (`name: realName || username` in the roster UI), so the fallback was
+ *     leaking PII onto the public v2 wire. The helper now uses only `djName`,
+ *     and callers degrade to null when it's unresolvable.
  */
 import { resolveDjDisplayName } from '../../../apps/backend/services/flowsheet.service';
 
 describe('resolveDjDisplayName', () => {
-  it('returns djName when both inputs are present and djName is not Anonymous', () => {
-    expect(resolveDjDisplayName('DJ Stardust', 'Alex Stardust')).toBe('DJ Stardust');
+  it('returns djName when present and not Anonymous', () => {
+    expect(resolveDjDisplayName('DJ Stardust')).toBe('DJ Stardust');
   });
 
-  it('falls back to name when djName is null', () => {
-    expect(resolveDjDisplayName(null, 'Alex Stardust')).toBe('Alex Stardust');
+  it('returns null when djName is null', () => {
+    expect(resolveDjDisplayName(null)).toBeNull();
   });
 
-  it('falls back to name when djName is an empty string', () => {
-    expect(resolveDjDisplayName('', 'Alex Stardust')).toBe('Alex Stardust');
+  it('returns null when djName is an empty string', () => {
+    expect(resolveDjDisplayName('')).toBeNull();
   });
 
-  it('falls back to name when djName is whitespace-only', () => {
-    expect(resolveDjDisplayName('   ', 'Alex Stardust')).toBe('Alex Stardust');
+  it('returns null when djName is whitespace-only', () => {
+    expect(resolveDjDisplayName('   ')).toBeNull();
   });
 
-  it('returns null when both inputs are null', () => {
-    expect(resolveDjDisplayName(null, null)).toBeNull();
-  });
-
-  it('returns null when both inputs are empty strings', () => {
-    expect(resolveDjDisplayName('', '')).toBeNull();
-  });
-
-  it('returns null when both inputs are whitespace-only', () => {
-    expect(resolveDjDisplayName('   ', '\t\n ')).toBeNull();
-  });
-
-  it('returns null when djName is the literal "Anonymous" and name is null', () => {
-    expect(resolveDjDisplayName('Anonymous', null)).toBeNull();
-  });
-
-  it('returns null when djName is the literal "Anonymous" and name is empty', () => {
-    expect(resolveDjDisplayName('Anonymous', '')).toBeNull();
+  it('returns null when djName is the literal "Anonymous"', () => {
+    expect(resolveDjDisplayName('Anonymous')).toBeNull();
   });
 
   it('returns null when djName is "anonymous" (case-insensitive)', () => {
-    expect(resolveDjDisplayName('anonymous', null)).toBeNull();
+    expect(resolveDjDisplayName('anonymous')).toBeNull();
   });
 
   it('returns null when djName is "ANONYMOUS" (case-insensitive)', () => {
-    expect(resolveDjDisplayName('ANONYMOUS', null)).toBeNull();
+    expect(resolveDjDisplayName('ANONYMOUS')).toBeNull();
   });
 
-  it('returns null when djName is "  anonymous  " (trim + case)', () => {
-    expect(resolveDjDisplayName('  Anonymous  ', null)).toBeNull();
-  });
-
-  it('returns name when djName is "Anonymous" but name is a real value (fallback past Anonymous)', () => {
-    // Asymmetric design: if the user has a real `name`, prefer it over rendering
-    // the public "Anonymous" string. This is the Aubrey Hearst incident path —
-    // her auth_user.dj_name was "Anonymous" but better-auth `name` was empty,
-    // so the marker correctly degrades to unresolvable.
-    expect(resolveDjDisplayName('Anonymous', 'Aubrey Hearst')).toBe('Aubrey Hearst');
+  it('returns null when djName is "  Anonymous  " (trim + case)', () => {
+    expect(resolveDjDisplayName('  Anonymous  ')).toBeNull();
   });
 
   it('does not strip "Anonymous" from a longer name (substring match must not fire)', () => {
-    expect(resolveDjDisplayName('DJ Anonymous Mouse', null)).toBe('DJ Anonymous Mouse');
+    expect(resolveDjDisplayName('DJ Anonymous Mouse')).toBe('DJ Anonymous Mouse');
   });
 
   it('returns trimmed djName when valid (no surrounding whitespace bleed)', () => {
-    expect(resolveDjDisplayName('  DJ Stardust  ', null)).toBe('DJ Stardust');
-  });
-
-  it('returns trimmed name when name is the source of the value', () => {
-    expect(resolveDjDisplayName(null, '  Alex Stardust  ')).toBe('Alex Stardust');
+    expect(resolveDjDisplayName('  DJ Stardust  ')).toBe('DJ Stardust');
   });
 });

--- a/tests/unit/services/flowsheet.resolveDjName.test.ts
+++ b/tests/unit/services/flowsheet.resolveDjName.test.ts
@@ -2,11 +2,16 @@
  * Unit tests for the resolveDjNameForShow helper used by the live insert path
  * (step 5b.2) to denormalize the resolved DJ name onto each new flowsheet row.
  *
- * Priority after BS#1321 (migration 0090):
- *   1. shows.dj_name_override (per-show operator-intent override)
+ * Priority (post-BS#1371 PII fix):
+ *   1. shows.dj_name_override (per-show operator-intent override, BS#1321)
  *   2. auth_user.dj_name (Anonymous-filtered)
  *   3. shows.legacy_dj_name (tubafrenzy-owned fallback)
- *   4. auth_user.name
+ *
+ * `auth_user.name` is intentionally NOT in the chain — dj-site provisioning
+ * writes the user's real name into that column, so surfacing it on the
+ * public v2 wire would leak PII. When neither djName nor legacy_dj_name
+ * resolves, the resolver returns null and the caller's asymmetric-fallback
+ * policy degrades the marker template.
  */
 import { jest } from '@jest/globals';
 
@@ -16,8 +21,12 @@ import { resolveDjNameForShow } from '../../../apps/backend/services/flowsheet.s
 const mockDb = db as unknown as { _chain: Record<string, jest.Mock> };
 const chain = mockDb._chain;
 
-const setUserLookupResult = (rows: Array<{ djName: string | null; name: string | null }>) => {
+const setUserLookupResult = (rows: Array<{ djName: string | null; name?: string | null }>) => {
   // The user lookup ends in `.limit(1)`; configure it to resolve to `rows`.
+  // `name` is accepted on the row shape but ignored by the resolver — the
+  // SELECT now only projects `djName` (post-BS#1371 PII fix). Keep accepting
+  // `name` in test rows so existing tests that pass it as documentation
+  // of the underlying auth_user state don't have to be rewritten.
   chain.limit.mockResolvedValueOnce(rows);
 };
 
@@ -60,14 +69,24 @@ describe('resolveDjNameForShow', () => {
     expect(result).toBe('Legacy DJ Name');
   });
 
-  it('falls back to user.name when both djName and legacy_dj_name are null', async () => {
-    setUserLookupResult([{ djName: null, name: 'Alex Stardust' }]);
+  it('returns null when both djName and legacy_dj_name are unresolvable — never leaks auth_user.name (BS#1371 PII)', async () => {
+    setUserLookupResult([{ djName: null, name: 'Alex Stardust (real name)' }]);
     const result = await resolveDjNameForShow({
       id: 1,
       primary_dj_id: 'user-1',
       legacy_dj_name: null,
     } as any);
-    expect(result).toBe('Alex Stardust');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when djName is "Anonymous" and legacy_dj_name is null — never leaks auth_user.name (BS#1371 PII)', async () => {
+    setUserLookupResult([{ djName: 'Anonymous', name: 'Aubrey Hearst (real name)' }]);
+    const result = await resolveDjNameForShow({
+      id: 1,
+      primary_dj_id: 'user-1',
+      legacy_dj_name: null,
+    } as any);
+    expect(result).toBeNull();
   });
 
   it('returns legacy_dj_name when the user lookup yields no row', async () => {

--- a/tests/unit/services/flowsheet.startShow.test.ts
+++ b/tests/unit/services/flowsheet.startShow.test.ts
@@ -54,9 +54,9 @@ describe('startShow', () => {
     );
   });
 
-  it('falls back to user.name when djName is null', async () => {
+  it('persists null dj_name when djName is null — never leaks auth_user.name (BS#1371 PII)', async () => {
     const userSelect = createMockQueryChain();
-    userSelect.limit.mockResolvedValue([{ djName: null, name: 'Alex Stardust' }]);
+    userSelect.limit.mockResolvedValue([{ djName: null, name: 'Alex Stardust (real name)' }]);
     db.select.mockReturnValueOnce(userSelect);
 
     db.insert.mockReturnValueOnce(createMockQueryChain([{ id: 42 }]));
@@ -69,7 +69,9 @@ describe('startShow', () => {
     await startShow('user-1');
 
     const flowsheetValues = flowsheetInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(flowsheetValues.dj_name).toBe('Alex Stardust');
+    // The show_start row is kept (the show happened) but dj_name is null;
+    // startShow's asymmetric-fallback emits the degraded message body.
+    expect(flowsheetValues.dj_name).toBeNull();
   });
 
   it('persists null dj_name when the user has neither djName nor name', async () => {


### PR DESCRIPTION
Closes #1371.

## Summary

`POST /internal/flowsheet-webhook` inserted flowsheet rows without `dj_name`, so every `show_start` / `show_end` (and any `dj_join` / `dj_leave`) delivered by tubafrenzy landed with `dj_name=NULL`. The v2 wire emitted `''` on the next read and iOS rendered an empty handle — 118,919 historical rows affected, bleed ongoing.

Widen the show resolver to also project `COALESCE(auth_user.dj_name, shows.legacy_dj_name, auth_user.name)` via a LEFT JOIN on `shows.primary_dj_id` (one query, no extra round-trip). The webhook INSERT writes this onto the four marker entry types only; track / message rows keep their existing population paths.

Raw `COALESCE` (not `resolveDjDisplayName`) matches the ETL + `flowsheet-dj-name-backfill` convention. Using the helper here would diverge from the same row when later re-resolved by the ETL / backfill, swapping one drift for another — the issue calls this out explicitly.

## Caveat

`dj_join` / `dj_leave`: the tubafrenzy payload has no per-event DJ id (only `radioShowId`), so guest-join markers attribute to `shows.primary_dj_id`. Same known limitation as `jobs/flowsheet-dj-name-backfill`; the live `createJoinNotification` path is the only one that gets guest attribution right.

## Order of operations

1. Land + deploy this fix so new webhook rows stop arriving NULL.
2. Re-run `jobs/flowsheet-dj-name-backfill` (idempotent on `dj_name IS NULL`) to drain the existing backlog of NULL marker rows.

## Test plan

- [x] `npm run typecheck` — passes across all workspaces
- [x] `npm run lint` — 0 errors (the warnings on touched lines are pre-existing `any`-typed `req.body` access)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 2873 passing (48 in `tests/unit/routes/internal.route.test.ts`, including 6 new BS#1371 cases covering show_start / show_end / unresolvable name / track-row no-overwrite / talkset-row no-overwrite / `radioShowId=0` short-circuit)
- [ ] Integration test `tests/integration/internal-flowsheet-webhook.spec.js` adds two new cases (seed a stub show with `legacy_dj_name`, deliver a `show_start`, assert resolved `dj_name`; companion track case asserting NULL). Will run as part of CI.
- [ ] Post-deploy: re-run `flowsheet-dj-name-backfill` and confirm the `etl_backfill_miss` count drops from 118,919 to ~21 residual.

## Follow-up

The issue's "E2E contract test" acceptance criterion lands in `wxyc-shared/tests/e2e-contracts.test.ts` — a separate PR over there will add a webhook-path case to `FLOWSHEET_DJ_NAME_NON_NULL` so a future regression trips the cross-service suite. Tracking separately.