### PR TITLE
feat(1441): project album_metadata genres/styles into V2 flowsheet response

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -26,6 +26,10 @@ export interface IFSEntryMetadata {
   soundcloud_url: string | null;
   artist_bio: string | null;
   artist_wikipedia_url: string | null;
+  // album_metadata-only fields (BS#1441); no inline flowsheet column, so they
+  // are not top-level IFSEntry fields — only here in the nested metadata view.
+  genres: string[] | null;
+  styles: string[] | null;
 }
 
 // search_doc is a STORED GENERATED tsvector used only by the search hot path

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -195,6 +195,10 @@ const FSEntryFieldsRaw = {
   artist_wikipedia_url: sql<
     string | null
   >`coalesce(${album_metadata.artist_wikipedia_url}, ${flowsheet.artist_wikipedia_url})`,
+  // genres/styles live ONLY on album_metadata (no inline flowsheet column to
+  // COALESCE over), so these are plain column reads. BS#1441.
+  genres: album_metadata.genres,
+  styles: album_metadata.styles,
   on_streaming: library.on_streaming,
   metadata_status: flowsheet.metadata_status,
   enriching_since: flowsheet.enriching_since,
@@ -235,6 +239,8 @@ type FSEntryRaw = {
   soundcloud_url: string | null;
   artist_bio: string | null;
   artist_wikipedia_url: string | null;
+  genres: string[] | null;
+  styles: string[] | null;
   on_streaming: boolean | null;
   metadata_status: FSEntry['metadata_status'];
   enriching_since: Date | null;
@@ -279,7 +285,9 @@ const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
   on_streaming: raw.on_streaming ?? null,
   metadata_status: raw.metadata_status,
   enriching_since: raw.enriching_since,
-  // Nested metadata view (used by transformToV2)
+  // Nested metadata view (used by transformToV2). genres/styles are
+  // album_metadata-only fields (BS#1441) and so live here, NOT as top-level
+  // IFSEntry/FSEntry fields (that type mirrors the flowsheet table).
   metadata: {
     artwork_url: raw.artwork_url,
     discogs_url: raw.discogs_url,
@@ -291,6 +299,8 @@ const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
     soundcloud_url: raw.soundcloud_url,
     artist_bio: raw.artist_bio,
     artist_wikipedia_url: raw.artist_wikipedia_url,
+    genres: raw.genres,
+    styles: raw.styles,
   },
 });
 
@@ -997,6 +1007,11 @@ export const transformToV2 = (entry: IFSEntry): Record<string, unknown> => {
         soundcloud_url: entry.metadata?.soundcloud_url ?? null,
         artist_bio: entry.metadata?.artist_bio ?? null,
         artist_wikipedia_url: entry.metadata?.artist_wikipedia_url ?? null,
+        // Arrays coerce empty→null (unlike the sibling scalars' plain `?? null`):
+        // a `'{}'` album_metadata row carries no information, so it collapses to
+        // the same `null` the contract uses for "absent". See BS#1441 rationale.
+        genres: entry.metadata?.genres?.length ? entry.metadata.genres : null,
+        styles: entry.metadata?.styles?.length ? entry.metadata.styles : null,
         on_streaming: entry.on_streaming ?? null,
         // BS#891. iOS branches on this to decide whether to render inline
         // metadata or fall back to the proxy-fetch path

--- a/tests/integration/metadata.spec.js
+++ b/tests/integration/metadata.spec.js
@@ -447,6 +447,127 @@ describe('album_metadata COALESCE projection (BS#897)', () => {
   });
 });
 
+describe('V2 flowsheet genres/styles projection (BS#1441)', () => {
+  // iOS's Playcut Detail card renders genre/style capsules from inline
+  // `genres`/`styles` on the V2 track entry (wxyc-ios-64#402). Unlike the
+  // 10 sibling metadata fields, genres/styles live ONLY on `album_metadata`
+  // (not the flowsheet inline columns), so `transformToV2` reads them
+  // straight from the nested metadata view with no COALESCE fallback.
+  //
+  // The one wire-shape decision (see the plan's empty-vs-null section): an
+  // empty array carries no information, so a `'{}'` album_metadata row
+  // collapses to the same `null` the contract uses for an absent row. Both
+  // the empty and the missing-row cases therefore present as `null`.
+  //
+  // As in the BS#897 block above, force LML to 500 so the runtime
+  // fire-and-forget enrichment's catch arm (an `onConflictDoNothing` INSERT
+  // that writes only URL fields) can neither clobber the seeded sentinel row
+  // nor synthesize genres/styles from a live LML response.
+
+  let sql;
+  let mockApiAvailable = false;
+  const SENTINEL_ALBUM_ID = 5; // real library.id; FK album_metadata.album_id ON DELETE CASCADE
+  // Discogs-style genre/style taxonomy labels (not artist names); the values
+  // are what LML would surface for a WXYC-representative release.
+  const GENRES = ['Rock', 'Electronic'];
+  const STYLES = ['Post-Rock', 'Ambient'];
+
+  beforeAll(async () => {
+    sql = makeSql();
+    mockApiAvailable = await isMockApiAvailable();
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end();
+  });
+
+  beforeEach(async () => {
+    // Clear before each case so an interrupted prior run can't leave a stale
+    // sentinel row that poisons the next (BS#897 cleans up the same id 5).
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".album_metadata WHERE album_id = ${SENTINEL_ALBUM_ID}`);
+    if (mockApiAvailable) await resetMockApi();
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
+  });
+
+  afterEach(async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".album_metadata WHERE album_id = ${SENTINEL_ALBUM_ID}`);
+    if (mockApiAvailable) await resetMockApi();
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
+  });
+
+  // Add a track linked to the sentinel album and read it back through the V2
+  // serializer (GET /flowsheet maps every entry through transformToV2).
+  const addTrackAndRead = async (title) => {
+    const addRes = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({ album_id: SENTINEL_ALBUM_ID, track_title: title })
+      .expect(201);
+
+    const getRes = await request.get('/flowsheet').query({ limit: 10 }).send().expect(200);
+    const entry = getRes.body.entries.find((e) => e.id === addRes.body.id);
+    expect(entry).toBeDefined();
+    return entry;
+  };
+
+  test('populated album_metadata genres/styles project onto the V2 track entry', async () => {
+    if (!mockApiAvailable) {
+      console.warn('Skipping: mock API server not available for LML failure simulation');
+      return;
+    }
+    await simulateError('lml', '/api/v1/lookup', 500);
+
+    // Parameterized array binding (not a `'{...}'::text[]` literal) so genre
+    // labels round-trip without element-boundary corruption.
+    await sql`
+      INSERT INTO ${sql(`${SCHEMA}.album_metadata`)} (album_id, genres, styles)
+      VALUES (${SENTINEL_ALBUM_ID}, ${GENRES}::text[], ${STYLES}::text[])
+    `;
+
+    const entry = await addTrackAndRead('BS1441 populated genres/styles track');
+    expect(entry.genres).toEqual(GENRES);
+    expect(entry.styles).toEqual(STYLES);
+  });
+
+  test('empty genres/styles arrays coerce to null on the wire', async () => {
+    if (!mockApiAvailable) {
+      console.warn('Skipping: mock API server not available for LML failure simulation');
+      return;
+    }
+    await simulateError('lml', '/api/v1/lookup', 500);
+
+    // Empty-array literal is safe here (no values → no comma-boundary trap).
+    await sql`
+      INSERT INTO ${sql(`${SCHEMA}.album_metadata`)} (album_id, genres, styles)
+      VALUES (${SENTINEL_ALBUM_ID}, '{}'::text[], '{}'::text[])
+    `;
+
+    const entry = await addTrackAndRead('BS1441 empty genres/styles track');
+    expect(entry.genres).toBeNull();
+    expect(entry.styles).toBeNull();
+  });
+
+  test('no album_metadata row yields null genres/styles (no leak from populated case)', async () => {
+    if (!mockApiAvailable) {
+      console.warn('Skipping: mock API server not available for LML failure simulation');
+      return;
+    }
+    // No insert: beforeEach cleared the sentinel row. With LML forced to 500
+    // the catch arm only ever writes URL fields, so genres/styles read as SQL
+    // NULL regardless of whether the LEFT JOIN misses (no row) or hits a
+    // URL-only fallback row — either way `null` on the wire.
+    await simulateError('lml', '/api/v1/lookup', 500);
+
+    const entry = await addTrackAndRead('BS1441 no-row genres/styles track');
+    expect(entry.genres).toBeNull();
+    expect(entry.styles).toBeNull();
+    // The populated-case sentinel arrays must not leak in (guard style mirrors
+    // the BS#897 fallthrough test).
+    expect(entry.genres).not.toEqual(GENRES);
+    expect(entry.styles).not.toEqual(STYLES);
+  });
+});
+
 describe('Metadata Service Initialization', () => {
   test('Backend healthcheck passes (metadata service initialized)', async () => {
     // Body conforms to HealthCheckResponse from @wxyc/shared (#804).

--- a/tests/unit/services/flowsheet.service.test.ts
+++ b/tests/unit/services/flowsheet.service.test.ts
@@ -17,6 +17,8 @@ const nullMetadata: IFSEntryMetadata = {
   soundcloud_url: null,
   artist_bio: null,
   artist_wikipedia_url: null,
+  genres: null,
+  styles: null,
 };
 
 // Helper to create a base entry with common fields
@@ -238,6 +240,48 @@ describe('flowsheet.service', () => {
         expect(result.soundcloud_url).toBe('soundcloud.com');
         expect(result.artist_bio).toBe('A great band');
         expect(result.artist_wikipedia_url).toBe('wiki.com');
+      });
+
+      // BS#1441: genres/styles are album_metadata-only arrays. Unlike the
+      // scalar siblings (plain `?? null`), they coerce empty→null so the wire
+      // has one canonical "no genres" value matching the LEFT-JOIN-miss case.
+      it('projects populated genres/styles arrays for tracks', () => {
+        const entry = createBaseEntry({
+          entry_type: 'track',
+          metadata: {
+            genres: ['Rock', 'Electronic'],
+            styles: ['Post-Rock', 'Ambient'],
+          },
+        });
+
+        const result = transformToV2(entry);
+
+        expect(result.genres).toEqual(['Rock', 'Electronic']);
+        expect(result.styles).toEqual(['Post-Rock', 'Ambient']);
+      });
+
+      it('coerces empty genres/styles arrays to null', () => {
+        const entry = createBaseEntry({
+          entry_type: 'track',
+          metadata: {
+            genres: [],
+            styles: [],
+          },
+        });
+
+        const result = transformToV2(entry);
+
+        expect(result.genres).toBeNull();
+        expect(result.styles).toBeNull();
+      });
+
+      it('projects null genres/styles when metadata has none', () => {
+        const entry = createBaseEntry({ entry_type: 'track' });
+
+        const result = transformToV2(entry);
+
+        expect(result.genres).toBeNull();
+        expect(result.styles).toBeNull();
       });
     });
 

--- a/tests/unit/services/flowsheet.transformToV2.metadata-status.test.ts
+++ b/tests/unit/services/flowsheet.transformToV2.metadata-status.test.ts
@@ -16,6 +16,8 @@ const nullMetadata: IFSEntryMetadata = {
   soundcloud_url: null,
   artist_bio: null,
   artist_wikipedia_url: null,
+  genres: null,
+  styles: null,
 };
 
 const createTrackEntry = (overrides: Partial<IFSEntry> = {}): IFSEntry => ({


### PR DESCRIPTION
## Summary

The iOS Playcut Detail card stopped rendering genre/style capsules: the detail view short-circuits on inline metadata and skips `/proxy/metadata/album` when streaming URLs ride along inline (the common case), so genres only reach the card if they are carried inline on the V2 flowsheet payload. The V2 track entry emitted 10 enriched album fields but not `genres`/`styles`.

This is the missing middle layer of a 4-layer chain — a shipped iOS client already expects inline `genres`/`styles` on V2 track entries that the backend did not yet emit. Additive, read-path only.

Closes #1441

## What changed

`genres`/`styles` are projected onto the V2 flowsheet track entry from `album_metadata`:

- `FSEntryFieldsRaw` selects `album_metadata.genres` / `album_metadata.styles` as **plain column reads (no COALESCE)** — unlike the 10 sibling metadata fields, these exist only on `album_metadata`, with no inline `flowsheet` column to fall back to.
- They live **only** in the nested `metadata` view (`IFSEntryMetadata`), not as top-level `IFSEntry`/`FSEntry` fields (that type mirrors the `flowsheet` table).
- `transformToV2` projects them onto the track arm with an **empty→null coercion**.

## The one design decision: empty-vs-null wire shape

The V2 contract declares `genres`/`styles` as always-present `nullable: true` arrays (same as `artwork_url` et al.), so the proxy's "omit the key" convention isn't expressible here. The faithful V2 analog of "empty is not a meaningful value" is to coerce **empty → `null`**:

```ts
genres: entry.metadata?.genres?.length ? entry.metadata.genres : null,
styles: entry.metadata?.styles?.length ? entry.metadata.styles : null,
```

| `album_metadata.genres` state | wire `genres` |
| --- | --- |
| no `album_metadata` row (LEFT JOIN miss → SQL NULL) | `null` |
| row with `genres = '{}'` (empty array) | `null` |
| row with `genres = '{Rock,Electronic}'` | `["Rock","Electronic"]` |

This is the only field that coerces (arrays can express "empty"; the scalar siblings can't, so `null` is their only absent-signal). Contract-valid, one canonical "no genres" representation, and iOS treats `[]` and `null` identically. Flagged for reviewer judgment — trivially reversible to a plain `?? null` passthrough if preferred.

## Scope

Read-path + wire-shape only. **No migration, no schema change** (columns shipped in migration 0102, #1336), **no `@wxyc/shared` bump** required to compile (`transformToV2` returns `Record<string, unknown>`; `IFSEntryMetadata` is backend-local), **no enrichment-writer change** (persistence landed in #1336).

## Cross-repo wiring

Merge order is `risk:cross-repo-merge-order`: contract → this → iOS. Both ends are already merged, so this is strictly catch-up.

- **#1336** (blocker, merged) — migration 0102 added `genres`/`styles` to `album_metadata`; writer persists them; `/proxy/metadata/album` projects them.
- **WXYC/wxyc-shared#181** (contract, merged) — `FlowsheetV2TrackEntry` declares `genres`/`styles` as nullable string arrays.
- **WXYC/wxyc-ios-64#402** (consumer, shipped) — already decodes inline `genres`/`styles` and renders capsules.

## Freeze note

Critical surface under Post-launch hardening (org project #32). The change is additive and read-only — no write-path or migration risk — and closes a regression the freeze's own iOS layer already shipped against.

## Test plan

- New `describe('V2 flowsheet genres/styles projection (BS#1441)')` in `tests/integration/metadata.spec.js`, mirroring the BS#897 block (sentinel album, LML forced to 500 so the fire-and-forget catch arm can't clobber the seeded row): **populated**, **empty → null**, **no row → null**.
- Unit coverage of the `transformToV2` coercion (populated / empty→null / missing→null).
- Verified locally: `typecheck`, `lint`, `format:check`, unit tests, and the full `metadata.spec.js` integration suite (31 tests, including the 3 new cases) against the CI Docker stack.
