### PR TITLE
fix(1432): mirror flowsheetEntryType=2 for typed-in rotation plays

### DIFF
--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -18,6 +18,7 @@ import {
   mapShowToTubafrenzy,
   mapUpdateToTubafrenzy,
 } from './http.mirror.js';
+import { isActiveRotationMatch } from './rotation-match.mirror.js';
 
 const FLOWSHEET_ENTRY_TABLE = 'FLOWSHEET_ENTRY_PROD';
 const RADIO_SHOW_TABLE = 'FLOWSHEET_RADIO_SHOW_PROD';
@@ -300,7 +301,8 @@ export const addEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entry) 
     }
   }
 
-  const body = mapEntryToTubafrenzy(entry, radioShowID);
+  const isRotationMatch = await isActiveRotationMatch(entry);
+  const body = mapEntryToTubafrenzy(entry, radioShowID, isRotationMatch);
   const tubafrenzyId = await mirrorCreateEntry(body);
   if (tubafrenzyId != null) {
     cacheEntryId(entry.play_order, tubafrenzyId);
@@ -330,7 +332,8 @@ export const updateEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entr
     return;
   }
 
-  const body = mapUpdateToTubafrenzy(entry);
+  const isRotationMatch = await isActiveRotationMatch(entry);
+  const body = mapUpdateToTubafrenzy(entry, isRotationMatch);
   await mirrorUpdateEntry(tubafrenzyId, body);
 });
 

--- a/apps/backend/middleware/legacy/http.mirror.ts
+++ b/apps/backend/middleware/legacy/http.mirror.ts
@@ -44,66 +44,89 @@ interface MirrorEntry {
 
 /**
  * Mirror operation taxonomy. Each operation declares:
+ *
  *   - `category`: `'http'` for outbound tubafrenzy calls (the 2026-06-05
  *     runbook is keyed on `category:http`); `'db'` for local DB queries
  *     in the helper layer.
+ *
  *   - `useFingerprint`: whether the Sentry event opts into an explicit
  *     `['mirror-failure', operation]` fingerprint. The pre-existing HTTP
- *     ops (`create_entry`, `update_entry`, `signoff_show`) DO NOT
- *     fingerprint — they group via Sentry's default message-based grouping
- *     to preserve their existing issue lineage (alert rules / muted-issue
- *     subscriptions / runbook links wired to historical IDs would silently
- *     stop firing if we forked the lineage). `rotation_lookup` is new in
- *     BS#1432, so it opts into an explicit fingerprint from the start.
+ *     ops DO NOT fingerprint — they group via Sentry's default
+ *     message-based grouping to preserve their existing issue lineage
+ *     (alert rules / muted-issue subscriptions / runbook links wired to
+ *     historical IDs would silently stop firing if we forked the
+ *     lineage). `rotation_lookup` is new in BS#1432, so it opts into an
+ *     explicit fingerprint from the start.
  *
- * Adding a new operation REQUIRES a new entry here — TypeScript will fail
- * the build via the `Record<MirrorOperation, ...>` exhaustiveness check.
- * This collapses the two parallel string-equality ternaries the prior
- * shape used (fingerprint + category) into a single registry that the
- * compiler keeps in sync.
+ *   - `useException`: whether `Error`-valued failures route through
+ *     `Sentry.captureException` (true) or stay on `captureMessage`
+ *     (false). The pre-existing HTTP ops MUST stay on captureMessage
+ *     even for catch-arm Errors: Sentry's default exception-grouping
+ *     algorithm keys by exception type + top stack frame, NOT by the
+ *     `Mirror: <op> failed` message string. Routing HTTP-op Errors
+ *     through captureException would silently fork their issue lineage
+ *     (round-3 review caught this). `rotation_lookup` opts into the
+ *     captureException lane because it's a new op with no historical
+ *     lineage to preserve, and its explicit fingerprint overrides
+ *     Sentry's default exception grouping anyway.
+ *
+ * Adding a new operation REQUIRES a new entry here — TypeScript's
+ * `satisfies Record<MirrorOperation, MirrorOperationMeta>` enforces
+ * exhaustiveness. `as const` then preserves literal types AND prevents
+ * accidental runtime mutation of the registry by downstream importers.
  */
 export type MirrorOperation = 'create_entry' | 'update_entry' | 'signoff_show' | 'rotation_lookup';
 
 interface MirrorOperationMeta {
   category: 'http' | 'db';
   useFingerprint: boolean;
+  useException: boolean;
 }
 
-export const MIRROR_OPERATION_META: Record<MirrorOperation, MirrorOperationMeta> = {
-  create_entry: { category: 'http', useFingerprint: false },
-  update_entry: { category: 'http', useFingerprint: false },
-  signoff_show: { category: 'http', useFingerprint: false },
-  rotation_lookup: { category: 'db', useFingerprint: true },
-};
+export const MIRROR_OPERATION_META = {
+  create_entry: { category: 'http', useFingerprint: false, useException: false },
+  update_entry: { category: 'http', useFingerprint: false, useException: false },
+  signoff_show: { category: 'http', useFingerprint: false, useException: false },
+  rotation_lookup: { category: 'db', useFingerprint: true, useException: true },
+} as const satisfies Record<MirrorOperation, MirrorOperationMeta>;
 
 /** Defensive cap for stack-trace strings sent to Sentry, mirroring the
  *  responseBody cap pattern. Long async stacks from drizzle + postgres-js
  *  wrappers can be many KB; Sentry's per-event payload limit is finite,
- *  and under sustained DB outage the helper emits one warning per entry
- *  add/update — preferring a truncated stack over dropped events. */
+ *  and under sustained outage we emit one event per entry add/update.
+ *  Only applied on the captureMessage path (where we manually surface the
+ *  stack via `extra.stack`). The captureException path relies on Sentry's
+ *  native exception lane, which has its own framing/truncation. */
 const STACK_TRACE_MAX_LENGTH = 4000;
 
 /**
- * Capture a mirror call failure to Sentry. Grouping behavior is governed
- * by the per-operation entry in `MIRROR_OPERATION_META`:
+ * Capture a mirror call failure to Sentry. Routing is governed by the
+ * per-operation entry in `MIRROR_OPERATION_META`:
  *
  *   - HTTP operations (`create_entry`, `update_entry`, `signoff_show`)
- *     use Sentry's default message-based grouping. Their existing issue
- *     identity (wired in by the 2026-06-05 tubafrenzy auth-config drift
- *     incident, which replaced silent console.error logs) is preserved.
+ *     always emit via `Sentry.captureMessage` regardless of whether the
+ *     failure is a status code (`!response.ok`) or a catch-arm Error
+ *     (network error, fetch reject). This preserves their historical
+ *     issue identity: Sentry's default message grouping keys on
+ *     `'Mirror: <op> failed'`, so all four failure-mode subsets (401,
+ *     5xx, ECONNREFUSED, timeout) roll into the same operation-keyed
+ *     issue. The on-call runbook (2026-06-05 tubafrenzy auth-config
+ *     drift) is wired to that issue lineage. Error stacks are surfaced
+ *     via `extra.stack` (sliced to `STACK_TRACE_MAX_LENGTH`) since
+ *     captureMessage doesn't auto-extract them.
  *
- *   - The DB operation (`rotation_lookup`) opts into an explicit
- *     fingerprint `['mirror-failure', 'rotation_lookup']` so it's grouped
- *     under a dedicated issue from the start (new in BS#1432).
+ *   - The DB operation (`rotation_lookup`) emits via
+ *     `Sentry.captureException` for Error-valued failures, with an
+ *     explicit fingerprint `['mirror-failure', 'rotation_lookup']` so
+ *     it's grouped under a dedicated issue from the start (new in
+ *     BS#1432). Sentry's native exception lane handles the stack —
+ *     matches the codebase pattern in enrichment-worker / auth /
+ *     provision-user. Non-Error failures (defensive — should be rare)
+ *     fall through to captureMessage with the same fingerprint.
  *
- * For Error instances we call `Sentry.captureException` instead of
- * `captureMessage` to use Sentry's native stack capture (matches the
- * codebase pattern in enrichment-worker / auth). For non-Error cases
- * (HTTP failures where only `status`/`responseBody` are present), we
- * fall back to `captureMessage` with the stringified status surfaced as
- * a tag. `status` is captured as a tag (filterable in search but not
- * part of the group hash) so a sustained outage rolls up into a single
- * issue with an occurrence count rather than fanning out per-row.
+ * `status` is captured as a tag (filterable in search but not part of
+ * the group hash) so a sustained outage rolls up into a single issue
+ * with an occurrence count rather than fanning out per-row.
  */
 export function captureMirrorFailure(
   operation: MirrorOperation,
@@ -123,16 +146,13 @@ export function captureMirrorFailure(
     ...(details.responseBody != null ? { responseBody: details.responseBody.slice(0, 500) } : {}),
   };
 
-  if (details.error instanceof Error) {
-    // captureException is the codebase convention for Error instances
-    // (enrichment-worker, auth/provision-user) — Sentry parses the stack
-    // into its native lane (source-map-aware, deduplicates by exception
-    // type+location), and we tag/extra/level/fingerprint the same way.
-    // We attach a truncated stack copy under extra as a belt-and-braces
-    // fallback in case Sentry's native stack lane gets dropped.
-    if (details.error.stack != null) {
-      extra.stack = details.error.stack.slice(0, STACK_TRACE_MAX_LENGTH);
-    }
+  // captureException path: only for ops that opt in (currently just
+  // rotation_lookup) AND only when the failure is a real Error. Sentry's
+  // native exception lane handles the stack; no manual `extra.stack`
+  // forwarding here (matches the convention in enrichment-worker / auth
+  // / provision-user / check-request-ban-handler — none of those sites
+  // duplicate err.stack into extra).
+  if (meta.useException && details.error instanceof Error) {
     Sentry.captureException(details.error, {
       level,
       ...(fingerprint != null ? { fingerprint } : {}),
@@ -142,11 +162,17 @@ export function captureMirrorFailure(
     return;
   }
 
-  // Non-Error case (HTTP failure with status/responseBody, or a thrown
-  // non-Error value). Fall back to captureMessage; surface the value via
-  // String() since there's no .stack to forward.
+  // captureMessage path: HTTP ops always (preserves message-grouped
+  // issue lineage even for catch-arm Errors), plus the defensive
+  // non-Error rotation_lookup case. Surface the error value as a
+  // stringified summary; for Error instances, also forward a truncated
+  // stack via extra so triagers don't lose it (captureMessage doesn't
+  // auto-extract stacks the way captureException does).
   if (details.error != null) {
     extra.error = String(details.error);
+    if (details.error instanceof Error && details.error.stack != null) {
+      extra.stack = details.error.stack.slice(0, STACK_TRACE_MAX_LENGTH);
+    }
   }
   Sentry.captureMessage(`Mirror: ${operation} failed`, {
     level,

--- a/apps/backend/middleware/legacy/http.mirror.ts
+++ b/apps/backend/middleware/legacy/http.mirror.ts
@@ -51,12 +51,14 @@ interface MirrorEntry {
  * 2026-06-05 tubafrenzy auth-config drift (missing `MIRROR_API_KEY` on the
  * tubafrenzy side) ran silent through a full DJ's show.
  */
-function captureMirrorFailure(
-  operation: 'create_entry' | 'update_entry' | 'signoff_show',
-  details: { status?: number; responseBody?: string; error?: unknown }
+export function captureMirrorFailure(
+  operation: 'create_entry' | 'update_entry' | 'signoff_show' | 'rotation_lookup',
+  details: { status?: number; responseBody?: string; error?: unknown },
+  level: 'error' | 'warning' = 'error'
 ): void {
   Sentry.captureMessage(`Mirror: ${operation} failed`, {
-    level: 'error',
+    level,
+    fingerprint: ['mirror-failure', operation],
     tags: {
       subsystem: 'legacy-mirror',
       operation,
@@ -141,7 +143,11 @@ export function clearEntryIdMap(): void {
  * When radioShowID is provided, it's included so tubafrenzy doesn't auto-resolve.
  * nowPlayingFlag is always 0 (dropped — nothing in tubafrenzy reads it).
  */
-export function mapEntryToTubafrenzy(entry: MirrorEntry, radioShowID?: number | null): Record<string, unknown> {
+export function mapEntryToTubafrenzy(
+  entry: MirrorEntry,
+  radioShowID?: number | null,
+  isRotationMatch = false
+): Record<string, unknown> {
   const startMs = entry.add_time ? new Date(entry.add_time).getTime() : Date.now();
   const radioHour = Math.floor(startMs / 3_600_000) * 3_600_000;
 
@@ -194,7 +200,7 @@ export function mapEntryToTubafrenzy(entry: MirrorEntry, radioShowID?: number | 
 
   // Track entries
   let flowsheetEntryType = 0;
-  if (entry.rotation_id && entry.rotation_id > 0) {
+  if ((entry.rotation_id && entry.rotation_id > 0) || isRotationMatch) {
     flowsheetEntryType = 2;
   } else if (entry.album_id && entry.album_id > 0) {
     flowsheetEntryType = 6;
@@ -220,9 +226,9 @@ export function mapEntryToTubafrenzy(entry: MirrorEntry, radioShowID?: number | 
  * Maps a Backend-Service FSEntry to the tubafrenzy PATCH JSON body.
  * Only includes fields that can be updated on an existing entry.
  */
-export function mapUpdateToTubafrenzy(entry: MirrorEntry): Record<string, unknown> {
+export function mapUpdateToTubafrenzy(entry: MirrorEntry, isRotationMatch = false): Record<string, unknown> {
   let flowsheetEntryType = 0;
-  if (entry.rotation_id && entry.rotation_id > 0) {
+  if ((entry.rotation_id && entry.rotation_id > 0) || isRotationMatch) {
     flowsheetEntryType = 2;
   } else if (entry.album_id && entry.album_id > 0) {
     flowsheetEntryType = 6;

--- a/apps/backend/middleware/legacy/http.mirror.ts
+++ b/apps/backend/middleware/legacy/http.mirror.ts
@@ -72,8 +72,12 @@ interface MirrorEntry {
  *
  * Adding a new operation REQUIRES a new entry here — TypeScript's
  * `satisfies Record<MirrorOperation, MirrorOperationMeta>` enforces
- * exhaustiveness. `as const` then preserves literal types AND prevents
- * accidental runtime mutation of the registry by downstream importers.
+ * exhaustiveness. `as const` preserves literal types so consumers see
+ * narrow `'http' | 'db'` and literal-`true`/`false` types instead of
+ * widened `string` / `boolean`. `Object.freeze` makes the registry
+ * actually immutable at runtime — `as const` is TypeScript-only, so
+ * without the freeze a downstream importer doing `(meta as any).x = y`
+ * could corrupt grouping for the lifetime of the process.
  */
 export type MirrorOperation = 'create_entry' | 'update_entry' | 'signoff_show' | 'rotation_lookup';
 
@@ -83,12 +87,12 @@ interface MirrorOperationMeta {
   useException: boolean;
 }
 
-export const MIRROR_OPERATION_META = {
-  create_entry: { category: 'http', useFingerprint: false, useException: false },
-  update_entry: { category: 'http', useFingerprint: false, useException: false },
-  signoff_show: { category: 'http', useFingerprint: false, useException: false },
-  rotation_lookup: { category: 'db', useFingerprint: true, useException: true },
-} as const satisfies Record<MirrorOperation, MirrorOperationMeta>;
+export const MIRROR_OPERATION_META = Object.freeze({
+  create_entry: Object.freeze({ category: 'http', useFingerprint: false, useException: false }),
+  update_entry: Object.freeze({ category: 'http', useFingerprint: false, useException: false }),
+  signoff_show: Object.freeze({ category: 'http', useFingerprint: false, useException: false }),
+  rotation_lookup: Object.freeze({ category: 'db', useFingerprint: true, useException: true }),
+} as const) satisfies Readonly<Record<MirrorOperation, Readonly<MirrorOperationMeta>>>;
 
 /** Defensive cap for stack-trace strings sent to Sentry, mirroring the
  *  responseBody cap pattern. Long async stacks from drizzle + postgres-js

--- a/apps/backend/middleware/legacy/http.mirror.ts
+++ b/apps/backend/middleware/legacy/http.mirror.ts
@@ -43,54 +43,116 @@ interface MirrorEntry {
 }
 
 /**
- * Capture a mirror call failure to Sentry. The three HTTP operations
- * (`create_entry`, `update_entry`, `signoff_show`) group via Sentry's default
- * message-based grouping — they each send a stable `Mirror: <op> failed`
- * message which keys their existing issues. `rotation_lookup` is the new
- * helper-side operation (a local DB `EXISTS` query, not an HTTP call) and
- * opts into an explicit `fingerprint: ['mirror-failure', 'rotation_lookup']`
- * so it's grouped under a dedicated issue from the start.
+ * Mirror operation taxonomy. Each operation declares:
+ *   - `category`: `'http'` for outbound tubafrenzy calls (the 2026-06-05
+ *     runbook is keyed on `category:http`); `'db'` for local DB queries
+ *     in the helper layer.
+ *   - `useFingerprint`: whether the Sentry event opts into an explicit
+ *     `['mirror-failure', operation]` fingerprint. The pre-existing HTTP
+ *     ops (`create_entry`, `update_entry`, `signoff_show`) DO NOT
+ *     fingerprint — they group via Sentry's default message-based grouping
+ *     to preserve their existing issue lineage (alert rules / muted-issue
+ *     subscriptions / runbook links wired to historical IDs would silently
+ *     stop firing if we forked the lineage). `rotation_lookup` is new in
+ *     BS#1432, so it opts into an explicit fingerprint from the start.
  *
- * Why not fingerprint the HTTP operations too: adding a fingerprint to a
- * captureMessage that previously had none forks the issue lineage in Sentry
- * — existing alert rules / muted-issue subscriptions / runbook links keyed
- * to the historical issue IDs would silently stop firing. The 2026-06-05
- * tubafrenzy auth-config drift incident wired the entry and signoff paths
- * into Sentry (replacing console.error) and that issue history is the
- * record the on-call runbook references; we preserve it by leaving the
- * HTTP operations on default grouping.
+ * Adding a new operation REQUIRES a new entry here — TypeScript will fail
+ * the build via the `Record<MirrorOperation, ...>` exhaustiveness check.
+ * This collapses the two parallel string-equality ternaries the prior
+ * shape used (fingerprint + category) into a single registry that the
+ * compiler keeps in sync.
+ */
+export type MirrorOperation = 'create_entry' | 'update_entry' | 'signoff_show' | 'rotation_lookup';
+
+interface MirrorOperationMeta {
+  category: 'http' | 'db';
+  useFingerprint: boolean;
+}
+
+export const MIRROR_OPERATION_META: Record<MirrorOperation, MirrorOperationMeta> = {
+  create_entry: { category: 'http', useFingerprint: false },
+  update_entry: { category: 'http', useFingerprint: false },
+  signoff_show: { category: 'http', useFingerprint: false },
+  rotation_lookup: { category: 'db', useFingerprint: true },
+};
+
+/** Defensive cap for stack-trace strings sent to Sentry, mirroring the
+ *  responseBody cap pattern. Long async stacks from drizzle + postgres-js
+ *  wrappers can be many KB; Sentry's per-event payload limit is finite,
+ *  and under sustained DB outage the helper emits one warning per entry
+ *  add/update — preferring a truncated stack over dropped events. */
+const STACK_TRACE_MAX_LENGTH = 4000;
+
+/**
+ * Capture a mirror call failure to Sentry. Grouping behavior is governed
+ * by the per-operation entry in `MIRROR_OPERATION_META`:
  *
- * `status` is captured as a tag (filterable in search but not part of the
- * group hash) so a sustained outage rolls up into a single issue with an
- * occurrence count rather than fanning out per-row.
+ *   - HTTP operations (`create_entry`, `update_entry`, `signoff_show`)
+ *     use Sentry's default message-based grouping. Their existing issue
+ *     identity (wired in by the 2026-06-05 tubafrenzy auth-config drift
+ *     incident, which replaced silent console.error logs) is preserved.
+ *
+ *   - The DB operation (`rotation_lookup`) opts into an explicit
+ *     fingerprint `['mirror-failure', 'rotation_lookup']` so it's grouped
+ *     under a dedicated issue from the start (new in BS#1432).
+ *
+ * For Error instances we call `Sentry.captureException` instead of
+ * `captureMessage` to use Sentry's native stack capture (matches the
+ * codebase pattern in enrichment-worker / auth). For non-Error cases
+ * (HTTP failures where only `status`/`responseBody` are present), we
+ * fall back to `captureMessage` with the stringified status surfaced as
+ * a tag. `status` is captured as a tag (filterable in search but not
+ * part of the group hash) so a sustained outage rolls up into a single
+ * issue with an occurrence count rather than fanning out per-row.
  */
 export function captureMirrorFailure(
-  operation: 'create_entry' | 'update_entry' | 'signoff_show' | 'rotation_lookup',
+  operation: MirrorOperation,
   details: { status?: number; responseBody?: string; error?: unknown },
   level: 'error' | 'warning' = 'error'
 ): void {
+  const meta = MIRROR_OPERATION_META[operation];
+  const fingerprint: string[] | undefined = meta.useFingerprint ? ['mirror-failure', operation] : undefined;
+  const tags: Record<string, string> = {
+    subsystem: 'legacy-mirror',
+    operation,
+    category: meta.category,
+    ...(details.status != null ? { status: String(details.status) } : {}),
+  };
+  const extra: Record<string, unknown> = {
+    ...(details.status != null ? { status: details.status } : {}),
+    ...(details.responseBody != null ? { responseBody: details.responseBody.slice(0, 500) } : {}),
+  };
+
+  if (details.error instanceof Error) {
+    // captureException is the codebase convention for Error instances
+    // (enrichment-worker, auth/provision-user) — Sentry parses the stack
+    // into its native lane (source-map-aware, deduplicates by exception
+    // type+location), and we tag/extra/level/fingerprint the same way.
+    // We attach a truncated stack copy under extra as a belt-and-braces
+    // fallback in case Sentry's native stack lane gets dropped.
+    if (details.error.stack != null) {
+      extra.stack = details.error.stack.slice(0, STACK_TRACE_MAX_LENGTH);
+    }
+    Sentry.captureException(details.error, {
+      level,
+      ...(fingerprint != null ? { fingerprint } : {}),
+      tags,
+      extra,
+    });
+    return;
+  }
+
+  // Non-Error case (HTTP failure with status/responseBody, or a thrown
+  // non-Error value). Fall back to captureMessage; surface the value via
+  // String() since there's no .stack to forward.
+  if (details.error != null) {
+    extra.error = String(details.error);
+  }
   Sentry.captureMessage(`Mirror: ${operation} failed`, {
     level,
-    // Explicit fingerprint ONLY for the new helper-side operation so
-    // pre-existing HTTP operations keep their default-grouping issue
-    // identity. See doc comment above.
-    ...(operation === 'rotation_lookup' ? { fingerprint: ['mirror-failure', 'rotation_lookup'] } : {}),
-    tags: {
-      subsystem: 'legacy-mirror',
-      operation,
-      // category disambiguates HTTP failures (mirror calls to tubafrenzy)
-      // from the local DB EXISTS query in `isActiveRotationMatch`. Triagers
-      // filtering on `category:http` see only outbound-mirror issues; the
-      // 2026-06-05 runbook is keyed on those.
-      category: operation === 'rotation_lookup' ? 'db' : 'http',
-      ...(details.status != null ? { status: String(details.status) } : {}),
-    },
-    extra: {
-      ...(details.status != null ? { status: details.status } : {}),
-      ...(details.responseBody != null ? { responseBody: details.responseBody.slice(0, 500) } : {}),
-      ...(details.error != null ? { error: String(details.error) } : {}),
-      ...(details.error instanceof Error && details.error.stack != null ? { stack: details.error.stack } : {}),
-    },
+    ...(fingerprint != null ? { fingerprint } : {}),
+    tags,
+    extra,
   });
 }
 
@@ -220,7 +282,20 @@ export function mapEntryToTubafrenzy(
     };
   }
 
-  // Track entries
+  // Track entries.
+  //
+  // Gate `entry.rotation_id && entry.rotation_id > 0` is intentionally
+  // looser than the helper's `entry.rotation_id != null` (BS#1432 round-2
+  // tightened the helper for read-path parity). End-to-end the two
+  // surfaces still agree: for `rotation_id = 0` the helper short-circuits
+  // (returns false), `isRotationMatch` is false, this branch falls through
+  // to the album_id check — yielding the same classification the read
+  // path would produce (FK join misses, IS-NULL-gated subquery doesn't
+  // fire, no badge). Schema FK to `rotation.id` (a serial starting at 1)
+  // makes `rotation_id = 0` theoretical drift in practice, but keeping
+  // this gate aligned with the schema-positive invariant rather than the
+  // helper's "any non-NULL = FK lane owns it" semantic preserves the
+  // explicit "real rotation FK" intent at the mapper layer.
   let flowsheetEntryType = 0;
   if ((entry.rotation_id && entry.rotation_id > 0) || isRotationMatch) {
     flowsheetEntryType = 2;

--- a/apps/backend/middleware/legacy/http.mirror.ts
+++ b/apps/backend/middleware/legacy/http.mirror.ts
@@ -43,13 +43,26 @@ interface MirrorEntry {
 }
 
 /**
- * Capture a mirror call failure to Sentry. Grouping is by `operation` (in
- * the message) and sub-tagged by `status` so a sustained outage rolls up
- * into a single issue with an occurrence count rather than fanning out
- * per-row. `mirrorCreateShow` had this since its 5-retry path; the entry
- * and signoff paths previously logged to console only, which is how the
- * 2026-06-05 tubafrenzy auth-config drift (missing `MIRROR_API_KEY` on the
- * tubafrenzy side) ran silent through a full DJ's show.
+ * Capture a mirror call failure to Sentry. The three HTTP operations
+ * (`create_entry`, `update_entry`, `signoff_show`) group via Sentry's default
+ * message-based grouping — they each send a stable `Mirror: <op> failed`
+ * message which keys their existing issues. `rotation_lookup` is the new
+ * helper-side operation (a local DB `EXISTS` query, not an HTTP call) and
+ * opts into an explicit `fingerprint: ['mirror-failure', 'rotation_lookup']`
+ * so it's grouped under a dedicated issue from the start.
+ *
+ * Why not fingerprint the HTTP operations too: adding a fingerprint to a
+ * captureMessage that previously had none forks the issue lineage in Sentry
+ * — existing alert rules / muted-issue subscriptions / runbook links keyed
+ * to the historical issue IDs would silently stop firing. The 2026-06-05
+ * tubafrenzy auth-config drift incident wired the entry and signoff paths
+ * into Sentry (replacing console.error) and that issue history is the
+ * record the on-call runbook references; we preserve it by leaving the
+ * HTTP operations on default grouping.
+ *
+ * `status` is captured as a tag (filterable in search but not part of the
+ * group hash) so a sustained outage rolls up into a single issue with an
+ * occurrence count rather than fanning out per-row.
  */
 export function captureMirrorFailure(
   operation: 'create_entry' | 'update_entry' | 'signoff_show' | 'rotation_lookup',
@@ -58,16 +71,25 @@ export function captureMirrorFailure(
 ): void {
   Sentry.captureMessage(`Mirror: ${operation} failed`, {
     level,
-    fingerprint: ['mirror-failure', operation],
+    // Explicit fingerprint ONLY for the new helper-side operation so
+    // pre-existing HTTP operations keep their default-grouping issue
+    // identity. See doc comment above.
+    ...(operation === 'rotation_lookup' ? { fingerprint: ['mirror-failure', 'rotation_lookup'] } : {}),
     tags: {
       subsystem: 'legacy-mirror',
       operation,
+      // category disambiguates HTTP failures (mirror calls to tubafrenzy)
+      // from the local DB EXISTS query in `isActiveRotationMatch`. Triagers
+      // filtering on `category:http` see only outbound-mirror issues; the
+      // 2026-06-05 runbook is keyed on those.
+      category: operation === 'rotation_lookup' ? 'db' : 'http',
       ...(details.status != null ? { status: String(details.status) } : {}),
     },
     extra: {
       ...(details.status != null ? { status: details.status } : {}),
       ...(details.responseBody != null ? { responseBody: details.responseBody.slice(0, 500) } : {}),
       ...(details.error != null ? { error: String(details.error) } : {}),
+      ...(details.error instanceof Error && details.error.stack != null ? { stack: details.error.stack } : {}),
     },
   });
 }

--- a/apps/backend/middleware/legacy/http.mirror.ts
+++ b/apps/backend/middleware/legacy/http.mirror.ts
@@ -74,10 +74,14 @@ interface MirrorEntry {
  * `satisfies Record<MirrorOperation, MirrorOperationMeta>` enforces
  * exhaustiveness. `as const` preserves literal types so consumers see
  * narrow `'http' | 'db'` and literal-`true`/`false` types instead of
- * widened `string` / `boolean`. `Object.freeze` makes the registry
- * actually immutable at runtime — `as const` is TypeScript-only, so
- * without the freeze a downstream importer doing `(meta as any).x = y`
- * could corrupt grouping for the lifetime of the process.
+ * widened `string` / `boolean`. `Object.freeze` (outer + per-entry,
+ * since freeze is shallow) makes the registry actually immutable at
+ * runtime: `as const` is TypeScript-only, so it catches only writes in
+ * typechecked code. The runtime freeze closes the TS-bypass paths —
+ * `(meta as any).x = y` casts, JS-from-TS imports, `Object.assign`
+ * targets, and anything else the compiler can't see. Both layers
+ * together prevent a downstream importer from silently corrupting
+ * grouping for the lifetime of the process.
  */
 export type MirrorOperation = 'create_entry' | 'update_entry' | 'signoff_show' | 'rotation_lookup';
 

--- a/apps/backend/middleware/legacy/rotation-match.mirror.ts
+++ b/apps/backend/middleware/legacy/rotation-match.mirror.ts
@@ -1,0 +1,84 @@
+/**
+ * Active-rotation fallback helper for the tubafrenzy mirror write path.
+ *
+ * When a DJ types an entry by hand instead of using the rotation picker,
+ * `flowsheet.rotation_id` stays NULL even when the (artist, album) matches
+ * an active rotation row. Without this helper the mirror sends
+ * `flowsheetEntryType=0`, tubafrenzy's `FlowsheetEntry.isRotation()` returns
+ * false, and the entry shows unbadged on wxyc.info.
+ *
+ * Three-cohort match mirrors BS#1362's read-path COALESCE subquery exactly so
+ * the two surfaces stay in sync. See apps/backend/services/flowsheet.service.ts
+ * FSEntryFieldsRaw.rotation_bin for the read-path reference implementation.
+ */
+
+import { db, rotation, library, artists } from '@wxyc/database';
+import { sql } from 'drizzle-orm';
+import { captureMirrorFailure } from './http.mirror.js';
+
+export interface RotationMatchEntry {
+  rotation_id?: number | null;
+  album_id?: number | null;
+  artist_name?: string | null;
+  album_title?: string | null;
+  add_time?: Date | string | number | null;
+}
+
+/**
+ * Returns true when the entry matches an active rotation row via any of three
+ * cohorts, mirroring the COALESCE fallback on the read path (BS#1362):
+ *   (a) `flowsheet.album_id = rotation.album_id` (library-linked rows)
+ *   (b) (artist_name, album_title) matches rotation's denormalized snapshot
+ *   (c) (artist_name, album_title) matches through library + artists join
+ *
+ * `kill_date` is compared against `add_time` so historical shows are
+ * classified using the rotation state at the time of the play, not now.
+ *
+ * Returns false immediately — without querying the DB — when:
+ *   - `rotation_id` is set (the primary FK path handles those entries)
+ *   - `artist_name` or `album_title` is empty (no cohort can fire meaningfully;
+ *     mirrors the `artist_name <> '' AND album_title <> ''` guard on the
+ *     read-path CASE WHEN)
+ *
+ * On DB error, captures to Sentry at `warning` level and returns false so the
+ * caller falls through to the existing album_id → type-6 branch.
+ */
+export async function isActiveRotationMatch(entry: RotationMatchEntry): Promise<boolean> {
+  if (entry.rotation_id != null && entry.rotation_id > 0) return false;
+
+  const artistName = (entry.artist_name ?? '').trim();
+  const albumTitle = (entry.album_title ?? '').trim();
+  if (artistName.length === 0 || albumTitle.length === 0) return false;
+
+  const addTime = entry.add_time ? new Date(entry.add_time as Date | string | number) : new Date();
+
+  try {
+    const albumIdCohort = entry.album_id != null ? sql`r2.album_id = ${entry.album_id}` : sql`false`;
+
+    const result = await db.execute(sql`
+      SELECT EXISTS(
+        SELECT 1
+        FROM ${rotation} r2
+        LEFT JOIN ${library} l2 ON l2.id = r2.album_id
+        LEFT JOIN ${artists} a2 ON a2.id = l2.artist_id
+        WHERE (r2.kill_date IS NULL OR r2.kill_date > ${addTime}::date)
+          AND (
+            ${albumIdCohort}
+            OR (
+              lower(trim(coalesce(r2.artist_name, ''))) = lower(trim(${artistName}))
+              AND lower(trim(coalesce(r2.album_title, ''))) = lower(trim(${albumTitle}))
+            )
+            OR (
+              lower(trim(coalesce(a2.artist_name, ''))) = lower(trim(${artistName}))
+              AND lower(trim(coalesce(l2.album_title, ''))) = lower(trim(${albumTitle}))
+            )
+          )
+      ) AS match
+    `);
+
+    return (result as unknown as Array<{ match: boolean }>)[0]?.match === true;
+  } catch (e) {
+    captureMirrorFailure('rotation_lookup', { error: e }, 'warning');
+    return false;
+  }
+}

--- a/apps/backend/middleware/legacy/rotation-match.mirror.ts
+++ b/apps/backend/middleware/legacy/rotation-match.mirror.ts
@@ -7,9 +7,26 @@
  * `flowsheetEntryType=0`, tubafrenzy's `FlowsheetEntry.isRotation()` returns
  * false, and the entry shows unbadged on wxyc.info.
  *
- * Three-cohort match mirrors BS#1362's read-path COALESCE subquery exactly so
- * the two surfaces stay in sync. See apps/backend/services/flowsheet.service.ts
+ * Three-cohort match mirrors BS#1362's read-path COALESCE subquery at the
+ * cohort level. See apps/backend/services/flowsheet.service.ts
  * FSEntryFieldsRaw.rotation_bin for the read-path reference implementation.
+ *
+ * Known shape differences from the read-path subquery (kept in sync at the
+ * cohort/predicate level, not literally):
+ *   - Aggregation: this helper wraps as `SELECT EXISTS(...)` (returns
+ *     boolean); read path uses `SELECT r2.rotation_bin ... ORDER BY r2.id
+ *     LIMIT 1` (returns the bin letter). The write path only needs a
+ *     boolean to decide flowsheetEntryType=2 vs fall-through, so no
+ *     tie-break is needed here.
+ *   - Gate: read-path's outer CASE uses `${flowsheet.rotation_id} IS NULL`;
+ *     this helper's JS guard matches via `entry.rotation_id == null` so
+ *     non-NULL values (including 0 and negatives, theoretical but
+ *     representable) skip the fallback — aligned with the read path.
+ *   - Empty-name guard: applied against the raw input value (no JS-side
+ *     trim) so the SQL `lower(trim(coalesce(col, '')))` on both sides
+ *     stays the single normalizer. JS `String.prototype.trim()` is broader
+ *     than PG's `trim()` (strips Unicode whitespace like NBSP); pre-
+ *     trimming on the JS side would fork the comparison key.
  */
 
 import { db, rotation, library, artists } from '@wxyc/database';
@@ -35,22 +52,42 @@ export interface RotationMatchEntry {
  * classified using the rotation state at the time of the play, not now.
  *
  * Returns false immediately — without querying the DB — when:
- *   - `rotation_id` is set (the primary FK path handles those entries)
- *   - `artist_name` or `album_title` is empty (no cohort can fire meaningfully;
- *     mirrors the `artist_name <> '' AND album_title <> ''` guard on the
- *     read-path CASE WHEN)
+ *   - `rotation_id` is non-NULL (matches the read-path `IS NULL` gate; the
+ *     primary FK path handles those entries)
+ *   - `artist_name` or `album_title` is missing or the empty string (no
+ *     cohort can fire meaningfully; mirrors the read-path's outer
+ *     `coalesce(col, '') <> ''` guard)
  *
- * On DB error, captures to Sentry at `warning` level and returns false so the
- * caller falls through to the existing album_id → type-6 branch.
+ * On DB error, captures to Sentry at `warning` level (with `category=db`
+ * via captureMirrorFailure) and returns false so the caller falls through
+ * to the existing album_id → type-6 branch.
  */
 export async function isActiveRotationMatch(entry: RotationMatchEntry): Promise<boolean> {
-  if (entry.rotation_id != null && entry.rotation_id > 0) return false;
+  // Read-path parity: gate on IS NULL only. A non-NULL rotation_id —
+  // including 0 or any negative drift — means the FK lane already owns
+  // this row; skip the fallback so the two surfaces classify it the same
+  // way. BS#1432 round-2 review tightened this from `> 0` to match the
+  // read-path subquery's `${flowsheet.rotation_id} IS NULL` semantic.
+  if (entry.rotation_id != null) return false;
 
-  const artistName = (entry.artist_name ?? '').trim();
-  const albumTitle = (entry.album_title ?? '').trim();
-  if (artistName.length === 0 || albumTitle.length === 0) return false;
+  // Outer empty-guard on the raw input, mirroring read-path's
+  // `coalesce(col, '') <> ''`. JS-side trim is deliberately NOT applied
+  // here: PG's `trim()` strips only ASCII space, but JS
+  // `String.prototype.trim()` also strips Unicode whitespace (NBSP
+  // U+00A0, U+2028, ...). Pre-trimming on the JS side would normalize one
+  // side of the comparison more aggressively than the SQL `lower(trim(
+  // coalesce(col, '')))` on the other, forking the match key on rotation
+  // rows bulk-loaded from CSV sources that occasionally carry a leading
+  // NBSP.
+  const artistName = entry.artist_name ?? '';
+  const albumTitle = entry.album_title ?? '';
+  if (artistName === '' || albumTitle === '') return false;
 
-  const addTime = entry.add_time ? new Date(entry.add_time as Date | string | number) : new Date();
+  // Use `!= null` (not a falsy check) so epoch 0 (1970-01-01) is treated
+  // as a real timestamp, not "no add_time". flowsheet.add_time is NOT
+  // NULL with a NOW() default in the schema, so the new-Date fallback is
+  // purely defensive against a caller that passes undefined.
+  const addTime = entry.add_time != null ? new Date(entry.add_time as Date | string | number) : new Date();
 
   try {
     const albumIdCohort = entry.album_id != null ? sql`r2.album_id = ${entry.album_id}` : sql`false`;
@@ -65,18 +102,23 @@ export async function isActiveRotationMatch(entry: RotationMatchEntry): Promise<
           AND (
             ${albumIdCohort}
             OR (
-              lower(trim(coalesce(r2.artist_name, ''))) = lower(trim(${artistName}))
-              AND lower(trim(coalesce(r2.album_title, ''))) = lower(trim(${albumTitle}))
+              lower(trim(coalesce(r2.artist_name, ''))) = lower(trim(coalesce(${artistName}, '')))
+              AND lower(trim(coalesce(r2.album_title, ''))) = lower(trim(coalesce(${albumTitle}, '')))
             )
             OR (
-              lower(trim(coalesce(a2.artist_name, ''))) = lower(trim(${artistName}))
-              AND lower(trim(coalesce(l2.album_title, ''))) = lower(trim(${albumTitle}))
+              lower(trim(coalesce(a2.artist_name, ''))) = lower(trim(coalesce(${artistName}, '')))
+              AND lower(trim(coalesce(l2.album_title, ''))) = lower(trim(coalesce(${albumTitle}, '')))
             )
           )
       ) AS match
     `);
 
-    return (result as unknown as Array<{ match: boolean }>)[0]?.match === true;
+    // `!!` (truthy coercion) instead of strict `=== true` so a future
+    // driver change that returns 't'/'f' strings, 1/0 numerics, or wraps
+    // rows in `{rows: [...]}` doesn't silently disable the fallback. The
+    // wrapped-object case still returns false (no badge) — same safe
+    // default as a "no match" result.
+    return !!(result as unknown as Array<{ match: unknown }>)[0]?.match;
   } catch (e) {
     captureMirrorFailure('rotation_lookup', { error: e }, 'warning');
     return false;

--- a/apps/backend/middleware/legacy/rotation-match.mirror.ts
+++ b/apps/backend/middleware/legacy/rotation-match.mirror.ts
@@ -92,6 +92,11 @@ export async function isActiveRotationMatch(entry: RotationMatchEntry): Promise<
   try {
     const albumIdCohort = entry.album_id != null ? sql`r2.album_id = ${entry.album_id}` : sql`false`;
 
+    // Cohort SQL is structurally identical to the read-path subquery's
+    // WHERE clause (flowsheet.service.ts:147-165). Bound values
+    // (artistName, albumTitle) are non-null JS strings post `?? ''` plus
+    // the empty-guard above, so no inner `coalesce(..., '')` is needed on
+    // the JS-bound side — matches the read path's column-ref shape exactly.
     const result = await db.execute(sql`
       SELECT EXISTS(
         SELECT 1
@@ -102,12 +107,12 @@ export async function isActiveRotationMatch(entry: RotationMatchEntry): Promise<
           AND (
             ${albumIdCohort}
             OR (
-              lower(trim(coalesce(r2.artist_name, ''))) = lower(trim(coalesce(${artistName}, '')))
-              AND lower(trim(coalesce(r2.album_title, ''))) = lower(trim(coalesce(${albumTitle}, '')))
+              lower(trim(coalesce(r2.artist_name, ''))) = lower(trim(${artistName}))
+              AND lower(trim(coalesce(r2.album_title, ''))) = lower(trim(${albumTitle}))
             )
             OR (
-              lower(trim(coalesce(a2.artist_name, ''))) = lower(trim(coalesce(${artistName}, '')))
-              AND lower(trim(coalesce(l2.album_title, ''))) = lower(trim(coalesce(${albumTitle}, '')))
+              lower(trim(coalesce(a2.artist_name, ''))) = lower(trim(${artistName}))
+              AND lower(trim(coalesce(l2.album_title, ''))) = lower(trim(${albumTitle}))
             )
           )
       ) AS match

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -32,6 +32,7 @@ import {
   mapShowToTubafrenzy,
   captureMirrorFailure,
   MIRROR_OPERATION_META,
+  type MirrorOperation,
 } from '../../../../apps/backend/middleware/legacy/http.mirror';
 
 beforeEach(() => {
@@ -902,15 +903,40 @@ describe('http.mirror', () => {
       }
     );
 
-    // BS#1432 round-5: defense-in-depth — verify the registry actually
+    // BS#1432 round-5/6: defense-in-depth — verify the registry actually
     // resists runtime mutation. `as const` is TypeScript-only; without
-    // `Object.freeze` an `(meta as any).x = y` write would corrupt
-    // grouping for the process lifetime. The freeze should make the
-    // assignment a silent no-op in non-strict mode and throw in strict.
-    it('MIRROR_OPERATION_META is frozen at runtime', () => {
+    // `Object.freeze` a downstream `(meta as any).x = y` write would
+    // corrupt grouping for the process lifetime. The backend runs under
+    // `alwaysStrict: true` (tsconfig.base.json) so every mutation
+    // attempt throws TypeError — there is no non-strict path here.
+    //
+    // Round-6 expanded coverage to:
+    //   (a) loop over EVERY entry (round-5 spot-checked only 2 of 4 —
+    //       a future regression dropping the inner freeze on one of the
+    //       unchecked entries would have slipped past).
+    //   (b) assert the behavioral contract (the comment-promised throw)
+    //       in addition to the `isFrozen` structural flag, so the test
+    //       fails loud if Object.freeze's runtime semantics ever change
+    //       or if a future refactor swaps it for a non-throwing
+    //       Readonly-by-convention shape.
+    it('MIRROR_OPERATION_META and every entry are deeply frozen at runtime', () => {
       expect(Object.isFrozen(MIRROR_OPERATION_META)).toBe(true);
-      expect(Object.isFrozen(MIRROR_OPERATION_META.rotation_lookup)).toBe(true);
-      expect(Object.isFrozen(MIRROR_OPERATION_META.create_entry)).toBe(true);
+      for (const op of Object.keys(MIRROR_OPERATION_META) as MirrorOperation[]) {
+        expect(Object.isFrozen(MIRROR_OPERATION_META[op])).toBe(true);
+      }
+    });
+
+    it('mutating a frozen entry throws TypeError under strict mode', () => {
+      // Verifies the behavioral promise of the freeze, not just the
+      // structural flag. Cast to `any` to bypass TS's readonly guard
+      // (that's the exact attack vector the round-5 freeze was added
+      // to defend against).
+      expect(() => {
+        (MIRROR_OPERATION_META.create_entry as { category: string }).category = 'db';
+      }).toThrow(TypeError);
+      expect(() => {
+        (MIRROR_OPERATION_META as { [k: string]: unknown }).new_op = {};
+      }).toThrow(TypeError);
     });
   });
 

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -673,19 +673,21 @@ describe('http.mirror', () => {
       );
     });
 
-    // Round-3 review: Error instances route through captureException so
-    // Sentry parses the stack into its native lane (matches the codebase
-    // pattern in enrichment-worker / auth). The level/tags/fingerprint
-    // flow through unchanged.
-    it('mirrorCreateEntry captures network error via captureException (Error instance path)', async () => {
+    // Round-4 review: HTTP ops MUST stay on captureMessage even for
+    // catch-arm Errors. Routing them through captureException would
+    // silently fork their message-grouped issue lineage (Sentry's
+    // exception grouping keys by exception type + top stack frame, not
+    // by the 'Mirror: <op> failed' message). The 2026-06-05 runbook is
+    // wired to the existing message-keyed issue. Stack is forwarded via
+    // extra.stack because captureMessage doesn't auto-extract it.
+    it('mirrorCreateEntry captures network error via captureMessage (preserves HTTP-op issue lineage)', async () => {
       const err = new Error('ECONNREFUSED');
       mockFetch.mockRejectedValue(err);
 
       await mirrorCreateEntry({ radioHour: 0 });
 
-      expect(mockCaptureException).toHaveBeenCalledTimes(1);
-      expect(mockCaptureException).toHaveBeenCalledWith(
-        err,
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        'Mirror: create_entry failed',
         expect.objectContaining({
           level: 'error',
           tags: expect.objectContaining({
@@ -693,15 +695,19 @@ describe('http.mirror', () => {
             operation: 'create_entry',
             category: 'http',
           }),
-          extra: expect.objectContaining({ stack: expect.any(String) }),
+          extra: expect.objectContaining({
+            error: expect.stringContaining('ECONNREFUSED'),
+            stack: expect.any(String),
+          }),
         })
       );
-      // captureMessage should NOT be called when the error is an Error.
-      expect(mockCaptureMessage).not.toHaveBeenCalled();
-      const call = mockCaptureException.mock.calls[0][1];
+      // HTTP-op Errors do NOT route through captureException — that would
+      // fork the historical message-grouped Sentry issue.
+      expect(mockCaptureException).not.toHaveBeenCalled();
+      const call = mockCaptureMessage.mock.calls[0][1];
       expect(call.tags).not.toHaveProperty('status');
       // HTTP ops never use a fingerprint — they group via Sentry's
-      // default message/exception grouping to preserve issue identity.
+      // default message grouping to preserve issue identity.
       expect(call).not.toHaveProperty('fingerprint');
     });
 
@@ -784,46 +790,58 @@ describe('http.mirror', () => {
       }
     });
 
-    it('stack is sliced to STACK_TRACE_MAX_LENGTH (4000 chars) for long stacks', async () => {
+    it('stack is sliced to STACK_TRACE_MAX_LENGTH (4000 chars) for long stacks on captureMessage path', async () => {
       const err = new Error('deep stack');
       err.stack = 'Error: deep stack\n' + 'x'.repeat(10_000);
       mockFetch.mockRejectedValue(err);
 
       await mirrorCreateEntry({ radioHour: 0 });
 
-      const call = mockCaptureException.mock.calls[0][1];
+      // HTTP-op Errors go to captureMessage with extra.stack; that's the
+      // path the slice cap protects (captureException relies on Sentry's
+      // native exception lane and doesn't need the manual slice).
+      const call = mockCaptureMessage.mock.calls[0][1];
       expect(call.extra.stack.length).toBe(4000);
     });
   });
 
-  // Round-3 review: dedicated suite for captureMirrorFailure's
-  // operation→meta contract. These tests cover the DB-category path
-  // (rotation_lookup) which the rotation-match unit tests can't reach
-  // because they mock captureMirrorFailure directly.
+  // Round-3/4 review: dedicated suite for captureMirrorFailure's
+  // operation→meta contract. These tests cover all four operations'
+  // routing decisions (captureException vs captureMessage), the
+  // category tag, the fingerprint shape, and the extra.error/extra.stack
+  // contract. The rotation-match unit tests can't reach this because
+  // they mock captureMirrorFailure directly.
   describe('captureMirrorFailure operation→meta contract', () => {
     it('MIRROR_OPERATION_META declares the four current operations with correct shape', () => {
       // Lock the registry shape so a future entry that drops a key or
       // sets an unexpected value fails the build (TS) and this test.
       expect(MIRROR_OPERATION_META).toEqual({
-        create_entry: { category: 'http', useFingerprint: false },
-        update_entry: { category: 'http', useFingerprint: false },
-        signoff_show: { category: 'http', useFingerprint: false },
-        rotation_lookup: { category: 'db', useFingerprint: true },
+        create_entry: { category: 'http', useFingerprint: false, useException: false },
+        update_entry: { category: 'http', useFingerprint: false, useException: false },
+        signoff_show: { category: 'http', useFingerprint: false, useException: false },
+        rotation_lookup: { category: 'db', useFingerprint: true, useException: true },
       });
     });
 
-    it('rotation_lookup gets category=db and the explicit fingerprint', () => {
+    it('rotation_lookup with Error routes through captureException (Sentry native stack)', () => {
       const err = new Error('select EXISTS failed');
       captureMirrorFailure('rotation_lookup', { error: err }, 'warning');
 
       expect(mockCaptureException).toHaveBeenCalledTimes(1);
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
       const [capturedErr, opts] = mockCaptureException.mock.calls[0];
       expect(capturedErr).toBe(err);
       expect(opts.level).toBe('warning');
       expect(opts.tags.category).toBe('db');
       expect(opts.tags.operation).toBe('rotation_lookup');
       expect(opts.fingerprint).toEqual(['mirror-failure', 'rotation_lookup']);
-      expect(opts.extra.stack).toEqual(expect.any(String));
+      // Sentry's native exception lane carries the stack — extra.stack
+      // is NOT duplicated on the captureException path (matches the
+      // codebase pattern in enrichment-worker / auth / provision-user).
+      expect(opts.extra).not.toHaveProperty('stack');
+      // extra.error is not set either — the Error is the first arg to
+      // captureException, so Sentry extracts the message natively.
+      expect(opts.extra).not.toHaveProperty('error');
     });
 
     it('non-Error rotation_lookup details fall through to captureMessage', () => {
@@ -836,9 +854,12 @@ describe('http.mirror', () => {
       expect(mockCaptureException).not.toHaveBeenCalled();
       expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
       const [, opts] = mockCaptureMessage.mock.calls[0];
+      expect(opts.level).toBe('warning'); // symmetric with Error sibling
       expect(opts.tags.category).toBe('db');
       expect(opts.fingerprint).toEqual(['mirror-failure', 'rotation_lookup']);
       expect(opts.extra.error).toBe('string-thrown-value');
+      // No stack on a non-Error.
+      expect(opts.extra).not.toHaveProperty('stack');
     });
 
     it('HTTP ops with only a status code (no error) use captureMessage and no fingerprint', () => {
@@ -849,7 +870,28 @@ describe('http.mirror', () => {
       const [msg, opts] = mockCaptureMessage.mock.calls[0];
       expect(msg).toBe('Mirror: create_entry failed');
       expect(opts.tags.category).toBe('http');
+      expect(opts.tags.status).toBe('500');
       expect(opts).not.toHaveProperty('fingerprint');
+      expect(opts.extra).not.toHaveProperty('error');
+      expect(opts.extra).not.toHaveProperty('stack');
+    });
+
+    it('HTTP ops with Error route through captureMessage too (preserves issue lineage)', () => {
+      // BS#1432 round-4 contract: HTTP ops never use captureException,
+      // even for catch-arm Errors, because Sentry's exception grouping
+      // would fork the message-grouped issue lineage the 2026-06-05
+      // runbook depends on. Stack is forwarded via extra.
+      const err = new Error('ETIMEDOUT');
+      captureMirrorFailure('update_entry', { error: err });
+
+      expect(mockCaptureException).not.toHaveBeenCalled();
+      expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
+      const [msg, opts] = mockCaptureMessage.mock.calls[0];
+      expect(msg).toBe('Mirror: update_entry failed');
+      expect(opts.tags.category).toBe('http');
+      expect(opts).not.toHaveProperty('fingerprint');
+      expect(opts.extra.error).toContain('ETIMEDOUT');
+      expect(opts.extra.stack).toEqual(expect.any(String));
     });
   });
 

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -223,6 +223,35 @@ describe('http.mirror', () => {
       expect(result.flowsheetEntryType).toBe(0);
     });
 
+    // BS#1432: isRotationMatch fallback for typed-in rotation plays
+    it('maps isRotationMatch=true with rotation_id=null to flowsheetEntryType 2', () => {
+      const result = mapEntryToTubafrenzy(baseTrack, undefined, true);
+      expect(result.flowsheetEntryType).toBe(2);
+    });
+
+    it('isRotationMatch=true takes priority over album_id-only (type 6)', () => {
+      const entry = { ...baseTrack, album_id: 123 };
+      const result = mapEntryToTubafrenzy(entry, undefined, true);
+      expect(result.flowsheetEntryType).toBe(2);
+    });
+
+    it('isRotationMatch=false with rotation_id=null and album_id set yields type 6', () => {
+      const entry = { ...baseTrack, album_id: 123 };
+      const result = mapEntryToTubafrenzy(entry, undefined, false);
+      expect(result.flowsheetEntryType).toBe(6);
+    });
+
+    it('isRotationMatch=false with rotation_id=null and no album_id yields type 0', () => {
+      const result = mapEntryToTubafrenzy(baseTrack, undefined, false);
+      expect(result.flowsheetEntryType).toBe(0);
+    });
+
+    it('rotation_id set still wins regardless of isRotationMatch value', () => {
+      const entry = { ...baseTrack, rotation_id: 456 };
+      const result = mapEntryToTubafrenzy(entry, undefined, false);
+      expect(result.flowsheetEntryType).toBe(2);
+    });
+
     it('maps request_flag true', () => {
       const entry = { ...baseTrack, request_flag: true };
       const result = mapEntryToTubafrenzy(entry);
@@ -471,6 +500,24 @@ describe('http.mirror', () => {
       const result = mapUpdateToTubafrenzy(entry);
       expect(result.flowsheetEntryType).toBe(2);
       expect(result.rotationReleaseID).toBe(456);
+    });
+
+    // BS#1432: isRotationMatch fallback for typed-in rotation plays
+    it('maps isRotationMatch=true with rotation_id=null to flowsheetEntryType 2', () => {
+      const result = mapUpdateToTubafrenzy(baseTrack, true);
+      expect(result.flowsheetEntryType).toBe(2);
+    });
+
+    it('isRotationMatch=true with album_id set yields type 2 (not 6)', () => {
+      const entry = { ...baseTrack, album_id: 123 };
+      const result = mapUpdateToTubafrenzy(entry, true);
+      expect(result.flowsheetEntryType).toBe(2);
+    });
+
+    it('isRotationMatch=false with album_id set yields type 6', () => {
+      const entry = { ...baseTrack, album_id: 123 };
+      const result = mapUpdateToTubafrenzy(entry, false);
+      expect(result.flowsheetEntryType).toBe(6);
     });
 
     it('does not include radioShowID or radioHour', () => {

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -10,7 +10,11 @@ const mockFetch = jest.fn();
 global.fetch = mockFetch as any;
 
 const mockCaptureMessage = jest.fn();
-jest.mock('@sentry/node', () => ({ captureMessage: (...args: unknown[]) => mockCaptureMessage(...args) }));
+const mockCaptureException = jest.fn();
+jest.mock('@sentry/node', () => ({
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
 
 import {
   mirrorCreateEntry,
@@ -26,11 +30,14 @@ import {
   getCachedShowId,
   clearShowIdMap,
   mapShowToTubafrenzy,
+  captureMirrorFailure,
+  MIRROR_OPERATION_META,
 } from '../../../../apps/backend/middleware/legacy/http.mirror';
 
 beforeEach(() => {
   mockFetch.mockReset();
   mockCaptureMessage.mockReset();
+  mockCaptureException.mockReset();
   clearEntryIdMap();
   clearShowIdMap();
 });
@@ -666,22 +673,36 @@ describe('http.mirror', () => {
       );
     });
 
-    it('mirrorCreateEntry captures network error without status tag', async () => {
+    // Round-3 review: Error instances route through captureException so
+    // Sentry parses the stack into its native lane (matches the codebase
+    // pattern in enrichment-worker / auth). The level/tags/fingerprint
+    // flow through unchanged.
+    it('mirrorCreateEntry captures network error via captureException (Error instance path)', async () => {
       const err = new Error('ECONNREFUSED');
       mockFetch.mockRejectedValue(err);
 
       await mirrorCreateEntry({ radioHour: 0 });
 
-      expect(mockCaptureMessage).toHaveBeenCalledWith(
-        'Mirror: create_entry failed',
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        err,
         expect.objectContaining({
           level: 'error',
-          tags: expect.objectContaining({ subsystem: 'legacy-mirror', operation: 'create_entry' }),
-          extra: expect.objectContaining({ error: expect.stringContaining('ECONNREFUSED') }),
+          tags: expect.objectContaining({
+            subsystem: 'legacy-mirror',
+            operation: 'create_entry',
+            category: 'http',
+          }),
+          extra: expect.objectContaining({ stack: expect.any(String) }),
         })
       );
-      const call = mockCaptureMessage.mock.calls[0][1];
+      // captureMessage should NOT be called when the error is an Error.
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
+      const call = mockCaptureException.mock.calls[0][1];
       expect(call.tags).not.toHaveProperty('status');
+      // HTTP ops never use a fingerprint — they group via Sentry's
+      // default message/exception grouping to preserve issue identity.
+      expect(call).not.toHaveProperty('fingerprint');
     });
 
     it('mirrorUpdateEntry captures HTTP error', async () => {
@@ -738,6 +759,97 @@ describe('http.mirror', () => {
       await mirrorCreateEntry({ radioHour: 0 });
 
       expect(mockCaptureMessage).not.toHaveBeenCalled();
+      expect(mockCaptureException).not.toHaveBeenCalled();
+    });
+
+    // Round-3 review: pin the operation→meta registry contract. The
+    // category tag and absence-of-fingerprint for HTTP ops are
+    // load-bearing for the 2026-06-05 runbook + issue-lineage promise
+    // in the captureMirrorFailure docstring.
+    it('HTTP ops are tagged with category=http and have no explicit fingerprint', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('boom'),
+      });
+
+      await mirrorCreateEntry({ radioHour: 0 });
+      await mirrorUpdateEntry(42, { songTitle: 'x' });
+      await mirrorSignoffShow(171500, 1773799200000);
+
+      expect(mockCaptureMessage).toHaveBeenCalledTimes(3);
+      for (const [, opts] of mockCaptureMessage.mock.calls) {
+        expect(opts.tags.category).toBe('http');
+        expect(opts).not.toHaveProperty('fingerprint');
+      }
+    });
+
+    it('stack is sliced to STACK_TRACE_MAX_LENGTH (4000 chars) for long stacks', async () => {
+      const err = new Error('deep stack');
+      err.stack = 'Error: deep stack\n' + 'x'.repeat(10_000);
+      mockFetch.mockRejectedValue(err);
+
+      await mirrorCreateEntry({ radioHour: 0 });
+
+      const call = mockCaptureException.mock.calls[0][1];
+      expect(call.extra.stack.length).toBe(4000);
+    });
+  });
+
+  // Round-3 review: dedicated suite for captureMirrorFailure's
+  // operation→meta contract. These tests cover the DB-category path
+  // (rotation_lookup) which the rotation-match unit tests can't reach
+  // because they mock captureMirrorFailure directly.
+  describe('captureMirrorFailure operation→meta contract', () => {
+    it('MIRROR_OPERATION_META declares the four current operations with correct shape', () => {
+      // Lock the registry shape so a future entry that drops a key or
+      // sets an unexpected value fails the build (TS) and this test.
+      expect(MIRROR_OPERATION_META).toEqual({
+        create_entry: { category: 'http', useFingerprint: false },
+        update_entry: { category: 'http', useFingerprint: false },
+        signoff_show: { category: 'http', useFingerprint: false },
+        rotation_lookup: { category: 'db', useFingerprint: true },
+      });
+    });
+
+    it('rotation_lookup gets category=db and the explicit fingerprint', () => {
+      const err = new Error('select EXISTS failed');
+      captureMirrorFailure('rotation_lookup', { error: err }, 'warning');
+
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+      const [capturedErr, opts] = mockCaptureException.mock.calls[0];
+      expect(capturedErr).toBe(err);
+      expect(opts.level).toBe('warning');
+      expect(opts.tags.category).toBe('db');
+      expect(opts.tags.operation).toBe('rotation_lookup');
+      expect(opts.fingerprint).toEqual(['mirror-failure', 'rotation_lookup']);
+      expect(opts.extra.stack).toEqual(expect.any(String));
+    });
+
+    it('non-Error rotation_lookup details fall through to captureMessage', () => {
+      // Defensive: should be rare (the helper only catches), but the
+      // captureMirrorFailure surface accepts non-Error errors. Pin the
+      // fallback so a future refactor that drops the captureMessage
+      // branch is loud.
+      captureMirrorFailure('rotation_lookup', { error: 'string-thrown-value' }, 'warning');
+
+      expect(mockCaptureException).not.toHaveBeenCalled();
+      expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
+      const [, opts] = mockCaptureMessage.mock.calls[0];
+      expect(opts.tags.category).toBe('db');
+      expect(opts.fingerprint).toEqual(['mirror-failure', 'rotation_lookup']);
+      expect(opts.extra.error).toBe('string-thrown-value');
+    });
+
+    it('HTTP ops with only a status code (no error) use captureMessage and no fingerprint', () => {
+      captureMirrorFailure('create_entry', { status: 500, responseBody: 'boom' });
+
+      expect(mockCaptureException).not.toHaveBeenCalled();
+      expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
+      const [msg, opts] = mockCaptureMessage.mock.calls[0];
+      expect(msg).toBe('Mirror: create_entry failed');
+      expect(opts.tags.category).toBe('http');
+      expect(opts).not.toHaveProperty('fingerprint');
     });
   });
 

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -903,12 +903,16 @@ describe('http.mirror', () => {
       }
     );
 
-    // BS#1432 round-5/6: defense-in-depth — verify the registry actually
+    // BS#1432 round-5/6/7: defense-in-depth — verify the registry actually
     // resists runtime mutation. `as const` is TypeScript-only; without
     // `Object.freeze` a downstream `(meta as any).x = y` write would
-    // corrupt grouping for the process lifetime. The backend runs under
-    // `alwaysStrict: true` (tsconfig.base.json) so every mutation
-    // attempt throws TypeError — there is no non-strict path here.
+    // corrupt grouping for the process lifetime. ES modules execute in
+    // strict mode by default (per the ECMAScript spec), so the
+    // production code (apps/backend/middleware/legacy/http.mirror.ts —
+    // `module: ESNext` in tsconfig.base.json) AND these tests (compiled
+    // by ts-jest under `module: ESNext` in tests/tsconfig.json) both
+    // run strict, and any mutation attempt on a frozen object throws
+    // TypeError.
     //
     // Round-6 expanded coverage to:
     //   (a) loop over EVERY entry (round-5 spot-checked only 2 of 4 —

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -876,22 +876,41 @@ describe('http.mirror', () => {
       expect(opts.extra).not.toHaveProperty('stack');
     });
 
-    it('HTTP ops with Error route through captureMessage too (preserves issue lineage)', () => {
-      // BS#1432 round-4 contract: HTTP ops never use captureException,
-      // even for catch-arm Errors, because Sentry's exception grouping
-      // would fork the message-grouped issue lineage the 2026-06-05
-      // runbook depends on. Stack is forwarded via extra.
-      const err = new Error('ETIMEDOUT');
-      captureMirrorFailure('update_entry', { error: err });
+    // BS#1432 round-4 contract: HTTP ops never use captureException,
+    // even for catch-arm Errors, because Sentry's exception grouping
+    // would fork the message-grouped issue lineage the 2026-06-05
+    // runbook depends on. Stack is forwarded via extra. Round-5:
+    // parameterized over all three HTTP ops so signoff_show's routing
+    // regression would also be caught (round-4 covered only update_entry).
+    it.each(['create_entry', 'update_entry', 'signoff_show'] as const)(
+      'HTTP op %s with Error routes through captureMessage (preserves issue lineage)',
+      (operation) => {
+        const err = new Error('ETIMEDOUT');
+        captureMirrorFailure(operation, { error: err });
 
-      expect(mockCaptureException).not.toHaveBeenCalled();
-      expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
-      const [msg, opts] = mockCaptureMessage.mock.calls[0];
-      expect(msg).toBe('Mirror: update_entry failed');
-      expect(opts.tags.category).toBe('http');
-      expect(opts).not.toHaveProperty('fingerprint');
-      expect(opts.extra.error).toContain('ETIMEDOUT');
-      expect(opts.extra.stack).toEqual(expect.any(String));
+        expect(mockCaptureException).not.toHaveBeenCalled();
+        expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
+        const [msg, opts] = mockCaptureMessage.mock.calls[0];
+        expect(msg).toBe(`Mirror: ${operation} failed`);
+        expect(opts.level).toBe('error'); // default level when caller omits it
+        expect(opts.tags.subsystem).toBe('legacy-mirror');
+        expect(opts.tags.operation).toBe(operation);
+        expect(opts.tags.category).toBe('http');
+        expect(opts).not.toHaveProperty('fingerprint');
+        expect(opts.extra.error).toContain('ETIMEDOUT');
+        expect(opts.extra.stack).toEqual(expect.any(String));
+      }
+    );
+
+    // BS#1432 round-5: defense-in-depth — verify the registry actually
+    // resists runtime mutation. `as const` is TypeScript-only; without
+    // `Object.freeze` an `(meta as any).x = y` write would corrupt
+    // grouping for the process lifetime. The freeze should make the
+    // assignment a silent no-op in non-strict mode and throw in strict.
+    it('MIRROR_OPERATION_META is frozen at runtime', () => {
+      expect(Object.isFrozen(MIRROR_OPERATION_META)).toBe(true);
+      expect(Object.isFrozen(MIRROR_OPERATION_META.rotation_lookup)).toBe(true);
+      expect(Object.isFrozen(MIRROR_OPERATION_META.create_entry)).toBe(true);
     });
   });
 

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -906,13 +906,12 @@ describe('http.mirror', () => {
     // BS#1432 round-5/6/7: defense-in-depth — verify the registry actually
     // resists runtime mutation. `as const` is TypeScript-only; without
     // `Object.freeze` a downstream `(meta as any).x = y` write would
-    // corrupt grouping for the process lifetime. ES modules execute in
-    // strict mode by default (per the ECMAScript spec), so the
-    // production code (apps/backend/middleware/legacy/http.mirror.ts —
-    // `module: ESNext` in tsconfig.base.json) AND these tests (compiled
-    // by ts-jest under `module: ESNext` in tests/tsconfig.json) both
-    // run strict, and any mutation attempt on a frozen object throws
-    // TypeError.
+    // corrupt grouping for the process lifetime. Both tsconfigs target
+    // ES modules (production: `module: NodeNext` in tsconfig.base.json;
+    // tests: `module: ESNext` in tests/tsconfig.json, threaded through
+    // ts-jest via jest.unit.config.ts), and ES modules execute in strict
+    // mode by default per the ECMAScript spec — so any mutation attempt
+    // on a frozen object throws TypeError in both runtimes.
     //
     // Round-6 expanded coverage to:
     //   (a) loop over EVERY entry (round-5 spot-checked only 2 of 4 —

--- a/tests/unit/middleware/legacy/http.mirror.test.ts
+++ b/tests/unit/middleware/legacy/http.mirror.test.ts
@@ -520,6 +520,14 @@ describe('http.mirror', () => {
       expect(result.flowsheetEntryType).toBe(6);
     });
 
+    // Symmetric with mapEntryToTubafrenzy's 'rotation_id set still wins regardless of isRotationMatch value' (BS#1432).
+    it('rotation_id set still wins regardless of isRotationMatch value', () => {
+      const entry = { ...baseTrack, rotation_id: 456 };
+      const result = mapUpdateToTubafrenzy(entry, false);
+      expect(result.flowsheetEntryType).toBe(2);
+      expect(result.rotationReleaseID).toBe(456);
+    });
+
     it('does not include radioShowID or radioHour', () => {
       const result = mapUpdateToTubafrenzy(baseTrack);
       expect(result).not.toHaveProperty('radioShowID');

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -81,6 +81,10 @@ jest.mock('@sentry/node', () => ({
   captureException: jest.fn(),
 }));
 
+jest.mock('../../../../apps/backend/middleware/legacy/rotation-match.mirror', () => ({
+  isActiveRotationMatch: jest.fn().mockResolvedValue(false),
+}));
+
 import { EventEmitter } from 'events';
 
 // Helper: create mock Express response that simulates the middleware lifecycle
@@ -210,7 +214,7 @@ describe('mirror loop prevention', () => {
 
       void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
         expect(mockCacheShowId).toHaveBeenCalledWith(100, 171500);
-        expect(mockMapEntryToTubafrenzy).toHaveBeenCalledWith(expect.anything(), 171500);
+        expect(mockMapEntryToTubafrenzy).toHaveBeenCalledWith(expect.anything(), 171500, false);
         done();
       });
     });
@@ -222,7 +226,7 @@ describe('mirror loop prevention', () => {
 
       void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
         expect(mockCacheShowId).not.toHaveBeenCalled();
-        expect(mockMapEntryToTubafrenzy).toHaveBeenCalledWith(expect.anything(), null);
+        expect(mockMapEntryToTubafrenzy).toHaveBeenCalledWith(expect.anything(), null, false);
         done();
       });
     });

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -150,9 +150,15 @@ describe('mirror loop prevention', () => {
     jest.clearAllMocks();
     mockGetCachedEntryId.mockReturnValue(undefined);
     mockSelectLimitResult = [];
-    // jest.clearAllMocks() resets the rotation-match mock's default
-    // resolution; re-stamp the "no match" default here so the per-test
-    // positive overrides via mockResolvedValueOnce(true) are deliberate.
+    // jest.clearAllMocks() only clears call history (mock.calls/results) —
+    // it does NOT clear the queued `mockResolvedValueOnce(true)` impls or
+    // the default `mockResolvedValue(false)` set at module-load. A queued
+    // Once that the test under it never consumed (e.g., because an
+    // earlier `expect` throw bypassed the helper call) would leak into
+    // the next test. Use `mockReset()` to clear both queue and impl, then
+    // re-stamp the module-load default so subsequent tests see "no match"
+    // unless they explicitly opt into a positive case via mockResolvedValueOnce.
+    mockIsActiveRotationMatch.mockReset();
     mockIsActiveRotationMatch.mockResolvedValue(false);
   });
 

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -81,8 +81,9 @@ jest.mock('@sentry/node', () => ({
   captureException: jest.fn(),
 }));
 
+const mockIsActiveRotationMatch = jest.fn().mockResolvedValue(false);
 jest.mock('../../../../apps/backend/middleware/legacy/rotation-match.mirror', () => ({
-  isActiveRotationMatch: jest.fn().mockResolvedValue(false),
+  isActiveRotationMatch: mockIsActiveRotationMatch,
 }));
 
 import { EventEmitter } from 'events';
@@ -149,6 +150,10 @@ describe('mirror loop prevention', () => {
     jest.clearAllMocks();
     mockGetCachedEntryId.mockReturnValue(undefined);
     mockSelectLimitResult = [];
+    // jest.clearAllMocks() resets the rotation-match mock's default
+    // resolution; re-stamp the "no match" default here so the per-test
+    // positive overrides via mockResolvedValueOnce(true) are deliberate.
+    mockIsActiveRotationMatch.mockResolvedValue(false);
   });
 
   const baseEntry = {
@@ -230,6 +235,25 @@ describe('mirror loop prevention', () => {
         done();
       });
     });
+
+    // BS#1432 round-2 review: pin the positive-flow propagation so a future
+    // refactor that drops the `await isActiveRotationMatch(entry)` call (or
+    // accidentally hard-codes the third arg to false) doesn't silently
+    // regress the typed-in-rotation-play badge.
+    it('propagates isRotationMatch=true to mapEntryToTubafrenzy when helper resolves true', (done) => {
+      mockMirrorCreateEntry.mockResolvedValue(99);
+      mockIsActiveRotationMatch.mockResolvedValueOnce(true);
+
+      void runMiddleware(flowsheetMirror.addEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
+        expect(mockIsActiveRotationMatch).toHaveBeenCalledWith(expect.objectContaining({ rotation_id: null }));
+        // The default `mockSelectLimitResult = []` (empty) makes the
+        // radioShowID lookup resolve to null in this test environment;
+        // matcher pins the third arg specifically while accepting the
+        // first two as the entry object and `null` radioShowID.
+        expect(mockMapEntryToTubafrenzy).toHaveBeenCalledWith(expect.any(Object), null, true);
+        done();
+      });
+    });
   });
 
   describe('updateEntry', () => {
@@ -246,8 +270,25 @@ describe('mirror loop prevention', () => {
       mockGetCachedEntryId.mockReturnValue(99);
 
       void runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
-        expect(mockMapUpdateToTubafrenzy).toHaveBeenCalled();
+        // Pin both args: BS#1432 added isRotationMatch as the second arg
+        // and the default-false flow must be visible at the call site so
+        // a regression that drops the helper call is loud.
+        expect(mockMapUpdateToTubafrenzy).toHaveBeenCalledWith(expect.anything(), false);
         expect(mockMirrorUpdateEntry).toHaveBeenCalledWith(99, expect.any(Object));
+        done();
+      });
+    });
+
+    // BS#1432 round-2 review: symmetric positive-case for updateEntry. Same
+    // rationale as the addEntry test above — guard against a refactor that
+    // silently disables the typed-in-rotation-play classification on update.
+    it('propagates isRotationMatch=true to mapUpdateToTubafrenzy when helper resolves true', (done) => {
+      mockGetCachedEntryId.mockReturnValue(99);
+      mockIsActiveRotationMatch.mockResolvedValueOnce(true);
+
+      void runMiddleware(flowsheetMirror.updateEntry, { ...baseEntry, legacy_entry_id: null }).then(() => {
+        expect(mockIsActiveRotationMatch).toHaveBeenCalledWith(expect.objectContaining({ rotation_id: null }));
+        expect(mockMapUpdateToTubafrenzy).toHaveBeenCalledWith(expect.anything(), true);
         done();
       });
     });

--- a/tests/unit/middleware/legacy/rotation-match.mirror.test.ts
+++ b/tests/unit/middleware/legacy/rotation-match.mirror.test.ts
@@ -5,11 +5,25 @@
  * active rotation row via any of the three cohorts, false on non-match, and
  * false (with Sentry warning) on DB error — so the caller falls through to
  * the existing album_id → type-6 branch rather than regressing to type-0.
+ *
+ * SQL parity reference: the cohort SQL inside the helper is a near-verbatim
+ * write-path counterpart of the read-path COALESCE subquery in
+ * `apps/backend/services/flowsheet.service.ts`'s `FSEntryFieldsRaw.rotation_bin`
+ * (BS#1362). That subquery has direct integration coverage in
+ * `tests/integration/flowsheet.spec.js:801+` ("rotation_bin read-path
+ * fallback (dj-site#750)") which seeds rotation rows and exercises all three
+ * cohorts (album_id, denorm snapshot, library+artists join) + kill_date
+ * filter + the negative no-match case against a real Postgres. The helper's
+ * WHERE clause is identical to that subquery's WHERE clause; if the read-
+ * path tests pass, the helper's SQL parses and the predicates select the
+ * same rows. The unit suite below covers the JS branch logic, the
+ * driver-shape contract, and the catch-path behavior that the read-path
+ * integration tests don't reach.
  */
 
-const mockCaptureMessage = jest.fn();
+const mockCaptureMirrorFailure = jest.fn();
 jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
-  captureMirrorFailure: mockCaptureMessage,
+  captureMirrorFailure: mockCaptureMirrorFailure,
 }));
 
 const mockDbExecute = jest.fn();
@@ -40,8 +54,27 @@ describe('isActiveRotationMatch', () => {
   };
 
   describe('early returns (no DB query)', () => {
-    it('returns false when rotation_id is set', async () => {
+    it('returns false when rotation_id is set (positive)', async () => {
       const entry = { ...baseEntry, rotation_id: 42 };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(false);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    // Read-path parity (BS#1432 round-2 review): the read path's
+    // `${flowsheet.rotation_id} IS NULL` gate treats any non-NULL value as
+    // "FK lane owns this row". Helper now matches that exactly via
+    // `rotation_id != null`, so 0 and negative drift values short-circuit
+    // here instead of running the DB lookup.
+    it('returns false when rotation_id is 0 (non-NULL means FK lane owns)', async () => {
+      const entry = { ...baseEntry, rotation_id: 0 };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(false);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns false when rotation_id is negative (non-NULL means FK lane owns)', async () => {
+      const entry = { ...baseEntry, rotation_id: -1 };
       const result = await isActiveRotationMatch(entry);
       expect(result).toBe(false);
       expect(mockDbExecute).not.toHaveBeenCalled();
@@ -49,13 +82,6 @@ describe('isActiveRotationMatch', () => {
 
     it('returns false when artist_name is empty', async () => {
       const entry = { ...baseEntry, artist_name: '' };
-      const result = await isActiveRotationMatch(entry);
-      expect(result).toBe(false);
-      expect(mockDbExecute).not.toHaveBeenCalled();
-    });
-
-    it('returns false when artist_name is whitespace only', async () => {
-      const entry = { ...baseEntry, artist_name: '   ' };
       const result = await isActiveRotationMatch(entry);
       expect(result).toBe(false);
       expect(mockDbExecute).not.toHaveBeenCalled();
@@ -80,6 +106,20 @@ describe('isActiveRotationMatch', () => {
       const result = await isActiveRotationMatch(entry);
       expect(result).toBe(false);
       expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    // Read-path parity (BS#1432 round-2 review): JS-side trim is NOT
+    // applied to the empty-guard because PG's `trim()` strips only ASCII
+    // space while JS's `String.prototype.trim()` also strips Unicode
+    // whitespace. Whitespace-only values now reach the DB (where the SQL
+    // `lower(trim(coalesce(col, '')))` normalizes both sides identically)
+    // instead of being short-circuited by JS-side `.trim().length === 0`.
+    it('does not short-circuit on JS-trimmable whitespace-only artist_name (reaches DB)', async () => {
+      mockDbExecute.mockResolvedValue([{ match: false }]);
+      const entry = { ...baseEntry, artist_name: '   ' };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(false);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -140,20 +180,20 @@ describe('isActiveRotationMatch', () => {
       const err = new Error('Connection refused');
       mockDbExecute.mockRejectedValue(err);
       await isActiveRotationMatch(baseEntry);
-      expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
-      expect(mockCaptureMessage).toHaveBeenCalledWith('rotation_lookup', { error: err }, 'warning');
+      expect(mockCaptureMirrorFailure).toHaveBeenCalledTimes(1);
+      expect(mockCaptureMirrorFailure).toHaveBeenCalledWith('rotation_lookup', { error: err }, 'warning');
     });
 
     it('does not call captureMirrorFailure on success', async () => {
       mockDbExecute.mockResolvedValue([{ match: true }]);
       await isActiveRotationMatch(baseEntry);
-      expect(mockCaptureMessage).not.toHaveBeenCalled();
+      expect(mockCaptureMirrorFailure).not.toHaveBeenCalled();
     });
 
     it('does not call captureMirrorFailure on no-match', async () => {
       mockDbExecute.mockResolvedValue([{ match: false }]);
       await isActiveRotationMatch(baseEntry);
-      expect(mockCaptureMessage).not.toHaveBeenCalled();
+      expect(mockCaptureMirrorFailure).not.toHaveBeenCalled();
     });
   });
 
@@ -180,13 +220,38 @@ describe('isActiveRotationMatch', () => {
       expect(result).toBe(true);
     });
 
-    it('returns false when rotation_id is 0 (not positive)', async () => {
-      mockDbExecute.mockResolvedValue([{ match: true }]);
-      const entry = { ...baseEntry, rotation_id: 0 };
-      const result = await isActiveRotationMatch(entry);
-      // rotation_id = 0 is falsy, so we fall through to the DB query
+    // Driver-shape-contract tests (BS#1432 round-2 review). The helper
+    // accesses `(result[0]?.match)` via `!!` coercion (rather than `=== true`)
+    // so a future postgres-js or drizzle-orm change that returns rows in a
+    // different shape doesn't silently disable the fallback. These tests pin
+    // the contract:
+    //   - bare-array `[{match: true}]` → true (current shape)
+    //   - bare-array `[{match: false}]` → false (current shape, negative)
+    //   - empty array → false (no rows)
+    //   - wrapped-object `{rows: [...]}` → false (safe default; caller's
+    //     responsibility to unwrap if a driver change lands)
+    //   - `match: 't'` → true (truthy string survives coercion)
+    //   - `match: null` → false
+    it('coerces truthy match value via !! (string "t" treated as true)', async () => {
+      mockDbExecute.mockResolvedValue([{ match: 't' }]);
+      const result = await isActiveRotationMatch(baseEntry);
       expect(result).toBe(true);
-      expect(mockDbExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('coerces falsy match value via !! (null treated as false)', async () => {
+      mockDbExecute.mockResolvedValue([{ match: null }]);
+      const result = await isActiveRotationMatch(baseEntry);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when driver wraps rows in {rows: [...]} (safe default; needs an unwrap when shape changes)', async () => {
+      mockDbExecute.mockResolvedValue({ rows: [{ match: true }] });
+      const result = await isActiveRotationMatch(baseEntry);
+      // Safe default: a future driver evolution that wraps rows MUST be
+      // accompanied by an unwrap layer at the helper, or the fallback
+      // silently regresses. This test locks that boundary so the
+      // regression is loud.
+      expect(result).toBe(false);
     });
   });
 });

--- a/tests/unit/middleware/legacy/rotation-match.mirror.test.ts
+++ b/tests/unit/middleware/legacy/rotation-match.mirror.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for the rotation-match mirror helper (BS#1432).
+ *
+ * Verifies that isActiveRotationMatch returns true when the entry matches an
+ * active rotation row via any of the three cohorts, false on non-match, and
+ * false (with Sentry warning) on DB error — so the caller falls through to
+ * the existing album_id → type-6 branch rather than regressing to type-0.
+ */
+
+const mockCaptureMessage = jest.fn();
+jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
+  captureMirrorFailure: mockCaptureMessage,
+}));
+
+const mockDbExecute = jest.fn();
+jest.mock('@wxyc/database', () => ({
+  db: { execute: mockDbExecute },
+  rotation: { id: 'rotation.id' },
+  library: { id: 'library.id' },
+  artists: { id: 'artists.id' },
+}));
+
+jest.mock('drizzle-orm', () => ({
+  sql: jest.fn((_strings: TemplateStringsArray, ..._values: unknown[]) => ({})),
+}));
+
+import { isActiveRotationMatch } from '../../../../apps/backend/middleware/legacy/rotation-match.mirror';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('isActiveRotationMatch', () => {
+  const baseEntry = {
+    rotation_id: null as number | null,
+    album_id: null as number | null,
+    artist_name: 'Juana Molina',
+    album_title: 'DOGA',
+    add_time: new Date('2024-06-14T22:00:00Z'),
+  };
+
+  describe('early returns (no DB query)', () => {
+    it('returns false when rotation_id is set', async () => {
+      const entry = { ...baseEntry, rotation_id: 42 };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(false);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns false when artist_name is empty', async () => {
+      const entry = { ...baseEntry, artist_name: '' };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(false);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns false when artist_name is whitespace only', async () => {
+      const entry = { ...baseEntry, artist_name: '   ' };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(false);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns false when album_title is empty', async () => {
+      const entry = { ...baseEntry, album_title: '' };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(false);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns false when artist_name is null', async () => {
+      const entry = { ...baseEntry, artist_name: null };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(false);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns false when album_title is null', async () => {
+      const entry = { ...baseEntry, album_title: null };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(false);
+      expect(mockDbExecute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cohort (b): name-match on rotation snapshot fields', () => {
+    it('returns true when DB finds a match', async () => {
+      mockDbExecute.mockResolvedValue([{ match: true }]);
+      const result = await isActiveRotationMatch(baseEntry);
+      expect(result).toBe(true);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false when DB finds no match', async () => {
+      mockDbExecute.mockResolvedValue([{ match: false }]);
+      const result = await isActiveRotationMatch(baseEntry);
+      expect(result).toBe(false);
+    });
+
+    it('returns false when DB returns empty array', async () => {
+      mockDbExecute.mockResolvedValue([]);
+      const result = await isActiveRotationMatch(baseEntry);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('cohort (a): album_id match', () => {
+    it('queries DB and returns true when match via album_id', async () => {
+      mockDbExecute.mockResolvedValue([{ match: true }]);
+      const entry = { ...baseEntry, album_id: 123 };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(true);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false when album_id present but no rotation match', async () => {
+      mockDbExecute.mockResolvedValue([{ match: false }]);
+      const entry = { ...baseEntry, album_id: 999 };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('cohort (c): name-match through library + artists join', () => {
+    it('queries DB and returns true when match via join', async () => {
+      mockDbExecute.mockResolvedValue([{ match: true }]);
+      const result = await isActiveRotationMatch(baseEntry);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('DB error handling', () => {
+    it('returns false on DB error', async () => {
+      mockDbExecute.mockRejectedValue(new Error('Connection refused'));
+      const result = await isActiveRotationMatch(baseEntry);
+      expect(result).toBe(false);
+    });
+
+    it('calls captureMirrorFailure at warning level on DB error', async () => {
+      const err = new Error('Connection refused');
+      mockDbExecute.mockRejectedValue(err);
+      await isActiveRotationMatch(baseEntry);
+      expect(mockCaptureMessage).toHaveBeenCalledTimes(1);
+      expect(mockCaptureMessage).toHaveBeenCalledWith('rotation_lookup', { error: err }, 'warning');
+    });
+
+    it('does not call captureMirrorFailure on success', async () => {
+      mockDbExecute.mockResolvedValue([{ match: true }]);
+      await isActiveRotationMatch(baseEntry);
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not call captureMirrorFailure on no-match', async () => {
+      mockDbExecute.mockResolvedValue([{ match: false }]);
+      await isActiveRotationMatch(baseEntry);
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles null add_time (uses current time)', async () => {
+      mockDbExecute.mockResolvedValue([{ match: true }]);
+      const entry = { ...baseEntry, add_time: null };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(true);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles numeric add_time (epoch ms)', async () => {
+      mockDbExecute.mockResolvedValue([{ match: true }]);
+      const entry = { ...baseEntry, add_time: new Date('2024-06-14T22:00:00Z').getTime() };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(true);
+    });
+
+    it('handles string add_time (ISO)', async () => {
+      mockDbExecute.mockResolvedValue([{ match: true }]);
+      const entry = { ...baseEntry, add_time: '2024-06-14T22:00:00Z' };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when rotation_id is 0 (not positive)', async () => {
+      mockDbExecute.mockResolvedValue([{ match: true }]);
+      const entry = { ...baseEntry, rotation_id: 0 };
+      const result = await isActiveRotationMatch(entry);
+      // rotation_id = 0 is falsy, so we fall through to the DB query
+      expect(result).toBe(true);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/middleware/legacy/rotation-match.mirror.test.ts
+++ b/tests/unit/middleware/legacy/rotation-match.mirror.test.ts
@@ -220,6 +220,22 @@ describe('isActiveRotationMatch', () => {
       expect(result).toBe(true);
     });
 
+    // Round-3 review: pins the helper's `!= null` add_time check (vs the
+    // round-1 falsy check that would have treated 0 as "no add_time"). With
+    // add_time=0 (epoch ms = 1970-01-01) the helper must hit the DB and
+    // pass the actual epoch into the kill_date filter — not silently fall
+    // back to `new Date()` ("now"). Schema makes add_time NOT NULL so this
+    // is theoretical in production, but pinning the contract prevents a
+    // future "simplify the null check to a falsy ternary" refactor from
+    // silently losing the 1970-01-01 timestamp.
+    it('handles add_time=0 epoch (1970-01-01) as a real timestamp, not "no add_time"', async () => {
+      mockDbExecute.mockResolvedValue([{ match: true }]);
+      const entry = { ...baseEntry, add_time: 0 };
+      const result = await isActiveRotationMatch(entry);
+      expect(result).toBe(true);
+      expect(mockDbExecute).toHaveBeenCalledTimes(1);
+    });
+
     // Driver-shape-contract tests (BS#1432 round-2 review). The helper
     // accesses `(result[0]?.match)` via `!!` coercion (rather than `=== true`)
     // so a future postgres-js or drizzle-orm change that returns rows in a


### PR DESCRIPTION
## Summary

- Adds `isActiveRotationMatch` helper (`rotation-match.mirror.ts`) that queries the `rotation` table via a three-cohort EXISTS subquery — the same logic as BS#1362's read-path `rotation_bin` COALESCE — and returns `true` when a typed-in entry matches an active rotation row via album_id FK (a), denormalized artist/album snapshot (b), or library+artists JOIN (c).
- `mapEntryToTubafrenzy` and `mapUpdateToTubafrenzy` gain an `isRotationMatch: boolean` param; branch chain becomes `rotation_id > 0 ⇒ 2` ▸ `isRotationMatch ⇒ 2` ▸ `album_id > 0 ⇒ 6` ▸ `0`.
- `addEntry` / `updateEntry` in `flowsheet.mirror.ts` call the helper before the mapper.
- `captureMirrorFailure` is exported, gains `rotation_lookup` in its operation union, an optional `level` param (defaults `'error'`; helper uses `'warning'`), and a `fingerprint` so the four operation modes dedupe in Sentry rather than fanning out per-row.
- 3265 unit tests pass (236 suites). New file `rotation-match.mirror.test.ts` covers all three cohorts, no-match, early-returns, DB-error fallthrough, and `add_time` type variants.

## Test plan

- [ ] All 3265 unit tests pass
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` no new errors
- [ ] `npm run format:check` clean
- [ ] E2E: start a show, type an entry whose (artist, album) is in the active rotation without using the picker. After mirroring, `curl wxyc.info/playlists/dailyEntries?dayStart=<epoch>` shows `"rotation":"true"` for that entry (see issue #1432 acceptance-criteria curl recipe).

Closes #1434. Analog to #1362 (read-path rotation_bin fallback).

## Related

- #1432 — spec issue (filed directly with implementation detail; this PR implements it)
- #1362 — read-path COALESCE that this mirrors on the write path