### PR TITLE
feat(library): BMI performance-list endpoint shell (BS#1500)

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -279,6 +279,79 @@ components:
           format: date
           nullable: true
 
+    BmiPerformanceRow:
+      type: object
+      description: >
+        One played musical work in the `GET /library/bmi-performance-list` export
+        (BS#1500). Flat projection of a `flowsheet` track row with a usable artist.
+        `composer_source` is raw open-ended text (a source added after the endpoint,
+        e.g. `musicbrainz_work`, can appear); consumers should not treat it as a
+        closed enum.
+      properties:
+        artist_name:
+          type: string
+        track_title:
+          type: string
+          nullable: true
+        album_title:
+          type: string
+          nullable: true
+        record_label:
+          type: string
+          nullable: true
+        composer:
+          type: string
+          nullable: true
+        composer_source:
+          type: string
+          nullable: true
+          description: 'Provenance of `composer`: discogs_track | discogs_release | artist_proxy | a later source | null.'
+        played_at:
+          type: string
+          format: date-time
+          description: The play's logging instant (`flowsheet.add_time`), ISO-8601.
+
+    BmiCoverage:
+      type: object
+      description: >
+        Composer-provenance breakdown for the pre-submit preview. The five counts
+        partition `total`. `none` = no composer credit at all; `unknown` = a non-null
+        `composer_source` outside the known set (a real credit from a later source),
+        kept distinct from `none` so a credited play is never reported as having no composer.
+      properties:
+        total:
+          type: integer
+        real_track:
+          type: integer
+        real_release:
+          type: integer
+        artist_proxy:
+          type: integer
+        none:
+          type: integer
+        unknown:
+          type: integer
+
+    BmiPerformanceList:
+      type: object
+      description: The `GET /library/bmi-performance-list` response envelope (BS#1500).
+      properties:
+        range:
+          type: object
+          properties:
+            from:
+              type: string
+              format: date
+            to:
+              type: string
+              format: date
+        coverage:
+          $ref: '#/components/schemas/BmiCoverage'
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/BmiPerformanceRow'
+
     Rotation:
       type: object
       properties:
@@ -960,6 +1033,49 @@ paths:
           description: Catalog unchanged since `If-Modified-Since` / `since`.
         '401':
           description: Missing or invalid bearer token.
+
+  /library/bmi-performance-list:
+    get:
+      summary: BMI played-works export for a date range (BS#1500)
+      description: >
+        Successor to tubafrenzy's `recentBMI` servlet: the played musical works the
+        station librarian submits to BMI for royalty reporting. Reads `flowsheet` track
+        rows with a usable artist whose `add_time` falls in the half-open `[from, to]`
+        window (the whole `to` day is included), ordered chronologically, and returns the
+        rows plus a composer-provenance `coverage` summary the dj-site admin tool previews
+        before submit. Gated to MD/SM via `catalog:['write']`. The window width is capped
+        (max 366 days); the exact BMI submission text format and the artist-proxy inclusion
+        default are finalized in #1507 and do not change this envelope.
+      security:
+        - BearerAuth: ['catalog-write']
+      parameters:
+        - name: from
+          in: query
+          required: true
+          description: Inclusive start of the window, `YYYY-MM-DD` (UTC-day boundary).
+          schema:
+            type: string
+            format: date
+        - name: to
+          in: query
+          required: true
+          description: Inclusive end of the window, `YYYY-MM-DD`. Must not precede `from`; the window may span at most 366 days.
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Played works in the window plus the coverage summary.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BmiPerformanceList'
+        '400':
+          description: Missing, malformed, out-of-order, or too-wide `from`/`to` range.
+        '401':
+          description: Missing or invalid bearer token.
+        '403':
+          description: Authenticated role lacks `catalog:write` (below musicDirector).
 
   /library/rotation:
     get:

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -12,6 +12,7 @@ import {
 import { gunzipSync } from 'node:zlib';
 import * as libraryService from '../services/library.service.js';
 import * as catalogExportService from '../services/catalog-export.service.js';
+import * as bmiPerformanceService from '../services/bmi-performance.service.js';
 import * as labelsService from '../services/labels.service.js';
 import * as librarySearchService from '../services/library-search.service.js';
 import type { CatalogSort, CatalogOrder } from '../services/library-search.service.js';
@@ -645,4 +646,27 @@ export const exportCatalog: RequestHandler = async (req, res) => {
   const inflated = gunzipSync(gzipped);
   res.setHeader('Content-Length', inflated.length);
   res.status(200).end(inflated);
+};
+
+// ---------------------------------------------------------------------------
+// GET /library/bmi-performance-list — played-works export for BMI (BS#1500)
+// ---------------------------------------------------------------------------
+
+/**
+ * Successor to tubafrenzy's `recentBMI` servlet: the played-works list the
+ * station librarian submits to BMI for royalty reporting. Gated to MD/SM via
+ * `catalog:['write']` (the route), keyed on a real `from`/`to` date range
+ * (deliberately not `recentBMI`'s stateless "recent 1000"), and returns
+ * structured JSON — the rows plus a composer-provenance coverage summary the
+ * dj-site admin tool previews before the librarian submits.
+ *
+ * The exact BMI submission *format* and the artist-proxy inclusion default are
+ * deferred to #1507; the range/filter/coverage contract here does not depend on
+ * either and the dj-site shell reads this JSON directly. A malformed range
+ * throws `WxycError(400)`, which the async handler forwards to `errorHandler`.
+ */
+export const exportBmiPerformanceList: RequestHandler = async (req, res) => {
+  const range = bmiPerformanceService.parseBmiDateRange(req.query.from, req.query.to);
+  const payload = await bmiPerformanceService.getBmiPerformanceList(range);
+  res.status(200).json(payload);
 };

--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -27,6 +27,17 @@ library_route.get(
   libraryController.exportCatalog
 );
 
+// BMI played-works export (BS#1500 — tubafrenzy `recentBMI` successor). Gated
+// to MD/SM via `catalog:['write']` (DJs/members lack it), which is exactly the
+// librarian/MD submission audience with no new permission minted. Keyed on a
+// real `?from=&to=` date range. Output *format* + artist-proxy default are
+// finalized in #1507; the range/filter/coverage contract lands here.
+library_route.get(
+  '/bmi-performance-list',
+  requirePermissions({ catalog: ['write'] }),
+  libraryController.exportBmiPerformanceList
+);
+
 library_route.post('/', requirePermissions({ catalog: ['write'] }), libraryController.addAlbum);
 
 library_route.get('/rotation', requirePermissions({ catalog: ['read'] }), libraryController.getRotation);

--- a/apps/backend/services/bmi-performance.service.ts
+++ b/apps/backend/services/bmi-performance.service.ts
@@ -24,16 +24,24 @@
  * 'discogs_release' | 'artist_proxy' | null.
  */
 
-import { and, asc, eq, gte, isNotNull, lt } from 'drizzle-orm';
+import { and, asc, eq, gte, lt, sql } from 'drizzle-orm';
 import { db, flowsheet } from '@wxyc/database';
 import WxycError from '../utils/error.js';
 
-export type BmiComposerSource = 'discogs_track' | 'discogs_release' | 'artist_proxy' | null;
+/**
+ * The composer-provenance values this shell knows how to bucket. `flowsheet.composer_source`
+ * is deliberately open-ended `text` (schema.ts) — a new source (e.g. `musicbrainz_work`,
+ * LML#699) can land without a migration — so a row can carry a value outside this set. Such a
+ * value is preserved verbatim on the row (`BmiPerformanceRow.composer_source` is `string | null`)
+ * and counted under `coverage.unknown` rather than silently mis-bucketed as `none`.
+ */
+export type BmiComposerSource = 'discogs_track' | 'discogs_release' | 'artist_proxy';
 
 /**
  * One played work as reported to BMI. Flat projection over the `flowsheet`
  * track rows in the requested window. `played_at` is the row's logging instant
- * (`flowsheet.add_time`) as an ISO-8601 string.
+ * (`flowsheet.add_time`) as an ISO-8601 string. `composer_source` is the raw DB
+ * text (an open-ended column), not narrowed to the known set — see `BmiComposerSource`.
  */
 export type BmiPerformanceRow = {
   artist_name: string;
@@ -41,17 +49,25 @@ export type BmiPerformanceRow = {
   album_title: string | null;
   record_label: string | null;
   composer: string | null;
-  composer_source: BmiComposerSource;
+  composer_source: string | null;
   played_at: string;
 };
 
-/** Composer-provenance breakdown for the dj-site pre-submit coverage preview. */
+/**
+ * Composer-provenance breakdown for the dj-site pre-submit coverage preview.
+ * `none` counts rows with no composer credit at all (`composer_source IS NULL`);
+ * `unknown` counts rows whose `composer_source` is non-null but outside the known
+ * set — a real credit from a source this shell predates, kept distinct from `none`
+ * so the preview never tells the librarian a credited play has no composer.
+ * The five buckets partition `total`.
+ */
 export type BmiCoverage = {
   total: number;
   real_track: number;
   real_release: number;
   artist_proxy: number;
   none: number;
+  unknown: number;
 };
 
 /** The full endpoint payload: the echoed range, the coverage summary, the rows. */
@@ -69,8 +85,23 @@ export type BmiDateRange = {
   toExclusive: Date;
 };
 
+// Shape-only ISO-day guard. A byte-identical regex backs the weaker shape-only
+// `isISODate` (library.service.ts); `parseIsoDay` below intentionally goes further,
+// also rejecting impossible calendar dates via an ISO round-trip. Not consolidated
+// here: reusing `isISODate` would drop the calendar-validity check, and promoting the
+// stronger check into a shared util would change `killRotation`'s accepted inputs —
+// out of scope for this shell.
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Upper bound on the requested window width (inclusive day count). The librarian pulls
+// semiannually (~184 days); a full leap year of headroom covers any legitimate pull while
+// capping the result set. Without it a multi-year range would materialize the entire
+// `flowsheet` track slice into memory and block the event loop on a synchronous
+// `JSON.stringify` — a pod-wide stall / OOM risk (there is no LIMIT or streaming here,
+// unlike the gzipped/watermarked `exportCatalog`). A hard 400 (vs silent truncation) keeps
+// the royalty report from quietly dropping performances.
+const MAX_RANGE_DAYS = 366;
 
 /**
  * Validate a single `YYYY-MM-DD` bound and return its UTC midnight instant.
@@ -115,6 +146,13 @@ export function parseBmiDateRange(fromRaw: unknown, toRaw: unknown): BmiDateRang
   if (fromDate.getTime() > toDate.getTime()) {
     throw new WxycError(`bmi-performance-list: 'from' (${from}) must not be after 'to' (${to})`, 400);
   }
+  const widthDays = (toDate.getTime() - fromDate.getTime()) / MS_PER_DAY + 1;
+  if (widthDays > MAX_RANGE_DAYS) {
+    throw new WxycError(
+      `bmi-performance-list: range ${from}..${to} spans ${widthDays} days; the maximum is ${MAX_RANGE_DAYS}. Narrow the window.`,
+      400
+    );
+  }
   return { from, to, fromDate, toExclusive: new Date(toDate.getTime() + MS_PER_DAY) };
 }
 
@@ -138,29 +176,58 @@ export function projectBmiRow(raw: {
     album_title: raw.album_title,
     record_label: raw.record_label,
     composer: raw.composer,
-    composer_source: raw.composer_source as BmiComposerSource,
+    // Raw passthrough — no cast to the known union. `composer_source` is open-ended
+    // text; a value this shell predates is preserved verbatim, not asserted to be a
+    // known member (which would be a TS lie) and not dropped.
+    composer_source: raw.composer_source,
     played_at: raw.add_time.toISOString(),
   };
 }
 
-/** Bucket rows by composer provenance for the dj-site pre-submit preview. */
+/**
+ * Bucket rows by composer provenance for the dj-site pre-submit preview. A non-null
+ * `composer_source` outside the known set (a source added after this shell, e.g.
+ * `musicbrainz_work`) is counted under `unknown` — never folded into `none` (which would
+ * tell the librarian a credited play has no composer) — and surfaced via a single warn so a
+ * new provenance is noticed rather than silently miscounted.
+ */
 export function summarizeCoverage(rows: BmiPerformanceRow[]): BmiCoverage {
-  const coverage: BmiCoverage = { total: rows.length, real_track: 0, real_release: 0, artist_proxy: 0, none: 0 };
+  const coverage: BmiCoverage = {
+    total: rows.length,
+    real_track: 0,
+    real_release: 0,
+    artist_proxy: 0,
+    none: 0,
+    unknown: 0,
+  };
+  const unknownSources = new Set<string>();
   for (const row of rows) {
-    if (row.composer_source === 'discogs_track') coverage.real_track += 1;
+    if (row.composer_source === null) coverage.none += 1;
+    else if (row.composer_source === 'discogs_track') coverage.real_track += 1;
     else if (row.composer_source === 'discogs_release') coverage.real_release += 1;
     else if (row.composer_source === 'artist_proxy') coverage.artist_proxy += 1;
-    else coverage.none += 1;
+    else {
+      coverage.unknown += 1;
+      unknownSources.add(row.composer_source);
+    }
+  }
+  if (unknownSources.size > 0) {
+    console.warn(
+      `bmi-performance-list: unrecognized composer_source value(s) counted as 'unknown': ${[...unknownSources].join(', ')}`
+    );
   }
   return coverage;
 }
 
 /**
- * Read the played works in the window: `flowsheet` track rows with a non-null
+ * Read the played works in the window: `flowsheet` track rows with a usable
  * artist, `add_time` inside `[fromDate, toExclusive)`, ordered chronologically.
- * `entry_type = 'track'` excludes breakpoints/talksets/marker rows; the
- * `artist_name IS NOT NULL` guard drops the handful of malformed track rows.
- * Read-only — no mutation, matching the `exportCatalog` read pattern.
+ * `entry_type = 'track'` excludes breakpoints/talksets/marker rows. The artist
+ * guard drops malformed rows with no artist — both NULL and empty/whitespace-only,
+ * since the live free-text insert path (flowsheet.controller.ts) only rejects an
+ * absent `artist_name`, so a blank one is writable. Mirrors the stricter sibling
+ * read `coalesce(artist_name,'') <> ''` (flowsheet.service.ts). Read-only — no
+ * mutation, matching the `exportCatalog` read pattern.
  */
 export async function getBmiPerformanceRows(range: BmiDateRange): Promise<BmiPerformanceRow[]> {
   const rows = await db
@@ -177,15 +244,15 @@ export async function getBmiPerformanceRows(range: BmiDateRange): Promise<BmiPer
     .where(
       and(
         eq(flowsheet.entry_type, 'track'),
-        isNotNull(flowsheet.artist_name),
+        sql`coalesce(trim(${flowsheet.artist_name}), '') <> ''`,
         gte(flowsheet.add_time, range.fromDate),
         lt(flowsheet.add_time, range.toExclusive)
       )
     )
     .orderBy(asc(flowsheet.add_time));
 
-  // `artist_name` is guaranteed non-null by the WHERE; the cast narrows the
-  // Drizzle column type (nullable varchar) to the projection's contract.
+  // `artist_name` is guaranteed non-null/non-blank by the WHERE; the cast narrows
+  // the Drizzle column type (nullable varchar) to the projection's contract.
   return rows.map((r) => projectBmiRow({ ...r, artist_name: r.artist_name as string }));
 }
 

--- a/apps/backend/services/bmi-performance.service.ts
+++ b/apps/backend/services/bmi-performance.service.ts
@@ -1,0 +1,204 @@
+/**
+ * BMI Performance List export (BS#1500 — successor to tubafrenzy's `recentBMI`).
+ *
+ * The station librarian (a non-engineer) semiannually pulls the list of played
+ * musical works and submits it to BMI for royalty reporting. tubafrenzy served
+ * this from `RecentBMIServlet` as a stateless "recent 1000" `###`-delimited
+ * dump; that path dies with the 2026-08-31 turndown (org Project #36). This
+ * module is the Backend-Service replacement, read by an MD/SM-gated dj-site
+ * admin tool (`/dashboard/admin/bmi`) so the pull becomes self-serve.
+ *
+ * SHELL SCOPE (this file): the date-range contract, the entry/composer
+ * projection, the DB read, and the coverage summary the dj-site preview shows.
+ * DEFERRED to #1507 (the BMI submission-format ticket): the exact wire format
+ * BMI accepts (tubafrenzy emitted `artist###song###release###composer######`),
+ * and whether `artist_proxy` composer rows are included or excluded. Neither
+ * decision changes the contract below — the endpoint returns structured JSON;
+ * the finalization pass renders the accepted text format from it. See the
+ * proposal on WXYC/Backend-Service#1500.
+ *
+ * Composer provenance (`composer_source`) is carried through untouched so the
+ * dj-site preview can warn the librarian how much of the window is backed by a
+ * real Discogs writer credit vs an artist-name proxy vs nothing before they
+ * submit. Values mirror `flowsheet.composer_source` (#1499): 'discogs_track' |
+ * 'discogs_release' | 'artist_proxy' | null.
+ */
+
+import { and, asc, eq, gte, isNotNull, lt } from 'drizzle-orm';
+import { db, flowsheet } from '@wxyc/database';
+import WxycError from '../utils/error.js';
+
+export type BmiComposerSource = 'discogs_track' | 'discogs_release' | 'artist_proxy' | null;
+
+/**
+ * One played work as reported to BMI. Flat projection over the `flowsheet`
+ * track rows in the requested window. `played_at` is the row's logging instant
+ * (`flowsheet.add_time`) as an ISO-8601 string.
+ */
+export type BmiPerformanceRow = {
+  artist_name: string;
+  track_title: string | null;
+  album_title: string | null;
+  record_label: string | null;
+  composer: string | null;
+  composer_source: BmiComposerSource;
+  played_at: string;
+};
+
+/** Composer-provenance breakdown for the dj-site pre-submit coverage preview. */
+export type BmiCoverage = {
+  total: number;
+  real_track: number;
+  real_release: number;
+  artist_proxy: number;
+  none: number;
+};
+
+/** The full endpoint payload: the echoed range, the coverage summary, the rows. */
+export type BmiPerformanceList = {
+  range: { from: string; to: string };
+  coverage: BmiCoverage;
+  rows: BmiPerformanceRow[];
+};
+
+/** A validated, half-open `[fromDate, toExclusive)` window over `add_time`. */
+export type BmiDateRange = {
+  from: string;
+  to: string;
+  fromDate: Date;
+  toExclusive: Date;
+};
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Validate a single `YYYY-MM-DD` bound and return its UTC midnight instant.
+ * Rejects non-strings, wrong shapes (timestamps, slashes), and impossible
+ * calendar dates (e.g. `2026-02-30`, which `Date` would silently roll into
+ * March) by round-tripping the parse back to the same string.
+ */
+function parseIsoDay(raw: unknown, field: string): Date {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new WxycError(`bmi-performance-list: '${field}' is required (YYYY-MM-DD)`, 400);
+  }
+  if (!ISO_DATE.test(raw)) {
+    throw new WxycError(`bmi-performance-list: '${field}' must be an ISO date (YYYY-MM-DD), got '${raw}'`, 400);
+  }
+  const ms = Date.parse(`${raw}T00:00:00.000Z`);
+  if (Number.isNaN(ms)) {
+    throw new WxycError(`bmi-performance-list: '${field}' is not a valid date: '${raw}'`, 400);
+  }
+  const d = new Date(ms);
+  // Reject rolled-over dates: `2026-02-30` parses to March 2, whose ISO date
+  // slice no longer equals the input.
+  if (d.toISOString().slice(0, 10) !== raw) {
+    throw new WxycError(`bmi-performance-list: '${field}' is not a valid calendar date: '${raw}'`, 400);
+  }
+  return d;
+}
+
+/**
+ * Parse and validate the `from`/`to` query params into an inclusive date
+ * window, expressed as a half-open `[fromDate, toExclusive)` interval so the
+ * whole `to` day is included. Both bounds are required; `from` must not be
+ * after `to`. Boundaries are UTC-midnight — ET-vs-UTC alignment of the day
+ * edges is a finalization detail deferred to #1507 alongside the wire format.
+ */
+export function parseBmiDateRange(fromRaw: unknown, toRaw: unknown): BmiDateRange {
+  const fromDate = parseIsoDay(fromRaw, 'from');
+  const toDate = parseIsoDay(toRaw, 'to');
+  // parseIsoDay throws unless the input is a well-formed date string, so both
+  // are strings here; narrow them for the return + message.
+  const from = fromRaw as string;
+  const to = toRaw as string;
+  if (fromDate.getTime() > toDate.getTime()) {
+    throw new WxycError(`bmi-performance-list: 'from' (${from}) must not be after 'to' (${to})`, 400);
+  }
+  return { from, to, fromDate, toExclusive: new Date(toDate.getTime() + MS_PER_DAY) };
+}
+
+/**
+ * Explicit projection to exactly the BMI contract fields — not a passthrough —
+ * so a server-only column on the source row (`search_doc`, `dj_name`,
+ * `metadata_status`, …) can never leak into the librarian-facing export.
+ */
+export function projectBmiRow(raw: {
+  artist_name: string;
+  track_title: string | null;
+  album_title: string | null;
+  record_label: string | null;
+  composer: string | null;
+  composer_source: string | null;
+  add_time: Date;
+}): BmiPerformanceRow {
+  return {
+    artist_name: raw.artist_name,
+    track_title: raw.track_title,
+    album_title: raw.album_title,
+    record_label: raw.record_label,
+    composer: raw.composer,
+    composer_source: raw.composer_source as BmiComposerSource,
+    played_at: raw.add_time.toISOString(),
+  };
+}
+
+/** Bucket rows by composer provenance for the dj-site pre-submit preview. */
+export function summarizeCoverage(rows: BmiPerformanceRow[]): BmiCoverage {
+  const coverage: BmiCoverage = { total: rows.length, real_track: 0, real_release: 0, artist_proxy: 0, none: 0 };
+  for (const row of rows) {
+    if (row.composer_source === 'discogs_track') coverage.real_track += 1;
+    else if (row.composer_source === 'discogs_release') coverage.real_release += 1;
+    else if (row.composer_source === 'artist_proxy') coverage.artist_proxy += 1;
+    else coverage.none += 1;
+  }
+  return coverage;
+}
+
+/**
+ * Read the played works in the window: `flowsheet` track rows with a non-null
+ * artist, `add_time` inside `[fromDate, toExclusive)`, ordered chronologically.
+ * `entry_type = 'track'` excludes breakpoints/talksets/marker rows; the
+ * `artist_name IS NOT NULL` guard drops the handful of malformed track rows.
+ * Read-only — no mutation, matching the `exportCatalog` read pattern.
+ */
+export async function getBmiPerformanceRows(range: BmiDateRange): Promise<BmiPerformanceRow[]> {
+  const rows = await db
+    .select({
+      artist_name: flowsheet.artist_name,
+      track_title: flowsheet.track_title,
+      album_title: flowsheet.album_title,
+      record_label: flowsheet.record_label,
+      composer: flowsheet.composer,
+      composer_source: flowsheet.composer_source,
+      add_time: flowsheet.add_time,
+    })
+    .from(flowsheet)
+    .where(
+      and(
+        eq(flowsheet.entry_type, 'track'),
+        isNotNull(flowsheet.artist_name),
+        gte(flowsheet.add_time, range.fromDate),
+        lt(flowsheet.add_time, range.toExclusive)
+      )
+    )
+    .orderBy(asc(flowsheet.add_time));
+
+  // `artist_name` is guaranteed non-null by the WHERE; the cast narrows the
+  // Drizzle column type (nullable varchar) to the projection's contract.
+  return rows.map((r) => projectBmiRow({ ...r, artist_name: r.artist_name as string }));
+}
+
+/**
+ * Compose the full endpoint payload for a validated range: query the rows and
+ * attach the coverage summary. Kept thin so the controller stays a request
+ * adapter.
+ */
+export async function getBmiPerformanceList(range: BmiDateRange): Promise<BmiPerformanceList> {
+  const rows = await getBmiPerformanceRows(range);
+  return {
+    range: { from: range.from, to: range.to },
+    coverage: summarizeCoverage(rows),
+    rows,
+  };
+}

--- a/apps/backend/services/bmi-performance.service.ts
+++ b/apps/backend/services/bmi-performance.service.ts
@@ -223,11 +223,14 @@ export function summarizeCoverage(rows: BmiPerformanceRow[]): BmiCoverage {
  * Read the played works in the window: `flowsheet` track rows with a usable
  * artist, `add_time` inside `[fromDate, toExclusive)`, ordered chronologically.
  * `entry_type = 'track'` excludes breakpoints/talksets/marker rows. The artist
- * guard drops malformed rows with no artist — both NULL and empty/whitespace-only,
- * since the live free-text insert path (flowsheet.controller.ts) only rejects an
- * absent `artist_name`, so a blank one is writable. Mirrors the stricter sibling
- * read `coalesce(artist_name,'') <> ''` (flowsheet.service.ts). Read-only — no
- * mutation, matching the `exportCatalog` read pattern.
+ * guard drops malformed rows with no usable artist — NULL, empty, and
+ * whitespace-only — via `~ '[^[:space:]]'` (has at least one non-whitespace
+ * char). The live free-text insert path (flowsheet.controller.ts) only rejects an
+ * absent `artist_name`, so a blank or whitespace one is writable. This is stricter
+ * than the sibling read `coalesce(artist_name,'') <> ''` (flowsheet.service.ts),
+ * which drops only NULL/empty; the regex additionally catches tabs/newlines that a
+ * `trim()`-and-compare would leave through. Read-only — no mutation, matching the
+ * `exportCatalog` read pattern.
  */
 export async function getBmiPerformanceRows(range: BmiDateRange): Promise<BmiPerformanceRow[]> {
   const rows = await db
@@ -244,7 +247,7 @@ export async function getBmiPerformanceRows(range: BmiDateRange): Promise<BmiPer
     .where(
       and(
         eq(flowsheet.entry_type, 'track'),
-        sql`coalesce(trim(${flowsheet.artist_name}), '') <> ''`,
+        sql`coalesce(${flowsheet.artist_name}, '') ~ '[^[:space:]]'`,
         gte(flowsheet.add_time, range.fromDate),
         lt(flowsheet.add_time, range.toExclusive)
       )

--- a/tests/integration/library-bmi-performance-list.spec.js
+++ b/tests/integration/library-bmi-performance-list.spec.js
@@ -60,17 +60,20 @@ describe('GET /library/bmi-performance-list (BS#1500)', () => {
       CLEANUP_TO,
     ]);
 
-    // Four in-window TRACK rows, one per composer provenance, at DISTINCT ascending
-    // timestamps so ORDER BY add_time ASC is assertable. The first sits exactly at the
-    // lower bound (00:00 == fromDate) to pin the inclusive `gte` boundary.
+    // Four in-window TRACK rows, one per composer provenance, at DISTINCT timestamps
+    // (00:00/06:00/12:00/18:00) so ORDER BY add_time ASC is assertable. The 00:00 row
+    // sits exactly at the lower bound (== fromDate) to pin the inclusive `gte` boundary.
+    // Deliberately INSERTED in reverse-chronological order: neither insertion order nor
+    // the DESC add_time index yields the asserted ascending order, so a DROPPED (not just
+    // flipped) `orderBy` fails the ordering assertion too.
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".flowsheet
          (entry_type, play_order, artist_name, track_title, album_title, record_label, composer, composer_source, add_time)
        VALUES
-         ('track', 8500, $1, 'real-track cut',   'Album A', 'Label A', 'Composer A', 'discogs_track',   '2013-07-04T00:00:00.000Z'),
-         ('track', 8501, $1, 'real-release cut', 'Album B', 'Label B', 'Composer B', 'discogs_release', '2013-07-04T06:00:00.000Z'),
-         ('track', 8502, $1, 'proxy cut',        'Album C', 'Label C', $1,           'artist_proxy',    '2013-07-04T12:00:00.000Z'),
-         ('track', 8503, $1, 'unenriched cut',   'Album D', 'Label D', NULL,          NULL,             '2013-07-04T18:00:00.000Z')`,
+         ('track', 8500, $1, 'unenriched cut',   'Album D', 'Label D', NULL,          NULL,             '2013-07-04T18:00:00.000Z'),
+         ('track', 8501, $1, 'proxy cut',        'Album C', 'Label C', $1,           'artist_proxy',    '2013-07-04T12:00:00.000Z'),
+         ('track', 8502, $1, 'real-release cut', 'Album B', 'Label B', 'Composer B', 'discogs_release', '2013-07-04T06:00:00.000Z'),
+         ('track', 8503, $1, 'real-track cut',   'Album A', 'Label A', 'Composer A', 'discogs_track',   '2013-07-04T00:00:00.000Z')`,
       [ARTIST]
     );
 
@@ -80,14 +83,16 @@ describe('GET /library/bmi-performance-list (BS#1500)', () => {
        VALUES ('breakpoint', 8504, 'BS#1500 breakpoint probe', '2013-07-04T12:00:00.000Z')`
     );
     // Excluded: track rows with no usable artist — NULL, empty, and whitespace-only.
-    // The live free-text insert path only rejects an ABSENT artist_name, so '' and '   '
-    // are writable; the read must drop them (coalesce(trim(artist_name),'') <> '').
+    // The live free-text insert path only rejects an ABSENT artist_name, so '', spaces,
+    // and tabs/newlines are all writable; the read drops them via `~ '[^[:space:]]'`.
+    // The tab+newline+space row would survive a `trim()`-and-compare (trim strips only
+    // ASCII spaces), so it pins the regex predicate specifically.
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".flowsheet (entry_type, play_order, artist_name, track_title, add_time)
        VALUES
-         ('track', 8505, NULL,  'null-artist cut',       '2013-07-04T12:00:00.000Z'),
-         ('track', 8506, '',    'blank-artist cut',      '2013-07-04T12:00:00.000Z'),
-         ('track', 8507, '   ', 'whitespace-artist cut', '2013-07-04T12:00:00.000Z')`
+         ('track', 8505, NULL,       'null-artist cut',       '2013-07-04T12:00:00.000Z'),
+         ('track', 8506, '',         'blank-artist cut',      '2013-07-04T12:00:00.000Z'),
+         ('track', 8507, E'\t\n ',   'whitespace-artist cut', '2013-07-04T12:00:00.000Z')`
     );
     // Excluded: an in-artist track just BEFORE the window and one AT the exclusive
     // upper bound (proves the half-open [from, toExclusive) interval).

--- a/tests/integration/library-bmi-performance-list.spec.js
+++ b/tests/integration/library-bmi-performance-list.spec.js
@@ -3,17 +3,20 @@
  *
  * The station librarian pulls played musical works for a date range to submit to
  * BMI. This pins the load-bearing server contract the dj-site admin tool reads:
- * the `flowsheet` filter (track rows with an artist, `add_time` in the requested
- * window), the composer-provenance coverage summary, and the `from`/`to`
- * validation. The BMI submission *format* + artist-proxy inclusion default are
- * finalized in #1507; this spec deliberately does not assert them.
+ * the `flowsheet` filter (track rows with a usable artist, `add_time` in the
+ * requested half-open window), chronological ordering, the composer-provenance
+ * coverage summary, and the `from`/`to` validation (including the max-width cap).
+ * The BMI submission *format* + artist-proxy inclusion default are finalized in
+ * #1507; this spec deliberately does not assert them.
  *
  * Postgres-backed (BS `pg` analogue): direct SQL seeds a deterministic set of
  * rows in an isolated historical window (2013-07-04) that no other spec writes
- * to, so the global coverage counts are exact. The permission gate
- * (`catalog:['write']`, MD/SM) is not asserted here — the CI env runs with
- * AUTH_BYPASS, so `requirePermissions` is a no-op; the gate is the same proven
- * middleware guarding POST /library.
+ * to, so the global coverage counts are exact. Cleanup is a `add_time`-window
+ * DELETE (not artist/message-predicated) so every seeded row — including the
+ * NULL/blank-artist rows that no equality predicate matches — is removed and
+ * cannot leak across runs. The permission gate (`catalog:['write']`, MD/SM) is
+ * not asserted here — the CI env runs with AUTH_BYPASS, so `requirePermissions`
+ * is a no-op; the gate is the same proven middleware guarding POST /library.
  */
 
 const postgres = require('postgres');
@@ -23,9 +26,12 @@ const { createAuthRequest } = require('../utils/test_helpers');
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 const ARTIST = 'BS#1500 BMI Probe Artist';
 const WINDOW_DAY = '2013-07-04'; // isolated: no other spec seeds 2013 timestamps
-const IN_WINDOW = '2013-07-04T12:00:00.000Z';
-const BEFORE_WINDOW = '2013-07-03T12:00:00.000Z';
-const AT_EXCLUSIVE_END = '2013-07-05T00:00:00.000Z'; // == toExclusive -> excluded (half-open)
+const EMPTY_DAY = '2013-07-06'; // isolated day with zero seeded rows -> empty-window path
+const AT_LOWER_BOUND = '2013-07-04T00:00:00.000Z'; // == fromDate -> included (half-open lower bound)
+const AT_EXCLUSIVE_END = '2013-07-05T00:00:00.000Z'; // == toExclusive -> excluded (half-open upper bound)
+// Cleanup window brackets every seeded add_time (2013-07-03 .. 2013-07-05) with margin.
+const CLEANUP_FROM = '2013-07-01T00:00:00.000Z';
+const CLEANUP_TO = '2013-07-08T00:00:00.000Z';
 
 function makeSql() {
   return postgres({
@@ -47,52 +53,58 @@ describe('GET /library/bmi-performance-list (BS#1500)', () => {
     auth = createAuthRequest(request, global.access_token);
     sql = makeSql();
 
-    // Idempotent across re-runs of this spec (shared schema, --runInBand).
-    await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE artist_name = $1 OR message = $2`, [
-      ARTIST,
-      'BS#1500 breakpoint probe',
+    // Idempotent across re-runs (shared schema, --runInBand). Window DELETE covers
+    // every seeded row regardless of artist_name/message, so nothing leaks.
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE add_time >= $1 AND add_time < $2`, [
+      CLEANUP_FROM,
+      CLEANUP_TO,
     ]);
 
-    // Four in-window TRACK rows, one per composer provenance -> all returned.
+    // Four in-window TRACK rows, one per composer provenance, at DISTINCT ascending
+    // timestamps so ORDER BY add_time ASC is assertable. The first sits exactly at the
+    // lower bound (00:00 == fromDate) to pin the inclusive `gte` boundary.
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".flowsheet
          (entry_type, play_order, artist_name, track_title, album_title, record_label, composer, composer_source, add_time)
        VALUES
-         ('track', 8500, $1, 'real-track cut',   'Album A', 'Label A', 'Composer A', 'discogs_track',   $2),
-         ('track', 8501, $1, 'real-release cut', 'Album B', 'Label B', 'Composer B', 'discogs_release', $2),
-         ('track', 8502, $1, 'proxy cut',        'Album C', 'Label C', $1,           'artist_proxy',    $2),
-         ('track', 8503, $1, 'unenriched cut',   'Album D', 'Label D', NULL,          NULL,             $2)`,
-      [ARTIST, IN_WINDOW]
+         ('track', 8500, $1, 'real-track cut',   'Album A', 'Label A', 'Composer A', 'discogs_track',   '2013-07-04T00:00:00.000Z'),
+         ('track', 8501, $1, 'real-release cut', 'Album B', 'Label B', 'Composer B', 'discogs_release', '2013-07-04T06:00:00.000Z'),
+         ('track', 8502, $1, 'proxy cut',        'Album C', 'Label C', $1,           'artist_proxy',    '2013-07-04T12:00:00.000Z'),
+         ('track', 8503, $1, 'unenriched cut',   'Album D', 'Label D', NULL,          NULL,             '2013-07-04T18:00:00.000Z')`,
+      [ARTIST]
     );
 
     // Excluded: a non-track (breakpoint) row in the window.
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".flowsheet (entry_type, play_order, message, add_time)
-       VALUES ('breakpoint', 8504, 'BS#1500 breakpoint probe', $1)`,
-      [IN_WINDOW]
+       VALUES ('breakpoint', 8504, 'BS#1500 breakpoint probe', '2013-07-04T12:00:00.000Z')`
     );
-    // Excluded: a track with NULL artist in the window.
+    // Excluded: track rows with no usable artist — NULL, empty, and whitespace-only.
+    // The live free-text insert path only rejects an ABSENT artist_name, so '' and '   '
+    // are writable; the read must drop them (coalesce(trim(artist_name),'') <> '').
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".flowsheet (entry_type, play_order, artist_name, track_title, add_time)
-       VALUES ('track', 8505, NULL, 'null-artist cut', $1)`,
-      [IN_WINDOW]
+       VALUES
+         ('track', 8505, NULL,  'null-artist cut',       '2013-07-04T12:00:00.000Z'),
+         ('track', 8506, '',    'blank-artist cut',      '2013-07-04T12:00:00.000Z'),
+         ('track', 8507, '   ', 'whitespace-artist cut', '2013-07-04T12:00:00.000Z')`
     );
-    // Excluded: an in-artist track just BEFORE the window and one AT the
-    // exclusive upper bound (proves the half-open [from, to] interval).
+    // Excluded: an in-artist track just BEFORE the window and one AT the exclusive
+    // upper bound (proves the half-open [from, toExclusive) interval).
     await sql.unsafe(
       `INSERT INTO "${SCHEMA}".flowsheet
          (entry_type, play_order, artist_name, track_title, composer_source, add_time)
        VALUES
-         ('track', 8506, $1, 'before-window cut', 'discogs_track', $2),
-         ('track', 8507, $1, 'after-window cut',  'discogs_track', $3)`,
-      [ARTIST, BEFORE_WINDOW, AT_EXCLUSIVE_END]
+         ('track', 8508, $1, 'before-window cut', 'discogs_track', '2013-07-03T12:00:00.000Z'),
+         ('track', 8509, $1, 'after-window cut',  'discogs_track', $2)`,
+      [ARTIST, AT_EXCLUSIVE_END]
     );
   });
 
   afterAll(async () => {
-    await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE artist_name = $1 OR message = $2`, [
-      ARTIST,
-      'BS#1500 breakpoint probe',
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE add_time >= $1 AND add_time < $2`, [
+      CLEANUP_FROM,
+      CLEANUP_TO,
     ]);
     await sql.end();
   });
@@ -103,25 +115,35 @@ describe('GET /library/bmi-performance-list (BS#1500)', () => {
     expect(res.status).toBe(200);
     expect(res.body.range).toEqual({ from: WINDOW_DAY, to: WINDOW_DAY });
     // Window is isolated to this spec, so the global counts are exactly the four seeded tracks.
-    expect(res.body.coverage).toEqual({ total: 4, real_track: 1, real_release: 1, artist_proxy: 1, none: 1 });
+    expect(res.body.coverage).toEqual({
+      total: 4,
+      real_track: 1,
+      real_release: 1,
+      artist_proxy: 1,
+      none: 1,
+      unknown: 0,
+    });
     expect(res.body.rows).toHaveLength(4);
     expect(res.body.coverage.total).toBe(res.body.rows.length);
   });
 
-  it('excludes non-track rows, null-artist rows, and rows outside the half-open window', async () => {
+  it('orders rows chronologically, includes the lower bound, and excludes non-track / no-artist / out-of-window rows', async () => {
     const res = await auth.get(`/library/bmi-performance-list?from=${WINDOW_DAY}&to=${WINDOW_DAY}`);
 
     const titles = res.body.rows.map((r) => r.track_title);
-    expect(titles).toEqual(
-      expect.arrayContaining(['real-track cut', 'real-release cut', 'proxy cut', 'unenriched cut'])
-    );
+    // Exact ordered comparison pins ORDER BY add_time ASC (00:00 -> 06:00 -> 12:00 -> 18:00)
+    // AND the inclusive lower bound: 'real-track cut' is logged at exactly `from` midnight,
+    // so a `gt`-instead-of-`gte` regression would drop it and fail this assertion.
+    expect(titles).toEqual(['real-track cut', 'real-release cut', 'proxy cut', 'unenriched cut']);
     expect(titles).not.toContain('null-artist cut'); // artist_name IS NULL
+    expect(titles).not.toContain('blank-artist cut'); // artist_name = ''
+    expect(titles).not.toContain('whitespace-artist cut'); // artist_name = '   ' (trimmed to '')
     expect(titles).not.toContain('before-window cut'); // add_time < from
     expect(titles).not.toContain('after-window cut'); // add_time == toExclusive (excluded)
-    // Every row is a real artist play inside the window.
+    // Every row is a real artist play inside the half-open window.
     for (const row of res.body.rows) {
       expect(row.artist_name).toBe(ARTIST);
-      expect(new Date(row.played_at).getTime()).toBeGreaterThanOrEqual(new Date(`${WINDOW_DAY}T00:00:00Z`).getTime());
+      expect(new Date(row.played_at).getTime()).toBeGreaterThanOrEqual(new Date(AT_LOWER_BOUND).getTime());
       expect(new Date(row.played_at).getTime()).toBeLessThan(new Date(AT_EXCLUSIVE_END).getTime());
     }
   });
@@ -139,12 +161,29 @@ describe('GET /library/bmi-performance-list (BS#1500)', () => {
     expect(row).not.toHaveProperty('id');
   });
 
+  it('returns 200 with an empty row list and all-zero coverage for a window with no plays', async () => {
+    const res = await auth.get(`/library/bmi-performance-list?from=${EMPTY_DAY}&to=${EMPTY_DAY}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.range).toEqual({ from: EMPTY_DAY, to: EMPTY_DAY });
+    expect(res.body.rows).toEqual([]);
+    expect(res.body.coverage).toEqual({
+      total: 0,
+      real_track: 0,
+      real_release: 0,
+      artist_proxy: 0,
+      none: 0,
+      unknown: 0,
+    });
+  });
+
   it.each([
     ['from missing', `/library/bmi-performance-list?to=${WINDOW_DAY}`],
     ['to missing', `/library/bmi-performance-list?from=${WINDOW_DAY}`],
     ['from malformed', `/library/bmi-performance-list?from=07-04-2013&to=${WINDOW_DAY}`],
     ['impossible date', `/library/bmi-performance-list?from=2013-02-30&to=${WINDOW_DAY}`],
     ['from after to', `/library/bmi-performance-list?from=2013-07-05&to=2013-07-04`],
+    ['range too wide', `/library/bmi-performance-list?from=2013-01-01&to=2014-12-31`],
   ])('rejects a bad range with 400 (%s)', async (_label, path) => {
     const res = await auth.get(path);
     expect(res.status).toBe(400);

--- a/tests/integration/library-bmi-performance-list.spec.js
+++ b/tests/integration/library-bmi-performance-list.spec.js
@@ -1,0 +1,152 @@
+/**
+ * BS#1500 — `GET /library/bmi-performance-list` (tubafrenzy `recentBMI` successor).
+ *
+ * The station librarian pulls played musical works for a date range to submit to
+ * BMI. This pins the load-bearing server contract the dj-site admin tool reads:
+ * the `flowsheet` filter (track rows with an artist, `add_time` in the requested
+ * window), the composer-provenance coverage summary, and the `from`/`to`
+ * validation. The BMI submission *format* + artist-proxy inclusion default are
+ * finalized in #1507; this spec deliberately does not assert them.
+ *
+ * Postgres-backed (BS `pg` analogue): direct SQL seeds a deterministic set of
+ * rows in an isolated historical window (2013-07-04) that no other spec writes
+ * to, so the global coverage counts are exact. The permission gate
+ * (`catalog:['write']`, MD/SM) is not asserted here — the CI env runs with
+ * AUTH_BYPASS, so `requirePermissions` is a no-op; the gate is the same proven
+ * middleware guarding POST /library.
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const ARTIST = 'BS#1500 BMI Probe Artist';
+const WINDOW_DAY = '2013-07-04'; // isolated: no other spec seeds 2013 timestamps
+const IN_WINDOW = '2013-07-04T12:00:00.000Z';
+const BEFORE_WINDOW = '2013-07-03T12:00:00.000Z';
+const AT_EXCLUSIVE_END = '2013-07-05T00:00:00.000Z'; // == toExclusive -> excluded (half-open)
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+describe('GET /library/bmi-performance-list (BS#1500)', () => {
+  let auth;
+  let sql;
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = makeSql();
+
+    // Idempotent across re-runs of this spec (shared schema, --runInBand).
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE artist_name = $1 OR message = $2`, [
+      ARTIST,
+      'BS#1500 breakpoint probe',
+    ]);
+
+    // Four in-window TRACK rows, one per composer provenance -> all returned.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".flowsheet
+         (entry_type, play_order, artist_name, track_title, album_title, record_label, composer, composer_source, add_time)
+       VALUES
+         ('track', 8500, $1, 'real-track cut',   'Album A', 'Label A', 'Composer A', 'discogs_track',   $2),
+         ('track', 8501, $1, 'real-release cut', 'Album B', 'Label B', 'Composer B', 'discogs_release', $2),
+         ('track', 8502, $1, 'proxy cut',        'Album C', 'Label C', $1,           'artist_proxy',    $2),
+         ('track', 8503, $1, 'unenriched cut',   'Album D', 'Label D', NULL,          NULL,             $2)`,
+      [ARTIST, IN_WINDOW]
+    );
+
+    // Excluded: a non-track (breakpoint) row in the window.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".flowsheet (entry_type, play_order, message, add_time)
+       VALUES ('breakpoint', 8504, 'BS#1500 breakpoint probe', $1)`,
+      [IN_WINDOW]
+    );
+    // Excluded: a track with NULL artist in the window.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".flowsheet (entry_type, play_order, artist_name, track_title, add_time)
+       VALUES ('track', 8505, NULL, 'null-artist cut', $1)`,
+      [IN_WINDOW]
+    );
+    // Excluded: an in-artist track just BEFORE the window and one AT the
+    // exclusive upper bound (proves the half-open [from, to] interval).
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".flowsheet
+         (entry_type, play_order, artist_name, track_title, composer_source, add_time)
+       VALUES
+         ('track', 8506, $1, 'before-window cut', 'discogs_track', $2),
+         ('track', 8507, $1, 'after-window cut',  'discogs_track', $3)`,
+      [ARTIST, BEFORE_WINDOW, AT_EXCLUSIVE_END]
+    );
+  });
+
+  afterAll(async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE artist_name = $1 OR message = $2`, [
+      ARTIST,
+      'BS#1500 breakpoint probe',
+    ]);
+    await sql.end();
+  });
+
+  it('returns the in-window track rows with an exact composer-provenance coverage summary', async () => {
+    const res = await auth.get(`/library/bmi-performance-list?from=${WINDOW_DAY}&to=${WINDOW_DAY}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.range).toEqual({ from: WINDOW_DAY, to: WINDOW_DAY });
+    // Window is isolated to this spec, so the global counts are exactly the four seeded tracks.
+    expect(res.body.coverage).toEqual({ total: 4, real_track: 1, real_release: 1, artist_proxy: 1, none: 1 });
+    expect(res.body.rows).toHaveLength(4);
+    expect(res.body.coverage.total).toBe(res.body.rows.length);
+  });
+
+  it('excludes non-track rows, null-artist rows, and rows outside the half-open window', async () => {
+    const res = await auth.get(`/library/bmi-performance-list?from=${WINDOW_DAY}&to=${WINDOW_DAY}`);
+
+    const titles = res.body.rows.map((r) => r.track_title);
+    expect(titles).toEqual(
+      expect.arrayContaining(['real-track cut', 'real-release cut', 'proxy cut', 'unenriched cut'])
+    );
+    expect(titles).not.toContain('null-artist cut'); // artist_name IS NULL
+    expect(titles).not.toContain('before-window cut'); // add_time < from
+    expect(titles).not.toContain('after-window cut'); // add_time == toExclusive (excluded)
+    // Every row is a real artist play inside the window.
+    for (const row of res.body.rows) {
+      expect(row.artist_name).toBe(ARTIST);
+      expect(new Date(row.played_at).getTime()).toBeGreaterThanOrEqual(new Date(`${WINDOW_DAY}T00:00:00Z`).getTime());
+      expect(new Date(row.played_at).getTime()).toBeLessThan(new Date(AT_EXCLUSIVE_END).getTime());
+    }
+  });
+
+  it('projects exactly the BMI contract fields and no server-only columns', async () => {
+    const res = await auth.get(`/library/bmi-performance-list?from=${WINDOW_DAY}&to=${WINDOW_DAY}`);
+
+    const row = res.body.rows.find((r) => r.track_title === 'real-track cut');
+    expect(Object.keys(row).sort()).toEqual(
+      ['album_title', 'artist_name', 'composer', 'composer_source', 'played_at', 'record_label', 'track_title'].sort()
+    );
+    expect(row.composer_source).toBe('discogs_track');
+    expect(row).not.toHaveProperty('dj_name');
+    expect(row).not.toHaveProperty('search_doc');
+    expect(row).not.toHaveProperty('id');
+  });
+
+  it.each([
+    ['from missing', `/library/bmi-performance-list?to=${WINDOW_DAY}`],
+    ['to missing', `/library/bmi-performance-list?from=${WINDOW_DAY}`],
+    ['from malformed', `/library/bmi-performance-list?from=07-04-2013&to=${WINDOW_DAY}`],
+    ['impossible date', `/library/bmi-performance-list?from=2013-02-30&to=${WINDOW_DAY}`],
+    ['from after to', `/library/bmi-performance-list?from=2013-07-05&to=2013-07-04`],
+  ])('rejects a bad range with 400 (%s)', async (_label, path) => {
+    const res = await auth.get(path);
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/unit/services/bmi-performance.service.test.ts
+++ b/tests/unit/services/bmi-performance.service.test.ts
@@ -128,6 +128,11 @@ describe('bmi-performance.service: projectBmiRow', () => {
 });
 
 describe('bmi-performance.service: summarizeCoverage', () => {
+  // Restore any console.warn spy even if an assertion in a test throws first — the unit
+  // config sets clearMocks (call data) but not restoreMocks (original impl), so without
+  // this a thrown assertion would leave console.warn stubbed for the rest of the worker.
+  afterEach(() => jest.restoreAllMocks());
+
   const row = (composer_source: string | null, composer: string | null): BmiPerformanceRow => ({
     artist_name: 'Jessica Pratt',
     track_title: 'Back, Baby',
@@ -175,7 +180,7 @@ describe('bmi-performance.service: summarizeCoverage', () => {
     });
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('musicbrainz_work'));
-    warn.mockRestore();
+    // Restore is handled by afterEach so a thrown assertion above still cleans up.
   });
 
   it('summarizes an empty list to all-zero counts', () => {

--- a/tests/unit/services/bmi-performance.service.test.ts
+++ b/tests/unit/services/bmi-performance.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import {
   parseBmiDateRange,
   summarizeCoverage,
@@ -72,6 +72,24 @@ describe('bmi-performance.service: parseBmiDateRange', () => {
     expect(range.fromDate.toISOString()).toBe('2026-03-15T00:00:00.000Z');
     expect(range.toExclusive.toISOString()).toBe('2026-03-16T00:00:00.000Z');
   });
+
+  it('accepts a range at the maximum window width (366 inclusive days)', () => {
+    // 2024 is a leap year: 2024-01-01..2024-12-31 is exactly 366 inclusive days.
+    const range = parseBmiDateRange('2024-01-01', '2024-12-31');
+    expect(range.fromDate.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+    expect(range.toExclusive.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+  });
+
+  it('throws WxycError(400) when the window exceeds the maximum width', () => {
+    // 367 inclusive days — one past the cap. Guards the unbounded-result-set /
+    // event-loop-block risk (the underlying read has no LIMIT).
+    expect(() => parseBmiDateRange('2024-01-01', '2025-01-01')).toThrow(WxycError);
+    try {
+      parseBmiDateRange('2024-01-01', '2025-01-01');
+    } catch (e) {
+      expect((e as WxycError).statusCode).toBe(400);
+    }
+  });
 });
 
 describe('bmi-performance.service: projectBmiRow', () => {
@@ -100,6 +118,13 @@ describe('bmi-performance.service: projectBmiRow', () => {
     expect(projected.composer).toBeNull();
     expect(projected.composer_source).toBeNull();
   });
+
+  it('preserves an unrecognized composer_source verbatim rather than coercing it', () => {
+    // `composer_source` is open-ended text; a source added after this shell
+    // (e.g. `musicbrainz_work`) must survive on the row, not be dropped/cast away.
+    const projected = projectBmiRow(rawRow({ composer_source: 'musicbrainz_work' }));
+    expect(projected.composer_source).toBe('musicbrainz_work');
+  });
 });
 
 describe('bmi-performance.service: summarizeCoverage', () => {
@@ -109,7 +134,7 @@ describe('bmi-performance.service: summarizeCoverage', () => {
     album_title: 'On Your Own Love Again',
     record_label: 'Drag City',
     composer,
-    composer_source: composer_source as BmiPerformanceRow['composer_source'],
+    composer_source,
     played_at: '2026-03-15T18:42:00.000Z',
   });
 
@@ -128,7 +153,29 @@ describe('bmi-performance.service: summarizeCoverage', () => {
       real_release: 1,
       artist_proxy: 1,
       none: 1,
+      unknown: 0,
     });
+  });
+
+  it('counts an unrecognized composer_source as `unknown`, never as `none`, and warns once', () => {
+    // A future provenance (added without a migration, e.g. `musicbrainz_work`) is a
+    // real writer credit; folding it into `none` would tell the librarian a credited
+    // play has no composer. It must land in `unknown`, distinct from the null case,
+    // and surface a single warn naming the unrecognized value.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const rows = [row('musicbrainz_work', 'X'), row('musicbrainz_work', 'Y'), row(null, null)];
+
+    expect(summarizeCoverage(rows)).toEqual({
+      total: 3,
+      real_track: 0,
+      real_release: 0,
+      artist_proxy: 0,
+      none: 1,
+      unknown: 2,
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('musicbrainz_work'));
+    warn.mockRestore();
   });
 
   it('summarizes an empty list to all-zero counts', () => {
@@ -138,6 +185,7 @@ describe('bmi-performance.service: summarizeCoverage', () => {
       real_release: 0,
       artist_proxy: 0,
       none: 0,
+      unknown: 0,
     });
   });
 });

--- a/tests/unit/services/bmi-performance.service.test.ts
+++ b/tests/unit/services/bmi-performance.service.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  parseBmiDateRange,
+  summarizeCoverage,
+  projectBmiRow,
+  type BmiPerformanceRow,
+} from '../../../apps/backend/services/bmi-performance.service';
+import WxycError from '../../../apps/backend/utils/error';
+
+// BS#1500 — successor to tubafrenzy's `recentBMI` export. The endpoint's
+// output *format* is deferred to #1507 (whatever BMI accepts), but its
+// date-range contract, the entry/composer projection, and the coverage
+// summary the dj-site preview reads are stable and pinned here.
+
+const rawRow = (overrides: Record<string, unknown> = {}) => ({
+  artist_name: 'Juana Molina',
+  track_title: 'la paradoja',
+  album_title: 'DOGA',
+  record_label: 'Sonamos',
+  composer: 'Juana Molina',
+  composer_source: 'discogs_track',
+  add_time: new Date('2026-03-15T18:42:00.000Z'),
+  ...overrides,
+});
+
+describe('bmi-performance.service: parseBmiDateRange', () => {
+  it('accepts a valid YYYY-MM-DD range and yields an inclusive [from, to] window as a half-open interval', () => {
+    const range = parseBmiDateRange('2026-01-01', '2026-06-30');
+
+    expect(range.from).toBe('2026-01-01');
+    expect(range.to).toBe('2026-06-30');
+    // Lower bound is the start of `from`; upper bound is the start of the day
+    // AFTER `to`, so the whole `to` day is included (half-open interval).
+    expect(range.fromDate.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+    expect(range.toExclusive.toISOString()).toBe('2026-07-01T00:00:00.000Z');
+  });
+
+  it('rolls the exclusive upper bound across a month boundary correctly', () => {
+    const range = parseBmiDateRange('2026-01-31', '2026-01-31');
+    expect(range.fromDate.toISOString()).toBe('2026-01-31T00:00:00.000Z');
+    expect(range.toExclusive.toISOString()).toBe('2026-02-01T00:00:00.000Z');
+  });
+
+  it.each([
+    ['both missing', undefined, undefined],
+    ['from missing', undefined, '2026-06-30'],
+    ['to missing', '2026-01-01', undefined],
+    ['empty string', '', '2026-06-30'],
+  ])('throws WxycError(400) when a bound is absent (%s)', (_label, from, to) => {
+    expect(() => parseBmiDateRange(from, to)).toThrow(WxycError);
+    try {
+      parseBmiDateRange(from, to);
+    } catch (e) {
+      expect((e as WxycError).statusCode).toBe(400);
+    }
+  });
+
+  it.each([
+    ['not ISO', '01/01/2026', '2026-06-30'],
+    ['timestamp not date', '2026-01-01T00:00:00Z', '2026-06-30'],
+    ['impossible calendar date', '2026-02-30', '2026-06-30'],
+  ])('throws WxycError(400) on a malformed bound (%s)', (_label, from, to) => {
+    expect(() => parseBmiDateRange(from, to)).toThrow(WxycError);
+  });
+
+  it('throws WxycError(400) when from is after to', () => {
+    expect(() => parseBmiDateRange('2026-06-30', '2026-01-01')).toThrow(WxycError);
+  });
+
+  it('accepts a single-day range (from === to)', () => {
+    const range = parseBmiDateRange('2026-03-15', '2026-03-15');
+    expect(range.fromDate.toISOString()).toBe('2026-03-15T00:00:00.000Z');
+    expect(range.toExclusive.toISOString()).toBe('2026-03-16T00:00:00.000Z');
+  });
+});
+
+describe('bmi-performance.service: projectBmiRow', () => {
+  it('projects exactly the BMI contract fields, ISO-stamping the play time', () => {
+    const projected = projectBmiRow(rawRow());
+
+    expect(Object.keys(projected).sort()).toEqual(
+      ['album_title', 'artist_name', 'composer', 'composer_source', 'played_at', 'record_label', 'track_title'].sort()
+    );
+    expect(projected.played_at).toBe('2026-03-15T18:42:00.000Z');
+    expect(projected.artist_name).toBe('Juana Molina');
+    expect(projected.composer_source).toBe('discogs_track');
+  });
+
+  it('does not leak server-only columns present on the source row', () => {
+    const projected = projectBmiRow(
+      rawRow({ search_doc: 'juana molina', dj_name: 'DJ Nightowl', metadata_status: 'complete' })
+    );
+    expect(projected).not.toHaveProperty('search_doc');
+    expect(projected).not.toHaveProperty('dj_name');
+    expect(projected).not.toHaveProperty('metadata_status');
+  });
+
+  it('carries a null composer/composer_source through as null (un-enriched play)', () => {
+    const projected = projectBmiRow(rawRow({ composer: null, composer_source: null }));
+    expect(projected.composer).toBeNull();
+    expect(projected.composer_source).toBeNull();
+  });
+});
+
+describe('bmi-performance.service: summarizeCoverage', () => {
+  const row = (composer_source: string | null, composer: string | null): BmiPerformanceRow => ({
+    artist_name: 'Jessica Pratt',
+    track_title: 'Back, Baby',
+    album_title: 'On Your Own Love Again',
+    record_label: 'Drag City',
+    composer,
+    composer_source: composer_source as BmiPerformanceRow['composer_source'],
+    played_at: '2026-03-15T18:42:00.000Z',
+  });
+
+  it('buckets rows by composer provenance so the dj-site preview can warn before submit', () => {
+    const rows = [
+      row('discogs_track', 'A'),
+      row('discogs_track', 'B'),
+      row('discogs_release', 'C'),
+      row('artist_proxy', 'Jessica Pratt'),
+      row(null, null),
+    ];
+
+    expect(summarizeCoverage(rows)).toEqual({
+      total: 5,
+      real_track: 2,
+      real_release: 1,
+      artist_proxy: 1,
+      none: 1,
+    });
+  });
+
+  it('summarizes an empty list to all-zero counts', () => {
+    expect(summarizeCoverage([])).toEqual({
+      total: 0,
+      real_track: 0,
+      real_release: 0,
+      artist_proxy: 0,
+      none: 0,
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds `GET /library/bmi-performance-list?from=<date>&to=<date>`, the Backend-Service successor to tubafrenzy's `recentBMI` servlet. The station librarian pulls this list of played musical works to submit to BMI for royalty reporting; tubafrenzy (which served it as a stateless "recent 1000" `###`-delimited dump) is decommissioned 2026-08-31, so this replaces it with a real date-range export that an MD/SM-gated dj-site admin tool will read.

This is the **endpoint shell** — the piece the [#1500 proposal](https://github.com/WXYC/Backend-Service/issues/1500) scoped as buildable now. It intentionally does not finalize the BMI submission wire format.

## Contract

- **Auth:** `requirePermissions({ catalog: ['write'] })` — MD and SM hold `catalog:write`; DJs and members do not, so this is exactly the librarian/MD submission audience with no new permission minted.
- **Filter:** read-only over `flowsheet`, `entry_type = 'track'` and a usable artist (`coalesce(artist_name,'') ~ '[^[:space:]]'` — NULL, empty, and whitespace-only artists are dropped, since the live free-text insert path only rejects an *absent* `artist_name`), `add_time` inside a validated half-open `[from, to]` window (the whole `to` day is included). Deliberately not `recentBMI`'s stateless "recent 1000" footgun.
- **Range validation:** both bounds required and `YYYY-MM-DD` (impossible calendar dates rejected); `from` must not follow `to`; the window is capped at 366 days (a hard `400`, not silent truncation) so a wide range can't materialize the whole track slice into memory and block the event loop — this read has no `LIMIT`/streaming, unlike `exportCatalog`.
- **Provenance:** each row carries `composer` + `composer_source` (raw open-ended text — `discogs_track` | `discogs_release` | `artist_proxy` | a future source | null, from #1499). The response includes a `coverage` summary bucketing the window by provenance so the dj-site preview can warn the librarian how much is backed by a real Discogs writer credit vs an artist-name proxy vs nothing before they submit. A non-null `composer_source` outside the known set is counted under `unknown` (not folded into `none`, which would misreport a credited play as having no composer).
- **Response:** structured JSON — `{ range, coverage: { total, real_track, real_release, artist_proxy, none, unknown }, rows: [...] }`, rows ordered by `add_time`. Documented in `apps/backend/app.yaml` (Swagger); the cross-repo `wxyc-shared/api.yaml` SSOT registration lands with the #1507 format finalization (the shape may still move there).

## Deferred to #1507 (does not affect this contract)

- The exact BMI submission **text format** (tubafrenzy emitted `artist###song###release###composer######`) — the finalization pass renders the accepted format from this JSON.
- The **artist-proxy inclusion default** (include vs exclude `artist_proxy` composer rows).
- The **`wxyc-shared/api.yaml` SSOT registration** — the envelope is documented in-repo via `app.yaml` now; registering it in the cross-repo SSOT (which fans out codegen to dj-site/iOS/Android) lands alongside the finalized shape.
- **ET-vs-UTC day-edge alignment** — bounds are UTC-midnight; consistent semiannual tiling neither drops nor duplicates rows.

## Tests

- Unit (`tests/unit/services/bmi-performance.service.test.ts`, 20 cases): date-range validation (required bounds, ISO shape, impossible calendar dates, `from > to`, month-boundary rollover, single-day, **max-width accept at 366 / reject at 367**), projection field-set + server-only-column no-leak + null passthrough + **unrecognized-source verbatim passthrough**, and coverage bucketing including the **`unknown` bucket + one-shot warn**.
- Integration (`tests/integration/library-bmi-performance-list.spec.js`, 10 cases): the DB filter, exclusion of non-track / NULL- / empty- / **tab+newline-artist** / out-of-window rows, the half-open **lower (inclusive) and upper (exclusive)** boundaries, **chronological ordering pinned via reverse-insertion seeding**, exact coverage counts over an isolated historical window, an **empty-window 200**, the exact projected field set, and the `400` validation paths (including range-too-wide). Verified locally against a clean Docker CI DB.

Full local gate green: typecheck, lint (0 errors), format, build, and the full unit suite (261 suites / 3633 tests).

## Not in this PR

- The dj-site `admin/bmi` MD/SM tool (separate repo; shape in the #1500 proposal).
- The historical `BMI_COMPOSER` backfill for pre-2026-06-29 plays (blocked on the final tubafrenzy dump — umbrella #1543, item 4).

Part of #1500. Format + proxy finalization tracked on #1507.
