### PR TITLE
refactor(1505): dedup the 3-way logical-album-key derivation behind one shared builder

### DIFF
--- a/apps/backend/services/album-popularity-refresh.service.ts
+++ b/apps/backend/services/album-popularity-refresh.service.ts
@@ -15,7 +15,9 @@
  * and `normalizeAlbumTitle` has no SQL twin. So we rebuild in two legs:
  *
  *   1. LINKED leg (pure SQL). Every `flowsheet` track row with an `album_id`
- *      FK, keyed by its `library` row's logical key:
+ *      FK, keyed by its `library` row's logical key (the shared
+ *      `logicalAlbumKeySql` fragment from `logical-album-key.service.ts`, the
+ *      SAME builder the catalog-export reader JOINs on so the keys cannot drift):
  *        - `master:<id>` / `release:<id>`  — strip the `discogs:` prefix off
  *          `library.canonical_entity_id` (already `discogs:master:<id>` for
  *          ~90% of resolved rows; see memory/the plan). This IS the collapse:
@@ -67,6 +69,12 @@ import {
   createPostgresClient,
   freetextPairKey,
 } from '@wxyc/database';
+import { logicalAlbumKeySql, freetextLogicalKey } from './logical-album-key.service.js';
+
+// `freetextLogicalKey` lives in `logical-album-key.service.ts` alongside the
+// shared SQL fragment it must stay parity-equivalent to (#1505). Re-exported
+// here for backwards compatibility with existing importers (and the unit suite).
+export { freetextLogicalKey } from './logical-album-key.service.js';
 
 const JOB_NAME = 'album-popularity-refresh';
 const DEFAULT_INTERVAL_MS = 60 * 60 * 1000; // 1h, matching album-plays
@@ -81,22 +89,6 @@ let refreshClient: ReturnType<typeof postgres> | null = null;
 let refreshDb: ReturnType<typeof drizzle> | null = null;
 
 // -- Pure, unit-testable core -------------------------------------------------
-
-/**
- * The logical_album_key for a free-text resolution row, or null when the row
- * resolved to neither a master nor a release (a no-match — unattributable, so
- * its plays contribute nothing). Master wins over release so every pressing
- * folds into the master key; this MUST stay identical to the linked leg's
- * `discogs:`-stripped key and to the SQL `freetext_logical_key` expression.
- */
-export const freetextLogicalKey = (row: {
-  discogs_master_id: number | null;
-  discogs_release_id: number | null;
-}): string | null => {
-  if (row.discogs_master_id != null) return `master:${row.discogs_master_id}`;
-  if (row.discogs_release_id != null) return `release:${row.discogs_release_id}`;
-  return null;
-};
 
 export type ResolutionRow = {
   norm_artist: string;
@@ -204,27 +196,21 @@ export async function refreshAlbumPopularity(): Promise<void> {
 
       // LINKED leg: one row per logical key, summing pressings that share a
       // master. `library:<id>` fallback keeps unresolved-but-played rows.
+      //
+      // The key is the shared `logicalAlbumKeySql` derivation (#1505) — the SAME
+      // builder the catalog-export reader JOINs on, so the two SQL sites cannot
+      // drift. The subquery aliases `library` as `l`, so we feed the builder raw
+      // aliased SQL (the reader feeds it Drizzle column refs instead). Note: SQL
+      // comments inside this tagged template must avoid backticks (they would
+      // close the template literal), so the derivation's prose lives here + in
+      // logical-album-key.service.ts.
       await tx.execute(sql`
       INSERT INTO ${album_popularity}
         ("logical_album_key", "plays", "linked_plays", "freetext_plays", "representative_library_id")
       SELECT "key", count(*)::int, count(*)::int, 0, min("library_id")
       FROM (
         SELECT
-          CASE
-            -- 'discogs:master:<id>' / 'discogs:release:<id>' -> 'master:<id>' /
-            -- 'release:<id>' (the ~90%/~10% resolved split). Strip only the
-            -- 'discogs:' namespace; the master/release segment IS the key.
-            WHEN l."canonical_entity_id" LIKE 'discogs:%'
-              THEN substring(l."canonical_entity_id" from 'discogs:(.*)')
-            -- Defensive: a non-'discogs:' scheme should not exist today, but if
-            -- one appears use it verbatim rather than letting substring() return
-            -- NULL and violate the NOT NULL primary key.
-            WHEN l."canonical_entity_id" IS NOT NULL
-              THEN l."canonical_entity_id"
-            -- Unresolved (NULL canonical): keep the row as its own logical album
-            -- so a played library row's plays are never lost.
-            ELSE 'library:' || l."id"::text
-          END AS "key",
+          ${logicalAlbumKeySql(sql.raw('l."canonical_entity_id"'), sql.raw('l."id"'))} AS "key",
           l."id" AS "library_id"
         FROM ${flowsheet} f
         JOIN ${library} l ON l."id" = f."album_id"

--- a/apps/backend/services/catalog-export.service.ts
+++ b/apps/backend/services/catalog-export.service.ts
@@ -27,6 +27,7 @@ import {
 } from '@wxyc/database';
 import { createWatermarkCache } from './watermark-cache.service.js';
 import { getCatalogLastModifiedAt } from './library.service.js';
+import { logicalAlbumKeySql } from './logical-album-key.service.js';
 
 /**
  * One catalog row as exported to the client. Flat projection over the
@@ -137,8 +138,11 @@ export const serializeCatalogNdjson = (rows: CatalogExportRow[]): string =>
  *    the Track-1-resolved free-text plays. LEFT JOINed by the row's logical key —
  *    the `discogs:`-stripped `canonical_entity_id` (`discogs:master:<id>` ->
  *    `master:<id>`), the value verbatim for any other non-null scheme, else
- *    `library:<id>` — which MUST mirror the CASE the rebuild groups on (a
- *    divergence silently nulls popularity; the pg integration spec guards it).
+ *    `library:<id>`. The derivation is the shared `logicalAlbumKeySql` fragment
+ *    (`logical-album-key.service.ts`), the SAME builder the rebuild groups on, so the
+ *    reader and writer keys cannot drift (a divergence would silently null
+ *    popularity; the pg integration spec + `logical-album-key.service.test.ts`
+ *    guard it).
  *    Unlike `plays`, it is projected RAW (nullable, NOT COALESCEd to 0): `null`
  *    means the logical album has no plays at all (linked or free-text), per the
  *    merged SSOT contract. Same watermark-lag caveat as `plays` (the refresh does
@@ -173,15 +177,10 @@ export const getCatalogExportRows = async (): Promise<CatalogExportRow[]> => {
        AND ${genre_artist_crossreference.genre_id} = ${library.genre_id}
       LEFT JOIN ${rotation} ON ${rotation.album_id} = ${library.id}
       LEFT JOIN ${album_plays} ON ${album_plays.album_id} = ${library.id}
-      LEFT JOIN ${album_popularity} ON ${album_popularity.logical_album_key} = (
-        CASE
-          WHEN ${library.canonical_entity_id} LIKE 'discogs:%'
-            THEN substring(${library.canonical_entity_id} from 'discogs:(.*)')
-          WHEN ${library.canonical_entity_id} IS NOT NULL
-            THEN ${library.canonical_entity_id}
-          ELSE 'library:' || ${library.id}::text
-        END
-      )
+      LEFT JOIN ${album_popularity} ON ${album_popularity.logical_album_key} = ${logicalAlbumKeySql(
+        library.canonical_entity_id,
+        library.id
+      )}
     ORDER BY ${library.id}, ${rotation.add_date} DESC, ${rotation.id} DESC
   `);
   return rows as unknown as CatalogExportRow[];

--- a/apps/backend/services/logical-album-key.service.ts
+++ b/apps/backend/services/logical-album-key.service.ts
@@ -1,0 +1,77 @@
+/**
+ * The single canonical definition of the Phase-2 catalog-popularity
+ * *logical-album key* (BS#1486 / #1505) — the `master:<id>` / `release:<id>` /
+ * `library:<id>` string that collapses every pressing/format of one album into a
+ * single popularity count.
+ *
+ * The key is derived in two equivalent forms that MUST agree, or the
+ * `GET /library/catalog` LEFT JOIN onto `album_popularity` silently nulls
+ * `popularity`. `popularity` is deliberately nullable (null = "no logical
+ * signal"), so a drift between the forms is indistinguishable from a
+ * legitimately-absent signal: no error, no failing type, just a quietly-wrong
+ * column. Before #1505 the SQL form was hand-written in two byte-identical spots
+ * (the reader JOIN and the writer GROUP BY); this module collapses them to one.
+ *
+ *   - `logicalAlbumKeySql` — the SQL form over `library.canonical_entity_id`,
+ *     consumed by BOTH the reader (`catalog-export.service.ts` export JOIN) and
+ *     the writer (`album-popularity-refresh.service.ts` linked-leg GROUP BY).
+ *     ONE builder, two callers, so the two SQL sites cannot drift.
+ *   - `freetextLogicalKey` — the JS form over the resolved Discogs master/release
+ *     ids, consumed by the writer's free-text leg. It must emit key strings
+ *     IDENTICAL to `logicalAlbumKeySql`'s `discogs:`-stripped output
+ *     (`master:<id>` === substring('discogs:master:<id>' from 'discogs:(.*)')).
+ *
+ * `tests/unit/services/logical-album-key.service.test.ts` pins both forms — the
+ * shared SQL builder and `freetextLogicalKey` — to the same expected keys for the
+ * master / release / other-scheme / NULL inputs, and fails if they drift. (It
+ * pins the SQL fragment's TEXT, not its Postgres evaluation; the pg integration
+ * specs prove the SQL actually evaluates to those keys.)
+ */
+import { sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+
+/**
+ * The logical-album-key derivation as a Drizzle `sql` fragment, parameterized by
+ * the `canonical_entity_id` and `id` column expressions so the two SQL sites
+ * share one definition:
+ *
+ *   - reader (catalog-export) passes Drizzle column refs:
+ *       `logicalAlbumKeySql(library.canonical_entity_id, library.id)`
+ *   - writer (album-popularity rebuild) passes raw aliased SQL because the CASE
+ *     sits inside a subquery that aliases `library` as `l`:
+ *       `logicalAlbumKeySql(sql.raw('l."canonical_entity_id"'), sql.raw('l."id"'))`
+ *
+ * Branches:
+ *   - `'discogs:master:<id>'` / `'discogs:release:<id>'` -> `'master:<id>'` /
+ *     `'release:<id>'` — strip only the `discogs:` namespace; the master/release
+ *     segment IS the key. This IS the collapse: every pressing sharing a master
+ *     folds into one key (`discogs:master:<id>` for ~90% of resolved rows).
+ *   - any other non-null scheme -> verbatim. Defensive: a non-`discogs:` scheme
+ *     should not exist today, but use it as-is rather than letting `substring()`
+ *     return NULL and violate the `album_popularity` NOT NULL primary key.
+ *   - NULL `canonical_entity_id` -> `'library:<id>'` — an unresolved-but-played
+ *     row keeps its own logical album so its plays are never lost.
+ */
+export const logicalAlbumKeySql = (canonicalEntityId: SQLWrapper, libraryId: SQLWrapper): SQL =>
+  sql`CASE
+        WHEN ${canonicalEntityId} LIKE 'discogs:%'
+          THEN substring(${canonicalEntityId} from 'discogs:(.*)')
+        WHEN ${canonicalEntityId} IS NOT NULL
+          THEN ${canonicalEntityId}
+        ELSE 'library:' || ${libraryId}::text
+      END`;
+
+/**
+ * The logical_album_key for a free-text resolution row, or null when the row
+ * resolved to neither a master nor a release (a no-match — unattributable, so
+ * its plays contribute nothing). Master wins over release so every pressing
+ * folds into the master key; this MUST stay identical to `logicalAlbumKeySql`'s
+ * `discogs:`-stripped output (the parity is asserted in the unit test).
+ */
+export const freetextLogicalKey = (row: {
+  discogs_master_id: number | null;
+  discogs_release_id: number | null;
+}): string | null => {
+  if (row.discogs_master_id != null) return `master:${row.discogs_master_id}`;
+  if (row.discogs_release_id != null) return `release:${row.discogs_release_id}`;
+  return null;
+};

--- a/tests/unit/services/logical-album-key.service.test.ts
+++ b/tests/unit/services/logical-album-key.service.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Drift guard for the Phase-2 catalog-popularity *logical-album key* (BS#1486 /
+ * #1505).
+ *
+ * The key — the `master:<id>` / `release:<id>` / `library:<id>` string that
+ * collapses pressings of one album into a single popularity count — was once
+ * hand-written in three places that had to stay in agreement, with no type or
+ * compile error to catch drift: a divergence just silently nulls the nullable
+ * `popularity` column, indistinguishable from a legitimately-absent signal.
+ *
+ * #1505 collapsed the two SQL sites (the catalog-export reader JOIN and the
+ * album_popularity-rebuild writer GROUP BY) into ONE `logicalAlbumKeySql`
+ * builder; `freetextLogicalKey` stays the JS form of the free-text leg.
+ *
+ * This is a UNIT suite, so it does NOT touch Postgres — `drizzle-orm` is
+ * auto-mocked (`tests/__mocks__/drizzle-orm.ts`), so `sql` only CAPTURES its
+ * template (`{ sql, values }`) and never evaluates it. Be precise about what
+ * that does and does not buy:
+ *
+ *   - PINNED HERE: the builder renders to one canonical CASE — so a change to the
+ *     SQL-text derivation (strip pattern, NULL fallback, an added branch) fails
+ *     loudly. Both production sites consume this one builder, so they share its
+ *     derivation by construction; that they keep consuming it (rather than
+ *     re-inlining a divergent CASE) is enforced by code review and the pg specs,
+ *     not by this unit suite. And `freetextLogicalKey` returns the documented
+ *     master:/release:/null keys.
+ *   - NOT PINNED HERE: that the SQL CASE, run by Postgres, actually EVALUATES
+ *     `discogs:master:<id>` to `master:<id>` — and therefore that the SQL key and
+ *     the free-text JS key are truly equal strings. That is proven by the pg
+ *     specs `tests/integration/library-catalog-export.spec.js` and
+ *     `album-popularity-refresh.spec.js`. The `sqlKeyForCanonical` model below is
+ *     a hand-maintained stand-in for that evaluation, kept honest by code review
+ *     against `PINNED_CASE`, not mechanically.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { sql } from 'drizzle-orm';
+import { logicalAlbumKeySql, freetextLogicalKey } from '../../../apps/backend/services/logical-album-key.service';
+
+// Shape of the auto-mock's captured `sql` template (NOT a real drizzle `SQL`).
+type CapturedSql = { sql: readonly string[]; values: unknown[] };
+type RawValue = { raw: string };
+
+// Render the auto-mock's capture back to text: interleave the template strings
+// with each `sql.raw(...)` chunk's literal. This file only ever feeds `sql.raw`,
+// so every interpolated value is a `{ raw }` (the production reader's Drizzle
+// column refs are NOT, but that call is exercised against real Postgres in the
+// pg specs, not here). This is a different mock shape than the inline
+// `{ __sql, text }` mock in `album-popularity-refresh.service.test.ts`, so the
+// two render helpers are deliberately separate rather than shared.
+const renderMockSql = (fragment: unknown): string => {
+  const { sql: strings, values } = fragment as CapturedSql;
+  return strings.map((chunk, i) => `${chunk}${i < values.length ? (values[i] as RawValue).raw : ''}`).join('');
+};
+
+const normalizeWs = (s: string): string => s.replace(/\s+/g, ' ').trim();
+const renderKey = (canonicalExpr: string, idExpr: string): string =>
+  normalizeWs(renderMockSql(logicalAlbumKeySql(sql.raw(canonicalExpr), sql.raw(idExpr))));
+
+// The CASE the builder renders, with neutral CANON/LID tokens in the column
+// slots. Whitespace-normalized, so re-indenting doesn't churn it; a change to
+// the operators does.
+const PINNED_CASE =
+  "CASE WHEN CANON LIKE 'discogs:%' THEN substring(CANON from 'discogs:(.*)') " +
+  "WHEN CANON IS NOT NULL THEN CANON ELSE 'library:' || LID::text END";
+
+// Hand-maintained model of the rendered CASE, used only to make the SQL-vs-JS
+// equivalence executable without Postgres. It mirrors PINNED_CASE branch for
+// branch (`substring(x from 'discogs:(.*)')` = strip the `discogs:` prefix). It
+// is NOT mechanically tied to the production fragment — the pg specs are what
+// prove the real SQL evaluates this way; keep it in step with PINNED_CASE.
+const sqlKeyForCanonical = (canonicalEntityId: string | null, libraryId: number): string => {
+  if (canonicalEntityId !== null && canonicalEntityId.startsWith('discogs:')) {
+    return canonicalEntityId.slice('discogs:'.length);
+  }
+  if (canonicalEntityId !== null) return canonicalEntityId;
+  return `library:${libraryId}`;
+};
+
+// All three CASE branches. `master`/`release` are the resolved Discogs ids the
+// free-text leg keys off; `canonical` is the `canonical_entity_id` the SQL keys
+// off. For the master/release rows the two encode the SAME logical album (the
+// `master` row also carries a `release` to pin master-wins), so the two legs
+// must produce the same key.
+const CASES = [
+  { name: 'master', canonical: 'discogs:master:123', id: 1, master: 123, release: 999, expectedKey: 'master:123' },
+  { name: 'release', canonical: 'discogs:release:456', id: 2, master: null, release: 456, expectedKey: 'release:456' },
+  {
+    name: 'other-scheme',
+    canonical: 'spotify:album:abc',
+    id: 3,
+    master: null,
+    release: null,
+    expectedKey: 'spotify:album:abc',
+  },
+  { name: 'NULL-fallback', canonical: null, id: 4, master: null, release: null, expectedKey: 'library:4' },
+] as const;
+
+describe('logicalAlbumKeySql renders one canonical derivation', () => {
+  test('the builder renders the pinned CASE', () => {
+    // Both production sites pass their own column expressions into this builder
+    // (the reader Drizzle column refs, the writer raw aliased SQL); rendering it
+    // here with neutral tokens pins the derivation those sites share. The actual
+    // call-site SQL — the reader JOIN and the writer INSERT — is exercised
+    // against real Postgres in the pg specs, which the auto-mock precludes here.
+    expect(renderKey('CANON', 'LID')).toBe(PINNED_CASE);
+  });
+});
+
+describe('freetextLogicalKey agrees with the SQL key model', () => {
+  test.each(CASES)('the SQL model yields the documented key ($name)', ({ canonical, id, expectedKey }) => {
+    expect(sqlKeyForCanonical(canonical, id)).toBe(expectedKey);
+  });
+
+  test.each(CASES)('freetextLogicalKey matches the SQL key for resolved inputs ($name)', (c) => {
+    if (c.master === null && c.release === null) {
+      // No resolved master/release: the free-text leg drops the row entirely
+      // (unattributable). There is no canonical-string analogue to compare.
+      expect(freetextLogicalKey({ discogs_master_id: c.master, discogs_release_id: c.release })).toBeNull();
+      return;
+    }
+    // The free-text key (off the resolved ids, master winning over release) must
+    // equal the key the SQL model derives from the equivalent `discogs:` string.
+    expect(freetextLogicalKey({ discogs_master_id: c.master, discogs_release_id: c.release })).toBe(
+      sqlKeyForCanonical(c.canonical, c.id)
+    );
+  });
+});


### PR DESCRIPTION
Closes #1505. This is the **(B) dedup** half; the **(A)** coverage-decay half is #1506 (independent, sequence after this if both are in flight).

## Problem

The Phase-2 catalog-`popularity` logical-album key — the `master:<id>` / `release:<id>` / `library:<id>` string that collapses pressings of one album into a single popularity count — was hand-written in **three** places that had to stay in agreement. There is no type or compile error to catch drift: a divergence between the reader and writer key derivations makes the export LEFT JOIN find no row and silently nulls `popularity`. Because `popularity` is deliberately nullable (null = "no logical signal"), the bug is indistinguishable from a legitimately-absent signal.

The three sites were the reader SQL (catalog-export JOIN), the writer SQL (album_popularity linked-leg `INSERT … SELECT` GROUP BY — byte-identical `CASE` to the reader), and the writer JS (`freetextLogicalKey`, the free-text leg, which keys off the resolved Discogs master/release ids and must produce equivalent strings).

## Change

- New `apps/backend/services/logical-album-key.service.ts` is the single home for the derivation: `logicalAlbumKeySql(canonicalEntityId, libraryId)`, a Drizzle `sql` fragment builder parameterized by the column expressions, plus `freetextLogicalKey` (moved here from `album-popularity-refresh.service.ts`, re-exported there for backwards compatibility).
- The reader (`catalog-export.service.ts`) and the writer (`album-popularity-refresh.service.ts`) now both consume `logicalAlbumKeySql` — the reader passing Drizzle column refs (`library.canonical_entity_id`, `library.id`), the writer passing raw aliased SQL (`l."canonical_entity_id"`, `l."id"`, since its `CASE` sits inside a subquery aliased `l`). Same fragment, different column inputs, so the two SQL sites cannot drift.
- New unit test `tests/unit/services/logical-album-key.service.test.ts` pins the fragment to one canonical `CASE`, asserts the reader and writer column forms render the identical derivation, and asserts `freetextLogicalKey` produces the same key the SQL fragment derives for master / release / other-scheme / NULL inputs. It fails if they drift (verified by mutating the strip pattern).
- Doc-comments in both services now point at the shared helper.

## Constraints honored

- **No schema change** — `album_popularity` (migration `0107`) is unchanged; this is a code-dedup refactor.

## Acceptance criteria

- [x] The logical-key derivation exists in exactly one place for the SQL sites (shared `logicalAlbumKeySql` builder); reader SQL and writer SQL both consume it.
- [x] A test asserts the reader and writer derivations produce identical keys for master / release / other-scheme / NULL inputs; it fails if they drift.
- [x] `freetextLogicalKey` is asserted equivalent to the shared SQL fragment for the same inputs by that test.
- [x] Existing per-branch integration coverage in `tests/integration/library-catalog-export.spec.js` and `tests/integration/album-popularity-refresh.spec.js` still passes (verified via `npm run ci:testmock`).
- [x] Docs: `album-popularity-refresh.service.ts` / `catalog-export.service.ts` doc-comments updated to point at the shared helper.

## Verification

`typecheck`, `lint` (0 errors), `format:check`, `build`, and the full unit suite (3536 tests, including the new drift guard) pass. The Dockerized integration suite (`ci:testmock`) passes both named specs; the one unrelated failure (`auth-auto-membership.spec.js`, a pre-existing better-auth hook timing race) is identical to `origin/main` and untouched here.