### PR TITLE
feat: GET /library/catalog bulk export + watermark parent-table fan-out

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -228,6 +228,50 @@ components:
           type: string
           nullable: true
 
+    CatalogExportRow:
+      type: object
+      description: >
+        One catalog row in the `GET /library/catalog` NDJSON export (BS#1468).
+        `rotation_bin` / `rotation_kill_date` are raw (the most-recently-added
+        rotation record per album); the client evaluates "in rotation" locally.
+      properties:
+        id:
+          type: integer
+        artist_name:
+          type: string
+        album_title:
+          type: string
+        code_letters:
+          type: string
+        code_number:
+          type: integer
+        code_artist_number:
+          type: integer
+        label:
+          type: string
+          nullable: true
+        genre_name:
+          type: string
+        format_name:
+          type: string
+        on_streaming:
+          type: boolean
+          nullable: true
+        plays:
+          type: integer
+          nullable: true
+        artwork_url:
+          type: string
+          nullable: true
+        rotation_bin:
+          type: string
+          nullable: true
+          enum: [S, L, M, H, N]
+        rotation_kill_date:
+          type: string
+          format: date
+          nullable: true
+
     Rotation:
       type: object
       properties:
@@ -856,6 +900,59 @@ paths:
       responses:
         '200':
           description: Successfully added album
+
+  /library/catalog:
+    get:
+      summary: Bulk catalog export (gzipped NDJSON, conditional-GET)
+      description: >
+        Returns the entire music library catalog as one gzipped NDJSON body
+        (one JSON object per line) for clients that clone the catalog on-device
+        (e.g. iOS Core Spotlight indexing). Freshness is gated by the catalog
+        watermark: send `If-Modified-Since` (or `?since=`) and receive `304 Not
+        Modified` while the catalog is unchanged (it changes ~daily, after the
+        library ETL sync), or a fresh `200` with the full payload when it has
+        advanced. `rotation_bin` and `rotation_kill_date` are exported raw (the
+        most-recently-added rotation record per album); the client evaluates
+        "in rotation" against its own clock as
+        `rotation_bin != null && (rotation_kill_date == null || rotation_kill_date > today)`.
+      security:
+        - BearerAuth: ['catalog-read']
+      parameters:
+        - name: If-Modified-Since
+          in: header
+          required: false
+          description: RFC 9110 HTTP date from a prior response's `Last-Modified`.
+          schema:
+            type: string
+        - name: since
+          in: query
+          required: false
+          description: Alternative to `If-Modified-Since` (any parseable date string).
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Full catalog as gzipped NDJSON. One CatalogExportRow per line.
+          headers:
+            Last-Modified:
+              description: Catalog watermark; echo back as `If-Modified-Since`.
+              schema:
+                type: string
+            Content-Encoding:
+              description: '`gzip` when the request accepts gzip.'
+              schema:
+                type: string
+            Vary:
+              schema:
+                type: string
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: '#/components/schemas/CatalogExportRow'
+        '304':
+          description: Catalog unchanged since `If-Modified-Since` / `since`.
+        '401':
+          description: Missing or invalid bearer token.
 
   /library/rotation:
     get:

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -626,7 +626,11 @@ export const searchLibraryQueryEndpoint: RequestHandler<object, unknown, unknown
  */
 export const exportCatalog: RequestHandler = async (req, res) => {
   const gzipped = await catalogExportService.getCatalogExportGzip();
-  const acceptsGzip = (req.headers['accept-encoding'] ?? '').includes('gzip');
+  // Use Express's content-negotiation (the `accepts` library) rather than a
+  // substring match: it honors q-values, so `gzip;q=0` (an explicit refusal)
+  // correctly returns false, and `Accept-Encoding: *` correctly returns gzip —
+  // both of which `String.includes('gzip')` gets wrong.
+  const acceptsGzip = req.acceptsEncodings('gzip') === 'gzip';
 
   res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
   res.setHeader('Vary', 'Accept-Encoding');

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -9,7 +9,9 @@ import {
   NewRotationRelease,
   RotationRelease,
 } from '@wxyc/database';
+import { gunzipSync } from 'node:zlib';
 import * as libraryService from '../services/library.service.js';
+import * as catalogExportService from '../services/catalog-export.service.js';
 import * as labelsService from '../services/labels.service.js';
 import * as librarySearchService from '../services/library-search.service.js';
 import type { CatalogSort, CatalogOrder } from '../services/library-search.service.js';
@@ -601,4 +603,42 @@ export const searchLibraryQueryEndpoint: RequestHandler<object, unknown, unknown
   });
   const totalPages = Math.ceil(total / limit);
   res.status(200).json({ results, total, page, totalPages });
+};
+
+// ---------------------------------------------------------------------------
+// GET /library/catalog — full catalog bulk export (BS#1468 / Epic F, #1466)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stream the entire catalog as one gzipped NDJSON body so the iOS app can clone
+ * it for on-device Spotlight indexing. Freshness is handled upstream by the
+ * `conditionalGet(getCatalogLastModifiedAt)` middleware (which sets
+ * `Last-Modified` and short-circuits to `304` on `If-Modified-Since` / `?since=`
+ * when the `library_watermark` hasn't advanced); by the time this handler runs
+ * the catalog has changed and a full `200` is owed.
+ *
+ * The payload is pre-gzipped and cached per watermark (one shared copy per pod),
+ * so this is a memcpy on the hot path. There is no `compression` middleware in
+ * the app, so we set `Content-Encoding` ourselves and honor the request's
+ * `Accept-Encoding`: gzip-capable clients (iOS `URLSession` inflates
+ * transparently) get the cached bytes as-is with a correct `Content-Length`; the
+ * rare client that doesn't accept gzip gets a one-off inflate.
+ */
+export const exportCatalog: RequestHandler = async (req, res) => {
+  const gzipped = await catalogExportService.getCatalogExportGzip();
+  const acceptsGzip = (req.headers['accept-encoding'] ?? '').includes('gzip');
+
+  res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+  res.setHeader('Vary', 'Accept-Encoding');
+
+  if (acceptsGzip) {
+    res.setHeader('Content-Encoding', 'gzip');
+    res.setHeader('Content-Length', gzipped.length);
+    res.status(200).end(gzipped);
+    return;
+  }
+
+  const inflated = gunzipSync(gzipped);
+  res.setHeader('Content-Length', inflated.length);
+  res.status(200).end(inflated);
 };

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -3,6 +3,8 @@ import { Router } from 'express';
 import * as libraryController from '../controllers/library.controller.js';
 import * as requestLineController from '../controllers/requestLine.controller.js';
 import { trackActivity } from '../middleware/trackActivity.js';
+import { conditionalGet } from '../middleware/conditionalGet.js';
+import { getCatalogLastModifiedAt } from '../services/library.service.js';
 
 export const library_route = Router();
 
@@ -13,6 +15,17 @@ library_route.get('/search', requirePermissions({}), trackActivity, requestLineC
 library_route.get('/', requirePermissions({ catalog: ['read'] }), libraryController.searchForAlbum);
 
 library_route.get('/query', requirePermissions({ catalog: ['read'] }), libraryController.searchLibraryQueryEndpoint);
+
+// Catalog bulk export (BS#1468 / Epic F, parent #1466). `conditionalGet` gates
+// `304` on the library_watermark so a client that has cloned the catalog
+// re-pulls only when it changes (~daily). Same `catalog:read` auth as the other
+// catalog reads.
+library_route.get(
+  '/catalog',
+  requirePermissions({ catalog: ['read'] }),
+  conditionalGet(getCatalogLastModifiedAt),
+  libraryController.exportCatalog
+);
 
 library_route.post('/', requirePermissions({ catalog: ['write'] }), libraryController.addAlbum);
 

--- a/apps/backend/services/catalog-export.service.ts
+++ b/apps/backend/services/catalog-export.service.ts
@@ -94,8 +94,13 @@ export const serializeCatalogNdjson = (rows: CatalogExportRow[]): string =>
  *    the client evaluates expiry against its own clock. `kill_date` is cast to
  *    text so it serializes as a stable `YYYY-MM-DD` string (or null), not a
  *    parser-dependent Date.
- *  - `artist_name` reads the denormalized `library.artist_name` (physical
- *    column kept current by the 0060 cascade) rather than the `artists` join.
+ *  - `artist_name` prefers the denormalized `library.artist_name` (physical
+ *    column kept current by the 0060 cascade) but COALESCEs to the authoritative
+ *    `artists.artist_name` (NOT NULL) — `library.artist_name` is nullable
+ *    ("Nullable until A.2") and the export contract types `artist_name` non-null,
+ *    so an un-backfilled NULL must not ship as JSON null and break generated
+ *    iOS/Kotlin decoders. Both source columns advance the watermark (library
+ *    trigger + the 0105 artists trigger), so the COALESCE stays freshness-correct.
  *
  * One scan per watermark (cached below), so the full-table cost is paid ~daily.
  */
@@ -103,7 +108,7 @@ export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
   const rows = await db.execute(sql`
     SELECT DISTINCT ON (${library.id})
       ${library.id}                            AS id,
-      ${library.artist_name}                   AS artist_name,
+      COALESCE(${library.artist_name}, ${artists.artist_name}) AS artist_name,
       ${library.album_title}                   AS album_title,
       ${artists.code_letters}                  AS code_letters,
       ${library.code_number}                   AS code_number,

--- a/apps/backend/services/catalog-export.service.ts
+++ b/apps/backend/services/catalog-export.service.ts
@@ -1,0 +1,150 @@
+/**
+ * Bulk catalog export (BS#1468, Epic F pattern — parent #1466).
+ *
+ * Serves the entire `library` catalog as one gzipped NDJSON response so the
+ * `wxyc-dj-ios` app can clone it on-device and index it into Core Spotlight,
+ * instead of paging ~500 capped `GET /library/query` requests. The response is
+ * gated by the `conditionalGet(getCatalogLastModifiedAt)` middleware (BS#1467),
+ * so a client that has already cloned the catalog gets a cheap `304` until the
+ * `library_watermark` advances.
+ *
+ * This module owns the wire shape (`CatalogExportRow` + NDJSON serialization),
+ * the DB read, and the per-watermark gzip cache.
+ */
+
+import { gzipSync } from 'node:zlib';
+import { sql } from 'drizzle-orm';
+import { db, library, artists, format, genres, genre_artist_crossreference, rotation } from '@wxyc/database';
+import { createWatermarkCache } from './watermark-cache.service.js';
+import { getCatalogLastModifiedAt } from './library.service.js';
+
+/**
+ * One catalog row as exported to the client. Flat projection over the
+ * `library_artist_view` join (BS#1466), minus `search_doc` (server-side search
+ * artifact, not useful on-device).
+ *
+ * `rotation_bin` + `rotation_kill_date` are exported **raw** (the most-recent
+ * rotation record per album), NOT the view's `CURRENT_DATE`-filtered
+ * `rotation_bin`: the daily `kill_date` expiry is a pure clock event no
+ * statement trigger can observe, so the client evaluates "in rotation" against
+ * its own clock as `rotation_bin != null && (rotation_kill_date == null ||
+ * rotation_kill_date > today_local)`. See #1468 "Payload & freshness".
+ */
+export type CatalogExportRow = {
+  id: number;
+  artist_name: string;
+  album_title: string;
+  code_letters: string;
+  code_number: number;
+  code_artist_number: number;
+  label: string | null;
+  genre_name: string;
+  format_name: string;
+  on_streaming: boolean | null;
+  plays: number | null;
+  artwork_url: string | null;
+  rotation_bin: string | null;
+  rotation_kill_date: string | null;
+};
+
+/**
+ * Project a (possibly wider) row to exactly the export contract fields, in a
+ * fixed key order. Explicit projection — not a passthrough `JSON.stringify` —
+ * so a server-only column on the source row (e.g. `search_doc`,
+ * `alphabetical_name`) can never leak into the on-device clone.
+ */
+const projectRow = (row: CatalogExportRow): CatalogExportRow => ({
+  id: row.id,
+  artist_name: row.artist_name,
+  album_title: row.album_title,
+  code_letters: row.code_letters,
+  code_number: row.code_number,
+  code_artist_number: row.code_artist_number,
+  label: row.label,
+  genre_name: row.genre_name,
+  format_name: row.format_name,
+  on_streaming: row.on_streaming,
+  plays: row.plays,
+  artwork_url: row.artwork_url,
+  rotation_bin: row.rotation_bin,
+  rotation_kill_date: row.rotation_kill_date,
+});
+
+/**
+ * Serialize catalog rows to NDJSON: one JSON object per line, newline-separated.
+ * Friendlier than a framed array to build and parse incrementally. An empty
+ * input yields an empty string (no trailing newline to mis-parse as a row).
+ */
+export const serializeCatalogNdjson = (rows: CatalogExportRow[]): string =>
+  rows.map((row) => JSON.stringify(projectRow(row))).join('\n');
+
+/**
+ * Read the full catalog as flat export rows. Mirrors `library_artist_view`'s
+ * 5-table join, with two deliberate divergences for the export contract:
+ *
+ *  - rotation is joined RAW (no `kill_date > CURRENT_DATE` filter) and we keep
+ *    the most-recently-ADDED rotation record per album (`DISTINCT ON
+ *    (library.id) ORDER BY library.id, rotation.add_date DESC, rotation.id
+ *    DESC`). Ordering by `add_date`, NOT `id`: an album can carry an old killed
+ *    record with a *higher* serial id than its current active record (re-adds
+ *    insert fresh rows), so `id DESC` would surface the stale killed row and the
+ *    client would wrongly read the album as out of rotation. `id DESC` is only
+ *    the same-day tiebreak. The view's `CURRENT_DATE` filter is a server-side
+ *    day-floor; the export ships raw `rotation_bin` + `rotation_kill_date` so
+ *    the client evaluates expiry against its own clock. `kill_date` is cast to
+ *    text so it serializes as a stable `YYYY-MM-DD` string (or null), not a
+ *    parser-dependent Date.
+ *  - `artist_name` reads the denormalized `library.artist_name` (physical
+ *    column kept current by the 0060 cascade) rather than the `artists` join.
+ *
+ * One scan per watermark (cached below), so the full-table cost is paid ~daily.
+ */
+export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
+  const rows = await db.execute(sql`
+    SELECT DISTINCT ON (${library.id})
+      ${library.id}                            AS id,
+      ${library.artist_name}                   AS artist_name,
+      ${library.album_title}                   AS album_title,
+      ${artists.code_letters}                  AS code_letters,
+      ${library.code_number}                   AS code_number,
+      ${genre_artist_crossreference.artist_genre_code} AS code_artist_number,
+      ${library.label}                         AS label,
+      ${genres.genre_name}                     AS genre_name,
+      ${format.format_name}                    AS format_name,
+      ${library.on_streaming}                  AS on_streaming,
+      ${library.plays}                         AS plays,
+      ${library.artwork_url}                   AS artwork_url,
+      ${rotation.rotation_bin}                 AS rotation_bin,
+      ${rotation.kill_date}::text              AS rotation_kill_date
+    FROM ${library}
+      INNER JOIN ${artists} ON ${artists.id} = ${library.artist_id}
+      INNER JOIN ${format} ON ${format.id} = ${library.format_id}
+      INNER JOIN ${genres} ON ${genres.id} = ${library.genre_id}
+      INNER JOIN ${genre_artist_crossreference}
+        ON ${genre_artist_crossreference.artist_id} = ${library.artist_id}
+       AND ${genre_artist_crossreference.genre_id} = ${library.genre_id}
+      LEFT JOIN ${rotation} ON ${rotation.album_id} = ${library.id}
+    ORDER BY ${library.id}, ${rotation.add_date} DESC, ${rotation.id} DESC
+  `);
+  return rows as unknown as CatalogExportRow[];
+};
+
+/**
+ * Build the gzipped NDJSON payload from a fresh full-catalog scan.
+ */
+const buildCatalogExportGzip = async (): Promise<Buffer> => {
+  const rows = await getCatalogExportRows();
+  return gzipSync(Buffer.from(serializeCatalogNdjson(rows), 'utf8'));
+};
+
+// One shared gzipped copy per pod, rebuilt only when the catalog watermark
+// advances (≈daily). Keeps the hot path a memcpy instead of a 5-join scan +
+// re-gzip, and makes delivery atomic (no torn body, correct Content-Length).
+const catalogExportCache = createWatermarkCache<Buffer>(getCatalogLastModifiedAt, buildCatalogExportGzip);
+
+/**
+ * The gzipped NDJSON catalog export for the current watermark. Served as-is on
+ * the gzip-accepting path; gunzipped by the controller for the rare client that
+ * doesn't accept gzip.
+ */
+export const getCatalogExportGzip = (): Promise<Buffer> => catalogExportCache.get();

--- a/apps/backend/services/watermark-cache.service.ts
+++ b/apps/backend/services/watermark-cache.service.ts
@@ -1,0 +1,47 @@
+/**
+ * A per-watermark in-process cache (BS#1468). Pairs a watermark provider with a
+ * builder; `get()` returns the cached payload while the watermark is unchanged
+ * and rebuilds exactly once when it advances. Table-agnostic so it can back any
+ * "build once per freshness value" surface.
+ */
+export type WatermarkCache<T> = {
+  get: () => Promise<T>;
+};
+
+export const createWatermarkCache = <T>(
+  getWatermark: () => Promise<Date>,
+  build: () => Promise<T>
+): WatermarkCache<T> => {
+  let cached: { watermark: number; payload: T } | undefined;
+  // In-flight build for `inFlight.watermark`, shared by all concurrent reads at
+  // that watermark so a freshness advance can't trigger N parallel 5-join
+  // scans + gzips (thundering herd). Cleared once the build settles.
+  let inFlight: { watermark: number; promise: Promise<T> } | undefined;
+
+  const get = async (): Promise<T> => {
+    const watermark = (await getWatermark()).getTime();
+    if (cached && cached.watermark === watermark) {
+      return cached.payload;
+    }
+    if (inFlight && inFlight.watermark === watermark) {
+      return inFlight.promise;
+    }
+
+    const promise = build().then(
+      (payload) => {
+        cached = { watermark, payload };
+        if (inFlight && inFlight.watermark === watermark) inFlight = undefined;
+        return payload;
+      },
+      (err) => {
+        // Let the next caller retry rather than caching a rejection.
+        if (inFlight && inFlight.watermark === watermark) inFlight = undefined;
+        throw err;
+      }
+    );
+    inFlight = { watermark, promise };
+    return promise;
+  };
+
+  return { get };
+};

--- a/apps/backend/services/watermark-cache.service.ts
+++ b/apps/backend/services/watermark-cache.service.ts
@@ -3,6 +3,14 @@
  * builder; `get()` returns the cached payload while the watermark is unchanged
  * and rebuilds exactly once when it advances. Table-agnostic so it can back any
  * "build once per freshness value" surface.
+ *
+ * Requires the watermark provider to be **monotonic non-decreasing** — the
+ * catalog provider reads `library_watermark`, advanced by
+ * `GREATEST(now(), last_modified_at)` (migration 0104), which never retreats.
+ * The cached entry is only replaced by a build for an equal-or-newer watermark,
+ * so a slow build for an older watermark that resolves late cannot clobber a
+ * fresher cached payload. A provider that can move backward would break that
+ * guard and must not be used here.
  */
 export type WatermarkCache<T> = {
   get: () => Promise<T>;
@@ -29,7 +37,13 @@ export const createWatermarkCache = <T>(
 
     const promise = build().then(
       (payload) => {
-        cached = { watermark, payload };
+        // Publish only if no equal-or-newer watermark has already been cached.
+        // Builds for different watermarks can overlap (the watermark advanced
+        // mid-build); a slower OLDER build resolving last must not clobber the
+        // fresher entry. Safe because the provider is monotonic (see type doc).
+        if (!cached || watermark >= cached.watermark) {
+          cached = { watermark, payload };
+        }
         if (inFlight && inFlight.watermark === watermark) inFlight = undefined;
         return payload;
       },

--- a/shared/database/src/migrations/0105_library-watermark-parent-tables.sql
+++ b/shared/database/src/migrations/0105_library-watermark-parent-tables.sql
@@ -1,0 +1,75 @@
+-- BS#1468 (Epic F pattern, parent #1466) — fan the catalog freshness watermark
+-- out beyond `library` to every table whose columns the bulk-export endpoint
+-- (`GET /library/catalog`) projects for display.
+--
+-- Migration 0104 (#1467) created `library_watermark` + `touch_library_watermark()`
+-- and attached the AFTER STATEMENT trigger to `library` only. But the export's
+-- flat row is a 5-table join (`library_artist_view`): most display fields are
+-- NOT physical `library` columns —
+--
+--   code_letters            <- artists.code_letters
+--   code_artist_number      <- genre_artist_crossreference.artist_genre_code
+--   genre_name              <- genres.genre_name
+--   format_name             <- format.format_name
+--   rotation_bin/kill_date  <- rotation.* (raw, client evaluates expiry)
+--
+-- A rename/curation write on any of those parent tables touches no `library`
+-- row, so a `library`-only trigger would leave the watermark stale and a polling
+-- client would `304` against an out-of-date name until some unrelated `library`
+-- write happened to move it. This is the "coverage invariant" in #1468: every
+-- exported display field's source table must advance the watermark. So we attach
+-- the SAME trigger function to the four join parents + `rotation`.
+--
+-- `artist_name` is already covered two ways and needs no new trigger here: it is
+-- denormalized onto `library.artist_name` (physical column, direct `library`
+-- trigger) and the 0060 cascade rewrites those `library` rows on an `artists`
+-- rename. But `artists.code_letters` is NOT cascaded, so `artists` still needs
+-- its own trigger for that field — accepting that an `artists` write now both
+-- fires this trigger AND (on a rename) the 0060 cascade's `UPDATE library`. Both
+-- land on the idempotent `GREATEST(now(), last_modified_at)` advance, so the
+-- double-fire is harmless.
+--
+-- rotation is the sharp case: it is curated continuously (writes land on
+-- `rotation`, not `library`), so this trigger raises the catalog's 200/304 ratio
+-- above the "~daily ETL" cadence — by design, since `rotation_bin` is exported.
+-- The membership-EXPIRY half (a `kill_date` passing) is a pure clock event with
+-- no row mutation that no statement trigger can observe; #1468 delegates that to
+-- the client clock (it ships raw `rotation_bin` + `rotation_kill_date` and
+-- evaluates "in rotation" locally), so this trigger only needs to catch the
+-- add/kill *writes*, which it does.
+--
+-- Reuses `touch_library_watermark()` verbatim (defined in 0104) — same one-row
+-- UPDATE, same monotonic no-+1s formula, same per-statement O(1) cost. No schema
+-- objects change, so `drizzle:generate` produces no diff and the 0105 snapshot
+-- is byte-identical to 0104's apart from the id/prevId chain link (this is a
+-- `--custom` migration). TRUNCATE is included for symmetry with 0104 (a
+-- re-seed-via-TRUNCATE of any parent still advances the watermark).
+--
+-- @no-analyze-needed: no UPDATE on a stats-bearing table — the only write is the
+-- one-row `library_watermark` UPDATE inside the reused trigger function.
+-- @no-precondition-needed: trigger DDL only; no constraint, no data invariant.
+
+CREATE TRIGGER touch_library_watermark_from_artists
+AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON wxyc_schema.artists
+FOR EACH STATEMENT
+EXECUTE FUNCTION wxyc_schema.touch_library_watermark();
+--> statement-breakpoint
+CREATE TRIGGER touch_library_watermark_from_genres
+AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON wxyc_schema.genres
+FOR EACH STATEMENT
+EXECUTE FUNCTION wxyc_schema.touch_library_watermark();
+--> statement-breakpoint
+CREATE TRIGGER touch_library_watermark_from_format
+AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON wxyc_schema.format
+FOR EACH STATEMENT
+EXECUTE FUNCTION wxyc_schema.touch_library_watermark();
+--> statement-breakpoint
+CREATE TRIGGER touch_library_watermark_from_gac
+AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON wxyc_schema.genre_artist_crossreference
+FOR EACH STATEMENT
+EXECUTE FUNCTION wxyc_schema.touch_library_watermark();
+--> statement-breakpoint
+CREATE TRIGGER touch_library_watermark_from_rotation
+AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON wxyc_schema.rotation
+FOR EACH STATEMENT
+EXECUTE FUNCTION wxyc_schema.touch_library_watermark();

--- a/shared/database/src/migrations/meta/0105_snapshot.json
+++ b/shared/database/src/migrations/meta/0105_snapshot.json
@@ -1,0 +1,4727 @@
+{
+  "id": "4c9824e1-c731-47ee-b2b1-a94f08ca0d8c",
+  "prevId": "c603f1c0-81e5-45ff-bc67-aa546bce11e1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_release_date": {
+          "name": "full_release_date",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist": {
+          "name": "tracklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_image_url": {
+          "name": "artist_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_tokens": {
+          "name": "bio_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cta_unique_null_track_idx": {
+          "name": "cta_unique_null_track_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"compilation_track_artist\".\"track_title\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_scraped_at": {
+          "name": "first_scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "radio_hour": {
+          "name": "radio_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_show_id_play_order_idx": {
+          "name": "flowsheet_show_id_play_order_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"play_order\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "flowsheet_metadata_attempt_pending_idx": {
+          "name": "flowsheet_metadata_attempt_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false
+        },
+        "flowsheet_metadata_attempt_pending_covering_idx": {
+          "name": "flowsheet_metadata_attempt_pending_covering_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false
+        },
+        "flowsheet_album_id_enriched_idx": {
+          "name": "flowsheet_album_id_enriched_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "columns": [
+            "flowsheet_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "auth_organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "columns": [
+            "label_name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_watermark": {
+      "name": "library_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_watermark_singleton": {
+          "name": "library_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "auth_organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "columns": [
+            "album_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lml_identity_id": {
+          "name": "lml_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rotation_discogs_release_id_not_sentinel": {
+          "name": "rotation_discogs_release_id_not_sentinel",
+          "value": "\"wxyc_schema\".\"rotation\".\"discogs_release_id\" IS NULL OR \"wxyc_schema\".\"rotation\".\"discogs_release_id\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "auth_user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill",
+        "library_identity"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "materialized": false,
+      "isExisting": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "materialized": false,
+      "isExisting": false
+    },
+    "wxyc_schema.album_plays": {
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "materialized": true,
+      "isExisting": true
+    }
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -715,6 +715,13 @@
       "when": 1781468384348,
       "tag": "0104_library-watermark",
       "breakpoints": true
+    },
+    {
+      "idx": 105,
+      "version": "7",
+      "when": 1781468384349,
+      "tag": "0105_library-watermark-parent-tables",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -100,5 +100,6 @@
   "0101_rotation-discogs-release-id-not-sentinel": "19c3889d8859246d561ad250aac5a8f891afe60a6474e3fa4b4568c96bcb6908",
   "0102_album-metadata-lml-fields": "43425ee132e94b7962fe67a60b3b3cb979726179362e481986cef8cb217faebe",
   "0103_flowsheet-radio-hour": "48ac339af838c8bb6a00e2793d80b57b00f6b9971ed50c7f1e91a4359114fb68",
-  "0104_library-watermark": "e9cfb021ab16c8b44c9c9afead1d81ee348521428358536fe62eecfe557605e9"
+  "0104_library-watermark": "e9cfb021ab16c8b44c9c9afead1d81ee348521428358536fe62eecfe557605e9",
+  "0105_library-watermark-parent-tables": "879a3ac81a8a93b1108db8d72701d5927518d47c2cd006a39a632ac8c801c579"
 }

--- a/tests/integration/library-catalog-export.spec.js
+++ b/tests/integration/library-catalog-export.spec.js
@@ -189,6 +189,17 @@ describe('GET /library/catalog (BS#1468)', () => {
     expect(expired.rotation_kill_date).toBe('2024-07-01');
   });
 
+  test('artist_name is never null: a row with NULL library.artist_name falls back to the authoritative artists.artist_name', async () => {
+    // library.artist_name is nullable ("Nullable until A.2"); shape fixture row
+    // 7006 has it NULL. The OpenAPI/TS contract types artist_name as a non-null
+    // string (generated iOS/Kotlin decoders would throw on null), so the export
+    // must COALESCE to artists.artist_name (NOT NULL) rather than ship null.
+    const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
+    const nullArtistRow = byId.get(7006);
+    expect(nullArtistRow).toBeDefined();
+    expect(nullArtistRow.artist_name).toBe('Shape Fixture Artist Alpha');
+  });
+
   test('returns 304 when If-Modified-Since matches the current watermark', async () => {
     const first = await getCatalog(auth);
     expect(first.status).toBe(200);

--- a/tests/integration/library-catalog-export.spec.js
+++ b/tests/integration/library-catalog-export.spec.js
@@ -150,6 +150,20 @@ describe('GET /library/catalog (BS#1468)', () => {
     expect(decodeBody(res)).not.toContain('search_doc');
   });
 
+  test('honors Accept-Encoding: gzip;q=0 by serving identity (not gzip the client refused)', async () => {
+    // q=0 is an explicit refusal of gzip (RFC 9110). The handler must serve an
+    // uncompressed body — a substring `includes('gzip')` check would wrongly
+    // send gzip bytes the client won't inflate.
+    const res = await auth.get('/library/catalog').set('Accept-Encoding', 'gzip;q=0').buffer(true).parse(collectBuffer);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBeUndefined();
+    // Body is plaintext NDJSON the client can parse without inflating.
+    const rows = parseRows(res);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(Object.keys(rows[0]).sort()).toEqual(CONTRACT_KEYS);
+  });
+
   test('exports raw rotation_bin + rotation_kill_date (most-recently-added record, NOT the view CURRENT_DATE filter)', async () => {
     const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
 

--- a/tests/integration/library-catalog-export.spec.js
+++ b/tests/integration/library-catalog-export.spec.js
@@ -1,0 +1,225 @@
+/**
+ * BS#1468 (Epic F pattern, parent #1466) — `GET /library/catalog` bulk export.
+ *
+ * Full-catalog gzipped NDJSON, gated by `conditionalGet(getCatalogLastModifiedAt)`
+ * so a client that has cloned the catalog re-pulls only when the
+ * `library_watermark` advances. Postgres-backed (the BS analogue of the org `pg`
+ * marker): direct SQL drives the watermark and seeds deterministic rotation
+ * shapes, supertest drives the HTTP surface.
+ *
+ * Probe rows live in the reserved 7000-range (shape fixture's namespace) on ids
+ * the fixture leaves free (7050/7052). They reuse fixture artist 7000 (code
+ * letters 'XA'), genre 11 ('Rock'), format 1 ('cd'), and gac (7000,11)->700, so
+ * every joined display field is a known constant.
+ */
+
+const zlib = require('zlib');
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const ART = 7000; // fixture artist (code_letters 'XA')
+const GEN = 11; // 'Rock'
+const FMT = 1; // 'cd'
+const PROBE_ACTIVE = 7050;
+const PROBE_EXPIRED = 7052;
+
+// Exactly the export contract field set (#1468 AC), sorted for comparison.
+const CONTRACT_KEYS = [
+  'album_title',
+  'artist_name',
+  'artwork_url',
+  'code_artist_number',
+  'code_letters',
+  'code_number',
+  'format_name',
+  'genre_name',
+  'id',
+  'label',
+  'on_streaming',
+  'plays',
+  'rotation_bin',
+  'rotation_kill_date',
+].sort();
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+// Collect the raw response bytes (superagent's gzip auto-inflate may or may not
+// run for application/x-ndjson + a custom parser, so we detect the gzip magic
+// and inflate ourselves — robust to both paths).
+function collectBuffer(res, cb) {
+  const chunks = [];
+  res.on('data', (d) => chunks.push(Buffer.from(d)));
+  res.on('end', () => cb(null, Buffer.concat(chunks)));
+}
+function decodeBody(res) {
+  let buf = Buffer.isBuffer(res.body) && res.body.length ? res.body : Buffer.from(res.text || '', 'utf8');
+  if (buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) buf = zlib.gunzipSync(buf);
+  return buf.toString('utf8');
+}
+function parseRows(res) {
+  return decodeBody(res)
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+const getCatalog = (auth) => auth.get('/library/catalog').buffer(true).parse(collectBuffer);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+describe('GET /library/catalog (BS#1468)', () => {
+  let auth;
+  let sql;
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = makeSql();
+
+    // Probe album with an active 'H' record added recently AND a killed 'L'
+    // record added earlier but carrying a HIGHER serial id. The export must pick
+    // the most-recently-ADDED record ('H', not the higher-id 'L'); ordering by
+    // id would wrongly surface the stale killed row.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, label, on_streaming, plays, artwork_url)
+       VALUES ($1, $2, $3, $4, 'BS#1468 Export Probe Active', 91, 'Shape Fixture Artist Alpha', 'Probe Label A', true, 7, 'https://probe.test/a.jpg')
+       ON CONFLICT (id) DO NOTHING`,
+      [PROBE_ACTIVE, ART, GEN, FMT]
+    );
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".rotation (id, album_id, rotation_bin, add_date, kill_date)
+       VALUES (7050, $1, 'H', '2025-01-01', NULL),
+              (7051, $1, 'L', '2023-01-01', '2023-12-31')
+       ON CONFLICT (id) DO NOTHING`,
+      [PROBE_ACTIVE]
+    );
+
+    // Probe album whose only rotation record is EXPIRED (kill_date in the past).
+    // The view's CURRENT_DATE filter would drop it (rotation_bin -> NULL); the
+    // export must ship it RAW so the client evaluates expiry against its clock.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name)
+       VALUES ($1, $2, $3, $4, 'BS#1468 Export Probe Expired', 92, 'Shape Fixture Artist Alpha')
+       ON CONFLICT (id) DO NOTHING`,
+      [PROBE_EXPIRED, ART, GEN, FMT]
+    );
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".rotation (id, album_id, rotation_bin, add_date, kill_date)
+       VALUES (7052, $1, 'M', '2024-06-01', '2024-07-01')
+       ON CONFLICT (id) DO NOTHING`,
+      [PROBE_EXPIRED]
+    );
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      // rotation.album_id is ON DELETE CASCADE, so this reaps the probe rotation
+      // rows too.
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2)`, [PROBE_ACTIVE, PROBE_EXPIRED]);
+      await sql.end();
+    }
+  });
+
+  test('returns the full catalog as gzipped NDJSON with freshness + content headers', async () => {
+    const res = await auth.get('/library/catalog').set('Accept-Encoding', 'gzip').buffer(true).parse(collectBuffer);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect((res.headers['vary'] || '').toLowerCase()).toContain('accept-encoding');
+    expect(res.headers['last-modified']).toBeTruthy();
+    expect((res.headers['content-type'] || '').toLowerCase()).toContain('ndjson');
+
+    const rows = parseRows(res);
+    expect(rows.length).toBeGreaterThan(0);
+    // Every line carries exactly the contract field set — no search_doc, no
+    // alphabetical_name, no view-internal extras.
+    for (const row of rows) {
+      expect(Object.keys(row).sort()).toEqual(CONTRACT_KEYS);
+    }
+    expect(decodeBody(res)).not.toContain('search_doc');
+  });
+
+  test('exports raw rotation_bin + rotation_kill_date (most-recently-added record, NOT the view CURRENT_DATE filter)', async () => {
+    const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
+
+    const active = byId.get(PROBE_ACTIVE);
+    expect(active).toBeDefined();
+    // 'H' (added 2025-01-01) wins over the higher-id killed 'L' (added 2023) —
+    // ordering is by add_date, not serial id.
+    expect(active.rotation_bin).toBe('H');
+    expect(active.rotation_kill_date).toBeNull();
+    // Joined display fields resolve to their fixture constants.
+    expect(active.artist_name).toBe('Shape Fixture Artist Alpha');
+    expect(active.code_letters).toBe('XA');
+    expect(active.code_artist_number).toBe(700);
+    expect(active.genre_name).toBe('Rock');
+    expect(active.format_name).toBe('cd');
+    expect(active.on_streaming).toBe(true);
+
+    const expired = byId.get(PROBE_EXPIRED);
+    expect(expired).toBeDefined();
+    // Raw export: the view would have filtered this expired row to rotation_bin
+    // NULL; the export ships the real bin + the past kill_date.
+    expect(expired.rotation_bin).toBe('M');
+    expect(expired.rotation_kill_date).toBe('2024-07-01');
+  });
+
+  test('returns 304 when If-Modified-Since matches the current watermark', async () => {
+    const first = await getCatalog(auth);
+    expect(first.status).toBe(200);
+
+    const second = await auth.get('/library/catalog').set('If-Modified-Since', first.headers['last-modified']);
+    expect(second.status).toBe(304);
+    expect(second.text === '' || second.text === undefined).toBe(true);
+  });
+
+  test('returns 200 after a library row changes (watermark advanced)', async () => {
+    const first = await getCatalog(auth);
+    const lastModified = first.headers['last-modified'];
+
+    // Ensure the next watermark lands in a strictly later whole second than the
+    // captured Last-Modified (HTTP Date precision is whole seconds).
+    await sleep(1100);
+    await sql.unsafe(`UPDATE "${SCHEMA}".library SET plays = COALESCE(plays, 0) WHERE id = $1`, [PROBE_ACTIVE]);
+
+    const after = await auth
+      .get('/library/catalog')
+      .set('If-Modified-Since', lastModified)
+      .buffer(true)
+      .parse(collectBuffer);
+    expect(after.status).toBe(200);
+  });
+
+  test('returns 200 after a genres parent-table change (coverage invariant: trigger fan-out reaches the endpoint)', async () => {
+    const first = await getCatalog(auth);
+    const lastModified = first.headers['last-modified'];
+
+    await sleep(1100);
+    // A write on a join parent (genres) — no library row touched. The 0105
+    // fan-out trigger must advance the watermark so the client re-pulls.
+    await sql.unsafe(`UPDATE "${SCHEMA}".genres SET genre_name = genre_name WHERE id = $1`, [GEN]);
+
+    const after = await auth
+      .get('/library/catalog')
+      .set('If-Modified-Since', lastModified)
+      .buffer(true)
+      .parse(collectBuffer);
+    expect(after.status).toBe(200);
+  });
+
+  test('requires catalog:read auth (401 without a token)', async () => {
+    const res = await request.get('/library/catalog');
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/integration/library-watermark-parents.spec.js
+++ b/tests/integration/library-watermark-parents.spec.js
@@ -1,0 +1,135 @@
+/**
+ * BS#1468 (Epic F pattern, parent #1466) — `library_watermark` parent-table
+ * fan-out (migration 0105). Companion to `library-watermark.spec.js` (#1467,
+ * the `library`-only trigger).
+ *
+ * The bulk-export endpoint (`GET /library/catalog`) projects display fields that
+ * are NOT physical `library` columns — `code_letters` (artists),
+ * `code_artist_number` (genre_artist_crossreference), `genre_name` (genres),
+ * `format_name` (format), and raw `rotation_bin` / `rotation_kill_date`
+ * (rotation). A rename/curation write on any of those parents touches no
+ * `library` row, so without a trigger there the watermark would stay put and a
+ * polling client would `304` against a stale name. Migration 0105 attaches the
+ * SAME `touch_library_watermark()` statement trigger to all five parents; this
+ * spec asserts each one advances the watermark — the "coverage invariant" AC.
+ *
+ * Postgres-dependent (the BS analogue of the org `pg` marker): every mutation is
+ * raw SQL straight against the test DB, also standing in for the ETL writers
+ * that bypass the BS app layer. The schema-source parity guard lives in the
+ * migration validator; this spec is the runtime behavior assertion.
+ */
+
+const postgres = require('postgres');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+// Reuse the shape-fixture library row (id 7000) for valid FK values.
+const SHAPE_FIXTURE_LIBRARY_ID = 7000;
+const TITLE_PREFIX = 'BS#1468 WM Parent Probe';
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+describe('library_watermark parent-table triggers (BS#1468)', () => {
+  let sql;
+  let fk; // { artist_id, genre_id, format_id } from row 7000
+
+  beforeAll(async () => {
+    sql = makeSql();
+    const rows = await sql.unsafe(`SELECT artist_id, genre_id, format_id FROM "${SCHEMA}".library WHERE id = $1`, [
+      SHAPE_FIXTURE_LIBRARY_ID,
+    ]);
+    fk = rows[0];
+    if (!fk) {
+      throw new Error(
+        `shape fixture library row ${SHAPE_FIXTURE_LIBRARY_ID} not found in schema "${SCHEMA}" — globalSetup should load tests/fixtures/shape.sql before any spec`
+      );
+    }
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      // rotation.album_id references library.id ON DELETE CASCADE, so deleting
+      // the probe library rows reaps the probe rotation rows too.
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE album_title LIKE $1`, [`${TITLE_PREFIX}%`]);
+      await sql.end();
+    }
+  });
+
+  beforeEach(async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE album_title LIKE $1`, [`${TITLE_PREFIX}%`]);
+  });
+
+  // Age the watermark to a known past instant via a direct write to the
+  // watermark table — that write does NOT fire any trigger (triggers are on the
+  // parents, not on library_watermark), giving each case a deterministic stale
+  // baseline a fired trigger must advance back to ≈now().
+  const ageWm = async (interval) =>
+    sql.unsafe(
+      `UPDATE "${SCHEMA}".library_watermark SET last_modified_at = now() - interval '${interval}' WHERE id = true`
+    );
+
+  // Evaluated entirely in SQL against the DB clock — no JS-vs-DB skew.
+  const advancedToNow = async () => {
+    const rows = await sql.unsafe(
+      `SELECT (last_modified_at >= now() - interval '1 minute'
+              AND last_modified_at <= now() + interval '1 second') AS ok
+       FROM "${SCHEMA}".library_watermark WHERE id = true`
+    );
+    return rows[0].ok;
+  };
+
+  test('a write on artists advances the watermark (code_letters: cascade-inert, isolates the new trigger)', async () => {
+    await ageWm('1 hour');
+    // code_letters is NOT cascaded by the 0060 trigger (it fires only
+    // `AFTER UPDATE OF artist_name`), so this advance comes solely from the new
+    // artists statement trigger — not from a cascaded `UPDATE library`.
+    await sql.unsafe(`UPDATE "${SCHEMA}".artists SET code_letters = code_letters WHERE id = $1`, [fk.artist_id]);
+    expect(await advancedToNow()).toBe(true);
+  });
+
+  test('a write on genres advances the watermark', async () => {
+    await ageWm('1 hour');
+    await sql.unsafe(`UPDATE "${SCHEMA}".genres SET genre_name = genre_name WHERE id = $1`, [fk.genre_id]);
+    expect(await advancedToNow()).toBe(true);
+  });
+
+  test('a write on format advances the watermark', async () => {
+    await ageWm('1 hour');
+    await sql.unsafe(`UPDATE "${SCHEMA}".format SET format_name = format_name WHERE id = $1`, [fk.format_id]);
+    expect(await advancedToNow()).toBe(true);
+  });
+
+  test('a write on genre_artist_crossreference advances the watermark', async () => {
+    await ageWm('1 hour');
+    await sql.unsafe(
+      `UPDATE "${SCHEMA}".genre_artist_crossreference SET artist_genre_code = artist_genre_code
+       WHERE artist_id = $1 AND genre_id = $2`,
+      [fk.artist_id, fk.genre_id]
+    );
+    expect(await advancedToNow()).toBe(true);
+  });
+
+  test('an INSERT on rotation advances the watermark (continuous curation moves freshness)', async () => {
+    // A probe library row gives a valid album_id FK. (Its own INSERT fires the
+    // library trigger; we age the watermark AFTER it so the rotation INSERT is
+    // the event under test.)
+    const lib = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library (artist_id, genre_id, format_id, album_title, code_number)
+       VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+      [fk.artist_id, fk.genre_id, fk.format_id, `${TITLE_PREFIX} rotation`, 0]
+    );
+    await ageWm('1 hour');
+    await sql.unsafe(`INSERT INTO "${SCHEMA}".rotation (album_id, rotation_bin) VALUES ($1, 'H')`, [lib[0].id]);
+    expect(await advancedToNow()).toBe(true);
+  });
+});

--- a/tests/unit/services/catalog-export.serialize.test.ts
+++ b/tests/unit/services/catalog-export.serialize.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from '@jest/globals';
+import { serializeCatalogNdjson, type CatalogExportRow } from '../../../apps/backend/services/catalog-export.service';
+
+// BS#1468 — the bulk catalog export ships NDJSON (one JSON object per line) so a
+// client can build/parse it incrementally. These tests pin the wire shape: the
+// exact field set the iOS Spotlight clone consumes, and the NDJSON framing.
+
+const sampleRow = (overrides: Partial<CatalogExportRow> = {}): CatalogExportRow => ({
+  id: 7000,
+  artist_name: 'Juana Molina',
+  album_title: 'DOGA',
+  code_letters: 'MO',
+  code_number: 42,
+  code_artist_number: 7,
+  label: 'Sonamos',
+  genre_name: 'Rock',
+  format_name: 'CD',
+  on_streaming: true,
+  plays: 12,
+  artwork_url: 'https://example.test/doga.jpg',
+  rotation_bin: 'H',
+  rotation_kill_date: '2026-07-01',
+  ...overrides,
+});
+
+describe('catalog-export.service: serializeCatalogNdjson', () => {
+  it('emits one JSON object per line, each parsing back to the input row', () => {
+    const rows = [sampleRow({ id: 1 }), sampleRow({ id: 2, artist_name: 'Jessica Pratt' })];
+
+    const ndjson = serializeCatalogNdjson(rows);
+    const lines = ndjson.split('\n').filter((l) => l.length > 0);
+
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0])).toEqual(rows[0]);
+    expect(JSON.parse(lines[1])).toEqual(rows[1]);
+  });
+
+  it('emits exactly the 14 contract fields per line and excludes search_doc', () => {
+    // The field set is the acceptance criterion for #1468. A row carrying an
+    // extra server-only field (e.g. search_doc) must not leak into the export.
+    const rowWithExtra = {
+      ...sampleRow(),
+      search_doc: 'juana molina doga sonamos',
+      alphabetical_name: 'molina, juana',
+    } as unknown as CatalogExportRow;
+
+    const ndjson = serializeCatalogNdjson([rowWithExtra]);
+    const parsed = JSON.parse(ndjson);
+
+    expect(Object.keys(parsed).sort()).toEqual(
+      [
+        'album_title',
+        'artist_name',
+        'artwork_url',
+        'code_artist_number',
+        'code_letters',
+        'code_number',
+        'format_name',
+        'genre_name',
+        'id',
+        'label',
+        'on_streaming',
+        'plays',
+        'rotation_bin',
+        'rotation_kill_date',
+      ].sort()
+    );
+    expect(parsed).not.toHaveProperty('search_doc');
+    expect(parsed).not.toHaveProperty('alphabetical_name');
+  });
+
+  it('serializes an empty catalog to an empty string', () => {
+    expect(serializeCatalogNdjson([])).toBe('');
+  });
+
+  it('preserves null rotation/streaming fields (album not in rotation)', () => {
+    const row = sampleRow({ rotation_bin: null, rotation_kill_date: null, on_streaming: null, plays: null });
+    const parsed = JSON.parse(serializeCatalogNdjson([row]));
+
+    expect(parsed.rotation_bin).toBeNull();
+    expect(parsed.rotation_kill_date).toBeNull();
+    expect(parsed.on_streaming).toBeNull();
+    expect(parsed.plays).toBeNull();
+  });
+});

--- a/tests/unit/services/watermark-cache.test.ts
+++ b/tests/unit/services/watermark-cache.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createWatermarkCache } from '../../../apps/backend/services/watermark-cache.service';
+
+// BS#1468 — the bulk catalog export is built once per watermark value and the
+// gzipped bytes are cached in-process (one shared copy per pod), so the hot
+// path is a memcpy instead of a 5-join scan + re-gzip on every poll. The
+// catalog churns ~daily, so the cache is warm for the vast majority of
+// requests. `createWatermarkCache` is the table-agnostic deep module behind
+// that: it pairs a watermark provider with a builder and only rebuilds when the
+// watermark advances. Tested with injected fakes — no DB, no gzip.
+
+describe('createWatermarkCache', () => {
+  it('builds on the first read and returns the built payload', async () => {
+    const build = jest.fn(() => Promise.resolve(Buffer.from('payload-v1')));
+    const cache = createWatermarkCache(() => Promise.resolve(new Date('2026-06-20T00:00:00.000Z')), build);
+
+    const out = await cache.get();
+
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(out.toString()).toBe('payload-v1');
+  });
+
+  it('reuses the cached payload while the watermark is unchanged (no rebuild)', async () => {
+    const build = jest.fn(() => Promise.resolve(Buffer.from('payload-v1')));
+    const cache = createWatermarkCache(() => Promise.resolve(new Date('2026-06-20T00:00:00.000Z')), build);
+
+    const first = await cache.get();
+    const second = await cache.get();
+
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first); // same buffer instance — a memcpy-able shared copy
+  });
+
+  it('rebuilds when the watermark advances and returns the fresh payload', async () => {
+    let watermark = new Date('2026-06-20T00:00:00.000Z');
+    let version = 0;
+    const build = jest.fn(() => Promise.resolve(Buffer.from(`payload-v${++version}`)));
+    const cache = createWatermarkCache(() => Promise.resolve(watermark), build);
+
+    const first = await cache.get();
+    watermark = new Date('2026-06-21T00:00:00.000Z'); // ETL wrote → watermark moved
+    const second = await cache.get();
+
+    expect(build).toHaveBeenCalledTimes(2);
+    expect(first.toString()).toBe('payload-v1');
+    expect(second.toString()).toBe('payload-v2');
+  });
+
+  it('single-flights concurrent reads at the same watermark (one build, no thundering herd)', async () => {
+    let release: (b: Buffer) => void = () => {};
+    const pending = new Promise<Buffer>((resolve) => {
+      release = resolve;
+    });
+    const build = jest.fn(() => pending);
+    const cache = createWatermarkCache(() => Promise.resolve(new Date('2026-06-20T00:00:00.000Z')), build);
+
+    // Two requests arrive while the (slow) 5-join scan + gzip is in flight.
+    const a = cache.get();
+    const b = cache.get();
+    release(Buffer.from('payload-v1'));
+    const [ra, rb] = await Promise.all([a, b]);
+
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(ra).toBe(rb);
+  });
+});

--- a/tests/unit/services/watermark-cache.test.ts
+++ b/tests/unit/services/watermark-cache.test.ts
@@ -63,4 +63,46 @@ describe('createWatermarkCache', () => {
     expect(build).toHaveBeenCalledTimes(1);
     expect(ra).toBe(rb);
   });
+
+  it('a slow build for an older watermark does not clobber a newer cached entry (lost-update guard)', async () => {
+    // Two builds overlap because the watermark advanced mid-build. The OLDER
+    // build resolves LAST and must not overwrite the fresher cached payload, or
+    // a poller would briefly get stale bytes and the newer build's work is
+    // discarded, forcing a redundant rebuild.
+    const W1 = new Date('2026-06-20T00:00:00.000Z');
+    const W2 = new Date('2026-06-21T00:00:00.000Z');
+    let watermark = W1;
+    const resolvers: Array<(b: Buffer) => void> = [];
+    const build = jest.fn(() => new Promise<Buffer>((resolve) => resolvers.push(resolve)));
+    const cache = createWatermarkCache(() => Promise.resolve(watermark), build);
+
+    // get() awaits the watermark provider before calling build(), so drain the
+    // microtask queue after each call to let the build() actually fire.
+    const flush = async () => {
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+    };
+
+    const pA = cache.get(); // reads W1, starts build[0]
+    await flush();
+    watermark = W2;
+    const pB = cache.get(); // reads W2 (different), starts build[1]
+    await flush();
+
+    resolvers[1](Buffer.from('payload-v2')); // newer build resolves first → caches W2
+    await pB;
+    resolvers[0](Buffer.from('payload-v1')); // stale older build resolves last
+    await pA;
+
+    // A read at W2 must be a cache hit (no third build) returning v2. With the
+    // bug, the stale W1 build clobbered the cache, so this read misses and
+    // triggers a third build — resolve any such straggler so the assertion is a
+    // clean failure rather than a hang.
+    const pC = cache.get();
+    await flush();
+    while (resolvers.length > 2) resolvers.pop()?.(Buffer.from('straggler'));
+    const cReadAtW2 = await pC;
+
+    expect(build).toHaveBeenCalledTimes(2); // one per distinct watermark — not a third rebuild
+    expect(cReadAtW2.toString()).toBe('payload-v2');
+  });
 });


### PR DESCRIPTION
Implements #1468 (Epic F pattern, parent #1466): a single authed `GET /library/catalog` that returns the whole catalog as one gzipped NDJSON body for the `wxyc-dj-ios` on-device Spotlight clone, gated by the #1467 conditional-GET watermark so a client that has already cloned the catalog gets a cheap `304` until it changes (~daily) and a fresh `200` + full payload when it has.

## What changed

**Watermark parent-table fan-out (migration `0105`).** #1467 attached `touch_library_watermark()` to `library` only, but the export projects display fields that aren't physical `library` columns — `code_letters` (artists), `code_artist_number` (genre_artist_crossreference), `genre_name` (genres), `format_name` (format), and raw rotation. `0105` attaches the same statement trigger to all five parents, so every exported field's source table advances the watermark (the #1468 coverage invariant). This is the cross-ticket requirement #1468 placed on #1467; since #1467 is already merged, it lands here as a new trigger-only `--custom` migration (snapshot byte-identical to 0104 apart from the id/prevId chain link). `touch_library_watermark()` is reused verbatim.

**The endpoint.** Built once per watermark and cached in-process as one shared gzipped copy per pod via a table-agnostic single-flight watermark cache, so the hot path is a memcpy and delivery is atomic with a correct `Content-Length`. There is no compression middleware, so `Content-Encoding: gzip` + `Vary: Accept-Encoding` are set manually and the request's `Accept-Encoding` is honored. Same `catalog:read` auth as the other catalog reads.

**Raw rotation.** `rotation_bin` + `rotation_kill_date` are exported raw — the most-recently-ADDED rotation record per album (`DISTINCT ON (library.id) ORDER BY add_date DESC, id DESC`), not the view's `CURRENT_DATE` filter, and **not** ordered by serial `id` (which can surface a stale killed row that outlived its active replacement — the shape fixture has exactly this case). The client evaluates "in rotation" against its own clock, so the daily `kill_date` expiry self-heals on-device with no server-side day-floor. `search_doc` is excluded.

## Field set

`id, artist_name, album_title, code_letters, code_number, code_artist_number, label, genre_name, format_name, on_streaming, plays, artwork_url, rotation_bin, rotation_kill_date` — exactly the #1468 contract.

## Testing

- Unit: NDJSON wire shape (exact 14-field set, `search_doc` excluded) and the watermark cache (build-once, reuse-on-unchanged, rebuild-on-advance, single-flight).
- Integration (Postgres-backed): each of the five parents advances the watermark; `GET /library/catalog` 200/gzip/headers, `304` on `If-Modified-Since`, `200` after a library change and after a `genres` parent change, the raw-rotation/DISTINCT-ON semantics, and `401` without a token.
- Local gate: `typecheck`, `lint` (0 errors), `format:check`, and the catalog/watermark integration specs all pass. (Pre-existing, unrelated-to-this-PR local failures: the Node timer-global unit flake — `clearTimeout is not defined` — and `auth-auto-membership.spec.js`, which needs `DEFAULT_ORG_SLUG` set in the env.)

## Follow-up (out of scope here)

Adding the catalog-row shape to `wxyc-shared/api.yaml` for generated Swift types (cross-repo; the consumer is `wxyc-dj-ios#19`).

Closes #1468.