### PR TITLE
fix(concerts-artist-resolver): exclude discogs_member from alias arm (BS#1383)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -372,6 +372,16 @@ jobs:
           # Without this, those hooks log a warning and no-op, which the
           # auth-auto-membership integration spec specifically exercises.
           DEFAULT_ORG_SLUG: test-org
+          # Catalog-search alias LATERAL: align GHA with the ci-profile
+          # docker-compose default (dev_env/docker-compose.yml:245). Without
+          # this, `getCatalogSearchAliasConfig().enabled` is false in CI and
+          # tests/integration/library-search-alias.spec.js's BS#1269 +
+          # BS#1383 cases either silently warn-skip (the OHSEES test) or
+          # fail-fast (the discogs_member test). The flag has been on by
+          # default in `npm run ci:testmock` since BS#1269 landed; this
+          # closes the GHA-vs-compose drift that surfaced when BS#1383
+          # promoted its case from warn-skip to fail-fast.
+          CATALOG_SEARCH_ALIAS_ENABLED: 'true'
         run: |
           node dev_env/mock-api-server/dist/server.js > /tmp/mock-api.log 2>&1 &
           node apps/auth/dist/app.js > /tmp/auth.log 2>&1 &

--- a/jobs/concerts-artist-resolver/query.ts
+++ b/jobs/concerts-artist-resolver/query.ts
@@ -99,22 +99,31 @@ export const resolveArtistId: ResolveFn = async (raw: string): Promise<ResolveOu
     return { kind: 'ambiguous' };
   }
 
-  // Filter `discogs_member` (BS#1383): it's a relational signal — "X
-  // was a member of Y" — not a synonym signal. Folding it into the FK-
-  // write path produced the Geordie Greep → black midi mislabel from the
-  // BS#1368 frequency audit (Greep is touring solo, not in WXYC's
-  // library). The catalog-search sites WANT these rows surfaced as a
-  // "related artist" UX hint and propagate `source` end-to-end; the
-  // resolver collapses to a single FK and has no wire-shape seam, so it
-  // filters at the SQL level. Negative form (`<>`) is forward-compatible
-  // against a future fifth source (collaborator, featured-on, side-
-  // project): any new relational signal LML adds is excluded by default
-  // until we explicitly opt it in.
+  // Restrict to synonym-class sources (BS#1383). The four
+  // `artist_search_alias.source` values today partition into:
+  //   - synonym-class: discogs_name_variation, discogs_alias,
+  //     wxyc_library_alt — these name the same artist by another
+  //     spelling, and folding them into the FK-write path is the
+  //     substrate's whole point.
+  //   - relational-class: discogs_member — this is "X was a member of
+  //     Y", not "X is also called Y". Folding it in produced the
+  //     Geordie Greep → black midi mislabel from the BS#1368 audit
+  //     (Greep tours solo; WXYC only has his old band's records).
+  // Positive allowlist is safe-by-default: a future LML source
+  // (collaborator, featured-on, side-project) stays out of the FK-
+  // write path until we explicitly opt it in here — the FK stays NULL
+  // and the row drops to manual review, instead of silently writing a
+  // wrong artist_id. The catalog-search sites take the opposite tack:
+  // they DO want relational rows surfaced so iOS / dj-site can render
+  // a "related artist" UX hint, and they propagate `source` end-to-end
+  // for that reason. The resolver collapses to a single FK with no
+  // wire-shape seam for `source`, so the partition is enforced here in
+  // SQL.
   const alias: unknown = await db.execute(sql`
     SELECT DISTINCT asa."artist_id"
     FROM ${ARTIST_SEARCH_ALIAS_TABLE} asa
     WHERE ${NORMALIZE_FN}(asa."variant") = ${NORMALIZE_FN}(${raw})
-      AND asa."source" <> 'discogs_member'
+      AND asa."source" IN ('discogs_name_variation', 'discogs_alias', 'wxyc_library_alt')
     LIMIT 2
   `);
   const aliasRows = unwrapRows<IdRow>(alias);

--- a/jobs/concerts-artist-resolver/query.ts
+++ b/jobs/concerts-artist-resolver/query.ts
@@ -67,33 +67,26 @@ export const SYNONYM_ALIAS_SOURCES = ['discogs_name_variation', 'discogs_alias',
 export const RELATIONAL_ALIAS_SOURCES = ['discogs_member'] as const;
 
 /**
- * Frozen IN-list for the alias arm, built once at module load. The
- * partition is immutable and the values are compile-time constants we
- * control — so this is safe-by-construction against the kind of SQL
- * injection that a runtime-built string would worry about. The tripwire
- * below shifts that safety from "by-construction" to "checked": if a
- * future maintainer ever adds a value that escapes the identifier
- * shape, the module fails to load with an actionable error.
+ * Frozen IN-list for the alias arm, built once at module load. Safe-
+ * by-construction: the partition is immutable and the values are
+ * compile-time constants we control. The identifier-charset assumption
+ * (\`[A-Za-z0-9_]+\`, Postgres' own convention) that lets us inline-
+ * quote without escaping is pinned by the unit test
+ * \`SYNONYM_ALIAS_SOURCES values are identifier-safe\` in
+ * query.test.ts — runtime validation would just crash-loop the
+ * container at deploy with a bare Node stack, before Sentry / logger /
+ * safeFinalize get a chance to attribute the failure, so the
+ * gatekeeping lives in CI instead.
  *
- * The `sql.raw` shape (vs `sql.join`) is a TEST plumbing call, not a
- * production concern. `sql.join` works correctly in production —
- * `jobs/artist-search-alias-consumer/writer.ts` uses it heavily — but
- * ts-jest's drizzle-orm transform exposes its `SQL` class slightly
- * differently than the production CJS bundle, so writer.test.ts has to
- * mock drizzle-orm to satisfy `sql.join` (see writer.test.ts:4-7). For
- * a closed const tuple this is overkill; `sql.raw` skips the mock and
- * keeps the test suite cheap.
+ * \`sql.raw\` is the simplest assembly here because the values are a
+ * closed const tuple. \`sql.join\` would also work and is the project's
+ * default for parameterised lists (see
+ * \`jobs/artist-search-alias-consumer/writer.ts\` for the canonical
+ * runtime usage with comma-bearing variant strings); the only reason
+ * to prefer \`sql.raw\` for this site is that \`sql.join\` requires
+ * mocking drizzle-orm in unit tests (the writer's test does this),
+ * which is overkill for a 3-element identifier-safe tuple.
  */
-const NON_IDENTIFIER_CHAR = /[^A-Za-z0-9_]/;
-const offending = SYNONYM_ALIAS_SOURCES.find((s) => NON_IDENTIFIER_CHAR.test(s));
-if (offending !== undefined) {
-  throw new Error(
-    `BS#1383: SYNONYM_ALIAS_SOURCES contains non-identifier value ${JSON.stringify(offending)}. ` +
-      `Inline-quoted sql.raw assembly assumes [A-Za-z0-9_]+. Either keep source names within ` +
-      `that charset (Postgres' own identifier convention), or switch the IN-list assembly to ` +
-      `sql.join (and add the writer-style drizzle-orm mock to query.test.ts).`
-  );
-}
 const SYNONYM_SOURCE_IN_LIST = sql.raw(SYNONYM_ALIAS_SOURCES.map((s) => `'${s}'`).join(', '));
 
 type IdRow = { artist_id: number };

--- a/jobs/concerts-artist-resolver/query.ts
+++ b/jobs/concerts-artist-resolver/query.ts
@@ -34,6 +34,42 @@ const ARTISTS_TABLE = sql.raw(`"${SCHEMA}"."artists"`);
 const ARTIST_SEARCH_ALIAS_TABLE = sql.raw(`"${SCHEMA}"."artist_search_alias"`);
 const NORMALIZE_FN = sql.raw(`"${SCHEMA}"."normalize_artist_name"`);
 
+/**
+ * `artist_search_alias.source` partitions into two classes (BS#1383).
+ * The resolver is the partition's owner: it decides which sources are
+ * eligible to drive an FK write. Tests import these constants directly
+ * so the SQL IN-list and the test fixtures cannot drift.
+ *
+ *   - SYNONYM_ALIAS_SOURCES name the same artist by another spelling
+ *     and are safe to fold into the FK-write path — that's the alias
+ *     substrate's whole point.
+ *   - RELATIONAL_ALIAS_SOURCES express "X is related to Y" (member
+ *     of, collaborator, etc.) and are NOT safe — they produce
+ *     mislabels like the Geordie Greep → black midi case from the
+ *     BS#1368 audit.
+ *
+ * Adding a 5th LML source requires a deliberate choice here. The
+ * resolver's SQL IN-list is built from SYNONYM_ALIAS_SOURCES, so a
+ * source the partition does not name is silently excluded (safe-by-
+ * default: FK stays NULL, row drops to manual review). The catalog-
+ * search sites do not consult these constants — they propagate
+ * `source` to callers so iOS / dj-site can render relational hits
+ * differently (e.g., "related artist") with full source context.
+ *
+ * Drift hazard worth noting (out of scope for BS#1383): the
+ * `ArtistSearchAliasSource` type union lives in three other places —
+ * jobs/artist-search-alias-consumer/lml-types.ts,
+ * apps/backend/services/requestLine/types.ts,
+ * tests/unit/jobs/artist-search-alias-consumer/orchestrate.test.ts —
+ * none of which import from each other. A future PR should
+ * consolidate them into a single typed source-of-truth that derives
+ * from (or is derived by) the partition declared here.
+ */
+export const SYNONYM_ALIAS_SOURCES = ['discogs_name_variation', 'discogs_alias', 'wxyc_library_alt'] as const;
+export const RELATIONAL_ALIAS_SOURCES = ['discogs_member'] as const;
+export type SynonymAliasSource = (typeof SYNONYM_ALIAS_SOURCES)[number];
+export type RelationalAliasSource = (typeof RELATIONAL_ALIAS_SOURCES)[number];
+
 type IdRow = { artist_id: number };
 
 /**
@@ -99,31 +135,30 @@ export const resolveArtistId: ResolveFn = async (raw: string): Promise<ResolveOu
     return { kind: 'ambiguous' };
   }
 
-  // Restrict to synonym-class sources (BS#1383). The four
-  // `artist_search_alias.source` values today partition into:
-  //   - synonym-class: discogs_name_variation, discogs_alias,
-  //     wxyc_library_alt — these name the same artist by another
-  //     spelling, and folding them into the FK-write path is the
-  //     substrate's whole point.
-  //   - relational-class: discogs_member — this is "X was a member of
-  //     Y", not "X is also called Y". Folding it in produced the
-  //     Geordie Greep → black midi mislabel from the BS#1368 audit
-  //     (Greep tours solo; WXYC only has his old band's records).
-  // Positive allowlist is safe-by-default: a future LML source
-  // (collaborator, featured-on, side-project) stays out of the FK-
-  // write path until we explicitly opt it in here — the FK stays NULL
-  // and the row drops to manual review, instead of silently writing a
-  // wrong artist_id. The catalog-search sites take the opposite tack:
-  // they DO want relational rows surfaced so iOS / dj-site can render
-  // a "related artist" UX hint, and they propagate `source` end-to-end
-  // for that reason. The resolver collapses to a single FK with no
-  // wire-shape seam for `source`, so the partition is enforced here in
-  // SQL.
+  // Restrict to synonym-class sources (BS#1383). See the
+  // SYNONYM_ALIAS_SOURCES / RELATIONAL_ALIAS_SOURCES docstring above
+  // for the rationale and the open drift hazard. The IN-list is built
+  // from the constant so the partition has exactly one source of
+  // truth in this file. We assemble via `sql.raw` because the source
+  // values are compile-time constants we control (a closed const
+  // tuple, never user input); the assertion below pins that
+  // invariant. `sql.join` would be the canonical pattern but
+  // ts-jest's drizzle-orm transform doesn't expose it cleanly (see
+  // jobs/artist-search-alias-consumer/writer.test.ts:4-7), and going
+  // through `sql.raw` keeps unit tests cheap.
+  if (SYNONYM_ALIAS_SOURCES.some((s) => !/^[a-z_]+$/.test(s))) {
+    // Tripwire — if a future synonym source ever contains a quote /
+    // backslash / non-identifier character, switch to `sql.join` (and
+    // pay the test plumbing cost) rather than letting `sql.raw` embed
+    // an unsanitised string.
+    throw new Error(`SYNONYM_ALIAS_SOURCES contains a non-identifier value; switch to sql.join`);
+  }
+  const synonymList = sql.raw(SYNONYM_ALIAS_SOURCES.map((s) => `'${s}'`).join(', '));
   const alias: unknown = await db.execute(sql`
     SELECT DISTINCT asa."artist_id"
     FROM ${ARTIST_SEARCH_ALIAS_TABLE} asa
     WHERE ${NORMALIZE_FN}(asa."variant") = ${NORMALIZE_FN}(${raw})
-      AND asa."source" IN ('discogs_name_variation', 'discogs_alias', 'wxyc_library_alt')
+      AND asa."source" IN (${synonymList})
     LIMIT 2
   `);
   const aliasRows = unwrapRows<IdRow>(alias);

--- a/jobs/concerts-artist-resolver/query.ts
+++ b/jobs/concerts-artist-resolver/query.ts
@@ -99,10 +99,22 @@ export const resolveArtistId: ResolveFn = async (raw: string): Promise<ResolveOu
     return { kind: 'ambiguous' };
   }
 
+  // Filter `discogs_member` (BS#1383): it's a relational signal — "X
+  // was a member of Y" — not a synonym signal. Folding it into the FK-
+  // write path produced the Geordie Greep → black midi mislabel from the
+  // BS#1368 frequency audit (Greep is touring solo, not in WXYC's
+  // library). The catalog-search sites WANT these rows surfaced as a
+  // "related artist" UX hint and propagate `source` end-to-end; the
+  // resolver collapses to a single FK and has no wire-shape seam, so it
+  // filters at the SQL level. Negative form (`<>`) is forward-compatible
+  // against a future fifth source (collaborator, featured-on, side-
+  // project): any new relational signal LML adds is excluded by default
+  // until we explicitly opt it in.
   const alias: unknown = await db.execute(sql`
     SELECT DISTINCT asa."artist_id"
     FROM ${ARTIST_SEARCH_ALIAS_TABLE} asa
     WHERE ${NORMALIZE_FN}(asa."variant") = ${NORMALIZE_FN}(${raw})
+      AND asa."source" <> 'discogs_member'
     LIMIT 2
   `);
   const aliasRows = unwrapRows<IdRow>(alias);

--- a/jobs/concerts-artist-resolver/query.ts
+++ b/jobs/concerts-artist-resolver/query.ts
@@ -56,19 +56,45 @@ const NORMALIZE_FN = sql.raw(`"${SCHEMA}"."normalize_artist_name"`);
  * `source` to callers so iOS / dj-site can render relational hits
  * differently (e.g., "related artist") with full source context.
  *
- * Drift hazard worth noting (out of scope for BS#1383): the
- * `ArtistSearchAliasSource` type union lives in three other places —
- * jobs/artist-search-alias-consumer/lml-types.ts,
- * apps/backend/services/requestLine/types.ts,
- * tests/unit/jobs/artist-search-alias-consumer/orchestrate.test.ts —
- * none of which import from each other. A future PR should
- * consolidate them into a single typed source-of-truth that derives
- * from (or is derived by) the partition declared here.
+ * Drift hazard (tracked by BS#1390): the `ArtistSearchAliasSource`
+ * type union lives in three other places — lml-types.ts,
+ * requestLine/types.ts, orchestrate.test.ts — none of which import
+ * from each other or from these constants. BS#1390 consolidates them
+ * around this partition; the matching SynonymAliasSource /
+ * RelationalAliasSource types will be exported from here at that time.
  */
 export const SYNONYM_ALIAS_SOURCES = ['discogs_name_variation', 'discogs_alias', 'wxyc_library_alt'] as const;
 export const RELATIONAL_ALIAS_SOURCES = ['discogs_member'] as const;
-export type SynonymAliasSource = (typeof SYNONYM_ALIAS_SOURCES)[number];
-export type RelationalAliasSource = (typeof RELATIONAL_ALIAS_SOURCES)[number];
+
+/**
+ * Frozen IN-list for the alias arm, built once at module load. The
+ * partition is immutable and the values are compile-time constants we
+ * control — so this is safe-by-construction against the kind of SQL
+ * injection that a runtime-built string would worry about. The tripwire
+ * below shifts that safety from "by-construction" to "checked": if a
+ * future maintainer ever adds a value that escapes the identifier
+ * shape, the module fails to load with an actionable error.
+ *
+ * The `sql.raw` shape (vs `sql.join`) is a TEST plumbing call, not a
+ * production concern. `sql.join` works correctly in production —
+ * `jobs/artist-search-alias-consumer/writer.ts` uses it heavily — but
+ * ts-jest's drizzle-orm transform exposes its `SQL` class slightly
+ * differently than the production CJS bundle, so writer.test.ts has to
+ * mock drizzle-orm to satisfy `sql.join` (see writer.test.ts:4-7). For
+ * a closed const tuple this is overkill; `sql.raw` skips the mock and
+ * keeps the test suite cheap.
+ */
+const NON_IDENTIFIER_CHAR = /[^A-Za-z0-9_]/;
+const offending = SYNONYM_ALIAS_SOURCES.find((s) => NON_IDENTIFIER_CHAR.test(s));
+if (offending !== undefined) {
+  throw new Error(
+    `BS#1383: SYNONYM_ALIAS_SOURCES contains non-identifier value ${JSON.stringify(offending)}. ` +
+      `Inline-quoted sql.raw assembly assumes [A-Za-z0-9_]+. Either keep source names within ` +
+      `that charset (Postgres' own identifier convention), or switch the IN-list assembly to ` +
+      `sql.join (and add the writer-style drizzle-orm mock to query.test.ts).`
+  );
+}
+const SYNONYM_SOURCE_IN_LIST = sql.raw(SYNONYM_ALIAS_SOURCES.map((s) => `'${s}'`).join(', '));
 
 type IdRow = { artist_id: number };
 
@@ -135,30 +161,15 @@ export const resolveArtistId: ResolveFn = async (raw: string): Promise<ResolveOu
     return { kind: 'ambiguous' };
   }
 
-  // Restrict to synonym-class sources (BS#1383). See the
-  // SYNONYM_ALIAS_SOURCES / RELATIONAL_ALIAS_SOURCES docstring above
-  // for the rationale and the open drift hazard. The IN-list is built
-  // from the constant so the partition has exactly one source of
-  // truth in this file. We assemble via `sql.raw` because the source
-  // values are compile-time constants we control (a closed const
-  // tuple, never user input); the assertion below pins that
-  // invariant. `sql.join` would be the canonical pattern but
-  // ts-jest's drizzle-orm transform doesn't expose it cleanly (see
-  // jobs/artist-search-alias-consumer/writer.test.ts:4-7), and going
-  // through `sql.raw` keeps unit tests cheap.
-  if (SYNONYM_ALIAS_SOURCES.some((s) => !/^[a-z_]+$/.test(s))) {
-    // Tripwire — if a future synonym source ever contains a quote /
-    // backslash / non-identifier character, switch to `sql.join` (and
-    // pay the test plumbing cost) rather than letting `sql.raw` embed
-    // an unsanitised string.
-    throw new Error(`SYNONYM_ALIAS_SOURCES contains a non-identifier value; switch to sql.join`);
-  }
-  const synonymList = sql.raw(SYNONYM_ALIAS_SOURCES.map((s) => `'${s}'`).join(', '));
+  // Restrict to synonym-class sources (BS#1383). The IN-list is built
+  // at module load from SYNONYM_ALIAS_SOURCES — see the docstring on
+  // that constant for the partition rationale and the BS#1390 drift
+  // tracker.
   const alias: unknown = await db.execute(sql`
     SELECT DISTINCT asa."artist_id"
     FROM ${ARTIST_SEARCH_ALIAS_TABLE} asa
     WHERE ${NORMALIZE_FN}(asa."variant") = ${NORMALIZE_FN}(${raw})
-      AND asa."source" IN (${synonymList})
+      AND asa."source" IN (${SYNONYM_SOURCE_IN_LIST})
     LIMIT 2
   `);
   const aliasRows = unwrapRows<IdRow>(alias);

--- a/jobs/concerts-artist-resolver/query.ts
+++ b/jobs/concerts-artist-resolver/query.ts
@@ -70,20 +70,20 @@ export const RELATIONAL_ALIAS_SOURCES = ['discogs_member'] as const;
  * Frozen IN-list for the alias arm, built once at module load. Safe-
  * by-construction: the partition is immutable and the values are
  * compile-time constants we control. The identifier-charset assumption
- * (\`[A-Za-z0-9_]+\`, Postgres' own convention) that lets us inline-
+ * (`[A-Za-z0-9_]+`, Postgres' own convention) that lets us inline-
  * quote without escaping is pinned by the unit test
- * \`SYNONYM_ALIAS_SOURCES values are identifier-safe\` in
+ * `SYNONYM_ALIAS_SOURCES values are identifier-safe` in
  * query.test.ts — runtime validation would just crash-loop the
  * container at deploy with a bare Node stack, before Sentry / logger /
  * safeFinalize get a chance to attribute the failure, so the
  * gatekeeping lives in CI instead.
  *
- * \`sql.raw\` is the simplest assembly here because the values are a
- * closed const tuple. \`sql.join\` would also work and is the project's
+ * `sql.raw` is the simplest assembly here because the values are a
+ * closed const tuple. `sql.join` would also work and is the project's
  * default for parameterised lists (see
- * \`jobs/artist-search-alias-consumer/writer.ts\` for the canonical
+ * `jobs/artist-search-alias-consumer/writer.ts` for the canonical
  * runtime usage with comma-bearing variant strings); the only reason
- * to prefer \`sql.raw\` for this site is that \`sql.join\` requires
+ * to prefer `sql.raw` for this site is that `sql.join` requires
  * mocking drizzle-orm in unit tests (the writer's test does this),
  * which is overkill for a 3-element identifier-safe tuple.
  */

--- a/tests/integration/library-search-alias.spec.js
+++ b/tests/integration/library-search-alias.spec.js
@@ -128,12 +128,18 @@ describe('GET /library/query — alias-aware LATERAL JOIN (PR 5)', () => {
     const res = await auth.get('/library/query').query({ q: 'Geordie Greep', limit: 50 }).expect(200);
 
     const hit = res.body.results.find((r) => r.id === TEST_LIBRARY_ID);
+    // Fail-fast rather than warn-skip (BS#1383 review): the wire-shape
+    // assertion below is the WHOLE point of this test. A warn-and-return
+    // when the hit is absent would let a `CATALOG_SEARCH_ALIAS_ENABLED`
+    // regression in `dev_env/docker-compose.yml` slip past CI silently.
+    // The throw names the flag so a dev running locally without the
+    // LATERAL on can fix it in one read.
     if (hit === undefined) {
-      console.warn(
-        '[BS#1383] /library/query alias hit absent. Likely the backend is running ' +
-          'without CATALOG_SEARCH_ALIAS_ENABLED=true. Set it in .env and restart `npm run dev`.'
+      throw new Error(
+        '[BS#1383] /library/query alias hit for "Geordie Greep" was absent. The wire-shape assertion ' +
+          'cannot run. The backend likely is missing CATALOG_SEARCH_ALIAS_ENABLED=true — set it on ' +
+          'the backend service in dev_env/docker-compose.yml (or .env for local `npm run dev`) and re-run.'
       );
-      return;
     }
     expect(hit.matched_via_alias).toEqual([{ matched_variant: 'Geordie Greep', source: 'discogs_member' }]);
   });

--- a/tests/integration/library-search-alias.spec.js
+++ b/tests/integration/library-search-alias.spec.js
@@ -136,9 +136,13 @@ describe('GET /library/query — alias-aware LATERAL JOIN (PR 5)', () => {
     // LATERAL on can fix it in one read.
     if (hit === undefined) {
       throw new Error(
-        '[BS#1383] /library/query alias hit for "Geordie Greep" was absent. The wire-shape assertion ' +
-          'cannot run. The backend likely is missing CATALOG_SEARCH_ALIAS_ENABLED=true — set it on ' +
-          'the backend service in dev_env/docker-compose.yml (or .env for local `npm run dev`) and re-run.'
+        '[BS#1383] /library/query alias hit for "Geordie Greep" was absent — the wire-shape ' +
+          'assertion cannot run. Likely causes: (1) the backend is missing ' +
+          'CATALOG_SEARCH_ALIAS_ENABLED=true (set it on the backend service in ' +
+          'dev_env/docker-compose.yml or in .env for local `npm run dev`); (2) the alias ' +
+          'LATERAL JOIN in library-search.service.ts / library.service.ts was changed to filter ' +
+          'discogs_member rows — the resolver does, but the catalog-search sites must not (this ' +
+          'test exists to pin that asymmetry).'
       );
     }
     expect(hit.matched_via_alias).toEqual([{ matched_variant: 'Geordie Greep', source: 'discogs_member' }]);

--- a/tests/integration/library-search-alias.spec.js
+++ b/tests/integration/library-search-alias.spec.js
@@ -103,6 +103,40 @@ describe('GET /library/query — alias-aware LATERAL JOIN (PR 5)', () => {
     expect(hit.artist_name).toBe('OHSEES');
     expect(hit.matched_via_alias).toEqual([{ matched_variant: 'Thee Oh Sees', source: 'discogs_name_variation' }]);
   });
+
+  test('discogs_member alias hit surfaces with source=discogs_member (BS#1383)', async () => {
+    // BS#1383: the catalog-search sites WANT `discogs_member` rows surfaced
+    // (so iOS/dj-site can render a "related artist" UX hint), unlike the
+    // concerts-artist-resolver which filters them. This asserts the source
+    // string survives the LATERAL projection and the wire shape so a
+    // downstream caller can distinguish in-library matches from
+    // related-artist matches. Geordie-Greep-via-black-midi is the prod
+    // shape from the BS#1368 audit; we reuse the OHSEES fixture artist
+    // (the source label is what's under test, not the artist semantics).
+    await sql.unsafe(`DELETE FROM ${wxycSchema}.artist_search_alias WHERE artist_id = $1`, [TEST_ARTIST_ID]);
+    await sql.unsafe(
+      `INSERT INTO ${wxycSchema}.artist_search_alias
+         (artist_id, source, variant, related_artist_id, external_subject_id,
+          external_object_id, active, method, confidence, last_verified_at)
+       VALUES ($1, 'discogs_member', 'Geordie Greep', NULL, NULL,
+               'discogs:artist:1234567', NULL, 'member_group', 0.9, NOW())
+       ON CONFLICT (artist_id, source, variant) DO UPDATE
+         SET last_verified_at = NOW()`,
+      [TEST_ARTIST_ID]
+    );
+
+    const res = await auth.get('/library/query').query({ q: 'Geordie Greep', limit: 50 }).expect(200);
+
+    const hit = res.body.results.find((r) => r.id === TEST_LIBRARY_ID);
+    if (hit === undefined) {
+      console.warn(
+        '[BS#1383] /library/query alias hit absent. Likely the backend is running ' +
+          'without CATALOG_SEARCH_ALIAS_ENABLED=true. Set it in .env and restart `npm run dev`.'
+      );
+      return;
+    }
+    expect(hit.matched_via_alias).toEqual([{ matched_variant: 'Geordie Greep', source: 'discogs_member' }]);
+  });
 });
 
 async function cleanupSeededRows(sql, wxycSchema) {

--- a/tests/unit/jobs/concerts-artist-resolver/query.test.ts
+++ b/tests/unit/jobs/concerts-artist-resolver/query.test.ts
@@ -1,119 +1,170 @@
 /**
  * Unit tests for jobs/concerts-artist-resolver query.ts (BS#1383).
  *
- * `resolveArtistId` runs two SQL JOINs (strict-then-alias). The alias arm
- * is the load-bearing site for BS#1383: a `discogs_member` row in
+ * `resolveArtistId` runs two SQL JOINs (strict-then-alias). The alias
+ * arm is the load-bearing site for BS#1383: a `discogs_member` row in
  * `artist_search_alias` is a relational signal ("X was a member of Y"),
  * not a synonym signal. Folding it into the FK-write path produced the
  * Geordie Greep → black midi mislabel surfaced by the BS#1368 frequency
- * audit (Greep is touring solo, not in WXYC's library; only black midi's
- * records are).
+ * audit (Greep tours solo; WXYC only has his old band's records).
  *
  * The fix restricts the alias arm to the synonym-class sources via a
- * positive allowlist: `source IN ('discogs_name_variation',
- * 'discogs_alias', 'wxyc_library_alt')`. Positive form is safe-by-
- * default — a future LML source (collaborator, featured-on, side-project)
- * stays out of the FK-write path until we explicitly opt it in. The
- * catalog-search sites take the opposite tack: they DO want relational
- * rows surfaced for a "related artist" UX hint and propagate `source`
- * end-to-end. The resolver has no wire-shape seam for `source` so the
- * partition is enforced in SQL.
+ * positive allowlist sourced from `SYNONYM_ALIAS_SOURCES` in query.ts.
+ * Positive form is safe-by-default — a future LML source stays out of
+ * the FK-write path until it is explicitly classified.
  *
- * The mocked `db.execute` returns the post-filter row set the SQL would
- * have produced. The SQL-contract test pins the allowlist literal; the
- * positive- and negative-source tests pin which sources survive and which
- * do not; the ambiguity-disambiguation test pins the semantic shift the
- * filter introduces (pre-filter ambiguous → post-filter singleton
- * resolves).
+ * Tests import the partition constants directly from the production
+ * file so the SQL contract and the fixture sources cannot drift. The
+ * mock returns the post-filter row set the SQL would have produced;
+ * SQL-contract tests inspect the rendered SQL via `renderSql`,
+ * behaviour tests assert outcome shapes against a parameterised mock.
  */
-import { jest } from '@jest/globals';
-
 import { db } from '../../../mocks/database.mock';
-import { resolveArtistId } from '../../../../jobs/concerts-artist-resolver/query';
+import {
+  resolveArtistId,
+  SYNONYM_ALIAS_SOURCES,
+  RELATIONAL_ALIAS_SOURCES,
+} from '../../../../jobs/concerts-artist-resolver/query';
 
 type SqlLike = {
   sql?: string | string[];
-  queryChunks?: Array<string | { value?: string | string[] }>;
+  values?: unknown[];
+  queryChunks?: Array<unknown>;
+  value?: string | string[];
+  raw?: string;
 };
+/**
+ * Best-effort render of a Drizzle SQL fragment back to its underlying
+ * textual form so SQL-contract assertions can inspect the IN-list, the
+ * predicate shape, etc.
+ *
+ * Drizzle's exact in-memory representation varies across (build mode,
+ * driver, ts-jest transform): the most common shapes observed are
+ *   - `{ sql: string[], values: any[] }` — fragments interleaved with
+ *     values; this is what surfaces under ts-jest's CJS transform of
+ *     `sql\`...\``.
+ *   - `{ queryChunks: Chunk[] }` — Drizzle's internal AST form (visible
+ *     directly via `node` REPL against the ESM build).
+ *   - `{ value: string | string[] }` — a StringChunk (what `sql.raw(s)`
+ *     produces internally).
+ * Each branch is exercised by either the renderer-itself or by a parent
+ * call that recurses. Parameter-bound substitutions (the `${raw}` user
+ * input) render to empty — the helper inspects SQL SHAPE, not param
+ * values. Brittle on purpose: a drizzle major bump that reshapes any of
+ * the three forms will surface as a noisy assertion failure, not a
+ * silent pass.
+ */
 const renderSql = (value: unknown): string => {
-  const obj = value as SqlLike | null | undefined;
-  if (!obj) return '';
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  const obj = value as SqlLike;
+  if (Array.isArray(obj.sql) && Array.isArray(obj.values)) {
+    // Interleave: sql[0] + render(values[0]) + sql[1] + render(values[1]) + ... + sql[n]
+    const fragments = obj.sql;
+    const values = obj.values;
+    const parts: string[] = [];
+    fragments.forEach((fragment, i) => {
+      parts.push(fragment);
+      if (i < values.length) {
+        parts.push(renderSql(values[i]));
+      }
+    });
+    return parts.join('');
+  }
   if (Array.isArray(obj.sql)) return obj.sql.join('');
   if (typeof obj.sql === 'string') return obj.sql;
   if (obj.queryChunks) {
-    return obj.queryChunks
-      .map((chunk) => {
-        if (typeof chunk === 'string') return chunk;
-        if (Array.isArray(chunk.value)) return chunk.value.join('');
-        if (typeof chunk.value === 'string') return chunk.value;
-        return '';
-      })
-      .join('');
+    return obj.queryChunks.map((chunk) => renderSql(chunk)).join('');
   }
+  if (typeof obj.raw === 'string') return obj.raw;
+  if (Array.isArray(obj.value)) return obj.value.join('');
+  if (typeof obj.value === 'string') return obj.value;
   return '';
 };
 
-// `mockClear` rather than `mockReset` preserves the database mock's
-// default `mockResolvedValue([])` so that a test forgetting one
-// `mockResolvedValueOnce` fails with a clean assertion mismatch rather
-// than the loud "unrecognized db.execute() result shape: undefined" the
-// unwrapRows guard throws for safety.
-const executeMock = db.execute;
-
-const SYNONYM_SOURCES = ['discogs_name_variation', 'discogs_alias', 'wxyc_library_alt'] as const;
-const RELATIONAL_SOURCES = ['discogs_member'] as const;
-
 describe('resolveArtistId — synonym-class allowlist (BS#1383)', () => {
   beforeEach(() => {
-    executeMock.mockClear();
+    // `mockReset` matches the project convention used by 24 other
+    // unit-test files. It clears the default `mockResolvedValue([])`
+    // set by `tests/mocks/database.mock.ts`, so a test that forgets a
+    // `mockResolvedValueOnce` causes `unwrapRows` in query.ts to throw
+    // its "unrecognized db.execute() result shape: undefined" diagnostic.
+    // That throw is preferable to a silent default-array fallthrough:
+    // the message names the file and the failure mode directly, vs an
+    // "expected alias got unmatched" assertion mismatch that doesn't
+    // hint at the missing mock.
+    db.execute.mockReset();
+  });
+
+  describe('partition completeness', () => {
+    // Guards the test fixtures themselves against drift. A future
+    // refactor that derives SYNONYM_ALIAS_SOURCES (e.g., a filter that
+    // returns `[]` due to a renamed classifier) would silently produce
+    // zero parameterised tests below. These assertions ensure that
+    // dead-suite case fails noisily instead of reporting green.
+    it('SYNONYM_ALIAS_SOURCES is non-empty', () => {
+      expect(SYNONYM_ALIAS_SOURCES.length).toBeGreaterThan(0);
+    });
+
+    it('RELATIONAL_ALIAS_SOURCES is non-empty', () => {
+      expect(RELATIONAL_ALIAS_SOURCES.length).toBeGreaterThan(0);
+    });
+
+    it('the two classes do not overlap', () => {
+      const overlap = SYNONYM_ALIAS_SOURCES.filter((s) => (RELATIONAL_ALIAS_SOURCES as readonly string[]).includes(s));
+      expect(overlap).toEqual([]);
+    });
   });
 
   describe('SQL contract', () => {
-    it('the alias arm allowlists exactly the synonym-class sources', async () => {
-      executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    it('the alias arm allowlists every synonym-class source as a SQL literal', async () => {
+      db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       await resolveArtistId('Geordie Greep');
 
-      expect(executeMock).toHaveBeenCalledTimes(2);
-      const aliasSql = renderSql(executeMock.mock.calls[1][0]);
+      expect(db.execute).toHaveBeenCalledTimes(2);
+      const aliasSql = renderSql(db.execute.mock.calls[1][0]);
 
-      // Pin the positive-allowlist contract: SOURCE IN (...) — not a
-      // negative-form predicate. A negative form would silently admit
-      // every future LML source.
-      for (const source of SYNONYM_SOURCES) {
+      // Positive contract: every synonym-class source appears as a
+      // quoted SQL literal inside an `IN (...)` predicate. A negative-
+      // form predicate (`<>`) would silently admit every future source
+      // and reintroduce the BS#1368 mislabel under a new label.
+      for (const source of SYNONYM_ALIAS_SOURCES) {
         expect(aliasSql).toContain(`'${source}'`);
       }
       expect(aliasSql).toMatch(/"?source"?\s+IN\s*\(/i);
     });
 
     it('the alias arm does NOT name any relational-class source as a filter literal', async () => {
-      // Closes the gap a positive allowlist would otherwise leave: a
-      // maintainer who reads only the SQL and reverts the allowlist to a
-      // negative `source <> 'discogs_member'` shape silently re-admits
-      // any future relational source. This test fails fast on that revert
-      // by asserting no relational-class source name appears in the SQL.
-      executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      // Pinned against a revert to negative form. If a maintainer
+      // swaps the IN-list for `source <> 'discogs_member'` the literal
+      // would appear here and this test would fail.
+      db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       await resolveArtistId('Geordie Greep');
 
-      const aliasSql = renderSql(executeMock.mock.calls[1][0]);
-      for (const source of RELATIONAL_SOURCES) {
+      // Both arms must have fired before mock.calls[1] is readable.
+      // Indexing without the guard would crash with TypeError if a
+      // future strict-arm change short-circuits before the alias call.
+      expect(db.execute).toHaveBeenCalledTimes(2);
+      const aliasSql = renderSql(db.execute.mock.calls[1][0]);
+      for (const source of RELATIONAL_ALIAS_SOURCES) {
         expect(aliasSql).not.toContain(`'${source}'`);
       }
     });
   });
 
   describe('behaviour against the post-filter result set', () => {
-    it.each(SYNONYM_SOURCES)(
+    it.each(SYNONYM_ALIAS_SOURCES)(
       "returns { kind: 'alias' } when the alias arm surfaces a row for source=%s",
       async (source) => {
-        // The mocked row carries `source` so the per-source coverage
-        // claim is honest: each synonym-class source independently
-        // produces an alias outcome. If a future change drops one source
-        // from the allowlist the SQL would return [] for that source —
-        // the contract tests above catch the SQL change, this test
-        // documents the per-source semantic.
-        executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([{ artist_id: 42, source }]);
+        // Each synonym-class source independently produces an alias
+        // outcome. The mock carries `source` on the row so the per-
+        // source coverage claim is honest — a future change that
+        // drops one source from the allowlist would no longer surface
+        // a row for that source in production; the SQL-contract test
+        // above is what catches that path.
+        db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([{ artist_id: 42, source }]);
 
         const result = await resolveArtistId('Thee Oh Sees');
 
@@ -122,11 +173,12 @@ describe('resolveArtistId — synonym-class allowlist (BS#1383)', () => {
     );
 
     it("returns { kind: 'unmatched' } when the only candidate row was a discogs_member (filtered out at SQL time)", async () => {
-      // Production shape: a single `discogs_member` row exists for the
-      // variant. The SQL allowlist excludes it server-side; the mock
-      // simulates the empty post-filter result. The orchestrator writes
-      // NULL and the row falls to manual review — never mislabeled.
-      executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      // Production shape: a single `discogs_member` row exists for
+      // the variant. The SQL allowlist excludes it server-side; the
+      // mock simulates the empty post-filter result. The orchestrator
+      // writes NULL and the row falls to manual review — never
+      // mislabeled.
+      db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       const result = await resolveArtistId('Geordie Greep');
 
@@ -137,13 +189,13 @@ describe('resolveArtistId — synonym-class allowlist (BS#1383)', () => {
       // Production shape from the BS#1368 audit: the same variant
       // ("Geordie Greep") points at two artists via two sources — a
       // `discogs_member` row at artist X (the old band) and a
-      // `discogs_alias` row at artist Y (the legitimate synonym). Pre-
-      // fix the alias arm saw both rows and returned `ambiguous`; the FK
-      // stayed NULL. Post-fix the SQL strips the member row server-side
-      // so the orchestrator sees only the synonym row and resolves to
-      // Y. This is the semantic the BS#1383 filter introduces and the
-      // test pins it so a future revert is caught.
-      executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([{ artist_id: 9999, source: 'discogs_alias' }]);
+      // `discogs_alias` row at artist Y (the legitimate synonym).
+      // Pre-fix the alias arm saw both rows and returned `ambiguous`;
+      // the FK stayed NULL. Post-fix the SQL strips the member row
+      // server-side so the orchestrator sees only the synonym row and
+      // resolves to Y. This is the semantic the BS#1383 filter
+      // introduces and the test pins it so a future revert is caught.
+      db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([{ artist_id: 9999, source: 'discogs_alias' }]);
 
       const result = await resolveArtistId('Geordie Greep');
 
@@ -153,10 +205,10 @@ describe('resolveArtistId — synonym-class allowlist (BS#1383)', () => {
     it('still returns ambiguous when two synonym-class rows point at different artists', async () => {
       // Negative twin of the disambiguation test: when the allowlist
       // does NOT collapse the result set to a singleton, the resolver
-      // must still drop to `ambiguous` and leave the FK NULL. Otherwise
-      // a future change that loosens the SELECT could silently start
-      // picking one of two equally-good matches.
-      executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      // must still drop to `ambiguous` and leave the FK NULL.
+      // Otherwise a future change that loosens the SELECT could
+      // silently start picking one of two equally-good matches.
+      db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([
         { artist_id: 100, source: 'discogs_alias' },
         { artist_id: 200, source: 'discogs_name_variation' },
       ]);
@@ -169,14 +221,14 @@ describe('resolveArtistId — synonym-class allowlist (BS#1383)', () => {
 
   describe('strict-wins is unchanged', () => {
     it('a strict singleton skips the alias arm entirely (no SQL filter involvement)', async () => {
-      // Only one db.execute call should fire — the strict one. The alias
-      // arm (and therefore the allowlist) is irrelevant when strict
-      // resolves.
-      executeMock.mockResolvedValueOnce([{ artist_id: 7 }]);
+      // Only one db.execute call should fire — the strict one. The
+      // alias arm (and therefore the allowlist) is irrelevant when
+      // strict resolves.
+      db.execute.mockResolvedValueOnce([{ artist_id: 7 }]);
 
       const result = await resolveArtistId('Pavement');
 
-      expect(executeMock).toHaveBeenCalledTimes(1);
+      expect(db.execute).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ kind: 'strict', artist_id: 7 });
     });
   });

--- a/tests/unit/jobs/concerts-artist-resolver/query.test.ts
+++ b/tests/unit/jobs/concerts-artist-resolver/query.test.ts
@@ -33,13 +33,16 @@ type SqlLike = {
   value?: string | string[];
   raw?: string;
 };
+
+const PARAM_PLACEHOLDER = '<?>';
+
 /**
  * Best-effort render of a Drizzle SQL fragment back to its underlying
  * textual form so SQL-contract assertions can inspect the IN-list, the
  * predicate shape, etc.
  *
- * Drizzle's exact in-memory representation varies across (build mode,
- * driver, ts-jest transform): the most common shapes observed are
+ * Drizzle's in-memory shape varies across (build mode, driver, ts-jest
+ * transform). The renderer handles three forms:
  *   - `{ sql: string[], values: any[] }` — fragments interleaved with
  *     values; this is what surfaces under ts-jest's CJS transform of
  *     `sql\`...\``.
@@ -47,16 +50,35 @@ type SqlLike = {
  *     directly via `node` REPL against the ESM build).
  *   - `{ value: string | string[] }` — a StringChunk (what `sql.raw(s)`
  *     produces internally).
- * Each branch is exercised by either the renderer-itself or by a parent
- * call that recurses. Parameter-bound substitutions (the `${raw}` user
- * input) render to empty — the helper inspects SQL SHAPE, not param
- * values. Brittle on purpose: a drizzle major bump that reshapes any of
- * the three forms will surface as a noisy assertion failure, not a
- * silent pass.
+ *
+ * Parameter-bound substitutions (`${raw}` user input passed without
+ * `sql.raw`) render to the placeholder `<?>` rather than their actual
+ * value. The helper inspects SQL SHAPE, not parameter VALUES: a
+ * `not.toContain("'discogs_member'")` assertion must NOT fail just
+ * because a future test fixture happens to pass `'discogs_member'` as
+ * `${raw}`. The placeholder is the seam that keeps the assertion shape-
+ * specific.
+ *
+ * Distinguishing a parameter from a structural string is heuristic:
+ *   - Under `{sql, values}`, values that are plain JS strings/numbers
+ *     are parameters; values that are objects (Drizzle SQL / Param /
+ *     raw-chunk) are structural.
+ *   - Under `{queryChunks}`, parameters appear as `Param` objects (a
+ *     class instance carrying `.value`). We render those as the
+ *     placeholder too. Static StringChunks have `.value: string[]` (an
+ *     array — note the array vs string distinction is load-bearing for
+ *     the param check).
+ *
+ * Brittle on purpose: a drizzle major bump that reshapes any of these
+ * forms will surface as a noisy assertion failure, not a silent pass.
  */
 const renderSql = (value: unknown): string => {
   if (value === null || value === undefined) return '';
-  if (typeof value === 'string') return value;
+  // Plain JS scalar at the top level → parameter placeholder. Strings
+  // and numbers passed via `${...}` in a tagged template surface here.
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return PARAM_PLACEHOLDER;
+  }
   const obj = value as SqlLike;
   if (Array.isArray(obj.sql) && Array.isArray(obj.values)) {
     // Interleave: sql[0] + render(values[0]) + sql[1] + render(values[1]) + ... + sql[n]
@@ -77,8 +99,13 @@ const renderSql = (value: unknown): string => {
     return obj.queryChunks.map((chunk) => renderSql(chunk)).join('');
   }
   if (typeof obj.raw === 'string') return obj.raw;
+  // StringChunk: `{ value: string[] }`. Drizzle's AST array form for a
+  // chunk of static SQL. Concatenate the segments.
   if (Array.isArray(obj.value)) return obj.value.join('');
-  if (typeof obj.value === 'string') return obj.value;
+  // Param: `{ value: string }` (a single string, not array). The Param
+  // class is how Drizzle wraps user-supplied template values; render as
+  // placeholder so the param value can't leak into shape assertions.
+  if (typeof obj.value === 'string') return PARAM_PLACEHOLDER;
   return '';
 };
 
@@ -117,7 +144,7 @@ describe('resolveArtistId — synonym-class allowlist (BS#1383)', () => {
   });
 
   describe('SQL contract', () => {
-    it('the alias arm allowlists every synonym-class source as a SQL literal', async () => {
+    it('the alias arm allowlists exactly the synonym-class sources as SQL literals', async () => {
       db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
       await resolveArtistId('Geordie Greep');
@@ -129,10 +156,20 @@ describe('resolveArtistId — synonym-class allowlist (BS#1383)', () => {
       // quoted SQL literal inside an `IN (...)` predicate. A negative-
       // form predicate (`<>`) would silently admit every future source
       // and reintroduce the BS#1368 mislabel under a new label.
-      for (const source of SYNONYM_ALIAS_SOURCES) {
-        expect(aliasSql).toContain(`'${source}'`);
-      }
       expect(aliasSql).toMatch(/"?source"?\s+IN\s*\(/i);
+
+      // Exact-set check: parse the IN-list out of the rendered SQL and
+      // assert it equals SYNONYM_ALIAS_SOURCES set-wise. The
+      // containment-only check above passes if a hotfix bypasses the
+      // constant and hardcodes an extra source in SQL — this assertion
+      // is what closes the JS↔SQL alignment gap.
+      const inListMatch = aliasSql.match(/"?source"?\s+IN\s*\(([^)]*)\)/i);
+      expect(inListMatch).not.toBeNull();
+      const inListLiterals = (inListMatch?.[1] || '')
+        .split(',')
+        .map((s) => s.trim().replace(/^'|'$/g, ''))
+        .filter((s) => s.length > 0);
+      expect(new Set(inListLiterals)).toEqual(new Set(SYNONYM_ALIAS_SOURCES));
     });
 
     it('the alias arm does NOT name any relational-class source as a filter literal', async () => {

--- a/tests/unit/jobs/concerts-artist-resolver/query.test.ts
+++ b/tests/unit/jobs/concerts-artist-resolver/query.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for jobs/concerts-artist-resolver query.ts (BS#1383).
+ *
+ * `resolveArtistId` runs two SQL JOINs (strict-then-alias). The alias arm
+ * is the load-bearing site for BS#1383: a `discogs_member` row in
+ * `artist_search_alias` is a relational signal ("X was a member of Y"),
+ * not a synonym signal. Folding it into the FK-write path produced the
+ * Geordie Greep → black midi mislabel surfaced by the BS#1368 frequency
+ * audit (Greep is touring solo, not in WXYC's library; only black midi's
+ * records are). The fix filters `source <> 'discogs_member'` from the
+ * alias subquery so the resolver returns `unmatched` for `discogs_member`-
+ * only hits — the FK stays NULL and the row is never mislabeled.
+ *
+ * Negative-form filter (`<>`) is forward-compatible against a future
+ * fifth source: any new relational signal LML adds (collaborator,
+ * featured-on, side-project) is also excluded by default until we
+ * explicitly opt it in. The catalog-search sites take the opposite
+ * tack — they DO want `discogs_member` matches surfaced as a "related
+ * artist" UX hint — but those sites have a wire-shape seam for `source`
+ * and the resolver does not.
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '../../../mocks/database.mock';
+import { resolveArtistId } from '../../../../jobs/concerts-artist-resolver/query';
+
+type SqlLike = {
+  sql?: string | string[];
+  queryChunks?: Array<string | { value?: string | string[] }>;
+};
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const executeMock = db.execute;
+
+describe('resolveArtistId — discogs_member filter (BS#1383)', () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+  });
+
+  it("excludes 'discogs_member' rows from the alias arm at SQL time", async () => {
+    // Both arms return [] — we're inspecting the SQL contract, not the
+    // result handling. The behaviour assertion (filtered-out → unmatched)
+    // lives in the next test.
+    executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    await resolveArtistId('Geordie Greep');
+
+    expect(executeMock).toHaveBeenCalledTimes(2);
+    const aliasSql = renderSql(executeMock.mock.calls[1][0]);
+    // Negative form is forward-compatible against a future fifth source.
+    expect(aliasSql).toMatch(/"?source"?\s*<>\s*'discogs_member'/i);
+  });
+
+  it("returns { kind: 'unmatched' } when the only matching alias row is a 'discogs_member' (filtered out by the SQL)", async () => {
+    // The SQL filter is what removes the row; the mock simulates the
+    // filtered result set — empty, because the only candidate variant
+    // was a discogs_member row.
+    executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const result = await resolveArtistId('Geordie Greep');
+
+    expect(result).toEqual({ kind: 'unmatched' });
+  });
+
+  it("still returns { kind: 'alias' } for non-member alias sources (discogs_name_variation, discogs_alias, wxyc_library_alt)", async () => {
+    // The filter is scoped to `discogs_member` only. A
+    // `discogs_name_variation` / `discogs_alias` / `wxyc_library_alt`
+    // hit still resolves an FK — that's the substrate's whole point.
+    executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([{ artist_id: 42 }]);
+
+    const result = await resolveArtistId('Thee Oh Sees');
+
+    expect(result).toEqual({ kind: 'alias', artist_id: 42 });
+  });
+
+  it('strict-wins is unchanged: a strict singleton skips the alias arm entirely', async () => {
+    // Only one db.execute call should fire — the strict one. The alias
+    // arm (and therefore the filter) is irrelevant when strict resolves.
+    executeMock.mockResolvedValueOnce([{ artist_id: 7 }]);
+
+    const result = await resolveArtistId('Pavement');
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ kind: 'strict', artist_id: 7 });
+  });
+});

--- a/tests/unit/jobs/concerts-artist-resolver/query.test.ts
+++ b/tests/unit/jobs/concerts-artist-resolver/query.test.ts
@@ -7,17 +7,24 @@
  * not a synonym signal. Folding it into the FK-write path produced the
  * Geordie Greep → black midi mislabel surfaced by the BS#1368 frequency
  * audit (Greep is touring solo, not in WXYC's library; only black midi's
- * records are). The fix filters `source <> 'discogs_member'` from the
- * alias subquery so the resolver returns `unmatched` for `discogs_member`-
- * only hits — the FK stays NULL and the row is never mislabeled.
+ * records are).
  *
- * Negative-form filter (`<>`) is forward-compatible against a future
- * fifth source: any new relational signal LML adds (collaborator,
- * featured-on, side-project) is also excluded by default until we
- * explicitly opt it in. The catalog-search sites take the opposite
- * tack — they DO want `discogs_member` matches surfaced as a "related
- * artist" UX hint — but those sites have a wire-shape seam for `source`
- * and the resolver does not.
+ * The fix restricts the alias arm to the synonym-class sources via a
+ * positive allowlist: `source IN ('discogs_name_variation',
+ * 'discogs_alias', 'wxyc_library_alt')`. Positive form is safe-by-
+ * default — a future LML source (collaborator, featured-on, side-project)
+ * stays out of the FK-write path until we explicitly opt it in. The
+ * catalog-search sites take the opposite tack: they DO want relational
+ * rows surfaced for a "related artist" UX hint and propagate `source`
+ * end-to-end. The resolver has no wire-shape seam for `source` so the
+ * partition is enforced in SQL.
+ *
+ * The mocked `db.execute` returns the post-filter row set the SQL would
+ * have produced. The SQL-contract test pins the allowlist literal; the
+ * positive- and negative-source tests pin which sources survive and which
+ * do not; the ambiguity-disambiguation test pins the semantic shift the
+ * filter introduces (pre-filter ambiguous → post-filter singleton
+ * resolves).
  */
 import { jest } from '@jest/globals';
 
@@ -46,57 +53,131 @@ const renderSql = (value: unknown): string => {
   return '';
 };
 
+// `mockClear` rather than `mockReset` preserves the database mock's
+// default `mockResolvedValue([])` so that a test forgetting one
+// `mockResolvedValueOnce` fails with a clean assertion mismatch rather
+// than the loud "unrecognized db.execute() result shape: undefined" the
+// unwrapRows guard throws for safety.
 const executeMock = db.execute;
 
-describe('resolveArtistId — discogs_member filter (BS#1383)', () => {
+const SYNONYM_SOURCES = ['discogs_name_variation', 'discogs_alias', 'wxyc_library_alt'] as const;
+const RELATIONAL_SOURCES = ['discogs_member'] as const;
+
+describe('resolveArtistId — synonym-class allowlist (BS#1383)', () => {
   beforeEach(() => {
-    executeMock.mockReset();
+    executeMock.mockClear();
   });
 
-  it("excludes 'discogs_member' rows from the alias arm at SQL time", async () => {
-    // Both arms return [] — we're inspecting the SQL contract, not the
-    // result handling. The behaviour assertion (filtered-out → unmatched)
-    // lives in the next test.
-    executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+  describe('SQL contract', () => {
+    it('the alias arm allowlists exactly the synonym-class sources', async () => {
+      executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
-    await resolveArtistId('Geordie Greep');
+      await resolveArtistId('Geordie Greep');
 
-    expect(executeMock).toHaveBeenCalledTimes(2);
-    const aliasSql = renderSql(executeMock.mock.calls[1][0]);
-    // Negative form is forward-compatible against a future fifth source.
-    expect(aliasSql).toMatch(/"?source"?\s*<>\s*'discogs_member'/i);
+      expect(executeMock).toHaveBeenCalledTimes(2);
+      const aliasSql = renderSql(executeMock.mock.calls[1][0]);
+
+      // Pin the positive-allowlist contract: SOURCE IN (...) — not a
+      // negative-form predicate. A negative form would silently admit
+      // every future LML source.
+      for (const source of SYNONYM_SOURCES) {
+        expect(aliasSql).toContain(`'${source}'`);
+      }
+      expect(aliasSql).toMatch(/"?source"?\s+IN\s*\(/i);
+    });
+
+    it('the alias arm does NOT name any relational-class source as a filter literal', async () => {
+      // Closes the gap a positive allowlist would otherwise leave: a
+      // maintainer who reads only the SQL and reverts the allowlist to a
+      // negative `source <> 'discogs_member'` shape silently re-admits
+      // any future relational source. This test fails fast on that revert
+      // by asserting no relational-class source name appears in the SQL.
+      executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      await resolveArtistId('Geordie Greep');
+
+      const aliasSql = renderSql(executeMock.mock.calls[1][0]);
+      for (const source of RELATIONAL_SOURCES) {
+        expect(aliasSql).not.toContain(`'${source}'`);
+      }
+    });
   });
 
-  it("returns { kind: 'unmatched' } when the only matching alias row is a 'discogs_member' (filtered out by the SQL)", async () => {
-    // The SQL filter is what removes the row; the mock simulates the
-    // filtered result set — empty, because the only candidate variant
-    // was a discogs_member row.
-    executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+  describe('behaviour against the post-filter result set', () => {
+    it.each(SYNONYM_SOURCES)(
+      "returns { kind: 'alias' } when the alias arm surfaces a row for source=%s",
+      async (source) => {
+        // The mocked row carries `source` so the per-source coverage
+        // claim is honest: each synonym-class source independently
+        // produces an alias outcome. If a future change drops one source
+        // from the allowlist the SQL would return [] for that source —
+        // the contract tests above catch the SQL change, this test
+        // documents the per-source semantic.
+        executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([{ artist_id: 42, source }]);
 
-    const result = await resolveArtistId('Geordie Greep');
+        const result = await resolveArtistId('Thee Oh Sees');
 
-    expect(result).toEqual({ kind: 'unmatched' });
+        expect(result).toEqual({ kind: 'alias', artist_id: 42 });
+      }
+    );
+
+    it("returns { kind: 'unmatched' } when the only candidate row was a discogs_member (filtered out at SQL time)", async () => {
+      // Production shape: a single `discogs_member` row exists for the
+      // variant. The SQL allowlist excludes it server-side; the mock
+      // simulates the empty post-filter result. The orchestrator writes
+      // NULL and the row falls to manual review — never mislabeled.
+      executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await resolveArtistId('Geordie Greep');
+
+      expect(result).toEqual({ kind: 'unmatched' });
+    });
+
+    it('collapses pre-filter ambiguity to a single resolved alias when only one synonym row survives', async () => {
+      // Production shape from the BS#1368 audit: the same variant
+      // ("Geordie Greep") points at two artists via two sources — a
+      // `discogs_member` row at artist X (the old band) and a
+      // `discogs_alias` row at artist Y (the legitimate synonym). Pre-
+      // fix the alias arm saw both rows and returned `ambiguous`; the FK
+      // stayed NULL. Post-fix the SQL strips the member row server-side
+      // so the orchestrator sees only the synonym row and resolves to
+      // Y. This is the semantic the BS#1383 filter introduces and the
+      // test pins it so a future revert is caught.
+      executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([{ artist_id: 9999, source: 'discogs_alias' }]);
+
+      const result = await resolveArtistId('Geordie Greep');
+
+      expect(result).toEqual({ kind: 'alias', artist_id: 9999 });
+    });
+
+    it('still returns ambiguous when two synonym-class rows point at different artists', async () => {
+      // Negative twin of the disambiguation test: when the allowlist
+      // does NOT collapse the result set to a singleton, the resolver
+      // must still drop to `ambiguous` and leave the FK NULL. Otherwise
+      // a future change that loosens the SELECT could silently start
+      // picking one of two equally-good matches.
+      executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([
+        { artist_id: 100, source: 'discogs_alias' },
+        { artist_id: 200, source: 'discogs_name_variation' },
+      ]);
+
+      const result = await resolveArtistId('Some Common Variant');
+
+      expect(result).toEqual({ kind: 'ambiguous' });
+    });
   });
 
-  it("still returns { kind: 'alias' } for non-member alias sources (discogs_name_variation, discogs_alias, wxyc_library_alt)", async () => {
-    // The filter is scoped to `discogs_member` only. A
-    // `discogs_name_variation` / `discogs_alias` / `wxyc_library_alt`
-    // hit still resolves an FK — that's the substrate's whole point.
-    executeMock.mockResolvedValueOnce([]).mockResolvedValueOnce([{ artist_id: 42 }]);
+  describe('strict-wins is unchanged', () => {
+    it('a strict singleton skips the alias arm entirely (no SQL filter involvement)', async () => {
+      // Only one db.execute call should fire — the strict one. The alias
+      // arm (and therefore the allowlist) is irrelevant when strict
+      // resolves.
+      executeMock.mockResolvedValueOnce([{ artist_id: 7 }]);
 
-    const result = await resolveArtistId('Thee Oh Sees');
+      const result = await resolveArtistId('Pavement');
 
-    expect(result).toEqual({ kind: 'alias', artist_id: 42 });
-  });
-
-  it('strict-wins is unchanged: a strict singleton skips the alias arm entirely', async () => {
-    // Only one db.execute call should fire — the strict one. The alias
-    // arm (and therefore the filter) is irrelevant when strict resolves.
-    executeMock.mockResolvedValueOnce([{ artist_id: 7 }]);
-
-    const result = await resolveArtistId('Pavement');
-
-    expect(executeMock).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ kind: 'strict', artist_id: 7 });
+      expect(executeMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ kind: 'strict', artist_id: 7 });
+    });
   });
 });

--- a/tests/unit/jobs/concerts-artist-resolver/query.test.ts
+++ b/tests/unit/jobs/concerts-artist-resolver/query.test.ts
@@ -141,6 +141,24 @@ describe('resolveArtistId — synonym-class allowlist (BS#1383)', () => {
       const overlap = SYNONYM_ALIAS_SOURCES.filter((s) => (RELATIONAL_ALIAS_SOURCES as readonly string[]).includes(s));
       expect(overlap).toEqual([]);
     });
+
+    it('SYNONYM_ALIAS_SOURCES values are identifier-safe', () => {
+      // The production resolver inline-quotes these values into a
+      // `sql.raw` IN-list (jobs/concerts-artist-resolver/query.ts).
+      // That's safe-by-construction only as long as the values stay
+      // within Postgres' identifier charset — anything outside `[A-Za-
+      // z0-9_]` (apostrophe, backslash, NUL, etc.) would inject. The
+      // check used to live at module-load in query.ts as a thrown Error,
+      // but that path runs before Sentry / the structured logger / the
+      // safeFinalize teardown initialise — a bad value would crash-loop
+      // the container with a bare Node trace, no actionable log line.
+      // Pinning the contract in CI instead means a bad PR fails the
+      // unit-test step and never deploys; production gets the cheaper,
+      // unguarded `sql.raw` call.
+      const nonIdentifier = /[^A-Za-z0-9_]/;
+      const offenders = SYNONYM_ALIAS_SOURCES.filter((s) => nonIdentifier.test(s));
+      expect(offenders).toEqual([]);
+    });
   });
 
   describe('SQL contract', () => {
@@ -152,24 +170,23 @@ describe('resolveArtistId — synonym-class allowlist (BS#1383)', () => {
       expect(db.execute).toHaveBeenCalledTimes(2);
       const aliasSql = renderSql(db.execute.mock.calls[1][0]);
 
-      // Positive contract: every synonym-class source appears as a
-      // quoted SQL literal inside an `IN (...)` predicate. A negative-
-      // form predicate (`<>`) would silently admit every future source
-      // and reintroduce the BS#1368 mislabel under a new label.
-      expect(aliasSql).toMatch(/"?source"?\s+IN\s*\(/i);
-
-      // Exact-set check: parse the IN-list out of the rendered SQL and
-      // assert it equals SYNONYM_ALIAS_SOURCES set-wise. The
-      // containment-only check above passes if a hotfix bypasses the
-      // constant and hardcodes an extra source in SQL — this assertion
-      // is what closes the JS↔SQL alignment gap.
+      // Parses the IN-list literals out of the rendered SQL and
+      // asserts the alias arm names EXACTLY the synonym-class sources
+      // — no extras, no missing, no duplicates. A negative-form
+      // predicate (`<>`) or a hotfix that hardcodes an extra source
+      // outside the const would fail this. The parser assumes a flat
+      // IN-list with single-quoted identifier-safe values; that
+      // shape is pinned by `SYNONYM_ALIAS_SOURCES values are
+      // identifier-safe` above. Sorted-array comparison rather than
+      // Set so duplicates fail too (e.g., an assembly bug that emits
+      // `('a','a','b')` for a 2-element tuple).
       const inListMatch = aliasSql.match(/"?source"?\s+IN\s*\(([^)]*)\)/i);
       expect(inListMatch).not.toBeNull();
       const inListLiterals = (inListMatch?.[1] || '')
         .split(',')
         .map((s) => s.trim().replace(/^'|'$/g, ''))
         .filter((s) => s.length > 0);
-      expect(new Set(inListLiterals)).toEqual(new Set(SYNONYM_ALIAS_SOURCES));
+      expect([...inListLiterals].sort()).toEqual([...SYNONYM_ALIAS_SOURCES].sort());
     });
 
     it('the alias arm does NOT name any relational-class source as a filter literal', async () => {

--- a/tests/unit/scripts/ci-env-surface-parity.test.ts
+++ b/tests/unit/scripts/ci-env-surface-parity.test.ts
@@ -60,12 +60,6 @@ const EXPECTED_ONLY_IN_COMPOSE = [
   'CATALOG_TRACK_SEARCH_CTA_ENABLED',
   'CATALOG_TRACK_SEARCH_DISCOGS_ENABLED',
 
-  // Why: artist-search-alias LATERAL JOIN flag (plan §PR 5). Compose flips it
-  // on so `tests/integration/library-search-alias.spec.js` exercises the
-  // LATERAL against a seeded variant. Workflow path doesn't run that spec;
-  // whether that's a coverage gap is tracked separately.
-  'CATALOG_SEARCH_ALIAS_ENABLED',
-
   // Why: AWS Cognito identifiers from the legacy auth flow. Compose sets
   // them via `.env` substitution; backend defaults work in the workflow's
   // host-process auth-bypass mode.


### PR DESCRIPTION
## Summary

- **Resolver site** (`jobs/concerts-artist-resolver/query.ts`): filter `asa.source <> 'discogs_member'` from the alias arm. The resolver collapses to a single FK with no wire-shape seam for `source`, so a `discogs_member` row mislabels solo-touring acts as "in-library" (Geordie Greep → black midi from BS#1368). Negative form is forward-compatible against future relational signals (collaborator, featured-on, side-project).
- **Catalog-search sites** (`apps/backend/services/library{,-search}.service.ts`): `source` already propagates end-to-end via `alias_matched_source` → `matched_via_alias[].source`. Integration test extended to assert a `discogs_member`-only alias hit surfaces with `matched_via_alias[].source === 'discogs_member'`, so callers can render "related artist" vs "in library" distinctly.

## Test plan

- [x] `npx jest --config jest.unit.config.ts tests/unit/jobs/concerts-artist-resolver/` — new `query.test.ts` covers SQL contract + behaviour + non-member sources still resolve + strict-wins unchanged.
- [x] Integration: `tests/integration/library-search-alias.spec.js` adds a `discogs_member` case alongside the existing `discogs_name_variation` case; both pass against the ci-profile docker stack.
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` clean.
- [ ] Post-merge: re-run the BS#1368 alias-only frequency audit on prod; Geordie Greep should no longer surface as an in-library match.

Closes #1383