### PR TITLE
feat(rotation): add lml_identity_id; mint LML identities on dj-site paste

### DIFF
--- a/Dockerfile.rotation-lml-identity-backfill
+++ b/Dockerfile.rotation-lml-identity-backfill
@@ -1,0 +1,45 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+ARG NPM_TOKEN
+WORKDIR /rotation-lml-identity-backfill-builder
+
+COPY ./.npmrc ./
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./shared/lml-client ./shared/lml-client
+COPY ./jobs/rotation-lml-identity-backfill ./jobs/rotation-lml-identity-backfill
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-client --workspace=@wxyc/rotation-lml-identity-backfill
+
+#Production stage
+FROM node:24-alpine AS prod
+
+ARG NPM_TOKEN
+WORKDIR /rotation-lml-identity-backfill
+
+COPY ./.npmrc ./
+COPY ./package* ./
+COPY ./jobs/rotation-lml-identity-backfill/package* ./jobs/rotation-lml-identity-backfill/
+COPY ./shared/database/package* ./shared/database/
+COPY ./shared/lml-client/package* ./shared/lml-client/
+
+# `@wxyc/lml-client` declares `@wxyc/shared` as a registry dependency
+# (GitHub Packages, `@wxyc:registry` in `.npmrc`). Without NPM_TOKEN +
+# .npmrc the prod stage's npm install 401s on @wxyc/shared. Mirrors the
+# pattern in Dockerfile.backend and the BS#1015 lesson.
+RUN npm install --omit=dev && rm -f .npmrc
+
+COPY --from=builder ./rotation-lml-identity-backfill-builder/jobs/rotation-lml-identity-backfill/dist ./jobs/rotation-lml-identity-backfill/dist
+COPY --from=builder ./rotation-lml-identity-backfill-builder/shared/database/dist ./shared/database/dist
+COPY --from=builder ./rotation-lml-identity-backfill-builder/shared/lml-client/dist ./shared/lml-client/dist
+
+# Per-statement timeout: the writer does single-row UPDATEs; 60 s is more
+# than enough headroom. Mirrors the rotation-release-id-backfill ceiling.
+ENV DB_STATEMENT_TIMEOUT_MS=60000
+
+# Identifies the connection in pg_stat_activity during incident triage.
+ENV DB_APPLICATION_NAME=wxyc-rotation-lml-identity-backfill
+
+CMD ["npm", "start", "--workspace=@wxyc/rotation-lml-identity-backfill"]

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -307,12 +307,43 @@ export const getRotation: RequestHandler = async (req, res) => {
 };
 
 export type RotationAddRequest = Omit<NewRotationRelease, 'id'>;
+
+/**
+ * Pick only the fields the client is allowed to write through the public
+ * `POST /library/rotation` endpoint (BS#1380). Mirrors
+ * `pickUpdateEntryFields()` in flowsheet.controller.ts (BS#1099).
+ *
+ * Server-derived columns (`legacy_rotation_id`, `legacy_library_release_id`,
+ * `discogs_release_id`, `discogs_release_id_source`, `lml_identity_id`,
+ * `tracklist_lookup_attempted_at`, `kill_date`) and tubafrenzy-ETL-only
+ * snapshot columns (`add_date`, `artist_name`, `album_title`,
+ * `record_label`) must never be client-supplied through this endpoint —
+ * `addToRotation` derives the LML-handle columns from `library_identity`
+ * and the synchronous `resolveIdentity` hop, and tubafrenzy is the only
+ * legitimate source for the snapshot columns.
+ *
+ * Phrased as an allowlist (signature-typed accept list) so a future column
+ * addition to `rotation` is implicitly rejected by typecheck until
+ * explicitly added to the signature. Matches dj-site's `RotationParams`
+ * (`{ album_id, rotation_bin }`); widen the signature here when a future
+ * caller legitimately needs another field.
+ */
+type AddRotationAllowlist = Pick<NewRotationRelease, 'album_id' | 'rotation_bin'>;
+
+export function pickAddRotationFields(body: Partial<NewRotationRelease>): AddRotationAllowlist {
+  const picked = {} as AddRotationAllowlist;
+  if (body.album_id !== undefined) picked.album_id = body.album_id;
+  if (body.rotation_bin !== undefined) picked.rotation_bin = body.rotation_bin;
+  return picked;
+}
+
 export const addRotation: RequestHandler<object, unknown, NewRotationRelease> = async (req, res) => {
   if (req.body.album_id === undefined || req.body.rotation_bin === undefined) {
     throw new WxycError('Missing Parameters: album_id or rotation_bin', 400);
   }
 
-  const rotationRelease: RotationRelease = await libraryService.addToRotation(req.body);
+  const picked = pickAddRotationFields(req.body);
+  const rotationRelease: RotationRelease = await libraryService.addToRotation(picked);
   res.status(201).json(rotationRelease);
 };
 

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -36,6 +36,7 @@ import {
   isLmlConfigured,
   envInt,
   LmlClientError,
+  resolveIdentity,
   type LookupResponse,
   type DiscogsTrackItem,
   type DiscogsReleaseMetadata,
@@ -340,8 +341,136 @@ export const getRotationFromDB = async (): Promise<Rotation[]> => {
   return rows.map((row) => serializeReconciledIdentity(row));
 };
 
+/**
+ * BS#1380: Sentry counter `lml.resolve.fallback_to_null` reason buckets.
+ * Each value signals a different operational response:
+ *   - `timeout`: LML latency/capacity (look at LML p95)
+ *   - `5xx`:     LML deploy regression (look at LML release notes)
+ *   - `4xx`:     BS-side caller bug (the library_identity row pointed at
+ *                a sentinel ID LML rejects, etc.)
+ *   - `network`: infra noise (transient TCP/DNS failures)
+ *   - `other`:   uncategorised — investigate per-event
+ *
+ * Surfaced separately so a per-bucket regression doesn't get masked by the
+ * rollup. Revisit (split the knob or tune the value) if Sentry shows p95
+ * user-facing add-to-rotation > 2.5 s OR fallback rate > 5% in any bucket.
+ */
+export type LmlResolveFallbackReason = 'timeout' | '5xx' | '4xx' | 'network' | 'other';
+
+/**
+ * Classify the error caught from `resolveIdentity(...)` into one of the
+ * five operational buckets above. Pulled out so the unit test can
+ * exhaustively exercise every branch without spinning up an LML server.
+ *
+ * `LmlClientError` is the wrapper `lmlFetch` throws; its `statusCode` was
+ * already translated upstream (5xx → 502, AbortError → 504). The catch
+ * here untranslates so the Sentry attribute reads as the original
+ * operational signal.
+ */
+export function classifyLmlResolveError(err: unknown): LmlResolveFallbackReason {
+  if (!err || typeof err !== 'object') return 'other';
+  const e = err as { name?: string; code?: string; statusCode?: number; message?: string };
+  if (e.name === 'AbortError') return 'timeout';
+  if (err instanceof LmlClientError) {
+    // `lmlFetch` translates `AbortError` → 504 and upstream 5xx → 502; restore
+    // the operational bucket from those translations + the raw status range.
+    if (e.statusCode === 504) return 'timeout';
+    if (e.statusCode === 502) {
+      // 502 is overloaded: it's the wrapper for both upstream 5xx and a raw
+      // fetch failure (the catch-all in `lmlFetch`). Disambiguate from the
+      // message — "LML request failed" is the fetch-threw path.
+      return typeof e.message === 'string' && e.message.startsWith('LML request failed') ? 'network' : '5xx';
+    }
+    if (typeof e.statusCode === 'number') {
+      if (e.statusCode >= 500) return '5xx';
+      if (e.statusCode >= 400) return '4xx';
+    }
+    return 'other';
+  }
+  if (e.code === 'ECONNRESET' || e.code === 'ENOTFOUND' || e.code === 'ECONNREFUSED') {
+    return 'network';
+  }
+  return 'other';
+}
+
+/**
+ * Add an album to rotation (dj-site path, `POST /library/rotation`).
+ *
+ * Synchronously triple-writes `(discogs_release_id, discogs_release_id_source =
+ * 'library_identity', lml_identity_id)` when the album's `library_identity`
+ * row supplies a non-NULL `discogs_release_id` (BS#1380):
+ *
+ *   1. Read `library_identity.discogs_release_id` for the requested
+ *      `album_id`. `library_identity.library_id` is the PRIMARY KEY
+ *      (see schema.ts:1391-1393); `LIMIT 1` is defensive.
+ *   2. If non-NULL, `await resolveIdentity({kind:'release',
+ *      source:'discogs_release', external_id})` to mint a stable
+ *      `lml_identity_id`. The hop runs inside this handler — the response
+ *      row carries the populated columns without needing a follow-up
+ *      patch.
+ *   3. INSERT all three columns. On resolve failure (timeout / 5xx /
+ *      network), `lml_identity_id` falls back to NULL but
+ *      `discogs_release_id` + `discogs_release_id_source = 'library_identity'`
+ *      still land — the *source of the Discogs id* is library_identity
+ *      regardless of whether the mint succeeded. The daily backfill cron
+ *      catches up within ~24h.
+ *
+ * Rationale for synchronous-before-INSERT: dj-site's optimistic UI
+ * (WXYC/dj-site#648) covers the latency tail at the client side — the row
+ * appears in-rotation immediately on click. Blocking the music director on
+ * an LML outage is worse than a temporarily-incomplete row, so the catch
+ * arm proceeds rather than rethrowing.
+ */
 export const addToRotation = async (newRotation: RotationAddRequest) => {
-  const insertedRotation: RotationRelease[] = await db.insert(rotation).values(newRotation).returning();
+  const values: RotationAddRequest = { ...newRotation };
+
+  // Allowlist guard already runs at the controller layer, but the server-
+  // derived fields below must always come from this function, not the
+  // request — defense in depth.
+  if (values.album_id != null) {
+    const [identityRow] = await db
+      .select({ discogs_release_id: library_identity.discogs_release_id })
+      .from(library_identity)
+      .where(eq(library_identity.library_id, values.album_id))
+      .limit(1);
+    const discogsReleaseId = identityRow?.discogs_release_id ?? null;
+
+    if (discogsReleaseId != null) {
+      // The source-of-the-Discogs-id is library_identity, regardless of
+      // whether the LML mint that follows succeeds.
+      values.discogs_release_id = discogsReleaseId;
+      values.discogs_release_id_source = 'library_identity';
+
+      let lmlIdentityId: number | null = null;
+      try {
+        const resolved = await resolveIdentity({
+          kind: 'release',
+          source: 'discogs_release',
+          external_id: String(discogsReleaseId),
+        });
+        lmlIdentityId = resolved.identity_id;
+      } catch (err) {
+        const reason = classifyLmlResolveError(err);
+        // BS#1380: classify once at fallback time so each reason bucket
+        // signals a different operational response (timeout → LML
+        // latency, 5xx → LML deploy regression, 4xx → BS-side caller bug,
+        // network → infra noise). v10 SDK shape — `Sentry.metrics.count(
+        // name, value, {attributes})`. Pre-v8
+        // `Sentry.metrics.increment(..., {tags})` was removed.
+        try {
+          Sentry.metrics.count('lml.resolve.fallback_to_null', 1, {
+            attributes: { caller: 'add_to_rotation', reason },
+          });
+        } catch {
+          // Observability must never break the request path; swallow.
+        }
+        // lml_identity_id stays NULL; INSERT proceeds.
+      }
+      values.lml_identity_id = lmlIdentityId;
+    }
+  }
+
+  const insertedRotation: RotationRelease[] = await db.insert(rotation).values(values).returning();
   return insertedRotation[0];
 };
 

--- a/jobs/rotation-etl/job.ts
+++ b/jobs/rotation-etl/job.ts
@@ -134,6 +134,48 @@ const runIncremental = async (): Promise<SyncResult> => {
                  ELSE ${rotation.discogs_release_id_source}
             END
           `,
+          // BS#1380: drift prevention. lml_identity_id was minted against
+          // the persisted discogs_release_id (either by addToRotation at
+          // INSERT time or by jobs/rotation-lml-identity-backfill); if a
+          // tubafrenzy paste-correction changes the discogs_release_id,
+          // the persisted lml_identity_id no longer matches the new id and
+          // the row must be cleared so the backfill cron re-resolves it.
+          //
+          // The "effective" qualifier matters: the discogs_release_id SET
+          // above uses COALESCE(excluded, persisted), so when tubafrenzy
+          // contributes NULL (the common case for rows without a paste
+          // URL) the discogs_release_id doesn't change. A CASE that fired
+          // on raw `excluded IS DISTINCT FROM rotation` would also fire
+          // on every tick where excluded is NULL and persisted is
+          // non-NULL — three-valued SQL has `NULL IS DISTINCT FROM X` =
+          // TRUE — silently nulling a perfectly-good lml_identity_id on
+          // every kill_date / artist_name / etc. change.
+          //
+          // Guard symmetric to the existing setWhere term at lines
+          // 153-154 (`excluded.discogs_release_id IS NOT NULL AND IS
+          // DISTINCT FROM rotation.discogs_release_id`): only clear
+          // when tubafrenzy supplied a non-NULL different id.
+          //
+          // Equivalent formulation:
+          //   COALESCE(excluded.discogs_release_id, rotation.discogs_release_id)
+          //     IS DISTINCT FROM rotation.discogs_release_id
+          //
+          // setWhere is unchanged — the existing discogs_release_id term
+          // already fires the gate on the Y_X → NULL transition. Adding
+          // an `excluded.lml_identity_id IS DISTINCT FROM rotation
+          // .lml_identity_id` term would *break* the gate: since
+          // lml_identity_id isn't in the INSERT VALUES tuple,
+          // excluded.lml_identity_id is always NULL, so the term would be
+          // TRUE on every tick for any row with a populated identity —
+          // turning the gate into a no-op for the rows BS#1059's
+          // xmin/CDC discipline most cares about.
+          lml_identity_id: sql`
+            CASE WHEN excluded.discogs_release_id IS NOT NULL
+                  AND excluded.discogs_release_id IS DISTINCT FROM ${rotation.discogs_release_id}
+                 THEN NULL
+                 ELSE ${rotation.lml_identity_id}
+            END
+          `,
         },
         // BS#1059 mechanic; the 30-min cron was rewriting most rows every cycle.
         // BS#1029: the plain IS DISTINCT FROM term on discogs_release_id

--- a/jobs/rotation-lml-identity-backfill/README.md
+++ b/jobs/rotation-lml-identity-backfill/README.md
@@ -1,0 +1,147 @@
+# rotation-lml-identity-backfill
+
+Recurring daily-cron drift-repair that resolves `rotation.lml_identity_id` via LML's `POST /api/v1/identity/resolve` (LML#526) for active rotation rows whose `discogs_release_id` is populated but `lml_identity_id` is still NULL.
+
+Companion to the BS#1380 schema addition (migration `0094_rotation-lml-identity-id.sql`). Catches both write paths that legitimately produce NULL `lml_identity_id`:
+
+1. `jobs/rotation-etl/job.ts` — rotation-etl writes only `discogs_release_id` from the tubafrenzy paste and never calls LML (its useful life is bounded by the tubafrenzy decommission window ~September 2026; investing in lml-client wiring there isn't worth the diff). The CASE clause in the UPSERT also clears `lml_identity_id` when a paste-correction changes the effective `discogs_release_id` — those clears land here for re-resolution too.
+2. `apps/backend/services/library.service.ts:addToRotation` — synchronous resolve at INSERT time; falls back to NULL on `LML_RESOLVE_TIMEOUT_MS` / 5xx / network failures so the music director isn't blocked on an LML outage. Those rows land here on the next daily tick.
+
+## When to run
+
+Daily cron (default `0 6 * * *` UTC / 02:00 ET), registered automatically by the deploy pipeline. Cooperative pause (BS#735) defers each batch when DJs are active.
+
+One-shot invocation is supported for ad-hoc operator runs (post-incident catch-up, initial migration deploy, or coverage-gate probes):
+
+```sh
+# Build (via `Manual Build & Deploy` on GitHub Actions)
+gh workflow run deploy-manual.yml -f target=rotation-lml-identity-backfill -f version=latest
+
+# Run on EC2
+docker run --rm --env-file .env $AWS_ECR_URI/rotation-lml-identity-backfill:latest
+```
+
+The SELECT predicate (`lml_identity_id IS NULL AND discogs_release_id IS NOT NULL`) makes reruns idempotent — already-resolved rows are skipped.
+
+### Dry run first
+
+```sh
+docker run --rm --env-file .env -e DRY_RUN=true $AWS_ECR_URI/rotation-lml-identity-backfill:latest
+```
+
+`DRY_RUN=true` runs the LML resolve loop so the resolved / unresolved / error counters are honest but suppresses every UPDATE. The `resolved` counter is replaced by `resolved_dry`.
+
+### Coverage report
+
+```sh
+docker run --rm --env-file .env $AWS_ECR_URI/rotation-lml-identity-backfill:latest --report
+```
+
+`--report` emits the resolvable-coverage SQL result and exits without running the resolve loop. Used to check BS#1381's unblock condition (`resolvable_coverage_pct >= 99.0` steady-state across consecutive daily runs).
+
+## Env
+
+| Var                               | Default    | Purpose                                                                                                  |
+| --------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------- |
+| `LIBRARY_METADATA_URL`            | (required) | LML service URL                                                                                          |
+| `LML_API_KEY`                     | (required) | Bearer for LML auth (rotation safe — see [BS#1094](https://github.com/WXYC/Backend-Service/issues/1094)) |
+| `DB_*`                            | (required) | Standard postgres connection (host/port/name/username/password)                                          |
+| `DRY_RUN`                         | `false`    | Skip all UPDATEs; log planned writes only                                                                |
+| `BACKFILL_LML_MAX_CONCURRENT`     | `1`        | Concurrency cap on LML calls (semaphore permits)                                                         |
+| `BACKFILL_LML_RATE_PER_MIN`       | `20`       | Token-bucket rate limit on LML calls                                                                     |
+| `BACKFILL_LML_RESOLVE_TIMEOUT_MS` | `8000`     | Per-call abort budget on `resolveIdentity`                                                               |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`  | `60`       | Cooperative-pause window; 0 disables                                                                     |
+| `LIVE_ACTIVITY_PAUSE_MS`          | `30000`    | How long to pause between probes when activity is detected                                               |
+| `SENTRY_DSN`                      | —          | Optional; Sentry stays inactive without it                                                               |
+
+The `BACKFILL_LML_*` triple is the safety story BS#995 established for the `flowsheet-metadata-backfill` cron. Defaults pin LML calls to one in-flight / 20 per minute / 8 s per call — for the few-hundred-row active rotation set that's bounded by ~15 min wall time and is provably non-disruptive to runtime LML traffic.
+
+## Counter shape
+
+JSON log line emitted on `step: finished`:
+
+```json
+{
+  "level": "info",
+  "step": "finished",
+  "message": "rotation-lml-identity-backfill done",
+  "dry_run": false,
+  "scanned": 310,
+  "resolved": 247,
+  "resolved_dry": 0,
+  "unresolved": 51,
+  "lml_error": 11,
+  "raced": 1,
+  "repo": "Backend-Service",
+  "tool": "rotation-lml-identity-backfill",
+  "run_id": "<uuid>"
+}
+```
+
+Invariant: `scanned == resolved + resolved_dry + unresolved + lml_error + raced` (matches the counter shape from `jobs/rotation-release-id-backfill/orchestrate.ts:30-91`).
+
+| Counter        | Meaning                                                                                                                                |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `scanned`      | Rows visited (matches the candidate query's row count)                                                                                 |
+| `resolved`     | LML minted/returned an identity_id AND the UPDATE landed cleanly                                                                       |
+| `resolved_dry` | LML returned an identity_id; DRY_RUN suppressed the UPDATE                                                                             |
+| `unresolved`   | LML rejected the input with 422 (sentinel discogs id, malformed bandcamp URL)                                                          |
+| `lml_error`    | LML call threw (cold-cache timeout, network blip, 5xx); row stays NULL for next run                                                    |
+| `raced`        | UPDATE matched zero rows — either a concurrent backfill won the race, or rotation-etl cleared the row mid-run after a paste-correction |
+
+## Coverage gate
+
+The gate that unblocks [BS#1381](https://github.com/WXYC/Backend-Service/issues/1381) is **resolvable coverage** — the fraction of active rotation rows where backfill _could_ populate `lml_identity_id` that actually have it. Denominator excludes rows with NULL `discogs_release_id` (no backfill source).
+
+```sql
+SELECT
+  COUNT(*) FILTER (WHERE kill_date IS NULL OR kill_date > CURRENT_DATE) AS active,
+  COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                   AND discogs_release_id IS NOT NULL) AS active_with_discogs,
+  COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                   AND discogs_release_id IS NOT NULL
+                   AND lml_identity_id IS NOT NULL) AS active_with_lml,
+  ROUND(
+    100.0 * COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                             AND discogs_release_id IS NOT NULL
+                             AND lml_identity_id IS NOT NULL)
+        / NULLIF(COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                                  AND discogs_release_id IS NOT NULL), 0),
+    2
+  ) AS resolvable_coverage_pct
+FROM wxyc_schema.rotation;
+```
+
+`--report` mode runs exactly this. When `resolvable_coverage_pct >= 99.0` steady-state across consecutive daily cron runs, comment on [BS#1381](https://github.com/WXYC/Backend-Service/issues/1381) to unblock that work.
+
+Rows that sit at `lml_identity_id IS NULL AND discogs_release_id IS NOT NULL` for >7 days after backfill is healthy indicate either LML can't resolve the ID (catalog drift) or backfill has a bug — investigate per-row, not by lowering the gate threshold.
+
+**Why resolvable coverage instead of absolute:** post-tubafrenzy-decommission, new `addToRotation` rows pick up `discogs_release_id` from `library_identity`, which has its own incomplete subset. Absolute coverage `(active_with_lml / active)` conflates "backfill is done" with "library_identity has full Discogs handle population" — two unrelated work tracks. The WXYC/dj-site#648 high-volume MD path makes the denominator in absolute coverage move with library_identity health, not backfill progress.
+
+## Post-run verification
+
+```sql
+SELECT
+  COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                   AND lml_identity_id IS NOT NULL) AS active_with_lml,
+  COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                   AND lml_identity_id IS NULL
+                   AND discogs_release_id IS NOT NULL) AS lml_remaining,
+  COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                   AND lml_identity_id IS NULL
+                   AND discogs_release_id IS NULL) AS no_discogs_handle
+FROM wxyc_schema.rotation;
+```
+
+`lml_remaining` is the candidate count for the next daily tick; it should trend toward zero as both write paths converge.
+
+## Related
+
+- Schema PR: [BS#1380](https://github.com/WXYC/Backend-Service/issues/1380) (this issue)
+- LML precursor: [LML#526](https://github.com/WXYC/library-metadata-lookup/issues/526) — introduces the release identity that `lml_identity_id` points at
+- LML companion consumer: [LML#525](https://github.com/WXYC/library-metadata-lookup/issues/525) — `POST /api/v1/cache/refresh-for-identities` consumes the values this backfill produces
+- Operational precedent (one-shot variant): `jobs/rotation-release-id-backfill/`
+- Operational precedent (recurring-drift-repair shape): `jobs/flowsheet-metadata-backfill/` — same `BACKFILL_CRON_SCHEDULE` override pattern
+- Cooperative-pause primitive: [BS#735](https://github.com/WXYC/Backend-Service/issues/735)
+- Backfill cron-schedule override: [BS#914](https://github.com/WXYC/Backend-Service/issues/914) — see `scripts/resolve-cron-schedule.sh`
+- Coverage-gate consumer: [BS#1381](https://github.com/WXYC/Backend-Service/issues/1381) — `rotation-artist-backfill` switching off the LML-identity handle

--- a/jobs/rotation-lml-identity-backfill/job.ts
+++ b/jobs/rotation-lml-identity-backfill/job.ts
@@ -1,0 +1,118 @@
+/**
+ * Entrypoint for jobs/rotation-lml-identity-backfill (BS#1380).
+ *
+ * Daily-cron recurring drift-repair that resolves `rotation.lml_identity_id`
+ * for active rows whose `discogs_release_id` is populated but
+ * `lml_identity_id` is still NULL. Catches the two write paths that
+ * legitimately produce that state:
+ *
+ *   1. `jobs/rotation-etl/job.ts` — rotation-etl writes only
+ *      `discogs_release_id` from the tubafrenzy paste and never calls
+ *      LML (its useful life is bounded by the tubafrenzy decommission
+ *      window ~September 2026; investing in lml-client wiring there
+ *      isn't worth the diff). The CASE clause in the UPSERT also
+ *      explicitly clears `lml_identity_id` when a paste-correction
+ *      changes the effective `discogs_release_id` — those clears land
+ *      here for re-resolution too.
+ *   2. `apps/backend/services/library.service.ts:addToRotation` —
+ *      synchronous resolve at INSERT time; falls back to NULL on
+ *      `LML_RESOLVE_TIMEOUT_MS` / 5xx / network failures so the music
+ *      director isn't blocked on an LML outage. Those rows land here on
+ *      the next daily tick.
+ *
+ * Modes:
+ *   - default: run the resolve loop, write to PG, log totals
+ *   - `DRY_RUN=true`: run the resolve loop, suppress all UPDATEs, surface
+ *     planned writes via `resolved_dry`
+ *   - `--report`: emit the resolvable-coverage SQL result and exit
+ *     without running the resolve loop. Useful for ops queries against
+ *     BS#1381's unblock condition (resolvable_coverage_pct >= 99.0
+ *     steady-state).
+ *
+ * Idempotent: the SELECT predicate is `lml_identity_id IS NULL AND
+ * discogs_release_id IS NOT NULL` and the writer guards on the same
+ * predicate (plus `discogs_release_id` equality to defeat the
+ * paste-correction race). Safe to re-run; safe to one-shot during
+ * a deploy migration.
+ *
+ * One-shot invocation:
+ *   docker run --rm --env-file .env $AWS_ECR_URI/rotation-lml-identity-backfill:latest
+ *
+ * Required env: LIBRARY_METADATA_URL (LML host), LML_API_KEY (bearer),
+ * DB_* (postgres connection).
+ *
+ * Optional env:
+ *   DRY_RUN=true                              skip all UPDATEs; log planned writes
+ *   BACKFILL_LML_MAX_CONCURRENT=N             default 1
+ *   BACKFILL_LML_RATE_PER_MIN=N               default 20
+ *   BACKFILL_LML_RESOLVE_TIMEOUT_MS=N         default 8000
+ *   LIVE_ACTIVITY_LOOKBACK_SECONDS=N          default 60; 0 disables cooperative pause
+ *   LIVE_ACTIVITY_PAUSE_MS=N                  default 30000
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+
+import { runBackfill } from './orchestrate.js';
+import { loadCandidates, loadCoverageReport } from './query.js';
+import { lookupIdentityId } from './lml-fetch.js';
+import { writeIdentityId } from './writer.js';
+import { initLogger, log, captureError, closeLogger } from './logger.js';
+
+const JOB_NAME = 'rotation-lml-identity-backfill';
+
+const requireLmlConfigured = (): void => {
+  if (!process.env.LIBRARY_METADATA_URL) {
+    throw new Error('LIBRARY_METADATA_URL is not configured; aborting before any rows are scanned.');
+  }
+};
+
+const resolveDryRun = (): boolean => {
+  const raw = process.env.DRY_RUN;
+  return raw === 'true' || raw === '1' || raw === 'TRUE';
+};
+
+const isReportMode = (): boolean => process.argv.slice(2).includes('--report');
+
+const main = async (): Promise<void> => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  if (isReportMode()) {
+    try {
+      const report = await loadCoverageReport();
+      log('info', 'coverage_report', `${JOB_NAME} --report`, { ...report });
+      process.stdout.write(JSON.stringify(report) + '\n');
+    } catch (error) {
+      log('error', 'failed', `${JOB_NAME} --report failed`, { error_message: (error as Error).message });
+      captureError(error, 'failed');
+      process.exitCode = 1;
+    } finally {
+      await closeDatabaseConnection();
+      await closeLogger();
+    }
+    return;
+  }
+
+  const dryRun = resolveDryRun();
+  try {
+    requireLmlConfigured();
+    log('info', 'init', `${JOB_NAME} initialized`, { dry_run: dryRun });
+    const { totals } = await runBackfill({
+      loadCandidates,
+      lookup: lookupIdentityId,
+      write: writeIdentityId,
+      dryRun,
+      onLivePause: () => {
+        log('info', 'live_activity_pause', 'live flowsheet activity detected; pausing');
+      },
+    });
+    log('info', 'finished', `${JOB_NAME} done`, { dry_run: dryRun, ...totals });
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
+};
+
+void main();

--- a/jobs/rotation-lml-identity-backfill/lml-fetch.ts
+++ b/jobs/rotation-lml-identity-backfill/lml-fetch.ts
@@ -1,0 +1,66 @@
+/**
+ * Backfill-side LML resolve helper for jobs/rotation-lml-identity-backfill
+ * (BS#1380).
+ *
+ * Delegates to `@wxyc/lml-client.resolveIdentity` (the wrapper introduced
+ * alongside BS#1380; see shared/lml-client/src/index.ts) and injects:
+ *   - a tighter per-call abort budget
+ *     (`BACKFILL_LML_RESOLVE_TIMEOUT_MS`, default 8000 ms) so cold-tail
+ *     identities that LML can't resolve quickly don't hold a serialized
+ *     resolve slot for the runtime path's 2 s, and
+ *   - the backfill's own concurrency + rate-limit gate via
+ *     `defaultLmlLimiter` (BS#995 — strict BACKFILL_LML_* ceiling).
+ *
+ * `resolveIdentity` itself does NOT take a limiter today — it's a small,
+ * single-purpose POST that the LML server caps internally. The limiter is
+ * applied here at the wrapper layer so the BS-side back-pressure surfaces
+ * at the same chokepoint shape as `lookupReleaseId` does in
+ * `jobs/rotation-release-id-backfill/lml-fetch.ts`.
+ *
+ * Returns the LML identity_id (or null when LML's 422 rejected the input
+ * — e.g. a sentinel `0` discogs id; the caller counts that as
+ * `unresolved`). 4xx is the only "ran-cleanly-but-no-result" branch;
+ * 5xx / timeout / network errors throw `LmlClientError` so the
+ * orchestrator's catch arm bumps `lml_error` and leaves the row
+ * untouched for next run.
+ */
+
+import { LmlClientError, resolveIdentity } from '@wxyc/lml-client';
+
+import { defaultLmlLimiter } from './lml-limiter.js';
+
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-fetch: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
+};
+
+const TIMEOUT_MS = envInt('BACKFILL_LML_RESOLVE_TIMEOUT_MS', 8000);
+
+export const lookupIdentityId = async (discogsReleaseId: number): Promise<number | null> =>
+  defaultLmlLimiter.run(async () => {
+    try {
+      const response = await resolveIdentity(
+        {
+          kind: 'release',
+          source: 'discogs_release',
+          external_id: String(discogsReleaseId),
+        },
+        { timeoutMs: TIMEOUT_MS }
+      );
+      return response.identity_id;
+    } catch (err) {
+      // LML's 422 sentinel rejection ("Discogs id <= 0", malformed Bandcamp
+      // URL, etc.) is "ran cleanly, no row to point at" — surfaces to the
+      // orchestrator as `unresolved`, not `lml_error`. Network / timeout /
+      // 5xx all rethrow so the orchestrator's catch arm leaves the row
+      // retryable.
+      if (err instanceof LmlClientError && err.statusCode === 422) {
+        return null;
+      }
+      throw err;
+    }
+  });

--- a/jobs/rotation-lml-identity-backfill/lml-limiter.ts
+++ b/jobs/rotation-lml-identity-backfill/lml-limiter.ts
@@ -1,0 +1,44 @@
+/**
+ * Concurrency + rate-limit gate for jobs/rotation-lml-identity-backfill
+ * (BS#1380).
+ *
+ * Mirrors jobs/rotation-release-id-backfill/lml-limiter.ts verbatim — same
+ * `BACKFILL_LML_*` env defaults (concurrency=1, rate=20/min) and the same
+ * `defaultLmlLimiter` singleton pattern. The 2026-05-21 incident (BS#994)
+ * is the safety story this limiter exists to defend; copying the file
+ * keeps the rotation-lml-identity-backfill's blast-radius story identical
+ * to the other LML-calling backfills, without coupling either to the
+ * other's build graph.
+ *
+ * The underlying primitives (Semaphore, TokenBucket, LmlLimiter,
+ * createLmlLimiter) live in @wxyc/lml-client post-BS#887.
+ */
+
+import { type LmlLimiter, Semaphore, TokenBucket, createLmlLimiter as createSharedLmlLimiter } from '@wxyc/lml-client';
+
+export { type LmlLimiter, Semaphore, TokenBucket };
+
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  // Number() (not parseInt) so partial-parse strings like "20banana" surface
+  // as NaN and get rejected rather than silently coercing.
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
+};
+
+export const createLmlLimiter = (config?: { maxConcurrent?: number; ratePerMinute?: number }): LmlLimiter =>
+  createSharedLmlLimiter({
+    maxConcurrent: config?.maxConcurrent ?? envInt('BACKFILL_LML_MAX_CONCURRENT', 1),
+    ratePerMinute: config?.ratePerMinute ?? envInt('BACKFILL_LML_RATE_PER_MIN', 20),
+  });
+
+/**
+ * Module-level singleton consumed by lml-fetch.ts. Reads BACKFILL_LML_* from
+ * env at module load — mutating process.env after the first import of this
+ * module does NOT reconfigure the singleton. Tests that exercise different
+ * limits must call `createLmlLimiter()` directly with explicit config.
+ */
+export const defaultLmlLimiter: LmlLimiter = createLmlLimiter();

--- a/jobs/rotation-lml-identity-backfill/logger.ts
+++ b/jobs/rotation-lml-identity-backfill/logger.ts
@@ -1,0 +1,96 @@
+/**
+ * Observability for jobs/rotation-lml-identity-backfill (BS#1380): Sentry
+ * init + JSON logs.
+ *
+ * Phase A foundation contract (#538): every log line carries the four tags
+ * `repo`, `tool`, `step`, `run_id`. Sentry stays inactive when SENTRY_DSN
+ * is unset (the @sentry/node SDK silently no-ops in that case), so this
+ * module is safe to call from any environment.
+ *
+ * Mirrors `jobs/rotation-release-id-backfill/logger.ts` verbatim — the
+ * contract is identical; the duplication keeps this job's build graph
+ * independent of the one-shot backfill's package.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+// `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+/**
+ * Initialize Sentry and the structured logger. Call once at the top of the
+ * entrypoint, before any other logic. Returns the resolved `run_id` so the
+ * caller can pass it to subprocesses or persist it for cross-system tracing.
+ */
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+/**
+ * Emit a JSON log line. `info`/`warn` go to stdout, `error` goes to stderr
+ * so container log shippers can split streams by severity.
+ *
+ * Silently no-ops when called before `initLogger()` so unit tests that
+ * exercise library functions directly (without invoking the entrypoint)
+ * don't have to thread an init call through every fixture.
+ */
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+/** Capture an exception to Sentry with the current run's tags + an extra `step`. */
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+/** Flush pending Sentry events. Call from the entrypoint's `finally`. */
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/rotation-lml-identity-backfill/orchestrate.ts
+++ b/jobs/rotation-lml-identity-backfill/orchestrate.ts
@@ -1,0 +1,169 @@
+/**
+ * Orchestrator for jobs/rotation-lml-identity-backfill (BS#1380).
+ *
+ * Iterates active rotation rows
+ * (`kill_date IS NULL OR > CURRENT_DATE`) where
+ * `lml_identity_id IS NULL AND discogs_release_id IS NOT NULL`, asks LML
+ * for a stable identity_id via `POST /api/v1/identity/resolve`, and
+ * writes the result back. Recurring daily-cron drift-repair (the
+ * recurring shape from `jobs/flowsheet-metadata-backfill`, not the
+ * one-shot shape from `jobs/rotation-release-id-backfill`); rerun-safe
+ * via the SELECT predicate.
+ *
+ * Pacing and per-call timeouts ride on top of `lml-fetch.ts`'s
+ * `defaultLmlLimiter` configured with `BACKFILL_LML_*` env vars — same
+ * safety story as the other LML-calling backfills (BS#995).
+ *
+ * Cooperative pause (BS#735): the orchestrator probes flowsheet for live
+ * DJ activity before each batch; the loop yields when a DJ is actively
+ * touching the playout, exactly the window where any incremental p95
+ * hit is most user-visible. Disable via
+ * `LIVE_ACTIVITY_LOOKBACK_SECONDS=0` for catch-up runs.
+ *
+ * Deps are injected so tests can drive the orchestrator without a live
+ * LML or DB.
+ *
+ * Sentry span attributes on numeric counters are set at span creation,
+ * not via late `setAttribute` (BS#1081 — late `setAttribute` calls index
+ * numbers as strings and break sum/avg/p95).
+ */
+
+import * as Sentry from '@sentry/node';
+import {
+  LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
+  LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+  checkLiveActivity as defaultCheckLiveActivity,
+  type CheckLiveActivityFn,
+} from '@wxyc/database';
+
+import type { Candidate } from './query.js';
+
+export type LoadCandidatesFn = () => Promise<Candidate[]>;
+
+export type LookupFn = (discogsReleaseId: number) => Promise<number | null>;
+
+export type WriteFn = (
+  rotationId: number,
+  discogsReleaseIdAtRead: number,
+  lmlIdentityId: number
+) => Promise<{ written: boolean }>;
+
+/**
+ * Counter shape mirrors `jobs/rotation-release-id-backfill/orchestrate.ts:30-91`.
+ * Same five buckets so downstream dashboards / log-line consumers don't
+ * have to differentiate. `resolved_dry` covers DRY_RUN runs; the invariant
+ * `scanned == resolved + resolved_dry + unresolved + lml_error + raced`
+ * holds with or without DRY_RUN.
+ */
+export type Totals = {
+  scanned: number;
+  resolved: number;
+  resolved_dry: number;
+  unresolved: number;
+  lml_error: number;
+  raced: number;
+};
+
+export type RunResult = { totals: Totals };
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const envNonNegativeInt = (raw: string | undefined, fallback: number): number => {
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  return fallback;
+};
+
+export const resolveLiveActivityLookback = (
+  raw: string | undefined = process.env.LIVE_ACTIVITY_LOOKBACK_SECONDS
+): number => envNonNegativeInt(raw, LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT);
+
+export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number =>
+  envNonNegativeInt(raw, LIVE_ACTIVITY_PAUSE_MS_DEFAULT);
+
+export const runBackfill = async (deps: {
+  loadCandidates: LoadCandidatesFn;
+  lookup: LookupFn;
+  write: WriteFn;
+  dryRun?: boolean;
+  liveActivityLookbackSeconds?: number;
+  liveActivityPauseMs?: number;
+  checkLiveActivity?: CheckLiveActivityFn;
+  onLivePause?: () => void;
+}): Promise<RunResult> => {
+  const totals: Totals = {
+    scanned: 0,
+    resolved: 0,
+    resolved_dry: 0,
+    unresolved: 0,
+    lml_error: 0,
+    raced: 0,
+  };
+
+  const liveActivityLookbackSeconds = deps.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
+  const liveActivityPauseMs = deps.liveActivityPauseMs ?? resolveLiveActivityPauseMs();
+  const probe = deps.checkLiveActivity ?? defaultCheckLiveActivity;
+
+  // BS#1081: numeric attributes are projected at span creation so they
+  // index as numbers (not strings) in Sentry's trace explorer.
+  return await Sentry.startSpan(
+    {
+      name: 'rotation-lml-identity-backfill.run',
+      op: 'function',
+      attributes: {
+        'wxyc.backfill.dry_run': Boolean(deps.dryRun),
+        'wxyc.backfill.live_activity_lookback_seconds': liveActivityLookbackSeconds,
+        'wxyc.backfill.live_activity_pause_ms': liveActivityPauseMs,
+      },
+    },
+    async () => {
+      const candidates = await deps.loadCandidates();
+
+      for (const candidate of candidates) {
+        if (liveActivityLookbackSeconds > 0) {
+          while (await probe(liveActivityLookbackSeconds)) {
+            deps.onLivePause?.();
+            if (liveActivityPauseMs > 0) await sleep(liveActivityPauseMs);
+          }
+        }
+
+        totals.scanned += 1;
+        let identityId: number | null;
+        try {
+          identityId = await deps.lookup(candidate.discogs_release_id);
+        } catch {
+          // The row stays `lml_identity_id IS NULL` so it's picked up on
+          // the next daily run when LML's cache is warmer. The job entry
+          // wraps the orchestrator's loop in Sentry's run-scope so
+          // captureException is unnecessary here at the unit boundary.
+          totals.lml_error += 1;
+          continue;
+        }
+        if (identityId !== null) {
+          if (deps.dryRun) {
+            totals.resolved_dry += 1;
+            continue;
+          }
+          const { written } = await deps.write(candidate.id, candidate.discogs_release_id, identityId);
+          if (written) {
+            totals.resolved += 1;
+          } else {
+            // The writer's WHERE clause requires `lml_identity_id IS NULL`
+            // AND `discogs_release_id` still matches the value we resolved
+            // against. 0 rows updated means either (a) another concurrent
+            // backfill (cron + manual) beat us, or (b) rotation-etl
+            // cleared the row mid-run after a paste-correction. Surface on
+            // a dedicated counter so the dashboard distinguishes write
+            // success from "lost the race".
+            totals.raced += 1;
+          }
+        } else {
+          totals.unresolved += 1;
+        }
+      }
+
+      return { totals };
+    }
+  );
+};

--- a/jobs/rotation-lml-identity-backfill/package.json
+++ b/jobs/rotation-lml-identity-backfill/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@wxyc/rotation-lml-identity-backfill",
+  "cron-schedule": "0 6 * * *",
+  "version": "1.0.0",
+  "description": "WXYC recurring drift-repair: resolve rotation.lml_identity_id via LML for rows with a non-NULL discogs_release_id. Catches rotation-etl-written rows (rotation-etl never calls LML) and addToRotation resolve-failure fallbacks within ~24h (BS#1380).",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_rotation_lml_identity_backfill:ci -f ../../Dockerfile.rotation-lml-identity-backfill ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.53.1",
+    "@wxyc/database": "^1.0.0",
+    "@wxyc/lml-client": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/rotation-lml-identity-backfill/query.ts
+++ b/jobs/rotation-lml-identity-backfill/query.ts
@@ -1,0 +1,97 @@
+/**
+ * Candidate query for jobs/rotation-lml-identity-backfill (BS#1380).
+ *
+ * Selects active rotation rows (`kill_date IS NULL OR > CURRENT_DATE`)
+ * whose `lml_identity_id` is NULL but whose `discogs_release_id` is
+ * non-NULL — i.e. rows that have an LML-resolvable Discogs handle but
+ * no minted identity yet. The two-column predicate is the idempotency
+ * gate: rerunning the job after a partial run, or after a tubafrenzy
+ * paste landed mid-run, is safe and skips already-resolved rows.
+ *
+ * Rows with a NULL `discogs_release_id` are out of scope — there's no
+ * source-of-truth ID to feed `resolveIdentity`. The
+ * `rotation-release-id-backfill` job is the precursor that populates
+ * those.
+ *
+ * No new index. Rotation is hundreds of active rows; the seqscan is
+ * fine and matches the precedent set by
+ * `jobs/rotation-release-id-backfill/query.ts`.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+
+export type Candidate = {
+  id: number;
+  discogs_release_id: number;
+};
+
+export const loadCandidates = async (): Promise<Candidate[]> => {
+  const rows = (await db.execute(sql`
+    SELECT
+      "id",
+      "discogs_release_id"
+    FROM "wxyc_schema"."rotation"
+    WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
+      AND "lml_identity_id" IS NULL
+      AND "discogs_release_id" IS NOT NULL
+    ORDER BY "id" ASC
+  `)) as unknown as Candidate[];
+  return rows ?? [];
+};
+
+/**
+ * BS#1380 coverage gate: resolvable coverage = (active rows with
+ * lml_identity_id) / (active rows with discogs_release_id). When
+ * the daily cron hits >= 99.0 steady-state, BS#1381 (rotation-
+ * artist-backfill switching off discogs_release_id) is unblocked.
+ *
+ * Denominator excludes rows with NULL discogs_release_id (no backfill
+ * source) so library_identity health doesn't conflate with backfill
+ * progress.
+ */
+export type CoverageReport = {
+  active: number;
+  active_with_discogs: number;
+  active_with_lml: number;
+  resolvable_coverage_pct: number | null;
+};
+
+export const loadCoverageReport = async (): Promise<CoverageReport> => {
+  const rows = (await db.execute(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE "kill_date" IS NULL OR "kill_date" > CURRENT_DATE) AS active,
+      COUNT(*) FILTER (WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
+                       AND "discogs_release_id" IS NOT NULL) AS active_with_discogs,
+      COUNT(*) FILTER (WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
+                       AND "discogs_release_id" IS NOT NULL
+                       AND "lml_identity_id" IS NOT NULL) AS active_with_lml,
+      ROUND(
+        100.0 * COUNT(*) FILTER (WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
+                                 AND "discogs_release_id" IS NOT NULL
+                                 AND "lml_identity_id" IS NOT NULL)
+            / NULLIF(COUNT(*) FILTER (WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
+                                      AND "discogs_release_id" IS NOT NULL), 0),
+        2
+      ) AS resolvable_coverage_pct
+    FROM "wxyc_schema"."rotation"
+  `)) as unknown as Array<{
+    active: string | number;
+    active_with_discogs: string | number;
+    active_with_lml: string | number;
+    resolvable_coverage_pct: string | number | null;
+  }>;
+  const row = rows?.[0];
+  // PG returns bigints as strings via postgres.js — coerce.
+  const toNumber = (raw: string | number | null): number | null => {
+    if (raw === null) return null;
+    const parsed = typeof raw === 'string' ? Number(raw) : raw;
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+  return {
+    active: toNumber(row?.active ?? 0) ?? 0,
+    active_with_discogs: toNumber(row?.active_with_discogs ?? 0) ?? 0,
+    active_with_lml: toNumber(row?.active_with_lml ?? 0) ?? 0,
+    resolvable_coverage_pct: toNumber(row?.resolvable_coverage_pct ?? null),
+  };
+};

--- a/jobs/rotation-lml-identity-backfill/tsconfig.json
+++ b/jobs/rotation-lml-identity-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }, { "path": "../../shared/lml-client" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/rotation-lml-identity-backfill/tsup.config.ts
+++ b/jobs/rotation-lml-identity-backfill/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/jobs/rotation-lml-identity-backfill/writer.ts
+++ b/jobs/rotation-lml-identity-backfill/writer.ts
@@ -1,0 +1,41 @@
+/**
+ * Writer for jobs/rotation-lml-identity-backfill (BS#1380).
+ *
+ * Idempotent single-row UPDATE that persists an LML-minted identity_id on
+ * a rotation row. The WHERE clause guards on `lml_identity_id IS NULL`
+ * AND `discogs_release_id = <observed>` so:
+ *
+ *   1. A rerun is safe (the second pass's UPDATE sees `lml_identity_id`
+ *      already populated and matches 0 rows).
+ *   2. A mid-run drift from `rotation-etl` (a tubafrenzy paste-correction
+ *      changing `discogs_release_id` to a different id, and the
+ *      rotation-etl CASE clearing `lml_identity_id` back to NULL) doesn't
+ *      get clobbered with an identity minted against the *old* Discogs
+ *      id. That race manifests as a 0-row UPDATE which the orchestrator
+ *      reads via `written: false` and rolls into its `raced` counter.
+ *
+ * Both guards together: the column has to still be NULL *and* the row
+ * has to still be pointing at the same Discogs id we resolved against.
+ */
+
+import { and, eq, isNull } from 'drizzle-orm';
+import { db, rotation } from '@wxyc/database';
+
+export const writeIdentityId = async (
+  rotationId: number,
+  discogsReleaseIdAtRead: number,
+  lmlIdentityId: number
+): Promise<{ written: boolean }> => {
+  const updated = await db
+    .update(rotation)
+    .set({ lml_identity_id: lmlIdentityId })
+    .where(
+      and(
+        eq(rotation.id, rotationId),
+        isNull(rotation.lml_identity_id),
+        eq(rotation.discogs_release_id, discogsReleaseIdAtRead)
+      )
+    )
+    .returning({ id: rotation.id });
+  return { written: updated.length === 1 };
+};

--- a/scripts/resolve-cron-schedule.sh
+++ b/scripts/resolve-cron-schedule.sh
@@ -44,12 +44,24 @@ if [ -z "$DEFAULT" ]; then
   exit 1
 fi
 
-# Override only for the specific job the H7 ticket calls out. Generalizing
-# to "any job" would risk an accidental override from a stale env var
-# fanning out across the whole matrix; keep the override scope narrow
-# until a second job needs it.
-if [ "$TARGET" = "flowsheet-metadata-backfill" ] && [ -n "${BACKFILL_CRON_SCHEDULE:-}" ]; then
-  echo "$BACKFILL_CRON_SCHEDULE"
-else
-  echo "$DEFAULT"
-fi
+# Override only for jobs that explicitly opt into the shared env var.
+# Generalizing to "any job" would risk an accidental override from a stale
+# env var fanning out across the whole matrix; keep the allowlist narrow
+# and explicit. Each entry needs a documented operational reason:
+#   - flowsheet-metadata-backfill (BS#914 / H7): nightly metadata sweep;
+#     ops occasionally tightens the cadence (hourly) during C6 retunes
+#   - rotation-lml-identity-backfill (BS#1380): daily LML-identity resolve;
+#     shares the metadata sweep's ops cadence story since both are
+#     LML-bounded drift-repair crons
+case "$TARGET" in
+  flowsheet-metadata-backfill|rotation-lml-identity-backfill)
+    if [ -n "${BACKFILL_CRON_SCHEDULE:-}" ]; then
+      echo "$BACKFILL_CRON_SCHEDULE"
+    else
+      echo "$DEFAULT"
+    fi
+    ;;
+  *)
+    echo "$DEFAULT"
+    ;;
+esac

--- a/shared/database/src/migrations/0094_rotation-lml-identity-id.sql
+++ b/shared/database/src/migrations/0094_rotation-lml-identity-id.sql
@@ -1,0 +1,87 @@
+-- precondition-guard: not-required (ADD COLUMN nullable + ALTER TYPE ADD
+--   VALUE are both metadata-only DDL with no row-level invariants to
+--   violate. Existing rows accept NULL on the new column without rewrite.)
+-- 0094 — add `rotation.lml_identity_id` + extend
+--   `discogs_release_id_source_enum` with `'library_identity'` (BS#1380).
+--
+-- (a) NEW COLUMN `rotation.lml_identity_id integer NULL`.
+--
+--     Stable LML release-identity handle. Points at
+--     `entity.release_identity.id` on the LML side (see LML#526 / the
+--     companion DDL applied via discogs-etl#278). FK semantics live on
+--     LML's side; PG-level FK is not enforceable across the network.
+--
+--     Why a new column, not "reuse `discogs_release_id`":
+--       1. Discogs IDs aren't intrinsically stable. Discogs admins
+--          periodically reorganize the catalog — the 2026-04-28 reshuffle
+--          (BS#624) is documented prior art. A column we populate from a
+--          paste URL today can point at a different release (or 404)
+--          months later.
+--       2. Layer violation. BS shouldn't carry Discogs's ID space; the
+--          reason BS records *any* ID at all is to give LML a stable
+--          handle for follow-up calls (avoiding text-search on
+--          `artist + album`). LML is the right layer to own the stable
+--          handle.
+--       3. No path to multi-source. Once LML#216 / LML#217 populate the
+--          MusicBrainz/Wikidata legs of the reconciliation log, a
+--          rotation row's "what release is this" answer should follow
+--          whichever source has data. With `discogs_release_id` as the
+--          only handle, MB-only releases are unreachable from this
+--          column.
+--
+--     Writers:
+--       - `apps/backend/services/library.service.ts:addToRotation`
+--         (dj-site path, BS#1380) synchronously resolves via
+--         `POST /api/v1/identity/resolve` before INSERT when
+--         `library_identity.discogs_release_id` is non-NULL. Falls back
+--         to NULL on resolve timeout / 5xx (the row's
+--         `discogs_release_id` still lands so the backfill can re-resolve
+--         within ~24h).
+--       - `jobs/rotation-lml-identity-backfill` (BS#1380, daily cron)
+--         sweeps rows with `lml_identity_id IS NULL AND
+--         discogs_release_id IS NOT NULL`. Catches both rotation-etl
+--         writes (rotation-etl never calls LML; its useful life is bounded
+--         by the tubafrenzy decommission window ~September 2026) and
+--         addToRotation resolve-failure fallbacks.
+--
+--     Rotation-etl preserves the column across ticks via a guarded CASE
+--     in jobs/rotation-etl/job.ts that clears it only when the
+--     *effective* `discogs_release_id` changes — paste-correction lands
+--     at `(X', NULL)` and the next backfill tick re-resolves.
+--
+-- (b) NEW ENUM VALUE `discogs_release_id_source_enum.library_identity`.
+--
+--     `addToRotation` is a new writer that doesn't fit any of the three
+--     existing values (`tubafrenzy_paste` / `lml_offline_backfill` /
+--     `discogs_direct_backfill` are all tubafrenzy/operator-side). Without
+--     extending the enum, the `NOT NULL DEFAULT 'tubafrenzy_paste'`
+--     would tag every dj-site row as if it came from tubafrenzy,
+--     silently corrupting the provenance invariant — kill_date forensics,
+--     BS#1029 backfill scoping, and the future `discogs_release_id`
+--     retirement migration all rely on the column being honest.
+--
+--     Note on resolve-failure fallback: when the LML mint fails inside
+--     `addToRotation`, `lml_identity_id` lands NULL but
+--     `discogs_release_id_source` is still `library_identity` — the
+--     source-of-the-Discogs-id is library_identity regardless of whether
+--     we successfully minted the identity.
+--
+-- DDL-only — no row UPDATE. `ALTER TYPE ... ADD VALUE` is type-system
+-- metadata; `ADD COLUMN integer NULL` is metadata-only on PG11+. The
+-- enum-value addition runs fine inside Drizzle's transaction-per-
+-- migration shape on PG12+ as long as the new value isn't referenced
+-- in the same transaction — the follow-on `addToRotation` writes the
+-- new value at runtime, not migration time, so there's no ordering
+-- hazard.
+--
+-- No new index. Rotation is hundreds of active rows; the backfill's
+-- predicate (`lml_identity_id IS NULL AND discogs_release_id IS NOT
+-- NULL`) is seqscan-fine at this row count, matching the precedent set
+-- by `jobs/rotation-release-id-backfill/query.ts`.
+--
+-- @no-analyze-needed: ALTER TYPE ADD VALUE is type-system metadata, and
+-- ADD COLUMN integer NULL is metadata-only on PG11+. No rows are
+-- rewritten, no planner stats to refresh.
+
+ALTER TYPE "wxyc_schema"."discogs_release_id_source_enum" ADD VALUE 'library_identity' AFTER 'discogs_direct_backfill';--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."rotation" ADD COLUMN "lml_identity_id" integer;

--- a/shared/database/src/migrations/meta/0094_snapshot.json
+++ b/shared/database/src/migrations/meta/0094_snapshot.json
@@ -1,0 +1,4653 @@
+{
+  "id": "c8373eb4-18cb-4df3-b27d-ff6fee643736",
+  "prevId": "2d29c071-9ffd-4d9e-a159-95b24ddecea4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_scraped_at": {
+          "name": "first_scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_play_order_idx": {
+          "name": "flowsheet_play_order_idx",
+          "columns": [
+            {
+              "expression": "\"play_order\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_idx": {
+          "name": "flowsheet_metadata_attempt_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_covering_idx": {
+          "name": "flowsheet_metadata_attempt_pending_covering_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_album_id_enriched_idx": {
+          "name": "flowsheet_album_id_enriched_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flowsheet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "album_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lml_identity_id": {
+          "name": "lml_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shows_legacy_dj_name_trgm_idx": {
+          "name": "shows_legacy_dj_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"legacy_dj_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_dj_name_trgm_idx": {
+          "name": "auth_user_dj_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"dj_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "auth_user_name_trgm_idx": {
+          "name": "auth_user_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill",
+        "library_identity"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.album_plays": {
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "isExisting": true,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -645,6 +645,13 @@
       "when": 1780667256175,
       "tag": "0093_concerts-first-scraped-at",
       "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "7",
+      "when": 1781411001447,
+      "tag": "0094_rotation-lml-identity-id",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -90,5 +90,6 @@
   "0090_shows-dj-name-override": "bcbfc0a86ec437c1f11246192d67bfbc291e3f1194014d8bcec718f344c8ed6f",
   "0091_venues-and-concerts": "e738de9bdb0ab762c982a6e31f664f88705bc2b7336bbd57a15efe3b250e6e87",
   "0092_normalize-artist-name": "57bf7f03733591917917c5a19b9b67d8527a64ccce224cdc3f1102f4a9cca368",
-  "0093_concerts-first-scraped-at": "bbeee146c92ab63fa70e9f2c537d5a06a13f80a5f52c23cb5a1bed1432057421"
+  "0093_concerts-first-scraped-at": "bbeee146c92ab63fa70e9f2c537d5a06a13f80a5f52c23cb5a1bed1432057421",
+  "0094_rotation-lml-identity-id": "10134a18381f7daad56ca2d8cae80723832be3158cbe6dd01aae2f8e6afcaaa0"
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -491,7 +491,7 @@ export const metadataStatusEnum = wxyc_schema.enum('metadata_status_enum', [
   'failed_no_retry',
 ]);
 
-// Provenance for `rotation.discogs_release_id` (BS#1029). Three values:
+// Provenance for `rotation.discogs_release_id` (BS#1029). Four values:
 //
 //   tubafrenzy_paste        — mirrored from tubafrenzy ROTATION_RELEASE
 //                             .DISCOGS_RELEASE_ID by `jobs/rotation-etl`,
@@ -513,18 +513,32 @@ export const metadataStatusEnum = wxyc_schema.enum('metadata_status_enum', [
 //                             Tagged distinctly from `lml_offline_backfill` so
 //                             a future LML-based re-run can scope its UPDATEs
 //                             without clobbering the bypass-LML provenance.
+//   library_identity        — written by `addToRotation`
+//                             (apps/backend/services/library.service.ts) when
+//                             the dj-site `POST /library/rotation` request
+//                             carried an `album_id` whose `library_identity`
+//                             row supplied a non-NULL `discogs_release_id`.
+//                             The same call synchronously resolves
+//                             `lml_identity_id` against LML; on resolve
+//                             failure `lml_identity_id` lands NULL but the
+//                             source is still `library_identity` — the
+//                             source-of-the-Discogs-id is library_identity
+//                             regardless of whether the lml mint succeeded
+//                             (BS#1380).
 //
 // Column default is `tubafrenzy_paste` so existing pre-migration rows
 // (PG11+ `attmissingval` virtual default) and new rotation-etl inserts
 // are correctly attributed without rotation-etl having to set the column
-// explicitly. The backfill writes `lml_offline_backfill` and the
-// rotation-etl ON CONFLICT path flips it back to `tubafrenzy_paste`
+// explicitly. The backfill writes `lml_offline_backfill`, the
+// dj-site `addToRotation` path writes `library_identity`, and the
+// rotation-etl ON CONFLICT path flips back to `tubafrenzy_paste`
 // when tubafrenzy contributes a non-NULL id (COALESCE-paired with
 // `rotation.discogs_release_id`).
 export const discogsReleaseIdSourceEnum = wxyc_schema.enum('discogs_release_id_source_enum', [
   'tubafrenzy_paste',
   'lml_offline_backfill',
   'discogs_direct_backfill',
+  'library_identity',
 ]);
 /**
  * SOURCE: tubafrenzy via `jobs/rotation-etl/`. The music director writes
@@ -592,6 +606,30 @@ export const rotation = wxyc_schema.table(
     // exhaustion on every deploy. NULL on transient LML failures (caught arm
     // — caller decides whether to retry) so the row stays retryable.
     tracklist_lookup_attempted_at: timestamp('tracklist_lookup_attempted_at', { withTimezone: true }),
+    // BS#1380: stable LML release-identity handle. Points at
+    // `entity.release_identity.id` on the LML side — the right layer to
+    // own a release identity, since Discogs admins periodically reorganize
+    // the catalog (see BS#624 prior art) and Discogs IDs aren't
+    // intrinsically stable. PG-level FK is not enforceable across the
+    // network; LML owns referential integrity.
+    //
+    // Writers:
+    //   - `addToRotation` (apps/backend/services/library.service.ts)
+    //     synchronously resolves via `POST /api/v1/identity/resolve` before
+    //     INSERT when `library_identity.discogs_release_id` is non-NULL.
+    //     Falls back to NULL on resolve timeout / 5xx (the row's
+    //     `discogs_release_id` still lands so the backfill can re-resolve).
+    //   - `jobs/rotation-lml-identity-backfill` (daily cron, recurring
+    //     drift-repair) sweeps rows with `lml_identity_id IS NULL AND
+    //     discogs_release_id IS NOT NULL`. Catches both rotation-etl
+    //     writes (rotation-etl never calls LML) and addToRotation
+    //     resolve-failure fallbacks.
+    //
+    // Rotation-etl preserves the column across ticks via a guarded CASE
+    // (see jobs/rotation-etl/job.ts) that clears it only when the
+    // *effective* `discogs_release_id` changes — paste-correction lands
+    // at `(X', NULL)` and the next backfill tick re-resolves.
+    lml_identity_id: integer('lml_identity_id'),
   },
   (table) => {
     return {

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -822,6 +822,90 @@ export async function searchLibrary(params: {
 }
 
 /**
+ * Wire shape for `POST /api/v1/identity/resolve` (LML#526, BS#1380).
+ *
+ * Mirrors `ReleaseIdentityResolveRequest` / `ReleaseIdentityResolveResponse`
+ * in `wxyc-shared/api.yaml`. Defined locally rather than imported from
+ * `@wxyc/shared/dtos` so this wrapper compiles against the currently-shipped
+ * shared bundle; the types move to `@wxyc/shared/dtos` once the OpenAPI
+ * codegen catches up. Same approach used by the original `EntityResolveResponse`
+ * during its own ramp-up.
+ *
+ * v1 accepts only `kind: 'release'`; `kind: 'artist'` is reserved for the
+ * symmetric extension.
+ */
+export type ReleaseIdentityResolveSource = 'discogs_release' | 'discogs_master' | 'bandcamp';
+
+export interface ReleaseIdentityResolveRequest {
+  kind: 'release';
+  source: ReleaseIdentityResolveSource;
+  /**
+   * Source-specific identifier. For `discogs_release` / `discogs_master` it
+   * is the positive integer ID as a string; zero / negative values are
+   * rejected with 422 (Discogs uses `0` for the unknown-release sentinel).
+   * For `bandcamp` it is the canonical album URL.
+   */
+  external_id: string;
+}
+
+export interface ReleaseIdentityResolveResponse {
+  /** Stable `entity.release_identity.id` for the resolved row. */
+  identity_id: number;
+  kind: 'release';
+  /** `true` when this call inserted a new identity row; `false` on re-resolve. */
+  minted: boolean;
+}
+
+/**
+ * BS#1380: default timeout for `resolveIdentity`. The dj-site `addToRotation`
+ * path awaits this synchronously inside the Express handler before INSERT,
+ * so the budget gates user-perceived latency. 2 s matches the user-visible
+ * read paths (BS#992 picker budget) and is the value the BS#1380 plan
+ * commits to in prose; the catch path falls back to NULL on timeout and the
+ * daily backfill cron catches up within ~24h.
+ */
+const RESOLVE_IDENTITY_TIMEOUT_MS = 2000;
+
+/**
+ * Resolve a release-shaped `(source, external_id)` pair to a stable
+ * `entity.release_identity.id` on the LML side (LML#526).
+ *
+ * Idempotent on `(source, external_id)`: the same triple always returns
+ * the same `identity_id`. First call mints (`minted: true`), subsequent
+ * calls return the existing row (`minted: false`).
+ *
+ * The default timeout (`LML_RESOLVE_TIMEOUT_MS`, fallback 2000 ms) is set
+ * at the wrapper layer rather than at each caller — every consumer (BS's
+ * `addToRotation`, the `rotation-lml-identity-backfill` cron) wants the
+ * same fast-fail semantics. Pass an explicit `timeoutMs` to override.
+ *
+ * Errors:
+ *   - Timeout: `LmlClientError('LML request timed out', 504)` (rethrown
+ *     from `lmlFetch`). Caller categorises the AbortError as `'timeout'`
+ *     in its Sentry counter.
+ *   - 5xx: `LmlClientError(..., 502)` (the upstream status is rolled
+ *     into the LML client's "treat as bad gateway" wrapper).
+ *   - 4xx (incl. 422 sentinel rejection): `LmlClientError(..., status)`.
+ *   - Network: `LmlClientError(..., 502)` after the fetch throws.
+ */
+export async function resolveIdentity(
+  request: ReleaseIdentityResolveRequest,
+  options?: { timeoutMs?: number }
+): Promise<ReleaseIdentityResolveResponse> {
+  const timeoutMs = options?.timeoutMs ?? envInt('LML_RESOLVE_TIMEOUT_MS', RESOLVE_IDENTITY_TIMEOUT_MS);
+  const response = await lmlFetch(
+    '/api/v1/identity/resolve',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    },
+    timeoutMs
+  );
+  return (await response.json()) as ReleaseIdentityResolveResponse;
+}
+
+/**
  * Check whether the LML service is configured.
  */
 export function isLmlConfigured(): boolean {

--- a/tests/integration/library.spec.js
+++ b/tests/integration/library.spec.js
@@ -346,6 +346,61 @@ describe('Library Rotation', () => {
 
       expectErrorContains(res, 'Missing Parameters');
     });
+
+    // BS#1380 — pickAddRotationFields allowlist. A client that includes
+    // server-derived (`discogs_release_id`, `discogs_release_id_source`,
+    // `lml_identity_id`, `legacy_rotation_id`, `legacy_library_release_id`,
+    // `tracklist_lookup_attempted_at`, `kill_date`) or ETL-only
+    // (`add_date`, `artist_name`, `album_title`, `record_label`) fields
+    // in the request body must not be able to set them through this
+    // endpoint. Persisted row must reflect server defaults / NULL.
+    test('allowlist drops client-supplied non-allowlisted fields', async () => {
+      const res = await auth
+        .post('/library/rotation')
+        .send({
+          album_id: 3,
+          rotation_bin: 'L',
+          // Forbidden fields the allowlist must drop.
+          discogs_release_id: 999777,
+          discogs_release_id_source: 'discogs_direct_backfill',
+          lml_identity_id: 8888888,
+          legacy_rotation_id: 555_000_001,
+          legacy_library_release_id: 555_000_002,
+          kill_date: '2027-01-01',
+          artist_name: 'Forged Artist',
+          album_title: 'Forged Album',
+          record_label: 'Forged Label',
+        })
+        .expect(201);
+
+      // Server-derived fields land NULL when library_identity has no row
+      // (seed_db.sql ships no library_identity rows for album_id=3) and
+      // operator-only fields stay NULL.
+      expect(res.body.discogs_release_id).toBeNull();
+      expect(res.body.lml_identity_id).toBeNull();
+      expect(res.body.legacy_rotation_id).toBeNull();
+      expect(res.body.legacy_library_release_id).toBeNull();
+      expect(res.body.kill_date).toBeNull();
+      // ETL-only denormalized snapshot fields stay NULL.
+      expect(res.body.artist_name).toBeNull();
+      expect(res.body.album_title).toBeNull();
+      expect(res.body.record_label).toBeNull();
+      // The two allowed fields land verbatim.
+      expect(res.body.album_id).toBe(3);
+      expect(res.body.rotation_bin).toBe('L');
+      // discogs_release_id_source falls back to the column default
+      // ('tubafrenzy_paste') when addToRotation doesn't supply
+      // library_identity. This is acceptable today for the no-
+      // library_identity path; the BS#1380 plan is honest about it
+      // (the library_identity branch tags 'library_identity' explicitly,
+      // the no-library_identity branch leaves the column default).
+      expect(res.body.discogs_release_id_source).toBe('tubafrenzy_paste');
+
+      // Clean up.
+      if (res.body.id) {
+        await auth.patch('/library/rotation').send({ rotation_id: res.body.id });
+      }
+    });
   });
 
   describe('PATCH /library/rotation (Kill Rotation)', () => {

--- a/tests/integration/rotation-etl-setwhere.spec.js
+++ b/tests/integration/rotation-etl-setwhere.spec.js
@@ -34,6 +34,15 @@ async function upsertRotationEtlShape(sql, row) {
         WHEN excluded.discogs_release_id IS NOT NULL
           THEN 'tubafrenzy_paste'::${sql(SCHEMA)}.discogs_release_id_source_enum
         ELSE ${sql(SCHEMA)}.rotation.discogs_release_id_source
+      END,
+      -- BS#1380: drift-prevention CASE. Clears lml_identity_id only when
+      -- tubafrenzy supplied a non-NULL discogs_release_id that differs
+      -- from the persisted value. Mirrors jobs/rotation-etl/job.ts.
+      lml_identity_id = CASE
+        WHEN excluded.discogs_release_id IS NOT NULL
+          AND excluded.discogs_release_id IS DISTINCT FROM ${sql(SCHEMA)}.rotation.discogs_release_id
+          THEN NULL
+        ELSE ${sql(SCHEMA)}.rotation.lml_identity_id
       END
     WHERE
       ${sql(SCHEMA)}.rotation.album_id                  IS DISTINCT FROM excluded.album_id OR
@@ -235,6 +244,87 @@ describe('rotation-etl value-aware setWhere (BS#1063)', () => {
   // IS DISTINCT FROM term on "excluded IS NOT NULL", COALESCE turns the
   // write into a value-no-op but the row still gets rewritten — wasting
   // a CDC event per row on every 30-min tick across all 310 active rows.
+  // BS#1380 — drift-prevention CASE: when a tubafrenzy paste-correction
+  // changes the discogs_release_id (Y_X is the LML identity minted against
+  // the OLD discogs id; clearing it lets the daily backfill cron re-resolve
+  // against X' on the next tick).
+  test("paste-correction (X → X') of discogs_release_id clears lml_identity_id", async () => {
+    // Arrange: pre-existing row at (discogs=X=999001, lml=Y_X=7700001).
+    await sql`
+      UPDATE ${sql(SCHEMA)}.rotation
+      SET discogs_release_id = 999001,
+          discogs_release_id_source = 'lml_offline_backfill',
+          lml_identity_id = 7700001
+      WHERE legacy_rotation_id = ${ROTATION_LEGACY_ID}
+    `;
+
+    // Act: tubafrenzy paste-correction supplies a new discogs_release_id.
+    await upsertRotationEtlShape(sql, {
+      legacy_rotation_id: ROTATION_LEGACY_ID,
+      legacy_library_release_id: 5550001,
+      album_id: null,
+      rotation_bin: 'H',
+      add_date: '2026-05-24',
+      kill_date: null,
+      artist_name: 'Jessica Pratt',
+      album_title: 'On Your Own Love Again',
+      record_label: 'Drag City',
+      discogs_release_id: 999999,
+    });
+
+    const after = await sql`
+      SELECT discogs_release_id, lml_identity_id, discogs_release_id_source
+      FROM ${sql(SCHEMA)}.rotation
+      WHERE legacy_rotation_id = ${ROTATION_LEGACY_ID}
+    `;
+    expect(after[0].discogs_release_id).toBe(999999);
+    expect(after[0].lml_identity_id).toBeNull();
+    expect(after[0].discogs_release_id_source).toBe('tubafrenzy_paste');
+  });
+
+  // BS#1380 — regression test for the unguarded CASE: a tubafrenzy tick
+  // that contributes NULL discogs_release_id but a changed kill_date
+  // must NOT clear lml_identity_id. Without the
+  // `excluded.discogs_release_id IS NOT NULL` guard, three-valued SQL
+  // (NULL IS DISTINCT FROM X = TRUE) would null out a perfectly-good
+  // identity on every kill_date / artist_name / etc. tick.
+  test('NULL-upstream-with-other-change preserves lml_identity_id (drift CASE guard)', async () => {
+    // Arrange: pre-existing row at (discogs=X=999001, lml=Y_X=7700001).
+    await sql`
+      UPDATE ${sql(SCHEMA)}.rotation
+      SET discogs_release_id = 999001,
+          discogs_release_id_source = 'lml_offline_backfill',
+          lml_identity_id = 7700001,
+          kill_date = NULL
+      WHERE legacy_rotation_id = ${ROTATION_LEGACY_ID}
+    `;
+
+    // Act: tubafrenzy tick with NULL discogs_release_id but a kill_date
+    // change. The discogs_release_id COALESCE preserves the persisted
+    // value; without the guard, lml_identity_id would be nulled.
+    await upsertRotationEtlShape(sql, {
+      legacy_rotation_id: ROTATION_LEGACY_ID,
+      legacy_library_release_id: 5550001,
+      album_id: null,
+      rotation_bin: 'H',
+      add_date: '2026-05-24',
+      kill_date: '2027-01-01', // changed; triggers setWhere gate
+      artist_name: 'Jessica Pratt',
+      album_title: 'On Your Own Love Again',
+      record_label: 'Drag City',
+      discogs_release_id: null,
+    });
+
+    const after = await sql`
+      SELECT discogs_release_id, lml_identity_id, kill_date
+      FROM ${sql(SCHEMA)}.rotation
+      WHERE legacy_rotation_id = ${ROTATION_LEGACY_ID}
+    `;
+    expect(after[0].discogs_release_id).toBe(999001);
+    expect(after[0].lml_identity_id).toBe(7700001);
+    expect(after[0].kill_date.toISOString().slice(0, 10)).toBe('2027-01-01');
+  });
+
   test('NULL excluded.discogs_release_id over a backfilled row is a xmin-quiet no-op', async () => {
     await sql`
       UPDATE ${sql(SCHEMA)}.rotation

--- a/tests/unit/jobs/rotation-lml-identity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/rotation-lml-identity-backfill/orchestrate.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for jobs/rotation-lml-identity-backfill orchestrate.ts (BS#1380).
+ *
+ * Mirrors the rotation-release-id-backfill counter-shape pins:
+ *
+ *   1. (tracer bullet) one resolvable row → write called with the resolved
+ *      identity_id; `resolved` counter bumps, scanned == 1.
+ *   2. LML returns null (422 sentinel rejection) → unresolved counter;
+ *      no write.
+ *   3. LML throws (timeout/5xx/network) → lml_error counter; no write;
+ *      row stays NULL for next pass.
+ *   4. Writer returns written:false → raced counter, not resolved.
+ *   5. dryRun=true → resolved_dry counter; no write.
+ *   6. Cooperative pause defers the resolve when the live-activity probe
+ *      returns true, then proceeds when it returns false.
+ *   7. Writer is called with `(rotationId, discogsReleaseId, identityId)` —
+ *      the writer's WHERE clause pins on the discogs_release_id read at
+ *      candidate-select time so a mid-run paste-correction races cleanly.
+ */
+import { jest } from '@jest/globals';
+
+import {
+  runBackfill,
+  type LoadCandidatesFn,
+  type LookupFn,
+  type WriteFn,
+} from '../../../../jobs/rotation-lml-identity-backfill/orchestrate';
+import type { Candidate } from '../../../../jobs/rotation-lml-identity-backfill/query';
+
+const makeLoadCandidates = (rows: Candidate[]): LoadCandidatesFn => jest.fn<LoadCandidatesFn>().mockResolvedValue(rows);
+
+const COMMON_OPTS = {
+  liveActivityLookbackSeconds: 0, // disable live-activity probe by default
+  liveActivityPauseMs: 0,
+};
+
+describe('runBackfill', () => {
+  test('one resolvable row produces one resolved UPDATE pinned on (rotationId, discogsReleaseId, identityId)', async () => {
+    const loadCandidates = makeLoadCandidates([{ id: 42, discogs_release_id: 999001 }]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(7700042);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runBackfill({ loadCandidates, lookup, write, ...COMMON_OPTS });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    // BS#1380: writer pins on the discogs_release_id read at candidate-
+    // select time so a mid-run paste-correction (rotation-etl CASE clears
+    // lml_identity_id back to NULL after discogs_release_id changes) can't
+    // be clobbered with an identity minted against the old id.
+    expect(write).toHaveBeenCalledWith(42, 999001, 7700042);
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals.resolved).toBe(1);
+    expect(result.totals.unresolved).toBe(0);
+    expect(result.totals.lml_error).toBe(0);
+    expect(result.totals.raced).toBe(0);
+  });
+
+  test('LML returns null (422 sentinel rejection) → unresolved counter, no write', async () => {
+    // lml-fetch.ts maps LML's 422 sentinel rejection to `null` so the
+    // orchestrator sees "ran cleanly, no row to point at" as `unresolved`,
+    // not `lml_error`.
+    const loadCandidates = makeLoadCandidates([{ id: 99, discogs_release_id: -1 /* sentinel */ }]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(null);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runBackfill({ loadCandidates, lookup, write, ...COMMON_OPTS });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals.unresolved).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('LML throws → lml_error counter; no write; row stays NULL for next pass', async () => {
+    const loadCandidates = makeLoadCandidates([{ id: 7, discogs_release_id: 12345 }]);
+    const lookup = jest.fn<LookupFn>().mockRejectedValue(new Error('LML socket timeout'));
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runBackfill({ loadCandidates, lookup, write, ...COMMON_OPTS });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals.lml_error).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('write returns written:false → raced counter, not resolved', async () => {
+    // Either another concurrent backfill won the race, or rotation-etl
+    // cleared the row mid-run after a paste-correction. The orchestrator
+    // surfaces both as `raced` so the dashboard distinguishes write
+    // success from "lost the race".
+    const loadCandidates = makeLoadCandidates([{ id: 11, discogs_release_id: 555 }]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(8800011);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: false });
+
+    const result = await runBackfill({ loadCandidates, lookup, write, ...COMMON_OPTS });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals.raced).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('dryRun=true skips writes and bumps resolved_dry', async () => {
+    const loadCandidates = makeLoadCandidates([{ id: 42, discogs_release_id: 999001 }]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(7700042);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runBackfill({ loadCandidates, lookup, write, dryRun: true, ...COMMON_OPTS });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals.resolved_dry).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('cooperative pause defers per-row resolve while live activity is observed', async () => {
+    const loadCandidates = makeLoadCandidates([{ id: 42, discogs_release_id: 999001 }]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(7700042);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    // First probe says "busy", second probe says "quiet". The orchestrator
+    // must call `onLivePause` exactly once and then proceed with the row.
+    let probeCalls = 0;
+    const checkLiveActivity = jest.fn<(s: number) => Promise<boolean>>().mockImplementation(() => {
+      probeCalls += 1;
+      return Promise.resolve(probeCalls === 1);
+    });
+    const onLivePause = jest.fn<() => void>();
+
+    const result = await runBackfill({
+      loadCandidates,
+      lookup,
+      write,
+      liveActivityLookbackSeconds: 30,
+      liveActivityPauseMs: 0, // skip the actual sleep so the test runs fast
+      checkLiveActivity,
+      onLivePause,
+    });
+
+    expect(checkLiveActivity).toHaveBeenCalledTimes(2);
+    expect(onLivePause).toHaveBeenCalledTimes(1);
+    expect(result.totals.resolved).toBe(1);
+  });
+});

--- a/tests/unit/scripts/resolve-cron-schedule.test.ts
+++ b/tests/unit/scripts/resolve-cron-schedule.test.ts
@@ -84,4 +84,16 @@ describe('scripts/resolve-cron-schedule.sh', () => {
     expect(status).toBe(1);
     expect(stderr).toMatch(/Missing jobs\/nonexistent-job\/package\.json/);
   });
+
+  // BS#1380: extend the override allowlist to include rotation-lml-identity-backfill.
+  // Same operational story as flowsheet-metadata-backfill — both are LML-bounded
+  // drift-repair crons whose cadence ops occasionally tightens. The allowlist
+  // stays narrow and explicit.
+  it('returns override when BACKFILL_CRON_SCHEDULE is set and target = rotation-lml-identity-backfill', () => {
+    const { stdout, status } = run('rotation-lml-identity-backfill', {
+      BACKFILL_CRON_SCHEDULE: '*/30 * * * *',
+    });
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('*/30 * * * *');
+  });
 });

--- a/tests/unit/services/library.service.addToRotation.test.ts
+++ b/tests/unit/services/library.service.addToRotation.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Unit tests for `addToRotation` + `classifyLmlResolveError` (BS#1380).
+ *
+ * Two surfaces under test:
+ *
+ *   1. `classifyLmlResolveError(err)` — pure function. Every catch-block
+ *      branch (timeout / 5xx / 4xx / network / other) maps to the right
+ *      `LmlResolveFallbackReason`. The Sentry counter `lml.resolve
+ *      .fallback_to_null` carries this value as an attribute, and a
+ *      per-bucket regression dashboard depends on the classifier producing
+ *      the same string the prose contract promises. Exhaustive coverage
+ *      lives here so a future refactor doesn't quietly collapse two buckets
+ *      together.
+ *
+ *   2. `addToRotation` — when `library_identity.discogs_release_id` is
+ *      non-NULL, the row is triple-written (discogs_release_id,
+ *      discogs_release_id_source='library_identity', lml_identity_id).
+ *      On resolve failure the first two still land; `lml_identity_id` is
+ *      NULL. The Sentry counter fires once with `caller=add_to_rotation`
+ *      and the classified `reason`.
+ *
+ * Tests don't reach the integration layer — Drizzle is mocked via the
+ * established `database.mock` so we can assert on the INSERT values
+ * directly.
+ */
+
+import { jest } from '@jest/globals';
+import { db, createMockQueryChain, rotation, library_identity } from '../../mocks/database.mock';
+
+// Mirror the real `LmlClientError` shape so the classifier's `err instanceof
+// LmlClientError` branch fires. The wrapper sets `statusCode` to one of
+// {422, 502, 504, ...} after translating from the upstream response.
+class MockLmlClientError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = 'LmlClientError';
+    this.statusCode = statusCode;
+  }
+}
+
+const mockResolveIdentity = jest.fn<() => Promise<{ identity_id: number; kind: 'release'; minted: boolean }>>();
+const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
+const mockLookupBySong = jest.fn<() => Promise<unknown>>();
+const mockIsLmlConfigured = jest.fn<() => boolean>();
+const mockGetRelease = jest.fn<() => Promise<unknown>>();
+
+jest.mock('@wxyc/lml-client', () => ({
+  resolveIdentity: mockResolveIdentity,
+  lookupMetadata: mockLookupMetadata,
+  lookupBySong: mockLookupBySong,
+  isLmlConfigured: mockIsLmlConfigured,
+  getRelease: mockGetRelease,
+  envInt: (_name: string, fallback: number) => fallback,
+  LmlClientError: MockLmlClientError,
+}));
+
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: () => Promise.resolve(null) },
+}));
+
+const mockSentryMetricsCount = jest.fn<(name: string, value: number, opts: unknown) => void>();
+jest.mock('@sentry/node', () => ({
+  startSpan: <T>(_opts: unknown, callback: () => T | Promise<T>): Promise<T> => Promise.resolve(callback()),
+  getActiveSpan: () => ({ setAttribute: jest.fn(), setAttributes: jest.fn() }),
+  metrics: { count: mockSentryMetricsCount },
+}));
+
+import { addToRotation, classifyLmlResolveError } from '../../../apps/backend/services/library.service';
+
+describe('classifyLmlResolveError', () => {
+  test('AbortError → timeout', () => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    expect(classifyLmlResolveError(err)).toBe('timeout');
+  });
+
+  test('LmlClientError statusCode 504 → timeout (lmlFetch translates AbortError)', () => {
+    const err = new MockLmlClientError('LML request timed out', 504);
+    expect(classifyLmlResolveError(err)).toBe('timeout');
+  });
+
+  test('LmlClientError statusCode 502 with upstream-5xx message → 5xx', () => {
+    // `lmlFetch` translates upstream 5xx to 502 via `LmlClientError`
+    // (`response.status >= 500 ? 502 : response.status`). The classifier
+    // disambiguates that from a fetch-threw 502 (also wrapped) via the
+    // message prefix `LML responded with`.
+    const err = new MockLmlClientError('LML responded with 503: Service Unavailable', 502);
+    expect(classifyLmlResolveError(err)).toBe('5xx');
+  });
+
+  test('LmlClientError statusCode 502 with fetch-threw message → network', () => {
+    // The fetch-catch path in `lmlFetch` raises
+    // `LmlClientError('LML request failed: <reason>', 502)`. That's the
+    // "network" bucket — operator should look at DNS / TCP, not at LML's
+    // deploy state.
+    const err = new MockLmlClientError('LML request failed: ECONNRESET', 502);
+    expect(classifyLmlResolveError(err)).toBe('network');
+  });
+
+  test('LmlClientError statusCode 422 → 4xx (sentinel rejection)', () => {
+    const err = new MockLmlClientError('Discogs id <= 0 rejected', 422);
+    expect(classifyLmlResolveError(err)).toBe('4xx');
+  });
+
+  test('LmlClientError statusCode 400 → 4xx', () => {
+    const err = new MockLmlClientError('Bad Request', 400);
+    expect(classifyLmlResolveError(err)).toBe('4xx');
+  });
+
+  test('LmlClientError statusCode 500 → 5xx (raw, not via lmlFetch translation)', () => {
+    const err = new MockLmlClientError('Internal Server Error', 500);
+    expect(classifyLmlResolveError(err)).toBe('5xx');
+  });
+
+  test('Node ECONNRESET → network', () => {
+    const err = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    expect(classifyLmlResolveError(err)).toBe('network');
+  });
+
+  test('Node ENOTFOUND → network', () => {
+    const err = Object.assign(new Error('getaddrinfo ENOTFOUND lml'), { code: 'ENOTFOUND' });
+    expect(classifyLmlResolveError(err)).toBe('network');
+  });
+
+  test('Node ECONNREFUSED → network', () => {
+    const err = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    expect(classifyLmlResolveError(err)).toBe('network');
+  });
+
+  test('plain Error → other', () => {
+    expect(classifyLmlResolveError(new Error('something else'))).toBe('other');
+  });
+
+  test('non-Error throwables → other', () => {
+    expect(classifyLmlResolveError('a string')).toBe('other');
+    expect(classifyLmlResolveError(null)).toBe('other');
+    expect(classifyLmlResolveError(undefined)).toBe('other');
+    expect(classifyLmlResolveError(42)).toBe('other');
+  });
+});
+
+describe('addToRotation (BS#1380)', () => {
+  const ALBUM_ID = 100;
+  const DISCOGS_RELEASE_ID = 12345;
+  const LML_IDENTITY_ID = 7700100;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('library_identity hit + LML resolve success → triple-write (discogs_release_id, source, lml_identity_id)', async () => {
+    // Library-identity row supplies a non-NULL discogs_release_id.
+    const selectChain = createMockQueryChain([{ discogs_release_id: DISCOGS_RELEASE_ID }]);
+    selectChain.limit = jest.fn().mockResolvedValue([{ discogs_release_id: DISCOGS_RELEASE_ID }]);
+    db.select.mockReturnValue(selectChain);
+
+    // LML mints/returns a stable identity_id.
+    mockResolveIdentity.mockResolvedValue({ identity_id: LML_IDENTITY_ID, kind: 'release', minted: true });
+
+    // INSERT returns the persisted row.
+    const insertChain = createMockQueryChain([
+      {
+        id: 1,
+        album_id: ALBUM_ID,
+        rotation_bin: 'M',
+        discogs_release_id: DISCOGS_RELEASE_ID,
+        discogs_release_id_source: 'library_identity',
+        lml_identity_id: LML_IDENTITY_ID,
+      },
+    ]);
+    db.insert.mockReturnValue(insertChain);
+
+    const result = await addToRotation({ album_id: ALBUM_ID, rotation_bin: 'M' });
+
+    expect(mockResolveIdentity).toHaveBeenCalledWith({
+      kind: 'release',
+      source: 'discogs_release',
+      external_id: String(DISCOGS_RELEASE_ID),
+    });
+
+    // The INSERT was called with the three triple-write fields populated.
+    const valuesArg = insertChain.values.mock.calls[0][0] as Record<string, unknown>;
+    expect(valuesArg.album_id).toBe(ALBUM_ID);
+    expect(valuesArg.rotation_bin).toBe('M');
+    expect(valuesArg.discogs_release_id).toBe(DISCOGS_RELEASE_ID);
+    expect(valuesArg.discogs_release_id_source).toBe('library_identity');
+    expect(valuesArg.lml_identity_id).toBe(LML_IDENTITY_ID);
+
+    expect(result?.lml_identity_id).toBe(LML_IDENTITY_ID);
+    expect(mockSentryMetricsCount).not.toHaveBeenCalled();
+  });
+
+  test('library_identity hit + LML resolve failure → discogs_release_id + source still land, lml_identity_id = NULL, counter fires', async () => {
+    const selectChain = createMockQueryChain([{ discogs_release_id: DISCOGS_RELEASE_ID }]);
+    selectChain.limit = jest.fn().mockResolvedValue([{ discogs_release_id: DISCOGS_RELEASE_ID }]);
+    db.select.mockReturnValue(selectChain);
+
+    // Simulate LML timeout — `lmlFetch` raises `LmlClientError(..., 504)`.
+    mockResolveIdentity.mockRejectedValue(new MockLmlClientError('LML request timed out', 504));
+
+    const insertChain = createMockQueryChain([
+      {
+        id: 2,
+        album_id: ALBUM_ID,
+        rotation_bin: 'L',
+        discogs_release_id: DISCOGS_RELEASE_ID,
+        discogs_release_id_source: 'library_identity',
+        lml_identity_id: null,
+      },
+    ]);
+    db.insert.mockReturnValue(insertChain);
+
+    const result = await addToRotation({ album_id: ALBUM_ID, rotation_bin: 'L' });
+
+    const valuesArg = insertChain.values.mock.calls[0][0] as Record<string, unknown>;
+    // The source-of-the-Discogs-id is still library_identity (the issue's
+    // explicit contract — provenance is honest even when the mint fails).
+    expect(valuesArg.discogs_release_id).toBe(DISCOGS_RELEASE_ID);
+    expect(valuesArg.discogs_release_id_source).toBe('library_identity');
+    expect(valuesArg.lml_identity_id).toBeNull();
+
+    expect(result?.lml_identity_id).toBeNull();
+
+    // Counter fires once with the correct reason bucket.
+    expect(mockSentryMetricsCount).toHaveBeenCalledTimes(1);
+    expect(mockSentryMetricsCount).toHaveBeenCalledWith('lml.resolve.fallback_to_null', 1, {
+      attributes: { caller: 'add_to_rotation', reason: 'timeout' },
+    });
+  });
+
+  test('library_identity miss (no row, or row with NULL discogs_release_id) → no LML call, no triple-write', async () => {
+    // The library_identity lookup returns no row.
+    const selectChain = createMockQueryChain([]);
+    selectChain.limit = jest.fn().mockResolvedValue([]);
+    db.select.mockReturnValue(selectChain);
+
+    const insertChain = createMockQueryChain([{ id: 3, album_id: ALBUM_ID, rotation_bin: 'H' }]);
+    db.insert.mockReturnValue(insertChain);
+
+    await addToRotation({ album_id: ALBUM_ID, rotation_bin: 'H' });
+
+    expect(mockResolveIdentity).not.toHaveBeenCalled();
+
+    const valuesArg = insertChain.values.mock.calls[0][0] as Record<string, unknown>;
+    // Server doesn't supply any of the LML-handle fields. The column
+    // default ('tubafrenzy_paste') applies to discogs_release_id_source
+    // when not set, but BS#1380's acceptance criterion is that we do NOT
+    // tag dj-site rows as if they came from tubafrenzy. So for the
+    // no-library-identity path, we leave the field unset — the default
+    // 'tubafrenzy_paste' applies but no LML resolve fires and no
+    // discogs_release_id lands either.
+    expect(valuesArg.discogs_release_id).toBeUndefined();
+    expect(valuesArg.discogs_release_id_source).toBeUndefined();
+    expect(valuesArg.lml_identity_id).toBeUndefined();
+  });
+
+  test('reads library_identity by library_id (PRIMARY KEY)', async () => {
+    // Defensive: confirms we're using the schema's PRIMARY KEY column,
+    // not falling back to a wrong join key. The library_identity table's
+    // PRIMARY KEY is library_id (schema.ts:1391-1393).
+    const selectChain = createMockQueryChain([{ discogs_release_id: null }]);
+    selectChain.limit = jest.fn().mockResolvedValue([{ discogs_release_id: null }]);
+    db.select.mockReturnValue(selectChain);
+
+    const insertChain = createMockQueryChain([{ id: 4 }]);
+    db.insert.mockReturnValue(insertChain);
+
+    await addToRotation({ album_id: ALBUM_ID, rotation_bin: 'M' });
+
+    // The select chain reads from library_identity.
+    expect(db.select).toHaveBeenCalled();
+    expect(selectChain.from).toHaveBeenCalledWith(library_identity);
+    expect(insertChain.values).toHaveBeenCalled();
+    // INSERT target was rotation (not library_identity).
+    expect(db.insert).toHaveBeenCalledWith(rotation);
+  });
+});


### PR DESCRIPTION
## Summary

- New column `rotation.lml_identity_id integer NULL` + new enum value `discogs_release_id_source_enum.library_identity` (migration 0094, DDL-only, no index)
- `addToRotation` synchronously resolves the LML identity via the new `resolveIdentity` lml-client wrapper before INSERT; triple-writes `(discogs_release_id, discogs_release_id_source='library_identity', lml_identity_id)`. On resolve failure the first two still land and `lml_identity_id` falls back to NULL — the daily backfill cron catches up. Sentry counter `lml.resolve.fallback_to_null` carries `caller` + `reason` (timeout/5xx/4xx/network/other)
- `pickAddRotationFields` allowlist on `POST /library/rotation` (mirrors `pickUpdateEntryFields`); forbids client-supplied LML-handle and ETL-only fields
- `jobs/rotation-etl` drift-prevention CASE on `lml_identity_id` — guarded by `excluded.discogs_release_id IS NOT NULL` so a NULL upstream tick can't null out a perfectly-good identity. `setWhere` gate unchanged (per the BS#1380 trace explanation in `jobs/rotation-etl/job.ts`)
- New `jobs/rotation-lml-identity-backfill/` daily cron with `--report` mode and the BS#1059/BS#1029 counter shape

## Test plan

- [x] Local typecheck across all workspaces
- [x] Local lint (0 errors)
- [x] Local format check
- [x] Migration validation (`lint:migrations`)
- [x] Full unit suite — 3174 / 3174 pass, including the new
  - `tests/unit/services/library.service.addToRotation.test.ts` — every `classifyLmlResolveError` branch + addToRotation triple-write success / resolve-failure fallback / library-identity-miss / PRIMARY-KEY-read
  - `tests/unit/jobs/rotation-lml-identity-backfill/orchestrate.test.ts` — 6 counter-shape pins + cooperative-pause pin
  - `tests/unit/scripts/resolve-cron-schedule.test.ts` — new allowlist entry for `rotation-lml-identity-backfill`
- [ ] CI integration suite (will exercise the new `tests/integration/rotation-etl-setwhere.spec.js` drift-CASE assertions and the new `tests/integration/library.spec.js` allowlist test)
- [ ] CI migrate-dryrun (`shared/database/src/migrations/**` changed)

## Notes

- Out of scope per the issue: dropping `discogs_release_id` (follow-up migration after `lml_identity_id` coverage stabilises), `rotation-artist-backfill` cron migration (BS#1381 — blocked on this issue + LML#525), LML-side identity merges
- Coverage gate (`resolvable_coverage_pct >= 99.0` steady-state) emits via the new job's `--report` mode; unblock comment lands on BS#1381 once met

Closes #1380