### PR TITLE
feat(1493): export popularity field from album_popularity (Phase-2 Track 3)

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -260,6 +260,14 @@ components:
         plays:
           type: integer
           nullable: true
+        popularity:
+          type: integer
+          nullable: true
+          description: >
+            Attribution-corrected, master-collapsed popularity (BS#1486 Phase-2):
+            collapses pressings sharing a Discogs master and folds in resolved
+            free-text plays. null when the logical album has no plays. The SSOT
+            (wxyc-shared api.yaml) carries the authoritative description.
         artwork_url:
           type: string
           nullable: true

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -23,7 +23,7 @@
     "@wxyc/database": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^1.13.0",
+    "@wxyc/shared": "^1.15.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.18.0",

--- a/apps/backend/services/catalog-export.service.ts
+++ b/apps/backend/services/catalog-export.service.ts
@@ -23,6 +23,7 @@ import {
   genre_artist_crossreference,
   rotation,
   album_plays,
+  album_popularity,
 } from '@wxyc/database';
 import { createWatermarkCache } from './watermark-cache.service.js';
 import { getCatalogLastModifiedAt } from './library.service.js';
@@ -51,6 +52,7 @@ export type CatalogExportRow = {
   format_name: string;
   on_streaming: boolean | null;
   plays: number | null;
+  popularity: number | null;
   artwork_url: string | null;
   rotation_bin: string | null;
   rotation_kill_date: string | null;
@@ -74,6 +76,7 @@ const projectRow = (row: CatalogExportRow): CatalogExportRow => ({
   format_name: row.format_name,
   on_streaming: row.on_streaming,
   plays: row.plays,
+  popularity: row.popularity,
   artwork_url: row.artwork_url,
   rotation_bin: row.rotation_bin,
   rotation_kill_date: row.rotation_kill_date,
@@ -127,6 +130,19 @@ export const serializeCatalogNdjson = (rows: CatalogExportRow[]): string =>
  *    change surfaces in the export only once the next library/parent write bumps
  *    the watermark and rebuilds the cache below — acceptable day-scale lag for a
  *    slow-moving popularity signal.
+ *  - `popularity` is the attribution-corrected logical-album signal from the
+ *    `album_popularity` table (BS#1486 Phase-2 Track 2, refreshed by
+ *    `album-popularity-refresh.service.ts`), addressing both `plays` limitations
+ *    above: it collapses the pressings sharing one Discogs master and folds in
+ *    the Track-1-resolved free-text plays. LEFT JOINed by the row's logical key —
+ *    the `discogs:`-stripped `canonical_entity_id` (`discogs:master:<id>` ->
+ *    `master:<id>`), the value verbatim for any other non-null scheme, else
+ *    `library:<id>` — which MUST mirror the CASE the rebuild groups on (a
+ *    divergence silently nulls popularity; the pg integration spec guards it).
+ *    Unlike `plays`, it is projected RAW (nullable, NOT COALESCEd to 0): `null`
+ *    means the logical album has no plays at all (linked or free-text), per the
+ *    merged SSOT contract. Same watermark-lag caveat as `plays` (the refresh does
+ *    not advance `library_watermark`).
  *
  * One scan per watermark (cached below), so the full-table cost is paid ~daily.
  */
@@ -144,6 +160,7 @@ export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
       ${format.format_name}                    AS format_name,
       ${library.on_streaming}                  AS on_streaming,
       COALESCE(${album_plays.plays}, 0)::int   AS plays,
+      ${album_popularity.plays}::int           AS popularity,
       ${library.artwork_url}                   AS artwork_url,
       ${rotation.rotation_bin}                 AS rotation_bin,
       ${rotation.kill_date}::text              AS rotation_kill_date
@@ -156,6 +173,15 @@ export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
        AND ${genre_artist_crossreference.genre_id} = ${library.genre_id}
       LEFT JOIN ${rotation} ON ${rotation.album_id} = ${library.id}
       LEFT JOIN ${album_plays} ON ${album_plays.album_id} = ${library.id}
+      LEFT JOIN ${album_popularity} ON ${album_popularity.logical_album_key} = (
+        CASE
+          WHEN ${library.canonical_entity_id} LIKE 'discogs:%'
+            THEN substring(${library.canonical_entity_id} from 'discogs:(.*)')
+          WHEN ${library.canonical_entity_id} IS NOT NULL
+            THEN ${library.canonical_entity_id}
+          ELSE 'library:' || ${library.id}::text
+        END
+      )
     ORDER BY ${library.id}, ${rotation.add_date} DESC, ${rotation.id} DESC
   `);
   return rows as unknown as CatalogExportRow[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "@wxyc/database": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^1.13.0",
+        "@wxyc/shared": "^1.15.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.18.0",
@@ -6094,9 +6094,9 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "1.13.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.13.0/5c964690a095748229f8bf036f58f76240f0927b",
-      "integrity": "sha512-/RDt3W+Y/8T1UGRKktGgVF7ExfsxxS/8QsVdEVCSHIlSid14FYl+5+TyyNDIauawEje8Ajbha14i5PnnjMaW3Q==",
+      "version": "1.15.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.15.0/4f5abe0230cabb364ef42cc5525f3e2eb35c8c58",
+      "integrity": "sha512-SIBAvLc0lQ31n6aYlSUlSZw4CwPeLcasStcWXcca6h44tmZR8qAHDrM+POhQvQUBwVFWmvn8VEJVvlb9NB/jlA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/tests/integration/library-catalog-export.spec.js
+++ b/tests/integration/library-catalog-export.spec.js
@@ -27,7 +27,16 @@ const PROBE_EXPIRED = 7052;
 const PROBE_PLAYS = 7054; // album with seeded flowsheet track plays (BS#1486)
 const PROBE_PLAYS_COUNT = 5; // number of 'track' flowsheet rows seeded for PROBE_PLAYS
 
-// Exactly the export contract field set (#1468 AC), sorted for comparison.
+// BS#1493 Track 3 popularity probes: two pressings of one Discogs master that
+// MUST collapse to one popularity, plus an unsignaled row that ships raw null.
+const PROBE_POP_A = 7056; // pressing of master 55501, with its own linked plays
+const PROBE_POP_B = 7057; // ANOTHER pressing of master 55501 -> same popularity
+const PROBE_POP_NULL = 7058; // no album_popularity row -> popularity raw null
+const POP_MASTER_KEY = 'master:55501';
+const POP_TOTAL = 9; // seeded album_popularity.plays (linked 6 + free-text 3)
+const PROBE_POP_A_PLAYS = 2; // single-pressing linked plays for PROBE_POP_A
+
+// Exactly the export contract field set (#1468 AC + #1493 popularity), sorted.
 const CONTRACT_KEYS = [
   'album_title',
   'artist_name',
@@ -41,6 +50,7 @@ const CONTRACT_KEYS = [
   'label',
   'on_streaming',
   'plays',
+  'popularity',
   'rotation_bin',
   'rotation_kill_date',
 ].sort();
@@ -149,6 +159,39 @@ describe('GET /library/catalog (BS#1468)', () => {
        VALUES ($1, 'breakpoint', 9100, 'non-track row that must NOT count toward plays')`,
       [PROBE_PLAYS]
     );
+
+    // BS#1493 Track 3: `popularity` is the master-collapsed, free-text-folded
+    // signal from `album_popularity`, LEFT JOINed by the row's logical key (the
+    // `discogs:`-stripped `canonical_entity_id`). Seed two pressings sharing one
+    // master (so they collapse to the same popularity) and an unsignaled row.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library
+         (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, canonical_entity_id)
+       VALUES ($1, $4, $5, $6, 'BS#1493 Pop Pressing A', 94, 'Shape Fixture Artist Alpha', 'discogs:master:55501'),
+              ($2, $4, $5, $6, 'BS#1493 Pop Pressing B', 95, 'Shape Fixture Artist Alpha', 'discogs:master:55501'),
+              ($3, $4, $5, $6, 'BS#1493 Pop Unsignaled', 96, 'Shape Fixture Artist Alpha', NULL)
+       ON CONFLICT (id) DO NOTHING`,
+      [PROBE_POP_A, PROBE_POP_B, PROBE_POP_NULL, ART, GEN, FMT]
+    );
+    // Give pressing A its own linked plays so `popularity` (the collapsed master
+    // total) can be asserted >= a single pressing's per-pressing `plays`.
+    for (let i = 0; i < PROBE_POP_A_PLAYS; i++) {
+      await sql.unsafe(
+        `INSERT INTO "${SCHEMA}".flowsheet (album_id, entry_type, play_order, artist_name, album_title, track_title)
+         VALUES ($1, 'track', $2, 'Shape Fixture Artist Alpha', 'BS#1493 Pop Pressing A', $3)`,
+        [PROBE_POP_A, 9200 + i, `pop track ${i}`]
+      );
+    }
+    // The album_popularity row for the shared master, seeded directly (the
+    // refresh service's 1h timer never fires in-suite). plays = linked + free-text.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".album_popularity
+         (logical_album_key, plays, linked_plays, freetext_plays, representative_library_id)
+       VALUES ($1, $2, 6, 3, $3)
+       ON CONFLICT (logical_album_key) DO UPDATE
+         SET plays = EXCLUDED.plays, representative_library_id = EXCLUDED.representative_library_id`,
+      [POP_MASTER_KEY, POP_TOTAL, PROBE_POP_A]
+    );
   });
 
   afterAll(async () => {
@@ -158,11 +201,17 @@ describe('GET /library/catalog (BS#1468)', () => {
       // unfindable). rotation.album_id is ON DELETE CASCADE, so the library delete
       // reaps the probe rotation rows.
       await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE album_id = $1`, [PROBE_PLAYS]);
-      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2, $3)`, [
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE album_id = $1`, [PROBE_POP_A]);
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2, $3, $4, $5, $6)`, [
         PROBE_ACTIVE,
         PROBE_EXPIRED,
         PROBE_PLAYS,
+        PROBE_POP_A,
+        PROBE_POP_B,
+        PROBE_POP_NULL,
       ]);
+      // album_popularity has no FK to library, so reap the seeded row by its key.
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".album_popularity WHERE logical_album_key = $1`, [POP_MASTER_KEY]);
       // Drop the now-stale PROBE_PLAYS row from the MV so it can't leak into a
       // later test's export.
       await sql.unsafe(`REFRESH MATERIALIZED VIEW "${SCHEMA}".album_plays`);
@@ -261,6 +310,43 @@ describe('GET /library/catalog (BS#1468)', () => {
     const unplayed = byId.get(PROBE_EXPIRED);
     expect(unplayed).toBeDefined();
     expect(unplayed.plays).toBe(0);
+  });
+
+  test('popularity is the master-collapsed album_popularity signal joined by logical key; raw null when unsignaled (BS#1486 Track 3)', async () => {
+    // album_popularity refresh does NOT advance library_watermark, so bump it
+    // (touch a probe) to rebuild the per-watermark export cache against the seeded
+    // album_popularity; refresh album_plays so pressing A's `plays` is current.
+    await sql.unsafe(`REFRESH MATERIALIZED VIEW "${SCHEMA}".album_plays`);
+    await sql.unsafe(`UPDATE "${SCHEMA}".library SET album_title = album_title WHERE id = $1`, [PROBE_POP_A]);
+
+    const byId = new Map(parseRows(await getCatalog(auth)).map((r) => [r.id, r]));
+
+    const a = byId.get(PROBE_POP_A);
+    const b = byId.get(PROBE_POP_B);
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+
+    // Both pressings of master 55501 collapse to the SAME popularity — the join
+    // derives `master:55501` from each row's `discogs:master:55501` canonical id.
+    expect(a.popularity).toBe(POP_TOTAL);
+    expect(b.popularity).toBe(POP_TOTAL);
+
+    // Headline #1493 criterion: the multi-pressing logical album's popularity is
+    // >= a single pressing's per-pressing linked `plays`.
+    expect(a.plays).toBe(PROBE_POP_A_PLAYS);
+    expect(a.popularity).toBeGreaterThanOrEqual(a.plays);
+
+    // Pressing B has no linked plays of its own (plays COALESCEd to 0) yet still
+    // carries the collapsed popularity — exactly what the collapse buys.
+    expect(b.plays).toBe(0);
+    expect(b.popularity).toBe(POP_TOTAL);
+
+    // A row with no album_popularity entry ships popularity RAW null (NOT 0 like
+    // plays): the merged SSOT contract distinguishes "no logical signal" from 0.
+    const unsignaled = byId.get(PROBE_POP_NULL);
+    expect(unsignaled).toBeDefined();
+    expect(unsignaled.popularity).toBeNull();
+    expect(unsignaled.plays).toBe(0);
   });
 
   test('returns 304 when If-Modified-Since matches the current watermark', async () => {

--- a/tests/integration/library-catalog-export.spec.js
+++ b/tests/integration/library-catalog-export.spec.js
@@ -8,7 +8,8 @@
  * shapes, supertest drives the HTTP surface.
  *
  * Probe rows live in the reserved 7000-range (shape fixture's namespace) on ids
- * the fixture leaves free (7050/7052). They reuse fixture artist 7000 (code
+ * the fixture leaves free (this spec owns 7050-7059 + 7061; 7060/7062 belong to
+ * library-query-sort-plays.spec.js). They reuse fixture artist 7000 (code
  * letters 'XA'), genre 11 ('Rock'), format 1 ('cd'), and gac (7000,11)->700, so
  * every joined display field is a known constant.
  */
@@ -35,6 +36,18 @@ const PROBE_POP_NULL = 7058; // no album_popularity row -> popularity raw null
 const POP_MASTER_KEY = 'master:55501';
 const POP_TOTAL = 9; // seeded album_popularity.plays (linked 6 + free-text 3)
 const PROBE_POP_A_PLAYS = 2; // single-pressing linked plays for PROBE_POP_A
+// The reader's logical-key CASE has THREE branches; the master probes above only
+// exercise the `discogs:master:` form of branch 1. These two cover the other
+// join-success branches so a reader/writer divergence on them can't silently null
+// popularity undetected (the largest unguarded class is NULL-canonical, ~34k rows).
+const PROBE_POP_RELEASE = 7059; // canonical 'discogs:release:88812' -> key 'release:88812'
+const POP_RELEASE_KEY = 'release:88812';
+const POP_RELEASE_TOTAL = 4; // seeded album_popularity.plays for the release key
+// 7061, not 7060: library-query-sort-plays.spec.js owns 7060 (PROBE_ZERO) and the
+// pg suite shares one schema under --runInBand, so probe ids must not collide.
+const PROBE_POP_LIBFALLBACK = 7061; // NULL canonical -> ELSE branch key 'library:7061'
+const POP_LIBFALLBACK_KEY = `library:${PROBE_POP_LIBFALLBACK}`;
+const POP_LIBFALLBACK_TOTAL = 7; // seeded album_popularity.plays for the library: key
 
 // Exactly the export contract field set (#1468 AC + #1493 popularity), sorted.
 const CONTRACT_KEYS = [
@@ -167,11 +180,13 @@ describe('GET /library/catalog (BS#1468)', () => {
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".library
          (id, artist_id, genre_id, format_id, album_title, code_number, artist_name, canonical_entity_id)
-       VALUES ($1, $4, $5, $6, 'BS#1493 Pop Pressing A', 94, 'Shape Fixture Artist Alpha', 'discogs:master:55501'),
-              ($2, $4, $5, $6, 'BS#1493 Pop Pressing B', 95, 'Shape Fixture Artist Alpha', 'discogs:master:55501'),
-              ($3, $4, $5, $6, 'BS#1493 Pop Unsignaled', 96, 'Shape Fixture Artist Alpha', NULL)
+       VALUES ($1, $6, $7, $8, 'BS#1493 Pop Pressing A', 94, 'Shape Fixture Artist Alpha', 'discogs:master:55501'),
+              ($2, $6, $7, $8, 'BS#1493 Pop Pressing B', 95, 'Shape Fixture Artist Alpha', 'discogs:master:55501'),
+              ($3, $6, $7, $8, 'BS#1493 Pop Unsignaled', 96, 'Shape Fixture Artist Alpha', NULL),
+              ($4, $6, $7, $8, 'BS#1493 Pop Release', 97, 'Shape Fixture Artist Alpha', 'discogs:release:88812'),
+              ($5, $6, $7, $8, 'BS#1493 Pop LibFallback', 98, 'Shape Fixture Artist Alpha', NULL)
        ON CONFLICT (id) DO NOTHING`,
-      [PROBE_POP_A, PROBE_POP_B, PROBE_POP_NULL, ART, GEN, FMT]
+      [PROBE_POP_A, PROBE_POP_B, PROBE_POP_NULL, PROBE_POP_RELEASE, PROBE_POP_LIBFALLBACK, ART, GEN, FMT]
     );
     // Give pressing A its own linked plays so `popularity` (the collapsed master
     // total) can be asserted >= a single pressing's per-pressing `plays`.
@@ -192,6 +207,25 @@ describe('GET /library/catalog (BS#1468)', () => {
          SET plays = EXCLUDED.plays, representative_library_id = EXCLUDED.representative_library_id`,
       [POP_MASTER_KEY, POP_TOTAL, PROBE_POP_A]
     );
+    // album_popularity rows for the release-form and library-fallback logical keys
+    // so the reader's other two CASE branches are JOIN-tested, not just the master
+    // form. A non-null result here proves the reader derives `release:88812` /
+    // `library:7061` exactly as the writer groups, so the equi-join lands.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".album_popularity
+         (logical_album_key, plays, linked_plays, freetext_plays, representative_library_id)
+       VALUES ($1, $2, $2, 0, $3), ($4, $5, $5, 0, $6)
+       ON CONFLICT (logical_album_key) DO UPDATE
+         SET plays = EXCLUDED.plays, representative_library_id = EXCLUDED.representative_library_id`,
+      [
+        POP_RELEASE_KEY,
+        POP_RELEASE_TOTAL,
+        PROBE_POP_RELEASE,
+        POP_LIBFALLBACK_KEY,
+        POP_LIBFALLBACK_TOTAL,
+        PROBE_POP_LIBFALLBACK,
+      ]
+    );
   });
 
   afterAll(async () => {
@@ -202,16 +236,22 @@ describe('GET /library/catalog (BS#1468)', () => {
       // reaps the probe rotation rows.
       await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE album_id = $1`, [PROBE_PLAYS]);
       await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE album_id = $1`, [PROBE_POP_A]);
-      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2, $3, $4, $5, $6)`, [
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE id IN ($1, $2, $3, $4, $5, $6, $7, $8)`, [
         PROBE_ACTIVE,
         PROBE_EXPIRED,
         PROBE_PLAYS,
         PROBE_POP_A,
         PROBE_POP_B,
         PROBE_POP_NULL,
+        PROBE_POP_RELEASE,
+        PROBE_POP_LIBFALLBACK,
       ]);
-      // album_popularity has no FK to library, so reap the seeded row by its key.
-      await sql.unsafe(`DELETE FROM "${SCHEMA}".album_popularity WHERE logical_album_key = $1`, [POP_MASTER_KEY]);
+      // album_popularity has no FK to library, so reap the seeded rows by their keys.
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".album_popularity WHERE logical_album_key IN ($1, $2, $3)`, [
+        POP_MASTER_KEY,
+        POP_RELEASE_KEY,
+        POP_LIBFALLBACK_KEY,
+      ]);
       // Drop the now-stale PROBE_PLAYS row from the MV so it can't leak into a
       // later test's export.
       await sql.unsafe(`REFRESH MATERIALIZED VIEW "${SCHEMA}".album_plays`);
@@ -312,7 +352,7 @@ describe('GET /library/catalog (BS#1468)', () => {
     expect(unplayed.plays).toBe(0);
   });
 
-  test('popularity is the master-collapsed album_popularity signal joined by logical key; raw null when unsignaled (BS#1486 Track 3)', async () => {
+  test('popularity is the album_popularity signal joined on every logical-key branch (master-collapsed, release, library-fallback); raw null when unsignaled (BS#1486 Track 3)', async () => {
     // album_popularity refresh does NOT advance library_watermark, so bump it
     // (touch a probe) to rebuild the per-watermark export cache against the seeded
     // album_popularity; refresh album_plays so pressing A's `plays` is current.
@@ -347,6 +387,20 @@ describe('GET /library/catalog (BS#1468)', () => {
     expect(unsignaled).toBeDefined();
     expect(unsignaled.popularity).toBeNull();
     expect(unsignaled.plays).toBe(0);
+
+    // The reader's logical-key CASE has two more JOIN-success branches the master
+    // probes above never reach. These guard reader/writer parity on them (a
+    // divergence here silently nulls popularity for whole row classes):
+    //  - `discogs:release:<id>` -> the substring branch must yield `release:88812`.
+    const release = byId.get(PROBE_POP_RELEASE);
+    expect(release).toBeDefined();
+    expect(release.popularity).toBe(POP_RELEASE_TOTAL);
+    //  - NULL canonical -> the ELSE branch must yield `library:<id>` and join. This
+    //    is the largest class in prod (~34k NULL-canonical rows); distinct from
+    //    PROBE_POP_NULL (which has no album_popularity row -> the null-OUTPUT path).
+    const libFallback = byId.get(PROBE_POP_LIBFALLBACK);
+    expect(libFallback).toBeDefined();
+    expect(libFallback.popularity).toBe(POP_LIBFALLBACK_TOTAL);
   });
 
   test('returns 304 when If-Modified-Since matches the current watermark', async () => {

--- a/tests/unit/services/catalog-export.serialize.test.ts
+++ b/tests/unit/services/catalog-export.serialize.test.ts
@@ -17,6 +17,7 @@ const sampleRow = (overrides: Partial<CatalogExportRow> = {}): CatalogExportRow 
   format_name: 'CD',
   on_streaming: true,
   plays: 12,
+  popularity: 17,
   artwork_url: 'https://example.test/doga.jpg',
   rotation_bin: 'H',
   rotation_kill_date: '2026-07-01',
@@ -35,7 +36,7 @@ describe('catalog-export.service: serializeCatalogNdjson', () => {
     expect(JSON.parse(lines[1])).toEqual(rows[1]);
   });
 
-  it('emits exactly the 14 contract fields per line and excludes search_doc', () => {
+  it('emits exactly the 15 contract fields per line and excludes search_doc', () => {
     // The field set is the acceptance criterion for #1468. A row carrying an
     // extra server-only field (e.g. search_doc) must not leak into the export.
     const rowWithExtra = {
@@ -61,6 +62,7 @@ describe('catalog-export.service: serializeCatalogNdjson', () => {
         'label',
         'on_streaming',
         'plays',
+        'popularity',
         'rotation_bin',
         'rotation_kill_date',
       ].sort()
@@ -73,13 +75,23 @@ describe('catalog-export.service: serializeCatalogNdjson', () => {
     expect(serializeCatalogNdjson([])).toBe('');
   });
 
-  it('preserves null rotation/streaming fields (album not in rotation)', () => {
-    const row = sampleRow({ rotation_bin: null, rotation_kill_date: null, on_streaming: null, plays: null });
+  it('preserves null rotation/streaming/popularity fields (album not in rotation, no logical popularity signal)', () => {
+    // `popularity` is the only field whose null is a distinct contract value: it
+    // ships raw-nullable (NOT COALESCEd to 0 like `plays`), so null must round-trip
+    // as JSON null and not be dropped or coerced (BS#1486 Track 3 / SSOT #198).
+    const row = sampleRow({
+      rotation_bin: null,
+      rotation_kill_date: null,
+      on_streaming: null,
+      plays: null,
+      popularity: null,
+    });
     const parsed = JSON.parse(serializeCatalogNdjson([row]));
 
     expect(parsed.rotation_bin).toBeNull();
     expect(parsed.rotation_kill_date).toBeNull();
     expect(parsed.on_streaming).toBeNull();
     expect(parsed.plays).toBeNull();
+    expect(parsed).toHaveProperty('popularity', null);
   });
 });


### PR DESCRIPTION
## What

The final delivery step of BS#1486 Phase-2: the catalog export (`GET /library/catalog`) now ships a `popularity` field — the attribution-corrected, master-collapsed signal from the `album_popularity` table that Track 2 (#1492) built. Consumers (the deferred ranked-bundle seed in WXYC/wxyc-dj-ios#44) can rank releases by real popularity, while `plays` stays the honest per-pressing linked count.

## How

`apps/backend/services/catalog-export.service.ts`:
- `popularity` added to the private `CatalogExportRow` type + `projectRow`.
- LEFT JOIN `album_popularity` on the row's **logical key**, derived by the same CASE the rebuild groups on: strip the `discogs:` namespace off `canonical_entity_id` (`discogs:master:<id>` → `master:<id>`), keep any other non-null scheme verbatim, else `library:<id>`. Cross-referenced to `album-popularity-refresh.service.ts` (the writer); a divergence would silently null popularity, so the pg integration spec guards the join end-to-end.
- Projected **raw** (`::int`, nullable), **not** `COALESCE(...,0)` like `plays`: `null` distinguishes "the logical album has no plays at all (linked or free-text)" from a genuine 0, per the merged SSOT contract (wxyc-shared#198).

## Dependency

`@wxyc/shared` bumped `^1.13.0` → `^1.15.0` — the release that published `popularity` to the SSOT `CatalogExportRow`. The parity drift-guard (`catalog-export.parity.test.ts`) reads the installed dist, so this bump is load-bearing (it goes red without it).

## Tests

- Parity guard passes (private type ↔ SSOT key sets agree at 15 fields).
- Integration (`pg`): two pressings of one Discogs master collapse to the same `popularity` (validates the logical-key join); the multi-pressing logical album's `popularity` ≥ a single pressing's `plays` (the #1493 acceptance criterion); a pressing with no plays of its own still shows the collapsed popularity; an unsignaled row ships `popularity: null` (raw, not 0).

## Scope

No migration (reads the existing `album_popularity`). No new endpoint. iOS / Kotlin decoders pick up `popularity` on their next `@wxyc/shared` regen — additive + nullable, so existing decoders keep working.

Closes #1493
