### PR TITLE
fix(playlist-proxy): clear pending reconnect timer on stop (#1132)

### DIFF
--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -159,13 +159,21 @@ export function getRecentEntries(n: number): GroupedResponse {
  * Open the SSE connection to tubafrenzy. Call once at startup.
  */
 export function startPlaylistProxy(): void {
+  stopped = false;
   connectSSE();
 }
 
 /**
  * Close the SSE connection, cancel pending reconnects, and clear state.
+ * Idempotent: safe to call multiple times.
+ *
+ * The `stopped` flag gates the 'error' handler so an error that fires
+ * *after* this call (queued in the EventLoop, or emitted by `close()`
+ * itself in some EventSource implementations) cannot schedule a fresh
+ * reconnect (BS#1132).
  */
 export function stopPlaylistProxy(): void {
+  stopped = true;
   if (currentEventSource) {
     currentEventSource.close();
     currentEventSource = null;
@@ -203,8 +211,12 @@ let reconnectDelay = 1000;
 const MAX_RECONNECT_DELAY = 30000;
 let currentEventSource: EventSource | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+// `stopped` gates the 'error' handler from scheduling a reconnect after
+// `stopPlaylistProxy()`. Cleared by `startPlaylistProxy`/`connectSSE`.
+let stopped = false;
 
 function connectSSE(): void {
+  stopped = false;
   const url = `${TUBAFRENZY_URL}/playlists/recentStream`;
   console.log(`[playlist-proxy] Connecting to SSE: ${url}`);
 
@@ -238,10 +250,25 @@ function connectSSE(): void {
   });
 
   es.addEventListener('error', () => {
-    console.error(`[playlist-proxy] SSE error, reconnecting in ${reconnectDelay}ms`);
     es.close();
     if (currentEventSource === es) currentEventSource = null;
+
+    // If the operator has stopped the proxy, do not schedule a
+    // reconnect. Without this guard, errors that fire after stop
+    // (queued in the EventLoop, or emitted by `close()` itself)
+    // would silently reopen the upstream connection. BS#1132.
+    if (stopped) return;
+
+    console.error(`[playlist-proxy] SSE error, reconnecting in ${reconnectDelay}ms`);
+
+    // Clear any prior pending timer before assigning a fresh one.
+    // Cascading 'error' events (e.g. during a deploy disconnect)
+    // would otherwise stack parallel reconnects, each invoking
+    // `connectSSE()` independently. BS#1132.
+    if (reconnectTimer) clearTimeout(reconnectTimer);
     reconnectTimer = setTimeout(() => connectSSE(), reconnectDelay);
+
+    // Only escalate the backoff when a reconnect is actually scheduled.
     reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY);
   });
 }

--- a/tests/unit/services/playlist-proxy.stop.test.ts
+++ b/tests/unit/services/playlist-proxy.stop.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for stopPlaylistProxy lifecycle and reconnect-timer hygiene.
+ *
+ * The 'error' handler unconditionally schedules `reconnectTimer =
+ * setTimeout(() => connectSSE(), reconnectDelay)`. Two failure modes
+ * fall out of that (BS#1132):
+ *
+ *   1. Cancellation race — if `stopPlaylistProxy()` runs *before* a
+ *      pending reconnect fires, the queued reconnect still wakes up
+ *      and reopens the upstream connection the operator just asked
+ *      to tear down.
+ *
+ *   2. Stacked timers — if multiple 'error' events fire in quick
+ *      succession before any reconnect runs (e.g. a cascading TCP
+ *      failure during deploy), each handler reassigns `reconnectTimer`
+ *      to a fresh `setTimeout` without clearing the prior handle. The
+ *      stop path's `clearTimeout(reconnectTimer)` only cancels the
+ *      most recent handle, so the earlier ones still fire and stack
+ *      parallel SSE connections.
+ *
+ * The fix:
+ *   - A module-level `stopped` flag, set by `stopPlaylistProxy` and
+ *     cleared by `startPlaylistProxy`/`connectSSE`, gated by the
+ *     'error' handler before it schedules a reconnect.
+ *   - Each new `reconnectTimer` assignment clears the prior handle
+ *     before overwriting it.
+ *   - `reconnectDelay` backoff escalates only when a reconnect is
+ *     actually scheduled (i.e. inside the guard), so a stopped proxy
+ *     doesn't push the delay toward the ceiling for no reason.
+ */
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+// --- Mock EventSource that tracks instances and captures listeners ---
+
+type EventHandler = (event: { data: string }) => void;
+
+interface MockES {
+  url: string;
+  listeners: Map<string, EventHandler[]>;
+  addEventListener: jest.Mock;
+  close: jest.Mock;
+  readyState: number;
+}
+
+const instances: MockES[] = [];
+
+jest.mock('eventsource', () => ({
+  EventSource: jest.fn().mockImplementation((url: string) => {
+    const listeners = new Map<string, EventHandler[]>();
+    const instance: MockES = {
+      url,
+      listeners,
+      addEventListener: jest.fn((type: string, fn: EventHandler) => {
+        if (!listeners.has(type)) listeners.set(type, []);
+        listeners.get(type)?.push(fn);
+      }),
+      close: jest.fn(),
+      readyState: 1,
+    };
+    instances.push(instance);
+    return instance;
+  }),
+}));
+
+// drizzle-orm mock (needed by enrichPlaycuts even though it's not exercised here)
+jest.mock('drizzle-orm', () => ({
+  sql: Object.assign(jest.fn(), { raw: jest.fn() }),
+  inArray: jest.fn(),
+  isNotNull: jest.fn(),
+  and: jest.fn(),
+  eq: jest.fn(),
+}));
+
+// Suppress console output
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'error').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+// Import after mocks are in place. @wxyc/database is mapped to the
+// shared mock by jest.unit.config.ts moduleNameMapper.
+import {
+  startPlaylistProxy,
+  stopPlaylistProxy,
+  resetState,
+} from '../../../apps/backend/services/playlist-proxy.service';
+
+/** Fire a named event on a mock EventSource instance. */
+function fireEvent(es: MockES, type: string, data: unknown = {}): void {
+  const handlers = es.listeners.get(type) ?? [];
+  const event: { data: string } = { data: typeof data === 'string' ? data : JSON.stringify(data) };
+  for (const handler of handlers) handler(event);
+}
+
+describe('playlist-proxy stopPlaylistProxy reconnect-timer hygiene', () => {
+  beforeEach(() => {
+    instances.length = 0;
+    resetState();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('error fired after stopPlaylistProxy does not schedule a reconnect', () => {
+    // Open the SSE connection and let it establish.
+    startPlaylistProxy();
+    expect(instances).toHaveLength(1);
+    fireEvent(instances[0], 'init', []);
+
+    // Operator stops the proxy.
+    const stoppedEs = instances[0];
+    stopPlaylistProxy();
+
+    // An 'error' event is still queued in the EventLoop and fires
+    // after the stop. Without the guard, this handler would schedule
+    // a fresh reconnect timer that wakes up and reopens the SSE.
+    fireEvent(stoppedEs, 'error');
+
+    // Advance well past MAX_RECONNECT_DELAY (30 s) so any pending
+    // reconnect would have fired.
+    jest.advanceTimersByTime(60_000);
+
+    // No fresh EventSource should have been constructed.
+    expect(instances).toHaveLength(1);
+  });
+
+  test('queued reconnect timer is cleared by stopPlaylistProxy', () => {
+    startPlaylistProxy();
+    fireEvent(instances[0], 'init', []);
+    fireEvent(instances[0], 'error');
+
+    // Stop before the timer wakes up.
+    stopPlaylistProxy();
+
+    jest.advanceTimersByTime(60_000);
+    expect(instances).toHaveLength(1);
+  });
+
+  test('stacked errors do not produce parallel reconnects after stop', () => {
+    startPlaylistProxy();
+    expect(instances).toHaveLength(1);
+    fireEvent(instances[0], 'init', []);
+
+    // Cascading errors before any reconnect timer fires.
+    fireEvent(instances[0], 'error');
+    fireEvent(instances[0], 'error');
+    fireEvent(instances[0], 'error');
+
+    // Stop before any timer wakes up.
+    stopPlaylistProxy();
+
+    jest.advanceTimersByTime(120_000);
+
+    // No new EventSource instances; all queued timers were cancelled
+    // (or, equivalently, gated out by the stopped flag).
+    expect(instances).toHaveLength(1);
+  });
+
+  test('multiple stopPlaylistProxy calls in a row are idempotent', () => {
+    startPlaylistProxy();
+    fireEvent(instances[0], 'init', []);
+    fireEvent(instances[0], 'error');
+
+    expect(() => {
+      stopPlaylistProxy();
+      stopPlaylistProxy();
+      stopPlaylistProxy();
+    }).not.toThrow();
+
+    jest.advanceTimersByTime(60_000);
+    expect(instances).toHaveLength(1);
+  });
+
+  test('startPlaylistProxy after stop clears the stopped flag and reconnects on error', () => {
+    startPlaylistProxy();
+    fireEvent(instances[0], 'init', []);
+    stopPlaylistProxy();
+
+    // Re-start: stopped flag must be cleared so subsequent errors
+    // schedule reconnects again.
+    startPlaylistProxy();
+    expect(instances).toHaveLength(2);
+    fireEvent(instances[1], 'init', []);
+    fireEvent(instances[1], 'error');
+
+    // Advance past the 1 s base delay so the reconnect fires.
+    jest.advanceTimersByTime(1_500);
+
+    expect(instances).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
Closes #1132.

## Problem

`apps/backend/services/playlist-proxy.service.ts`'s EventSource `'error'` handler unconditionally schedules a reconnect timer with no guard against `stopPlaylistProxy` having been called. Two failure modes:

1. **Cancellation race** — an `'error'` event queued in the EventLoop (or emitted by `close()` itself in some EventSource implementations) fires *after* `stopPlaylistProxy()`. The handler schedules a fresh reconnect that wakes up and reopens the upstream connection the operator just asked to tear down.

2. **Stacked timers** — if multiple `'error'` events fire in rapid succession before any reconnect runs (cascading TCP failure during a deploy disconnect), each handler reassigns `reconnectTimer` to a fresh `setTimeout` without clearing the prior handle. `stopPlaylistProxy`'s `clearTimeout(reconnectTimer)` only cancels the most recent handle, so the earlier ones still fire and stack parallel SSE connections.

The second pattern also unnecessarily escalates `reconnectDelay` past `MAX_RECONNECT_DELAY` (the `* 2` ran on every error, even ones whose timers were immediately cancelled).

## Fix

- Module-level `stopped` flag, set by `stopPlaylistProxy` and cleared by `startPlaylistProxy` / `connectSSE`. The `'error'` handler returns early when `stopped` is true.
- Before assigning a new `reconnectTimer`, `clearTimeout` the prior value — prevents the stacked-timer case directly even if the flag check is bypassed.
- `reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY)` moved inside the guard so backoff only escalates when a reconnect is actually scheduled.
- `stopPlaylistProxy` is now explicitly idempotent (documented; behavior unchanged for the single-call case).

## Test plan

New unit suite `tests/unit/services/playlist-proxy.stop.test.ts` covers:

- [x] Error fired after `stopPlaylistProxy` does not schedule a reconnect (failure mode #1)
- [x] Queued reconnect timer is cleared by `stopPlaylistProxy`
- [x] Cascading errors followed by stop produce no parallel reconnects (failure mode #2)
- [x] Multiple `stopPlaylistProxy` calls in a row are idempotent
- [x] `startPlaylistProxy` after stop clears the `stopped` flag and re-arms reconnect behavior

Local CI:
- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 3156/3156 passing