### PR TITLE
chore(ci): filter snapshot Status==available + skip lockfile in shape-report

### DIFF
--- a/.github/workflows/schema-shape-report.yml
+++ b/.github/workflows/schema-shape-report.yml
@@ -45,8 +45,13 @@ jobs:
 
       - name: Install dependencies (postgres only)
         # We don't need the full workspace install for this script — the
-        # `postgres` client is the only runtime dep. Keep it cheap.
-        run: npm install --no-audit --no-fund --no-save postgres@^3.4.9
+        # `postgres` client is the only runtime dep. `--no-package-lock`
+        # skips the lockfile walk so npm doesn't try to resolve the
+        # repo's `@wxyc/shared` entry against GitHub Packages, which
+        # would 401 here (this step intentionally doesn't expose
+        # NPM_TOKEN — observed on PR #1348 / run 27185185058). Keep it
+        # cheap.
+        run: npm install --no-audit --no-fund --no-save --no-package-lock postgres@^3.4.9
 
       - name: Compute diff
         id: diff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -507,10 +507,16 @@ jobs:
         # all torn down in the always-run steps below.
         run: |
           set -euo pipefail
+          # Filter to Status==available so we don't pick up a snapshot
+          # AWS is still mid-creating (RDS's automated-backup window
+          # raced this step on PR #1348 / run 27185185066 → exit 254
+          # 'DBSnapshot must have state available but actually has
+          # creating'). The trailing `[-1]` then gives the most-recent
+          # *available* snapshot.
           SNAPSHOT_ID=$(aws rds describe-db-snapshots \
             --db-instance-identifier "${{ secrets.PROD_DB_ID }}" \
             --snapshot-type automated \
-            --query 'sort_by(DBSnapshots, &SnapshotCreateTime)[-1].DBSnapshotIdentifier' \
+            --query 'sort_by(DBSnapshots[?Status==`available`], &SnapshotCreateTime)[-1].DBSnapshotIdentifier' \
             --output text)
           SANDBOX_ID="dryrun-${{ github.run_id }}"
           echo "SANDBOX_ID=$SANDBOX_ID" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

Closes two recurring CI failures, both infra-only (no code path affected). Surfaced on PR #1348 (runs 27185185066 and 27185185058) but each has likely bitten other PRs too.

### 1. migrate-dryrun: filter snapshot to `Status==available`

The previous JMESPath took the most-recent snapshot regardless of state:

\`\`\`
'sort_by(DBSnapshots, &SnapshotCreateTime)[-1].DBSnapshotIdentifier'
\`\`\`

If CI fires inside RDS's automated-backup window, the picker returns a snapshot in \`creating\` state and \`RestoreDBInstanceFromDBSnapshot\` aborts with **\"DBSnapshot must have state available but actually has creating\"** — the migration is never evaluated.

Adds a \`[?Status=='available']\` filter so only completed snapshots are considered.

### 2. shape-report: \`--no-package-lock\`

The targeted install \`npm install --no-audit --no-fund --no-save postgres@^3.4.9\` would still walk \`package-lock.json\` and try to resolve every workspace dep — including \`@wxyc/shared\` from GitHub Packages, which 401s because the step doesn't expose \`NPM_TOKEN\`.

This step only needs the \`postgres\` client to talk to staging — it doesn't need the workspace lockfile at all. Adding \`--no-package-lock\` skips the walk.

## Test plan

- [ ] CI on this PR re-exercises both workflows. migrate-dryrun runs only on db-init paths (won't trigger here), so the snapshot fix needs to be validated by the next migration-touching PR after merge (or by manually triggering test.yml's job).
- [ ] shape-report runs on all PRs; the \`Install dependencies (postgres only)\` step should pass without 401.