### PR TITLE
fix(internal-webhook): heal sibling marker rows that lost the stub race (#1444)

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -297,27 +297,26 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // Net effect: every new tubafrenzy show renders a nameless "signed on"
       // on the v2 wire until sign-off.
       //
-      // Fix: on the FIRST delivery of an entry whose show now resolves a name,
-      // backfill that show's still-NULL marker rows. A live show's show_start
-      // heals at the next track add after the ETL fills the name — minutes, not
-      // at sign-off — and the show_end heals itself / its siblings at sign-off.
-      // Scoped to `MARKER_ENTRY_TYPES` + `dj_name IS NULL`, so track rows (own
-      // population path) and already-resolved markers are never touched.
+      // Fix: whenever a delivery for the show resolves a non-null name, backfill
+      // the show's still-NULL marker rows. A live show's show_start heals at the
+      // next entry for the show — track add, edit, or sign-off — after the ETL
+      // fills the name. Healing on ANY delivery (not just fresh inserts) matters
+      // for the short-show case: a show whose start AND end both land before the
+      // ETL fill would otherwise never heal, since the ETL's resolveDjNames
+      // skips webhook-inserted rows (they arrive as updates, not inserts) — a
+      // later edit is then the only delivery that can fill them. Scoped to
+      // `MARKER_ENTRY_TYPES` + `dj_name IS NULL`, so track rows (own population
+      // path) and already-resolved markers are never touched.
       //
-      // Two deliberate gates keep this off the hot path:
-      //   1. `created` only — a re-delivery / tubafrenzy edit can't introduce a
-      //      new unhealed sibling (marker rows are created on their own first
-      //      delivery), and a re-delivered marker self-heals via the conflict
-      //      branch above. This skips the high-frequency edit-churn path.
-      //   2. Probe-before-write — a bare UPDATE that matches zero rows still
-      //      fires the STATEMENT-level `flowsheet_watermark` trigger (migration
-      //      0084), ratcheting the conditional-GET watermark +1s and thrashing
-      //      iOS/dj-site pollers (the very churn BS#902/Epic F's watermark
-      //      exists to prevent). A SELECT fires no trigger, so we read first and
-      //      issue the watermark-touching UPDATE only when a marker is actually
-      //      unhealed — at most once per show. Both queries are index-backed by
-      //      `flowsheet_show_id_idx`.
-      if (created && resolvedShowName !== null && showId !== null) {
+      // Probe-before-write — a bare UPDATE that matches zero rows still fires the
+      // STATEMENT-level `flowsheet_watermark` trigger (migration 0084),
+      // ratcheting the conditional-GET watermark +1s and thrashing iOS/dj-site
+      // pollers (the very churn BS#902/Epic F's watermark exists to prevent). A
+      // SELECT fires no trigger, so we read first and issue the watermark-
+      // touching UPDATE only when a marker is actually unhealed — at most once
+      // per show, after which every later delivery pays only the read. Both
+      // queries are index-backed by `flowsheet_show_id_idx`.
+      if (resolvedShowName !== null && showId !== null) {
         const unhealedMarkerWhere = and(
           eq(flowsheet.show_id, showId),
           isNull(flowsheet.dj_name),

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -23,6 +23,10 @@ const MARKER_ENTRY_TYPES: ReadonlySet<BackendEntryType> = new Set<BackendEntryTy
   'dj_leave',
 ]);
 
+// Materialized once for `inArray(...)` in the sibling-marker heal below — avoids
+// re-spreading the Set into an array on every webhook delivery.
+const MARKER_ENTRY_TYPE_LIST: BackendEntryType[] = [...MARKER_ENTRY_TYPES];
+
 export const internal_route = Router();
 
 /**
@@ -293,25 +297,40 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // Net effect: every new tubafrenzy show renders a nameless "signed on"
       // on the v2 wire until sign-off.
       //
-      // Fix: whenever ANY later webhook entry for the show resolves a non-null
-      // name, backfill that show's still-NULL marker rows. Firing on every
-      // entry (incl. tracks) heals a live show's show_start at the next track
-      // add after the ETL fills the name — minutes, not at sign-off. Scoped to
-      // `MARKER_ENTRY_TYPES` + `dj_name IS NULL`, so track rows (own population
-      // path) and already-resolved markers are never touched. Index-backed by
-      // `flowsheet_show_id_idx`; once a show is healed the predicate matches
-      // zero rows, so steady-state deliveries pay only an empty index probe.
-      if (resolvedShowName !== null && showId !== null) {
-        await db
-          .update(flowsheet)
-          .set({ dj_name: resolvedShowName })
-          .where(
-            and(
-              eq(flowsheet.show_id, showId),
-              isNull(flowsheet.dj_name),
-              inArray(flowsheet.entry_type, [...MARKER_ENTRY_TYPES])
-            )
-          );
+      // Fix: on the FIRST delivery of an entry whose show now resolves a name,
+      // backfill that show's still-NULL marker rows. A live show's show_start
+      // heals at the next track add after the ETL fills the name — minutes, not
+      // at sign-off — and the show_end heals itself / its siblings at sign-off.
+      // Scoped to `MARKER_ENTRY_TYPES` + `dj_name IS NULL`, so track rows (own
+      // population path) and already-resolved markers are never touched.
+      //
+      // Two deliberate gates keep this off the hot path:
+      //   1. `created` only — a re-delivery / tubafrenzy edit can't introduce a
+      //      new unhealed sibling (marker rows are created on their own first
+      //      delivery), and a re-delivered marker self-heals via the conflict
+      //      branch above. This skips the high-frequency edit-churn path.
+      //   2. Probe-before-write — a bare UPDATE that matches zero rows still
+      //      fires the STATEMENT-level `flowsheet_watermark` trigger (migration
+      //      0084), ratcheting the conditional-GET watermark +1s and thrashing
+      //      iOS/dj-site pollers (the very churn BS#902/Epic F's watermark
+      //      exists to prevent). A SELECT fires no trigger, so we read first and
+      //      issue the watermark-touching UPDATE only when a marker is actually
+      //      unhealed — at most once per show. Both queries are index-backed by
+      //      `flowsheet_show_id_idx`.
+      if (created && resolvedShowName !== null && showId !== null) {
+        const unhealedMarkerWhere = and(
+          eq(flowsheet.show_id, showId),
+          isNull(flowsheet.dj_name),
+          inArray(flowsheet.entry_type, MARKER_ENTRY_TYPE_LIST)
+        );
+        const [unhealedMarker] = await db
+          .select({ id: flowsheet.id })
+          .from(flowsheet)
+          .where(unhealedMarkerWhere)
+          .limit(1);
+        if (unhealedMarker) {
+          await db.update(flowsheet).set({ dj_name: resolvedShowName }).where(unhealedMarkerWhere);
+        }
       }
     }
 

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -315,7 +315,10 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // SELECT fires no trigger, so we read first and issue the watermark-
       // touching UPDATE only when a marker is actually unhealed — at most once
       // per show, after which every later delivery pays only the read. Both
-      // queries are index-backed by `flowsheet_show_id_idx`.
+      // queries are index-backed by `flowsheet_show_id_idx`. (Two deliveries
+      // for the same show can still race between probe and UPDATE and fire one
+      // bounded spurious bump before the marker is healed; correctness is
+      // unaffected — the UPDATE re-checks `dj_name IS NULL`.)
       if (resolvedShowName !== null && showId !== null) {
         const unhealedMarkerWhere = and(
           eq(flowsheet.show_id, showId),

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { db, flowsheet, shows, rotation, library, truncate, user } from '@wxyc/database';
 import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
 import { mapProdEntryType, isMessageEntryType, type BackendEntryType } from '../utils/flowsheet-transform.js';
@@ -207,7 +207,8 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       // joining guest. Same known limitation as flowsheet-dj-name-backfill;
       // the live createJoinNotification path is the only one that gets
       // guest attribution right today.
-      const markerDjName = MARKER_ENTRY_TYPES.has(entryType) ? normalizeMarkerName(show?.dj_name) : null;
+      const resolvedShowName = normalizeMarkerName(show?.dj_name);
+      const markerDjName = MARKER_ENTRY_TYPES.has(entryType) ? resolvedShowName : null;
 
       // INSERT ... ON CONFLICT DO NOTHING RETURNING { id }: either we win
       // the insert and PG hands back exactly one row, or a concurrent
@@ -277,6 +278,40 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
           refresh.dj_name = markerDjName;
         }
         await db.update(flowsheet).set(refresh).where(eq(flowsheet.legacy_entry_id, entry.id));
+      }
+
+      // Sibling-marker heal (BS#1444 — residual of BS#1371).
+      //
+      // The conflict path above only heals the SAME `legacy_entry_id`, but a
+      // `show_start` is the FIRST entry of a show, so when it arrives
+      // `resolveShow` has only just created the stub `shows` row — no
+      // `legacy_dj_name` yet — and the marker lands with dj_name=NULL (see the
+      // `ResolvedShow.dj_name` docstring). Tubafrenzy never re-delivers that
+      // create event, the periodic ETL's resolveDjNames only re-resolves ids
+      // it bulk-fetched, and `flowsheet-dj-name-backfill` is one-shot — so
+      // nothing ever fills the show_start once `shows.legacy_dj_name` lands.
+      // Net effect: every new tubafrenzy show renders a nameless "signed on"
+      // on the v2 wire until sign-off.
+      //
+      // Fix: whenever ANY later webhook entry for the show resolves a non-null
+      // name, backfill that show's still-NULL marker rows. Firing on every
+      // entry (incl. tracks) heals a live show's show_start at the next track
+      // add after the ETL fills the name — minutes, not at sign-off. Scoped to
+      // `MARKER_ENTRY_TYPES` + `dj_name IS NULL`, so track rows (own population
+      // path) and already-resolved markers are never touched. Index-backed by
+      // `flowsheet_show_id_idx`; once a show is healed the predicate matches
+      // zero rows, so steady-state deliveries pay only an empty index probe.
+      if (resolvedShowName !== null && showId !== null) {
+        await db
+          .update(flowsheet)
+          .set({ dj_name: resolvedShowName })
+          .where(
+            and(
+              eq(flowsheet.show_id, showId),
+              isNull(flowsheet.dj_name),
+              inArray(flowsheet.entry_type, [...MARKER_ENTRY_TYPES])
+            )
+          );
       }
     }
 

--- a/tests/integration/internal-flowsheet-webhook.spec.js
+++ b/tests/integration/internal-flowsheet-webhook.spec.js
@@ -238,4 +238,77 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
     expect(rows.length).toBe(1);
     expect(rows[0].album_title).toBe('DOGA (remastered)');
   });
+
+  // BS#1444 (residual of #1371): the show_start is the FIRST entry of a show,
+  // so it loses a structural race — when it arrives the stub `shows` row has no
+  // `legacy_dj_name` yet, and the marker lands NULL. The ETL fills the name
+  // minutes later, but the conflict path only heals the SAME legacy_entry_id
+  // (which never re-delivers for a create). The sibling-marker heal backfills
+  // the still-NULL marker rows when ANY later entry for the show resolves a
+  // name — so the live "signed on" stops rendering nameless mid-show.
+  test('a later entry heals a show_start that lost the stub race (BS#1444)', async () => {
+    const LEGACY_SHOW_ID = 9_999_987;
+    const SHOW_START_ID = 9_999_985;
+    const TRACK_ID = 9_999_984;
+
+    // Stub show with no resolvable name yet (mirrors resolveShow's stub insert).
+    await seedShow(LEGACY_SHOW_ID, { legacyDjName: null });
+
+    const cleanup = async () => {
+      await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id IN ($1, $2)`, [SHOW_START_ID, TRACK_ID]);
+      await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
+    };
+
+    try {
+      // 1) show_start arrives first → lands NULL (no name source on the stub).
+      const startRes = await request
+        .post('/internal/flowsheet-webhook')
+        .set('X-Internal-Key', INTERNAL_KEY)
+        .send({
+          action: 'create',
+          entry: buildEntry({ id: SHOW_START_ID, flowsheetEntryType: 9, radioShowId: LEGACY_SHOW_ID }),
+        });
+      expect(startRes.status).toBe(200);
+
+      const [startBefore] = await sql.unsafe(
+        `SELECT entry_type, dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`,
+        [SHOW_START_ID]
+      );
+      expect(startBefore.entry_type).toBe('show_start');
+      expect(startBefore.dj_name).toBeNull();
+
+      // 2) ETL fills shows.legacy_dj_name (simulated).
+      await sql.unsafe(`UPDATE ${SCHEMA}.shows SET legacy_dj_name = $1 WHERE legacy_show_id = $2`, [
+        'Healed Handle',
+        LEGACY_SHOW_ID,
+      ]);
+
+      // 3) A later TRACK delivery for the same show triggers the sibling heal.
+      const trackRes = await request
+        .post('/internal/flowsheet-webhook')
+        .set('X-Internal-Key', INTERNAL_KEY)
+        .send({
+          action: 'create',
+          entry: buildEntry({ id: TRACK_ID, flowsheetEntryType: 6, radioShowId: LEGACY_SHOW_ID }),
+        });
+      expect(trackRes.status).toBe(200);
+
+      // show_start is now healed...
+      const [startAfter] = await sql.unsafe(`SELECT dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+        SHOW_START_ID,
+      ]);
+      expect(startAfter.dj_name).toBe('Healed Handle');
+
+      // ...but the track row that triggered the heal keeps its own NULL dj_name
+      // (track rows have a separate population path; the heal must not touch them).
+      const [trackRow] = await sql.unsafe(
+        `SELECT entry_type, dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`,
+        [TRACK_ID]
+      );
+      expect(trackRow.entry_type).toBe('track');
+      expect(trackRow.dj_name).toBeNull();
+    } finally {
+      await cleanup();
+    }
+  });
 });

--- a/tests/integration/internal-flowsheet-webhook.spec.js
+++ b/tests/integration/internal-flowsheet-webhook.spec.js
@@ -312,61 +312,66 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
     }
   });
 
-  // BS#1444 guard: the heal is scoped to `dj_name IS NULL`, so a marker that
-  // already resolved to one handle must NOT be clobbered when the show's
-  // resolved name later changes (e.g. PII remediation re-points primary_dj_id,
-  // or an operator edits the handle). Without this, dropping the isNull
-  // predicate would silently overwrite correct stored handles.
-  test('heal does not overwrite a marker that already has a dj_name (BS#1444)', async () => {
+  // BS#1444 guard: in a single delivery the heal must fix a still-NULL marker
+  // (proving the machinery is live) WHILE leaving an already-named sibling
+  // untouched (proving the `dj_name IS NULL` scope holds). Distinct values
+  // ('Old' vs 'New') make a clobber visible — dropping the isNull predicate
+  // would rewrite the named row to the new value and fail this test, and a dead
+  // heal would leave the NULL row unhealed and also fail it.
+  test('heal fixes a NULL marker while sparing an already-named sibling (BS#1444)', async () => {
     const LEGACY_SHOW_ID = 9_999_986;
     const SHOW_START_ID = 9_999_983;
+    const SHOW_END_ID = 9_999_981;
     const TRACK_ID = 9_999_982;
 
-    // Show already has a resolvable name when the show_start arrives.
-    await seedShow(LEGACY_SHOW_ID, { legacyDjName: 'First Handle' });
+    // show_start arrives while the show has a name → lands named 'Old Handle'.
+    await seedShow(LEGACY_SHOW_ID, { legacyDjName: 'Old Handle' });
 
     const cleanup = async () => {
-      await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id IN ($1, $2)`, [SHOW_START_ID, TRACK_ID]);
+      await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id IN ($1, $2, $3)`, [
+        SHOW_START_ID,
+        SHOW_END_ID,
+        TRACK_ID,
+      ]);
       await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
     };
 
-    try {
-      // show_start lands already-named (resolved at insert).
-      const startRes = await request
-        .post('/internal/flowsheet-webhook')
-        .set('X-Internal-Key', INTERNAL_KEY)
-        .send({
-          action: 'create',
-          entry: buildEntry({ id: SHOW_START_ID, flowsheetEntryType: 9, radioShowId: LEGACY_SHOW_ID }),
-        });
-      expect(startRes.status).toBe(200);
+    const post = (entry) =>
+      request.post('/internal/flowsheet-webhook').set('X-Internal-Key', INTERNAL_KEY).send({ action: 'create', entry });
 
+    try {
+      // 1) show_start lands already-named.
+      await post(buildEntry({ id: SHOW_START_ID, flowsheetEntryType: 9, radioShowId: LEGACY_SHOW_ID }));
+
+      // 2) name goes unresolvable, then show_end arrives → lands NULL (stub race).
+      await sql.unsafe(`UPDATE ${SCHEMA}.shows SET legacy_dj_name = NULL WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
+      await post(buildEntry({ id: SHOW_END_ID, flowsheetEntryType: 10, radioShowId: LEGACY_SHOW_ID }));
+
+      // Precondition: one named marker + one NULL marker on the same show.
       const [startBefore] = await sql.unsafe(`SELECT dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
         SHOW_START_ID,
       ]);
-      expect(startBefore.dj_name).toBe('First Handle');
+      const [endBefore] = await sql.unsafe(`SELECT dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+        SHOW_END_ID,
+      ]);
+      expect(startBefore.dj_name).toBe('Old Handle');
+      expect(endBefore.dj_name).toBeNull();
 
-      // The show's resolved name changes...
+      // 3) name resolves to a DIFFERENT value; a later entry triggers the heal.
       await sql.unsafe(`UPDATE ${SCHEMA}.shows SET legacy_dj_name = $1 WHERE legacy_show_id = $2`, [
-        'Second Handle',
+        'New Handle',
         LEGACY_SHOW_ID,
       ]);
-
-      // ...and a later entry arrives. The heal must leave the already-named
-      // show_start alone (its dj_name IS NOT NULL).
-      const trackRes = await request
-        .post('/internal/flowsheet-webhook')
-        .set('X-Internal-Key', INTERNAL_KEY)
-        .send({
-          action: 'create',
-          entry: buildEntry({ id: TRACK_ID, flowsheetEntryType: 6, radioShowId: LEGACY_SHOW_ID }),
-        });
-      expect(trackRes.status).toBe(200);
+      await post(buildEntry({ id: TRACK_ID, flowsheetEntryType: 6, radioShowId: LEGACY_SHOW_ID }));
 
       const [startAfter] = await sql.unsafe(`SELECT dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
         SHOW_START_ID,
       ]);
-      expect(startAfter.dj_name).toBe('First Handle'); // unchanged, not 'Second Handle'
+      const [endAfter] = await sql.unsafe(`SELECT dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+        SHOW_END_ID,
+      ]);
+      expect(endAfter.dj_name).toBe('New Handle'); // NULL marker healed → machinery is live
+      expect(startAfter.dj_name).toBe('Old Handle'); // already-named sibling spared, not 'New Handle'
     } finally {
       await cleanup();
     }

--- a/tests/integration/internal-flowsheet-webhook.spec.js
+++ b/tests/integration/internal-flowsheet-webhook.spec.js
@@ -311,4 +311,64 @@ describe('POST /internal/flowsheet-webhook — concurrent INSERT race (BS#909)',
       await cleanup();
     }
   });
+
+  // BS#1444 guard: the heal is scoped to `dj_name IS NULL`, so a marker that
+  // already resolved to one handle must NOT be clobbered when the show's
+  // resolved name later changes (e.g. PII remediation re-points primary_dj_id,
+  // or an operator edits the handle). Without this, dropping the isNull
+  // predicate would silently overwrite correct stored handles.
+  test('heal does not overwrite a marker that already has a dj_name (BS#1444)', async () => {
+    const LEGACY_SHOW_ID = 9_999_986;
+    const SHOW_START_ID = 9_999_983;
+    const TRACK_ID = 9_999_982;
+
+    // Show already has a resolvable name when the show_start arrives.
+    await seedShow(LEGACY_SHOW_ID, { legacyDjName: 'First Handle' });
+
+    const cleanup = async () => {
+      await sql.unsafe(`DELETE FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id IN ($1, $2)`, [SHOW_START_ID, TRACK_ID]);
+      await sql.unsafe(`DELETE FROM ${SCHEMA}.shows WHERE legacy_show_id = $1`, [LEGACY_SHOW_ID]);
+    };
+
+    try {
+      // show_start lands already-named (resolved at insert).
+      const startRes = await request
+        .post('/internal/flowsheet-webhook')
+        .set('X-Internal-Key', INTERNAL_KEY)
+        .send({
+          action: 'create',
+          entry: buildEntry({ id: SHOW_START_ID, flowsheetEntryType: 9, radioShowId: LEGACY_SHOW_ID }),
+        });
+      expect(startRes.status).toBe(200);
+
+      const [startBefore] = await sql.unsafe(`SELECT dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+        SHOW_START_ID,
+      ]);
+      expect(startBefore.dj_name).toBe('First Handle');
+
+      // The show's resolved name changes...
+      await sql.unsafe(`UPDATE ${SCHEMA}.shows SET legacy_dj_name = $1 WHERE legacy_show_id = $2`, [
+        'Second Handle',
+        LEGACY_SHOW_ID,
+      ]);
+
+      // ...and a later entry arrives. The heal must leave the already-named
+      // show_start alone (its dj_name IS NOT NULL).
+      const trackRes = await request
+        .post('/internal/flowsheet-webhook')
+        .set('X-Internal-Key', INTERNAL_KEY)
+        .send({
+          action: 'create',
+          entry: buildEntry({ id: TRACK_ID, flowsheetEntryType: 6, radioShowId: LEGACY_SHOW_ID }),
+        });
+      expect(trackRes.status).toBe(200);
+
+      const [startAfter] = await sql.unsafe(`SELECT dj_name FROM ${SCHEMA}.flowsheet WHERE legacy_entry_id = $1`, [
+        SHOW_START_ID,
+      ]);
+      expect(startAfter.dj_name).toBe('First Handle'); // unchanged, not 'Second Handle'
+    } finally {
+      await cleanup();
+    }
+  });
 });

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -533,6 +533,55 @@ describe('POST /internal/flowsheet-webhook', () => {
     expect(setClause).toEqual(expect.objectContaining({ entry_type: 'track' }));
   });
 
+  // -- Sibling-marker heal probe-before-write (BS#1444) --
+  //
+  // The heal SELECTs for a still-NULL marker first and only issues the
+  // watermark-touching UPDATE when one exists. These two tests pin that
+  // behaviour: a regression back to an unconditional UPDATE (the round-1
+  // over-fire that re-touches flowsheet_watermark on every delivery) would
+  // flip the "no UPDATE" assertion below.
+
+  it('heal fires a dj_name-only UPDATE when the probe finds an unhealed marker (BS#1444)', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Aubrey' }]) // resolveShow
+      .mockResolvedValueOnce([]) // resolveAlbumId (unlinked)
+      .mockResolvedValueOnce([{ id: 4242 }]) // heal probe → an unhealed marker exists
+      .mockResolvedValue([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]); // fresh INSERT (created=true)
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry }); // track → fresh insert, no conflict UPDATE
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+    // The only UPDATE is the heal: dj_name alone (the conflict refresh would
+    // also carry entry_type), proving the probe-hit path issued it.
+    expect(lastUpdateSet()).toEqual({ dj_name: 'Aubrey' });
+  });
+
+  it('heal issues NO UPDATE when the probe finds no unhealed marker (BS#1444 watermark guard)', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Aubrey' }]) // resolveShow
+      .mockResolvedValueOnce([]) // resolveAlbumId
+      .mockResolvedValueOnce([]) // heal probe → nothing to heal
+      .mockResolvedValue([]);
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]); // fresh INSERT (created=true)
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: validEntry });
+
+    expect(res.status).toBe(200);
+    // Fresh insert → no conflict UPDATE; empty probe → no heal UPDATE. A bare
+    // unconditional heal would re-touch the watermark here on every delivery.
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it('INSERT trims whitespace-only resolved dj_name to null on a marker entry', async () => {
     // shows.legacy_dj_name='   ' (whitespace) — without normalizeMarkerName
     // this would persist as '   ' and v2 wire would emit whitespace.

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -271,7 +271,8 @@ describe('POST /internal/flowsheet-webhook', () => {
     mockLimit
       .mockResolvedValueOnce([{ id: 9999, dj_name: 'Default Test DJ' }])
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ id: 4242 }]);
+      .mockResolvedValueOnce([{ id: 4242 }])
+      .mockResolvedValue([]); // BS#1444 sibling-heal probe finds no unhealed marker
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
 
     const res = await request(app)
@@ -315,7 +316,8 @@ describe('POST /internal/flowsheet-webhook', () => {
     mockLimit
       .mockResolvedValueOnce([{ id: 9999, dj_name: 'Default Test DJ' }])
       .mockResolvedValueOnce([{ id: 7777 }])
-      .mockResolvedValueOnce([{ id: 4242 }]);
+      .mockResolvedValueOnce([{ id: 4242 }])
+      .mockResolvedValue([]); // BS#1444 sibling-heal probe finds no unhealed marker
     mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
 
     const res = await request(app)


### PR DESCRIPTION
Closes #1444.

## Problem

On the v2 flowsheet, tubafrenzy-originated **`show_start` ("signed on") markers render nameless**, while the paired `show_end` for the same show is named correctly. Confirmed live on 2026-06-18 — the on-air show (`show_id 1949352`, DJ "annie") showed a nameless "SIGNED ON" even though `shows.legacy_dj_name = 'annie'` was already populated.

This is the residual gap from #1371 / PR #1374. The `show_start` is the **first** entry of a show, so when its webhook arrives `resolveShow` has only just created the stub `shows` row (no `legacy_dj_name` yet) and the marker lands `dj_name = NULL`. The ETL fills the name minutes later, but nothing re-resolves the already-written row: the conflict path heals only the *same* `legacy_entry_id` (never re-delivered for a create), the periodic ETL re-resolves only ids it bulk-fetched, and `flowsheet-dj-name-backfill` is one-shot. Net: every new tubafrenzy show renders a nameless "signed on" until sign-off.

Prod evidence (read-only): 100% of NULL markers are webhook-origin (zero live-path NULLs); new nameless `show_start`s recur daily *after* #1374 shipped (~7–9/day).

## Fix

After resolving `show`, heal that show's still-NULL marker rows whenever a later webhook entry resolves a non-null name:

- Fires on **every** entry (incl. tracks), so a live show's `show_start` heals at the next track add after the ETL fills the name — minutes, not at sign-off.
- Scoped to `MARKER_ENTRY_TYPES` + `dj_name IS NULL`, so track rows (own population path) and already-resolved markers are never touched.
- Index-backed by `flowsheet_show_id_idx`; once a show is healed the predicate matches zero rows, so steady-state deliveries pay only an empty index probe.
- Uses the same 2-arm `COALESCE(auth_user.dj_name, shows.legacy_dj_name)` as `resolveShow` (no `auth_user.name` — PII).

## Tests

New integration case in `internal-flowsheet-webhook.spec.js`: deliver a `show_start` against a stub show (NULL name) → asserts it lands NULL; fill `shows.legacy_dj_name`; deliver a later track for the same show → asserts the `show_start` is healed **and** the triggering track row keeps its own NULL `dj_name`.

Local verification: typecheck clean; lint 0 errors; prettier clean; `internal.route` unit suite 53/53; the full webhook integration spec 6/6 against the Dockerized (Node 24) backend running this fix.

## Note

The historical backlog (~9.6k NULL `show_start`s back to 2008) is mostly unrecoverable — its `legacy_dj_name` source was scrubbed by the DJ_HANDLE PII remediation (#1393 / PR #1394). The 43 still-recoverable rows are healed separately via a scoped one-time UPDATE; this PR prevents recurrence.