### PR TITLE
fix(mirror): guard endShow against ShowDJ payloads from guest-DJ leaves

### DIFF
--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -79,6 +79,12 @@ const startShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
 });
 
 export const endShow = createHttpMirrorMiddleware<Show>(async (_req, show) => {
+  // BS#1119: /flowsheet/end serves leave semantics too — a guest-DJ leave (or
+  // the Auto-DJ orchestrator's restart recovery) responds with a ShowDJ, which
+  // has no `id`. Only a finalized Show carries the serial PK; discriminate on
+  // it rather than primary_dj_id, which is nullable on a real Show.
+  if (show.id == null) return;
+
   const endMs = toMs(show.end_time ?? Date.now());
 
   // Resolve tubafrenzy show ID: in-memory cache → persisted legacy_show_id

--- a/tests/integration/mirror-http.spec.js
+++ b/tests/integration/mirror-http.spec.js
@@ -144,3 +144,77 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
     }
   });
 });
+
+/**
+ * BS#1119: POST /flowsheet/end serves leave semantics too — a guest-DJ leave
+ * returns a ShowDJ, not a Show, through the same route. The endShow mirror
+ * must not sign off (or run any endShow logic) on that payload. The
+ * primary-plus-guest fixture here is the one BS#1533's dj-scoping tests want.
+ */
+describe('endShow mirror shape guard on guest-DJ leave (BS#1119)', () => {
+  const isSignoff = (r) => r.method === 'POST' && r.path.includes('/api/radioShow/signoff');
+
+  afterEach(async () => {
+    if (!mockApiAvailable) return;
+    // Best-effort cleanup so a mid-test failure can't leak an open show into
+    // later specs (suite runs --runInBand against shared show state).
+    await fls_util.leave_show(global.secondary_dj_id, global.secondary_access_token);
+    await fls_util.leave_show(global.primary_dj_id, global.access_token);
+  });
+
+  test('guest-DJ leave does not sign off the show; primary end signs off once', async () => {
+    if (!mockApiAvailable) return;
+
+    await resetMockApi();
+
+    // Primary A starts the show, guest B joins as co-host
+    await fls_util.join_show(global.primary_dj_id, global.access_token);
+    await fls_util.join_show(global.secondary_dj_id, global.secondary_access_token);
+
+    const addRes = await request
+      .post('/flowsheet')
+      .set('Authorization', global.access_token)
+      .send({
+        artist_name: 'Juana Molina',
+        album_title: 'DOGA',
+        track_title: 'la paradoja',
+      })
+      .expect(201);
+    const entryId = addRes.body.id;
+
+    // Let join/add mirror traffic flush, then observe only the leave
+    await new Promise((r) => setTimeout(r, 300));
+    await resetMockApi();
+
+    // Guest B calls /flowsheet/end — leave semantics, controller returns ShowDJ
+    const leaveRes = await fls_util.leave_show(global.secondary_dj_id, global.secondary_access_token);
+    expect(leaveRes.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    // (a) No signoff reached tubafrenzy
+    const afterLeave = await getMockRequests('tubafrenzy');
+    expect(afterLeave.filter(isSignoff)).toHaveLength(0);
+
+    // (b) The show is still live for primary A
+    const onAirRes = await request.get('/flowsheet/on-air').query({ dj_id: global.primary_dj_id }).expect(200);
+    expect(onAirRes.body.is_live).toBe(true);
+
+    // (c) The prior flowsheet entry is untouched
+    const entriesRes = await request.get('/flowsheet').query({ limit: 10 }).expect(200);
+    const entry = entriesRes.body.entries.find((e) => e.id === entryId);
+    expect(entry).toBeDefined();
+    expect(entry.track_title).toBe('la paradoja');
+    expect(entry.artist_name).toBe('Juana Molina');
+
+    // Positive control: primary A ends the show → exactly one signoff
+    await resetMockApi();
+    const endRes = await fls_util.leave_show(global.primary_dj_id, global.access_token);
+    expect(endRes.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    const afterEnd = await getMockRequests('tubafrenzy');
+    expect(afterEnd.filter(isSignoff)).toHaveLength(1);
+  });
+});

--- a/tests/integration/mirror-http.spec.js
+++ b/tests/integration/mirror-http.spec.js
@@ -147,9 +147,15 @@ describe('Mirror HTTP to Tubafrenzy (Mock API)', () => {
 
 /**
  * BS#1119: POST /flowsheet/end serves leave semantics too — a guest-DJ leave
- * returns a ShowDJ, not a Show, through the same route. The endShow mirror
- * must not sign off (or run any endShow logic) on that payload. The
- * primary-plus-guest fixture here is the one BS#1533's dj-scoping tests want.
+ * returns a ShowDJ, not a Show, through the same route. This locks the
+ * end-to-end signoff CONTRACT: a guest leave signs off zero times and leaves
+ * the show live, while the primary's end signs off exactly once.
+ *
+ * The guard's unit-level regression pin lives in endshow-shape-guard.test.ts.
+ * These black-box assertions hold with or without the `show.id == null` guard —
+ * signoff is separately gated on a resolved tubafrenzy show id, so it stays
+ * silent for a ShowDJ either way — so their value here is contract coverage
+ * plus the primary-plus-guest fixture BS#1533's dj-scoping tests reuse.
  */
 describe('endShow mirror shape guard on guest-DJ leave (BS#1119)', () => {
   const isSignoff = (r) => r.method === 'POST' && r.path.includes('/api/radioShow/signoff');

--- a/tests/unit/middleware/legacy/endshow-shape-guard.test.ts
+++ b/tests/unit/middleware/legacy/endshow-shape-guard.test.ts
@@ -1,0 +1,155 @@
+/**
+ * BS#1119 — POST /flowsheet/end mirror runs endShow on leaveShow responses.
+ *
+ * The /flowsheet/end route registers flowsheetMirror.endShow unconditionally,
+ * but the controller returns a Show only on the primary-DJ branch; a guest-DJ
+ * leave (or the Auto-DJ orchestrator's restart recovery) returns a ShowDJ
+ * (show_id, dj_id, active — no id, end_time, or legacy_show_id). The mirror
+ * must not execute any endShow logic (signoff or the show_end announcement
+ * re-query) on a ShowDJ payload.
+ *
+ * Harness follows mirror.loop-prevention.test.ts: real middleware, mocks only
+ * at process boundaries (tubafrenzy HTTP client, database, PostHog, Sentry).
+ */
+
+// --- Mocks ---
+
+const mockMirrorSignoffShow = jest.fn().mockResolvedValue(undefined);
+const mockMirrorCreateEntry = jest.fn().mockResolvedValue(null);
+const mockGetCachedShowId = jest.fn().mockReturnValue(undefined);
+const mockMapEntryToTubafrenzy = jest.fn().mockReturnValue({ artistName: 'test' });
+
+jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
+  mirrorCreateEntry: mockMirrorCreateEntry,
+  mirrorCreateShow: jest.fn(),
+  mirrorSignoffShow: mockMirrorSignoffShow,
+  mirrorUpdateEntry: jest.fn(),
+  cacheEntryId: jest.fn(),
+  cacheShowId: jest.fn(),
+  getCachedEntryId: jest.fn(),
+  getCachedShowId: mockGetCachedShowId,
+  clearEntryIdMap: jest.fn(),
+  clearShowIdMap: jest.fn(),
+  mapEntryToTubafrenzy: mockMapEntryToTubafrenzy,
+  mapShowToTubafrenzy: jest.fn(),
+  mapUpdateToTubafrenzy: jest.fn(),
+}));
+
+const mockDbUpdate = jest.fn().mockReturnValue({
+  set: jest.fn().mockReturnValue({
+    where: jest.fn().mockResolvedValue(undefined),
+  }),
+});
+
+// Configurable per-test: default resolves to [] (no announcement entry found)
+let mockSelectLimitResult: unknown[] = [];
+
+const mockDbSelect = jest.fn().mockReturnValue({
+  from: jest.fn().mockReturnValue({
+    where: jest.fn().mockReturnValue({
+      orderBy: jest.fn().mockReturnValue({
+        limit: jest.fn().mockImplementation(() => Promise.resolve(mockSelectLimitResult)),
+      }),
+      limit: jest.fn().mockImplementation(() => Promise.resolve(mockSelectLimitResult)),
+    }),
+  }),
+});
+
+jest.mock('@wxyc/database', () => ({
+  db: {
+    select: mockDbSelect,
+    update: mockDbUpdate,
+  },
+  user: {},
+  flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id', show_id: 'show_id' },
+  shows: { id: 'id', legacy_show_id: 'legacy_show_id' },
+}));
+
+jest.mock('drizzle-orm', () => ({
+  eq: jest.fn((...args: unknown[]) => args),
+  desc: jest.fn(),
+  asc: jest.fn(),
+}));
+
+jest.mock('posthog-node', () => ({
+  PostHog: jest.fn().mockImplementation(() => ({
+    isFeatureEnabled: jest.fn().mockResolvedValue(true),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+const mockCaptureException = jest.fn();
+jest.mock('@sentry/node', () => ({
+  captureException: mockCaptureException,
+}));
+
+const mockIsActiveRotationMatch = jest.fn().mockResolvedValue(false);
+jest.mock('../../../../apps/backend/middleware/legacy/rotation-match.mirror', () => ({
+  isActiveRotationMatch: mockIsActiveRotationMatch,
+}));
+
+import { runMiddleware } from './http-mirror-harness';
+
+// Import the middleware AFTER all mocks are set up
+import { flowsheetMirror } from '../../../../apps/backend/middleware/legacy/flowsheet.mirror';
+
+describe('endShow mirror payload shape guard (BS#1119)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCachedShowId.mockReturnValue(undefined);
+    mockSelectLimitResult = [];
+  });
+
+  // What flowsheet_service.leaveShow returns for a guest-DJ leave: the
+  // show_djs row — (show_id, dj_id, active) with no id / end_time / legacy_show_id.
+  const showDJPayload = {
+    show_id: 100,
+    dj_id: 'guest-dj-user-id',
+    active: false,
+  };
+
+  it('executes no endShow logic when a guest-DJ leave returns a ShowDJ payload', async () => {
+    await runMiddleware(flowsheetMirror.endShow, showDJPayload);
+
+    // No signoff, no announcement re-query (the re-query is what throws on the
+    // undefined show_id bind in production and lands in Sentry), no error.
+    expect(mockMirrorSignoffShow).not.toHaveBeenCalled();
+    expect(mockDbSelect).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('still signs off and mirrors the announcement when the primary DJ ends the show', async () => {
+    const endedShowPayload = {
+      id: 200,
+      primary_dj_id: 'primary-dj-user-id',
+      legacy_show_id: 171500,
+      start_time: '2026-07-06T14:00:00.000Z',
+      end_time: '2026-07-06T16:00:00.000Z',
+    };
+
+    await runMiddleware(flowsheetMirror.endShow, endedShowPayload);
+
+    expect(mockMirrorSignoffShow).toHaveBeenCalledWith(171500, new Date('2026-07-06T16:00:00.000Z').getTime());
+    // The show_end announcement re-query ran against the finalized show
+    expect(mockDbSelect).toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('still signs off a show whose primary DJ account was deleted mid-show', async () => {
+    // shows.primary_dj_id is nullable (onDelete: 'set null'). The guard must
+    // discriminate on `id`, not primary_dj_id truthiness — startShow's guard
+    // style would silently drop this signoff.
+    const orphanedShowPayload = {
+      id: 201,
+      primary_dj_id: null,
+      legacy_show_id: 171501,
+      start_time: '2026-07-06T14:00:00.000Z',
+      end_time: '2026-07-06T16:00:00.000Z',
+    };
+
+    await runMiddleware(flowsheetMirror.endShow, orphanedShowPayload);
+
+    expect(mockMirrorSignoffShow).toHaveBeenCalledWith(171501, new Date('2026-07-06T16:00:00.000Z').getTime());
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/middleware/legacy/endshow-shape-guard.test.ts
+++ b/tests/unit/middleware/legacy/endshow-shape-guard.test.ts
@@ -66,7 +66,18 @@ jest.mock('@wxyc/database', () => ({
 }));
 
 jest.mock('drizzle-orm', () => ({
-  eq: jest.fn((...args: unknown[]) => args),
+  // Faithfully simulate postgres-js rejecting an `undefined` bind. The BS#1119
+  // prod symptom is the show_end announcement re-query binding
+  // `eq(flowsheet.show_id, undefined)` — a ShowDJ has no `id` — which throws in
+  // the driver and lands in Sentry once per guest leave. Making eq() throw on an
+  // undefined operand lets the ShowDJ test pin that exact symptom (the mirror
+  // catching into Sentry) rather than only the proxy "db.select was reached".
+  eq: jest.fn((column: unknown, value: unknown) => {
+    if (value === undefined) {
+      throw new Error('cannot bind undefined to a query parameter (simulated postgres-js undefined bind)');
+    }
+    return [column, value];
+  }),
   desc: jest.fn(),
   asc: jest.fn(),
 }));
@@ -111,11 +122,16 @@ describe('endShow mirror payload shape guard (BS#1119)', () => {
   it('executes no endShow logic when a guest-DJ leave returns a ShowDJ payload', async () => {
     await runMiddleware(flowsheetMirror.endShow, showDJPayload);
 
-    // No signoff, no announcement re-query (the re-query is what throws on the
-    // undefined show_id bind in production and lands in Sentry), no error.
-    expect(mockMirrorSignoffShow).not.toHaveBeenCalled();
+    // Two independent regression pins — both flip red if the `show.id == null`
+    // guard is removed. Without the guard the show_end announcement re-query
+    // runs (mockDbSelect) and binds `show_id = undefined`, which the eq() mock
+    // rejects exactly as postgres-js does in prod — the mirror catches that
+    // throw into Sentry once per guest leave (mockCaptureException). The signoff
+    // is a secondary check: it stays silent either way because it is separately
+    // gated on a resolved tubafrenzy show id.
     expect(mockDbSelect).not.toHaveBeenCalled();
     expect(mockCaptureException).not.toHaveBeenCalled();
+    expect(mockMirrorSignoffShow).not.toHaveBeenCalled();
   });
 
   it('still signs off and mirrors the announcement when the primary DJ ends the show', async () => {

--- a/tests/unit/middleware/legacy/http-mirror-harness.ts
+++ b/tests/unit/middleware/legacy/http-mirror-harness.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared harness for unit-testing the HTTP mirror middleware
+ * (createHttpMirrorMiddleware handlers in flowsheet.mirror.ts).
+ *
+ * Simulates the Express response lifecycle the middleware taps: `send`
+ * captures the JSON payload into `res.locals.mirrorData`, then `finish` fires
+ * the mirror's async handler. jest.mock() calls stay in each test file (they
+ * must be hoisted per-module); only the lifecycle plumbing lives here.
+ *
+ * Not a test file — the `.test.ts` glob in jest.unit.config.ts skips it.
+ */
+
+import { EventEmitter } from 'events';
+
+export function createMockRes(statusCode: number) {
+  const emitter = new EventEmitter();
+  const locals: Record<string, unknown> = {};
+  const res = {
+    statusCode,
+    locals,
+    getHeader: jest.fn().mockReturnValue('application/json'),
+    send: jest.fn(),
+    once: emitter.once.bind(emitter),
+    on: emitter.on.bind(emitter),
+    emit: emitter.emit.bind(emitter),
+  };
+
+  // After send is called, emit 'finish' to trigger mirror logic
+  res.send.mockImplementation((data: unknown) => {
+    locals.mirrorData = typeof data === 'string' ? JSON.parse(data) : data;
+    setTimeout(() => emitter.emit('finish'), 0);
+    return res;
+  });
+
+  return res;
+}
+
+export function createMockReq() {
+  return {
+    ip: '127.0.0.1',
+    user: { id: 'test-user' },
+  };
+}
+
+/**
+ * Invoke a mirror middleware with a JSON payload and wait for the
+ * fire-and-forget finish handler to complete.
+ */
+export async function runMiddleware(
+  middleware: (req: unknown, res: unknown, next: unknown) => Promise<void> | void,
+  payload: Record<string, unknown>,
+  statusCode = 200
+) {
+  const req = createMockReq();
+  const res = createMockRes(statusCode);
+  const next = jest.fn();
+
+  // Middleware may or may not return a promise
+  void middleware(req, res, next);
+  expect(next).toHaveBeenCalled();
+
+  // Trigger send (which populates mirrorData and emits finish)
+  res.send(JSON.stringify(payload));
+
+  // Wait for async finish handler to complete
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}

--- a/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
+++ b/tests/unit/middleware/legacy/mirror.loop-prevention.test.ts
@@ -86,61 +86,7 @@ jest.mock('../../../../apps/backend/middleware/legacy/rotation-match.mirror', ()
   isActiveRotationMatch: mockIsActiveRotationMatch,
 }));
 
-import { EventEmitter } from 'events';
-
-// Helper: create mock Express response that simulates the middleware lifecycle
-function createMockRes(statusCode: number, body: Record<string, unknown>) {
-  const emitter = new EventEmitter();
-  const locals: Record<string, unknown> = {};
-  const res = {
-    statusCode,
-    locals,
-    getHeader: jest.fn().mockReturnValue('application/json'),
-    send: jest.fn(),
-    once: emitter.once.bind(emitter),
-    on: emitter.on.bind(emitter),
-    emit: emitter.emit.bind(emitter),
-    _body: body,
-  };
-
-  // After send is called, emit 'finish' to trigger mirror logic
-  res.send.mockImplementation((data: unknown) => {
-    locals.mirrorData = typeof data === 'string' ? JSON.parse(data) : data;
-    // Simulate Express: emit finish after send
-    setTimeout(() => emitter.emit('finish'), 0);
-    return res;
-  });
-
-  return res;
-}
-
-function createMockReq() {
-  return {
-    ip: '127.0.0.1',
-    user: { id: 'test-user' },
-  };
-}
-
-// Helper: call middleware and wait for the async finish handler
-async function runMiddleware(
-  middleware: (req: any, res: any, next: any) => Promise<void> | void,
-  entry: Record<string, unknown>,
-  statusCode = 201
-) {
-  const req = createMockReq();
-  const res = createMockRes(statusCode, entry);
-  const next = jest.fn();
-
-  // Middleware may or may not return a promise
-  void middleware(req, res, next);
-  expect(next).toHaveBeenCalled();
-
-  // Trigger send (which populates mirrorData and emits finish)
-  res.send(JSON.stringify(entry));
-
-  // Wait for async finish handler to complete
-  await new Promise((resolve) => setTimeout(resolve, 50));
-}
+import { runMiddleware } from './http-mirror-harness';
 
 // Import the middleware AFTER all mocks are set up
 import { flowsheetMirror } from '../../../../apps/backend/middleware/legacy/flowsheet.mirror';


### PR DESCRIPTION
Closes #1119

## Problem

`POST /flowsheet/end` registers the `endShow` HTTP mirror unconditionally, but the controller's `leaveShow` returns a `Show` only on the primary-DJ branch — a guest-DJ leave (and the Auto-DJ orchestrator's restart-recovery path, WXYC/auto-dj-orchestrator#13) returns a `ShowDJ` through the same route. The mirror dereferenced the payload as a `Show`: the signoff was skipped only by luck (`getCachedShowId(undefined)` always misses and the `legacy_show_id` fallback is undefined), and the show_end announcement re-query ran `eq(flowsheet.show_id, undefined)`, which throws at the postgres driver and lands in Sentry tagged `subsystem:legacy-mirror` (`Failed query … params: ,1`) on every guest leave.

## Fix

Early-return in the `endShow` mirror handler unless the payload is actually a `Show`, discriminating on `show.id` — a non-null serial on every finalized `Show` and absent from `show_djs`. Deliberately not `startShow`'s truthiness-guard style (`!show.primary_dj_id`): `shows.primary_dj_id` is nullable (`onDelete: 'set null'`), so a truthiness check would silently drop the signoff for a show whose primary DJ account was deleted mid-show. A unit test pins that edge against a future "harmonize with startShow" refactor.

## Tests

- **Unit** (`tests/unit/middleware/legacy/endshow-shape-guard.test.ts`, new): exercises the real middleware through the response-tap lifecycle with mocks only at process boundaries. Three cases: `ShowDJ` payload executes no endShow logic (no signoff, no announcement re-query, no Sentry capture — red before the fix); `Show` payload still signs off and mirrors the announcement; `Show` with `primary_dj_id: null` still signs off.
- **Harness extraction**: the mock-res/req/`runMiddleware` lifecycle plumbing moved from `mirror.loop-prevention.test.ts` into a shared `http-mirror-harness.ts`, consumed by both files (jest module mocks stay per-file as required by hoisting).
- **Integration** (`tests/integration/mirror-http.spec.js`): primary A + guest B fixture — B's `POST /flowsheet/end` produces no `radioShow/signoff` call against mock tubafrenzy, leaves the show live for A, and leaves the prior entry untouched; A's end then signs off exactly once. This adds the suite's first positive signoff-path coverage, and the primary-plus-guest fixture is the one #1533 wants for the dj-scoping contract tests — cross-referencing rather than implementing that scope here.

## Verification

`typecheck`, `lint`, `format:check`, full unit suite (3,558 tests), and `ci:testmock` (45 integration suites) all green locally.