### PR TITLE
Reject no-op discogs_name_variation rows in artist_search_alias writer (BS#1382)

### DIFF
--- a/jobs/artist-search-alias-consumer/orchestrate.ts
+++ b/jobs/artist-search-alias-consumer/orchestrate.ts
@@ -42,6 +42,7 @@ export type FetchBulkFn = (names: string[]) => Promise<ArtistSearchAliasesBulkRe
 export type FetchAltsFn = (artistIds: number[]) => Promise<Map<number, string[]>>;
 export type WriteArtistVariantsFn = (
   artist_id: number,
+  canonicalName: string,
   variants: ArtistSearchAliasVariant[],
   sourcesPresent: string[]
 ) => Promise<{ variants_written: number }>;
@@ -227,7 +228,7 @@ export const runConsumer = async (opts: {
         }
 
         try {
-          const outcome = await opts.writeArtistVariants(artist_id, allVariants, sourcesPresent);
+          const outcome = await opts.writeArtistVariants(artist_id, group.artist_name, allVariants, sourcesPresent);
           totals.source_rows_written += outcome.variants_written;
         } catch (error) {
           totals.writer_errors += 1;

--- a/jobs/artist-search-alias-consumer/writer.ts
+++ b/jobs/artist-search-alias-consumer/writer.ts
@@ -40,10 +40,29 @@
  *     rather than `null`. Use `${v.field ?? null}` on every nullable
  *     column (BS#1300 cost 899 writer_errors on the 2026-06-03 first
  *     prod run — ~20% of substrate rows).
+ *
+ * One substrate-cleanup invariant (BS#1382, from the BS#1368 Path A audit):
+ *   - **Reject no-op `discogs_name_variation` variants where
+ *     `normalizeArtistName(variant) === normalizeArtistName(canonical)`.**
+ *     The consumer's match arm normalizes both sides before comparing, so a
+ *     variant whose normalized form equals the canonical's contributes zero
+ *     recall over the canonical row — anything that would match the variant
+ *     already matches the canonical post-normalization — while actively
+ *     introducing FPs by colliding the de-normalized form against same-named
+ *     distinct library artists ("The Format" → "Format" colliding with a
+ *     different "Format"). The rule is expressed against the shared
+ *     `normalizeArtistName` so writer-reject and consumer-match cannot
+ *     drift; it covers the leading-"The" subform plus any future expansion
+ *     of the normalization key (case-only, accent-only, etc.). Scoped to
+ *     `discogs_name_variation` because it is the only source LML emits as a
+ *     pure name-shape synonym — `discogs_alias` / `discogs_member` /
+ *     `wxyc_library_alt` carry relational or curatorial signal even when
+ *     their text normalizes to the canonical. The one-shot cleanup of
+ *     existing rows lives at `scripts/cleanup-no-op-name-variations.sql`.
  */
 
 import { sql } from 'drizzle-orm';
-import { db } from '@wxyc/database';
+import { db, normalizeArtistName } from '@wxyc/database';
 
 import type { ArtistSearchAliasVariant } from './lml-types.js';
 
@@ -58,9 +77,17 @@ export type WriteOutcome = {
  * Reconcile one artist's alias variants. Returns the per-call counts the
  * orchestrator accumulates. On any error the transaction rolls back; the
  * caller is responsible for catching + counting the failure.
+ *
+ * `canonicalName` is the canonical `artists.artist_name` for `artist_id` and
+ * is used to gate no-op `discogs_name_variation` rows out of the substrate
+ * at write time (BS#1382). Passing the canonical here — rather than
+ * re-reading it from the DB inside the writer — keeps the writer free of an
+ * extra round-trip per artist; the orchestrator already has the grouped
+ * canonical (`NameGroup.artist_name`) on hand.
  */
 export const writeArtistVariants = async (
   artist_id: number,
+  canonicalName: string,
   variants: ArtistSearchAliasVariant[],
   sourcesPresent: string[]
 ): Promise<WriteOutcome> => {
@@ -68,6 +95,20 @@ export const writeArtistVariants = async (
     // No composer leg ran — leave the cache untouched.
     return { variants_written: 0 };
   }
+
+  // BS#1382: reject `discogs_name_variation` rows whose normalized form
+  // equals the normalized canonical. Anything that would match the variant
+  // already matches the canonical post-normalization (the consumer
+  // normalizes both sides before comparing), so the row is pure dead
+  // weight — and it actively introduces FPs by colliding the de-normalized
+  // form against same-named distinct library artists. Scoped to
+  // `discogs_name_variation` because `discogs_alias` / `discogs_member` /
+  // `wxyc_library_alt` carry relational or curatorial signal that doesn't
+  // collapse on normalization.
+  const normalizedCanonical = normalizeArtistName(canonicalName);
+  const nonNoopVariants = variants.filter(
+    (v) => v.source !== 'discogs_name_variation' || normalizeArtistName(v.variant) !== normalizedCanonical
+  );
 
   // Defensive filter against the `artist_search_alias_variant_nonblank`
   // CHECK constraint. A single blank-after-trim variant rolls the whole
@@ -77,7 +118,7 @@ export const writeArtistVariants = async (
   // alt-name-source.ts forwards as a `wxyc_library_alt` variant (it only
   // filters NULL). Drop blanks at the writer boundary so one bad row
   // doesn't poison the whole artist's run.
-  const filteredVariants = variants.filter((v) => v.variant.trim().length > 0);
+  const filteredVariants = nonNoopVariants.filter((v) => v.variant.trim().length > 0);
 
   const lastVerifiedAt = new Date().toISOString(); // Pre-stringify (BS#802 trap).
 

--- a/scripts/cleanup-no-op-name-variations.sql
+++ b/scripts/cleanup-no-op-name-variations.sql
@@ -1,0 +1,117 @@
+-- One-shot cleanup (BS#1382): delete `artist_search_alias` rows where
+-- `source='discogs_name_variation'` and the variant normalizes to the
+-- same key as the canonical `artists.artist_name`.
+--
+-- Why this exists:
+--   The BS#1368 Path A frequency analysis (120 upcoming Triangle concerts)
+--   surfaced 3 alias-only matches over strict-name; all three audit as
+--   likely false positives. Two distinct FP shapes; this script covers
+--   Shape 1 (substrate side). Shape 2 (consumer-side `discogs_member`
+--   distinction) is tracked separately under BS#1383.
+--
+--   Shape 1 — `discogs_name_variation` emits no-op variants
+--   (norm-equivalent to canonical): a variant whose normalized form
+--   equals the canonical's normalized form adds zero recall over the
+--   canonical row (anything that would match the variant already matches
+--   the canonical post-normalization) while actively introducing FPs by
+--   colliding the de-normalized form against same-named distinct library
+--   artists. The audit surfaced two instances of the leading-"The"-strip
+--   subform:
+--
+--     artist_id | canonical    | no-op variant  | collides with
+--     ----------+--------------+----------------+---------------------
+--           260 | "The Format" | "Format"       | a different "Format"
+--         20351 | "The Snares" | "Snares"       | a different "Snares"
+--
+--   The rule is general — any `discogs_name_variation` row whose
+--   normalized form equals the canonical's is dead weight. Case-only and
+--   accent-only variants collapse the same way as the leading-"The"
+--   subform under the canonical normalization key
+--   (`wxyc_schema.normalize_artist_name(text)`, migration 0092).
+--
+-- Companion code change:
+--   `jobs/artist-search-alias-consumer/writer.ts` is updated in the same
+--   PR to reject these rows at write time so the substrate stays clean
+--   going forward. Without the writer-side fix this script is a one-shot
+--   patch — the next nightly run of the consumer would write the no-op
+--   rows back.
+--
+-- Scope:
+--   Only `source='discogs_name_variation'`. The other three sources
+--   (`discogs_alias` / `discogs_member` / `wxyc_library_alt`) carry
+--   relational or curatorial signal that does not collapse on
+--   normalization — a `discogs_alias` row whose text matches its
+--   canonical may still be a curated synonym worth preserving in the
+--   substrate. (Shape 2's `discogs_member` consumer fix is in BS#1383.)
+--
+-- Expected scale (from the BS#1368 audit body):
+--   Dozens, not thousands. The pre-flight SELECT below is the
+--   verify-before-mutate check; abort if the count is materially higher
+--   than expected.
+--
+-- Idempotent: the WHERE clause matches only rows still in the no-op
+-- shape, so re-running is a no-op once the writer-side fix is deployed
+-- and any earlier no-op rows have been cleared.
+--
+-- Per WXYC data-safety rule: SELECT scope first, then DELETE.
+--
+-- Run as operator post-deploy of the writer-side fix:
+--
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+--     -f scripts/cleanup-no-op-name-variations.sql
+
+\echo '-- pre-flight scope by source (only discogs_name_variation should appear):'
+SELECT
+  asa.source,
+  COUNT(*) AS no_op_count
+FROM wxyc_schema.artist_search_alias asa
+JOIN wxyc_schema.artists a ON a.id = asa.artist_id
+WHERE wxyc_schema.normalize_artist_name(asa.variant)
+    = wxyc_schema.normalize_artist_name(a.artist_name)
+GROUP BY asa.source
+ORDER BY asa.source;
+
+\echo '-- audit sample (top 20 to-be-deleted rows, BS#1368-style table):'
+SELECT
+  asa.artist_id,
+  a.artist_name AS canonical,
+  asa.variant   AS no_op_variant,
+  asa.source,
+  asa.last_verified_at
+FROM wxyc_schema.artist_search_alias asa
+JOIN wxyc_schema.artists a ON a.id = asa.artist_id
+WHERE asa.source = 'discogs_name_variation'
+  AND wxyc_schema.normalize_artist_name(asa.variant)
+    = wxyc_schema.normalize_artist_name(a.artist_name)
+ORDER BY asa.artist_id, asa.variant
+LIMIT 20;
+
+\echo '-- delete:'
+BEGIN;
+
+DELETE FROM wxyc_schema.artist_search_alias asa
+USING wxyc_schema.artists a
+WHERE asa.artist_id = a.id
+  AND asa.source = 'discogs_name_variation'
+  AND wxyc_schema.normalize_artist_name(asa.variant)
+    = wxyc_schema.normalize_artist_name(a.artist_name);
+
+\echo '-- post-delete scope (expect zero discogs_name_variation no-op rows):'
+SELECT
+  asa.source,
+  COUNT(*) AS no_op_count
+FROM wxyc_schema.artist_search_alias asa
+JOIN wxyc_schema.artists a ON a.id = asa.artist_id
+WHERE wxyc_schema.normalize_artist_name(asa.variant)
+    = wxyc_schema.normalize_artist_name(a.artist_name)
+GROUP BY asa.source
+ORDER BY asa.source;
+
+COMMIT;
+
+-- @no-analyze-needed: the DELETE removes a small number of rows (audit
+--   expects dozens, not thousands) from a table where the relevant
+--   indexes (`artist_search_alias_variant_trgm_idx` GIN,
+--   `artist_search_alias_normalized_variant_idx` btree on the functional
+--   form) are over the variant column, not its presence/absence. Planner
+--   stats drift from a sub-thousand-row DELETE is below the noise floor.

--- a/tests/unit/jobs/artist-search-alias-consumer/orchestrate.test.ts
+++ b/tests/unit/jobs/artist-search-alias-consumer/orchestrate.test.ts
@@ -29,6 +29,7 @@ type FetchBulkFn = (names: string[]) => Promise<ArtistSearchAliasesBulkResponse>
 type FetchAltsFn = (artistIds: number[]) => Promise<Map<number, string[]>>;
 type WriteFn = (
   artist_id: number,
+  canonicalName: string,
   variants: unknown[],
   sourcesPresent: string[]
 ) => Promise<{ variants_written: number }>;
@@ -85,7 +86,7 @@ describe('runConsumer — happy path', () => {
     const fetchAlts = jest.fn<FetchAltsFn>().mockResolvedValue(new Map());
     const writeArtistVariants = jest
       .fn<WriteFn>()
-      .mockImplementation((_id, variants) => Promise.resolve({ variants_written: variants.length }));
+      .mockImplementation((_id, _canonicalName, variants) => Promise.resolve({ variants_written: variants.length }));
 
     const result = await runConsumer({
       loadNameGroups,
@@ -110,10 +111,11 @@ describe('runConsumer — happy path', () => {
     // sources (the LML composer didn't run those legs for it).
     const missingCall = writeArtistVariants.mock.calls.find(
       (c) => (c as unknown as [number])[0] === 9999
-    ) as unknown as [number, unknown[], string[]] | undefined;
+    ) as unknown as [number, string, unknown[], string[]] | undefined;
     expect(missingCall).toBeDefined();
-    expect(missingCall?.[1]).toEqual([]);
-    expect(missingCall?.[2]).toEqual(['wxyc_library_alt']);
+    // missingCall: [artist_id, canonicalName, variants, sourcesPresent]
+    expect(missingCall?.[2]).toEqual([]);
+    expect(missingCall?.[3]).toEqual(['wxyc_library_alt']);
 
     expect(result.totals.names_scanned).toBe(3);
     expect(result.totals.names_resolved).toBe(2);
@@ -228,7 +230,9 @@ describe('runConsumer — happy path', () => {
       dryRun: false,
     });
 
-    const sourcesPresentArg = (writeArtistVariants.mock.calls[0] as unknown as [number, unknown[], string[]])[2];
+    const sourcesPresentArg = (
+      writeArtistVariants.mock.calls[0] as unknown as [number, string, unknown[], string[]]
+    )[3];
     expect(sourcesPresentArg).toContain('discogs_name_variation');
     expect(sourcesPresentArg).toContain('wxyc_library_alt');
   });
@@ -258,10 +262,11 @@ describe('runConsumer — happy path', () => {
 
     const writeArgs = writeArtistVariants.mock.calls[0] as unknown as [
       number,
+      string,
       Array<Record<string, unknown>>,
       string[],
     ];
-    const variants = writeArgs[1];
+    const variants = writeArgs[2];
     expect(variants.length).toBe(2);
     variants.forEach((v) => {
       expect(v.source).toBe('wxyc_library_alt');
@@ -391,6 +396,44 @@ describe('runConsumer — happy path', () => {
     expect(result.totals.names_resolved).toBe(1);
     expect(result.totals.names_missing).toBe(0); // NOT bucketed as missing.
     expect(result.totals.names_unaccounted).toBe(1);
+  });
+
+  it("BS#1382: forwards the group's canonical artist_name to writeArtistVariants so the writer can gate no-op variants", async () => {
+    // The writer's no-op-discogs_name_variation filter requires the
+    // canonical `artists.artist_name` to normalize-compare against. The
+    // orchestrator passes `group.artist_name` (the canonical it grouped
+    // by) so the filter doesn't pay an extra DB round-trip per artist.
+    // The audit case from BS#1368: canonical 'The Format', variant
+    // 'Format'. We assert the canonical reaches the writer; the no-op
+    // filter is verified in writer.test.ts.
+    const batch: NameGroup[] = [{ artist_name: 'The Format', artist_ids: [260, 261] }];
+    const loadNameGroups = jest.fn<LoadNameGroupsFn>().mockResolvedValueOnce(batch).mockResolvedValue([]);
+
+    const fetchBulk = jest.fn<FetchBulkFn>().mockResolvedValue({
+      artists: [makeLmlResult('The Format', 1)],
+      missing: [],
+    });
+    const fetchAlts = jest.fn<FetchAltsFn>().mockResolvedValue(new Map());
+    const writeArtistVariants = jest.fn<WriteFn>().mockResolvedValue({ variants_written: 1 });
+
+    await runConsumer({
+      loadNameGroups,
+      fetchBulk,
+      fetchAlts,
+      writeArtistVariants,
+      batchSize: 500,
+      throttleMs: 0,
+      staleDays: 7,
+      partition: { index: 0, count: 1, description: 'partition=none' },
+      dryRun: false,
+    });
+
+    // Both fan-out writes receive the canonical 'The Format' in slot [1].
+    expect(writeArtistVariants).toHaveBeenCalledTimes(2);
+    const firstCall = writeArtistVariants.mock.calls[0] as unknown as [number, string, unknown[], string[]];
+    const secondCall = writeArtistVariants.mock.calls[1] as unknown as [number, string, unknown[], string[]];
+    expect(firstCall[1]).toBe('The Format');
+    expect(secondCall[1]).toBe('The Format');
   });
 
   it('counts per-artist writer failures into the writer_errors counter (source_rows_written unaffected)', async () => {

--- a/tests/unit/jobs/artist-search-alias-consumer/writer.test.ts
+++ b/tests/unit/jobs/artist-search-alias-consumer/writer.test.ts
@@ -61,6 +61,15 @@ jest.mock('@wxyc/database', () => ({
     transaction: (...args: unknown[]) => mockTransaction(...(args as [(tx: unknown) => Promise<void>])),
     execute: mockExecute,
   },
+  // Mirror of `shared/database/src/normalize-artist-name.ts` (the
+  // TS twin of the SQL `wxyc_schema.normalize_artist_name(text)`). The
+  // mock factory cannot import the real module (the auto-mocker runs
+  // before the file's top-level imports are evaluated), so we re-inline
+  // the rule. Keep in sync if the canonical normalization changes.
+  normalizeArtistName: (input: string | null | undefined): string => {
+    const coalesced = input ?? '';
+    return coalesced.replace(/^the[ \t\n\r\f\v]+/i, '').toLowerCase();
+  },
 }));
 
 import type { ArtistSearchAliasVariant } from '../../../../jobs/artist-search-alias-consumer/lml-types';
@@ -87,26 +96,32 @@ beforeEach(() => {
   mockTransaction.mockClear();
 });
 
+// Default canonical that does NOT normalize-collide with the default
+// `variant()` fixture (`'Thee Oh Sees'`). Tests that exercise the no-op
+// filter pass an explicit canonical (e.g. `'The Format'` for the
+// BS#1382 leading-"The" subform).
+const CANONICAL = 'Oh Sees';
+
 describe('writeArtistVariants', () => {
   it('short-circuits with no transaction and no SQL when sourcesPresent is empty', async () => {
-    const outcome = await writeArtistVariants(42, [variant()], []);
+    const outcome = await writeArtistVariants(42, CANONICAL, [variant()], []);
     expect(mockTransaction).toHaveBeenCalledTimes(0);
     expect(mockExecute).toHaveBeenCalledTimes(0);
     expect(outcome.variants_written).toBe(0);
   });
 
   it('opens a transaction when sourcesPresent is non-empty', async () => {
-    await writeArtistVariants(42, [variant()], ['discogs_name_variation']);
+    await writeArtistVariants(42, CANONICAL, [variant()], ['discogs_name_variation']);
     expect(mockTransaction).toHaveBeenCalledTimes(1);
   });
 
   it('emits a single SQL statement (DELETE only) when variants is empty', async () => {
-    await writeArtistVariants(42, [], ['discogs_alias', 'wxyc_library_alt']);
+    await writeArtistVariants(42, CANONICAL, [], ['discogs_alias', 'wxyc_library_alt']);
     expect(mockExecute).toHaveBeenCalledTimes(1);
   });
 
   it('uses sql.join for the source list (anti-regression vs text[] literal)', async () => {
-    await writeArtistVariants(42, [], ['discogs_alias', 'wxyc_library_alt']);
+    await writeArtistVariants(42, CANONICAL, [], ['discogs_alias', 'wxyc_library_alt']);
     // sql.join is the parameterized-VALUES helper; if the writer ever
     // regressed to building a `'{${arr.join(",")}}'::text[]` literal,
     // sql.join would never be called.
@@ -118,7 +133,9 @@ describe('writeArtistVariants', () => {
       variant({ source: 'discogs_name_variation', variant: 'OH SEES' }),
       variant({ source: 'discogs_alias', variant: 'Oh Sees', method: 'alias_curated', confidence: 0.85 }),
     ];
-    await writeArtistVariants(42, variants, ['discogs_name_variation', 'discogs_alias']);
+    // Canonical 'Thee Oh Sees' so neither variant normalize-collides with
+    // it ('OH SEES' lowercases to 'oh sees' which does not equal 'thee oh sees').
+    await writeArtistVariants(42, 'Thee Oh Sees', variants, ['discogs_name_variation', 'discogs_alias']);
     // 1 DELETE + 2 INSERTs.
     expect(mockExecute).toHaveBeenCalledTimes(3);
   });
@@ -126,6 +143,7 @@ describe('writeArtistVariants', () => {
   it('uses sql.join twice in the non-empty-variants branch (source list and pair list)', async () => {
     await writeArtistVariants(
       42,
+      'Thee Oh Sees',
       [variant(), variant({ variant: 'OH SEES' })],
       ['discogs_name_variation', 'discogs_alias']
     );
@@ -136,7 +154,9 @@ describe('writeArtistVariants', () => {
   });
 
   it('pre-stringifies last_verified_at (BS#802 drizzle Date trap)', async () => {
-    await writeArtistVariants(42, [variant()], ['discogs_name_variation']);
+    // Canonical is distinct (normalization-wise) from 'Thee Oh Sees' so
+    // the default variant isn't filtered out by the no-op-variant gate.
+    await writeArtistVariants(42, 'Osees', [variant()], ['discogs_name_variation']);
     // Inspect every captured `sql\`...\`` call's bind values. The
     // last_verified_at slot is the only timestamp-shaped bind in the
     // INSERT; it must be a string, never a Date.
@@ -150,6 +170,7 @@ describe('writeArtistVariants', () => {
   it('binds the artist_id, source, and variant text as positional params', async () => {
     await writeArtistVariants(
       42,
+      'Sinead OConnor',
       [variant({ source: 'discogs_alias', variant: "Sinéad O'Connor" })],
       ['discogs_alias']
     );
@@ -164,8 +185,12 @@ describe('writeArtistVariants', () => {
   });
 
   it('returns variants_written equal to the variants supplied (when sourcesPresent is non-empty)', async () => {
+    // Canonical 'Osees' so neither default variant ('Thee Oh Sees') nor
+    // the two override variants ('OH SEES' / 'OHSEES') normalize-collide
+    // with it. The no-op-variant gate is exercised in the BS#1382-tagged
+    // cases below; this case checks the count-through behaviour.
     const variants = [variant(), variant({ variant: 'OH SEES' }), variant({ variant: 'OHSEES' })];
-    const outcome = await writeArtistVariants(42, variants, ['discogs_name_variation']);
+    const outcome = await writeArtistVariants(42, 'Osees', variants, ['discogs_name_variation']);
     expect(outcome.variants_written).toBe(3);
   });
 
@@ -184,7 +209,7 @@ describe('writeArtistVariants', () => {
       variant({ variant: '\t\n  ' }), // whitespace-only
       variant({ variant: 'Another Valid' }),
     ];
-    const outcome = await writeArtistVariants(42, variants, ['discogs_name_variation']);
+    const outcome = await writeArtistVariants(42, CANONICAL, variants, ['discogs_name_variation']);
     // Only the 2 valid variants reach the INSERT loop. 1 DELETE + 2 INSERTs.
     expect(outcome.variants_written).toBe(2);
     expect(mockExecute).toHaveBeenCalledTimes(3);
@@ -218,7 +243,7 @@ describe('writeArtistVariants', () => {
       // are absent — `v.x` is `undefined` at runtime.
     } as unknown as ArtistSearchAliasVariant;
 
-    await writeArtistVariants(42, [sparseVariant], ['discogs_name_variation']);
+    await writeArtistVariants(42, 'Sonic Youth', [sparseVariant], ['discogs_name_variation']);
 
     const allBinds = sqlTagCalls.flatMap((c) => c.values);
     // No `undefined` binds anywhere — every nullable slot must coerce
@@ -233,7 +258,95 @@ describe('writeArtistVariants', () => {
   it('falls back to DELETE-only when every variant is blank-after-trim (treats filtered-out as variants=[])', async () => {
     // If the only variants supplied are all blank, the writer should
     // behave as if variants=[] was passed: scoped DELETE, no INSERT.
-    await writeArtistVariants(42, [variant({ variant: '   ' }), variant({ variant: '' })], ['discogs_name_variation']);
+    await writeArtistVariants(
+      42,
+      CANONICAL,
+      [variant({ variant: '   ' }), variant({ variant: '' })],
+      ['discogs_name_variation']
+    );
+    // Exactly one statement fires — the DELETE-only branch.
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------
+  // BS#1382 — substrate FP cleanup. The writer must reject no-op
+  // `discogs_name_variation` rows whose normalized form equals the
+  // canonical's normalized form. The audit (BS#1368 Path A) surfaced
+  // "The Format" → "Format" and "The Snares" → "Snares" as the
+  // leading-"The" subform; the rule is expressed against the shared
+  // normalize function so any future expansion of the normalization key
+  // (case-only, accent-only, etc.) covers automatically.
+  // ---------------------------------------------------------------
+
+  it("BS#1382 (leading-The subform): rejects discogs_name_variation row where the variant is the de-The'd canonical", async () => {
+    // From the BS#1368 audit table: artist_id=260, canonical='The Format',
+    // variant='Format' on source='discogs_name_variation'. Normalization
+    // strips the leading "The " from both sides, so the variant adds zero
+    // recall over the canonical row while actively colliding the
+    // de-normalized form against a distinct library "Format".
+    const variants = [
+      variant({ source: 'discogs_name_variation', variant: 'Format' }),
+      // A real synonym from a different source survives.
+      variant({ source: 'discogs_alias', variant: 'The Formats', method: 'alias_curated', confidence: 0.85 }),
+    ];
+    const outcome = await writeArtistVariants(260, 'The Format', variants, ['discogs_name_variation', 'discogs_alias']);
+    // Only the surviving variant is INSERTed; the DELETE still fires.
+    expect(outcome.variants_written).toBe(1);
+    expect(mockExecute).toHaveBeenCalledTimes(2); // 1 DELETE + 1 INSERT
+    const allBinds = sqlTagCalls.flatMap((c) => c.values);
+    expect(allBinds).not.toContain('Format');
+    expect(allBinds).toContain('The Formats');
+  });
+
+  it('BS#1382 (non-The norm-equivalent subform): rejects discogs_name_variation row whose only difference from the canonical collapses on normalization (case-only)', async () => {
+    // The rule is general: any `discogs_name_variation` row whose
+    // normalized form equals the canonical's normalized form is a no-op.
+    // `normalize` lowercases, so "Stereolab" / "STEREOLAB" / "stereolab"
+    // all collapse to the same key. This case locks in the generality of
+    // the rule beyond the leading-"The" subform documented in the audit.
+    const variants = [
+      variant({ source: 'discogs_name_variation', variant: 'STEREOLAB' }),
+      // A truly distinct name-variation survives.
+      variant({ source: 'discogs_name_variation', variant: 'Stereo-Lab' }),
+    ];
+    const outcome = await writeArtistVariants(7, 'Stereolab', variants, ['discogs_name_variation']);
+    expect(outcome.variants_written).toBe(1);
+    const allBinds = sqlTagCalls.flatMap((c) => c.values);
+    expect(allBinds).not.toContain('STEREOLAB');
+    expect(allBinds).toContain('Stereo-Lab');
+  });
+
+  it('BS#1382: leaves `discogs_alias` / `discogs_member` / `wxyc_library_alt` rows untouched even if normalize-equivalent to canonical', async () => {
+    // Only `discogs_name_variation` is gated. The other three sources
+    // carry relational or curatorial signal that does not collapse on
+    // normalization — a `discogs_alias` row pointing to the same name as
+    // its canonical may still be a curated synonym worth preserving in
+    // the substrate (and shape 2 — `discogs_member` — is the consumer-side
+    // problem covered by #1383, not the substrate's). The writer must NOT
+    // filter those.
+    const variants = [
+      variant({ source: 'discogs_alias', variant: 'Format', method: 'alias_curated', confidence: 0.85 }),
+      variant({ source: 'discogs_member', variant: 'Format', method: 'member_group', confidence: 0.7 }),
+      variant({ source: 'wxyc_library_alt', variant: 'Format', method: 'alt_curated', confidence: 0.85 }),
+    ];
+    const outcome = await writeArtistVariants(260, 'The Format', variants, [
+      'discogs_alias',
+      'discogs_member',
+      'wxyc_library_alt',
+    ]);
+    // All three survive.
+    expect(outcome.variants_written).toBe(3);
+  });
+
+  it('BS#1382: falls back to DELETE-only when the only variant is a no-op `discogs_name_variation`', async () => {
+    // If the only variant for an artist is the no-op row, the writer
+    // should reconcile away any stale row but emit no INSERT.
+    await writeArtistVariants(
+      20351,
+      'The Snares',
+      [variant({ source: 'discogs_name_variation', variant: 'Snares' })],
+      ['discogs_name_variation']
+    );
     // Exactly one statement fires — the DELETE-only branch.
     expect(mockExecute).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Closes #1382.

## Summary

The BS#1368 Path A frequency analysis surfaced 3 alias-only matches over strict-name on a 120-concert sample of upcoming Triangle shows. All three audit as likely false positives. Two distinct FP shapes — this PR lands **Shape 1 (substrate-build side + one-shot cleanup)**. Shape 2 (consumer-side `discogs_member` distinction, Geordie Greep) is intentionally a separate PR under #1383.

Shape 1: `discogs_name_variation` rows whose normalized form equals the canonical's normalized form add **zero recall** over the canonical row (the consumer normalizes both sides before comparing) while **actively introducing FPs** by colliding the de-normalized form against same-named distinct library artists. The audit surfaced two instances of the leading-"The" subform:

| artist_id | canonical | no-op variant | collides with |
|---|---|---|---|
| 260 | "The Format" | "Format" | a different "Format" |
| 20351 | "The Snares" | "Snares" | a different "Snares" |

The rule is general — case-only and accent-only variants collapse the same way under the canonical normalization key (`wxyc_schema.normalize_artist_name(text)`, migration 0092 / BS#1372).

## Changes

- `jobs/artist-search-alias-consumer/writer.ts` — takes the canonical `artist_name` as a new parameter (passed by the orchestrator from `NameGroup.artist_name` — no extra DB round-trip) and filters out `discogs_name_variation` rows where `normalizeArtistName(variant) === normalizeArtistName(canonicalName)`. Scoped to that single source because `discogs_alias` / `discogs_member` / `wxyc_library_alt` carry relational or curatorial signal that doesn't collapse on normalization.
- `jobs/artist-search-alias-consumer/orchestrate.ts` — forwards `group.artist_name` to the writer.
- `scripts/cleanup-no-op-name-variations.sql` — one-shot operator-run cleanup. SELECT-before-DELETE pre-flight broken down `GROUP BY source` (confirms only `discogs_name_variation` is affected) per the data-safety rule; audit-sample top 20 for visual confirmation; transactional DELETE inside `BEGIN`/`COMMIT` with post-check. Uses `wxyc_schema.normalize_artist_name` on both sides so it stays in lockstep with the writer-side rule and the consumer's match arm.
- Unit tests — locked-in cases for the leading-"The" subform (BS#1368 audit case) plus a non-The norm-equivalent case (case-only `"STEREOLAB"` vs canonical `"Stereolab"`) so the rule's generality is regression-tested. Plus a "leaves `discogs_alias` / `discogs_member` / `wxyc_library_alt` rows untouched" case and a DELETE-only fallback when the only variant is a no-op. Orchestrator test verifies the canonical is forwarded to all fan-out writes.

## Sequencing

Lands before #1274 flips `CATALOG_SEARCH_ALIAS_ENABLED=true` — the FPs become user-visible the moment the runtime flag flips ON. #1318 (LATERAL → precomputed alias-hits CTE rewrite) is the remaining substrate-side gate on #1274 once this merges.

Companion follow-up #1383 handles the `discogs_member` consumer-side distinction; intentionally a separate PR because the surfaces are different (#1383 resolver site filters at SQL time, catalog-search sites propagate `source` through the wire shape).

## Operator runbook

After the auto-deploy succeeds, run the one-shot cleanup against prod (expected scale per the BS#1368 audit body: dozens, not thousands):

```bash
ssh wxyc-ec2 'docker exec -i backend psql "$DATABASE_URL" -v ON_ERROR_STOP=1' \
  < scripts/cleanup-no-op-name-variations.sql
```

The script's first `SELECT` confirms scope GROUP BY source before the DELETE fires; abort if `discogs_name_variation` count is materially above the audit's expected dozens, or if any non-`discogs_name_variation` source appears (would indicate the rule's scope assumption broke upstream).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (521 pre-existing warnings, no new ones)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 3068 / 3068 pass (53 in `tests/unit/jobs/artist-search-alias-consumer/`)
- [x] `node scripts/check-bulk-update-analyze.mjs` — pass
- [ ] CI green
- [ ] Post-merge: run `scripts/cleanup-no-op-name-variations.sql` against prod via the BS EC2 host
- [ ] Post-cleanup: re-run BS#1368 Path A alias-only audit on prod and confirm The Format / The Snares no longer surface as in-library matches

## Related

- #1368 — Path A frequency analysis (where the FPs surfaced)
- #1383 — sibling ticket, consumer-side `discogs_member` distinction (Geordie Greep)
- #1307 — `artist_search_alias` substrate
- #1274 — runtime alias flag flip (double-blocked on #1318 + this PR's #1382)
- #1318 — LATERAL → precomputed alias-hits CTE rewrite (remaining substrate gate on #1274)
- #1372 — `normalize_artist_name(text)` SQL function + TS twin (migration 0092)