### PR TITLE
fix(flowsheet): deterministic tiebreak in getEntriesByShow live read

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -436,7 +436,14 @@ export const getEntriesByShow = async (...show_ids: number[]): Promise<IFSEntry[
     .leftJoin(library, eq(library.id, flowsheet.album_id))
     .leftJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
     .where(inArray(flowsheet.show_id, show_ids))
-    .orderBy(desc(flowsheet.play_order));
+    // play_order can collide within a show: the tubafrenzy webhook and the
+    // dj-site live-insert path assign it independently and the schema
+    // intentionally allows overlap (no per-show UNIQUE — see schema.ts). Tied
+    // rows must therefore break on a stable secondary key, or the live
+    // flowsheet reshuffles between polls (the "randomly rearranging" report).
+    // flowsheet.id is globally monotonic, so it orders the two writers'
+    // entries deterministically at every shared play_order.
+    .orderBy(desc(flowsheet.play_order), desc(flowsheet.id));
 
   return raw.map(transformToIFSEntry);
 };

--- a/tests/unit/services/flowsheet.getEntriesByShow.ordering.test.ts
+++ b/tests/unit/services/flowsheet.getEntriesByShow.ordering.test.ts
@@ -1,0 +1,54 @@
+// Regression guard: getEntriesByShow serves the live per-show flowsheet
+// (GET /flowsheet?shows_limit=N → flowsheet.controller.ts). play_order is set
+// independently by the tubafrenzy webhook and the dj-site live-insert path and
+// CAN collide within a show (schema.ts docstring: "the read layer reconciles";
+// per-show UNIQUE on play_order is explicitly forbidden). Ordering by
+// play_order alone leaves tied rows in arbitrary heap order, so the live
+// flowsheet "randomly rearranges" between polls. A deterministic secondary
+// sort on flowsheet.id (globally monotonic) fixes the reconciliation without a
+// schema change.
+
+import { jest } from '@jest/globals';
+import { db, flowsheet } from '@wxyc/database';
+import { desc } from 'drizzle-orm';
+import { getEntriesByShow } from '../../../apps/backend/services/flowsheet.service';
+
+describe('flowsheet.service', () => {
+  describe('getEntriesByShow ordering (duplicate play_order tiebreak)', () => {
+    // Chain: select → from → leftJoin(rotation) → leftJoin(library) →
+    // leftJoin(album_metadata) → where → orderBy.
+    const orderByMock = jest.fn().mockResolvedValue([]);
+    const whereMock = jest.fn().mockReturnValue({ orderBy: orderByMock });
+    const leftJoinMock3 = jest.fn().mockReturnValue({ where: whereMock });
+    const leftJoinMock2 = jest.fn().mockReturnValue({ leftJoin: leftJoinMock3 });
+    const leftJoinMock1 = jest.fn().mockReturnValue({ leftJoin: leftJoinMock2 });
+    const fromMock = jest.fn().mockReturnValue({ leftJoin: leftJoinMock1 });
+
+    beforeEach(() => {
+      orderByMock.mockReset();
+      orderByMock.mockResolvedValue([]);
+      whereMock.mockReset();
+      whereMock.mockReturnValue({ orderBy: orderByMock });
+      leftJoinMock1.mockReset();
+      leftJoinMock1.mockReturnValue({ leftJoin: leftJoinMock2 });
+      leftJoinMock2.mockReset();
+      leftJoinMock2.mockReturnValue({ leftJoin: leftJoinMock3 });
+      leftJoinMock3.mockReset();
+      leftJoinMock3.mockReturnValue({ where: whereMock });
+      fromMock.mockReset();
+      fromMock.mockReturnValue({ leftJoin: leftJoinMock1 });
+      (db as unknown as { select: jest.Mock }).select = jest.fn().mockReturnValue({ from: fromMock });
+    });
+
+    it('orders by play_order DESC then id DESC as a deterministic tiebreak', async () => {
+      await getEntriesByShow(1);
+
+      expect(orderByMock).toHaveBeenCalledTimes(1);
+      const orderByArgs = orderByMock.mock.calls[0];
+      expect(orderByArgs[0]).toEqual(desc(flowsheet.play_order));
+      // Secondary key: without it, rows with equal play_order sort
+      // nondeterministically and the live flowsheet reshuffles between polls.
+      expect(orderByArgs[1]).toEqual(desc(flowsheet.id));
+    });
+  });
+});


### PR DESCRIPTION
## What

`getEntriesByShow` serves the live per-show flowsheet via `GET /flowsheet?shows_limit=N` (polled by dj-site every 60s, read by iOS) and ordered solely by `play_order DESC`. Within a show, `play_order` is intentionally non-unique — the tubafrenzy webhook and the dj-site live-insert path assign it independently and the schema explicitly forbids a per-show UNIQUE (`shared/database/src/schema.ts`: "the two paths can produce overlapping values and the read layer reconciles"). When two rows in a show share a `play_order`, Postgres returns the tied rows in arbitrary heap-scan order, which flips between queries, so the live flowsheet appears to randomly rearrange the track order between polls. This is the read-layer half of the reconciliation the schema promises, and it was missing.

## Fix

Add `desc(flowsheet.id)` as a deterministic secondary sort key. `id` is globally monotonic, so the two writers' entries order stably at every shared `play_order`. `play_order` stays primary (it is the DJ's intended within-show order). No schema change; does not add the forbidden per-show UNIQUE. Read-layer sibling to #714, which fixed the same class of bug in `getEntriesByRange`.

## Test

New unit guard `tests/unit/services/flowsheet.getEntriesByShow.ordering.test.ts` (mirrors the #714 `orderBy`-assertion pattern): red before the change (`orderByArgs[1]` was `undefined`), green after.

## Local verification

- `typecheck`, `lint`, `format:check`: pass
- affected flowsheet service + controller unit tests: pass (188)

Pre-existing, unrelated timer/websocket test failures on `main` (cdc-websocket, sse-metrics, album-plays-refresh, lml.client) are environmental on this machine and not touched by this change; the affected-tests-only PR CI does not run them for this diff.

Closes #1470
