### PR TITLE
refactor(ci): drop unused :ci build from e2e:env; build :e2e every run

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ci:clean": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile ci down -v",
     "ci:testmock": "npm run ci:env && npm run ci:test && npm run ci:clean",
     "ci:testmock:full": "npm run ci:env:full && npm run ci:test:full && npm run ci:clean",
-    "e2e:env": "npm run ci:build && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up -d e2e-db && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up e2e-db-init && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up -d e2e-auth e2e-backend",
+    "e2e:env": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up -d e2e-db && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up e2e-db-init && docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e up -d --build e2e-auth e2e-backend",
     "e2e:setup-users": "E2E_DB_PORT=${E2E_DB_PORT:-5434} DB_PORT=${E2E_DB_PORT:-5434} npm run setup:e2e-users",
     "e2e:clean": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile e2e down -v",
     "etl:library": "./scripts/run-library-etl.sh",


### PR DESCRIPTION
## What

`e2e:env` led with `npm run ci:build`, which builds `wxyc_auth_service:ci` and `wxyc_backend_service:ci`. Those `:ci` images are consumed **only** by the `ci`-profile services (`ci:testmock` flow) — never by any `e2e`-profile service. The `e2e-auth` / `e2e-backend` services build their own **`:e2e`**-tagged images from the same Dockerfiles via compose `build:` directives, so the prefix did no useful work beyond warming the shared layer cache.

This drops the `ci:build` prefix and adds `--build` to the e2e `up`:

```diff
-"e2e:env": "npm run ci:build && docker compose ... --profile e2e up -d e2e-db && ... up e2e-db-init && ... up -d e2e-auth e2e-backend",
+"e2e:env": "docker compose ... --profile e2e up -d e2e-db && ... up e2e-db-init && ... up -d --build e2e-auth e2e-backend",
```

## Decision (AC#3): rebuild `:e2e` on every run

Chose **option 2** from the ticket (`--build`) over option 1 (drop the prefix entirely). Rationale: today `e2e:env` never passed `--build`, so an existing `:e2e` image was reused **stale** regardless of the `ci:build` prefix — change source, re-run `e2e:env`, silently test the old build. For an environment whose whole purpose is exercising current source, freshness-on-every-run is the right contract, and a no-change rebuild is mostly Docker layer-cache hits. Option 1 would have removed the wasted `:ci` work but left the staleness footgun in place.

## Verification

Run on a machine with **no pre-built `:e2e` images** (clean-machine condition for AC#1):

- ✅ **AC#1** — `npm run e2e:env` built both `:e2e` images from source and brought up `e2e-auth` + `e2e-backend` **healthy** (`docker ps` healthy; backend `/healthcheck` → `200`).
- ✅ **AC#2** — `e2e:env` no longer builds `wxyc_*_service:ci`. The `:ci` image IDs/timestamps were **byte-identical** before and after the run (`sha256:d062c8…`, `sha256:c70f96…` — untouched).
- ✅ **AC#3** — decision recorded above.

No external dependency on the old behavior: `e2e:env` is referenced only in `package.json` (no workflow or script invokes it), and the `:ci` images are still produced independently by `ci:build` / `ci:env` for the `ci:testmock` flow.

Closes #1456