### PR TITLE
docs: add schema-first rule (new endpoint => wxyc-shared/api.yaml SSOT) to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Key middleware:
 - `errorHandler` — Centralized error handling returning standardized responses
 - Legacy mirror middleware — Syncs flowsheet data to tubafrenzy. Show lifecycle (`startShow`, `endShow`) and entry CRUD (`addEntry`, `updateEntry`) use HTTP REST calls to tubafrenzy's mirror API. `deleteEntry` uses raw SQL via SSH. Show IDs live in two places: an in-memory `showIdMap` (process-local, populated lazily by `cacheShowId`, cleared on process exit) and the persisted `shows.legacy_show_id` column (written alongside the cache after `mirrorCreateShow`). On BS restart the map starts empty; read paths fall back to the persisted column, paying one extra DB round-trip on the first lookup per show.
 
-Server timeout is 35 seconds globally — strictly greater than the LML client's 30 s `AbortController` (`@wxyc/lml-client`, `shared/lml-client/src/index.ts`) so a slow LML lookup's catch path can flush a 200-with-fallback response instead of racing the socket teardown to a CORS-less 502. SSE routes opt out via `res.setTimeout(0)`. Swagger API docs are served at `/api-docs` from `app.yaml`.
+Server timeout is 35 seconds globally — strictly greater than the LML client's 30 s `AbortController` (`@wxyc/lml-client`, `shared/lml-client/src/index.ts`) so a slow LML lookup's catch path can flush a 200-with-fallback response instead of racing the socket teardown to a CORS-less 502. SSE routes opt out via `res.setTimeout(0)`. Swagger API docs are served at `/api-docs` from `app.yaml` — Swagger-UI display only, **not** a codegen source; the cross-repo SSOT is `wxyc-shared/api.yaml` (see Code Quality).
 
 ### Auth Server (`apps/auth`)
 
@@ -185,6 +185,8 @@ npm run format           # Prettier formatting
 npm run format:check     # Verify formatting (used in CI)
 npm run build            # Compile all workspaces
 ```
+
+**Schema-first rule:** a new public endpoint's request/response shape goes into `wxyc-shared/api.yaml` (the cross-repo SSOT that feeds iOS/Kotlin/dj-site codegen) first, before or alongside the private TS type. `apps/backend/app.yaml` is Swagger-UI docs only — not a codegen source — so a shape that lives only there (or only as a private TS type) is invisible to SSOT consumers and the specs drift.
 
 ### Doc hygiene
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ npm run format:check     # Verify formatting (used in CI)
 npm run build            # Compile all workspaces
 ```
 
-**Schema-first rule:** a new public endpoint's request/response shape goes into `wxyc-shared/api.yaml` (the cross-repo SSOT that feeds iOS/Kotlin/dj-site codegen) first, before or alongside the private TS type. `apps/backend/app.yaml` is Swagger-UI docs only — not a codegen source — so a shape that lives only there (or only as a private TS type) is invisible to SSOT consumers and the specs drift.
+**Schema-first rule:** a new public endpoint's request/response shape goes into `wxyc-shared/api.yaml` (the cross-repo SSOT whose codegen feeds this repo, dj-site, iOS, and Android) first, before or alongside the private TS type. `apps/backend/app.yaml` is Swagger-UI docs only — not a codegen source — so a shape that lives only there (or only as a private TS type) is invisible to SSOT consumers and the specs drift.
 
 ### Doc hygiene
 


### PR DESCRIPTION
## What

Adds a concise **schema-first** rule to `CLAUDE.md`: a new public endpoint's request/response shape goes into `wxyc-shared/api.yaml` — the cross-repo SSOT that feeds the iOS/Kotlin/dj-site codegen — first, before or alongside the private TS type. Makes explicit that `apps/backend/app.yaml` is Swagger-UI docs only (not a codegen source), so a shape that lives only there, or only as a private TS type, is invisible to SSOT consumers.

## Why

`GET /library/catalog` (#1468) and the flowsheet conditional-GET export (#902) both shipped with wire shapes defined only as private TS types plus a Swagger-only `app.yaml` entry, never propagated to the SSOT. SSOT-mirroring consumers had nothing to generate from and the specs drifted (WXYC/wxyc-shared#186). This is a recurring root cause, not a one-off — the rule gives a future agent the signal before they repeat the miss.

## Changes

- One `**Schema-first rule:**` line under the **Code Quality** section.
- A short clause co-located with the existing `/api-docs` from `app.yaml` note, marking it Swagger-UI display only and pointing at the SSOT.

Scope is the single doc file. Does not touch `apps/backend/app.yaml` (#1479) or any test (#1477).

## Checks

- `npm run check:doc-budget` — exits 0 (warn-only). The file was already over its ALARM threshold before this change; the addition is ~3 lines, the leanest form that names both `api.yaml` (SSOT) and `app.yaml` (Swagger-only). Rationale/backstory lives in the ticket, not the doc, so there is no separate block to extract.
- `npm run check:doc-rules` — exits 0 (pre-existing `docs/migrations.md` compress-candidate warnings only, unrelated).
- `prettier --check CLAUDE.md` — clean.

Closes #1478.