### PR TITLE
ci: add code-audit PR-comment workflow

### DIFF
--- a/.github/workflows/code-audit-pr-comment.yml
+++ b/.github/workflows/code-audit-pr-comment.yml
@@ -16,9 +16,9 @@ permissions:
 
 jobs:
   audit:
-    # Pinned to v0.3.2 (latest stable as of wiring). Bump to @v1 once the
+    # Pinned to v0.3.3 (latest stable as of wiring). Bump to @v1 once the
     # pipeline cuts a v1.0.0 release — at that point both this ref and the
     # audit-binary-version input can move to floating major pins.
-    uses: jakebromberg/code-audit-pipeline/.github/workflows/pr-comment-reusable.yml@v0.3.2
+    uses: jakebromberg/code-audit-pipeline/.github/workflows/pr-comment-reusable.yml@v0.3.3
     with:
-      audit-binary-version: v0.3.2
+      audit-binary-version: v0.3.3

--- a/.github/workflows/code-audit-pr-comment.yml
+++ b/.github/workflows/code-audit-pr-comment.yml
@@ -1,0 +1,24 @@
+name: code-audit (PR comment)
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# The reusable workflow declares these same permissions internally, but a
+# job-level grant here is still required: reusable-workflow permissions are
+# an UPPER BOUND, never an additive grant. marocchino needs pull-requests:write
+# to post / edit the sticky comment.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  audit:
+    # Pinned to v0.3.2 (latest stable as of wiring). Bump to @v1 once the
+    # pipeline cuts a v1.0.0 release — at that point both this ref and the
+    # audit-binary-version input can move to floating major pins.
+    uses: jakebromberg/code-audit-pipeline/.github/workflows/pr-comment-reusable.yml@v0.3.2
+    with:
+      audit-binary-version: v0.3.2

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ mirror-logs
 __pycache__
 .pytest_cache
 .dryrun-provisioning-state.json
+.audit/


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/code-audit-pr-comment.yml` — calls `jakebromberg/code-audit-pipeline/.github/workflows/pr-comment-reusable.yml@v0.3.3` to post a sticky structural-impact comment on every PR (duplicate clusters, cross-package shadows, near-duplicates touched by the diff). Fail-quiet — the audit never blocks a PR.
- Adds `.audit/` to `.gitignore` so the pipeline's runner-temp output never ends up tracked.

## Notes

- Pinned to `@v0.3.3` (latest stable). Bump to `@v1` once the pipeline cuts v1.0.0 — at that point both the `uses:` ref and the `audit-binary-version` input can move to a floating major pin.
- `contents: read` + `pull-requests: write` granted at the workflow level (reusable-workflow permissions are an upper bound, not additive). No new secrets required.
- First run lands as a comment on this PR itself, which doubles as the smoke test.

## Test plan

- [ ] CI runs the new workflow on this PR
- [ ] Sticky structural-impact comment appears on this PR with no error/diagnostic body
- [ ] Comment marker matches `code-audit-pipeline-v1` (so a future re-run edits in place rather than posting again)

Closes #1422