### PR TITLE
refactor(ci): reuse ci:build in e2e:env instead of inlining the docker:build glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ci:clean": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile ci down -v",
     "ci:testmock": "npm run ci:env && npm run ci:test && npm run ci:clean",
     "ci:testmock:full": "npm run ci:env:full && npm run ci:test:full && npm run ci:clean",
-    "e2e:env": "npm run docker:build --workspace=apps/** --if-present && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up -d e2e-db && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up e2e-db-init && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up -d e2e-auth e2e-backend",
+    "e2e:env": "npm run ci:build && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up -d e2e-db && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up e2e-db-init && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up -d e2e-auth e2e-backend",
     "e2e:setup-users": "E2E_DB_PORT=${E2E_DB_PORT:-5434} DB_PORT=${E2E_DB_PORT:-5434} npm run setup:e2e-users",
     "e2e:clean": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e down -v",
     "etl:library": "./scripts/run-library-etl.sh",


### PR DESCRIPTION
## What

`e2e:env` inlined `npm run docker:build --workspace=apps/** --if-present`, a verbatim copy of the `ci:build` script's body. This points `e2e:env` at the named script instead:

```diff
- "e2e:env": "npm run docker:build --workspace=apps/** --if-present && docker compose ... e2e ...",
+ "e2e:env": "npm run ci:build && docker compose ... e2e ...",
```

## Why

`scripts/ci-env.sh` already invokes the build step by name (`npm run ci:build`); `e2e:env` was the lone holdout duplicating the body. After this, "build every app's docker image" is defined in exactly one place. That duplication is what forced the [#1431](https://github.com/WXYC/Backend-Service/issues/1431) fix (PR #1452) to apply `--if-present` at two call sites — any future change to the app-image build now lands in `ci:build` alone.

## Verification

Behavior-preserving by construction — `npm run ci:build` expands to the exact command that was inlined. `format:check`, `typecheck`, and `lint` (0 errors) all pass locally.

Closes #1454