### PR TITLE
feat(flowsheet): emit breakpoint radio_hour (ETL + webhook + transformToV2)

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^10.53.1",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.11.0",
+    "@wxyc/shared": "^1.12.0",
     "better-auth": "^1.6.14",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -70,6 +70,7 @@ components:
         show_start/show_end entries include dj_name and timestamp.
         dj_join/dj_leave entries include dj_name.
         talkset/breakpoint/message entries include message.
+        breakpoint entries also include radio_hour (the authoritative top-of-hour as an ISO date-time, or null) — clients should format this rather than add_time.
 
     FlowsheetPaginatedResponse:
       type: object

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -47,14 +47,12 @@ export interface IFSEntryMetadata {
 // controller layer because the V2 wire format projects metadata_status onto
 // track rows for iOS branch logic (WXYC/wxyc-ios-64#270).
 //
-// `radio_hour` (migration 0103, BS#1448) is added to the flowsheet schema but is
-// not yet surfaced through the service/wire types — it's excluded here so the
-// schema-only migration PR builds cleanly. BS#1449 removes it from this Omit when
-// it wires the read path (SELECT + FSEntryRaw + transformToIFSEntry) and the V2
-// breakpoint serialization.
+// `radio_hour` (migration 0103, BS#1448) IS surfaced (BS#1449): the read path
+// projects it and transformToV2 emits it on breakpoint entries as the
+// authoritative top-of-hour. It's a present-but-nullable property here.
 export interface IFSEntry extends Omit<
   FSEntry,
-  'search_doc' | 'legacy_link_attempted_at' | 'metadata_attempt_at' | 'updated_at' | 'radio_hour'
+  'search_doc' | 'legacy_link_attempted_at' | 'metadata_attempt_at' | 'updated_at'
 > {
   label_id: number | null;
   rotation_bin: string | null;

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -23,7 +23,7 @@
     "@wxyc/database": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^1.11.0",
+    "@wxyc/shared": "^1.12.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.1.1",
     "axios": "^1.16.1",

--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -2,7 +2,12 @@ import { Router } from 'express';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { db, flowsheet, shows, rotation, library, truncate, user } from '@wxyc/database';
 import { serverEventsMgr, Topics, FsEvents } from '../utils/serverEvents.js';
-import { mapProdEntryType, isMessageEntryType, type BackendEntryType } from '../utils/flowsheet-transform.js';
+import {
+  mapProdEntryType,
+  isMessageEntryType,
+  resolveRadioHour,
+  type BackendEntryType,
+} from '../utils/flowsheet-transform.js';
 
 const ETL_NOTIFY_KEY = process.env.ETL_NOTIFY_KEY ?? '';
 
@@ -214,6 +219,14 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       const resolvedShowName = normalizeMarkerName(show?.dj_name);
       const markerDjName = MARKER_ENTRY_TYPES.has(entryType) ? resolvedShowName : null;
 
+      // tubafrenzy's authoritative top-of-hour for a breakpoint (BS#1449).
+      // `radioHour` (epoch ms) is present on breakpoint payloads only once
+      // tubafrenzy#593 ships; resolveRadioHour (shared with the ETL) tolerates
+      // its absence (null) and any malformed value (→ null via epochMsToDate),
+      // so deploy ordering is safe and a garbage payload can't write an Invalid
+      // Date. Computed once and shared by the INSERT and the ON-CONFLICT heal.
+      const breakpointRadioHour = resolveRadioHour(entryType, entry.radioHour ?? null);
+
       // INSERT ... ON CONFLICT DO NOTHING RETURNING { id }: either we win
       // the insert and PG hands back exactly one row, or a concurrent
       // INSERT / prior webhook delivery already claimed the
@@ -248,6 +261,7 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
           segue: false,
           play_order: entry.sequenceWithinShow ?? 0,
           add_time: entry.startTime ? new Date(entry.startTime) : new Date(),
+          radio_hour: breakpointRadioHour,
         })
         .onConflictDoNothing()
         .returning({ id: flowsheet.id });
@@ -280,6 +294,11 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
         };
         if (markerDjName !== null) {
           refresh.dj_name = markerDjName;
+        }
+        // Heal breakpoint rows inserted before radio_hour existed (BS#1449).
+        // Like dj_name, only set when present — never overwrite with NULL.
+        if (breakpointRadioHour) {
+          refresh.radio_hour = breakpointRadioHour;
         }
         await db.update(flowsheet).set(refresh).where(eq(flowsheet.legacy_entry_id, entry.id));
       }

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -202,6 +202,9 @@ const FSEntryFieldsRaw = {
   on_streaming: library.on_streaming,
   metadata_status: flowsheet.metadata_status,
   enriching_since: flowsheet.enriching_since,
+  // tubafrenzy's authoritative top-of-hour for breakpoint rows (BS#1449); NULL
+  // on every other type. transformToV2 emits it only on the breakpoint case.
+  radio_hour: flowsheet.radio_hour,
 };
 
 // Raw result type from SQL query
@@ -244,6 +247,7 @@ type FSEntryRaw = {
   on_streaming: boolean | null;
   metadata_status: FSEntry['metadata_status'];
   enriching_since: Date | null;
+  radio_hour: Date | null;
 };
 
 /** Transform flat SQL result to nested IFSEntry structure */
@@ -285,6 +289,7 @@ const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
   on_streaming: raw.on_streaming ?? null,
   metadata_status: raw.metadata_status,
   enriching_since: raw.enriching_since,
+  radio_hour: raw.radio_hour ?? null,
   // Nested metadata view (used by transformToV2). genres/styles are
   // album_metadata-only fields (BS#1441) and so live here, NOT as top-level
   // IFSEntry/FSEntry fields (that type mirrors the flowsheet table).
@@ -1048,6 +1053,9 @@ export const transformToV2 = (entry: IFSEntry): Record<string, unknown> => {
       return {
         ...baseFields,
         message: entry.message,
+        // The authoritative top-of-hour (BS#1449). Date here; res.json emits ISO
+        // (or null). Clients format this instead of the early add_time.
+        radio_hour: entry.radio_hour,
       };
 
     default: {

--- a/apps/backend/utils/flowsheet-transform.ts
+++ b/apps/backend/utils/flowsheet-transform.ts
@@ -5,6 +5,8 @@
  * entry type codes or truncation rules change.
  */
 
+import { epochMsToDate } from '@wxyc/database';
+
 export type BackendEntryType =
   | 'track'
   | 'show_start'
@@ -47,6 +49,19 @@ export const mapProdEntryType = (typeCode: number): BackendEntryType => {
 /** Entry types whose legacy ARTIST_NAME text is display content, not a real artist. */
 export const isMessageEntryType = (entryType: string): boolean =>
   entryType === 'breakpoint' || entryType === 'talkset' || entryType === 'message';
+
+/**
+ * Resolve the breakpoint top-of-hour for a flowsheet entry (BS#1449).
+ *
+ * tubafrenzy's RADIO_HOUR (epoch ms) is the authoritative top-of-hour a
+ * breakpoint marks, distinct from the ~1-min-early add_time. Only breakpoint
+ * rows carry it; every other type stores null. Routing through epochMsToDate
+ * (rather than a bare `new Date`) maps 0/absent/non-finite/Invalid → null, so a
+ * missing OR malformed RADIO_HOUR yields null instead of an Invalid Date.
+ * Mirrors resolveRadioHour in jobs/flowsheet-etl/transform.ts.
+ */
+export const resolveRadioHour = (entryType: BackendEntryType, radioHourMs: number | null): Date | null =>
+  entryType === 'breakpoint' ? epochMsToDate(radioHourMs) : null;
 
 /**
  * Truncate a string to a max length, returning null if empty.

--- a/jobs/flowsheet-etl/fetch-legacy.ts
+++ b/jobs/flowsheet-etl/fetch-legacy.ts
@@ -41,6 +41,9 @@ export type LegacyEntryRow = {
   timeCreated: number;
   timeLastModified: number;
   legacyReleaseId: number | null;
+  // RADIO_HOUR (epoch ms): tubafrenzy's authoritative top-of-hour, only
+  // meaningful on breakpoint rows. 0/absent normalizes to null (BS#1449).
+  radioHour: number | null;
   segueFlag: number;
 };
 
@@ -91,9 +94,13 @@ export const fetchLegacyShows = async (sinceMs: number | null): Promise<LegacySh
  *   0: ID, 1: RADIO_SHOW_ID, 2: ENTRY_TYPE_CODE, 3: ARTIST_NAME,
  *   4: RELEASE_TITLE, 5: SONG_TITLE, 6: LABEL_NAME, 7: REQUEST_FLAG,
  *   8: SEQUENCE_WITHIN_SHOW, 9: START_TIME, 10: TIME_CREATED,
- *   11: TIME_LAST_MODIFIED, 12: LIBRARY_RELEASE_ID [, 13: SEGUE_FLAG — optional]
+ *   11: TIME_LAST_MODIFIED, 12: LIBRARY_RELEASE_ID, 13: RADIO_HOUR
+ *   [, 14: SEGUE_FLAG — optional]
  *
- * columnCount: 13 (without SEGUE_FLAG) or 14 (with)
+ * RADIO_HOUR (BS#1449) is a stable column; SEGUE_FLAG stays the optional
+ * trailing column behind the fetchLegacyEntries try/catch.
+ *
+ * columnCount: 14 (without SEGUE_FLAG) or 15 (with)
  */
 export const parseEntryRows = (raw: string, columnCount: number): LegacyEntryRow[] => {
   if (raw.trim().length === 0) return [];
@@ -106,6 +113,7 @@ export const parseEntryRows = (raw: string, columnCount: number): LegacyEntryRow
       continue;
     }
     const rawReleaseId = Number(cols[12]) || 0;
+    const rawRadioHour = Number(cols[13]);
     rows.push({
       id: Number(cols[0]),
       showId: Number(cols[1]),
@@ -120,7 +128,8 @@ export const parseEntryRows = (raw: string, columnCount: number): LegacyEntryRow
       timeCreated: Number(cols[10]) || 0,
       timeLastModified: Number(cols[11]) || 0,
       legacyReleaseId: rawReleaseId === 0 ? null : rawReleaseId,
-      segueFlag: columnCount >= 14 ? Number(cols[13]) || 0 : 0,
+      radioHour: Number.isFinite(rawRadioHour) && rawRadioHour !== 0 ? rawRadioHour : null,
+      segueFlag: columnCount >= 15 ? Number(cols[14]) || 0 : 0,
     });
   }
   return rows;
@@ -139,7 +148,8 @@ const BASE_ENTRY_COLUMNS = `
       fe.START_TIME,
       fe.TIME_CREATED,
       fe.TIME_LAST_MODIFIED,
-      fe.LIBRARY_RELEASE_ID`;
+      fe.LIBRARY_RELEASE_ID,
+      fe.RADIO_HOUR`;
 
 export const fetchLegacyEntries = async (sinceMs: number | null): Promise<LegacyEntryRow[]> => {
   const filter =
@@ -151,12 +161,12 @@ export const fetchLegacyEntries = async (sinceMs: number | null): Promise<Legacy
   try {
     const queryWithSegue = `SELECT ${BASE_ENTRY_COLUMNS}, fe.SEGUE_FLAG FROM FLOWSHEET_ENTRY_PROD fe ${filter} ORDER BY fe.ID ASC;`;
     const raw = await legacyDB.send(queryWithSegue);
-    return parseEntryRows(raw, 14);
+    return parseEntryRows(raw, 15);
   } catch {
     console.warn('[flowsheet-etl] SEGUE_FLAG not available, defaulting to 0.');
     const queryWithout = `SELECT ${BASE_ENTRY_COLUMNS} FROM FLOWSHEET_ENTRY_PROD fe ${filter} ORDER BY fe.ID ASC;`;
     const raw = await legacyDB.send(queryWithout);
-    return parseEntryRows(raw, 13);
+    return parseEntryRows(raw, 14);
   }
 };
 

--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -29,7 +29,7 @@ import {
   truncate,
 } from '@wxyc/database';
 import { parseInsertLine } from './parse-dump.js';
-import { mapProdEntryType, resolveEntryTimestamp } from './transform.js';
+import { mapProdEntryType, resolveEntryTimestamp, resolveRadioHour } from './transform.js';
 import { fetchLegacyShows, fetchLegacyEntries, closeLegacyConnection } from './fetch-legacy.js';
 import { initLogger, log, captureError, closeLogger } from './logger.js';
 
@@ -178,6 +178,7 @@ type BulkEntryRow = {
   segue: boolean;
   play_order: number;
   add_time: Date;
+  radio_hour: Date | null;
 };
 
 type DbClient = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
@@ -259,6 +260,8 @@ const importEntries = async (dbClient: DbClient, lines: string[], showIdMap: Map
         segue: tuple.length > 21 ? Number(tuple[21]) === 1 : false,
         play_order: Number(tuple[13]) || 0,
         add_time: addTime,
+        // tuple[9] = RADIO_HOUR (epoch ms); only breakpoints carry a top-of-hour.
+        radio_hour: resolveRadioHour(entryType, Number(tuple[9]) || 0),
       });
 
       if (pendingEntries.length >= BATCH_SIZE) {
@@ -433,6 +436,7 @@ export const runIncremental = async (): Promise<SyncResult> => {
         segue: entry.segueFlag === 1,
         play_order: entry.playOrder,
         add_time: addTime,
+        radio_hour: resolveRadioHour(entryType, entry.radioHour),
       })
       .onConflictDoUpdate({
         target: flowsheet.legacy_entry_id,
@@ -448,6 +452,8 @@ export const runIncremental = async (): Promise<SyncResult> => {
           add_time: sql`excluded.add_time`,
           show_id: sql`excluded.show_id`,
           play_order: sql`excluded.play_order`,
+          // Self-heal breakpoint rows synced before the column existed (BS#1449).
+          radio_hour: sql`excluded.radio_hour`,
         },
         // tubafrenzy bumps TIME_LAST_MODIFIED on adjacent rows during normal
         // operation (flowsheet.mirror.ts close-prior-now-playing UPDATE), so
@@ -466,7 +472,8 @@ export const runIncremental = async (): Promise<SyncResult> => {
           ${flowsheet.entry_type} IS DISTINCT FROM excluded.entry_type OR
           ${flowsheet.add_time} IS DISTINCT FROM excluded.add_time OR
           ${flowsheet.show_id} IS DISTINCT FROM excluded.show_id OR
-          ${flowsheet.play_order} IS DISTINCT FROM excluded.play_order
+          ${flowsheet.play_order} IS DISTINCT FROM excluded.play_order OR
+          ${flowsheet.radio_hour} IS DISTINCT FROM excluded.radio_hour
         `,
       });
 

--- a/jobs/flowsheet-etl/transform.ts
+++ b/jobs/flowsheet-etl/transform.ts
@@ -133,6 +133,18 @@ export const resolveEntryTimestamp = (
   return epochMsToDate(startTime) ?? epochMsToDate(timeCreated) ?? epochMsToDate(timeLastModified);
 };
 
+/**
+ * Resolve the breakpoint top-of-hour for a flowsheet entry (BS#1449).
+ *
+ * tubafrenzy's RADIO_HOUR (epoch ms) is the authoritative top-of-hour a
+ * breakpoint marks (e.g. 12:00 PM) — distinct from add_time, the ~1-min-early
+ * logging instant that floors one hour early when a client formats "h a".
+ * Only breakpoint rows carry it; every other type stores null. epochMsToDate
+ * maps 0/absent → null, so a breakpoint missing RADIO_HOUR also yields null.
+ */
+export const resolveRadioHour = (entryType: BackendEntryType, radioHourMs: number | null): Date | null =>
+  entryType === 'breakpoint' ? epochMsToDate(radioHourMs) : null;
+
 // truncate is re-exported from @wxyc/database above
 
 export type TransformedShow = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,19 +58,6 @@
         "node": "24.x"
       }
     },
-    "../../git-merge-append": {
-      "version": "0.1.0",
-      "extraneous": true,
-      "license": "MIT",
-      "bin": {
-        "git-merge-append": "dist/src/cli.js"
-      },
-      "devDependencies": {
-        "@types/node": "^22",
-        "typescript": "^5.7",
-        "vitest": "^3"
-      }
-    },
     "apps/auth": {
       "name": "@wxyc/auth-service",
       "version": "1.0.0",
@@ -79,7 +66,7 @@
         "@sentry/node": "^10.53.1",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.11.0",
+        "@wxyc/shared": "^1.12.0",
         "better-auth": "^1.6.14",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -248,9 +235,9 @@
       }
     },
     "apps/auth/node_modules/@wxyc/shared": {
-      "version": "1.11.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.11.0/62bf03b80ede011aef90772eeb328bd954cbe83b",
-      "integrity": "sha512-vcr9ZG1KiZAFYEtjfT18mp5TdxVsPFczhuTQiNF1DRnRlEeCKiJUlRykTknfO22nyYsOr8QzT8AWTFmQk3uu4w==",
+      "version": "1.12.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.12.0/9fe97b74b3013be5616d34539e9e0165addfdb8a",
+      "integrity": "sha512-9B9rr2UY4z9j/jcGEKwj2F/1pmZUrD7/w6Xc0loQmp10QhB5kwKTtJP1q6XSTS38f6qimzme2VM53Qg8txktZA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -380,7 +367,7 @@
         "@wxyc/database": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^1.11.0",
+        "@wxyc/shared": "^1.12.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.1.1",
         "axios": "^1.16.1",
@@ -560,9 +547,9 @@
       }
     },
     "apps/backend/node_modules/@wxyc/shared": {
-      "version": "1.11.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.11.0/62bf03b80ede011aef90772eeb328bd954cbe83b",
-      "integrity": "sha512-vcr9ZG1KiZAFYEtjfT18mp5TdxVsPFczhuTQiNF1DRnRlEeCKiJUlRykTknfO22nyYsOr8QzT8AWTFmQk3uu4w==",
+      "version": "1.12.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.12.0/9fe97b74b3013be5616d34539e9e0165addfdb8a",
+      "integrity": "sha512-9B9rr2UY4z9j/jcGEKwj2F/1pmZUrD7/w6Xc0loQmp10QhB5kwKTtJP1q6XSTS38f6qimzme2VM53Qg8txktZA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -963,22 +950,6 @@
         "drizzle-orm": "^0.45.0"
       }
     },
-    "jobs/library-identity-backfill": {
-      "name": "@wxyc/library-identity-backfill",
-      "version": "1.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/node": "^10.52.0",
-        "@wxyc/database": "^1.0.0"
-      },
-      "devDependencies": {
-        "typescript": "^6.0.3"
-      },
-      "peerDependencies": {
-        "drizzle-orm": "^0.45.0"
-      }
-    },
     "jobs/library-identity-consumer": {
       "name": "@wxyc/library-identity-consumer",
       "version": "1.0.0",
@@ -1002,22 +973,6 @@
         "@sentry/node": "^10.53.1",
         "@wxyc/database": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0"
-      },
-      "devDependencies": {
-        "typescript": "^6.0.3"
-      },
-      "peerDependencies": {
-        "drizzle-orm": "^0.45.0"
-      }
-    },
-    "jobs/rotation-dedupe": {
-      "name": "@wxyc/rotation-dedupe",
-      "version": "1.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/node": "^10.50.0",
-        "@wxyc/database": "^1.0.0"
       },
       "devDependencies": {
         "typescript": "^6.0.3"
@@ -14698,7 +14653,7 @@
         "@aws-sdk/client-ses": "^3.1053.0",
         "@sentry/node": "^10.53.1",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.11.0",
+        "@wxyc/shared": "^1.12.0",
         "better-auth": "^1.6.14",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -14861,9 +14816,9 @@
       }
     },
     "shared/authentication/node_modules/@wxyc/shared": {
-      "version": "1.11.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.11.0/62bf03b80ede011aef90772eeb328bd954cbe83b",
-      "integrity": "sha512-vcr9ZG1KiZAFYEtjfT18mp5TdxVsPFczhuTQiNF1DRnRlEeCKiJUlRykTknfO22nyYsOr8QzT8AWTFmQk3uu4w==",
+      "version": "1.12.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.12.0/9fe97b74b3013be5616d34539e9e0165addfdb8a",
+      "integrity": "sha512-9B9rr2UY4z9j/jcGEKwj2F/1pmZUrD7/w6Xc0loQmp10QhB5kwKTtJP1q6XSTS38f6qimzme2VM53Qg8txktZA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
@@ -15001,7 +14956,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^10.53.1",
-        "@wxyc/shared": "^1.11.0"
+        "@wxyc/shared": "^1.12.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",
@@ -15035,9 +14990,9 @@
       }
     },
     "shared/lml-client/node_modules/@wxyc/shared": {
-      "version": "1.11.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.11.0/62bf03b80ede011aef90772eeb328bd954cbe83b",
-      "integrity": "sha512-vcr9ZG1KiZAFYEtjfT18mp5TdxVsPFczhuTQiNF1DRnRlEeCKiJUlRykTknfO22nyYsOr8QzT8AWTFmQk3uu4w==",
+      "version": "1.12.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.12.0/9fe97b74b3013be5616d34539e9e0165addfdb8a",
+      "integrity": "sha512-9B9rr2UY4z9j/jcGEKwj2F/1pmZUrD7/w6Xc0loQmp10QhB5kwKTtJP1q6XSTS38f6qimzme2VM53Qg8txktZA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-ses": "^3.1053.0",
     "@sentry/node": "^10.53.1",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.11.0",
+    "@wxyc/shared": "^1.12.0",
     "better-auth": "^1.6.14",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.53.1",
-    "@wxyc/shared": "^1.11.0"
+    "@wxyc/shared": "^1.12.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/tests/unit/jobs/flowsheet-etl/fetch-legacy.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/fetch-legacy.test.ts
@@ -52,12 +52,16 @@ describe('fetch-legacy parsing', () => {
   });
 
   describe('parseEntryRows', () => {
-    // Columns: ID, SHOW_ID, TYPE, ARTIST, ALBUM, TRACK, LABEL, REQ, SEQ, START, TIME_CREATED, TLM, LIBRARY_RELEASE_ID [, SEGUE_FLAG]
+    // Columns: 0-12 base (ID, SHOW_ID, TYPE, ARTIST, ALBUM, TRACK, LABEL, REQ,
+    // SEQ, START, TIME_CREATED, TLM, LIBRARY_RELEASE_ID), 13: RADIO_HOUR
+    // [, 14: SEGUE_FLAG]. RADIO_HOUR (BS#1449) is a stable column; SEGUE_FLAG
+    // stays the optional trailing column behind the fetchLegacyEntries try/catch.
 
-    it('parses 13-column format (without SEGUE_FLAG)', () => {
+    it('parses 14-column format (without SEGUE_FLAG)', () => {
+      // RADIO_HOUR=0 on a track row → radioHour null (tracks carry no top-of-hour).
       const raw =
-        '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t0\t1\t1706799600000\t1706799650000\t1706799700000\t101';
-      const rows = parseEntryRows(raw, 13);
+        '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t0\t1\t1706799600000\t1706799650000\t1706799700000\t101\t0';
+      const rows = parseEntryRows(raw, 14);
 
       expect(rows).toHaveLength(1);
       expect(rows[0]).toEqual({
@@ -74,40 +78,59 @@ describe('fetch-legacy parsing', () => {
         timeCreated: 1706799650000,
         timeLastModified: 1706799700000,
         legacyReleaseId: 101,
+        radioHour: null,
         segueFlag: 0,
       });
     });
 
-    it('parses 14-column format (with SEGUE_FLAG)', () => {
-      const raw =
-        '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t1\t1\t1706799600000\t1706799650000\t1706799700000\t101\t1';
+    it('parses a populated RADIO_HOUR (breakpoint) as epoch ms at index 13', () => {
+      // entryTypeCode 8 = HOURLY_BREAK; RADIO_HOUR is the authoritative top-of-hour.
+      const raw = '100\t200\t8\t--- 12:00 PM ---\t\t\t\t0\t1\t1718726280000\t0\t0\t0\t1718726400000';
       const rows = parseEntryRows(raw, 14);
+
+      expect(rows[0].radioHour).toBe(1718726400000);
+    });
+
+    it('parses 15-column format (with SEGUE_FLAG) — segue read from the shifted index 14', () => {
+      // RADIO_HOUR=0 at index 13, SEGUE_FLAG=1 at index 14. Guards against a
+      // segue-index regression from inserting RADIO_HOUR ahead of SEGUE_FLAG.
+      const raw =
+        '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t1\t1\t1706799600000\t1706799650000\t1706799700000\t101\t0\t1';
+      const rows = parseEntryRows(raw, 15);
 
       expect(rows).toHaveLength(1);
       expect(rows[0].requestFlag).toBe(1);
       expect(rows[0].timeCreated).toBe(1706799650000);
       expect(rows[0].timeLastModified).toBe(1706799700000);
       expect(rows[0].legacyReleaseId).toBe(101);
+      expect(rows[0].radioHour).toBeNull();
       expect(rows[0].segueFlag).toBe(1);
     });
 
-    it('defaults segueFlag to 0 in 13-column format', () => {
-      const raw = '100\t200\t0\tArtist\tAlbum\tTrack\tLabel\t0\t1\t1000\t1500\t2000\t42';
-      const rows = parseEntryRows(raw, 13);
+    it('defaults segueFlag to 0 in 14-column format', () => {
+      const raw = '100\t200\t0\tArtist\tAlbum\tTrack\tLabel\t0\t1\t1000\t1500\t2000\t42\t0';
+      const rows = parseEntryRows(raw, 14);
 
       expect(rows[0].segueFlag).toBe(0);
     });
 
+    it('sets radioHour to null when RADIO_HOUR is 0', () => {
+      const raw = '100\t200\t8\t--- breakpoint ---\t\t\t\t0\t1\t1718726280000\t0\t0\t0\t0';
+      const rows = parseEntryRows(raw, 14);
+
+      expect(rows[0].radioHour).toBeNull();
+    });
+
     it('sets legacyReleaseId to null when value is 0', () => {
-      const raw = '100\t200\t7\tTALKSET\t\t\t\t0\t5\t1000\t1500\t2000\t0';
-      const rows = parseEntryRows(raw, 13);
+      const raw = '100\t200\t7\tTALKSET\t\t\t\t0\t5\t1000\t1500\t2000\t0\t0';
+      const rows = parseEntryRows(raw, 14);
 
       expect(rows[0].legacyReleaseId).toBeNull();
     });
 
     it('handles NULL/empty text fields', () => {
-      const raw = '100\t200\t7\tNULL\t\t\t\t0\t5\t1000\t1500\t2000\t0';
-      const rows = parseEntryRows(raw, 13);
+      const raw = '100\t200\t7\tNULL\t\t\t\t0\t5\t1000\t1500\t2000\t0\t0';
+      const rows = parseEntryRows(raw, 14);
 
       expect(rows[0].artistName).toBeNull();
       expect(rows[0].albumTitle).toBeNull();
@@ -119,7 +142,7 @@ describe('fetch-legacy parsing', () => {
       const raw = '100\t200\t0\tArtist';
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-      const rows = parseEntryRows(raw, 13);
+      const rows = parseEntryRows(raw, 14);
 
       expect(rows).toHaveLength(0);
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('malformed'), expect.any(String));
@@ -127,16 +150,16 @@ describe('fetch-legacy parsing', () => {
     });
 
     it('returns empty array for empty input', () => {
-      expect(parseEntryRows('', 13)).toEqual([]);
-      expect(parseEntryRows('   ', 13)).toEqual([]);
+      expect(parseEntryRows('', 14)).toEqual([]);
+      expect(parseEntryRows('   ', 14)).toEqual([]);
     });
 
     it('parses multiple rows', () => {
       const raw = [
-        '1\t100\t0\tArtist1\tAlbum1\tTrack1\tLabel1\t0\t1\t1000\t1500\t2000\t101',
-        '2\t100\t0\tArtist2\tAlbum2\tTrack2\tLabel2\t1\t2\t3000\t3500\t4000\t102',
+        '1\t100\t0\tArtist1\tAlbum1\tTrack1\tLabel1\t0\t1\t1000\t1500\t2000\t101\t0',
+        '2\t100\t0\tArtist2\tAlbum2\tTrack2\tLabel2\t1\t2\t3000\t3500\t4000\t102\t0',
       ].join('\n');
-      const rows = parseEntryRows(raw, 13);
+      const rows = parseEntryRows(raw, 14);
 
       expect(rows).toHaveLength(2);
       expect(rows[0].id).toBe(1);
@@ -148,8 +171,9 @@ describe('fetch-legacy parsing', () => {
     });
 
     it('preserves timeCreated when START_TIME is 0', () => {
-      const raw = '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t0\t1\t0\t1706799650000\t1706799700000\t101';
-      const rows = parseEntryRows(raw, 13);
+      const raw =
+        '100\t200\t0\tAutechre\tConfield\tVI Scose Poise\tWarp\t0\t1\t0\t1706799650000\t1706799700000\t101\t0';
+      const rows = parseEntryRows(raw, 14);
 
       expect(rows).toHaveLength(1);
       expect(rows[0].startTime).toBe(0);

--- a/tests/unit/jobs/flowsheet-etl/job.djName.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.djName.test.ts
@@ -49,6 +49,7 @@ const makeEntry = (overrides: Partial<LegacyEntryRow> = {}): LegacyEntryRow => (
   timeLastModified: 1706799700000,
   legacyReleaseId: 101,
   segueFlag: 0,
+  radioHour: null,
   ...overrides,
 });
 

--- a/tests/unit/jobs/flowsheet-etl/job.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.test.ts
@@ -57,6 +57,7 @@ const makeEntry = (overrides: Partial<LegacyEntryRow> = {}): LegacyEntryRow => (
   timeLastModified: 1706799700000,
   legacyReleaseId: 101,
   segueFlag: 0,
+  radioHour: null,
   ...overrides,
 });
 
@@ -98,6 +99,36 @@ describe('runIncremental', () => {
     // The key assertion: add_time should come from TIME_CREATED (the fallback),
     // not be null/skipped because START_TIME was 0
     expect(values.add_time).toEqual(new Date(1706799650000));
+  });
+
+  it('writes radio_hour from RADIO_HOUR for a breakpoint entry', async () => {
+    mockFetchLegacyShows.mockResolvedValue([makeShow()]);
+    mockFetchLegacyEntries.mockResolvedValue([makeEntry({ id: 3003, entryTypeCode: 8, radioHour: 1718726400000 })]);
+
+    await runIncremental();
+
+    const flowsheetInsert = chain.values.mock.calls.find(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).legacy_entry_id === 3003
+    );
+    expect(flowsheetInsert).toBeDefined();
+    const values = flowsheetInsert![0] as Record<string, unknown>;
+    expect(values.entry_type).toBe('breakpoint');
+    expect(values.radio_hour).toEqual(new Date(1718726400000));
+  });
+
+  it('writes radio_hour: null for a track entry even when RADIO_HOUR is present', async () => {
+    mockFetchLegacyShows.mockResolvedValue([makeShow()]);
+    mockFetchLegacyEntries.mockResolvedValue([makeEntry({ id: 3004, entryTypeCode: 0, radioHour: 1718726400000 })]);
+
+    await runIncremental();
+
+    const flowsheetInsert = chain.values.mock.calls.find(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).legacy_entry_id === 3004
+    );
+    expect(flowsheetInsert).toBeDefined();
+    const values = flowsheetInsert![0] as Record<string, unknown>;
+    expect(values.entry_type).toBe('track');
+    expect(values.radio_hour).toBeNull();
   });
 
   it('skips entry when all three timestamps are 0', async () => {

--- a/tests/unit/jobs/flowsheet-etl/transform.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/transform.test.ts
@@ -3,6 +3,7 @@ import {
   mapProdEntryType,
   epochMsToDate,
   resolveEntryTimestamp,
+  resolveRadioHour,
   parseMySQLDatetime,
   truncate,
   transformShow,
@@ -26,6 +27,27 @@ describe('flowsheet-etl transform', () => {
 
     it.each([8, 9, 10, 99, -1])('maps unknown code %d to "message"', (code) => {
       expect(mapEntryType(code)).toBe('message');
+    });
+  });
+
+  describe('resolveRadioHour', () => {
+    // tubafrenzy's RADIO_HOUR is the authoritative top-of-hour for a breakpoint;
+    // it is only meaningful for breakpoint rows (BS#1449).
+    it('maps a breakpoint RADIO_HOUR (epoch ms) to a Date', () => {
+      const topOfHour = 1718722800000; // 2024-06-18T15:00:00Z
+      expect(resolveRadioHour('breakpoint', topOfHour)).toEqual(new Date(topOfHour));
+    });
+
+    it('returns null for a non-breakpoint type even when RADIO_HOUR is present', () => {
+      expect(resolveRadioHour('track', 1718722800000)).toBeNull();
+    });
+
+    it('returns null for a breakpoint with RADIO_HOUR=0 (absent)', () => {
+      expect(resolveRadioHour('breakpoint', 0)).toBeNull();
+    });
+
+    it('returns null for a breakpoint with a null RADIO_HOUR', () => {
+      expect(resolveRadioHour('breakpoint', null)).toBeNull();
     });
   });
 

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -265,6 +265,63 @@ describe('POST /internal/flowsheet-webhook', () => {
     expect(lastInsertValues()).toEqual(expect.objectContaining({ album_id: null }));
   });
 
+  // -- radio_hour ingestion (BS#1449). tubafrenzy#593 adds `radioHour` (epoch
+  // ms, the authoritative top-of-hour) to the breakpoint webhook payload. BS
+  // persists it only for breakpoint rows; everything else stays null.
+
+  it('writes radio_hour for a breakpoint INSERT when radioHour is present', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 8, radioHour: 1718726400000 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(
+      expect.objectContaining({ entry_type: 'breakpoint', radio_hour: new Date(1718726400000) })
+    );
+  });
+
+  it('writes radio_hour: null on a breakpoint INSERT when radioHour is absent (pre-#593)', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 8 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'breakpoint', radio_hour: null }));
+  });
+
+  it('writes radio_hour: null (not an Invalid Date) on a breakpoint INSERT with a malformed radioHour', async () => {
+    // Hardening: resolveRadioHour routes through epochMsToDate, so a
+    // contract-violating non-numeric/out-of-range radioHour degrades to null
+    // rather than persisting an Invalid Date or 500-ing the delivery.
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 8, radioHour: 'not-a-number' } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'breakpoint', radio_hour: null }));
+  });
+
+  it('writes radio_hour: null on a track INSERT even when radioHour is present', async () => {
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 0, radioHour: 1718726400000 } });
+
+    expect(res.status).toBe(200);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'track', radio_hour: null }));
+  });
+
   it('forwards the resolved rotation_id when rotationReleaseId matches a rotation row', async () => {
     // resolveShow → 9999, resolveAlbumId → unlinked, resolveRotationId → 4242.
     mockLimit.mockReset();
@@ -516,6 +573,53 @@ describe('POST /internal/flowsheet-webhook', () => {
     const setClause = lastUpdateSet();
     expect(setClause).not.toHaveProperty('dj_name');
     expect(setClause).toEqual(expect.objectContaining({ entry_type: 'show_start' }));
+  });
+
+  // -- ON CONFLICT UPDATE radio_hour refresh (BS#1449 self-heal) --
+  //
+  // A breakpoint row inserted before the radio_hour column existed (NULL) heals
+  // on a later redelivery once tubafrenzy#593 ships `radioHour`. Mirrors the
+  // dj_name conditional: only set when present, never on non-breakpoints.
+
+  it('UPDATE on conflict refreshes radio_hour for a breakpoint with radioHour', async () => {
+    mockReturning.mockResolvedValueOnce([]); // conflict signal
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 8, radioHour: 1718726400000 } });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(lastUpdateSet()).toEqual(
+      expect.objectContaining({ entry_type: 'breakpoint', radio_hour: new Date(1718726400000) })
+    );
+  });
+
+  it('UPDATE on conflict OMITS radio_hour for a breakpoint without radioHour (never overwrite with NULL)', async () => {
+    mockReturning.mockResolvedValueOnce([]); // conflict signal
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 8 } });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(lastUpdateSet()).not.toHaveProperty('radio_hour');
+  });
+
+  it('UPDATE on conflict OMITS radio_hour for a track even when radioHour is present', async () => {
+    mockReturning.mockResolvedValueOnce([]); // conflict signal
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'update', entry: { ...validEntry, flowsheetEntryType: 0, radioHour: 1718726400000 } });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(lastUpdateSet()).not.toHaveProperty('radio_hour');
   });
 
   it('UPDATE on conflict OMITS dj_name on a track entry (non-marker entry types never set dj_name)', async () => {

--- a/tests/unit/services/flowsheet.service.test.ts
+++ b/tests/unit/services/flowsheet.service.test.ts
@@ -41,6 +41,7 @@ const createBaseEntry = (overrides: Partial<IFSEntry & { metadata?: Partial<IFSE
     segue: false,
     message: null,
     add_time: new Date('2024-01-15T12:00:00Z'),
+    radio_hour: null,
     dj_name: null,
     rotation_bin: null,
     on_streaming: null,
@@ -481,6 +482,47 @@ describe('flowsheet.service', () => {
 
         expect(result.entry_type).toBe('breakpoint');
         expect(result.message).toBeNull();
+      });
+
+      it('emits radio_hour as the breakpoint top-of-hour Date (BS#1449)', () => {
+        // add_time is the early logging instant; radio_hour is the authoritative
+        // top-of-hour that clients should format instead.
+        const topOfHour = new Date('2024-06-18T16:00:00Z');
+        const entry = createBaseEntry({
+          entry_type: 'breakpoint',
+          message: '--- 12:00 PM BREAKPOINT ---',
+          add_time: new Date('2024-06-18T15:58:42Z'),
+          radio_hour: topOfHour,
+        });
+
+        const result = transformToV2(entry);
+
+        // transformToV2 emits the Date; Express res.json serializes it to ISO.
+        expect(result.radio_hour).toEqual(topOfHour);
+      });
+
+      it('emits radio_hour as null when the breakpoint has none', () => {
+        const entry = createBaseEntry({
+          entry_type: 'breakpoint',
+          message: '--- breakpoint ---',
+          radio_hour: null,
+        });
+
+        const result = transformToV2(entry);
+
+        expect(result.radio_hour).toBeNull();
+      });
+
+      it('omits radio_hour entirely for non-breakpoint (track) entries', () => {
+        const entry = createBaseEntry({
+          entry_type: 'track',
+          artist_name: 'Juana Molina',
+          radio_hour: new Date('2024-06-18T16:00:00Z'),
+        });
+
+        const result = transformToV2(entry);
+
+        expect(result.radio_hour).toBeUndefined();
       });
     });
 

--- a/tests/unit/services/flowsheet.transformToV2.metadata-status.test.ts
+++ b/tests/unit/services/flowsheet.transformToV2.metadata-status.test.ts
@@ -47,6 +47,7 @@ const createTrackEntry = (overrides: Partial<IFSEntry> = {}): IFSEntry => ({
   linked_at: null,
   metadata_status: 'pending',
   enriching_since: null,
+  radio_hour: null,
   metadata: nullMetadata,
   ...overrides,
 });


### PR DESCRIPTION
## Summary

Carries tubafrenzy's authoritative top-of-hour (`RADIO_HOUR`) through to the V2 flowsheet so iOS "Now Playing / Recently Played" hour-marker chips stop rendering **one hour early**. A breakpoint's `add_time` is its ~1-min-early *logging* instant; clients format `"h a"` and floor across the boundary (a 12:00 PM breakpoint logged 15:58Z / 11:58 ET renders "11 AM"). The real top-of-hour now flows through the `flowsheet.radio_hour` column (migration 0103) instead of being dropped on ingestion. **No rounding/flooring of `add_time`** — the real `RADIO_HOUR` is carried.

This is the keystone of the epic: the change that actually makes the service emit `radio_hour`. The contract (`@wxyc/shared@1.12.0`, `radio_hour?: string | null`) and the migration (#1450) are already merged.

## Changes

- **Read path + serialization** (`flowsheet.controller.ts`, `flowsheet.service.ts`): un-omit `radio_hour` from `IFSEntry` (present-but-nullable); project it in `FSEntryFieldsRaw` / `FSEntryRaw` / `transformToIFSEntry`; emit it from `transformToV2` on the **breakpoint case only**. Non-breakpoint V2 entries omit the key, honoring the optional+nullable wire contract. `transformToV2` emits the `Date`; `res.json` serializes ISO/null (same as `add_time`).
- **Webhook** (`internal.route.ts`): INSERT and the ON-CONFLICT refresh both set `radio_hour` for breakpoints, guarded `entryType === 'breakpoint' && entry.radioHour`. The payload field (`radioHour`, epoch ms) only arrives once **tubafrenzy#593** ships; the guard tolerates its absence, so this leg is inert-but-safe until then. The refresh conditional heals rows inserted before the column existed, never overwriting a value with NULL.
- **ETL** (`flowsheet-etl`): new pure `resolveRadioHour(entryType, radioHourMs)` (breakpoint → `Date`, else `null`; `epochMsToDate` handles 0/absent). Wired into both `job.ts` insert paths — bulk `importEntries` (dump `tuple[9]`) and incremental `runIncremental` — with `radio_hour` added to the upsert `set` + `setWhere` so re-synced breakpoints self-heal. `fetch-legacy` adds `RADIO_HOUR` as a stable column (index 13) in `BASE_ENTRY_COLUMNS`; `SEGUE_FLAG` stays the optional trailing column, shifting to index 14.
- **Contract**: bump `@wxyc/shared` → `^1.12.0` across the four workspaces. The lockfile update also prunes two pre-existing **extraneous** entries (`../../git-merge-append`, `jobs/library-identity-backfill`) that `npm install` removes on sight — incidental, idempotent cleanup.

## Tests (TDD)

`resolveRadioHour`; the `fetch-legacy` column shift (incl. an explicit segue-index regression guard for the 13→14/14→15 move); the incremental insert (breakpoint → `radio_hour`, track → `null`); `transformToV2` breakpoint output (Date / null / track-omits); and the webhook INSERT + ON-CONFLICT paths (breakpoint sets, track ignores, absent → null/omit).

## Verification

`npm run typecheck` (+ direct `tsc` on `jobs/flowsheet-etl`), `npm run lint` (0 errors), `npm run format:check`, and the affected unit suites (212/212) all pass locally. No migration → CI skips `migrate-dryrun`. (The local full suite's only failures are the unrelated Node-26 `setTimeout` timer flake in CDC/SSE/lml-client suites.)

## Sequencing

- Webhook leg is **inert until tubafrenzy#593** adds `radioHour` to the payload (safe to merge first — guarded). ETL leg works immediately off the MySQL `RADIO_HOUR` column.
- ios#404 already reads the field with an `add_time` fallback; the user-visible fix completes once this emits it.

Closes #1449
Part of #1447