### PR TITLE
feat(1428): per-job Sentry trace-sampling opt-in for crons (enable on rotation-artist-backfill)

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -458,6 +458,13 @@ jobs:
               # in tested code rather than inline workflow yaml. See BS#914.
               CRON_SCHEDULE=$(scripts/resolve-cron-schedule.sh "$TARGET_APP")
               echo "cron_schedule=$CRON_SCHEDULE" >> $GITHUB_OUTPUT
+              # Per-job Sentry trace-sampling opt-in (BS#1428). Empty unless the
+              # job's package.json sets `sentry-traces-sample-rate`, so non-opted
+              # crons keep their default (0 -> spans suppressed) and neither the
+              # shared API nor the high-cardinality backfills are affected. Read
+              # inline with yq, matching how `job-type` is read above.
+              SENTRY_TRACES_SAMPLE_RATE=$(yq -r '.["sentry-traces-sample-rate"] // ""' jobs/$TARGET_APP/package.json)
+              echo "sentry_traces_sample_rate=$SENTRY_TRACES_SAMPLE_RATE" >> $GITHUB_OUTPUT
             else
               echo "Unknown job-type '$JOB_TYPE' in jobs/$TARGET_APP/package.json (expected 'cron' or 'one-shot')" >&2
               exit 1
@@ -500,6 +507,7 @@ jobs:
             TARGET_APP=${{ matrix.target }}
             DEPLOY_TAG=${{ steps.determine_version.outputs.deploy_version }}
             CRON_SCHEDULE='${{ steps.deploy_vars.outputs.cron_schedule }}'
+            SENTRY_TRACES_SAMPLE_RATE='${{ steps.deploy_vars.outputs.sentry_traces_sample_rate }}'
             AWS_ECR_URI=${{ secrets.AWS_ECR_URI }}
             AWS_REGION=${{ secrets.AWS_REGION }}
 
@@ -510,7 +518,17 @@ jobs:
             echo "Pulling Docker image for deploy..."
             docker pull $AWS_ECR_URI/$TARGET_APP:$DEPLOY_TAG
 
-            CRON_CMD="docker rm -f ${TARGET_APP}-cron >/dev/null 2>&1 || true; docker run --name ${TARGET_APP}-cron --env-file .env $AWS_ECR_URI/$TARGET_APP:$DEPLOY_TAG"
+            # Inject the per-job trace-sampling override only when the job opted
+            # in (non-empty). Absent -> no -e -> the job's own default (0) ->
+            # spans suppressed, exactly as before. `-e` beats the shared
+            # `--env-file .env` for this container only, so the API and
+            # non-opted crons are unaffected (BS#1428).
+            SENTRY_ENV_ARG=""
+            if [ -n "$SENTRY_TRACES_SAMPLE_RATE" ]; then
+              SENTRY_ENV_ARG="-e SENTRY_TRACES_SAMPLE_RATE=$SENTRY_TRACES_SAMPLE_RATE"
+            fi
+
+            CRON_CMD="docker rm -f ${TARGET_APP}-cron >/dev/null 2>&1 || true; docker run --name ${TARGET_APP}-cron --env-file .env $SENTRY_ENV_ARG $AWS_ECR_URI/$TARGET_APP:$DEPLOY_TAG"
 
             echo "CRON DETAILS: $CRON_ID"
             echo "SCHEDULE: $CRON_SCHEDULE"

--- a/jobs/rotation-artist-backfill/package.json
+++ b/jobs/rotation-artist-backfill/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@wxyc/rotation-artist-backfill",
   "cron-schedule": "30 4 * * *",
+  "sentry-traces-sample-rate": "1.0",
   "version": "1.0.0",
   "description": "WXYC daily cron: refresh LML's release + artist caches for every release currently in BS rotation, keyed by rotation.lml_identity_id (BS#1380). One-tier batched call to POST /api/v1/cache/refresh-for-identities (LML#525) — LML maps each identity to its per-source (source, external_id) pairs and walks to artists internally. Closes BS#1381; supersedes the Discogs-specific iteration from BS#1361 (PR #1376).",
   "type": "module",


### PR DESCRIPTION
## Summary

The `rotation-artist-backfill` cron runs in prod with `SENTRY_TRACES_SAMPLE_RATE` **unset** (defaults to `0`), so it emits **no spans**. The `backfill.*` totals the [BS#1428](https://github.com/WXYC/Backend-Service/issues/1428) metric alerts read (`backfill.not_found`, `backfill.lml_error`) therefore never reach Sentry — they live only in the cron's stdout. Verified against the prod EC2 container: the 2026-06-18 04:30 UTC run warmed 125 releases / 141 artists with **zero** spans emitted.

This enables trace sampling for the cron, as a **per-job opt-in**.

## Mechanism

- New optional `sentry-traces-sample-rate` field in the job's `package.json` (mirrors the existing `cron-schedule` field).
- `deploy-base.yml` reads it inline with `yq` in *Get Deploy Vars* (same as `job-type`), and the *Deploy Cron Job* step injects `docker run -e SENTRY_TRACES_SAMPLE_RATE=<val>` on the cron container **only when the field is set**.
- `rotation-artist-backfill/package.json` opts in at `1.0`.

## Why opt-in (not a global `.env` change)

The cron's `docker run` uses the **shared** `--env-file .env`. Setting the rate there would also make the high-traffic API sample at that rate, and blanket-enabling all crons would risk span floods from the high-cardinality backfills (`flowsheet-metadata-backfill` per-row, `album-level-backfill` ~35k ids). The per-container `-e` overrides the shared env-file for that container only; jobs that don't opt in get no `-e` and keep the default `0` — behavior-preserving.

`1.0` because it's a **once-daily** run emitting a handful of spans; a fractional rate could drop the only run of the day and leave the 24h-window alerts empty.

## Effect

Takes effect on the next deploy (re-registers the crontab with the `-e`); the next 04:30 UTC run emits spans, including the `rotation-artist-backfill.run.totals` span carrying the `backfill.*` attributes. Fully reproducible across host replacement. Rollback = delete the one `package.json` line.

## Scope / not-closing

This is **one of two** prerequisites for BS#1428 and does **not** close it. The second — an **alert-filter mismatch** — is recorded on the issue: BS#1428's alerts filter `span.op:rotation-artist-backfill.*`, but the attribute-bearing span has that string as its **name** (`rotation-artist-backfill.run.totals`), with no matching `op` (orchestrate.ts:282-300, whose own comment says grouping was intended "by span name pattern"). That's a Sentry-config fix, not a code change — folding a job-specific `op` into the code to satisfy a mis-written filter would entrench the wrong assumption.

## Testing

`yq`-read logic validated via `jq` (opted-in → `1.0`; opted-out job → empty → no `-e`); `deploy-base.yml` YAML parses; `package.json` valid; `prettier --check` clean on both files. The deploy path isn't covered by CI tests (the real exercise is the deploy + next run); the change is additive and opt-in, so the empty-default preserves current behavior for every other job.

Refs #1428