### PR TITLE
fix(flowsheet): report legacy DJs on GET /flowsheet/djs-on-air (#1547)

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -498,11 +498,10 @@ export const leaveShow: RequestHandler<object, unknown, { dj_id: string }> = asy
 };
 
 export const getDJList: RequestHandler = async (req, res) => {
-  const currentDJs = await flowsheet_service.getDJsInCurrentShow();
-  const cleanDJList = currentDJs.map((dj) => {
-    return { id: dj.id, dj_name: flowsheet_service.resolveDjDisplayName(dj.djName ?? null) };
-  });
-  res.status(200).json(cleanDJList);
+  // getOnAirDJs preserves the account-DJ shape ({ id, dj_name }) and additionally
+  // surfaces legacy/tubafrenzy-mirrored shows (null id, legacy_dj_name) that the
+  // show_djs-only derivation used to miss — BS#1547.
+  res.status(200).json(await flowsheet_service.getOnAirDJs());
 };
 
 export const getOnAir: RequestHandler = async (req, res) => {

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -864,6 +864,17 @@ export const getOnAirDJName = async (): Promise<string | null> => {
   return await resolveDjNameForShow(latest_show);
 };
 
+/**
+ * Whether the given user account is on air right now. Backs GET /flowsheet/on-air.
+ *
+ * This is a per-*user* liveness check: it asks whether `dj_id` is an active
+ * member of the open show's `show_djs` join. It therefore cannot answer for
+ * legacy/tubafrenzy-mirrored shows, whose on-air DJ has no `auth_user` row and
+ * no `show_djs` membership (their identity is `shows.legacy_dj_name`) — there is
+ * simply no `dj_id` to pass. The endpoint that surfaces legacy on-air identity
+ * is GET /flowsheet/djs-on-air via `getOnAirDJs`; this one is intentionally left
+ * account-scoped (BS#1547).
+ */
 export const getOnAirStatusForDJ = async (dj_id: string): Promise<boolean> => {
   const latest_show = await getLatestShow();
   if (!latest_show || latest_show.end_time !== null) {
@@ -881,6 +892,45 @@ export const getDJsInCurrentShow = async (): Promise<User[]> => {
   }
 
   return getDJsInShow(current_show.id, true);
+};
+
+/**
+ * The on-air DJ list backing GET /flowsheet/djs-on-air.
+ *
+ * When the open show has active `show_djs` rows (DJs with Backend-Service
+ * accounts, including co-hosts), returns each with their `auth_user.id` string
+ * and Anonymous-filtered `dj_name` — the pre-existing behavior, preserved
+ * byte-for-byte (a filtered-away name yields `dj_name: null`, as it always has).
+ *
+ * When the open show has NO account rows, it is a legacy/tubafrenzy-mirrored
+ * show whose DJ identity lives in `shows.legacy_dj_name`. Those shows previously
+ * reported an empty list (the "Off Air while a human DJ is live" bug); here they
+ * surface a single entry resolved via `resolveDjNameForShow` — the same
+ * precedence chain (`dj_name_override` → primary DJ's `user.djName` →
+ * `legacy_dj_name`) that `getOnAirDJName` uses for the banner — with a `null`
+ * `id` because there is no user account. Returns `[]` when off air (no open
+ * show) or when the open legacy show has no resolvable name.
+ *
+ * `id` is nullable because a legacy DJ has no `auth_user.id`; see wxyc-shared
+ * `OnAirDJ` (BS#1547).
+ */
+export const getOnAirDJs = async (): Promise<Array<{ id: string | null; dj_name: string | null }>> => {
+  const current_show = await getLatestShow();
+  if (!current_show || current_show.end_time !== null) {
+    return [];
+  }
+
+  const accountDJs = await getDJsInShow(current_show.id, true);
+  if (accountDJs.length > 0) {
+    return accountDJs.map((dj) => ({
+      id: dj.id as string,
+      dj_name: resolveDjDisplayName((dj.djName as string | null | undefined) ?? null),
+    }));
+  }
+
+  // Legacy/tubafrenzy-mirrored show: no account rows; identity is legacy_dj_name.
+  const legacyName = await resolveDjNameForShow(current_show);
+  return legacyName ? [{ id: null, dj_name: legacyName }] : [];
 };
 
 export const getDJsInShow = async (show_id: number, activeOnly: boolean): Promise<User[]> => {

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -15,6 +15,7 @@ const mockTransformToV2 = jest.fn((entry: unknown) => ({ ...(entry as Record<str
 const mockAddTrack = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockGetLatestShow = jest.fn<() => Promise<Record<string, unknown> | null>>();
 const mockGetOnAirDJName = jest.fn<() => Promise<string | null>>();
+const mockGetOnAirDJs = jest.fn<() => Promise<Array<{ id: string | null; dj_name: string | null }>>>();
 const mockGetAlbumFromDB = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockResolveDjNameForShow = jest.fn<() => Promise<string | null>>();
 const mockUpdateEntry = jest.fn<() => Promise<Record<string, unknown>>>();
@@ -35,6 +36,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   addTrack: mockAddTrack,
   getLatestShow: mockGetLatestShow,
   getOnAirDJName: mockGetOnAirDJName,
+  getOnAirDJs: mockGetOnAirDJs,
   getAlbumFromDB: mockGetAlbumFromDB,
   resolveDjNameForShow: mockResolveDjNameForShow,
   updateEntry: mockUpdateEntry,
@@ -54,6 +56,7 @@ import {
   getEntries,
   getLatest,
   getShowInfo,
+  getDJList,
   addEntry,
   updateEntry,
   deleteEntry,
@@ -351,6 +354,34 @@ describe('flowsheet.controller', () => {
       const res = createMockRes();
 
       await expect(getLatest(req as Request, res as Response, mockNext)).rejects.toThrow(error);
+    });
+  });
+
+  describe('getDJList (GET /flowsheet/djs-on-air)', () => {
+    it('responds 200 with the on-air DJ list from getOnAirDJs (a legacy DJ carries a null id)', async () => {
+      const djs = [{ id: null, dj_name: 'DJ MONSTER' }];
+      mockGetOnAirDJs.mockResolvedValue(djs);
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getDJList(req as Request, res as Response, mockNext);
+
+      expect(mockGetOnAirDJs).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(djs);
+    });
+
+    it('responds 200 with an empty array when off air', async () => {
+      mockGetOnAirDJs.mockResolvedValue([]);
+
+      const req = createMockReq();
+      const res = createMockRes();
+
+      await getDJList(req as Request, res as Response, mockNext);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([]);
     });
   });
 

--- a/tests/unit/services/flowsheet.getOnAirDJs.test.ts
+++ b/tests/unit/services/flowsheet.getOnAirDJs.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for getOnAirDJs — the on-air DJ list backing GET /flowsheet/djs-on-air.
+ *
+ * The pre-existing endpoint derived its list from the `show_djs` join table only
+ * (`getDJsInCurrentShow` → `getDJsInShow`), so tubafrenzy-mirrored shows — which
+ * have no `show_djs` rows because their DJ has no Backend-Service account —
+ * reported an empty list while a human DJ was live (dj-site's NowPlaying banner
+ * then read "Off Air"). getOnAirDJs keeps the account-DJ behavior (active
+ * co-hosts, each with their `auth_user.id` string) and adds a legacy fallback:
+ * when the open show has no account rows, it surfaces the DJ from
+ * `resolveDjNameForShow` with a null id (BS#1547).
+ *
+ * Mock mechanics: getLatestShow → getNShows(1) terminates in `.limit()`.
+ * getDJsInShow issues two queries that terminate in `.where()` (the show_djs
+ * join, then the user lookup), so those are queued on the separate `.where`
+ * once-queue. resolveDjNameForShow only queries (via `.limit(1)`) when a primary
+ * DJ is present; the legacy branch here has `primary_dj_id: null`, so it
+ * short-circuits to `legacy_dj_name` with no extra query.
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '@wxyc/database';
+import { getOnAirDJs } from '../../../apps/backend/services/flowsheet.service';
+
+const mockDb = db as unknown as { _chain: Record<string, jest.Mock> };
+const chain = mockDb._chain;
+
+// getLatestShow's terminal `.limit()`. Left unqueued, getLatestShow → undefined.
+const queueLimit = (rows: unknown[]) => chain.limit.mockResolvedValueOnce(rows);
+// getDJsInShow's two terminal `.where()` reads (show_djs join, then user lookup).
+const queueWhere = (rows: unknown[]) => chain.where.mockResolvedValueOnce(rows);
+
+describe('getOnAirDJs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns legacy_dj_name with a null id for an open tubafrenzy-mirrored show (show_djs empty) — the DJ MONSTER production bug', async () => {
+    queueLimit([
+      { id: 1950003, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: 'DJ MONSTER' },
+    ]);
+    queueWhere([]); // show_djs join: no account rows
+    queueWhere([]); // user lookup over the (empty) dj_ids
+
+    expect(await getOnAirDJs()).toEqual([{ id: null, dj_name: 'DJ MONSTER' }]);
+  });
+
+  it('returns active account DJs with their user id and resolved name when show_djs has rows (co-hosts preserved)', async () => {
+    queueLimit([{ id: 2, end_time: null, primary_dj_id: 'user-1', dj_name_override: null, legacy_dj_name: null }]);
+    queueWhere([
+      { dj_id: 'user-1', active: true },
+      { dj_id: 'user-2', active: true },
+    ]);
+    queueWhere([
+      { id: 'user-1', djName: 'DJ HOUNDSTOOTH' },
+      { id: 'user-2', djName: 'DJ MONSTER' },
+    ]);
+
+    expect(await getOnAirDJs()).toEqual([
+      { id: 'user-1', dj_name: 'DJ HOUNDSTOOTH' },
+      { id: 'user-2', dj_name: 'DJ MONSTER' },
+    ]);
+  });
+
+  it('preserves the existing Anonymous-filtering behavior on the account path (dj_name null, id retained)', async () => {
+    queueLimit([{ id: 6, end_time: null, primary_dj_id: 'user-9', dj_name_override: null, legacy_dj_name: null }]);
+    queueWhere([{ dj_id: 'user-9', active: true }]);
+    queueWhere([{ id: 'user-9', djName: 'Anonymous' }]);
+
+    expect(await getOnAirDJs()).toEqual([{ id: 'user-9', dj_name: null }]);
+  });
+
+  it('returns [] when the latest show has already ended (automation)', async () => {
+    queueLimit([
+      {
+        id: 4,
+        end_time: new Date('2026-07-07T18:00:00Z'),
+        primary_dj_id: null,
+        dj_name_override: null,
+        legacy_dj_name: 'DJ MONSTER',
+      },
+    ]);
+
+    expect(await getOnAirDJs()).toEqual([]);
+  });
+
+  it('returns [] when there is no latest show at all', async () => {
+    expect(await getOnAirDJs()).toEqual([]);
+  });
+
+  it('returns [] for an open legacy show with no resolvable DJ name (no show_djs, null legacy_dj_name)', async () => {
+    queueLimit([{ id: 5, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: null }]);
+    queueWhere([]); // show_djs join
+    queueWhere([]); // user lookup
+
+    expect(await getOnAirDJs()).toEqual([]);
+  });
+});

--- a/tests/unit/services/flowsheet.getOnAirDJs.test.ts
+++ b/tests/unit/services/flowsheet.getOnAirDJs.test.ts
@@ -62,6 +62,18 @@ describe('getOnAirDJs', () => {
     ]);
   });
 
+  it('prefers active account DJs over legacy_dj_name when a show carries both', async () => {
+    // Precedence guard: the account branch (show_djs rows present) must win, so
+    // legacy_dj_name is ignored — never merged in or preferred.
+    queueLimit([
+      { id: 7, end_time: null, primary_dj_id: 'user-1', dj_name_override: null, legacy_dj_name: 'DJ MONSTER' },
+    ]);
+    queueWhere([{ dj_id: 'user-1', active: true }]);
+    queueWhere([{ id: 'user-1', djName: 'DJ HOUNDSTOOTH' }]);
+
+    expect(await getOnAirDJs()).toEqual([{ id: 'user-1', dj_name: 'DJ HOUNDSTOOTH' }]);
+  });
+
   it('preserves the existing Anonymous-filtering behavior on the account path (dj_name null, id retained)', async () => {
     queueLimit([{ id: 6, end_time: null, primary_dj_id: 'user-9', dj_name_override: null, legacy_dj_name: null }]);
     queueWhere([{ dj_id: 'user-9', active: true }]);


### PR DESCRIPTION
Closes #1547

## What

`GET /flowsheet/djs-on-air` derived its list from `getDJsInCurrentShow` → `getDJsInShow`, which reads only the `show_djs` join table. Tubafrenzy-mirrored shows have no `show_djs` rows (their DJ has no Backend-Service account; identity lives in `shows.legacy_dj_name`), so the endpoint returned `[]` for essentially every legacy live show — dj-site's NowPlaying banner then read "Off Air" while a human DJ was on air. Same root cause as the on-air banner "AUTO DJ" bug (#1546), on the other on-air code path.

Adds `getOnAirDJs()`: for an open show with active `show_djs` rows it returns each account DJ with their `auth_user.id` string and Anonymous-filtered `dj_name` (existing behavior, preserved byte-for-byte, co-hosts included); otherwise it falls back to `resolveDjNameForShow` — the same `dj_name_override` → primary DJ's `user.djName` → `legacy_dj_name` precedence `getOnAirDJName` uses for the banner — surfacing the legacy DJ with a `null` id. `getDJList` delegates to it. `getDJsInCurrentShow` is untouched (still used by `checkShowMember`).

The `null` id matches the nullable `OnAirDJ.id` contract in wxyc-shared (WXYC/wxyc-shared#210). The singular per-user `GET /flowsheet/on-air` is left as-is (it cannot answer for account-less legacy shows) with a doc comment on `getOnAirStatusForDJ` recording why.

## Test plan

- `tests/unit/services/flowsheet.getOnAirDJs.test.ts` — legacy null-id / account co-hosts / Anonymous-filtered dj_name / ended show / no show / unresolvable legacy name
- `tests/unit/controllers/flowsheet.controller.test.ts` — `getDJList` delegates to `getOnAirDJs` (legacy null-id + off-air empty)
- `npm run typecheck`, `npm run test:unit` (3652 pass; the one failure is a pre-existing timing flake in `library.controller.test.ts`, green in isolation), `npm run format:check`, `npm run lint` (0 errors) — pass

## Related (cross-repo on-air fix)

- wxyc-shared OnAirDJ.id nullable string: WXYC/wxyc-shared#210
- dj-site widens OnAirDJResponse.id: WXYC/dj-site#828
