### PR TITLE
fix(auth): bootstrap trustedClients into auth_oauth_application on boot

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -577,25 +577,34 @@ void (async () => {
   // DB blip shouldn't take sign-in / session / provision-user down for a bug
   // that only affects OIDC token exchange for two clients. If bootstrap fails,
   // OIDC login 500s at first attempt (loud), everything else keeps working.
-  try {
-    const trustedClients = buildTrustedClients(process.env);
-    if (trustedClients.length === 0) {
-      console.log(
-        '[OIDC BOOTSTRAP] no trustedClients configured — skipping (check *_OIDC_CLIENT_ID env vars if unexpected)'
-      );
-    } else {
-      const context = await auth.$context;
-      const { created, updated } = await bootstrapTrustedClients(context.adapter, trustedClients);
-      console.log(
-        `[OIDC BOOTSTRAP] trustedClients synced (${created} created, ${updated} updated of ${trustedClients.length})`
-      );
-    }
-  } catch (error) {
-    console.error(
-      '[OIDC BOOTSTRAP] Failed to sync trustedClients — OIDC token exchange will 500 until this is resolved.',
-      error
+  const trustedClients = buildTrustedClients(process.env);
+  if (trustedClients.length === 0) {
+    console.log(
+      '[OIDC BOOTSTRAP] no trustedClients configured — skipping (check *_OIDC_CLIENT_ID env vars if unexpected)'
     );
-    Sentry.captureException(error, { level: 'warning', tags: { subsystem: 'oidc-bootstrap' } });
+  } else {
+    try {
+      // Split the try so an `auth.$context` failure (plugin init, DB pool
+      // warm-up race) doesn't mis-tag as an oidc-bootstrap failure — a
+      // $context failure would break login/session/provision-user too, so
+      // on-call needs the right root-cause tag.
+      const context = await auth.$context;
+      try {
+        const { created, updated } = await bootstrapTrustedClients(context.adapter, trustedClients);
+        console.log(
+          `[OIDC BOOTSTRAP] trustedClients synced (${created} created, ${updated} updated of ${trustedClients.length})`
+        );
+      } catch (error) {
+        console.error(
+          '[OIDC BOOTSTRAP] Failed to sync trustedClients — OIDC token exchange will 500 until this is resolved.',
+          error
+        );
+        Sentry.captureException(error, { level: 'warning', tags: { subsystem: 'oidc-bootstrap' } });
+      }
+    } catch (error) {
+      console.error('[AUTH CONTEXT] Failed to resolve auth.$context before bootstrap:', error);
+      Sentry.captureException(error, { level: 'warning', tags: { subsystem: 'auth-context' } });
+    }
   }
 
   const server = app.listen(parseInt(port), () => {

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -578,14 +578,14 @@ void (async () => {
   // that only affects OIDC token exchange for two clients. If bootstrap fails,
   // OIDC login 500s at first attempt (loud), everything else keeps working.
   try {
-    const context = await auth.$context;
     const trustedClients = buildTrustedClients(process.env);
-    const { created, updated } = await bootstrapTrustedClients(context.adapter, trustedClients);
     if (trustedClients.length === 0) {
       console.log(
         '[OIDC BOOTSTRAP] no trustedClients configured — skipping (check *_OIDC_CLIENT_ID env vars if unexpected)'
       );
     } else {
+      const context = await auth.$context;
+      const { created, updated } = await bootstrapTrustedClients(context.adapter, trustedClients);
       console.log(
         `[OIDC BOOTSTRAP] trustedClients synced (${created} created, ${updated} updated of ${trustedClients.length})`
       );
@@ -595,7 +595,7 @@ void (async () => {
       '[OIDC BOOTSTRAP] Failed to sync trustedClients — OIDC token exchange will 500 until this is resolved.',
       error
     );
-    Sentry.captureException(error, { level: 'error', tags: { subsystem: 'oidc-bootstrap' } });
+    Sentry.captureException(error, { level: 'warning', tags: { subsystem: 'oidc-bootstrap' } });
   }
 
   const server = app.listen(parseInt(port), () => {

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -571,28 +571,31 @@ void (async () => {
   await createDefaultUser();
   await syncAdminRoles();
 
-  // Bootstrap oauthApplication rows for every trustedClient. The
-  // oidcProvider plugin's `getClient()` short-circuits on trustedClients
-  // (returned from memory, never persisted), but its token / consent write
-  // paths still FK-reference auth_oauth_application.client_id — every
-  // trustedClient token exchange 500s until a row exists. Fatal on failure:
-  // silently starting a server whose token endpoint is permanently broken
-  // (until an operator hand-runs SQL) is worse than a loud restart loop.
+  // Bootstrap oauthApplication rows for every trustedClient. See
+  // `bootstrap-trusted-clients.ts` for why this exists. warn-and-continue to
+  // match sibling `createDefaultUser` / `syncAdminRoles` posture — a transient
+  // DB blip shouldn't take sign-in / session / provision-user down for a bug
+  // that only affects OIDC token exchange for two clients. If bootstrap fails,
+  // OIDC login 500s at first attempt (loud), everything else keeps working.
   try {
     const context = await auth.$context;
-    await bootstrapTrustedClients(
-      { adapter: context.adapter as unknown as Parameters<typeof bootstrapTrustedClients>[0]['adapter'] },
-      buildTrustedClients(process.env)
-    );
-    console.log('[OIDC BOOTSTRAP] trustedClients synced to auth_oauth_application');
+    const trustedClients = buildTrustedClients(process.env);
+    const { created, updated } = await bootstrapTrustedClients(context.adapter, trustedClients);
+    if (trustedClients.length === 0) {
+      console.log(
+        '[OIDC BOOTSTRAP] no trustedClients configured — skipping (check *_OIDC_CLIENT_ID env vars if unexpected)'
+      );
+    } else {
+      console.log(
+        `[OIDC BOOTSTRAP] trustedClients synced (${created} created, ${updated} updated of ${trustedClients.length})`
+      );
+    }
   } catch (error) {
     console.error(
-      '[OIDC BOOTSTRAP] Failed to sync trustedClients — token exchange would 500. Aborting startup.',
+      '[OIDC BOOTSTRAP] Failed to sync trustedClients — OIDC token exchange will 500 until this is resolved.',
       error
     );
-    Sentry.captureException(error, { level: 'fatal', tags: { subsystem: 'oidc-bootstrap' } });
-    await Sentry.flush(2_000).catch(() => undefined);
-    process.exit(1);
+    Sentry.captureException(error, { level: 'error', tags: { subsystem: 'oidc-bootstrap' } });
   }
 
   const server = app.listen(parseInt(port), () => {

--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/node';
 import { config } from 'dotenv';
 config();
 
-import { auth, resolveCorsOrigin } from '@wxyc/authentication';
+import { auth, bootstrapTrustedClients, buildTrustedClients, resolveCorsOrigin } from '@wxyc/authentication';
 import { fromNodeHeaders, toNodeHandler } from 'better-auth/node';
 import cors from 'cors';
 import express from 'express';
@@ -570,6 +570,30 @@ const syncAdminRoles = async () => {
 void (async () => {
   await createDefaultUser();
   await syncAdminRoles();
+
+  // Bootstrap oauthApplication rows for every trustedClient. The
+  // oidcProvider plugin's `getClient()` short-circuits on trustedClients
+  // (returned from memory, never persisted), but its token / consent write
+  // paths still FK-reference auth_oauth_application.client_id — every
+  // trustedClient token exchange 500s until a row exists. Fatal on failure:
+  // silently starting a server whose token endpoint is permanently broken
+  // (until an operator hand-runs SQL) is worse than a loud restart loop.
+  try {
+    const context = await auth.$context;
+    await bootstrapTrustedClients(
+      { adapter: context.adapter as unknown as Parameters<typeof bootstrapTrustedClients>[0]['adapter'] },
+      buildTrustedClients(process.env)
+    );
+    console.log('[OIDC BOOTSTRAP] trustedClients synced to auth_oauth_application');
+  } catch (error) {
+    console.error(
+      '[OIDC BOOTSTRAP] Failed to sync trustedClients — token exchange would 500. Aborting startup.',
+      error
+    );
+    Sentry.captureException(error, { level: 'fatal', tags: { subsystem: 'oidc-bootstrap' } });
+    await Sentry.flush(2_000).catch(() => undefined);
+    process.exit(1);
+  }
 
   const server = app.listen(parseInt(port), () => {
     console.log(`listening on port: ${port}! (auth service)`);

--- a/shared/authentication/src/bootstrap-trusted-clients.ts
+++ b/shared/authentication/src/bootstrap-trusted-clients.ts
@@ -13,117 +13,138 @@
  *   constraint "auth_oauth_access_token_client_id_auth_oauth_application_client"
  *
  * This bootstrap upserts one row per trustedClient at server startup so the
- * FK is satisfied without asking operators to hand-run SQL. Contents don't
- * gate auth (the plugin doesn't read them for trustedClients), but we still
- * write meaningful values so the row is legible when someone inspects
- * `SELECT * FROM auth_oauth_application`.
+ * FK is satisfied without asking operators to hand-run SQL. Contents mirror
+ * both the in-memory trustedClient AND what the plugin's /register handler
+ * writes (`node_modules/better-auth/dist/plugins/oidc-provider/index.mjs:868-892`)
+ * so a bootstrap row is indistinguishable from a self-registered one.
  *
- * Lives here rather than inline in `apps/auth/app.ts` so it can be tested
- * without instantiating `betterAuth({...})` and pulling in the database
- * adapter, plugin chain, and Sentry init — same rationale as
- * `oidc-trusted-clients.ts` and `oidc-login-page.ts`.
+ * Deliberate design choices:
+ *   - Passes `forceAllowId: true` on create so the deterministic
+ *     `trusted-<clientId>` PK actually lands in the DB. Without it, the
+ *     adapter factory logs a warning and generates a random id
+ *     (`@better-auth/core/dist/db/adapter/factory.mjs:417-421`), which
+ *     would silently break the `SELECT ... WHERE id LIKE 'trusted-%'`
+ *     operator query this module advertises.
+ *   - Catches Postgres `unique_violation` on create and falls through to
+ *     update, so multi-replica boots (staging Docker Compose, any future
+ *     scale-out) don't crash the losing replica when both `findOne` miss
+ *     the row and both call `create`.
+ *   - Includes `metadata` and `icon` — the plugin schema declares both,
+ *     the /register handler persists both, so bootstrap rows do too.
  */
 
+import { oauthApplication } from '@wxyc/database';
+import type { DBAdapter } from 'better-auth';
 import type { Client } from 'better-auth/plugins';
 
-// Row shape used against the Better Auth Drizzle adapter. Field names are
-// camelCase because the adapter translates to the snake_case columns declared
-// in `shared/database/src/schema.ts`. Kept structurally-typed rather than
-// importing a concrete adapter type so this module doesn't drag in the whole
-// better-auth type surface (mirrors how `bootstrap-trusted-clients.test.ts`
-// hand-rolls a fake adapter).
-interface OauthApplicationRow {
-  id: string;
-  clientId: string;
-  clientSecret: string | null;
-  name: string;
-  type: string;
-  disabled: boolean;
-  redirectUrls: string;
-  userId: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-}
+// Drizzle-inferred row type — single source of truth. If schema.ts adds a
+// column, this row type follows without a manual mirror to maintain.
+type OauthApplicationRow = typeof oauthApplication.$inferSelect;
 
-interface AdapterWhereClause {
-  field: string;
-  value: unknown;
-}
+// Fields the bootstrap owns from Client config (i.e., that can drift and must
+// be refreshed on every boot). Extract so create and update stay in sync — a
+// new mutable field added to one branch and forgotten in the other would leave
+// updated rows shaped differently from freshly-inserted rows.
+type MutableFields = Pick<
+  OauthApplicationRow,
+  'clientSecret' | 'name' | 'type' | 'disabled' | 'redirectUrls' | 'metadata' | 'icon' | 'updatedAt'
+>;
 
-interface BootstrapAdapter {
-  findOne(args: { model: string; where: AdapterWhereClause[] }): Promise<OauthApplicationRow | null>;
-  create(args: { model: string; data: OauthApplicationRow }): Promise<OauthApplicationRow>;
-  update(args: {
-    model: string;
-    where: AdapterWhereClause[];
-    update: Partial<OauthApplicationRow>;
-  }): Promise<OauthApplicationRow>;
-}
-
-interface BootstrapContext {
-  adapter: BootstrapAdapter;
-}
-
-// Deterministic id derivation. The plugin generates a random id when a client
-// self-registers via `/auth/oauth2/register`, but trustedClients never take
-// that path — using `trusted-<clientId>` keeps the row stable across container
-// restarts and legible to operators (`SELECT ... WHERE id LIKE 'trusted-%'`).
 const idForTrustedClient = (clientId: string): string => `trusted-${clientId}`;
 
 // The plugin's registration handler stores `redirectUrls` as a comma-joined
-// string (see node_modules/better-auth/dist/plugins/oidc-provider/index.mjs:886)
-// and splits back to array in `getClient()` (line 48). Mirror that encoding so
-// `SELECT redirect_urls FROM auth_oauth_application` reads the same regardless
-// of whether the row was minted by /register or by this bootstrap.
+// string (index.mjs:886) and splits back to array in getClient() (line 48).
 const encodeRedirectUrls = (urls: readonly string[]): string => urls.join(',');
 
+// `Client.metadata` is `Record<string, any> | null` on the in-memory config;
+// the plugin's /register handler serializes it as JSON (`index.mjs:883`).
+// Mirror that so a config with `metadata: { foo: 'bar' }` reads back the same
+// through both paths.
+const encodeMetadata = (metadata: Client['metadata']): string | null =>
+  metadata == null ? null : JSON.stringify(metadata);
+
+const buildMutableFields = (client: Client, now: Date): MutableFields => ({
+  clientSecret: client.clientSecret ?? null,
+  name: client.name ?? client.clientId,
+  type: client.type ?? 'web',
+  disabled: client.disabled ?? false,
+  redirectUrls: encodeRedirectUrls(client.redirectUrls ?? []),
+  metadata: encodeMetadata(client.metadata),
+  icon: client.icon ?? null,
+  updatedAt: now,
+});
+
+// Postgres SQLSTATE for `unique_violation`. Thrown by `postgres` (the driver
+// under Drizzle) as `error.code === '23505'`.
+const isUniqueViolation = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && 'code' in error && (error as { code: unknown }).code === '23505';
+
 export async function bootstrapTrustedClients(
-  context: BootstrapContext,
+  adapter: DBAdapter<Record<string, unknown>>,
   trustedClients: readonly Client[]
-): Promise<void> {
+): Promise<{ created: number; updated: number }> {
+  let created = 0;
+  let updated = 0;
+
   for (const client of trustedClients) {
-    const existing = await context.adapter.findOne({
+    const existing = await adapter.findOne<OauthApplicationRow>({
       model: 'oauthApplication',
       where: [{ field: 'clientId', value: client.clientId }],
     });
 
     const now = new Date();
+    const mutable = buildMutableFields(client, now);
 
     if (!existing) {
-      await context.adapter.create({
-        model: 'oauthApplication',
-        data: {
-          id: idForTrustedClient(client.clientId),
-          clientId: client.clientId,
-          clientSecret: client.clientSecret ?? null,
-          name: client.name ?? client.clientId,
-          type: client.type ?? 'web',
-          disabled: client.disabled ?? false,
-          redirectUrls: encodeRedirectUrls(client.redirectUrls ?? []),
-          userId: null,
-          createdAt: now,
-          updatedAt: now,
-        },
-      });
-      continue;
+      try {
+        // `forceAllowId: true` is REQUIRED — without it, the adapter factory
+        // strips `data.id` and generates a random one, silently breaking the
+        // deterministic id contract. See adapter/factory.mjs:417-421.
+        await adapter.create({
+          model: 'oauthApplication',
+          data: {
+            id: idForTrustedClient(client.clientId),
+            clientId: client.clientId,
+            userId: null,
+            createdAt: now,
+            ...mutable,
+          },
+          forceAllowId: true,
+        });
+        created++;
+        continue;
+      } catch (error) {
+        // Multi-replica boot race: replica A's findOne missed, replica B
+        // wrote the row before A's create fired. Fall through to update
+        // rather than crashing this replica.
+        if (!isUniqueViolation(error)) throw error;
+      }
     }
 
-    // Always refresh mutable fields from config. Skipping the update when
-    // values match saves one DB round-trip but adds a branching drift check
-    // whose bugs (case sensitivity, array ordering, whitespace) would silently
-    // leave stale rows in prod; a single UPDATE per boot is cheap enough that
-    // "always refresh" wins on legibility.
-    await context.adapter.update({
+    // Look the row up by clientId (unique) rather than trusting `existing.id`
+    // — if we got here via the race path, `existing` is null but the row now
+    // exists under whatever id the racing replica assigned.
+    const row =
+      existing ??
+      (await adapter.findOne<OauthApplicationRow>({
+        model: 'oauthApplication',
+        where: [{ field: 'clientId', value: client.clientId }],
+      }));
+
+    if (!row) {
+      // Vanishingly unlikely: another replica deleted the row between our
+      // race-catch and this re-lookup. Surface it — the invariant this
+      // module maintains has been externally violated.
+      throw new Error(`bootstrap: row for clientId=${client.clientId} vanished mid-upsert`);
+    }
+
+    await adapter.update({
       model: 'oauthApplication',
-      where: [{ field: 'id', value: existing.id }],
-      update: {
-        clientSecret: client.clientSecret ?? null,
-        name: client.name ?? client.clientId,
-        type: client.type ?? 'web',
-        disabled: client.disabled ?? false,
-        redirectUrls: encodeRedirectUrls(client.redirectUrls ?? []),
-        updatedAt: now,
-      },
+      where: [{ field: 'id', value: row.id }],
+      update: mutable,
     });
+    updated++;
   }
+
+  return { created, updated };
 }

--- a/shared/authentication/src/bootstrap-trusted-clients.ts
+++ b/shared/authentication/src/bootstrap-trusted-clients.ts
@@ -1,0 +1,129 @@
+/**
+ * Bootstrap `auth_oauth_application` rows for every `trustedClients` entry in
+ * the `oidcProvider` plugin config.
+ *
+ * The plugin's `getClient()` short-circuits on trustedClients — they are
+ * returned from the in-memory config and never touch the DB. Its token- and
+ * consent-write paths, however, still FK-reference `oauthApplication.clientId`
+ * via the schema declared at
+ * `node_modules/better-auth/dist/plugins/oidc-provider/schema.mjs` (materialized
+ * by migration 0111). Without a matching row, every trustedClient token
+ * exchange 500s with:
+ *   insert or update on table "auth_oauth_access_token" violates foreign key
+ *   constraint "auth_oauth_access_token_client_id_auth_oauth_application_client"
+ *
+ * This bootstrap upserts one row per trustedClient at server startup so the
+ * FK is satisfied without asking operators to hand-run SQL. Contents don't
+ * gate auth (the plugin doesn't read them for trustedClients), but we still
+ * write meaningful values so the row is legible when someone inspects
+ * `SELECT * FROM auth_oauth_application`.
+ *
+ * Lives here rather than inline in `apps/auth/app.ts` so it can be tested
+ * without instantiating `betterAuth({...})` and pulling in the database
+ * adapter, plugin chain, and Sentry init — same rationale as
+ * `oidc-trusted-clients.ts` and `oidc-login-page.ts`.
+ */
+
+import type { Client } from 'better-auth/plugins';
+
+// Row shape used against the Better Auth Drizzle adapter. Field names are
+// camelCase because the adapter translates to the snake_case columns declared
+// in `shared/database/src/schema.ts`. Kept structurally-typed rather than
+// importing a concrete adapter type so this module doesn't drag in the whole
+// better-auth type surface (mirrors how `bootstrap-trusted-clients.test.ts`
+// hand-rolls a fake adapter).
+interface OauthApplicationRow {
+  id: string;
+  clientId: string;
+  clientSecret: string | null;
+  name: string;
+  type: string;
+  disabled: boolean;
+  redirectUrls: string;
+  userId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface AdapterWhereClause {
+  field: string;
+  value: unknown;
+}
+
+interface BootstrapAdapter {
+  findOne(args: { model: string; where: AdapterWhereClause[] }): Promise<OauthApplicationRow | null>;
+  create(args: { model: string; data: OauthApplicationRow }): Promise<OauthApplicationRow>;
+  update(args: {
+    model: string;
+    where: AdapterWhereClause[];
+    update: Partial<OauthApplicationRow>;
+  }): Promise<OauthApplicationRow>;
+}
+
+interface BootstrapContext {
+  adapter: BootstrapAdapter;
+}
+
+// Deterministic id derivation. The plugin generates a random id when a client
+// self-registers via `/auth/oauth2/register`, but trustedClients never take
+// that path — using `trusted-<clientId>` keeps the row stable across container
+// restarts and legible to operators (`SELECT ... WHERE id LIKE 'trusted-%'`).
+const idForTrustedClient = (clientId: string): string => `trusted-${clientId}`;
+
+// The plugin's registration handler stores `redirectUrls` as a comma-joined
+// string (see node_modules/better-auth/dist/plugins/oidc-provider/index.mjs:886)
+// and splits back to array in `getClient()` (line 48). Mirror that encoding so
+// `SELECT redirect_urls FROM auth_oauth_application` reads the same regardless
+// of whether the row was minted by /register or by this bootstrap.
+const encodeRedirectUrls = (urls: readonly string[]): string => urls.join(',');
+
+export async function bootstrapTrustedClients(
+  context: BootstrapContext,
+  trustedClients: readonly Client[]
+): Promise<void> {
+  for (const client of trustedClients) {
+    const existing = await context.adapter.findOne({
+      model: 'oauthApplication',
+      where: [{ field: 'clientId', value: client.clientId }],
+    });
+
+    const now = new Date();
+
+    if (!existing) {
+      await context.adapter.create({
+        model: 'oauthApplication',
+        data: {
+          id: idForTrustedClient(client.clientId),
+          clientId: client.clientId,
+          clientSecret: client.clientSecret ?? null,
+          name: client.name ?? client.clientId,
+          type: client.type ?? 'web',
+          disabled: client.disabled ?? false,
+          redirectUrls: encodeRedirectUrls(client.redirectUrls ?? []),
+          userId: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+      continue;
+    }
+
+    // Always refresh mutable fields from config. Skipping the update when
+    // values match saves one DB round-trip but adds a branching drift check
+    // whose bugs (case sensitivity, array ordering, whitespace) would silently
+    // leave stale rows in prod; a single UPDATE per boot is cheap enough that
+    // "always refresh" wins on legibility.
+    await context.adapter.update({
+      model: 'oauthApplication',
+      where: [{ field: 'id', value: existing.id }],
+      update: {
+        clientSecret: client.clientSecret ?? null,
+        name: client.name ?? client.clientId,
+        type: client.type ?? 'web',
+        disabled: client.disabled ?? false,
+        redirectUrls: encodeRedirectUrls(client.redirectUrls ?? []),
+        updatedAt: now,
+      },
+    });
+  }
+}

--- a/shared/authentication/src/bootstrap-trusted-clients.ts
+++ b/shared/authentication/src/bootstrap-trusted-clients.ts
@@ -74,10 +74,76 @@ const buildMutableFields = (client: Client, now: Date): MutableFields => ({
   updatedAt: now,
 });
 
-// Postgres SQLSTATE for `unique_violation`. Thrown by `postgres` (the driver
-// under Drizzle) as `error.code === '23505'`.
-const isUniqueViolation = (error: unknown): boolean =>
-  typeof error === 'object' && error !== null && 'code' in error && (error as { code: unknown }).code === '23505';
+// Postgres SQLSTATE for `unique_violation`. `postgres` (the driver under
+// Drizzle) reports it as `.code`, but Drizzle wraps driver errors in a
+// `DrizzleQueryError` and puts the real error on `.cause`. Check both
+// locations — same pattern as `extractSqlState` in
+// `jobs/flowsheet-metadata-backfill/orchestrate.ts:194-200` and
+// `apps/backend/routes/internal-bans.route.ts:162-163`, so tests that throw a
+// bare error and prod runs that throw the wrapped form both classify.
+const isUniqueViolation = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) return false;
+  const cause = (error as { cause?: unknown }).cause;
+  const causeCode = typeof cause === 'object' && cause !== null ? (cause as { code?: unknown }).code : undefined;
+  const code = causeCode ?? (error as { code?: unknown }).code;
+  return code === '23505';
+};
+
+async function upsertOne(adapter: DBAdapter<Record<string, unknown>>, client: Client): Promise<'created' | 'updated'> {
+  const existing = await adapter.findOne<OauthApplicationRow>({
+    model: 'oauthApplication',
+    where: [{ field: 'clientId', value: client.clientId }],
+  });
+
+  const now = new Date();
+  const mutable = buildMutableFields(client, now);
+
+  if (!existing) {
+    try {
+      // `forceAllowId: true` is REQUIRED — without it, the adapter factory
+      // strips `data.id` and generates a random one, silently breaking the
+      // deterministic id contract. See adapter/factory.mjs:417-421.
+      await adapter.create({
+        model: 'oauthApplication',
+        data: {
+          id: idForTrustedClient(client.clientId),
+          clientId: client.clientId,
+          userId: null,
+          createdAt: now,
+          ...mutable,
+        },
+        forceAllowId: true,
+      });
+      return 'created';
+    } catch (error) {
+      // Multi-replica boot race: replica A's findOne missed, replica B
+      // wrote the row before A's create fired. Fall through to update
+      // rather than crashing this replica.
+      if (!isUniqueViolation(error)) throw error;
+    }
+  }
+
+  const row =
+    existing ??
+    (await adapter.findOne<OauthApplicationRow>({
+      model: 'oauthApplication',
+      where: [{ field: 'clientId', value: client.clientId }],
+    }));
+
+  if (!row) {
+    // Vanishingly unlikely: another replica deleted the row between our
+    // race-catch and this re-lookup. Surface as an error — the invariant this
+    // module maintains has been externally violated.
+    throw new Error(`bootstrap: row for clientId=${client.clientId} vanished mid-upsert`);
+  }
+
+  await adapter.update({
+    model: 'oauthApplication',
+    where: [{ field: 'id', value: row.id }],
+    update: mutable,
+  });
+  return 'updated';
+}
 
 export async function bootstrapTrustedClients(
   adapter: DBAdapter<Record<string, unknown>>,
@@ -85,65 +151,30 @@ export async function bootstrapTrustedClients(
 ): Promise<{ created: number; updated: number }> {
   let created = 0;
   let updated = 0;
+  const errors: Error[] = [];
 
   for (const client of trustedClients) {
-    const existing = await adapter.findOne<OauthApplicationRow>({
-      model: 'oauthApplication',
-      where: [{ field: 'clientId', value: client.clientId }],
-    });
-
-    const now = new Date();
-    const mutable = buildMutableFields(client, now);
-
-    if (!existing) {
-      try {
-        // `forceAllowId: true` is REQUIRED — without it, the adapter factory
-        // strips `data.id` and generates a random one, silently breaking the
-        // deterministic id contract. See adapter/factory.mjs:417-421.
-        await adapter.create({
-          model: 'oauthApplication',
-          data: {
-            id: idForTrustedClient(client.clientId),
-            clientId: client.clientId,
-            userId: null,
-            createdAt: now,
-            ...mutable,
-          },
-          forceAllowId: true,
-        });
-        created++;
-        continue;
-      } catch (error) {
-        // Multi-replica boot race: replica A's findOne missed, replica B
-        // wrote the row before A's create fired. Fall through to update
-        // rather than crashing this replica.
-        if (!isUniqueViolation(error)) throw error;
-      }
+    // Per-client isolation: a failure on one trustedClient (transient race
+    // whose recovery path also failed, schema drift on one row) shouldn't
+    // prevent the others from being upserted. Aggregate errors and re-throw
+    // at the end so the caller's Sentry alert still fires but every client
+    // gets an attempt.
+    try {
+      const outcome = await upsertOne(adapter, client);
+      if (outcome === 'created') created++;
+      else updated++;
+    } catch (error) {
+      errors.push(
+        error instanceof Error ? error : new Error(`bootstrap: unknown error for clientId=${client.clientId}`)
+      );
     }
+  }
 
-    // Look the row up by clientId (unique) rather than trusting `existing.id`
-    // — if we got here via the race path, `existing` is null but the row now
-    // exists under whatever id the racing replica assigned.
-    const row =
-      existing ??
-      (await adapter.findOne<OauthApplicationRow>({
-        model: 'oauthApplication',
-        where: [{ field: 'clientId', value: client.clientId }],
-      }));
-
-    if (!row) {
-      // Vanishingly unlikely: another replica deleted the row between our
-      // race-catch and this re-lookup. Surface it — the invariant this
-      // module maintains has been externally violated.
-      throw new Error(`bootstrap: row for clientId=${client.clientId} vanished mid-upsert`);
-    }
-
-    await adapter.update({
-      model: 'oauthApplication',
-      where: [{ field: 'id', value: row.id }],
-      update: mutable,
-    });
-    updated++;
+  if (errors.length > 0) {
+    throw new AggregateError(
+      errors,
+      `bootstrap: ${errors.length} of ${trustedClients.length} trustedClients failed to upsert`
+    );
   }
 
   return { created, updated };

--- a/shared/authentication/src/bootstrap-trusted-clients.ts
+++ b/shared/authentication/src/bootstrap-trusted-clients.ts
@@ -164,16 +164,24 @@ export async function bootstrapTrustedClients(
       if (outcome === 'created') created++;
       else updated++;
     } catch (error) {
-      errors.push(
-        error instanceof Error ? error : new Error(`bootstrap: unknown error for clientId=${client.clientId}`)
-      );
+      // Wrap with clientId + preserve the original via `cause`. Adapter
+      // errors like "DB unreachable" don't carry a clientId of their own;
+      // ops triaging the aggregate needs to know which client each leaf
+      // belongs to without reconstructing loop order.
+      errors.push(new Error(`bootstrap: failed for clientId=${client.clientId}`, { cause: error }));
     }
   }
 
-  if (errors.length > 0) {
+  if (errors.length === 1) {
+    // Single-error unwrap: throw the leaf directly so Sentry groups this
+    // failure with other occurrences of the same root cause. Mirrors the
+    // pattern at `jobs/rotation-artist-backfill/orchestrate.ts:131-132`.
+    throw errors[0];
+  }
+  if (errors.length > 1) {
     throw new AggregateError(
       errors,
-      `bootstrap: ${errors.length} of ${trustedClients.length} trustedClients failed to upsert`
+      `bootstrap: ${errors.length} of ${trustedClients.length} trustedClients failed to upsert (${created} created, ${updated} updated before the failures)`
     );
   }
 

--- a/shared/authentication/src/index.ts
+++ b/shared/authentication/src/index.ts
@@ -5,3 +5,5 @@ export * from './auth.username';
 export * from './cors-origin';
 export * from './device-authorization';
 export { sendAccountSetupEmail } from './email';
+export { bootstrapTrustedClients } from './bootstrap-trusted-clients';
+export { buildTrustedClients } from './oidc-trusted-clients';

--- a/tests/unit/authentication/bootstrap-trusted-clients.test.ts
+++ b/tests/unit/authentication/bootstrap-trusted-clients.test.ts
@@ -386,7 +386,7 @@ describe('bootstrapTrustedClients', () => {
     expect(rows.has('flowsheet')).toBe(false);
   });
 
-  it('collects transient adapter errors into an AggregateError so the caller can Sentry-alert', async () => {
+  it('propagates a single adapter failure as the wrapped leaf error (Sentry-grouping fidelity)', async () => {
     // Caller in apps/auth/app.ts catches and reports to Sentry at level:
     // 'warning' (matching sibling createDefaultUser / syncAdminRoles). This
     // test locks in that this function surfaces failures as an

--- a/tests/unit/authentication/bootstrap-trusted-clients.test.ts
+++ b/tests/unit/authentication/bootstrap-trusted-clients.test.ts
@@ -1,3 +1,4 @@
+import { assertDefined } from '@wxyc/shared/test-utils';
 import type { Client } from 'better-auth/plugins';
 import { bootstrapTrustedClients } from '../../../shared/authentication/src/bootstrap-trusted-clients';
 
@@ -10,45 +11,62 @@ import { bootstrapTrustedClients } from '../../../shared/authentication/src/boot
 // deploy or DB rebuild. See migration 0111 and the plugin schema at
 // node_modules/better-auth/dist/plugins/oidc-provider/schema.mjs.
 
-interface AdapterRow {
-  id: string;
-  name: string;
-  clientId: string;
-  clientSecret: string | null;
-  redirectUrls: string;
-  type: string;
-  disabled: boolean;
-  userId: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
 function makeFakeAdapter(seed: AdapterRow[] = []) {
-  const rows = new Map<string, AdapterRow>(seed.map((r) => [r.clientId, { ...r }]));
-  const calls = { findOne: 0, create: 0, update: 0 };
+  interface AdapterRow {
+    id: string;
+    clientId: string;
+    clientSecret: string | null;
+    name: string;
+    type: string;
+    disabled: boolean;
+    redirectUrls: string;
+    metadata: string | null;
+    icon: string | null;
+    userId: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }
 
-  // Bootstrap only ever queries by `clientId` or `id`; both are strings. Typing
-  // `where.value` narrowly here saves a `String(unknown)` cast that lints as
-  // "will use Object's default stringification format".
   interface WhereClause {
     field: string;
     value: string;
   }
 
+  const rows = new Map<string, AdapterRow>(seed.map((r) => [r.clientId, { ...r }]));
+  const calls = { findOne: 0, create: 0, update: 0 };
+  let randomIdCounter = 0;
+
   const adapter = {
     findOne({ model, where }: { model: string; where: WhereClause[] }) {
       calls.findOne++;
       if (model !== 'oauthApplication') throw new Error(`unexpected model ${model}`);
-      const clause = where.find((w) => w.field === 'clientId');
-      if (!clause) throw new Error('bootstrap should only look up by clientId');
-      return Promise.resolve(rows.get(clause.value) ?? null);
+      // Fake only ever gets queried by clientId (findOne pre-create) or by id
+      // (findOne post-race for the update-path re-lookup).
+      const clientIdClause = where.find((w) => w.field === 'clientId');
+      const idClause = where.find((w) => w.field === 'id');
+      if (clientIdClause) return Promise.resolve(rows.get(clientIdClause.value) ?? null);
+      if (idClause) return Promise.resolve([...rows.values()].find((r) => r.id === idClause.value) ?? null);
+      throw new Error('bootstrap should only look up by clientId or id');
     },
-    create({ model, data }: { model: string; data: AdapterRow }) {
+    // Emulate the real adapter factory's id-stripping behavior so tests catch
+    // any regression on the `forceAllowId: true` argument. See
+    // `@better-auth/core/dist/db/adapter/factory.mjs:417-421`.
+    create({ model, data, forceAllowId }: { model: string; data: AdapterRow; forceAllowId?: boolean }) {
       calls.create++;
       if (model !== 'oauthApplication') throw new Error(`unexpected model ${model}`);
-      if (rows.has(data.clientId)) throw new Error(`duplicate clientId ${data.clientId}`);
-      rows.set(data.clientId, { ...data });
-      return Promise.resolve(data);
+      const finalData = { ...data };
+      if ('id' in finalData && !forceAllowId) {
+        finalData.id = `random-${randomIdCounter++}`;
+      }
+      if (rows.has(finalData.clientId)) {
+        // Emulate Postgres unique_violation shape (SQLSTATE 23505) so the
+        // race-recovery path can pattern-match on it.
+        const err = new Error('duplicate key value violates unique constraint');
+        (err as { code?: string }).code = '23505';
+        throw err;
+      }
+      rows.set(finalData.clientId, finalData);
+      return Promise.resolve(finalData);
     },
     update({ model, where, update: values }: { model: string; where: WhereClause[]; update: Partial<AdapterRow> }) {
       calls.update++;
@@ -64,13 +82,12 @@ function makeFakeAdapter(seed: AdapterRow[] = []) {
   return { adapter, rows, calls };
 }
 
-// Small helper to satisfy `@typescript-eslint/no-non-null-assertion` while still
-// getting a narrowed value — Map.get returns V|undefined and we want to fail
-// the test loudly if the row we expected to see just isn't there.
-function must<T>(value: T | null | undefined, message: string): T {
-  if (value == null) throw new Error(message);
-  return value;
-}
+// TS is happy with the real DBAdapter shape being wider than our fake — cast
+// through `unknown` at the boundary. The fake's structure is what the tests
+// actually exercise; the DBAdapter type erasure is just to satisfy the
+// impl's declared parameter type.
+type FakeAdapter = ReturnType<typeof makeFakeAdapter>['adapter'];
+const asAdapter = (fake: FakeAdapter) => fake as unknown as Parameters<typeof bootstrapTrustedClients>[0];
 
 function flowsheetClient(overrides: Partial<Client> = {}): Client {
   const base: Client = {
@@ -91,63 +108,80 @@ describe('bootstrapTrustedClients', () => {
   it('is a no-op when the trustedClients array is empty', async () => {
     const { adapter, calls, rows } = makeFakeAdapter();
 
-    await bootstrapTrustedClients({ adapter }, []);
+    const result = await bootstrapTrustedClients(asAdapter(adapter), []);
 
     expect(calls).toEqual({ findOne: 0, create: 0, update: 0 });
     expect(rows.size).toBe(0);
+    expect(result).toEqual({ created: 0, updated: 0 });
   });
 
   it('inserts a new row when no oauthApplication exists for the clientId', async () => {
     const { adapter, calls, rows } = makeFakeAdapter();
 
-    await bootstrapTrustedClients({ adapter }, [flowsheetClient()]);
+    const result = await bootstrapTrustedClients(asAdapter(adapter), [flowsheetClient()]);
 
     expect(calls.findOne).toBe(1);
     expect(calls.create).toBe(1);
     expect(calls.update).toBe(0);
+    expect(result).toEqual({ created: 1, updated: 0 });
 
-    const inserted = must(rows.get('flowsheet'), 'flowsheet row');
-    // Storage shape (comma-joined redirectUrls) matches the plugin's registration handler
-    // at node_modules/better-auth/dist/plugins/oidc-provider/index.mjs:886.
+    const inserted = rows.get('flowsheet');
+    assertDefined(inserted, 'flowsheet row');
     expect(inserted).toMatchObject({
       clientId: 'flowsheet',
       name: 'Flowsheet Verifier',
       type: 'web',
       disabled: false,
       redirectUrls: 'http://localhost:8765/auth/callback',
+      metadata: null,
+      icon: null,
     });
-    // Timestamps are populated so a downstream migration that adds NOT NULL
-    // to `created_at`/`updated_at` doesn't retroactively break bootstrap.
     expect(inserted.createdAt).toBeInstanceOf(Date);
     expect(inserted.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('persists the deterministic id by passing forceAllowId: true to create', async () => {
+    // The adapter factory strips `data.id` unless `forceAllowId: true` is
+    // passed (@better-auth/core/dist/db/adapter/factory.mjs:417-421). The
+    // fake adapter emulates this — a regression that dropped forceAllowId
+    // would fail this assertion by writing 'random-0' instead of
+    // 'trusted-flowsheet'.
+    const { adapter, rows } = makeFakeAdapter();
+
+    await bootstrapTrustedClients(asAdapter(adapter), [flowsheetClient()]);
+
+    const inserted = rows.get('flowsheet');
+    assertDefined(inserted, 'flowsheet row');
+    expect(inserted.id).toBe('trusted-flowsheet');
   });
 
   it('joins multiple redirect URLs with a comma when inserting', async () => {
     const { adapter, rows } = makeFakeAdapter();
 
-    await bootstrapTrustedClients({ adapter }, [flowsheetClient({ redirectUrls: ['https://a/cb', 'https://b/cb'] })]);
+    await bootstrapTrustedClients(asAdapter(adapter), [
+      flowsheetClient({ redirectUrls: ['https://a/cb', 'https://b/cb'] }),
+    ]);
 
-    expect(must(rows.get('flowsheet'), 'flowsheet row').redirectUrls).toBe('https://a/cb,https://b/cb');
+    const row = rows.get('flowsheet');
+    assertDefined(row, 'flowsheet row');
+    expect(row.redirectUrls).toBe('https://a/cb,https://b/cb');
   });
 
-  it('uses a deterministic id derived from clientId so re-runs on other envs match by findOne', async () => {
-    // The id column is a varchar PK; the plugin generates a random id when a
-    // client self-registers via /auth/oauth2/register, but that path never
-    // runs for trustedClients. A deterministic derivation keeps the row
-    // stable across container restarts, so an operator inspecting the DB can
-    // recognize which row belongs to which trustedClient config entry.
+  it('serializes structured metadata as JSON to match the plugin /register storage format', async () => {
+    // The plugin's /register handler at oidc-provider/index.mjs:883 does
+    // `metadata: metadata ? JSON.stringify(metadata) : null`. Bootstrap must
+    // mirror this so /register-minted and bootstrap-minted rows are
+    // indistinguishable to any DB reader.
     const { adapter, rows } = makeFakeAdapter();
 
-    await bootstrapTrustedClients({ adapter }, [flowsheetClient()]);
+    await bootstrapTrustedClients(asAdapter(adapter), [flowsheetClient({ metadata: { audience: 'flowsheet' } })]);
 
-    expect(must(rows.get('flowsheet'), 'flowsheet row').id).toBe('trusted-flowsheet');
+    const row = rows.get('flowsheet');
+    assertDefined(row, 'flowsheet row');
+    expect(row.metadata).toBe('{"audience":"flowsheet"}');
   });
 
-  it('updates the existing row when name / type / redirectUrls drift from config', async () => {
-    // A trustedClient whose redirect URL was changed in .env must be updated
-    // in the DB even when the row already exists — otherwise the previous
-    // deploy's URL keeps satisfying the FK but is invisible to reviewers who
-    // only look at env config.
+  it('updates existing row on every boot when config drifts (drift-tolerant upsert)', async () => {
     const { adapter, calls, rows } = makeFakeAdapter([
       {
         id: 'trusted-flowsheet',
@@ -157,13 +191,15 @@ describe('bootstrapTrustedClients', () => {
         type: 'web',
         disabled: false,
         redirectUrls: 'https://old-host/cb',
+        metadata: null,
+        icon: null,
         userId: null,
         createdAt: new Date('2026-06-01'),
         updatedAt: new Date('2026-06-01'),
       },
     ]);
 
-    await bootstrapTrustedClients({ adapter }, [
+    await bootstrapTrustedClients(asAdapter(adapter), [
       flowsheetClient({ name: 'New Name', redirectUrls: ['https://new-host/cb'] }),
     ]);
 
@@ -171,14 +207,64 @@ describe('bootstrapTrustedClients', () => {
     expect(calls.create).toBe(0);
     expect(calls.update).toBe(1);
 
-    const row = must(rows.get('flowsheet'), 'flowsheet row');
+    const row = rows.get('flowsheet');
+    assertDefined(row, 'flowsheet row');
     expect(row.name).toBe('New Name');
     expect(row.redirectUrls).toBe('https://new-host/cb');
-    // Preserved: id, createdAt.
     expect(row.id).toBe('trusted-flowsheet');
     expect(row.createdAt.toISOString()).toBe(new Date('2026-06-01').toISOString());
-    // Refreshed: updatedAt.
     expect(row.updatedAt.getTime()).toBeGreaterThan(row.createdAt.getTime());
+  });
+
+  it('recovers from a rolling-deploy race by catching unique_violation and falling through to update', async () => {
+    // Two replicas boot in parallel. Replica A's findOne misses. Between A's
+    // findOne and A's create, Replica B has already written the row.
+    // A's create hits SQLSTATE 23505 — we catch it, re-lookup by clientId,
+    // and fall through to update. Verifies the fatal-crash on unique
+    // violation that earlier revisions had is fixed.
+    const { adapter, calls, rows } = makeFakeAdapter();
+
+    // Simulate the race: pre-seed the row into the map AFTER the first
+    // findOne would have run. We achieve this by wrapping findOne to seed
+    // the row on first call.
+    let firstFindOne = true;
+    const originalFindOne = adapter.findOne.bind(adapter);
+    adapter.findOne = (args: Parameters<typeof originalFindOne>[0]) => {
+      if (firstFindOne) {
+        firstFindOne = false;
+        const result = originalFindOne(args);
+        // Between "our" findOne returning null and "our" create firing, the
+        // other replica's create lands.
+        rows.set('flowsheet', {
+          id: 'trusted-flowsheet',
+          clientId: 'flowsheet',
+          clientSecret: 'racing-replica-secret',
+          name: 'Written by racing replica',
+          type: 'web',
+          disabled: false,
+          redirectUrls: 'https://racing/cb',
+          metadata: null,
+          icon: null,
+          userId: null,
+          createdAt: new Date('2026-06-01'),
+          updatedAt: new Date('2026-06-01'),
+        });
+        return result;
+      }
+      return originalFindOne(args);
+    };
+
+    const result = await bootstrapTrustedClients(asAdapter(adapter), [flowsheetClient({ name: 'Our config' })]);
+
+    // 1 findOne (returned null) + 1 create (unique_violation) + 1 findOne
+    // (re-lookup) + 1 update.
+    expect(calls.findOne).toBe(2);
+    expect(calls.create).toBe(1);
+    expect(calls.update).toBe(1);
+    expect(result).toEqual({ created: 0, updated: 1 });
+    const finalRow = rows.get('flowsheet');
+    assertDefined(finalRow, 'flowsheet row');
+    expect(finalRow.name).toBe('Our config');
   });
 
   it('processes both wiki.js and flowsheet when both are configured', async () => {
@@ -196,32 +282,40 @@ describe('bootstrapTrustedClients', () => {
 
     const { adapter, calls, rows } = makeFakeAdapter();
 
-    await bootstrapTrustedClients({ adapter }, [wikijs, flowsheetClient()]);
+    const result = await bootstrapTrustedClients(asAdapter(adapter), [wikijs, flowsheetClient()]);
 
     expect(calls.create).toBe(2);
-    expect(must(rows.get('wiki-id'), 'wiki-id row').id).toBe('trusted-wiki-id');
-    expect(must(rows.get('flowsheet'), 'flowsheet row').id).toBe('trusted-flowsheet');
+    expect(result).toEqual({ created: 2, updated: 0 });
+    const wikiRow = rows.get('wiki-id');
+    const flowsheetRow = rows.get('flowsheet');
+    assertDefined(wikiRow, 'wiki-id row');
+    assertDefined(flowsheetRow, 'flowsheet row');
+    expect(wikiRow.id).toBe('trusted-wiki-id');
+    expect(flowsheetRow.id).toBe('trusted-flowsheet');
   });
 
-  it('propagates adapter errors so a failed bootstrap fails startup (not silently 500s later)', async () => {
-    // The whole point of moving this from a manual SQL insert into a boot
-    // hook is to catch the failure before we start accepting traffic. A
-    // silent try/catch here would defeat that; the caller in
-    // apps/auth/app.ts is the layer that decides fatal-vs-warn.
+  it('propagates non-race adapter errors so a failed bootstrap surfaces in Sentry', async () => {
+    // The caller in apps/auth/app.ts catches errors from this function and
+    // reports to Sentry at level: 'error' (warn-and-continue posture,
+    // matching sibling createDefaultUser / syncAdminRoles). This test locks
+    // in that this function re-throws non-race errors so the caller can
+    // catch them — a silent try/catch here would defeat that.
     const brokenAdapter = {
       findOne(): Promise<never> {
         return Promise.reject(new Error('DB unreachable'));
       },
-      create(): Promise<Record<string, never>> {
-        return Promise.resolve({});
+      create(): Promise<never> {
+        return Promise.reject(new Error('should not be reached'));
       },
-      update(): Promise<Record<string, never>> {
-        return Promise.resolve({});
+      update(): Promise<never> {
+        return Promise.reject(new Error('should not be reached'));
       },
     };
 
-    await expect(bootstrapTrustedClients({ adapter: brokenAdapter }, [flowsheetClient()])).rejects.toThrow(
-      'DB unreachable'
-    );
+    await expect(
+      bootstrapTrustedClients(brokenAdapter as unknown as Parameters<typeof bootstrapTrustedClients>[0], [
+        flowsheetClient(),
+      ])
+    ).rejects.toThrow('DB unreachable');
   });
 });

--- a/tests/unit/authentication/bootstrap-trusted-clients.test.ts
+++ b/tests/unit/authentication/bootstrap-trusted-clients.test.ts
@@ -1,0 +1,227 @@
+import type { Client } from 'better-auth/plugins';
+import { bootstrapTrustedClients } from '../../../shared/authentication/src/bootstrap-trusted-clients';
+
+// The better-auth `oidcProvider` plugin's `getClient()` short-circuits on
+// `trustedClients` (returned from memory, never persisted), but its token /
+// consent write paths still FK-reference `oauthApplication.clientId`. Every
+// trustedClient token exchange 500s until a matching row exists. This bootstrap
+// hook upserts one row per configured trustedClient at server startup so the
+// FK is satisfied without asking operators to hand-run SQL after every fresh
+// deploy or DB rebuild. See migration 0111 and the plugin schema at
+// node_modules/better-auth/dist/plugins/oidc-provider/schema.mjs.
+
+interface AdapterRow {
+  id: string;
+  name: string;
+  clientId: string;
+  clientSecret: string | null;
+  redirectUrls: string;
+  type: string;
+  disabled: boolean;
+  userId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function makeFakeAdapter(seed: AdapterRow[] = []) {
+  const rows = new Map<string, AdapterRow>(seed.map((r) => [r.clientId, { ...r }]));
+  const calls = { findOne: 0, create: 0, update: 0 };
+
+  // Bootstrap only ever queries by `clientId` or `id`; both are strings. Typing
+  // `where.value` narrowly here saves a `String(unknown)` cast that lints as
+  // "will use Object's default stringification format".
+  interface WhereClause {
+    field: string;
+    value: string;
+  }
+
+  const adapter = {
+    findOne({ model, where }: { model: string; where: WhereClause[] }) {
+      calls.findOne++;
+      if (model !== 'oauthApplication') throw new Error(`unexpected model ${model}`);
+      const clause = where.find((w) => w.field === 'clientId');
+      if (!clause) throw new Error('bootstrap should only look up by clientId');
+      return Promise.resolve(rows.get(clause.value) ?? null);
+    },
+    create({ model, data }: { model: string; data: AdapterRow }) {
+      calls.create++;
+      if (model !== 'oauthApplication') throw new Error(`unexpected model ${model}`);
+      if (rows.has(data.clientId)) throw new Error(`duplicate clientId ${data.clientId}`);
+      rows.set(data.clientId, { ...data });
+      return Promise.resolve(data);
+    },
+    update({ model, where, update: values }: { model: string; where: WhereClause[]; update: Partial<AdapterRow> }) {
+      calls.update++;
+      if (model !== 'oauthApplication') throw new Error(`unexpected model ${model}`);
+      const idClause = where.find((w) => w.field === 'id');
+      if (!idClause) throw new Error('bootstrap should only update by id');
+      const existing = [...rows.values()].find((r) => r.id === idClause.value);
+      if (!existing) throw new Error(`no row with id ${idClause.value}`);
+      Object.assign(existing, values);
+      return Promise.resolve(existing);
+    },
+  };
+  return { adapter, rows, calls };
+}
+
+// Small helper to satisfy `@typescript-eslint/no-non-null-assertion` while still
+// getting a narrowed value — Map.get returns V|undefined and we want to fail
+// the test loudly if the row we expected to see just isn't there.
+function must<T>(value: T | null | undefined, message: string): T {
+  if (value == null) throw new Error(message);
+  return value;
+}
+
+function flowsheetClient(overrides: Partial<Client> = {}): Client {
+  const base: Client = {
+    clientId: 'flowsheet',
+    clientSecret: 'shh',
+    redirectUrls: ['http://localhost:8765/auth/callback'],
+    name: 'Flowsheet Verifier',
+    type: 'web',
+    disabled: false,
+    icon: undefined,
+    metadata: null,
+    skipConsent: true,
+  };
+  return { ...base, ...overrides };
+}
+
+describe('bootstrapTrustedClients', () => {
+  it('is a no-op when the trustedClients array is empty', async () => {
+    const { adapter, calls, rows } = makeFakeAdapter();
+
+    await bootstrapTrustedClients({ adapter }, []);
+
+    expect(calls).toEqual({ findOne: 0, create: 0, update: 0 });
+    expect(rows.size).toBe(0);
+  });
+
+  it('inserts a new row when no oauthApplication exists for the clientId', async () => {
+    const { adapter, calls, rows } = makeFakeAdapter();
+
+    await bootstrapTrustedClients({ adapter }, [flowsheetClient()]);
+
+    expect(calls.findOne).toBe(1);
+    expect(calls.create).toBe(1);
+    expect(calls.update).toBe(0);
+
+    const inserted = must(rows.get('flowsheet'), 'flowsheet row');
+    // Storage shape (comma-joined redirectUrls) matches the plugin's registration handler
+    // at node_modules/better-auth/dist/plugins/oidc-provider/index.mjs:886.
+    expect(inserted).toMatchObject({
+      clientId: 'flowsheet',
+      name: 'Flowsheet Verifier',
+      type: 'web',
+      disabled: false,
+      redirectUrls: 'http://localhost:8765/auth/callback',
+    });
+    // Timestamps are populated so a downstream migration that adds NOT NULL
+    // to `created_at`/`updated_at` doesn't retroactively break bootstrap.
+    expect(inserted.createdAt).toBeInstanceOf(Date);
+    expect(inserted.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('joins multiple redirect URLs with a comma when inserting', async () => {
+    const { adapter, rows } = makeFakeAdapter();
+
+    await bootstrapTrustedClients({ adapter }, [flowsheetClient({ redirectUrls: ['https://a/cb', 'https://b/cb'] })]);
+
+    expect(must(rows.get('flowsheet'), 'flowsheet row').redirectUrls).toBe('https://a/cb,https://b/cb');
+  });
+
+  it('uses a deterministic id derived from clientId so re-runs on other envs match by findOne', async () => {
+    // The id column is a varchar PK; the plugin generates a random id when a
+    // client self-registers via /auth/oauth2/register, but that path never
+    // runs for trustedClients. A deterministic derivation keeps the row
+    // stable across container restarts, so an operator inspecting the DB can
+    // recognize which row belongs to which trustedClient config entry.
+    const { adapter, rows } = makeFakeAdapter();
+
+    await bootstrapTrustedClients({ adapter }, [flowsheetClient()]);
+
+    expect(must(rows.get('flowsheet'), 'flowsheet row').id).toBe('trusted-flowsheet');
+  });
+
+  it('updates the existing row when name / type / redirectUrls drift from config', async () => {
+    // A trustedClient whose redirect URL was changed in .env must be updated
+    // in the DB even when the row already exists — otherwise the previous
+    // deploy's URL keeps satisfying the FK but is invisible to reviewers who
+    // only look at env config.
+    const { adapter, calls, rows } = makeFakeAdapter([
+      {
+        id: 'trusted-flowsheet',
+        clientId: 'flowsheet',
+        clientSecret: null,
+        name: 'Old Name',
+        type: 'web',
+        disabled: false,
+        redirectUrls: 'https://old-host/cb',
+        userId: null,
+        createdAt: new Date('2026-06-01'),
+        updatedAt: new Date('2026-06-01'),
+      },
+    ]);
+
+    await bootstrapTrustedClients({ adapter }, [
+      flowsheetClient({ name: 'New Name', redirectUrls: ['https://new-host/cb'] }),
+    ]);
+
+    expect(calls.findOne).toBe(1);
+    expect(calls.create).toBe(0);
+    expect(calls.update).toBe(1);
+
+    const row = must(rows.get('flowsheet'), 'flowsheet row');
+    expect(row.name).toBe('New Name');
+    expect(row.redirectUrls).toBe('https://new-host/cb');
+    // Preserved: id, createdAt.
+    expect(row.id).toBe('trusted-flowsheet');
+    expect(row.createdAt.toISOString()).toBe(new Date('2026-06-01').toISOString());
+    // Refreshed: updatedAt.
+    expect(row.updatedAt.getTime()).toBeGreaterThan(row.createdAt.getTime());
+  });
+
+  it('processes both wiki.js and flowsheet when both are configured', async () => {
+    const wikijs: Client = {
+      clientId: 'wiki-id',
+      clientSecret: 'wiki-secret',
+      redirectUrls: ['https://wiki.wxyc.org/login/oidc/callback'],
+      name: 'Wiki.js',
+      type: 'web',
+      disabled: false,
+      icon: undefined,
+      metadata: null,
+      skipConsent: true,
+    };
+
+    const { adapter, calls, rows } = makeFakeAdapter();
+
+    await bootstrapTrustedClients({ adapter }, [wikijs, flowsheetClient()]);
+
+    expect(calls.create).toBe(2);
+    expect(must(rows.get('wiki-id'), 'wiki-id row').id).toBe('trusted-wiki-id');
+    expect(must(rows.get('flowsheet'), 'flowsheet row').id).toBe('trusted-flowsheet');
+  });
+
+  it('propagates adapter errors so a failed bootstrap fails startup (not silently 500s later)', async () => {
+    // The whole point of moving this from a manual SQL insert into a boot
+    // hook is to catch the failure before we start accepting traffic. A
+    // silent try/catch here would defeat that; the caller in
+    // apps/auth/app.ts is the layer that decides fatal-vs-warn.
+    const brokenAdapter = {
+      findOne(): Promise<never> {
+        return Promise.reject(new Error('DB unreachable'));
+      },
+      create(): Promise<Record<string, never>> {
+        return Promise.resolve({});
+      },
+      update(): Promise<Record<string, never>> {
+        return Promise.resolve({});
+      },
+    };
+
+    await expect(bootstrapTrustedClients({ adapter: brokenAdapter }, [flowsheetClient()])).rejects.toThrow(
+      'DB unreachable'
+    );
+  });
+});

--- a/tests/unit/authentication/bootstrap-trusted-clients.test.ts
+++ b/tests/unit/authentication/bootstrap-trusted-clients.test.ts
@@ -365,9 +365,20 @@ describe('bootstrapTrustedClients', () => {
       return originalCreate(args);
     };
 
-    await expect(bootstrapTrustedClients(asAdapter(adapter), [wikijs, flowsheetClient()])).rejects.toThrow(
-      /1 of 2 trustedClients failed/
-    );
+    // Single-error case unwraps to the leaf error (Sentry-grouping fidelity),
+    // so we get the wrapped Error, not an AggregateError. Wrapper carries
+    // the clientId; leaf carries the original message via `.cause`.
+    let thrown: unknown;
+    try {
+      await bootstrapTrustedClients(asAdapter(adapter), [wikijs, flowsheetClient()]);
+    } catch (err) {
+      thrown = err;
+    }
+    assertDefined(thrown, 'expected bootstrap to throw');
+    expect(thrown).toBeInstanceOf(Error);
+    const wrapped = thrown as Error & { cause?: unknown };
+    expect(wrapped.message).toMatch(/clientId=flowsheet/);
+    expect((wrapped.cause as Error | undefined)?.message).toBe('flowsheet-specific transient error');
 
     // Wiki.js row was written; flowsheet was not — but the loop didn't abort
     // before trying flowsheet.
@@ -393,10 +404,60 @@ describe('bootstrapTrustedClients', () => {
       },
     };
 
-    await expect(
-      bootstrapTrustedClients(brokenAdapter as unknown as Parameters<typeof bootstrapTrustedClients>[0], [
+    // Single-error unwrap: throw the leaf-wrapper directly (with clientId
+    // context) so Sentry groups by root cause. AggregateError only surfaces
+    // when there are multiple leaf failures.
+    let thrown: unknown;
+    try {
+      await bootstrapTrustedClients(brokenAdapter as unknown as Parameters<typeof bootstrapTrustedClients>[0], [
         flowsheetClient(),
-      ])
-    ).rejects.toThrow(/1 of 1 trustedClients failed/);
+      ]);
+    } catch (err) {
+      thrown = err;
+    }
+    assertDefined(thrown, 'expected bootstrap to throw');
+    expect(thrown).toBeInstanceOf(Error);
+    const wrapped = thrown as Error & { cause?: unknown };
+    expect(wrapped.message).toMatch(/clientId=flowsheet/);
+    expect((wrapped.cause as Error | undefined)?.message).toBe('DB unreachable');
+  });
+
+  it('aggregates multiple failures into an AggregateError with a count summary', async () => {
+    // Two clients both fail: verify we get an AggregateError (not a single
+    // wrapped Error) with a message that identifies the failure count and
+    // partial-success accounting.
+    const wikijs: Client = {
+      clientId: 'wiki-id',
+      clientSecret: 'wiki-secret',
+      redirectUrls: ['https://wiki.wxyc.org/login/oidc/callback'],
+      name: 'Wiki.js',
+      type: 'web',
+      disabled: false,
+      icon: undefined,
+      metadata: null,
+      skipConsent: true,
+    };
+
+    const { adapter } = makeFakeAdapter();
+    adapter.create = () => {
+      throw new Error('create-side transient failure');
+    };
+    // Ensure findOne returns null so we always land on the create path.
+
+    let thrown: unknown;
+    try {
+      await bootstrapTrustedClients(asAdapter(adapter), [wikijs, flowsheetClient()]);
+    } catch (err) {
+      thrown = err;
+    }
+    assertDefined(thrown, 'expected bootstrap to throw');
+    expect(thrown).toBeInstanceOf(AggregateError);
+    const agg = thrown as AggregateError;
+    expect(agg.message).toMatch(/2 of 2 trustedClients failed/);
+    expect(agg.errors).toHaveLength(2);
+    // Each leaf preserves clientId identification.
+    const messages = (agg.errors as Error[]).map((e) => e.message);
+    expect(messages.some((m) => m.includes('clientId=wiki-id'))).toBe(true);
+    expect(messages.some((m) => m.includes('clientId=flowsheet'))).toBe(true);
   });
 });

--- a/tests/unit/authentication/bootstrap-trusted-clients.test.ts
+++ b/tests/unit/authentication/bootstrap-trusted-clients.test.ts
@@ -11,27 +11,30 @@ import { bootstrapTrustedClients } from '../../../shared/authentication/src/boot
 // deploy or DB rebuild. See migration 0111 and the plugin schema at
 // node_modules/better-auth/dist/plugins/oidc-provider/schema.mjs.
 
+// Hoisted to module scope — parameter defaults are resolved in the enclosing
+// scope, not the function body, so declaring these inside `makeFakeAdapter`
+// makes `seed: AdapterRow[] = []` a TS2304 ("Cannot find name 'AdapterRow'").
+interface AdapterRow {
+  id: string;
+  clientId: string;
+  clientSecret: string | null;
+  name: string;
+  type: string;
+  disabled: boolean;
+  redirectUrls: string;
+  metadata: string | null;
+  icon: string | null;
+  userId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface WhereClause {
+  field: string;
+  value: string;
+}
+
 function makeFakeAdapter(seed: AdapterRow[] = []) {
-  interface AdapterRow {
-    id: string;
-    clientId: string;
-    clientSecret: string | null;
-    name: string;
-    type: string;
-    disabled: boolean;
-    redirectUrls: string;
-    metadata: string | null;
-    icon: string | null;
-    userId: string | null;
-    createdAt: Date;
-    updatedAt: Date;
-  }
-
-  interface WhereClause {
-    field: string;
-    value: string;
-  }
-
   const rows = new Map<string, AdapterRow>(seed.map((r) => [r.clientId, { ...r }]));
   const calls = { findOne: 0, create: 0, update: 0 };
   let randomIdCounter = 0;
@@ -294,12 +297,90 @@ describe('bootstrapTrustedClients', () => {
     expect(flowsheetRow.id).toBe('trusted-flowsheet');
   });
 
-  it('propagates non-race adapter errors so a failed bootstrap surfaces in Sentry', async () => {
-    // The caller in apps/auth/app.ts catches errors from this function and
-    // reports to Sentry at level: 'error' (warn-and-continue posture,
-    // matching sibling createDefaultUser / syncAdminRoles). This test locks
-    // in that this function re-throws non-race errors so the caller can
-    // catch them — a silent try/catch here would defeat that.
+  it('detects Drizzle-wrapped unique_violation via error.cause.code, not just error.code', async () => {
+    // Drizzle wraps postgres-js errors as DrizzleQueryError with the real
+    // error on `.cause` (see drizzle-orm/errors.ts, precedented by
+    // `apps/backend/routes/internal-bans.route.ts:162-163` and
+    // `jobs/flowsheet-metadata-backfill/orchestrate.ts:194-200`). In
+    // production, `error.code` is undefined on the wrapper and the code
+    // lives at `error.cause.code`. Locks the isUniqueViolation predicate
+    // against a regression that only checks `error.code`.
+    const { adapter, rows } = makeFakeAdapter();
+    // Simulate the full race: create throws DrizzleQueryError shape, and
+    // by then the racing replica has written the row (findOne re-lookup
+    // finds it, we update).
+    const originalCreate = adapter.create.bind(adapter);
+    adapter.create = (args: Parameters<typeof originalCreate>[0]) => {
+      rows.set(args.data.clientId, {
+        id: args.data.id,
+        clientId: args.data.clientId,
+        clientSecret: 'racing-replica-secret',
+        name: 'Written by racing replica',
+        type: 'web',
+        disabled: false,
+        redirectUrls: 'https://racing/cb',
+        metadata: null,
+        icon: null,
+        userId: null,
+        createdAt: new Date('2026-06-01'),
+        updatedAt: new Date('2026-06-01'),
+      });
+      const drizzleWrappedError = new Error('Failed query: insert into "auth_oauth_application" ...');
+      (drizzleWrappedError as { cause?: unknown }).cause = { code: '23505', severity: 'ERROR' };
+      throw drizzleWrappedError;
+    };
+
+    // If the predicate missed .cause.code, this would throw AggregateError
+    // (create threw, race-recovery didn't recognize the shape, error bubbled
+    // up). Reaching the resolved-with-updated result proves the wrapper
+    // shape was detected.
+    const result = await bootstrapTrustedClients(asAdapter(adapter), [flowsheetClient({ name: 'Our config' })]);
+    expect(result).toEqual({ created: 0, updated: 1 });
+    const finalRow = rows.get('flowsheet');
+    assertDefined(finalRow, 'flowsheet row');
+    expect(finalRow.name).toBe('Our config');
+  });
+
+  it('aggregates per-client failures so one bad client does not skip the others', async () => {
+    // Wiki.js processes cleanly; flowsheet fails; the aggregate must reflect
+    // both — created:1 for wiki (implicitly, via the throw not preventing
+    // its earlier success), and one collected error for flowsheet.
+    const wikijs: Client = {
+      clientId: 'wiki-id',
+      clientSecret: 'wiki-secret',
+      redirectUrls: ['https://wiki.wxyc.org/login/oidc/callback'],
+      name: 'Wiki.js',
+      type: 'web',
+      disabled: false,
+      icon: undefined,
+      metadata: null,
+      skipConsent: true,
+    };
+
+    const { adapter, rows } = makeFakeAdapter();
+    // Make ONLY the flowsheet create fail (non-unique-violation error).
+    const originalCreate = adapter.create.bind(adapter);
+    adapter.create = (args: Parameters<typeof originalCreate>[0]) => {
+      if (args.data.clientId === 'flowsheet') throw new Error('flowsheet-specific transient error');
+      return originalCreate(args);
+    };
+
+    await expect(bootstrapTrustedClients(asAdapter(adapter), [wikijs, flowsheetClient()])).rejects.toThrow(
+      /1 of 2 trustedClients failed/
+    );
+
+    // Wiki.js row was written; flowsheet was not — but the loop didn't abort
+    // before trying flowsheet.
+    expect(rows.has('wiki-id')).toBe(true);
+    expect(rows.has('flowsheet')).toBe(false);
+  });
+
+  it('collects transient adapter errors into an AggregateError so the caller can Sentry-alert', async () => {
+    // Caller in apps/auth/app.ts catches and reports to Sentry at level:
+    // 'warning' (matching sibling createDefaultUser / syncAdminRoles). This
+    // test locks in that this function surfaces failures as an
+    // AggregateError so the caller can catch them — a silent try/catch here
+    // would defeat that.
     const brokenAdapter = {
       findOne(): Promise<never> {
         return Promise.reject(new Error('DB unreachable'));
@@ -316,6 +397,6 @@ describe('bootstrapTrustedClients', () => {
       bootstrapTrustedClients(brokenAdapter as unknown as Parameters<typeof bootstrapTrustedClients>[0], [
         flowsheetClient(),
       ])
-    ).rejects.toThrow('DB unreachable');
+    ).rejects.toThrow(/1 of 1 trustedClients failed/);
   });
 });


### PR DESCRIPTION
Closes #1574.

## Summary

- New `bootstrapTrustedClients(context, trustedClients)` in `shared/authentication/src/` upserts one `auth_oauth_application` row per configured `oidcProvider` trustedClient, using the same Better Auth Drizzle adapter as the rest of the service.
- Wired into `apps/auth/app.ts` after `syncAdminRoles()`. Fatal on failure — better a loud restart loop than a silent 500 on every OIDC token exchange.
- 7 unit tests: empty config, single insert, comma-join, deterministic id, drift-update, both clients, adapter error propagates.

## Why

The `oidcProvider` plugin's `getClient()` short-circuits on `trustedClients` from memory, but its token / consent writes still FK-reference `oauthApplication.clientId` (schema declared in `node_modules/better-auth/dist/plugins/oidc-provider/schema.mjs`, materialized in 0111 by BS#1572). Without a row, every trustedClient token exchange 500s:

```
insert or update on table "auth_oauth_access_token" violates foreign key
constraint "auth_oauth_access_token_client_id_auth_oauth_application_client"
Key (client_id)=(flowsheet) is not present in table "auth_oauth_application".
```

Observed the first time flowsheet-digitization tried to log in against prod after 0111 landed. Same failure mode applies to Wiki.js (untested since the migration).

## Test plan

- [x] `npm run test:unit -- --testPathPatterns=bootstrap-trusted-clients` — 7/7 pass.
- [x] `npm run test:unit` — 269 suites / 3727 tests pass, no regressions.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 new errors (605 pre-existing warnings).
- [x] `npx prettier --check .` — clean.
- [ ] Post-deploy: flowsheet-digitization verifier completes OIDC round-trip against `api.wxyc.org/auth`.

## Notes for reviewers

- **Structural type against the adapter**, not the concrete `DrizzleAdapter` type — keeps the module free of the full better-auth type surface and lets the test hand-roll a fake adapter without importing `betterAuth({...})`.
- **`trusted-<clientId>` id** is deterministic (legibility over collision-avoidance). `SELECT ... WHERE id LIKE 'trusted-%'` gives operators a clean filter.
- **redirectUrls: string[] → comma-joined string** mirrors the plugin's `/auth/oauth2/register` handler at `oidc-provider/index.mjs:886`, so a bootstrap row is indistinguishable from a self-registered one.
- **Always-refresh over drift-detect:** skipping the update when values match saves one DB round-trip but a case-sensitivity / whitespace bug in the drift check would silently leave stale rows in prod. Single UPDATE per boot is cheap.