### PR TITLE
fix(enrichment-worker): drain in-flight candidates on SIGTERM

### DIFF
--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -70,6 +70,66 @@ import { finalizeRow, type FinalizeOutcome } from './enrich.js';
 const ENRICHMENT_LML_BUDGET_MS = envInt('ENRICHMENT_LML_BUDGET_MS', 29000);
 
 /**
+ * Registry of in-flight `handleCandidate` invocations, used by the worker's
+ * SIGTERM/SIGINT drain (BS#1108). Mirrors the backend's
+ * `inFlightEnrichments` shape in
+ * `apps/backend/services/metadata/enrichment.service.ts`.
+ *
+ * Without this registry the worker's shutdown path closes the PG pool while
+ * LML lookups are still pending; the subsequent claim or finalize write
+ * throws on a torn-down connection and the row stays in
+ * `metadata_status='enriching'` until the C6 sweep (#895) reverts it past
+ * `enriching_since + 60s` and triggers a second Discogs lookup whose answer
+ * was already retrieved and discarded.
+ */
+const inFlightCandidates = new Set<Promise<unknown>>();
+
+export function getInFlightCandidateCount(): number {
+  return inFlightCandidates.size;
+}
+
+/**
+ * Test-only: clear the registry without awaiting any of the in-flight
+ * promises. Production code must never call this — drained candidates still
+ * mutate the DB once their lookup resolves, so dropping them on the floor
+ * mid-flight is exactly the bug this module avoids. The leading underscore
+ * keeps that intent loud.
+ */
+export function _resetInFlightCandidatesForTest(): void {
+  inFlightCandidates.clear();
+}
+
+/**
+ * Wait up to `deadlineMs` for every in-flight candidate in the snapshot
+ * taken at call time to settle, then return the *current registry size* —
+ * which may include candidates added during the wait (a CDC event that
+ * arrives between SIGTERM and `stopCdcListener()` completing can still
+ * dispatch one). The returned count is therefore a drop *estimate*, not a
+ * strict count of unsettled snapshot members; that's the right shape for a
+ * `level: 'warning'` Sentry signal.
+ *
+ * Never throws. Returns 0 immediately when the registry is empty so a
+ * healthy shutdown pays no setTimeout cost. Mirrors the backend's
+ * `drainInFlightEnrichments` (BS#905).
+ */
+export async function drainInFlightCandidates(deadlineMs: number): Promise<number> {
+  if (inFlightCandidates.size === 0) return 0;
+  const snapshot = Array.from(inFlightCandidates);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.allSettled(snapshot),
+      new Promise<void>((resolve) => {
+        timeoutId = setTimeout(resolve, deadlineMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+  return inFlightCandidates.size;
+}
+
+/**
  * Build a CDC event handler that runs the full enrichment chain.
  *
  * The returned function is the long-lived handler that
@@ -84,7 +144,17 @@ export function makeEnrichmentHandler(): (event: CdcEvent) => void {
     // we awaited, slow LML lookups would back-pressure the listener and
     // cause it to drop events. The handler is internally bounded by the
     // shared LML Semaphore(5) so concurrency is capped at the chokepoint.
-    void handleCandidate(candidate);
+    //
+    // BS#1108: register in the in-flight set so the SIGTERM drain can await
+    // pending lookups before the DB pool closes. `handleCandidate` itself
+    // never throws (its outer try/catch routes both LML errors and DB
+    // errors through Sentry + console.error), so the .finally below always
+    // fires and the registry can't slow-leak past a tick.
+    const promise = handleCandidate(candidate);
+    inFlightCandidates.add(promise);
+    void promise.finally(() => {
+      inFlightCandidates.delete(promise);
+    });
   };
 }
 

--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -146,15 +146,25 @@ export function makeEnrichmentHandler(): (event: CdcEvent) => void {
     // shared LML Semaphore(5) so concurrency is capped at the chokepoint.
     //
     // BS#1108: register in the in-flight set so the SIGTERM drain can await
-    // pending lookups before the DB pool closes. `handleCandidate` itself
-    // never throws (its outer try/catch routes both LML errors and DB
-    // errors through Sentry + console.error), so the .finally below always
-    // fires and the registry can't slow-leak past a tick.
+    // pending lookups before the DB pool closes. `handleCandidate`'s body
+    // is wrapped in try/catch for LML + DB errors, but the outer
+    // `Sentry.startSpan(...)` call itself sits outside any try/catch — if
+    // Sentry's internals throw (e.g. exporter error, disposed hub during
+    // shutdown) the promise rejects. Chain `.catch(() => {})` so the
+    // discarded `void promise.finally(...)` can't produce an
+    // unhandledRejection that crashes the worker mid-shutdown. Mirrors
+    // backend's pattern in apps/backend/services/metadata/enrichment.service.ts.
     const promise = handleCandidate(candidate);
     inFlightCandidates.add(promise);
-    void promise.finally(() => {
-      inFlightCandidates.delete(promise);
-    });
+    void promise
+      .catch(() => {
+        // Swallow defensively; handleCandidate already routes its own
+        // failures through Sentry + console.error. A reject reaching here
+        // is a Sentry/runtime bug, not a row-level error worth re-surfacing.
+      })
+      .finally(() => {
+        inFlightCandidates.delete(promise);
+      });
   };
 }
 

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -23,7 +23,7 @@ import {
   stopCdcListener,
 } from '@wxyc/database';
 import { envInt } from '@wxyc/lml-client';
-import { makeEnrichmentHandler } from './handler.js';
+import { drainInFlightCandidates, makeEnrichmentHandler } from './handler.js';
 import { startHealthcheckServer, type HealthState } from './healthcheck.js';
 import { sweepStrandedClaims } from './sweep.js';
 
@@ -45,6 +45,24 @@ const SWEEP_INTERVAL_MS = envInt('ENRICHMENT_SWEEP_INTERVAL_MS', 60_000);
  * `process.exit(0)` fires unconditionally in the outer finally.
  */
 const SHUTDOWN_STEP_BOUND_MS = 5_000;
+
+/**
+ * In-flight candidate drain budget (BS#1108). Set wide enough for an
+ * in-flight `lookupMetadata` to finish — the shared client's
+ * `ENRICHMENT_LML_BUDGET_MS` defaults to 29s, so 30s gives the lookup a
+ * full budget plus 1s of slack to write the finalize row before the drain
+ * gives up. Override via env for tighter integration runs. A hung LML call
+ * is bounded by this ceiling so it can't block deploy indefinitely.
+ *
+ * Note: this is the deadline for `drainInFlightCandidates` *itself*, NOT a
+ * `runShutdownStep` bound — drain owns its own internal timeout (the
+ * `Promise.race` inside `drainInFlightCandidates`), and the per-step bound
+ * would cap it lower than the drain deadline. The drain step is invoked
+ * without `runShutdownStep` so the full WORKER_DRAIN_DEADLINE_MS budget is
+ * available; its rejection-safe contract removes the need for outer
+ * try/catch.
+ */
+const WORKER_DRAIN_DEADLINE_MS = envInt('ENRICHMENT_WORKER_DRAIN_DEADLINE_MS', 30_000);
 
 /**
  * Run a shutdown step with a per-step bound and a swallow-and-capture
@@ -115,11 +133,42 @@ const main = async (): Promise<void> => {
       //      don't fire fresh DB writes during the sweep wait.
       //   2. Drain any in-flight sweep so closeDatabaseConnection
       //      doesn't tear its UPDATE.
-      //   3. Close the pool, then the healthcheck server.
-      //   4. Flush Sentry LAST so captures from earlier steps also land.
+      //   3. Drain in-flight `handleCandidate` invocations (BS#1108) so
+      //      pending LML lookups can finalize their `metadata_status`
+      //      write before the pool closes. Bounded by
+      //      WORKER_DRAIN_DEADLINE_MS internally — bypasses
+      //      runShutdownStep so the full deadline is available (the
+      //      per-step bound would cap it lower).
+      //   4. Close the pool, then the healthcheck server.
+      //   5. Flush Sentry LAST so captures from earlier steps also land.
       await runShutdownStep('stop_cdc', stopCdcListener);
       if (activeSweep !== null) {
         await runShutdownStep('drain_sweep', activeSweep);
+      }
+      // BS#1108: signal-driven count of candidates that didn't finish in
+      // time. Mirrors the backend's `metric: 'in_flight_dropped'` tag
+      // shape so a single Sentry alert can fan over both surfaces.
+      try {
+        const remaining = await drainInFlightCandidates(WORKER_DRAIN_DEADLINE_MS);
+        if (remaining > 0) {
+          Sentry.captureMessage(`enrichment-worker exiting with ${remaining} in-flight candidate(s)`, {
+            level: 'warning',
+            tags: {
+              component: 'enrichment-worker',
+              subsystem: 'metadata',
+              metric: 'in_flight_dropped',
+            },
+            extra: { remaining, signal, deadline_ms: WORKER_DRAIN_DEADLINE_MS },
+          });
+          console.warn(`[enrichment-worker] drained shutdown with ${remaining} in-flight candidate(s)`);
+        }
+      } catch (err) {
+        // Defensive: drainInFlightCandidates is contractually
+        // non-throwing, but if a future change reintroduces a throw we'd
+        // rather capture it than skip the close_db step below.
+        Sentry.captureException(err, {
+          tags: { component: 'enrichment-worker', step: 'shutdown_drain_in_flight' },
+        });
       }
       await runShutdownStep('close_db', closeDatabaseConnection);
       await runShutdownStep(

--- a/apps/enrichment-worker/worker.ts
+++ b/apps/enrichment-worker/worker.ts
@@ -47,12 +47,26 @@ const SWEEP_INTERVAL_MS = envInt('ENRICHMENT_SWEEP_INTERVAL_MS', 60_000);
 const SHUTDOWN_STEP_BOUND_MS = 5_000;
 
 /**
- * In-flight candidate drain budget (BS#1108). Set wide enough for an
- * in-flight `lookupMetadata` to finish — the shared client's
- * `ENRICHMENT_LML_BUDGET_MS` defaults to 29s, so 30s gives the lookup a
- * full budget plus 1s of slack to write the finalize row before the drain
- * gives up. Override via env for tighter integration runs. A hung LML call
- * is bounded by this ceiling so it can't block deploy indefinitely.
+ * Hard ceiling on the in-flight candidate drain budget. The worker runs in
+ * a Docker container stopped with `docker stop $TARGET_APP` (no `-t` flag —
+ * see `.github/actions/deploy-service/action.yml`), so SIGTERM-to-SIGKILL
+ * is the Docker default of 10s. The drain step runs after `stop_cdc` and
+ * `drain_sweep` (each bounded by SHUTDOWN_STEP_BOUND_MS=5s), so by the
+ * time control reaches the drain Docker has at most ~10s left in absolute
+ * terms — any deadline above ~5s is dead budget. Clamp the env override at
+ * SHUTDOWN_STEP_BOUND_MS so a deploy-config typo can't push the deadline
+ * past Docker's kill window.
+ */
+const WORKER_DRAIN_DEADLINE_CEILING_MS = SHUTDOWN_STEP_BOUND_MS;
+
+/**
+ * In-flight candidate drain budget (BS#1108). Matches the backend's
+ * ENRICHMENT_DRAIN_DEADLINE_MS=2_000 (apps/backend/app.ts) — tuned to the
+ * same 10s docker-stop grace window. A hung LML call is bounded by this
+ * ceiling so it can't block deploy past Docker's SIGKILL. Override via env
+ * for tighter integration runs; the override is clamped at
+ * WORKER_DRAIN_DEADLINE_CEILING_MS so an over-eager deploy variable can't
+ * blow past the grace window.
  *
  * Note: this is the deadline for `drainInFlightCandidates` *itself*, NOT a
  * `runShutdownStep` bound — drain owns its own internal timeout (the
@@ -62,7 +76,10 @@ const SHUTDOWN_STEP_BOUND_MS = 5_000;
  * available; its rejection-safe contract removes the need for outer
  * try/catch.
  */
-const WORKER_DRAIN_DEADLINE_MS = envInt('ENRICHMENT_WORKER_DRAIN_DEADLINE_MS', 30_000);
+const WORKER_DRAIN_DEADLINE_MS = Math.min(
+  envInt('ENRICHMENT_WORKER_DRAIN_DEADLINE_MS', 2_000),
+  WORKER_DRAIN_DEADLINE_CEILING_MS
+);
 
 /**
  * Run a shutdown step with a per-step bound and a swallow-and-capture

--- a/tests/unit/apps/enrichment-worker/drain.test.ts
+++ b/tests/unit/apps/enrichment-worker/drain.test.ts
@@ -103,6 +103,14 @@ function dispatchTick(id: number): void {
 describe('enrichment-worker in-flight drain (BS#1108)', () => {
   beforeEach(() => {
     _resetInFlightCandidatesForTest();
+    // Every mock today uses `mockReturnValueOnce` / `mockResolvedValueOnce`,
+    // so leakage between cases is latent rather than observable. Reset
+    // pinned here so a future test that uses `mockReturnValue` (sticky) or
+    // forgets to re-mock can't silently inherit a previous case's stub —
+    // the failure mode would be a flaky test that passes in isolation and
+    // fails in suite order, which is exactly the kind of bug a unit-test
+    // file should refuse to harbor.
+    jest.resetAllMocks();
   });
 
   describe('inFlightCandidates registry', () => {
@@ -159,6 +167,37 @@ describe('enrichment-worker in-flight drain (BS#1108)', () => {
       await new Promise((resolve) => setImmediate(resolve));
 
       expect(getInFlightCandidateCount()).toBe(0);
+    });
+
+    it('does not raise unhandledRejection when Sentry.startSpan throws synchronously', async () => {
+      // Defensive: handleCandidate wraps its body in try/catch but the outer
+      // `await Sentry.startSpan(...)` sits outside any try/catch. If Sentry's
+      // internals throw (exporter error, disposed hub during shutdown), the
+      // handleCandidate promise rejects. The dispatcher's `void promise.finally(...)`
+      // would otherwise discard the rejection and surface as an
+      // unhandledRejection in production. The `.catch(() => {})` chain pins
+      // that contract here.
+      mockFilterForEnrichment.mockReturnValueOnce(makeCandidate(99));
+      (Sentry.startSpan as jest.Mock).mockImplementation(() => {
+        throw new Error('Sentry exporter dead during shutdown');
+      });
+
+      const unhandled = jest.fn();
+      process.on('unhandledRejection', unhandled);
+      try {
+        const handler = makeEnrichmentHandler();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        handler({} as any);
+        // Two macrotask yields: one to let the rejection propagate through
+        // the .catch + .finally chain, one to let Node's microtask queue
+        // surface any unhandled rejection it would have emitted.
+        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(unhandled).not.toHaveBeenCalled();
+        expect(getInFlightCandidateCount()).toBe(0);
+      } finally {
+        process.off('unhandledRejection', unhandled);
+      }
     });
   });
 

--- a/tests/unit/apps/enrichment-worker/drain.test.ts
+++ b/tests/unit/apps/enrichment-worker/drain.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for the enrichment-worker in-flight drain (BS#1108).
+ *
+ * The CDC dispatcher invokes `handleCandidate(candidate)` as
+ * `void handleCandidate(...)` — fire-and-forget. Without a registry the
+ * worker's SIGTERM handler would tear down the DB pool while LML lookups
+ * are still pending; the subsequent claim or finalize write throws and the
+ * row stays in `metadata_status='enriching'` until C6 (#895) sweeps it
+ * (which itself round-trips a second Discogs lookup whose answer was
+ * already retrieved and discarded).
+ *
+ * `handleCandidate` self-registers in the `inFlightCandidates` set and
+ * unregisters via `.finally`. `drainInFlightCandidates(deadlineMs)` races
+ * `Promise.allSettled(snapshot)` against `setTimeout(deadlineMs)`, returns
+ * the *current registry size* afterward (mirrors the backend's
+ * `drainInFlightEnrichments` contract in
+ * `apps/backend/services/metadata/enrichment.service.ts`).
+ *
+ * Three contract guarantees pinned here:
+ *   1. Each invocation auto-registers + auto-unregisters on settle (resolved
+ *      AND rejected) so the registry can never slow-leak past a tick.
+ *   2. `drainInFlightCandidates` awaits pending promises and returns 0 when
+ *      they finish inside the deadline.
+ *   3. `drainInFlightCandidates` bounds the wait by `deadlineMs` and returns
+ *      the unsettled count — never throws — so a hung LML call can't block
+ *      deploy indefinitely.
+ */
+
+import { jest } from '@jest/globals';
+
+jest.mock('@sentry/node', () => ({
+  startSpan: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+const mockLookupMetadata = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+jest.mock('@wxyc/lml-client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+const mockClaimRowForEnrichment =
+  jest.fn<(id: number) => Promise<{ claimed: true; id: number } | { claimed: false }>>();
+jest.mock('../../../../apps/enrichment-worker/claim.js', () => ({
+  claimRowForEnrichment: mockClaimRowForEnrichment,
+}));
+
+const mockFilterForEnrichment = jest.fn<(event: unknown) => unknown>();
+jest.mock('../../../../apps/enrichment-worker/cdc-subscriber.js', () => ({
+  filterForEnrichment: mockFilterForEnrichment,
+}));
+
+const mockFinalizeRow = jest.fn<(...args: unknown[]) => Promise<string>>();
+jest.mock('../../../../apps/enrichment-worker/enrich.js', () => {
+  const actual = jest.requireActual<typeof import('../../../../apps/enrichment-worker/enrich')>(
+    '../../../../apps/enrichment-worker/enrich'
+  );
+  return {
+    ...actual,
+    finalizeRow: mockFinalizeRow,
+  };
+});
+
+import * as Sentry from '@sentry/node';
+
+import {
+  drainInFlightCandidates,
+  getInFlightCandidateCount,
+  makeEnrichmentHandler,
+  _resetInFlightCandidatesForTest,
+} from '../../../../apps/enrichment-worker/handler';
+
+type SpanLike = { setAttribute: jest.Mock };
+
+const makeCandidate = (id: number) => ({
+  id,
+  entry_type: 'track' as const,
+  metadata_status: 'pending' as const,
+  artist_name: 'Stereolab',
+  album_title: 'Dots and Loops',
+  track_title: 'Miss Modular',
+  album_id: null,
+});
+
+/**
+ * Dispatch one CDC tick. Returns the candidate's id so tests can correlate
+ * across multiple in-flight invocations.
+ */
+function dispatchTick(id: number): void {
+  const span: SpanLike = { setAttribute: jest.fn() };
+  (Sentry.startSpan as jest.Mock).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (_opts: unknown, fn: any) => fn(span)
+  );
+  mockFilterForEnrichment.mockReturnValueOnce(makeCandidate(id));
+  mockClaimRowForEnrichment.mockResolvedValueOnce({ claimed: true, id });
+  const handler = makeEnrichmentHandler();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler({} as any);
+}
+
+describe('enrichment-worker in-flight drain (BS#1108)', () => {
+  beforeEach(() => {
+    _resetInFlightCandidatesForTest();
+  });
+
+  describe('inFlightCandidates registry', () => {
+    it('starts empty', () => {
+      expect(getInFlightCandidateCount()).toBe(0);
+    });
+
+    it('registers an in-flight candidate while the LML lookup is pending', async () => {
+      // Never-resolving lookup so the promise stays in-flight for assertion.
+      mockLookupMetadata.mockReturnValueOnce(new Promise(() => undefined));
+
+      dispatchTick(1);
+      // Yield once so the dispatched `void handleCandidate(...)` reaches
+      // its `await Sentry.startSpan(...)` and the wrapper has had a chance
+      // to add itself to the registry.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(getInFlightCandidateCount()).toBe(1);
+    });
+
+    it('unregisters the candidate after a successful tick (settle on resolve)', async () => {
+      mockLookupMetadata.mockResolvedValueOnce({ results: [] });
+      mockFinalizeRow.mockResolvedValueOnce('enriched_no_match');
+
+      dispatchTick(2);
+      // Allow the full tick chain (lookup -> finalize -> .finally) to run.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(getInFlightCandidateCount()).toBe(0);
+    });
+
+    it('unregisters the candidate when the LML lookup rejects (settle on reject)', async () => {
+      // The handler's internal try/catch turns the LML throw into a
+      // resolved promise (logging + capturing the error), so the wrapper's
+      // .finally must still fire and the registry must reach 0. Without
+      // the unregister side, a slow stream of LML errors would slow-leak
+      // the registry and inflate the shutdown-time "dropped" count.
+      mockLookupMetadata.mockRejectedValueOnce(new Error('LML timeout'));
+
+      dispatchTick(3);
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(getInFlightCandidateCount()).toBe(0);
+    });
+
+    it('skips registration when the CDC filter rejects the event (no candidate)', async () => {
+      mockFilterForEnrichment.mockReturnValueOnce(null);
+
+      const handler = makeEnrichmentHandler();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handler({} as any);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(getInFlightCandidateCount()).toBe(0);
+    });
+  });
+
+  describe('drainInFlightCandidates', () => {
+    it('returns 0 immediately when the registry is empty', async () => {
+      const remaining = await drainInFlightCandidates(2_000);
+      expect(remaining).toBe(0);
+    });
+
+    it('awaits in-flight promises and returns 0 when they settle inside the deadline', async () => {
+      let resolveLookup: (value: unknown) => void = () => undefined;
+      mockLookupMetadata.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveLookup = resolve;
+        })
+      );
+      mockFinalizeRow.mockResolvedValueOnce('enriched_no_match');
+
+      dispatchTick(4);
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(getInFlightCandidateCount()).toBe(1);
+
+      // Resolve the pending lookup on the next tick — well within the
+      // 2s deadline. The drain must wait for the resolution, see the
+      // unregister fire, and return 0.
+      setImmediate(() => resolveLookup({ results: [] }));
+
+      const remaining = await drainInFlightCandidates(2_000);
+      expect(remaining).toBe(0);
+      expect(getInFlightCandidateCount()).toBe(0);
+    });
+
+    it('returns the unsettled count after the deadline elapses (bounds the wait)', async () => {
+      // Two never-resolving lookups simulate hung LML calls during deploy.
+      // The drain must NOT hang the SIGTERM — it returns the count of
+      // promises still pending after `deadlineMs`.
+      mockLookupMetadata.mockReturnValueOnce(new Promise(() => undefined));
+      mockLookupMetadata.mockReturnValueOnce(new Promise(() => undefined));
+
+      dispatchTick(5);
+      dispatchTick(6);
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(getInFlightCandidateCount()).toBe(2);
+
+      // 50ms test-only deadline. Production uses 30s (WORKER_DRAIN_DEADLINE_MS).
+      const start = Date.now();
+      const remaining = await drainInFlightCandidates(50);
+      const elapsed = Date.now() - start;
+
+      expect(remaining).toBe(2);
+      // Sanity: the drain returned promptly after the deadline, not after
+      // the never-resolving lookups.
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it('does not throw when an in-flight handler rejected mid-drain', async () => {
+      // handleCandidate's internal try/catch already converts LML throws
+      // into resolved promises; this case pins that the wrapper's
+      // .finally chain doesn't reintroduce an unhandled rejection that
+      // would crash the shutdown path.
+      mockLookupMetadata.mockRejectedValueOnce(new Error('LML timeout'));
+
+      dispatchTick(7);
+      // Don't yield yet — the rejection happens inside the drain.
+
+      const remaining = await drainInFlightCandidates(2_000);
+      expect(remaining).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1108

## Summary

- The CDC dispatcher invokes `handleCandidate` fire-and-forget (`void handleCandidate(...)`), so SIGTERM tore down the PG pool while LML lookups were still pending — the subsequent claim/finalize write would throw on a torn-down connection, leaving the row stranded in `metadata_status='enriching'` until C6 swept it.
- Adds an `inFlightCandidates` registry in `handler.ts` (mirrors the backend's `inFlightEnrichments` in `apps/backend/services/metadata/enrichment.service.ts`): each tick auto-registers and unregisters via `.finally` so the registry never slow-leaks past a settle.
- Adds `drainInFlightCandidates(deadlineMs)` that races `Promise.allSettled(snapshot)` against `setTimeout(deadlineMs)` and returns the current registry size — never throws, returns 0 immediately on empty.
- Wires the drain into `worker.ts` shutdown between `stopCdcListener` and `closeDatabaseConnection`. Bounded by `WORKER_DRAIN_DEADLINE_MS` (default 30s, env-overridable via `ENRICHMENT_WORKER_DRAIN_DEADLINE_MS`) so a hung LML call can't block deploy indefinitely.
- Sentry `captureMessage` on non-zero remaining count uses the same `metric: 'in_flight_dropped'` tag shape as the backend's BS#905 path so a single alert can fan over both surfaces.

Reduces but does not eliminate the BS#895 sweep traffic referenced in the issue body.

## Test plan

- [x] new in-flight registry tests in `tests/unit/apps/enrichment-worker/drain.test.ts` pin: empty-registry fast-return, register-on-dispatch, unregister-on-resolve, unregister-on-reject, skip-on-filter-reject, drain-awaits-pending, drain-bounds-deadline, drain-survives-rejection
- [x] all 84 `enrichment-worker` unit tests pass; full unit suite 3160/3160 green
- [x] `npm run lint && npm run format:check && npm run typecheck` clean