### PR TITLE
test(1464): drain mockImplementationOnce queue in runIncremental beforeEach

### DIFF
--- a/tests/unit/jobs/flowsheet-etl/job.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.test.ts
@@ -71,6 +71,13 @@ describe('runIncremental', () => {
     // Default: no previous run (full sync)
     (getLastRunTimestamp as jest.Mock).mockResolvedValue(null);
 
+    // jest.clearAllMocks() (and clearMocks: true) reset mock.calls but do NOT
+    // drain the mockImplementationOnce queue — only mockReset() does. A test
+    // that short-circuits before consuming both onces (e.g. an empty-entries
+    // run that skips the existing-IDs query) would otherwise leak its leftover
+    // once into the next test. Drain here so the block is reorder/insert-safe.
+    chain.then.mockReset();
+
     // Default: show map query returns one show mapping
     // Then: existing entry IDs query returns empty (all entries are new)
     chain.then
@@ -156,7 +163,10 @@ describe('runIncremental', () => {
     mockFetchLegacyShows.mockResolvedValue([]);
     mockFetchLegacyEntries.mockResolvedValue([]);
 
-    // Reset chain.then for the show map + existing IDs queries
+    // Override the beforeEach default onces with this test's values (show map
+    // empty, existing IDs empty). mockReset() is load-bearing here: it clears
+    // the defaults so these onces are the ones consumed — not redundant with
+    // the beforeEach drain, which only resets between tests.
     chain.then
       .mockReset()
       .mockImplementationOnce((resolve: (v: unknown) => void) => resolve([]))
@@ -175,7 +185,10 @@ describe('runIncremental', () => {
       makeEntry({ id: 2002, trackTitle: 'Pen Expers', playOrder: 2 }), // existing entry
     ]);
 
-    // Show map query, then existing IDs query returns one match
+    // Override the beforeEach default onces: show map query, then existing IDs
+    // query returns one match. mockReset() is load-bearing — it clears the
+    // defaults so these onces are consumed (not redundant with the beforeEach
+    // drain).
     chain.then
       .mockReset()
       .mockImplementationOnce((resolve: (v: unknown) => void) => resolve([{ id: 10, legacyId: 1001 }]))


### PR DESCRIPTION
## Problem

The `describe('runIncremental')` block in `tests/unit/jobs/flowsheet-etl/job.test.ts` provisioned `chain.then` with two `mockImplementationOnce` callbacks in its `beforeEach` but never drained the queue between tests. `jest.clearAllMocks()` (and `clearMocks: true`) reset `mock.calls` but do **not** drain the `mockImplementationOnce` queue — only `mockReset()` does. The `'clamps overlapping show end_times'` test sets `mockFetchLegacyEntries` to `[]`, so `runIncremental` short-circuits before the existing-IDs query and consumes only the first once, leaking the second (`resolve([])`) into the next test. That made the two per-test `mockReset()` calls load-bearing and the block fragile to reordering or insertion.

## Fix

Drain `chain.then` in the block's `beforeEach`, before re-provisioning the defaults, so every test starts from a clean queue regardless of what a prior test left behind. This immunizes the whole block, not just the one currently-leaky test. A comment documents that `clearAllMocks()` does not drain the once-queue.

Also clarified the two per-test resets: verification showed they remain load-bearing for a second, independent reason — they override the `beforeEach` defaults with test-specific values — so a future cleanup shouldn't delete them as redundant with the new drain.

## Verification

- `job.test.ts`: 13/13 pass.
- Confirmed (via scratch variants) that stripping the per-test resets while keeping the `beforeEach` drain still fails `'distinguishes inserts from updates'`, proving those resets serve the override role.
- The current leak is latent/benign (the leaked `[]`, shifted one position, lands on the show-map value which has no `lid` field and parses as empty), so no existing test fails today — this is fragility hardening, matching the ticket's framing.

Test-harness hygiene only; no production code changed.

Closes #1464