### PR TITLE
feat(auth): register dedicated wxyc-canary OIDC trusted client (public + PKCE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,5 +174,5 @@ FLOWSHEET_OIDC_REDIRECT_URLS=http://localhost:8765/auth/callback
 # URL is hardcoded to https://canary.wxyc.org/authorize-echo (never has to
 # resolve — the canary reads the 302 Location, doesn't follow it). Set on
 # prod only; leave unset locally.
-WXYC_CANARY_OIDC_CLIENT_ID=wxyc-canary
+# WXYC_CANARY_OIDC_CLIENT_ID=wxyc-canary
 

--- a/.env.example
+++ b/.env.example
@@ -167,3 +167,12 @@ FLOWSHEET_OIDC_REDIRECT_URLS=http://localhost:8765/auth/callback
 # WIKIJS_OIDC_CLIENT_SECRET=
 # WIKIJS_URL=
 
+# wxyc-canary probe (see WXYC/wxyc-canary#60). Public client, PKCE-only:
+# there is deliberately NO `WXYC_CANARY_OIDC_CLIENT_SECRET` — the canary
+# stops at the /authorize 302 without exchanging the code, so a client
+# secret would only widen the blast radius of a leaked canary env. Redirect
+# URL is hardcoded to https://canary.wxyc.org/authorize-echo (never has to
+# resolve — the canary reads the 302 Location, doesn't follow it). Set on
+# prod only; leave unset locally.
+WXYC_CANARY_OIDC_CLIENT_ID=wxyc-canary
+

--- a/.github/workflows/set-ec2-env-var.yml
+++ b/.github/workflows/set-ec2-env-var.yml
@@ -41,6 +41,10 @@ jobs:
           # supports has to be listed here.
           LML_API_KEY: ${{ secrets.LML_API_KEY }}
           LIBRARY_METADATA_URL: ${{ secrets.LIBRARY_METADATA_URL }}
+          # wxyc-canary OIDC probe client id (WXYC/wxyc-canary#60). Public
+          # client — there is no companion `WXYC_CANARY_OIDC_CLIENT_SECRET`
+          # by design; do not add one.
+          WXYC_CANARY_OIDC_CLIENT_ID: ${{ secrets.WXYC_CANARY_OIDC_CLIENT_ID }}
         run: |
           set -euo pipefail
           KEY="${{ inputs.key }}"
@@ -48,6 +52,7 @@ jobs:
           case "$SECRET_NAME" in
             LML_API_KEY) VALUE="$LML_API_KEY" ;;
             LIBRARY_METADATA_URL) VALUE="$LIBRARY_METADATA_URL" ;;
+            WXYC_CANARY_OIDC_CLIENT_ID) VALUE="$WXYC_CANARY_OIDC_CLIENT_ID" ;;
             *)
               echo "::error::Unsupported secret_name '$SECRET_NAME'. Add it to the resolve step's env block."
               exit 1

--- a/shared/authentication/src/oidc-trusted-clients.ts
+++ b/shared/authentication/src/oidc-trusted-clients.ts
@@ -63,5 +63,29 @@ export function buildTrustedClients(env: NodeJS.ProcessEnv): Client[] {
     }
   }
 
+  // wxyc-canary — the synthetic-DJ probe that runs every 5 min and walks the
+  // full OIDC code + PKCE dance to catch the regression class that produced
+  // #1571 (`oauthConsent` schema drift → login 500). Deliberately a PUBLIC
+  // client: no `client_secret` in the canary env, and the probe stops at the
+  // /authorize 302 without exchanging the code — so `type: 'public'` gates the
+  // token endpoint's `client_secret` check (better-auth's
+  // `node_modules/.../oidc-provider/index.mjs:541`) to require `code_verifier`
+  // instead. The redirect URL is a placeholder; the canary reads the 302
+  // `Location` with `redirect: 'manual'` and inspects it in-process — no
+  // listener stands up at `canary.wxyc.org/authorize-echo`. See wxyc-canary#60.
+  if (env.WXYC_CANARY_OIDC_CLIENT_ID) {
+    clients.push({
+      clientId: env.WXYC_CANARY_OIDC_CLIENT_ID,
+      clientSecret: undefined,
+      redirectUrls: ['https://canary.wxyc.org/authorize-echo'],
+      name: 'WXYC Canary',
+      type: 'public',
+      disabled: false,
+      icon: undefined,
+      metadata: null,
+      skipConsent: true,
+    });
+  }
+
   return clients;
 }

--- a/tests/unit/authentication/build-trusted-clients.test.ts
+++ b/tests/unit/authentication/build-trusted-clients.test.ts
@@ -135,8 +135,90 @@ describe('buildTrustedClients', () => {
     });
   });
 
-  describe('both clients', () => {
-    it('returns Wiki.js first, Flowsheet second, when both are fully configured', () => {
+  describe('wxyc-canary client', () => {
+    it('produces a public-client entry when WXYC_CANARY_OIDC_CLIENT_ID is set', () => {
+      // The canary is a public client (PKCE-only): no client_secret in its env,
+      // and its 5-min probe stops at the /authorize 302 without exchanging
+      // the code — so `type: 'public'` gates the code-exchange path (better-
+      // auth's `node_modules/.../oidc-provider/index.mjs:541`) to require
+      // `code_verifier` instead of `client_secret`. The redirect URL is a
+      // placeholder — canary.wxyc.org/authorize-echo doesn't have to resolve
+      // because the canary reads the 302 `Location` with `redirect: 'manual'`
+      // and inspects it in-process. Contract pinned by wxyc-canary#60 (the
+      // blocked-by ticket that consumes this trustedClient).
+      const clients = buildTrustedClients({
+        WXYC_CANARY_OIDC_CLIENT_ID: 'wxyc-canary',
+      });
+
+      expect(clients).toHaveLength(1);
+      expect(clients[0]).toEqual({
+        clientId: 'wxyc-canary',
+        clientSecret: undefined,
+        redirectUrls: ['https://canary.wxyc.org/authorize-echo'],
+        name: 'WXYC Canary',
+        type: 'public',
+        disabled: false,
+        icon: undefined,
+        metadata: null,
+        skipConsent: true,
+      });
+    });
+
+    it('omits the wxyc-canary entry when WXYC_CANARY_OIDC_CLIENT_ID is unset', () => {
+      // Matches the file-level docstring: a partially configured client
+      // (here: absent id) is omitted rather than silently pushed. Local dev
+      // .env-less boots won't assert a canary client that isn't wired
+      // upstream on prod. Symmetric with the wiki.js / flowsheet unset gates.
+      expect(buildTrustedClients({})).toEqual([]);
+    });
+
+    it('omits the wxyc-canary entry when WXYC_CANARY_OIDC_CLIENT_ID is empty string', () => {
+      // Defense-in-depth: an operator who accidentally sets the var to ''
+      // in the EC2 `.env` shouldn't produce a client with clientId ''. The
+      // truthy check on the env var covers this.
+      expect(buildTrustedClients({ WXYC_CANARY_OIDC_CLIENT_ID: '' })).toEqual([]);
+    });
+
+    it('does not require or read WXYC_CANARY_OIDC_CLIENT_SECRET (public client)', () => {
+      // The canary env deliberately carries NO secret — its whole scope-of-
+      // damage argument is "a leaked canary env carries no OIDC secret." A
+      // future refactor that quietly starts gating on a *_SECRET env var
+      // would rebuild the exact exposure the ticket exists to avoid. Pin the
+      // absence explicitly by asserting the client is still produced when
+      // only the id is present, and clientSecret comes back undefined.
+      const clients = buildTrustedClients({
+        WXYC_CANARY_OIDC_CLIENT_ID: 'wxyc-canary',
+      });
+
+      expect(clients).toHaveLength(1);
+      expect(clients[0].clientSecret).toBeUndefined();
+      expect(clients[0].type).toBe('public');
+    });
+  });
+
+  describe('all clients together', () => {
+    it('returns Wiki.js first, Flowsheet second, WXYC Canary third, when all are fully configured', () => {
+      const clients = buildTrustedClients({
+        WIKIJS_OIDC_CLIENT_ID: 'wiki-id',
+        WIKIJS_OIDC_CLIENT_SECRET: 'wiki-secret',
+        WIKIJS_URL: 'https://wiki.wxyc.org',
+        FLOWSHEET_OIDC_CLIENT_ID: 'flowsheet',
+        FLOWSHEET_OIDC_CLIENT_SECRET: 'shh',
+        FLOWSHEET_OIDC_REDIRECT_URLS: 'https://flowsheet.wxyc.org/auth/callback',
+        WXYC_CANARY_OIDC_CLIENT_ID: 'wxyc-canary',
+      });
+
+      expect(clients).toHaveLength(3);
+      expect(clients[0].name).toBe('Wiki.js');
+      expect(clients[1].name).toBe('Flowsheet Verifier');
+      expect(clients[2].name).toBe('WXYC Canary');
+    });
+
+    it('still returns Wiki.js first, Flowsheet second when only those two are configured', () => {
+      // Pins the pre-canary ordering — a refactor that appends the canary
+      // block in the wrong place (before wiki.js / flowsheet) shouldn't
+      // silently perturb the existing two-client order the previous test
+      // used to lock in on its own.
       const clients = buildTrustedClients({
         WIKIJS_OIDC_CLIENT_ID: 'wiki-id',
         WIKIJS_OIDC_CLIENT_SECRET: 'wiki-secret',

--- a/tests/unit/authentication/build-trusted-clients.test.ts
+++ b/tests/unit/authentication/build-trusted-clients.test.ts
@@ -198,6 +198,13 @@ describe('buildTrustedClients', () => {
 
   describe('all clients together', () => {
     it('returns Wiki.js first, Flowsheet second, WXYC Canary third, when all are fully configured', () => {
+      // Full-shape assertion (not just `.name`): a refactor that silently
+      // flips wiki.js's `type: 'web' → 'public'` or drops `skipConsent` from
+      // flowsheet would sail past a name-only check. The individual describe
+      // blocks pin the shape when each client is configured in isolation;
+      // pin it again in the "all three together" configuration so an
+      // ordering-dependent bug (e.g. mutation of a shared literal) can't
+      // hide either.
       const clients = buildTrustedClients({
         WIKIJS_OIDC_CLIENT_ID: 'wiki-id',
         WIKIJS_OIDC_CLIENT_SECRET: 'wiki-secret',
@@ -209,16 +216,47 @@ describe('buildTrustedClients', () => {
       });
 
       expect(clients).toHaveLength(3);
-      expect(clients[0].name).toBe('Wiki.js');
-      expect(clients[1].name).toBe('Flowsheet Verifier');
-      expect(clients[2].name).toBe('WXYC Canary');
+      expect(clients[0]).toEqual({
+        clientId: 'wiki-id',
+        clientSecret: 'wiki-secret',
+        redirectUrls: ['https://wiki.wxyc.org/login/oidc/callback'],
+        name: 'Wiki.js',
+        type: 'web',
+        disabled: false,
+        icon: undefined,
+        metadata: null,
+        skipConsent: true,
+      });
+      expect(clients[1]).toEqual({
+        clientId: 'flowsheet',
+        clientSecret: 'shh',
+        redirectUrls: ['https://flowsheet.wxyc.org/auth/callback'],
+        name: 'Flowsheet Verifier',
+        type: 'web',
+        disabled: false,
+        icon: undefined,
+        metadata: null,
+        skipConsent: true,
+      });
+      expect(clients[2]).toEqual({
+        clientId: 'wxyc-canary',
+        clientSecret: undefined,
+        redirectUrls: ['https://canary.wxyc.org/authorize-echo'],
+        name: 'WXYC Canary',
+        type: 'public',
+        disabled: false,
+        icon: undefined,
+        metadata: null,
+        skipConsent: true,
+      });
     });
 
     it('still returns Wiki.js first, Flowsheet second when only those two are configured', () => {
       // Pins the pre-canary ordering — a refactor that appends the canary
       // block in the wrong place (before wiki.js / flowsheet) shouldn't
       // silently perturb the existing two-client order the previous test
-      // used to lock in on its own.
+      // used to lock in on its own. Full-shape here too so a partial-config
+      // refactor can't drop `skipConsent` or flip `type` unnoticed.
       const clients = buildTrustedClients({
         WIKIJS_OIDC_CLIENT_ID: 'wiki-id',
         WIKIJS_OIDC_CLIENT_SECRET: 'wiki-secret',
@@ -229,8 +267,28 @@ describe('buildTrustedClients', () => {
       });
 
       expect(clients).toHaveLength(2);
-      expect(clients[0].name).toBe('Wiki.js');
-      expect(clients[1].name).toBe('Flowsheet Verifier');
+      expect(clients[0]).toEqual({
+        clientId: 'wiki-id',
+        clientSecret: 'wiki-secret',
+        redirectUrls: ['https://wiki.wxyc.org/login/oidc/callback'],
+        name: 'Wiki.js',
+        type: 'web',
+        disabled: false,
+        icon: undefined,
+        metadata: null,
+        skipConsent: true,
+      });
+      expect(clients[1]).toEqual({
+        clientId: 'flowsheet',
+        clientSecret: 'shh',
+        redirectUrls: ['https://flowsheet.wxyc.org/auth/callback'],
+        name: 'Flowsheet Verifier',
+        type: 'web',
+        disabled: false,
+        icon: undefined,
+        metadata: null,
+        skipConsent: true,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a `wxyc-canary` `trustedClients` entry (`type: 'public'`, no `clientSecret`, redirect URL `https://canary.wxyc.org/authorize-echo`, `skipConsent: true`) so WXYC/wxyc-canary#60 can exercise the full `/auth/oauth2/authorize` code + PKCE flow every 5 minutes without polluting the existing `flowsheet` client or landing a secret in the canary env.
- Extends `.github/workflows/set-ec2-env-var.yml`'s `resolve` step to accept `WXYC_CANARY_OIDC_CLIENT_ID` so operators can flow the value from a GH secret to EC2 without editing the workflow.
- Documents the new var (and the deliberate absence of a `_SECRET` companion) in `.env.example`.

## Why the choices

- **Public client + PKCE.** The canary reads the 302 `Location` header with `redirect: 'manual'` and stops there — it never exchanges the code. A `client_secret` would only widen the blast radius of a leaked canary env.
- **`skipConsent: true`** routes through better-auth's `!requireConsent` branch (`node_modules/.../oidc-provider/authorize.mjs:133`), which redirects with the code and does NOT insert into `auth_oauth_consent`. Confirmed idempotent under 5-minute polling — no companion cleanup job needed.
- **No migration.** `shared/authentication/src/bootstrap-trusted-clients.ts` (from #1575) upserts an `auth_oauth_application` row on the next server boot for every configured `trustedClients` entry, so setting the env var + restarting the auth container is the whole deploy step.

## Deploy sequence after merge

1. Create the `WXYC_CANARY_OIDC_CLIENT_ID` GitHub secret on this repo with value `wxyc-canary`.
2. `gh workflow run set-ec2-env-var.yml -f key=WXYC_CANARY_OIDC_CLIENT_ID -f secret_name=WXYC_CANARY_OIDC_CLIENT_ID`.
3. Confirm the workflow's post-restart healthcheck passes.
4. Verify: `SELECT client_id FROM auth_oauth_application WHERE client_id='wxyc-canary'` should return one row (bootstrap upserted it on container boot).
5. Only then merge WXYC/wxyc-canary#60 (which will start hitting `/auth/oauth2/authorize?client_id=wxyc-canary` every 5 min).

## Test plan

- [x] `tests/unit/authentication/build-trusted-clients.test.ts` extended with a `wxyc-canary client` block: present/absent env-var cases, `type: 'public'` + no `clientSecret` pinned, `WXYC_CANARY_OIDC_CLIENT_SECRET` explicitly asserted to be neither read nor required.
- [x] `all clients together` test asserts the three-client ordering (wiki.js → flowsheet → wxyc-canary).
- [x] `npm run typecheck` green.
- [x] `npm run test:unit tests/unit/authentication/` green (166 tests).
- [x] `npm run lint` green (warnings only, no new errors).
- [x] `npm run format:check` green.

## Round 1 review response

### Inline fixes

- **F1 (`.env.example:177`)** — commented out the `WXYC_CANARY_OIDC_CLIENT_ID=wxyc-canary` value line to match the block's own "leave unset locally" docstring and the Wiki.js block's pattern. Prevents `cp .env.example .env` (documented local bootstrap in `wxyc-shared/scripts/setup-dev-environment.sh`) from registering the production canary trustedClient identity locally. Commit `6c777cbd`.
- **F4 (`tests/unit/authentication/build-trusted-clients.test.ts`)** — restored full-shape `toEqual({...})` assertions for all three clients in the "all clients together" three-client test, and for wiki.js + flowsheet in the two-client test. Name-only assertions would have missed a `type: 'web' → 'public'` flip or a dropped `skipConsent`; verified meaningfulness locally by temporarily flipping wiki.js's type in the source and watching both tests fail. Commit `3c91796c`.

### Follow-up tickets (not in this PR)

- **F2 — Duplicate-clientId collision:** WXYC/Backend-Service#1579. `buildTrustedClients` doesn't guard against two env-gated blocks emitting the same `clientId`; a collision would silently flip an existing DB row's `type` from `'web'` to `'public'` on the next bootstrap and break Wiki.js login. Filed as a dedup-guard-at-boot ticket.
- **F3 — HS256 empty-HMAC-key on public-client token exchange:** WXYC/Backend-Service#1580. Latent bug in better-auth's oidc-provider at `index.mjs:649` where `sign(new TextEncoder().encode(client.clientSecret))` on a `clientSecret: undefined` client throws `JWSInvalid → 500`. The canary probe stops at `/authorize` today so it doesn't fire, but any future full-flow probe or a #1579 collision would trigger it.

### Deferred (out of scope for this PR)

- **F5** (three hand-rolled client blocks → config-driven registry) — architectural, not warranted at 3 clients.
- **F6** (allowlist duplication in `set-ec2-env-var.yml`) — pre-existing pattern; not this PR's job to unify.
- **F7** (`.env.example` line-wrapping) — global house-style violation, out of scope for a targeted fix PR.

## Round 2 review response

Round 2 verdict: NIT (0 blockers, 9 findings). Both round-1 fixes (F1, F4) verified correct.

### Deferred to follow-ups

- `.invalid` redirect_uri hardening — [WXYC/Backend-Service#1584](https://github.com/WXYC/Backend-Service/issues/1584)
- Bootstrap public-client shape test coverage — [WXYC/Backend-Service#1585](https://github.com/WXYC/Backend-Service/issues/1585)
- Env-var whitespace trimming — [WXYC/Backend-Service#1586](https://github.com/WXYC/Backend-Service/issues/1586)

### Deferred (not filed)

- `.env.example` RHS still contains the literal prod clientId (cousin of F1; minor drift pattern)
- 5-way copy of full-shape client literals in test file (drift-prone; the fixture-const refactor is straightforward but out of scope for a NIT PR)
- Missing `wiki+canary` / `flowsheet+canary` permutation tests
- Stale `describe('neither client')` label
- Missing `docs/env-vars.md` canary entry

Closes #1576
