### PR TITLE
Align app.yaml CatalogExportRow.rotation_bin to the SSOT (drop enum)

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -266,7 +266,6 @@ components:
         rotation_bin:
           type: string
           nullable: true
-          enum: [S, L, M, H, N]
         rotation_kill_date:
           type: string
           format: date


### PR DESCRIPTION
Closes #1479.

## What

`apps/backend/app.yaml` is a Swagger-UI-only doc — `apps/backend/app.ts` imports it as `swaggerContent`, parses it with `parse_yaml`, and serves it at `/api-docs`. Nothing generates from or validates against it. Its hand-maintained `CatalogExportRow` copy carried `rotation_bin` as `type: string, nullable: true, enum: [S, L, M, H, N]`, which contradicted the ratified cross-repo SSOT (`wxyc-shared/api.yaml`, merged in WXYC/wxyc-shared#186), where `rotation_bin` is a **raw nullable string with no enum** — chosen so a value outside the known cohorts can not break a strict decoder.

This drops the `enum: [S, L, M, H, N]` line, leaving `type: string, nullable: true`, so the docs copy stops contradicting the SSOT.

```diff
         rotation_bin:
           type: string
           nullable: true
-          enum: [S, L, M, H, N]
```

## Option chosen: (b) de-enum, not (a) delete

The ticket offered two paths: delete the duplicated block, or drop the enum. I chose **de-enum** because the `/library/catalog` `200` response `$ref`s `#/components/schemas/CatalogExportRow` (app.yaml around the NDJSON content schema). Deleting the schema block would leave a **dangling `$ref`** and break the Swagger doc. De-enum is the surgical, low-risk fix that satisfies the acceptance criterion ("no longer carries a `rotation_bin` that contradicts the SSOT") without restructuring the path or inlining the shape. The block stays referenced and the doc stays valid.

## Verification

`/api-docs` still serves: I parsed the edited `app.yaml` with the exact `yaml` parser `app.ts` uses (`parse as parse_yaml`) and confirmed:

- the file parses cleanly (all top-level OpenAPI keys present);
- `CatalogExportRow` is present and `rotation_bin` is now `{ type: string, nullable: true }` with no `enum`;
- the `/library/catalog` `200` `$ref` still resolves to a live schema (no dangling reference).

Prettier `--check` passes on the file. No TypeScript or wire behavior changes — this is a docs-only edit and `app.yaml` feeds nothing but the Swagger UI.

## Scope

Touches only `apps/backend/app.yaml`. The private TS type in `catalog-export.service.ts` (#1478, schema-first rule) and the parity test (#1477) are out of scope and untouched.