### PR TITLE
feat(concerts): migration 0112 triangle-shows substrate + RHP writer starts_on

### DIFF
--- a/jobs/flowsheet-etl/transform.ts
+++ b/jobs/flowsheet-etl/transform.ts
@@ -79,6 +79,12 @@ export const mapProdEntryType = (typeCode: number): BackendEntryType => {
 /**
  * Resolve the UTC offset for America/New_York at a given instant.
  * Returns a string like "-05:00" (EST) or "-04:00" (EDT).
+ *
+ * See also: `@wxyc/database`'s `shared/database/src/ny-time.ts`
+ * (`nyWallClockToUtc`) is the newer shared sibling of this same two-pass
+ * NY offset converge, with an explicit DST-gap policy. A DST- or
+ * Intl-parsing fix here almost certainly applies there too; consolidating
+ * this module onto ny-time is a known follow-up — until then, patch both.
  */
 const easternOffsetAt = (probeUtc: Date): string => {
   const parts = new Intl.DateTimeFormat('en-US', {

--- a/jobs/venue-events-scraper/parse.ts
+++ b/jobs/venue-events-scraper/parse.ts
@@ -325,7 +325,10 @@ const extractAddress = (location: SchemaEvent['location']): string | null => {
 
 /** The longest `headlining_artist_raw` we'll send to a varchar(256). */
 const MAX_HEADLINING_ARTIST_LEN = 256;
-/** Matches the schema's `concerts.source_id varchar(256)` ceiling. */
+/** RHP-side sanity cap on the pathname-derived source_id. Deliberate writer
+ *  policy, NOT a schema ceiling: migration 0112 widened `concerts.source_id`
+ *  to `text` (triangle-shows venue-qualified keys reach ~1201 chars), but an
+ *  RHP event-page path longer than this is a scraper bug, not a real key. */
 const MAX_SOURCE_ID_LEN = 256;
 /** Matches the schema's `venues.name varchar(128)` ceiling. */
 const MAX_VENUE_NAME_LEN = 128;

--- a/jobs/venue-events-scraper/writer.ts
+++ b/jobs/venue-events-scraper/writer.ts
@@ -14,7 +14,7 @@
  * threading state through the writer.
  */
 
-import { db, venues, concerts } from '@wxyc/database';
+import { db, venues, concerts, nyCalendarDate } from '@wxyc/database';
 import { eq, sql } from 'drizzle-orm';
 
 import type { ParsedConcert } from './rhp-types.js';
@@ -188,7 +188,10 @@ export const makeVenueCache = (): VenueCache => {
  * (sold_out / cancelled / rescheduled). The RHP JSON-LD's `Offer.availability`
  * isn't reliable enough to drive automated status transitions — adding
  * that pipeline is queued behind real cancellation data from the source
- * (tracked separately from this PR).
+ * (tracked separately from this PR). Contrast: `jobs/triangle-shows-etl`
+ * refreshes status on every upsert — its source maintains an explicit
+ * status enum; see that job's README before assuming this insert-only
+ * policy is a table-wide invariant.
  *
  * `scraped_at` is set per-call so the orchestrator can distinguish
  * "stamped this run" from "missed this run". A row that disappears from
@@ -204,11 +207,15 @@ export const upsertConcert = async (
 ): Promise<WriteConcertOutcome> => {
   const scrapedAtIso = scrapedAt.toISOString(); // Pre-stringify (BS#802 trap).
 
+  const startsAt = new Date(parsed.starts_at);
   const values: ConcertsValue = {
     source: 'rhp_scrape',
     source_id: parsed.source_id,
     venue_id: venueId,
-    starts_at: new Date(parsed.starts_at), // Drizzle typed builder serializes Date safely.
+    starts_at: startsAt, // Drizzle typed builder serializes Date safely.
+    // Venue-local calendar date (migration 0112 NOT NULL). In `set` below
+    // too — a reschedule can move the calendar date.
+    starts_on: nyCalendarDate(startsAt),
     headlining_artist_raw: parsed.headlining_artist,
     supporting_artists_raw: parsed.supporting_artists,
     ticket_url: parsed.ticket_url,
@@ -234,6 +241,7 @@ export const upsertConcert = async (
       set: {
         venue_id: values.venue_id,
         starts_at: values.starts_at,
+        starts_on: values.starts_on,
         headlining_artist_raw: values.headlining_artist_raw,
         supporting_artists_raw: values.supporting_artists_raw,
         ticket_url: values.ticket_url,

--- a/shared/database/src/index.ts
+++ b/shared/database/src/index.ts
@@ -10,3 +10,4 @@ export * from './env-parsers.js';
 export * from './normalize-artist-name.js';
 export * from './normalize-album-title.js';
 export * from './freetext-norm.js';
+export * from './ny-time.js';

--- a/shared/database/src/migrations/0112_triangle-shows-concerts.sql
+++ b/shared/database/src/migrations/0112_triangle-shows-concerts.sql
@@ -1,0 +1,50 @@
+-- 0112 triangle-shows concerts substrate (BS#1589, Phase 1 of the BS#1570 decision record).
+--
+-- Prepares `concerts` for the triangle-shows pull ETL (jobs/triangle-shows-etl):
+--   * new `concert_source_enum` value 'triangle_shows' — the documented extension path
+--     (see jobs/venue-events-scraper/README.md: "extend the enum rather than replacing
+--     this job"). Added but never USED in this transaction, so the PG12+ in-transaction
+--     ALTER TYPE ... ADD VALUE restriction doesn't bite.
+--   * `source_id` varchar(256) -> text. Binary-coercible type change: no table rewrite,
+--     no change to existing rhp_scrape values, and concerts_source_source_id_idx (plain
+--     btree unique) needs no REINDEX. Needed because triangle-shows keying is
+--     '<venue_slug>:' + source_key with a theoretical max ~1165 chars, and PG varchar
+--     errors rather than truncates.
+--   * `starts_at` drops NOT NULL — many triangle-shows events are date-only and we never
+--     fabricate times. `starts_on date NOT NULL` (venue-local America/New_York calendar
+--     date) becomes the windowing column. Backfill-then-SET-NOT-NULL below; derivation
+--     covers 100% of existing rows because starts_at is NOT NULL until this migration.
+--     In-migration DML is within the DDL-only rule's ~10k threshold (concerts holds the
+--     RHP scraper's 5 venues; O(hundreds) rows). No row drop — first_scraped_at anchors
+--     BS#1373's stability clock (BS#1570 correction 1).
+--   * promoted columns (all nullable; existing rhp_scrape rows untouched): title,
+--     doors_at, price_min/price_max numeric(8,2) dollars, age_restriction, removed_at
+--     (source-observed tombstone). Long-tail fields (genre/subgenre/description) stay in
+--     raw_data per BS#1570 Decision 2.
+--   * partial index for Phase 2's curated feed, starts_on-first because both existing
+--     composite indexes key on the now-nullable starts_at (BS#1570 correction 4).
+--
+-- Lock behavior: each ALTER takes AccessExclusiveLock briefly; the table is small and
+-- nothing user-facing reads it yet (read API is Phase 2). The paired writer change
+-- (jobs/venue-events-scraper/writer.ts computing starts_on) ships in the SAME PR —
+-- deploying this migration without it breaks the next 05:00 UTC scrape's inserts.
+ALTER TYPE "wxyc_schema"."concert_source_enum" ADD VALUE 'triangle_shows';--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."concerts" ALTER COLUMN "source_id" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."concerts" ALTER COLUMN "starts_at" DROP NOT NULL;--> statement-breakpoint
+-- Hand-split from the generated `ADD COLUMN "starts_on" date NOT NULL` (which cannot
+-- apply to a non-empty table): add nullable -> backfill -> SET NOT NULL.
+ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "starts_on" date;--> statement-breakpoint
+-- @no-analyze-needed: ANALYZE follows at the bottom of this migration.
+UPDATE "wxyc_schema"."concerts" SET "starts_on" = ("starts_at" AT TIME ZONE 'America/New_York')::date WHERE "starts_on" IS NULL;--> statement-breakpoint
+-- @no-precondition-needed: the backfill UPDATE in this same transaction covers every
+-- row (starts_at is NOT NULL until this migration drops the constraint above), so the
+-- SET NOT NULL is provably safe.
+ALTER TABLE "wxyc_schema"."concerts" ALTER COLUMN "starts_on" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "doors_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "title" text;--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "price_min" numeric(8, 2);--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "price_max" numeric(8, 2);--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "age_restriction" varchar(50);--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "removed_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "concerts_curated_starts_on_idx" ON "wxyc_schema"."concerts" USING btree ("starts_on") WHERE "wxyc_schema"."concerts"."headlining_artist_id" IS NOT NULL AND "wxyc_schema"."concerts"."removed_at" IS NULL;--> statement-breakpoint
+ANALYZE "wxyc_schema"."concerts";

--- a/shared/database/src/migrations/0112_triangle-shows-concerts.sql
+++ b/shared/database/src/migrations/0112_triangle-shows-concerts.sql
@@ -4,7 +4,12 @@
 --   * new `concert_source_enum` value 'triangle_shows' — the documented extension path
 --     (see jobs/venue-events-scraper/README.md: "extend the enum rather than replacing
 --     this job"). Added but never USED in this transaction, so the PG12+ in-transaction
---     ALTER TYPE ... ADD VALUE restriction doesn't bite.
+--     ALTER TYPE ... ADD VALUE restriction doesn't bite. CAUTION for later migrations:
+--     drizzle's migrator runs ALL pending migrations of a deploy in ONE transaction, so
+--     a later migration batched with this one must not reference 'triangle_shows' in
+--     DML or index predicates either — on a DB where the enum type pre-exists (prod)
+--     that raises 55P04 "unsafe use of new value", while fresh CI DBs never reproduce
+--     it (0091 creates the type in the same batch). migrate-dryrun usually catches it.
 --   * `source_id` varchar(256) -> text. Binary-coercible type change: no table rewrite,
 --     no change to existing rhp_scrape values, and concerts_source_source_id_idx (plain
 --     btree unique) needs no REINDEX. Needed because triangle-shows keying is
@@ -23,18 +28,20 @@
 --     raw_data per BS#1570 Decision 2.
 --   * partial index for Phase 2's curated feed, starts_on-first because both existing
 --     composite indexes key on the now-nullable starts_at (BS#1570 correction 4).
+--   * `concerts_derive_starts_on` BEFORE trigger: the DB owns the invariant
+--     "starts_on == starts_at's NY calendar date whenever starts_at is set" (0084/0060
+--     trigger precedent). Also makes an app ROLLBACK to a pre-0112 image safe: the old
+--     writer omits starts_on, and the trigger derives it before the NOT NULL check.
 --
 -- Lock behavior: each ALTER takes AccessExclusiveLock briefly; the table is small and
 -- nothing user-facing reads it yet (read API is Phase 2). The paired writer change
--- (jobs/venue-events-scraper/writer.ts computing starts_on) ships in the SAME PR —
--- deploying this migration without it breaks the next 05:00 UTC scrape's inserts.
+-- (jobs/venue-events-scraper/writer.ts computing starts_on) ships in the SAME PR.
 ALTER TYPE "wxyc_schema"."concert_source_enum" ADD VALUE 'triangle_shows';--> statement-breakpoint
 ALTER TABLE "wxyc_schema"."concerts" ALTER COLUMN "source_id" SET DATA TYPE text;--> statement-breakpoint
 ALTER TABLE "wxyc_schema"."concerts" ALTER COLUMN "starts_at" DROP NOT NULL;--> statement-breakpoint
 -- Hand-split from the generated `ADD COLUMN "starts_on" date NOT NULL` (which cannot
 -- apply to a non-empty table): add nullable -> backfill -> SET NOT NULL.
 ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "starts_on" date;--> statement-breakpoint
--- @no-analyze-needed: ANALYZE follows at the bottom of this migration.
 UPDATE "wxyc_schema"."concerts" SET "starts_on" = ("starts_at" AT TIME ZONE 'America/New_York')::date WHERE "starts_on" IS NULL;--> statement-breakpoint
 -- @no-precondition-needed: the backfill UPDATE in this same transaction covers every
 -- row (starts_at is NOT NULL until this migration drops the constraint above), so the
@@ -47,4 +54,25 @@ ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "price_max" numeric(8, 2);--> st
 ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "age_restriction" varchar(50);--> statement-breakpoint
 ALTER TABLE "wxyc_schema"."concerts" ADD COLUMN "removed_at" timestamp with time zone;--> statement-breakpoint
 CREATE INDEX "concerts_curated_starts_on_idx" ON "wxyc_schema"."concerts" USING btree ("starts_on") WHERE "wxyc_schema"."concerts"."headlining_artist_id" IS NOT NULL AND "wxyc_schema"."concerts"."removed_at" IS NULL;--> statement-breakpoint
+-- DB-side ownership of the starts_on <-> starts_at consistency invariant, in the
+-- style of 0084's bump_flowsheet_updated_at (and 0060's rationale: a forgotten
+-- call site would silently drift). Whenever a row carries an instant, starts_on
+-- is derived from it — so an UPDATE that moves starts_at across midnight (Phase-2
+-- mutation, manual psql remediation) can't leave a stale calendar date, and an
+-- app rollback to a pre-0112 image (whose writer doesn't supply starts_on) still
+-- inserts cleanly: BEFORE ROW triggers run before the NOT NULL check. Date-only
+-- rows (starts_at IS NULL) pass through untouched — their starts_on is the
+-- source's authoritative calendar date and must be supplied by the writer.
+CREATE OR REPLACE FUNCTION wxyc_schema.concerts_derive_starts_on() RETURNS trigger AS $$
+BEGIN
+  IF NEW.starts_at IS NOT NULL THEN
+    NEW.starts_on := (NEW.starts_at AT TIME ZONE 'America/New_York')::date;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;--> statement-breakpoint
+CREATE TRIGGER concerts_derive_starts_on
+BEFORE INSERT OR UPDATE ON wxyc_schema.concerts
+FOR EACH ROW
+EXECUTE FUNCTION wxyc_schema.concerts_derive_starts_on();--> statement-breakpoint
 ANALYZE "wxyc_schema"."concerts";

--- a/shared/database/src/migrations/0112_triangle-shows-concerts.sql
+++ b/shared/database/src/migrations/0112_triangle-shows-concerts.sql
@@ -13,8 +13,9 @@
 --   * `source_id` varchar(256) -> text. Binary-coercible type change: no table rewrite,
 --     no change to existing rhp_scrape values, and concerts_source_source_id_idx (plain
 --     btree unique) needs no REINDEX. Needed because triangle-shows keying is
---     '<venue_slug>:' + source_key with a theoretical max ~1165 chars, and PG varchar
---     errors rather than truncates.
+--     '<venue_slug>:' + source_key: theoretical max ~1201 chars (slug String(100) + ':'
+--     + key String(1100)), ~1165 in practice under the ETL's slug<=64 assertion — and
+--     PG varchar errors rather than truncates.
 --   * `starts_at` drops NOT NULL — many triangle-shows events are date-only and we never
 --     fabricate times. `starts_on date NOT NULL` (venue-local America/New_York calendar
 --     date) becomes the windowing column. Backfill-then-SET-NOT-NULL below; derivation
@@ -63,6 +64,9 @@ CREATE INDEX "concerts_curated_starts_on_idx" ON "wxyc_schema"."concerts" USING 
 -- inserts cleanly: BEFORE ROW triggers run before the NOT NULL check. Date-only
 -- rows (starts_at IS NULL) pass through untouched — their starts_on is the
 -- source's authoritative calendar date and must be supplied by the writer.
+-- Remediation corollary: on a TIMED row, starts_on is trigger-owned — a manual
+-- `UPDATE ... SET starts_on = X` reports UPDATE 1 but is silently re-derived; to
+-- move a timed row's calendar date, move starts_at (or NULL it first).
 CREATE OR REPLACE FUNCTION wxyc_schema.concerts_derive_starts_on() RETURNS trigger AS $$
 BEGIN
   IF NEW.starts_at IS NOT NULL THEN

--- a/shared/database/src/migrations/meta/0112_snapshot.json
+++ b/shared/database/src/migrations/meta/0112_snapshot.json
@@ -1,0 +1,5441 @@
+{
+  "id": "c7a94c9a-4121-4a95-95dd-b27186ec4fc6",
+  "prevId": "46b953ed-da9f-44ac-94ce-ae862815933a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_release_date": {
+          "name": "full_release_date",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist": {
+          "name": "tracklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_image_url": {
+          "name": "artist_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_tokens": {
+          "name": "bio_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_popularity": {
+      "name": "album_popularity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "logical_album_key": {
+          "name": "logical_album_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_plays": {
+          "name": "linked_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freetext_plays": {
+          "name": "freetext_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "representative_library_id": {
+          "name": "representative_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_null_track_idx": {
+          "name": "cta_unique_null_track_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"compilation_track_artist\".\"track_title\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doors_at": {
+          "name": "doors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_min": {
+          "name": "price_min",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_max": {
+          "name": "price_max",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_restriction": {
+          "name": "age_restriction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_scraped_at": {
+          "name": "first_scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_curated_starts_on_idx": {
+          "name": "concerts_curated_starts_on_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"concerts\".\"headlining_artist_id\" IS NOT NULL AND \"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_device_code": {
+      "name": "auth_device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_device_code_device_code_key": {
+          "name": "auth_device_code_device_code_key",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_user_code_key": {
+          "name": "auth_device_code_user_code_key",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_expires_at_idx": {
+          "name": "auth_device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_device_code_user_id_auth_user_id_fk": {
+          "name": "auth_device_code_user_id_auth_user_id_fk",
+          "tableFrom": "auth_device_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "radio_hour": {
+          "name": "radio_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer": {
+          "name": "composer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer_source": {
+          "name": "composer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_play_order_idx": {
+          "name": "flowsheet_show_id_play_order_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"play_order\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_idx": {
+          "name": "flowsheet_metadata_attempt_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_covering_idx": {
+          "name": "flowsheet_metadata_attempt_pending_covering_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_album_id_enriched_idx": {
+          "name": "flowsheet_album_id_enriched_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_freetext_resolution": {
+      "name": "flowsheet_freetext_resolution",
+      "schema": "wxyc_schema",
+      "columns": {
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_source": {
+          "name": "match_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_at": {
+          "name": "attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "flowsheet_freetext_resolution_norm_artist_norm_album_pk": {
+          "name": "flowsheet_freetext_resolution_norm_artist_norm_album_pk",
+          "columns": [
+            "norm_artist",
+            "norm_album"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flowsheet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_watermark": {
+      "name": "library_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_watermark_singleton": {
+          "name": "library_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_access_token_client_id_idx": {
+          "name": "auth_oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_access_token_user_id_idx": {
+          "name": "auth_oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_access_token_key": {
+          "name": "auth_oauth_access_token_access_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "auth_oauth_access_token_refresh_token_key": {
+          "name": "auth_oauth_access_token_refresh_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_application": {
+      "name": "auth_oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_application_user_id_idx": {
+          "name": "auth_oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_application_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_application_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_application_client_id_key": {
+          "name": "auth_oauth_application_client_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_oauth_consent_client_id_idx": {
+          "name": "auth_oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_consent_user_id_idx": {
+          "name": "auth_oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "album_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lml_identity_id": {
+          "name": "lml_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rotation_discogs_release_id_not_sentinel": {
+          "name": "rotation_discogs_release_id_not_sentinel",
+          "value": "\"wxyc_schema\".\"rotation\".\"discogs_release_id\" IS NULL OR \"wxyc_schema\".\"rotation\".\"discogs_release_id\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_flow_expires_at": {
+          "name": "device_flow_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape",
+        "triangle_shows"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill",
+        "library_identity",
+        "md_verified"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.album_plays": {
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "isExisting": true,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -764,6 +764,13 @@
       "when": 1783648865581,
       "tag": "0111_oidc-provider-substrate",
       "breakpoints": true
+    },
+    {
+      "idx": 112,
+      "version": "7",
+      "when": 1783648865582,
+      "tag": "0112_triangle-shows-concerts",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -108,5 +108,5 @@
   "0109_md-verified-release-id-source": "375bf7877d19df633615ce8be9e052b0a5a89c7e9fda13748f3f498e3a11eb12",
   "0110_qr-device-auth": "0284b4f41fb20265ce3901f5e2bdf9226ade145df0cae44b60b7da822901dae2",
   "0111_oidc-provider-substrate": "f12255a3ff9ab9e2b8266741d90c6654b8fa451bdca418ebdd060dd5e54f28b7",
-  "0112_triangle-shows-concerts": "2dab0393be0ebe8020863a44852dffdae2b748c3e33cf4b152539ec27da41c71"
+  "0112_triangle-shows-concerts": "a48a85325a9be136f50539434e13d93b50fc007341336d4aa1ba0c79998ee48d"
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -107,5 +107,6 @@
   "0108_flowsheet-composer": "6ac7db945d6624bb764b7882627cbfc9d01f9fde5d04897f84ba592da0da40cd",
   "0109_md-verified-release-id-source": "375bf7877d19df633615ce8be9e052b0a5a89c7e9fda13748f3f498e3a11eb12",
   "0110_qr-device-auth": "0284b4f41fb20265ce3901f5e2bdf9226ade145df0cae44b60b7da822901dae2",
-  "0111_oidc-provider-substrate": "f12255a3ff9ab9e2b8266741d90c6654b8fa451bdca418ebdd060dd5e54f28b7"
+  "0111_oidc-provider-substrate": "f12255a3ff9ab9e2b8266741d90c6654b8fa451bdca418ebdd060dd5e54f28b7",
+  "0112_triangle-shows-concerts": "f15843c8d248ff0b5c35ba9a623bd072310cfae6734a5e1b8692e1b4f0cedce8"
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -108,5 +108,5 @@
   "0109_md-verified-release-id-source": "375bf7877d19df633615ce8be9e052b0a5a89c7e9fda13748f3f498e3a11eb12",
   "0110_qr-device-auth": "0284b4f41fb20265ce3901f5e2bdf9226ade145df0cae44b60b7da822901dae2",
   "0111_oidc-provider-substrate": "f12255a3ff9ab9e2b8266741d90c6654b8fa451bdca418ebdd060dd5e54f28b7",
-  "0112_triangle-shows-concerts": "f15843c8d248ff0b5c35ba9a623bd072310cfae6734a5e1b8692e1b4f0cedce8"
+  "0112_triangle-shows-concerts": "2dab0393be0ebe8020863a44852dffdae2b748c3e33cf4b152539ec27da41c71"
 }

--- a/shared/database/src/ny-time.ts
+++ b/shared/database/src/ny-time.ts
@@ -1,0 +1,67 @@
+/**
+ * America/New_York calendar helpers for the concert writers (migration 0112,
+ * BS#1589). `concerts.starts_on` is defined as the *venue-local* calendar
+ * date — all covered venues are in the Eastern time zone — so both writers
+ * must agree on the same conversion:
+ *
+ *   - `jobs/venue-events-scraper` derives `starts_on` FROM an instant
+ *     (`nyCalendarDate`), mirroring the migration's one-time backfill
+ *     (`(starts_at AT TIME ZONE 'America/New_York')::date`).
+ *   - `jobs/triangle-shows-etl` composes `starts_at`/`doors_at` from the
+ *     source's date + local-time fields (`nyWallClockToUtc`).
+ *
+ * Built on Intl.DateTimeFormat (Node ships full IANA tz data) — no
+ * dependency, DST handled by the platform.
+ */
+
+const NY_TIME_ZONE = 'America/New_York';
+
+// en-CA formats dates as ISO YYYY-MM-DD directly.
+const nyDateFormat = new Intl.DateTimeFormat('en-CA', {
+  timeZone: NY_TIME_ZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const nyOffsetFormat = new Intl.DateTimeFormat('en-US', {
+  timeZone: NY_TIME_ZONE,
+  timeZoneName: 'longOffset',
+});
+
+/** The `YYYY-MM-DD` America/New_York calendar date of an instant. */
+export const nyCalendarDate = (instant: Date): string => nyDateFormat.format(instant);
+
+/** New York's UTC offset in milliseconds at the given instant (negative: -5h EST / -4h EDT). */
+const nyOffsetMsAt = (instant: Date): number => {
+  const part = nyOffsetFormat.formatToParts(instant).find((p) => p.type === 'timeZoneName');
+  // e.g. "GMT-05:00" / "GMT-4" — Intl guarantees the GMT±H[:mm] shape for longOffset.
+  const match = part?.value.match(/GMT([+-])(\d{1,2})(?::(\d{2}))?/);
+  if (!match) {
+    throw new Error(`nyOffsetMsAt: unparseable timeZoneName '${part?.value ?? '<missing>'}'`);
+  }
+  const sign = match[1] === '-' ? -1 : 1;
+  return sign * (Number(match[2]) * 60 + Number(match[3] ?? '0')) * 60_000;
+};
+
+/**
+ * Interpret `isoDate` (`YYYY-MM-DD`) + `isoTime` (`HH:MM[:SS]`) as an
+ * America/New_York wall-clock reading and return the UTC instant.
+ *
+ * Callers own the null branch — a date-only event's `starts_at` stays NULL
+ * (never a fabricated time), so both arguments here are non-null.
+ *
+ * DST via the standard two-pass converge: guess the offset as if the wall
+ * clock were UTC, then re-read the offset at the corrected instant. Times
+ * inside the spring-forward gap resolve to the post-transition instant;
+ * fall-back ambiguous times resolve to one consistent occurrence. Both
+ * stay on the intended NY calendar date, which is what `starts_on` needs.
+ */
+export const nyWallClockToUtc = (isoDate: string, isoTime: string): Date => {
+  const candidate = new Date(`${isoDate}T${isoTime.length === 5 ? `${isoTime}:00` : isoTime}Z`);
+  if (Number.isNaN(candidate.getTime())) {
+    throw new Error(`nyWallClockToUtc: unparseable date/time '${isoDate}' / '${isoTime}'`);
+  }
+  const firstPass = new Date(candidate.getTime() - nyOffsetMsAt(candidate));
+  return new Date(candidate.getTime() - nyOffsetMsAt(firstPass));
+};

--- a/shared/database/src/ny-time.ts
+++ b/shared/database/src/ny-time.ts
@@ -50,6 +50,11 @@ const ISO_DATE_SHAPE = /^\d{4}-\d{2}-\d{2}$/;
  * fail fast here instead.
  */
 export const nyCalendarDate = (instant: Date): string => {
+  if (Number.isNaN(instant.getTime())) {
+    // Fail with an attributed message instead of Intl's bare
+    // 'RangeError: Invalid time value' pointing into formatter internals.
+    throw new Error('nyCalendarDate: received an Invalid Date');
+  }
   const formatted = nyDateFormat.format(instant);
   if (!ISO_DATE_SHAPE.test(formatted)) {
     throw new Error(
@@ -95,6 +100,13 @@ export const nyWallClockToUtc = (isoDate: string, time: string): Date => {
   const timeMatch = time.match(TIME_SHAPE);
   if (!ISO_DATE_SHAPE.test(isoDate) || !timeMatch) {
     throw new Error(`nyWallClockToUtc: unparseable date/time '${isoDate}' / '${time}' (want YYYY-MM-DD + HH:MM[:SS])`);
+  }
+  if (Number(timeMatch[1]) > 23) {
+    // Reject explicitly: ECMA-262 quietly accepts T24:00 as next-day
+    // midnight, which would window the event one calendar day late with
+    // no error anywhere. A source meaning end-of-day midnight must say
+    // which day it means ('00:00' on the next date).
+    throw new Error(`nyWallClockToUtc: hour out of range in '${time}' (want 00-23; T24:00 is ambiguous about the day)`);
   }
   const normalizedTime = `${timeMatch[1].padStart(2, '0')}:${timeMatch[2]}:${timeMatch[3] ?? '00'}`;
   const candidate = new Date(`${isoDate}T${normalizedTime}Z`);

--- a/shared/database/src/ny-time.ts
+++ b/shared/database/src/ny-time.ts
@@ -5,16 +5,26 @@
  * must agree on the same conversion:
  *
  *   - `jobs/venue-events-scraper` derives `starts_on` FROM an instant
- *     (`nyCalendarDate`), mirroring the migration's one-time backfill
+ *     (`nyCalendarDate`), mirroring migration 0112's backfill and the
+ *     `concerts_derive_starts_on` trigger expression
  *     (`(starts_at AT TIME ZONE 'America/New_York')::date`).
  *   - `jobs/triangle-shows-etl` composes `starts_at`/`doors_at` from the
  *     source's date + local-time fields (`nyWallClockToUtc`).
  *
  * Built on Intl.DateTimeFormat (Node ships full IANA tz data) — no
  * dependency, DST handled by the platform.
+ *
+ * See also: `jobs/flowsheet-etl/transform.ts` (`easternOffsetAt` +
+ * `parseMySQLDatetime`) carries an older sibling of the same two-pass NY
+ * offset converge for tubafrenzy MySQL datetimes. A DST- or Intl-parsing
+ * fix here almost certainly applies there too; consolidation onto this
+ * module is a known follow-up — until then, patch both.
  */
 
-const NY_TIME_ZONE = 'America/New_York';
+/** The station's home time zone. Exported so consumers reference this
+ *  constant instead of re-hardcoding the literal (it already appears in
+ *  flowsheet.service.ts and flowsheet-etl). */
+export const NY_TIME_ZONE = 'America/New_York';
 
 // en-CA formats dates as ISO YYYY-MM-DD directly.
 const nyDateFormat = new Intl.DateTimeFormat('en-CA', {
@@ -29,8 +39,25 @@ const nyOffsetFormat = new Intl.DateTimeFormat('en-US', {
   timeZoneName: 'longOffset',
 });
 
-/** The `YYYY-MM-DD` America/New_York calendar date of an instant. */
-export const nyCalendarDate = (instant: Date): string => nyDateFormat.format(instant);
+const ISO_DATE_SHAPE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * The `YYYY-MM-DD` America/New_York calendar date of an instant.
+ *
+ * The output shape is validated: on a Node built without full ICU, Intl
+ * silently falls back to locale data that formats en-CA as `MM/DD/YYYY`,
+ * which would otherwise flow into the NOT NULL `date` column unnoticed —
+ * fail fast here instead.
+ */
+export const nyCalendarDate = (instant: Date): string => {
+  const formatted = nyDateFormat.format(instant);
+  if (!ISO_DATE_SHAPE.test(formatted)) {
+    throw new Error(
+      `nyCalendarDate: Intl 'en-CA' produced '${formatted}', not YYYY-MM-DD — is this Node built with full-icu?`
+    );
+  }
+  return formatted;
+};
 
 /** New York's UTC offset in milliseconds at the given instant (negative: -5h EST / -4h EDT). */
 const nyOffsetMsAt = (instant: Date): number => {
@@ -44,24 +71,48 @@ const nyOffsetMsAt = (instant: Date): number => {
   return sign * (Number(match[2]) * 60 + Number(match[3] ?? '0')) * 60_000;
 };
 
+// HH:MM or HH:MM:SS, hour optionally unpadded (some feeds emit '9:30').
+const TIME_SHAPE = /^(\d{1,2}):(\d{2})(?::(\d{2}))?$/;
+
 /**
- * Interpret `isoDate` (`YYYY-MM-DD`) + `isoTime` (`HH:MM[:SS]`) as an
- * America/New_York wall-clock reading and return the UTC instant.
+ * Interpret `isoDate` (`YYYY-MM-DD`) + `time` (`HH:MM[:SS]`, hour may be
+ * unpadded) as an America/New_York wall-clock reading and return the UTC
+ * instant.
  *
  * Callers own the null branch — a date-only event's `starts_at` stays NULL
  * (never a fabricated time), so both arguments here are non-null.
  *
- * DST via the standard two-pass converge: guess the offset as if the wall
- * clock were UTC, then re-read the offset at the corrected instant. Times
- * inside the spring-forward gap resolve to the post-transition instant;
- * fall-back ambiguous times resolve to one consistent occurrence. Both
- * stay on the intended NY calendar date, which is what `starts_on` needs.
+ * DST policy (matches Temporal/java.time 'compatible'): a wall time inside
+ * the spring-forward gap resolves FORWARD to the post-transition instant
+ * (02:30 EST doesn't exist → 03:30 EDT); a fall-back ambiguous time
+ * resolves to its first (earlier, EDT) occurrence. Implementation: probe
+ * the NY offset treating the wall clock as UTC, re-probe at the corrected
+ * instant; when the two probes disagree AND applying the second still
+ * doesn't produce a self-consistent reading (the gap), keep the first
+ * probe's result — which is the forward resolution.
  */
-export const nyWallClockToUtc = (isoDate: string, isoTime: string): Date => {
-  const candidate = new Date(`${isoDate}T${isoTime.length === 5 ? `${isoTime}:00` : isoTime}Z`);
-  if (Number.isNaN(candidate.getTime())) {
-    throw new Error(`nyWallClockToUtc: unparseable date/time '${isoDate}' / '${isoTime}'`);
+export const nyWallClockToUtc = (isoDate: string, time: string): Date => {
+  const timeMatch = time.match(TIME_SHAPE);
+  if (!ISO_DATE_SHAPE.test(isoDate) || !timeMatch) {
+    throw new Error(`nyWallClockToUtc: unparseable date/time '${isoDate}' / '${time}' (want YYYY-MM-DD + HH:MM[:SS])`);
   }
-  const firstPass = new Date(candidate.getTime() - nyOffsetMsAt(candidate));
-  return new Date(candidate.getTime() - nyOffsetMsAt(firstPass));
+  const normalizedTime = `${timeMatch[1].padStart(2, '0')}:${timeMatch[2]}:${timeMatch[3] ?? '00'}`;
+  const candidate = new Date(`${isoDate}T${normalizedTime}Z`);
+  if (Number.isNaN(candidate.getTime())) {
+    throw new Error(`nyWallClockToUtc: invalid date/time '${isoDate}' / '${time}'`);
+  }
+
+  const offsetAtCandidate = nyOffsetMsAt(candidate);
+  const firstPass = new Date(candidate.getTime() - offsetAtCandidate);
+  const offsetAtFirstPass = nyOffsetMsAt(firstPass);
+  if (offsetAtFirstPass === offsetAtCandidate) {
+    return firstPass; // Probes agree — the common case.
+  }
+  const secondPass = new Date(candidate.getTime() - offsetAtFirstPass);
+  // If the offset at secondPass matches the offset we applied, secondPass
+  // reads back as the requested wall clock (a real instant — the DST
+  // boundary just sat between our probes). If it does NOT match, the wall
+  // clock is unrepresentable (spring-forward gap): firstPass is the
+  // forward resolution (requested time + gap width on the far side).
+  return nyOffsetMsAt(secondPass) === offsetAtFirstPass ? secondPass : firstPass;
 };

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -14,6 +14,7 @@ import {
   index,
   pgEnum,
   date,
+  numeric,
   uniqueIndex,
   customType,
   real,
@@ -1932,6 +1933,7 @@ export type NewArtistSearchAlias = InferInsertModel<typeof artist_search_alias>;
  */
 export const concertSourceEnum = wxyc_schema.enum('concert_source_enum', [
   'rhp_scrape', // Rockhouse Partners venue sites (catscradle.com, local506.com, ...)
+  'triangle_shows', // triangle-shows pull ETL (jobs/triangle-shows-etl, BS#1589)
 ]);
 
 /**
@@ -2003,18 +2005,47 @@ export type NewVenue = InferInsertModel<typeof venues>;
  * in the current environment. Downstream consumers asking "≥30 days
  * steady?" must filter against the migration's per-env apply timestamp
  * rather than treat backfilled rows as real first-scrape moments.
+ *
+ * Date semantics (migration 0112, BS#1589): `starts_on` is the venue-local
+ * (America/New_York) calendar date and the NOT NULL windowing column —
+ * "upcoming" queries filter on it. `starts_at` is the exact instant and is
+ * nullable: many `triangle_shows` events are date-only and we never
+ * fabricate times. For `rhp_scrape` rows the writer derives `starts_on`
+ * from `starts_at`; the two `starts_at` indexes simply don't cover
+ * null-`starts_at` rows, and the curated feed reads the `starts_on`-first
+ * partial index instead.
+ *
+ * `removed_at` (triangle_shows only): mirrors the source's soft tombstone —
+ * set when the source stamps it, cleared when a delisted event reappears.
+ * It is an observation ("the venue stopped advertising this"), never
+ * inferred from absence-from-snapshot: source rows hard-delete 7 days past
+ * their date, so some rows age out with `removed_at` never observed, which
+ * is fine because `starts_on` windowing retires them from any feed.
+ *
+ * `triangle_shows` keying: `source_id = '<venue_slug>:' + source_key`.
+ * triangle-shows' `source_key` is unique only per-venue (its unique index
+ * is `(venue_id, source_key)`; VenuePilot ids are small integers that
+ * collide across venues), so the venue qualifier is load-bearing. Max
+ * length ~1165 chars (slug ≤100 + ':' + key ≤1100) — why `source_id` is
+ * `text`, not varchar(256).
  */
 export const concerts = wxyc_schema.table(
   'concerts',
   {
     id: serial('id').primaryKey(),
     source: concertSourceEnum('source').notNull(),
-    source_id: varchar('source_id', { length: 256 }).notNull(),
+    source_id: text('source_id').notNull(),
     venue_id: integer('venue_id')
       .notNull()
       .references(() => venues.id, { onDelete: 'restrict' }),
-    starts_at: timestamp('starts_at', { withTimezone: true }).notNull(),
+    // Venue-local calendar date; the windowing column. See table JSDoc.
+    starts_on: date('starts_on').notNull(),
+    // Exact instant; NULL for date-only events (no fabricated times).
+    starts_at: timestamp('starts_at', { withTimezone: true }),
+    doors_at: timestamp('doors_at', { withTimezone: true }),
     headlining_artist_raw: varchar('headlining_artist_raw', { length: 256 }).notNull(),
+    // Event name as the source displays it, when distinct from the artist.
+    title: text('title'),
     headlining_artist_id: integer('headlining_artist_id').references(() => artists.id, {
       onDelete: 'set null',
     }),
@@ -2024,7 +2055,13 @@ export const concerts = wxyc_schema.table(
       .default(sql`'{}'::text[]`),
     ticket_url: text('ticket_url'),
     image_url: text('image_url'),
+    // Dollars. free events carry price_min = 0 (status maps to on_sale).
+    price_min: numeric('price_min', { precision: 8, scale: 2 }),
+    price_max: numeric('price_max', { precision: 8, scale: 2 }),
+    age_restriction: varchar('age_restriction', { length: 50 }),
     status: concertStatusEnum('status').notNull().default('on_sale'),
+    // Source-observed soft tombstone; cleared on reappearance. See JSDoc.
+    removed_at: timestamp('removed_at', { withTimezone: true }),
     raw_data: jsonb('raw_data').notNull(),
     scraped_at: timestamp('scraped_at', { withTimezone: true }).notNull(),
     // INSERT-only scraper-stability anchor — writer omits from ON CONFLICT
@@ -2037,6 +2074,12 @@ export const concerts = wxyc_schema.table(
     uniqueIndex('concerts_source_source_id_idx').on(table.source, table.source_id),
     index('concerts_venue_starts_at_idx').on(table.venue_id, table.starts_at),
     index('concerts_headlining_artist_starts_at_idx').on(table.headlining_artist_id, table.starts_at),
+    // Curated-feed path (Phase 2's GET /concerts?curated=true): resolver-
+    // stamped, not tombstoned, windowed by calendar date. starts_on-first
+    // because starts_at is nullable post-0112 (BS#1570 correction 4).
+    index('concerts_curated_starts_on_idx')
+      .on(table.starts_on)
+      .where(sql`${table.headlining_artist_id} IS NOT NULL AND ${table.removed_at} IS NULL`),
   ]
 );
 

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -2010,10 +2010,14 @@ export type NewVenue = InferInsertModel<typeof venues>;
  * (America/New_York) calendar date and the NOT NULL windowing column —
  * "upcoming" queries filter on it. `starts_at` is the exact instant and is
  * nullable: many `triangle_shows` events are date-only and we never
- * fabricate times. For `rhp_scrape` rows the writer derives `starts_on`
- * from `starts_at`; the two `starts_at` indexes simply don't cover
- * null-`starts_at` rows, and the curated feed reads the `starts_on`-first
- * partial index instead.
+ * fabricate times. Whenever `starts_at` is set, the DB derives `starts_on`
+ * from it via the `concerts_derive_starts_on` BEFORE trigger (0112), so an
+ * UPDATE moving the instant across midnight can't leave a stale calendar
+ * date; date-only rows pass through with the writer-supplied `starts_on`.
+ * Query note for Phase 2: range predicates on `starts_at` never match
+ * null-`starts_at` rows (SQL NULL semantics — the btree indexes themselves
+ * do store NULLs), so date-window queries must filter on `starts_on`; the
+ * curated feed reads the `starts_on`-first partial index.
  *
  * `removed_at` (triangle_shows only): mirrors the source's soft tombstone —
  * set when the source stamps it, cleared when a delisted event reappears.
@@ -2026,8 +2030,10 @@ export type NewVenue = InferInsertModel<typeof venues>;
  * triangle-shows' `source_key` is unique only per-venue (its unique index
  * is `(venue_id, source_key)`; VenuePilot ids are small integers that
  * collide across venues), so the venue qualifier is load-bearing. Max
- * length ~1165 chars (slug ≤100 + ':' + key ≤1100) — why `source_id` is
- * `text`, not varchar(256).
+ * length ~1201 chars (source slug String(100) + ':' + key String(1100);
+ * in practice the ETL's startup assertion caps ingested slugs at 64 to fit
+ * `venues.slug`, giving ~1165) — why `source_id` is `text`, not
+ * varchar(256).
  */
 export const concerts = wxyc_schema.table(
   'concerts',

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -135,13 +135,20 @@ export const concerts = {
   source: 'source',
   source_id: 'source_id',
   venue_id: 'venue_id',
+  starts_on: 'starts_on',
   starts_at: 'starts_at',
+  doors_at: 'doors_at',
   headlining_artist_raw: 'headlining_artist_raw',
+  title: 'title',
   headlining_artist_id: 'headlining_artist_id',
   supporting_artists_raw: 'supporting_artists_raw',
   ticket_url: 'ticket_url',
   image_url: 'image_url',
+  price_min: 'price_min',
+  price_max: 'price_max',
+  age_restriction: 'age_restriction',
   status: 'status',
+  removed_at: 'removed_at',
   raw_data: 'raw_data',
   scraped_at: 'scraped_at',
   first_scraped_at: 'first_scraped_at',
@@ -347,6 +354,7 @@ export type { IntParserOptions } from '../../shared/database/src/env-parsers.js'
 export { normalizeArtistName } from '../../shared/database/src/normalize-artist-name.js';
 export { normalizeAlbumTitle } from '../../shared/database/src/normalize-album-title.js';
 export { freetextPairKey, normalizeFreetextArtist } from '../../shared/database/src/freetext-norm.js';
+export { nyCalendarDate, nyWallClockToUtc } from '../../shared/database/src/ny-time.js';
 
 // Mock types
 export type AnonymousDevice = {

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -354,7 +354,7 @@ export type { IntParserOptions } from '../../shared/database/src/env-parsers.js'
 export { normalizeArtistName } from '../../shared/database/src/normalize-artist-name.js';
 export { normalizeAlbumTitle } from '../../shared/database/src/normalize-album-title.js';
 export { freetextPairKey, normalizeFreetextArtist } from '../../shared/database/src/freetext-norm.js';
-export { nyCalendarDate, nyWallClockToUtc } from '../../shared/database/src/ny-time.js';
+export { NY_TIME_ZONE, nyCalendarDate, nyWallClockToUtc } from '../../shared/database/src/ny-time.js';
 
 // Mock types
 export type AnonymousDevice = {

--- a/tests/unit/database/ny-time.test.ts
+++ b/tests/unit/database/ny-time.test.ts
@@ -7,7 +7,13 @@
  * these, so DST correctness is pinned explicitly on both transition days.
  */
 import { describe, test, expect } from '@jest/globals';
-import { nyCalendarDate, nyWallClockToUtc } from '../../../shared/database/src/ny-time';
+import { NY_TIME_ZONE, nyCalendarDate, nyWallClockToUtc } from '../../../shared/database/src/ny-time';
+
+describe('NY_TIME_ZONE', () => {
+  test('is the canonical IANA name (consumers import this instead of re-hardcoding)', () => {
+    expect(NY_TIME_ZONE).toBe('America/New_York');
+  });
+});
 
 describe('nyCalendarDate', () => {
   test.each([
@@ -23,6 +29,10 @@ describe('nyCalendarDate', () => {
   ])('nyCalendarDate(%s) -> %s', (iso, expected) => {
     expect(nyCalendarDate(new Date(iso))).toBe(expected);
   });
+
+  test('output always matches the YYYY-MM-DD shape the date column expects (full-icu guard)', () => {
+    expect(nyCalendarDate(new Date('2026-06-14T01:30:00Z'))).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
 });
 
 describe('nyWallClockToUtc', () => {
@@ -31,30 +41,47 @@ describe('nyWallClockToUtc', () => {
     ['2026-01-15', '20:00:00', '2026-01-16T01:00:00.000Z'],
     // EDT summer date: 20:00 NY == 00:00Z next day.
     ['2026-07-04', '20:00:00', '2026-07-05T00:00:00.000Z'],
-    // Seconds honored, HH:MM accepted.
+    // Seconds optional; HH:MM accepted.
     ['2026-07-04', '19:30', '2026-07-04T23:30:00.000Z'],
-    // Spring-forward day (2026-03-08): 02:30 NY doesn't exist; resolves to
-    // the post-transition instant (03:30 EDT == 07:30Z, same as 02:30 EST
-    // read forward). Either post-gap reading is 07:30Z under the two-pass
-    // converge; what we pin is: not NaN, and the evening of that day is EDT.
+    // Unpadded hour accepted ('9:30' — some feeds emit it).
+    ['2026-07-04', '9:30', '2026-07-04T13:30:00.000Z'],
+    // Evening of the spring-forward day is EDT.
     ['2026-03-08', '20:00:00', '2026-03-09T00:00:00.000Z'],
-    // Fall-back day (2026-11-01): 01:30 NY is ambiguous; two-pass converge
-    // lands on a valid instant whose NY reading is 01:30 — pin the evening
-    // of that day as EST.
+    // Evening of the fall-back day is EST.
     ['2026-11-01', '20:00:00', '2026-11-02T01:00:00.000Z'],
+    // Just before the spring-forward gap: 01:30 EST.
+    ['2026-03-08', '01:30:00', '2026-03-08T06:30:00.000Z'],
+    // Just after the gap: 03:30 EDT.
+    ['2026-03-08', '03:30:00', '2026-03-08T07:30:00.000Z'],
   ])('nyWallClockToUtc(%s, %s) -> %s', (date, time, expectedIso) => {
     expect(nyWallClockToUtc(date, time).toISOString()).toBe(expectedIso);
   });
 
-  test('spring-forward gap time resolves to a valid instant that round-trips to the same NY calendar date', () => {
+  test('spring-forward gap time resolves FORWARD to the post-transition instant (Temporal-"compatible" policy)', () => {
+    // 02:30 on 2026-03-08 does not exist in New York; the documented
+    // resolution is 03:30 EDT == 07:30Z. Pinning the exact instant (not
+    // just "some valid instant") is what keeps the implementation honest
+    // about which side of the gap it lands on.
     const instant = nyWallClockToUtc('2026-03-08', '02:30:00');
-    expect(Number.isNaN(instant.getTime())).toBe(false);
+    expect(instant.toISOString()).toBe('2026-03-08T07:30:00.000Z');
     expect(nyCalendarDate(instant)).toBe('2026-03-08');
   });
 
-  test('fall-back ambiguous time resolves to a valid instant on the same NY calendar date', () => {
+  test('fall-back ambiguous time resolves to the FIRST (EDT) occurrence', () => {
+    // 01:30 on 2026-11-01 happens twice; "compatible" picks the earlier
+    // one: 01:30 EDT == 05:30Z (the second would be 06:30Z EST).
     const instant = nyWallClockToUtc('2026-11-01', '01:30:00');
-    expect(Number.isNaN(instant.getTime())).toBe(false);
+    expect(instant.toISOString()).toBe('2026-11-01T05:30:00.000Z');
     expect(nyCalendarDate(instant)).toBe('2026-11-01');
+  });
+
+  test.each([
+    ['2026-07-04', '25:00:00'], // out-of-range hour parses to an invalid Date
+    ['2026-07-04', '19'], // not HH:MM[:SS]
+    ['2026-07-04', '19:30:00-05:00'], // offset suffix not part of the contract
+    ['07/04/2026', '19:30:00'], // date must be ISO
+    ['2026-07-04', ''],
+  ])('rejects malformed input %s / %s with a clear error', (date, time) => {
+    expect(() => nyWallClockToUtc(date, time)).toThrow(/nyWallClockToUtc/);
   });
 });

--- a/tests/unit/database/ny-time.test.ts
+++ b/tests/unit/database/ny-time.test.ts
@@ -76,12 +76,22 @@ describe('nyWallClockToUtc', () => {
   });
 
   test.each([
-    ['2026-07-04', '25:00:00'], // out-of-range hour parses to an invalid Date
+    ['2026-07-04', '25:00:00'], // out-of-range hour
+    // ECMA-262 quietly accepts T24:00 as next-day midnight, which would
+    // window the event a day late with no error — rejected explicitly.
+    ['2026-07-04', '24:00'],
+    ['2026-07-04', '24:00:00'],
     ['2026-07-04', '19'], // not HH:MM[:SS]
     ['2026-07-04', '19:30:00-05:00'], // offset suffix not part of the contract
     ['07/04/2026', '19:30:00'], // date must be ISO
     ['2026-07-04', ''],
   ])('rejects malformed input %s / %s with a clear error', (date, time) => {
     expect(() => nyWallClockToUtc(date, time)).toThrow(/nyWallClockToUtc/);
+  });
+});
+
+describe('nyCalendarDate — invalid input', () => {
+  test("throws an attributed error on an Invalid Date (not Intl's bare RangeError)", () => {
+    expect(() => nyCalendarDate(new Date('not a date'))).toThrow(/nyCalendarDate/);
   });
 });

--- a/tests/unit/database/ny-time.test.ts
+++ b/tests/unit/database/ny-time.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Pins the America/New_York calendar-date and wall-clock helpers shared by
+ * the two concert writers (`jobs/venue-events-scraper/writer.ts` derives
+ * `starts_on` from an instant; `jobs/triangle-shows-etl` composes
+ * `starts_at`/`doors_at` from the source's date + local time). Both sides
+ * of migration 0112's `starts_on date NOT NULL` invariant flow through
+ * these, so DST correctness is pinned explicitly on both transition days.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { nyCalendarDate, nyWallClockToUtc } from '../../../shared/database/src/ny-time';
+
+describe('nyCalendarDate', () => {
+  test.each([
+    // EST (UTC-5): 2026-01-15T04:59Z is still Jan 14 in New York.
+    ['2026-01-15T04:59:00Z', '2026-01-14'],
+    ['2026-01-15T05:00:00Z', '2026-01-15'],
+    // EDT (UTC-4): 2026-07-04T03:59Z is still Jul 3 in New York.
+    ['2026-07-04T03:59:00Z', '2026-07-03'],
+    ['2026-07-04T04:00:00Z', '2026-07-04'],
+    // The RHP-writer regression case: a late show stored as an 01:30 UTC
+    // instant belongs to the PREVIOUS Eastern calendar day.
+    ['2026-06-14T01:30:00Z', '2026-06-13'],
+  ])('nyCalendarDate(%s) -> %s', (iso, expected) => {
+    expect(nyCalendarDate(new Date(iso))).toBe(expected);
+  });
+});
+
+describe('nyWallClockToUtc', () => {
+  test.each([
+    // EST winter date: 20:00 NY == 01:00Z next day.
+    ['2026-01-15', '20:00:00', '2026-01-16T01:00:00.000Z'],
+    // EDT summer date: 20:00 NY == 00:00Z next day.
+    ['2026-07-04', '20:00:00', '2026-07-05T00:00:00.000Z'],
+    // Seconds honored, HH:MM accepted.
+    ['2026-07-04', '19:30', '2026-07-04T23:30:00.000Z'],
+    // Spring-forward day (2026-03-08): 02:30 NY doesn't exist; resolves to
+    // the post-transition instant (03:30 EDT == 07:30Z, same as 02:30 EST
+    // read forward). Either post-gap reading is 07:30Z under the two-pass
+    // converge; what we pin is: not NaN, and the evening of that day is EDT.
+    ['2026-03-08', '20:00:00', '2026-03-09T00:00:00.000Z'],
+    // Fall-back day (2026-11-01): 01:30 NY is ambiguous; two-pass converge
+    // lands on a valid instant whose NY reading is 01:30 — pin the evening
+    // of that day as EST.
+    ['2026-11-01', '20:00:00', '2026-11-02T01:00:00.000Z'],
+  ])('nyWallClockToUtc(%s, %s) -> %s', (date, time, expectedIso) => {
+    expect(nyWallClockToUtc(date, time).toISOString()).toBe(expectedIso);
+  });
+
+  test('spring-forward gap time resolves to a valid instant that round-trips to the same NY calendar date', () => {
+    const instant = nyWallClockToUtc('2026-03-08', '02:30:00');
+    expect(Number.isNaN(instant.getTime())).toBe(false);
+    expect(nyCalendarDate(instant)).toBe('2026-03-08');
+  });
+
+  test('fall-back ambiguous time resolves to a valid instant on the same NY calendar date', () => {
+    const instant = nyWallClockToUtc('2026-11-01', '01:30:00');
+    expect(Number.isNaN(instant.getTime())).toBe(false);
+    expect(nyCalendarDate(instant)).toBe('2026-11-01');
+  });
+});

--- a/tests/unit/database/schema.concerts.test.ts
+++ b/tests/unit/database/schema.concerts.test.ts
@@ -96,14 +96,14 @@ describe('schema: venues + concerts (migration 0091, venue-events-scraper)', () 
       );
     });
 
-    it('declares the (venue_id, starts_at) index for "what is playing at X this week?" queries', () => {
+    it('declares the (venue_id, starts_at) index for "what is playing at X this week?" queries (timed rows only post-0112 — date-only rows window on starts_on)', () => {
       const def = extractTableDef('concerts');
       expect(def).toMatch(
         /index\(['"]concerts_venue_starts_at_idx['"]\)[\s\S]*?\.on\(table\.venue_id,\s*table\.starts_at\)/
       );
     });
 
-    it('declares the (headlining_artist_id, starts_at) index for "next tour date for artist Y?" queries', () => {
+    it('declares the (headlining_artist_id, starts_at) index for "next tour date for artist Y?" queries (timed rows only post-0112 — date-only rows window on starts_on)', () => {
       const def = extractTableDef('concerts');
       expect(def).toMatch(
         /index\(['"]concerts_headlining_artist_starts_at_idx['"]\)[\s\S]*?\.on\(table\.headlining_artist_id,\s*table\.starts_at\)/
@@ -157,11 +157,33 @@ describe('schema: venues + concerts (migration 0091, venue-events-scraper)', () 
       expect(d).toMatch(/price_max:\s*numeric\(['"]price_max['"],\s*\{\s*precision:\s*8,\s*scale:\s*2\s*\}\)/);
       expect(d).toMatch(/age_restriction:\s*varchar\(['"]age_restriction['"],\s*\{\s*length:\s*50\s*\}\)/);
       expect(d).toMatch(/removed_at:\s*timestamp\(['"]removed_at['"]/);
-      for (const promoted of ['title:', 'doors_at:', 'price_min:', 'price_max:', 'age_restriction:', 'removed_at:']) {
-        const column = d.match(new RegExp(`${promoted}[^,\\n]*(?:\\{[^}]*\\})?[^,\\n]*`));
+      // Paren-bounded extraction (the idiom the first_scraped_at pin above
+      // uses): `X: builder([...])<chain-until-comma-or-newline>`. A naive
+      // `[^,\n]*` from the column name stops at the comma INSIDE the
+      // builder call and never sees a chained .notNull() — which is the
+      // exact thing this test exists to catch.
+      for (const promoted of ['title', 'doors_at', 'price_min', 'price_max', 'age_restriction', 'removed_at']) {
+        const column = d.match(new RegExp(`${promoted}:\\s*\\w+\\([^)]*\\)[^,\\n]*`));
         expect(column?.[0]).toBeDefined();
         expect(column?.[0]).not.toMatch(/\.notNull\(\)/);
       }
+    });
+
+    it('declares the concerts_derive_starts_on trigger in 0112 (DB owns the starts_on <-> starts_at invariant)', () => {
+      const sql112 = fs.readFileSync(
+        path.join(
+          migrationsDir,
+          `${journal.entries.find((e) => e.tag.startsWith('0112_'))?.tag ?? '0112-missing'}.sql`
+        ),
+        'utf-8'
+      );
+      expect(sql112).toMatch(/CREATE OR REPLACE FUNCTION wxyc_schema\.concerts_derive_starts_on\(\)/);
+      expect(sql112).toMatch(
+        /CREATE TRIGGER concerts_derive_starts_on\s*\nBEFORE INSERT OR UPDATE ON wxyc_schema\.concerts/
+      );
+      // The NULL guard is what preserves date-only rows' writer-supplied
+      // starts_on; without it the trigger would null-out their windowing.
+      expect(sql112).toMatch(/IF NEW\.starts_at IS NOT NULL THEN/);
     });
 
     it('declares the starts_on-first curated-feed partial index (resolver-stamped, not tombstoned)', () => {
@@ -187,24 +209,26 @@ describe('schema: venues + concerts (migration 0091, venue-events-scraper)', () 
     });
 
     it('backfills starts_on before SET NOT NULL and pairs the UPDATE with an ANALYZE', () => {
-      // Order matters: add nullable -> backfill -> SET NOT NULL. A plain
-      // `ADD COLUMN starts_on date NOT NULL` cannot apply to a non-empty
-      // table, which is exactly the deploy-wedge this pin guards against.
-      const addIdx = sql112.indexOf('ADD COLUMN "starts_on" date');
-      const backfillIdx = sql112.indexOf('SET "starts_on" =');
-      const notNullIdx = sql112.indexOf('ALTER COLUMN "starts_on" SET NOT NULL');
-      expect(addIdx).toBeGreaterThan(-1);
-      expect(backfillIdx).toBeGreaterThan(addIdx);
-      expect(notNullIdx).toBeGreaterThan(backfillIdx);
-      // Scan DDL lines only — the migration's comment header quotes the
-      // forbidden single-statement form when explaining the hand-split.
+      // Scan DDL lines only for EVERY position probe — the migration's
+      // comment header quotes 'ADD COLUMN "starts_on" date NOT NULL' when
+      // explaining the hand-split, so an indexOf against the raw file
+      // would anchor on the comment and make the ordering pin vacuous.
       const ddlOnly = sql112
         .split('\n')
         .filter((line) => !line.trimStart().startsWith('--'))
         .join('\n');
+      // Order matters: add nullable -> backfill -> SET NOT NULL. A plain
+      // `ADD COLUMN starts_on date NOT NULL` cannot apply to a non-empty
+      // table, which is exactly the deploy-wedge this pin guards against.
+      const addIdx = ddlOnly.indexOf('ADD COLUMN "starts_on" date');
+      const backfillIdx = ddlOnly.indexOf('SET "starts_on" =');
+      const notNullIdx = ddlOnly.indexOf('ALTER COLUMN "starts_on" SET NOT NULL');
+      expect(addIdx).toBeGreaterThan(-1);
+      expect(backfillIdx).toBeGreaterThan(addIdx);
+      expect(notNullIdx).toBeGreaterThan(backfillIdx);
       expect(ddlOnly).not.toMatch(/ADD COLUMN "starts_on" date NOT NULL/);
-      expect(sql112).toMatch(/AT TIME ZONE 'America\/New_York'/);
-      expect(sql112).toMatch(/ANALYZE "wxyc_schema"\."concerts"/);
+      expect(ddlOnly).toMatch(/AT TIME ZONE 'America\/New_York'/);
+      expect(ddlOnly).toMatch(/ANALYZE "wxyc_schema"\."concerts"/);
     });
 
     it('drops NOT NULL on starts_at (never drops rows — first_scraped_at anchors #1373)', () => {

--- a/tests/unit/database/schema.concerts.test.ts
+++ b/tests/unit/database/schema.concerts.test.ts
@@ -64,10 +64,10 @@ describe('schema: venues + concerts (migration 0091, venue-events-scraper)', () 
       expect(schemaSource).toMatch(/export const concerts\s*=\s*wxyc_schema\.table/);
     });
 
-    it('has the source-tagged identity columns', () => {
+    it('has the source-tagged identity columns (source_id is text post-0112 — triangle-shows venue-qualified keys reach ~1165 chars)', () => {
       const def = extractTableDef('concerts');
       expect(def).toMatch(/source:\s*concertSourceEnum\(['"]source['"]/);
-      expect(def).toMatch(/source_id:\s*varchar\(['"]source_id['"]/);
+      expect(def).toMatch(/source_id:\s*text\(['"]source_id['"]/);
     });
 
     it('FKs venue_id to venues.id with ON DELETE restrict (concerts live only when their venue does)', () => {
@@ -131,10 +131,93 @@ describe('schema: venues + concerts (migration 0091, venue-events-scraper)', () 
     });
   });
 
+  // Migration 0112 (BS#1589): triangle-shows substrate. starts_on is the
+  // NOT NULL venue-local windowing column; starts_at goes nullable
+  // (date-only events, no fabricated times); promoted columns are all
+  // nullable so existing rhp_scrape rows are untouched.
+  describe('concerts table — 0112 triangle-shows substrate (BS#1589)', () => {
+    const def = () => extractTableDef('concerts');
+
+    it('declares starts_on as a NOT NULL date (the windowing column)', () => {
+      expect(def()).toMatch(/starts_on:\s*date\(['"]starts_on['"]\)\.notNull\(\)/);
+    });
+
+    it('declares starts_at as a NULLABLE timestamptz (date-only events carry no time)', () => {
+      const column = def().match(/starts_at:\s*timestamp\([^)]*\)[^,]*/);
+      expect(column?.[0]).toBeDefined();
+      expect(column?.[0]).toMatch(/withTimezone:\s*true/);
+      expect(column?.[0]).not.toMatch(/\.notNull\(\)/);
+    });
+
+    it('has the promoted columns, all nullable', () => {
+      const d = def();
+      expect(d).toMatch(/title:\s*text\(['"]title['"]\)/);
+      expect(d).toMatch(/doors_at:\s*timestamp\(['"]doors_at['"]/);
+      expect(d).toMatch(/price_min:\s*numeric\(['"]price_min['"],\s*\{\s*precision:\s*8,\s*scale:\s*2\s*\}\)/);
+      expect(d).toMatch(/price_max:\s*numeric\(['"]price_max['"],\s*\{\s*precision:\s*8,\s*scale:\s*2\s*\}\)/);
+      expect(d).toMatch(/age_restriction:\s*varchar\(['"]age_restriction['"],\s*\{\s*length:\s*50\s*\}\)/);
+      expect(d).toMatch(/removed_at:\s*timestamp\(['"]removed_at['"]/);
+      for (const promoted of ['title:', 'doors_at:', 'price_min:', 'price_max:', 'age_restriction:', 'removed_at:']) {
+        const column = d.match(new RegExp(`${promoted}[^,\\n]*(?:\\{[^}]*\\})?[^,\\n]*`));
+        expect(column?.[0]).toBeDefined();
+        expect(column?.[0]).not.toMatch(/\.notNull\(\)/);
+      }
+    });
+
+    it('declares the starts_on-first curated-feed partial index (resolver-stamped, not tombstoned)', () => {
+      expect(def()).toMatch(
+        /index\(['"]concerts_curated_starts_on_idx['"]\)[\s\S]*?\.on\(table\.starts_on\)[\s\S]*?\.where\(sql`[\s\S]*?headlining_artist_id[\s\S]*?IS NOT NULL[\s\S]*?removed_at[\s\S]*?IS NULL/
+      );
+    });
+  });
+
+  describe('migration 0112 (triangle-shows substrate, BS#1589)', () => {
+    const entry112 = journal.entries.find((e) => e.tag.startsWith('0112_'));
+    const sqlPath112 = entry112 ? path.join(migrationsDir, `${entry112.tag}.sql`) : null;
+    const sql112 = sqlPath112 && fs.existsSync(sqlPath112) ? fs.readFileSync(sqlPath112, 'utf-8') : '';
+
+    it('exists in the journal', () => {
+      expect(entry112).toBeDefined();
+      expect(entry112?.tag).toMatch(/^0112_triangle-shows-concerts$/);
+    });
+
+    it('adds the triangle_shows enum value and widens source_id to text', () => {
+      expect(sql112).toMatch(/ALTER TYPE "wxyc_schema"\."concert_source_enum" ADD VALUE 'triangle_shows'/);
+      expect(sql112).toMatch(/ALTER COLUMN "source_id" SET DATA TYPE text/);
+    });
+
+    it('backfills starts_on before SET NOT NULL and pairs the UPDATE with an ANALYZE', () => {
+      // Order matters: add nullable -> backfill -> SET NOT NULL. A plain
+      // `ADD COLUMN starts_on date NOT NULL` cannot apply to a non-empty
+      // table, which is exactly the deploy-wedge this pin guards against.
+      const addIdx = sql112.indexOf('ADD COLUMN "starts_on" date');
+      const backfillIdx = sql112.indexOf('SET "starts_on" =');
+      const notNullIdx = sql112.indexOf('ALTER COLUMN "starts_on" SET NOT NULL');
+      expect(addIdx).toBeGreaterThan(-1);
+      expect(backfillIdx).toBeGreaterThan(addIdx);
+      expect(notNullIdx).toBeGreaterThan(backfillIdx);
+      // Scan DDL lines only — the migration's comment header quotes the
+      // forbidden single-statement form when explaining the hand-split.
+      const ddlOnly = sql112
+        .split('\n')
+        .filter((line) => !line.trimStart().startsWith('--'))
+        .join('\n');
+      expect(ddlOnly).not.toMatch(/ADD COLUMN "starts_on" date NOT NULL/);
+      expect(sql112).toMatch(/AT TIME ZONE 'America\/New_York'/);
+      expect(sql112).toMatch(/ANALYZE "wxyc_schema"\."concerts"/);
+    });
+
+    it('drops NOT NULL on starts_at (never drops rows — first_scraped_at anchors #1373)', () => {
+      expect(sql112).toMatch(/ALTER COLUMN "starts_at" DROP NOT NULL/);
+      expect(sql112).not.toMatch(/DELETE FROM/i);
+    });
+  });
+
   describe('enums', () => {
-    it('declares concert_source_enum with rhp_scrape as initial value', () => {
+    it('declares concert_source_enum with rhp_scrape and triangle_shows (0112)', () => {
       expect(schemaSource).toMatch(/concertSourceEnum\s*=\s*wxyc_schema\.enum\(['"]concert_source_enum['"]/);
       expect(schemaSource).toMatch(/['"]rhp_scrape['"]/);
+      expect(schemaSource).toMatch(/['"]triangle_shows['"]/);
     });
 
     it('declares concert_status_enum with the four lifecycle states', () => {

--- a/tests/unit/jobs/venue-events-scraper/writer.test.ts
+++ b/tests/unit/jobs/venue-events-scraper/writer.test.ts
@@ -36,6 +36,37 @@ const fakeParsed = (suffix: string): ParsedConcert => ({
   raw: { '@type': 'Event', name: 'Test Headliner', startDate: '2026-11-06T20:00:00-0500' },
 });
 
+// ---- shared mock-chain plumbing (used by the BS#1385 and 0112 blocks) ----
+
+// Normalize Drizzle's `values(obj | obj[])` overload — return EVERY row so a
+// future refactor to a batched `values([r0, r1, ...])` call can't slip a
+// regression past us by only touching r1+. Plain-object form is wrapped to a
+// 1-element array for uniform iteration.
+const rowsFromValuesArg = (arg: unknown): Record<string, unknown>[] => {
+  const rows = Array.isArray(arg) ? arg : [arg];
+  return rows.filter((r): r is Record<string, unknown> => !!r && typeof r === 'object');
+};
+
+// Structural discriminator — pick the concerts upsert out of any co-located
+// mock invocations (e.g. ensureVenue under a future refactor) by keys that
+// uniquely belong to concerts and NOT to venues' payload: `source_id`
+// (venues uses `slug`) + `venue_id` (an FK venues' own row has no reason to
+// carry). Deliberately does NOT include `scraped_at` so the BS#1385 block's
+// scraped_at-presence anchor can actually fire if the writer drops it.
+// ONE definition shared by both describe blocks — a drifted copy would let
+// them disagree about which calls are the concerts upsert.
+const isConcertRow = (r: Record<string, unknown>): boolean => 'source_id' in r && 'venue_id' in r;
+
+const concertInsertRows = (): Record<string, unknown>[] =>
+  mockDb._chain.values.mock.calls.flatMap((c: unknown[]) => rowsFromValuesArg(c[0])).filter(isConcertRow);
+
+// Discriminate set: clauses via `venue_id` — concerts' set lists it; venues'
+// seeded-path set lists name/city/state/address/last_modified only.
+const concertSetClauses = (): Record<string, unknown>[] =>
+  mockDb._chain.onConflictDoUpdate.mock.calls
+    .map((c: unknown[]) => (c[0] as { set?: Record<string, unknown> } | undefined)?.set)
+    .filter((set): set is Record<string, unknown> => !!set && 'venue_id' in set);
+
 describe('upsertConcert', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -83,27 +114,6 @@ describe('upsertConcert', () => {
   // insert-time value. One decision (omit the column from the upsert
   // payload), pinned at both read-positions.
   describe('first_scraped_at INSERT-only invariant (BS#1385)', () => {
-    // Normalize Drizzle's `values(obj | obj[])` overload — return EVERY
-    // row so a future refactor to a batched `values([r0, r1, ...])` call
-    // can't slip a regression past us by only adding first_scraped_at to
-    // r1+. Plain-object form is wrapped to a 1-element array for uniform
-    // iteration below.
-    const concertRows = (arg: unknown): Record<string, unknown>[] => {
-      const rows = Array.isArray(arg) ? arg : [arg];
-      return rows.filter((r): r is Record<string, unknown> => !!r && typeof r === 'object');
-    };
-
-    // Structural discriminator — pick the concerts upsert out of any
-    // co-located mock invocations (e.g. ensureVenue under a future
-    // refactor) by keys that uniquely belong to concerts and NOT to
-    // venues' payload: `source_id` (venues uses `slug`) + `venue_id`
-    // (an FK that venues' own row has no reason to carry). Deliberately
-    // does NOT include `scraped_at` so the separate scraped_at-presence
-    // anchor below can actually fire if the writer ever drops it.
-    // Keeps the test green if the writer ever routes `source` through a
-    // constant / enum reference instead of the literal 'rhp_scrape'.
-    const isConcertRow = (r: Record<string, unknown>): boolean => 'source_id' in r && 'venue_id' in r;
-
     it('omits first_scraped_at from both the INSERT values and the ON CONFLICT set', async () => {
       mockDb._chain.returning.mockResolvedValueOnce([{ id: 1, inserted: true }]);
 
@@ -114,8 +124,7 @@ describe('upsertConcert', () => {
       // absent everywhere — the schema's DEFAULT now() is what populates
       // it; spelling it in `values` would shadow the DEFAULT and
       // re-collapse the stability clock into per-writer wall-clock noise.
-      const allInsertRows = mockDb._chain.values.mock.calls.flatMap((c: unknown[]) => concertRows(c[0]));
-      const concertInserts = allInsertRows.filter(isConcertRow);
+      const concertInserts = concertInsertRows();
       // Sanity-anchor: at least one concerts INSERT row materialized AND
       // the writer still spells `scraped_at` (which BS#1385's clock
       // contrast hangs on). Pinning the anchor explicitly means a future
@@ -133,21 +142,15 @@ describe('upsertConcert', () => {
       // refactor that drops .onConflictDoUpdate() (split INSERT/UPDATE,
       // raw SQL, etc.) doesn't make the loop body silently vacuous.
       expect(mockDb._chain.onConflictDoUpdate).toHaveBeenCalled();
-      const concertSetClauses = mockDb._chain.onConflictDoUpdate.mock.calls
-        .map((c: unknown[]) => (c[0] as { set?: Record<string, unknown> } | undefined)?.set)
-        // Discriminate via `venue_id` — concerts' set: lists it; venues'
-        // seeded-path set: lists name/city/state/address/last_modified
-        // only. Excluding `scraped_at` from the discriminator keeps the
-        // independent anchor below meaningful.
-        .filter((set): set is Record<string, unknown> => !!set && 'venue_id' in set);
+      const sets = concertSetClauses();
       // Same anchor on the UPDATE side: at least one concerts set: clause
       // present, and `scraped_at` is still in it (the contrast that
       // motivates first_scraped_at). Catches a future refactor that
       // reformulates "last successful sweep" via a different column
       // before it silently disables the BS#1385 guard.
-      expect(concertSetClauses.length).toBeGreaterThan(0);
-      expect(concertSetClauses[0]).toHaveProperty('scraped_at');
-      for (const set of concertSetClauses) {
+      expect(sets.length).toBeGreaterThan(0);
+      expect(sets[0]).toHaveProperty('scraped_at');
+      for (const set of sets) {
         // Adding first_scraped_at to `set` would overwrite the insert
         // moment on every nightly re-scrape — the exact failure mode
         // scraped_at already has, and the reason this column exists.
@@ -168,16 +171,6 @@ describe('starts_on venue-local calendar date (migration 0112, BS#1589)', () => 
     jest.clearAllMocks();
   });
 
-  const insertRowsAndSetClauses = () => {
-    const values = mockDb._chain.values.mock.calls
-      .flatMap((c: unknown[]) => (Array.isArray(c[0]) ? c[0] : [c[0]]))
-      .filter((r): r is Record<string, unknown> => !!r && typeof r === 'object' && 'source_id' in r);
-    const sets = mockDb._chain.onConflictDoUpdate.mock.calls
-      .map((c: unknown[]) => (c[0] as { set?: Record<string, unknown> } | undefined)?.set)
-      .filter((set): set is Record<string, unknown> => !!set && 'venue_id' in set);
-    return { values, sets };
-  };
-
   it('writes starts_on in both the INSERT values and the ON CONFLICT set', async () => {
     mockDb._chain.returning.mockResolvedValueOnce([{ id: 1, inserted: true }]);
 
@@ -185,7 +178,8 @@ describe('starts_on venue-local calendar date (migration 0112, BS#1589)', () => 
     // the NY calendar date is Nov 6.
     await upsertConcert(fakeParsed('starts-on'), 1, new Date('2026-06-05T12:00:00Z'));
 
-    const { values, sets } = insertRowsAndSetClauses();
+    const values = concertInsertRows();
+    const sets = concertSetClauses();
     expect(values.length).toBeGreaterThan(0);
     expect(sets.length).toBeGreaterThan(0);
     for (const row of values) expect(row).toHaveProperty('starts_on', '2026-11-06');
@@ -199,7 +193,7 @@ describe('starts_on venue-local calendar date (migration 0112, BS#1589)', () => 
     const parsed = { ...fakeParsed('late-show'), starts_at: '2026-06-14T01:30:00Z' };
     await upsertConcert(parsed, 1, new Date('2026-06-05T12:00:00Z'));
 
-    const { values } = insertRowsAndSetClauses();
+    const values = concertInsertRows();
     expect(values.length).toBeGreaterThan(0);
     expect(values[0]).toHaveProperty('starts_on', '2026-06-13');
   });

--- a/tests/unit/jobs/venue-events-scraper/writer.test.ts
+++ b/tests/unit/jobs/venue-events-scraper/writer.test.ts
@@ -157,6 +157,54 @@ describe('upsertConcert', () => {
   });
 });
 
+// Migration 0112 (BS#1589) — `starts_on date NOT NULL` is the venue-local
+// calendar-date windowing column. The RHP writer must compute it from
+// `starts_at` in America/New_York in BOTH the insert values and the ON
+// CONFLICT set (a reschedule can move the calendar date). Missing either
+// side fails the NOT NULL constraint on the first post-deploy scrape —
+// and `npm run typecheck` doesn't cover jobs/**, so this test is the net.
+describe('starts_on venue-local calendar date (migration 0112, BS#1589)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const insertRowsAndSetClauses = () => {
+    const values = mockDb._chain.values.mock.calls
+      .flatMap((c: unknown[]) => (Array.isArray(c[0]) ? c[0] : [c[0]]))
+      .filter((r): r is Record<string, unknown> => !!r && typeof r === 'object' && 'source_id' in r);
+    const sets = mockDb._chain.onConflictDoUpdate.mock.calls
+      .map((c: unknown[]) => (c[0] as { set?: Record<string, unknown> } | undefined)?.set)
+      .filter((set): set is Record<string, unknown> => !!set && 'venue_id' in set);
+    return { values, sets };
+  };
+
+  it('writes starts_on in both the INSERT values and the ON CONFLICT set', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 1, inserted: true }]);
+
+    // fakeParsed's starts_at is 2026-11-06T20:00:00-0500 == 2026-11-07T01:00Z;
+    // the NY calendar date is Nov 6.
+    await upsertConcert(fakeParsed('starts-on'), 1, new Date('2026-06-05T12:00:00Z'));
+
+    const { values, sets } = insertRowsAndSetClauses();
+    expect(values.length).toBeGreaterThan(0);
+    expect(sets.length).toBeGreaterThan(0);
+    for (const row of values) expect(row).toHaveProperty('starts_on', '2026-11-06');
+    for (const set of sets) expect(set).toHaveProperty('starts_on', '2026-11-06');
+  });
+
+  it('assigns a late show stored as an early-UTC instant to the PREVIOUS Eastern calendar day', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 2, inserted: true }]);
+
+    // 01:30 UTC on Jun 14 is 21:30 EDT on Jun 13 — the show belongs to Jun 13.
+    const parsed = { ...fakeParsed('late-show'), starts_at: '2026-06-14T01:30:00Z' };
+    await upsertConcert(parsed, 1, new Date('2026-06-05T12:00:00Z'));
+
+    const { values } = insertRowsAndSetClauses();
+    expect(values.length).toBeGreaterThan(0);
+    expect(values[0]).toHaveProperty('starts_on', '2026-06-13');
+  });
+});
+
 describe('ensureVenue (seeded path)', () => {
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
Part 1 + Part 2 of #1589 (Phase 1 of the #1570 touring-events integration): the `concerts` schema substrate for the triangle-shows ETL, plus the RHP writer change that must ride with it. The ETL job itself follows in a stacked PR so this one isolates the schema change.

## Migration 0112

- `concert_source_enum` += `'triangle_shows'` — the documented extension path (venue-events-scraper README: "extend the enum rather than replacing this job"). Added but never used in-transaction, so the PG12+ `ALTER TYPE ... ADD VALUE` restriction doesn't bite.
- `source_id` `varchar(256)` → `text`. The ETL keys rows as `'<venue_slug>:' + source_key` (venue-qualified — triangle-shows uniqueness is per-venue), max ~1165 chars. Binary-coercible: no table rewrite, no REINDEX, existing `rhp_scrape` values untouched.
- `starts_at` drops NOT NULL — many triangle-shows events are date-only and we never fabricate times.
- New `starts_on date NOT NULL` — the venue-local (America/New_York) calendar-date windowing column. Hand-split into add-nullable → backfill (`(starts_at AT TIME ZONE 'America/New_York')::date`, covers 100% of rows since `starts_at` was NOT NULL) → `SET NOT NULL`, + `ANALYZE`. **No row drop** — `first_scraped_at` anchors #1373's stability clock (#1570 correction 1).
- Nullable promoted columns (#1570 Decision 2): `title`, `doors_at`, `price_min`/`price_max` `numeric(8,2)` dollars, `age_restriction varchar(50)`, `removed_at`. `genre`/`subgenre`/`description` stay in `raw_data`.
- `concerts_curated_starts_on_idx` partial index (`WHERE headlining_artist_id IS NOT NULL AND removed_at IS NULL`), `starts_on`-first because both existing composite indexes key on the now-nullable `starts_at` (#1570 correction 4).

Micro-decisions per #1589's proposed resolutions: prices as `numeric(8,2)` dollars (`free` maps to `price_min = 0` in the ETL; formatting is client-side); `source_id` widened rather than hash-compressed (debuggability; btree handles ~1.2k chars).

## RHP writer (`jobs/venue-events-scraper/writer.ts`)

Computes `starts_on` via the new `@wxyc/database` `nyCalendarDate` helper in **both** the insert values and the `onConflictDoUpdate` set (a reschedule can move the calendar date). Deploying the migration without this breaks every insert on the next 05:00 UTC scrape — and `npm run typecheck` doesn't cover `jobs/**`, hence the same-PR rule (#1570 correction 6) and the direct `tsc -p jobs/venue-events-scraper` verification below.

`nyWallClockToUtc` (two-pass DST converge, `Intl`-based, no new dependency) ships alongside for the stacked ETL PR's date+time composition; both helpers are pinned on the DST transition days in `tests/unit/database/ny-time.test.ts`.

## Verification

- Full migration chain applies on a fresh dev DB (`db:start`); post-apply shape verified column-by-column (`starts_on date NOT NULL`, nullable `starts_at`, `source_id text`, partial index, enum value).
- `npm run lint:migrations` clean (journal `when` = tail+1; `@no-precondition-needed` on the SET NOT NULL — the same-transaction backfill covers every row; ANALYZE paired with the UPDATE).
- `npm run typecheck` + direct `npx tsc --noEmit -p jobs/venue-events-scraper` clean; lint 0 errors; unit suite 3,754 green including new pins: `starts_on` in both writer clauses (with the late-show previous-Eastern-day case), 0112 shape assertions, and the hand-split ordering (add → backfill → SET NOT NULL) so the deploy-wedge form can't regress.
- `migrate-dryrun` CI exercises 0112 against the prod snapshot (db-init paths change).

## Deploy note

Migration-touching PR: per the cadence rule, verify the auto-deploy succeeds after merge, then confirm the next 05:00 UTC RHP scrape writes `starts_on` cleanly.

Part of #1589 (closed by the stacked ETL PR, #1593).