### PR TITLE
feat(flowsheet): expose on_air DJ on the paginated GET /flowsheet response

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -88,6 +88,20 @@ components:
           type: integer
         totalPages:
           type: integer
+        on_air:
+          allOf:
+            - $ref: '#/components/schemas/OnAirInfo'
+          nullable: true
+          description: >-
+            The DJ currently on air, when known. An OnAirInfo object means a named DJ is live; JSON null means the station is confirmed on automation ("Auto DJ"); the field being absent means the server does not report on-air status and clients should treat it as unknown. Not in required so absence stays distinct from an explicit null.
+
+    OnAirInfo:
+      type: object
+      required: [dj_name]
+      properties:
+        dj_name:
+          type: string
+          description: Display name of the DJ currently on air.
 
     FlowsheetEntryAdd:
       type: object

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -1,5 +1,6 @@
 import { Request, RequestHandler, Response } from 'express';
 import { Mutex } from 'async-mutex';
+import * as Sentry from '@sentry/node';
 import { NewFSEntry as FullNewFSEntry, FSEntry, Show, ShowDJ } from '@wxyc/database';
 
 // play_order is computed by the service layer, not provided by controllers
@@ -121,23 +122,36 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
   const [entries, total, onAirDjName] = await Promise.all([
     flowsheet_service.getEntriesByPage(offset, limit),
     flowsheet_service.getEntryCount(),
-    flowsheet_service.getOnAirDJName(),
+    // Best-effort: the on-air banner is auxiliary, so a failure resolving it must
+    // not fail the whole flowsheet read. On error we report to Sentry and return
+    // `undefined`, which omits `on_air` below — clients decode an absent field as
+    // "unknown" and hide the banner, rather than the endpoint 500ing the playlist.
+    flowsheet_service.getOnAirDJName().catch((error: unknown) => {
+      Sentry.captureException(error);
+      return undefined;
+    }),
   ]);
 
   const totalPages = Math.ceil(total / limit);
 
   // `on_air` lets clients render the on-air banner without scanning the fetched
   // entry window for a show_start marker (which can fall outside a 30-entry
-  // page). An OnAirInfo object means a named DJ is live; `null` means confirmed
-  // automation. Only the default paginated branch carries it — the iOS app
-  // polls this branch. See wxyc-shared api.yaml FlowsheetV2PaginatedResponse.
+  // page). Three states, matching wxyc-shared api.yaml FlowsheetV2PaginatedResponse:
+  // an OnAirInfo object = a named DJ is live; `null` = confirmed automation; the
+  // field ABSENT = the banner query failed (unknown). Only the default paginated
+  // branch carries it — the iOS app polls this branch.
+  //
+  // Freshness note: this route is wrapped in conditionalGet(getLastModifiedAt),
+  // which 304s on the flowsheet watermark. A rare `on_air` change that writes no
+  // flowsheet row (e.g. a mid-show dj_name_override edit) can be masked behind a
+  // stale 304 until the next flowsheet mutation.
   res.status(200).json({
     entries: entries.map(flowsheet_service.transformToV2),
     total,
     page,
     limit,
     totalPages,
-    on_air: onAirDjName ? { dj_name: onAirDjName } : null,
+    ...(onAirDjName !== undefined && { on_air: onAirDjName ? { dj_name: onAirDjName } : null }),
   });
 };
 

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -118,19 +118,26 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
   if (isNaN(page) || page < 0) throw new WxycError('page must be a non-negative number', 400);
 
   const offset = page * limit;
-  const [entries, total] = await Promise.all([
+  const [entries, total, onAirDjName] = await Promise.all([
     flowsheet_service.getEntriesByPage(offset, limit),
     flowsheet_service.getEntryCount(),
+    flowsheet_service.getOnAirDJName(),
   ]);
 
   const totalPages = Math.ceil(total / limit);
 
+  // `on_air` lets clients render the on-air banner without scanning the fetched
+  // entry window for a show_start marker (which can fall outside a 30-entry
+  // page). An OnAirInfo object means a named DJ is live; `null` means confirmed
+  // automation. Only the default paginated branch carries it — the iOS app
+  // polls this branch. See wxyc-shared api.yaml FlowsheetV2PaginatedResponse.
   res.status(200).json({
     entries: entries.map(flowsheet_service.transformToV2),
     total,
     page,
     limit,
     totalPages,
+    on_air: onAirDjName ? { dj_name: onAirDjName } : null,
   });
 };
 

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -846,6 +846,13 @@ export const getLatestShow = async (): Promise<Show | undefined> => {
  * while a human DJ is live" bug. `legacy_dj_name` is the authoritative identity
  * for those shows, and `resolveDjNameForShow` already reads it.
  *
+ * Known limitation (inherited from the `getLatestShow`-based on-air endpoints):
+ * legacy/tubafrenzy shows are created open (`end_time: null`) and closed later by
+ * the ETL. Between a legacy show actually ending and the ETL stamping `end_time`,
+ * this reports that DJ as live — i.e. `on_air` can name a just-departed DJ during
+ * real automation. That is the lesser evil versus the false-"Auto DJ" bug this
+ * fixes, and it is the practical limit of the "`null` means automation" guarantee.
+ *
  * @returns the on-air DJ's display name, or `null` when no show is open or the
  *   open show has no resolvable name.
  */

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -829,6 +829,34 @@ export const getLatestShow = async (): Promise<Show | undefined> => {
   return (await getNShows(1))[0];
 };
 
+/**
+ * Resolve the display name of the DJ currently on air, or `null` when the
+ * station is on automation.
+ *
+ * Backs the `on_air` field on the default paginated GET /flowsheet response.
+ * A show is "on air" when the latest show (`MAX(shows.id)`) has no `end_time`;
+ * its display name comes from `resolveDjNameForShow`, the same precedence chain
+ * (`dj_name_override` → primary DJ's `user.djName` → `legacy_dj_name`) used to
+ * denormalize DJ names onto flowsheet rows.
+ *
+ * Deliberately does NOT consult the `show_djs` join table the way
+ * `getDJsInCurrentShow`/`getOnAirStatusForDJ` do: tubafrenzy-mirrored shows have
+ * no `show_djs` rows (the DJ has no Backend-Service account), so a join-table
+ * read reports automation for essentially every legacy live show — the "AUTO DJ
+ * while a human DJ is live" bug. `legacy_dj_name` is the authoritative identity
+ * for those shows, and `resolveDjNameForShow` already reads it.
+ *
+ * @returns the on-air DJ's display name, or `null` when no show is open or the
+ *   open show has no resolvable name.
+ */
+export const getOnAirDJName = async (): Promise<string | null> => {
+  const latest_show = await getLatestShow();
+  if (!latest_show || latest_show.end_time !== null) {
+    return null;
+  }
+  return await resolveDjNameForShow(latest_show);
+};
+
 export const getOnAirStatusForDJ = async (dj_id: string): Promise<boolean> => {
   const latest_show = await getLatestShow();
   if (!latest_show || latest_show.end_time !== null) {

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -13,6 +13,7 @@ const mockGetShowMetadata = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockTransformToV2 = jest.fn((entry: unknown) => ({ ...(entry as Record<string, unknown>), v2: true }));
 const mockAddTrack = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockGetLatestShow = jest.fn<() => Promise<Record<string, unknown> | null>>();
+const mockGetOnAirDJName = jest.fn<() => Promise<string | null>>();
 const mockGetAlbumFromDB = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockResolveDjNameForShow = jest.fn<() => Promise<string | null>>();
 const mockUpdateEntry = jest.fn<() => Promise<Record<string, unknown>>>();
@@ -31,6 +32,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   transformToV2: mockTransformToV2,
   addTrack: mockAddTrack,
   getLatestShow: mockGetLatestShow,
+  getOnAirDJName: mockGetOnAirDJName,
   getAlbumFromDB: mockGetAlbumFromDB,
   resolveDjNameForShow: mockResolveDjNameForShow,
   updateEntry: mockUpdateEntry,
@@ -96,6 +98,7 @@ describe('flowsheet.controller', () => {
       const entries = [createMockEntry(1), createMockEntry(2)];
       mockGetEntriesByPage.mockResolvedValue(entries);
       mockGetEntryCount.mockResolvedValue(2);
+      mockGetOnAirDJName.mockResolvedValue(null);
 
       const req = createMockReq();
       const res = createMockRes();
@@ -111,7 +114,39 @@ describe('flowsheet.controller', () => {
         page: 0,
         limit: 30,
         totalPages: 1,
+        on_air: null,
       });
+    });
+
+    // on_air (BS on-air-banner fix): the default paginated branch carries the
+    // current on-air DJ so clients render the banner without scanning the
+    // fetched entry window for a show_start marker. An OnAirInfo object means a
+    // named DJ is live; JSON null means confirmed automation ("Auto DJ").
+    it('includes on_air with the DJ name when a DJ is live', async () => {
+      mockGetEntriesByPage.mockResolvedValue([createMockEntry(1)]);
+      mockGetEntryCount.mockResolvedValue(1);
+      mockGetOnAirDJName.mockResolvedValue('DJ MONSTER');
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getEntries(req as Request, res as Response, mockNext);
+
+      expect(mockGetOnAirDJName).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ on_air: { dj_name: 'DJ MONSTER' } }));
+    });
+
+    it('sets on_air to null when the station is on automation', async () => {
+      mockGetEntriesByPage.mockResolvedValue([createMockEntry(1)]);
+      mockGetEntryCount.mockResolvedValue(1);
+      mockGetOnAirDJName.mockResolvedValue(null);
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getEntries(req as Request, res as Response, mockNext);
+
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ on_air: null }));
     });
 
     it('calculates offset from page and limit', async () => {

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -9,6 +9,7 @@ jest.mock('@sentry/node', () => ({ captureException: mockCaptureException }));
 const mockGetEntriesByPage = jest.fn<() => Promise<unknown[]>>();
 const mockGetEntryCount = jest.fn<() => Promise<number>>();
 const mockGetEntriesByShow = jest.fn<() => Promise<unknown[]>>();
+const mockGetNShows = jest.fn<() => Promise<unknown[]>>();
 const mockGetShowMetadata = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockTransformToV2 = jest.fn((entry: unknown) => ({ ...(entry as Record<string, unknown>), v2: true }));
 const mockAddTrack = jest.fn<() => Promise<Record<string, unknown>>>();
@@ -28,6 +29,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getEntriesByPage: mockGetEntriesByPage,
   getEntryCount: mockGetEntryCount,
   getEntriesByShow: mockGetEntriesByShow,
+  getNShows: mockGetNShows,
   getShowMetadata: mockGetShowMetadata,
   transformToV2: mockTransformToV2,
   addTrack: mockAddTrack,
@@ -147,6 +149,46 @@ describe('flowsheet.controller', () => {
       await getEntries(req as Request, res as Response, mockNext);
 
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ on_air: null }));
+    });
+
+    // The banner is auxiliary: if getOnAirDJName rejects, the field is omitted
+    // (clients decode absent → unknown → hide banner) and the playlist read still
+    // succeeds — a banner-query failure must not 500 the whole endpoint.
+    it('omits on_air and still returns the playlist when getOnAirDJName throws', async () => {
+      const entries = [createMockEntry(1), createMockEntry(2)];
+      mockGetEntriesByPage.mockResolvedValue(entries);
+      mockGetEntryCount.mockResolvedValue(2);
+      mockGetOnAirDJName.mockRejectedValue(new Error('shows lookup failed'));
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getEntries(req as Request, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = (res.json as jest.Mock).mock.calls[0][0] as Record<string, unknown>;
+      expect(body).not.toHaveProperty('on_air');
+      expect(body).toMatchObject({ total: 2, page: 0, limit: 30, totalPages: 1 });
+      expect(mockNext).not.toHaveBeenCalled();
+      // the failure is reported, not silently swallowed
+      expect(mockCaptureException).toHaveBeenCalled();
+    });
+
+    // on_air rides only on the default paginated branch (the branch the iOS app
+    // polls). The shows_limit branch returns a bare array, so it must neither
+    // compute nor emit on_air — locking in that "default branch only" decision.
+    it('does not compute on_air on the shows_limit branch', async () => {
+      mockGetNShows.mockResolvedValue([{ id: 1 }]);
+      mockGetEntriesByShow.mockResolvedValue([createMockEntry(1)]);
+
+      const req = createMockReq({ shows_limit: '1' });
+      const res = createMockRes();
+
+      await getEntries(req as Request, res as Response, mockNext);
+
+      expect(mockGetOnAirDJName).not.toHaveBeenCalled();
+      const body = (res.json as jest.Mock).mock.calls[0][0];
+      expect(Array.isArray(body)).toBe(true);
     });
 
     it('calculates offset from page and limit', async () => {

--- a/tests/unit/services/flowsheet.getOnAirDJName.test.ts
+++ b/tests/unit/services/flowsheet.getOnAirDJName.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for getOnAirDJName — the helper backing the `on_air` field on the
+ * default paginated GET /flowsheet response (BS on-air-banner fix).
+ *
+ * It resolves the display name of the DJ currently on air by reading the latest
+ * show and running it through resolveDjNameForShow. Crucially it does NOT read
+ * the `show_djs` join table (the pre-existing `/djs-on-air` + `/on-air` bug):
+ * tubafrenzy-mirrored shows have no `show_djs` rows, so their DJ identity lives
+ * only in `shows.legacy_dj_name`. The regression this fixes is the banner
+ * showing "AUTO DJ" while DJ MONSTER — a legacy-mirrored show — was live.
+ *
+ * Mock mechanics: getLatestShow → getNShows(1) terminates in `.limit()`, and
+ * resolveDjNameForShow's user lookup also terminates in `.limit()`. Both consume
+ * from the same `_chain.limit` once-queue, so queued values are order-sensitive:
+ * the show row first, then (only when a primary DJ is present) the user row.
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '@wxyc/database';
+import { getOnAirDJName } from '../../../apps/backend/services/flowsheet.service';
+
+const mockDb = db as unknown as { _chain: Record<string, jest.Mock> };
+const chain = mockDb._chain;
+
+// Queue the next value the terminal `.limit()` resolves to. Left unqueued, the
+// default mock returns the chain itself, so getLatestShow() yields undefined.
+const queueLimit = (rows: unknown[]) => chain.limit.mockResolvedValueOnce(rows);
+
+describe('getOnAirDJName', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns shows.legacy_dj_name for an open tubafrenzy-mirrored show — the DJ MONSTER production bug', async () => {
+    queueLimit([
+      { id: 1950003, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: 'DJ MONSTER' },
+    ]);
+
+    expect(await getOnAirDJName()).toBe('DJ MONSTER');
+  });
+
+  it('resolves the primary DJ user.djName for an open show with a Backend-Service account', async () => {
+    queueLimit([{ id: 2, end_time: null, primary_dj_id: 'user-1', dj_name_override: null, legacy_dj_name: null }]);
+    queueLimit([{ djName: 'DJ HOUNDSTOOTH' }]); // resolveDjNameForShow user lookup
+
+    expect(await getOnAirDJName()).toBe('DJ HOUNDSTOOTH');
+  });
+
+  it('returns null for an open show with no resolvable DJ name', async () => {
+    queueLimit([{ id: 3, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: null }]);
+
+    expect(await getOnAirDJName()).toBeNull();
+  });
+
+  it('returns null when the latest show has already ended (end_time set) — automation', async () => {
+    queueLimit([
+      {
+        id: 4,
+        end_time: new Date('2026-07-07T18:00:00Z'),
+        primary_dj_id: null,
+        dj_name_override: null,
+        legacy_dj_name: 'DJ MONSTER',
+      },
+    ]);
+
+    expect(await getOnAirDJName()).toBeNull();
+  });
+
+  it('returns null when there is no latest show at all', async () => {
+    // No queued value → getLatestShow() resolves undefined.
+    expect(await getOnAirDJName()).toBeNull();
+  });
+});

--- a/tests/unit/services/flowsheet.getOnAirDJName.test.ts
+++ b/tests/unit/services/flowsheet.getOnAirDJName.test.ts
@@ -66,6 +66,22 @@ describe('getOnAirDJName', () => {
     expect(await getOnAirDJName()).toBeNull();
   });
 
+  it('honours dj_name_override precedence for an open show', async () => {
+    // The override short-circuits resolveDjNameForShow ahead of the user lookup,
+    // so only getLatestShow's terminal .limit() is consumed.
+    queueLimit([
+      {
+        id: 5,
+        end_time: null,
+        primary_dj_id: 'user-1',
+        dj_name_override: 'DJ HOUNDSTOOTH',
+        legacy_dj_name: 'DJ MONSTER',
+      },
+    ]);
+
+    expect(await getOnAirDJName()).toBe('DJ HOUNDSTOOTH');
+  });
+
   it('returns null when there is no latest show at all', async () => {
     // No queued value → getLatestShow() resolves undefined.
     expect(await getOnAirDJName()).toBeNull();


### PR DESCRIPTION
Closes #1546

## What

Adds `getOnAirDJName()` and emits a top-level `on_air` field on the default paginated `GET /flowsheet` branch, so clients render the on-air banner directly instead of scanning the fetched entry window for a `show_start` marker (which falls outside a 30-entry page once a show accumulates enough entries — the "AUTO DJ while a human DJ is live" bug).

`getOnAirDJName()` reads the latest show and, when it's open (`end_time` null), resolves its display name via the existing `resolveDjNameForShow` chain (`dj_name_override` → primary DJ's `user.djName` → `legacy_dj_name`). It deliberately does **not** read the `show_djs` join table the way `getDJsInCurrentShow`/`getOnAirStatusForDJ` do — tubafrenzy-mirrored shows have no `show_djs` rows, so those derivations report automation for essentially every legacy live show. `legacy_dj_name` is the authoritative identity there.

Emitted only on the default paginated branch (the iOS app polls it). `shows_limit` and `start_id/end_id` branches are untouched.

Contract is defined in wxyc-shared `api.yaml` (SSOT, WXYC/wxyc-shared#208); `app.yaml` is updated for Swagger-docs parity. Backend-Service doesn't consume `@wxyc/shared` for this type (the response is a plain literal), so there's no publish dependency.

## Test plan

- `tests/unit/services/flowsheet.getOnAirDJName.test.ts` — legacy_dj_name / primary DJ / no-name / ended-show / no-show
- `tests/unit/controllers/flowsheet.controller.test.ts` — default-branch JSON carries `on_air: { dj_name }` when live and `on_air: null` on automation
- Full unit suite 3640/3640, `npm run typecheck` (all workspaces), prettier, eslint — pass

## Related (cross-repo on-air banner fix)

- wxyc-shared `on_air` contract: WXYC/wxyc-shared#208
- iOS consumes `on_air`: WXYC/wxyc-ios-64#421
- Follow-up (pre-existing `/djs-on-air` + `/on-air` share the `show_djs`-only bug): WXYC/Backend-Service#1547
