### PR TITLE
fix(1489): sort catalog browse by real plays from album_plays, not the dead library.plays column

### DIFF
--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -1,6 +1,13 @@
 import * as Sentry from '@sentry/node';
 import { sql, type SQL } from 'drizzle-orm';
-import { db, library_artist_view, genres, format as formatTable, artist_search_alias } from '@wxyc/database';
+import {
+  db,
+  library_artist_view,
+  genres,
+  format as formatTable,
+  artist_search_alias,
+  album_plays,
+} from '@wxyc/database';
 import type { TrackMatchHint } from '@wxyc/shared/dtos';
 import {
   parseSearchQuery,
@@ -53,10 +60,24 @@ const FIELD_COLUMNS: Record<CatalogField, SQL> = {
   label: sql`${library_artist_view.label}`,
 };
 
+// BS#1489: `library_artist_view.plays` projects the physical `library.plays`
+// column, which nothing maintains — it is 0 for every row, so `sort=plays`
+// ordered a constant (silently a no-op, falling through to the secondary
+// tiebreak). The real per-album play count lives in the `album_plays` MV
+// (migration 0059) — the same live `COUNT(*)` over flowsheet track entries the
+// catalog export and the tsvector ranker read. Scope a LEFT JOIN to it into the
+// search query and source `plays` from it, rather than redefining the view (the
+// view is read by several other code paths; this keeps the blast radius on the
+// one surface with the bug). The join is 1:1 (unique index on
+// `album_plays.album_id`), so it never changes the result set or `COUNT(*)`;
+// COALESCE 0 covers never-played albums, which have no MV row.
+const albumPlaysJoin = sql`LEFT JOIN ${album_plays} ON ${album_plays.album_id} = ${library_artist_view.id}`;
+const playsColumn = sql`COALESCE(${album_plays.plays}, 0)`;
+
 const SORT_COLUMNS: Record<CatalogSort, SQL> = {
   artist: sql`${library_artist_view.artist_name}`,
   album: sql`${library_artist_view.album_title}`,
-  plays: sql`${library_artist_view.plays}`,
+  plays: playsColumn,
   date: sql`${library_artist_view.add_date}`,
 };
 
@@ -184,7 +205,7 @@ export async function searchLibrary(
       ${library_artist_view.label} AS label,
       ${library_artist_view.label_id} AS label_id,
       ${library_artist_view.rotation_bin} AS rotation_bin,
-      ${library_artist_view.plays} AS plays,
+      ${playsColumn} AS plays,
       ${library_artist_view.on_streaming} AS on_streaming,
       ${library_artist_view.album_artist} AS album_artist,
       NULL::real AS alias_max_sim,
@@ -203,7 +224,7 @@ export async function searchLibrary(
       ${library_artist_view.label} AS label,
       ${library_artist_view.label_id} AS label_id,
       ${library_artist_view.rotation_bin} AS rotation_bin,
-      ${library_artist_view.plays} AS plays,
+      ${playsColumn} AS plays,
       ${library_artist_view.on_streaming} AS on_streaming,
       ${library_artist_view.album_artist} AS album_artist,
       alias_hits.max_sim AS alias_max_sim,
@@ -211,11 +232,11 @@ export async function searchLibrary(
       alias_hits.matched_source AS alias_matched_source`;
 
     const branchAFrom = branchAWhere
-      ? sql`FROM ${library_artist_view} WHERE ${branchAWhere}`
-      : sql`FROM ${library_artist_view}`;
+      ? sql`FROM ${library_artist_view} ${albumPlaysJoin} WHERE ${branchAWhere}`
+      : sql`FROM ${library_artist_view} ${albumPlaysJoin}`;
     const branchBFrom = branchBWhere
-      ? sql`FROM ${library_artist_view} INNER JOIN alias_hits ON alias_hits.artist_id = ${library_artist_view.artist_id} WHERE ${branchBWhere}`
-      : sql`FROM ${library_artist_view} INNER JOIN alias_hits ON alias_hits.artist_id = ${library_artist_view.artist_id}`;
+      ? sql`FROM ${library_artist_view} INNER JOIN alias_hits ON alias_hits.artist_id = ${library_artist_view.artist_id} ${albumPlaysJoin} WHERE ${branchBWhere}`
+      : sql`FROM ${library_artist_view} INNER JOIN alias_hits ON alias_hits.artist_id = ${library_artist_view.artist_id} ${albumPlaysJoin}`;
 
     const unionBody = sql`(
       SELECT ${branchAProjection}
@@ -242,7 +263,9 @@ export async function searchLibrary(
     // no CTE, no UNION ALL — byte-identical to pre-#1318 behavior.
     const queryWhere = buildWhereClause(conditions);
     const where = combineWhere(queryWhere, filterWhere);
-    const fromClause = where ? sql`FROM ${library_artist_view} WHERE ${where}` : sql`FROM ${library_artist_view}`;
+    const fromClause = where
+      ? sql`FROM ${library_artist_view} ${albumPlaysJoin} WHERE ${where}`
+      : sql`FROM ${library_artist_view} ${albumPlaysJoin}`;
     const orderBy = sql`${SORT_COLUMNS[params.sort]} ${orderDirection}, ${SECONDARY_SORT[params.sort]} ASC, ${library_artist_view.id} ASC`;
     dataQuery = sql`
       SELECT
@@ -258,7 +281,7 @@ export async function searchLibrary(
         ${library_artist_view.label} AS label,
         ${library_artist_view.label_id} AS label_id,
         ${library_artist_view.rotation_bin} AS rotation_bin,
-        ${library_artist_view.plays} AS plays,
+        ${playsColumn} AS plays,
         ${library_artist_view.on_streaming} AS on_streaming,
         ${library_artist_view.album_artist} AS album_artist
       ${fromClause}

--- a/tests/integration/library-query-sort-plays.spec.js
+++ b/tests/integration/library-query-sort-plays.spec.js
@@ -1,0 +1,134 @@
+/**
+ * BS#1489 — `GET /library/query?sort=plays` orders by a REAL play count.
+ *
+ * Regression coverage for the dead-column bug: the browse/sort path read
+ * `library_artist_view.plays`, which projected the physical `library.plays`
+ * column. Nothing maintains `library.plays` (it is 0 for every row), so
+ * `sort=plays` silently ordered a constant and fell back to the secondary
+ * `artist_name` / `id` tiebreak. The fix scopes a LEFT JOIN to the `album_plays`
+ * MV into the search query (`library-search.service.ts`) and sources both the
+ * sort key and the projected `plays` from `COALESCE(album_plays.plays, 0)` —
+ * the same live per-album COUNT(*) the catalog export uses — so the sort and
+ * the projected value carry real signal. (Scoped join, not a view
+ * redefinition: the view is read by several other code paths.)
+ *
+ * Postgres-backed (direct SQL seeds two probe albums + flowsheet plays and
+ * refreshes the MV; supertest drives the HTTP surface) — same harness as
+ * library-catalog-export.spec.js.
+ *
+ * The two probes are arranged so the test FAILS under the old behavior:
+ *   - PROBE_ZERO has the LOWER id and zero plays.
+ *   - PROBE_HIGH has the HIGHER id and HIGH_PLAYS_COUNT plays.
+ * Under the dead-column bug, `sort=plays desc` sees both as 0 and falls to the
+ * `id ASC` tiebreak, surfacing the (wrong) zero-plays row first. With the fix,
+ * the played album sorts first regardless of id.
+ *
+ * Probe rows live in the reserved 7000-range on ids the shape fixture leaves
+ * free (7060/7062), reusing fixture artist 7000 ('XA'), genre 11 ('Rock'),
+ * format 1 ('cd'), and gac (7000,11)->700 so every joined display field exists.
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const ART = 7000; // fixture artist (code_letters 'XA')
+const GEN = 11; // 'Rock'
+const FMT = 1; // 'cd'
+const PROBE_ZERO = 7060; // LOWER id, zero plays (no album_plays row -> COALESCE 0)
+const PROBE_HIGH = 7062; // HIGHER id, real plays
+const HIGH_PLAYS_COUNT = 4;
+// Unique token shared by both album titles so `album:<token>` isolates exactly
+// the two probes (contains-match, field-qualified -> deterministic primary path).
+const TOKEN = 'zzsortprobe1489';
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+describe('GET /library/query?sort=plays (BS#1489)', () => {
+  let auth;
+  let sql;
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = makeSql();
+
+    // Zero-plays probe: lower id, no flowsheet rows.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name)
+       VALUES ($1, $2, $3, $4, $5, 60, 'Shape Fixture Artist Alpha')
+       ON CONFLICT (id) DO NOTHING`,
+      [PROBE_ZERO, ART, GEN, FMT, `${TOKEN} Zero Plays`]
+    );
+
+    // High-plays probe: higher id, HIGH_PLAYS_COUNT 'track' flowsheet rows.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name)
+       VALUES ($1, $2, $3, $4, $5, 62, 'Shape Fixture Artist Alpha')
+       ON CONFLICT (id) DO NOTHING`,
+      [PROBE_HIGH, ART, GEN, FMT, `${TOKEN} High Plays`]
+    );
+    for (let i = 0; i < HIGH_PLAYS_COUNT; i++) {
+      await sql.unsafe(
+        `INSERT INTO "${SCHEMA}".flowsheet (album_id, entry_type, play_order, artist_name, album_title, track_title)
+         VALUES ($1, 'track', $2, 'Shape Fixture Artist Alpha', $3, $4)`,
+        [PROBE_HIGH, 9200 + i, `${TOKEN} High Plays`, `probe track ${i}`]
+      );
+    }
+
+    // Roll the seeded track rows into the MV the view now reads.
+    await sql.unsafe(`REFRESH MATERIALIZED VIEW "${SCHEMA}".album_plays`);
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      // flowsheet.album_id is ON DELETE SET NULL — reap the play rows by
+      // album_id BEFORE deleting the library row (album_id goes NULL after).
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE album_id = $1`, [PROBE_HIGH]);
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2)`, [PROBE_ZERO, PROBE_HIGH]);
+      // Drop the now-stale probe row from the MV so it can't leak into a later test.
+      await sql.unsafe(`REFRESH MATERIALIZED VIEW "${SCHEMA}".album_plays`);
+      await sql.end();
+    }
+  });
+
+  test('sort=plays desc surfaces the played album first (not the lower-id zero-plays row)', async () => {
+    const res = await auth
+      .get('/library/query')
+      .query({ q: `album:${TOKEN}`, sort: 'plays', order: 'desc', limit: 10 })
+      .expect(200);
+
+    // Exactly the two probes match the unique token.
+    expect(res.body.total).toBe(2);
+    expect(res.body.results.map((r) => r.id)).toEqual([PROBE_HIGH, PROBE_ZERO]);
+
+    const [first, second] = res.body.results;
+    // The projected `plays` now carries real signal (was 0 for every row).
+    expect(first.plays).toBe(HIGH_PLAYS_COUNT);
+    // Unplayed album has no album_plays row -> LEFT JOIN -> COALESCE 0 (never null).
+    expect(second.plays).toBe(0);
+  });
+
+  test('sort=plays asc surfaces the zero-plays album first', async () => {
+    const res = await auth
+      .get('/library/query')
+      .query({ q: `album:${TOKEN}`, sort: 'plays', order: 'asc', limit: 10 })
+      .expect(200);
+
+    expect(res.body.results.map((r) => r.id)).toEqual([PROBE_ZERO, PROBE_HIGH]);
+    expect(res.body.results[0].plays).toBe(0);
+    expect(res.body.results[1].plays).toBe(HIGH_PLAYS_COUNT);
+  });
+});


### PR DESCRIPTION
## Problem

`GET /library/query?sort=plays` ordered `library_artist_view.plays`, which projects the physical `library.plays` column. Nothing maintains that column — the flowsheet add/delete increments are commented out and the only writer hard-codes `0` — so it is `0` for every row. `sort=plays` therefore ordered a constant and silently fell through to the secondary `artist_name` / `id` tiebreak: "sort by plays" did nothing.

Same dead-column root cause as the catalog-export `plays = 0` bug (#1486 / #1487), on a different surface (the browse/sort path reads `library_artist_view`; the export reads its own query, already fixed in the Phase-1 child).

## Fix

Scope a `LEFT JOIN` to the `album_plays` materialized view (migration 0059 — the same live per-album `COUNT(*)` over flowsheet track entries that the catalog export and the tsvector ranker already read) into the search query, and source both the `plays` sort key and the projected `plays` value from `COALESCE(album_plays.plays, 0)`.

- The join is **1:1** (unique index on `album_plays.album_id`), so it never changes the result set or `COUNT(*)`; `COALESCE 0` covers never-played albums (no MV row).
- Implemented as a **scoped join rather than a view redefinition**: the issue flagged that `library_artist_view` is read by several other code paths, so changing the view has wider blast radius. The join + `plays` expression are shared SQL fragments, so the fix flows through every branch of the search query — the alias-off legacy path and **both branches of the #1318 alias `UNION`** — without touching the view.

## Scope / limitation

The catalog-track-search cascade's in-memory sort (`runCascade` → `taggedRowToAlbumSearchResultRow`) still reads the view's `plays`. That is a bounded LML fallback that only fires on a primary 0-hit and is left out of scope here.

## Test

Adds `tests/integration/library-query-sort-plays.spec.js`, seeding two probe albums arranged so the assertion **fails under the old behavior**: the played album gets the *higher* id and real plays, the unplayed album the *lower* id and zero plays. Under the dead column, `sort=plays desc` tiebreaks to the lower-id zero-plays row first; with the fix the played album sorts first regardless of id. Also asserts the projected `plays` now carries the real count (and `0`, never null, for unplayed).

## Verification

- `typecheck`, `lint` (0 errors), `format:check`, full `test:unit` (248 suites) — green.
- Integration (Docker CI mock): the new spec plus the related `library-query`, `library-search-alias` (the modified alias `UNION` path), `library-catalog-export`, and `library.search-ranking` suites all pass (41 + 2). The full suite's only failure is the pre-existing, unrelated `auth-auto-membership` auto-membership-hook test, which fails standalone and on an unchanged tree (this branch touches no auth code).

Closes #1489