### PR TITLE
feat(auth): delegate OIDC loginPage to dj-site /login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,16 @@ BETTER_AUTH_JWKS_URL=http://localhost:8082/auth/jwks
 BETTER_AUTH_ISSUER=http://localhost:8082
 BETTER_AUTH_AUDIENCE=http://localhost:8082
 
+# dj-site (Next.js) base URL — single env var that defines the canonical
+# frontend origin used by:
+#   - `trustedOrigins` (CORS for auth endpoints)
+#   - `rewriteUrlForFrontend` (rewriting email-link hosts)
+#   - `buildLoginPage` (OIDC `loginPage` target — the `oidcProvider` plugin
+#     redirects unauthenticated users to `${FRONTEND_SOURCE}/login` and the
+#     dj-site app resumes the flow on successful sign-in)
+# When unset, all three fall back to `http://localhost:3000`.
+FRONTEND_SOURCE=http://localhost:3000
+
 ### DB Info
 DB_HOST=your-db-host.example.com
 DB_NAME=wxyc_db

--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,18 @@ BETTER_AUTH_AUDIENCE=http://localhost:8082
 
 # dj-site (Next.js) base URL — single env var that defines the canonical
 # frontend origin used by:
-#   - `trustedOrigins` (CORS for auth endpoints)
-#   - `rewriteUrlForFrontend` (rewriting email-link hosts)
+#   - `trustedOrigins` (CORS for auth endpoints) — falls back to localhost
+#     when both BETTER_AUTH_TRUSTED_ORIGINS and FRONTEND_SOURCE are unset
+#   - `rewriteUrlForFrontend` (rewriting email-link hosts) — falls back to
+#     localhost on parse error or missing value
 #   - `buildLoginPage` (OIDC `loginPage` target — the `oidcProvider` plugin
 #     redirects unauthenticated users to `${FRONTEND_SOURCE}/login` and the
-#     dj-site app resumes the flow on successful sign-in)
-# When unset, all three fall back to `http://localhost:3000`.
+#     dj-site app resumes the flow on successful sign-in) — falls back to
+#     localhost in dev, but THROWS at module-load when NODE_ENV=production
+#     and FRONTEND_SOURCE is unset (silent localhost fallback in prod would
+#     redirect every OIDC user to a host their browser can't reach).
+# Whitespace is trimmed; only the URL origin (scheme + host + port) is used,
+# so paste-from-browser values with trailing paths/queries/fragments work.
 FRONTEND_SOURCE=http://localhost:3000
 
 ### DB Info

--- a/.env.example
+++ b/.env.example
@@ -11,18 +11,25 @@ BETTER_AUTH_AUDIENCE=http://localhost:8082
 
 # dj-site (Next.js) base URL — single env var that defines the canonical
 # frontend origin used by:
-#   - `trustedOrigins` (CORS for auth endpoints) — falls back to localhost
-#     when both BETTER_AUTH_TRUSTED_ORIGINS and FRONTEND_SOURCE are unset
-#   - `rewriteUrlForFrontend` (rewriting email-link hosts) — falls back to
-#     localhost on parse error or missing value
+#   - `trustedOrigins` (CORS for auth endpoints) — falls back to
+#     `http://localhost:3000` when both `BETTER_AUTH_TRUSTED_ORIGINS` and
+#     `FRONTEND_SOURCE` are unset; no error on missing value
+#   - `rewriteUrlForFrontend` (email-link host rewriting) — falls back to
+#     `http://localhost:3000` only when FRONTEND_SOURCE is missing/empty;
+#     parse errors on the FRONTEND_SOURCE value (e.g. whitespace-only,
+#     missing scheme) cause it to leave the source URL untouched, so email
+#     links keep their internal `better-auth-url` host. No error logged.
 #   - `buildLoginPage` (OIDC `loginPage` target — the `oidcProvider` plugin
 #     redirects unauthenticated users to `${FRONTEND_SOURCE}/login` and the
 #     dj-site app resumes the flow on successful sign-in) — falls back to
-#     localhost in dev, but THROWS at module-load when NODE_ENV=production
-#     and FRONTEND_SOURCE is unset (silent localhost fallback in prod would
-#     redirect every OIDC user to a host their browser can't reach).
-# Whitespace is trimmed; only the URL origin (scheme + host + port) is used,
-# so paste-from-browser values with trailing paths/queries/fragments work.
+#     `http://localhost:3000` ONLY when `NODE_ENV` is `development` or
+#     `test`. For any other `NODE_ENV` value (including unset, `production`,
+#     `staging`), missing/empty/whitespace-only/non-URL/non-http(s) values
+#     THROW at module load. Silent localhost fallback in prod would redirect
+#     every OIDC user to a host their browser cannot reach.
+# Whitespace is trimmed; only the URL origin (scheme + host + port) is used
+# by `buildLoginPage`, so paste-from-browser values with trailing
+# paths/queries/fragments are normalized to the origin only.
 FRONTEND_SOURCE=http://localhost:3000
 
 ### DB Info

--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -342,6 +342,18 @@ services:
         NPM_TOKEN: ${NPM_TOKEN:-}
     profiles: [e2e]
     environment:
+      # Override the Dockerfile's `ENV NODE_ENV=production` pin (BS#1097) so
+      # the production-shaped guards in shared/authentication (buildLoginPage
+      # fail-loud when FRONTEND_SOURCE is unset) don't fire in tests.
+      # Matches the ci-profile backend at line 173.
+      - NODE_ENV=test
+      # `apps/backend/app.ts` imports `requirePermissions` from
+      # `@wxyc/authentication`, which evaluates `betterAuth({...})` at module
+      # load and calls buildLoginPage(process.env). Without FRONTEND_SOURCE
+      # the helper falls back to localhost — fine here because the e2e
+      # backend never serves the OIDC redirect, but the value still has to
+      # be present for the dev-fallback branch to fire.
+      - FRONTEND_SOURCE=http://e2e-frontend:3000
       - DB_HOST=e2e-db
       - DB_PORT=5432
       - DB_USERNAME=${DB_USERNAME:-e2euser}

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -18,6 +18,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import { WXYCRoles } from './auth.roles';
 import { sendEmail, sendOTPEmail, sendResetPasswordEmail, sendVerificationEmailMessage } from './email';
 import { buildTrustedClients } from './oidc-trusted-clients';
+import { buildLoginPage } from './oidc-login-page';
 import { rewriteUrlForFrontend } from './url-rewrite';
 
 const buildResetUrl = (url: string, redirectTo?: string) => {
@@ -174,7 +175,7 @@ export const auth = betterAuth({
       },
     }),
     oidcProvider({
-      loginPage: '/sign-in',
+      loginPage: buildLoginPage(process.env),
       allowDynamicClientRegistration: false,
       requirePKCE: true,
       trustedClients: buildTrustedClients(process.env),

--- a/shared/authentication/src/oidc-login-page.ts
+++ b/shared/authentication/src/oidc-login-page.ts
@@ -1,0 +1,24 @@
+/**
+ * `loginPage` URL for the Better Auth `oidcProvider`.
+ *
+ * Better Auth's authorize endpoint redirects an unauthenticated user to
+ * `${loginPage}?${original-query-string}` and sets a signed `oidc_login_prompt`
+ * cookie. The dj-site Next.js app (the canonical WXYC login UI) hosts that
+ * page at `/login` and, on successful sign-in, redirects back to
+ * `${api}/auth/oauth2/authorize?<original-query>` to resume the OIDC flow.
+ *
+ * Lives in its own file (rather than inline in `auth.definition.ts`) so the
+ * helper is testable without instantiating `betterAuth({...})` and pulling in
+ * the database adapter, plugin chain, and Sentry init — same rationale as
+ * `oidc-trusted-clients.ts`.
+ *
+ * Env var reuse: `FRONTEND_SOURCE` is already the dj-site base URL across the
+ * auth surface (`trustedOrigins`, email-link rewriting via
+ * `rewriteUrlForFrontend`). Reusing it here means one env var defines the
+ * canonical frontend origin for every redirect target.
+ */
+
+export function buildLoginPage(env: NodeJS.ProcessEnv): string {
+  const base = (env.FRONTEND_SOURCE || 'http://localhost:3000').replace(/\/+$/, '');
+  return `${base}/login`;
+}

--- a/shared/authentication/src/oidc-login-page.ts
+++ b/shared/authentication/src/oidc-login-page.ts
@@ -7,18 +7,45 @@
  * page at `/login` and, on successful sign-in, redirects back to
  * `${api}/auth/oauth2/authorize?<original-query>` to resume the OIDC flow.
  *
- * Lives in its own file (rather than inline in `auth.definition.ts`) so the
- * helper is testable without instantiating `betterAuth({...})` and pulling in
- * the database adapter, plugin chain, and Sentry init — same rationale as
- * `oidc-trusted-clients.ts`.
+ * Lives in its own file so the helper is testable without instantiating
+ * `betterAuth({...})` and pulling in the database adapter, plugin chain, and
+ * Sentry init — same rationale as `oidc-trusted-clients.ts`.
  *
- * Env var reuse: `FRONTEND_SOURCE` is already the dj-site base URL across the
- * auth surface (`trustedOrigins`, email-link rewriting via
- * `rewriteUrlForFrontend`). Reusing it here means one env var defines the
- * canonical frontend origin for every redirect target.
+ * Env contract:
+ *   - `FRONTEND_SOURCE` (required in production) — the dj-site origin. Parsed
+ *     with `new URL()`; only the origin is used (any path / query / fragment
+ *     on the env value is discarded, so paste-from-browser-URL accidents
+ *     don't poison the OIDC redirect target).
+ *   - In dev (`NODE_ENV !== 'production'`), missing/empty/whitespace
+ *     `FRONTEND_SOURCE` falls back to `http://localhost:3000`.
+ *   - In production, missing `FRONTEND_SOURCE` throws at module load. Silent
+ *     localhost fallback in prod would 302 every unauthenticated OIDC user to
+ *     a host their browser can't reach, with no auth-service error.
+ *
+ * `FRONTEND_SOURCE` is also consumed by `trustedOrigins` and
+ * `rewriteUrlForFrontend`. Each applies its own normalization today; future
+ * cleanup could collapse them behind a shared `getFrontendBaseUrl(env)`.
  */
 
+const DEV_FALLBACK = 'http://localhost:3000';
+
 export function buildLoginPage(env: NodeJS.ProcessEnv): string {
-  const base = (env.FRONTEND_SOURCE || 'http://localhost:3000').replace(/\/+$/, '');
-  return `${base}/login`;
+  const raw = env.FRONTEND_SOURCE?.trim();
+  if (!raw) {
+    if (env.NODE_ENV === 'production') {
+      throw new Error(
+        '[oidc-login-page] FRONTEND_SOURCE must be set in production — it determines the OIDC loginPage redirect target. Refusing to fall back to http://localhost:3000.'
+      );
+    }
+    return `${DEV_FALLBACK}/login`;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(
+      `[oidc-login-page] FRONTEND_SOURCE is not a valid URL: ${JSON.stringify(raw)}. Expected an absolute URL such as https://dj.wxyc.org.`
+    );
+  }
+  return `${parsed.origin}/login`;
 }

--- a/shared/authentication/src/oidc-login-page.ts
+++ b/shared/authentication/src/oidc-login-page.ts
@@ -12,29 +12,38 @@
  * Sentry init — same rationale as `oidc-trusted-clients.ts`.
  *
  * Env contract:
- *   - `FRONTEND_SOURCE` (required in production) — the dj-site origin. Parsed
- *     with `new URL()`; only the origin is used (any path / query / fragment
- *     on the env value is discarded, so paste-from-browser-URL accidents
- *     don't poison the OIDC redirect target).
- *   - In dev (`NODE_ENV !== 'production'`), missing/empty/whitespace
- *     `FRONTEND_SOURCE` falls back to `http://localhost:3000`.
- *   - In production, missing `FRONTEND_SOURCE` throws at module load. Silent
- *     localhost fallback in prod would 302 every unauthenticated OIDC user to
- *     a host their browser can't reach, with no auth-service error.
+ *   - `FRONTEND_SOURCE` (required outside test/dev) — the dj-site origin.
+ *     Parsed with `new URL()`; only `http:`/`https:` are accepted; only the
+ *     origin is used (path / query / fragment on the env value are discarded,
+ *     so paste-from-browser-URL accidents don't poison the OIDC redirect
+ *     target).
+ *   - When `NODE_ENV` is `development` or `test` (the only two values that
+ *     opt-in to the localhost fallback), missing/empty/whitespace values fall
+ *     back to `http://localhost:3000`. Every other `NODE_ENV` — including
+ *     unset, `production`, `staging`, etc. — is treated as production-shaped
+ *     and throws at module load when `FRONTEND_SOURCE` is missing. Inverting
+ *     the polarity this way matches the defense-in-depth posture documented
+ *     in `auth.middleware.ts` for BS#1097 (NODE_ENV unset on EC2 silently
+ *     enabled an AUTH_BYPASS dev hatch in prod).
+ *   - Silent localhost fallback in prod would 302 every unauthenticated OIDC
+ *     user to a host their browser cannot reach with no auth-service error,
+ *     so the throw is the only acceptable failure mode.
  *
  * `FRONTEND_SOURCE` is also consumed by `trustedOrigins` and
- * `rewriteUrlForFrontend`. Each applies its own normalization today; future
- * cleanup could collapse them behind a shared `getFrontendBaseUrl(env)`.
+ * `rewriteUrlForFrontend`; each applies its own normalization today.
  */
 
 const DEV_FALLBACK = 'http://localhost:3000';
+const DEV_LIKE_NODE_ENVS = new Set(['development', 'test']);
+const ALLOWED_SCHEMES = new Set(['http:', 'https:']);
 
 export function buildLoginPage(env: NodeJS.ProcessEnv): string {
+  const isDevLike = DEV_LIKE_NODE_ENVS.has(env.NODE_ENV ?? '');
   const raw = env.FRONTEND_SOURCE?.trim();
   if (!raw) {
-    if (env.NODE_ENV === 'production') {
+    if (!isDevLike) {
       throw new Error(
-        '[oidc-login-page] FRONTEND_SOURCE must be set in production — it determines the OIDC loginPage redirect target. Refusing to fall back to http://localhost:3000.'
+        '[oidc-login-page] FRONTEND_SOURCE must be set when NODE_ENV is not development or test — it determines the OIDC loginPage redirect target. Refusing to fall back to http://localhost:3000.'
       );
     }
     return `${DEV_FALLBACK}/login`;
@@ -43,9 +52,19 @@ export function buildLoginPage(env: NodeJS.ProcessEnv): string {
   try {
     parsed = new URL(raw);
   } catch {
+    // Don't echo the env value into the error message: operators sometimes
+    // paste URLs that embed session tokens or other query secrets while
+    // debugging OAuth flows, and Sentry / CloudWatch would keep the leaked
+    // value indefinitely. The operator can re-check their own config.
     throw new Error(
-      `[oidc-login-page] FRONTEND_SOURCE is not a valid URL: ${JSON.stringify(raw)}. Expected an absolute URL such as https://dj.wxyc.org.`
+      '[oidc-login-page] FRONTEND_SOURCE is not a valid URL. Expected an absolute URL such as https://dj.wxyc.org.'
     );
+  }
+  if (!ALLOWED_SCHEMES.has(parsed.protocol)) {
+    // `new URL('mailto:...')` and other non-special-scheme inputs parse
+    // successfully but `parsed.origin` returns the literal string 'null',
+    // producing a useless 'null/login' redirect target. Reject explicitly.
+    throw new Error(`[oidc-login-page] FRONTEND_SOURCE must use http: or https:; got ${parsed.protocol}`);
   }
   return `${parsed.origin}/login`;
 }

--- a/tests/unit/authentication/build-login-page.test.ts
+++ b/tests/unit/authentication/build-login-page.test.ts
@@ -1,16 +1,33 @@
 import { buildLoginPage } from '../../../shared/authentication/src/oidc-login-page';
 
+// All happy-path / fallback tests pin NODE_ENV explicitly. The helper
+// fail-louds on any value of NODE_ENV other than 'development' or 'test',
+// which means `buildLoginPage({ FRONTEND_SOURCE: ... })` without a NODE_ENV
+// would throw the production guard. Tests are explicit so a future reader
+// understands which branch each case exercises.
+const DEV = { NODE_ENV: 'development' } as const;
+const TEST = { NODE_ENV: 'test' } as const;
+const PROD = { NODE_ENV: 'production' } as const;
+
 describe('buildLoginPage', () => {
   describe('happy path', () => {
     it('builds the login page URL from FRONTEND_SOURCE', () => {
-      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org' })).toBe('https://dj.wxyc.org/login');
+      expect(buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'https://dj.wxyc.org' })).toBe('https://dj.wxyc.org/login');
     });
 
     it('preserves a non-default port on FRONTEND_SOURCE', () => {
       // Devs sometimes run dj-site on a non-default port. `new URL().origin`
       // keeps the port; if a future refactor switched to `.host` or string
       // concat, port-preservation would silently regress.
-      expect(buildLoginPage({ FRONTEND_SOURCE: 'http://localhost:3001' })).toBe('http://localhost:3001/login');
+      expect(buildLoginPage({ ...DEV, FRONTEND_SOURCE: 'http://localhost:3001' })).toBe('http://localhost:3001/login');
+    });
+
+    it('accepts http: as well as https:', () => {
+      // Local dev (and the e2e docker network) speak http; only http and
+      // https are accepted, every other scheme is rejected.
+      expect(buildLoginPage({ ...DEV, FRONTEND_SOURCE: 'http://e2e-frontend:3000' })).toBe(
+        'http://e2e-frontend:3000/login'
+      );
     });
   });
 
@@ -21,17 +38,27 @@ describe('buildLoginPage', () => {
     // query / fragment can't poison the OIDC redirect target.
 
     it('strips a single trailing slash', () => {
-      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org/' })).toBe('https://dj.wxyc.org/login');
+      expect(buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'https://dj.wxyc.org/' })).toBe('https://dj.wxyc.org/login');
     });
 
     it('strips multiple trailing slashes', () => {
-      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org///' })).toBe('https://dj.wxyc.org/login');
+      expect(buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'https://dj.wxyc.org///' })).toBe('https://dj.wxyc.org/login');
     });
 
     it('discards an embedded path', () => {
-      // Operator copies the actual login URL into the env var.
-      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org/login' })).toBe('https://dj.wxyc.org/login');
-      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org/dashboard/playlists' })).toBe(
+      // Operator copies the actual login URL into the env var. Two distinct
+      // path shapes asserted separately so a regression in either origin
+      // extraction OR `/login` appending points at the right behavior.
+      expect(buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'https://dj.wxyc.org/dashboard/playlists' })).toBe(
+        'https://dj.wxyc.org/login'
+      );
+    });
+
+    it('discards an embedded /login path (no /login/login)', () => {
+      // Separate `it` block so a refactor that silently broke origin
+      // extraction (returning `parsed.toString()` instead of
+      // `parsed.origin + '/login'`) would point only at the wrong invariant.
+      expect(buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'https://dj.wxyc.org/login' })).toBe(
         'https://dj.wxyc.org/login'
       );
     });
@@ -40,61 +67,91 @@ describe('buildLoginPage', () => {
       // Paste-from-browser with a `?utm_source=...` query: without `new
       // URL().origin` this would concatenate `/login` into the query value
       // and the OIDC query better-auth appends would land after a second `?`.
-      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org/?utm_source=docs' })).toBe(
+      expect(buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'https://dj.wxyc.org/?utm_source=docs' })).toBe(
         'https://dj.wxyc.org/login'
       );
     });
 
     it('discards a trailing fragment', () => {
-      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org#frag' })).toBe('https://dj.wxyc.org/login');
+      expect(buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'https://dj.wxyc.org#frag' })).toBe(
+        'https://dj.wxyc.org/login'
+      );
+    });
+
+    it('strips embedded credentials', () => {
+      // `new URL('https://user:pass@host').origin` is `'https://host'`. Test
+      // pins the behavior so a future refactor that switched to `.href` or
+      // `.toString()` (which would leak the creds back into the redirect
+      // target) would fail loud.
+      expect(buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'https://user:pass@dj.wxyc.org' })).toBe(
+        'https://dj.wxyc.org/login'
+      );
     });
 
     it('trims surrounding whitespace before parsing', () => {
-      expect(buildLoginPage({ FRONTEND_SOURCE: '  https://dj.wxyc.org  ' })).toBe('https://dj.wxyc.org/login');
+      expect(buildLoginPage({ ...PROD, FRONTEND_SOURCE: '  https://dj.wxyc.org  ' })).toBe('https://dj.wxyc.org/login');
     });
   });
 
-  describe('dev fallback (NODE_ENV !== production)', () => {
-    it('falls back to localhost when FRONTEND_SOURCE is unset', () => {
-      expect(buildLoginPage({})).toBe('http://localhost:3000/login');
+  describe('dev-like fallback (NODE_ENV in {development, test})', () => {
+    it('falls back to localhost when FRONTEND_SOURCE is unset under NODE_ENV=test', () => {
+      expect(buildLoginPage(TEST)).toBe('http://localhost:3000/login');
+    });
+
+    it('falls back to localhost when FRONTEND_SOURCE is unset under NODE_ENV=development', () => {
+      expect(buildLoginPage(DEV)).toBe('http://localhost:3000/login');
     });
 
     it('falls back when FRONTEND_SOURCE is an empty string', () => {
       // `dotenvx` and shell `export VAR=` both produce an empty string rather
       // than `undefined`.
-      expect(buildLoginPage({ FRONTEND_SOURCE: '' })).toBe('http://localhost:3000/login');
+      expect(buildLoginPage({ ...DEV, FRONTEND_SOURCE: '' })).toBe('http://localhost:3000/login');
     });
 
     it('falls back when FRONTEND_SOURCE is whitespace-only', () => {
       // Trailing newlines or spaces from `.env` parsers are truthy under `||`
       // but mean nothing. Trim before the empty-check so this collapses to
       // the dev fallback instead of returning ` /login`.
-      expect(buildLoginPage({ FRONTEND_SOURCE: '   ' })).toBe('http://localhost:3000/login');
-    });
-
-    it('falls back when NODE_ENV is explicitly development', () => {
-      expect(buildLoginPage({ NODE_ENV: 'development' })).toBe('http://localhost:3000/login');
+      expect(buildLoginPage({ ...DEV, FRONTEND_SOURCE: '   ' })).toBe('http://localhost:3000/login');
     });
   });
 
-  describe('production fail-loud', () => {
-    // In prod, falling back to localhost silently breaks SSO for every
-    // unauthenticated user. The peer pattern in `oidc-trusted-clients.ts`
-    // refuses to register clients with incomplete env; this throws.
+  describe('production-shaped fail-loud (any NODE_ENV outside {development, test})', () => {
+    // Falling back to localhost in prod silently breaks SSO for every
+    // unauthenticated user. The polarity is inverted relative to the
+    // straw-man `=== 'production'` check so an unset NODE_ENV (the
+    // BS#1097 scenario) also throws.
 
-    it('throws when FRONTEND_SOURCE is unset in production', () => {
-      expect(() => buildLoginPage({ NODE_ENV: 'production' })).toThrow(/FRONTEND_SOURCE must be set in production/);
+    it('throws when FRONTEND_SOURCE is unset under NODE_ENV=production', () => {
+      expect(() => buildLoginPage(PROD)).toThrow(
+        /FRONTEND_SOURCE must be set when NODE_ENV is not development or test/
+      );
+    });
+
+    it('throws when FRONTEND_SOURCE is unset under NODE_ENV=staging', () => {
+      // Repo runs no staging deploy today, but the polarity must protect any
+      // non-dev environment a future operator stands up.
+      expect(() => buildLoginPage({ NODE_ENV: 'staging' })).toThrow(
+        /FRONTEND_SOURCE must be set when NODE_ENV is not development or test/
+      );
+    });
+
+    it('throws when FRONTEND_SOURCE is unset and NODE_ENV is unset entirely', () => {
+      // Mirrors the BS#1097 incident shape: NODE_ENV missing on EC2 + dev
+      // hatch silently active in prod. Here, unset NODE_ENV must NOT enable
+      // the dev fallback.
+      expect(() => buildLoginPage({})).toThrow(/FRONTEND_SOURCE must be set when NODE_ENV is not development or test/);
     });
 
     it('throws when FRONTEND_SOURCE is empty in production', () => {
-      expect(() => buildLoginPage({ NODE_ENV: 'production', FRONTEND_SOURCE: '' })).toThrow(
-        /FRONTEND_SOURCE must be set in production/
+      expect(() => buildLoginPage({ ...PROD, FRONTEND_SOURCE: '' })).toThrow(
+        /FRONTEND_SOURCE must be set when NODE_ENV is not development or test/
       );
     });
 
     it('throws when FRONTEND_SOURCE is whitespace-only in production', () => {
-      expect(() => buildLoginPage({ NODE_ENV: 'production', FRONTEND_SOURCE: '   ' })).toThrow(
-        /FRONTEND_SOURCE must be set in production/
+      expect(() => buildLoginPage({ ...PROD, FRONTEND_SOURCE: '   ' })).toThrow(
+        /FRONTEND_SOURCE must be set when NODE_ENV is not development or test/
       );
     });
   });
@@ -105,11 +162,56 @@ describe('buildLoginPage', () => {
     // 302. Throwing at module-load makes the misconfiguration loud.
 
     it('throws when FRONTEND_SOURCE has no scheme', () => {
-      expect(() => buildLoginPage({ FRONTEND_SOURCE: 'dj.wxyc.org' })).toThrow(/not a valid URL/);
+      expect(() => buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'dj.wxyc.org' })).toThrow(/not a valid URL/);
     });
 
     it('throws when FRONTEND_SOURCE is not a URL at all', () => {
-      expect(() => buildLoginPage({ FRONTEND_SOURCE: 'not a url' })).toThrow(/not a valid URL/);
+      expect(() => buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'not a url' })).toThrow(/not a valid URL/);
+    });
+
+    it("does not echo the env value into the 'not a valid URL' message", () => {
+      // Operators sometimes paste URLs that embed session tokens (e.g. a
+      // copied browser URL with `?session=...`). Echoing the raw env value
+      // into the throw would land it in Sentry + CloudWatch indefinitely.
+      try {
+        buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'malformed?token=eyJhbGc-secret' });
+        fail('expected throw');
+      } catch (e) {
+        expect((e as Error).message).not.toContain('eyJhbGc-secret');
+        expect((e as Error).message).not.toContain('malformed?token');
+      }
+    });
+  });
+
+  describe('disallowed schemes (http: / https: only)', () => {
+    // `new URL('mailto:...')` and other non-special schemes parse
+    // successfully but `parsed.origin` returns the literal string 'null',
+    // producing a useless 'null/login' redirect target. Reject explicitly
+    // so the bad config surfaces at boot instead of in user-facing 302s.
+
+    it('throws on mailto:', () => {
+      expect(() => buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'mailto:admin@wxyc.org' })).toThrow(
+        /must use http: or https:/
+      );
+    });
+
+    it('throws on file:', () => {
+      expect(() => buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'file:///etc/passwd' })).toThrow(
+        /must use http: or https:/
+      );
+    });
+
+    it('throws on javascript:', () => {
+      expect(() => buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'javascript:alert(1)' })).toThrow(
+        /must use http: or https:/
+      );
+    });
+
+    it('throws on ws:', () => {
+      // WebSocket scheme is real and parseable but not valid for a redirect.
+      expect(() => buildLoginPage({ ...PROD, FRONTEND_SOURCE: 'ws://dj.wxyc.org' })).toThrow(
+        /must use http: or https:/
+      );
     });
   });
 });

--- a/tests/unit/authentication/build-login-page.test.ts
+++ b/tests/unit/authentication/build-login-page.test.ts
@@ -1,0 +1,29 @@
+import { buildLoginPage } from '../../../shared/authentication/src/oidc-login-page';
+
+describe('buildLoginPage', () => {
+  it('builds the login page URL from FRONTEND_SOURCE', () => {
+    expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org' })).toBe('https://dj.wxyc.org/login');
+  });
+
+  it('strips a trailing slash on FRONTEND_SOURCE before appending /login', () => {
+    // The dev `.env.example` shows FRONTEND_SOURCE without a trailing slash,
+    // but operators routinely paste a copy-from-browser URL with one. A
+    // doubled slash (`https://dj.wxyc.org//login`) silently breaks the
+    // round-trip when better-auth's authorize endpoint redirects here.
+    expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org/' })).toBe('https://dj.wxyc.org/login');
+  });
+
+  it('falls back to http://localhost:3000/login when FRONTEND_SOURCE is unset', () => {
+    // Mirrors the default in `rewriteUrlForFrontend` so a fresh-clone dev
+    // setup with no .env still completes the OIDC round-trip against the
+    // dj-site dev server on port 3000.
+    expect(buildLoginPage({})).toBe('http://localhost:3000/login');
+  });
+
+  it('falls back to the localhost default when FRONTEND_SOURCE is an empty string', () => {
+    // `dotenvx` and shell `export VAR=` both produce an empty string rather
+    // than `undefined`. Treat empty-string the same as unset so the dev
+    // default still applies.
+    expect(buildLoginPage({ FRONTEND_SOURCE: '' })).toBe('http://localhost:3000/login');
+  });
+});

--- a/tests/unit/authentication/build-login-page.test.ts
+++ b/tests/unit/authentication/build-login-page.test.ts
@@ -1,29 +1,115 @@
 import { buildLoginPage } from '../../../shared/authentication/src/oidc-login-page';
 
 describe('buildLoginPage', () => {
-  it('builds the login page URL from FRONTEND_SOURCE', () => {
-    expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org' })).toBe('https://dj.wxyc.org/login');
+  describe('happy path', () => {
+    it('builds the login page URL from FRONTEND_SOURCE', () => {
+      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org' })).toBe('https://dj.wxyc.org/login');
+    });
+
+    it('preserves a non-default port on FRONTEND_SOURCE', () => {
+      // Devs sometimes run dj-site on a non-default port. `new URL().origin`
+      // keeps the port; if a future refactor switched to `.host` or string
+      // concat, port-preservation would silently regress.
+      expect(buildLoginPage({ FRONTEND_SOURCE: 'http://localhost:3001' })).toBe('http://localhost:3001/login');
+    });
   });
 
-  it('strips a trailing slash on FRONTEND_SOURCE before appending /login', () => {
-    // The dev `.env.example` shows FRONTEND_SOURCE without a trailing slash,
-    // but operators routinely paste a copy-from-browser URL with one. A
-    // doubled slash (`https://dj.wxyc.org//login`) silently breaks the
-    // round-trip when better-auth's authorize endpoint redirects here.
-    expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org/' })).toBe('https://dj.wxyc.org/login');
+  describe('paste-from-browser hardening (only origin survives)', () => {
+    // FRONTEND_SOURCE is documented as a base URL, but operators routinely
+    // paste a deeper URL from a browser tab. `new URL(raw).origin` drops
+    // every part of the input except scheme/host/port, so a stray path /
+    // query / fragment can't poison the OIDC redirect target.
+
+    it('strips a single trailing slash', () => {
+      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org/' })).toBe('https://dj.wxyc.org/login');
+    });
+
+    it('strips multiple trailing slashes', () => {
+      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org///' })).toBe('https://dj.wxyc.org/login');
+    });
+
+    it('discards an embedded path', () => {
+      // Operator copies the actual login URL into the env var.
+      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org/login' })).toBe('https://dj.wxyc.org/login');
+      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org/dashboard/playlists' })).toBe(
+        'https://dj.wxyc.org/login'
+      );
+    });
+
+    it('discards a trailing query string', () => {
+      // Paste-from-browser with a `?utm_source=...` query: without `new
+      // URL().origin` this would concatenate `/login` into the query value
+      // and the OIDC query better-auth appends would land after a second `?`.
+      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org/?utm_source=docs' })).toBe(
+        'https://dj.wxyc.org/login'
+      );
+    });
+
+    it('discards a trailing fragment', () => {
+      expect(buildLoginPage({ FRONTEND_SOURCE: 'https://dj.wxyc.org#frag' })).toBe('https://dj.wxyc.org/login');
+    });
+
+    it('trims surrounding whitespace before parsing', () => {
+      expect(buildLoginPage({ FRONTEND_SOURCE: '  https://dj.wxyc.org  ' })).toBe('https://dj.wxyc.org/login');
+    });
   });
 
-  it('falls back to http://localhost:3000/login when FRONTEND_SOURCE is unset', () => {
-    // Mirrors the default in `rewriteUrlForFrontend` so a fresh-clone dev
-    // setup with no .env still completes the OIDC round-trip against the
-    // dj-site dev server on port 3000.
-    expect(buildLoginPage({})).toBe('http://localhost:3000/login');
+  describe('dev fallback (NODE_ENV !== production)', () => {
+    it('falls back to localhost when FRONTEND_SOURCE is unset', () => {
+      expect(buildLoginPage({})).toBe('http://localhost:3000/login');
+    });
+
+    it('falls back when FRONTEND_SOURCE is an empty string', () => {
+      // `dotenvx` and shell `export VAR=` both produce an empty string rather
+      // than `undefined`.
+      expect(buildLoginPage({ FRONTEND_SOURCE: '' })).toBe('http://localhost:3000/login');
+    });
+
+    it('falls back when FRONTEND_SOURCE is whitespace-only', () => {
+      // Trailing newlines or spaces from `.env` parsers are truthy under `||`
+      // but mean nothing. Trim before the empty-check so this collapses to
+      // the dev fallback instead of returning ` /login`.
+      expect(buildLoginPage({ FRONTEND_SOURCE: '   ' })).toBe('http://localhost:3000/login');
+    });
+
+    it('falls back when NODE_ENV is explicitly development', () => {
+      expect(buildLoginPage({ NODE_ENV: 'development' })).toBe('http://localhost:3000/login');
+    });
   });
 
-  it('falls back to the localhost default when FRONTEND_SOURCE is an empty string', () => {
-    // `dotenvx` and shell `export VAR=` both produce an empty string rather
-    // than `undefined`. Treat empty-string the same as unset so the dev
-    // default still applies.
-    expect(buildLoginPage({ FRONTEND_SOURCE: '' })).toBe('http://localhost:3000/login');
+  describe('production fail-loud', () => {
+    // In prod, falling back to localhost silently breaks SSO for every
+    // unauthenticated user. The peer pattern in `oidc-trusted-clients.ts`
+    // refuses to register clients with incomplete env; this throws.
+
+    it('throws when FRONTEND_SOURCE is unset in production', () => {
+      expect(() => buildLoginPage({ NODE_ENV: 'production' })).toThrow(/FRONTEND_SOURCE must be set in production/);
+    });
+
+    it('throws when FRONTEND_SOURCE is empty in production', () => {
+      expect(() => buildLoginPage({ NODE_ENV: 'production', FRONTEND_SOURCE: '' })).toThrow(
+        /FRONTEND_SOURCE must be set in production/
+      );
+    });
+
+    it('throws when FRONTEND_SOURCE is whitespace-only in production', () => {
+      expect(() => buildLoginPage({ NODE_ENV: 'production', FRONTEND_SOURCE: '   ' })).toThrow(
+        /FRONTEND_SOURCE must be set in production/
+      );
+    });
+  });
+
+  describe('invalid URL', () => {
+    // Better-auth's authorize endpoint concatenates loginPage into a Location
+    // header without re-parsing, so a malformed value silently produces a bad
+    // 302. Throwing at module-load makes the misconfiguration loud.
+
+    it('throws when FRONTEND_SOURCE has no scheme', () => {
+      expect(() => buildLoginPage({ FRONTEND_SOURCE: 'dj.wxyc.org' })).toThrow(/not a valid URL/);
+    });
+
+    it('throws when FRONTEND_SOURCE is not a URL at all', () => {
+      expect(() => buildLoginPage({ FRONTEND_SOURCE: 'not a url' })).toThrow(/not a valid URL/);
+    });
   });
 });


### PR DESCRIPTION
Closes #1395. Companion PR: WXYC/dj-site#761.

## Summary

- The `oidcProvider` plugin had `loginPage: '/sign-in'` — a route that doesn't exist on the auth Express app. Existing reviewers of the flowsheet verifier (and any future OIDC client) were landing on a 404 instead of a sign-in form. This PR points `loginPage` at the canonical WXYC login UI in dj-site.
- New helper `shared/authentication/src/oidc-login-page.ts::buildLoginPage(env)` builds the URL from `FRONTEND_SOURCE` — the existing dj-site base-URL env var already consumed by `trustedOrigins` and `rewriteUrlForFrontend`. Reusing it keeps the canonical frontend origin defined in exactly one env var. Falls back to `http://localhost:3000/login` when unset, matching `rewriteUrlForFrontend`'s default.
- Strips a trailing slash on `FRONTEND_SOURCE` so a copy-from-browser URL doesn't produce a doubled-slash `loginPage`.
- Helper lives in its own file (rather than inline) for the same testability reasons as `oidc-trusted-clients.ts` — pure function over a `NodeJS.ProcessEnv`, no `betterAuth({…})` instantiation needed to exercise the contract.
- `.env.example` now documents `FRONTEND_SOURCE` (it was previously only referenced in code).

## Deployment

`FRONTEND_SOURCE` already exists on the EC2 auth container — **no new env var to set**. Before merging, confirm the existing value points to the dj-site origin in each environment:
- production: the canonical dj-site origin (e.g. `https://dj.wxyc.org`).
- staging: dj-site preview URL.
- local: helper default applies if unset.

## Test plan

- [x] `buildLoginPage` unit tests cover: `FRONTEND_SOURCE` set, trailing slash, unset, empty string.
- [x] All 86 existing authentication unit tests still pass; no new failures (pre-existing service-test failures on origin/main from an unrelated LRUCache issue are unchanged).
- [x] `prettier --check` clean on changed files.
- [ ] Manual end-to-end against staging once the dj-site companion (WXYC/dj-site#761) deploys: visit `${BETTER_AUTH_URL}/oauth2/authorize?client_id=flowsheet&response_type=code&...`, confirm bounce to dj-site `/login?<query>`, sign in, confirm the resume URL goes back to authorize and the final redirect to the flowsheet verifier client.