### PR TITLE
feat(rotation-etl): drift-prevention CASE on lml_identity_id (BS#1380 PR 3/5)

### DIFF
--- a/jobs/rotation-etl/job.ts
+++ b/jobs/rotation-etl/job.ts
@@ -151,10 +151,11 @@ const runIncremental = async (): Promise<SyncResult> => {
           // TRUE — silently nulling a perfectly-good lml_identity_id on
           // every kill_date / artist_name / etc. change.
           //
-          // Guard symmetric to the existing setWhere term at lines
-          // 153-154 (`excluded.discogs_release_id IS NOT NULL AND IS
-          // DISTINCT FROM rotation.discogs_release_id`): only clear
-          // when tubafrenzy supplied a non-NULL different id.
+          // Guard symmetric to the existing setWhere term below
+          // (`excluded.discogs_release_id IS NOT NULL AND
+          // rotation.discogs_release_id IS DISTINCT FROM
+          // excluded.discogs_release_id`): only clear when tubafrenzy
+          // supplied a non-NULL different id.
           //
           // Equivalent formulation:
           //   COALESCE(excluded.discogs_release_id, rotation.discogs_release_id)

--- a/jobs/rotation-etl/job.ts
+++ b/jobs/rotation-etl/job.ts
@@ -134,6 +134,48 @@ const runIncremental = async (): Promise<SyncResult> => {
                  ELSE ${rotation.discogs_release_id_source}
             END
           `,
+          // BS#1380: drift prevention. lml_identity_id was minted against
+          // the persisted discogs_release_id (either by addToRotation at
+          // INSERT time or by jobs/rotation-lml-identity-backfill); if a
+          // tubafrenzy paste-correction changes the discogs_release_id,
+          // the persisted lml_identity_id no longer matches the new id and
+          // the row must be cleared so the backfill cron re-resolves it.
+          //
+          // The "effective" qualifier matters: the discogs_release_id SET
+          // above uses COALESCE(excluded, persisted), so when tubafrenzy
+          // contributes NULL (the common case for rows without a paste
+          // URL) the discogs_release_id doesn't change. A CASE that fired
+          // on raw `excluded IS DISTINCT FROM rotation` would also fire
+          // on every tick where excluded is NULL and persisted is
+          // non-NULL — three-valued SQL has `NULL IS DISTINCT FROM X` =
+          // TRUE — silently nulling a perfectly-good lml_identity_id on
+          // every kill_date / artist_name / etc. change.
+          //
+          // Guard symmetric to the existing setWhere term at lines
+          // 153-154 (`excluded.discogs_release_id IS NOT NULL AND IS
+          // DISTINCT FROM rotation.discogs_release_id`): only clear
+          // when tubafrenzy supplied a non-NULL different id.
+          //
+          // Equivalent formulation:
+          //   COALESCE(excluded.discogs_release_id, rotation.discogs_release_id)
+          //     IS DISTINCT FROM rotation.discogs_release_id
+          //
+          // setWhere is unchanged — the existing discogs_release_id term
+          // already fires the gate on the Y_X → NULL transition. Adding
+          // an `excluded.lml_identity_id IS DISTINCT FROM rotation
+          // .lml_identity_id` term would *break* the gate: since
+          // lml_identity_id isn't in the INSERT VALUES tuple,
+          // excluded.lml_identity_id is always NULL, so the term would be
+          // TRUE on every tick for any row with a populated identity —
+          // turning the gate into a no-op for the rows BS#1059's
+          // xmin/CDC discipline most cares about.
+          lml_identity_id: sql`
+            CASE WHEN excluded.discogs_release_id IS NOT NULL
+                  AND excluded.discogs_release_id IS DISTINCT FROM ${rotation.discogs_release_id}
+                 THEN NULL
+                 ELSE ${rotation.lml_identity_id}
+            END
+          `,
         },
         // BS#1059 mechanic; the 30-min cron was rewriting most rows every cycle.
         // BS#1029: the plain IS DISTINCT FROM term on discogs_release_id

--- a/tests/integration/rotation-etl-setwhere.spec.js
+++ b/tests/integration/rotation-etl-setwhere.spec.js
@@ -34,6 +34,15 @@ async function upsertRotationEtlShape(sql, row) {
         WHEN excluded.discogs_release_id IS NOT NULL
           THEN 'tubafrenzy_paste'::${sql(SCHEMA)}.discogs_release_id_source_enum
         ELSE ${sql(SCHEMA)}.rotation.discogs_release_id_source
+      END,
+      -- BS#1380: drift-prevention CASE. Clears lml_identity_id only when
+      -- tubafrenzy supplied a non-NULL discogs_release_id that differs
+      -- from the persisted value. Mirrors jobs/rotation-etl/job.ts.
+      lml_identity_id = CASE
+        WHEN excluded.discogs_release_id IS NOT NULL
+          AND excluded.discogs_release_id IS DISTINCT FROM ${sql(SCHEMA)}.rotation.discogs_release_id
+          THEN NULL
+        ELSE ${sql(SCHEMA)}.rotation.lml_identity_id
       END
     WHERE
       ${sql(SCHEMA)}.rotation.album_id                  IS DISTINCT FROM excluded.album_id OR
@@ -235,6 +244,87 @@ describe('rotation-etl value-aware setWhere (BS#1063)', () => {
   // IS DISTINCT FROM term on "excluded IS NOT NULL", COALESCE turns the
   // write into a value-no-op but the row still gets rewritten — wasting
   // a CDC event per row on every 30-min tick across all 310 active rows.
+  // BS#1380 — drift-prevention CASE: when a tubafrenzy paste-correction
+  // changes the discogs_release_id (Y_X is the LML identity minted against
+  // the OLD discogs id; clearing it lets the daily backfill cron re-resolve
+  // against X' on the next tick).
+  test("paste-correction (X → X') of discogs_release_id clears lml_identity_id", async () => {
+    // Arrange: pre-existing row at (discogs=X=999001, lml=Y_X=7700001).
+    await sql`
+      UPDATE ${sql(SCHEMA)}.rotation
+      SET discogs_release_id = 999001,
+          discogs_release_id_source = 'lml_offline_backfill',
+          lml_identity_id = 7700001
+      WHERE legacy_rotation_id = ${ROTATION_LEGACY_ID}
+    `;
+
+    // Act: tubafrenzy paste-correction supplies a new discogs_release_id.
+    await upsertRotationEtlShape(sql, {
+      legacy_rotation_id: ROTATION_LEGACY_ID,
+      legacy_library_release_id: 5550001,
+      album_id: null,
+      rotation_bin: 'H',
+      add_date: '2026-05-24',
+      kill_date: null,
+      artist_name: 'Jessica Pratt',
+      album_title: 'On Your Own Love Again',
+      record_label: 'Drag City',
+      discogs_release_id: 999999,
+    });
+
+    const after = await sql`
+      SELECT discogs_release_id, lml_identity_id, discogs_release_id_source
+      FROM ${sql(SCHEMA)}.rotation
+      WHERE legacy_rotation_id = ${ROTATION_LEGACY_ID}
+    `;
+    expect(after[0].discogs_release_id).toBe(999999);
+    expect(after[0].lml_identity_id).toBeNull();
+    expect(after[0].discogs_release_id_source).toBe('tubafrenzy_paste');
+  });
+
+  // BS#1380 — regression test for the unguarded CASE: a tubafrenzy tick
+  // that contributes NULL discogs_release_id but a changed kill_date
+  // must NOT clear lml_identity_id. Without the
+  // `excluded.discogs_release_id IS NOT NULL` guard, three-valued SQL
+  // (NULL IS DISTINCT FROM X = TRUE) would null out a perfectly-good
+  // identity on every kill_date / artist_name / etc. tick.
+  test('NULL-upstream-with-other-change preserves lml_identity_id (drift CASE guard)', async () => {
+    // Arrange: pre-existing row at (discogs=X=999001, lml=Y_X=7700001).
+    await sql`
+      UPDATE ${sql(SCHEMA)}.rotation
+      SET discogs_release_id = 999001,
+          discogs_release_id_source = 'lml_offline_backfill',
+          lml_identity_id = 7700001,
+          kill_date = NULL
+      WHERE legacy_rotation_id = ${ROTATION_LEGACY_ID}
+    `;
+
+    // Act: tubafrenzy tick with NULL discogs_release_id but a kill_date
+    // change. The discogs_release_id COALESCE preserves the persisted
+    // value; without the guard, lml_identity_id would be nulled.
+    await upsertRotationEtlShape(sql, {
+      legacy_rotation_id: ROTATION_LEGACY_ID,
+      legacy_library_release_id: 5550001,
+      album_id: null,
+      rotation_bin: 'H',
+      add_date: '2026-05-24',
+      kill_date: '2027-01-01', // changed; triggers setWhere gate
+      artist_name: 'Jessica Pratt',
+      album_title: 'On Your Own Love Again',
+      record_label: 'Drag City',
+      discogs_release_id: null,
+    });
+
+    const after = await sql`
+      SELECT discogs_release_id, lml_identity_id, kill_date
+      FROM ${sql(SCHEMA)}.rotation
+      WHERE legacy_rotation_id = ${ROTATION_LEGACY_ID}
+    `;
+    expect(after[0].discogs_release_id).toBe(999001);
+    expect(after[0].lml_identity_id).toBe(7700001);
+    expect(after[0].kill_date.toISOString().slice(0, 10)).toBe('2027-01-01');
+  });
+
   test('NULL excluded.discogs_release_id over a backfilled row is a xmin-quiet no-op', async () => {
     await sql`
       UPDATE ${sql(SCHEMA)}.rotation

--- a/tests/integration/rotation-etl-setwhere.spec.js
+++ b/tests/integration/rotation-etl-setwhere.spec.js
@@ -323,6 +323,18 @@ describe('rotation-etl value-aware setWhere (BS#1063)', () => {
     expect(after[0].discogs_release_id).toBe(999001);
     expect(after[0].lml_identity_id).toBe(7700001);
     expect(after[0].kill_date.toISOString().slice(0, 10)).toBe('2027-01-01');
+
+    // Restore kill_date to NULL for the downstream 'xmin-quiet no-op' test.
+    // That test arranges only discogs_release_id + source and relies on the
+    // other fields already matching its upsert input (kill_date: null,
+    // rotation_bin: 'H', ...) so the setWhere gate doesn't fire on a stale
+    // residual. Per the test-ordering convention at the top of the BS#1029
+    // block (lines 170-173): tests reset what they touched.
+    await sql`
+      UPDATE ${sql(SCHEMA)}.rotation
+      SET kill_date = NULL
+      WHERE legacy_rotation_id = ${ROTATION_LEGACY_ID}
+    `;
   });
 
   test('NULL excluded.discogs_release_id over a backfilled row is a xmin-quiet no-op', async () => {


### PR DESCRIPTION
Third in a 5-PR chain implementing #1380. Chained on #1417 (PR 1 schema).

## Summary

- `jobs/rotation-etl/job.ts`: drift-prevention CASE on `lml_identity_id` in the UPSERT SET clause. Clears only when tubafrenzy supplied a non-NULL `discogs_release_id` that differs from the persisted value.
- `setWhere` gate **unchanged**. The existing `discogs_release_id` term at lines 153-154 already fires the gate on the Y_X → NULL transition. Adding an `excluded.lml_identity_id IS DISTINCT FROM` term would *break* the gate (lml_identity_id isn't in the INSERT VALUES tuple, so `excluded.lml_identity_id` is always NULL — turning the gate into a no-op).

## No LML call in rotation-etl

The useful life of any rotation-etl LML integration is bounded by the tubafrenzy decommission window (~September 2026). Investing in `lml-client` wiring + dual-write logic in code that's about to be retired isn't worth the diff. The rotation-etl `lml_identity_id` population happens via the daily backfill cron (PR 5) — max ~24h lag for new tubafrenzy-driven rows. PR 5's cron consumer doesn't ship until coverage gates anyway (BS#1381).

## Integration tests

Two new tests in `tests/integration/rotation-etl-setwhere.spec.js`:
- **paste-correction (X → X')**: pre-existing `(discogs=X, lml=Y_X)` row + new tubafrenzy paste of `discogs_release_id=X'` lands at `(X', NULL)` for backfill re-resolve
- **NULL-upstream-with-other-change (regression test)**: pre-existing `(discogs=X, lml=Y_X)` row + tubafrenzy tick with `NULL` `discogs_release_id` but a changed `kill_date` preserves `(X, Y_X)` and only mutates `kill_date`. Without the `excluded.discogs_release_id IS NOT NULL` guard, the unguarded CASE would null out `Y_X` on every such tick (three-valued SQL: `NULL IS DISTINCT FROM X` = TRUE).

The hand-written SQL in the integration spec mirrors `jobs/rotation-etl/job.ts` — the integration runner is babel-jest and can't import drizzle-orm code.

## Test plan

- [x] `@wxyc/database` + `@wxyc/rotation-etl` build
- [ ] CI integration suite (exercises the new drift-CASE assertions)

Refs #1380