### PR TITLE
fix(rotation-release-id-backfill): reject non-direct LML search_type before persisting release ids

### DIFF
--- a/jobs/rotation-release-id-backfill/README.md
+++ b/jobs/rotation-release-id-backfill/README.md
@@ -73,15 +73,15 @@ JSON log line emitted on `step: finished`:
 
 Invariant: `scanned == resolved + resolved_dry + unresolved + lml_error + raced + sentinel_rejected + trust_rejected`.
 
-| Counter             | Meaning                                                                                                      |
-| ------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `scanned`           | Rows visited (matches the candidate query's row count)                                                       |
-| `resolved`          | LML returned a positive release id on a `direct` match AND the UPDATE landed cleanly                         |
-| `resolved_dry`      | LML returned a positive release id on a `direct` match; DRY_RUN suppressed the UPDATE                        |
-| `unresolved`        | LML returned no Discogs match (`response.results[0].artwork.release_id` was null)                            |
-| `lml_error`         | LML call threw (cold-cache timeout, network blip, etc.); row stays NULL for next run                         |
-| `raced`             | UPDATE matched zero rows because a tubafrenzy paste won the race between candidate-select and update         |
-| `sentinel_rejected` | LML returned `<= 0` (cache pollution / upstream regression); pre-empted before write per BS#1429 CHECK fence |
+| Counter             | Meaning                                                                                                                                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scanned`           | Rows visited (matches the candidate query's row count)                                                                                                                                                                  |
+| `resolved`          | LML returned a positive release id on a `direct` match AND the UPDATE landed cleanly                                                                                                                                    |
+| `resolved_dry`      | LML returned a positive release id on a `direct` match; DRY_RUN suppressed the UPDATE                                                                                                                                   |
+| `unresolved`        | LML returned no Discogs match (`response.results[0].artwork.release_id` was null)                                                                                                                                       |
+| `lml_error`         | LML call threw (cold-cache timeout, network blip, etc.); row stays NULL for next run                                                                                                                                    |
+| `raced`             | UPDATE matched zero rows because a tubafrenzy paste won the race between candidate-select and update                                                                                                                    |
+| `sentinel_rejected` | LML returned `<= 0` (cache pollution / upstream regression); pre-empted before write per BS#1429 CHECK fence                                                                                                            |
 | `trust_rejected`    | LML returned a candidate id on a non-`direct` (or absent) `search_type` — an artist-fallback answer pointing at a **different album**; never persisted (BS#1516, the Yenbett→Tzenni recurrence BS#1515). Row stays NULL |
 
 `trust_rejected` rows are candidates for LML-side match improvements (or the album has no Discogs release yet); `unresolved` rows need Discogs/catalog additions. Both re-enter the candidate set on the next run.

--- a/jobs/rotation-release-id-backfill/README.md
+++ b/jobs/rotation-release-id-backfill/README.md
@@ -60,27 +60,31 @@ JSON log line emitted on `step: finished`:
   "scanned": 310,
   "resolved": 247,
   "resolved_dry": 0,
-  "unresolved": 51,
+  "unresolved": 43,
   "lml_error": 11,
   "raced": 1,
   "sentinel_rejected": 0,
+  "trust_rejected": 8,
   "repo": "Backend-Service",
   "tool": "rotation-release-id-backfill",
   "run_id": "<uuid>"
 }
 ```
 
-Invariant: `scanned == resolved + resolved_dry + unresolved + lml_error + raced + sentinel_rejected`.
+Invariant: `scanned == resolved + resolved_dry + unresolved + lml_error + raced + sentinel_rejected + trust_rejected`.
 
 | Counter             | Meaning                                                                                                      |
 | ------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `scanned`           | Rows visited (matches the candidate query's row count)                                                       |
-| `resolved`          | LML returned a positive release id AND the UPDATE landed cleanly                                             |
-| `resolved_dry`      | LML returned a positive release id; DRY_RUN suppressed the UPDATE                                            |
+| `resolved`          | LML returned a positive release id on a `direct` match AND the UPDATE landed cleanly                         |
+| `resolved_dry`      | LML returned a positive release id on a `direct` match; DRY_RUN suppressed the UPDATE                        |
 | `unresolved`        | LML returned no Discogs match (`response.results[0].artwork.release_id` was null)                            |
 | `lml_error`         | LML call threw (cold-cache timeout, network blip, etc.); row stays NULL for next run                         |
 | `raced`             | UPDATE matched zero rows because a tubafrenzy paste won the race between candidate-select and update         |
 | `sentinel_rejected` | LML returned `<= 0` (cache pollution / upstream regression); pre-empted before write per BS#1429 CHECK fence |
+| `trust_rejected`    | LML returned a candidate id on a non-`direct` (or absent) `search_type` — an artist-fallback answer pointing at a **different album**; never persisted (BS#1516, the Yenbett→Tzenni recurrence BS#1515). Row stays NULL |
+
+`trust_rejected` rows are candidates for LML-side match improvements (or the album has no Discogs release yet); `unresolved` rows need Discogs/catalog additions. Both re-enter the candidate set on the next run.
 
 ## Post-run verification
 

--- a/jobs/rotation-release-id-backfill/lml-fetch.ts
+++ b/jobs/rotation-release-id-backfill/lml-fetch.ts
@@ -12,15 +12,18 @@
  *     don't hold one of LML's serialized Discogs fan-out slots for the
  *     runtime path's 30 s (BS#994 / BS#1017).
  *
- * Returns the resolved Discogs release id (or null when LML found no
- * Discogs match). Mirrors the runtime tier-3 path's extraction at
- * `apps/backend/services/library.service.ts:492` so the SAME entity is
- * persisted whether the resolution happened at runtime or offline.
+ * Returns a discriminated `LookupOutcome`: `resolved` (a `direct`-match
+ * Discogs release id), `no_match` (LML found no candidate id), or
+ * `trust_rejected` (a candidate id arrived on a non-`direct` — or absent —
+ * `search_type` and must not be persisted; BS#1516). Mirrors the runtime
+ * tier-3 path's extraction plus its BS#1351/BS#1355 trust gate so the SAME
+ * entity is persisted whether the resolution happened at runtime or offline.
  */
 
 import { lookupMetadata as sharedLookupMetadata } from '@wxyc/lml-client';
 
 import { defaultLmlLimiter } from './lml-limiter.js';
+import type { LookupOutcome } from './orchestrate.js';
 
 const envInt = (name: string, fallback: number): number => {
   const raw = process.env[name];
@@ -61,10 +64,25 @@ const decodeHtmlEntities = (input: string): string =>
     return String.fromCodePoint(codepoint);
   });
 
-export const lookupReleaseId = async (artist: string, album: string): Promise<number | null> => {
+export const lookupReleaseId = async (artist: string, album: string): Promise<LookupOutcome> => {
   const response = await sharedLookupMetadata(decodeHtmlEntities(artist), decodeHtmlEntities(album), undefined, {
     limiter: defaultLmlLimiter,
     timeoutMs: TIMEOUT_MS,
   });
-  return response.results?.[0]?.artwork?.release_id ?? null;
+  const releaseId = response.results?.[0]?.artwork?.release_id ?? null;
+  if (releaseId === null) return { kind: 'no_match' };
+  // BS#1516: only a `direct` match may be persisted. Non-direct
+  // `search_type` values are artist-fallback answers — `results[0]` is a
+  // DIFFERENT album by the same artist (the Yenbett→Tzenni recurrence,
+  // BS#1515), and a persisted wrong id is served by tier 1 forever; the
+  // runtime BS#1351 gate never re-checks stored ids. Fail closed when
+  // `search_type` is absent: no trust signal, no persist. Mirrors the
+  // coordinator's `requireSearchType: 'direct'` (BS#1355), which this job
+  // can't use because it imports `@wxyc/lml-client` directly.
+  if (response.search_type !== 'direct') {
+    return { kind: 'trust_rejected', searchType: response.search_type ?? 'absent' };
+  }
+  // `release_id: 0` (BS#1185 streaming-only sentinel) intentionally passes
+  // through as `resolved` — the orchestrator owns sentinel counting (BS#1429).
+  return { kind: 'resolved', releaseId };
 };

--- a/jobs/rotation-release-id-backfill/orchestrate.ts
+++ b/jobs/rotation-release-id-backfill/orchestrate.ts
@@ -23,7 +23,19 @@ export type Candidate = {
 
 export type LoadCandidatesFn = () => Promise<Candidate[]>;
 
-export type LookupFn = (artist: string, album: string) => Promise<number | null>;
+/**
+ * Outcome of one LML lookup (BS#1516). `trust_rejected` is distinct from
+ * `no_match` because the two demand different operator responses:
+ * `trust_rejected` rows have an LML answer we refused (candidates for
+ * LML-side match improvements), `no_match` rows have no candidate at all
+ * (need Discogs/catalog additions).
+ */
+export type LookupOutcome =
+  | { kind: 'resolved'; releaseId: number }
+  | { kind: 'no_match' }
+  | { kind: 'trust_rejected'; searchType: string };
+
+export type LookupFn = (artist: string, album: string) => Promise<LookupOutcome>;
 
 export type WriteFn = (rotationId: number, releaseId: number) => Promise<{ written: boolean }>;
 
@@ -35,6 +47,7 @@ export type Totals = {
   lml_error: number;
   raced: number;
   sentinel_rejected: number;
+  trust_rejected: number;
 };
 
 export type RunResult = { totals: Totals };
@@ -53,14 +66,15 @@ export const runBackfill = async (deps: {
     lml_error: 0,
     raced: 0,
     sentinel_rejected: 0,
+    trust_rejected: 0,
   };
 
   const candidates = await deps.loadCandidates();
   for (const candidate of candidates) {
     totals.scanned += 1;
-    let releaseId: number | null;
+    let outcome: LookupOutcome;
     try {
-      releaseId = await deps.lookup(candidate.artist_name, candidate.album_title);
+      outcome = await deps.lookup(candidate.artist_name, candidate.album_title);
     } catch {
       // The row stays `discogs_release_id IS NULL`, so it's picked up
       // again on the next run when LML's cache is warmer. The job entry
@@ -69,32 +83,40 @@ export const runBackfill = async (deps: {
       totals.lml_error += 1;
       continue;
     }
-    if (releaseId !== null) {
-      if (releaseId <= 0) {
-        // BS#1429: rotation.discogs_release_id has a CHECK rejecting `0`
-        // and negative ids. Pre-empt the constraint trip here so a
-        // poisoned LML response (cache pollution, upstream regression)
-        // is contained to one candidate counter instead of crashing the
-        // whole nightly batch.
-        totals.sentinel_rejected += 1;
-        continue;
-      }
-      if (deps.dryRun) {
-        totals.resolved_dry += 1;
-        continue;
-      }
-      const { written } = await deps.write(candidate.id, releaseId);
-      if (written) {
-        totals.resolved += 1;
-      } else {
-        // The writer's WHERE clause guards on `discogs_release_id IS NULL`;
-        // 0 rows updated means a tubafrenzy paste won the race between our
-        // SELECT and our UPDATE. Surface it on a dedicated counter so the
-        // dashboard distinguishes write success from "tubafrenzy beat us".
-        totals.raced += 1;
-      }
-    } else {
+    if (outcome.kind === 'trust_rejected') {
+      // BS#1516: LML answered, but not with a `direct` match — persisting
+      // it would pin a wrong-album release id that tier 1 serves forever
+      // (the Yenbett→Tzenni recurrence, BS#1515). The row stays NULL.
+      totals.trust_rejected += 1;
+      continue;
+    }
+    if (outcome.kind === 'no_match') {
       totals.unresolved += 1;
+      continue;
+    }
+    const releaseId = outcome.releaseId;
+    if (releaseId <= 0) {
+      // BS#1429: rotation.discogs_release_id has a CHECK rejecting `0`
+      // and negative ids. Pre-empt the constraint trip here so a
+      // poisoned LML response (cache pollution, upstream regression)
+      // is contained to one candidate counter instead of crashing the
+      // whole nightly batch.
+      totals.sentinel_rejected += 1;
+      continue;
+    }
+    if (deps.dryRun) {
+      totals.resolved_dry += 1;
+      continue;
+    }
+    const { written } = await deps.write(candidate.id, releaseId);
+    if (written) {
+      totals.resolved += 1;
+    } else {
+      // The writer's WHERE clause guards on `discogs_release_id IS NULL`;
+      // 0 rows updated means a tubafrenzy paste won the race between our
+      // SELECT and our UPDATE. Surface it on a dedicated counter so the
+      // dashboard distinguishes write success from "tubafrenzy beat us".
+      totals.raced += 1;
     }
   }
 

--- a/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
+++ b/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
@@ -1,27 +1,27 @@
 // Pin the HTML-entity decode added in BS#1223 and the search_type trust
 // gate added in BS#1516. Rationale for both lives next to the
 // implementation at jobs/rotation-release-id-backfill/lml-fetch.ts.
+beforeEach(() => {
+  jest.resetModules();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const loadModule = async (
+  mockLookup: jest.Mock
+): Promise<typeof import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js')> => {
+  jest.doMock('../../../../jobs/rotation-release-id-backfill/lml-limiter.js', () => ({
+    defaultLmlLimiter: { run: jest.fn() },
+  }));
+  jest.doMock('@wxyc/lml-client', () => ({
+    lookupMetadata: mockLookup,
+  }));
+  return import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js');
+};
+
 describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () => {
-  beforeEach(() => {
-    jest.resetModules();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  const loadModule = async (
-    mockLookup: jest.Mock
-  ): Promise<typeof import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js')> => {
-    jest.doMock('../../../../jobs/rotation-release-id-backfill/lml-limiter.js', () => ({
-      defaultLmlLimiter: { run: jest.fn() },
-    }));
-    jest.doMock('@wxyc/lml-client', () => ({
-      lookupMetadata: mockLookup,
-    }));
-    return import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js');
-  };
-
   it('decodes numeric HTML entities in artist before calling LML', async () => {
     const mockLookup = jest
       .fn()
@@ -132,26 +132,6 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () 
 });
 
 describe('jobs/rotation-release-id-backfill/lml-fetch (search_type trust gate, BS#1516)', () => {
-  beforeEach(() => {
-    jest.resetModules();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  const loadModule = async (
-    mockLookup: jest.Mock
-  ): Promise<typeof import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js')> => {
-    jest.doMock('../../../../jobs/rotation-release-id-backfill/lml-limiter.js', () => ({
-      defaultLmlLimiter: { run: jest.fn() },
-    }));
-    jest.doMock('@wxyc/lml-client', () => ({
-      lookupMetadata: mockLookup,
-    }));
-    return import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js');
-  };
-
   it('rejects the artist-fallback answer that caused the Yenbett→Tzenni recurrence (BS#1515)', async () => {
     // LML has no direct match for the typed album, so it answers with other
     // releases by the same artist. results[0] is a DIFFERENT album — trusting

--- a/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
+++ b/tests/unit/jobs/rotation-release-id-backfill/lml-fetch.test.ts
@@ -1,4 +1,5 @@
-// Pin the HTML-entity decode added in BS#1223. Rationale lives next to the
+// Pin the HTML-entity decode added in BS#1223 and the search_type trust
+// gate added in BS#1516. Rationale for both lives next to the
 // implementation at jobs/rotation-release-id-backfill/lml-fetch.ts.
 describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () => {
   beforeEach(() => {
@@ -22,20 +23,25 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () 
   };
 
   it('decodes numeric HTML entities in artist before calling LML', async () => {
-    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 12345 } }] });
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 12345 } }] });
 
     const { lookupReleaseId } = await loadModule(mockLookup);
     const result = await lookupReleaseId('Rome&#769;o Poirier', 'Off the Record');
 
     expect(mockLookup).toHaveBeenCalledTimes(1);
     // &#769; is U+0301 (combining acute); decoded form is NFD-decomposed,
-    // which is what LML's downstream NFKD strip needs to act on.
-    expect(mockLookup).toHaveBeenCalledWith('Roméo Poirier', 'Off the Record', undefined, expect.any(Object));
-    expect(result).toBe(12345);
+    // which is what LML's downstream NFKD strip needs to act on. Spelled
+    // with an explicit escape so an editor can't silently precompose it.
+    expect(mockLookup).toHaveBeenCalledWith('Rome\u0301o Poirier', 'Off the Record', undefined, expect.any(Object));
+    expect(result).toEqual({ kind: 'resolved', releaseId: 12345 });
   });
 
   it('decodes named HTML entities in both artist and album', async () => {
-    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 67890 } }] });
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 67890 } }] });
 
     const { lookupReleaseId } = await loadModule(mockLookup);
     await lookupReleaseId('Duke Ellington &amp; John Coltrane', 'Duke Ellington &amp; John Coltrane');
@@ -49,7 +55,9 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () 
   });
 
   it('leaves plain strings unchanged (idempotent)', async () => {
-    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 1 } }] });
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 1 } }] });
 
     const { lookupReleaseId } = await loadModule(mockLookup);
     await lookupReleaseId('Jessica Pratt', 'On Your Own Love Again');
@@ -58,7 +66,9 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () 
   });
 
   it('decodes hex HTML entities', async () => {
-    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 2 } }] });
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 2 } }] });
 
     const { lookupReleaseId } = await loadModule(mockLookup);
     // &#xf6; is precomposed ö (U+00F6).
@@ -68,7 +78,9 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () 
   });
 
   it('passes unknown named entities through unchanged', async () => {
-    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 3 } }] });
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 3 } }] });
 
     const { lookupReleaseId } = await loadModule(mockLookup);
     await lookupReleaseId('Foo &copy; Bar', '&trade;');
@@ -77,7 +89,9 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () 
   });
 
   it('decodes multiple entities in the same string', async () => {
-    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 4 } }] });
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 4 } }] });
 
     const { lookupReleaseId } = await loadModule(mockLookup);
     await lookupReleaseId('A &amp; B &#38; C', 'X');
@@ -86,7 +100,9 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () 
   });
 
   it('passes lone-surrogate codepoints through unchanged (avoids ill-formed UTF-16)', async () => {
-    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: { release_id: 5 } }] });
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 5 } }] });
 
     const { lookupReleaseId } = await loadModule(mockLookup);
     // U+D800 is a high-surrogate; String.fromCodePoint accepts it silently
@@ -96,21 +112,113 @@ describe('jobs/rotation-release-id-backfill/lml-fetch (HTML-entity decode)', () 
     expect(mockLookup).toHaveBeenCalledWith('Bad &#xd800; input', 'X', undefined, expect.any(Object));
   });
 
-  it('returns null when LML returns no Discogs match', async () => {
-    const mockLookup = jest.fn().mockResolvedValue({ results: [{ artwork: null }] });
+  it('returns no_match when LML returns no Discogs match', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ search_type: 'direct', results: [{ artwork: null }] });
 
     const { lookupReleaseId } = await loadModule(mockLookup);
     const result = await lookupReleaseId('Some Artist', 'Some Album');
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ kind: 'no_match' });
   });
 
-  it('returns null when LML returns an empty results array', async () => {
-    const mockLookup = jest.fn().mockResolvedValue({ results: [] });
+  it('returns no_match when LML returns an empty results array', async () => {
+    const mockLookup = jest.fn().mockResolvedValue({ search_type: 'none', results: [] });
 
     const { lookupReleaseId } = await loadModule(mockLookup);
     const result = await lookupReleaseId('Some Artist', 'Some Album');
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ kind: 'no_match' });
+  });
+});
+
+describe('jobs/rotation-release-id-backfill/lml-fetch (search_type trust gate, BS#1516)', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const loadModule = async (
+    mockLookup: jest.Mock
+  ): Promise<typeof import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js')> => {
+    jest.doMock('../../../../jobs/rotation-release-id-backfill/lml-limiter.js', () => ({
+      defaultLmlLimiter: { run: jest.fn() },
+    }));
+    jest.doMock('@wxyc/lml-client', () => ({
+      lookupMetadata: mockLookup,
+    }));
+    return import('../../../../jobs/rotation-release-id-backfill/lml-fetch.js');
+  };
+
+  it('rejects the artist-fallback answer that caused the Yenbett→Tzenni recurrence (BS#1515)', async () => {
+    // LML has no direct match for the typed album, so it answers with other
+    // releases by the same artist. results[0] is a DIFFERENT album — trusting
+    // it is how rotation row 21529 got Tzenni's release id persisted.
+    const mockLookup = jest.fn().mockResolvedValue({
+      search_type: 'alternative',
+      results: [
+        { library_item: { title: 'Tzenni' }, artwork: { album: 'Tzenni', release_id: 5879935 } },
+        { library_item: { title: 'Arbina' }, artwork: { album: 'Arbina', release_id: 9239170 } },
+      ],
+    });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    const result = await lookupReleaseId('Noura Mint Seymali', 'Yenbett');
+
+    expect(result).toEqual({ kind: 'trust_rejected', searchType: 'alternative' });
+  });
+
+  it.each(['fallback', 'alternative', 'compilation', 'song_as_artist', 'none'] as const)(
+    'rejects search_type=%s when a candidate release id is present',
+    async (searchType) => {
+      const mockLookup = jest.fn().mockResolvedValue({
+        search_type: searchType,
+        results: [{ artwork: { release_id: 424242 } }],
+      });
+
+      const { lookupReleaseId } = await loadModule(mockLookup);
+      const result = await lookupReleaseId('Stereolab', 'Dots and Loops');
+
+      expect(result).toEqual({ kind: 'trust_rejected', searchType });
+    }
+  );
+
+  it('fails closed when search_type is absent but a candidate release id is present', async () => {
+    // search_type is optional on the wire DTO. An LML build that omits it
+    // gives us no trust signal — never persist on silence.
+    const mockLookup = jest.fn().mockResolvedValue({
+      results: [{ artwork: { release_id: 424242 } }],
+    });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    const result = await lookupReleaseId('Cat Power', 'Moon Pix');
+
+    expect(result).toEqual({ kind: 'trust_rejected', searchType: 'absent' });
+  });
+
+  it('passes the BS#1185 streaming-only sentinel (release_id 0) through as resolved for the orchestrator to reject', async () => {
+    // Sentinel handling (BS#1429) lives in the orchestrator so the counter
+    // taxonomy stays in one place; the gate must not swallow it as no_match.
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 0 } }] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    const result = await lookupReleaseId('Chuquimamani-Condori', 'Edits');
+
+    expect(result).toEqual({ kind: 'resolved', releaseId: 0 });
+  });
+
+  it('accepts a direct match and returns its release id', async () => {
+    const mockLookup = jest
+      .fn()
+      .mockResolvedValue({ search_type: 'direct', results: [{ artwork: { release_id: 35719330 } }] });
+
+    const { lookupReleaseId } = await loadModule(mockLookup);
+    const result = await lookupReleaseId('Noura Mint Seymali', 'Yenbett');
+
+    expect(result).toEqual({ kind: 'resolved', releaseId: 35719330 });
   });
 });

--- a/tests/unit/jobs/rotation-release-id-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/rotation-release-id-backfill/orchestrate.test.ts
@@ -4,10 +4,13 @@
  * Behaviors covered:
  *   1. (tracer bullet) one resolvable row → write called with the resolved id;
  *      `resolved` counter bumps, scanned == 1.
- *   2. LML returns null → unresolved counter; no write.
+ *   2. LML finds no match → unresolved counter; no write.
  *   3. LML throws → lml_error counter; no write; row stays NULL for next pass.
  *   4. Writer returns written:false → raced counter, not resolved.
  *   5. dryRun=true → resolved_dry counter; no write.
+ *   6. Trust gate (BS#1516): a non-direct LML answer → trust_rejected
+ *      counter; no write; the row stays NULL rather than persisting a
+ *      wrong-album release id.
  */
 import { jest } from '@jest/globals';
 
@@ -26,7 +29,7 @@ describe('runBackfill', () => {
     const loadCandidates = makeLoadCandidates([
       { id: 42, artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again' },
     ]);
-    const lookup = jest.fn<LookupFn>().mockResolvedValue(999001);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ kind: 'resolved', releaseId: 999001 });
     const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
 
     const result = await runBackfill({ loadCandidates, lookup, write });
@@ -40,11 +43,11 @@ describe('runBackfill', () => {
     expect(result.totals.raced).toBe(0);
   });
 
-  test('LML returns null (no Discogs match) → unresolved counter, no write', async () => {
+  test('LML finds no Discogs match → unresolved counter, no write', async () => {
     const loadCandidates = makeLoadCandidates([
       { id: 99, artist_name: 'Chuquimamani-Condori', album_title: 'Untitled Acetate' },
     ]);
-    const lookup = jest.fn<LookupFn>().mockResolvedValue(null);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ kind: 'no_match' });
     const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
 
     const result = await runBackfill({ loadCandidates, lookup, write });
@@ -77,7 +80,7 @@ describe('runBackfill', () => {
     const loadCandidates = makeLoadCandidates([
       { id: 11, artist_name: 'Duke Ellington & John Coltrane', album_title: 'Duke Ellington & John Coltrane' },
     ]);
-    const lookup = jest.fn<LookupFn>().mockResolvedValue(555);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ kind: 'resolved', releaseId: 555 });
     const write = jest.fn<WriteFn>().mockResolvedValue({ written: false });
 
     const result = await runBackfill({ loadCandidates, lookup, write });
@@ -97,7 +100,10 @@ describe('runBackfill', () => {
       { id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' },
       { id: 8, artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again' },
     ]);
-    const lookup = jest.fn<LookupFn>().mockResolvedValueOnce(0).mockResolvedValueOnce(999001);
+    const lookup = jest
+      .fn<LookupFn>()
+      .mockResolvedValueOnce({ kind: 'resolved', releaseId: 0 })
+      .mockResolvedValueOnce({ kind: 'resolved', releaseId: 999001 });
     const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
 
     const result = await runBackfill({ loadCandidates, lookup, write });
@@ -112,7 +118,7 @@ describe('runBackfill', () => {
 
   test('LML returns a negative id → sentinel_rejected counter, no write (BS#1429)', async () => {
     const loadCandidates = makeLoadCandidates([{ id: 7, artist_name: 'Juana Molina', album_title: 'DOGA' }]);
-    const lookup = jest.fn<LookupFn>().mockResolvedValue(-1);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ kind: 'resolved', releaseId: -1 });
     const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
 
     const result = await runBackfill({ loadCandidates, lookup, write });
@@ -126,7 +132,7 @@ describe('runBackfill', () => {
     const loadCandidates = makeLoadCandidates([
       { id: 42, artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again' },
     ]);
-    const lookup = jest.fn<LookupFn>().mockResolvedValue(999001);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue({ kind: 'resolved', releaseId: 999001 });
     const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
 
     const result = await runBackfill({ loadCandidates, lookup, write, dryRun: true });
@@ -135,5 +141,74 @@ describe('runBackfill', () => {
     expect(result.totals.scanned).toBe(1);
     expect(result.totals.resolved_dry).toBe(1);
     expect(result.totals.resolved).toBe(0);
+  });
+
+  test('trust-rejected lookup → trust_rejected counter, no write; batch continues (BS#1516)', async () => {
+    // A wrong-album persist is permanent: tier 1 serves it forever and the
+    // runtime BS#1351 gate never re-checks stored ids. The row must stay
+    // NULL so the (trust-gated) tier-3 path or a later re-run can resolve it.
+    const loadCandidates = makeLoadCandidates([
+      { id: 21529, artist_name: 'Noura Mint Seymali', album_title: 'Yenbett' },
+      { id: 8, artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again' },
+    ]);
+    const lookup = jest
+      .fn<LookupFn>()
+      .mockResolvedValueOnce({ kind: 'trust_rejected', searchType: 'alternative' })
+      .mockResolvedValueOnce({ kind: 'resolved', releaseId: 999001 });
+    const write = jest.fn<WriteFn>().mockResolvedValue({ written: true });
+
+    const result = await runBackfill({ loadCandidates, lookup, write });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith(8, 999001);
+    expect(result.totals.scanned).toBe(2);
+    expect(result.totals.trust_rejected).toBe(1);
+    expect(result.totals.resolved).toBe(1);
+    expect(result.totals.unresolved).toBe(0);
+  });
+
+  test('counter invariant holds across a mixed batch (scanned == sum of outcome counters)', async () => {
+    const loadCandidates = makeLoadCandidates([
+      { id: 1, artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again' },
+      { id: 2, artist_name: 'Noura Mint Seymali', album_title: 'Yenbett' },
+      { id: 3, artist_name: 'Chuquimamani-Condori', album_title: 'Untitled Acetate' },
+      { id: 4, artist_name: 'Juana Molina', album_title: 'DOGA' },
+      { id: 5, artist_name: 'Stereolab', album_title: 'Dots and Loops' },
+      { id: 6, artist_name: 'Cat Power', album_title: 'Moon Pix' },
+    ]);
+    const lookup = jest
+      .fn<LookupFn>()
+      .mockResolvedValueOnce({ kind: 'resolved', releaseId: 111 }) // resolved
+      .mockResolvedValueOnce({ kind: 'trust_rejected', searchType: 'alternative' }) // trust_rejected
+      .mockResolvedValueOnce({ kind: 'no_match' }) // unresolved
+      .mockResolvedValueOnce({ kind: 'resolved', releaseId: 0 }) // sentinel_rejected
+      .mockRejectedValueOnce(new Error('LML socket timeout')) // lml_error
+      .mockResolvedValueOnce({ kind: 'resolved', releaseId: 222 }); // raced
+    const write = jest
+      .fn<WriteFn>()
+      .mockResolvedValueOnce({ written: true })
+      .mockResolvedValueOnce({ written: false });
+
+    const { totals } = await runBackfill({ loadCandidates, lookup, write });
+
+    expect(totals).toEqual({
+      scanned: 6,
+      resolved: 1,
+      resolved_dry: 0,
+      unresolved: 1,
+      lml_error: 1,
+      raced: 1,
+      sentinel_rejected: 1,
+      trust_rejected: 1,
+    });
+    expect(totals.scanned).toBe(
+      totals.resolved +
+        totals.resolved_dry +
+        totals.unresolved +
+        totals.lml_error +
+        totals.raced +
+        totals.sentinel_rejected +
+        totals.trust_rejected
+    );
   });
 });

--- a/tests/unit/jobs/rotation-release-id-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/rotation-release-id-backfill/orchestrate.test.ts
@@ -184,10 +184,7 @@ describe('runBackfill', () => {
       .mockResolvedValueOnce({ kind: 'resolved', releaseId: 0 }) // sentinel_rejected
       .mockRejectedValueOnce(new Error('LML socket timeout')) // lml_error
       .mockResolvedValueOnce({ kind: 'resolved', releaseId: 222 }); // raced
-    const write = jest
-      .fn<WriteFn>()
-      .mockResolvedValueOnce({ written: true })
-      .mockResolvedValueOnce({ written: false });
+    const write = jest.fn<WriteFn>().mockResolvedValueOnce({ written: true }).mockResolvedValueOnce({ written: false });
 
     const { totals } = await runBackfill({ loadCandidates, lookup, write });
 


### PR DESCRIPTION
Closes #1516.

## What

`jobs/rotation-release-id-backfill` now refuses to persist an LML lookup answer unless `search_type === 'direct'`. `lookupReleaseId` returns a discriminated `LookupOutcome` (`resolved` / `no_match` / `trust_rejected`), the orchestrator counts trust rejections on a new `trust_rejected` counter, and the README's counter table + invariant are updated.

## Why

The job took `results[0].artwork.release_id` blindly. When LML answers with an artist-fallback (`search_type: "alternative"`), `results[0]` is a **different album** by the same artist — and once persisted to `rotation.discogs_release_id`, tier 1 of `resolveRotationPickerSource` serves it deterministically. The runtime trust gate from #1351/#1352 never re-checks stored ids, so one bad offline write permanently defeats it. That is the mechanism behind the Yenbett→Tzenni recurrence in #1515 (rotation row 21529 stored 5879935 = Tzenni 2014, verified via Sentry trace + Discogs API).

The coordinator-level gate from #1355 (`requireSearchType: 'direct'` on `lmlLookupCoordinator`) can't cover this path: job bundles import `@wxyc/lml-client` directly, so the gate is mirrored at the job's extraction point with a matching rationale comment.

## Decisions

- **Fail closed on absent `search_type`** — it's optional on the wire DTO; silence is not a trust signal (`searchType: 'absent'` in the rejection for observability).
- **`trust_rejected` ≠ `unresolved`**: trust-rejected rows have an LML answer we refused (LML-side match improvements / album not on Discogs yet); unresolved rows have no candidate at all (need catalog additions). Both stay NULL and re-enter the candidate set on the next run.
- **Sentinel (`release_id: 0`, BS#1185) still passes through as `resolved`** so the BS#1429 sentinel counting stays in the orchestrator — one counter taxonomy owner.
- **`catalog-popularity-freetext-resolve` not folded in**: same ungated pattern, but it records `match_confidence` and feeds popularity linkage, so its trust policy is a per-surface decision (cf. #1359). Deferred to #1518.

## Tests

- `lml-fetch.test.ts`: existing decode tests updated to the new outcome shape; new trust-gate block with a named Yenbett→Tzenni regression case, parameterized rejection across all five non-direct `search_type` values, fail-closed-on-absent, sentinel passthrough, and direct-accept.
- `orchestrate.test.ts`: all mocks moved to `LookupOutcome`; new `trust_rejected` continuation test and a mixed-batch counter-invariant test.

Local checks: typecheck clean, lint 0 errors, unit suite 254 suites / 3555 tests green.

## Related

- #1515 — the DJ-facing data fix this unblocks re-running the backfill for
- #1517 — fleet audit of already-persisted rows (natively blocked by #1516)
- #1518 — sibling trust-policy decision for the popularity job
