### PR TITLE
feat(rotation-lml-identity-backfill): new daily cron job (BS#1380 PR 5/5)

### DIFF
--- a/Dockerfile.rotation-lml-identity-backfill
+++ b/Dockerfile.rotation-lml-identity-backfill
@@ -1,0 +1,45 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+ARG NPM_TOKEN
+WORKDIR /rotation-lml-identity-backfill-builder
+
+COPY ./.npmrc ./
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./shared/lml-client ./shared/lml-client
+COPY ./jobs/rotation-lml-identity-backfill ./jobs/rotation-lml-identity-backfill
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-client --workspace=@wxyc/rotation-lml-identity-backfill
+
+#Production stage
+FROM node:24-alpine AS prod
+
+ARG NPM_TOKEN
+WORKDIR /rotation-lml-identity-backfill
+
+COPY ./.npmrc ./
+COPY ./package* ./
+COPY ./jobs/rotation-lml-identity-backfill/package* ./jobs/rotation-lml-identity-backfill/
+COPY ./shared/database/package* ./shared/database/
+COPY ./shared/lml-client/package* ./shared/lml-client/
+
+# `@wxyc/lml-client` declares `@wxyc/shared` as a registry dependency
+# (GitHub Packages, `@wxyc:registry` in `.npmrc`). Without NPM_TOKEN +
+# .npmrc the prod stage's npm install 401s on @wxyc/shared. Mirrors the
+# pattern in Dockerfile.backend and the BS#1015 lesson.
+RUN npm install --omit=dev && rm -f .npmrc
+
+COPY --from=builder ./rotation-lml-identity-backfill-builder/jobs/rotation-lml-identity-backfill/dist ./jobs/rotation-lml-identity-backfill/dist
+COPY --from=builder ./rotation-lml-identity-backfill-builder/shared/database/dist ./shared/database/dist
+COPY --from=builder ./rotation-lml-identity-backfill-builder/shared/lml-client/dist ./shared/lml-client/dist
+
+# Per-statement timeout: the writer does single-row UPDATEs; 60 s is more
+# than enough headroom. Mirrors the rotation-release-id-backfill ceiling.
+ENV DB_STATEMENT_TIMEOUT_MS=60000
+
+# Identifies the connection in pg_stat_activity during incident triage.
+ENV DB_APPLICATION_NAME=wxyc-rotation-lml-identity-backfill
+
+CMD ["npm", "start", "--workspace=@wxyc/rotation-lml-identity-backfill"]

--- a/jobs/rotation-lml-identity-backfill/README.md
+++ b/jobs/rotation-lml-identity-backfill/README.md
@@ -1,0 +1,147 @@
+# rotation-lml-identity-backfill
+
+Recurring daily-cron drift-repair that resolves `rotation.lml_identity_id` via LML's `POST /api/v1/identity/resolve` (LML#526) for active rotation rows whose `discogs_release_id` is populated but `lml_identity_id` is still NULL.
+
+Companion to the BS#1380 schema addition (migration `0094_rotation-lml-identity-id.sql`). Catches both write paths that legitimately produce NULL `lml_identity_id`:
+
+1. `jobs/rotation-etl/job.ts` — rotation-etl writes only `discogs_release_id` from the tubafrenzy paste and never calls LML (its useful life is bounded by the tubafrenzy decommission window ~September 2026; investing in lml-client wiring there isn't worth the diff). The CASE clause in the UPSERT also clears `lml_identity_id` when a paste-correction changes the effective `discogs_release_id` — those clears land here for re-resolution too.
+2. `apps/backend/services/library.service.ts:addToRotation` — synchronous resolve at INSERT time; falls back to NULL on `LML_RESOLVE_TIMEOUT_MS` / 5xx / network failures so the music director isn't blocked on an LML outage. Those rows land here on the next daily tick.
+
+## When to run
+
+Daily cron (default `0 6 * * *` UTC / 02:00 ET), registered automatically by the deploy pipeline. Cooperative pause (BS#735) defers each batch when DJs are active.
+
+One-shot invocation is supported for ad-hoc operator runs (post-incident catch-up, initial migration deploy, or coverage-gate probes):
+
+```sh
+# Build (via `Manual Build & Deploy` on GitHub Actions)
+gh workflow run deploy-manual.yml -f target=rotation-lml-identity-backfill -f version=latest
+
+# Run on EC2
+docker run --rm --env-file .env $AWS_ECR_URI/rotation-lml-identity-backfill:latest
+```
+
+The SELECT predicate (`lml_identity_id IS NULL AND discogs_release_id IS NOT NULL`) makes reruns idempotent — already-resolved rows are skipped.
+
+### Dry run first
+
+```sh
+docker run --rm --env-file .env -e DRY_RUN=true $AWS_ECR_URI/rotation-lml-identity-backfill:latest
+```
+
+`DRY_RUN=true` runs the LML resolve loop so the resolved / unresolved / error counters are honest but suppresses every UPDATE. The `resolved` counter is replaced by `resolved_dry`.
+
+### Coverage report
+
+```sh
+docker run --rm --env-file .env $AWS_ECR_URI/rotation-lml-identity-backfill:latest --report
+```
+
+`--report` emits the resolvable-coverage SQL result and exits without running the resolve loop. Used to check BS#1381's unblock condition (`resolvable_coverage_pct >= 99.0` steady-state across consecutive daily runs).
+
+## Env
+
+| Var                               | Default    | Purpose                                                                                                  |
+| --------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------- |
+| `LIBRARY_METADATA_URL`            | (required) | LML service URL                                                                                          |
+| `LML_API_KEY`                     | (required) | Bearer for LML auth (rotation safe — see [BS#1094](https://github.com/WXYC/Backend-Service/issues/1094)) |
+| `DB_*`                            | (required) | Standard postgres connection (host/port/name/username/password)                                          |
+| `DRY_RUN`                         | `false`    | Skip all UPDATEs; log planned writes only                                                                |
+| `BACKFILL_LML_MAX_CONCURRENT`     | `1`        | Concurrency cap on LML calls (semaphore permits)                                                         |
+| `BACKFILL_LML_RATE_PER_MIN`       | `20`       | Token-bucket rate limit on LML calls                                                                     |
+| `BACKFILL_LML_RESOLVE_TIMEOUT_MS` | `8000`     | Per-call abort budget on `resolveIdentity`                                                               |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`  | `60`       | Cooperative-pause window; 0 disables                                                                     |
+| `LIVE_ACTIVITY_PAUSE_MS`          | `30000`    | How long to pause between probes when activity is detected                                               |
+| `SENTRY_DSN`                      | —          | Optional; Sentry stays inactive without it                                                               |
+
+The `BACKFILL_LML_*` triple is the safety story BS#995 established for the `flowsheet-metadata-backfill` cron. Defaults pin LML calls to one in-flight / 20 per minute / 8 s per call — for the few-hundred-row active rotation set that's bounded by ~15 min wall time and is provably non-disruptive to runtime LML traffic.
+
+## Counter shape
+
+JSON log line emitted on `step: finished`:
+
+```json
+{
+  "level": "info",
+  "step": "finished",
+  "message": "rotation-lml-identity-backfill done",
+  "dry_run": false,
+  "scanned": 310,
+  "resolved": 247,
+  "resolved_dry": 0,
+  "unresolved": 51,
+  "lml_error": 11,
+  "raced": 1,
+  "repo": "Backend-Service",
+  "tool": "rotation-lml-identity-backfill",
+  "run_id": "<uuid>"
+}
+```
+
+Invariant: `scanned == resolved + resolved_dry + unresolved + lml_error + raced` (matches the counter shape from `jobs/rotation-release-id-backfill/orchestrate.ts:30-91`).
+
+| Counter        | Meaning                                                                                                                                |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `scanned`      | Rows visited (matches the candidate query's row count)                                                                                 |
+| `resolved`     | LML minted/returned an identity_id AND the UPDATE landed cleanly                                                                       |
+| `resolved_dry` | LML returned an identity_id; DRY_RUN suppressed the UPDATE                                                                             |
+| `unresolved`   | LML rejected the input with 422 (sentinel discogs id, malformed bandcamp URL)                                                          |
+| `lml_error`    | LML call threw (cold-cache timeout, network blip, 5xx); row stays NULL for next run                                                    |
+| `raced`        | UPDATE matched zero rows — either a concurrent backfill won the race, or rotation-etl cleared the row mid-run after a paste-correction |
+
+## Coverage gate
+
+The gate that unblocks [BS#1381](https://github.com/WXYC/Backend-Service/issues/1381) is **resolvable coverage** — the fraction of active rotation rows where backfill _could_ populate `lml_identity_id` that actually have it. Denominator excludes rows with NULL `discogs_release_id` (no backfill source).
+
+```sql
+SELECT
+  COUNT(*) FILTER (WHERE kill_date IS NULL OR kill_date > CURRENT_DATE) AS active,
+  COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                   AND discogs_release_id IS NOT NULL) AS active_with_discogs,
+  COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                   AND discogs_release_id IS NOT NULL
+                   AND lml_identity_id IS NOT NULL) AS active_with_lml,
+  ROUND(
+    100.0 * COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                             AND discogs_release_id IS NOT NULL
+                             AND lml_identity_id IS NOT NULL)
+        / NULLIF(COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                                  AND discogs_release_id IS NOT NULL), 0),
+    2
+  ) AS resolvable_coverage_pct
+FROM wxyc_schema.rotation;
+```
+
+`--report` mode runs exactly this. When `resolvable_coverage_pct >= 99.0` steady-state across consecutive daily cron runs, comment on [BS#1381](https://github.com/WXYC/Backend-Service/issues/1381) to unblock that work.
+
+Rows that sit at `lml_identity_id IS NULL AND discogs_release_id IS NOT NULL` for >7 days after backfill is healthy indicate either LML can't resolve the ID (catalog drift) or backfill has a bug — investigate per-row, not by lowering the gate threshold.
+
+**Why resolvable coverage instead of absolute:** post-tubafrenzy-decommission, new `addToRotation` rows pick up `discogs_release_id` from `library_identity`, which has its own incomplete subset. Absolute coverage `(active_with_lml / active)` conflates "backfill is done" with "library_identity has full Discogs handle population" — two unrelated work tracks. The WXYC/dj-site#648 high-volume MD path makes the denominator in absolute coverage move with library_identity health, not backfill progress.
+
+## Post-run verification
+
+```sql
+SELECT
+  COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                   AND lml_identity_id IS NOT NULL) AS active_with_lml,
+  COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                   AND lml_identity_id IS NULL
+                   AND discogs_release_id IS NOT NULL) AS lml_remaining,
+  COUNT(*) FILTER (WHERE (kill_date IS NULL OR kill_date > CURRENT_DATE)
+                   AND lml_identity_id IS NULL
+                   AND discogs_release_id IS NULL) AS no_discogs_handle
+FROM wxyc_schema.rotation;
+```
+
+`lml_remaining` is the candidate count for the next daily tick; it should trend toward zero as both write paths converge.
+
+## Related
+
+- Schema PR: [BS#1380](https://github.com/WXYC/Backend-Service/issues/1380) (this issue)
+- LML precursor: [LML#526](https://github.com/WXYC/library-metadata-lookup/issues/526) — introduces the release identity that `lml_identity_id` points at
+- LML companion consumer: [LML#525](https://github.com/WXYC/library-metadata-lookup/issues/525) — `POST /api/v1/cache/refresh-for-identities` consumes the values this backfill produces
+- Operational precedent (one-shot variant): `jobs/rotation-release-id-backfill/`
+- Operational precedent (recurring-drift-repair shape): `jobs/flowsheet-metadata-backfill/` — same `BACKFILL_CRON_SCHEDULE` override pattern
+- Cooperative-pause primitive: [BS#735](https://github.com/WXYC/Backend-Service/issues/735)
+- Backfill cron-schedule override: [BS#914](https://github.com/WXYC/Backend-Service/issues/914) — see `scripts/resolve-cron-schedule.sh`
+- Coverage-gate consumer: [BS#1381](https://github.com/WXYC/Backend-Service/issues/1381) — `rotation-artist-backfill` switching off the LML-identity handle

--- a/jobs/rotation-lml-identity-backfill/job.ts
+++ b/jobs/rotation-lml-identity-backfill/job.ts
@@ -1,0 +1,118 @@
+/**
+ * Entrypoint for jobs/rotation-lml-identity-backfill (BS#1380).
+ *
+ * Daily-cron recurring drift-repair that resolves `rotation.lml_identity_id`
+ * for active rows whose `discogs_release_id` is populated but
+ * `lml_identity_id` is still NULL. Catches the two write paths that
+ * legitimately produce that state:
+ *
+ *   1. `jobs/rotation-etl/job.ts` — rotation-etl writes only
+ *      `discogs_release_id` from the tubafrenzy paste and never calls
+ *      LML (its useful life is bounded by the tubafrenzy decommission
+ *      window ~September 2026; investing in lml-client wiring there
+ *      isn't worth the diff). The CASE clause in the UPSERT also
+ *      explicitly clears `lml_identity_id` when a paste-correction
+ *      changes the effective `discogs_release_id` — those clears land
+ *      here for re-resolution too.
+ *   2. `apps/backend/services/library.service.ts:addToRotation` —
+ *      synchronous resolve at INSERT time; falls back to NULL on
+ *      `LML_RESOLVE_TIMEOUT_MS` / 5xx / network failures so the music
+ *      director isn't blocked on an LML outage. Those rows land here on
+ *      the next daily tick.
+ *
+ * Modes:
+ *   - default: run the resolve loop, write to PG, log totals
+ *   - `DRY_RUN=true`: run the resolve loop, suppress all UPDATEs, surface
+ *     planned writes via `resolved_dry`
+ *   - `--report`: emit the resolvable-coverage SQL result and exit
+ *     without running the resolve loop. Useful for ops queries against
+ *     BS#1381's unblock condition (resolvable_coverage_pct >= 99.0
+ *     steady-state).
+ *
+ * Idempotent: the SELECT predicate is `lml_identity_id IS NULL AND
+ * discogs_release_id IS NOT NULL` and the writer guards on the same
+ * predicate (plus `discogs_release_id` equality to defeat the
+ * paste-correction race). Safe to re-run; safe to one-shot during
+ * a deploy migration.
+ *
+ * One-shot invocation:
+ *   docker run --rm --env-file .env $AWS_ECR_URI/rotation-lml-identity-backfill:latest
+ *
+ * Required env: LIBRARY_METADATA_URL (LML host), LML_API_KEY (bearer),
+ * DB_* (postgres connection).
+ *
+ * Optional env:
+ *   DRY_RUN=true                              skip all UPDATEs; log planned writes
+ *   BACKFILL_LML_MAX_CONCURRENT=N             default 1
+ *   BACKFILL_LML_RATE_PER_MIN=N               default 20
+ *   BACKFILL_LML_RESOLVE_TIMEOUT_MS=N         default 8000
+ *   LIVE_ACTIVITY_LOOKBACK_SECONDS=N          default 60; 0 disables cooperative pause
+ *   LIVE_ACTIVITY_PAUSE_MS=N                  default 30000
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+
+import { runBackfill } from './orchestrate.js';
+import { loadCandidates, loadCoverageReport } from './query.js';
+import { lookupIdentityId } from './lml-fetch.js';
+import { writeIdentityId } from './writer.js';
+import { initLogger, log, captureError, closeLogger } from './logger.js';
+
+const JOB_NAME = 'rotation-lml-identity-backfill';
+
+const requireLmlConfigured = (): void => {
+  if (!process.env.LIBRARY_METADATA_URL) {
+    throw new Error('LIBRARY_METADATA_URL is not configured; aborting before any rows are scanned.');
+  }
+};
+
+const resolveDryRun = (): boolean => {
+  const raw = process.env.DRY_RUN;
+  return raw === 'true' || raw === '1' || raw === 'TRUE';
+};
+
+const isReportMode = (): boolean => process.argv.slice(2).includes('--report');
+
+const main = async (): Promise<void> => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  if (isReportMode()) {
+    try {
+      const report = await loadCoverageReport();
+      log('info', 'coverage_report', `${JOB_NAME} --report`, { ...report });
+      process.stdout.write(JSON.stringify(report) + '\n');
+    } catch (error) {
+      log('error', 'failed', `${JOB_NAME} --report failed`, { error_message: (error as Error).message });
+      captureError(error, 'failed');
+      process.exitCode = 1;
+    } finally {
+      await closeDatabaseConnection();
+      await closeLogger();
+    }
+    return;
+  }
+
+  const dryRun = resolveDryRun();
+  try {
+    requireLmlConfigured();
+    log('info', 'init', `${JOB_NAME} initialized`, { dry_run: dryRun });
+    const { totals } = await runBackfill({
+      loadCandidates,
+      lookup: lookupIdentityId,
+      write: writeIdentityId,
+      dryRun,
+      onLivePause: () => {
+        log('info', 'live_activity_pause', 'live flowsheet activity detected; pausing');
+      },
+    });
+    log('info', 'finished', `${JOB_NAME} done`, { dry_run: dryRun, ...totals });
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
+};
+
+void main();

--- a/jobs/rotation-lml-identity-backfill/lml-fetch.ts
+++ b/jobs/rotation-lml-identity-backfill/lml-fetch.ts
@@ -1,0 +1,66 @@
+/**
+ * Backfill-side LML resolve helper for jobs/rotation-lml-identity-backfill
+ * (BS#1380).
+ *
+ * Delegates to `@wxyc/lml-client.resolveIdentity` (the wrapper introduced
+ * alongside BS#1380; see shared/lml-client/src/index.ts) and injects:
+ *   - a tighter per-call abort budget
+ *     (`BACKFILL_LML_RESOLVE_TIMEOUT_MS`, default 8000 ms) so cold-tail
+ *     identities that LML can't resolve quickly don't hold a serialized
+ *     resolve slot for the runtime path's 2 s, and
+ *   - the backfill's own concurrency + rate-limit gate via
+ *     `defaultLmlLimiter` (BS#995 — strict BACKFILL_LML_* ceiling).
+ *
+ * `resolveIdentity` itself does NOT take a limiter today — it's a small,
+ * single-purpose POST that the LML server caps internally. The limiter is
+ * applied here at the wrapper layer so the BS-side back-pressure surfaces
+ * at the same chokepoint shape as `lookupReleaseId` does in
+ * `jobs/rotation-release-id-backfill/lml-fetch.ts`.
+ *
+ * Returns the LML identity_id (or null when LML's 422 rejected the input
+ * — e.g. a sentinel `0` discogs id; the caller counts that as
+ * `unresolved`). 4xx is the only "ran-cleanly-but-no-result" branch;
+ * 5xx / timeout / network errors throw `LmlClientError` so the
+ * orchestrator's catch arm bumps `lml_error` and leaves the row
+ * untouched for next run.
+ */
+
+import { LmlClientError, resolveIdentity } from '@wxyc/lml-client';
+
+import { defaultLmlLimiter } from './lml-limiter.js';
+
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-fetch: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
+};
+
+const TIMEOUT_MS = envInt('BACKFILL_LML_RESOLVE_TIMEOUT_MS', 8000);
+
+export const lookupIdentityId = async (discogsReleaseId: number): Promise<number | null> =>
+  defaultLmlLimiter.run(async () => {
+    try {
+      const response = await resolveIdentity(
+        {
+          kind: 'release',
+          source: 'discogs_release',
+          external_id: String(discogsReleaseId),
+        },
+        { timeoutMs: TIMEOUT_MS }
+      );
+      return response.identity_id;
+    } catch (err) {
+      // LML's 422 sentinel rejection ("Discogs id <= 0", malformed Bandcamp
+      // URL, etc.) is "ran cleanly, no row to point at" — surfaces to the
+      // orchestrator as `unresolved`, not `lml_error`. Network / timeout /
+      // 5xx all rethrow so the orchestrator's catch arm leaves the row
+      // retryable.
+      if (err instanceof LmlClientError && err.statusCode === 422) {
+        return null;
+      }
+      throw err;
+    }
+  });

--- a/jobs/rotation-lml-identity-backfill/lml-limiter.ts
+++ b/jobs/rotation-lml-identity-backfill/lml-limiter.ts
@@ -1,0 +1,44 @@
+/**
+ * Concurrency + rate-limit gate for jobs/rotation-lml-identity-backfill
+ * (BS#1380).
+ *
+ * Mirrors jobs/rotation-release-id-backfill/lml-limiter.ts verbatim — same
+ * `BACKFILL_LML_*` env defaults (concurrency=1, rate=20/min) and the same
+ * `defaultLmlLimiter` singleton pattern. The 2026-05-21 incident (BS#994)
+ * is the safety story this limiter exists to defend; copying the file
+ * keeps the rotation-lml-identity-backfill's blast-radius story identical
+ * to the other LML-calling backfills, without coupling either to the
+ * other's build graph.
+ *
+ * The underlying primitives (Semaphore, TokenBucket, LmlLimiter,
+ * createLmlLimiter) live in @wxyc/lml-client post-BS#887.
+ */
+
+import { type LmlLimiter, Semaphore, TokenBucket, createLmlLimiter as createSharedLmlLimiter } from '@wxyc/lml-client';
+
+export { type LmlLimiter, Semaphore, TokenBucket };
+
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  // Number() (not parseInt) so partial-parse strings like "20banana" surface
+  // as NaN and get rejected rather than silently coercing.
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
+};
+
+export const createLmlLimiter = (config?: { maxConcurrent?: number; ratePerMinute?: number }): LmlLimiter =>
+  createSharedLmlLimiter({
+    maxConcurrent: config?.maxConcurrent ?? envInt('BACKFILL_LML_MAX_CONCURRENT', 1),
+    ratePerMinute: config?.ratePerMinute ?? envInt('BACKFILL_LML_RATE_PER_MIN', 20),
+  });
+
+/**
+ * Module-level singleton consumed by lml-fetch.ts. Reads BACKFILL_LML_* from
+ * env at module load — mutating process.env after the first import of this
+ * module does NOT reconfigure the singleton. Tests that exercise different
+ * limits must call `createLmlLimiter()` directly with explicit config.
+ */
+export const defaultLmlLimiter: LmlLimiter = createLmlLimiter();

--- a/jobs/rotation-lml-identity-backfill/logger.ts
+++ b/jobs/rotation-lml-identity-backfill/logger.ts
@@ -1,0 +1,96 @@
+/**
+ * Observability for jobs/rotation-lml-identity-backfill (BS#1380): Sentry
+ * init + JSON logs.
+ *
+ * Phase A foundation contract (#538): every log line carries the four tags
+ * `repo`, `tool`, `step`, `run_id`. Sentry stays inactive when SENTRY_DSN
+ * is unset (the @sentry/node SDK silently no-ops in that case), so this
+ * module is safe to call from any environment.
+ *
+ * Mirrors `jobs/rotation-release-id-backfill/logger.ts` verbatim — the
+ * contract is identical; the duplication keeps this job's build graph
+ * independent of the one-shot backfill's package.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+// `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+/**
+ * Initialize Sentry and the structured logger. Call once at the top of the
+ * entrypoint, before any other logic. Returns the resolved `run_id` so the
+ * caller can pass it to subprocesses or persist it for cross-system tracing.
+ */
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+/**
+ * Emit a JSON log line. `info`/`warn` go to stdout, `error` goes to stderr
+ * so container log shippers can split streams by severity.
+ *
+ * Silently no-ops when called before `initLogger()` so unit tests that
+ * exercise library functions directly (without invoking the entrypoint)
+ * don't have to thread an init call through every fixture.
+ */
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+/** Capture an exception to Sentry with the current run's tags + an extra `step`. */
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+/** Flush pending Sentry events. Call from the entrypoint's `finally`. */
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/rotation-lml-identity-backfill/orchestrate.ts
+++ b/jobs/rotation-lml-identity-backfill/orchestrate.ts
@@ -1,0 +1,169 @@
+/**
+ * Orchestrator for jobs/rotation-lml-identity-backfill (BS#1380).
+ *
+ * Iterates active rotation rows
+ * (`kill_date IS NULL OR > CURRENT_DATE`) where
+ * `lml_identity_id IS NULL AND discogs_release_id IS NOT NULL`, asks LML
+ * for a stable identity_id via `POST /api/v1/identity/resolve`, and
+ * writes the result back. Recurring daily-cron drift-repair (the
+ * recurring shape from `jobs/flowsheet-metadata-backfill`, not the
+ * one-shot shape from `jobs/rotation-release-id-backfill`); rerun-safe
+ * via the SELECT predicate.
+ *
+ * Pacing and per-call timeouts ride on top of `lml-fetch.ts`'s
+ * `defaultLmlLimiter` configured with `BACKFILL_LML_*` env vars — same
+ * safety story as the other LML-calling backfills (BS#995).
+ *
+ * Cooperative pause (BS#735): the orchestrator probes flowsheet for live
+ * DJ activity before each batch; the loop yields when a DJ is actively
+ * touching the playout, exactly the window where any incremental p95
+ * hit is most user-visible. Disable via
+ * `LIVE_ACTIVITY_LOOKBACK_SECONDS=0` for catch-up runs.
+ *
+ * Deps are injected so tests can drive the orchestrator without a live
+ * LML or DB.
+ *
+ * Sentry span attributes on numeric counters are set at span creation,
+ * not via late `setAttribute` (BS#1081 — late `setAttribute` calls index
+ * numbers as strings and break sum/avg/p95).
+ */
+
+import * as Sentry from '@sentry/node';
+import {
+  LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
+  LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+  checkLiveActivity as defaultCheckLiveActivity,
+  type CheckLiveActivityFn,
+} from '@wxyc/database';
+
+import type { Candidate } from './query.js';
+
+export type LoadCandidatesFn = () => Promise<Candidate[]>;
+
+export type LookupFn = (discogsReleaseId: number) => Promise<number | null>;
+
+export type WriteFn = (
+  rotationId: number,
+  discogsReleaseIdAtRead: number,
+  lmlIdentityId: number
+) => Promise<{ written: boolean }>;
+
+/**
+ * Counter shape mirrors `jobs/rotation-release-id-backfill/orchestrate.ts:30-91`.
+ * Same five buckets so downstream dashboards / log-line consumers don't
+ * have to differentiate. `resolved_dry` covers DRY_RUN runs; the invariant
+ * `scanned == resolved + resolved_dry + unresolved + lml_error + raced`
+ * holds with or without DRY_RUN.
+ */
+export type Totals = {
+  scanned: number;
+  resolved: number;
+  resolved_dry: number;
+  unresolved: number;
+  lml_error: number;
+  raced: number;
+};
+
+export type RunResult = { totals: Totals };
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const envNonNegativeInt = (raw: string | undefined, fallback: number): number => {
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  return fallback;
+};
+
+export const resolveLiveActivityLookback = (
+  raw: string | undefined = process.env.LIVE_ACTIVITY_LOOKBACK_SECONDS
+): number => envNonNegativeInt(raw, LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT);
+
+export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number =>
+  envNonNegativeInt(raw, LIVE_ACTIVITY_PAUSE_MS_DEFAULT);
+
+export const runBackfill = async (deps: {
+  loadCandidates: LoadCandidatesFn;
+  lookup: LookupFn;
+  write: WriteFn;
+  dryRun?: boolean;
+  liveActivityLookbackSeconds?: number;
+  liveActivityPauseMs?: number;
+  checkLiveActivity?: CheckLiveActivityFn;
+  onLivePause?: () => void;
+}): Promise<RunResult> => {
+  const totals: Totals = {
+    scanned: 0,
+    resolved: 0,
+    resolved_dry: 0,
+    unresolved: 0,
+    lml_error: 0,
+    raced: 0,
+  };
+
+  const liveActivityLookbackSeconds = deps.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
+  const liveActivityPauseMs = deps.liveActivityPauseMs ?? resolveLiveActivityPauseMs();
+  const probe = deps.checkLiveActivity ?? defaultCheckLiveActivity;
+
+  // BS#1081: numeric attributes are projected at span creation so they
+  // index as numbers (not strings) in Sentry's trace explorer.
+  return await Sentry.startSpan(
+    {
+      name: 'rotation-lml-identity-backfill.run',
+      op: 'function',
+      attributes: {
+        'wxyc.backfill.dry_run': Boolean(deps.dryRun),
+        'wxyc.backfill.live_activity_lookback_seconds': liveActivityLookbackSeconds,
+        'wxyc.backfill.live_activity_pause_ms': liveActivityPauseMs,
+      },
+    },
+    async () => {
+      const candidates = await deps.loadCandidates();
+
+      for (const candidate of candidates) {
+        if (liveActivityLookbackSeconds > 0) {
+          while (await probe(liveActivityLookbackSeconds)) {
+            deps.onLivePause?.();
+            if (liveActivityPauseMs > 0) await sleep(liveActivityPauseMs);
+          }
+        }
+
+        totals.scanned += 1;
+        let identityId: number | null;
+        try {
+          identityId = await deps.lookup(candidate.discogs_release_id);
+        } catch {
+          // The row stays `lml_identity_id IS NULL` so it's picked up on
+          // the next daily run when LML's cache is warmer. The job entry
+          // wraps the orchestrator's loop in Sentry's run-scope so
+          // captureException is unnecessary here at the unit boundary.
+          totals.lml_error += 1;
+          continue;
+        }
+        if (identityId !== null) {
+          if (deps.dryRun) {
+            totals.resolved_dry += 1;
+            continue;
+          }
+          const { written } = await deps.write(candidate.id, candidate.discogs_release_id, identityId);
+          if (written) {
+            totals.resolved += 1;
+          } else {
+            // The writer's WHERE clause requires `lml_identity_id IS NULL`
+            // AND `discogs_release_id` still matches the value we resolved
+            // against. 0 rows updated means either (a) another concurrent
+            // backfill (cron + manual) beat us, or (b) rotation-etl
+            // cleared the row mid-run after a paste-correction. Surface on
+            // a dedicated counter so the dashboard distinguishes write
+            // success from "lost the race".
+            totals.raced += 1;
+          }
+        } else {
+          totals.unresolved += 1;
+        }
+      }
+
+      return { totals };
+    }
+  );
+};

--- a/jobs/rotation-lml-identity-backfill/package.json
+++ b/jobs/rotation-lml-identity-backfill/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@wxyc/rotation-lml-identity-backfill",
+  "cron-schedule": "0 6 * * *",
+  "version": "1.0.0",
+  "description": "WXYC recurring drift-repair: resolve rotation.lml_identity_id via LML for rows with a non-NULL discogs_release_id. Catches rotation-etl-written rows (rotation-etl never calls LML) and addToRotation resolve-failure fallbacks within ~24h (BS#1380).",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_rotation_lml_identity_backfill:ci -f ../../Dockerfile.rotation-lml-identity-backfill ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.53.1",
+    "@wxyc/database": "^1.0.0",
+    "@wxyc/lml-client": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/rotation-lml-identity-backfill/query.ts
+++ b/jobs/rotation-lml-identity-backfill/query.ts
@@ -1,0 +1,97 @@
+/**
+ * Candidate query for jobs/rotation-lml-identity-backfill (BS#1380).
+ *
+ * Selects active rotation rows (`kill_date IS NULL OR > CURRENT_DATE`)
+ * whose `lml_identity_id` is NULL but whose `discogs_release_id` is
+ * non-NULL — i.e. rows that have an LML-resolvable Discogs handle but
+ * no minted identity yet. The two-column predicate is the idempotency
+ * gate: rerunning the job after a partial run, or after a tubafrenzy
+ * paste landed mid-run, is safe and skips already-resolved rows.
+ *
+ * Rows with a NULL `discogs_release_id` are out of scope — there's no
+ * source-of-truth ID to feed `resolveIdentity`. The
+ * `rotation-release-id-backfill` job is the precursor that populates
+ * those.
+ *
+ * No new index. Rotation is hundreds of active rows; the seqscan is
+ * fine and matches the precedent set by
+ * `jobs/rotation-release-id-backfill/query.ts`.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+
+export type Candidate = {
+  id: number;
+  discogs_release_id: number;
+};
+
+export const loadCandidates = async (): Promise<Candidate[]> => {
+  const rows = (await db.execute(sql`
+    SELECT
+      "id",
+      "discogs_release_id"
+    FROM "wxyc_schema"."rotation"
+    WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
+      AND "lml_identity_id" IS NULL
+      AND "discogs_release_id" IS NOT NULL
+    ORDER BY "id" ASC
+  `)) as unknown as Candidate[];
+  return rows ?? [];
+};
+
+/**
+ * BS#1380 coverage gate: resolvable coverage = (active rows with
+ * lml_identity_id) / (active rows with discogs_release_id). When
+ * the daily cron hits >= 99.0 steady-state, BS#1381 (rotation-
+ * artist-backfill switching off discogs_release_id) is unblocked.
+ *
+ * Denominator excludes rows with NULL discogs_release_id (no backfill
+ * source) so library_identity health doesn't conflate with backfill
+ * progress.
+ */
+export type CoverageReport = {
+  active: number;
+  active_with_discogs: number;
+  active_with_lml: number;
+  resolvable_coverage_pct: number | null;
+};
+
+export const loadCoverageReport = async (): Promise<CoverageReport> => {
+  const rows = (await db.execute(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE "kill_date" IS NULL OR "kill_date" > CURRENT_DATE) AS active,
+      COUNT(*) FILTER (WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
+                       AND "discogs_release_id" IS NOT NULL) AS active_with_discogs,
+      COUNT(*) FILTER (WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
+                       AND "discogs_release_id" IS NOT NULL
+                       AND "lml_identity_id" IS NOT NULL) AS active_with_lml,
+      ROUND(
+        100.0 * COUNT(*) FILTER (WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
+                                 AND "discogs_release_id" IS NOT NULL
+                                 AND "lml_identity_id" IS NOT NULL)
+            / NULLIF(COUNT(*) FILTER (WHERE ("kill_date" IS NULL OR "kill_date" > CURRENT_DATE)
+                                      AND "discogs_release_id" IS NOT NULL), 0),
+        2
+      ) AS resolvable_coverage_pct
+    FROM "wxyc_schema"."rotation"
+  `)) as unknown as Array<{
+    active: string | number;
+    active_with_discogs: string | number;
+    active_with_lml: string | number;
+    resolvable_coverage_pct: string | number | null;
+  }>;
+  const row = rows?.[0];
+  // PG returns bigints as strings via postgres.js — coerce.
+  const toNumber = (raw: string | number | null): number | null => {
+    if (raw === null) return null;
+    const parsed = typeof raw === 'string' ? Number(raw) : raw;
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+  return {
+    active: toNumber(row?.active ?? 0) ?? 0,
+    active_with_discogs: toNumber(row?.active_with_discogs ?? 0) ?? 0,
+    active_with_lml: toNumber(row?.active_with_lml ?? 0) ?? 0,
+    resolvable_coverage_pct: toNumber(row?.resolvable_coverage_pct ?? null),
+  };
+};

--- a/jobs/rotation-lml-identity-backfill/tsconfig.json
+++ b/jobs/rotation-lml-identity-backfill/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }, { "path": "../../shared/lml-client" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/rotation-lml-identity-backfill/tsup.config.ts
+++ b/jobs/rotation-lml-identity-backfill/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/jobs/rotation-lml-identity-backfill/writer.ts
+++ b/jobs/rotation-lml-identity-backfill/writer.ts
@@ -1,0 +1,41 @@
+/**
+ * Writer for jobs/rotation-lml-identity-backfill (BS#1380).
+ *
+ * Idempotent single-row UPDATE that persists an LML-minted identity_id on
+ * a rotation row. The WHERE clause guards on `lml_identity_id IS NULL`
+ * AND `discogs_release_id = <observed>` so:
+ *
+ *   1. A rerun is safe (the second pass's UPDATE sees `lml_identity_id`
+ *      already populated and matches 0 rows).
+ *   2. A mid-run drift from `rotation-etl` (a tubafrenzy paste-correction
+ *      changing `discogs_release_id` to a different id, and the
+ *      rotation-etl CASE clearing `lml_identity_id` back to NULL) doesn't
+ *      get clobbered with an identity minted against the *old* Discogs
+ *      id. That race manifests as a 0-row UPDATE which the orchestrator
+ *      reads via `written: false` and rolls into its `raced` counter.
+ *
+ * Both guards together: the column has to still be NULL *and* the row
+ * has to still be pointing at the same Discogs id we resolved against.
+ */
+
+import { and, eq, isNull } from 'drizzle-orm';
+import { db, rotation } from '@wxyc/database';
+
+export const writeIdentityId = async (
+  rotationId: number,
+  discogsReleaseIdAtRead: number,
+  lmlIdentityId: number
+): Promise<{ written: boolean }> => {
+  const updated = await db
+    .update(rotation)
+    .set({ lml_identity_id: lmlIdentityId })
+    .where(
+      and(
+        eq(rotation.id, rotationId),
+        isNull(rotation.lml_identity_id),
+        eq(rotation.discogs_release_id, discogsReleaseIdAtRead)
+      )
+    )
+    .returning({ id: rotation.id });
+  return { written: updated.length === 1 };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1023,6 +1023,22 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/rotation-lml-identity-backfill": {
+      "name": "@wxyc/rotation-lml-identity-backfill",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.53.1",
+        "@wxyc/database": "^1.0.0",
+        "@wxyc/lml-client": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/rotation-release-id-backfill": {
       "name": "@wxyc/rotation-release-id-backfill",
       "version": "1.0.0",
@@ -6677,6 +6693,10 @@
     },
     "node_modules/@wxyc/rotation-etl": {
       "resolved": "jobs/rotation-etl",
+      "link": true
+    },
+    "node_modules/@wxyc/rotation-lml-identity-backfill": {
+      "resolved": "jobs/rotation-lml-identity-backfill",
       "link": true
     },
     "node_modules/@wxyc/rotation-release-id-backfill": {

--- a/scripts/resolve-cron-schedule.sh
+++ b/scripts/resolve-cron-schedule.sh
@@ -44,12 +44,24 @@ if [ -z "$DEFAULT" ]; then
   exit 1
 fi
 
-# Override only for the specific job the H7 ticket calls out. Generalizing
-# to "any job" would risk an accidental override from a stale env var
-# fanning out across the whole matrix; keep the override scope narrow
-# until a second job needs it.
-if [ "$TARGET" = "flowsheet-metadata-backfill" ] && [ -n "${BACKFILL_CRON_SCHEDULE:-}" ]; then
-  echo "$BACKFILL_CRON_SCHEDULE"
-else
-  echo "$DEFAULT"
-fi
+# Override only for jobs that explicitly opt into the shared env var.
+# Generalizing to "any job" would risk an accidental override from a stale
+# env var fanning out across the whole matrix; keep the allowlist narrow
+# and explicit. Each entry needs a documented operational reason:
+#   - flowsheet-metadata-backfill (BS#914 / H7): nightly metadata sweep;
+#     ops occasionally tightens the cadence (hourly) during C6 retunes
+#   - rotation-lml-identity-backfill (BS#1380): daily LML-identity resolve;
+#     shares the metadata sweep's ops cadence story since both are
+#     LML-bounded drift-repair crons
+case "$TARGET" in
+  flowsheet-metadata-backfill|rotation-lml-identity-backfill)
+    if [ -n "${BACKFILL_CRON_SCHEDULE:-}" ]; then
+      echo "$BACKFILL_CRON_SCHEDULE"
+    else
+      echo "$DEFAULT"
+    fi
+    ;;
+  *)
+    echo "$DEFAULT"
+    ;;
+esac

--- a/tests/unit/jobs/rotation-lml-identity-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/rotation-lml-identity-backfill/orchestrate.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for jobs/rotation-lml-identity-backfill orchestrate.ts (BS#1380).
+ *
+ * Mirrors the rotation-release-id-backfill counter-shape pins:
+ *
+ *   1. (tracer bullet) one resolvable row → write called with the resolved
+ *      identity_id; `resolved` counter bumps, scanned == 1.
+ *   2. LML returns null (422 sentinel rejection) → unresolved counter;
+ *      no write.
+ *   3. LML throws (timeout/5xx/network) → lml_error counter; no write;
+ *      row stays NULL for next pass.
+ *   4. Writer returns written:false → raced counter, not resolved.
+ *   5. dryRun=true → resolved_dry counter; no write.
+ *   6. Cooperative pause defers the resolve when the live-activity probe
+ *      returns true, then proceeds when it returns false.
+ *   7. Writer is called with `(rotationId, discogsReleaseId, identityId)` —
+ *      the writer's WHERE clause pins on the discogs_release_id read at
+ *      candidate-select time so a mid-run paste-correction races cleanly.
+ */
+import { jest } from '@jest/globals';
+
+import {
+  runBackfill,
+  type LoadCandidatesFn,
+  type LookupFn,
+  type WriteFn,
+} from '../../../../jobs/rotation-lml-identity-backfill/orchestrate';
+import type { Candidate } from '../../../../jobs/rotation-lml-identity-backfill/query';
+
+const makeLoadCandidates = (rows: Candidate[]): LoadCandidatesFn => jest.fn<LoadCandidatesFn>().mockResolvedValue(rows);
+
+const COMMON_OPTS = {
+  liveActivityLookbackSeconds: 0, // disable live-activity probe by default
+  liveActivityPauseMs: 0,
+};
+
+describe('runBackfill', () => {
+  test('one resolvable row produces one resolved UPDATE pinned on (rotationId, discogsReleaseId, identityId)', async () => {
+    const loadCandidates = makeLoadCandidates([{ id: 42, discogs_release_id: 999001 }]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(7700042);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runBackfill({ loadCandidates, lookup, write, ...COMMON_OPTS });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    // BS#1380: writer pins on the discogs_release_id read at candidate-
+    // select time so a mid-run paste-correction (rotation-etl CASE clears
+    // lml_identity_id back to NULL after discogs_release_id changes) can't
+    // be clobbered with an identity minted against the old id.
+    expect(write).toHaveBeenCalledWith(42, 999001, 7700042);
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals.resolved).toBe(1);
+    expect(result.totals.unresolved).toBe(0);
+    expect(result.totals.lml_error).toBe(0);
+    expect(result.totals.raced).toBe(0);
+  });
+
+  test('LML returns null (422 sentinel rejection) → unresolved counter, no write', async () => {
+    // lml-fetch.ts maps LML's 422 sentinel rejection to `null` so the
+    // orchestrator sees "ran cleanly, no row to point at" as `unresolved`,
+    // not `lml_error`.
+    const loadCandidates = makeLoadCandidates([{ id: 99, discogs_release_id: -1 /* sentinel */ }]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(null);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runBackfill({ loadCandidates, lookup, write, ...COMMON_OPTS });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals.unresolved).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('LML throws → lml_error counter; no write; row stays NULL for next pass', async () => {
+    const loadCandidates = makeLoadCandidates([{ id: 7, discogs_release_id: 12345 }]);
+    const lookup = jest.fn<LookupFn>().mockRejectedValue(new Error('LML socket timeout'));
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runBackfill({ loadCandidates, lookup, write, ...COMMON_OPTS });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals.lml_error).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('write returns written:false → raced counter, not resolved', async () => {
+    // Either another concurrent backfill won the race, or rotation-etl
+    // cleared the row mid-run after a paste-correction. The orchestrator
+    // surfaces both as `raced` so the dashboard distinguishes write
+    // success from "lost the race".
+    const loadCandidates = makeLoadCandidates([{ id: 11, discogs_release_id: 555 }]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(8800011);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: false });
+
+    const result = await runBackfill({ loadCandidates, lookup, write, ...COMMON_OPTS });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals.raced).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('dryRun=true skips writes and bumps resolved_dry', async () => {
+    const loadCandidates = makeLoadCandidates([{ id: 42, discogs_release_id: 999001 }]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(7700042);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runBackfill({ loadCandidates, lookup, write, dryRun: true, ...COMMON_OPTS });
+
+    expect(write).not.toHaveBeenCalled();
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals.resolved_dry).toBe(1);
+    expect(result.totals.resolved).toBe(0);
+  });
+
+  test('cooperative pause defers per-row resolve while live activity is observed', async () => {
+    const loadCandidates = makeLoadCandidates([{ id: 42, discogs_release_id: 999001 }]);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(7700042);
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    // First probe says "busy", second probe says "quiet". The orchestrator
+    // must call `onLivePause` exactly once and then proceed with the row.
+    let probeCalls = 0;
+    const checkLiveActivity = jest.fn<(s: number) => Promise<boolean>>().mockImplementation(() => {
+      probeCalls += 1;
+      return Promise.resolve(probeCalls === 1);
+    });
+    const onLivePause = jest.fn<() => void>();
+
+    const result = await runBackfill({
+      loadCandidates,
+      lookup,
+      write,
+      liveActivityLookbackSeconds: 30,
+      liveActivityPauseMs: 0, // skip the actual sleep so the test runs fast
+      checkLiveActivity,
+      onLivePause,
+    });
+
+    expect(checkLiveActivity).toHaveBeenCalledTimes(2);
+    expect(onLivePause).toHaveBeenCalledTimes(1);
+    expect(result.totals.resolved).toBe(1);
+  });
+});

--- a/tests/unit/scripts/resolve-cron-schedule.test.ts
+++ b/tests/unit/scripts/resolve-cron-schedule.test.ts
@@ -84,4 +84,16 @@ describe('scripts/resolve-cron-schedule.sh', () => {
     expect(status).toBe(1);
     expect(stderr).toMatch(/Missing jobs\/nonexistent-job\/package\.json/);
   });
+
+  // BS#1380: extend the override allowlist to include rotation-lml-identity-backfill.
+  // Same operational story as flowsheet-metadata-backfill — both are LML-bounded
+  // drift-repair crons whose cadence ops occasionally tightens. The allowlist
+  // stays narrow and explicit.
+  it('returns override when BACKFILL_CRON_SCHEDULE is set and target = rotation-lml-identity-backfill', () => {
+    const { stdout, status } = run('rotation-lml-identity-backfill', {
+      BACKFILL_CRON_SCHEDULE: '*/30 * * * *',
+    });
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe('*/30 * * * *');
+  });
 });


### PR DESCRIPTION
Final PR in the 5-PR chain implementing #1380. Chained on #1420 (PR 4 addToRotation, which carries PRs 1-3). Carries the `Closes #1380`.

## Summary

New job `jobs/rotation-lml-identity-backfill/` resolves `rotation.lml_identity_id` via LML's `POST /api/v1/identity/resolve` for active rows whose `discogs_release_id` is populated but `lml_identity_id` is still NULL. Catches both write paths that produce that state:

1. `jobs/rotation-etl` writes only `discogs_release_id` from the tubafrenzy paste and never calls LML. The PR 3 drift CASE also clears `lml_identity_id` when a paste-correction changes the effective `discogs_release_id` — those clears land here too.
2. `apps/backend addToRotation` (PR 4) synchronously resolves at INSERT time but falls back to NULL on `LML_RESOLVE_TIMEOUT_MS` / 5xx / network failures.

## Job shape

- **Daily cron** with default schedule `0 6 * * *` UTC (02:00 ET); registered automatically via `package.json` `cron-schedule` + deploy-base
- **`BACKFILL_CRON_SCHEDULE` override** now allowlists this job alongside `flowsheet-metadata-backfill` (BS#914 pattern). Same operational story — both are LML-bounded drift-repair crons.
- **Cooperative pause** (BS#735) defers per-row resolve when DJs are active.
- **Counter shape** mirrors `jobs/rotation-release-id-backfill/orchestrate.ts:30-91` — `scanned/resolved/resolved_dry/unresolved/lml_error/raced`. Invariant: `scanned == resolved + resolved_dry + unresolved + lml_error + raced`.
- **One-shot mode** for ad-hoc operator runs.
- **`--report` mode** emits the resolvable-coverage SQL result and exits without running the resolve loop — used to check BS#1381's unblock condition (`resolvable_coverage_pct >= 99.0` steady-state).
- **Sentry span attributes** (`wxyc.backfill.*`) set at `startSpan`-time per BS#1081 (late `setAttribute` calls index numbers as strings and break sum/avg/p95).
- **Writer UPDATE** guards on `lml_identity_id IS NULL AND discogs_release_id = <observed>` so a mid-run paste-correction can't be clobbered with an identity minted against the old id; race manifests as `raced`.
- **lml-fetch** maps LML's 422 sentinel rejection → null (`unresolved`, not `lml_error`).

## Operational doc

`jobs/rotation-lml-identity-backfill/README.md` mirrors BS#1029's README structure: schedule, env vars, counter shape, coverage gate, post-run verification SQL.

## Test plan

- [x] Unit tests pin all 6 counter behaviors + cooperative pause + writer race-protection signature
- [x] `scripts/resolve-cron-schedule.sh` allowlist extended; new test covers `rotation-lml-identity-backfill` override
- [x] Full typecheck across all workspaces
- [ ] CI build of the new Docker image + workspace lockfile validation

## Companion chain

| PR | Component |
|---|---|
| #1417 | PR 1 — schema + migration |
| #1418 | PR 2 — `lml-client` `resolveIdentity` wrapper |
| #1419 | PR 3 — `rotation-etl` drift-prevention CASE |
| #1420 | PR 4 — `addToRotation` + `pickAddRotationFields` allowlist |
| **this PR** | PR 5 — daily-cron backfill job |

Closes #1380