### PR TITLE
test(flowsheet): pin dj-scoping contract on /on-air and /end (Auto-DJ recovery safety)

### DIFF
--- a/apps/backend/middleware/checkShowMember.ts
+++ b/apps/backend/middleware/checkShowMember.ts
@@ -2,13 +2,15 @@ import { RequestHandler } from 'express';
 import { getDJsInCurrentShow } from '../services/flowsheet.service.js';
 
 export const showMemberMiddleware: RequestHandler = async (req, res, next) => {
-  // Positive-list gate (BS#1097): bypass requires explicit dev/test NODE_ENV.
+  // Positive-list gate (BS#1097): bypass requires explicit NODE_ENV=development.
   // Previously this middleware had no NODE_ENV gate at all, so a stray
   // `AUTH_BYPASS=true` in any environment would skip show-membership checks.
-  if (
-    process.env.AUTH_BYPASS === 'true' &&
-    (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test')
-  ) {
+  // NODE_ENV=test was dropped from the list (BS#1533): the integration env
+  // runs with AUTH_BYPASS=true, and short-circuiting here left the deployed
+  // membership chain untested. The auth bypass still populates req.auth.id
+  // (JWT decode or raw user-id fallback), so the check below runs correctly
+  // under bypass; only local dev keeps the hatch.
+  if (process.env.AUTH_BYPASS === 'true' && process.env.NODE_ENV === 'development') {
     return next();
   }
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -62,7 +62,7 @@ The Backend container does not call SES, so no additional AWS credentials are ne
 
 ## Testing
 
-- `AUTH_BYPASS` — Set `true` to skip JWT verification in tests
+- `AUTH_BYPASS` — Set `true` to skip JWT verification in tests. Honored only when `NODE_ENV` is `development` or `test` (positive-list gate, BS#1097). Note: `showMemberMiddleware`'s bypass is narrower — `development` only (BS#1533) — so show-membership checks run for real in the integration env; the auth bypass still populates `req.auth.id` from the Bearer (JWT decode or raw user-id fallback), which is what the membership check reads.
 - `AUTH_USERNAME`, `AUTH_PASSWORD` — Test account credentials (when `AUTH_BYPASS=false`)
 - `TEST_HOST` — Test server host
 

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -266,15 +266,29 @@ describe('End Show', () => {
   test('Non-member with valid write auth cannot end the show (BS#1533)', async () => {
     // showMemberMiddleware runs for real in the integration env — the
     // AUTH_BYPASS short-circuit is development-only post-BS#1533. The
-    // secondary DJ never joined this show, so the outermost guard must 400
+    // secondary DJ never joined this show, so showMemberMiddleware must 400
     // before the mirror or controller run. This is the contract protecting
     // a live human DJ's show from an Auto-DJ recovery end()
     // (WXYC/auto-dj-orchestrator#13).
+    //
+    // dj_id is the PRIMARY's id on purpose, so this test actually pins the
+    // middleware. If it were the secondary's own id, reverting the BS#1533
+    // gate would still yield a byte-identical 400: the request would fall
+    // through to the controller (dj_id === auth.id passes the BS#1102 check),
+    // take the co-host leaveShow branch, and flowsheet.service.leaveShow would
+    // throw the same 'DJ not a member of show' 400 on its 0-row UPDATE — so the
+    // assertion could not distinguish "middleware fired" from "middleware
+    // bypassed". Naming the primary makes the two states diverge: with the
+    // middleware present it 400s here (secondary is not a member, checked ahead
+    // of the controller); on a gate revert the controller's BS#1102 guard fires
+    // instead with a 403 (dj_id=primary !== auth.id=secondary — the same path
+    // the 'Forbidden when dj_id does not match' test below pins), failing this
+    // assertion and surfacing the regression.
     const res = await request
       .post('/flowsheet/end')
       .set('Authorization', global.secondary_access_token)
       .send({
-        dj_id: global.secondary_dj_id,
+        dj_id: global.primary_dj_id,
       })
       .expect(400);
     expect(res.body.message).toBe('Bad Request: DJ not a member of show');
@@ -300,6 +314,8 @@ describe('End Show', () => {
     // DJ has to send their own Bearer to get past the auth check. With no
     // active show the 400 comes from showMemberMiddleware (empty member
     // list — the middleware runs for real in this env post-BS#1533).
+    // Pin the exact message: on a gate revert the controller's "No active
+    // show session found." 400 fires instead, so this discriminates the two.
     const res = await request
       .post('/flowsheet/end')
       .set('Authorization', global.secondary_access_token)
@@ -307,7 +323,7 @@ describe('End Show', () => {
         dj_id: global.secondary_dj_id,
       })
       .expect(400);
-    expect(res.body.message).toBeDefined();
+    expect(res.body.message).toBe('Bad Request: DJ not a member of show');
   });
 });
 
@@ -365,6 +381,8 @@ describe('Leave Show', () => {
     // requires the secondary's own Bearer for the dj_id=auth.id cross-check.
     // With no active show the 400 comes from showMemberMiddleware's empty
     // member list (the middleware runs for real in this env post-BS#1533).
+    // Pin the exact message: on a gate revert the controller's "No active
+    // show session found." 400 fires instead, so this discriminates the two.
     const res = await request
       .post('/flowsheet/end')
       .set('Authorization', global.secondary_access_token)
@@ -372,7 +390,7 @@ describe('Leave Show', () => {
         dj_id: global.secondary_dj_id,
       })
       .expect(400);
-    expect(res.body.message).toBeDefined();
+    expect(res.body.message).toBe('Bad Request: DJ not a member of show');
   });
 });
 

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -263,6 +263,32 @@ describe('End Show', () => {
       .expect(200);
   });
 
+  test('Non-member with valid write auth cannot end the show (BS#1533)', async () => {
+    // showMemberMiddleware runs for real in the integration env — the
+    // AUTH_BYPASS short-circuit is development-only post-BS#1533. The
+    // secondary DJ never joined this show, so the outermost guard must 400
+    // before the mirror or controller run. This is the contract protecting
+    // a live human DJ's show from an Auto-DJ recovery end()
+    // (WXYC/auto-dj-orchestrator#13).
+    const res = await request
+      .post('/flowsheet/end')
+      .set('Authorization', global.secondary_access_token)
+      .send({
+        dj_id: global.secondary_dj_id,
+      })
+      .expect(400);
+    expect(res.body.message).toBe('Bad Request: DJ not a member of show');
+
+    // The show must remain open: the primary DJ still reads as on air,
+    // which requires shows.end_time to still be null.
+    const onAir = await request
+      .get('/flowsheet/on-air')
+      .query({ dj_id: global.primary_dj_id })
+      .set('Authorization', global.access_token)
+      .expect(200);
+    expect(onAir.body.is_live).toBe(true);
+  });
+
   test('No Active Show Session', async () => {
     // End active show
     await request.post('/flowsheet/end').set('Authorization', global.access_token).send({
@@ -271,8 +297,9 @@ describe('End Show', () => {
 
     // Secondary DJ attempts to /flowsheet/end after the show is over.
     // BS#1102: dj_id must match the authenticated caller, so the secondary
-    // DJ has to send their own Bearer to get past the auth check; the
-    // 400 then comes from "No active show".
+    // DJ has to send their own Bearer to get past the auth check. With no
+    // active show the 400 comes from showMemberMiddleware (empty member
+    // list — the middleware runs for real in this env post-BS#1533).
     const res = await request
       .post('/flowsheet/end')
       .set('Authorization', global.secondary_access_token)
@@ -336,6 +363,8 @@ describe('Leave Show', () => {
 
     // Secondary DJ attempts to /flowsheet/end the (now-ended) show. BS#1102
     // requires the secondary's own Bearer for the dj_id=auth.id cross-check.
+    // With no active show the 400 comes from showMemberMiddleware's empty
+    // member list (the middleware runs for real in this env post-BS#1533).
     const res = await request
       .post('/flowsheet/end')
       .set('Authorization', global.secondary_access_token)
@@ -1297,6 +1326,36 @@ describe('On Air Status', () => {
       expect(res.body).toBeDefined();
       expect(res.body.id).toBe(global.primary_dj_id);
       expect(res.body.is_live).toBe(true);
+
+      // Clean up
+      await fls_util.leave_show(global.primary_dj_id, global.access_token);
+    });
+
+    test('returns false for a real DJ who is not in the active show (BS#1533)', async () => {
+      // The dj-scoping contract the Auto-DJ orchestrator's restart-recovery
+      // probe depends on (WXYC/auto-dj-orchestrator#13): another DJ's live
+      // show must not read as "on air" for a DJ who is not in it. A
+      // regression that answered "any show is on air" would pass the other
+      // tests in this block but not this one.
+      await fls_util.join_show(global.primary_dj_id, global.access_token);
+
+      const res = await request
+        .get('/flowsheet/on-air')
+        .query({ dj_id: global.secondary_dj_id })
+        .set('Authorization', global.access_token)
+        .expect(200);
+
+      expect(res.body.id).toBe(global.secondary_dj_id);
+      expect(res.body.is_live).toBe(false);
+
+      // Same probe for the DJ who IS in the show, pinning the discrimination
+      // within a single show lifetime (not just "everything reads false").
+      const primaryRes = await request
+        .get('/flowsheet/on-air')
+        .query({ dj_id: global.primary_dj_id })
+        .set('Authorization', global.access_token)
+        .expect(200);
+      expect(primaryRes.body.is_live).toBe(true);
 
       // Clean up
       await fls_util.leave_show(global.primary_dj_id, global.access_token);

--- a/tests/integration/metadata.spec.js
+++ b/tests/integration/metadata.spec.js
@@ -29,6 +29,10 @@ function makeSql() {
  *
  * NOTE: Uses secondary_dj_id to avoid conflicts with flowsheet.spec.js
  * which uses primary_dj_id. This allows parallel test execution.
+ *
+ * Mutations must use secondary_access_token: showMemberMiddleware runs for
+ * real in this env (BS#1533), so the caller has to be a member of the show
+ * this suite joins as the secondary DJ.
  */
 
 // Use secondary DJ to avoid conflicts with flowsheet.spec.js
@@ -47,7 +51,7 @@ describe('Metadata Fields in Flowsheet Response', () => {
     // Add a track (uses album 4 to avoid conflicts with flowsheet.spec.js in parallel)
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 4, // Sufjan Stevens - Illinois
         track_title: 'Chicago',
@@ -78,7 +82,7 @@ describe('Metadata Fields in Flowsheet Response', () => {
   test('/flowsheet/latest includes metadata fields', async () => {
     await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 5, // Kendrick Lamar - To Pimp a Butterfly
         track_title: 'Alright',
@@ -110,7 +114,7 @@ describe('Fire-and-Forget Metadata Fetch', () => {
     // even though metadata fetch is triggered in the background
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 4, // Sufjan Stevens - Illinois
         track_title: 'Casimir Pulaski Day',
@@ -136,7 +140,7 @@ describe('Fire-and-Forget Metadata Fetch', () => {
     // Add a track without album_id (non-library entry)
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         artist_name: 'Radiohead',
         album_title: 'OK Computer',
@@ -159,7 +163,7 @@ describe('Fire-and-Forget Metadata Fetch', () => {
     // Add a message (no artist_name)
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         message: 'PSA: Station ID at the top of the hour',
       })
@@ -196,7 +200,7 @@ describe('Flowsheet CRUD with Metadata', () => {
     // Add a new track (uses album 5 to avoid conflicts with flowsheet.spec.js)
     await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 5,
         track_title: 'CRUD Test Track',
@@ -214,7 +218,7 @@ describe('Flowsheet CRUD with Metadata', () => {
     // Add a track to delete (uses album 6 to avoid conflicts with flowsheet.spec.js)
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 6,
         track_title: 'Delete Test Track',
@@ -230,7 +234,7 @@ describe('Flowsheet CRUD with Metadata', () => {
     // Delete the track
     await request
       .delete('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({ entry_id: entryId })
       .expect(200);
 
@@ -243,7 +247,7 @@ describe('Flowsheet CRUD with Metadata', () => {
     // Add a track (uses album 4 to avoid conflicts with flowsheet.spec.js)
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 4,
         track_title: 'Update Test Original',
@@ -255,7 +259,7 @@ describe('Flowsheet CRUD with Metadata', () => {
     // Update the track
     await request
       .patch('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         entry_id: entryId,
         data: { track_title: 'Update Test Modified' },
@@ -291,7 +295,7 @@ describe('Metadata with Rotation Entries', () => {
     // Add a track with rotation_id (album_id 4 is in rotation per seed with rotation_id 2)
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 4,
         track_title: 'Rotation Test Track',
@@ -397,7 +401,7 @@ describe('album_metadata COALESCE projection (BS#897)', () => {
     // arm's ON CONFLICT DO NOTHING — sentinel survives intact.
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: SENTINEL_ALBUM_ID,
         track_title: 'BS897 projection test track',
@@ -429,7 +433,7 @@ describe('album_metadata COALESCE projection (BS#897)', () => {
     // the sentinel values from the previous test must NOT leak.
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: SENTINEL_ALBUM_ID,
         track_title: 'BS897 fallthrough test track',
@@ -500,7 +504,7 @@ describe('V2 flowsheet genres/styles projection (BS#1441)', () => {
   const addTrackAndRead = async (title) => {
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({ album_id: SENTINEL_ALBUM_ID, track_title: title })
       .expect(201);
 
@@ -590,7 +594,7 @@ describe('Flowsheet Cache Behavior', () => {
     // Add a track to ensure there's data
     await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 4,
         track_title: 'Cache Consistency Test',
@@ -613,7 +617,7 @@ describe('Flowsheet Cache Behavior', () => {
     // Add a new track
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 5,
         track_title: 'Cache Invalidation Test Add',
@@ -631,7 +635,7 @@ describe('Flowsheet Cache Behavior', () => {
     // Add a track first
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 4,
         track_title: 'Cache Invalidation Test Delete',
@@ -647,7 +651,7 @@ describe('Flowsheet Cache Behavior', () => {
     // Delete the track
     await request
       .delete('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({ entry_id: entryId })
       .expect(200);
 
@@ -660,7 +664,7 @@ describe('Flowsheet Cache Behavior', () => {
     // Add a track
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         album_id: 4,
         track_title: 'Cache Update Original',
@@ -677,7 +681,7 @@ describe('Flowsheet Cache Behavior', () => {
     // Update the track
     await request
       .patch('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         entry_id: entryId,
         data: { track_title: 'Cache Update Modified' },
@@ -741,7 +745,7 @@ describe('Conditional GET (304 Not Modified)', () => {
       // Add a track first so there's data (uses album 4 to avoid conflicts)
       await request
         .post('/flowsheet')
-        .set('Authorization', global.access_token)
+        .set('Authorization', global.secondary_access_token)
         .send({
           album_id: 4,
           track_title: 'Last-Modified Header Test',
@@ -781,7 +785,7 @@ describe('Conditional GET (304 Not Modified)', () => {
       // Add a new track to modify the flowsheet
       await request
         .post('/flowsheet')
-        .set('Authorization', global.access_token)
+        .set('Authorization', global.secondary_access_token)
         .send({
           album_id: 4,
           track_title: 'Modification Test Track',
@@ -806,7 +810,7 @@ describe('Conditional GET (304 Not Modified)', () => {
       // Add a track so there's data (uses album 5 to avoid conflicts)
       await request
         .post('/flowsheet')
-        .set('Authorization', global.access_token)
+        .set('Authorization', global.secondary_access_token)
         .send({
           album_id: 5,
           track_title: 'Latest 304 Test',
@@ -852,7 +856,7 @@ describe('Conditional GET (304 Not Modified)', () => {
       // Add a new track to modify the flowsheet (uses album 4 to avoid conflicts)
       await request
         .post('/flowsheet')
-        .set('Authorization', global.access_token)
+        .set('Authorization', global.secondary_access_token)
         .send({
           album_id: 4,
           track_title: 'Since Query Param Test',
@@ -878,7 +882,7 @@ describe('Conditional GET (304 Not Modified)', () => {
       // Add a track to modify the flowsheet (uses album 4 to avoid conflicts)
       await request
         .post('/flowsheet')
-        .set('Authorization', global.access_token)
+        .set('Authorization', global.secondary_access_token)
         .send({
           album_id: 4,
           track_title: 'Precedence Test Track',
@@ -902,7 +906,7 @@ describe('Conditional GET (304 Not Modified)', () => {
       // Add a track so there's data (uses album 5 to avoid conflicts)
       await request
         .post('/flowsheet')
-        .set('Authorization', global.access_token)
+        .set('Authorization', global.secondary_access_token)
         .send({
           album_id: 5,
           track_title: 'Latest Since Test',

--- a/tests/integration/mirror-http.spec.js
+++ b/tests/integration/mirror-http.spec.js
@@ -12,6 +12,9 @@ const { isMockApiAvailable, resetMockApi, getMockRequests, simulateError } = req
  *
  * NOTE: Mirror is ON by default when POSTHOG_API_KEY is unset (CI case).
  * Uses secondary_dj_id to avoid conflicts with other flowsheet tests.
+ * Mutations must use secondary_access_token: showMemberMiddleware runs for
+ * real in this env (BS#1533), so the caller has to be a member of the show
+ * this suite joins as the secondary DJ.
  */
 
 let mockApiAvailable = false;
@@ -41,7 +44,7 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
 
     await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         artist_name: 'Autechre',
         album_title: 'Confield',
@@ -67,7 +70,7 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
 
     await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         artist_name: 'Jessica Pratt',
         album_title: 'On Your Own Love Again',
@@ -92,7 +95,7 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
 
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         artist_name: 'Chuquimamani-Condori',
         album_title: 'Edits',
@@ -109,7 +112,7 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
 
     const addRes = await request
       .post('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         artist_name: 'Autechre',
         album_title: 'Confield',
@@ -126,7 +129,7 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
     // Update the entry
     await request
       .patch('/flowsheet')
-      .set('Authorization', global.access_token)
+      .set('Authorization', global.secondary_access_token)
       .send({
         entry_id: entryId,
         data: { track_title: 'Cfern (Updated)' },

--- a/tests/unit/middleware/checkShowMember.test.ts
+++ b/tests/unit/middleware/checkShowMember.test.ts
@@ -77,16 +77,20 @@ describe('showMemberMiddleware', () => {
       expect(next).not.toHaveBeenCalled();
     });
 
-    it('short-circuits when AUTH_BYPASS=true and NODE_ENV=test', async () => {
+    it('does NOT short-circuit when AUTH_BYPASS=true and NODE_ENV=test (BS#1533)', async () => {
+      // The integration env runs with AUTH_BYPASS=true + NODE_ENV=test; the
+      // membership check must run for real there so the deployed middleware
+      // chain is exercised. Only NODE_ENV=development keeps the hatch.
       process.env.AUTH_BYPASS = 'true';
       process.env.NODE_ENV = 'test';
+      mockGetDJsInCurrentShow.mockResolvedValue([{ id: 'dj-alice' }]);
 
       const { req, res, next, statusMock } = createMockReqResNext('dj-charlie');
 
       await showMemberMiddleware(req, res, next);
 
-      expect(next).toHaveBeenCalled();
-      expect(statusMock).not.toHaveBeenCalled();
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('short-circuits when AUTH_BYPASS=true and NODE_ENV=development', async () => {


### PR DESCRIPTION
## Summary

Closes #1533. Pins the dj-scoping contract that the Auto-DJ orchestrator's restart-recovery probe depends on (WXYC/auto-dj-orchestrator#13) with integration coverage, so a regression in either behavior fails CI before it reaches the recovery path.

Two blind spots surfaced while confirming #1530:

**Gap 1 — `/flowsheet/on-air` scoping.** The existing `On Air Status` tests never probed a live show with a *different* DJ's id. The non-existent-DJ test runs after the prior test ended the show, so it's equivalent to the no-show case. A regression that made `getOnAirStatusForDJ` answer "any show is on air" would pass the suite. Added a test that starts DJ A's show, probes `dj_id=B` (a real DJ not in the show) expecting `is_live:false`, then re-probes A expecting `true` — pinning the discrimination within one show lifetime.

**Gap 2 — `showMemberMiddleware`'s non-member 400 on `POST /flowsheet/end`.** The rejection path was unit-covered only; the integration env runs with `AUTH_BYPASS=true` + `NODE_ENV=test`, which short-circuited the middleware entirely via the BS#1097 positive-list gate, so the deployed guard chain was never exercised. This is the outermost guard protecting a human DJ's show from an Auto-DJ recovery `end()`.

## Approach for gap 2

Narrowed the positive-list gate in `checkShowMember.ts` from `development || test` to `development` only, so the membership check runs for real in the integration env. The auth bypass still populates `req.auth.id` (JWT decode for the primary's better-auth token, raw user-id fallback for the secondary's), so the check works correctly under bypass; local dev keeps the convenience hatch.

The decision (chosen over the unit-only fallback) is recorded on #1533 with the full audit. The audit traced every HTTP call to the five guarded flowsheet routes across all 46 integration spec files and found the enforcement change breaks exactly two files, both mechanically:

- **`metadata.spec.js` (26) / `mirror-http.spec.js` (5)** join the show as the secondary DJ but mutated with the primary's token. Swapped those mutation Bearers to `secondary_access_token` so the caller is a member.
- **`flowsheet.spec.js`** survives; its two "No Active Show Session" 400s now come from the middleware's empty-member path instead of the controller. Refreshed those comments.

Side benefit: every existing mutation test now exercises the deployed middleware for real, so a regression that rejected legitimate members would fail dozens of tests, not just the new one.

## Changes

- `apps/backend/middleware/checkShowMember.ts` — narrow the bypass gate to `development` only.
- `tests/unit/middleware/checkShowMember.test.ts` — flip the `NODE_ENV=test` case to assert enforcement.
- `tests/integration/flowsheet.spec.js` — new gap-1 on-air scoping test; new gap-2 non-member `/flowsheet/end` test (400 + show stays open); refreshed two now-stale comments.
- `tests/integration/metadata.spec.js`, `tests/integration/mirror-http.spec.js` — swap 31 mutation Bearers to the secondary's token; header-comment note.
- `docs/env-vars.md` — document the narrower `showMemberMiddleware` gate.

## Testing

- `npm run ci:testmock` — full integration suite green with the narrowed gate; both new tests pass, all touched specs pass. (Two unrelated pre-existing issues surfaced during local runs and were ruled out: `auth-auto-membership` needs `DEFAULT_ORG_SLUG` — set in GHA, absent from local `.env`; `requestLine` is a known mock-API `--runInBand` ordering flake that passes in isolation. Neither touches `showMemberMiddleware`.)
- `npm run test:unit` — 3555 pass.
- typecheck, lint (0 errors), format:check — clean.

## Acceptance criteria

- [x] Integration test: DJ A active; `GET /flowsheet/on-air?dj_id=<B>` returns `is_live:false` for a real DJ B not in the show.
- [x] Integration test: authenticated non-member calling `POST /flowsheet/end` gets 400 and the active show's `end_time` stays null.
- [x] Existing integration suite still passes.
