### PR TITLE
fix(cdc-ws): add bufferedAmount check + native ping/pong (#1134)

### DIFF
--- a/apps/backend/services/cdc/cdc-websocket.ts
+++ b/apps/backend/services/cdc/cdc-websocket.ts
@@ -11,19 +11,94 @@
  * `setupMetadataBroadcast()` work whether or not `CDC_SECRET` is configured.
  * This module owns only the external WebSocket exposure and remains
  * hard-gated on `CDC_SECRET`.
+ *
+ * Back-pressure & liveness (BS#1134). The previous implementation called
+ * `client.send(msg, errCb)` for every CDC event with no `bufferedAmount`
+ * check — a slow consumer (paused tab, suspended mobile network, paused
+ * iOS test harness) accumulated outbound bytes in the `ws` library buffer
+ * and Node's socket buffer with no upper bound. The 30s app-level
+ * heartbeat only terminated on a send-callback error; a quietly-buffering
+ * dead-but-not-closed TCP connection never tripped it. Two guards now
+ * cap that growth:
+ *
+ *   1. `BACKPRESSURE_THRESHOLD_BYTES` (1 MiB): before every send (fan-out
+ *      and heartbeat) we check `client.bufferedAmount`. Over the threshold,
+ *      we `terminate()` and surface a Sentry warning
+ *      (`cdc_ws.buffered_amount_high`). The CDC stream offers no replay,
+ *      so dropping a single event for a slow consumer is no worse than
+ *      what already happens when they reconnect — see `docs/cdc.md` for
+ *      the "consumers reconcile out-of-band" contract.
+ *
+ *   2. Native WebSocket ping/pong on the heartbeat timer. Each tick pings
+ *      every client; clients reset `isAlive=true` on `'pong'`. A client
+ *      that hasn't ponged since the previous tick is terminated with a
+ *      Sentry warning (`cdc_ws.missed_pong`). This decouples "client is
+ *      gone" from "client is slow" — pre-#1134 a single signal mixed both.
  */
 
 import { Server as HttpServer, IncomingMessage } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { URL } from 'url';
+import * as Sentry from '@sentry/node';
 import { onCdcEvent } from '@wxyc/database';
 import type { CdcEvent } from '@wxyc/database';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const CDC_PATH = '/cdc';
 
+/**
+ * Per-client outbound-buffer ceiling, in bytes. A consumer that exceeds
+ * this is terminated rather than accumulating unbounded memory. 1 MiB is
+ * the issue body's recommendation — large enough to absorb routine bursts
+ * (a CDC event is typically <10 KiB), small enough that even a few hundred
+ * connected clients can't aggregate into runaway RSS growth.
+ */
+const BACKPRESSURE_THRESHOLD_BYTES = 1024 * 1024;
+
+/**
+ * Per-client liveness flag. Set true on `'pong'` arrival, cleared at the
+ * start of each heartbeat tick after we ping. A client whose flag is still
+ * false on the next tick has missed a pong round-trip and is terminated.
+ *
+ * Held as a `WeakMap` so closing the underlying connection lets the GC
+ * release the bookkeeping — we never see `'close'` for a `terminate()`d
+ * synthetic client in tests, and never want stale state to outlive a real
+ * client.
+ */
+const isAlive = new WeakMap<WebSocket, boolean>();
+
 let wss: WebSocketServer | null = null;
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Sends `msg` to `client` after a `bufferedAmount` check. If the buffer is
+ * already over the threshold the client is terminated, a Sentry warning is
+ * surfaced, and the send is skipped. Returns whether the message was sent.
+ */
+function safeSend(client: WebSocket, msg: string): boolean {
+  if (client.bufferedAmount > BACKPRESSURE_THRESHOLD_BYTES) {
+    Sentry.captureMessage(
+      `cdc_ws.buffered_amount_high — terminating slow consumer (${client.bufferedAmount} bytes buffered)`,
+      {
+        level: 'warning',
+        tags: { tool: 'cdc-ws', step: 'backpressure' },
+        extra: {
+          bufferedAmount: client.bufferedAmount,
+          threshold: BACKPRESSURE_THRESHOLD_BYTES,
+        },
+      }
+    );
+    console.warn(
+      `[cdc-ws] Terminating slow consumer: bufferedAmount=${client.bufferedAmount} > ${BACKPRESSURE_THRESHOLD_BYTES}`
+    );
+    client.terminate();
+    return false;
+  }
+  client.send(msg, (err) => {
+    if (err) client.terminate();
+  });
+  return true;
+}
 
 /**
  * Sets up the CDC WebSocket server on the given HTTP server.
@@ -63,14 +138,22 @@ export async function setupCdcWebSocket(server: HttpServer): Promise<void> {
   });
 
   wss.on('connection', (ws: WebSocket) => {
+    // Track liveness for native ping/pong (BS#1134). A client is "alive"
+    // immediately on connect; the first heartbeat tick will ping it.
+    isAlive.set(ws, true);
+    ws.on('pong', () => {
+      isAlive.set(ws, true);
+    });
+
     const connected = JSON.stringify({
       type: 'connected',
       serverTime: Date.now(),
     });
-    ws.send(connected);
+    safeSend(ws, connected);
     console.log(`[cdc-ws] Client connected, total=${wss!.clients.size}`);
 
     ws.on('close', () => {
+      isAlive.delete(ws);
       console.log(`[cdc-ws] Client disconnected, total=${wss!.clients.size}`);
     });
 
@@ -79,16 +162,49 @@ export async function setupCdcWebSocket(server: HttpServer): Promise<void> {
     });
   });
 
-  // Start heartbeat
+  // Heartbeat: native WebSocket ping/pong (BS#1134). On each tick we
+  // terminate any client that didn't pong since the previous tick (dead
+  // socket), then ping the survivors and clear their flag for next tick.
+  // Pre-#1134 this was an app-level JSON message which couldn't distinguish
+  // a wedged client from a slow one.
   heartbeatTimer = setInterval(() => {
     if (!wss || wss.clients.size === 0) return;
-    const msg = JSON.stringify({ type: 'heartbeat', timestamp: Date.now() });
     for (const client of wss.clients) {
-      if (client.readyState === WebSocket.OPEN) {
-        client.send(msg, (err) => {
-          if (err) client.terminate();
+      if (client.readyState !== WebSocket.OPEN) continue;
+
+      if (isAlive.get(client) === false) {
+        Sentry.captureMessage('cdc_ws.missed_pong — terminating unresponsive consumer', {
+          level: 'warning',
+          tags: { tool: 'cdc-ws', step: 'missed-pong' },
         });
+        console.warn('[cdc-ws] Terminating unresponsive consumer (missed pong)');
+        client.terminate();
+        continue;
       }
+
+      // Back-pressure check before issuing the ping — a wedged outbound
+      // buffer means the ping won't reach the wire either.
+      if (client.bufferedAmount > BACKPRESSURE_THRESHOLD_BYTES) {
+        Sentry.captureMessage(
+          `cdc_ws.buffered_amount_high — terminating slow consumer (${client.bufferedAmount} bytes buffered)`,
+          {
+            level: 'warning',
+            tags: { tool: 'cdc-ws', step: 'backpressure-heartbeat' },
+            extra: {
+              bufferedAmount: client.bufferedAmount,
+              threshold: BACKPRESSURE_THRESHOLD_BYTES,
+            },
+          }
+        );
+        console.warn(
+          `[cdc-ws] Terminating slow consumer on heartbeat: bufferedAmount=${client.bufferedAmount} > ${BACKPRESSURE_THRESHOLD_BYTES}`
+        );
+        client.terminate();
+        continue;
+      }
+
+      isAlive.set(client, false);
+      client.ping();
     }
   }, HEARTBEAT_INTERVAL_MS);
   heartbeatTimer.unref();
@@ -99,9 +215,7 @@ export async function setupCdcWebSocket(server: HttpServer): Promise<void> {
     const msg = JSON.stringify(event);
     for (const client of wss.clients) {
       if (client.readyState === WebSocket.OPEN) {
-        client.send(msg, (err) => {
-          if (err) client.terminate();
-        });
+        safeSend(client, msg);
       }
     }
   });

--- a/docs/cdc.md
+++ b/docs/cdc.md
@@ -31,6 +31,13 @@ PostgreSQL triggers (`cdc_notify()`) fire `pg_notify('cdc', payload)` on every I
 - `apps/backend/services/cdc/dispatcher.ts` — per-process LISTEN startup/shutdown. Runs unconditionally so in-process consumers (`metadata-broadcast`) work regardless of `CDC_SECRET` (BS#1187)
 - `apps/backend/services/cdc/cdc-websocket.ts` — WebSocket server with auth and heartbeat; gated on `CDC_SECRET` (external-listener channel only)
 
+## Back-pressure and liveness (BS#1134)
+
+Per-client guards in `cdc-websocket.ts` keep one misbehaving consumer from leaking memory or wedging the heartbeat signal:
+
+- **Back-pressure**: every send (fan-out and heartbeat) checks `client.bufferedAmount`. Over `BACKPRESSURE_THRESHOLD_BYTES` (1 MiB) the client is `terminate()`d and a Sentry `cdc_ws.buffered_amount_high` warning is captured. The CDC stream offers no replay, so dropping a single event for a slow consumer is no worse than what already happens at reconnect (see the "consumers reconcile out-of-band" contract above).
+- **Native ping/pong**: the 30s heartbeat now uses `ws.ping()` and tracks `'pong'` arrival, not an app-level JSON message. Clients that miss a pong before the next tick are terminated with a Sentry `cdc_ws.missed_pong` warning. This decouples "client is wedged" from "client is slow" — pre-#1134 the app-level message conflated both into a single send-callback signal.
+
 ## Reconciliation monitor
 
 ```bash

--- a/tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts
+++ b/tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts
@@ -1,5 +1,6 @@
 /**
- * Unit tests for the CDC dispatcher / websocket split (BS#1187).
+ * Unit tests for the CDC dispatcher / websocket split (BS#1187) and the
+ * back-pressure + native ping/pong hardening (BS#1134).
  *
  * Pre-BS#1187, `setupCdcWebSocket` owned both the WebSocket exposure AND
  * the per-process `startCdcListener()` call. A missing `CDC_SECRET` short-
@@ -16,6 +17,18 @@
  *   4. With `CDC_SECRET` set: dispatcher started, websocket fan-out
  *      handler registered, no second LISTEN start.
  *
+ * BS#1134 additions:
+ *   5. Per-client `bufferedAmount` is checked before every send (heartbeat
+ *      and fan-out). When it exceeds the threshold the client is
+ *      `terminate()`d, a Sentry warning is captured, and the event is not
+ *      sent — this caps unbounded outbound buffer growth caused by a slow
+ *      consumer.
+ *   6. The heartbeat now uses native WebSocket ping/pong frames (not an
+ *      app-level JSON message). Clients that don't pong before the next
+ *      heartbeat tick are terminated with a Sentry warning.
+ *   7. The `'pong'` arrival keeps the connection alive across the next
+ *      heartbeat tick.
+ *
  * The metadata-broadcast subscriber's actual filtering is covered in
  * `metadata-broadcast.test.ts`; this file pins the wiring contract that
  * lets it fire in the first place.
@@ -27,16 +40,28 @@ jest.mock('@wxyc/database', () => ({
   stopCdcListener: jest.fn().mockResolvedValue(undefined),
 }));
 
+const captureMessageMock = jest.fn();
+jest.mock('@sentry/node', () => ({
+  captureMessage: (...args: unknown[]) => captureMessageMock(...args),
+}));
+
+// Captured server-level handlers so tests can drive the `'connection'` event
+// against a synthetic client. Reset in `beforeEach`.
+const wssHandlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+const wssClients = new Set<unknown>();
+
 jest.mock('ws', () => {
-  const onMock = jest.fn();
-  const closeMock = jest.fn();
-  const WebSocketServer = jest.fn().mockImplementation(() => ({
-    on: onMock,
-    close: closeMock,
-    clients: new Set(),
-    handleUpgrade: jest.fn(),
-    emit: jest.fn(),
-  }));
+  const WebSocketServer = jest.fn().mockImplementation(() => {
+    return {
+      on: (event: string, handler: (...args: unknown[]) => void) => {
+        (wssHandlers[event] ||= []).push(handler);
+      },
+      close: jest.fn(),
+      clients: wssClients,
+      handleUpgrade: jest.fn(),
+      emit: jest.fn(),
+    };
+  });
   return {
     WebSocketServer,
     WebSocket: { OPEN: 1 },
@@ -54,6 +79,44 @@ const makeServer = (): HttpServer => {
   return server as unknown as HttpServer;
 };
 
+/**
+ * Synthetic client modelled on the surface `cdc-websocket.ts` consumes from
+ * the `ws` library: `readyState`, `bufferedAmount`, `send`, `ping`,
+ * `terminate`, and event-handler registration via `on`. The connection-time
+ * `'pong'` handler is captured so tests can simulate a client responding to
+ * a heartbeat ping.
+ */
+type SyntheticClient = {
+  readyState: number;
+  bufferedAmount: number;
+  send: jest.Mock;
+  ping: jest.Mock;
+  terminate: jest.Mock;
+  on: jest.Mock;
+  /** Convenience: fire whichever `'pong'` handler the production code registered. */
+  triggerPong: () => void;
+  handlers: Record<string, Array<(...args: unknown[]) => void>>;
+};
+
+function makeClient(): SyntheticClient {
+  const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+  const client: SyntheticClient = {
+    readyState: 1, // OPEN
+    bufferedAmount: 0,
+    send: jest.fn(),
+    ping: jest.fn(),
+    terminate: jest.fn(),
+    on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+      (handlers[event] ||= []).push(handler);
+    }),
+    triggerPong: () => {
+      for (const h of handlers['pong'] ?? []) h();
+    },
+    handlers,
+  };
+  return client;
+}
+
 /** Run `fn` with CDC_SECRET pinned to `value` (or unset when `null`) and restore the prior value afterwards. */
 async function withCdcSecret(value: string | null, fn: () => Promise<void>): Promise<void> {
   const prev = process.env.CDC_SECRET;
@@ -67,6 +130,12 @@ async function withCdcSecret(value: string | null, fn: () => Promise<void>): Pro
   }
 }
 
+function resetSharedMocks(): void {
+  for (const k of Object.keys(wssHandlers)) delete wssHandlers[k];
+  wssClients.clear();
+  captureMessageMock.mockReset();
+}
+
 describe('startCdcDispatcher (BS#1187)', () => {
   // The dispatcher must own LISTEN startup so in-process subscribers
   // (`setupMetadataBroadcast`, future consumers) work whether or not the
@@ -74,6 +143,7 @@ describe('startCdcDispatcher (BS#1187)', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    resetSharedMocks();
   });
 
   it('calls startCdcListener regardless of CDC_SECRET', async () => {
@@ -97,6 +167,7 @@ describe('startCdcDispatcher (BS#1187)', () => {
 describe('shutdownCdcDispatcher (BS#1187)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetSharedMocks();
   });
 
   it('calls stopCdcListener', async () => {
@@ -110,6 +181,7 @@ describe('setupCdcWebSocket (BS#1187)', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    resetSharedMocks();
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   });
 
@@ -153,10 +225,187 @@ describe('setupCdcWebSocket (BS#1187)', () => {
 describe('shutdownCdcWebSocket (BS#1187)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetSharedMocks();
   });
 
   it('does not call stopCdcListener — the dispatcher owns the LISTEN lifecycle', async () => {
     await shutdownCdcWebSocket();
     expect(stopCdcListener).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * BS#1134 — back-pressure + native ping/pong.
+ *
+ * These tests drive the production code's per-client paths by synthesising a
+ * `'connection'` event with a `SyntheticClient` and exercising both the
+ * heartbeat tick and the fan-out callback registered via `onCdcEvent`.
+ */
+describe('CDC WebSocket back-pressure and ping/pong (BS#1134)', () => {
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSharedMocks();
+    jest.useFakeTimers();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    await shutdownCdcWebSocket();
+  });
+
+  /**
+   * Drive the captured `onCdcEvent` callback with one fan-out event. The
+   * production code registers exactly one callback during `setupCdcWebSocket`.
+   */
+  function fireFanoutEvent(): void {
+    const call = (onCdcEvent as jest.Mock).mock.calls[0];
+    expect(call).toBeDefined();
+    const fanoutCb = call[0] as (event: unknown) => void;
+    fanoutCb({ table: 'flowsheet', schema: 'wxyc_schema', action: 'INSERT', data: {}, timestamp: 0 });
+  }
+
+  /** Drive the `'connection'` handler registered on the WebSocketServer. */
+  function connectClient(client: SyntheticClient): void {
+    wssClients.add(client);
+    const connHandlers = wssHandlers['connection'] ?? [];
+    expect(connHandlers.length).toBeGreaterThan(0);
+    for (const h of connHandlers) h(client, {});
+  }
+
+  describe('back-pressure', () => {
+    it('terminates a client and skips the send when bufferedAmount exceeds the threshold during fan-out', async () => {
+      await withCdcSecret('test-secret', async () => {
+        await setupCdcWebSocket(makeServer());
+
+        const client = makeClient();
+        connectClient(client);
+
+        // Saturate the outbound buffer beyond the threshold. The exact
+        // threshold is private to the module; 2 MB clears 1 MB without
+        // hard-coding the constant here.
+        client.bufferedAmount = 2 * 1024 * 1024;
+
+        // The initial `'connected'` envelope was already enqueued at
+        // connection time — clear that bookkeeping so the assertion below
+        // measures only the fan-out path.
+        client.send.mockClear();
+
+        fireFanoutEvent();
+
+        expect(client.send).not.toHaveBeenCalled();
+        expect(client.terminate).toHaveBeenCalledTimes(1);
+        expect(captureMessageMock).toHaveBeenCalledWith(
+          expect.stringMatching(/buffered_amount|back.?pressure/i),
+          expect.objectContaining({ level: 'warning' })
+        );
+      });
+    });
+
+    it('sends normally when bufferedAmount is below the threshold', async () => {
+      await withCdcSecret('test-secret', async () => {
+        await setupCdcWebSocket(makeServer());
+
+        const client = makeClient();
+        connectClient(client);
+        client.bufferedAmount = 0;
+        client.send.mockClear();
+
+        fireFanoutEvent();
+
+        expect(client.send).toHaveBeenCalledTimes(1);
+        expect(client.terminate).not.toHaveBeenCalled();
+      });
+    });
+
+    it('terminates a client on the heartbeat tick when bufferedAmount is over the threshold', async () => {
+      await withCdcSecret('test-secret', async () => {
+        await setupCdcWebSocket(makeServer());
+
+        const client = makeClient();
+        connectClient(client);
+        // Need a pong on the first tick so the missed-pong policy doesn't
+        // pre-empt the back-pressure path.
+        client.triggerPong();
+        client.bufferedAmount = 2 * 1024 * 1024;
+        client.ping.mockClear();
+
+        // Advance to the next heartbeat tick (30s).
+        jest.advanceTimersByTime(30_000);
+
+        expect(client.terminate).toHaveBeenCalled();
+        expect(client.ping).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('native ping/pong', () => {
+    it('sends a native ping (not an app-level JSON message) on the heartbeat tick', async () => {
+      await withCdcSecret('test-secret', async () => {
+        await setupCdcWebSocket(makeServer());
+
+        const client = makeClient();
+        connectClient(client);
+        // Clear the initial `'connected'` envelope so the assertion below
+        // measures only what the heartbeat tick produced.
+        client.send.mockClear();
+
+        jest.advanceTimersByTime(30_000);
+
+        expect(client.ping).toHaveBeenCalledTimes(1);
+        // App-level `{type:'heartbeat'}` payloads must no longer be sent —
+        // ping/pong is the wedge-detection channel.
+        for (const call of client.send.mock.calls) {
+          const payload = String(call[0] ?? '');
+          expect(payload).not.toMatch(/"type"\s*:\s*"heartbeat"/);
+        }
+      });
+    });
+
+    it('keeps a client alive across the next heartbeat tick when a pong arrives in between', async () => {
+      await withCdcSecret('test-secret', async () => {
+        await setupCdcWebSocket(makeServer());
+
+        const client = makeClient();
+        connectClient(client);
+
+        // First tick: send ping. Client responds with a pong.
+        jest.advanceTimersByTime(30_000);
+        expect(client.ping).toHaveBeenCalledTimes(1);
+        client.triggerPong();
+
+        // Second tick: still alive, should be pinged again, not terminated.
+        jest.advanceTimersByTime(30_000);
+        expect(client.terminate).not.toHaveBeenCalled();
+        expect(client.ping).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('terminates a client that misses a pong before the next heartbeat tick', async () => {
+      await withCdcSecret('test-secret', async () => {
+        await setupCdcWebSocket(makeServer());
+
+        const client = makeClient();
+        connectClient(client);
+
+        // First tick: pings the client. Client does NOT pong.
+        jest.advanceTimersByTime(30_000);
+        expect(client.ping).toHaveBeenCalledTimes(1);
+
+        // Second tick: missed pong → terminate.
+        jest.advanceTimersByTime(30_000);
+        expect(client.terminate).toHaveBeenCalledTimes(1);
+        expect(captureMessageMock).toHaveBeenCalledWith(
+          expect.stringMatching(/pong|heartbeat/i),
+          expect.objectContaining({ level: 'warning' })
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Per-client `bufferedAmount` check before every send (fan-out and heartbeat). Over `BACKPRESSURE_THRESHOLD_BYTES` (1 MiB) the client is `terminate()`d and a Sentry `cdc_ws.buffered_amount_high` warning is captured.
- Heartbeat switched from an app-level JSON message to native `ws.ping()` + `'pong'` tracking. Clients that miss a pong before the next 30s tick are terminated with a Sentry `cdc_ws.missed_pong` warning, decoupling "wedged" from "slow".
- Updated `docs/cdc.md` with a back-pressure / liveness section pointing at the new behaviour.

## Why

The previous CDC fan-out called `client.send(msg, errCb)` with no buffer check. A slow consumer (paused tab, NAT-idle mobile, paused iOS test harness) accumulated outbound bytes in the `ws` library buffer and Node's socket buffer with no upper bound — Node RSS climbed without termination because the send callback never errored. The app-level heartbeat couldn't disambiguate a wedged client from a slow one.

## Test plan

- [x] `npm run lint` — 0 errors (528 pre-existing warnings unrelated to this change)
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 228 suites / 3157 tests pass, including 13 in `tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts` (5 new BS#1134 cases + 8 BS#1187 regression pins)
- [ ] CI green on PR

Closes #1134