### PR TITLE
test(flowsheet-etl): guard bulk-load dump-column → flowsheet mapping (#1462)

### DIFF
--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -226,7 +226,13 @@ const buildShowIdMap = async (dbClient: DbClient) => {
   return map;
 };
 
-const importEntries = async (dbClient: DbClient, lines: string[], showIdMap: Map<number, number>) => {
+/**
+ * Parse FLOWSHEET_ENTRY_PROD dump lines into flowsheet rows and bulk-insert
+ * them. Exported so unit tests can pin the dump-column→row mapping — most
+ * importantly `radio_hour` from RADIO_HOUR (tuple[9]) — which otherwise has no
+ * CI regression guard against the dump column map drifting (#1462).
+ */
+export const importEntries = async (dbClient: DbClient, lines: string[], showIdMap: Map<number, number>) => {
   let entryCount = 0;
   const pendingEntries: BulkEntryRow[] = [];
 

--- a/tests/unit/jobs/flowsheet-etl/job.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.test.ts
@@ -62,7 +62,7 @@ const makeEntry = (overrides: Partial<LegacyEntryRow> = {}): LegacyEntryRow => (
 });
 
 // Import after mocks are set up
-import { runIncremental } from '../../../../jobs/flowsheet-etl/job';
+import { runIncremental, importEntries } from '../../../../jobs/flowsheet-etl/job';
 
 describe('runIncremental', () => {
   beforeEach(() => {
@@ -240,5 +240,96 @@ describe('runIncremental', () => {
     for (const [arg] of calls) {
       expect(arg.setWhere).toBeTruthy();
     }
+  });
+});
+
+/**
+ * Regression guard for the bulk-load path's dump-column → flowsheet mapping (#1462).
+ *
+ * importEntries reads each field from a hard-coded FLOWSHEET_ENTRY_PROD dump-tuple
+ * index (the column map documented above importEntries in job.ts). The incremental
+ * path is covered above; the bulk path had no test. A future reorder of that column
+ * map (tubafrenzy adds/removes a column) would silently populate every bulk-loaded
+ * row from the wrong column on a full reload, with nothing failing — the exact
+ * corruption #1449 fixed for radio_hour, at full-reload blast radius.
+ *
+ * radio_hour (tuple[9]) is the #1462 motivator, but the identical positional risk
+ * applies to its neighbors, so this pins the cluster: LABEL_NAME@8, RADIO_HOUR@9,
+ * START_TIME@10, RADIO_SHOW_ID@12, SEQUENCE_WITHIN_SHOW@13, ENTRY_TYPE_CODE@15,
+ * plus ARTIST_NAME@1 / SONG_TITLE@3 / RELEASE_TITLE@4. The fixture is deliberately
+ * discriminating — each asserted column carries a distinct, typed value (e.g.
+ * RADIO_HOUR@9 ≠ START_TIME@10, START_TIME@10 ≠ its add_time fallbacks
+ * TIME_LAST_MODIFIED@16 / TIME_CREATED@17, and LABEL_NAME@8 is a string) — so an
+ * off-by-one drift fails an assertion rather than passing silently.
+ */
+describe('importEntries — bulk-load dump-column mapping (#1462)', () => {
+  const RADIO_HOUR_MS = 1718726400000; // 16:00:00Z — RADIO_HOUR@9 (top of hour)
+  const START_TIME_MS = 1718726460000; // 16:01:00Z — START_TIME@10 (what add_time resolves to)
+  // add_time = resolveEntryTimestamp(START_TIME@10 ?? TIME_CREATED@17 ?? TIME_LAST_MODIFIED@16).
+  // Give the two fallbacks values distinct from START_TIME so the add_time assertion
+  // actually pins index 10 — if all three were equal a drift 10→16/17 would pass silently.
+  const TIME_LAST_MODIFIED_MS = 1718726490000; // 16:01:30Z — TIME_LAST_MODIFIED@16
+  const TIME_CREATED_MS = 1718726430000; // 16:00:30Z — TIME_CREATED@17
+
+  // One INSERT, three FLOWSHEET_ENTRY_PROD tuples (21 cols, 0..20 per the dump
+  // column map): a breakpoint with a real RADIO_HOUR, a track that carries a
+  // RADIO_HOUR but must drop it, and a breakpoint whose RADIO_HOUR is 0.
+  const dumpLine =
+    'INSERT INTO `FLOWSHEET_ENTRY_PROD` VALUES ' +
+    `(2006,'Top of the hour 4 PM',NULL,NULL,NULL,NULL,NULL,NULL,'Drag City',${RADIO_HOUR_MS},${START_TIME_MS},NULL,1001,5,0,8,${TIME_LAST_MODIFIED_MS},${TIME_CREATED_MS},0,9999,NULL),` +
+    `(2007,'Jessica Pratt',NULL,'Back, Baby','On Your Own Love Again',NULL,NULL,NULL,'Drag City',${RADIO_HOUR_MS},${START_TIME_MS},NULL,1001,6,0,0,${TIME_LAST_MODIFIED_MS},${TIME_CREATED_MS},0,10000,NULL),` +
+    `(2009,'Top of the hour 5 PM',NULL,NULL,NULL,NULL,NULL,NULL,'Drag City',0,${START_TIME_MS},NULL,1001,7,0,8,${TIME_LAST_MODIFIED_MS},${TIME_CREATED_MS},0,10001,NULL);`;
+
+  const showIdMap = new Map<number, number>([[1001, 10]]);
+
+  let pushed: Record<string, unknown>[];
+  // Throws (failing the test with a clear message) rather than returning
+  // undefined, so call sites read the row's fields without a non-null assertion.
+  const byId = (id: number): Record<string, unknown> => {
+    const row = pushed.find((r) => r.legacy_entry_id === id);
+    if (!row) throw new Error(`no bulk-loaded row with legacy_entry_id=${id}`);
+    return row;
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    // Bulk insert terminal: importEntries awaits .onConflictDoNothing() directly,
+    // so it must resolve (the chain's default .then would otherwise hang the await).
+    chain.onConflictDoNothing.mockResolvedValue(undefined);
+
+    await importEntries(db, [dumpLine], showIdMap);
+
+    // Rows are batched into .values([...]); flatMap is robust to any batch count.
+    pushed = chain.values.mock.calls.flatMap((call: unknown[]) => call[0] as Record<string, unknown>[]);
+  });
+
+  it('maps a breakpoint row from the right dump columns', () => {
+    const row = byId(2006);
+    expect(row.entry_type).toBe('breakpoint'); // ENTRY_TYPE_CODE@15 = 8
+    // The #1462 mapping: RADIO_HOUR@9. add_time below pins START_TIME@10 to a
+    // distinct value, and record_label pins LABEL_NAME@8 to a string, so a drift
+    // off index 9 to either neighbor fails one of these rather than passing.
+    expect(row.radio_hour).toEqual(new Date(RADIO_HOUR_MS)); // RADIO_HOUR@9
+    expect(row.add_time).toEqual(new Date(START_TIME_MS)); // START_TIME@10 (≠ TIME_*@16/@17, so it pins index 10)
+    expect(row.record_label).toBe('Drag City'); // LABEL_NAME@8
+    expect(row.show_id).toBe(10); // RADIO_SHOW_ID@12 = 1001, mapped via showIdMap
+    expect(row.play_order).toBe(5); // SEQUENCE_WITHIN_SHOW@13
+    expect(row.message).toBe('Top of the hour 4 PM'); // ARTIST_NAME@1 (message text for breakpoints)
+    expect(row.artist_name).toBeNull();
+  });
+
+  it('maps a track row and drops RADIO_HOUR to null', () => {
+    const row = byId(2007);
+    expect(row.entry_type).toBe('track'); // ENTRY_TYPE_CODE@15 = 0
+    expect(row.radio_hour).toBeNull(); // RADIO_HOUR present, but only breakpoints carry it
+    expect(row.artist_name).toBe('Jessica Pratt'); // ARTIST_NAME@1
+    expect(row.track_title).toBe('Back, Baby'); // SONG_TITLE@3 (comma inside the quoted value)
+    expect(row.album_title).toBe('On Your Own Love Again'); // RELEASE_TITLE@4
+  });
+
+  it('maps a breakpoint with RADIO_HOUR=0 to null', () => {
+    const row = byId(2009);
+    expect(row.entry_type).toBe('breakpoint');
+    expect(row.radio_hour).toBeNull(); // RADIO_HOUR@9 = 0 → epochMsToDate(0) = null
   });
 });


### PR DESCRIPTION
## Problem

The flowsheet ETL **bulk-load** path (`importEntries` in `jobs/flowsheet-etl/job.ts`) maps every field from a hard-coded `FLOWSHEET_ENTRY_PROD` mysqldump tuple index — `radio_hour` from `RADIO_HOUR` (`tuple[9]`) being the #1462 motivator — but nothing fails if that column map drifts:

- `importEntries` / `runBulkLoad` were **not exported** and never unit-tested. The existing unit tests only cover `runIncremental` (a different code path that reads `RADIO_HOUR` at a different index).
- The only test exercising the real bulk path (`tests/e2e/etl.test.ts`) never asserts these fields, and **the e2e suite does not run in CI**.

So a future reorder of the `FLOWSHEET_ENTRY_PROD` column map (tubafrenzy adds/removes a column) would **silently populate every bulk-loaded row from the wrong column during a full reload**, with no test catching it — the corruption #1449 fixed for `radio_hour`, at full-history blast radius.

## Change

- Export `importEntries` from `job.ts` (the seam that does the dump-tuple → row mapping).
- Add a unit test (`tests/unit/jobs/flowsheet-etl/job.test.ts`) — which **runs in CI** via the unit-tests job — that feeds a synthetic `INSERT INTO \`FLOWSHEET_ENTRY_PROD\` VALUES (…)` line through the **real `parse-dump` path** and pins the tuple-index cluster:
  - breakpoint `RADIO_HOUR` → `radio_hour = new Date(ms)`; track → `null`; breakpoint with `RADIO_HOUR=0` → `null`.
  - the neighbors that carry the identical drift risk: `ARTIST_NAME@1`, `SONG_TITLE@3`, `RELEASE_TITLE@4`, `LABEL_NAME@8`, `START_TIME@10`, `RADIO_SHOW_ID@12`, `SEQUENCE_WITHIN_SHOW@13`, `ENTRY_TYPE_CODE@15`.

The fixture is deliberately **discriminating**: each asserted column carries a distinct, typed value, and `START_TIME@10` differs from its `resolveEntryTimestamp` fallbacks `TIME_LAST_MODIFIED@16` / `TIME_CREATED@17`, so an off-by-one drift fails an assertion rather than passing silently.

## Verification

- `npm run lint` (0 errors), `npm run format:check`, `npm run typecheck`, `npm run build` — all clean.
- Targeted unit suite: 13/13 pass.
- **Mutation-verified** the guard is load-bearing: drifting the production mapping off any pinned index (e.g. `radio_hour` `9→8`/`9→10`, `add_time` `10→16`/`10→17`, `play_order` `13`, `show_id` `12`) turns the suite red; reverting restores green.

This implements **Option 1** from the issue. Wiring the e2e suite into CI (Option 2) remains a separate, larger gap and is intentionally out of scope here.

Closes #1462