### PR TITLE
fix(1534): project the anonymous liveFs SSE broadcast through the client-facing allow-list

### DIFF
--- a/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
+++ b/apps/backend/services/metadata-broadcast/metadata-broadcast.ts
@@ -16,12 +16,20 @@
  *   - data.metadata_status is a terminal state
  *     ('enriched_match' | 'enriched_no_match' | 'failed_no_retry')
  *
- * Payload is the full flowsheet row from `event.data` (BS-2). dj-site's
- * listener middleware patches the row into its RTK Query cache directly —
- * a /live viewer that just opened the page sees post-enrichment fields
- * (`artwork_url`, `release_year`, etc.) without a follow-up GET.
- * `wxyc-shared`'s `LiveFsUpdateEvent` is the canonical cross-language
- * shape; this file's `LiveFsUpdatePayload` mirrors that contract.
+ * Payload is the flowsheet row from `event.data`, projected through the
+ * client-facing `CLIENT_FACING_FLOWSHEET_COLUMNS` allow-list (BS-2 inlined
+ * the row; BS#1534 projects it). dj-site's listener middleware patches the
+ * row into its RTK Query cache directly — a /live viewer that just opened
+ * the page sees post-enrichment fields (`artwork_url`, `release_year`, etc.)
+ * without a follow-up GET. The `/events/stream` topic is anonymous
+ * (`Topics.liveFs` authz `[]`), so the projection keeps the raw CDC row's
+ * internal columns (`search_doc`, `composer`, `legacy_*`, `linkage_*`, …)
+ * off the public stream — the same allow-list the mutation echoes and DJ
+ * peek use (BS#1513). `wxyc-shared`'s `LiveFsUpdateEvent` is the canonical
+ * cross-language shape; this file's `LiveFsUpdatePayload` mirrors that
+ * contract. (The `/cdc` WebSocket fan-out stays unprojected by design — it
+ * is `CDC_SECRET`-gated and its reconciliation-monitor consumer needs the
+ * complete row; see `docs/cdc.md`.)
  *
  * False positives: the filter matches any flowsheet UPDATE that lands in
  * a terminal metadata_status. The historical `flowsheet-metadata-backfill`
@@ -39,15 +47,17 @@ import * as Sentry from '@sentry/node';
 import type { CdcEvent } from '@wxyc/database';
 import { onCdcEvent } from '@wxyc/database';
 import { serverEventsMgr, Topics, FsEvents } from '../../utils/serverEvents.js';
+import { pickClientFacingColumns } from '../../utils/flowsheet-projection.js';
 
 const TERMINAL_STATUSES = new Set(['enriched_match', 'enriched_no_match', 'failed_no_retry']);
 
 /**
  * Wire shape of the `liveFs:update` payload. Mirrors `LiveFsUpdateEvent` in
  * `wxyc-shared/api.yaml`. The two required fields (`id`, `metadata_status`)
- * are pinned because we assert them at the filter boundary; the rest of the
- * flowsheet columns (`artist_name`, `album_title`, `artwork_url`, ...) ride
- * along untyped at this seam — dj-site / iOS receive them via the typed
+ * are pinned because we assert them at the filter boundary; the remaining
+ * columns are the `CLIENT_FACING_FLOWSHEET_COLUMNS` allow-list subset
+ * (`artist_name`, `album_title`, `artwork_url`, ...) that `pickClientFacingColumns`
+ * projects (BS#1534) — dj-site / iOS receive them via the typed
  * `FlowsheetSongEntry` schema generated from `@wxyc/shared`, which is the
  * cross-language source of truth.
  */
@@ -70,8 +80,11 @@ export function filterMetadataUpdate(event: CdcEvent): LiveFsUpdatePayload | nul
   const id = data.id;
   if (typeof id !== 'number') return null;
 
+  // Project through the client-facing allow-list before the row hits the
+  // anonymous `/events/stream` (BS#1534): internal CDC columns (`search_doc`,
+  // `composer`, `legacy_*`, `linkage_*`, …) must not ride the public stream.
   return {
-    ...data,
+    ...pickClientFacingColumns(data),
     id,
     metadata_status: status as LiveFsUpdatePayload['metadata_status'],
   };

--- a/apps/backend/utils/flowsheet-projection.ts
+++ b/apps/backend/utils/flowsheet-projection.ts
@@ -121,3 +121,24 @@ export function projectFlowsheetEntry(row: FSEntry): ClientFacingFSEntry {
     artist_wikipedia_url: row.artist_wikipedia_url,
   };
 }
+
+/**
+ * JSON-tolerant sibling of {@link projectFlowsheetEntry} for flowsheet rows
+ * that arrive as parsed JSON rather than a typed `FSEntry` — notably the CDC
+ * `to_jsonb(NEW)` payload the anonymous `liveFs:update` SSE broadcast forwards
+ * (BS#1534), where dates are ISO strings and the static `FSEntry` shape doesn't
+ * apply. It loops the same `CLIENT_FACING_FLOWSHEET_COLUMNS` allow-list — one
+ * list, zero drift with the typed projector — and copies only the columns
+ * actually present on the row, so a partial row is not padded with invented
+ * keys. Values pass through untouched (an ISO-string date stays an ISO string).
+ */
+export function pickClientFacingColumns(row: Record<string, unknown>): Record<string, unknown> {
+  const projected: Record<string, unknown> = {};
+  for (const column of CLIENT_FACING_FLOWSHEET_COLUMNS) {
+    if (Object.hasOwn(row, column)) {
+      // eslint-disable-next-line security/detect-object-injection -- keys are the fixed allow-list const, not caller input
+      projected[column] = row[column];
+    }
+  }
+  return projected;
+}

--- a/tests/unit/apps/backend/services/metadata-broadcast.test.ts
+++ b/tests/unit/apps/backend/services/metadata-broadcast.test.ts
@@ -12,6 +12,7 @@
  */
 
 import type { CdcEvent } from '@wxyc/database';
+import { INTERNAL_FLOWSHEET_COLUMNS, makeFullFlowsheetRow } from '../../../../fixtures/flowsheet-row.fixture';
 
 jest.mock('@sentry/node', () => ({
   captureException: jest.fn(),
@@ -50,18 +51,26 @@ const flowsheetUpdate = (overrides: Partial<Record<string, unknown>> = {}): CdcE
 describe('filterMetadataUpdate (BS#892 PR-2)', () => {
   // Pre-BS-2 payload was `{id, metadata_status}` — dj-site's listener
   // middleware would patch only those two fields and rely on the rest
-  // already being in the local cache. BS-2 inlines the full row so
-  // newly-mounted clients (a /live viewer that just opened the page) can
-  // surface metadata-enriched fields like `artwork_url` without a follow-up
-  // GET. The wxyc-shared `LiveFsUpdateEvent` contract pins this shape.
+  // already being in the local cache. BS-2 inlined the row so newly-mounted
+  // clients (a /live viewer that just opened the page) can surface
+  // metadata-enriched fields like `artwork_url` without a follow-up GET.
+  // BS#1534 projects that row through the CLIENT_FACING_FLOWSHEET_COLUMNS
+  // allow-list before it hits the anonymous SSE stream: the payload stays
+  // rich enough to cache-patch (the `LiveFsUpdateEvent` contract), but the
+  // internal columns (search_doc, composer, legacy_*, linkage_*, …) that the
+  // raw CDC `to_jsonb(NEW)` row carried no longer ride the public broadcast.
 
-  it('returns the full row data as the payload (BS-2)', () => {
+  it('projects the client-facing row as the payload, dropping internal columns (BS#1534)', () => {
     const event = flowsheetUpdate({
       artist_name: 'Juana Molina',
       album_title: 'DOGA',
       track_title: 'la paradoja',
       record_label: 'Sonamos',
       artwork_url: 'https://example.com/doga.jpg',
+      // Internal columns present on the raw CDC row — must be stripped.
+      search_doc: "'juana':1A",
+      composer: 'Juana Molina',
+      legacy_entry_id: 9999,
     });
     expect(filterMetadataUpdate(event)).toEqual({
       id: 42,
@@ -71,6 +80,27 @@ describe('filterMetadataUpdate (BS#892 PR-2)', () => {
       track_title: 'la paradoja',
       record_label: 'Sonamos',
       artwork_url: 'https://example.com/doga.jpg',
+    });
+  });
+
+  it('strips every internal column and keeps every client column from a full CDC row (BS#1534)', () => {
+    // The shared leak fixture carries all 12 internal columns truthy alongside
+    // the client set — same fixture the mutation/peek leak suites use, so a new
+    // internal column is covered here from the one update site.
+    const payload = filterMetadataUpdate(flowsheetUpdate(makeFullFlowsheetRow()));
+    expect(payload).not.toBeNull();
+    for (const internalKey of INTERNAL_FLOWSHEET_COLUMNS) {
+      expect(payload).not.toHaveProperty(internalKey);
+    }
+    // A representative slice of client-facing columns survives, including the
+    // enrichment fields the SSE consumer exists to receive.
+    expect(payload).toMatchObject({
+      id: 42,
+      metadata_status: 'enriched_match',
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      artwork_url: 'https://example.com/art.jpg',
+      release_year: 2022,
     });
   });
 

--- a/tests/unit/utils/flowsheet-projection.test.ts
+++ b/tests/unit/utils/flowsheet-projection.test.ts
@@ -1,5 +1,6 @@
 import {
   projectFlowsheetEntry,
+  pickClientFacingColumns,
   CLIENT_FACING_FLOWSHEET_COLUMNS,
 } from '../../../apps/backend/utils/flowsheet-projection';
 import { INTERNAL_FLOWSHEET_COLUMNS, makeFullFlowsheetRow } from '../../fixtures/flowsheet-row.fixture';
@@ -82,5 +83,39 @@ describe('projectFlowsheetEntry (BS#1513)', () => {
     expect(projected.message).toBe('Talkset');
     expect(projected.entry_type).toBe('talkset');
     expect(projected).not.toHaveProperty('search_doc');
+  });
+});
+
+describe('pickClientFacingColumns (BS#1534)', () => {
+  // JSON-tolerant sibling for parsed-JSON rows (the CDC `to_jsonb(NEW)` payload
+  // on the anonymous SSE stream). Loops the same allow-list, so the leak-defense
+  // coverage carries over; these tests pin the JSON-specific behaviors.
+
+  it('drops every internal column and keeps the client columns from a full parsed row', () => {
+    // Emulate the parsed-JSON shape: dates arrive as ISO strings, not Dates.
+    const raw = JSON.parse(JSON.stringify(makeFullFlowsheetRow())) as Record<string, unknown>;
+    const picked = pickClientFacingColumns(raw);
+    for (const internalKey of INTERNAL_FLOWSHEET_COLUMNS) {
+      expect(picked).not.toHaveProperty(internalKey);
+    }
+    expect(new Set(Object.keys(picked))).toEqual(new Set(CLIENT_FACING_FLOWSHEET_COLUMNS));
+  });
+
+  it('copies only the columns actually present — a partial row is not padded with invented keys', () => {
+    const picked = pickClientFacingColumns({ id: 7, artist_name: 'Jessica Pratt', legacy_entry_id: 9999 });
+    expect(picked).toEqual({ id: 7, artist_name: 'Jessica Pratt' });
+    expect(picked).not.toHaveProperty('album_title');
+    expect(picked).not.toHaveProperty('legacy_entry_id');
+  });
+
+  it('passes values through untouched (ISO-string date stays a string)', () => {
+    const picked = pickClientFacingColumns({ id: 7, add_time: '2024-02-01T12:00:00.000Z' });
+    expect(picked.add_time).toBe('2024-02-01T12:00:00.000Z');
+  });
+
+  it('ignores a prototype-polluting key that collides with nothing in the allow-list', () => {
+    const picked = pickClientFacingColumns(JSON.parse('{"id":7,"__proto__":{"polluted":true}}'));
+    expect(picked).toEqual({ id: 7 });
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes #1534.

`filterMetadataUpdate` forwarded the CDC `to_jsonb(NEW)` row wholesale (`{...data, id, metadata_status}`) as the `liveFs:update` SSE payload. `Topics.liveFs` is authorized `[]` (public), and `GET /events/stream` carries no auth middleware — anonymity is pinned by `CONTRACTS.LIVE_FS_PUBLIC_TOPIC_NO_AUTH`. So on every terminal-enrichment UPDATE, unauthenticated SSE subscribers received the internal flowsheet columns: `search_doc` (always populated), `updated_at`, `enriching_since`, the enrichment/linkage markers, the BS#1499 `composer` / `composer_source` columns (actively written, `artist_proxy` fallback), and `legacy_entry_id` / `legacy_release_id`.

This is the same leak class #1513 closed on the mutation echoes and DJ peek — on the *most* exposed surface it has (anonymous SSE). Surfaced during the max-effort review of #1532; pre-existing since BS#892, so filed and fixed separately per the exposed-vs-created debt rule.

**Severity:** contract hygiene, not a security incident — every value derives from public playlist/Discogs data; the `dj_name` chain is PII-safe per BS#1371.

## Approach

`filterMetadataUpdate` now returns the client-facing projection: `{ ...pickClientFacingColumns(data), id, metadata_status }`. The pinned `id` + `metadata_status` keep their narrowed types.

`pickClientFacingColumns(row: Record<string, unknown>)` is a new JSON-tolerant sibling of `projectFlowsheetEntry` in the same module. The CDC row arrives as parsed JSON (ISO-string dates), so the typed `projectFlowsheetEntry(row: FSEntry)` doesn't fit directly — but the picker loops the **same** `CLIENT_FACING_FLOWSHEET_COLUMNS` const, so there's one allow-list and zero drift. It copies only the columns present on the row (a partial row isn't padded with invented keys) and passes values through untouched.

The `/cdc` WebSocket fan-out and the trigger SQL are left unprojected by design — `CDC_SECRET`-gated, and the reconciliation monitor needs the complete row (`docs/cdc.md`).

## Contract

Preserves the purpose of `CONTRACTS.LIVE_FS_UPDATE_INCLUDES_FULL_ROW`: the payload stays sufficient for dj-site's listener to cache-patch without a follow-up GET — no regression to the old `{id, metadata_status}` minimal shape. The projected set matches `FlowsheetEntryResponse` (the raw row never did — internal columns were undeclared `additionalProperties`), so the `api-spec.test.ts` `payload.$ref === FlowsheetEntryResponse` assertion holds.

The companion **prose** change (reword `LIVE_FS_UPDATE_INCLUDES_FULL_ROW`'s JSDoc + the `api.yaml` `LiveFsUpdateEvent` description from "full flowsheet row" → "client-facing `FlowsheetEntryResponse` projection") lands in a separate wxyc-shared PR, cross-referencing #1534.

## Consumer audit (from #1534)

The sole SSE consumer is dj-site `live-updates-listener.ts` (grep of wxyc-ios-64, wxyc-dj-ios, website, archive shows zero SSE usage). Its patch path wholesale-`Object.assign`s the payload into cached `FlowsheetEntry` objects, and every field its UI renders is in the allow-list — projection is a strict subtraction of junk keys smeared onto the cache today. **Zero behavioral change.**

## Testing

- `tests/unit/apps/backend/services/metadata-broadcast.test.ts` — asserts internal columns absent from the broadcast payload and client fields (incl. the enrichment fields the SSE consumer exists to receive) survive; reuses the shared leak fixture.
- `tests/unit/utils/flowsheet-projection.test.ts` — pins `pickClientFacingColumns`: full-row strip, partial-row tolerance (no invented keys), value passthrough (ISO date stays a string), `__proto__` key ignored.

Local CI green: `typecheck`, `lint` (0 errors), `format:check`, `test:unit` (3591 passed).

## Stacking

Based on `chore/1513-flowsheet-row-projection` (#1532) — it reuses `flowsheet-projection.ts`'s allow-list, which lands there. GitHub will retarget this PR to `main` when #1532 merges. Review/merge #1532 first.
