### PR TITLE
fix(auth): set session cookie on /device/token so the QR browser can sign in

### DIFF
--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -14,6 +14,7 @@ import {
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { createAuthMiddleware, getSessionFromCtx } from 'better-auth/api';
+import { setSessionCookie } from 'better-auth/cookies';
 import {
   admin,
   anonymous,
@@ -32,6 +33,7 @@ import {
   applyDeviceApproveRoleGate,
   applyDeviceTokenSessionTtl,
   capSessionUpdateAgainstDeviceFlow,
+  DEVICE_SESSION_TTL_MS,
 } from './device-authorization';
 import { sendEmail, sendOTPEmail, sendResetPasswordEmail, sendVerificationEmailMessage } from './email';
 import { buildTrustedClients } from './oidc-trusted-clients';
@@ -445,7 +447,22 @@ export const auth = betterAuth({
         const body = ctx.context.returned as { expires_in?: number } | undefined;
         // Only on the success path: failed polls (authorization_pending,
         // slow_down, expired_token, access_denied) don't populate newSession.
-        if (!token || !body) return;
+        if (!newSession || !token || !body) return;
+
+        // The device-authorization plugin's /device/token route creates the
+        // session (setNewSession) but never setSessionCookie — it is an OAuth
+        // token endpoint that hands the session back as a bearer `access_token`
+        // in the body. WXYC's shared-computer QR flow is browser-based (the
+        // "device" is the control-room browser), and that browser drives SSR
+        // requireAuth off the session *cookie*, not the bearer. Without this the
+        // poll 200s but the browser never actually signs in (WXYC/dj-site#841).
+        // Emit the cookie here, clamped to the same 12h ceiling as the DB row
+        // (ADR 0008) via an explicit maxAge override. Runs before the TTL-clamp
+        // DB write so a transient DB error can't leave the browser cookieless.
+        await setSessionCookie(ctx, newSession, false, {
+          maxAge: DEVICE_SESSION_TTL_MS / 1000,
+        });
+
         try {
           await applyDeviceTokenSessionTtl(token, body, new Date(), async (t, expiresAt, deviceFlowExpiresAt) => {
             await db.update(session).set({ expiresAt, deviceFlowExpiresAt }).where(eq(session.token, t));

--- a/tests/integration/device-authorization.spec.js
+++ b/tests/integration/device-authorization.spec.js
@@ -208,6 +208,19 @@ describe('QR device-authorization (ADR 0008)', () => {
     expect(tokenBody.token_type).toBe('Bearer');
     expect(tokenBody.expires_in).toBe(12 * 60 * 60);
 
+    // WXYC/dj-site#841: the shared control-room browser signs in off the
+    // session *cookie*, not the bearer `access_token` body. The plugin's token
+    // route only setNewSession()s (no setSessionCookie — it's an OAuth token
+    // endpoint), so our /device/token after-hook must emit the session cookie,
+    // clamped to the same 12h ceiling as the DB row (ADR 0008). Without it the
+    // poll 200s but the browser never establishes a session and hangs on /login.
+    const tokenSetCookies = tokenRes.headers.getSetCookie();
+    const sessionCookie = tokenSetCookies.find((c) => c.startsWith('better-auth.session_token='));
+    expect(sessionCookie).toBeDefined();
+    // Non-empty signed value, and 12h (43200s) max-age so cookie and DB agree.
+    expect(sessionCookie).toMatch(/^better-auth\.session_token=.+/);
+    expect(sessionCookie).toMatch(/Max-Age=43200\b/i);
+
     // Persisted session's expiresAt AND device_flow_expires_at should both
     // match — the row is written in a single UPDATE by the after-hook.
     const rows = await sql.unsafe(`SELECT expires_at, device_flow_expires_at FROM auth_session WHERE token = $1`, [

--- a/tests/integration/device-authorization.spec.js
+++ b/tests/integration/device-authorization.spec.js
@@ -214,11 +214,14 @@ describe('QR device-authorization (ADR 0008)', () => {
     // endpoint), so our /device/token after-hook must emit the session cookie,
     // clamped to the same 12h ceiling as the DB row (ADR 0008). Without it the
     // poll 200s but the browser never establishes a session and hangs on /login.
+    // Prefix-agnostic: better-auth prepends `__Secure-` only when the auth base
+    // is https (prod); the e2e/test env is http so the name is unprefixed here.
+    // Matching both keeps the assertion honest if a future harness runs secure.
     const tokenSetCookies = tokenRes.headers.getSetCookie();
-    const sessionCookie = tokenSetCookies.find((c) => c.startsWith('better-auth.session_token='));
+    const sessionCookie = tokenSetCookies.find((c) => /^(?:__Secure-)?better-auth\.session_token=/.test(c));
     expect(sessionCookie).toBeDefined();
     // Non-empty signed value, and 12h (43200s) max-age so cookie and DB agree.
-    expect(sessionCookie).toMatch(/^better-auth\.session_token=.+/);
+    expect(sessionCookie).toMatch(/^(?:__Secure-)?better-auth\.session_token=.+/);
     expect(sessionCookie).toMatch(/Max-Age=43200\b/i);
 
     // Persisted session's expiresAt AND device_flow_expires_at should both


### PR DESCRIPTION
## Summary

RFC 8628's `/device/token` is an OAuth token endpoint: better-auth's device-authorization plugin creates the session via `setNewSession()` and returns it as a bearer `access_token` in the body, but **never calls `setSessionCookie`**. WXYC's shared-computer QR flow (ADR 0008) is browser-based — the polling control-room browser drives dj-site's SSR `requireAuth()` off the session **cookie**, not the bearer — so the poll would 200 while the browser never actually signed in, hanging on `/login`.

This sets the session cookie in the existing `/device/token` `hooks.after`, clamped to the same 12h ceiling as the DB row (`maxAge` override), before the TTL-clamp DB write so a transient DB error can't leave the browser cookieless.

## Root cause & discovery

Proven end-to-end via the WXYC/dj-site#841 QR e2e (the first end-to-end exercise of the browser session path — unit/component tests mock `getSession`): `POST 200 /auth/device/token` returned **no `Set-Cookie`**; the browser had no `better-auth.session_token`; `get-session` → `null`. Contrast `sign-in/email` which calls `setSessionCookie` explicitly.

Not a live incident — `NEXT_PUBLIC_QR_LOGIN_ENABLED` is off in prod (pre-launch).

## Changes

- `shared/authentication/src/auth.definition.ts` — `/device/token` after-hook now `setSessionCookie(ctx, newSession, false, { maxAge: DEVICE_SESSION_TTL_MS / 1000 })`.
- `tests/integration/device-authorization.spec.js` — happy path asserts `Set-Cookie: better-auth.session_token=…; Max-Age=43200`.

## Test plan

- `npm run typecheck` — green (all workspaces).
- `npm run test:unit` — green (3699 tests).
- `prettier --check` — clean.
- Integration assertion runs in CI; verified equivalent behavior end-to-end via the dj-site#841 QR e2e against this branch (golden path signs in; full dj-site auth suite 61/61).

Closes #1568. Unblocks WXYC/dj-site#841.