### PR TITLE
feat(enrichment-worker): write composer + composer_source on flowsheet finalize (BS#1499 PR-3)

### DIFF
--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -90,9 +90,13 @@ type ComposerResolution = { composer: string; composer_source: ComposerSource };
  */
 export const resolveComposer = (row: EnrichRow, artwork: DiscogsMatchResult | null): ComposerResolution => {
   const wc = artwork?.writer_credits;
-  if (wc?.names?.length) {
+  // Drop blank names so a stray empty entry can't yield an empty composer
+  // mislabeled as a real Discogs credit (#1500's BMI export reads this
+  // verbatim); fall through to the artist proxy when nothing real remains.
+  const names = wc?.names?.filter((n) => n.trim());
+  if (wc && names?.length) {
     return {
-      composer: wc.names.join('; '),
+      composer: names.join('; '),
       composer_source: wc.provenance === 'track' ? 'discogs_track' : 'discogs_release',
     };
   }

--- a/apps/enrichment-worker/enrich.ts
+++ b/apps/enrichment-worker/enrich.ts
@@ -66,6 +66,40 @@ export type FinalizeOutcome =
   | 'enriched_no_match_raced';
 
 /**
+ * BMI composer provenance (BS#1499). Enum-like text on the flowsheet row,
+ * mirroring the `linkage_source` precedent in the same table — kept open as
+ * text (not a pg enum) so a future source (e.g. `musicbrainz_work`, flagged
+ * by LML#699) needs no enum migration. Const-asserted so every `.set({...})`
+ * call below is type-checked against exactly these three values.
+ */
+export type ComposerSource = 'discogs_track' | 'discogs_release' | 'artist_proxy';
+type ComposerResolution = { composer: string; composer_source: ComposerSource };
+
+/**
+ * Resolve the BMI composer for a playcut from LML's writer credits, with an
+ * artist-as-proxy fallback when nothing resolved (the dominant ~79% case per
+ * LML#699 — expected, not a regression; it mirrors tubafrenzy's existing
+ * auto-fill-BMI_COMPOSER-from-Artist default).
+ *
+ * Names join with `'; '` because Discogs writer names can themselves contain
+ * commas ("Last, First"), so a comma delimiter would be ambiguous; #1500's
+ * BMI export owns the field/record delimiters.
+ *
+ * This ternary is the SOLE site mapping `writer_credits.provenance` →
+ * `composer_source`; no other caller should invent a value.
+ */
+export const resolveComposer = (row: EnrichRow, artwork: DiscogsMatchResult | null): ComposerResolution => {
+  const wc = artwork?.writer_credits;
+  if (wc?.names?.length) {
+    return {
+      composer: wc.names.join('; '),
+      composer_source: wc.provenance === 'track' ? 'discogs_track' : 'discogs_release',
+    };
+  }
+  return { composer: row.artist_name, composer_source: 'artist_proxy' };
+};
+
+/**
  * Synthesized search URLs (per-service semantics deliberately asymmetric):
  *   - Spotify:       trackTitle > albumTitle > artistName. Path-style URL
  *                    matches LML's `_build_streaming_search_url` byte-for-byte
@@ -139,6 +173,10 @@ export const extractArtwork = (response: LookupResponse): DiscogsMatchResult | n
 export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Promise<FinalizeOutcome> => {
   const artwork = extractArtwork(response);
   const searchUrls = synthesizeSearchUrls(row);
+  // BS#1499: composer is a per-playcut property, so it rides the flowsheet
+  // UPDATE in all four arms below (never the album-keyed album_metadata
+  // UPSERT). Resolved once here; artist-as-proxy fallback on absent credit.
+  const { composer, composer_source } = resolveComposer(row, artwork);
 
   if (artwork) {
     if (row.album_id !== null) {
@@ -191,7 +229,9 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
         });
       const updated = await db
         .update(flowsheet)
-        .set({ metadata_status: 'enriched_match' })
+        // composer rides the flowsheet UPDATE, not the album_metadata UPSERT
+        // above (per-playcut, not album-level — BS#1499).
+        .set({ metadata_status: 'enriched_match', composer, composer_source })
         .where(and(eq(flowsheet.id, row.id), eq(flowsheet.metadata_status, 'enriching')))
         .returning({ id: flowsheet.id });
       return updated.length === 0 ? 'enriched_match_raced' : 'enriched_match';
@@ -216,6 +256,9 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
         artist_bio: artwork.artist_bio ? cleanDiscogsBio(artwork.artist_bio) : null,
         artist_wikipedia_url: artwork.wikipedia_url ?? null,
         metadata_status: 'enriched_match',
+        // BS#1499: per-playcut composer, alongside the inline metadata columns.
+        composer,
+        composer_source,
       })
       .where(and(eq(flowsheet.id, row.id), eq(flowsheet.metadata_status, 'enriching')))
       .returning({ id: flowsheet.id });
@@ -255,7 +298,10 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
       });
     const updated = await db
       .update(flowsheet)
-      .set({ metadata_status: 'enriched_no_match' })
+      // composer rides the flowsheet UPDATE, not the album_metadata UPSERT
+      // above (per-playcut, not album-level — BS#1499). On no-match this is
+      // the artist-as-proxy value.
+      .set({ metadata_status: 'enriched_no_match', composer, composer_source })
       .where(and(eq(flowsheet.id, row.id), eq(flowsheet.metadata_status, 'enriching')))
       .returning({ id: flowsheet.id });
     return updated.length === 0 ? 'enriched_no_match_raced' : 'enriched_no_match';
@@ -269,6 +315,9 @@ export const finalizeRow = async (row: EnrichRow, response: LookupResponse): Pro
       bandcamp_url: searchUrls.bandcamp_url,
       soundcloud_url: searchUrls.soundcloud_url,
       metadata_status: 'enriched_no_match',
+      // BS#1499: per-playcut composer (artist-as-proxy on no-match).
+      composer,
+      composer_source,
     })
     .where(and(eq(flowsheet.id, row.id), eq(flowsheet.metadata_status, 'enriching')))
     .returning({ id: flowsheet.id });

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -91,6 +91,34 @@ const extendedMatchResponse = {
         tracklist: [{ position: '1', title: 'la paradoja', duration: '4:12' }],
         artist_image_url: 'https://i.discogs.com/artist/juana.jpg',
         profile_tokens: [{ type: 'plainText', text: 'Argentine musician' }],
+        // BS#1499: track-level (precise) writer credit. provenance 'track'
+        // → composer_source = 'discogs_track'; composer = joined names.
+        writer_credits: {
+          names: ['Juana Molina'],
+          roles: ['Written-By'],
+          provenance: 'track',
+          track_position: 'A1',
+        },
+      },
+    },
+  ],
+} as unknown as LookupResponse;
+
+// Release-level (approximate) writer credit (BS#1499): provenance 'release'
+// → composer_source = 'discogs_release'. Multiple names join with '; '.
+// Exercises the linked + unlinked match arms with a release-provenance writer.
+const releaseWriterMatchResponse = {
+  results: [
+    {
+      artwork: {
+        artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+        release_url: 'https://discogs.com/release/123',
+        release_year: 2022,
+        writer_credits: {
+          names: ['Sessa', 'Bianca Vianna'],
+          roles: ['Written-By', 'Music By'],
+          provenance: 'release',
+        },
       },
     },
   ],
@@ -122,6 +150,29 @@ describe('finalizeRow (BS#892 PR-2)', () => {
     expect(setCall.soundcloud_url).toContain('soundcloud.com/search');
     expect(setCall.artist_bio).toBe('A great Some Artist from Argentina.');
     expect(setCall.artist_wikipedia_url).toBe('https://en.wikipedia.org/wiki/Juana_Molina');
+    // BS#1499: matchResponse carries no writer_credits → artist-as-proxy.
+    expect(setCall.composer).toBe('Juana Molina');
+    expect(setCall.composer_source).toBe('artist_proxy');
+  });
+
+  it('on match with a track-level writer credit: writes composer + discogs_track on flowsheet (BS#1499)', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    await finalizeRow(ROW, extendedMatchResponse);
+
+    const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setCall.composer).toBe('Juana Molina');
+    expect(setCall.composer_source).toBe('discogs_track');
+  });
+
+  it('on match with a release-level writer credit: joins names with "; " + discogs_release on flowsheet (BS#1499)', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    await finalizeRow(ROW, releaseWriterMatchResponse);
+
+    const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setCall.composer).toBe('Sessa; Bianca Vianna');
+    expect(setCall.composer_source).toBe('discogs_release');
   });
 
   it('on no-match: writes 4 synthesized search URLs and flips status to enriched_no_match', async () => {
@@ -146,6 +197,9 @@ describe('finalizeRow (BS#892 PR-2)', () => {
     expect(setCall.youtube_music_url).toContain('music.youtube.com/search');
     expect(setCall.bandcamp_url).toContain('bandcamp.com/search');
     expect(setCall.soundcloud_url).toContain('soundcloud.com/search');
+    // BS#1499: no match → no writer credit → artist-as-proxy composer.
+    expect(setCall.composer).toBe('Juana Molina');
+    expect(setCall.composer_source).toBe('artist_proxy');
   });
 
   it('returns _raced when the UPDATE matches 0 rows (status left enriching between claim and finalize)', async () => {
@@ -289,6 +343,39 @@ describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata
     expect(setCall.soundcloud_url).toBeUndefined();
     expect(setCall.artist_bio).toBeUndefined();
     expect(setCall.artist_wikipedia_url).toBeUndefined();
+    // BS#1499: composer is the deliberate exception — it IS written on the
+    // flowsheet UPDATE (it's a per-playcut property, not album-level), even
+    // though every other metadata column routes through album_metadata.
+    // matchResponse has no writer_credits → artist-as-proxy fallback.
+    expect(setCall.composer).toBe('Juana Molina');
+    expect(setCall.composer_source).toBe('artist_proxy');
+  });
+
+  it('linked match: composer rides the flowsheet UPDATE, not album_metadata (BS#1499)', async () => {
+    // The load-bearing design decision: composer is a property of the
+    // specific playcut (the track that played), not the album. album_metadata
+    // is album-keyed, so two flowsheet rows that played different tracks off
+    // the same release would clobber each other's composer there. Therefore
+    // composer/composer_source must land on the flowsheet UPDATE and must be
+    // ABSENT from the album_metadata UPSERT (insert + conflict-update) payload.
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 42 }]);
+
+    await finalizeRow(LINKED_ROW, extendedMatchResponse);
+
+    // Flowsheet UPDATE carries composer (track-level credit → discogs_track).
+    const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setCall.composer).toBe('Juana Molina');
+    expect(setCall.composer_source).toBe('discogs_track');
+
+    // album_metadata INSERT payload OMITS composer entirely.
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload.composer).toBeUndefined();
+    expect(insertPayload.composer_source).toBeUndefined();
+
+    // album_metadata conflict-update set OMITS composer entirely.
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as { set: Record<string, unknown> };
+    expect(conflictCfg.set.composer).toBeUndefined();
+    expect(conflictCfg.set.composer_source).toBeUndefined();
   });
 
   it('on extended match: UPSERTs the 8 LML-only columns into album_metadata (BS#1336)', async () => {
@@ -389,6 +476,14 @@ describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata
     const setCall = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(setCall.metadata_status).toBe('enriched_no_match');
     expect(setCall).not.toHaveProperty('youtube_music_url');
+    // BS#1499: linked no-match still writes composer on the flowsheet UPDATE
+    // (artist-as-proxy, since there's no writer credit) — and never on
+    // album_metadata.
+    expect(setCall.composer).toBe('Juana Molina');
+    expect(setCall.composer_source).toBe('artist_proxy');
+    const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(insertPayload.composer).toBeUndefined();
+    expect(insertPayload.composer_source).toBeUndefined();
   });
 
   it('on match: returns enriched_match_raced when the flowsheet UPDATE matches 0 rows', async () => {

--- a/tests/unit/apps/enrichment-worker/enrich.test.ts
+++ b/tests/unit/apps/enrichment-worker/enrich.test.ts
@@ -484,6 +484,13 @@ describe('finalizeRow (BS#899 / Epic D D3) — linked row UPSERTs album_metadata
     const insertPayload = mockDb._chain.values.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(insertPayload.composer).toBeUndefined();
     expect(insertPayload.composer_source).toBeUndefined();
+    // …and not on the album_metadata conflict-update set either (symmetry with
+    // the linked-match load-bearing assertion).
+    const conflictCfg = mockDb._chain.onConflictDoUpdate.mock.calls[0]?.[0] as {
+      set: Record<string, unknown>;
+    };
+    expect(conflictCfg.set.composer).toBeUndefined();
+    expect(conflictCfg.set.composer_source).toBeUndefined();
   });
 
   it('on match: returns enriched_match_raced when the flowsheet UPDATE matches 0 rows', async () => {

--- a/tests/unit/apps/enrichment-worker/resolve-composer.test.ts
+++ b/tests/unit/apps/enrichment-worker/resolve-composer.test.ts
@@ -99,6 +99,15 @@ describe('resolveComposer (BS#1499 PR-3)', () => {
     });
   });
 
+  it("writer_credits present but names are all blank → artist_name + 'artist_proxy'", () => {
+    const artwork = artworkWith({ writer_credits: { names: ['', '  '], provenance: 'track' } });
+
+    expect(resolveComposer(ROW, artwork)).toEqual({
+      composer: 'Juana Molina',
+      composer_source: 'artist_proxy',
+    });
+  });
+
   it("no-match (artwork null) → artist_name + 'artist_proxy'", () => {
     expect(resolveComposer(ROW, null)).toEqual({
       composer: 'Juana Molina',

--- a/tests/unit/apps/enrichment-worker/resolve-composer.test.ts
+++ b/tests/unit/apps/enrichment-worker/resolve-composer.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for `resolveComposer` (BS#1499 PR-3).
+ *
+ * `resolveComposer` is the sole site that maps an LML
+ * `DiscogsMatchResult.writer_credits` block onto the BMI-ready
+ * `composer` / `composer_source` pair written on the flowsheet row by
+ * `finalizeRow`. It is pure (no DB), so this file takes no `pg` marker and
+ * does no DB setup — mirroring `synthesize-search-urls-parity.test.ts`.
+ *
+ * Contract pinned here:
+ *   - `provenance: 'track'`   → `composer_source = 'discogs_track'`.
+ *   - `provenance: 'release'` → `composer_source = 'discogs_release'`.
+ *   - multiple names join with `'; '` (Discogs writer names can carry
+ *     commas, e.g. "Last, First", so a comma delimiter would be ambiguous).
+ *   - match but `writer_credits` undefined → artist-as-proxy fallback.
+ *   - no-match (artwork null)             → artist-as-proxy fallback.
+ *
+ * The artist-proxy fallback dominating (~79% of plays per LML#699) is
+ * expected, not a regression — it mirrors tubafrenzy's existing
+ * auto-fill-BMI_COMPOSER-from-Artist default.
+ */
+
+import type { DiscogsMatchResult } from '@wxyc/lml-client';
+import { resolveComposer } from '../../../../apps/enrichment-worker/enrich';
+import type { EnrichRow } from '../../../../apps/enrichment-worker/enrich';
+
+const ROW: EnrichRow = {
+  id: 1,
+  artist_name: 'Juana Molina',
+  album_title: 'DOGA',
+  track_title: 'la paradoja',
+  album_id: null,
+};
+
+// Helper: build a minimal artwork carrying only the writer_credits we vary.
+const artworkWith = (writer_credits: unknown): DiscogsMatchResult =>
+  ({ writer_credits } as unknown as DiscogsMatchResult);
+
+describe('resolveComposer (BS#1499 PR-3)', () => {
+  it("provenance 'track' → joined names + 'discogs_track'", () => {
+    const artwork = artworkWith({
+      names: ['Juana Molina'],
+      roles: ['Written-By'],
+      provenance: 'track',
+      track_position: 'A1',
+    });
+
+    expect(resolveComposer(ROW, artwork)).toEqual({
+      composer: 'Juana Molina',
+      composer_source: 'discogs_track',
+    });
+  });
+
+  it("provenance 'release' → joined names + 'discogs_release'", () => {
+    const artwork = artworkWith({
+      names: ['Sessa', 'Bianca Vianna'],
+      roles: ['Written-By', 'Music By'],
+      provenance: 'release',
+    });
+
+    expect(resolveComposer(ROW, artwork)).toEqual({
+      composer: 'Sessa; Bianca Vianna',
+      composer_source: 'discogs_release',
+    });
+  });
+
+  it("joins multiple names with '; ' (not ',', which Discogs names can contain)", () => {
+    const artwork = artworkWith({
+      names: ['Molina, Juana', 'Vianna, Bianca'],
+      provenance: 'track',
+      track_position: 'A1',
+    });
+
+    expect(resolveComposer(ROW, artwork).composer).toBe('Molina, Juana; Vianna, Bianca');
+  });
+
+  it("match but writer_credits undefined → artist_name + 'artist_proxy'", () => {
+    const artwork = artworkWith(undefined);
+
+    expect(resolveComposer(ROW, artwork)).toEqual({
+      composer: 'Juana Molina',
+      composer_source: 'artist_proxy',
+    });
+  });
+
+  it("writer_credits present but names empty → artist_name + 'artist_proxy'", () => {
+    const artwork = artworkWith({ names: [], provenance: 'release' });
+
+    expect(resolveComposer(ROW, artwork)).toEqual({
+      composer: 'Juana Molina',
+      composer_source: 'artist_proxy',
+    });
+  });
+
+  it("no-match (artwork null) → artist_name + 'artist_proxy'", () => {
+    expect(resolveComposer(ROW, null)).toEqual({
+      composer: 'Juana Molina',
+      composer_source: 'artist_proxy',
+    });
+  });
+});

--- a/tests/unit/apps/enrichment-worker/resolve-composer.test.ts
+++ b/tests/unit/apps/enrichment-worker/resolve-composer.test.ts
@@ -32,17 +32,20 @@ const ROW: EnrichRow = {
   album_id: null,
 };
 
-// Helper: build a minimal artwork carrying only the writer_credits we vary.
-const artworkWith = (writer_credits: unknown): DiscogsMatchResult =>
-  ({ writer_credits } as unknown as DiscogsMatchResult);
+// Build a minimal artwork carrying only the writer_credits we vary. Other
+// DiscogsMatchResult fields are irrelevant to resolveComposer, so the literal
+// stays partial; `resolveComposer` only reads `writer_credits`.
+const artworkWith = (artwork: Partial<DiscogsMatchResult>): Partial<DiscogsMatchResult> => artwork;
 
 describe('resolveComposer (BS#1499 PR-3)', () => {
   it("provenance 'track' → joined names + 'discogs_track'", () => {
     const artwork = artworkWith({
-      names: ['Juana Molina'],
-      roles: ['Written-By'],
-      provenance: 'track',
-      track_position: 'A1',
+      writer_credits: {
+        names: ['Juana Molina'],
+        roles: ['Written-By'],
+        provenance: 'track',
+        track_position: 'A1',
+      },
     });
 
     expect(resolveComposer(ROW, artwork)).toEqual({
@@ -53,9 +56,11 @@ describe('resolveComposer (BS#1499 PR-3)', () => {
 
   it("provenance 'release' → joined names + 'discogs_release'", () => {
     const artwork = artworkWith({
-      names: ['Sessa', 'Bianca Vianna'],
-      roles: ['Written-By', 'Music By'],
-      provenance: 'release',
+      writer_credits: {
+        names: ['Sessa', 'Bianca Vianna'],
+        roles: ['Written-By', 'Music By'],
+        provenance: 'release',
+      },
     });
 
     expect(resolveComposer(ROW, artwork)).toEqual({
@@ -66,16 +71,18 @@ describe('resolveComposer (BS#1499 PR-3)', () => {
 
   it("joins multiple names with '; ' (not ',', which Discogs names can contain)", () => {
     const artwork = artworkWith({
-      names: ['Molina, Juana', 'Vianna, Bianca'],
-      provenance: 'track',
-      track_position: 'A1',
+      writer_credits: {
+        names: ['Molina, Juana', 'Vianna, Bianca'],
+        provenance: 'track',
+        track_position: 'A1',
+      },
     });
 
     expect(resolveComposer(ROW, artwork).composer).toBe('Molina, Juana; Vianna, Bianca');
   });
 
   it("match but writer_credits undefined → artist_name + 'artist_proxy'", () => {
-    const artwork = artworkWith(undefined);
+    const artwork = artworkWith({ writer_credits: undefined });
 
     expect(resolveComposer(ROW, artwork)).toEqual({
       composer: 'Juana Molina',
@@ -84,7 +91,7 @@ describe('resolveComposer (BS#1499 PR-3)', () => {
   });
 
   it("writer_credits present but names empty → artist_name + 'artist_proxy'", () => {
-    const artwork = artworkWith({ names: [], provenance: 'release' });
+    const artwork = artworkWith({ writer_credits: { names: [], provenance: 'release' } });
 
     expect(resolveComposer(ROW, artwork)).toEqual({
       composer: 'Juana Molina',


### PR DESCRIPTION
## Summary

PR-3 (final) of BS#1499. The enrichment-worker now populates the `flowsheet.composer` and `flowsheet.composer_source` columns (added inert in PR-1, type surface wired in PR-2) so the #1500 BMI export-successor can emit a per-playcut songwriter without tubafrenzy/MySQL after the 2026-08-31 turndown.

`composer` is sourced from LML's `DiscogsMatchResult.writer_credits`, which `extended: true` (already set by `handler.ts`) surfaces on the top-1 artwork block — so this is purely a write of data already in hand: **no new LML call, no budget change**. When no writer credit resolves (match-but-no-writer, or no-match), it falls back to the artist name as proxy, mirroring tubafrenzy's existing auto-fill-`BMI_COMPOSER`-from-Artist default. Per LML#699's live-cache estimate, the proxy will dominate (~79% of plays); that's expected, not a regression — `composer_source` is the marker that lets the export tell a real credit from a proxy.

## What changed

- New exported pure helper `resolveComposer(row, artwork)` in `apps/enrichment-worker/enrich.ts`. Its ternary is the **sole** site mapping `writer_credits.provenance` → `composer_source` (`'discogs_track' | 'discogs_release' | 'artist_proxy'`, a const-asserted union). Multiple names join with `'; '` (Discogs writer names can contain commas, e.g. "Last, First").
- `finalizeRow` writes `composer` + `composer_source` onto the **flowsheet `.set({...})`** in **all four finalize arms** (linked-match, unlinked-match, linked-no-match, unlinked-no-match), inside the existing `metadata_status = 'enriching'` idempotency guard.

## Key design decision — composer lands on `flowsheet`, never `album_metadata`

Composer is a property of the specific *playcut* (the track that played), not the album. `album_metadata` is album-keyed, so two flowsheet rows that played different tracks off the same release would clobber each other's composer there. The linked-match arm therefore adds composer to the flowsheet status-flip UPDATE while leaving the `album_metadata` UPSERT payload **untouched**. A dedicated load-bearing test (`linked match: composer rides the flowsheet UPDATE, not album_metadata`) asserts the flowsheet `.set()` carries composer **and** the album_metadata insert + conflict-update payloads omit it.

## Tests (TDD, red → green)

- New `tests/unit/apps/enrichment-worker/resolve-composer.test.ts` — pure, no DB: track/release provenance, the `'; '` join, and the artist-proxy fallback (writer_credits undefined, names empty, and no-match artwork-null).
- Extended `tests/unit/apps/enrichment-worker/enrich.test.ts` — added `writer_credits` fixtures (track + release level, WXYC-representative names) and composer/composer_source assertions on all four arms, plus the flowsheet-not-album_metadata load-bearing case.
- No new pg integration spec — finalize-arm column writes are plain UPDATE/UPSERT already covered by the `@wxyc/database` mock, matching the coverage posture BS#1336's columns shipped with.

Local CI green: typecheck, lint (0 errors), format:check, and the enrichment-worker unit suite (98 passing).

## Project #32 freeze sign-off

This touches `apps/enrichment-worker/enrich.ts`, inside [Project #32](https://github.com/orgs/WXYC/projects/32)'s CDC-pipeline freeze. The Project #32 owner **granted sign-off on 2026-06-29**: https://github.com/WXYC/Backend-Service/issues/1499#issuecomment-4837336599 — additive change, no new LML call, `album_metadata` untouched, all inside the `enriching` guard. Do not merge ahead of an independent review pass.

## Out of scope

- No BS wire-shape change (`composer` is write-only for the #1500 export; not projected onto V2 flowsheet reads).
- The forward coverage-baseline measurement (per the acceptance criteria) is recorded post-deploy over the first ~2 weeks of enriched track rows.

Closes #1499