### PR TITLE
fix(legacy-mirror): recover MirrorCommandQueue after fatalStop

### DIFF
--- a/apps/backend/middleware/legacy/commandqueue.mirror.ts
+++ b/apps/backend/middleware/legacy/commandqueue.mirror.ts
@@ -88,7 +88,22 @@ function envInt(name: string, fallback: number): number {
 export class MirrorCommandQueue extends EventEmitter {
   private static _instance: MirrorCommandQueue | null = null;
 
+  /**
+   * Get the process-wide mirror queue. Auto-recycles after `fatalStop`:
+   * if the prior singleton went dead (5 failed attempts on any command
+   * tripped `fatalStop`, flipping `alive=false`), the next call returns a
+   * fresh live instance instead of the dead one. Without this, every
+   * caller after the first fatal would see `enqueue` return `null`
+   * silently for the lifetime of the process (BS#1123).
+   *
+   * In-flight write invariant: the dead instance's `workLoop` continues
+   * to drain (or fatal-stop) on its own promise chain; the fresh queue
+   * starts empty, so no command is torn between the two instances.
+   */
   static instance(options?: MirrorQueueOptions) {
+    if (this._instance && this._instance.isDead()) {
+      this._instance = null;
+    }
     if (!this._instance) {
       this._instance = new MirrorCommandQueue(options);
 

--- a/tests/unit/middleware/legacy/commandqueue.mirror.test.ts
+++ b/tests/unit/middleware/legacy/commandqueue.mirror.test.ts
@@ -142,6 +142,83 @@ describe('MirrorCommandQueue', () => {
     expect(queue.enqueue(['SELECT 2'])).toBeNull();
   });
 
+  describe('recovery after fatalStop', () => {
+    test('instance() returns a fresh live queue after the prior singleton went fatal', async () => {
+      mockSend.mockRejectedValueOnce(new Error('fatal 1'));
+
+      const dead = createQueue({ maxAttempts: 1 });
+      dead.enqueue(['SELECT 1']);
+      await jest.advanceTimersByTimeAsync(50);
+
+      expect(dead.isDead()).toBe(true);
+
+      // Simulate the next legacy-mirror cycle: it calls `instance()` again,
+      // expecting a usable queue. After fatalStop, that call must yield a
+      // fresh live instance, not the dead singleton.
+      mockSend.mockResolvedValueOnce('OK');
+      const recovered = MirrorCommandQueue.instance({
+        maxAttempts: 3,
+        baseBackoffMs: 10,
+        maxBackoffMs: 100,
+        jitterMs: 0,
+        logFile: '/tmp/test-mirror-logs',
+      });
+
+      expect(recovered).not.toBe(dead);
+      expect(recovered.isAlive()).toBe(true);
+
+      const succeededSpy = jest.fn();
+      recovered.on('succeeded', succeededSpy);
+
+      const cmd = recovered.enqueue(['SELECT 2']);
+      expect(cmd).not.toBeNull();
+
+      await jest.advanceTimersByTimeAsync(50);
+      expect(succeededSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('repeated fatalStop -> recover cycles do not leak listeners on the fresh instance', async () => {
+      mockSend.mockRejectedValueOnce(new Error('cycle 1 fatal')).mockRejectedValueOnce(new Error('cycle 2 fatal'));
+
+      const first = createQueue({ maxAttempts: 1 });
+      first.enqueue(['SELECT 1']);
+      await jest.advanceTimersByTimeAsync(50);
+      expect(first.isDead()).toBe(true);
+
+      const second = MirrorCommandQueue.instance({
+        maxAttempts: 1,
+        baseBackoffMs: 10,
+        maxBackoffMs: 100,
+        jitterMs: 0,
+        logFile: '/tmp/test-mirror-logs',
+      });
+      expect(second).not.toBe(first);
+      second.enqueue(['SELECT 2']);
+      await jest.advanceTimersByTimeAsync(50);
+      expect(second.isDead()).toBe(true);
+
+      const third = MirrorCommandQueue.instance({
+        maxAttempts: 3,
+        baseBackoffMs: 10,
+        maxBackoffMs: 100,
+        jitterMs: 0,
+        logFile: '/tmp/test-mirror-logs',
+      });
+      expect(third).not.toBe(second);
+      expect(third.isAlive()).toBe(true);
+
+      // Each lifecycle event has exactly one listener registered by the
+      // static `instance()` factory: the dispatch closure. Verifies that
+      // recovery did not re-register listeners on the same shared instance.
+      expect(third.listenerCount('enqueued')).toBe(1);
+      expect(third.listenerCount('started')).toBe(1);
+      expect(third.listenerCount('succeeded')).toBe(1);
+      expect(third.listenerCount('failedAttempt')).toBe(1);
+      expect(third.listenerCount('fatal')).toBe(1);
+      expect(third.listenerCount('persisted')).toBe(1);
+    });
+  });
+
   describe('fatal report on disk', () => {
     test('uses ring-buffer filename and never serializes raw SQL', async () => {
       mockSend.mockRejectedValue(new Error('connection refused'));


### PR DESCRIPTION
## Summary

After `MirrorCommandQueue.fatalStop` runs, the singleton flips `alive=false` and `fatalEmitted=true` permanently. The mirror middleware re-calls `MirrorCommandQueue.instance()` per response-finish, gets the dead instance back, and `enqueue()` returns `null` silently for the lifetime of the process — `deleteEntry`'s SQL-mirror writes drop, no further Sentry events fire (`fatalEmitted` short-circuits the second fatal report), and the `mirror` SSE topic goes dark.

Fix: auto-recycle in the static `instance()` factory. If the prior singleton is dead at call time, drop it and create a fresh one with listeners re-registered.

In-flight write invariant: the dead instance's `workLoop` continues to drain (or fatal-stop) on its own promise chain; the fresh queue starts empty, so no command is torn between the two instances. Recovery is idempotent — repeated fatalStop -> recover cycles each yield a fresh instance, never re-registering listeners on a shared one.

## Test plan

- [x] Added failing test: `instance()` after fatalStop returns a fresh live queue, not the dead singleton.
- [x] Added failing test: repeated fatalStop -> recover cycles register exactly one listener per lifecycle event on the fresh instance (no leak from shared-instance re-binding).
- [x] `npm run lint` — 0 errors.
- [x] `npm run format:check` — clean.
- [x] `npm run typecheck` — clean across all workspaces.
- [x] `npm run test:unit` — 3153/3153 pass.
- [ ] In prod: trigger a fatalStop (e.g., temporarily block the SSH tunnel for >5 attempts), restore, then verify the next mirror cycle re-enqueues successfully.

Closes #1123.