### PR TITLE
feat(lml-client): re-export DiscogsWriterCredits + bump @wxyc/shared to 1.16.0 (BS#1499 PR-2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6094,9 +6094,9 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "1.15.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.15.0/4f5abe0230cabb364ef42cc5525f3e2eb35c8c58",
-      "integrity": "sha512-SIBAvLc0lQ31n6aYlSUlSZw4CwPeLcasStcWXcca6h44tmZR8qAHDrM+POhQvQUBwVFWmvn8VEJVvlb9NB/jlA==",
+      "version": "1.16.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.16.0/270ba285feff65253fc48224d8fd03ea952007f0",
+      "integrity": "sha512-oq/U4QWVAP0EhhAap++XklJHPCpRbDF7eIlNJgKMfylEkS4s32uzNH+ltuV+/8NaqNFCiKgZZa+ArrqQ06j0WQ==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"
@@ -14645,7 +14645,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^10.59.0",
-        "@wxyc/shared": "^1.12.0"
+        "@wxyc/shared": "^1.16.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.59.0",
-    "@wxyc/shared": "^1.12.0"
+    "@wxyc/shared": "^1.16.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -22,6 +22,7 @@ import type {
 
 export type {
   DiscogsMatchResult,
+  DiscogsWriterCredits,
   DiscogsReleaseMetadata,
   DiscogsTrackItem,
   DiscogsArtistCredit,


### PR DESCRIPTION
## PR-2 — cross-repo type surface (BS#1499)

Mechanical, additive type-surface change. PR-2 of the 3-PR `flowsheet.composer` plan (`plans/bs1499-flowsheet-composer.md`).

### What changed
- **Bump `@wxyc/shared` to `^1.16.0`** in `shared/lml-client/package.json` (was `^1.12.0`). v1.16.0 is the release carrying `DiscogsWriterCredits` and the optional `DiscogsMatchResult.writer_credits` field (`wxyc-shared#200`, shipped 2026-06-29).
- **Re-export `DiscogsWriterCredits`** from `@wxyc/lml-client` — one new line in the existing `export type { … }` block in `shared/lml-client/src/index.ts`, imported from `@wxyc/shared/dtos` alongside its siblings. This lets PR-3's `resolveComposer` helper name the type in its signature. (`DiscogsMatchResult` is already re-exported, so `artwork.writer_credits` is reachable the moment the dep bump lands; the new re-export is purely for ergonomic naming.)
- **Lockfile**: `npm install` resolved the single hoisted `@wxyc/shared` from 1.15.0 → 1.16.0.

### Workspace consistency
This is an npm-workspaces monorepo with a single hoisted `@wxyc/shared`. 1.16.0 satisfies every existing pin (`apps/backend` `^1.15.0`; `apps/auth` / `shared/authentication` `^1.12.0`), so the hoist resolves cleanly to 1.16.0 with no stranded workspace and **no companion `package.json` bump required**. `writer_credits` / `DiscogsWriterCredits` is consumed nowhere in `apps/backend` today (only PR-3's future code uses it).

### Freeze-safe
Additive/mechanical. Touches only `shared/lml-client` + the lockfile — **not** any Project #32 hot file (`apps/enrichment-worker/enrich.ts`, metadata/lml services, orchestrator). Safe to land during the CDC-pipeline freeze; unblocks PR-3's helper signature early.

### Verification
Type-surface change → verification is typecheck + build green plus the existing suites staying green. All run locally on the worktree:
- `npm run typecheck` ✅ (9 workspaces, 0 errors)
- `npm run lint` ✅ (0 errors) · `npm run format:check` ✅
- `npm run build` ✅
- `npm run test:unit` ✅ (252 suites / 3525 tests)

No test added: `shared/lml-client` has no co-located `tests/` dir / types-construction pattern, and an "is-importable" assertion for a pure type re-export is already covered by typecheck — adding a bespoke harness would be contrived (per the plan's TDD posture for a type-surface PR).

Part of #1499