### PR TITLE
fix(flowsheet-metadata-backfill): isolate per-row enrich failures so one bad row can't wedge the drain

### DIFF
--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -258,9 +258,13 @@ export const processRow = async (
     const outcome = await deps.enrich(row, result.response);
     return { outcome, cacheHit: result.cacheHit };
   } catch (error) {
+    // Defend against non-Error throws (`throw 'string'`, `throw { code: x }`) —
+    // `(error as Error).message` would emit undefined and the JSON logger would
+    // drop the key, matching `readCacheFields`'s guard below.
+    const message = error instanceof Error ? error.message : String(error);
     log('warn', 'enrich_error', `enrich failed for flowsheet.id=${row.id}`, {
       flowsheet_id: row.id,
-      error_message: (error as Error).message,
+      error_message: message,
     });
     captureError(error, 'enrich_error', { flowsheet_id: row.id, artist, album, track });
     // Forward the lookup's real cacheHit (unlike the lml_error path, the

--- a/jobs/flowsheet-metadata-backfill/orchestrate.ts
+++ b/jobs/flowsheet-metadata-backfill/orchestrate.ts
@@ -15,9 +15,12 @@
  *   - Within a single run, batches paginate by `id` (last-id cursor).
  *     Across runs, the WHERE filter is what restarts — the cursor doesn't
  *     need to persist.
- *   - One LML failure is logged, counted as `lml_error`, and the loop
- *     continues. The row stays `metadata_attempt_at IS NULL`, so the
- *     next sweep (recurring drift-repair, #639 Phase 2) retries it.
+ *   - A per-row failure — an LML throw (`lml_error`) or a DB-write throw
+ *     (`enrich_error`, e.g. a mojibake title overflowing a varchar column,
+ *     BS#1011) — is logged, counted, and the loop continues. The row stays
+ *     `metadata_attempt_at IS NULL`, so the next sweep (recurring
+ *     drift-repair, #639 Phase 2) retries it; the id-cursor still advances
+ *     within the run, so one bad row can never wedge the drain.
  *   - Cooperative pause: WXYC has no quiet hours — there is always a DJ in
  *     the booth. Before each batch, the orchestrator probes `flowsheet` for
  *     any track row added in the last `LIVE_ACTIVITY_LOOKBACK_SECONDS`
@@ -191,9 +194,14 @@ export type Totals = {
   enriched_no_match: number;
   enriched_no_match_raced: number;
   lml_error: number;
+  // Enrich (DB-write) failure on a single row. Kept distinct from `lml_error`
+  // (upstream LML throw) so a run's log line separates "LML couldn't answer"
+  // from "we couldn't persist" — a spike in this bucket points at data, not
+  // the upstream (BS#1011: mojibake titles overflowing varchar(512) columns).
+  enrich_error: number;
 };
 
-export type ProcessOutcome = EnrichOutcome | 'lml_error';
+export type ProcessOutcome = EnrichOutcome | 'lml_error' | 'enrich_error';
 
 /**
  * Outcome plus cache provenance, so the per-row loop can skip the LML
@@ -213,9 +221,18 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 
 /**
  * Drive a single row through lookup → enrich. The result is the outcome
- * status (or 'lml_error' when LML threw). Errors are logged and consumed;
- * they do not bubble up so a single bad row cannot abort the run. The row
+ * status: 'lml_error' when the LML lookup threw, 'enrich_error' when the
+ * per-row DB write threw. BOTH failures are logged, captured, and consumed
+ * — neither bubbles up, so a single bad row cannot abort the run. The row
  * stays `metadata_attempt_at IS NULL` so the next sweep retries it.
+ *
+ * The enrich catch is load-bearing, not defensive boilerplate: without it a
+ * single row whose synthesized search URL overflows a varchar(512) column
+ * (mojibake titles from the legacy latin1→UTF-8 ETL) throws mid-batch, the
+ * throw propagates to `main` → exit 1, and because the failed UPDATE never
+ * stamps `metadata_attempt_at`, the id-cursor re-selects that same row as the
+ * smallest pending id on the next run and crashes again — a permanent stall
+ * (BS#1011). Isolating the throw here lets the cursor advance past it.
  */
 export const processRow = async (
   row: EnrichRow,
@@ -237,8 +254,20 @@ export const processRow = async (
     return { outcome: 'lml_error', cacheHit: false };
   }
 
-  const outcome = await deps.enrich(row, result.response);
-  return { outcome, cacheHit: result.cacheHit };
+  try {
+    const outcome = await deps.enrich(row, result.response);
+    return { outcome, cacheHit: result.cacheHit };
+  } catch (error) {
+    log('warn', 'enrich_error', `enrich failed for flowsheet.id=${row.id}`, {
+      flowsheet_id: row.id,
+      error_message: (error as Error).message,
+    });
+    captureError(error, 'enrich_error', { flowsheet_id: row.id, artist, album, track });
+    // Forward the lookup's real cacheHit (unlike the lml_error path, the
+    // lookup succeeded here): a cached hit made no LML call, so the caller
+    // should still skip the inter-row throttle.
+    return { outcome: 'enrich_error', cacheHit: result.cacheHit };
+  }
 };
 
 /**
@@ -278,7 +307,8 @@ const formatTotals = (totals: Totals): string =>
   `scanned=${totals.scanned} enriched_match=${totals.enriched_match} ` +
   `enriched_match_raced=${totals.enriched_match_raced} ` +
   `enriched_no_match=${totals.enriched_no_match} ` +
-  `enriched_no_match_raced=${totals.enriched_no_match_raced} lml_error=${totals.lml_error}`;
+  `enriched_no_match_raced=${totals.enriched_no_match_raced} lml_error=${totals.lml_error} ` +
+  `enrich_error=${totals.enrich_error}`;
 
 export const runBackfill = async (opts: {
   lookup: LookupFn;
@@ -313,6 +343,7 @@ export const runBackfill = async (opts: {
     enriched_no_match: 0,
     enriched_no_match_raced: 0,
     lml_error: 0,
+    enrich_error: 0,
   };
   let lastId = 0;
   let batchIndex = 0;

--- a/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
@@ -242,6 +242,36 @@ describe('processRow', () => {
     expect(enrich).not.toHaveBeenCalled();
   });
 
+  it('returns enrich_error (not a throw) when enrich rejects, so a single bad row cannot abort the run', async () => {
+    // BS#1011 poison-pill jam: a mojibake album title synthesizes a Bandcamp
+    // search URL that overflows flowsheet.bandcamp_url varchar(512); the
+    // UPDATE throws `value too long`. Before the fix the throw bubbled past
+    // processRow → main → exit 1, and because the failed UPDATE never stamped
+    // metadata_attempt_at the id-cursor re-selected the same row every run —
+    // a permanent stall. processRow must map the enrich throw to enrich_error
+    // (mirroring the lml_error catch) instead of propagating it.
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult(false));
+    const enrich = jest.fn<EnrichFn>().mockRejectedValue(new Error('value too long for type character varying(512)'));
+
+    const result = await processRow(row, { lookup, enrich });
+
+    expect(result).toEqual({ outcome: 'enrich_error', cacheHit: false });
+    expect(enrich).toHaveBeenCalledWith(row, matchedResponse);
+  });
+
+  it('forwards cacheHit through the enrich_error path (the lookup succeeded, so a cached hit still skips throttle)', async () => {
+    // Unlike lml_error (lookup itself threw → cacheHit forced false so the
+    // next LML attempt is still spaced), an enrich failure happens *after* a
+    // successful lookup, so the lookup's real cacheHit is meaningful and must
+    // flow through — a cache hit made no LML call and shouldn't be throttled.
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult(true));
+    const enrich = jest.fn<EnrichFn>().mockRejectedValue(new Error('DB write failed'));
+
+    const result = await processRow(row, { lookup, enrich });
+
+    expect(result).toEqual({ outcome: 'enrich_error', cacheHit: true });
+  });
+
   it('forwards undefined for null album_title / track_title (matches lml-fetch.ts contract)', async () => {
     const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult(false));
     const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_no_match');
@@ -345,6 +375,51 @@ describe('runBackfill', () => {
     // enrich is called twice (once per non-error row) — the LML-throw row
     // skips enrich entirely so its metadata_attempt_at stays NULL.
     expect(enrichLocal).toHaveBeenCalledTimes(2);
+  });
+
+  it('counts enrich_error and drains the rest of the batch when one row’s enrich throws (BS#1011 poison-pill jam regression)', async () => {
+    // The wedge that stalled the BS#1011 drain for ~2.5 weeks: a mojibake
+    // album title overflowed flowsheet.bandcamp_url varchar(512), the enrich
+    // UPDATE threw, and the throw aborted the whole run. The failed row never
+    // got its metadata_attempt_at marker, so the next run re-selected it as
+    // the smallest pending id and crashed again — zero forward progress. This
+    // pins that the poison row is now isolated (counted as enrich_error), the
+    // id-cursor advances past it, and the remaining rows in the batch drain.
+    const batch = [
+      { id: 10, artist_name: 'a', album_title: null, track_title: null, album_id: null },
+      { id: 20, artist_name: 'b', album_title: 'mojibake', track_title: null, album_id: null },
+      { id: 30, artist_name: 'c', album_title: null, track_title: null, album_id: null },
+    ];
+
+    (db.execute as jest.Mock).mockResolvedValueOnce(batch).mockResolvedValueOnce([]);
+
+    const enrichPoison = jest
+      .fn<EnrichFn>()
+      .mockResolvedValueOnce('enriched_match')
+      .mockRejectedValueOnce(new Error('value too long for type character varying(512)'))
+      .mockResolvedValueOnce('enriched_no_match');
+
+    const result = await runBackfill({
+      lookup,
+      enrich: enrichPoison,
+      throttleMs: 0,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    // Run completes normally (no exit 1). All three rows scanned; the poison
+    // row lands in its own bucket while the other two enrich as usual.
+    expect(result.totals.scanned).toBe(3);
+    expect(result.totals.enriched_match).toBe(1);
+    expect(result.totals.enriched_no_match).toBe(1);
+    expect(result.totals.enrich_error).toBe(1);
+    // enrich is attempted on all three (the lookup succeeded for each) — the
+    // poison row is only skipped *after* its DB write throws, not before.
+    expect(enrichPoison).toHaveBeenCalledTimes(3);
+
+    // The terminal (empty) poll must paginate from id > 30 — proof the cursor
+    // advanced *past* the poison row (id 20) rather than jamming on it.
+    const terminalPoll = (db.execute as jest.Mock).mock.calls[1]?.[0] as { values?: unknown[] };
+    expect(terminalPoll?.values).toContain(30);
   });
 
   it('exposes BATCH_SIZE and THROTTLE_MS constants for ops tuning', () => {

--- a/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-metadata-backfill/orchestrate.test.ts
@@ -272,6 +272,35 @@ describe('processRow', () => {
     expect(result).toEqual({ outcome: 'enrich_error', cacheHit: true });
   });
 
+  it('logs a non-Error enrich throw with a stringified message (not undefined)', async () => {
+    // A non-Error rejection (`throw 'string'`, `throw { code }`) must still
+    // surface a message on the enrich_error log line — `(error as Error).message`
+    // would emit undefined and the JSON logger would drop the key, leaving
+    // operators with no signal (mirrors readCacheFields's guard).
+    const initLogger = (await import('../../../../jobs/flowsheet-metadata-backfill/logger')).initLogger;
+    const closeLogger = (await import('../../../../jobs/flowsheet-metadata-backfill/logger')).closeLogger;
+    initLogger({ repo: 'Backend-Service', tool: 'test', runId: 'run-id-enrich-nonerror' });
+    const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult(false));
+      const enrich = jest.fn<EnrichFn>().mockRejectedValue('value too long for type character varying(512)');
+
+      const result = await processRow(row, { lookup, enrich });
+
+      expect(result).toEqual({ outcome: 'enrich_error', cacheHit: false });
+      const enrichErrorLine = writeSpy.mock.calls
+        .map((args) => String(args[0]))
+        .find((l) => l.includes('"step":"enrich_error"'));
+      if (!enrichErrorLine) throw new Error('expected an enrich_error log line');
+      const parsed = JSON.parse(enrichErrorLine.trim());
+      expect(parsed.error_message).toBe('value too long for type character varying(512)');
+    } finally {
+      writeSpy.mockRestore();
+      await closeLogger();
+    }
+  });
+
   it('forwards undefined for null album_title / track_title (matches lml-fetch.ts contract)', async () => {
     const lookup = jest.fn<LookupFn>().mockResolvedValue(noMatchResult(false));
     const enrich = jest.fn<EnrichFn>().mockResolvedValue('enriched_no_match');


### PR DESCRIPTION
## What

`processRow` in the `flowsheet-metadata-backfill` orchestrator caught LML lookup throws but **not** enrich (DB-write) throws. A single row whose synthesized Bandcamp search URL overflowed `flowsheet.bandcamp_url varchar(512)` — a mojibake album title from the legacy latin1→UTF-8 ETL — threw mid-batch, propagated to `main` → `exit 1`, and because the failed UPDATE never stamped `metadata_attempt_at`, the id-cursor re-selected that same row as the smallest pending id on the next run and crashed again.

The BS#1011 historical drain stalled on one such row (id `1396969`) for ~2.5 weeks with **zero forward progress** — 308,838 rows still pending, cursor 100% wedged (0 pending rows below the poison row).

## Fix

Wrap `deps.enrich()` in a try/catch that mirrors the existing `lml_error` path:
- log + Sentry-capture the failure, count it in a new `enrich_error` totals bucket (distinct from `lml_error` so a log line separates "LML couldn't answer" from "we couldn't persist");
- forward the lookup's real `cacheHit` (the lookup succeeded, so a cached hit still skips the inter-row throttle);
- return instead of throwing, so the per-row loop advances the id-cursor **past** the bad row.

The row stays `metadata_attempt_at IS NULL` and retries next sweep, but can no longer abort the run or wedge the cursor.

## Tests

- `processRow` returns `enrich_error` (not a throw) when enrich rejects; forwards `cacheHit` through that path.
- `runBackfill` regression: a poison row mid-batch is counted as `enrich_error`, the remaining rows drain, and the terminal poll paginates from `id > 30` — proof the cursor advanced past the poison row at id 20.
- Full job suite green (135/135); lint 0 errors, format clean, tsup build OK.

## Scope note

This isolates the failure; it does **not** repair the ~19 mojibake titles (they'll log as `enrich_error` and be skipped each run — garbage titles that wouldn't yield useful Bandcamp searches anyway) and does **not** retire the cron (that stays with BS#1011, which this unblocks).

## Verification after deploy

Next cron run should complete with non-zero `scanned` and a small `enrich_error`, and the pending cohort count should start falling again.

Closes #1560
Related: #1011
