### PR TITLE
fix(legacy-dj-name-remediation): truncate DJ_HANDLE to 128 chars (BS#1393 hot-fix)

### DIFF
--- a/jobs/legacy-dj-name-remediation/job.ts
+++ b/jobs/legacy-dj-name-remediation/job.ts
@@ -58,6 +58,20 @@ export const schemaPrefix = (): SQL => {
 
 export type HandleMapping = { showId: number; djHandle: string | null };
 
+/**
+ * Matches the varchar ceiling on `shows.legacy_dj_name` (shared/database/src/
+ * schema.ts:1175). The flowsheet ETL truncates its own DJ_NAME / DJ_HANDLE
+ * pulls to the same length at the source (jobs/flowsheet-etl/job.ts:200 +
+ * job.ts:338); without this, production rows whose DJ_HANDLE exceeds 128
+ * chars (e.g. the 300+ char Cynocephalus handle the tubafrenzy fix in #573
+ * documents) abort the batch CTE with `value too long for type character
+ * varying(128)` — exactly the failure that interrupted the first prod run
+ * at batch 5/15 mid-remediation. Truncation here matches what the ETL would
+ * write on the same row, so idempotency between the two writers is
+ * preserved.
+ */
+const LEGACY_DJ_NAME_MAX_LENGTH = 128;
+
 export const fetchHandleMappings = async (mirror = MirrorSQL.instance()): Promise<HandleMapping[]> => {
   console.log('[remediate] Fetching DJ_HANDLE mappings from tubafrenzy...');
   const raw = await mirror.send(`
@@ -79,7 +93,8 @@ export const fetchHandleMappings = async (mirror = MirrorSQL.instance()): Promis
     // Reject NUL bytes — Postgres refuses text containing U+0000, and a
     // dirty row would otherwise abort the batch mid-flight. Treat as missing.
     if (trimmed.includes('\0')) continue;
-    const djHandle = trimmed.length > 0 && trimmed !== 'NULL' ? trimmed : null;
+    const truncated = trimmed.slice(0, LEGACY_DJ_NAME_MAX_LENGTH);
+    const djHandle = truncated.length > 0 && truncated !== 'NULL' ? truncated : null;
     mappings.push({ showId, djHandle });
   }
 

--- a/tests/unit/jobs/legacy-dj-name-remediation/job.test.ts
+++ b/tests/unit/jobs/legacy-dj-name-remediation/job.test.ts
@@ -292,6 +292,23 @@ describe('legacy-dj-name-remediation: fetchHandleMappings', () => {
     ]);
   });
 
+  it('truncates DJ_HANDLE to 128 chars to match shows.legacy_dj_name varchar(128) ceiling', async () => {
+    // Production prior incident: a 300+ char DJ_HANDLE (the Cynocephalus
+    // handle, tubafrenzy#573) aborts the batch CTE mid-pass with `value too
+    // long for type character varying(128)`. The flowsheet ETL truncates at
+    // the source; this fetcher must do the same so the remediation matches
+    // what the ETL would write on the same row.
+    const longHandle = 'A'.repeat(300);
+    const mirror = {
+      send: jest.fn<() => Promise<string>>().mockResolvedValue(`1001\t${longHandle}\n`),
+      close: jest.fn(),
+    };
+
+    const mappings = await fetchHandleMappings(mirror as never);
+
+    expect(mappings).toEqual([{ showId: 1001, djHandle: 'A'.repeat(128) }]);
+  });
+
   it('treats empty / NULL / whitespace handles as null', async () => {
     // Use a sentinel non-whitespace value as the last row's handle so the
     // outer `.trim()` doesn't strip the row's tab delimiter and trigger the


### PR DESCRIPTION
## Context

First prod run of the legacy-dj-name-remediation job (PR #1394) aborted at batch 5/15:

\`\`\`
[remediate] batch 1/15: 4763 shows updated, 0 marker rows reset, 0 marker rows re-resolved.
[remediate] batch 2/15: 4756 shows updated, 0 marker rows reset, 4 marker rows re-resolved.
[remediate] batch 3/15: 4244 shows updated, 0 marker rows reset, 5763 marker rows re-resolved.
[remediate] batch 4/15: 3515 shows updated, 0 marker rows reset, 10026 marker rows re-resolved.
[remediate] Fatal error: DrizzleQueryError
  cause: PostgresError: value too long for type character varying(128)
\`\`\`

Production has DJ_HANDLE values longer than the \`shows.legacy_dj_name varchar(128)\` ceiling. The 300+ char Cynocephalus handle documented in [tubafrenzy#573](https://github.com/WXYC/tubafrenzy/pull/573) is one example.

The flowsheet ETL truncates at the source (\`jobs/flowsheet-etl/job.ts:200\` for bulk-load and \`job.ts:338\` for incremental); the remediation script's \`fetchHandleMappings\` did not, so an oversized handle on a single show aborted the per-batch CTE for the whole batch.

## Fix

Truncate to the same 128-char ceiling in \`fetchHandleMappings\`. Now matches what the ETL would write for the same row, so re-run idempotency between the two writers is preserved.

## Resume plan

Batches 1-4 of the prior run committed durably (~17,278 shows updated, ~15,793 markers re-resolved). The CTE's \`COALESCE(trim(legacy_dj_name), '') IS DISTINCT FROM\` filter skips already-clean rows on re-run, so the resumed pass will start at batch 5 and finish the remaining ~55k shows + truncated handles.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npm run test:unit\` — 17/17 pass on remediation suite (new test pins the 128-char cap)
- [ ] Post-merge: Manual Build & Deploy \`target=legacy-dj-name-remediation\`, then re-run without \`--dry-run\` on EC2; expect resume from batch 5/15.