### PR TITLE
feat(concerts-artist-resolver): backfill headlining_artist_id via local artist + alias resolver

### DIFF
--- a/Dockerfile.concerts-artist-resolver
+++ b/Dockerfile.concerts-artist-resolver
@@ -1,0 +1,30 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+WORKDIR /concerts-artist-resolver-builder
+
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./jobs/concerts-artist-resolver ./jobs/concerts-artist-resolver
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/concerts-artist-resolver
+
+#Production stage
+FROM node:24-alpine AS prod
+
+WORKDIR /concerts-artist-resolver
+
+ENV DB_STATEMENT_TIMEOUT_MS=60000
+ENV DB_APPLICATION_NAME=wxyc-concerts-artist-resolver
+
+COPY ./package* ./
+COPY ./jobs/concerts-artist-resolver/package* ./jobs/concerts-artist-resolver/
+COPY ./shared/database/package* ./shared/database/
+
+RUN npm install --omit=dev
+
+COPY --from=builder ./concerts-artist-resolver-builder/jobs/concerts-artist-resolver/dist ./jobs/concerts-artist-resolver/dist
+COPY --from=builder ./concerts-artist-resolver-builder/shared/database/dist ./shared/database/dist
+
+CMD ["npm", "start", "--workspace=@wxyc/concerts-artist-resolver"]

--- a/jobs/concerts-artist-resolver/README.md
+++ b/jobs/concerts-artist-resolver/README.md
@@ -21,6 +21,10 @@ The conservative bias matches the substrate intent: NULL is the documented stead
 - UPDATE WHERE clause: `id = ? AND headlining_artist_id IS NULL`. A concurrent pod or a scraper write that lands between SELECT and UPDATE manifests as a 0-row UPDATE which the orchestrator counts as `raced` rather than `resolved`.
 - A later alias-substrate refresh that would now resolve a previously-unmatched row picks it up on the next cron run. A later alias-substrate refresh that would now produce a _different_ singleton for an already-resolved row does **not** self-heal — that's the conservative-singleton-only trade.
 
+### Known limitation: scraper raw-name updates don't invalidate the FK
+
+The `venue-events-scraper` UPSERT writes a fresh `headlining_artist_raw` on every re-scrape (see `jobs/venue-events-scraper/writer.ts` — the `set` clause includes the raw column). If a venue upgrades an opener to headliner before show date — common when a pre-sale promo gets bumped — the raw column changes but `headlining_artist_id` doesn't (this resolver's WHERE clause skips non-NULL FK rows). The concert ends up with raw="Spoon" pointing at the artist row for Pavement. Follow-up captured separately; the safe fix is for the scraper to NULL the FK when it overwrites the raw, but that crosses substrate boundaries and is out of scope here.
+
 ## Recurring drain
 
 Cron schedule `15 5 * * *` UTC, registered via the `cron-schedule` field in `package.json` and picked up by `.github/workflows/deploy-base.yml` on merge to main.

--- a/jobs/concerts-artist-resolver/README.md
+++ b/jobs/concerts-artist-resolver/README.md
@@ -1,0 +1,75 @@
+# concerts-artist-resolver
+
+Daily cron ETL (BS#1372) that resolves `concerts.headlining_artist_raw` to `concerts.headlining_artist_id`. The `concerts` substrate (#1347) ships `headlining_artist_id` as nullable; the venue-events scraper (#1343) writes the raw name and leaves the FK NULL. This job fills the FK in via local-only matching against `artists` and `artist_search_alias` (no LML round-trip), keeping iOS and dj-site free to JOIN on `headlining_artist_id` instead of falling back to a brittle raw-name JOIN.
+
+## Resolution strategy
+
+Local-only. Both arms use the canonical `wxyc_schema.normalize_artist_name(text)` SQL function (migration 0092) — lowercase + strip a leading `the\s+`. The TypeScript twin lives at `shared/database/src/normalize-artist-name.ts` so any caller (this job, a future iOS canonical-id matcher, a sibling resolver) normalizes the same way.
+
+Two arms, run per row:
+
+1. **Strict.** `normalize_artist_name(headlining_artist_raw) = normalize_artist_name(a.artist_name)`. Backed by `artists_normalized_name_idx`.
+2. **Alias.** `normalize_artist_name(headlining_artist_raw) = normalize_artist_name(asa.variant)` against `artist_search_alias`. Backed by `artist_search_alias_normalized_variant_idx`. Fires **only when strict returns zero matches** (strict-wins).
+
+Each arm runs `LIMIT 2` against a `SELECT DISTINCT artist_id` so the orchestrator can distinguish singleton vs. ambiguous in one round-trip. Multiple variants for the same canonical artist count as one match (the `DISTINCT` collapses them). Multiple distinct `artist_id`s → `ambiguous`, leaves the FK NULL.
+
+The conservative bias matches the substrate intent: NULL is the documented steady state, not a defect. Known consequence — `artists` has ~235 groups with duplicate `artist_name` values; concerts whose raw name collides with those stay NULL forever under this rule. The trade is intentional — accept low recall in exchange for zero wrong-FK writes.
+
+## Idempotency + race-safety
+
+- SELECT predicate: `headlining_artist_id IS NULL AND headlining_artist_raw IS NOT NULL`. Already-resolved rows are never re-examined; the resolver is write-once-trust-forever.
+- UPDATE WHERE clause: `id = ? AND headlining_artist_id IS NULL`. A concurrent pod or a scraper write that lands between SELECT and UPDATE manifests as a 0-row UPDATE which the orchestrator counts as `raced` rather than `resolved`.
+- A later alias-substrate refresh that would now resolve a previously-unmatched row picks it up on the next cron run. A later alias-substrate refresh that would now produce a _different_ singleton for an already-resolved row does **not** self-heal — that's the conservative-singleton-only trade.
+
+## Recurring drain
+
+Cron schedule `15 5 * * *` UTC, registered via the `cron-schedule` field in `package.json` and picked up by `.github/workflows/deploy-base.yml` on merge to main.
+
+Cadence rationale:
+
+- `artist-search-alias-consumer` at `15 4 * * *` (alias substrate refreshed)
+- `venue-events-scraper` at `0 5 * * *` (#1343 — new concerts written)
+- `concerts-artist-resolver` at `15 5 * * *` (this job — pick up the new rows)
+
+Crontab has no dependency semantics; ordering is best-effort by wall clock. If the scraper runs late, the resolver runs on the prior day's data; the next run picks up the missed rows. Acceptable.
+
+Per-row no-op when nothing new matches. Steady state: one indexed `WHERE IS NULL` query, near-zero work.
+
+## Run shape
+
+```bash
+docker run --rm --env-file .env <image>
+```
+
+Required env: `DB_*` (postgres connection).
+
+Optional env: `SENTRY_DSN`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`.
+
+## Counters
+
+The run-end log line and Sentry span carry:
+
+| field                       | meaning                                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| `resolver.scanned`          | Rows read by the SELECT (including `null_raw_skipped`).                                  |
+| `resolver.resolved`         | Rows whose `headlining_artist_id` was stamped (sum of strict + alias).                   |
+| `resolver.resolved_strict`  | Singleton matches from the strict arm.                                                   |
+| `resolver.resolved_alias`   | Singleton matches from the alias arm (fired only on zero strict).                        |
+| `resolver.ambiguous`        | >1 distinct `artist_id` after dedup → FK stays NULL.                                     |
+| `resolver.unmatched`        | Zero matches from both arms → FK stays NULL.                                             |
+| `resolver.null_raw_skipped` | Defensive — production SELECT filters NULL `headlining_artist_raw`. Should be 0 in prod. |
+| `resolver.error`            | Transient resolver failure (e.g. PG timeout). Row stays NULL; retried next run.          |
+| `resolver.raced`            | Writer's WHERE clause matched 0 rows — a concurrent run set the FK first.                |
+
+## Tests
+
+```bash
+npm run test:unit -- tests/unit/jobs/concerts-artist-resolver tests/unit/database/normalize-artist-name.test.ts
+```
+
+The orchestrator is dep-injected so the unit tests drive the loop with in-memory resolver / loader / writer doubles. The TypeScript twin's test pins the byte-identical output the SQL function must produce.
+
+## Pattern reference
+
+- `jobs/rotation-release-id-backfill/` — dep-injected resolver shape (`loadCandidates → lookup → write`).
+- `jobs/artist-search-alias-consumer/` — daily cron via `cron-schedule` in `package.json`.

--- a/jobs/concerts-artist-resolver/job.ts
+++ b/jobs/concerts-artist-resolver/job.ts
@@ -43,15 +43,28 @@ const JOB_NAME = 'concerts-artist-resolver';
 /**
  * Pull a usable error message off `unknown` so a `throw 'string'` /
  * `throw null` / a Symbol from upstream code doesn't crash the catch
- * block via `(error as Error).message`. Mirrors the pattern in
- * `jobs/rotation-artist-backfill/job.ts` (BS#1361) — once a third
- * caller appears, promote to `shared/database` or a shared `jobs/`
- * helper.
+ * block via `(error as Error).message`. The whole body is wrapped in a
+ * try so even `e instanceof Error` (a Proxy with throwing
+ * `Symbol.hasInstance`) or a throwing `.message` getter can't escape —
+ * symmetric with `safeStringifyThrown` in orchestrate.ts. Mirrors the
+ * pattern in `jobs/rotation-artist-backfill/job.ts` (BS#1361) — once a
+ * third caller appears, promote to `shared/database` or a shared
+ * `jobs/` helper.
  */
 const errorMessage = (e: unknown): string => {
-  if (e instanceof Error) return e.message;
   try {
+    if (e instanceof Error) return e.message;
     return String(e);
+  } catch {
+    return '<unrepresentable error>';
+  }
+};
+
+/** Mirror of `errorMessage` for the discriminator field. */
+const errorName = (e: unknown): string => {
+  try {
+    if (e instanceof Error) return e.name;
+    return typeof e;
   } catch {
     return '<unrepresentable error>';
   }
@@ -63,12 +76,21 @@ const errorMessage = (e: unknown): string => {
  * `closeDatabaseConnection` would prevent `closeLogger` from running —
  * Sentry events would stay buffered and the PG pool would leak through
  * to process exit. Pattern landed independently for BS#1361.
+ *
+ * Sets `process.exitCode = 1` on failure so a teardown error after an
+ * otherwise-successful run doesn't masquerade as a clean exit —
+ * monitoring keyed on exit code (the cron's primary success signal)
+ * needs to see the failure even when the inner span resolved OK.
  */
 const safeFinalize = async (step: string, fn: () => Promise<void>): Promise<void> => {
   try {
     await fn();
   } catch (e) {
-    log('error', step, `${JOB_NAME} cleanup step failed`, { error_message: errorMessage(e) });
+    log('error', step, `${JOB_NAME} cleanup step failed`, {
+      error_message: errorMessage(e),
+      error_name: errorName(e),
+    });
+    process.exitCode = 1;
   }
 };
 
@@ -87,6 +109,7 @@ const main = async (): Promise<void> => {
             log('warn', 'row_error', `resolver row failed for concert ${candidate.id}`, {
               concert_id: candidate.id,
               error_message: errorMessage(error),
+              error_name: errorName(error),
             });
             captureError(error, 'row_error', { concert_id: candidate.id });
           },
@@ -120,7 +143,10 @@ const main = async (): Promise<void> => {
           }
         );
       } catch (error) {
-        log('error', 'failed', `${JOB_NAME} failed`, { error_message: errorMessage(error) });
+        log('error', 'failed', `${JOB_NAME} failed`, {
+          error_message: errorMessage(error),
+          error_name: errorName(error),
+        });
         captureError(error, 'failed');
         // Mark the wrapping `${JOB_NAME}.run` span as failed (Sentry
         // span-status code 2 = ERROR) so OTLP / Sentry alerts keyed on
@@ -161,6 +187,7 @@ main().catch((error: unknown) => {
         step: 'unhandled',
         message: `${JOB_NAME} unhandled top-level rejection`,
         error_message: errorMessage(error),
+        error_name: errorName(error),
       }) + '\n'
     );
   } catch {

--- a/jobs/concerts-artist-resolver/job.ts
+++ b/jobs/concerts-artist-resolver/job.ts
@@ -40,59 +40,97 @@ import { initLogger, log, captureError, closeLogger } from './logger.js';
 
 const JOB_NAME = 'concerts-artist-resolver';
 
+/**
+ * Pull a usable error message off `unknown` so a `throw 'string'` /
+ * `throw null` / a Symbol from upstream code doesn't crash the catch
+ * block via `(error as Error).message`. Mirrors the pattern in
+ * `jobs/rotation-artist-backfill/job.ts` (BS#1361) — once a third
+ * caller appears, promote to `shared/database` or a shared `jobs/`
+ * helper.
+ */
+const errorMessage = (e: unknown): string => {
+  if (e instanceof Error) return e.message;
+  try {
+    return String(e);
+  } catch {
+    return '<unrepresentable error>';
+  }
+};
+
+/**
+ * Run a teardown step and log+swallow any throw so a failure in one
+ * cleanup call doesn't skip the next. Without this, an exception out of
+ * `closeDatabaseConnection` would prevent `closeLogger` from running —
+ * Sentry events would stay buffered and the PG pool would leak through
+ * to process exit. Pattern landed independently for BS#1361.
+ */
+const safeFinalize = async (step: string, fn: () => Promise<void>): Promise<void> => {
+  try {
+    await fn();
+  } catch (e) {
+    log('error', step, `${JOB_NAME} cleanup step failed`, { error_message: errorMessage(e) });
+  }
+};
+
 const main = async (): Promise<void> => {
   initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
   try {
     await Sentry.startSpan({ name: `${JOB_NAME}.run`, op: 'job.run' }, async () => {
-      log('info', 'init', `${JOB_NAME} initialized`);
+      try {
+        log('info', 'init', `${JOB_NAME} initialized`);
 
-      const { totals } = await runResolver({
-        loadCandidates,
-        resolve: resolveArtistId,
-        write: writeArtistId,
-        onError: (candidate, error) => {
-          const message = error instanceof Error ? error.message : String(error);
-          log('warn', 'row_error', `resolver row failed for concert ${candidate.id}`, {
-            concert_id: candidate.id,
-            error_message: message,
-          });
-          captureError(error, 'row_error', { concert_id: candidate.id });
-        },
-      });
-
-      log('info', 'finished', `${JOB_NAME} done`, { ...totals });
-
-      // Surface run totals as a CHILD span whose numeric attributes are
-      // set at creation time (per BS#1081 / memory
-      // `feedback_sentry_attribute_typing_trap`: numeric values passed
-      // via `setAttribute(name, number)` AFTER the span has already
-      // started get indexed as strings, which breaks avg/p50/p95/sum
-      // aggregation on Sentry dashboards).
-      Sentry.startSpan(
-        {
-          name: `${JOB_NAME}.run.totals`,
-          attributes: {
-            'resolver.scanned': totals.scanned,
-            'resolver.resolved': totals.resolved,
-            'resolver.resolved_strict': totals.resolved_strict,
-            'resolver.resolved_alias': totals.resolved_alias,
-            'resolver.ambiguous': totals.ambiguous,
-            'resolver.unmatched': totals.unmatched,
-            'resolver.null_raw_skipped': totals.null_raw_skipped,
-            'resolver.error': totals.error,
-            'resolver.raced': totals.raced,
+        const { totals } = await runResolver({
+          loadCandidates,
+          resolve: resolveArtistId,
+          write: writeArtistId,
+          onError: (candidate, error) => {
+            log('warn', 'row_error', `resolver row failed for concert ${candidate.id}`, {
+              concert_id: candidate.id,
+              error_message: errorMessage(error),
+            });
+            captureError(error, 'row_error', { concert_id: candidate.id });
           },
-        },
-        () => {
-          /* attributes set at creation; nothing else to do */
-        }
-      );
+        });
+
+        log('info', 'finished', `${JOB_NAME} done`, { ...totals });
+
+        // Surface run totals as a CHILD span whose numeric attributes are
+        // set at creation time (per BS#1081 / memory
+        // `feedback_sentry_attribute_typing_trap`: numeric values passed
+        // via `setAttribute(name, number)` AFTER the span has already
+        // started get indexed as strings, which breaks avg/p50/p95/sum
+        // aggregation on Sentry dashboards).
+        Sentry.startSpan(
+          {
+            name: `${JOB_NAME}.run.totals`,
+            attributes: {
+              'resolver.scanned': totals.scanned,
+              'resolver.resolved': totals.resolved,
+              'resolver.resolved_strict': totals.resolved_strict,
+              'resolver.resolved_alias': totals.resolved_alias,
+              'resolver.ambiguous': totals.ambiguous,
+              'resolver.unmatched': totals.unmatched,
+              'resolver.null_raw_skipped': totals.null_raw_skipped,
+              'resolver.error': totals.error,
+              'resolver.raced': totals.raced,
+            },
+          },
+          () => {
+            /* attributes set at creation; nothing else to do */
+          }
+        );
+      } catch (error) {
+        log('error', 'failed', `${JOB_NAME} failed`, { error_message: errorMessage(error) });
+        captureError(error, 'failed');
+        // Mark the wrapping `${JOB_NAME}.run` span as failed (Sentry
+        // span-status code 2 = ERROR) so OTLP / Sentry alerts keyed on
+        // `op:job.run` error rate actually fire. Without this the span
+        // resolves with status:OK and the failure stays invisible to
+        // alerting even though captureError has logged the exception.
+        Sentry.getActiveSpan()?.setStatus({ code: 2, message: 'failed' });
+        process.exitCode = 1;
+      }
     });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    log('error', 'failed', `${JOB_NAME} failed`, { error_message: message });
-    captureError(error, 'failed');
-    process.exitCode = 1;
   } finally {
     // Cleanup runs OUTSIDE the `Sentry.startSpan` callback so the parent
     // `${JOB_NAME}.run` span's end event fires through a live transport.
@@ -101,9 +139,32 @@ const main = async (): Promise<void> => {
     // terminal event would land on an already-disabled client and the
     // whole transaction (including the .totals child span) would be
     // dropped silently.
-    await closeDatabaseConnection();
-    await closeLogger();
+    await safeFinalize('teardown_db', closeDatabaseConnection);
+    await safeFinalize('teardown_logger', closeLogger);
   }
 };
 
-void main();
+/**
+ * Top-level run guard. `void main()` would swallow a rejection from the
+ * finally block as an unhandled promise rejection — Node 19+ exits
+ * non-zero on default settings, Node 18 warns and continues; behavior
+ * also drifts across Node majors. Catching here means the cron always
+ * exits with a meaningful code regardless. Logger may already be closed
+ * by this point, so we write directly to stderr.
+ */
+main().catch((error: unknown) => {
+  try {
+    process.stderr.write(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: 'error',
+        step: 'unhandled',
+        message: `${JOB_NAME} unhandled top-level rejection`,
+        error_message: errorMessage(error),
+      }) + '\n'
+    );
+  } catch {
+    /* even stderr is gone — there is nothing else we can do */
+  }
+  process.exitCode = 1;
+});

--- a/jobs/concerts-artist-resolver/job.ts
+++ b/jobs/concerts-artist-resolver/job.ts
@@ -42,14 +42,22 @@ const JOB_NAME = 'concerts-artist-resolver';
 
 const main = async (): Promise<void> => {
   initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
-  await Sentry.startSpan({ name: `${JOB_NAME}.run`, op: 'job.run' }, async () => {
-    try {
+  try {
+    await Sentry.startSpan({ name: `${JOB_NAME}.run`, op: 'job.run' }, async () => {
       log('info', 'init', `${JOB_NAME} initialized`);
 
       const { totals } = await runResolver({
         loadCandidates,
         resolve: resolveArtistId,
         write: writeArtistId,
+        onError: (candidate, error) => {
+          const message = error instanceof Error ? error.message : String(error);
+          log('warn', 'row_error', `resolver row failed for concert ${candidate.id}`, {
+            concert_id: candidate.id,
+            error_message: message,
+          });
+          captureError(error, 'row_error', { concert_id: candidate.id });
+        },
       });
 
       log('info', 'finished', `${JOB_NAME} done`, { ...totals });
@@ -79,15 +87,22 @@ const main = async (): Promise<void> => {
           /* attributes set at creation; nothing else to do */
         }
       );
-    } catch (error) {
-      log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
-      captureError(error, 'failed');
-      process.exitCode = 1;
-    } finally {
-      await closeDatabaseConnection();
-      await closeLogger();
-    }
-  });
+    });
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    // Cleanup runs OUTSIDE the `Sentry.startSpan` callback so the parent
+    // `${JOB_NAME}.run` span's end event fires through a live transport.
+    // `closeLogger` calls `Sentry.close(2000)`, which disables the SDK —
+    // if we ran it in the span callback's finally, the parent span's
+    // terminal event would land on an already-disabled client and the
+    // whole transaction (including the .totals child span) would be
+    // dropped silently.
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
 };
 
 void main();

--- a/jobs/concerts-artist-resolver/job.ts
+++ b/jobs/concerts-artist-resolver/job.ts
@@ -1,0 +1,93 @@
+/**
+ * Entrypoint for jobs/concerts-artist-resolver (BS#1372).
+ *
+ * Daily cron (default `15 5 * * *` UTC). Resolves
+ * `concerts.headlining_artist_raw` to `concerts.headlining_artist_id`
+ * via the strict-then-alias local resolver using migration 0092's
+ * `normalize_artist_name(text)` function and the three functional
+ * indexes on `artists`, `artist_search_alias`, and the partial index on
+ * `concerts (id) WHERE headlining_artist_id IS NULL`. No LML round-trip.
+ *
+ * Idempotent: the SELECT predicate is `headlining_artist_id IS NULL`
+ * and the UPDATE's WHERE guard mirrors it — both rerun-safe and race-
+ * safe against a parallel pod or a scraper write that lands mid-run.
+ *
+ * Run shape:
+ *   - One pass over all eligible `concerts` rows.
+ *   - Per-row strict-then-alias resolver (each arm is a separate SQL
+ *     query — keeps the strict-wins rule explicit and lets Postgres
+ *     short-circuit when strict hits).
+ *   - Writes only on singleton match; ambiguous / unmatched / errored
+ *     rows leave the FK NULL and increment dedicated counters.
+ *
+ * Invocation:
+ *   docker run --rm --env-file .env <image>
+ *
+ * Required env: DB_* (postgres connection).
+ *
+ * Optional env:
+ *   SENTRY_DSN, SENTRY_RELEASE, SENTRY_TRACES_SAMPLE_RATE — observability.
+ */
+
+import * as Sentry from '@sentry/node';
+
+import { closeDatabaseConnection } from '@wxyc/database';
+
+import { runResolver } from './orchestrate.js';
+import { loadCandidates, resolveArtistId } from './query.js';
+import { writeArtistId } from './writer.js';
+import { initLogger, log, captureError, closeLogger } from './logger.js';
+
+const JOB_NAME = 'concerts-artist-resolver';
+
+const main = async (): Promise<void> => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  await Sentry.startSpan({ name: `${JOB_NAME}.run`, op: 'job.run' }, async () => {
+    try {
+      log('info', 'init', `${JOB_NAME} initialized`);
+
+      const { totals } = await runResolver({
+        loadCandidates,
+        resolve: resolveArtistId,
+        write: writeArtistId,
+      });
+
+      log('info', 'finished', `${JOB_NAME} done`, { ...totals });
+
+      // Surface run totals as a CHILD span whose numeric attributes are
+      // set at creation time (per BS#1081 / memory
+      // `feedback_sentry_attribute_typing_trap`: numeric values passed
+      // via `setAttribute(name, number)` AFTER the span has already
+      // started get indexed as strings, which breaks avg/p50/p95/sum
+      // aggregation on Sentry dashboards).
+      Sentry.startSpan(
+        {
+          name: `${JOB_NAME}.run.totals`,
+          attributes: {
+            'resolver.scanned': totals.scanned,
+            'resolver.resolved': totals.resolved,
+            'resolver.resolved_strict': totals.resolved_strict,
+            'resolver.resolved_alias': totals.resolved_alias,
+            'resolver.ambiguous': totals.ambiguous,
+            'resolver.unmatched': totals.unmatched,
+            'resolver.null_raw_skipped': totals.null_raw_skipped,
+            'resolver.error': totals.error,
+            'resolver.raced': totals.raced,
+          },
+        },
+        () => {
+          /* attributes set at creation; nothing else to do */
+        }
+      );
+    } catch (error) {
+      log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+      captureError(error, 'failed');
+      process.exitCode = 1;
+    } finally {
+      await closeDatabaseConnection();
+      await closeLogger();
+    }
+  });
+};
+
+void main();

--- a/jobs/concerts-artist-resolver/job.ts
+++ b/jobs/concerts-artist-resolver/job.ts
@@ -89,7 +89,8 @@ const main = async (): Promise<void> => {
       );
     });
   } catch (error) {
-    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    const message = error instanceof Error ? error.message : String(error);
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: message });
     captureError(error, 'failed');
     process.exitCode = 1;
   } finally {

--- a/jobs/concerts-artist-resolver/logger.ts
+++ b/jobs/concerts-artist-resolver/logger.ts
@@ -1,0 +1,81 @@
+/**
+ * Observability for jobs/concerts-artist-resolver (BS#1372): Sentry init
+ * + JSON logs.
+ *
+ * Phase A foundation contract (issue #538): every log line carries the
+ * four tags `repo`, `tool`, `step`, `run_id`. Sentry stays inactive when
+ * SENTRY_DSN is unset (the @sentry/node SDK silently no-ops in that
+ * case), so this module is safe to call from any environment.
+ *
+ * Mirrors `jobs/rotation-release-id-backfill/logger.ts` — the contract
+ * is identical and the duplication keeps this job's build graph
+ * independent of the rotation backfill's package.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+// `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/concerts-artist-resolver/orchestrate.ts
+++ b/jobs/concerts-artist-resolver/orchestrate.ts
@@ -101,9 +101,10 @@ const emptyTotals = (): Totals => ({
  * down, log throws EPIPE, etc.) is at least visible in container logs
  * instead of silently disappearing.
  */
-// Keep this prefix in sync with `JOB_NAME` in job.ts. Hardcoded so the
-// helper stays orchestrator-local (job.ts → orchestrate.ts already);
-// a rename of either side would surface in this file's tests.
+// Keep this prefix in sync with `JOB_NAME` in job.ts — a rename of either
+// side requires a manual matching edit on the other. Hardcoded so the
+// helper stays orchestrator-local (job.ts already imports from here, so
+// pulling JOB_NAME back over would invert the dependency direction).
 const SINK_FAILURE_PREFIX = 'concerts-artist-resolver';
 
 /**

--- a/jobs/concerts-artist-resolver/orchestrate.ts
+++ b/jobs/concerts-artist-resolver/orchestrate.ts
@@ -92,18 +92,27 @@ const emptyTotals = (): Totals => ({
 });
 
 /**
- * Invoke an `onError` sink without letting it abort the batch. A sync
- * throw OR an async rejection from the sink is caught and discarded —
- * the orchestrator's counter is the durable record. The dispatcher
- * normalizes both shapes through `Promise.resolve` so a sink that
- * returns void and a sink that returns Promise<void> are handled
- * identically.
+ * Invoke an `onError` sink without letting it abort the batch. `await`
+ * accepts both `void` and `Promise<void>` returns; a sync throw or an
+ * async rejection from the sink is caught and never re-raised, so a
+ * misbehaving sink can never break the loop. The counter is the durable
+ * record of failures, not the sink — but we still write a single stderr
+ * line on sink failure so a broken observability path (Sentry transport
+ * down, log throws EPIPE, etc.) is at least visible in container logs
+ * instead of silently disappearing.
  */
 const safeNotifyError = async (onError: OnRowErrorFn, candidate: Candidate, error: unknown): Promise<void> => {
   try {
     await onError(candidate, error);
-  } catch {
-    /* sink must never break the loop */
+  } catch (sinkError) {
+    const sinkMessage = sinkError instanceof Error ? sinkError.message : String(sinkError);
+    try {
+      process.stderr.write(
+        `concerts-artist-resolver: onError sink failed for concert ${candidate.id}: ${sinkMessage}\n`
+      );
+    } catch {
+      /* even stderr is gone — there is nothing else we can do */
+    }
   }
 };
 

--- a/jobs/concerts-artist-resolver/orchestrate.ts
+++ b/jobs/concerts-artist-resolver/orchestrate.ts
@@ -28,13 +28,27 @@
 export type Candidate = {
   id: number;
   /**
-   * The raw venue-scraped artist name. The production SELECT filters
-   * NULL out, but the type permits NULL so the orchestrator can stay
-   * defensive (counted as `null_raw_skipped`, the resolver is never
-   * called).
+   * The raw venue-scraped artist name. The DB column is `NOT NULL` and
+   * the production SELECT additionally filters `IS NOT NULL`, so this
+   * branch is unreachable in prod today. The type intentionally permits
+   * NULL as a forward-compat seam: a future editorial-submission source
+   * (#1347's note on multi-source ingest) may relax the constraint, and
+   * the orchestrator's `null_raw_skipped` counter is the tripwire that
+   * tells operators when that change reaches the resolver.
    */
   headlining_artist_raw: string | null;
 };
+
+/**
+ * Per-row callback the orchestrator uses to surface a resolver failure
+ * with concert-level context. Production wires this to a log + Sentry
+ * capture in `job.ts`; tests pass a no-op spy so the loop semantics
+ * (counter increment, `continue`) can be exercised without observability
+ * coupling. Reports the concert id and the underlying error message so
+ * dashboards triaging a `resolver.error` spike can pivot from the
+ * counter to the failing rows in one click.
+ */
+export type OnResolverErrorFn = (candidate: Candidate, error: unknown) => void;
 
 export type ResolveOutcome =
   | { kind: 'strict'; artist_id: number }
@@ -76,8 +90,10 @@ export const runResolver = async (deps: {
   loadCandidates: LoadCandidatesFn;
   resolve: ResolveFn;
   write: WriteFn;
+  onError?: OnResolverErrorFn;
 }): Promise<RunResult> => {
   const totals = emptyTotals();
+  const onError: OnResolverErrorFn = deps.onError ?? (() => {});
 
   const candidates = await deps.loadCandidates();
   for (const candidate of candidates) {
@@ -91,11 +107,13 @@ export const runResolver = async (deps: {
     let outcome: ResolveOutcome;
     try {
       outcome = await deps.resolve(candidate.headlining_artist_raw);
-    } catch {
+    } catch (error) {
       // Transient resolver failure (e.g. PG statement timeout). The row
       // stays `headlining_artist_id IS NULL`, so the next run picks it
-      // up again. The entrypoint wraps the loop in Sentry's run-scope
-      // so captureError isn't needed at this unit boundary.
+      // up again. Surface the concert id + error via `onError` so the
+      // run-scope dashboard's `resolver.error` counter pivots to the
+      // failing rows (without it, a spike of N errors is opaque).
+      onError(candidate, error);
       totals.error += 1;
       continue;
     }
@@ -103,8 +121,20 @@ export const runResolver = async (deps: {
     switch (outcome.kind) {
       case 'strict':
       case 'alias': {
-        const { written } = await deps.write(candidate.id, outcome.artist_id);
-        if (written) {
+        let writeResult: { written: boolean };
+        try {
+          writeResult = await deps.write(candidate.id, outcome.artist_id);
+        } catch (error) {
+          // Symmetric with the resolver-error path: a transient write
+          // failure (PG outage, FK race against a parallel artist
+          // delete, etc.) must not terminate the loop and leave the
+          // remaining candidates unprocessed. The row stays NULL and
+          // the next cron run drains it.
+          onError(candidate, error);
+          totals.error += 1;
+          break;
+        }
+        if (writeResult.written) {
           totals.resolved += 1;
           if (outcome.kind === 'strict') {
             totals.resolved_strict += 1;

--- a/jobs/concerts-artist-resolver/orchestrate.ts
+++ b/jobs/concerts-artist-resolver/orchestrate.ts
@@ -101,15 +101,34 @@ const emptyTotals = (): Totals => ({
  * down, log throws EPIPE, etc.) is at least visible in container logs
  * instead of silently disappearing.
  */
+// Keep this prefix in sync with `JOB_NAME` in job.ts. Hardcoded so the
+// helper stays orchestrator-local (job.ts → orchestrate.ts already);
+// a rename of either side would surface in this file's tests.
+const SINK_FAILURE_PREFIX = 'concerts-artist-resolver';
+
+/**
+ * Stringify a value that's already been thrown without re-throwing. We
+ * cannot trust the value's `.message` getter, `toString`, `Symbol.
+ * toPrimitive`, or any other coercion path — a pathological sink might
+ * throw values whose stringification itself throws. Default to a
+ * constant so the outer catch's "never re-raises" contract holds.
+ */
+const safeStringifyThrown = (value: unknown): string => {
+  try {
+    if (value instanceof Error) return value.message;
+    return String(value);
+  } catch {
+    return '<unrepresentable sink error>';
+  }
+};
+
 const safeNotifyError = async (onError: OnRowErrorFn, candidate: Candidate, error: unknown): Promise<void> => {
   try {
     await onError(candidate, error);
   } catch (sinkError) {
-    const sinkMessage = sinkError instanceof Error ? sinkError.message : String(sinkError);
+    const sinkMessage = safeStringifyThrown(sinkError);
     try {
-      process.stderr.write(
-        `concerts-artist-resolver: onError sink failed for concert ${candidate.id}: ${sinkMessage}\n`
-      );
+      process.stderr.write(`${SINK_FAILURE_PREFIX}: onError sink failed for concert ${candidate.id}: ${sinkMessage}\n`);
     } catch {
       /* even stderr is gone — there is nothing else we can do */
     }

--- a/jobs/concerts-artist-resolver/orchestrate.ts
+++ b/jobs/concerts-artist-resolver/orchestrate.ts
@@ -1,0 +1,133 @@
+/**
+ * Orchestrator for jobs/concerts-artist-resolver (BS#1372).
+ *
+ * Iterates `concerts` rows where `headlining_artist_id IS NULL` and
+ * `headlining_artist_raw IS NOT NULL`, asks the resolver to map the raw
+ * name to a single canonical `artists.id`, and writes the FK back when
+ * the resolver returns an unambiguous match. NULL stays NULL on every
+ * ambiguous / unmatched / errored row — the substrate (#1347) treats
+ * NULL as the documented steady state.
+ *
+ * The resolver is the SQL JOIN, not this loop. It runs strict-first
+ * against the functional index on `artists`, falls through to the
+ * `artist_search_alias` join only when strict returns zero matches, and
+ * collapses multi-`artist_id` outcomes to `ambiguous`. The orchestrator
+ * trusts the resolver's `kind` and never re-classifies — that's how the
+ * unit tests stay deterministic and how the strict-wins rule stays
+ * enforced in one place.
+ *
+ * Idempotency: the SELECT predicate gates a rerun-safe drain. Already-
+ * resolved rows are never re-examined; the resolver is write-once-trust-
+ * forever. Counters are reported at the run-end log line and emitted as
+ * Sentry span attributes by the entrypoint.
+ *
+ * Dep-injected so unit tests can drive the orchestrator without PG —
+ * see `tests/unit/jobs/concerts-artist-resolver/orchestrate.test.ts`.
+ */
+
+export type Candidate = {
+  id: number;
+  /**
+   * The raw venue-scraped artist name. The production SELECT filters
+   * NULL out, but the type permits NULL so the orchestrator can stay
+   * defensive (counted as `null_raw_skipped`, the resolver is never
+   * called).
+   */
+  headlining_artist_raw: string | null;
+};
+
+export type ResolveOutcome =
+  | { kind: 'strict'; artist_id: number }
+  | { kind: 'alias'; artist_id: number }
+  | { kind: 'ambiguous' }
+  | { kind: 'unmatched' };
+
+export type LoadCandidatesFn = () => Promise<Candidate[]>;
+export type ResolveFn = (raw: string) => Promise<ResolveOutcome>;
+export type WriteFn = (concertId: number, artistId: number) => Promise<{ written: boolean }>;
+
+export type Totals = {
+  scanned: number;
+  resolved: number;
+  resolved_strict: number;
+  resolved_alias: number;
+  ambiguous: number;
+  unmatched: number;
+  null_raw_skipped: number;
+  error: number;
+  raced: number;
+};
+
+export type RunResult = { totals: Totals };
+
+const emptyTotals = (): Totals => ({
+  scanned: 0,
+  resolved: 0,
+  resolved_strict: 0,
+  resolved_alias: 0,
+  ambiguous: 0,
+  unmatched: 0,
+  null_raw_skipped: 0,
+  error: 0,
+  raced: 0,
+});
+
+export const runResolver = async (deps: {
+  loadCandidates: LoadCandidatesFn;
+  resolve: ResolveFn;
+  write: WriteFn;
+}): Promise<RunResult> => {
+  const totals = emptyTotals();
+
+  const candidates = await deps.loadCandidates();
+  for (const candidate of candidates) {
+    totals.scanned += 1;
+
+    if (candidate.headlining_artist_raw === null) {
+      totals.null_raw_skipped += 1;
+      continue;
+    }
+
+    let outcome: ResolveOutcome;
+    try {
+      outcome = await deps.resolve(candidate.headlining_artist_raw);
+    } catch {
+      // Transient resolver failure (e.g. PG statement timeout). The row
+      // stays `headlining_artist_id IS NULL`, so the next run picks it
+      // up again. The entrypoint wraps the loop in Sentry's run-scope
+      // so captureError isn't needed at this unit boundary.
+      totals.error += 1;
+      continue;
+    }
+
+    switch (outcome.kind) {
+      case 'strict':
+      case 'alias': {
+        const { written } = await deps.write(candidate.id, outcome.artist_id);
+        if (written) {
+          totals.resolved += 1;
+          if (outcome.kind === 'strict') {
+            totals.resolved_strict += 1;
+          } else {
+            totals.resolved_alias += 1;
+          }
+        } else {
+          // The writer's WHERE clause guards on
+          // `headlining_artist_id IS NULL`. A 0-row UPDATE means a
+          // concurrent run beat us (the cron is rerun-safe, but two
+          // ETL pods could both pick the same row up mid-scan).
+          totals.raced += 1;
+        }
+        break;
+      }
+      case 'ambiguous':
+        totals.ambiguous += 1;
+        break;
+      case 'unmatched':
+        totals.unmatched += 1;
+        break;
+    }
+  }
+
+  return { totals };
+};

--- a/jobs/concerts-artist-resolver/orchestrate.ts
+++ b/jobs/concerts-artist-resolver/orchestrate.ts
@@ -40,15 +40,20 @@ export type Candidate = {
 };
 
 /**
- * Per-row callback the orchestrator uses to surface a resolver failure
- * with concert-level context. Production wires this to a log + Sentry
- * capture in `job.ts`; tests pass a no-op spy so the loop semantics
- * (counter increment, `continue`) can be exercised without observability
- * coupling. Reports the concert id and the underlying error message so
- * dashboards triaging a `resolver.error` spike can pivot from the
- * counter to the failing rows in one click.
+ * Per-row callback the orchestrator uses to surface a failure (resolver
+ * OR writer) with concert-level context. Production wires this to a log
+ * + Sentry capture in `job.ts`; tests pass a no-op spy so the loop
+ * semantics (counter increment, `continue`) can be exercised without
+ * observability coupling. Reports the concert id and the underlying
+ * error message so dashboards triaging a `resolver.error` spike can
+ * pivot from the counter to the failing rows in one click.
+ *
+ * The return type permits `Promise<void>` so async sinks (Slack, an
+ * external logger) compose cleanly — the orchestrator awaits the call
+ * and swallows any throw/rejection so a misbehaving sink can never
+ * abort the batch.
  */
-export type OnResolverErrorFn = (candidate: Candidate, error: unknown) => void;
+export type OnRowErrorFn = (candidate: Candidate, error: unknown) => void | Promise<void>;
 
 export type ResolveOutcome =
   | { kind: 'strict'; artist_id: number }
@@ -86,14 +91,30 @@ const emptyTotals = (): Totals => ({
   raced: 0,
 });
 
+/**
+ * Invoke an `onError` sink without letting it abort the batch. A sync
+ * throw OR an async rejection from the sink is caught and discarded —
+ * the orchestrator's counter is the durable record. The dispatcher
+ * normalizes both shapes through `Promise.resolve` so a sink that
+ * returns void and a sink that returns Promise<void> are handled
+ * identically.
+ */
+const safeNotifyError = async (onError: OnRowErrorFn, candidate: Candidate, error: unknown): Promise<void> => {
+  try {
+    await onError(candidate, error);
+  } catch {
+    /* sink must never break the loop */
+  }
+};
+
 export const runResolver = async (deps: {
   loadCandidates: LoadCandidatesFn;
   resolve: ResolveFn;
   write: WriteFn;
-  onError?: OnResolverErrorFn;
+  onError?: OnRowErrorFn;
 }): Promise<RunResult> => {
   const totals = emptyTotals();
-  const onError: OnResolverErrorFn = deps.onError ?? (() => {});
+  const onError: OnRowErrorFn = deps.onError ?? (() => {});
 
   const candidates = await deps.loadCandidates();
   for (const candidate of candidates) {
@@ -108,45 +129,42 @@ export const runResolver = async (deps: {
     try {
       outcome = await deps.resolve(candidate.headlining_artist_raw);
     } catch (error) {
-      // Transient resolver failure (e.g. PG statement timeout). The row
-      // stays `headlining_artist_id IS NULL`, so the next run picks it
-      // up again. Surface the concert id + error via `onError` so the
-      // run-scope dashboard's `resolver.error` counter pivots to the
-      // failing rows (without it, a spike of N errors is opaque).
-      onError(candidate, error);
+      // Transient resolver failure (e.g. PG statement timeout). Bump
+      // the counter FIRST so totals stay accurate even if the sink
+      // misbehaves, then notify observers. The row stays NULL; the
+      // next cron run picks it up via the IS-NULL gate.
       totals.error += 1;
+      await safeNotifyError(onError, candidate, error);
       continue;
     }
 
     switch (outcome.kind) {
       case 'strict':
       case 'alias': {
-        let writeResult: { written: boolean };
         try {
-          writeResult = await deps.write(candidate.id, outcome.artist_id);
+          const { written } = await deps.write(candidate.id, outcome.artist_id);
+          if (written) {
+            totals.resolved += 1;
+            if (outcome.kind === 'strict') {
+              totals.resolved_strict += 1;
+            } else {
+              totals.resolved_alias += 1;
+            }
+          } else {
+            // The writer's WHERE clause guards on
+            // `headlining_artist_id IS NULL`. A 0-row UPDATE means a
+            // concurrent run beat us (the cron is rerun-safe, but two
+            // ETL pods could both pick the same row up mid-scan).
+            totals.raced += 1;
+          }
         } catch (error) {
           // Symmetric with the resolver-error path: a transient write
           // failure (PG outage, FK race against a parallel artist
           // delete, etc.) must not terminate the loop and leave the
           // remaining candidates unprocessed. The row stays NULL and
           // the next cron run drains it.
-          onError(candidate, error);
           totals.error += 1;
-          break;
-        }
-        if (writeResult.written) {
-          totals.resolved += 1;
-          if (outcome.kind === 'strict') {
-            totals.resolved_strict += 1;
-          } else {
-            totals.resolved_alias += 1;
-          }
-        } else {
-          // The writer's WHERE clause guards on
-          // `headlining_artist_id IS NULL`. A 0-row UPDATE means a
-          // concurrent run beat us (the cron is rerun-safe, but two
-          // ETL pods could both pick the same row up mid-scan).
-          totals.raced += 1;
+          await safeNotifyError(onError, candidate, error);
         }
         break;
       }

--- a/jobs/concerts-artist-resolver/package.json
+++ b/jobs/concerts-artist-resolver/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@wxyc/concerts-artist-resolver",
+  "cron-schedule": "15 5 * * *",
+  "version": "1.0.0",
+  "description": "WXYC daily ETL: resolve concerts.headlining_artist_raw → concerts.headlining_artist_id via strict-then-alias local matching against artists + artist_search_alias, using migration 0092's normalize_artist_name(text) function. No LML round-trip; conservative singleton-only writes. Unblocks BS#1368 Path B JOIN. BS#1372.",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_concerts_artist_resolver:ci -f ../../Dockerfile.concerts-artist-resolver ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.53.1",
+    "@wxyc/database": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/concerts-artist-resolver/query.ts
+++ b/jobs/concerts-artist-resolver/query.ts
@@ -34,16 +34,34 @@ const ARTISTS_TABLE = sql.raw(`"${SCHEMA}"."artists"`);
 const ARTIST_SEARCH_ALIAS_TABLE = sql.raw(`"${SCHEMA}"."artist_search_alias"`);
 const NORMALIZE_FN = sql.raw(`"${SCHEMA}"."normalize_artist_name"`);
 
-type DistinctIdRow = { artist_id: number };
+type IdRow = { artist_id: number };
 
+/**
+ * Normalize `db.execute(sql\`...\`)` results across drizzle-orm driver
+ * shapes. postgres-js returns an array; node-postgres returns `{ rows }`.
+ * Anything else means the driver contract changed under us, in which
+ * case we want a LOUD failure — a silent `[]` fallback would turn the
+ * job into a healthy-looking zero-work no-op (counters all 0, dashboards
+ * green) while real candidates pile up unresolved.
+ */
 const unwrapRows = <T>(result: unknown): T[] => {
   if (Array.isArray(result)) return result as T[];
   if (result && typeof result === 'object' && Array.isArray((result as { rows?: unknown }).rows)) {
     return (result as { rows: T[] }).rows;
   }
-  return [];
+  throw new Error(
+    `concerts-artist-resolver: unrecognized db.execute() result shape: ${typeof result === 'object' ? JSON.stringify(Object.keys(result ?? {})) : typeof result}`
+  );
 };
 
+/**
+ * Volume assumption: ~16 venues × ~10 shows/wk × 52 wk ≈ ~8k rows/yr,
+ * but steady-state the SELECT returns only the unresolved tail (most
+ * rows have a FK). Pulling the full eligible set into memory is fine at
+ * current scale; if the substrate expands (new sources, a one-time
+ * resolver-rule change requires a re-drain), revisit with id-cursor
+ * batching à la `jobs/library-identity-consumer/select.ts`.
+ */
 export const loadCandidates = async (): Promise<Candidate[]> => {
   const result: unknown = await db.execute(sql`
     SELECT "id", "headlining_artist_raw"
@@ -56,13 +74,19 @@ export const loadCandidates = async (): Promise<Candidate[]> => {
 };
 
 export const resolveArtistId: ResolveFn = async (raw: string): Promise<ResolveOutcome> => {
+  // No DISTINCT: `artists.id` is the PK so the result set is already
+  // unique. DISTINCT here would force a Unique node on top of the
+  // IndexScan against `artists_normalized_name_idx` and inhibit
+  // `LIMIT 2` pushdown. The alias arm below DOES need DISTINCT —
+  // `artist_search_alias.artist_id` is non-unique by design (multiple
+  // variants per artist).
   const strict: unknown = await db.execute(sql`
-    SELECT DISTINCT a."id" AS artist_id
+    SELECT a."id" AS artist_id
     FROM ${ARTISTS_TABLE} a
     WHERE ${NORMALIZE_FN}(a."artist_name") = ${NORMALIZE_FN}(${raw})
     LIMIT 2
   `);
-  const strictRows = unwrapRows<DistinctIdRow>(strict);
+  const strictRows = unwrapRows<IdRow>(strict);
   if (strictRows.length === 1) {
     return { kind: 'strict', artist_id: strictRows[0].artist_id };
   }
@@ -76,7 +100,7 @@ export const resolveArtistId: ResolveFn = async (raw: string): Promise<ResolveOu
     WHERE ${NORMALIZE_FN}(asa."variant") = ${NORMALIZE_FN}(${raw})
     LIMIT 2
   `);
-  const aliasRows = unwrapRows<DistinctIdRow>(alias);
+  const aliasRows = unwrapRows<IdRow>(alias);
   if (aliasRows.length === 1) {
     return { kind: 'alias', artist_id: aliasRows[0].artist_id };
   }

--- a/jobs/concerts-artist-resolver/query.ts
+++ b/jobs/concerts-artist-resolver/query.ts
@@ -44,14 +44,19 @@ type IdRow = { artist_id: number };
  * job into a healthy-looking zero-work no-op (counters all 0, dashboards
  * green) while real candidates pile up unresolved.
  */
+const describeShape = (result: unknown): string => {
+  if (result === null) return 'null';
+  if (result === undefined) return 'undefined';
+  if (typeof result !== 'object') return typeof result;
+  return `object{${Object.keys(result).join(',')}}`;
+};
+
 const unwrapRows = <T>(result: unknown): T[] => {
   if (Array.isArray(result)) return result as T[];
   if (result && typeof result === 'object' && Array.isArray((result as { rows?: unknown }).rows)) {
     return (result as { rows: T[] }).rows;
   }
-  throw new Error(
-    `concerts-artist-resolver: unrecognized db.execute() result shape: ${typeof result === 'object' ? JSON.stringify(Object.keys(result ?? {})) : typeof result}`
-  );
+  throw new Error(`concerts-artist-resolver: unrecognized db.execute() result shape: ${describeShape(result)}`);
 };
 
 /**

--- a/jobs/concerts-artist-resolver/query.ts
+++ b/jobs/concerts-artist-resolver/query.ts
@@ -1,0 +1,88 @@
+/**
+ * Candidate query + resolver for jobs/concerts-artist-resolver (BS#1372).
+ *
+ * `loadCandidates` selects `concerts` rows that still need a canonical
+ * artist FK: `headlining_artist_id IS NULL AND headlining_artist_raw IS
+ * NOT NULL`. The `IS NULL` half is the idempotency gate — rerunning the
+ * job picks up only still-unresolved rows; resolved rows are never
+ * re-examined.
+ *
+ * `resolveArtistId` is the strict-then-alias resolver. Strict and alias
+ * arms each run a separate SQL JOIN. The CTE keeps the normalization
+ * call once per side, so the functional index from migration 0092 can
+ * drive the lookup. Multiple artists with the same normalized name
+ * collapse to `kind: 'ambiguous'`; alias matches dedup on `artist_id`
+ * before the same singleton check so multiple variants of the same
+ * canonical artist count as one match.
+ *
+ * Strict-wins: if the strict arm returns exactly one canonical match,
+ * we write that and never invoke the alias arm. The alias arm only
+ * fires when strict returns zero matches.
+ *
+ * Schema-qualified table refs honour `WXYC_SCHEMA_NAME` (parallel Jest
+ * workers override the var so each worker targets its own schema).
+ */
+
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+
+import type { Candidate, ResolveFn, ResolveOutcome } from './orchestrate.js';
+
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const CONCERTS_TABLE = sql.raw(`"${SCHEMA}"."concerts"`);
+const ARTISTS_TABLE = sql.raw(`"${SCHEMA}"."artists"`);
+const ARTIST_SEARCH_ALIAS_TABLE = sql.raw(`"${SCHEMA}"."artist_search_alias"`);
+const NORMALIZE_FN = sql.raw(`"${SCHEMA}"."normalize_artist_name"`);
+
+type DistinctIdRow = { artist_id: number };
+
+const unwrapRows = <T>(result: unknown): T[] => {
+  if (Array.isArray(result)) return result as T[];
+  if (result && typeof result === 'object' && Array.isArray((result as { rows?: unknown }).rows)) {
+    return (result as { rows: T[] }).rows;
+  }
+  return [];
+};
+
+export const loadCandidates = async (): Promise<Candidate[]> => {
+  const result: unknown = await db.execute(sql`
+    SELECT "id", "headlining_artist_raw"
+    FROM ${CONCERTS_TABLE}
+    WHERE "headlining_artist_id" IS NULL
+      AND "headlining_artist_raw" IS NOT NULL
+    ORDER BY "id" ASC
+  `);
+  return unwrapRows<Candidate>(result);
+};
+
+export const resolveArtistId: ResolveFn = async (raw: string): Promise<ResolveOutcome> => {
+  const strict: unknown = await db.execute(sql`
+    SELECT DISTINCT a."id" AS artist_id
+    FROM ${ARTISTS_TABLE} a
+    WHERE ${NORMALIZE_FN}(a."artist_name") = ${NORMALIZE_FN}(${raw})
+    LIMIT 2
+  `);
+  const strictRows = unwrapRows<DistinctIdRow>(strict);
+  if (strictRows.length === 1) {
+    return { kind: 'strict', artist_id: strictRows[0].artist_id };
+  }
+  if (strictRows.length > 1) {
+    return { kind: 'ambiguous' };
+  }
+
+  const alias: unknown = await db.execute(sql`
+    SELECT DISTINCT asa."artist_id"
+    FROM ${ARTIST_SEARCH_ALIAS_TABLE} asa
+    WHERE ${NORMALIZE_FN}(asa."variant") = ${NORMALIZE_FN}(${raw})
+    LIMIT 2
+  `);
+  const aliasRows = unwrapRows<DistinctIdRow>(alias);
+  if (aliasRows.length === 1) {
+    return { kind: 'alias', artist_id: aliasRows[0].artist_id };
+  }
+  if (aliasRows.length > 1) {
+    return { kind: 'ambiguous' };
+  }
+
+  return { kind: 'unmatched' };
+};

--- a/jobs/concerts-artist-resolver/tsconfig.json
+++ b/jobs/concerts-artist-resolver/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/concerts-artist-resolver/tsup.config.ts
+++ b/jobs/concerts-artist-resolver/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/jobs/concerts-artist-resolver/writer.ts
+++ b/jobs/concerts-artist-resolver/writer.ts
@@ -1,0 +1,27 @@
+/**
+ * Writer for jobs/concerts-artist-resolver (BS#1372).
+ *
+ * Idempotent single-row UPDATE that stamps a resolved canonical
+ * `artists.id` onto a `concerts` row. The WHERE clause guards on
+ * `headlining_artist_id IS NULL`, so a rerun is safe and a concurrent
+ * pod cannot clobber an existing FK — that case manifests as a 0-row
+ * UPDATE which the orchestrator reads via `written: false` and rolls
+ * into its `raced` counter.
+ *
+ * The resolver is conservatively write-once-trust-forever per the
+ * substrate intent (#1347): once a FK lands, no subsequent pass will
+ * revisit the row even if alias-substrate growth would now produce a
+ * different singleton match.
+ */
+
+import { and, eq, isNull } from 'drizzle-orm';
+import { db, concerts } from '@wxyc/database';
+
+export const writeArtistId = async (concertId: number, artistId: number): Promise<{ written: boolean }> => {
+  const updated = await db
+    .update(concerts)
+    .set({ headlining_artist_id: artistId })
+    .where(and(eq(concerts.id, concertId), isNull(concerts.headlining_artist_id)))
+    .returning({ id: concerts.id });
+  return { written: updated.length === 1 };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -782,6 +782,21 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/concerts-artist-resolver": {
+      "name": "@wxyc/concerts-artist-resolver",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.53.1",
+        "@wxyc/database": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/flowsheet-artwork-repair": {
       "name": "@wxyc/flowsheet-artwork-repair",
       "version": "1.0.0",
@@ -6576,6 +6591,10 @@
     },
     "node_modules/@wxyc/broken-fk-recovery": {
       "resolved": "jobs/broken-fk-recovery",
+      "link": true
+    },
+    "node_modules/@wxyc/concerts-artist-resolver": {
+      "resolved": "jobs/concerts-artist-resolver",
       "link": true
     },
     "node_modules/@wxyc/database": {

--- a/shared/database/src/index.ts
+++ b/shared/database/src/index.ts
@@ -7,3 +7,4 @@ export * from './cdc-listener.js';
 export * from './library-tiebreak.js';
 export * from './live-activity.js';
 export * from './env-parsers.js';
+export * from './normalize-artist-name.js';

--- a/shared/database/src/migrations/0092_normalize-artist-name.sql
+++ b/shared/database/src/migrations/0092_normalize-artist-name.sql
@@ -28,6 +28,22 @@
 -- makes the function total on NULL input — the indexes below depend on
 -- this to avoid emitting NULL keys for rows whose `artist_name` is NULL.
 --
+-- Separator class: the regex `^the[ \t\n\r\f\v]+` uses an explicit POSIX
+-- whitespace class instead of `\s`. PG ARE `\s` is ASCII-only; JS `\s`
+-- matches the full Unicode whitespace class. The TS twin
+-- (`shared/database/src/normalize-artist-name.ts`) uses the same explicit
+-- class so the contract is byte-identical regardless of regex-engine
+-- differences — NBSP / narrow no-break / U+2028 inputs are NOT stripped
+-- by either side. The venue-events scraper already decodes `&nbsp;` to
+-- ASCII space before this function runs, so the narrow class is fine in
+-- practice.
+--
+-- Collation note: PG's `lower()` is catalog-marked IMMUTABLE but is
+-- actually lc_ctype-dependent — the well-known foot-gun. The functional
+-- indexes below freeze whatever lc_ctype the cluster has at build time.
+-- WXYC RDS runs `en_US.UTF-8`; if that ever changes (or a restore
+-- targets a different lc_ctype), REINDEX both functional indexes.
+--
 -- Index choices:
 --
 --   - `artists_normalized_name_idx` supports the strict-match arm. ~120k
@@ -43,11 +59,15 @@
 --     similarity, not equality on the normalized form; the alias arm
 --     here is an equality predicate, so it needs its own btree.
 --
---   - `concerts_headlining_artist_id_null_idx` is a partial index on
---     `concerts.id WHERE headlining_artist_id IS NULL`. The recurring
---     drain (cron at "15 5 * * *") runs `SELECT ... WHERE
---     headlining_artist_id IS NULL` daily; once most rows are resolved,
---     the partial index keeps that read cheap.
+--   - `concerts_headlining_artist_id_null_idx` is a partial COVERING
+--     index on `concerts (id) INCLUDE (headlining_artist_raw)
+--     WHERE headlining_artist_id IS NULL`. The recurring drain
+--     (cron at "15 5 * * *") runs
+--       SELECT id, headlining_artist_raw FROM concerts
+--       WHERE headlining_artist_id IS NULL ...
+--     daily; the INCLUDE column lets PG serve the loader as an Index
+--     Only Scan and avoid a heap fetch per match. Pattern mirrors
+--     migration 0074's covering partial on flowsheet metadata-attempt.
 --
 -- Concurrency: per `docs/migrations.md`'s `if-not-exists-index` rule,
 -- the runbook for prod is to first build the three indexes out-of-band
@@ -67,14 +87,14 @@
 --     ON "wxyc_schema"."artist_search_alias" (wxyc_schema.normalize_artist_name("variant"));
 --
 --   CREATE INDEX CONCURRENTLY IF NOT EXISTS "concerts_headlining_artist_id_null_idx"
---     ON "wxyc_schema"."concerts" ("id") WHERE "headlining_artist_id" IS NULL;
+--     ON "wxyc_schema"."concerts" ("id") INCLUDE ("headlining_artist_raw") WHERE "headlining_artist_id" IS NULL;
 --
 -- Companion job: jobs/concerts-artist-resolver/ (this PR).
 
 CREATE OR REPLACE FUNCTION wxyc_schema.normalize_artist_name(input text) RETURNS text
   LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
-  SELECT lower(regexp_replace(coalesce(input, ''), '^the\s+', '', 'i'));
+  SELECT lower(regexp_replace(coalesce(input, ''), '^the[ \t\n\r\f\v]+', '', 'i'));
 $$;--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "artists_normalized_name_idx" ON "wxyc_schema"."artists" USING btree (wxyc_schema.normalize_artist_name("artist_name"));--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "artist_search_alias_normalized_variant_idx" ON "wxyc_schema"."artist_search_alias" USING btree (wxyc_schema.normalize_artist_name("variant"));--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "concerts_headlining_artist_id_null_idx" ON "wxyc_schema"."concerts" USING btree ("id") WHERE "headlining_artist_id" IS NULL;
+CREATE INDEX IF NOT EXISTS "concerts_headlining_artist_id_null_idx" ON "wxyc_schema"."concerts" USING btree ("id") INCLUDE ("headlining_artist_raw") WHERE "headlining_artist_id" IS NULL;

--- a/shared/database/src/migrations/0092_normalize-artist-name.sql
+++ b/shared/database/src/migrations/0092_normalize-artist-name.sql
@@ -1,0 +1,80 @@
+-- precondition-guard: not-required (no constraint added; CREATE FUNCTION
+--   and CREATE INDEX IF NOT EXISTS are evaluated against existing data
+--   only insofar as the index build reads every row, and the index
+--   expression is total — `normalize_artist_name(input text)` coerces
+--   NULL to '' via coalesce, so a NULL artist_name cannot raise.
+--   No existing-row invariant is added.)
+-- @no-precondition-needed: no constraint is added. The function is
+--   IMMUTABLE PARALLEL SAFE total over `text` and the indexes are
+--   plain btree on the function's output — neither admits a data
+--   invariant that current rows must satisfy.
+-- @no-analyze-needed: no UPDATE in this migration. The CREATE INDEX
+--   statements implicitly populate index stats during the build; the
+--   underlying table row counts and column stats are unaffected.
+--
+-- 0092 — `normalize_artist_name(text)` SQL function + three functional
+-- indexes supporting the concerts-artist-resolver job (BS#1372).
+--
+-- The resolver matches `concerts.headlining_artist_raw` against
+-- `artists.artist_name` and `artist_search_alias.variant` after applying
+-- a single canonical normalization: lowercase + strip a leading "The ".
+-- That rule lives here as a SQL function (so the resolver's JOIN can
+-- exploit a functional index instead of seq-scanning ~120k artists)
+-- with a TypeScript twin at `shared/database/src/normalize-artist-name.ts`
+-- (so iOS / dj-site / sibling resolvers normalize the same way).
+--
+-- The function is IMMUTABLE PARALLEL SAFE so Postgres can use it inside
+-- functional indexes and parallelize index scans. `coalesce(input, '')`
+-- makes the function total on NULL input — the indexes below depend on
+-- this to avoid emitting NULL keys for rows whose `artist_name` is NULL.
+--
+-- Index choices:
+--
+--   - `artists_normalized_name_idx` supports the strict-match arm. ~120k
+--     artist rows; without the index the resolver would seq-scan per
+--     concert. The index is non-unique because `artists.artist_name`
+--     itself has ~235 duplicate groups (memory: `project_canonical_artists`)
+--     — the resolver's "exactly one canonical match" guard is how those
+--     stay NULL safely.
+--
+--   - `artist_search_alias_normalized_variant_idx` supports the alias
+--     fallback arm. The existing `artist_search_alias_variant_trgm_idx`
+--     (migration 0089) is a GIN trigram index optimized for substring
+--     similarity, not equality on the normalized form; the alias arm
+--     here is an equality predicate, so it needs its own btree.
+--
+--   - `concerts_headlining_artist_id_null_idx` is a partial index on
+--     `concerts.id WHERE headlining_artist_id IS NULL`. The recurring
+--     drain (cron at "15 5 * * *") runs `SELECT ... WHERE
+--     headlining_artist_id IS NULL` daily; once most rows are resolved,
+--     the partial index keeps that read cheap.
+--
+-- Concurrency: per `docs/migrations.md`'s `if-not-exists-index` rule,
+-- the runbook for prod is to first build the three indexes out-of-band
+-- with `CREATE INDEX CONCURRENTLY` so the migration here is a no-op
+-- against the running database. The IF NOT EXISTS clauses below allow
+-- the migration to apply cleanly in either order. The function itself
+-- (CREATE OR REPLACE FUNCTION) is metadata-only and acquires no row-
+-- level lock; safe to ship in-band.
+--
+-- Production runbook for the indexes (each CREATE INDEX CONCURRENTLY
+-- runs outside any transaction; the function ships in the migration):
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS "artists_normalized_name_idx"
+--     ON "wxyc_schema"."artists" (wxyc_schema.normalize_artist_name("artist_name"));
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS "artist_search_alias_normalized_variant_idx"
+--     ON "wxyc_schema"."artist_search_alias" (wxyc_schema.normalize_artist_name("variant"));
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS "concerts_headlining_artist_id_null_idx"
+--     ON "wxyc_schema"."concerts" ("id") WHERE "headlining_artist_id" IS NULL;
+--
+-- Companion job: jobs/concerts-artist-resolver/ (this PR).
+
+CREATE OR REPLACE FUNCTION wxyc_schema.normalize_artist_name(input text) RETURNS text
+  LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+  SELECT lower(regexp_replace(coalesce(input, ''), '^the\s+', '', 'i'));
+$$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "artists_normalized_name_idx" ON "wxyc_schema"."artists" USING btree (wxyc_schema.normalize_artist_name("artist_name"));--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "artist_search_alias_normalized_variant_idx" ON "wxyc_schema"."artist_search_alias" USING btree (wxyc_schema.normalize_artist_name("variant"));--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "concerts_headlining_artist_id_null_idx" ON "wxyc_schema"."concerts" USING btree ("id") WHERE "headlining_artist_id" IS NULL;

--- a/shared/database/src/migrations/meta/0092_snapshot.json
+++ b/shared/database/src/migrations/meta/0092_snapshot.json
@@ -1,0 +1,4639 @@
+{
+  "id": "d1d534ad-2e06-41e4-a375-5e941768e6c9",
+  "prevId": "af212d86-54db-438a-b21f-fe3795b668f8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_play_order_idx": {
+          "name": "flowsheet_play_order_idx",
+          "columns": [
+            {
+              "expression": "\"play_order\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_metadata_attempt_pending_idx": {
+          "name": "flowsheet_metadata_attempt_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false
+        },
+        "flowsheet_metadata_attempt_pending_covering_idx": {
+          "name": "flowsheet_metadata_attempt_pending_covering_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false
+        },
+        "flowsheet_album_id_enriched_idx": {
+          "name": "flowsheet_album_id_enriched_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "columns": [
+            "flowsheet_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "auth_organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "columns": [
+            "label_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "auth_organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "columns": [
+            "album_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "shows_legacy_dj_name_trgm_idx": {
+          "name": "shows_legacy_dj_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"legacy_dj_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "auth_user_dj_name_trgm_idx": {
+          "name": "auth_user_dj_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"dj_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "auth_user_name_trgm_idx": {
+          "name": "auth_user_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "materialized": false,
+      "isExisting": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "materialized": false,
+      "isExisting": false
+    },
+    "wxyc_schema.album_plays": {
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "materialized": true,
+      "isExisting": true
+    }
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -631,6 +631,13 @@
       "when": 1780667256173,
       "tag": "0091_venues-and-concerts",
       "breakpoints": true
+    },
+    {
+      "idx": 92,
+      "version": "7",
+      "when": 1780667256174,
+      "tag": "0092_normalize-artist-name",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -89,5 +89,5 @@
   "0089_artist-search-alias": "267ecc41f1b0a0cc16805cbff13ad865a06bf430ba440b7441b57fdb6977068b",
   "0090_shows-dj-name-override": "bcbfc0a86ec437c1f11246192d67bfbc291e3f1194014d8bcec718f344c8ed6f",
   "0091_venues-and-concerts": "e738de9bdb0ab762c982a6e31f664f88705bc2b7336bbd57a15efe3b250e6e87",
-  "0092_normalize-artist-name": "dc099e7ec336a3d568a188a497fc70dc247776805d1447881fcbf5ba5811e93f"
+  "0092_normalize-artist-name": "57bf7f03733591917917c5a19b9b67d8527a64ccce224cdc3f1102f4a9cca368"
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -88,5 +88,6 @@
   "0088_banned-fingerprints": "fc26aef561df95cfa32e09892440b7a9ba614c1cb648a251708ced5e7419b059",
   "0089_artist-search-alias": "267ecc41f1b0a0cc16805cbff13ad865a06bf430ba440b7441b57fdb6977068b",
   "0090_shows-dj-name-override": "bcbfc0a86ec437c1f11246192d67bfbc291e3f1194014d8bcec718f344c8ed6f",
-  "0091_venues-and-concerts": "e738de9bdb0ab762c982a6e31f664f88705bc2b7336bbd57a15efe3b250e6e87"
+  "0091_venues-and-concerts": "e738de9bdb0ab762c982a6e31f664f88705bc2b7336bbd57a15efe3b250e6e87",
+  "0092_normalize-artist-name": "dc099e7ec336a3d568a188a497fc70dc247776805d1447881fcbf5ba5811e93f"
 }

--- a/shared/database/src/normalize-artist-name.ts
+++ b/shared/database/src/normalize-artist-name.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical artist-name normalization. TypeScript twin of the SQL function
+ * `wxyc_schema.normalize_artist_name(text)` defined in migration 0092
+ * (BS#1372).
+ *
+ * The single source-of-truth rule: lowercase, then strip a leading
+ * "The " prefix (case-insensitive, any unicode whitespace separator).
+ * This is the canonical form the concerts-artist-resolver uses to match
+ * `concerts.headlining_artist_raw` against `artists.artist_name` and
+ * `artist_search_alias.variant`. Any caller that wants to match a name
+ * the same way the resolver does — iOS canonical-id matcher, dj-site
+ * search, a sibling resolver — should normalize via this function (or
+ * the SQL twin) rather than rolling its own rule.
+ *
+ * The SQL function is `IMMUTABLE PARALLEL SAFE` and uses
+ * `coalesce(input, '')` so it is total over `NULL` input; this JS twin
+ * mirrors that by collapsing `null` and `undefined` to `''`. The regex
+ * `^the\s+` matches the SQL form `'^the\s+'` with the `'i'` flag, which
+ * is case-insensitive POSIX regex behaviour in Postgres.
+ *
+ * Drift between this twin and the SQL function surfaces as silent
+ * `headlining_artist_id IS NULL` rows that look like no-match but are
+ * actually mismatch-on-normalization. The unit test at
+ * `tests/unit/database/normalize-artist-name.test.ts` pins the table of
+ * inputs and outputs; the SQL function must change with this file.
+ */
+export const normalizeArtistName = (input: string | null | undefined): string => {
+  const coalesced = input ?? '';
+  return coalesced.replace(/^the\s+/i, '').toLowerCase();
+};

--- a/shared/database/src/normalize-artist-name.ts
+++ b/shared/database/src/normalize-artist-name.ts
@@ -4,19 +4,25 @@
  * (BS#1372).
  *
  * The single source-of-truth rule: lowercase, then strip a leading
- * "The " prefix (case-insensitive, any unicode whitespace separator).
- * This is the canonical form the concerts-artist-resolver uses to match
- * `concerts.headlining_artist_raw` against `artists.artist_name` and
- * `artist_search_alias.variant`. Any caller that wants to match a name
- * the same way the resolver does — iOS canonical-id matcher, dj-site
- * search, a sibling resolver — should normalize via this function (or
- * the SQL twin) rather than rolling its own rule.
+ * "The " prefix (case-insensitive). The separator class is intentionally
+ * narrow — ASCII space, tab, newline, carriage return, form feed,
+ * vertical tab — matching POSIX `[ \t\n\r\f\v]`. Both JS `\s` and PG
+ * `\s` would diverge on Unicode whitespace (NBSP U+00A0, narrow no-break
+ * U+202F, etc.) because PG's POSIX `\s` only matches ASCII whitespace
+ * while JS's `\s` matches the full Unicode whitespace class. We use the
+ * explicit char class on both sides so the twin's contract is
+ * byte-identical regardless of regex-engine differences.
+ *
+ * Upstream scrapers (`jobs/venue-events-scraper/parse.ts`) already
+ * decode `&nbsp;` to ASCII space and `.trim()` raw names, so NBSP
+ * separators don't reach this function in production. A `headlining_
+ * artist_raw` that still carries non-ASCII whitespace (e.g. raw U+00A0
+ * embedded in JSON-LD) won't get its "The " stripped — that's a known
+ * limitation; document upstream rather than expand the class here.
  *
  * The SQL function is `IMMUTABLE PARALLEL SAFE` and uses
  * `coalesce(input, '')` so it is total over `NULL` input; this JS twin
- * mirrors that by collapsing `null` and `undefined` to `''`. The regex
- * `^the\s+` matches the SQL form `'^the\s+'` with the `'i'` flag, which
- * is case-insensitive POSIX regex behaviour in Postgres.
+ * mirrors that by collapsing `null` and `undefined` to `''`.
  *
  * Drift between this twin and the SQL function surfaces as silent
  * `headlining_artist_id IS NULL` rows that look like no-match but are
@@ -26,5 +32,5 @@
  */
 export const normalizeArtistName = (input: string | null | undefined): string => {
   const coalesced = input ?? '';
-  return coalesced.replace(/^the\s+/i, '').toLowerCase();
+  return coalesced.replace(/^the[ \t\n\r\f\v]+/i, '').toLowerCase();
 };

--- a/tests/unit/database/normalize-artist-name.test.ts
+++ b/tests/unit/database/normalize-artist-name.test.ts
@@ -28,10 +28,21 @@ describe('normalizeArtistName', () => {
     ['does NOT strip inner "the"', 'Here Comes The Sun', 'here comes the sun'],
     ['does NOT strip "There"', 'There Will Be Fireworks', 'there will be fireworks'],
     ['does NOT strip "Them"', 'Them Crooked Vultures', 'them crooked vultures'],
+    ['does NOT strip "the" with no separator', 'theBeatles', 'thebeatles'],
     ['preserves trailing whitespace', 'Pavement ', 'pavement '],
     ['handles unicode (Björk)', 'Björk', 'björk'],
     ['handles ampersand', 'Simon & Garfunkel', 'simon & garfunkel'],
     ['handles slash', 'AC/DC', 'ac/dc'],
+    // The separator class is intentionally narrow — POSIX [ \t\n\r\f\v] —
+    // so the JS twin matches the PG ARE `\s` (ASCII-only) byte-for-byte.
+    // These cases pin the LIMITATION as part of the contract: NBSP /
+    // narrow no-break / line/paragraph separators do NOT count as
+    // "The " separators in either engine. The venue-events scraper
+    // converts `&nbsp;` to ASCII space upstream, so this gap is
+    // not reached in production today.
+    ['does NOT strip "The" with NBSP (U+00A0)', 'The Beatles', 'the beatles'],
+    ['does NOT strip "The" with narrow no-break (U+202F)', 'The Beatles', 'the beatles'],
+    ['does NOT strip "The" with line separator (U+2028)', 'The Beatles', 'the beatles'],
   ];
 
   it.each(cases)('%s: %j → %j', (_label, input, expected) => {

--- a/tests/unit/database/normalize-artist-name.test.ts
+++ b/tests/unit/database/normalize-artist-name.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for `normalizeArtistName` (BS#1372 / shared/database/src/normalize-artist-name.ts).
+ *
+ * This TypeScript twin must produce byte-identical output to the SQL
+ * function `wxyc_schema.normalize_artist_name(text)` defined in migration
+ * 0092 — the concerts-artist-resolver compares results across SQL and JS
+ * call sites, and any drift between them surfaces as silent NULL
+ * `headlining_artist_id` values that look like no-match but are actually
+ * mismatch-on-normalization. Each case here is paired with the SQL
+ * function's behavior; if the JS test changes shape, the migration must
+ * change to match.
+ */
+
+import { normalizeArtistName } from '../../../shared/database/src/normalize-artist-name';
+
+describe('normalizeArtistName', () => {
+  const cases: [string, string | null | undefined, string][] = [
+    ['null input', null, ''],
+    ['undefined input', undefined, ''],
+    ['empty string', '', ''],
+    ['plain ascii name', 'Pavement', 'pavement'],
+    ['mixed case', 'JESSICA Pratt', 'jessica pratt'],
+    ['strips leading "The "', 'The Beatles', 'beatles'],
+    ['strips leading "the " (lowercase)', 'the beatles', 'beatles'],
+    ['strips leading "THE " (uppercase)', 'THE BEATLES', 'beatles'],
+    ['strips "The" with multiple spaces', 'The   Beatles', 'beatles'],
+    ['strips "The" with tab', 'The\tBeatles', 'beatles'],
+    ['does NOT strip inner "the"', 'Here Comes The Sun', 'here comes the sun'],
+    ['does NOT strip "There"', 'There Will Be Fireworks', 'there will be fireworks'],
+    ['does NOT strip "Them"', 'Them Crooked Vultures', 'them crooked vultures'],
+    ['preserves trailing whitespace', 'Pavement ', 'pavement '],
+    ['handles unicode (Björk)', 'Björk', 'björk'],
+    ['handles ampersand', 'Simon & Garfunkel', 'simon & garfunkel'],
+    ['handles slash', 'AC/DC', 'ac/dc'],
+  ];
+
+  it.each(cases)('%s: %j → %j', (_label, input, expected) => {
+    expect(normalizeArtistName(input)).toBe(expected);
+  });
+});

--- a/tests/unit/jobs/concerts-artist-resolver/orchestrate.test.ts
+++ b/tests/unit/jobs/concerts-artist-resolver/orchestrate.test.ts
@@ -220,6 +220,63 @@ describe('runResolver', () => {
     expect(result.totals.resolved).toBe(1);
   });
 
+  test('resolver throws → onError invoked with the failing candidate and the underlying error', async () => {
+    const boom = new Error('PG statement timeout');
+    const loadCandidates = makeLoad([{ id: 50, headlining_artist_raw: 'Resolver Throws' }]);
+    const resolve = jest.fn<ResolveFn>().mockRejectedValue(boom);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+    const onError = jest.fn();
+
+    const result = await runResolver({ loadCandidates, resolve, write, onError });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith({ id: 50, headlining_artist_raw: 'Resolver Throws' }, boom);
+    expect(result.totals.error).toBe(1);
+  });
+
+  test('writer throws → error counter; FK stays NULL; loop continues for the next candidate (symmetric with resolver)', async () => {
+    // A transient writer failure (PG outage, FK race against a parallel
+    // artist delete) must not abort the entire batch. The current
+    // candidate stays unresolved (FK NULL) and the next cron run
+    // re-drains it via the idempotent IS-NULL gate.
+    const loadCandidates = makeLoad([
+      { id: 60, headlining_artist_raw: 'Writer Throws' },
+      { id: 61, headlining_artist_raw: 'Pavement' },
+    ]);
+    const resolve = makeResolver({
+      'Writer Throws': { kind: 'strict', artist_id: 9060 },
+      Pavement: { kind: 'strict', artist_id: 9061 },
+    });
+    const write = jest
+      .fn<WriteFn>()
+      .mockRejectedValueOnce(new Error('PG: relation "concerts" did not exist'))
+      .mockResolvedValueOnce({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(result.totals.error).toBe(1);
+    expect(result.totals.resolved).toBe(1);
+    expect(result.totals.resolved_strict).toBe(1);
+  });
+
+  test('writer throws → onError invoked with the failing candidate and the underlying error', async () => {
+    const boom = new Error('FK violation: artist 9070 not found');
+    const loadCandidates = makeLoad([{ id: 70, headlining_artist_raw: 'Writer Throws' }]);
+    const resolve = makeResolver({
+      'Writer Throws': { kind: 'strict', artist_id: 9070 },
+    });
+    const write = jest.fn<WriteFn>().mockRejectedValue(boom);
+    const onError = jest.fn();
+
+    const result = await runResolver({ loadCandidates, resolve, write, onError });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith({ id: 70, headlining_artist_raw: 'Writer Throws' }, boom);
+    expect(result.totals.error).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
   test('writer reports written:false → row was raced (FK already set between SELECT and UPDATE)', async () => {
     // The writer's WHERE clause guards on `headlining_artist_id IS NULL`.
     // A 0-row UPDATE means a concurrent run beat us (the recurring drain

--- a/tests/unit/jobs/concerts-artist-resolver/orchestrate.test.ts
+++ b/tests/unit/jobs/concerts-artist-resolver/orchestrate.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for jobs/concerts-artist-resolver orchestrate.ts (BS#1372).
+ *
+ * The orchestrator is the unit-testable seam: a pure-function loop over
+ * `loadCandidates() → resolve(raw) → write(id, artistId)`. Production
+ * wires the resolver to a Drizzle-typed SELECT that joins `artists` and
+ * `artist_search_alias` after normalization; tests drive the same shape
+ * through an in-memory resolver so every acceptance case from the issue
+ * is exercised without a live database.
+ *
+ * Acceptance cases per BS#1372:
+ *   - strict match (single artist, name matches after normalization)
+ *   - strict match with "The " prefix stripped on one side only
+ *   - alias match (zero strict, single alias hit)
+ *   - strict-wins (strict singleton + alias singleton for a different artist → strict wins)
+ *   - ambiguous strict (>1 artist with same normalized name → NULL, counter)
+ *   - ambiguous alias (>1 distinct artist_id from alias dedup → NULL, counter)
+ *   - no match (FK stays NULL, unmatched counter)
+ *   - NULL `headlining_artist_raw` (row skipped, null_raw_skipped counter)
+ *   - idempotent re-run (second pass over already-resolved rows is a no-op)
+ */
+import { jest } from '@jest/globals';
+
+import {
+  runResolver,
+  type Candidate,
+  type LoadCandidatesFn,
+  type ResolveFn,
+  type ResolveOutcome,
+  type WriteFn,
+} from '../../../../jobs/concerts-artist-resolver/orchestrate';
+
+const makeLoad = (rows: Candidate[]): LoadCandidatesFn => jest.fn<LoadCandidatesFn>().mockResolvedValue(rows);
+
+const makeResolver = (rules: Record<string, ResolveOutcome>): ResolveFn => {
+  const lookup = new Map(Object.entries(rules));
+  return jest
+    .fn<ResolveFn>()
+    .mockImplementation((raw: string) => Promise.resolve(lookup.get(raw) ?? { kind: 'unmatched' }));
+};
+
+describe('runResolver', () => {
+  test('strict match: single artist resolves and writes the FK', async () => {
+    const loadCandidates = makeLoad([{ id: 1, headlining_artist_raw: 'Pavement' }]);
+    const resolve = makeResolver({
+      Pavement: { kind: 'strict', artist_id: 9001 },
+    });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(resolve).toHaveBeenCalledWith('Pavement');
+    expect(write).toHaveBeenCalledWith(1, 9001);
+    expect(result.totals).toMatchObject({
+      scanned: 1,
+      resolved: 1,
+      resolved_strict: 1,
+      resolved_alias: 0,
+      ambiguous: 0,
+      unmatched: 0,
+      null_raw_skipped: 0,
+      error: 0,
+    });
+  });
+
+  test('strict match works even when only one side strips a leading "The "', async () => {
+    // The orchestrator is shape-only: it delegates the actual matching
+    // to the resolver. This test pins that a leading "The " on the raw
+    // value alone is the resolver's contract (the SQL JOIN normalizes
+    // both sides via normalize_artist_name) and the orchestrator does
+    // nothing case-special with it.
+    const loadCandidates = makeLoad([{ id: 2, headlining_artist_raw: 'The Beatles' }]);
+    const resolve = makeResolver({
+      'The Beatles': { kind: 'strict', artist_id: 9002 },
+    });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(write).toHaveBeenCalledWith(2, 9002);
+    expect(result.totals.resolved_strict).toBe(1);
+  });
+
+  test('alias match: zero strict matches + single alias hit writes the FK', async () => {
+    const loadCandidates = makeLoad([{ id: 3, headlining_artist_raw: 'Beck Hansen' }]);
+    const resolve = makeResolver({
+      'Beck Hansen': { kind: 'alias', artist_id: 9003 },
+    });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(write).toHaveBeenCalledWith(3, 9003);
+    expect(result.totals).toMatchObject({
+      resolved: 1,
+      resolved_strict: 0,
+      resolved_alias: 1,
+    });
+  });
+
+  test('strict-wins: strict singleton + alias singleton for a different artist → strict wins', async () => {
+    // The strict-wins rule is enforced at the SELECT level — the
+    // resolver returns the strict outcome and never falls through. The
+    // orchestrator simply trusts the resolver's `kind`. This test makes
+    // it explicit that a strict outcome is what's written when both
+    // could have produced a match.
+    const loadCandidates = makeLoad([{ id: 4, headlining_artist_raw: 'Pavement' }]);
+    const resolve = makeResolver({
+      Pavement: { kind: 'strict', artist_id: 9004 },
+    });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(write).toHaveBeenCalledWith(4, 9004);
+    expect(result.totals.resolved_strict).toBe(1);
+    expect(result.totals.resolved_alias).toBe(0);
+  });
+
+  test('ambiguous strict: >1 canonical artist with the same normalized name → FK stays NULL', async () => {
+    const loadCandidates = makeLoad([{ id: 5, headlining_artist_raw: 'Nirvana' }]);
+    const resolve = makeResolver({
+      Nirvana: { kind: 'ambiguous' },
+    });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals.ambiguous).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('ambiguous alias: >1 distinct artist_id after alias dedup → FK stays NULL', async () => {
+    // The dedup-on-artist_id rule (multiple variants for the same
+    // canonical artist count as one) lives in the SELECT. The
+    // orchestrator only sees the post-dedup outcome — `ambiguous` —
+    // and bumps the same counter as the strict-ambiguous case.
+    const loadCandidates = makeLoad([{ id: 6, headlining_artist_raw: 'Generic Band Name' }]);
+    const resolve = makeResolver({
+      'Generic Band Name': { kind: 'ambiguous' },
+    });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals.ambiguous).toBe(1);
+  });
+
+  test('no match: zero strict, zero alias → FK stays NULL, unmatched counter increments', async () => {
+    const loadCandidates = makeLoad([{ id: 7, headlining_artist_raw: 'A Brand New Band' }]);
+    const resolve = makeResolver({});
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals.unmatched).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('NULL headlining_artist_raw: row skipped, null_raw_skipped counter increments', async () => {
+    // The SELECT predicate filters `headlining_artist_raw IS NOT NULL`,
+    // so production should never hand a NULL raw to the orchestrator —
+    // but the candidate type permits it and the orchestrator handles
+    // it defensively rather than tripping the resolver on bad input.
+    const loadCandidates = makeLoad([{ id: 8, headlining_artist_raw: null }]);
+    const resolve = makeResolver({});
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals.null_raw_skipped).toBe(1);
+    expect(result.totals.scanned).toBe(1);
+  });
+
+  test('idempotent re-run: second pass produces no work when no rows remain unresolved', async () => {
+    // The SELECT predicate `headlining_artist_id IS NULL` is the
+    // idempotency gate — a rerun after a full first pass sees no
+    // candidates and the orchestrator returns the empty-totals shape.
+    const loadCandidates = jest.fn<LoadCandidatesFn>().mockResolvedValue([]);
+    const resolve = jest.fn<ResolveFn>();
+    const write = jest.fn<WriteFn>();
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals).toMatchObject({
+      scanned: 0,
+      resolved: 0,
+      resolved_strict: 0,
+      resolved_alias: 0,
+      ambiguous: 0,
+      unmatched: 0,
+      null_raw_skipped: 0,
+      error: 0,
+    });
+  });
+
+  test('resolver throws → error counter; FK stays NULL; loop continues for the next candidate', async () => {
+    const loadCandidates = makeLoad([
+      { id: 10, headlining_artist_raw: 'Resolver Throws' },
+      { id: 11, headlining_artist_raw: 'Pavement' },
+    ]);
+    const resolve = jest
+      .fn<ResolveFn>()
+      .mockRejectedValueOnce(new Error('PG statement timeout'))
+      .mockResolvedValueOnce({ kind: 'strict', artist_id: 9011 });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith(11, 9011);
+    expect(result.totals.error).toBe(1);
+    expect(result.totals.resolved).toBe(1);
+  });
+
+  test('writer reports written:false → row was raced (FK already set between SELECT and UPDATE)', async () => {
+    // The writer's WHERE clause guards on `headlining_artist_id IS NULL`.
+    // A 0-row UPDATE means a concurrent run beat us (the recurring drain
+    // is idempotent, but two ETL pods could both pick the same row up
+    // mid-scan). Counted separately so the cron dashboard distinguishes
+    // a real write from a no-op.
+    const loadCandidates = makeLoad([{ id: 12, headlining_artist_raw: 'Pavement' }]);
+    const resolve = makeResolver({
+      Pavement: { kind: 'strict', artist_id: 9012 },
+    });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: false });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(result.totals.raced).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('processes a mixed batch of every outcome without leaking state across candidates', async () => {
+    const loadCandidates = makeLoad([
+      { id: 20, headlining_artist_raw: 'Pavement' },
+      { id: 21, headlining_artist_raw: 'The Beatles' },
+      { id: 22, headlining_artist_raw: 'Beck Hansen' },
+      { id: 23, headlining_artist_raw: 'Nirvana' },
+      { id: 24, headlining_artist_raw: 'A Brand New Band' },
+      { id: 25, headlining_artist_raw: null },
+    ]);
+    const resolve = makeResolver({
+      Pavement: { kind: 'strict', artist_id: 100 },
+      'The Beatles': { kind: 'strict', artist_id: 101 },
+      'Beck Hansen': { kind: 'alias', artist_id: 102 },
+      Nirvana: { kind: 'ambiguous' },
+    });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runResolver({ loadCandidates, resolve, write });
+
+    expect(write).toHaveBeenCalledTimes(3);
+    expect(result.totals).toMatchObject({
+      scanned: 6,
+      resolved: 3,
+      resolved_strict: 2,
+      resolved_alias: 1,
+      ambiguous: 1,
+      unmatched: 1,
+      null_raw_skipped: 1,
+      error: 0,
+      raced: 0,
+    });
+  });
+});

--- a/tests/unit/jobs/concerts-artist-resolver/orchestrate.test.ts
+++ b/tests/unit/jobs/concerts-artist-resolver/orchestrate.test.ts
@@ -277,6 +277,63 @@ describe('runResolver', () => {
     expect(result.totals.resolved).toBe(0);
   });
 
+  test('synchronous onError throw does NOT abort the loop; counter still bumps and next candidate proceeds', async () => {
+    // Defensive: if a future caller wires an onError that synchronously
+    // throws (e.g., a misbehaving log adapter), the orchestrator must
+    // contain the throw. The counter is the durable record — bumped
+    // before the sink is called for this exact reason.
+    const loadCandidates = makeLoad([
+      { id: 80, headlining_artist_raw: 'Resolver Throws' },
+      { id: 81, headlining_artist_raw: 'Pavement' },
+    ]);
+    const resolve = jest
+      .fn<ResolveFn>()
+      .mockRejectedValueOnce(new Error('PG statement timeout'))
+      .mockResolvedValueOnce({ kind: 'strict', artist_id: 9081 });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+    const onError = jest.fn(() => {
+      throw new Error('EPIPE: stdout closed');
+    });
+
+    const result = await runResolver({ loadCandidates, resolve, write, onError });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith(81, 9081);
+    expect(result.totals.error).toBe(1);
+    expect(result.totals.resolved).toBe(1);
+  });
+
+  test('async onError rejection does NOT abort the loop or surface as unhandledRejection', async () => {
+    // The OnRowErrorFn type permits Promise<void>; callers like a Slack
+    // or DataDog sink commonly return promises. The orchestrator must
+    // await the call and swallow rejections so a flaky sink doesn't
+    // cascade into batch abort or process-level unhandledRejection.
+    const loadCandidates = makeLoad([
+      { id: 90, headlining_artist_raw: 'Writer Throws' },
+      { id: 91, headlining_artist_raw: 'Pavement' },
+    ]);
+    const resolve = makeResolver({
+      'Writer Throws': { kind: 'strict', artist_id: 9090 },
+      Pavement: { kind: 'strict', artist_id: 9091 },
+    });
+    const write = jest
+      .fn<WriteFn>()
+      .mockRejectedValueOnce(new Error('PG: write failed'))
+      .mockResolvedValueOnce({ written: true });
+    // Return a rejected promise directly so this is genuinely async (per
+    // ESLint @typescript-eslint/require-await: bare `throw` inside an
+    // async arrow gets flagged as a throw-not-reject equivalent).
+    const onError = jest.fn(() => Promise.reject(new Error('slack: 429 rate limited')));
+
+    const result = await runResolver({ loadCandidates, resolve, write, onError });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(result.totals.error).toBe(1);
+    expect(result.totals.resolved).toBe(1);
+    expect(result.totals.resolved_strict).toBe(1);
+  });
+
   test('writer reports written:false → row was raced (FK already set between SELECT and UPDATE)', async () => {
     // The writer's WHERE clause guards on `headlining_artist_id IS NULL`.
     // A 0-row UPDATE means a concurrent run beat us (the recurring drain


### PR DESCRIPTION
Closes #1372.

## Summary

- Adds `jobs/concerts-artist-resolver/`: a daily-cron ETL that resolves `concerts.headlining_artist_raw` to `concerts.headlining_artist_id` by matching against `artists` and `artist_search_alias` after canonical normalization. Local-only — no LML round-trip. Conservative singleton-only writes (ambiguous / unmatched rows leave the FK NULL). Idempotent SELECT/WHERE on `headlining_artist_id IS NULL`. Pure-function resolver + dep-injected orchestrator + Drizzle-typed writer, mirroring `jobs/rotation-release-id-backfill/`.
- Migration 0092 adds `wxyc_schema.normalize_artist_name(text)` (lowercase + strip leading `the\s+`, IMMUTABLE PARALLEL SAFE) and three functional indexes — on `artists`, on `artist_search_alias`, and a partial index on `concerts (id) WHERE headlining_artist_id IS NULL` — so both arms of the resolver and the steady-state cron query stay cheap.
- TypeScript twin at `shared/database/src/normalize-artist-name.ts` so iOS, dj-site, and sibling resolvers share the rule. A parameterized unit test pins the byte-identical I/O contract against the SQL function.
- Cron registered via `\"cron-schedule\": \"15 5 * * *\"` in `jobs/concerts-artist-resolver/package.json`. `.github/workflows/deploy-base.yml` picks it up automatically on merge to main.

## Stacking

Based on `feature/venues-concerts-schema` (#1348), which introduces the `concerts` table. Re-target to `main` once #1348 lands.

## Acceptance (per #1372)

- [x] `jobs/concerts-artist-resolver/` exists with pure-resolver + dep-injected orchestrator + Drizzle-typed writer.
- [x] `normalize_artist_name(text)` SQL function in migration 0092 + TS twin at `shared/database/src/normalize-artist-name.ts`.
- [x] Functional indexes on `artists`, `artist_search_alias`, and partial index on `concerts` in the same migration.
- [x] Resolves all currently-resolvable rows in one pass.
- [x] Stamps `headlining_artist_id` only on unambiguous singleton (strict-wins; alias only on zero strict matches).
- [x] Logs final tally: `resolved / ambiguous / unmatched / error / null_raw_skipped` (also `resolved_strict / resolved_alias / raced / scanned`).
- [x] Daily cron registered via deploy-base (`cron-schedule: \"15 5 * * *\"`).
- [x] Unit tests: strict / strict-after-The / alias / strict-wins / ambiguous strict / ambiguous alias / no-match / NULL raw / idempotent re-run, plus error and raced paths.
- [ ] BS#1368 Path B SQL revised to JOIN on `headlining_artist_id` — follow-up, owned by #1368.

## Test plan

- [x] \`npm run test:unit -- tests/unit/jobs/concerts-artist-resolver tests/unit/database/normalize-artist-name.test.ts\` — 29 passing.
- [x] Full unit suite — 2944 passing, no regressions.
- [x] \`npm run lint:migrations\` — passes.
- [x] \`node scripts/check-bulk-update-analyze.mjs\` — passes.
- [x] \`bash scripts/check-precondition-guards.sh\` — passes.
- [x] \`npm run typecheck\` — clean.
- [x] \`npx prettier --check\` over changed files — clean.
- [ ] Integration tests / CI green.
- [ ] Manual verification on staging once #1348 lands: dry-run resolver against a populated concerts table, confirm counter shape matches expectations.

## Notes

- The strict-wins rule lives in `query.ts` — the alias arm fires only when the strict arm returns zero. This makes the rule explicit in code, lets Postgres short-circuit when strict hits, and pins the orchestrator unit tests' simple state machine.
- The known consequence (~235 duplicate-name groups in `artists` produce permanent ambiguity for colliding concerts) is the intentional trade per the issue: accept low recall in exchange for zero wrong-FK writes.
- Snapshot 0092 is byte-identical to 0091 (apart from `id` / `prevId`) because the migration introduces no Drizzle-tracked schema elements — only a SQL function and three indexes Drizzle doesn't model. Generated via \`drizzle-kit generate --custom\` and renamed from the auto-numbered 0093.