### PR TITLE
fix(1487): catalog export ships real linked play counts from album_plays

### DIFF
--- a/apps/backend/services/catalog-export.service.ts
+++ b/apps/backend/services/catalog-export.service.ts
@@ -14,7 +14,16 @@
 
 import { gzipSync } from 'node:zlib';
 import { sql } from 'drizzle-orm';
-import { db, library, artists, format, genres, genre_artist_crossreference, rotation } from '@wxyc/database';
+import {
+  db,
+  library,
+  artists,
+  format,
+  genres,
+  genre_artist_crossreference,
+  rotation,
+  album_plays,
+} from '@wxyc/database';
 import { createWatermarkCache } from './watermark-cache.service.js';
 import { getCatalogLastModifiedAt } from './library.service.js';
 
@@ -80,7 +89,7 @@ export const serializeCatalogNdjson = (rows: CatalogExportRow[]): string =>
 
 /**
  * Read the full catalog as flat export rows. Mirrors `library_artist_view`'s
- * 5-table join, with two deliberate divergences for the export contract:
+ * 5-table join, with three deliberate divergences for the export contract:
  *
  *  - rotation is joined RAW (no `kill_date > CURRENT_DATE` filter) and we keep
  *    the most-recently-ADDED rotation record per album (`DISTINCT ON
@@ -101,6 +110,23 @@ export const serializeCatalogNdjson = (rows: CatalogExportRow[]): string =>
  *    so an un-backfilled NULL must not ship as JSON null and break generated
  *    iOS/Kotlin decoders. Both source columns advance the watermark (library
  *    trigger + the 0105 artists trigger), so the COALESCE stays freshness-correct.
+ *  - `plays` comes from the `album_plays` materialized view (migration 0059,
+ *    refreshed hourly by `album-plays-refresh.service.ts`), NOT the
+ *    `library_artist_view.plays` passthrough of the physical `library.plays`
+ *    column. `library.plays` is a dead counter — nothing maintains it (the
+ *    flowsheet add/delete increments are commented out), so it is `0` for every
+ *    row and shipped a no-signal field (BS#1486). `album_plays` is the live
+ *    per-album `COUNT(*)` over `flowsheet` track entries, LEFT JOINed and
+ *    COALESCEd to `0` so unplayed albums ship `0` (never JSON null). Two known
+ *    limitations, tracked as the Phase-2 attribution epic (BS#1486): (1) it
+ *    counts only flowsheet rows with a non-null `album_id` FK — ~43% of music
+ *    plays are free-text/unlinked and invisible here; (2) it is keyed per
+ *    `library.id` (per pressing/format), so the same logical album split across
+ *    multiple `library` rows is NOT collapsed. Freshness: `album_plays` refreshes
+ *    on its own timer and does not advance `library_watermark`, so a play-count
+ *    change surfaces in the export only once the next library/parent write bumps
+ *    the watermark and rebuilds the cache below — acceptable day-scale lag for a
+ *    slow-moving popularity signal.
  *
  * One scan per watermark (cached below), so the full-table cost is paid ~daily.
  */
@@ -117,7 +143,7 @@ export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
       ${genres.genre_name}                     AS genre_name,
       ${format.format_name}                    AS format_name,
       ${library.on_streaming}                  AS on_streaming,
-      ${library.plays}                         AS plays,
+      COALESCE(${album_plays.plays}, 0)::int   AS plays,
       ${library.artwork_url}                   AS artwork_url,
       ${rotation.rotation_bin}                 AS rotation_bin,
       ${rotation.kill_date}::text              AS rotation_kill_date
@@ -129,6 +155,7 @@ export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
         ON ${genre_artist_crossreference.artist_id} = ${library.artist_id}
        AND ${genre_artist_crossreference.genre_id} = ${library.genre_id}
       LEFT JOIN ${rotation} ON ${rotation.album_id} = ${library.id}
+      LEFT JOIN ${album_plays} ON ${album_plays.album_id} = ${library.id}
     ORDER BY ${library.id}, ${rotation.add_date} DESC, ${rotation.id} DESC
   `);
   return rows as unknown as CatalogExportRow[];

--- a/tests/integration/library-catalog-export.spec.js
+++ b/tests/integration/library-catalog-export.spec.js
@@ -24,6 +24,8 @@ const GEN = 11; // 'Rock'
 const FMT = 1; // 'cd'
 const PROBE_ACTIVE = 7050;
 const PROBE_EXPIRED = 7052;
+const PROBE_PLAYS = 7054; // album with seeded flowsheet track plays (BS#1486)
+const PROBE_PLAYS_COUNT = 5; // number of 'track' flowsheet rows seeded for PROBE_PLAYS
 
 // Exactly the export contract field set (#1468 AC), sorted for comparison.
 const CONTRACT_KEYS = [
@@ -120,13 +122,50 @@ describe('GET /library/catalog (BS#1468)', () => {
        ON CONFLICT (id) DO NOTHING`,
       [PROBE_EXPIRED]
     );
+
+    // Probe album with real flowsheet play history (BS#1486). `plays` is sourced
+    // from the `album_plays` MV (count of 'track' flowsheet rows with this
+    // album_id), NOT the dead `library.plays` column. Seed PROBE_PLAYS_COUNT
+    // 'track' rows plus one non-track ('breakpoint') row carrying the same
+    // album_id — the non-track row must be excluded by the MV's
+    // `entry_type='track'` filter, so the exported count stays exactly
+    // PROBE_PLAYS_COUNT, not +1.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name)
+       VALUES ($1, $2, $3, $4, 'BS#1486 Export Probe Plays', 93, 'Shape Fixture Artist Alpha')
+       ON CONFLICT (id) DO NOTHING`,
+      [PROBE_PLAYS, ART, GEN, FMT]
+    );
+    for (let i = 0; i < PROBE_PLAYS_COUNT; i++) {
+      await sql.unsafe(
+        `INSERT INTO "${SCHEMA}".flowsheet (album_id, entry_type, play_order, artist_name, album_title, track_title)
+         VALUES ($1, 'track', $2, 'Shape Fixture Artist Alpha', 'BS#1486 Export Probe Plays', $3)`,
+        [PROBE_PLAYS, 9000 + i, `probe track ${i}`]
+      );
+    }
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".flowsheet (album_id, entry_type, play_order, message)
+       VALUES ($1, 'breakpoint', 9100, 'non-track row that must NOT count toward plays')`,
+      [PROBE_PLAYS]
+    );
   });
 
   afterAll(async () => {
     if (sql) {
-      // rotation.album_id is ON DELETE CASCADE, so this reaps the probe rotation
-      // rows too.
-      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2)`, [PROBE_ACTIVE, PROBE_EXPIRED]);
+      // flowsheet.album_id is ON DELETE SET NULL, so reap the seeded play rows by
+      // album_id BEFORE deleting the library row (after which album_id is NULL and
+      // unfindable). rotation.album_id is ON DELETE CASCADE, so the library delete
+      // reaps the probe rotation rows.
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE album_id = $1`, [PROBE_PLAYS]);
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2, $3)`, [
+        PROBE_ACTIVE,
+        PROBE_EXPIRED,
+        PROBE_PLAYS,
+      ]);
+      // Drop the now-stale PROBE_PLAYS row from the MV so it can't leak into a
+      // later test's export.
+      await sql.unsafe(`REFRESH MATERIALIZED VIEW "${SCHEMA}".album_plays`);
       await sql.end();
     }
   });
@@ -198,6 +237,30 @@ describe('GET /library/catalog (BS#1468)', () => {
     const nullArtistRow = byId.get(7006);
     expect(nullArtistRow).toBeDefined();
     expect(nullArtistRow.artist_name).toBe('Shape Fixture Artist Alpha');
+  });
+
+  test('plays is the real per-release play count from album_plays, not the dead library.plays column (BS#1486)', async () => {
+    // Refresh the MV so the seeded flowsheet 'track' rows roll up into album_plays,
+    // then advance the watermark (the per-watermark export cache is keyed on
+    // library_watermark, which album_plays refresh does NOT bump) so the next GET
+    // rebuilds the export against the refreshed MV.
+    await sql.unsafe(`REFRESH MATERIALIZED VIEW "${SCHEMA}".album_plays`);
+    await sql.unsafe(`UPDATE "${SCHEMA}".library SET album_title = album_title WHERE id = $1`, [PROBE_PLAYS]);
+
+    const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
+
+    // A played album exports its real count — and exactly the count of 'track'
+    // rows, excluding the non-track ('breakpoint') row seeded with the same
+    // album_id.
+    const played = byId.get(PROBE_PLAYS);
+    expect(played).toBeDefined();
+    expect(played.plays).toBe(PROBE_PLAYS_COUNT);
+
+    // An album with no flowsheet track rows has no album_plays row; the LEFT JOIN
+    // COALESCEs to 0 — never JSON null — so consumers can rank numerically.
+    const unplayed = byId.get(PROBE_EXPIRED);
+    expect(unplayed).toBeDefined();
+    expect(unplayed.plays).toBe(0);
   });
 
   test('returns 304 when If-Modified-Since matches the current watermark', async () => {


### PR DESCRIPTION
## What

`GET /library/catalog` shipped its `plays` field from the physical `library.plays` column — a **dead counter** that nothing maintains (the flowsheet add/delete increments are commented out; the only writer hard-codes `0`), so the export shipped `plays = 0` for every row and the field carried no signal.

This sources `plays` from the existing `album_plays` materialized view instead — the live per-album `COUNT(*)` over `flowsheet` track entries (migration 0059, refreshed hourly, already consumed by the tsvector search ranker). The export now ships a real linked play count: `> 0` for played releases, `0` for unplayed (COALESCEd — never JSON null).

## Why this is the interim ("Phase 1") signal

This is the **linked-only, per-pressing** count. It does not fold in the ~43% of music plays that are free-text/unlinked, and it does not collapse multiple `library` pressings of one logical album. Those are the attribution-corrected signal tracked in the Phase-2 epic #1486 (LML-backed). The interim signal is monotonic and immediately useful — it unblocks the deferred ranked-bundle seed in WXYC/wxyc-dj-ios#44.

## Notes

- **No contract change.** `CatalogExportRow.plays` stays `integer, nullable: true` in the SSOT (`wxyc-shared/api.yaml`); only the value source changed. The parity guard (`catalog-export.parity.test.ts`, #1477) stays green and no `@wxyc/shared` release is needed.
- **Freshness.** `album_plays` refreshes on its own hourly timer and does not advance `library_watermark`, so a play-count change surfaces in the per-watermark export cache only after the next library/parent write rebuilds it — acceptable day-scale lag for a slow-moving popularity signal (documented in the service comment).
- The `library.plays` dead column is left in place (out of scope); a sibling dead-column bug on `GET /library/query?sort=plays` was found during this work and is noted for separate triage.

## Test

Adds an integration case to `library-catalog-export.spec.js`: seeds N `track` flowsheet rows (plus a non-`track` row carrying the same `album_id`), refreshes the MV, advances the watermark, and asserts the export reports exactly N for the played album (non-track row excluded) and `0` for an album with no plays.

Closes #1487
