### PR TITLE
Parity guard: CatalogExportRow private type vs @wxyc/shared SSOT

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -23,7 +23,7 @@
     "@wxyc/database": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^1.12.0",
+    "@wxyc/shared": "^1.13.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "@wxyc/database": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^1.12.0",
+        "@wxyc/shared": "^1.13.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.18.0",
@@ -6074,12 +6074,12 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "1.12.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.12.0/9fe97b74b3013be5616d34539e9e0165addfdb8a",
-      "integrity": "sha512-9B9rr2UY4z9j/jcGEKwj2F/1pmZUrD7/w6Xc0loQmp10QhB5kwKTtJP1q6XSTS38f6qimzme2VM53Qg8txktZA==",
+      "version": "1.13.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.13.0/5c964690a095748229f8bf036f58f76240f0927b",
+      "integrity": "sha512-/RDt3W+Y/8T1UGRKktGgVF7ExfsxxS/8QsVdEVCSHIlSid14FYl+5+TyyNDIauawEje8Ajbha14i5PnnjMaW3Q==",
       "license": "MIT",
       "dependencies": {
-        "date-fns": "^4.1.0"
+        "date-fns": "^4.4.0"
       },
       "engines": {
         "node": ">=24"

--- a/tests/unit/services/catalog-export.parity.test.ts
+++ b/tests/unit/services/catalog-export.parity.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Drift guard: the private `CatalogExportRow` (the `GET /library/catalog` wire
+ * shape, owned by `apps/backend/services/catalog-export.service.ts`) must stay
+ * in lockstep with the cross-repo SSOT `CatalogExportRow` published by
+ * `@wxyc/shared/dtos` (generated from `wxyc-shared/api.yaml`, added in
+ * WXYC/wxyc-shared#186). The SSOT type feeds the iOS / Kotlin / dj-site codegen,
+ * so a field added on one side but not the other ships a wrong on-device clone.
+ *
+ * These two definitions already drifted once (#1468 shipped the endpoint without
+ * ever propagating its row shape to the SSOT), which is why this guard exists
+ * (BS#1477). Nothing else keeps them in agreement.
+ *
+ * # What this guards
+ *
+ *   1. KEY SET (field add/remove). The two definitions must declare exactly the
+ *      same fields. Adding/removing a field on exactly one side fails this test.
+ *   2. `rotation_bin` stays a RAW nullable string on both sides — NOT re-narrowed
+ *      to the `RotationBin` ("H" | "M" | "L" | "S") enum. This is the specific
+ *      drift wxyc-shared#186 acceptance criterion G1 calls out: the endpoint
+ *      ships the raw current-rotation bin so a value outside the nominal cohorts
+ *      (e.g. 'N') can't break a strict-enum decoder on device. A bare key-set
+ *      check would not catch an enum re-narrowing, so it is pinned explicitly.
+ *
+ * # What this does NOT guard
+ *
+ * Per wxyc-shared#186 G1: this is field add/remove + the one `rotation_bin`
+ * type pin, NOT full type / `required` / enum parity for every field. The SSOT
+ * marks several fields optional (no `required:` entry in the schema) where the
+ * private type marks them required; that `?`-vs-required difference is expected
+ * and deliberately tolerated here (key-set comparison strips the `?`). It also
+ * does NOT guard the third hand-maintained copy in `app.yaml` (BS#1479).
+ *
+ * # Why source-grep, not a pure type-level assertion
+ *
+ * The unit suite runs through ts-jest with `isolatedModules: true`
+ * (`tests/tsconfig.json`), which transpiles per file WITHOUT type-checking — a
+ * `tsc`-level type error does not fail the jest run. So the runtime guard that
+ * actually fails CI reads each definition from its source-of-truth artifact as
+ * text (the private `.ts`, the installed SSOT `.d.ts`) and compares the
+ * extracted key sets — the same idiom as the other guards in
+ * `tests/unit/scripts/` and `tests/unit/config/healthcheck-shape.test.ts`.
+ *
+ * The compile-time `KeysEqual` / `rotation_bin` assertions below document the
+ * same contract at the type level and bite under a real `tsc` pass (the
+ * `apps/backend` typecheck already forces `projectRow` to mirror the private
+ * type); they are belt-and-suspenders, not the primary signal.
+ *
+ * # Copyable template
+ *
+ * This is the reference guard for the next bulk endpoint that hand-defines its
+ * wire shape instead of consuming the SSOT type. Copy it, swap the two source
+ * artifacts and the type name, keep the same two-layer (runtime grep +
+ * compile-time assertion) structure.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync, readdirSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { createRequire } from 'module';
+import type { CatalogExportRow as PrivateRow } from '../../../apps/backend/services/catalog-export.service';
+import type { CatalogExportRow as SharedRow } from '@wxyc/shared/dtos';
+
+// ---------------------------------------------------------------------------
+// Compile-time contract (belt-and-suspenders; enforced by a real `tsc`, e.g.
+// the `apps/backend` typecheck path, NOT by the ts-jest unit run).
+// ---------------------------------------------------------------------------
+
+// Mutual key-set equality: resolves to `true` only when both types declare the
+// exact same key union, `never` otherwise. (optional-vs-required does not change
+// `keyof`, so this tolerates the `?` differences the SSOT carries.)
+type KeysEqual<A, B> = [keyof A] extends [keyof B] ? ([keyof B] extends [keyof A] ? true : never) : never;
+const _keysAgree: KeysEqual<PrivateRow, SharedRow> = true;
+void _keysAgree;
+
+// `rotation_bin` must stay assignable from a raw string on BOTH sides — i.e. a
+// non-enum value like 'N' (the SSOT doc's own example) is accepted. If either
+// side were re-narrowed to the `RotationBin` ("H" | "M" | "L" | "S") enum, the
+// 'N' literal would no longer be assignable and this would fail to compile.
+const _privateBinAcceptsRawString: PrivateRow['rotation_bin'] = 'N';
+const _sharedBinAcceptsRawString: SharedRow['rotation_bin'] = 'N';
+void _privateBinAcceptsRawString;
+void _sharedBinAcceptsRawString;
+
+// ---------------------------------------------------------------------------
+// Runtime contract (the assertion that actually fails CI on drift).
+// ---------------------------------------------------------------------------
+
+/**
+ * Field names declared in the private `export type CatalogExportRow = { ... }`
+ * block of `apps/backend/services/catalog-export.service.ts`.
+ */
+function extractPrivateRowKeys(): string[] {
+  const servicePath = resolve(__dirname, '../../../apps/backend/services/catalog-export.service.ts');
+  const source = readFileSync(servicePath, 'utf-8');
+  const block = source.match(/export type CatalogExportRow = \{([\s\S]*?)\};/)?.[1];
+  if (!block) {
+    throw new Error('private `export type CatalogExportRow = { ... }` block not found in catalog-export.service.ts');
+  }
+  return extractObjectTypeKeys(block);
+}
+
+/**
+ * Field names declared in the SSOT `CatalogExportRow` schema, read from the
+ * actually-installed `@wxyc/shared` package. We resolve the `@wxyc/shared/dtos`
+ * entry, then read the sibling bundled `index-*.d.ts` (content-hashed name) that
+ * carries the full `components['schemas']['CatalogExportRow']` body — the
+ * `dtos/index.d.ts` itself is only a re-export. Reading the installed package
+ * (not a checked-in copy) makes the `@wxyc/shared` dependency bump load-bearing:
+ * a version without `CatalogExportRow` makes this throw.
+ */
+function extractSsotRowKeys(): string[] {
+  const block = readSsotCatalogExportRowBlock();
+  return extractObjectTypeKeys(block);
+}
+
+/**
+ * Locate and return the raw text of the SSOT `CatalogExportRow: { ... }` schema
+ * block from the installed `@wxyc/shared` bundled declaration file.
+ */
+function readSsotCatalogExportRowBlock(): string {
+  const require = createRequire(__filename);
+  // dist/dtos/index.js -> dist/
+  const distDir = dirname(dirname(require.resolve('@wxyc/shared/dtos')));
+  const bundle = readdirSync(distDir).find((f) => /^index-.*\.d\.ts$/.test(f));
+  if (!bundle) {
+    throw new Error(`bundled @wxyc/shared index-*.d.ts not found in ${distDir}`);
+  }
+  const decl = readFileSync(join(distDir, bundle), 'utf-8');
+  // The schema block: `CatalogExportRow: { ... };` under components['schemas'].
+  // Balance braces from the opening `{` so nested members don't end it early.
+  const startToken = 'CatalogExportRow: {';
+  const startIdx = decl.indexOf(startToken);
+  if (startIdx === -1) {
+    throw new Error(
+      `SSOT CatalogExportRow schema not found in ${bundle}. ` +
+        'Is the installed @wxyc/shared new enough to carry it (>= 1.13.0)?'
+    );
+  }
+  const braceOpen = startIdx + startToken.length - 1;
+  let depth = 0;
+  let i = braceOpen;
+  for (; i < decl.length; i++) {
+    if (decl[i] === '{') depth++;
+    else if (decl[i] === '}') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return decl.slice(braceOpen + 1, i);
+}
+
+/**
+ * Pull the top-level field names out of a TS object-type body. Handles the
+ * `name?:` optional marker (stripped), skips JSDoc / `//` comments, and ignores
+ * nested object members by only taking keys at the body's outermost depth.
+ */
+function extractObjectTypeKeys(body: string): string[] {
+  const keys = new Set<string>();
+  let depth = 0;
+  let inBlockComment = false;
+
+  for (const rawLine of body.split('\n')) {
+    let line = rawLine;
+
+    // Strip block comments (JSDoc) spanning the line or whole lines.
+    if (inBlockComment) {
+      const end = line.indexOf('*/');
+      if (end === -1) continue;
+      line = line.slice(end + 2);
+      inBlockComment = false;
+    }
+    // Remove inline block comments and detect an unterminated one.
+    line = line.replace(/\/\*[\s\S]*?\*\//g, '');
+    const openComment = line.indexOf('/*');
+    if (openComment !== -1) {
+      line = line.slice(0, openComment);
+      inBlockComment = true;
+    }
+    // Strip line comments.
+    line = line.replace(/\/\/.*$/, '');
+
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+
+    // Match a field declaration only at the outermost depth of the body.
+    if (depth === 0) {
+      const m = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\??\s*:/);
+      if (m) {
+        keys.add(m[1]);
+      }
+    }
+
+    // Track nesting AFTER attempting the match so a `name: {` line still
+    // registers `name` before we descend.
+    for (const ch of trimmed) {
+      if (ch === '{') depth++;
+      else if (ch === '}') depth = Math.max(0, depth - 1);
+    }
+  }
+
+  return [...keys].sort();
+}
+
+describe('CatalogExportRow parity: private TS type vs @wxyc/shared SSOT schema (BS#1477)', () => {
+  const privateKeys = extractPrivateRowKeys();
+  const ssotKeys = extractSsotRowKeys();
+
+  it('extracts a non-trivial key set from each side (sanity)', () => {
+    // Guards against an extractor that silently matches nothing and lets a real
+    // drift pass as two empty, "equal" sets.
+    expect(privateKeys.length).toBeGreaterThanOrEqual(10);
+    expect(ssotKeys.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('the private CatalogExportRow key set equals the @wxyc/shared SSOT key set', () => {
+    // Adding/removing a field on exactly one side fails here. To fix: propagate
+    // the field to BOTH the private type and wxyc-shared/api.yaml (then publish
+    // a new @wxyc/shared and bump the dependency).
+    expect(privateKeys).toEqual(ssotKeys);
+  });
+
+  it('pins rotation_bin as a raw nullable string on the SSOT side (not the RotationBin enum)', () => {
+    // wxyc-shared#186 G1 + the enum drift that motivated this ticket: the export
+    // ships the RAW rotation bin so an off-cohort value can't break a strict
+    // enum decoder. If api.yaml ever re-narrows rotation_bin to RotationBin, the
+    // generated type references the enum and this fails.
+    const ssotBlock = readSsotCatalogExportRowBlock();
+    const binLine = ssotBlock.split('\n').find((l) => /\brotation_bin\b\s*\??\s*:/.test(l));
+    expect(binLine).toBeDefined();
+    expect(binLine).toMatch(/:\s*string\b/);
+    expect(binLine).not.toMatch(/RotationBin/);
+  });
+
+  it('pins rotation_bin as `string | null` on the private side', () => {
+    const servicePath = resolve(__dirname, '../../../apps/backend/services/catalog-export.service.ts');
+    const source = readFileSync(servicePath, 'utf-8');
+    const block = source.match(/export type CatalogExportRow = \{([\s\S]*?)\};/)?.[1] ?? '';
+    const binLine = block.split('\n').find((l) => /\brotation_bin\b\s*:/.test(l));
+    expect(binLine).toBeDefined();
+    expect(binLine).toMatch(/rotation_bin\s*:\s*string\s*\|\s*null\s*;/);
+    expect(binLine).not.toMatch(/RotationBin/);
+  });
+});


### PR DESCRIPTION
Closes #1477.

## Problem

`CatalogExportRow` — the `GET /library/catalog` wire shape — is hand-defined in two places nothing keeps in agreement: the private TS type in `apps/backend/services/catalog-export.service.ts` and the cross-repo SSOT `CatalogExportRow` from `@wxyc/shared/dtos` (generated from `wxyc-shared/api.yaml`, added in WXYC/wxyc-shared#186). The SSOT type feeds the iOS / Kotlin / dj-site codegen. These already drifted once — #1468 shipped the endpoint without ever propagating its row shape to the SSOT — so a field added on one side but not the other ships a wrong on-device clone with no CI signal.

## What this PR does

- **Dependency bump.** `apps/backend/package.json` `@wxyc/shared`: `^1.12.0` -> `^1.13.0`. `1.13.0` is the first published version that carries `CatalogExportRow`; the lockfile now resolves `@wxyc/shared@1.13.0` (deduped to one hoisted copy that also satisfies the unchanged `apps/auth` `^1.12.0` pin). The pin bump is intentionally scoped to `apps/backend`.
- **Parity test** at `tests/unit/services/catalog-export.parity.test.ts` (sibling to the existing `catalog-export.serialize.test.ts`). It guards two things:
  1. **Key set** — the private and SSOT `CatalogExportRow` must declare exactly the same fields. Adding/removing a field on one side fails the test.
  2. **`rotation_bin` raw-string pin** — both sides keep `rotation_bin` a raw nullable string, NOT the `RotationBin` (`"H" | "M" | "L" | "S"`) enum. This is the specific drift wxyc-shared#186 acceptance criterion G1 calls out: the endpoint ships the raw current-rotation bin so an off-cohort value (e.g. `'N'`) can't break a strict-enum decoder on device.

## Approach: two complementary layers

The unit suite runs through ts-jest with `isolatedModules: true` (`tests/tsconfig.json`), which transpiles per file **without** type-checking — a `tsc`-level type error does not fail the jest run (verified empirically). So:

- **Runtime source-grep (the CI-enforced signal).** The test reads each definition from its source-of-truth artifact as text — the private `.ts`, and the installed `@wxyc/shared` bundled `.d.ts` (resolved via `@wxyc/shared/dtos`, so the dep bump is load-bearing: a version without the type makes the test throw) — extracts the field sets, and `expect`s them equal. This is the same idiom as the existing guards in `tests/unit/scripts/ci-env-surface-parity.test.ts` and `tests/unit/config/healthcheck-shape.test.ts`.
- **Compile-time assertions (belt-and-suspenders).** A `KeysEqual<PrivateRow, SharedRow>` mutual-key-equality type and `rotation_bin` raw-string assignability checks document the same contract and bite under a real `tsc` pass. Verified green under proper `bundler` module resolution (the backend build path); they tolerate the SSOT's optional-vs-required (`?`) differences because `keyof` ignores optionality, which is correct — this guard is field add/remove + the `rotation_bin` pin, not full `required`/type parity (wxyc-shared#186 G1).

The test carries a header comment pointing at wxyc-shared#186 / #1477 and is structured to be **copyable** as the template for the next bulk endpoint that hand-defines its wire shape instead of consuming the SSOT.

## Red -> green drift demonstration

With the test in place, I temporarily perturbed the private type and confirmed the guard fires for the right reason, then reverted (the committed service file is unchanged):

| Perturbation (private side only) | Runtime guard | Compile-time guard |
|---|---|---|
| Add `bogus_drift_field` | FAIL — key-set diff shows the extra key | FAIL — `KeysEqual` -> `Type 'true' is not assignable to type 'never'` |
| Re-narrow `rotation_bin` to `'H' \| 'M' \| 'L' \| 'S' \| null` | FAIL — `rotation_bin` pin no longer matches `string \| null` | FAIL — `'N'` not assignable to the narrowed enum |

Both perturbations were reverted; `git diff` against the service file is empty.

## Checks run locally (worktree, before push)

- `npm run typecheck` — pass (all workspaces; `apps/backend` resolves `@wxyc/shared@1.13.0`).
- `npm run lint` — 0 errors (warnings only, all pre-existing advisory `security/detect-*`, matching sibling test files).
- `npm run format:check` (prettier) — clean.
- Catalog-export unit suites (`catalog-export.serialize` + `catalog-export.parity`) — 8 passed.

Note: 4 unrelated suites (`cdc-websocket`, `album-plays-refresh`, `lml.client`, `sse-metrics`) fail locally with `ReferenceError: setTimeout is not defined` in jest workers — these reproduce identically on clean `main` and are a local Node 26 vs. the repo's Node 24 incompatibility, not related to this change.

## Scope

Touches only `apps/backend/package.json` (dep bump), `package-lock.json` (install side effect), and the new test file. Does not touch `catalog-export.service.ts` (only a temporary, reverted perturbation), `CLAUDE.md` (#1478), or `app.yaml` (#1479).