### PR TITLE
feat(1438): deploy-guard endpoint-probe fallback when LML commit_sha is null

### DIFF
--- a/jobs/rotation-artist-backfill/README.md
+++ b/jobs/rotation-artist-backfill/README.md
@@ -49,9 +49,14 @@ Recalibration only lands alongside an ingress change (CDN insertion, replica sca
 
 ## Deploy gate
 
-The job aborts unless LML's `/health` returns a `commit_sha` that is `8a1344c` (LML PR [#559](https://github.com/WXYC/library-metadata-lookup/pull/559), the feat PR that shipped LML#525) or a descendant of it. Without that commit, `POST /api/v1/cache/refresh-for-identities` returns 404 and every batch fails. See `deploy-guard.ts`.
+The gate's job is to refuse to run against an LML deploy that lacks `POST /api/v1/cache/refresh-for-identities` (the endpoint LML#525 introduced) — without it every batch 404s and the run does no work. It answers that question two ways:
 
-Local dev: set `LOCAL_DEV=1` to skip the gate when `commit_sha` is null (Railway only injects `RAILWAY_GIT_COMMIT_SHA` in deployed environments).
+1. **Fast path — `commit_sha` present.** When LML's `/health` returns a `commit_sha`, the job allows iff that sha is `8a1344c` (LML PR [#559](https://github.com/WXYC/library-metadata-lookup/pull/559), the feat PR that shipped LML#525) or a descendant of it, verified via GitHub's compare API.
+2. **Fallback — `commit_sha` null (BS#1438).** LML prod serves `commit_sha: null` **permanently**: it deploys via `railway up`, whose CLI source-deploys carry no git metadata ([LML#509](https://github.com/WXYC/library-metadata-lookup/issues/509)). The SHA path can therefore never succeed against prod, so instead of aborting, the gate probes the endpoint directly — a `POST` with an empty `{ "identity_ids": [] }` batch. A `404`/`405` means the route is absent ⇒ **abort**; any other status (`422` empty-batch reject, `400`, `401`/`403` auth, `200`, `503`) means the route is mounted ⇒ **allow**. A network error or timeout ⇒ **abort** (never silently allow). The probe is genuinely zero-work: LML rejects the empty batch at request-model validation (`min_length=1`) before reading provenance or touching Discogs, so it warms no cache and burns no Discogs budget.
+
+Because the LML#525 endpoint was introduced by the gate commit itself, "route mounted" is equivalent to "this LML has LML#525" — there is no older same-named endpoint to confuse the probe. Given LML prod's structural null sha, the probe path is the one that actually runs in production until LML#509 changes LML's deploy method. See `deploy-guard.ts`.
+
+Local dev: set `LOCAL_DEV=1` to skip the gate when `commit_sha` is null — the bypass short-circuits before the probe (Railway only injects `RAILWAY_GIT_COMMIT_SHA` in deployed environments).
 
 ## Configuration
 
@@ -105,7 +110,7 @@ The `backfill.not_found / backfill.identities_scanned > 1%` alert (BS#1402) sign
 ## Files
 
 - `job.ts` — entry point + run lifecycle.
-- `deploy-guard.ts` — `/health` + GitHub compare gate.
+- `deploy-guard.ts` — `/health` + GitHub compare gate, with a null-sha endpoint-probe fallback (BS#1438).
 - `query.ts` — SELECT for active rotation identity ids.
 - `lml-fetch.ts` — typed wrapper over LML's identity-refresh endpoint.
 - `lml-limiter.ts` — concurrency + rate-limit gate.

--- a/jobs/rotation-artist-backfill/deploy-guard.ts
+++ b/jobs/rotation-artist-backfill/deploy-guard.ts
@@ -175,6 +175,10 @@ export const probeRefreshEndpoint = async (
     });
     return !ENDPOINT_ABSENT_STATUSES.has(response.status);
   } catch (e) {
+    // Surface a DeployGuardError from baseUrl() (e.g. LIBRARY_METADATA_URL
+    // unset) as-is — re-wrapping it as "probe request failed" would mislabel a
+    // config error as a network error. Mirrors fetchLmlHealth / isDescendantOnGithub.
+    if (e instanceof DeployGuardError) throw e;
     if ((e as Error).name === 'AbortError') {
       throw new DeployGuardError(`LML cache-refresh probe timed out after ${signalTimeoutMs}ms`);
     }

--- a/jobs/rotation-artist-backfill/deploy-guard.ts
+++ b/jobs/rotation-artist-backfill/deploy-guard.ts
@@ -1,5 +1,5 @@
 /**
- * Deploy guard for rotation-artist-backfill (BS#1381).
+ * Deploy guard for rotation-artist-backfill (BS#1381, BS#1438).
  *
  * The job is a no-op against any LML deploy that predates LML#525's
  * `POST /api/v1/cache/refresh-for-identities` endpoint (`8a1344c`,
@@ -7,6 +7,14 @@
  * to call against. So before scanning any rotation rows we hit LML's
  * `/health` and verify that its `commit_sha` is `8a1344c` or a descendant
  * of it.
+ *
+ * BS#1438: LML prod serves `commit_sha: null` permanently — it deploys via
+ * `railway up`, whose CLI source-deploys carry no git metadata (LML#509). The
+ * SHA-descendant check can therefore never succeed against prod, so when the
+ * sha is null (and not LOCAL_DEV) the guard falls back to probing the endpoint
+ * directly rather than aborting. See `probeRefreshEndpoint`. The probe is the
+ * path that actually runs in production until LML#509 changes LML's deploy
+ * method.
  *
  * Why gate on the endpoint and not the `fetched_at` discriminator that
  * the previous incarnation (BS#1361, PR #1376) gated on: the discriminator
@@ -23,9 +31,11 @@
  *   - `commit_sha` is null AND `LOCAL_DEV=1` is set → allowed (local dev,
  *     CI, and unit tests, where Railway's `RAILWAY_GIT_COMMIT_SHA` is
  *     unset). The flag must be explicit so an accidental
- *     production env-var drop doesn't silently neuter the guard.
- *   - `commit_sha` is null AND `LOCAL_DEV` is not set → ABORT (treated as
- *     a misconfigured prod deploy).
+ *     production env-var drop doesn't silently neuter the guard. Short-
+ *     circuits before the endpoint probe.
+ *   - `commit_sha` is null AND `LOCAL_DEV` is not set → probe the endpoint
+ *     (BS#1438): mounted → allowed; absent (404/405) → ABORT; network /
+ *     timeout → ABORT.
  *   - `commit_sha` is the gate sha itself OR a descendant → allowed.
  *   - `commit_sha` is anything else → ABORT.
  *
@@ -42,9 +52,24 @@
 
 const LML_BASE_URL_ENV = 'LIBRARY_METADATA_URL';
 const HEALTH_PATH = '/health';
+const REFRESH_PATH = '/api/v1/cache/refresh-for-identities';
 
 const HEALTH_TIMEOUT_MS = 10_000;
 const COMPARE_TIMEOUT_MS = 15_000;
+const PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * HTTP statuses that mean `POST /api/v1/cache/refresh-for-identities` is NOT
+ * present as a POST handler on this LML deploy:
+ *   - 404 — the route isn't mounted (a deploy predating LML#525).
+ *   - 405 — the path resolves but POST isn't allowed (i.e. not the handler
+ *     LML#525 introduced).
+ * Every other status — 422 (Pydantic `min_length=1` rejects the empty batch),
+ * 400 (manual malformed/over-cap reject), 401/403 (`LML_REQUIRE_AUTH` gate),
+ * 200 (no-op), 503 (entity store / Discogs degraded) — proves the route IS
+ * mounted, which is the only question this probe answers. See `probeRefreshEndpoint`.
+ */
+const ENDPOINT_ABSENT_STATUSES = new Set([404, 405]);
 
 /** LML#525: `POST /api/v1/cache/refresh-for-identities` shipped (LML PR #559). */
 export const GATE_COMMIT_SHA = '8a1344c';
@@ -104,6 +129,56 @@ export const fetchLmlHealth = async (
       throw new DeployGuardError(`LML /health timed out after ${signalTimeoutMs}ms`);
     }
     throw new DeployGuardError(`LML /health request failed: ${(e as Error).message}`);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Probe whether LML exposes `POST /api/v1/cache/refresh-for-identities`
+ * (the endpoint LML#525 introduced, which this backfill needs to make any
+ * progress). Returns `true` when the route is mounted, `false` when it is
+ * absent (404/405); throws `DeployGuardError` on network failure or timeout.
+ *
+ * Why this exists: LML prod serves `/health.commit_sha = null` permanently
+ * (it deploys via `railway up`, whose CLI source-deploys carry no git
+ * metadata — LML#509 / BS#1438), so the SHA-descendant gate can never succeed
+ * against prod. The probe asks the real question the SHA was only a proxy for:
+ * does the endpoint exist? The path was introduced by the gate commit itself,
+ * so "route mounted" is equivalent to "this LML has LML#525" — no older
+ * same-named endpoint exists to confuse the signal.
+ *
+ * The probe sends an empty `identity_ids: []` batch. That body is genuinely
+ * zero-work: LML rejects it at request-model validation (`min_length=1` → 422)
+ * before reading provenance or touching Discogs, so the probe warms no cache
+ * and burns no Discogs budget (verified against `cache/router.py` /
+ * `cache/models.py` in library-metadata-lookup). The `LML_API_KEY` bearer is
+ * attached when set (mirroring the lml-client chokepoint) so an
+ * `LML_REQUIRE_AUTH=true` prod returns 422 rather than 401 — though either is
+ * treated as "present" since only 404/405 mean absent.
+ */
+export const probeRefreshEndpoint = async (
+  fetchImpl: FetchLike = fetch,
+  signalTimeoutMs: number = PROBE_TIMEOUT_MS
+): Promise<boolean> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), signalTimeoutMs);
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const apiKey = process.env.LML_API_KEY;
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+    const response = await fetchImpl(`${baseUrl()}${REFRESH_PATH}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ identity_ids: [] }),
+      signal: controller.signal,
+    });
+    return !ENDPOINT_ABSENT_STATUSES.has(response.status);
+  } catch (e) {
+    if ((e as Error).name === 'AbortError') {
+      throw new DeployGuardError(`LML cache-refresh probe timed out after ${signalTimeoutMs}ms`);
+    }
+    throw new DeployGuardError(`LML cache-refresh probe request failed: ${(e as Error).message}`);
   } finally {
     clearTimeout(timer);
   }
@@ -174,9 +249,25 @@ export const enforceDeployGuard = async (deps: DeployGuardDeps = {}): Promise<De
     if (isLocalDev()) {
       return { allowed: true, commit_sha: null, reason: 'LOCAL_DEV=1; commit_sha unavailable' };
     }
-    throw new DeployGuardError(
-      'LML /health returned commit_sha=null but LOCAL_DEV is not set. Refusing to run against an LML deploy whose SHA cannot be verified.'
-    );
+    // LML prod serves commit_sha=null permanently (deploys via `railway up`,
+    // which carries no git metadata — LML#509 / BS#1438), so the SHA-descendant
+    // path below can never succeed against prod. Fall back to asking the real
+    // question the SHA was only a proxy for: is the LML#525 endpoint actually
+    // mounted? A network/timeout failure rethrows from the probe (ABORT); only
+    // a definitive 404/405 (endpoint absent) reaches the throw here.
+    const present = await probeRefreshEndpoint(fetchImpl);
+    if (!present) {
+      throw new DeployGuardError(
+        'LML /health returned commit_sha=null and the endpoint probe found ' +
+          'POST /api/v1/cache/refresh-for-identities absent (404/405). Refusing to run — ' +
+          'the LML#525 endpoint is required for this backfill to make progress.'
+      );
+    }
+    return {
+      allowed: true,
+      commit_sha: null,
+      reason: 'commit_sha null; endpoint probe confirms POST /api/v1/cache/refresh-for-identities is present',
+    };
   }
 
   if (sha.startsWith(GATE_COMMIT_SHA)) {

--- a/tests/unit/jobs/rotation-artist-backfill/deploy-guard.test.ts
+++ b/tests/unit/jobs/rotation-artist-backfill/deploy-guard.test.ts
@@ -1,13 +1,14 @@
 /**
- * Unit tests for jobs/rotation-artist-backfill/deploy-guard.ts (BS#1381).
+ * Unit tests for jobs/rotation-artist-backfill/deploy-guard.ts (BS#1381, BS#1438).
  *
- * Covers the four allow/deny shapes:
+ * Covers the allow/deny shapes:
  *   1. commit_sha matches the gate (GATE_COMMIT_SHA prefix) → allowed.
  *   2. commit_sha descends from the gate (per GitHub compare) → allowed.
- *   3. commit_sha is null AND LOCAL_DEV=1 → allowed.
- *   4. commit_sha is null AND no LOCAL_DEV → throw DeployGuardError.
- *   5. commit_sha does NOT descend from the gate → throw.
- *   6. /health non-2xx, network errors, GitHub compare non-2xx → throw.
+ *   3. commit_sha is null AND LOCAL_DEV=1 → allowed (no endpoint probe).
+ *   4. commit_sha is null, not LOCAL_DEV, endpoint probe present → allowed (BS#1438).
+ *   5. commit_sha is null, not LOCAL_DEV, endpoint probe absent (404/405) → throw (BS#1438).
+ *   6. commit_sha does NOT descend from the gate → throw.
+ *   7. /health non-2xx, network errors, GitHub compare non-2xx, probe network/timeout → throw.
  */
 
 import { jest } from '@jest/globals';
@@ -18,6 +19,7 @@ import {
   enforceDeployGuard,
   fetchLmlHealth,
   isDescendantOnGithub,
+  probeRefreshEndpoint,
 } from '../../../../jobs/rotation-artist-backfill/deploy-guard';
 
 const ORIGINAL_ENV = process.env;
@@ -42,6 +44,7 @@ beforeEach(() => {
   process.env.LIBRARY_METADATA_URL = 'http://lml.test';
   delete process.env.LOCAL_DEV;
   delete process.env.GITHUB_TOKEN;
+  delete process.env.LML_API_KEY;
 });
 
 afterAll(() => {
@@ -147,6 +150,85 @@ describe('isDescendantOnGithub', () => {
   });
 });
 
+describe('probeRefreshEndpoint', () => {
+  it('returns true when the endpoint rejects the empty batch with 422 (present)', async () => {
+    const fetchImpl = makeFetch([() => makeResponse({ detail: 'empty' }, { status: 422 })]);
+    const present = await probeRefreshEndpoint(fetchImpl as unknown as typeof fetch);
+    expect(present).toBe(true);
+  });
+
+  it('returns false on 404 (route not mounted — older LML deploy)', async () => {
+    const fetchImpl = makeFetch([
+      () => makeResponse({ detail: 'Not Found' }, { status: 404, statusText: 'Not Found' }),
+    ]);
+    const present = await probeRefreshEndpoint(fetchImpl as unknown as typeof fetch);
+    expect(present).toBe(false);
+  });
+
+  it('returns false on 405 (path resolves but POST not allowed)', async () => {
+    const fetchImpl = makeFetch([() => makeResponse({}, { status: 405, statusText: 'Method Not Allowed' })]);
+    const present = await probeRefreshEndpoint(fetchImpl as unknown as typeof fetch);
+    expect(present).toBe(false);
+  });
+
+  // Every non-404/405 status proves the route is mounted — that is all the gate
+  // needs. 401/403 (auth gate), 400 (manual reject), 200 (no-op), 503 (degraded
+  // dependency) all mean "present".
+  it.each([200, 400, 401, 403, 503])('returns true on %d (route is mounted)', async (status) => {
+    const fetchImpl = makeFetch([() => makeResponse({ detail: String(status) }, { status })]);
+    const present = await probeRefreshEndpoint(fetchImpl as unknown as typeof fetch);
+    expect(present).toBe(true);
+  });
+
+  it('POSTs an empty identity_ids batch to the refresh path (zero-work probe)', async () => {
+    let seenUrl = '';
+    let seenInit: RequestInit = {};
+    const fetchImpl = jest.fn().mockImplementation((url: string, init?: RequestInit) => {
+      seenUrl = url;
+      seenInit = init ?? {};
+      return Promise.resolve(makeResponse({}, { status: 422 }));
+    });
+    await probeRefreshEndpoint(fetchImpl as unknown as typeof fetch);
+    expect(seenUrl).toBe('http://lml.test/api/v1/cache/refresh-for-identities');
+    expect(seenInit.method).toBe('POST');
+    expect(JSON.parse(seenInit.body as string)).toEqual({ identity_ids: [] });
+  });
+
+  it('attaches the LML_API_KEY bearer header when set', async () => {
+    process.env.LML_API_KEY = 'secret-key';
+    let seenHeaders: Record<string, string> = {};
+    const fetchImpl = jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      seenHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return Promise.resolve(makeResponse({}, { status: 422 }));
+    });
+    await probeRefreshEndpoint(fetchImpl as unknown as typeof fetch);
+    expect(seenHeaders.Authorization).toBe('Bearer secret-key');
+  });
+
+  it('omits Authorization when LML_API_KEY is unset', async () => {
+    let seenHeaders: Record<string, string> = {};
+    const fetchImpl = jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      seenHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return Promise.resolve(makeResponse({}, { status: 422 }));
+    });
+    await probeRefreshEndpoint(fetchImpl as unknown as typeof fetch);
+    expect(seenHeaders.Authorization).toBeUndefined();
+  });
+
+  it('throws DeployGuardError on a network failure (ABORT, never silently allow)', async () => {
+    const fetchImpl = jest.fn().mockImplementation(() => Promise.reject(new Error('ECONNREFUSED')));
+    await expect(probeRefreshEndpoint(fetchImpl as unknown as typeof fetch)).rejects.toBeInstanceOf(DeployGuardError);
+  });
+
+  it('throws DeployGuardError when the probe times out', async () => {
+    const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    const fetchImpl = jest.fn().mockImplementation(() => Promise.reject(abortErr));
+    await expect(probeRefreshEndpoint(fetchImpl as unknown as typeof fetch, 5)).rejects.toBeInstanceOf(
+      DeployGuardError
+    );
+  });
+});
+
 describe('enforceDeployGuard', () => {
   it('passes when commit_sha is the gate sha itself', async () => {
     const fetchImpl = makeFetch([() => makeResponse({ commit_sha: `${GATE_COMMIT_SHA}deadbeef` })]);
@@ -178,7 +260,7 @@ describe('enforceDeployGuard', () => {
     );
   });
 
-  it('passes when commit_sha is null and LOCAL_DEV=1', async () => {
+  it('passes when commit_sha is null and LOCAL_DEV=1 without probing the endpoint', async () => {
     process.env.LOCAL_DEV = '1';
     const fetchImpl = makeFetch([() => makeResponse({ commit_sha: null })]);
     const result = await enforceDeployGuard({
@@ -188,10 +270,31 @@ describe('enforceDeployGuard', () => {
     });
     expect(result.allowed).toBe(true);
     expect(result.commit_sha).toBeNull();
+    // Only /health — LOCAL_DEV short-circuits before the endpoint probe.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it('refuses when commit_sha is null and LOCAL_DEV is unset', async () => {
-    const fetchImpl = makeFetch([() => makeResponse({ commit_sha: null })]);
+  it('passes when commit_sha is null, not LOCAL_DEV, and the endpoint probe finds it present', async () => {
+    const fetchImpl = makeFetch([
+      () => makeResponse({ commit_sha: null }),
+      () => makeResponse({ detail: 'empty' }, { status: 422 }),
+    ]);
+    const result = await enforceDeployGuard({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      isLocalDev: () => false,
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.commit_sha).toBeNull();
+    // /health then the endpoint probe — the SHA-descendant path is skipped.
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.reason).toMatch(/probe/i);
+  });
+
+  it('refuses when commit_sha is null, not LOCAL_DEV, and the endpoint probe finds it absent (404)', async () => {
+    const fetchImpl = makeFetch([
+      () => makeResponse({ commit_sha: null }),
+      () => makeResponse({ detail: 'Not Found' }, { status: 404, statusText: 'Not Found' }),
+    ]);
     await expect(
       enforceDeployGuard({
         fetchImpl: fetchImpl as unknown as typeof fetch,

--- a/tests/unit/jobs/rotation-artist-backfill/deploy-guard.test.ts
+++ b/tests/unit/jobs/rotation-artist-backfill/deploy-guard.test.ts
@@ -217,15 +217,31 @@ describe('probeRefreshEndpoint', () => {
 
   it('throws DeployGuardError on a network failure (ABORT, never silently allow)', async () => {
     const fetchImpl = jest.fn().mockImplementation(() => Promise.reject(new Error('ECONNREFUSED')));
-    await expect(probeRefreshEndpoint(fetchImpl as unknown as typeof fetch)).rejects.toBeInstanceOf(DeployGuardError);
+    // Pin the label too — a regression that routed this into the timeout branch
+    // (or swallowed it) would otherwise stay green under a bare instanceof check.
+    await expect(probeRefreshEndpoint(fetchImpl as unknown as typeof fetch)).rejects.toThrow(
+      /probe request failed: ECONNREFUSED/
+    );
   });
 
   it('throws DeployGuardError when the probe times out', async () => {
     const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
     const fetchImpl = jest.fn().mockImplementation(() => Promise.reject(abortErr));
-    await expect(probeRefreshEndpoint(fetchImpl as unknown as typeof fetch, 5)).rejects.toBeInstanceOf(
-      DeployGuardError
+    await expect(probeRefreshEndpoint(fetchImpl as unknown as typeof fetch, 5)).rejects.toThrow(
+      /probe timed out after 5ms/
     );
+  });
+
+  it('rethrows a config DeployGuardError unchanged instead of re-wrapping it', async () => {
+    delete process.env.LIBRARY_METADATA_URL;
+    const fetchImpl = jest.fn();
+    // baseUrl() throws a DeployGuardError before any fetch; it must surface
+    // as-is, not be re-wrapped into the generic "probe request failed" message
+    // (which would mis-route an operator to debug the network instead of env).
+    await expect(probeRefreshEndpoint(fetchImpl as unknown as typeof fetch)).rejects.toThrow(
+      /^LIBRARY_METADATA_URL is not configured$/
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

`jobs/rotation-artist-backfill`'s deploy guard aborts when LML `/health` returns `commit_sha: null`. But LML prod serves `commit_sha: null` **permanently** — it deploys via `railway up`, whose CLI source-deploys carry no git metadata ([LML#509](https://github.com/WXYC/library-metadata-lookup/issues/509)) — so the SHA-descendant gate can never succeed against prod. The cron has wedged on `DeployGuardError` every daily run since 2026-06-10, so [BS#1425](https://github.com/WXYC/Backend-Service/issues/1425)'s cache-refresh fan-out has had zero production effect and [BS#1428](https://github.com/WXYC/Backend-Service/issues/1428)'s verification can't begin.

When `commit_sha` is null (and not `LOCAL_DEV`), the guard now **probes the endpoint directly** instead of aborting — asking the real question the SHA was only a proxy for: is `POST /api/v1/cache/refresh-for-identities` actually mounted?

## Behavior

| Condition | Outcome |
|---|---|
| `commit_sha` present | Unchanged — gate sha prefix or GitHub descendant check (fast path) |
| `commit_sha` null + `LOCAL_DEV=1` | Allow, **no probe** (short-circuits, unchanged) |
| `commit_sha` null + probe returns 404/405 | **Abort** — endpoint absent |
| `commit_sha` null + probe returns anything else (422/400/401/403/200/503) | **Allow** — route is mounted |
| `commit_sha` null + probe network error / timeout | **Abort** |

The probe sends an empty `{ "identity_ids": [] }` batch, which is genuinely **zero-work**: LML rejects it at request-model validation (`min_length=1`) before any provenance read or Discogs call, so it warms no cache and burns no Discogs budget. The `LML_API_KEY` bearer is attached when set.

Because the LML#525 endpoint was introduced by the gate commit itself, "route mounted" ⟺ "this LML has LML#525" — there's no older same-named endpoint to confuse the probe. Given prod's structural null sha, **the probe path is the one that runs in production** until LML#509 changes LML's deploy method.

## Correction to the issue's proposed contract

The issue proposed `200/400 ⇒ ALLOW`. Verifying against LML's own source (`cache/models.py` `min_length=1` → **422**; `core/auth.py` → **401/403** under `LML_REQUIRE_AUTH`) showed an empty batch never returns `400` on a healthy endpoint — the literal contract would have aborted against exactly the deploy it should permit. Shipped rule is **`404/405 ⇒ absent`, everything else ⇒ present**, which is immune to LML's auth posture. `refreshForIdentities([])` couldn't be reused (its client-side empty-batch guard throws before the wire call), so the probe is a thin standalone helper.

## Tests

`tests/unit/jobs/rotation-artist-backfill/deploy-guard.test.ts` — 32 → covers all four `enforceDeployGuard` branches plus the probe's own behaviors (404/405 absent; 200/400/401/403/422/503 present; zero-work request shape; `LML_API_KEY` attach/omit; network + timeout aborts). Full `rotation-artist-backfill` unit suite: 60/60. Repo-wide `format:check` / `lint` / `typecheck` / `build` green.

Closes #1438