### PR TITLE
feat(1433): flowsheet-reenrichment one-shot drain

### DIFF
--- a/Dockerfile.flowsheet-reenrichment
+++ b/Dockerfile.flowsheet-reenrichment
@@ -1,0 +1,53 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+ARG NPM_TOKEN
+WORKDIR /flowsheet-reenrichment-builder
+
+COPY ./.npmrc ./
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./shared/lml-client ./shared/lml-client
+COPY ./shared/metadata ./shared/metadata
+COPY ./jobs/flowsheet-reenrichment ./jobs/flowsheet-reenrichment
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-client --workspace=@wxyc/metadata --workspace=@wxyc/flowsheet-reenrichment
+
+#Production stage
+FROM node:24-alpine AS prod
+
+ARG NPM_TOKEN
+WORKDIR /flowsheet-reenrichment
+
+COPY ./.npmrc ./
+COPY ./package* ./
+COPY ./jobs/flowsheet-reenrichment/package* ./jobs/flowsheet-reenrichment/
+COPY ./shared/database/package* ./shared/database/
+COPY ./shared/lml-client/package* ./shared/lml-client/
+COPY ./shared/metadata/package* ./shared/metadata/
+
+# `@wxyc/lml-client` declares `@wxyc/shared` as a registry dependency
+# (GitHub Packages, `@wxyc:registry` in `.npmrc`). Without NPM_TOKEN +
+# .npmrc the prod stage's npm install 401s on @wxyc/shared.
+RUN npm install --omit=dev && rm -f .npmrc
+
+COPY --from=builder ./flowsheet-reenrichment-builder/jobs/flowsheet-reenrichment/dist ./jobs/flowsheet-reenrichment/dist
+COPY --from=builder ./flowsheet-reenrichment-builder/shared/database/dist ./shared/database/dist
+COPY --from=builder ./flowsheet-reenrichment-builder/shared/lml-client/dist ./shared/lml-client/dist
+COPY --from=builder ./flowsheet-reenrichment-builder/shared/metadata/dist ./shared/metadata/dist
+
+# Long-running per-statement timeout: per-row UPDATEs over a large table
+# can spend tens of seconds on hot batches. The API's tight 5s default is
+# too aggressive here.
+ENV DB_STATEMENT_TIMEOUT_MS=300000
+
+# Async commit: WHERE idempotency guard (`metadata_status='enriched_no_match'
+# AND album_id IS NULL`) naturally handles any work lost to an RDS crash,
+# so the RPO trade-off is safe.
+ENV DB_SYNCHRONOUS_COMMIT=off
+
+# Identifies the connection in pg_stat_activity during triage.
+ENV DB_APPLICATION_NAME=wxyc-flowsheet-reenrichment
+
+CMD ["npm", "start", "--workspace=@wxyc/flowsheet-reenrichment"]

--- a/jobs/flowsheet-reenrichment/README.md
+++ b/jobs/flowsheet-reenrichment/README.md
@@ -7,6 +7,7 @@ One-shot re-enrichment drain for BS#1433. Rescues ~11,965 `flowsheet` rows writt
 Before LML#583, `(artist, album)` pairs not in the WXYC library returned `results: []` from LML, causing `metadata_status='enriched_no_match'` to be written. Those rows are terminal in the new enum — the CDC consumer never revisits them. With LML#583 live, the same pairs now return Discogs metadata; this job performs a single sweep to recover them.
 
 **Target cohort** (verified on prod 2026-06-16, 11,965 rows):
+
 ```sql
 SELECT COUNT(*) FROM wxyc_schema.flowsheet
 WHERE metadata_status = 'enriched_no_match'
@@ -19,10 +20,12 @@ WHERE metadata_status = 'enriched_no_match'
 1. **LML#583 deployed**: PR #584 merged 2026-06-16T17:53:53Z; Railway auto-deploys on main push. Verify at Railway dashboard.
 
 2. **Sibling cron is stopped**: Both jobs share the `BACKFILL_LML_*` token bucket and LML's 50/min global ceiling. Concurrent runs trip the BS#994 outage pattern.
+
    ```bash
    docker ps -a --filter name=flowsheet-metadata-backfill-cron --format '{{.Status}}'
    # Must show: Exited (1)
    ```
+
    If not exited, coordinate with #1011's resume sequence before launching.
 
 3. **Run the pre-launch diagnostic** to understand the cohort partition:
@@ -68,6 +71,7 @@ Monitor real-time LML p95 via Sentry trace explorer; stay within +20% of baselin
 ## Post-run
 
 Source the flip count from the `finished` log line's `flipped` field:
+
 ```bash
 docker logs <container> 2>&1 | jq -r 'select(.step=="finished") | "flipped=\(.flipped) still_no_match=\(.still_no_match) lml_error=\(.lml_error)"'
 ```
@@ -78,14 +82,14 @@ Then spot-check 20 sample rows that flipped — verify `discogs_url`, `artwork_u
 
 ## Environment variables
 
-| Variable | Default | Notes |
-|---|---|---|
-| `BACKFILL_CUTOFF_TS` | (required) | LML#583 merge timestamp: `2026-06-16T17:53:53Z` |
-| `LIBRARY_METADATA_URL` | (required) | LML endpoint |
-| `BACKFILL_BATCH_SIZE` | 100 | Rows per SELECT |
-| `BACKFILL_LML_MAX_CONCURRENT` | 1 | Semaphore permit count |
-| `BACKFILL_LML_RATE_PER_MIN` | 20 | Token bucket rate |
-| `BACKFILL_LML_PER_CALL_TIMEOUT_MS` | 35000 | Per-LML-call timeout (ms) |
-| `LIVE_ACTIVITY_LOOKBACK_SECONDS` | 60 | Set 0 to disable cooperative pause |
-| `LIVE_ACTIVITY_PAUSE_MS` | 30000 | Pause duration when DJ activity detected |
-| `SENTRY_DSN` | (optional) | Sentry error reporting |
+| Variable                           | Default    | Notes                                           |
+| ---------------------------------- | ---------- | ----------------------------------------------- |
+| `BACKFILL_CUTOFF_TS`               | (required) | LML#583 merge timestamp: `2026-06-16T17:53:53Z` |
+| `LIBRARY_METADATA_URL`             | (required) | LML endpoint                                    |
+| `BACKFILL_BATCH_SIZE`              | 100        | Rows per SELECT                                 |
+| `BACKFILL_LML_MAX_CONCURRENT`      | 1          | Semaphore permit count                          |
+| `BACKFILL_LML_RATE_PER_MIN`        | 20         | Token bucket rate                               |
+| `BACKFILL_LML_PER_CALL_TIMEOUT_MS` | 35000      | Per-LML-call timeout (ms)                       |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`   | 60         | Set 0 to disable cooperative pause              |
+| `LIVE_ACTIVITY_PAUSE_MS`           | 30000      | Pause duration when DJ activity detected        |
+| `SENTRY_DSN`                       | (optional) | Sentry error reporting                          |

--- a/jobs/flowsheet-reenrichment/README.md
+++ b/jobs/flowsheet-reenrichment/README.md
@@ -61,13 +61,22 @@ WHERE metadata_status = 'enriched_no_match'
 gh workflow run deploy-manual.yml --ref main \
   -f target=flowsheet-reenrichment -f version=latest
 
-# 2. SSH to EC2 and run. `--name` is load-bearing — the kill-switch below
-# greps it; without it docker assigns a random name and `docker stop` fails.
+# 2. SSH to EC2 and run. Tee logs to a file BEFORE relying on `docker
+# logs` for the post-run summary — `--rm` auto-removes the container on
+# exit, after which `docker logs flowsheet-reenrichment` returns "No
+# such container" and the structured `finished`/`stopped` summary is
+# unrecoverable. The tee'd file persists across container teardown.
+#
+# `--name` is load-bearing for the kill-switch below; without it docker
+# assigns a random name and `docker stop flowsheet-reenrichment` fails.
 ssh wxyc-ec2
 docker run --rm --name flowsheet-reenrichment --env-file .env \
   -e BACKFILL_CUTOFF_TS='2026-06-16T17:53:53Z' \
-  <ECR-URI>/flowsheet-reenrichment:<tag>
+  <ECR-URI>/flowsheet-reenrichment:<tag> 2>&1 \
+  | tee /tmp/flowsheet-reenrichment-$(date +%Y%m%d-%H%M%S).log
 ```
+
+> **Note on env-var read timing**: `lml-fetch.ts` reads `BACKFILL_LML_PER_CALL_TIMEOUT_MS` and `lml-limiter.ts` reads `BACKFILL_LML_MAX_CONCURRENT` / `BACKFILL_LML_RATE_PER_MIN` at module-load time. The `--env-file .env` pattern above passes env vars to the container's PID 1 (Node) so they're visible before any module loads. Do NOT export env vars from inside the container after start — they'll be silently ignored.
 
 ## Pacing & wall-clock estimate
 
@@ -90,15 +99,16 @@ Monitor real-time LML p95 via Sentry trace explorer; stay within +20% of baselin
 
 ## Post-run
 
-1. **Source the flip count** from the `finished` (or `stopped`) log line. The `fromjson?` trick makes jq tolerant of any non-JSON lines (the `console.warn` env-validation lines from lml-fetch / lml-limiter would otherwise crash a raw jq invocation):
+1. **Source the flip count** from the `finished` / `stopped` / `failed` summary log line. `-R` (raw input) is required for `fromjson?` to skip non-JSON lines safely — the `console.warn` env-validation lines from lml-fetch / lml-limiter would otherwise crash a default-mode jq invocation:
 
    ```bash
-   docker logs flowsheet-reenrichment 2>&1 | \
-     jq -r 'fromjson? | select(.step=="finished" or .step=="stopped") |
+   # Read from the tee'd file (preferred — survives --rm container removal)
+   cat /tmp/flowsheet-reenrichment-*.log | \
+     jq -rR 'fromjson? | select(.step=="finished" or .step=="stopped" or .step=="failed") |
        "step=\(.step) scanned=\(.scanned) flipped=\(.flipped) match_raced=\(.match_raced) still_no_match=\(.still_no_match) lml_error=\(.lml_error) db_error=\(.db_error) last_id=\(.last_id)"'
    ```
 
-   If `step=stopped`, the run did NOT complete the cohort — re-run it to drain the remainder (the WHERE filter is idempotent against rows the run already flipped). Document the totals from the final completed run as a comment on BS#1433.
+   If `step=stopped` or `step=failed`, the run did NOT complete the cohort. Re-run it to drain the remainder (the WHERE filter is idempotent against rows the run already flipped); the `last_id` field from the partial run is the resume cursor (the next run's first SELECT will skip everything `id ≤ last_id`). Document the totals from the final completed run as a comment on BS#1433.
 
 2. **Linkage-race audit**: a parallel linkage resolver can flip `album_id` non-null between the orchestrator's SELECT and `reenrichRow`'s UPDATE, which the WHERE guard then skips (counted as `match_raced`). The audit SQL below catches every such orphan — a row with `album_id` non-null AND `metadata_status='enriched_no_match'` AND `artist_name IS NOT NULL` AND `add_time < cutoff`. Without rescue, no automated path revisits these rows; the run also emits one `match_raced_summary` log line with a bounded sample of IDs to cross-reference.
 

--- a/jobs/flowsheet-reenrichment/README.md
+++ b/jobs/flowsheet-reenrichment/README.md
@@ -77,38 +77,57 @@ docker run --rm --name flowsheet-reenrichment --env-file .env \
 ## Kill-switch
 
 ```bash
-docker stop flowsheet-reenrichment
+# -t 600 gives the container up to 10 minutes to drain its in-flight row,
+# emit the structured `stopped` log line, flush Sentry, and close the DB
+# pool. Docker's default 10s grace will SIGKILL before any of that runs;
+# the bare `docker stop` form is intentionally not the documented path.
+docker stop -t 600 flowsheet-reenrichment
 ```
 
-The container's SIGTERM handler flips a cooperative-stop flag; the run finishes its in-flight row, emits a `stop_requested` log line, and exits cleanly so Sentry flushes and the DB pool closes. Monitor real-time LML p95 via Sentry trace explorer; stay within +20% of baseline per the BS#994 acceptance criterion.
+The container's SIGTERM handler flips a cooperative-stop flag; the orchestrator checks the flag between rows (not just between batches), so a single in-flight LML lookup is the longest wait. A `step: "stopped"` log line is emitted on graceful break — the runbook's `finished`-step jq filter (below) will correctly skip a stopped run. A second SIGTERM falls through to Node's default handler (force-exit) — intentional escape hatch if an LML call hangs past `BACKFILL_LML_PER_CALL_TIMEOUT_MS`.
+
+Monitor real-time LML p95 via Sentry trace explorer; stay within +20% of baseline per the BS#994 acceptance criterion.
 
 ## Post-run
 
-1. **Source the flip count** from the `finished` log line:
+1. **Source the flip count** from the `finished` (or `stopped`) log line. The `fromjson?` trick makes jq tolerant of any non-JSON lines (the `console.warn` env-validation lines from lml-fetch / lml-limiter would otherwise crash a raw jq invocation):
 
    ```bash
    docker logs flowsheet-reenrichment 2>&1 | \
-     jq -r 'select(.step=="finished") |
-       "scanned=\(.scanned) flipped=\(.flipped) match_raced=\(.match_raced) still_no_match=\(.still_no_match) lml_error=\(.lml_error) db_error=\(.db_error)"'
+     jq -r 'fromjson? | select(.step=="finished" or .step=="stopped") |
+       "step=\(.step) scanned=\(.scanned) flipped=\(.flipped) match_raced=\(.match_raced) still_no_match=\(.still_no_match) lml_error=\(.lml_error) db_error=\(.db_error) last_id=\(.last_id)"'
    ```
 
-   Document these as a comment on BS#1433.
+   If `step=stopped`, the run did NOT complete the cohort — re-run it to drain the remainder (the WHERE filter is idempotent against rows the run already flipped). Document the totals from the final completed run as a comment on BS#1433.
 
-2. **Linkage-race audit**: a parallel linkage resolver can flip `album_id` non-null between the orchestrator's SELECT and `reenrichRow`'s UPDATE, which the WHERE guard then skips (counted as `match_raced`). Most `match_raced` rows are benign (another writer flipped the status), but the rare orphan case leaves a row with `album_id` non-null AND `metadata_status='enriched_no_match'` — no automated path revisits these. Catch them with:
+2. **Linkage-race audit**: a parallel linkage resolver can flip `album_id` non-null between the orchestrator's SELECT and `reenrichRow`'s UPDATE, which the WHERE guard then skips (counted as `match_raced`). The audit SQL below catches every such orphan — a row with `album_id` non-null AND `metadata_status='enriched_no_match'` AND `artist_name IS NOT NULL` AND `add_time < cutoff`. Without rescue, no automated path revisits these rows; the run also emits one `match_raced_summary` log line with a bounded sample of IDs to cross-reference.
 
    ```sql
+   -- Audit: identify orphans. WHERE must match the drain's WHERE
+   -- (artist_name IS NOT NULL) plus album_id IS NOT NULL (the race outcome).
    SELECT id, album_id, artist_name, album_title, add_time
    FROM wxyc_schema.flowsheet
    WHERE metadata_status = 'enriched_no_match'
      AND album_id IS NOT NULL
+     AND artist_name IS NOT NULL
      AND add_time < '2026-06-16T17:53:53Z'::timestamptz;
    ```
 
-   For each orphan row, manually trigger re-enrichment (e.g. via the CDC consumer by setting `metadata_status='pending'`) or open a follow-up ticket if the count is non-trivial. Cross-reference the `possible_linkage_race` log lines from the run (each `match_raced` row id is emitted as a structured warning).
+   **Rescue** (only if the audit returns rows): re-arm them for the nightly backfill cron (`flowsheet-metadata-backfill`), which filters on `metadata_attempt_at IS NULL` and will re-call LML. Setting `metadata_status='pending'` alone is NOT sufficient — the CDC consumer fires only on INSERT, and the backfill cron's WHERE keys on `metadata_attempt_at`. Clear BOTH:
+
+   ```sql
+   UPDATE wxyc_schema.flowsheet
+      SET metadata_status = 'pending',
+          metadata_attempt_at = NULL
+    WHERE id = ANY(ARRAY[<audit_ids>]);  -- explicit ID list, not a re-SELECT
+   ```
+
+   Do NOT use `WHERE metadata_status='enriched_no_match' AND album_id IS NOT NULL` — that would race a concurrent linkage flip and re-arm rows still being processed. Use the explicit ID list from the audit's output.
 
 3. **Spot-check 20 sample rows that flipped** — verify `discogs_url`, `artwork_url`, `release_year` populated and correct against the live Discogs release.
 
 4. **Drop the one-shot index** once the audit is complete:
+
    ```sql
    DROP INDEX CONCURRENTLY IF EXISTS wxyc_schema.flowsheet_reenrichment_idx;
    ```

--- a/jobs/flowsheet-reenrichment/README.md
+++ b/jobs/flowsheet-reenrichment/README.md
@@ -1,0 +1,91 @@
+# flowsheet-reenrichment
+
+One-shot re-enrichment drain for BS#1433. Rescues ~11,965 `flowsheet` rows written as `enriched_no_match` before LML#583 (merged 2026-06-16T17:53:53Z) closed the library-miss recall gap.
+
+## Problem
+
+Before LML#583, `(artist, album)` pairs not in the WXYC library returned `results: []` from LML, causing `metadata_status='enriched_no_match'` to be written. Those rows are terminal in the new enum — the CDC consumer never revisits them. With LML#583 live, the same pairs now return Discogs metadata; this job performs a single sweep to recover them.
+
+**Target cohort** (verified on prod 2026-06-16, 11,965 rows):
+```sql
+SELECT COUNT(*) FROM wxyc_schema.flowsheet
+WHERE metadata_status = 'enriched_no_match'
+  AND album_id IS NULL
+  AND artist_name IS NOT NULL;
+```
+
+## Pre-flight checklist
+
+1. **LML#583 deployed**: PR #584 merged 2026-06-16T17:53:53Z; Railway auto-deploys on main push. Verify at Railway dashboard.
+
+2. **Sibling cron is stopped**: Both jobs share the `BACKFILL_LML_*` token bucket and LML's 50/min global ceiling. Concurrent runs trip the BS#994 outage pattern.
+   ```bash
+   docker ps -a --filter name=flowsheet-metadata-backfill-cron --format '{{.Status}}'
+   # Must show: Exited (1)
+   ```
+   If not exited, coordinate with #1011's resume sequence before launching.
+
+3. **Run the pre-launch diagnostic** to understand the cohort partition:
+   ```sql
+   SELECT
+     CASE WHEN metadata_attempt_at IS NULL THEN 'null' ELSE 'populated' END AS bucket,
+     COUNT(*),
+     MIN(add_time) AS earliest_add_time,
+     MAX(add_time) AS latest_add_time
+   FROM wxyc_schema.flowsheet
+   WHERE metadata_status = 'enriched_no_match'
+     AND album_id IS NULL AND artist_name IS NOT NULL
+   GROUP BY 1;
+   ```
+
+## Run procedure
+
+```bash
+# 1. Build & push image
+gh workflow run deploy-manual.yml --ref main \
+  -f target=flowsheet-reenrichment -f version=latest
+
+# 2. SSH to EC2 and run
+ssh wxyc-ec2
+docker run --rm --env-file .env \
+  -e BACKFILL_CUTOFF_TS='2026-06-16T17:53:53Z' \
+  <ECR-URI>/flowsheet-reenrichment:<tag>
+```
+
+## Pacing & wall-clock estimate
+
+- Sem(1) + TB(20/min): ~12k rows ÷ 20/min ≈ ~10 hours raw rate
+- With cooperative-pause deferral during DJ activity (most of every 24h at WXYC): ~12-15 hours realistic
+
+## Kill-switch
+
+```bash
+docker stop flowsheet-reenrichment
+```
+
+Monitor real-time LML p95 via Sentry trace explorer; stay within +20% of baseline per the BS#994 acceptance criterion.
+
+## Post-run
+
+Source the flip count from the `finished` log line's `flipped` field:
+```bash
+docker logs <container> 2>&1 | jq -r 'select(.step=="finished") | "flipped=\(.flipped) still_no_match=\(.still_no_match) lml_error=\(.lml_error)"'
+```
+
+Document the count as a comment on BS#1433.
+
+Then spot-check 20 sample rows that flipped — verify `discogs_url`, `artwork_url`, `release_year` populated and correct.
+
+## Environment variables
+
+| Variable | Default | Notes |
+|---|---|---|
+| `BACKFILL_CUTOFF_TS` | (required) | LML#583 merge timestamp: `2026-06-16T17:53:53Z` |
+| `LIBRARY_METADATA_URL` | (required) | LML endpoint |
+| `BACKFILL_BATCH_SIZE` | 100 | Rows per SELECT |
+| `BACKFILL_LML_MAX_CONCURRENT` | 1 | Semaphore permit count |
+| `BACKFILL_LML_RATE_PER_MIN` | 20 | Token bucket rate |
+| `BACKFILL_LML_PER_CALL_TIMEOUT_MS` | 35000 | Per-LML-call timeout (ms) |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS` | 60 | Set 0 to disable cooperative pause |
+| `LIVE_ACTIVITY_PAUSE_MS` | 30000 | Pause duration when DJ activity detected |
+| `SENTRY_DSN` | (optional) | Sentry error reporting |

--- a/jobs/flowsheet-reenrichment/README.md
+++ b/jobs/flowsheet-reenrichment/README.md
@@ -93,7 +93,15 @@ docker run --rm --name flowsheet-reenrichment --env-file .env \
 docker stop -t 600 flowsheet-reenrichment
 ```
 
-The container's SIGTERM handler flips a cooperative-stop flag; the orchestrator checks the flag between rows (not just between batches), so a single in-flight LML lookup is the longest wait. A `step: "stopped"` log line is emitted on graceful break — the runbook's `finished`-step jq filter (below) will correctly skip a stopped run. A second SIGTERM falls through to Node's default handler (force-exit) — intentional escape hatch if an LML call hangs past `BACKFILL_LML_PER_CALL_TIMEOUT_MS`.
+The container's SIGTERM handler flips a cooperative-stop flag; the orchestrator checks the flag between rows (not just between batches), so a single in-flight LML lookup is the longest wait. A `step: "stopped"` log line is emitted on graceful break — the runbook's jq filter (below) treats `stopped` and `failed` the same as `finished` so the operator can read the resume cursor.
+
+The signal handler stays attached after the first SIGTERM, so additional SIGTERMs/SIGINTs are idempotent (they just re-flip the already-true flag). If an LML call is wedged past `BACKFILL_LML_PER_CALL_TIMEOUT_MS` and graceful stop isn't progressing, the escape hatch is SIGKILL:
+
+```bash
+docker kill flowsheet-reenrichment   # defaults to SIGKILL — force-exit
+```
+
+This skips the `finally` arm so Sentry won't flush the last seconds of captures and the DB pool isn't cleanly closed. Only reach for it when graceful stop has demonstrably stuck.
 
 Monitor real-time LML p95 via Sentry trace explorer; stay within +20% of baseline per the BS#994 acceptance criterion.
 

--- a/jobs/flowsheet-reenrichment/README.md
+++ b/jobs/flowsheet-reenrichment/README.md
@@ -23,12 +23,25 @@ WHERE metadata_status = 'enriched_no_match'
 
    ```bash
    docker ps -a --filter name=flowsheet-metadata-backfill-cron --format '{{.Status}}'
-   # Must show: Exited (1)
+   # Must show: Exited (any exit code is fine — running is not)
    ```
 
-   If not exited, coordinate with #1011's resume sequence before launching.
+   If `docker ps -a` shows `Up …`, coordinate with #1011's resume sequence before launching.
 
-3. **Run the pre-launch diagnostic** to understand the cohort partition:
+3. **Build the partial index out-of-band** (avoids the AccessExclusiveLock that an in-migration DDL would take on the 2.6M-row `flowsheet` table). The cohort's WHERE has no covering index in the current schema — without this, each batch SELECT degrades to a heap scan as the cursor advances, multiplying wall-clock by orders of magnitude:
+
+   ```sql
+   -- ssh to the host that can reach prod RDS, then psql:
+   CREATE INDEX CONCURRENTLY IF NOT EXISTS flowsheet_reenrichment_idx
+     ON wxyc_schema.flowsheet (id)
+     WHERE metadata_status = 'enriched_no_match'
+       AND album_id IS NULL
+       AND artist_name IS NOT NULL;
+   ```
+
+   `CONCURRENTLY` takes only a `ShareUpdateExclusiveLock`, so DJs continue inserting while the index builds (typically < 30 s for a partial covering ~12k of 2.6M rows). The index is one-shot — drop it after the run (see "Post-run").
+
+4. **Run the pre-launch diagnostic** to understand the cohort partition:
    ```sql
    SELECT
      CASE WHEN metadata_attempt_at IS NULL THEN 'null' ELSE 'populated' END AS bucket,
@@ -48,9 +61,10 @@ WHERE metadata_status = 'enriched_no_match'
 gh workflow run deploy-manual.yml --ref main \
   -f target=flowsheet-reenrichment -f version=latest
 
-# 2. SSH to EC2 and run
+# 2. SSH to EC2 and run. `--name` is load-bearing — the kill-switch below
+# greps it; without it docker assigns a random name and `docker stop` fails.
 ssh wxyc-ec2
-docker run --rm --env-file .env \
+docker run --rm --name flowsheet-reenrichment --env-file .env \
   -e BACKFILL_CUTOFF_TS='2026-06-16T17:53:53Z' \
   <ECR-URI>/flowsheet-reenrichment:<tag>
 ```
@@ -66,30 +80,49 @@ docker run --rm --env-file .env \
 docker stop flowsheet-reenrichment
 ```
 
-Monitor real-time LML p95 via Sentry trace explorer; stay within +20% of baseline per the BS#994 acceptance criterion.
+The container's SIGTERM handler flips a cooperative-stop flag; the run finishes its in-flight row, emits a `stop_requested` log line, and exits cleanly so Sentry flushes and the DB pool closes. Monitor real-time LML p95 via Sentry trace explorer; stay within +20% of baseline per the BS#994 acceptance criterion.
 
 ## Post-run
 
-Source the flip count from the `finished` log line's `flipped` field:
+1. **Source the flip count** from the `finished` log line:
 
-```bash
-docker logs <container> 2>&1 | jq -r 'select(.step=="finished") | "flipped=\(.flipped) still_no_match=\(.still_no_match) lml_error=\(.lml_error)"'
-```
+   ```bash
+   docker logs flowsheet-reenrichment 2>&1 | \
+     jq -r 'select(.step=="finished") |
+       "scanned=\(.scanned) flipped=\(.flipped) match_raced=\(.match_raced) still_no_match=\(.still_no_match) lml_error=\(.lml_error) db_error=\(.db_error)"'
+   ```
 
-Document the count as a comment on BS#1433.
+   Document these as a comment on BS#1433.
 
-Then spot-check 20 sample rows that flipped — verify `discogs_url`, `artwork_url`, `release_year` populated and correct.
+2. **Linkage-race audit**: a parallel linkage resolver can flip `album_id` non-null between the orchestrator's SELECT and `reenrichRow`'s UPDATE, which the WHERE guard then skips (counted as `match_raced`). Most `match_raced` rows are benign (another writer flipped the status), but the rare orphan case leaves a row with `album_id` non-null AND `metadata_status='enriched_no_match'` — no automated path revisits these. Catch them with:
+
+   ```sql
+   SELECT id, album_id, artist_name, album_title, add_time
+   FROM wxyc_schema.flowsheet
+   WHERE metadata_status = 'enriched_no_match'
+     AND album_id IS NOT NULL
+     AND add_time < '2026-06-16T17:53:53Z'::timestamptz;
+   ```
+
+   For each orphan row, manually trigger re-enrichment (e.g. via the CDC consumer by setting `metadata_status='pending'`) or open a follow-up ticket if the count is non-trivial. Cross-reference the `possible_linkage_race` log lines from the run (each `match_raced` row id is emitted as a structured warning).
+
+3. **Spot-check 20 sample rows that flipped** — verify `discogs_url`, `artwork_url`, `release_year` populated and correct against the live Discogs release.
+
+4. **Drop the one-shot index** once the audit is complete:
+   ```sql
+   DROP INDEX CONCURRENTLY IF EXISTS wxyc_schema.flowsheet_reenrichment_idx;
+   ```
 
 ## Environment variables
 
-| Variable                           | Default    | Notes                                           |
-| ---------------------------------- | ---------- | ----------------------------------------------- |
-| `BACKFILL_CUTOFF_TS`               | (required) | LML#583 merge timestamp: `2026-06-16T17:53:53Z` |
-| `LIBRARY_METADATA_URL`             | (required) | LML endpoint                                    |
-| `BACKFILL_BATCH_SIZE`              | 100        | Rows per SELECT                                 |
-| `BACKFILL_LML_MAX_CONCURRENT`      | 1          | Semaphore permit count                          |
-| `BACKFILL_LML_RATE_PER_MIN`        | 20         | Token bucket rate                               |
-| `BACKFILL_LML_PER_CALL_TIMEOUT_MS` | 35000      | Per-LML-call timeout (ms)                       |
-| `LIVE_ACTIVITY_LOOKBACK_SECONDS`   | 60         | Set 0 to disable cooperative pause              |
-| `LIVE_ACTIVITY_PAUSE_MS`           | 30000      | Pause duration when DJ activity detected        |
-| `SENTRY_DSN`                       | (optional) | Sentry error reporting                          |
+| Variable                           | Default    | Notes                                                                                              |
+| ---------------------------------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| `BACKFILL_CUTOFF_TS`               | (required) | LML#583 merge timestamp: `2026-06-16T17:53:53Z`. Validated as ISO 8601 + not-in-future at startup. |
+| `LIBRARY_METADATA_URL`             | (required) | LML endpoint                                                                                       |
+| `BACKFILL_BATCH_SIZE`              | 100        | Rows per SELECT                                                                                    |
+| `BACKFILL_LML_MAX_CONCURRENT`      | 1          | Semaphore permit count (positive integer)                                                          |
+| `BACKFILL_LML_RATE_PER_MIN`        | 20         | Token bucket rate (positive integer)                                                               |
+| `BACKFILL_LML_PER_CALL_TIMEOUT_MS` | 35000      | Per-LML-call timeout (ms)                                                                          |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`   | 60         | Set 0 to disable cooperative pause                                                                 |
+| `LIVE_ACTIVITY_PAUSE_MS`           | 30000      | Pause duration when DJ activity detected (ms)                                                      |
+| `SENTRY_DSN`                       | (optional) | Sentry error reporting                                                                             |

--- a/jobs/flowsheet-reenrichment/enrich.ts
+++ b/jobs/flowsheet-reenrichment/enrich.ts
@@ -1,0 +1,141 @@
+/**
+ * Per-row enrichment for the flowsheet-reenrichment one-shot drain (BS#1433).
+ *
+ * Modeled on `apps/enrichment-worker/enrich.ts:finalizeRow` with three
+ * changes:
+ *
+ *   1. Idempotency guard: WHERE narrows by `metadata_status='enriched_no_match'
+ *      AND album_id IS NULL` (replaces finalizeRow's `metadata_status='enriching'`).
+ *      The `album_id IS NULL` clause is load-bearing — defends against a
+ *      parallel linkage-resolver flipping album_id non-null between the
+ *      orchestrator's SELECT and this UPDATE.
+ *
+ *   2. No-match → no-op early return. The row's four synthesized search URLs
+ *      and `enriched_no_match` status are already correct from the original
+ *      pass. Skipping the no-match UPDATE avoids per-row trigger cost on
+ *      `flowsheet` per docs/bulk-update-playbook.md.
+ *
+ *   3. No linked branch at all. The cohort WHERE is `album_id IS NULL`, so
+ *      the function never touches `album_metadata`.
+ *
+ * `metadata_attempt_at` is NOT stamped — follow the CDC consumer convention
+ * (`apps/enrichment-worker/enrich.ts:22-26`). Post-Epic-C, that column is
+ * vestigial for the routine write path.
+ */
+
+import { and, eq, isNull } from 'drizzle-orm';
+import { db, flowsheet } from '@wxyc/database';
+import type { DiscogsMatchResult, LookupResponse } from '@wxyc/lml-client';
+import { cleanDiscogsBio, filterSpacerGif } from '@wxyc/metadata';
+
+export type ReenrichRow = {
+  id: number;
+  artist_name: string;
+  album_title: string | null;
+  track_title: string | null;
+  // album_id is always null for this cohort (enforced by WHERE in orchestrate.ts),
+  // so it is not part of this type — the function never touches album_metadata.
+};
+
+export type ReenrichOutcome = 'match' | 'match_raced' | 'still_no_match';
+
+/**
+ * Synthesized search URL fallbacks matching finalizeRow's inline copy.
+ * Per-service semantics deliberately asymmetric — mirrors
+ * `apps/enrichment-worker/enrich.ts:synthesizeSearchUrls` exactly so the
+ * payload-parity test can snapshot-equal both paths.
+ *
+ * Apple Music has no synthesized fallback (BS#1192): null is the
+ * load-bearing "no verified iTunes match" signal; a keyword-search URL
+ * would launder it into a clickable button.
+ */
+const synthesizeSearchUrls = (
+  row: ReenrichRow
+): { spotify_url: string; youtube_music_url: string; bandcamp_url: string; soundcloud_url: string } => {
+  const artist = row.artist_name;
+  const album = row.album_title ?? undefined;
+  const track = row.track_title ?? undefined;
+
+  const spotifyQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
+  const youtubeQuery = track ? `${artist} ${track}` : album ? `${artist} ${album}` : artist;
+  const bandcampQuery = album ? `${artist} ${album}` : artist;
+  const soundcloudQuery = track ? `${artist} ${track}` : artist;
+
+  return {
+    spotify_url: `https://open.spotify.com/search/${encodeURIComponent(spotifyQuery)}`,
+    youtube_music_url: `https://music.youtube.com/search?q=${encodeURIComponent(youtubeQuery)}`,
+    bandcamp_url: `https://bandcamp.com/search?q=${encodeURIComponent(bandcampQuery)}`,
+    soundcloud_url: `https://soundcloud.com/search?q=${encodeURIComponent(soundcloudQuery)}`,
+  };
+};
+
+export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | null => {
+  const first = response.results?.[0];
+  if (!first) return null;
+  if (!first.artwork) return null;
+  return first.artwork;
+};
+
+/**
+ * Apply a single LML response to a flowsheet row in the enriched_no_match
+ * cohort. Returns the outcome so the orchestrator can count it.
+ *
+ * On no-match: immediate no-op return (change 2 above). The existing
+ * search URLs and status are already correct.
+ *
+ * On match: write the 10-column payload + flip metadata_status to
+ * 'enriched_match'. If the idempotency WHERE returns 0 rows (another
+ * process raced), return 'match_raced' — same data outcome, distinct
+ * metric so the operator can distinguish "I personally flipped this row"
+ * from "it was flipped by someone else mid-run."
+ *
+ * Errors propagate — do not swallow here. The orchestrator's catch arm
+ * counts them as 'lml_error' and continues.
+ */
+export const reenrichRow = async (row: ReenrichRow, response: LookupResponse): Promise<ReenrichOutcome> => {
+  const artwork = extractArtwork(response);
+
+  // Change 2: no-match is a no-op. The four synthesized search URLs on
+  // the row are already correct from the original enriched_no_match pass.
+  if (!artwork) {
+    return 'still_no_match';
+  }
+
+  const searchUrls = synthesizeSearchUrls(row);
+
+  // 10-column payload mirrors finalizeRow's unlinked+match branch exactly
+  // (payload-parity.test.ts pins this). Simple ?? operators — no
+  // conditional spreads needed because this job has no dedup cache that
+  // strips per-track URL fields from artwork objects.
+  const payload = {
+    artwork_url: filterSpacerGif(artwork.artwork_url),
+    discogs_url: artwork.release_url ?? null,
+    // Discogs returns 0 as "year unknown"; coerce to null so iOS doesn't
+    // render literal "0". Mirrors metadata.service.ts#extractAlbumMetadata (#1002).
+    release_year: artwork.release_year || null,
+    spotify_url: artwork.spotify_url ?? searchUrls.spotify_url,
+    // Apple Music has no synthesized fallback — null is load-bearing (BS#1192).
+    apple_music_url: artwork.apple_music_url ?? null,
+    youtube_music_url: artwork.youtube_music_url ?? searchUrls.youtube_music_url,
+    bandcamp_url: artwork.bandcamp_url ?? searchUrls.bandcamp_url,
+    soundcloud_url: artwork.soundcloud_url ?? searchUrls.soundcloud_url,
+    artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
+    artist_wikipedia_url: artwork.wikipedia_url ?? null,
+    // Flip status as part of the same SET — atomically with the data write.
+    metadata_status: 'enriched_match' as const,
+    // Change 4: metadata_attempt_at is NOT stamped (CDC consumer convention).
+  };
+
+  // Change 1: idempotency guard. `album_id IS NULL` prevents racing a
+  // parallel linkage-resolver that may have flipped album_id non-null
+  // between the SELECT and this UPDATE.
+  const updated = await db
+    .update(flowsheet)
+    .set(payload)
+    .where(
+      and(eq(flowsheet.id, row.id), eq(flowsheet.metadata_status, 'enriched_no_match'), isNull(flowsheet.album_id))
+    )
+    .returning({ id: flowsheet.id });
+
+  return updated.length === 0 ? 'match_raced' : 'match';
+};

--- a/jobs/flowsheet-reenrichment/env.ts
+++ b/jobs/flowsheet-reenrichment/env.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared env-var parser for the flowsheet-reenrichment job.
+ *
+ * `Number(raw)` (not `parseInt`) so partial-parse strings like "35000banana"
+ * surface as NaN and get rejected instead of silently coercing to 35000.
+ * `Number.isSafeInteger` guards against precision-lost large values
+ * (2^53+1 silently rounds to 2^53 and isInteger returns true).
+ *
+ * Invalid values fall back with a `console.warn` — the JSON logger isn't
+ * available at module-load time (which is when these readers fire). A
+ * future cleanup could route through the structured logger after init.
+ */
+export const envInt = (name: string, fallback: number, prefix = 'env'): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
+  console.warn(`${prefix}: ${name}=${raw} is invalid (must be positive safe integer); using fallback ${fallback}`);
+  return fallback;
+};

--- a/jobs/flowsheet-reenrichment/job.ts
+++ b/jobs/flowsheet-reenrichment/job.ts
@@ -22,12 +22,15 @@
  * SIGTERM/SIGINT handling: the signal handler flips the orchestrator's
  * cooperative-stop flag; the run finishes its in-flight row (round 3:
  * between-row check, not between-batch), emits a structured `stopped`
- * log line, then falls through to the `finally` arm. A *second* SIGTERM
- * arriving before the run completes is allowed to terminate the process
- * via Node's default handler — this is intentional escape-hatch behavior
- * for operators who need to force-exit a wedged in-flight LML call. We
- * use `process.on` (not `process.once`) so any number of SIGTERMs flip
- * the flag idempotently; the override is the operator's responsibility.
+ * log line, then falls through to the `finally` arm. `process.on` (not
+ * `process.once`) is deliberate — every SIGTERM/SIGINT just re-flips
+ * the already-true flag (idempotent), so the handler never wears off.
+ *
+ * Force-exit escape hatch: a stuck in-flight LML call past
+ * BACKFILL_LML_PER_CALL_TIMEOUT_MS that needs to be killed is a SIGKILL
+ * case (`docker kill flowsheet-reenrichment` — defaults to SIGKILL —
+ * or `docker kill -s KILL`). SIGTERM/SIGINT will NOT force-exit because
+ * we keep the handler attached.
  */
 
 import { closeDatabaseConnection } from '@wxyc/database';

--- a/jobs/flowsheet-reenrichment/job.ts
+++ b/jobs/flowsheet-reenrichment/job.ts
@@ -73,10 +73,19 @@ const main = async () => {
     requireLmlConfigured();
     requireCutoffConfigured();
     log('info', 'init', `${JOB_NAME} initialized`, { cutoff_ts: process.env.BACKFILL_CUTOFF_TS });
-    await runReenrichment({
+    const result = await runReenrichment({
       lookup: lookupMetadata,
       enrich: reenrichRow,
     });
+    // Round 6: runReenrichment now catches its own loop exceptions to
+    // preserve the summary log + span. Without propagating that failure
+    // through the exit code, a wrapping script's `$?` check would
+    // believe the drain succeeded on a sustained RDS outage. The
+    // structured log carries the error_message; this is the boolean
+    // signal for container-exit-code-driven alerting.
+    if (result.failed) {
+      process.exitCode = 1;
+    }
   } catch (error) {
     log('error', 'failed', `${JOB_NAME} failed`, { error_message: errorMessage(error) });
     captureError(error, 'failed');

--- a/jobs/flowsheet-reenrichment/job.ts
+++ b/jobs/flowsheet-reenrichment/job.ts
@@ -12,24 +12,29 @@
  *     -e BACKFILL_CUTOFF_TS='2026-06-16T17:53:53Z' \
  *     <ECR-URI>/flowsheet-reenrichment:<tag>
  *
- * See jobs/flowsheet-reenrichment/README.md for the full run procedure.
+ * See jobs/flowsheet-reenrichment/README.md for the full run procedure,
+ * including the `docker stop -t 600` recommendation (default 10s grace
+ * isn't enough for an in-flight batch to drain through LML).
  *
  * Blocked by #1011 (shared LML budget). Pre-flight: verify the sibling
  * flowsheet-metadata-backfill-cron container is Exited before launching.
  *
- * SIGTERM/SIGINT (`docker stop`, Ctrl-C): signal handler flips the
- * orchestrator's cooperative-stop flag; the run finishes its in-flight
- * batch, writes a structured `stop_requested` log line, then falls
- * through to the `finally` arm which flushes Sentry and closes the DB
- * pool. Without this, Node's default SIGTERM handling exits the process
- * before `finally` runs and the last seconds of captures are lost.
+ * SIGTERM/SIGINT handling: the signal handler flips the orchestrator's
+ * cooperative-stop flag; the run finishes its in-flight row (round 3:
+ * between-row check, not between-batch), emits a structured `stopped`
+ * log line, then falls through to the `finally` arm. A *second* SIGTERM
+ * arriving before the run completes is allowed to terminate the process
+ * via Node's default handler — this is intentional escape-hatch behavior
+ * for operators who need to force-exit a wedged in-flight LML call. We
+ * use `process.on` (not `process.once`) so any number of SIGTERMs flip
+ * the flag idempotently; the override is the operator's responsibility.
  */
 
 import { closeDatabaseConnection } from '@wxyc/database';
 import { runReenrichment, requestStop } from './orchestrate.js';
 import { lookupMetadata } from './lml-fetch.js';
 import { reenrichRow } from './enrich.js';
-import { initLogger, log, captureError, closeLogger } from './logger.js';
+import { initLogger, log, captureError, closeLogger, errorMessage } from './logger.js';
 
 const JOB_NAME = 'flowsheet-reenrichment';
 
@@ -45,15 +50,17 @@ const requireCutoffConfigured = (): void => {
   }
 };
 
-const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
-
 const registerSignalHandlers = (): void => {
+  // `process.on` (not `process.once`): repeated SIGTERMs from `docker stop`
+  // retries simply re-flip the (already-true) stop flag — idempotent. An
+  // operator who *wants* a force-exit can attach a second handler or send
+  // SIGKILL; we don't pretend to defend against intentional force-exit.
   const onSignal = (signal: NodeJS.Signals) => {
     log('warn', 'signal', `received ${signal}; requesting graceful stop`, { signal });
     requestStop();
   };
-  process.once('SIGTERM', onSignal);
-  process.once('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+  process.on('SIGINT', onSignal);
 };
 
 const main = async () => {

--- a/jobs/flowsheet-reenrichment/job.ts
+++ b/jobs/flowsheet-reenrichment/job.ts
@@ -8,19 +8,25 @@
  * Run via deploy-manual.yml (target=flowsheet-reenrichment, version=latest),
  * then SSH to EC2 and:
  *
- *   docker run --rm --env-file .env \
+ *   docker run --rm --name flowsheet-reenrichment --env-file .env \
  *     -e BACKFILL_CUTOFF_TS='2026-06-16T17:53:53Z' \
  *     <ECR-URI>/flowsheet-reenrichment:<tag>
  *
- * See jobs/flowsheet-reenrichment/README.md for the full run procedure and
- * pre-flight checklist.
+ * See jobs/flowsheet-reenrichment/README.md for the full run procedure.
  *
  * Blocked by #1011 (shared LML budget). Pre-flight: verify the sibling
  * flowsheet-metadata-backfill-cron container is Exited before launching.
+ *
+ * SIGTERM/SIGINT (`docker stop`, Ctrl-C): signal handler flips the
+ * orchestrator's cooperative-stop flag; the run finishes its in-flight
+ * batch, writes a structured `stop_requested` log line, then falls
+ * through to the `finally` arm which flushes Sentry and closes the DB
+ * pool. Without this, Node's default SIGTERM handling exits the process
+ * before `finally` runs and the last seconds of captures are lost.
  */
 
 import { closeDatabaseConnection } from '@wxyc/database';
-import { runReenrichment } from './orchestrate.js';
+import { runReenrichment, requestStop } from './orchestrate.js';
 import { lookupMetadata } from './lml-fetch.js';
 import { reenrichRow } from './enrich.js';
 import { initLogger, log, captureError, closeLogger } from './logger.js';
@@ -39,8 +45,20 @@ const requireCutoffConfigured = (): void => {
   }
 };
 
+const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
+const registerSignalHandlers = (): void => {
+  const onSignal = (signal: NodeJS.Signals) => {
+    log('warn', 'signal', `received ${signal}; requesting graceful stop`, { signal });
+    requestStop();
+  };
+  process.once('SIGTERM', onSignal);
+  process.once('SIGINT', onSignal);
+};
+
 const main = async () => {
   initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  registerSignalHandlers();
   try {
     requireLmlConfigured();
     requireCutoffConfigured();
@@ -50,7 +68,7 @@ const main = async () => {
       enrich: reenrichRow,
     });
   } catch (error) {
-    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: errorMessage(error) });
     captureError(error, 'failed');
     process.exitCode = 1;
   } finally {

--- a/jobs/flowsheet-reenrichment/job.ts
+++ b/jobs/flowsheet-reenrichment/job.ts
@@ -1,0 +1,62 @@
+/**
+ * One-shot re-enrichment drain (BS#1433).
+ *
+ * Rescues ~11,965 flowsheet rows written as `enriched_no_match` before
+ * LML#583 (merged 2026-06-16T17:53:53Z) closed the library-miss recall
+ * gap. Set BACKFILL_CUTOFF_TS to the LML#583 merge timestamp.
+ *
+ * Run via deploy-manual.yml (target=flowsheet-reenrichment, version=latest),
+ * then SSH to EC2 and:
+ *
+ *   docker run --rm --env-file .env \
+ *     -e BACKFILL_CUTOFF_TS='2026-06-16T17:53:53Z' \
+ *     <ECR-URI>/flowsheet-reenrichment:<tag>
+ *
+ * See jobs/flowsheet-reenrichment/README.md for the full run procedure and
+ * pre-flight checklist.
+ *
+ * Blocked by #1011 (shared LML budget). Pre-flight: verify the sibling
+ * flowsheet-metadata-backfill-cron container is Exited before launching.
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { runReenrichment } from './orchestrate.js';
+import { lookupMetadata } from './lml-fetch.js';
+import { reenrichRow } from './enrich.js';
+import { initLogger, log, captureError, closeLogger } from './logger.js';
+
+const JOB_NAME = 'flowsheet-reenrichment';
+
+const requireLmlConfigured = (): void => {
+  if (!process.env.LIBRARY_METADATA_URL) {
+    throw new Error('LIBRARY_METADATA_URL is not configured; aborting before any rows are scanned.');
+  }
+};
+
+const requireCutoffConfigured = (): void => {
+  if (!process.env.BACKFILL_CUTOFF_TS) {
+    throw new Error('BACKFILL_CUTOFF_TS is not configured; set to the LML#583 merge timestamp (2026-06-16T17:53:53Z).');
+  }
+};
+
+const main = async () => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  try {
+    requireLmlConfigured();
+    requireCutoffConfigured();
+    log('info', 'init', `${JOB_NAME} initialized`, { cutoff_ts: process.env.BACKFILL_CUTOFF_TS });
+    await runReenrichment({
+      lookup: lookupMetadata,
+      enrich: reenrichRow,
+    });
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: (error as Error).message });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
+};
+
+void main();

--- a/jobs/flowsheet-reenrichment/lml-fetch.ts
+++ b/jobs/flowsheet-reenrichment/lml-fetch.ts
@@ -1,0 +1,26 @@
+/**
+ * Thin LML shim for flowsheet-reenrichment (BS#1433).
+ *
+ * 5-line shim over @wxyc/lml-client.lookupMetadata. No dedup cache needed:
+ * this is a one-shot drain of specific enriched_no_match rows, not the
+ * recurring cron that processes ~1.96M rows where (artist, album) repeats
+ * at 1.74×. The cacheHit field is always false; the orchestrator's throttle
+ * logic branches on it, so the field must be present on the return type.
+ *
+ * Timeout sized at 35 s to clear LML#370's 25.25 s per-item cascade-
+ * exhaustion cap plus headroom. Matches the sibling cron's setting.
+ */
+
+import { lookupMetadata as sharedLookupMetadata, type LookupResponse } from '@wxyc/lml-client';
+import { defaultLmlLimiter } from './lml-limiter.js';
+
+export type LookupResult = { response: LookupResponse; cacheHit: false };
+
+export const lookupMetadata = async (artist: string, album?: string, track?: string): Promise<LookupResult> => {
+  const response = await sharedLookupMetadata(artist, album, track, {
+    limiter: defaultLmlLimiter,
+    timeoutMs: 35_000,
+    caller: 'flowsheet-reenrichment',
+  });
+  return { response, cacheHit: false };
+};

--- a/jobs/flowsheet-reenrichment/lml-fetch.ts
+++ b/jobs/flowsheet-reenrichment/lml-fetch.ts
@@ -9,25 +9,14 @@
  *
  * Timeout: BACKFILL_LML_PER_CALL_TIMEOUT_MS, default 35 s — clears
  * LML#370's 25.25 s per-item cascade-exhaustion cap plus headroom. Reads
- * the env var (review-round-2) so operators can tune without rebuilding.
+ * the env var at module load; see README note on env-var timing.
  */
 
 import { lookupMetadata as sharedLookupMetadata, type LookupResponse } from '@wxyc/lml-client';
+import { envInt } from './env.js';
 import { defaultLmlLimiter } from './lml-limiter.js';
 
-const envInt = (name: string, fallback: number): number => {
-  const raw = process.env[name];
-  if (raw === undefined || raw === '') return fallback;
-  // Number(raw) — not parseInt — so partial-parse strings like "35000banana"
-  // surface as NaN and get rejected instead of silently coercing to 35000.
-  const parsed = Number(raw);
-  // isSafeInteger guards against precision-lost large values (round 3).
-  if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
-  console.warn(`lml-fetch: ${name}=${raw} is invalid (must be positive safe integer); using fallback ${fallback}`);
-  return fallback;
-};
-
-const TIMEOUT_MS = envInt('BACKFILL_LML_PER_CALL_TIMEOUT_MS', 35_000);
+const TIMEOUT_MS = envInt('BACKFILL_LML_PER_CALL_TIMEOUT_MS', 35_000, 'lml-fetch');
 
 export type LookupResult = { response: LookupResponse; cacheHit: boolean };
 

--- a/jobs/flowsheet-reenrichment/lml-fetch.ts
+++ b/jobs/flowsheet-reenrichment/lml-fetch.ts
@@ -1,25 +1,39 @@
 /**
  * Thin LML shim for flowsheet-reenrichment (BS#1433).
  *
- * 5-line shim over @wxyc/lml-client.lookupMetadata. No dedup cache needed:
- * this is a one-shot drain of specific enriched_no_match rows, not the
- * recurring cron that processes ~1.96M rows where (artist, album) repeats
- * at 1.74×. The cacheHit field is always false; the orchestrator's throttle
- * logic branches on it, so the field must be present on the return type.
+ * Shim over @wxyc/lml-client.lookupMetadata. No dedup cache: this is a
+ * one-shot drain of specific enriched_no_match rows, not the recurring
+ * cron whose ~1.96M rows see (artist, album) repeats at 1.74×. cacheHit is
+ * always false; the type carries `boolean` (not the literal `false`) so a
+ * future cache addition isn't a type-narrowing surprise.
  *
- * Timeout sized at 35 s to clear LML#370's 25.25 s per-item cascade-
- * exhaustion cap plus headroom. Matches the sibling cron's setting.
+ * Timeout: BACKFILL_LML_PER_CALL_TIMEOUT_MS, default 35 s — clears
+ * LML#370's 25.25 s per-item cascade-exhaustion cap plus headroom. Reads
+ * the env var (review-round-2) so operators can tune without rebuilding.
  */
 
 import { lookupMetadata as sharedLookupMetadata, type LookupResponse } from '@wxyc/lml-client';
 import { defaultLmlLimiter } from './lml-limiter.js';
 
-export type LookupResult = { response: LookupResponse; cacheHit: false };
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  // Number(raw) — not parseInt — so partial-parse strings like "35000banana"
+  // surface as NaN and get rejected instead of silently coercing to 35000.
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-fetch: ${name}=${raw} is invalid (must be positive integer); using fallback ${fallback}`);
+  return fallback;
+};
+
+const TIMEOUT_MS = envInt('BACKFILL_LML_PER_CALL_TIMEOUT_MS', 35_000);
+
+export type LookupResult = { response: LookupResponse; cacheHit: boolean };
 
 export const lookupMetadata = async (artist: string, album?: string, track?: string): Promise<LookupResult> => {
   const response = await sharedLookupMetadata(artist, album, track, {
     limiter: defaultLmlLimiter,
-    timeoutMs: 35_000,
+    timeoutMs: TIMEOUT_MS,
     caller: 'flowsheet-reenrichment',
   });
   return { response, cacheHit: false };

--- a/jobs/flowsheet-reenrichment/lml-fetch.ts
+++ b/jobs/flowsheet-reenrichment/lml-fetch.ts
@@ -21,8 +21,9 @@ const envInt = (name: string, fallback: number): number => {
   // Number(raw) — not parseInt — so partial-parse strings like "35000banana"
   // surface as NaN and get rejected instead of silently coercing to 35000.
   const parsed = Number(raw);
-  if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) return parsed;
-  console.warn(`lml-fetch: ${name}=${raw} is invalid (must be positive integer); using fallback ${fallback}`);
+  // isSafeInteger guards against precision-lost large values (round 3).
+  if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-fetch: ${name}=${raw} is invalid (must be positive safe integer); using fallback ${fallback}`);
   return fallback;
 };
 

--- a/jobs/flowsheet-reenrichment/lml-limiter.ts
+++ b/jobs/flowsheet-reenrichment/lml-limiter.ts
@@ -13,28 +13,14 @@
  */
 
 import { type LmlLimiter, Semaphore, TokenBucket, createLmlLimiter as createSharedLmlLimiter } from '@wxyc/lml-client';
+import { envInt } from './env.js';
 
 export { type LmlLimiter, Semaphore, TokenBucket };
 
-const envInt = (name: string, fallback: number): number => {
-  const raw = process.env[name];
-  if (raw === undefined || raw === '') return fallback;
-  // Number(raw) — not parseInt — so partial-parse strings like "20banana"
-  // surface as NaN and get rejected, instead of silently coercing to 20.
-  // Number.isInteger keeps 1.5 from passing to a Semaphore that expects a
-  // whole permit count.
-  const parsed = Number(raw);
-  // isSafeInteger guards against precision-lost values like 2^53+1 silently
-  // becoming valid Semaphore permit counts (round 3).
-  if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
-  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive safe integer); using fallback ${fallback}`);
-  return fallback;
-};
-
 export const createLmlLimiter = (config?: { maxConcurrent?: number; ratePerMinute?: number }): LmlLimiter =>
   createSharedLmlLimiter({
-    maxConcurrent: config?.maxConcurrent ?? envInt('BACKFILL_LML_MAX_CONCURRENT', 1),
-    ratePerMinute: config?.ratePerMinute ?? envInt('BACKFILL_LML_RATE_PER_MIN', 20),
+    maxConcurrent: config?.maxConcurrent ?? envInt('BACKFILL_LML_MAX_CONCURRENT', 1, 'lml-limiter'),
+    ratePerMinute: config?.ratePerMinute ?? envInt('BACKFILL_LML_RATE_PER_MIN', 20, 'lml-limiter'),
   });
 
 export const defaultLmlLimiter: LmlLimiter = createLmlLimiter();

--- a/jobs/flowsheet-reenrichment/lml-limiter.ts
+++ b/jobs/flowsheet-reenrichment/lml-limiter.ts
@@ -24,8 +24,10 @@ const envInt = (name: string, fallback: number): number => {
   // Number.isInteger keeps 1.5 from passing to a Semaphore that expects a
   // whole permit count.
   const parsed = Number(raw);
-  if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) return parsed;
-  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive integer); using fallback ${fallback}`);
+  // isSafeInteger guards against precision-lost values like 2^53+1 silently
+  // becoming valid Semaphore permit counts (round 3).
+  if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive safe integer); using fallback ${fallback}`);
   return fallback;
 };
 

--- a/jobs/flowsheet-reenrichment/lml-limiter.ts
+++ b/jobs/flowsheet-reenrichment/lml-limiter.ts
@@ -19,9 +19,13 @@ export { type LmlLimiter, Semaphore, TokenBucket };
 const envInt = (name: string, fallback: number): number => {
   const raw = process.env[name];
   if (raw === undefined || raw === '') return fallback;
+  // Number(raw) — not parseInt — so partial-parse strings like "20banana"
+  // surface as NaN and get rejected, instead of silently coercing to 20.
+  // Number.isInteger keeps 1.5 from passing to a Semaphore that expects a
+  // whole permit count.
   const parsed = Number(raw);
-  if (Number.isFinite(parsed) && parsed > 0) return parsed;
-  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  if (Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive integer); using fallback ${fallback}`);
   return fallback;
 };
 

--- a/jobs/flowsheet-reenrichment/lml-limiter.ts
+++ b/jobs/flowsheet-reenrichment/lml-limiter.ts
@@ -1,0 +1,34 @@
+/**
+ * Concurrency + rate-limit gate for flowsheet-reenrichment's LML calls.
+ *
+ * Mirrors jobs/flowsheet-metadata-backfill/lml-limiter.ts: same Sem(1) +
+ * TB(20/min) envelope so both jobs share LML's 50/min Discogs budget gently
+ * with real-time traffic. The 2026-05-21 incident (BS#994) established that
+ * a serial loop alone is insufficient — the token bucket caps burst rate
+ * independent of orchestrator speed.
+ *
+ * Reads BACKFILL_LML_* env vars (shared with the sibling cron) so operators
+ * can tune both jobs from a single knob. Pre-flight: verify the sibling cron
+ * container is Exited before running this job (shared budget).
+ */
+
+import { type LmlLimiter, Semaphore, TokenBucket, createLmlLimiter as createSharedLmlLimiter } from '@wxyc/lml-client';
+
+export { type LmlLimiter, Semaphore, TokenBucket };
+
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
+};
+
+export const createLmlLimiter = (config?: { maxConcurrent?: number; ratePerMinute?: number }): LmlLimiter =>
+  createSharedLmlLimiter({
+    maxConcurrent: config?.maxConcurrent ?? envInt('BACKFILL_LML_MAX_CONCURRENT', 1),
+    ratePerMinute: config?.ratePerMinute ?? envInt('BACKFILL_LML_RATE_PER_MIN', 20),
+  });
+
+export const defaultLmlLimiter: LmlLimiter = createLmlLimiter();

--- a/jobs/flowsheet-reenrichment/logger.ts
+++ b/jobs/flowsheet-reenrichment/logger.ts
@@ -67,6 +67,14 @@ export const captureError = (error: unknown, step: string, extra: Record<string,
   Sentry.captureException(error, { tags: { step }, extra });
 };
 
+/**
+ * Defend against non-Error throws (`throw 'string'`, `throw { code: x }`) —
+ * `(err as Error).message` would emit `undefined` and the JSON logger would
+ * drop the key. The canonical safe pattern from
+ * flowsheet-metadata-backfill/orchestrate.ts:381-384.
+ */
+export const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
 export const closeLogger = async (): Promise<void> => {
   await Sentry.close(2000);
   baseTags = null;

--- a/jobs/flowsheet-reenrichment/logger.ts
+++ b/jobs/flowsheet-reenrichment/logger.ts
@@ -1,0 +1,73 @@
+/**
+ * Observability for flowsheet-reenrichment: Sentry init + JSON logs.
+ *
+ * Mirrors jobs/flowsheet-metadata-backfill/logger.ts verbatim — the contract
+ * is identical, the duplication keeps the one-shot job's build graph
+ * independent of the recurring cron package.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/flowsheet-reenrichment/orchestrate.ts
+++ b/jobs/flowsheet-reenrichment/orchestrate.ts
@@ -213,33 +213,23 @@ const loadBatchOnce = async (afterId: number, batchSize: number, cutoffTs: strin
 };
 
 /**
- * Sentinel for the rare "stop arrived during a backoff sleep" path. The
- * outer loop treats this as a clean stop-break (NOT a failure), so the
- * run still emits the `stopped` summary log + summary span instead of
- * `failed` with no totals.
- */
-class StopRequestedDuringRetry extends Error {
-  constructor() {
-    super('stop requested during loadBatch retry backoff');
-    this.name = 'StopRequestedDuringRetry';
-  }
-}
-
-/**
  * loadBatch with transient-error retry. Honors stopRequested so shutdown
  * isn't blocked by retry backoffs. Exhausting retries throws the most
- * recent error. Stop-during-backoff throws a sentinel the outer loop
- * recognizes as a stop (not a failure), so the run still emits the
- * stopped summary instead of the failed-with-no-totals shape.
+ * recent error.
+ *
+ * Stop-during-retry signaling: caller distinguishes a stop-triggered exit
+ * from a real failure by checking the module-level `stopRequested` flag
+ * — no custom sentinel needed, since the flag was true at throw time and
+ * stays true until __resetStopForTesting (production never resets it).
  */
 const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): Promise<ReenrichRow[]> => {
+  let lastError: unknown;
   for (let attempt = 0; attempt < LOAD_BATCH_MAX_ATTEMPTS; attempt += 1) {
     try {
       return await loadBatchOnce(afterId, batchSize, cutoffTs);
     } catch (error) {
-      const isLast = attempt + 1 >= LOAD_BATCH_MAX_ATTEMPTS;
-      if (stopRequested) throw new StopRequestedDuringRetry();
-      if (isLast) throw error;
+      lastError = error;
+      if (stopRequested || attempt + 1 >= LOAD_BATCH_MAX_ATTEMPTS) throw error;
       const backoff = LOAD_BATCH_BACKOFF_MS[attempt] ?? LOAD_BATCH_BACKOFF_MS[LOAD_BATCH_BACKOFF_MS.length - 1];
       log('warn', 'load_batch_retry', `loadBatch attempt ${attempt + 1} failed; retrying in ${backoff}ms`, {
         attempt: attempt + 1,
@@ -248,11 +238,12 @@ const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): 
         error_message: errorMessage(error),
       });
       await stopAwareSleep(backoff);
-      if (stopRequested) throw new StopRequestedDuringRetry();
+      if (stopRequested) throw error;
     }
   }
-  // Unreachable: the loop above either returns or throws.
-  throw new Error('loadBatch: unreachable retry-exhaustion path');
+  // Unreachable: the loop above either returns or throws. The throw exists
+  // for TS narrowing — without it the function's return type widens.
+  throw lastError;
 };
 
 /**
@@ -319,6 +310,38 @@ export const runReenrichment = async (opts: {
   // Hoist deps outside the per-row loop — one object reused for ~12k rows.
   const deps = { lookup: opts.lookup, enrich: opts.enrich };
 
+  // On probe error: log + Sentry capture + assume no activity (defer to
+  // next batch). A transient RDS error in the probe SELECT shouldn't abort
+  // the whole drain — same posture as loadBatch's retry.
+  const safeProbe = async (): Promise<boolean> => {
+    try {
+      return await probe(liveActivityLookbackSeconds);
+    } catch (error) {
+      log('warn', 'probe_error', 'checkLiveActivity threw; assuming no activity', {
+        error_message: errorMessage(error),
+      });
+      captureError(error, 'probe_error');
+      return false;
+    }
+  };
+
+  // Returns true iff the run should stop (SIGTERM observed during the wait).
+  // Disabled (returns false immediately) when lookback==0.
+  const waitForQuietPeriod = async (): Promise<boolean> => {
+    if (liveActivityLookbackSeconds <= 0) return false;
+    let active = await safeProbe();
+    while (active) {
+      if (stopRequested) return true;
+      log('info', 'live_activity_pause', `live flowsheet activity detected; pausing ${liveActivityPauseMs}ms`, {
+        lookback_seconds: liveActivityLookbackSeconds,
+        pause_ms: liveActivityPauseMs,
+      });
+      await stopAwareSleep(liveActivityPauseMs);
+      active = await safeProbe();
+    }
+    return stopRequested;
+  };
+
   log('info', 'started', `${JOB_NAME} starting`, {
     cutoff_ts: cutoffTs,
     batch_size: batchSize,
@@ -340,68 +363,30 @@ export const runReenrichment = async (opts: {
   let batchIndex = 0;
   let stopped = false;
   let failed: { error: unknown } | null = null;
+  const flipped = (): number => totals.match;
 
   try {
-    outer: while (true) {
-      if (stopRequested) {
+    while (true) {
+      if (stopRequested || (await waitForQuietPeriod())) {
         stopped = true;
         break;
-      }
-
-      if (liveActivityLookbackSeconds > 0) {
-        // Wrap the probe SELECT in try/catch so a transient RDS error doesn't
-        // abort the whole run with no summary — same posture as loadBatch's
-        // retry. We don't bother retrying the probe (it's a single buffer
-        // read against a partial index); on failure we log and proceed as
-        // if no activity, deferring to the next batch.
-        let probeActive = false;
-        try {
-          probeActive = await probe(liveActivityLookbackSeconds);
-        } catch (error) {
-          log('warn', 'probe_error', 'checkLiveActivity threw; assuming no activity', {
-            error_message: errorMessage(error),
-          });
-          captureError(error, 'probe_error');
-        }
-        while (probeActive) {
-          if (stopRequested) {
-            stopped = true;
-            break outer;
-          }
-          log('info', 'live_activity_pause', `live flowsheet activity detected; pausing ${liveActivityPauseMs}ms`, {
-            lookback_seconds: liveActivityLookbackSeconds,
-            pause_ms: liveActivityPauseMs,
-          });
-          await stopAwareSleep(liveActivityPauseMs);
-          try {
-            probeActive = await probe(liveActivityLookbackSeconds);
-          } catch (error) {
-            log('warn', 'probe_error', 'checkLiveActivity threw; assuming no activity', {
-              error_message: errorMessage(error),
-            });
-            captureError(error, 'probe_error');
-            probeActive = false;
-          }
-        }
-        if (stopRequested) {
-          stopped = true;
-          break;
-        }
       }
 
       let rows: ReenrichRow[];
       try {
         rows = await loadBatch(lastId, batchSize, cutoffTs);
       } catch (error) {
-        if (error instanceof StopRequestedDuringRetry) {
-          // Treat as a clean stop — summary span + structured log still emit.
+        // Distinguish stop-triggered exit from real failure via the same
+        // module flag the inner retry observed. No custom sentinel class
+        // — just read the flag the SIGTERM handler set.
+        if (stopRequested) {
           stopped = true;
-          break;
+        } else {
+          // Sustained DB outage exhausted the retry budget. Capture so the
+          // finally arm still emits the summary span + log with last_id,
+          // enabling resume-from-last_id from the structured logs.
+          failed = { error };
         }
-        // Sustained DB outage exhausted the retry budget. Capture so the
-        // finally arm still emits the summary span + log with last_id,
-        // enabling resume-from-last_id from the structured logs.
-        failed = { error };
         break;
       }
       if (rows.length === 0) break;
@@ -451,8 +436,6 @@ export const runReenrichment = async (opts: {
       if (stopped) break;
     }
   } finally {
-    const flipped = totals.match;
-
     // Summary span carrying numeric attributes (BS#1081 typing-trap workaround).
     // Always emitted — even on stop/fail — so partial-run telemetry is
     // available in Sentry trace explorer.
@@ -460,7 +443,7 @@ export const runReenrichment = async (opts: {
       {
         name: 'reenrichment.run.summary',
         attributes: {
-          'reenrichment.flipped_count': flipped,
+          'reenrichment.flipped_count': flipped(),
           'reenrichment.still_no_match_count': totals.still_no_match,
           'reenrichment.match_raced_count': totals.match_raced,
           'reenrichment.lml_error_count': totals.lml_error,
@@ -498,16 +481,15 @@ export const runReenrichment = async (opts: {
     const level = failed ? 'error' : 'info';
     log(level, step, `${JOB_NAME} ${step}`, {
       ...totals,
-      flipped,
+      flipped: flipped(),
       last_id: lastId,
       stopped,
       failed: failed !== null,
       ...(failed ? { error_message: errorMessage(failed.error) } : {}),
     });
     if (failed) {
-      captureError(failed.error, 'failed', { last_id: lastId, scanned: totals.scanned, flipped });
+      captureError(failed.error, 'failed', { last_id: lastId, scanned: totals.scanned, flipped: flipped() });
     }
   }
-  const flipped = totals.match;
-  return { totals, flipped, stopped, failed: failed !== null };
+  return { totals, flipped: flipped(), stopped, failed: failed !== null };
 };

--- a/jobs/flowsheet-reenrichment/orchestrate.ts
+++ b/jobs/flowsheet-reenrichment/orchestrate.ts
@@ -16,14 +16,21 @@
  * The `lookup` and `enrich` functions are injected so tests can drive the
  * orchestration without a live LML or DB.
  *
- * Linkage-race note (review-round-2): a parallel linkage resolver can flip
- * album_id non-null between the orchestrator's SELECT and reenrichRow's
- * UPDATE. The UPDATE's `album_id IS NULL` guard then returns 0 rows
- * (counted as `match_raced`) — same as a true update race — and the row
- * is left in `enriched_no_match` with a linked album_id. The CDC consumer
- * never revisits `enriched_no_match`. README's post-run audit SQL catches
- * any such orphans; the run logs every `match_raced` as a `WARN
- * possible_linkage_race` so the runbook step is grep-able.
+ * Linkage-race note (review-round-2/3): a parallel linkage resolver can
+ * flip album_id non-null between the orchestrator's SELECT and
+ * reenrichRow's UPDATE. The UPDATE's `album_id IS NULL` guard then matches
+ * 0 rows (counted as `match_raced`) and the row is left in
+ * `enriched_no_match` with a linked album_id. Since no auto path revisits
+ * `enriched_no_match`, the README documents a post-run audit SQL that
+ * catches these and a working rescue UPDATE that re-arms them for the
+ * nightly backfill cron. The run logs the *count* and the first few IDs
+ * once at the end (review-round-3 — per-row warn was excessive).
+ *
+ * SIGTERM handling: stopRequested is checked between batches AND between
+ * rows AND inside the live-activity sleep AND inside the loadBatch retry
+ * sleeps, so docker stop responds within ~1 row latency. The early-break
+ * log uses `step: 'stopped'`, not `'finished'`, so the runbook jq filter
+ * doesn't mis-report partial totals as a completed run.
  */
 
 import * as Sentry from '@sentry/node';
@@ -39,7 +46,7 @@ import {
 } from '@wxyc/database';
 import type { LookupResponse } from '@wxyc/lml-client';
 import type { ReenrichRow, ReenrichOutcome } from './enrich.js';
-import { captureError, log } from './logger.js';
+import { captureError, errorMessage, log } from './logger.js';
 
 const JOB_NAME = 'flowsheet-reenrichment';
 
@@ -50,34 +57,62 @@ const FLOWSHEET_TABLE = sql.raw(`"${SCHEMA}"."flowsheet"`);
 
 /**
  * Retry budget for loadBatch's SELECT. A transient RDS failover or network
- * blip should not abort a 10-15h drain (we'd waste hours of LML budget
- * re-walking already-processed rows on the next run). Three attempts with
- * 500ms / 2s / 5s backoff covers typical multi-AZ failovers.
+ * blip should not abort a 10-15h drain. Backoff array length matches
+ * MAX_ATTEMPTS so every retry has a defined wait; total worst-case wait
+ * = sum(LOAD_BATCH_BACKOFF_MS[0..MAX_ATTEMPTS-2]) (the final attempt's
+ * sleep is never used because we throw on failure).
  */
 const LOAD_BATCH_MAX_ATTEMPTS = 3;
-const LOAD_BATCH_BACKOFF_MS = [500, 2000, 5000];
+const LOAD_BATCH_BACKOFF_MS = [500, 2000];
+
+/**
+ * Strict-ish ISO 8601 check: YYYY-MM-DDTHH:MM:SS[.fff][Z|±HH:MM]. Catches
+ * Date.parse-passes-but-PG-rejects inputs like '2026-6-16', '2026/06/16',
+ * '2026', '6/16/2026'. Also enforces Date.parse roundtrip equality so
+ * normalized out-of-range days (e.g. '2026-02-30' → '2026-03-02') are
+ * rejected even though Date.parse accepts them.
+ */
+const ISO_8601_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
 
 export const resolveBatchSize = (raw: string | undefined = process.env.BACKFILL_BATCH_SIZE): number =>
   requirePositiveInt(raw, 'BACKFILL_BATCH_SIZE', BATCH_SIZE);
 
 /**
- * Throws when BACKFILL_CUTOFF_TS is missing, syntactically invalid, or in
- * the future. Fail-fast so the operator sees a clear message rather than a
- * Postgres ::timestamptz cast stack trace inside the first loadBatch.
+ * Throws when BACKFILL_CUTOFF_TS is missing, syntactically invalid (not
+ * strict ISO 8601), has an out-of-range calendar day/hour/etc, or is in
+ * the future. Fail-fast so the operator sees a clear message rather than
+ * a Postgres ::timestamptz cast stack trace from the first loadBatch.
  *
- * Future-date guard catches the fat-finger '2027' typo that would otherwise
- * widen the cohort to include legitimately-terminal post-LML#583 rows,
- * burning Discogs budget for rows that will never flip.
+ * Calendar validation is done on the raw fields (irrespective of TZ),
+ * which is what Date.parse silently normalizes — e.g. '2026-02-30' →
+ * '2026-03-02' would otherwise pass JS validation and shift the cohort.
  */
 export const resolveCutoffTs = (raw: string | undefined = process.env.BACKFILL_CUTOFF_TS): string => {
   if (!raw) {
     throw new Error('BACKFILL_CUTOFF_TS is required; set to the LML#583 merge timestamp (2026-06-16T17:53:53Z).');
   }
+  if (!ISO_8601_RE.test(raw)) {
+    throw new Error(
+      `BACKFILL_CUTOFF_TS=${JSON.stringify(raw)} is not strict ISO 8601 (e.g. 2026-06-16T17:53:53Z or 2026-06-16T10:53:53-07:00).`
+    );
+  }
+  const year = Number(raw.slice(0, 4));
+  const month = Number(raw.slice(5, 7));
+  const day = Number(raw.slice(8, 10));
+  const hour = Number(raw.slice(11, 13));
+  const minute = Number(raw.slice(14, 16));
+  const second = Number(raw.slice(17, 19));
+  // Calendar bounds — month, hour, minute, second. Days-in-month uses Date
+  // (day 0 of next month is the last day of this month).
+  const lastDayOfMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  if (month < 1 || month > 12 || day < 1 || day > lastDayOfMonth || hour > 23 || minute > 59 || second > 59) {
+    throw new Error(
+      `BACKFILL_CUTOFF_TS=${JSON.stringify(raw)} has an out-of-range field (calendar / 24h validation failed).`
+    );
+  }
   const parsed = Date.parse(raw);
   if (Number.isNaN(parsed)) {
-    throw new Error(
-      `BACKFILL_CUTOFF_TS=${JSON.stringify(raw)} is not a valid ISO 8601 timestamp (e.g. 2026-06-16T17:53:53Z).`
-    );
+    throw new Error(`BACKFILL_CUTOFF_TS=${JSON.stringify(raw)} is not a parseable timestamp.`);
   }
   if (parsed > Date.now()) {
     throw new Error(
@@ -114,13 +149,13 @@ export type Totals = {
 export type RunResult = {
   totals: Totals;
   flipped: number;
+  stopped: boolean;
 };
 
 /**
  * Cooperative cancellation flag for graceful shutdown on SIGTERM. The
- * runReenrichment loop checks this between batches; `requestStop()` lets
- * job.ts's signal handler abort the run mid-flight without losing the
- * `finally` block's Sentry flush + DB close.
+ * runReenrichment loop checks this between batches, between rows, in the
+ * live-activity sleep, and in the loadBatch retry sleeps.
  */
 let stopRequested = false;
 export const requestStop = (): void => {
@@ -132,13 +167,21 @@ export const __resetStopForTesting = (): void => {
   stopRequested = false;
 };
 
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-
-const errorMessage = (error: unknown): string =>
-  // Defend against non-Error throws (`throw 'string'`, `throw { code: x }`) —
-  // `(err as Error).message` would emit `undefined` and the JSON logger
-  // would drop the key, leaving operators with no signal at all.
-  error instanceof Error ? error.message : String(error);
+/**
+ * Stop-aware sleep: returns early if stopRequested becomes true during the
+ * sleep window. Polls every min(500ms, remaining) so a SIGTERM during a
+ * 30s cooperative-pause doesn't keep the operator waiting most of those
+ * 30s before the run honors the stop.
+ */
+const stopAwareSleep = async (ms: number): Promise<void> => {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (stopRequested) return;
+    const remaining = deadline - Date.now();
+    const tick = Math.min(500, remaining);
+    await new Promise<void>((resolve) => setTimeout(resolve, tick));
+  }
+};
 
 const loadBatchOnce = async (afterId: number, batchSize: number, cutoffTs: string): Promise<ReenrichRow[]> => {
   const rows = (await db.execute(sql`
@@ -160,21 +203,17 @@ const loadBatchOnce = async (afterId: number, batchSize: number, cutoffTs: strin
 };
 
 /**
- * loadBatch with transient-error retry. A momentary RDS hiccup should not
- * abort a 10-15h drain — the next run would re-walk hours of already-
- * processed rows (correctness is fine via the WHERE filter, but the LML
- * budget is wasted on duplicate SELECTs). Exhausting the retries propagates
- * the original error to main()'s catch arm, which is the right behavior
- * for a sustained outage.
+ * loadBatch with transient-error retry. Honors stopRequested so shutdown
+ * isn't blocked by retry backoffs. Exhausting retries throws the most
+ * recent error.
  */
 const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): Promise<ReenrichRow[]> => {
-  let lastError: unknown;
   for (let attempt = 0; attempt < LOAD_BATCH_MAX_ATTEMPTS; attempt += 1) {
     try {
       return await loadBatchOnce(afterId, batchSize, cutoffTs);
     } catch (error) {
-      lastError = error;
-      if (attempt + 1 >= LOAD_BATCH_MAX_ATTEMPTS) break;
+      const isLast = attempt + 1 >= LOAD_BATCH_MAX_ATTEMPTS;
+      if (isLast || stopRequested) throw error;
       const backoff = LOAD_BATCH_BACKOFF_MS[attempt] ?? LOAD_BATCH_BACKOFF_MS[LOAD_BATCH_BACKOFF_MS.length - 1];
       log('warn', 'load_batch_retry', `loadBatch attempt ${attempt + 1} failed; retrying in ${backoff}ms`, {
         attempt: attempt + 1,
@@ -182,21 +221,16 @@ const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): 
         backoff_ms: backoff,
         error_message: errorMessage(error),
       });
-      await sleep(backoff);
+      await stopAwareSleep(backoff);
     }
   }
-  throw lastError;
+  // Unreachable: the loop above either returns or throws.
+  throw new Error('loadBatch: unreachable retry-exhaustion path');
 };
 
 /**
  * Drive a single row through lookup → enrich. Catches BOTH lookup AND
- * enrich (DB) errors so a single bad row cannot abort the run. The row
- * stays `enriched_no_match` so the next coverage expansion revisits it.
- *
- * The earlier shape (only lookup wrapped) violated the docstring invariant
- * — a transient PG error during reenrichRow's UPDATE would bubble through
- * the for-of loop, exit the Sentry span, and trigger main()'s catch arm.
- * Now both arms log+count and return.
+ * enrich (DB) errors so a single bad row cannot abort the run.
  */
 const processRow = async (
   row: ReenrichRow,
@@ -235,6 +269,12 @@ const processRow = async (
   }
 };
 
+// Cap on how many raced flowsheet IDs to include in the final summary log
+// — keeps the log line bounded if a parallel linkage resolver flips a
+// large number of rows. Operators with > MATCH_RACED_SAMPLE rows should
+// run the README's audit SQL to enumerate them all.
+const MATCH_RACED_SAMPLE = 20;
+
 export const runReenrichment = async (opts: {
   lookup: LookupFn;
   enrich: EnrichFn;
@@ -249,8 +289,7 @@ export const runReenrichment = async (opts: {
   const liveActivityLookbackSeconds = opts.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
   const liveActivityPauseMs = opts.liveActivityPauseMs ?? resolveLiveActivityPauseMs();
   const probe = opts.checkLiveActivity ?? defaultCheckLiveActivity;
-  // Hoist deps outside the per-row loop — one object reused for ~12k rows
-  // instead of one allocation per row.
+  // Hoist deps outside the per-row loop — one object reused for ~12k rows.
   const deps = { lookup: opts.lookup, enrich: opts.enrich };
 
   log('info', 'started', `${JOB_NAME} starting`, {
@@ -268,28 +307,34 @@ export const runReenrichment = async (opts: {
     lml_error: 0,
     db_error: 0,
   };
+  const matchRacedIds: number[] = [];
+  let matchRacedTruncatedCount = 0;
   let lastId = 0;
   let batchIndex = 0;
+  let stopped = false;
 
-  while (true) {
+  outer: while (true) {
     if (stopRequested) {
-      log('info', 'stop_requested', `${JOB_NAME} stop requested; exiting between batches`, { last_id: lastId });
+      stopped = true;
       break;
     }
 
     if (liveActivityLookbackSeconds > 0) {
       while (await probe(liveActivityLookbackSeconds)) {
-        if (stopRequested) break;
+        if (stopRequested) {
+          stopped = true;
+          break outer;
+        }
         log('info', 'live_activity_pause', `live flowsheet activity detected; pausing ${liveActivityPauseMs}ms`, {
           lookback_seconds: liveActivityLookbackSeconds,
           pause_ms: liveActivityPauseMs,
         });
-        // No `> 0` gate: sleep(0) still yields the event loop via
-        // setTimeout, so the prior "tight spin if pauseMs=0" footgun
-        // is closed.
-        await sleep(liveActivityPauseMs);
+        await stopAwareSleep(liveActivityPauseMs);
       }
-      if (stopRequested) break;
+      if (stopRequested) {
+        stopped = true;
+        break;
+      }
     }
 
     const rows = await loadBatch(lastId, batchSize, cutoffTs);
@@ -297,48 +342,54 @@ export const runReenrichment = async (opts: {
 
     batchIndex += 1;
     const batchStart = Date.now();
-    const batchTotals = { match: 0, match_raced: 0, still_no_match: 0, lml_error: 0, db_error: 0 };
+    // Snapshot totals before the batch so per-batch counters can be
+    // derived without a parallel batchTotals object (round 3 cleanup).
+    const before = { ...totals };
 
     for (const row of rows) {
       const outcome = await processRow(row, deps);
       totals.scanned += 1;
       totals[outcome] += 1;
-      batchTotals[outcome] += 1;
       if (outcome === 'match_raced') {
-        // Surface every raced UPDATE so the runbook's post-run linkage-race
-        // audit can correlate (see jobs/flowsheet-reenrichment/README.md).
-        // Most race-counted rows are benign (status already flipped); the
-        // rare orphan case is a linkage resolver flipping album_id non-null
-        // between SELECT and UPDATE, which the audit SELECT detects.
-        log('warn', 'possible_linkage_race', `match_raced at flowsheet.id=${row.id}; verify in post-run audit`, {
-          flowsheet_id: row.id,
-        });
+        if (matchRacedIds.length < MATCH_RACED_SAMPLE) matchRacedIds.push(row.id);
+        else matchRacedTruncatedCount += 1;
       }
       lastId = row.id;
+      // Stop check between rows (round 3): with batch_size=100 and ~3s/row
+      // a batch can take ~5 min — far beyond docker's 10s default grace.
+      // Per-row check keeps the README's "finishes its in-flight row" claim
+      // honest.
+      if (stopRequested) {
+        stopped = true;
+        break;
+      }
     }
 
     log('info', 'batch_done', `batch ${batchIndex} done`, {
       batch_index: batchIndex,
       wall_clock_ms: Date.now() - batchStart,
       last_id: lastId,
-      scanned: totals.scanned,
-      match: batchTotals.match,
-      match_raced: batchTotals.match_raced,
-      still_no_match: batchTotals.still_no_match,
-      lml_error: batchTotals.lml_error,
-      db_error: batchTotals.db_error,
-      flipped: batchTotals.match,
+      // Per-batch deltas (round 3): derived from the pre-batch snapshot so
+      // there's no parallel counter to keep in sync.
+      scanned: totals.scanned - before.scanned,
+      match: totals.match - before.match,
+      match_raced: totals.match_raced - before.match_raced,
+      still_no_match: totals.still_no_match - before.still_no_match,
+      lml_error: totals.lml_error - before.lml_error,
+      db_error: totals.db_error - before.db_error,
+      flipped: totals.match - before.match,
+      // Cumulative scanned for progress monitoring.
+      total_scanned: totals.scanned,
     });
+
+    if (stopped) break;
   }
 
   const flipped = totals.match;
 
-  // Summary span carrying numeric attributes (BS#1081 typing-trap workaround
-  // — set at creation so Sentry indexes as numbers, not strings).
-  // No outer span wrapping the multi-hour loop: a 10-15h span would skew
-  // Sentry's query-perf dashboards (op='db.query' is meant for sub-second
-  // ops), risk per-transaction span-count truncation, and risk the summary
-  // child span being orphaned on idle flush.
+  // Summary span carrying numeric attributes (BS#1081 typing-trap workaround).
+  // Note: span is sampled by Sentry's tracesSampleRate; for guaranteed
+  // delivery the structured log line below carries the same numbers.
   Sentry.startSpan(
     {
       name: 'reenrichment.run.summary',
@@ -349,6 +400,7 @@ export const runReenrichment = async (opts: {
         'reenrichment.lml_error_count': totals.lml_error,
         'reenrichment.db_error_count': totals.db_error,
         'reenrichment.scanned_count': totals.scanned,
+        'reenrichment.stopped': stopped,
       },
     },
     () => {
@@ -356,13 +408,26 @@ export const runReenrichment = async (opts: {
     }
   );
 
-  log('info', 'finished', `${JOB_NAME} done`, {
-    // Spread all of `totals` so runbook jq extraction sees match_raced,
-    // db_error, and any future counter without a contract change. Sibling
-    // cron uses the same pattern.
+  // Match-raced summary (round 3): replaces the per-row warn log with one
+  // bounded sample at run end so the runbook can cross-reference the audit
+  // SQL without per-row stdout amplification.
+  if (totals.match_raced > 0) {
+    log('warn', 'match_raced_summary', `${totals.match_raced} rows raced; run README post-run audit SQL to enumerate`, {
+      match_raced_count: totals.match_raced,
+      sample_ids: matchRacedIds,
+      truncated_count: matchRacedTruncatedCount,
+    });
+  }
+
+  // Round 3: use a distinct `step` on early break so the runbook's jq
+  // `select(.step=="finished")` filter doesn't mis-report partial totals
+  // as a completed run.
+  log('info', stopped ? 'stopped' : 'finished', `${JOB_NAME} ${stopped ? 'stopped' : 'done'}`, {
     ...totals,
     flipped,
+    last_id: lastId,
+    stopped,
   });
 
-  return { totals, flipped };
+  return { totals, flipped, stopped };
 };

--- a/jobs/flowsheet-reenrichment/orchestrate.ts
+++ b/jobs/flowsheet-reenrichment/orchestrate.ts
@@ -7,26 +7,23 @@
  *   AND artist_name IS NOT NULL
  *   AND add_time < $BACKFILL_CUTOFF_TS
  *
- * The cutoff is the LML#583 / PR#584 merge timestamp (2026-06-16T17:53:53Z),
- * which is when the library-miss gap was closed. Rows added after that
- * timestamp already ran through the new path at write time — they are not
- * in this cohort.
- *
- * Per-row (not bulk): this cohort is cascade-bound on cold Discogs lookups
+ * Per-row (not bulk): the cohort is cascade-bound on cold Discogs lookups
  * (the library-miss-by-definition path LML#583 introduces). Per-row gating
- * shares the LML 50/min Discogs budget gently with real-time traffic; a
- * bulk endpoint would fan multiple cascades into LML's semaphore and replay
- * the BS#994 outage shape.
+ * shares the LML 50/min Discogs budget gently with real-time traffic.
  *
  * Cooperative pause: same pattern as flowsheet-metadata-backfill (#735).
- * Before each batch, probe flowsheet for activity in the last
- * LIVE_ACTIVITY_LOOKBACK_SECONDS (default 60). If found, defer the batch by
- * LIVE_ACTIVITY_PAUSE_MS (default 30000) and re-probe. Set
- * LIVE_ACTIVITY_LOOKBACK_SECONDS=0 to disable for catch-up runs.
  *
  * The `lookup` and `enrich` functions are injected so tests can drive the
- * orchestration without a live LML or DB. Production wires them to
- * lml-fetch.ts:lookupMetadata and enrich.ts:reenrichRow.
+ * orchestration without a live LML or DB.
+ *
+ * Linkage-race note (review-round-2): a parallel linkage resolver can flip
+ * album_id non-null between the orchestrator's SELECT and reenrichRow's
+ * UPDATE. The UPDATE's `album_id IS NULL` guard then returns 0 rows
+ * (counted as `match_raced`) — same as a true update race — and the row
+ * is left in `enriched_no_match` with a linked album_id. The CDC consumer
+ * never revisits `enriched_no_match`. README's post-run audit SQL catches
+ * any such orphans; the run logs every `match_raced` as a `WARN
+ * possible_linkage_race` so the runbook step is grep-able.
  */
 
 import * as Sentry from '@sentry/node';
@@ -51,16 +48,42 @@ export const BATCH_SIZE = 100;
 const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
 const FLOWSHEET_TABLE = sql.raw(`"${SCHEMA}"."flowsheet"`);
 
+/**
+ * Retry budget for loadBatch's SELECT. A transient RDS failover or network
+ * blip should not abort a 10-15h drain (we'd waste hours of LML budget
+ * re-walking already-processed rows on the next run). Three attempts with
+ * 500ms / 2s / 5s backoff covers typical multi-AZ failovers.
+ */
+const LOAD_BATCH_MAX_ATTEMPTS = 3;
+const LOAD_BATCH_BACKOFF_MS = [500, 2000, 5000];
+
 export const resolveBatchSize = (raw: string | undefined = process.env.BACKFILL_BATCH_SIZE): number =>
   requirePositiveInt(raw, 'BACKFILL_BATCH_SIZE', BATCH_SIZE);
 
 /**
- * Throws when BACKFILL_CUTOFF_TS is missing — fail-fast so the operator
- * sees a clear message rather than a WHERE that silently matches all rows.
+ * Throws when BACKFILL_CUTOFF_TS is missing, syntactically invalid, or in
+ * the future. Fail-fast so the operator sees a clear message rather than a
+ * Postgres ::timestamptz cast stack trace inside the first loadBatch.
+ *
+ * Future-date guard catches the fat-finger '2027' typo that would otherwise
+ * widen the cohort to include legitimately-terminal post-LML#583 rows,
+ * burning Discogs budget for rows that will never flip.
  */
 export const resolveCutoffTs = (raw: string | undefined = process.env.BACKFILL_CUTOFF_TS): string => {
-  if (!raw)
+  if (!raw) {
     throw new Error('BACKFILL_CUTOFF_TS is required; set to the LML#583 merge timestamp (2026-06-16T17:53:53Z).');
+  }
+  const parsed = Date.parse(raw);
+  if (Number.isNaN(parsed)) {
+    throw new Error(
+      `BACKFILL_CUTOFF_TS=${JSON.stringify(raw)} is not a valid ISO 8601 timestamp (e.g. 2026-06-16T17:53:53Z).`
+    );
+  }
+  if (parsed > Date.now()) {
+    throw new Error(
+      `BACKFILL_CUTOFF_TS=${JSON.stringify(raw)} is in the future; cohort would include legitimately-terminal post-fix rows. Use the LML#583 merge timestamp.`
+    );
+  }
   return raw;
 };
 
@@ -85,6 +108,7 @@ export type Totals = {
   match_raced: number;
   still_no_match: number;
   lml_error: number;
+  db_error: number;
 };
 
 export type RunResult = {
@@ -92,9 +116,31 @@ export type RunResult = {
   flipped: number;
 };
 
+/**
+ * Cooperative cancellation flag for graceful shutdown on SIGTERM. The
+ * runReenrichment loop checks this between batches; `requestStop()` lets
+ * job.ts's signal handler abort the run mid-flight without losing the
+ * `finally` block's Sentry flush + DB close.
+ */
+let stopRequested = false;
+export const requestStop = (): void => {
+  stopRequested = true;
+};
+export const isStopRequested = (): boolean => stopRequested;
+/** Test-only seam to reset the singleton between tests. */
+export const __resetStopForTesting = (): void => {
+  stopRequested = false;
+};
+
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): Promise<ReenrichRow[]> => {
+const errorMessage = (error: unknown): string =>
+  // Defend against non-Error throws (`throw 'string'`, `throw { code: x }`) —
+  // `(err as Error).message` would emit `undefined` and the JSON logger
+  // would drop the key, leaving operators with no signal at all.
+  error instanceof Error ? error.message : String(error);
+
+const loadBatchOnce = async (afterId: number, batchSize: number, cutoffTs: string): Promise<ReenrichRow[]> => {
   const rows = (await db.execute(sql`
     SELECT
       "id",
@@ -114,27 +160,79 @@ const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): 
 };
 
 /**
- * Drive a single row through lookup → enrich. Returns the outcome or
- * 'lml_error' when LML threw. Errors are logged and consumed so a single
- * bad row cannot abort the run. The row stays enriched_no_match so the
- * next coverage expansion revisits it.
+ * loadBatch with transient-error retry. A momentary RDS hiccup should not
+ * abort a 10-15h drain — the next run would re-walk hours of already-
+ * processed rows (correctness is fine via the WHERE filter, but the LML
+ * budget is wasted on duplicate SELECTs). Exhausting the retries propagates
+ * the original error to main()'s catch arm, which is the right behavior
+ * for a sustained outage.
+ */
+const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): Promise<ReenrichRow[]> => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < LOAD_BATCH_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await loadBatchOnce(afterId, batchSize, cutoffTs);
+    } catch (error) {
+      lastError = error;
+      if (attempt + 1 >= LOAD_BATCH_MAX_ATTEMPTS) break;
+      const backoff = LOAD_BATCH_BACKOFF_MS[attempt] ?? LOAD_BATCH_BACKOFF_MS[LOAD_BATCH_BACKOFF_MS.length - 1];
+      log('warn', 'load_batch_retry', `loadBatch attempt ${attempt + 1} failed; retrying in ${backoff}ms`, {
+        attempt: attempt + 1,
+        after_id: afterId,
+        backoff_ms: backoff,
+        error_message: errorMessage(error),
+      });
+      await sleep(backoff);
+    }
+  }
+  throw lastError;
+};
+
+/**
+ * Drive a single row through lookup → enrich. Catches BOTH lookup AND
+ * enrich (DB) errors so a single bad row cannot abort the run. The row
+ * stays `enriched_no_match` so the next coverage expansion revisits it.
+ *
+ * The earlier shape (only lookup wrapped) violated the docstring invariant
+ * — a transient PG error during reenrichRow's UPDATE would bubble through
+ * the for-of loop, exit the Sentry span, and trigger main()'s catch arm.
+ * Now both arms log+count and return.
  */
 const processRow = async (
   row: ReenrichRow,
   deps: { lookup: LookupFn; enrich: EnrichFn }
-): Promise<ReenrichOutcome | 'lml_error'> => {
+): Promise<ReenrichOutcome | 'lml_error' | 'db_error'> => {
   let result: LookupResult;
   try {
     result = await deps.lookup(row.artist_name, row.album_title ?? undefined, row.track_title ?? undefined);
   } catch (error) {
     log('warn', 'lml_error', `LML lookup failed for flowsheet.id=${row.id}`, {
       flowsheet_id: row.id,
-      error_message: (error as Error).message,
+      error_message: errorMessage(error),
     });
-    captureError(error, 'lml_error', { flowsheet_id: row.id, artist: row.artist_name });
+    captureError(error, 'lml_error', {
+      flowsheet_id: row.id,
+      artist: row.artist_name,
+      album: row.album_title ?? null,
+      track: row.track_title ?? null,
+    });
     return 'lml_error';
   }
-  return deps.enrich(row, result.response);
+  try {
+    return await deps.enrich(row, result.response);
+  } catch (error) {
+    log('warn', 'db_error', `flowsheet UPDATE failed for flowsheet.id=${row.id}`, {
+      flowsheet_id: row.id,
+      error_message: errorMessage(error),
+    });
+    captureError(error, 'db_error', {
+      flowsheet_id: row.id,
+      artist: row.artist_name,
+      album: row.album_title ?? null,
+      track: row.track_title ?? null,
+    });
+    return 'db_error';
+  }
 };
 
 export const runReenrichment = async (opts: {
@@ -151,103 +249,120 @@ export const runReenrichment = async (opts: {
   const liveActivityLookbackSeconds = opts.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
   const liveActivityPauseMs = opts.liveActivityPauseMs ?? resolveLiveActivityPauseMs();
   const probe = opts.checkLiveActivity ?? defaultCheckLiveActivity;
+  // Hoist deps outside the per-row loop — one object reused for ~12k rows
+  // instead of one allocation per row.
+  const deps = { lookup: opts.lookup, enrich: opts.enrich };
 
-  return Sentry.startSpan(
-    {
-      name: 'reenrichment.run',
-      op: 'db.query',
-      attributes: {
-        'reenrichment.cutoff_ts': cutoffTs,
-        'reenrichment.batch_size': batchSize,
-      },
-    },
-    async () => {
-      log('info', 'started', `${JOB_NAME} starting`, {
-        cutoff_ts: cutoffTs,
-        batch_size: batchSize,
-        live_activity_lookback_seconds: liveActivityLookbackSeconds,
-        live_activity_pause_ms: liveActivityPauseMs,
-      });
+  log('info', 'started', `${JOB_NAME} starting`, {
+    cutoff_ts: cutoffTs,
+    batch_size: batchSize,
+    live_activity_lookback_seconds: liveActivityLookbackSeconds,
+    live_activity_pause_ms: liveActivityPauseMs,
+  });
 
-      const totals: Totals = {
-        scanned: 0,
-        match: 0,
-        match_raced: 0,
-        still_no_match: 0,
-        lml_error: 0,
-      };
-      let lastId = 0;
-      let batchIndex = 0;
+  const totals: Totals = {
+    scanned: 0,
+    match: 0,
+    match_raced: 0,
+    still_no_match: 0,
+    lml_error: 0,
+    db_error: 0,
+  };
+  let lastId = 0;
+  let batchIndex = 0;
 
-      while (true) {
-        if (liveActivityLookbackSeconds > 0) {
-          while (await probe(liveActivityLookbackSeconds)) {
-            log('info', 'live_activity_pause', `live flowsheet activity detected; pausing ${liveActivityPauseMs}ms`, {
-              lookback_seconds: liveActivityLookbackSeconds,
-              pause_ms: liveActivityPauseMs,
-            });
-            if (liveActivityPauseMs > 0) await sleep(liveActivityPauseMs);
-          }
-        }
+  while (true) {
+    if (stopRequested) {
+      log('info', 'stop_requested', `${JOB_NAME} stop requested; exiting between batches`, { last_id: lastId });
+      break;
+    }
 
-        const rows = await loadBatch(lastId, batchSize, cutoffTs);
-        if (rows.length === 0) break;
+    if (liveActivityLookbackSeconds > 0) {
+      while (await probe(liveActivityLookbackSeconds)) {
+        if (stopRequested) break;
+        log('info', 'live_activity_pause', `live flowsheet activity detected; pausing ${liveActivityPauseMs}ms`, {
+          lookback_seconds: liveActivityLookbackSeconds,
+          pause_ms: liveActivityPauseMs,
+        });
+        // No `> 0` gate: sleep(0) still yields the event loop via
+        // setTimeout, so the prior "tight spin if pauseMs=0" footgun
+        // is closed.
+        await sleep(liveActivityPauseMs);
+      }
+      if (stopRequested) break;
+    }
 
-        batchIndex += 1;
-        const batchStart = Date.now();
-        const batchTotals = { match: 0, match_raced: 0, still_no_match: 0, lml_error: 0 };
+    const rows = await loadBatch(lastId, batchSize, cutoffTs);
+    if (rows.length === 0) break;
 
-        for (const row of rows) {
-          const outcome = await processRow(row, { lookup: opts.lookup, enrich: opts.enrich });
-          totals.scanned += 1;
-          if (outcome === 'lml_error') {
-            totals.lml_error += 1;
-            batchTotals.lml_error += 1;
-          } else {
-            totals[outcome] += 1;
-            batchTotals[outcome as keyof typeof batchTotals] += 1;
-          }
-          lastId = row.id;
-        }
+    batchIndex += 1;
+    const batchStart = Date.now();
+    const batchTotals = { match: 0, match_raced: 0, still_no_match: 0, lml_error: 0, db_error: 0 };
 
-        const batchFlipped = batchTotals.match;
-        log('info', 'batch_done', `batch ${batchIndex} done`, {
-          batch_index: batchIndex,
-          wall_clock_ms: Date.now() - batchStart,
-          scanned: totals.scanned,
-          match: batchTotals.match,
-          match_raced: batchTotals.match_raced,
-          still_no_match: batchTotals.still_no_match,
-          lml_error: batchTotals.lml_error,
-          flipped: batchFlipped,
+    for (const row of rows) {
+      const outcome = await processRow(row, deps);
+      totals.scanned += 1;
+      totals[outcome] += 1;
+      batchTotals[outcome] += 1;
+      if (outcome === 'match_raced') {
+        // Surface every raced UPDATE so the runbook's post-run linkage-race
+        // audit can correlate (see jobs/flowsheet-reenrichment/README.md).
+        // Most race-counted rows are benign (status already flipped); the
+        // rare orphan case is a linkage resolver flipping album_id non-null
+        // between SELECT and UPDATE, which the audit SELECT detects.
+        log('warn', 'possible_linkage_race', `match_raced at flowsheet.id=${row.id}; verify in post-run audit`, {
+          flowsheet_id: row.id,
         });
       }
+      lastId = row.id;
+    }
 
-      const flipped = totals.match;
+    log('info', 'batch_done', `batch ${batchIndex} done`, {
+      batch_index: batchIndex,
+      wall_clock_ms: Date.now() - batchStart,
+      last_id: lastId,
+      scanned: totals.scanned,
+      match: batchTotals.match,
+      match_raced: batchTotals.match_raced,
+      still_no_match: batchTotals.still_no_match,
+      lml_error: batchTotals.lml_error,
+      db_error: batchTotals.db_error,
+      flipped: batchTotals.match,
+    });
+  }
 
-      // Child span carrying numeric summary attributes (BS#1081 — set at
-      // creation time so Sentry indexes them as numbers, not strings).
-      Sentry.startSpan(
-        {
-          name: 'reenrichment.run.summary',
-          attributes: {
-            'reenrichment.flipped_count': flipped,
-            'reenrichment.still_no_match_count': totals.still_no_match,
-          },
-        },
-        () => {
-          /* attributes set at creation; nothing else to do */
-        }
-      );
+  const flipped = totals.match;
 
-      log('info', 'finished', `${JOB_NAME} done`, {
-        scanned: totals.scanned,
-        flipped,
-        still_no_match: totals.still_no_match,
-        lml_error: totals.lml_error,
-      });
-
-      return { totals, flipped };
+  // Summary span carrying numeric attributes (BS#1081 typing-trap workaround
+  // — set at creation so Sentry indexes as numbers, not strings).
+  // No outer span wrapping the multi-hour loop: a 10-15h span would skew
+  // Sentry's query-perf dashboards (op='db.query' is meant for sub-second
+  // ops), risk per-transaction span-count truncation, and risk the summary
+  // child span being orphaned on idle flush.
+  Sentry.startSpan(
+    {
+      name: 'reenrichment.run.summary',
+      attributes: {
+        'reenrichment.flipped_count': flipped,
+        'reenrichment.still_no_match_count': totals.still_no_match,
+        'reenrichment.match_raced_count': totals.match_raced,
+        'reenrichment.lml_error_count': totals.lml_error,
+        'reenrichment.db_error_count': totals.db_error,
+        'reenrichment.scanned_count': totals.scanned,
+      },
+    },
+    () => {
+      /* attributes set at creation; nothing else to do */
     }
   );
+
+  log('info', 'finished', `${JOB_NAME} done`, {
+    // Spread all of `totals` so runbook jq extraction sees match_raced,
+    // db_error, and any future counter without a contract change. Sibling
+    // cron uses the same pattern.
+    ...totals,
+    flipped,
+  });
+
+  return { totals, flipped };
 };

--- a/jobs/flowsheet-reenrichment/orchestrate.ts
+++ b/jobs/flowsheet-reenrichment/orchestrate.ts
@@ -150,6 +150,16 @@ export type RunResult = {
   totals: Totals;
   flipped: number;
   stopped: boolean;
+  /**
+   * True iff the run terminated via the failed-step path (uncaught loop
+   * exception or loadBatch retry exhaustion). Used by job.ts main() to
+   * set process.exitCode=1 — without this, the container would exit 0
+   * on sustained RDS outage because runReenrichment now catches its own
+   * exceptions to preserve the summary log. The structured log carries
+   * the error_message; this field is the boolean shortcut for the
+   * wrapping script's `$?` check.
+   */
+  failed: boolean;
 };
 
 /**
@@ -499,5 +509,5 @@ export const runReenrichment = async (opts: {
     }
   }
   const flipped = totals.match;
-  return { totals, flipped, stopped };
+  return { totals, flipped, stopped, failed: failed !== null };
 };

--- a/jobs/flowsheet-reenrichment/orchestrate.ts
+++ b/jobs/flowsheet-reenrichment/orchestrate.ts
@@ -203,9 +203,24 @@ const loadBatchOnce = async (afterId: number, batchSize: number, cutoffTs: strin
 };
 
 /**
+ * Sentinel for the rare "stop arrived during a backoff sleep" path. The
+ * outer loop treats this as a clean stop-break (NOT a failure), so the
+ * run still emits the `stopped` summary log + summary span instead of
+ * `failed` with no totals.
+ */
+class StopRequestedDuringRetry extends Error {
+  constructor() {
+    super('stop requested during loadBatch retry backoff');
+    this.name = 'StopRequestedDuringRetry';
+  }
+}
+
+/**
  * loadBatch with transient-error retry. Honors stopRequested so shutdown
  * isn't blocked by retry backoffs. Exhausting retries throws the most
- * recent error.
+ * recent error. Stop-during-backoff throws a sentinel the outer loop
+ * recognizes as a stop (not a failure), so the run still emits the
+ * stopped summary instead of the failed-with-no-totals shape.
  */
 const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): Promise<ReenrichRow[]> => {
   for (let attempt = 0; attempt < LOAD_BATCH_MAX_ATTEMPTS; attempt += 1) {
@@ -213,7 +228,8 @@ const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): 
       return await loadBatchOnce(afterId, batchSize, cutoffTs);
     } catch (error) {
       const isLast = attempt + 1 >= LOAD_BATCH_MAX_ATTEMPTS;
-      if (isLast || stopRequested) throw error;
+      if (stopRequested) throw new StopRequestedDuringRetry();
+      if (isLast) throw error;
       const backoff = LOAD_BATCH_BACKOFF_MS[attempt] ?? LOAD_BATCH_BACKOFF_MS[LOAD_BATCH_BACKOFF_MS.length - 1];
       log('warn', 'load_batch_retry', `loadBatch attempt ${attempt + 1} failed; retrying in ${backoff}ms`, {
         attempt: attempt + 1,
@@ -222,6 +238,7 @@ const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): 
         error_message: errorMessage(error),
       });
       await stopAwareSleep(backoff);
+      if (stopRequested) throw new StopRequestedDuringRetry();
     }
   }
   // Unreachable: the loop above either returns or throws.
@@ -312,122 +329,175 @@ export const runReenrichment = async (opts: {
   let lastId = 0;
   let batchIndex = 0;
   let stopped = false;
+  let failed: { error: unknown } | null = null;
 
-  outer: while (true) {
-    if (stopRequested) {
-      stopped = true;
-      break;
-    }
+  try {
+    outer: while (true) {
+      if (stopRequested) {
+        stopped = true;
+        break;
+      }
 
-    if (liveActivityLookbackSeconds > 0) {
-      while (await probe(liveActivityLookbackSeconds)) {
+      if (liveActivityLookbackSeconds > 0) {
+        // Wrap the probe SELECT in try/catch so a transient RDS error doesn't
+        // abort the whole run with no summary — same posture as loadBatch's
+        // retry. We don't bother retrying the probe (it's a single buffer
+        // read against a partial index); on failure we log and proceed as
+        // if no activity, deferring to the next batch.
+        let probeActive = false;
+        try {
+          probeActive = await probe(liveActivityLookbackSeconds);
+        } catch (error) {
+          log('warn', 'probe_error', 'checkLiveActivity threw; assuming no activity', {
+            error_message: errorMessage(error),
+          });
+          captureError(error, 'probe_error');
+        }
+        while (probeActive) {
+          if (stopRequested) {
+            stopped = true;
+            break outer;
+          }
+          log('info', 'live_activity_pause', `live flowsheet activity detected; pausing ${liveActivityPauseMs}ms`, {
+            lookback_seconds: liveActivityLookbackSeconds,
+            pause_ms: liveActivityPauseMs,
+          });
+          await stopAwareSleep(liveActivityPauseMs);
+          try {
+            probeActive = await probe(liveActivityLookbackSeconds);
+          } catch (error) {
+            log('warn', 'probe_error', 'checkLiveActivity threw; assuming no activity', {
+              error_message: errorMessage(error),
+            });
+            captureError(error, 'probe_error');
+            probeActive = false;
+          }
+        }
         if (stopRequested) {
           stopped = true;
-          break outer;
+          break;
         }
-        log('info', 'live_activity_pause', `live flowsheet activity detected; pausing ${liveActivityPauseMs}ms`, {
-          lookback_seconds: liveActivityLookbackSeconds,
-          pause_ms: liveActivityPauseMs,
-        });
-        await stopAwareSleep(liveActivityPauseMs);
       }
-      if (stopRequested) {
-        stopped = true;
+
+      let rows: ReenrichRow[];
+      try {
+        rows = await loadBatch(lastId, batchSize, cutoffTs);
+      } catch (error) {
+        if (error instanceof StopRequestedDuringRetry) {
+          // Treat as a clean stop — summary span + structured log still emit.
+          stopped = true;
+          break;
+        }
+        // Sustained DB outage exhausted the retry budget. Capture so the
+        // finally arm still emits the summary span + log with last_id,
+        // enabling resume-from-last_id from the structured logs.
+        failed = { error };
         break;
       }
-    }
+      if (rows.length === 0) break;
 
-    const rows = await loadBatch(lastId, batchSize, cutoffTs);
-    if (rows.length === 0) break;
+      batchIndex += 1;
+      const batchStart = Date.now();
+      // Snapshot totals before the batch so per-batch counters can be
+      // derived without a parallel batchTotals object (round 3 cleanup).
+      const before = { ...totals };
 
-    batchIndex += 1;
-    const batchStart = Date.now();
-    // Snapshot totals before the batch so per-batch counters can be
-    // derived without a parallel batchTotals object (round 3 cleanup).
-    const before = { ...totals };
-
-    for (const row of rows) {
-      const outcome = await processRow(row, deps);
-      totals.scanned += 1;
-      totals[outcome] += 1;
-      if (outcome === 'match_raced') {
-        if (matchRacedIds.length < MATCH_RACED_SAMPLE) matchRacedIds.push(row.id);
-        else matchRacedTruncatedCount += 1;
+      for (const row of rows) {
+        const outcome = await processRow(row, deps);
+        totals.scanned += 1;
+        totals[outcome] += 1;
+        if (outcome === 'match_raced') {
+          if (matchRacedIds.length < MATCH_RACED_SAMPLE) matchRacedIds.push(row.id);
+          else matchRacedTruncatedCount += 1;
+        }
+        lastId = row.id;
+        // Stop check between rows (round 3): with batch_size=100 and ~3s/row
+        // a batch can take ~5 min — far beyond docker's 10s default grace.
+        // Per-row check keeps the README's "finishes its in-flight row" claim
+        // honest.
+        if (stopRequested) {
+          stopped = true;
+          break;
+        }
       }
-      lastId = row.id;
-      // Stop check between rows (round 3): with batch_size=100 and ~3s/row
-      // a batch can take ~5 min — far beyond docker's 10s default grace.
-      // Per-row check keeps the README's "finishes its in-flight row" claim
-      // honest.
-      if (stopRequested) {
-        stopped = true;
-        break;
-      }
+
+      log('info', 'batch_done', `batch ${batchIndex} done`, {
+        batch_index: batchIndex,
+        wall_clock_ms: Date.now() - batchStart,
+        last_id: lastId,
+        // Per-batch deltas (round 3): derived from the pre-batch snapshot so
+        // there's no parallel counter to keep in sync.
+        scanned: totals.scanned - before.scanned,
+        match: totals.match - before.match,
+        match_raced: totals.match_raced - before.match_raced,
+        still_no_match: totals.still_no_match - before.still_no_match,
+        lml_error: totals.lml_error - before.lml_error,
+        db_error: totals.db_error - before.db_error,
+        flipped: totals.match - before.match,
+        // Cumulative scanned for progress monitoring.
+        total_scanned: totals.scanned,
+      });
+
+      if (stopped) break;
     }
+  } finally {
+    const flipped = totals.match;
 
-    log('info', 'batch_done', `batch ${batchIndex} done`, {
-      batch_index: batchIndex,
-      wall_clock_ms: Date.now() - batchStart,
-      last_id: lastId,
-      // Per-batch deltas (round 3): derived from the pre-batch snapshot so
-      // there's no parallel counter to keep in sync.
-      scanned: totals.scanned - before.scanned,
-      match: totals.match - before.match,
-      match_raced: totals.match_raced - before.match_raced,
-      still_no_match: totals.still_no_match - before.still_no_match,
-      lml_error: totals.lml_error - before.lml_error,
-      db_error: totals.db_error - before.db_error,
-      flipped: totals.match - before.match,
-      // Cumulative scanned for progress monitoring.
-      total_scanned: totals.scanned,
-    });
-
-    if (stopped) break;
-  }
-
-  const flipped = totals.match;
-
-  // Summary span carrying numeric attributes (BS#1081 typing-trap workaround).
-  // Note: span is sampled by Sentry's tracesSampleRate; for guaranteed
-  // delivery the structured log line below carries the same numbers.
-  Sentry.startSpan(
-    {
-      name: 'reenrichment.run.summary',
-      attributes: {
-        'reenrichment.flipped_count': flipped,
-        'reenrichment.still_no_match_count': totals.still_no_match,
-        'reenrichment.match_raced_count': totals.match_raced,
-        'reenrichment.lml_error_count': totals.lml_error,
-        'reenrichment.db_error_count': totals.db_error,
-        'reenrichment.scanned_count': totals.scanned,
-        'reenrichment.stopped': stopped,
+    // Summary span carrying numeric attributes (BS#1081 typing-trap workaround).
+    // Always emitted — even on stop/fail — so partial-run telemetry is
+    // available in Sentry trace explorer.
+    Sentry.startSpan(
+      {
+        name: 'reenrichment.run.summary',
+        attributes: {
+          'reenrichment.flipped_count': flipped,
+          'reenrichment.still_no_match_count': totals.still_no_match,
+          'reenrichment.match_raced_count': totals.match_raced,
+          'reenrichment.lml_error_count': totals.lml_error,
+          'reenrichment.db_error_count': totals.db_error,
+          'reenrichment.scanned_count': totals.scanned,
+          'reenrichment.last_id': lastId,
+          'reenrichment.stopped': stopped,
+          'reenrichment.failed': failed !== null,
+        },
       },
-    },
-    () => {
-      /* attributes set at creation; nothing else to do */
+      () => {
+        /* attributes set at creation */
+      }
+    );
+
+    if (totals.match_raced > 0) {
+      log(
+        'warn',
+        'match_raced_summary',
+        `${totals.match_raced} rows raced; run README post-run audit SQL to enumerate`,
+        {
+          match_raced_count: totals.match_raced,
+          sample_ids: matchRacedIds,
+          truncated_count: matchRacedTruncatedCount,
+        }
+      );
     }
-  );
 
-  // Match-raced summary (round 3): replaces the per-row warn log with one
-  // bounded sample at run end so the runbook can cross-reference the audit
-  // SQL without per-row stdout amplification.
-  if (totals.match_raced > 0) {
-    log('warn', 'match_raced_summary', `${totals.match_raced} rows raced; run README post-run audit SQL to enumerate`, {
-      match_raced_count: totals.match_raced,
-      sample_ids: matchRacedIds,
-      truncated_count: matchRacedTruncatedCount,
+    // Distinct steps so the runbook's jq filter can differentiate:
+    //   - 'finished' — drain ran to completion (empty batch)
+    //   - 'stopped'  — SIGTERM caused a clean early break
+    //   - 'failed'   — uncaught exception; the structured log still
+    //                  carries last_id so the operator can resume.
+    const step = failed ? 'failed' : stopped ? 'stopped' : 'finished';
+    const level = failed ? 'error' : 'info';
+    log(level, step, `${JOB_NAME} ${step}`, {
+      ...totals,
+      flipped,
+      last_id: lastId,
+      stopped,
+      failed: failed !== null,
+      ...(failed ? { error_message: errorMessage(failed.error) } : {}),
     });
+    if (failed) {
+      captureError(failed.error, 'failed', { last_id: lastId, scanned: totals.scanned, flipped });
+    }
   }
-
-  // Round 3: use a distinct `step` on early break so the runbook's jq
-  // `select(.step=="finished")` filter doesn't mis-report partial totals
-  // as a completed run.
-  log('info', stopped ? 'stopped' : 'finished', `${JOB_NAME} ${stopped ? 'stopped' : 'done'}`, {
-    ...totals,
-    flipped,
-    last_id: lastId,
-    stopped,
-  });
-
+  const flipped = totals.match;
   return { totals, flipped, stopped };
 };

--- a/jobs/flowsheet-reenrichment/orchestrate.ts
+++ b/jobs/flowsheet-reenrichment/orchestrate.ts
@@ -1,0 +1,253 @@
+/**
+ * One-shot orchestrator for the flowsheet-reenrichment drain (BS#1433).
+ *
+ * Iterates flowsheet rows matching:
+ *   metadata_status = 'enriched_no_match'
+ *   AND album_id IS NULL
+ *   AND artist_name IS NOT NULL
+ *   AND add_time < $BACKFILL_CUTOFF_TS
+ *
+ * The cutoff is the LML#583 / PR#584 merge timestamp (2026-06-16T17:53:53Z),
+ * which is when the library-miss gap was closed. Rows added after that
+ * timestamp already ran through the new path at write time — they are not
+ * in this cohort.
+ *
+ * Per-row (not bulk): this cohort is cascade-bound on cold Discogs lookups
+ * (the library-miss-by-definition path LML#583 introduces). Per-row gating
+ * shares the LML 50/min Discogs budget gently with real-time traffic; a
+ * bulk endpoint would fan multiple cascades into LML's semaphore and replay
+ * the BS#994 outage shape.
+ *
+ * Cooperative pause: same pattern as flowsheet-metadata-backfill (#735).
+ * Before each batch, probe flowsheet for activity in the last
+ * LIVE_ACTIVITY_LOOKBACK_SECONDS (default 60). If found, defer the batch by
+ * LIVE_ACTIVITY_PAUSE_MS (default 30000) and re-probe. Set
+ * LIVE_ACTIVITY_LOOKBACK_SECONDS=0 to disable for catch-up runs.
+ *
+ * The `lookup` and `enrich` functions are injected so tests can drive the
+ * orchestration without a live LML or DB. Production wires them to
+ * lml-fetch.ts:lookupMetadata and enrich.ts:reenrichRow.
+ */
+
+import * as Sentry from '@sentry/node';
+import { sql } from 'drizzle-orm';
+import {
+  db,
+  checkLiveActivity as defaultCheckLiveActivity,
+  LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
+  LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+  requireNonNegativeInt,
+  requirePositiveInt,
+  type CheckLiveActivityFn,
+} from '@wxyc/database';
+import type { LookupResponse } from '@wxyc/lml-client';
+import type { ReenrichRow, ReenrichOutcome } from './enrich.js';
+import { captureError, log } from './logger.js';
+
+const JOB_NAME = 'flowsheet-reenrichment';
+
+export const BATCH_SIZE = 100;
+
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const FLOWSHEET_TABLE = sql.raw(`"${SCHEMA}"."flowsheet"`);
+
+export const resolveBatchSize = (raw: string | undefined = process.env.BACKFILL_BATCH_SIZE): number =>
+  requirePositiveInt(raw, 'BACKFILL_BATCH_SIZE', BATCH_SIZE);
+
+/**
+ * Throws when BACKFILL_CUTOFF_TS is missing — fail-fast so the operator
+ * sees a clear message rather than a WHERE that silently matches all rows.
+ */
+export const resolveCutoffTs = (raw: string | undefined = process.env.BACKFILL_CUTOFF_TS): string => {
+  if (!raw)
+    throw new Error('BACKFILL_CUTOFF_TS is required; set to the LML#583 merge timestamp (2026-06-16T17:53:53Z).');
+  return raw;
+};
+
+export const resolveLiveActivityLookback = (
+  raw: string | undefined = process.env.LIVE_ACTIVITY_LOOKBACK_SECONDS
+): number =>
+  requireNonNegativeInt(raw, 'LIVE_ACTIVITY_LOOKBACK_SECONDS', LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT, {
+    unit: 's',
+    note: 'Use 0 to disable the cooperative pause.',
+  });
+
+export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number =>
+  requireNonNegativeInt(raw, 'LIVE_ACTIVITY_PAUSE_MS', LIVE_ACTIVITY_PAUSE_MS_DEFAULT, { unit: 'ms' });
+
+export type LookupResult = { response: LookupResponse; cacheHit: boolean };
+export type LookupFn = (artist: string, album?: string, track?: string) => Promise<LookupResult>;
+export type EnrichFn = (row: ReenrichRow, response: LookupResponse) => Promise<ReenrichOutcome>;
+
+export type Totals = {
+  scanned: number;
+  match: number;
+  match_raced: number;
+  still_no_match: number;
+  lml_error: number;
+};
+
+export type RunResult = {
+  totals: Totals;
+  flipped: number;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): Promise<ReenrichRow[]> => {
+  const rows = (await db.execute(sql`
+    SELECT
+      "id",
+      "artist_name",
+      "album_title",
+      "track_title"
+    FROM ${FLOWSHEET_TABLE}
+    WHERE "metadata_status" = 'enriched_no_match'
+      AND "album_id" IS NULL
+      AND "artist_name" IS NOT NULL
+      AND "add_time" < ${cutoffTs}::timestamptz
+      AND "id" > ${afterId}
+    ORDER BY "id" ASC
+    LIMIT ${batchSize}
+  `)) as unknown as ReenrichRow[];
+  return rows ?? [];
+};
+
+/**
+ * Drive a single row through lookup → enrich. Returns the outcome or
+ * 'lml_error' when LML threw. Errors are logged and consumed so a single
+ * bad row cannot abort the run. The row stays enriched_no_match so the
+ * next coverage expansion revisits it.
+ */
+const processRow = async (
+  row: ReenrichRow,
+  deps: { lookup: LookupFn; enrich: EnrichFn }
+): Promise<ReenrichOutcome | 'lml_error'> => {
+  let result: LookupResult;
+  try {
+    result = await deps.lookup(row.artist_name, row.album_title ?? undefined, row.track_title ?? undefined);
+  } catch (error) {
+    log('warn', 'lml_error', `LML lookup failed for flowsheet.id=${row.id}`, {
+      flowsheet_id: row.id,
+      error_message: (error as Error).message,
+    });
+    captureError(error, 'lml_error', { flowsheet_id: row.id, artist: row.artist_name });
+    return 'lml_error';
+  }
+  return deps.enrich(row, result.response);
+};
+
+export const runReenrichment = async (opts: {
+  lookup: LookupFn;
+  enrich: EnrichFn;
+  cutoffTs?: string;
+  batchSize?: number;
+  liveActivityLookbackSeconds?: number;
+  liveActivityPauseMs?: number;
+  checkLiveActivity?: CheckLiveActivityFn;
+}): Promise<RunResult> => {
+  const cutoffTs = opts.cutoffTs ?? resolveCutoffTs();
+  const batchSize = opts.batchSize ?? resolveBatchSize();
+  const liveActivityLookbackSeconds = opts.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
+  const liveActivityPauseMs = opts.liveActivityPauseMs ?? resolveLiveActivityPauseMs();
+  const probe = opts.checkLiveActivity ?? defaultCheckLiveActivity;
+
+  return Sentry.startSpan(
+    {
+      name: 'reenrichment.run',
+      op: 'db.query',
+      attributes: {
+        'reenrichment.cutoff_ts': cutoffTs,
+        'reenrichment.batch_size': batchSize,
+      },
+    },
+    async () => {
+      log('info', 'started', `${JOB_NAME} starting`, {
+        cutoff_ts: cutoffTs,
+        batch_size: batchSize,
+        live_activity_lookback_seconds: liveActivityLookbackSeconds,
+        live_activity_pause_ms: liveActivityPauseMs,
+      });
+
+      const totals: Totals = {
+        scanned: 0,
+        match: 0,
+        match_raced: 0,
+        still_no_match: 0,
+        lml_error: 0,
+      };
+      let lastId = 0;
+      let batchIndex = 0;
+
+      while (true) {
+        if (liveActivityLookbackSeconds > 0) {
+          while (await probe(liveActivityLookbackSeconds)) {
+            log('info', 'live_activity_pause', `live flowsheet activity detected; pausing ${liveActivityPauseMs}ms`, {
+              lookback_seconds: liveActivityLookbackSeconds,
+              pause_ms: liveActivityPauseMs,
+            });
+            if (liveActivityPauseMs > 0) await sleep(liveActivityPauseMs);
+          }
+        }
+
+        const rows = await loadBatch(lastId, batchSize, cutoffTs);
+        if (rows.length === 0) break;
+
+        batchIndex += 1;
+        const batchStart = Date.now();
+        const batchTotals = { match: 0, match_raced: 0, still_no_match: 0, lml_error: 0 };
+
+        for (const row of rows) {
+          const outcome = await processRow(row, { lookup: opts.lookup, enrich: opts.enrich });
+          totals.scanned += 1;
+          if (outcome === 'lml_error') {
+            totals.lml_error += 1;
+            batchTotals.lml_error += 1;
+          } else {
+            totals[outcome] += 1;
+            batchTotals[outcome as keyof typeof batchTotals] += 1;
+          }
+          lastId = row.id;
+        }
+
+        const batchFlipped = batchTotals.match;
+        log('info', 'batch_done', `batch ${batchIndex} done`, {
+          batch_index: batchIndex,
+          wall_clock_ms: Date.now() - batchStart,
+          scanned: totals.scanned,
+          match: batchTotals.match,
+          match_raced: batchTotals.match_raced,
+          still_no_match: batchTotals.still_no_match,
+          lml_error: batchTotals.lml_error,
+          flipped: batchFlipped,
+        });
+      }
+
+      const flipped = totals.match;
+
+      // Child span carrying numeric summary attributes (BS#1081 — set at
+      // creation time so Sentry indexes them as numbers, not strings).
+      Sentry.startSpan(
+        {
+          name: 'reenrichment.run.summary',
+          attributes: {
+            'reenrichment.flipped_count': flipped,
+            'reenrichment.still_no_match_count': totals.still_no_match,
+          },
+        },
+        () => {
+          /* attributes set at creation; nothing else to do */
+        }
+      );
+
+      log('info', 'finished', `${JOB_NAME} done`, {
+        scanned: totals.scanned,
+        flipped,
+        still_no_match: totals.still_no_match,
+        lml_error: totals.lml_error,
+      });
+
+      return { totals, flipped };
+    }
+  );
+};

--- a/jobs/flowsheet-reenrichment/package.json
+++ b/jobs/flowsheet-reenrichment/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@wxyc/flowsheet-reenrichment",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "One-shot re-enrichment: drain enriched_no_match rows whose (artist, album) pairs were missed before LML#583 closed the library-miss gap. Runs once; keyed on BACKFILL_CUTOFF_TS (LML#583 merge timestamp). Per-row serial; Sem(1)+TB(20/min) to share LML budget with live traffic. BS#1433.",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_flowsheet_reenrichment:ci -f ../../Dockerfile.flowsheet-reenrichment ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.53.1",
+    "@wxyc/database": "^1.0.0",
+    "@wxyc/lml-client": "^1.0.0",
+    "@wxyc/metadata": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/flowsheet-reenrichment/tsconfig.json
+++ b/jobs/flowsheet-reenrichment/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/flowsheet-reenrichment/tsup.config.ts
+++ b/jobs/flowsheet-reenrichment/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -874,6 +874,23 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/flowsheet-reenrichment": {
+      "name": "@wxyc/flowsheet-reenrichment",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.53.1",
+        "@wxyc/database": "^1.0.0",
+        "@wxyc/lml-client": "^1.0.0",
+        "@wxyc/metadata": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/legacy-dj-name-remediation": {
       "name": "@wxyc/legacy-dj-name-remediation",
       "version": "1.0.0",
@@ -6653,6 +6670,10 @@
     },
     "node_modules/@wxyc/flowsheet-metadata-backfill": {
       "resolved": "jobs/flowsheet-metadata-backfill",
+      "link": true
+    },
+    "node_modules/@wxyc/flowsheet-reenrichment": {
+      "resolved": "jobs/flowsheet-reenrichment",
       "link": true
     },
     "node_modules/@wxyc/legacy-dj-name-remediation": {

--- a/tests/unit/jobs/flowsheet-reenrichment/enrich.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/enrich.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for flowsheet-reenrichment enrich.ts.
+ *
+ * Pins the row-level UPDATE shape per the issue's three changes from finalizeRow:
+ *
+ *   1. Idempotency guard: WHERE narrows by `metadata_status='enriched_no_match'
+ *      AND album_id IS NULL` (not `metadata_status='enriching'`).
+ *   2. No-match outcome is a no-op early return (no UPDATE). The four
+ *      synthesized search URLs and `enriched_no_match` status are already
+ *      correct from the original pass.
+ *   3. No linked branch. All rows in this cohort have `album_id IS NULL`.
+ *   4. `metadata_attempt_at` is NOT stamped (CDC consumer convention).
+ */
+import { jest } from '@jest/globals';
+
+import { db, flowsheet } from '@wxyc/database';
+import { reenrichRow, type ReenrichRow } from '../../../../jobs/flowsheet-reenrichment/enrich';
+import type { LookupResponse } from '@wxyc/lml-client';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: string | string[] }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (typeof chunk.value === 'string') return chunk.value;
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const mockDb = db as unknown as {
+  update: jest.Mock;
+  _chain: {
+    set: jest.Mock;
+    where: jest.Mock;
+    returning: jest.Mock;
+  };
+};
+
+const baseRow: ReenrichRow = {
+  id: 42,
+  artist_name: 'Autechre',
+  album_title: 'Confield',
+  track_title: 'VI Scose Poise',
+};
+
+const matchedResponse: LookupResponse = {
+  results: [
+    {
+      library_item: { id: 1 },
+      artwork: {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        artwork_url: 'https://i.discogs.com/art.jpg',
+        release_year: 2001,
+        artist_bio: '[a=Rob Brown] and [a=Sean Booth] are Autechre.',
+        wikipedia_url: 'https://en.wikipedia.org/wiki/Autechre',
+        spotify_url: 'https://open.spotify.com/album/abc',
+        apple_music_url: 'https://music.apple.com/album/xyz',
+        youtube_music_url: 'https://music.youtube.com/album/aaa',
+        bandcamp_url: null,
+        soundcloud_url: null,
+      },
+    },
+  ],
+  search_type: 'direct',
+  song_not_found: false,
+};
+
+const noMatchResponse: LookupResponse = {
+  results: [],
+  search_type: 'none',
+  song_not_found: true,
+};
+
+const noArtworkResponse: LookupResponse = {
+  results: [{ library_item: { id: 1 }, artwork: null }],
+  search_type: 'direct',
+};
+
+describe('reenrichRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb._chain.returning.mockResolvedValue([{ id: baseRow.id }]);
+  });
+
+  it('writes 10 metadata columns and flips metadata_status to enriched_match on LML match', async () => {
+    const outcome = await reenrichRow(baseRow, matchedResponse);
+    expect(outcome).toBe('match');
+    expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
+
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs).toMatchObject({
+      artwork_url: 'https://i.discogs.com/art.jpg',
+      discogs_url: 'https://www.discogs.com/release/12345',
+      release_year: 2001,
+      spotify_url: 'https://open.spotify.com/album/abc',
+      apple_music_url: 'https://music.apple.com/album/xyz',
+      youtube_music_url: 'https://music.youtube.com/album/aaa',
+      metadata_status: 'enriched_match',
+    });
+    // bandcamp/soundcloud null on LML response → fall back to synthesized
+    expect(setArgs.bandcamp_url).toContain('bandcamp.com/search');
+    expect(setArgs.soundcloud_url).toContain('soundcloud.com/search');
+    // Bio is cleaned of Discogs markup tags
+    expect(setArgs.artist_bio).toBe('Rob Brown and Sean Booth are Autechre.');
+    expect(setArgs.artist_wikipedia_url).toBe('https://en.wikipedia.org/wiki/Autechre');
+  });
+
+  it('does NOT stamp metadata_attempt_at (CDC consumer convention)', async () => {
+    await reenrichRow(baseRow, matchedResponse);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect('metadata_attempt_at' in setArgs).toBe(false);
+  });
+
+  it('idempotency guard: WHERE includes metadata_status=enriched_no_match AND album_id IS NULL', async () => {
+    await reenrichRow(baseRow, matchedResponse);
+    // Check the WHERE clause passed to the update chain
+    const whereCall = mockDb._chain.where.mock.calls[0]?.[0];
+    const whereStr = renderSql(whereCall) + JSON.stringify(whereCall);
+    // Must reference both conditions
+    expect(whereStr).toMatch(/enriched_no_match/);
+    expect(whereStr.toLowerCase()).toMatch(/album_id/);
+  });
+
+  it('still_no_match: returns still_no_match with no UPDATE when LML returns empty results', async () => {
+    const outcome = await reenrichRow(baseRow, noMatchResponse);
+    expect(outcome).toBe('still_no_match');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('still_no_match: returns still_no_match with no UPDATE when artwork is null', async () => {
+    const outcome = await reenrichRow(baseRow, noArtworkResponse);
+    expect(outcome).toBe('still_no_match');
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('match_raced: returns match_raced when UPDATE returns 0 rows (concurrent status change)', async () => {
+    mockDb._chain.returning.mockResolvedValue([]);
+    const outcome = await reenrichRow(baseRow, matchedResponse);
+    expect(outcome).toBe('match_raced');
+  });
+
+  it('does NOT touch album_metadata (no linked branch)', async () => {
+    // The new job never UPSERTs album_metadata — all rows are album_id IS NULL
+    const mockInsert = db as unknown as { insert: jest.Mock };
+    await reenrichRow(baseRow, matchedResponse);
+    expect(mockInsert.insert).not.toHaveBeenCalled();
+  });
+
+  it('strips Discogs spacer.gif placeholder from artwork_url', async () => {
+    const spacerResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: {
+            ...matchedResponse.results[0].artwork!,
+            artwork_url: 'https://s.discogs.com/images/spacer.gif',
+          },
+        },
+      ],
+    };
+
+    const outcome = await reenrichRow(baseRow, spacerResponse);
+    expect(outcome).toBe('match');
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs.artwork_url).toBeNull();
+  });
+
+  it('coerces release_year 0 to null (Discogs "year unknown" sentinel)', async () => {
+    const zeroYearResponse: LookupResponse = {
+      ...matchedResponse,
+      results: [
+        {
+          library_item: { id: 1 },
+          artwork: { ...matchedResponse.results[0].artwork!, release_year: 0 },
+        },
+      ],
+    };
+    await reenrichRow(baseRow, zeroYearResponse);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs.release_year).toBeNull();
+  });
+});

--- a/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
@@ -458,7 +458,28 @@ describe('runReenrichment — loadBatch retry on transient DB error', () => {
     });
 
     expect(result.stopped).toBe(false);
+    // Round 6: result.failed=true tells main() to set exitCode=1, so a
+    // wrapping script's $? check correctly detects the failed drain.
+    expect(result.failed).toBe(true);
     expect(result.totals.scanned).toBe(0);
     expect((db.execute as jest.Mock).mock.calls.length).toBe(3);
   }, 30_000);
+
+  it('result.failed is false on a clean completion', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    expect(result.failed).toBe(false);
+    expect(result.stopped).toBe(false);
+  });
 });

--- a/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for flowsheet-reenrichment orchestrate.ts.
+ *
+ * Pins the behaviors the one-shot drain depends on:
+ *   1. The loadBatch SELECT carries all four WHERE predicates:
+ *      metadata_status='enriched_no_match', album_id IS NULL,
+ *      artist_name IS NOT NULL, add_time < $BACKFILL_CUTOFF_TS,
+ *      plus the id-cursor and ORDER BY / LIMIT.
+ *   2. The ID cursor advances across batches and the loop terminates when
+ *      a batch returns empty.
+ *   3. Per-row outcome counters (match, match_raced, still_no_match,
+ *      lml_error) are correctly accumulated and logged.
+ *   4. Idempotency: the second pass over a row where enrich returns
+ *      'match_raced' is counted correctly and does not corrupt totals.
+ *   5. Cooperative pause defers batches when live activity is observed.
+ *   6. lml_error: lookup throws → the row is not passed to enrich, the
+ *      counter increments, and the loop continues.
+ */
+import { jest } from '@jest/globals';
+
+import { db, checkLiveActivity as mockCheckLiveActivity } from '@wxyc/database';
+import type { LookupResponse } from '@wxyc/lml-client';
+import {
+  runReenrichment,
+  type LookupFn,
+  type EnrichFn,
+  BATCH_SIZE,
+  resolveBatchSize,
+  resolveCutoffTs,
+  resolveLiveActivityLookback,
+  resolveLiveActivityPauseMs,
+} from '../../../../jobs/flowsheet-reenrichment/orchestrate';
+
+type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: unknown }> };
+const renderSql = (value: unknown): string => {
+  const obj = value as SqlLike | null | undefined;
+  if (!obj) return '';
+  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (typeof obj.sql === 'string') return obj.sql;
+  if (obj.queryChunks) {
+    return obj.queryChunks
+      .map((chunk) => {
+        if (typeof chunk === 'string') return chunk;
+        if (Array.isArray(chunk.value)) return chunk.value.join('');
+        if (chunk.value !== undefined && chunk.value !== null) return String(chunk.value);
+        return '';
+      })
+      .join('');
+  }
+  return '';
+};
+
+const matchedResponse: LookupResponse = {
+  results: [{ library_item: { id: 1 }, artwork: { release_id: 100, release_url: 'x' } }],
+  search_type: 'direct',
+};
+
+const noMatchResponse: LookupResponse = {
+  results: [],
+  search_type: 'none',
+};
+
+const matchedResult = () => ({ response: matchedResponse, cacheHit: false as const });
+const noMatchResult = () => ({ response: noMatchResponse, cacheHit: false as const });
+
+const CUTOFF = '2026-06-16T17:53:53Z';
+
+const makeRow = (id: number) => ({
+  id,
+  artist_name: 'Autechre',
+  album_title: 'Confield',
+  track_title: null,
+});
+
+describe('resolveBatchSize', () => {
+  it('falls back to BATCH_SIZE when env var is unset', () => {
+    expect(resolveBatchSize(undefined)).toBe(BATCH_SIZE);
+  });
+
+  it('returns the parsed value for a valid positive integer', () => {
+    expect(resolveBatchSize('200')).toBe(200);
+  });
+
+  it('throws on zero or negative', () => {
+    expect(() => resolveBatchSize('0')).toThrow(/BACKFILL_BATCH_SIZE/);
+    expect(() => resolveBatchSize('-1')).toThrow(/BACKFILL_BATCH_SIZE/);
+  });
+});
+
+describe('resolveCutoffTs', () => {
+  it('throws when BACKFILL_CUTOFF_TS is not set', () => {
+    expect(() => resolveCutoffTs(undefined)).toThrow(/BACKFILL_CUTOFF_TS/);
+  });
+
+  it('returns the value when set', () => {
+    expect(resolveCutoffTs(CUTOFF)).toBe(CUTOFF);
+  });
+});
+
+describe('resolveLiveActivityLookback', () => {
+  it('falls back to 60 when env var is unset', () => {
+    expect(resolveLiveActivityLookback(undefined)).toBe(60);
+  });
+
+  it('accepts 0 to disable the cooperative pause', () => {
+    expect(resolveLiveActivityLookback('0')).toBe(0);
+  });
+});
+
+describe('resolveLiveActivityPauseMs', () => {
+  it('falls back to 30000 when env var is unset', () => {
+    expect(resolveLiveActivityPauseMs(undefined)).toBe(30_000);
+  });
+
+  it('accepts 0', () => {
+    expect(resolveLiveActivityPauseMs('0')).toBe(0);
+  });
+});
+
+describe('runReenrichment — WHERE filter', () => {
+  it('SELECT carries all four predicates: metadata_status, album_id IS NULL, artist_name IS NOT NULL, add_time < cutoff', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1)]).mockResolvedValueOnce([]); // second SELECT → empty → stop
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('match');
+
+    await runReenrichment({ lookup, enrich, cutoffTs: CUTOFF, batchSize: 100, liveActivityLookbackSeconds: 0 });
+
+    const firstSelectSql = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]);
+    expect(firstSelectSql).toMatch(/enriched_no_match/);
+    expect(firstSelectSql).toMatch(/album_id.*IS NULL|IS NULL.*album_id/i);
+    expect(firstSelectSql.toLowerCase()).toMatch(/artist_name.*is not null/);
+    expect(firstSelectSql).toMatch(/add_time/);
+  });
+
+  it('ID cursor advances across batches: loop terminates when batch returns empty', async () => {
+    // Three batches: 2 rows, 1 row, then empty → loop exits
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([makeRow(10), makeRow(20)])
+      .mockResolvedValueOnce([makeRow(30)])
+      .mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 2,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    // 3 SELECT calls (batch1=2 rows, batch2=1 row, batch3=empty)
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(3);
+    // All 3 rows were scanned
+    expect(result.totals.scanned).toBe(3);
+    expect(result.totals.still_no_match).toBe(3);
+  });
+});
+
+describe('runReenrichment — outcome counters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    { name: 'match', enrichOutcome: 'match' as const, expectedField: 'match' },
+    { name: 'match_raced', enrichOutcome: 'match_raced' as const, expectedField: 'match_raced' },
+    { name: 'still_no_match', enrichOutcome: 'still_no_match' as const, expectedField: 'still_no_match' },
+  ])('$name outcome: scanned=1, $expectedField=1', async ({ enrichOutcome, expectedField }) => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue(enrichOutcome);
+
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    expect(result.totals.scanned).toBe(1);
+    expect(result.totals[expectedField as keyof typeof result.totals]).toBe(1);
+  });
+
+  it('lml_error: lookup throws → enrich not called, lml_error increments, loop continues', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1), makeRow(2)]).mockResolvedValueOnce([]);
+
+    const lookup = jest
+      .fn<LookupFn>()
+      .mockRejectedValueOnce(new Error('LML timeout'))
+      .mockResolvedValue(noMatchResult());
+
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    expect(result.totals.lml_error).toBe(1);
+    expect(result.totals.still_no_match).toBe(1);
+    expect(result.totals.scanned).toBe(2);
+    // enrich was called only for the second row (first threw)
+    expect(enrich).toHaveBeenCalledTimes(1);
+  });
+
+  it('flipped = match (not match_raced) in returned totals', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1), makeRow(2)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValueOnce('match').mockResolvedValueOnce('match_raced');
+
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    expect(result.totals.match).toBe(1);
+    expect(result.totals.match_raced).toBe(1);
+    // flipped is the non-raced subset
+    expect(result.flipped).toBe(1);
+  });
+});
+
+describe('runReenrichment — cooperative pause', () => {
+  it('defers when live activity is detected, continues when quiet', async () => {
+    // Two activity probes fire, then quiet
+    (mockCheckLiveActivity as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValue(false);
+
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 60,
+      liveActivityPauseMs: 0,
+      checkLiveActivity: mockCheckLiveActivity as jest.Mock,
+    });
+
+    // Probe was called at least 3 times (twice truthy, once falsy)
+    expect((mockCheckLiveActivity as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('skips probe when liveActivityLookbackSeconds=0', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+      checkLiveActivity: mockCheckLiveActivity as jest.Mock,
+    });
+
+    expect(mockCheckLiveActivity as jest.Mock).not.toHaveBeenCalled();
+  });
+});
+
+describe('runReenrichment — idempotency', () => {
+  it('second pass over same row (already match_raced from first pass) counts as match_raced not lml_error', async () => {
+    // Simulate two passes: first enrich returns match_raced, second also match_raced
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([makeRow(1)])
+      .mockResolvedValueOnce([makeRow(1)]) // second batch returns same row (simulates re-run)
+      .mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('match_raced');
+
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    expect(result.totals.match_raced).toBe(2);
+    expect(result.totals.lml_error).toBe(0);
+  });
+});

--- a/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
@@ -42,7 +42,7 @@ const renderSql = (value: unknown): string => {
       .map((chunk) => {
         if (typeof chunk === 'string') return chunk;
         if (Array.isArray(chunk.value)) return chunk.value.join('');
-        if (chunk.value !== undefined && chunk.value !== null) return String(chunk.value);
+        if (typeof chunk.value === 'number' || typeof chunk.value === 'string') return String(chunk.value);
         return '';
       })
       .join('');
@@ -252,11 +252,11 @@ describe('runReenrichment — cooperative pause', () => {
       batchSize: 100,
       liveActivityLookbackSeconds: 60,
       liveActivityPauseMs: 0,
-      checkLiveActivity: mockCheckLiveActivity as jest.Mock,
+      checkLiveActivity: mockCheckLiveActivity,
     });
 
     // Probe was called at least 3 times (twice truthy, once falsy)
-    expect((mockCheckLiveActivity as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(mockCheckLiveActivity.mock.calls.length).toBeGreaterThanOrEqual(3);
   });
 
   it('skips probe when liveActivityLookbackSeconds=0', async () => {
@@ -271,10 +271,10 @@ describe('runReenrichment — cooperative pause', () => {
       cutoffTs: CUTOFF,
       batchSize: 100,
       liveActivityLookbackSeconds: 0,
-      checkLiveActivity: mockCheckLiveActivity as jest.Mock,
+      checkLiveActivity: mockCheckLiveActivity,
     });
 
-    expect(mockCheckLiveActivity as jest.Mock).not.toHaveBeenCalled();
+    expect(mockCheckLiveActivity).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
@@ -98,9 +98,31 @@ describe('resolveCutoffTs', () => {
     expect(resolveCutoffTs(CUTOFF)).toBe(CUTOFF);
   });
 
-  it('throws on garbage (Date.parse → NaN)', () => {
-    expect(() => resolveCutoffTs('not-a-date')).toThrow(/not a valid ISO 8601/);
-    expect(() => resolveCutoffTs('yesterday')).toThrow(/not a valid ISO 8601/);
+  it('throws on garbage', () => {
+    expect(() => resolveCutoffTs('not-a-date')).toThrow(/strict ISO 8601/);
+    expect(() => resolveCutoffTs('yesterday')).toThrow(/strict ISO 8601/);
+  });
+
+  it('throws on non-strict-ISO formats Date.parse accepts but PG would reject (or interpret differently)', () => {
+    // round-3 hardening: Date.parse accepts these, but they could shift
+    // cohort semantics vs PG ::timestamptz.
+    expect(() => resolveCutoffTs('2026-6-16T17:53:53Z')).toThrow(/strict ISO 8601/);
+    expect(() => resolveCutoffTs('2026/06/16 17:53:53')).toThrow(/strict ISO 8601/);
+    expect(() => resolveCutoffTs('2026')).toThrow(/strict ISO 8601/);
+    expect(() => resolveCutoffTs('2026-06-16')).toThrow(/strict ISO 8601/); // date-only
+  });
+
+  it('throws on out-of-range day that Date.parse silently normalizes', () => {
+    // '2026-02-30' would normalize to '2026-03-02' under bare Date.parse;
+    // our calendar-validation catches it explicitly.
+    expect(() => resolveCutoffTs('2026-02-30T00:00:00Z')).toThrow(/out-of-range field/);
+    expect(() => resolveCutoffTs('2026-06-31T00:00:00Z')).toThrow(/out-of-range field/);
+    expect(() => resolveCutoffTs('2026-13-01T00:00:00Z')).toThrow(/out-of-range field/);
+    expect(() => resolveCutoffTs('2026-06-16T25:00:00Z')).toThrow(/out-of-range field/);
+  });
+
+  it('accepts timezone-offset form (e.g. -07:00)', () => {
+    expect(resolveCutoffTs('2026-06-16T10:53:53-07:00')).toBe('2026-06-16T10:53:53-07:00');
   });
 
   it('throws on a future timestamp (catches fat-finger year typos)', () => {

--- a/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
@@ -29,6 +29,8 @@ import {
   resolveCutoffTs,
   resolveLiveActivityLookback,
   resolveLiveActivityPauseMs,
+  requestStop,
+  __resetStopForTesting,
 } from '../../../../jobs/flowsheet-reenrichment/orchestrate';
 
 type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: unknown }> };
@@ -92,8 +94,17 @@ describe('resolveCutoffTs', () => {
     expect(() => resolveCutoffTs(undefined)).toThrow(/BACKFILL_CUTOFF_TS/);
   });
 
-  it('returns the value when set', () => {
+  it('returns the value when set to a valid past ISO timestamp', () => {
     expect(resolveCutoffTs(CUTOFF)).toBe(CUTOFF);
+  });
+
+  it('throws on garbage (Date.parse → NaN)', () => {
+    expect(() => resolveCutoffTs('not-a-date')).toThrow(/not a valid ISO 8601/);
+    expect(() => resolveCutoffTs('yesterday')).toThrow(/not a valid ISO 8601/);
+  });
+
+  it('throws on a future timestamp (catches fat-finger year typos)', () => {
+    expect(() => resolveCutoffTs('2099-01-01T00:00:00Z')).toThrow(/in the future/);
   });
 });
 
@@ -300,4 +311,127 @@ describe('runReenrichment — idempotency', () => {
     expect(result.totals.match_raced).toBe(2);
     expect(result.totals.lml_error).toBe(0);
   });
+});
+
+describe('runReenrichment — db_error catch arm (review-round-2)', () => {
+  it('counts db_error and continues when enrich throws (transient PG failure)', async () => {
+    // First row enrich throws (e.g. transient connection reset), second row succeeds
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1), makeRow(2)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult());
+    const enrich = jest.fn<EnrichFn>().mockRejectedValueOnce(new Error('connection reset')).mockResolvedValue('match');
+
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    // Critical: the run does NOT abort — both rows are scanned, one
+    // counted as db_error, one as match.
+    expect(result.totals.scanned).toBe(2);
+    expect(result.totals.db_error).toBe(1);
+    expect(result.totals.match).toBe(1);
+    expect(result.flipped).toBe(1);
+  });
+});
+
+describe('runReenrichment — cooperative stop (SIGTERM)', () => {
+  // Reset before AND after so the module-level stopRequested flag never
+  // leaks into a subsequent describe block (e.g. loadBatch-retry tests
+  // that would otherwise see stopRequested=true and exit before the
+  // first batch).
+  beforeEach(() => {
+    __resetStopForTesting();
+  });
+  afterEach(() => {
+    __resetStopForTesting();
+  });
+
+  it('exits between batches when requestStop() is called', async () => {
+    // Two batches available; stop is requested before the second loads
+    let batchCount = 0;
+    (db.execute as jest.Mock).mockImplementation(() => {
+      batchCount += 1;
+      if (batchCount === 1) {
+        return Promise.resolve([makeRow(1)]);
+      }
+      return Promise.resolve([makeRow(2)]);
+    });
+
+    const lookup = jest.fn<LookupFn>().mockImplementation(() => {
+      // Request stop after the first row is processed
+      requestStop();
+      return Promise.resolve(noMatchResult());
+    });
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    // First batch's single row processes; the loop checks stopRequested
+    // before the second loadBatch and exits. Row 2 is never scanned.
+    expect(result.totals.scanned).toBe(1);
+  });
+});
+
+describe('runReenrichment — loadBatch retry on transient DB error', () => {
+  // mockReset (not mockClear) wipes the previous test's mockImplementation
+  // so we can fully control db.execute here. Also reset the global
+  // stopRequested flag in case a prior SIGTERM test left it set.
+  beforeEach(() => {
+    (db.execute as jest.Mock).mockReset();
+    __resetStopForTesting();
+  });
+
+  it('retries up to 3 times before succeeding', async () => {
+    let attempts = 0;
+    (db.execute as jest.Mock).mockImplementation(() => {
+      attempts += 1;
+      if (attempts < 3) {
+        return Promise.reject(new Error('transient connection reset'));
+      }
+      return Promise.resolve([]); // third attempt succeeds with empty → loop exits
+    });
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    expect(attempts).toBe(3);
+    expect(result.totals.scanned).toBe(0);
+  }, 30_000);
+
+  it('propagates after exhausting retries', async () => {
+    const err = new Error('sustained outage');
+    (db.execute as jest.Mock).mockRejectedValueOnce(err).mockRejectedValueOnce(err).mockRejectedValueOnce(err);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    await expect(
+      runReenrichment({
+        lookup,
+        enrich,
+        cutoffTs: CUTOFF,
+        batchSize: 100,
+        liveActivityLookbackSeconds: 0,
+      })
+    ).rejects.toThrow(/sustained outage/);
+    expect((db.execute as jest.Mock).mock.calls.length).toBe(3);
+  }, 30_000);
 });

--- a/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
@@ -438,22 +438,27 @@ describe('runReenrichment — loadBatch retry on transient DB error', () => {
     expect(result.totals.scanned).toBe(0);
   }, 30_000);
 
-  it('propagates after exhausting retries', async () => {
+  it('captures exhaustion in failed-step summary instead of propagating (round 4)', async () => {
+    // Round 4: runReenrichment catches the exhaustion so its finally arm
+    // emits the structured `failed` log line (carrying last_id, the
+    // operator's resume cursor). The previous shape — throwing — lost
+    // the summary span and the structured totals.
     const err = new Error('sustained outage');
     (db.execute as jest.Mock).mockRejectedValueOnce(err).mockRejectedValueOnce(err).mockRejectedValueOnce(err);
 
     const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult());
     const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
 
-    await expect(
-      runReenrichment({
-        lookup,
-        enrich,
-        cutoffTs: CUTOFF,
-        batchSize: 100,
-        liveActivityLookbackSeconds: 0,
-      })
-    ).rejects.toThrow(/sustained outage/);
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    expect(result.stopped).toBe(false);
+    expect(result.totals.scanned).toBe(0);
     expect((db.execute as jest.Mock).mock.calls.length).toBe(3);
   }, 30_000);
 });

--- a/tests/unit/jobs/flowsheet-reenrichment/payload-parity.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/payload-parity.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Parity test: the on-match 10-column flowsheet UPDATE payload written by
+ * `jobs/flowsheet-reenrichment/enrich.ts:reenrichRow` MUST equal the
+ * unlinked+match branch of `apps/enrichment-worker/enrich.ts:finalizeRow`.
+ *
+ * Both jobs target the same column set; the only structural difference is the
+ * WHERE guard. If the payloads drift, iOS shows different metadata depending
+ * on which path enriched the row. This snapshot pins them in lockstep so
+ * the next drift fails CI loudly.
+ *
+ * Method: drive both functions with identical inputs, capture the `.set()`
+ * arg from the mocked DB chain, and assert deep-equal on the 10 metadata
+ * columns (excluding metadata_status, which differs by design).
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '@wxyc/database';
+import { reenrichRow, type ReenrichRow } from '../../../../jobs/flowsheet-reenrichment/enrich';
+import { finalizeRow, type EnrichRow as WorkerEnrichRow } from '../../../../apps/enrichment-worker/enrich';
+import type { LookupResponse } from '@wxyc/lml-client';
+
+const mockDb = db as unknown as {
+  update: jest.Mock;
+  _chain: {
+    set: jest.Mock;
+    where: jest.Mock;
+    returning: jest.Mock;
+  };
+};
+
+const METADATA_COLUMNS = [
+  'artwork_url',
+  'discogs_url',
+  'release_year',
+  'spotify_url',
+  'apple_music_url',
+  'youtube_music_url',
+  'bandcamp_url',
+  'soundcloud_url',
+  'artist_bio',
+  'artist_wikipedia_url',
+] as const;
+
+const matchedResponse: LookupResponse = {
+  results: [
+    {
+      library_item: { id: 1 },
+      artwork: {
+        release_id: 12345,
+        release_url: 'https://www.discogs.com/release/12345',
+        artwork_url: 'https://i.discogs.com/art.jpg',
+        release_year: 2001,
+        artist_bio: '[a=Rob Brown] and [a=Sean Booth] are Autechre.',
+        wikipedia_url: 'https://en.wikipedia.org/wiki/Autechre',
+        spotify_url: 'https://open.spotify.com/album/abc',
+        apple_music_url: 'https://music.apple.com/album/xyz',
+        youtube_music_url: 'https://music.youtube.com/album/aaa',
+        bandcamp_url: null,
+        soundcloud_url: null,
+      },
+    },
+  ],
+  search_type: 'direct',
+};
+
+const reenrichBaseRow: ReenrichRow = {
+  id: 99,
+  artist_name: 'Autechre',
+  album_title: 'Confield',
+  track_title: 'VI Scose Poise',
+};
+
+const finalizeBaseRow: WorkerEnrichRow = {
+  id: 99,
+  artist_name: 'Autechre',
+  album_title: 'Confield',
+  track_title: 'VI Scose Poise',
+  album_id: null, // unlinked, same as reenrichRow's implicit constraint
+};
+
+type Cases = {
+  name: string;
+  response: LookupResponse;
+  reenrichRow_row?: ReenrichRow;
+  finalizeRow_row?: WorkerEnrichRow;
+};
+const cases: Cases[] = [
+  { name: 'full LML match with all fields', response: matchedResponse },
+  {
+    name: 'artist-only row (no album/track)',
+    response: matchedResponse,
+    reenrichRow_row: { id: 99, artist_name: 'Stereolab', album_title: null, track_title: null },
+    finalizeRow_row: { id: 99, artist_name: 'Stereolab', album_title: null, track_title: null, album_id: null },
+  },
+  {
+    name: 'zero release_year coerced to null',
+    response: {
+      ...matchedResponse,
+      results: [
+        { ...matchedResponse.results[0], artwork: { ...matchedResponse.results[0].artwork!, release_year: 0 } },
+      ],
+    },
+  },
+  {
+    name: 'spacer.gif artwork_url filtered to null',
+    response: {
+      ...matchedResponse,
+      results: [
+        {
+          ...matchedResponse.results[0],
+          artwork: { ...matchedResponse.results[0].artwork!, artwork_url: 'https://s.discogs.com/images/spacer.gif' },
+        },
+      ],
+    },
+  },
+];
+
+describe('payload parity: reenrichRow vs finalizeRow (unlinked+match)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: UPDATE matched 1 row (non-raced)
+    mockDb._chain.returning.mockResolvedValue([{ id: 99 }]);
+  });
+
+  it.each(cases)('$name', async ({ response, reenrichRow_row, finalizeRow_row }) => {
+    const rRow = reenrichRow_row ?? reenrichBaseRow;
+    const fRow = finalizeRow_row ?? finalizeBaseRow;
+
+    // Capture reenrichRow's payload
+    await reenrichRow(rRow, response);
+    const reenrichSet = { ...(mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>) };
+    jest.clearAllMocks();
+    mockDb._chain.returning.mockResolvedValue([{ id: 99 }]);
+
+    // Capture finalizeRow's payload (unlinked branch → album_id=null → same shape)
+    await finalizeRow(fRow, response);
+    const finalizeSet = { ...(mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>) };
+
+    // Assert the 10 metadata columns match exactly
+    for (const col of METADATA_COLUMNS) {
+      expect({ col, value: reenrichSet[col] }).toEqual({ col, value: finalizeSet[col] });
+    }
+  });
+});

--- a/tests/unit/jobs/flowsheet-reenrichment/runbook-log-contract.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/runbook-log-contract.test.ts
@@ -15,7 +15,12 @@
 import { jest } from '@jest/globals';
 
 import { db } from '@wxyc/database';
-import { runReenrichment, type LookupFn, type EnrichFn } from '../../../../jobs/flowsheet-reenrichment/orchestrate';
+import {
+  runReenrichment,
+  type LookupFn,
+  type EnrichFn,
+  __resetStopForTesting,
+} from '../../../../jobs/flowsheet-reenrichment/orchestrate';
 import { initLogger, closeLogger } from '../../../../jobs/flowsheet-reenrichment/logger';
 import type { LookupResponse } from '@wxyc/lml-client';
 
@@ -50,8 +55,20 @@ const matchedResponse: LookupResponse = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // mockReset wipes the mockResolvedValueOnce queue too (clearAllMocks
+  // only clears call history, so an unconsumed mockResolvedValueOnce from
+  // an earlier test would leak into the next one and make db.execute
+  // return [] before the test's intended mock values).
+  (db.execute as jest.Mock).mockReset();
+  // Reset module-level singleton so tests that exercise requestStop()
+  // don't leak the flag into subsequent tests (round 3).
+  __resetStopForTesting();
   delete process.env.SENTRY_DSN;
   initLogger({ repo: 'Backend-Service', tool: 'flowsheet-reenrichment', runId: 'test-run' });
+});
+
+afterEach(() => {
+  __resetStopForTesting();
 });
 
 afterEach(async () => {
@@ -103,6 +120,73 @@ describe('runbook log contract — batch_done', () => {
     expect(rec?.match).toBe(1); // non-raced matches
     expect(rec?.match_raced).toBe(1); // raced matches
     expect(rec?.flipped).toBe(1); // = match (non-raced)
+  });
+});
+
+describe('runbook log contract — stopped step (round 3)', () => {
+  it('emits step=stopped (not finished) on SIGTERM-induced early break', async () => {
+    const { requestStop, __resetStopForTesting } = await import('../../../../jobs/flowsheet-reenrichment/orchestrate');
+    __resetStopForTesting();
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockImplementation(() => {
+      requestStop(); // simulate SIGTERM during processing of row 1
+      return Promise.resolve({ response: noMatchResponse, cacheHit: false });
+    });
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    const stdoutLines = captureJson('stdout');
+    const result = await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      batchSize: 10,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    // Runbook's jq filter is `select(.step=="finished" or .step=="stopped")`.
+    // A stopped run MUST be distinguishable from a finished one so the
+    // runbook can tell the operator to re-run.
+    const finished = stdoutLines.find((l) => l.step === 'finished');
+    const stopped = stdoutLines.find((l) => l.step === 'stopped');
+    expect(finished).toBeUndefined();
+    expect(stopped).toBeDefined();
+    expect(stopped?.stopped).toBe(true);
+    expect(result.stopped).toBe(true);
+    __resetStopForTesting();
+  });
+});
+
+describe('runbook log contract — match_raced_summary (round 3)', () => {
+  it('emits one summary log per run when match_raced > 0 (not per-row)', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1), makeRow(2), makeRow(3)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ response: matchedResponse, cacheHit: false });
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('match_raced');
+
+    const stdoutLines = captureJson('stdout');
+    const stderrLines = captureJson('stderr');
+    await runReenrichment({ lookup, enrich, cutoffTs: CUTOFF, batchSize: 10, liveActivityLookbackSeconds: 0 });
+
+    const summaries = [...stdoutLines, ...stderrLines].filter((l) => l.step === 'match_raced_summary');
+    expect(summaries.length).toBe(1);
+    expect(summaries[0].match_raced_count).toBe(3);
+    expect(summaries[0].sample_ids).toEqual([1, 2, 3]);
+    expect(summaries[0].truncated_count).toBe(0);
+  });
+
+  it('does NOT emit when match_raced is zero', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ response: noMatchResponse, cacheHit: false });
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    const stdoutLines = captureJson('stdout');
+    const stderrLines = captureJson('stderr');
+    await runReenrichment({ lookup, enrich, cutoffTs: CUTOFF, batchSize: 10, liveActivityLookbackSeconds: 0 });
+
+    const summaries = [...stdoutLines, ...stderrLines].filter((l) => l.step === 'match_raced_summary');
+    expect(summaries.length).toBe(0);
   });
 });
 

--- a/tests/unit/jobs/flowsheet-reenrichment/runbook-log-contract.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/runbook-log-contract.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Log-contract pin for flowsheet-reenrichment.
+ *
+ * The post-run comment on BS#1433 is sourced from the `finished` log line's
+ * `flipped` field. Renaming any of the contracted fields without updating
+ * the runbook + issue-comment procedure will silently break observability.
+ *
+ * Contracted shapes:
+ *   - `step: 'batch_done'` per batch: batch_index (number), wall_clock_ms
+ *     (number), scanned (number), match (number), still_no_match (number),
+ *     lml_error (number), flipped (number).
+ *   - `step: 'finished'` once: scanned (number), flipped (number),
+ *     still_no_match (number), lml_error (number).
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '@wxyc/database';
+import { runReenrichment, type LookupFn, type EnrichFn } from '../../../../jobs/flowsheet-reenrichment/orchestrate';
+import { initLogger, closeLogger } from '../../../../jobs/flowsheet-reenrichment/logger';
+import type { LookupResponse } from '@wxyc/lml-client';
+
+type JsonLine = Record<string, unknown>;
+
+const captureJson = (stream: 'stdout' | 'stderr'): JsonLine[] => {
+  const lines: JsonLine[] = [];
+  jest.spyOn(process[stream], 'write').mockImplementation((chunk: unknown) => {
+    const text = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString();
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        lines.push(JSON.parse(line) as JsonLine);
+      } catch {
+        // ignore non-JSON
+      }
+    }
+    return true;
+  });
+  return lines;
+};
+
+const makeRow = (id: number) => ({ id, artist_name: 'Juana Molina', album_title: 'DOGA', track_title: null });
+
+const CUTOFF = '2026-06-16T17:53:53Z';
+
+const noMatchResponse: LookupResponse = { results: [], search_type: 'none' };
+const matchedResponse: LookupResponse = {
+  results: [{ library_item: { id: 1 }, artwork: { release_id: 1, release_url: 'u' } }],
+  search_type: 'direct',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.SENTRY_DSN;
+  initLogger({ repo: 'Backend-Service', tool: 'flowsheet-reenrichment', runId: 'test-run' });
+});
+
+afterEach(async () => {
+  jest.restoreAllMocks();
+  await closeLogger();
+});
+
+describe('runbook log contract — batch_done', () => {
+  it('emits one batch_done JSON record per batch with the contracted numeric fields', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1), makeRow(2)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ response: noMatchResponse, cacheHit: false });
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    const stdoutLines = captureJson('stdout');
+    await runReenrichment({ lookup, enrich, cutoffTs: CUTOFF, batchSize: 2, liveActivityLookbackSeconds: 0 });
+
+    const batchDone = stdoutLines.filter((l) => l.step === 'batch_done');
+    expect(batchDone.length).toBe(1);
+
+    const rec = batchDone[0];
+    expect(typeof rec.batch_index).toBe('number');
+    expect(typeof rec.wall_clock_ms).toBe('number');
+    expect(typeof rec.scanned).toBe('number');
+    expect(typeof rec.match).toBe('number');
+    expect(typeof rec.still_no_match).toBe('number');
+    expect(typeof rec.lml_error).toBe('number');
+    expect(typeof rec.flipped).toBe('number');
+    expect(rec.repo).toBe('Backend-Service');
+    expect(rec.tool).toBe('flowsheet-reenrichment');
+    expect(rec.run_id).toBe('test-run');
+    expect(rec.scanned).toBe(2);
+    expect(rec.still_no_match).toBe(2);
+    expect(rec.match).toBe(0);
+    expect(rec.flipped).toBe(0);
+  });
+
+  it('tracks match and flipped separately when some UPDATEs race', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1), makeRow(2)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ response: matchedResponse, cacheHit: false });
+    // First row → match (non-raced), second → match_raced
+    const enrich = jest.fn<EnrichFn>().mockResolvedValueOnce('match').mockResolvedValueOnce('match_raced');
+
+    const stdoutLines = captureJson('stdout');
+    await runReenrichment({ lookup, enrich, cutoffTs: CUTOFF, batchSize: 10, liveActivityLookbackSeconds: 0 });
+
+    const rec = stdoutLines.find((l) => l.step === 'batch_done');
+    expect(rec?.match).toBe(1); // non-raced matches
+    expect(rec?.match_raced).toBe(1); // raced matches
+    expect(rec?.flipped).toBe(1); // = match (non-raced)
+  });
+});
+
+describe('runbook log contract — finished', () => {
+  it('emits finished with cumulative scanned / flipped / still_no_match / lml_error', async () => {
+    // Two batches: batch 1 has a match, batch 2 has a still_no_match
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([makeRow(1)])
+      .mockResolvedValueOnce([makeRow(2)])
+      .mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ response: matchedResponse, cacheHit: false });
+    const enrich = jest.fn<EnrichFn>().mockResolvedValueOnce('match').mockResolvedValueOnce('still_no_match');
+
+    const stdoutLines = captureJson('stdout');
+    await runReenrichment({ lookup, enrich, cutoffTs: CUTOFF, batchSize: 1, liveActivityLookbackSeconds: 0 });
+
+    const finished = stdoutLines.find((l) => l.step === 'finished');
+    expect(finished).toBeDefined();
+    expect(typeof finished?.scanned).toBe('number');
+    expect(typeof finished?.flipped).toBe('number');
+    expect(typeof finished?.still_no_match).toBe('number');
+    expect(typeof finished?.lml_error).toBe('number');
+    expect(finished?.scanned).toBe(2);
+    expect(finished?.flipped).toBe(1);
+    expect(finished?.still_no_match).toBe(1);
+    expect(finished?.lml_error).toBe(0);
+  });
+});

--- a/tests/unit/jobs/flowsheet-reenrichment/runbook-log-contract.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/runbook-log-contract.test.ts
@@ -123,6 +123,65 @@ describe('runbook log contract — batch_done', () => {
   });
 });
 
+describe('runbook log contract — db_error / match_raced field pinning (round 4)', () => {
+  it('batch_done emits db_error and match_raced as numeric fields', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ response: matchedResponse, cacheHit: false });
+    // db_error path: enrich throws → counted as db_error
+    const enrich = jest.fn<EnrichFn>().mockRejectedValueOnce(new Error('pg blip'));
+
+    const stdoutLines = captureJson('stdout');
+    await runReenrichment({ lookup, enrich, cutoffTs: CUTOFF, batchSize: 10, liveActivityLookbackSeconds: 0 });
+
+    const rec = stdoutLines.find((l) => l.step === 'batch_done');
+    expect(typeof rec?.db_error).toBe('number');
+    expect(typeof rec?.match_raced).toBe('number');
+    expect(rec?.db_error).toBe(1);
+  });
+
+  it('finished log carries match_raced, db_error, last_id, and stopped fields', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(7)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ response: matchedResponse, cacheHit: false });
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('match');
+
+    const stdoutLines = captureJson('stdout');
+    await runReenrichment({ lookup, enrich, cutoffTs: CUTOFF, batchSize: 10, liveActivityLookbackSeconds: 0 });
+
+    const finished = stdoutLines.find((l) => l.step === 'finished');
+    expect(typeof finished?.match_raced).toBe('number');
+    expect(typeof finished?.db_error).toBe('number');
+    expect(typeof finished?.last_id).toBe('number');
+    expect(typeof finished?.stopped).toBe('boolean');
+    expect(finished?.last_id).toBe(7); // resume cursor
+    expect(finished?.stopped).toBe(false);
+  });
+});
+
+describe('runbook log contract — failed step (round 4)', () => {
+  it('emits step=failed with last_id when loadBatch exhausts retries', async () => {
+    const err = new Error('sustained outage');
+    (db.execute as jest.Mock).mockRejectedValueOnce(err).mockRejectedValueOnce(err).mockRejectedValueOnce(err);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ response: noMatchResponse, cacheHit: false });
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('still_no_match');
+
+    const stdoutLines = captureJson('stdout');
+    const stderrLines = captureJson('stderr');
+    await runReenrichment({ lookup, enrich, cutoffTs: CUTOFF, batchSize: 100, liveActivityLookbackSeconds: 0 });
+
+    const failed = [...stdoutLines, ...stderrLines].find((l) => l.step === 'failed');
+    expect(failed).toBeDefined();
+    expect(failed?.failed).toBe(true);
+    expect(failed?.error_message).toMatch(/sustained outage/);
+    expect(typeof failed?.last_id).toBe('number');
+    expect(typeof failed?.scanned).toBe('number');
+    // Runbook's jq filter must include 'failed' alongside finished/stopped
+    // so the operator can extract last_id for resume after a sustained outage.
+  }, 30_000);
+});
+
 describe('runbook log contract — stopped step (round 3)', () => {
   it('emits step=stopped (not finished) on SIGTERM-induced early break', async () => {
     const { requestStop, __resetStopForTesting } = await import('../../../../jobs/flowsheet-reenrichment/orchestrate');


### PR DESCRIPTION
Closes #1433

## Summary

- Adds `jobs/flowsheet-reenrichment/` — a one-shot drain for ~11,965 `flowsheet` rows left as `enriched_no_match` before LML#583 (merged 2026-06-16T17:53:53Z) closed the library-miss recall gap. Those rows are terminal in the `metadata_status` enum; the CDC consumer never revisits them. This job is the only mechanism that will ever rescue them.
- `Dockerfile.flowsheet-reenrichment` at repo root; `job-type: one-shot` in `package.json` routes it through `deploy-base.yml`'s one-shot pathway (no crontab registration).
- 35 unit tests across 4 files: enrich, orchestrate, payload-parity (pins on-match 10-column payload against `finalizeRow`), runbook-log-contract (pins `batch_done` / `finished` log shapes).

## Key design points

**`enrich.ts`** — modeled on `finalizeRow` (enrichment-worker) with three changes per the issue spec:
1. Idempotency guard: `WHERE metadata_status='enriched_no_match' AND album_id IS NULL` (not `enriching`); `album_id IS NULL` defends against a concurrent linkage-resolver race.
2. No-match → no-op early return. The existing search URLs and status are already correct.
3. No linked branch / no `album_metadata` writes. All cohort rows have `album_id IS NULL`.
4. No `metadata_attempt_at` stamp (CDC consumer convention, post-Epic-C).

**Pacing**: Sem(1) + TB(20/min) via `BACKFILL_LML_*` env vars — same budget as the sibling cron. Pre-flight: verify `flowsheet-metadata-backfill-cron` is `Exited` before launching (blocked by #1011; shared LML budget).

**Telemetry**: outer `reenrichment.run` Sentry span with cutoff + batch_size attributes at creation; per-batch `batch_done` JSON log; `finished` summary log; child `reenrichment.run.summary` span with flipped/still_no_match counts as numeric attributes (BS#1081 pattern).

## Test plan

- [x] 35 unit tests pass (`npm run test:unit -- --testPathPattern flowsheet-reenrichment`)
- [x] Lint clean (`eslint jobs/flowsheet-reenrichment/` — 0 errors, 2 pre-existing security/detect-object-injection warnings same as all sibling jobs)
- [x] Typecheck clean for new job files
- [ ] Pre-run: verify `flowsheet-metadata-backfill-cron` is Exited per #1011
- [ ] Run `deploy-manual.yml` with `target=flowsheet-reenrichment version=latest`
- [ ] SSH to EC2, `docker run` with `BACKFILL_CUTOFF_TS='2026-06-16T17:53:53Z'`
- [ ] Post-run: document flip count from `finished` log line's `flipped` field as a comment on #1433
- [ ] Spot-check 20 flipped rows: verify `discogs_url`, `artwork_url`, `release_year` populated and correct