### PR TITLE
fix(cors): fail closed when FRONTEND_SOURCE is unset (BS#1107)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,13 @@ BETTER_AUTH_AUDIENCE=http://localhost:8082
 
 # dj-site (Next.js) base URL — single env var that defines the canonical
 # frontend origin used by:
+#   - `resolveCorsOrigin` (Express-level CORS `origin` for both apps,
+#     BS#1107) — accepts a single origin or a comma-separated list; when
+#     unset/empty, CORS FAILS CLOSED (no Access-Control-* headers served,
+#     `[cors]` error logged at startup) in every NODE_ENV. No wildcard
+#     fallback: `'*'` + `credentials: true` would let any web origin make
+#     credentialed requests. The auth service falls back to
+#     `BETTER_AUTH_TRUSTED_ORIGINS` before failing closed.
 #   - `trustedOrigins` (CORS for auth endpoints) — falls back to
 #     `http://localhost:3000` when both `BETTER_AUTH_TRUSTED_ORIGINS` and
 #     `FRONTEND_SOURCE` are unset; no error on missing value

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -347,6 +347,12 @@ jobs:
         env:
           NODE_ENV: test
           USE_MOCK_SERVICES: 'false'
+          # CORS fails closed when FRONTEND_SOURCE is unset (BS#1107). The
+          # integration suite never asserts CORS headers, but set it
+          # explicitly so both services take the configured-origin path and
+          # startup logs stay clean. Matches the ci-profile compose default
+          # in dev_env/docker-compose.yml.
+          FRONTEND_SOURCE: http://localhost:3000
           ANON_DEVICE_JWT_SECRET: ci-test-secret-key-for-anonymous-devices
           LIBRARY_METADATA_URL: http://localhost:9090
           SLACK_WEBHOOK_URL: http://localhost:9090

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/node';
 import { config } from 'dotenv';
 config();
 
-import { auth } from '@wxyc/authentication';
+import { auth, resolveCorsOrigin } from '@wxyc/authentication';
 import { fromNodeHeaders, toNodeHandler } from 'better-auth/node';
 import cors from 'cors';
 import express from 'express';
@@ -37,10 +37,19 @@ app.set('trust proxy', true);
 // Parse JSON bodies first (needed for auth endpoints)
 app.use(express.json());
 
-// Apply CORS globally to all routes (must be before auth handler)
+// Apply CORS globally to all routes (must be before auth handler).
+// Fail closed when neither FRONTEND_SOURCE nor BETTER_AUTH_TRUSTED_ORIGINS is
+// set (BS#1107): the old `|| '*'` fallback combined with `credentials: true`
+// reflected any request origin with Access-Control-Allow-Credentials, exposing
+// every cookie-authenticated better-auth route (including /auth/admin/*) to
+// credentialed calls from arbitrary web origins. `resolveCorsOrigin` returns
+// `false` (cors middleware disabled, no CORS headers served) and logs at
+// error level instead. BETTER_AUTH_TRUSTED_ORIGINS is consulted second so a
+// deploy that configures better-auth's trusted origins but not
+// FRONTEND_SOURCE keeps serving its login flow.
 app.use(
   cors({
-    origin: process.env.FRONTEND_SOURCE || '*',
+    origin: resolveCorsOrigin(process.env, ['FRONTEND_SOURCE', 'BETTER_AUTH_TRUSTED_ORIGINS']),
     credentials: true,
     // X-Device-Fingerprint is sent on /auth/check-request-ban (BS#1261).
     // Add here so a future browser-origin caller (dj-site admin tool, iOS

--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -43,7 +43,7 @@ import errorHandler from './middleware/errorHandler.js';
 import { shouldCaptureExpressError } from './middleware/sentryErrorFilter.js';
 import { requestIdMiddleware } from './middleware/requestId.js';
 import { responseMetricsMiddleware } from './middleware/responseMetrics.js';
-import { requirePermissions } from '@wxyc/authentication';
+import { requirePermissions, resolveCorsOrigin } from '@wxyc/authentication';
 import { closeDatabaseConnection, db } from '@wxyc/database';
 import { sql } from 'drizzle-orm';
 import type { HealthCheckResponse } from '@wxyc/shared/dtos';
@@ -66,10 +66,15 @@ app.use(requestIdMiddleware);
 // filter inside the listener keeps emission scoped to mutation routes only.
 app.use(responseMetricsMiddleware);
 
-//CORS
+// CORS. Fail closed when FRONTEND_SOURCE is unset (BS#1107): the old
+// `|| '*'` fallback combined with `credentials: true` reflected any request
+// origin with Access-Control-Allow-Credentials, so a deploy that forgot the
+// env var silently allowed credentialed cross-origin calls from the open web.
+// `resolveCorsOrigin` returns `false` (cors middleware disabled, no CORS
+// headers served) and logs at error level instead.
 app.use(
   cors({
-    origin: process.env.FRONTEND_SOURCE || '*',
+    origin: resolveCorsOrigin(process.env),
     methods: ['GET', 'POST', 'DELETE', 'PATCH'],
     allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-Id', 'X-Internal-Key'],
     exposedHeaders: ['X-Request-Id'],

--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -122,7 +122,9 @@ services:
       - BETTER_AUTH_ISSUER=http://auth:8080
       - BETTER_AUTH_AUDIENCE=http://auth:8080
       - BETTER_AUTH_TRUSTED_ORIGINS=${BETTER_AUTH_TRUSTED_ORIGINS}
-      - FRONTEND_SOURCE=${FRONTEND_SOURCE}
+      # Explicit default (BS#1107): CORS now fails closed when the value is
+      # empty, so an unset host var must not propagate as an empty string.
+      - FRONTEND_SOURCE=${FRONTEND_SOURCE:-http://localhost:3000}
       - DEFAULT_ORG_SLUG=${DEFAULT_ORG_SLUG}
       - DEFAULT_ORG_NAME=${DEFAULT_ORG_NAME}
       - DEFAULT_USER_EMAIL=${DEFAULT_USER_EMAIL}
@@ -188,6 +190,12 @@ services:
       - BETTER_AUTH_AUDIENCE=http://auth:8080
       - BETTER_AUTH_ISSUER=http://auth:8080
       - BETTER_AUTH_JWKS_URL=http://auth:8080/auth/jwks
+      # Explicit value (BS#1107): CORS now fails closed (no headers + error
+      # log) when FRONTEND_SOURCE is unset; this service previously relied on
+      # the removed `|| '*'` fallback. No test asserts CORS headers, but the
+      # explicit origin keeps the container's startup log clean and mirrors
+      # the e2e-backend service below.
+      - FRONTEND_SOURCE=${FRONTEND_SOURCE:-http://localhost:3000}
       # Metadata: route through mock LML server
       - LIBRARY_METADATA_URL=http://mock-api:9090
       - METADATA_ALBUM_CACHE_MAX_SIZE=${METADATA_ALBUM_CACHE_MAX_SIZE:-1000}

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -37,8 +37,8 @@ Full reference. CLAUDE.md links here. Variables marked _required_ have no defaul
 - `BETTER_AUTH_JWKS_URL` — e.g. `http://localhost:8082/auth/jwks`
 - `BETTER_AUTH_ISSUER` — e.g. `http://localhost:8082`
 - `BETTER_AUTH_AUDIENCE` — e.g. `http://localhost:8082`
-- `BETTER_AUTH_TRUSTED_ORIGINS` — Comma-separated CORS origins
-- `FRONTEND_SOURCE` — Frontend origin for CORS and redirects
+- `BETTER_AUTH_TRUSTED_ORIGINS` — Comma-separated CORS origins. Consumed by better-auth's `trustedOrigins` (`auth.definition.ts`) and, since BS#1107, as the auth service's Express-level CORS fallback when `FRONTEND_SOURCE` is unset.
+- `FRONTEND_SOURCE` — Frontend origin for CORS and redirects. Accepts a single origin or a comma-separated list (`resolveCorsOrigin` in `shared/authentication/src/cors-origin.ts`). **No wildcard fallback** (BS#1107): when unset, both apps serve no CORS headers at all (cross-origin browser calls fail closed) and log a `[cors]` error at startup — the old `|| '*'` fallback combined with `credentials: true` let any web origin make credentialed requests. The backend consults only this var; the auth service falls back to `BETTER_AUTH_TRUSTED_ORIGINS` before failing closed.
 
 ### OIDC trustedClients (better-auth `oidcProvider`)
 

--- a/shared/authentication/src/cors-origin.ts
+++ b/shared/authentication/src/cors-origin.ts
@@ -1,0 +1,61 @@
+/**
+ * Resolve the Express-level `cors` middleware `origin` option from env
+ * configuration — fail closed instead of open (BS#1107).
+ *
+ * Both apps used to configure `origin: process.env.FRONTEND_SOURCE || '*'`
+ * next to `credentials: true`. With the `cors` package, `'*'` + credentials
+ * reflects the request's `Origin` header back as
+ * `Access-Control-Allow-Origin` and emits
+ * `Access-Control-Allow-Credentials: true`, so any web origin could make
+ * credentialed (cookie-bearing) requests whenever `FRONTEND_SOURCE` was
+ * forgotten in a deploy. This helper removes the wildcard fallback entirely.
+ *
+ * Lives in its own file so the helper is testable without instantiating
+ * `betterAuth({...})` — same rationale as `oidc-login-page.ts` and
+ * `oidc-trusted-clients.ts`.
+ *
+ * Env contract:
+ *   - `envVarNames` are consulted in order; the first var with a non-empty
+ *     value wins. The backend passes the default (`FRONTEND_SOURCE` only);
+ *     the auth service additionally falls back to
+ *     `BETTER_AUTH_TRUSTED_ORIGINS` so a deploy that configures better-auth's
+ *     trusted origins but not `FRONTEND_SOURCE` keeps serving its login flow
+ *     instead of failing closed.
+ *   - Values are comma-separated origin lists, matching the
+ *     `BETTER_AUTH_TRUSTED_ORIGINS` parse in `auth.definition.ts`
+ *     (`trustedOrigins`): entries are trimmed and empty segments dropped.
+ *   - Exactly one entry returns the bare string, preserving the pre-BS#1107
+ *     header emission for single-origin deploys (the `cors` package sends the
+ *     configured literal as ACAO on every response). Multiple entries return
+ *     an array, which the `cors` package treats as a whitelist (ACAO is only
+ *     emitted when the request's Origin matches an entry).
+ *   - No usable value returns `false`, which disables the `cors` middleware —
+ *     no `Access-Control-*` headers are ever emitted, so browsers refuse
+ *     cross-origin reads while same-origin and non-browser clients (iOS app,
+ *     supertest, curl) are unaffected. An error-level log makes the
+ *     misconfigured deploy diagnosable; unlike `buildLoginPage` this does not
+ *     throw, because taking the whole API down would also break the
+ *     non-browser clients that never needed CORS.
+ */
+
+export type ResolvedCorsOrigin = string | string[] | false;
+
+export function resolveCorsOrigin(
+  env: NodeJS.ProcessEnv,
+  envVarNames: string[] = ['FRONTEND_SOURCE']
+): ResolvedCorsOrigin {
+  for (const name of envVarNames) {
+    const entries = (env[name] ?? '')
+      .split(',')
+      .map((origin) => origin.trim())
+      .filter(Boolean);
+    if (entries.length === 1) return entries[0];
+    if (entries.length > 1) return entries;
+  }
+  console.error(
+    `[cors] None of ${envVarNames.join(', ')} is set — cross-origin requests are disabled (no CORS headers will be served). ` +
+      `Set ${envVarNames[0]} to the frontend origin (comma-separated for multiple origins). ` +
+      'Refusing to fall back to the credentialed wildcard (BS#1107).'
+  );
+  return false;
+}

--- a/shared/authentication/src/index.ts
+++ b/shared/authentication/src/index.ts
@@ -2,4 +2,5 @@ export * from './auth.definition';
 export * from './auth.roles';
 export * from './auth.middleware';
 export * from './auth.username';
+export * from './cors-origin';
 export { sendAccountSetupEmail } from './email';

--- a/tests/mocks/authentication.mock.ts
+++ b/tests/mocks/authentication.mock.ts
@@ -19,3 +19,9 @@ export function requirePermissions(_required: Record<string, string[]>) {
     return next();
   };
 }
+
+// Real implementation, not a stub: `resolveCorsOrigin` is pure env parsing
+// with no auth/database dependencies, so consumers under unit test get the
+// production behavior (BS#1107).
+export { resolveCorsOrigin } from '../../shared/authentication/src/cors-origin';
+export type { ResolvedCorsOrigin } from '../../shared/authentication/src/cors-origin';

--- a/tests/unit/authentication/cors-origin.test.ts
+++ b/tests/unit/authentication/cors-origin.test.ts
@@ -1,0 +1,123 @@
+import { resolveCorsOrigin } from '../../../shared/authentication/src/cors-origin';
+
+// BS#1107: the Express-level CORS config in apps/backend/app.ts and
+// apps/auth/app.ts used `origin: process.env.FRONTEND_SOURCE || '*'` next to
+// `credentials: true`. With the `cors` package, `'*'` + credentials reflects
+// the request's Origin header back as Access-Control-Allow-Origin alongside
+// Access-Control-Allow-Credentials: true, so ANY web origin could make
+// credentialed (cookie-bearing) requests whenever FRONTEND_SOURCE was unset.
+// `resolveCorsOrigin` is the replacement: fail closed (`false` disables the
+// cors middleware entirely — no ACAO/ACAC headers) instead of failing open.
+
+describe('resolveCorsOrigin', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  describe('fail-closed when unset (the BS#1107 fix)', () => {
+    it('returns false when FRONTEND_SOURCE is missing', () => {
+      expect(resolveCorsOrigin({})).toBe(false);
+    });
+
+    it('returns false when FRONTEND_SOURCE is an empty string', () => {
+      // docker-compose passthrough (`FRONTEND_SOURCE=${FRONTEND_SOURCE}`)
+      // materializes an unset host var as an empty string in the container,
+      // so empty must fail closed exactly like missing.
+      expect(resolveCorsOrigin({ FRONTEND_SOURCE: '' })).toBe(false);
+    });
+
+    it('returns false when FRONTEND_SOURCE is whitespace-only', () => {
+      expect(resolveCorsOrigin({ FRONTEND_SOURCE: '   ' })).toBe(false);
+    });
+
+    it('returns false when FRONTEND_SOURCE is only commas and whitespace', () => {
+      expect(resolveCorsOrigin({ FRONTEND_SOURCE: ' , ,, ' })).toBe(false);
+    });
+
+    it('never returns the legacy wildcard', () => {
+      expect(resolveCorsOrigin({})).not.toBe('*');
+    });
+
+    it('logs at error level so a misconfigured deploy is diagnosable', () => {
+      resolveCorsOrigin({});
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(String(errorSpy.mock.calls[0][0])).toContain('FRONTEND_SOURCE');
+    });
+
+    it('does not log when a valid origin is configured', () => {
+      resolveCorsOrigin({ FRONTEND_SOURCE: 'https://dj.wxyc.org' });
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('single configured origin (existing contract preserved)', () => {
+    it('returns the configured origin verbatim', () => {
+      expect(resolveCorsOrigin({ FRONTEND_SOURCE: 'https://dj.wxyc.org' })).toBe('https://dj.wxyc.org');
+    });
+
+    it('trims surrounding whitespace', () => {
+      expect(resolveCorsOrigin({ FRONTEND_SOURCE: '  http://localhost:3000 ' })).toBe('http://localhost:3000');
+    });
+  });
+
+  describe('comma-separated whitelist (BETTER_AUTH_TRUSTED_ORIGINS semantics)', () => {
+    it('splits a comma-separated value into a whitelist array', () => {
+      expect(resolveCorsOrigin({ FRONTEND_SOURCE: 'https://dj.wxyc.org,https://wxyc.org' })).toEqual([
+        'https://dj.wxyc.org',
+        'https://wxyc.org',
+      ]);
+    });
+
+    it('trims each entry and drops empty segments', () => {
+      expect(resolveCorsOrigin({ FRONTEND_SOURCE: ' https://dj.wxyc.org , , https://wxyc.org, ' })).toEqual([
+        'https://dj.wxyc.org',
+        'https://wxyc.org',
+      ]);
+    });
+
+    it('collapses a whitelist with a single surviving entry to the string form', () => {
+      // The string form preserves the pre-BS#1107 header emission for
+      // single-origin deploys (ACAO always carries the configured literal).
+      expect(resolveCorsOrigin({ FRONTEND_SOURCE: 'https://dj.wxyc.org,' })).toBe('https://dj.wxyc.org');
+    });
+  });
+
+  describe('fallback env vars (auth service consults BETTER_AUTH_TRUSTED_ORIGINS)', () => {
+    const AUTH_VARS = ['FRONTEND_SOURCE', 'BETTER_AUTH_TRUSTED_ORIGINS'];
+
+    it('prefers the first candidate when it is set', () => {
+      expect(
+        resolveCorsOrigin(
+          { FRONTEND_SOURCE: 'https://dj.wxyc.org', BETTER_AUTH_TRUSTED_ORIGINS: 'https://other.example' },
+          AUTH_VARS
+        )
+      ).toBe('https://dj.wxyc.org');
+    });
+
+    it('falls back to the next candidate when the first is unset', () => {
+      expect(
+        resolveCorsOrigin({ BETTER_AUTH_TRUSTED_ORIGINS: 'https://dj.wxyc.org,https://wxyc.org' }, AUTH_VARS)
+      ).toEqual(['https://dj.wxyc.org', 'https://wxyc.org']);
+    });
+
+    it('falls back when the first candidate is empty rather than missing', () => {
+      expect(
+        resolveCorsOrigin({ FRONTEND_SOURCE: '', BETTER_AUTH_TRUSTED_ORIGINS: 'https://dj.wxyc.org' }, AUTH_VARS)
+      ).toBe('https://dj.wxyc.org');
+    });
+
+    it('fails closed and names every candidate when all are unset', () => {
+      expect(resolveCorsOrigin({}, AUTH_VARS)).toBe(false);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const message = String(errorSpy.mock.calls[0][0]);
+      expect(message).toContain('FRONTEND_SOURCE');
+      expect(message).toContain('BETTER_AUTH_TRUSTED_ORIGINS');
+    });
+  });
+});


### PR DESCRIPTION
Closes #1107.

## The fail-open

Both Express apps configured `cors()` with `origin: process.env.FRONTEND_SOURCE || '*'` alongside `credentials: true` (`apps/backend/app.ts`, `apps/auth/app.ts`). With the `cors` package, `'*'` + credentials reflects the request's `Origin` header back as `Access-Control-Allow-Origin` and emits `Access-Control-Allow-Credentials: true`, so on any deploy where `FRONTEND_SOURCE` was unset, every web origin could make credentialed (cookie-bearing) requests — defeating the same-origin policy for every cookie-authenticated better-auth route, including `/auth/admin/provision-user` and `/auth/admin/resolve-organization`.

## The fix

New `resolveCorsOrigin(env, envVarNames)` helper in `shared/authentication/src/cors-origin.ts` (same testable-without-`betterAuth` pattern as `oidc-login-page.ts`), consumed by both apps:

- **Unset/empty/whitespace** → returns `false`, which disables the `cors` middleware entirely: no `Access-Control-*` headers are ever served (browsers fail closed) and a `[cors]` error is logged at startup so a misconfigured prod deploy is diagnosable. It deliberately does not throw — taking the whole API down would also break the non-browser clients (iOS proxy traffic, ETL callers) that never needed CORS.
- **Single origin** → returned verbatim, preserving the exact pre-fix header emission for every correctly-configured deploy.
- **Comma-separated list** → parsed into a whitelist array with the same trim/filter semantics as `BETTER_AUTH_TRUSTED_ORIGINS` in `auth.definition.ts` (per the issue's acceptance criteria; the old code passed the raw string, which could never match a request origin).
- The auth service consults `BETTER_AUTH_TRUSTED_ORIGINS` as a fallback before failing closed, so a deploy that configures better-auth's trusted origins but not `FRONTEND_SOURCE` keeps serving its login flow.

TDD: `tests/unit/authentication/cors-origin.test.ts` (16 cases) covers missing/empty env fails closed with an error-level log and never returns `'*'`, single-origin verbatim passthrough, comma-separated whitelist parsing, and the auth service's fallback-var chain.

## Dev/CI impact check

- **Local dev** (`npm run dev`): `.env.example` sets `FRONTEND_SOURCE=http://localhost:3000`, so dev never relied on the wildcard. No change.
- **GHA integration tests**: the `Start services` step ran both services without `FRONTEND_SOURCE` (silently exercising the fail-open). No test asserts CORS headers, so nothing breaks either way, but the step now sets the var explicitly to keep services on the configured-origin path.
- **ci compose profile** (`npm run ci:testmock`): the `backend` service never received `FRONTEND_SOURCE` and the `auth` service used a bare passthrough that materializes an unset host var as an empty string — both now default to `http://localhost:3000`.
- **e2e compose profile**: already set the var explicitly for both services. No change.
- **Prod**: deploys with `FRONTEND_SOURCE` set are byte-for-byte unchanged. A deploy that forgets it now serves no CORS headers (cross-origin browser calls blocked, same-origin and non-browser clients unaffected) and logs a `[cors]` error instead of going fail-open.

`docs/env-vars.md` and the `.env.example` comment block document the new semantics. `tests/mocks/authentication.mock.ts` re-exports the real helper (pure env parsing, no auth/DB deps) so unit-tested consumers get production behavior.

Local checks: `typecheck`, `lint`, `format:check`, `build`, and the full unit suite (3571 tests / 255 suites) all pass.