### PR TITLE
fix(sse): register client before attaching close handler to fix race (#1128)

### DIFF
--- a/apps/backend/utils/serverEvents.ts
+++ b/apps/backend/utils/serverEvents.ts
@@ -117,6 +117,14 @@ export class ServerEventsManager {
       res: res,
     };
 
+    // Insert into the clients map BEFORE attaching the close handler and
+    // before any operation that can synchronously trigger 'close' (writeHead,
+    // write). Otherwise a TCP reset arriving between `on('close')` and
+    // `clients.set` would run the close handler's `unsubAll(client.id)` as a
+    // no-op against the not-yet-inserted entry, and the dead client would
+    // leak into the map permanently (BS#1128). No async boundary may sit
+    // between this set() and the on('close') attach below.
+    this.clients.set(client.id, client);
     this.startHeartbeat(client.id);
 
     client.res.on('close', () => {
@@ -141,8 +149,6 @@ export class ServerEventsManager {
       timestamp: new Date(),
     };
     client.res.write(`data: ${JSON.stringify(connectionEvent)}\n\n`);
-
-    this.clients.set(client.id, client);
 
     return client;
   };

--- a/tests/unit/utils/serverEvents.test.ts
+++ b/tests/unit/utils/serverEvents.test.ts
@@ -265,6 +265,53 @@ describe('ServerEventsManager', () => {
     });
   });
 
+  describe('registerClient close-before-insert race (BS#1128)', () => {
+    // Build a mock Response whose `write` synchronously emits `close`,
+    // mimicking a TCP RST that arrives between the close-handler attach
+    // and the final `this.clients.set(client.id, client)` insertion.
+    function createMockResponseClosingOnWrite(): Response {
+      const emitter = new EventEmitter();
+      const res = {
+        writeHead: jest.fn(),
+        write: jest.fn().mockImplementation(() => {
+          // Fire 'close' synchronously during writeHead/write — i.e. while
+          // registerClient is still mid-function, before clients.set runs.
+          emitter.emit('close');
+          return true;
+        }),
+        end: jest.fn(),
+        on: emitter.on.bind(emitter),
+        emit: emitter.emit.bind(emitter),
+      } as unknown as Response;
+      return res;
+    }
+
+    it('does not leave a dead client in the clients map when close fires before insert', () => {
+      const mgr = new ServerEventsManager('topic-a');
+      const res = createMockResponseClosingOnWrite();
+      const client = mgr.registerClient(res);
+
+      // If the race is fixed, the close handler observed the client in the
+      // map and removed it, OR the client was never inserted at all.
+      // Either way, a subscribe call must fail with a 404-style WxycError.
+      expect(() => mgr.subscribe(['topic-a'], client.id)).toThrow(/not found/i);
+    });
+
+    it('disconnect() of a raced client is a no-op (entry was already cleaned up)', () => {
+      const mgr = new ServerEventsManager('topic-a');
+      const res = createMockResponseClosingOnWrite();
+      const client = mgr.registerClient(res);
+
+      // If the dead client leaked into `clients`, disconnect() would find
+      // it and call `res.end()`. With the race fixed, the close handler
+      // already removed it (or it was never inserted), so end is untouched.
+      const endMock = res.end as jest.Mock;
+      endMock.mockClear();
+      mgr.disconnect(client.id);
+      expect(endMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getClientCountByTopic', () => {
     it('returns a count of subscribed clients per topic', () => {
       const mgr = new ServerEventsManager('topic-a', 'topic-b');


### PR DESCRIPTION
Closes #1128.

## Problem

`ServerEventsManager.registerClient` attached `client.res.on('close', ...)` before the final `this.clients.set(client.id, client)`. If the underlying socket closed in that window (e.g. a TCP RST while the SSE headers were still being flushed), the close handler's `unsubAll(client.id)` ran against a map that didn't yet contain the client — a silent no-op. The subsequent `clients.set` then inserted the (already-dead) client, where it lived forever: no inactivity timer, no live socket, and a guaranteed write-to-dead-socket attempt the next time anything broadcast to one of its topics.

## Fix

Move the `clients.set(client.id, client)` ahead of `startHeartbeat`, ahead of the `on('close')` attach, and ahead of the `writeHead`/initial write — eliminating the window in which `'close'` can fire against a not-yet-registered entry. No async boundary sits between the set and the on('close') attach, so the close handler is guaranteed to observe the inserted client when it runs.

## Test

`tests/unit/utils/serverEvents.test.ts` adds a `registerClient close-before-insert race (BS#1128)` block with two cases. Both use a mock `Response` whose `write` synchronously emits `'close'`, mimicking a socket reset arriving mid-`writeHead`/write:

1. After the race, `subscribe(...)` for that client throws a 404-style `WxycError` (the client was correctly removed from the map by the close handler).
2. After the race, `disconnect(...)` for that client does NOT call `res.end()` (no dead entry leaked into the map for `disconnect` to act on).

Both tests fail against `main` and pass after the reorder.

## Local CI

- `npm run lint` — 0 errors
- `npm run format:check` — clean
- `npm run typecheck` — clean
- `npm run test:unit` — 3153 passed (incl. 17 in `serverEvents.test.ts`, up from 15)