### PR TITLE
fix(rotation-badge): add rotation add_date lower bound to read-path + mirror fallbacks

### DIFF
--- a/apps/backend/middleware/legacy/rotation-match.mirror.ts
+++ b/apps/backend/middleware/legacy/rotation-match.mirror.ts
@@ -48,8 +48,11 @@ export interface RotationMatchEntry {
  *   (b) (artist_name, album_title) matches rotation's denormalized snapshot
  *   (c) (artist_name, album_title) matches through library + artists join
  *
- * `kill_date` is compared against `add_time` so historical shows are
- * classified using the rotation state at the time of the play, not now.
+ * The rotation window is bounded on both sides against `add_time` so historical
+ * shows are classified using the rotation state at the time of the play, not now:
+ * `add_date <= add_time` (inclusive lower bound — a play before the release
+ * entered rotation is not matched; BS#1526) and `kill_date IS NULL OR
+ * kill_date > add_time` (exclusive upper bound).
  *
  * Returns false immediately — without querying the DB — when:
  *   - `rotation_id` is non-NULL (matches the read-path `IS NULL` gate; the
@@ -93,7 +96,7 @@ export async function isActiveRotationMatch(entry: RotationMatchEntry): Promise<
     const albumIdCohort = entry.album_id != null ? sql`r2.album_id = ${entry.album_id}` : sql`false`;
 
     // Cohort SQL is structurally identical to the read-path subquery's
-    // WHERE clause (flowsheet.service.ts:147-165). Bound values
+    // WHERE clause (flowsheet.service.ts:150-168). Bound values
     // (artistName, albumTitle) are non-null JS strings post `?? ''` plus
     // the empty-guard above, so no inner `coalesce(..., '')` is needed on
     // the JS-bound side — matches the read path's column-ref shape exactly.
@@ -103,7 +106,8 @@ export async function isActiveRotationMatch(entry: RotationMatchEntry): Promise<
         FROM ${rotation} r2
         LEFT JOIN ${library} l2 ON l2.id = r2.album_id
         LEFT JOIN ${artists} a2 ON a2.id = l2.artist_id
-        WHERE (r2.kill_date IS NULL OR r2.kill_date > ${addTime}::date)
+        WHERE r2.add_date <= ${addTime}::date
+          AND (r2.kill_date IS NULL OR r2.kill_date > ${addTime}::date)
           AND (
             ${albumIdCohort}
             OR (

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -125,8 +125,11 @@ const FSEntryFieldsRaw = {
   //       (library-unlinked rotation rows hold the snapshot directly);
   //   (c) (artist, album) matches the library+artists join on an active rotation row's
   //       album_id (library-linked rows whose denorm fields are NULL).
-  // kill_date is compared against the flowsheet entry's add_time so historical rotation
-  // status is preserved — mirrors how tubafrenzy classifies at mirror time (WXYC/dj-site#750).
+  // The rotation window is bounded on BOTH sides against the flowsheet entry's add_time so
+  // historical rotation status is preserved: add_date <= add_time (inclusive lower bound —
+  // a play that aired before the release entered rotation is not badged; BS#1526) and
+  // kill_date IS NULL OR kill_date > add_time (exclusive upper bound). Mirrors how tubafrenzy
+  // classifies at mirror time (WXYC/dj-site#750).
   // Subquery only fires per-row on a missed FK join; on rows with a populated rotation_id
   // COALESCE short-circuits and the subquery is not evaluated.
   //
@@ -135,7 +138,7 @@ const FSEntryFieldsRaw = {
   // (re-bins, re-adds, label-driven re-promotes). Picking the lowest `id` (oldest active
   // row) is a deliberate, stable choice for the badge UX — when an album has been re-binned
   // L → M, the badge reports its original cohort rather than flipping retroactively. This
-  // matches the historical-correctness story above (kill_date filtering against add_time).
+  // matches the historical-correctness story above (add_date/kill_date window filtered against add_time).
   // The primary FK join via flowsheet.rotation_id remains canonical when present.
   rotation_bin: sql<string | null>`
     COALESCE(
@@ -148,7 +151,8 @@ const FSEntryFieldsRaw = {
         FROM ${rotation} r2
         LEFT JOIN ${library} l2 ON l2.id = r2.album_id
         LEFT JOIN ${artists} a2 ON a2.id = l2.artist_id
-        WHERE (r2.kill_date IS NULL OR r2.kill_date > ${flowsheet.add_time}::date)
+        WHERE r2.add_date <= ${flowsheet.add_time}::date
+          AND (r2.kill_date IS NULL OR r2.kill_date > ${flowsheet.add_time}::date)
           AND (
             (${flowsheet.album_id} IS NOT NULL AND r2.album_id = ${flowsheet.album_id})
             OR (

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -973,6 +973,99 @@ describe('rotation_bin read-path fallback (dj-site#750)', () => {
     expect(track.rotation_id).toBeNull();
     expect(track.rotation_bin).toBeNull();
   });
+
+  test('rotation_bin stays NULL when flowsheet add_time precedes rotation add_date (retroactive; BS#1526)', async () => {
+    // BS#1526: the fallback must not retroactively badge a play that aired
+    // BEFORE the release entered rotation. POST /flowsheet stamps
+    // add_time = NOW(), so provision a rotation row with a FUTURE add_date
+    // (the mirror image of the historical retroactive case) and confirm the
+    // just-now play is not badged. Without the add_date lower bound this row's
+    // NULL kill_date makes it "active forever" and the play gets an 'H' badge.
+    const inserted = await sql`
+      INSERT INTO ${sql(SCHEMA)}.rotation (album_id, rotation_bin, artist_name, album_title, add_date, kill_date)
+      VALUES (NULL, 'H', 'Future Artist', 'Future Album', (CURRENT_DATE + 30), NULL)
+      RETURNING id
+    `;
+    extraRotationIds.push(inserted[0].id);
+
+    await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: null,
+        artist_name: 'Future Artist',
+        album_title: 'Future Album',
+        track_title: 'Premature Track',
+      })
+      .expect(201);
+
+    const res = await request.get('/flowsheet').query({ limit: 5 }).send().expect(200);
+    const track = res.body.entries.find((e) => e.entry_type === 'track' && e.track_title === 'Premature Track');
+    expect(track).toBeDefined();
+    expect(track.rotation_id).toBeNull();
+    expect(track.rotation_bin).toBeNull();
+  });
+
+  test('rotation_bin populated when play falls inside the rotation window (past add_date, open kill_date; BS#1526)', async () => {
+    // Over-suppression guard: the new add_date lower bound must not drop a play
+    // that aired well inside the window — release added in the past, not yet
+    // killed. A just-now play sits strictly after add_date and before the open
+    // kill_date, so it stays badged.
+    const inserted = await sql`
+      INSERT INTO ${sql(SCHEMA)}.rotation (album_id, rotation_bin, artist_name, album_title, add_date, kill_date)
+      VALUES (NULL, 'H', 'Inwindow Artist', 'Inwindow Album', '2024-01-01', NULL)
+      RETURNING id
+    `;
+    extraRotationIds.push(inserted[0].id);
+
+    await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: null,
+        artist_name: 'Inwindow Artist',
+        album_title: 'Inwindow Album',
+        track_title: 'Inwindow Track',
+      })
+      .expect(201);
+
+    const res = await request.get('/flowsheet').query({ limit: 5 }).send().expect(200);
+    const track = res.body.entries.find((e) => e.entry_type === 'track' && e.track_title === 'Inwindow Track');
+    expect(track).toBeDefined();
+    expect(track.rotation_id).toBeNull();
+    expect(track.rotation_bin).toEqual('H');
+  });
+
+  test('rotation_bin populated when rotation add_date equals flowsheet add_time date (inclusive same-day boundary; BS#1526)', async () => {
+    // Day-precision boundary: a play on the SAME day the release was added is
+    // still badged. The floor is inclusive (`add_date <= add_time::date`) — the
+    // safer direction at day precision, since a strict `<` would drop a play
+    // aired later the same day the release was added. Provision a row added
+    // today; the just-now play (add_time = NOW(), same calendar day) must badge.
+    const inserted = await sql`
+      INSERT INTO ${sql(SCHEMA)}.rotation (album_id, rotation_bin, artist_name, album_title, add_date, kill_date)
+      VALUES (NULL, 'H', 'Sameday Artist', 'Sameday Album', CURRENT_DATE, NULL)
+      RETURNING id
+    `;
+    extraRotationIds.push(inserted[0].id);
+
+    await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        album_id: null,
+        artist_name: 'Sameday Artist',
+        album_title: 'Sameday Album',
+        track_title: 'Sameday Track',
+      })
+      .expect(201);
+
+    const res = await request.get('/flowsheet').query({ limit: 5 }).send().expect(200);
+    const track = res.body.entries.find((e) => e.entry_type === 'track' && e.track_title === 'Sameday Track');
+    expect(track).toBeDefined();
+    expect(track.rotation_id).toBeNull();
+    expect(track.rotation_bin).toEqual('H');
+  });
 });
 
 describe('Delete Flowsheet Entries', () => {


### PR DESCRIPTION
Closes #1526

## Problem

The read-path `rotation_bin` COALESCE fallback (`apps/backend/services/flowsheet.service.ts`, BS#1362) and the mirror-side classifier `isActiveRotationMatch` (`apps/backend/middleware/legacy/rotation-match.mirror.ts`, BS#1432) both decided "was this entry in rotation?" using only an **upper** bound on the rotation window (`kill_date IS NULL OR kill_date > add_time`). With no lower bound on `rotation.add_date`, a play that aired *before* the release entered rotation was badged as long as the release is (or later was) in rotation with a `kill_date` after the play — retroactively painting a rotation badge on historical plays. In tubafrenzy prod this affected 6,341 of 11,709 badged typed-in candidate plays (54% retroactive); e.g. a 2004 `Dave Douglas / Strange Liberation` play matched to a 2026 rotation stint.

## Change

Add the symmetric lower bound `r2.add_date <= ${add_time}::date` to both surfaces so BS only badges plays that aired while the release was genuinely in rotation. The floor is **inclusive** at day precision — the safer direction, since a strict `<` would drop a play aired later the same day a release was added. `rotation.add_date` already exists and is populated by `rotation-etl`, so no schema/ETL change is required. Both block comments are updated to describe the two-sided window so the doc doesn't drift from the code, and the mirror's cross-reference line numbers are corrected.

## Tests

New integration coverage in the `rotation_bin read-path fallback` block (`tests/integration/flowsheet.spec.js`):
- retroactive (play-before-add) exclusion — the regression this fixes
- in-window over-suppression guard (past `add_date`, open `kill_date`)
- inclusive same-day add/play boundary

Killed-before-play exclusion already existed. The mirror helper's unit test mocks `db.execute` and cannot exercise the SQL predicate, so the read-path integration coverage is the parity reference against which the helper's SQL is checked (no "retroactive" case added there, per the issue).

## Validation

Against a freshly-seeded CI env (`ci:clean` → `ci:env` → `ci:test`): all 9 `rotation_bin` tests pass, including the 3 new cases. Mirror unit test 25/25. `typecheck` clean, `lint` 0 errors, `prettier --check` clean.

Two unrelated full-suite failures were observed and are **not** caused by this change (diff touches only rotation badging): `requestLine.spec.js` "result object on success" is flaky (passes in isolation), and `auth-auto-membership.spec.js` fails deterministically in the non-`--full` CI env because the auto-membership hook needs a default org that env doesn't provision — it runs unchanged auth-service code.

## Related

- WXYC/tubafrenzy#599 — companion wxyc.info fix. This BS fix yields `[add, kill)`; tubafrenzy's backfill yields `(add, kill]`. They converge on the window interior and differ only on boundary-day plays; realigning the `kill_date` boundary is out of scope (existing behavior, not this bug).
- #1362 — introduced the read-path `rotation_bin` COALESCE fallback.
- #1432 — introduced `isActiveRotationMatch`.