### PR TITLE
fix(oidc): trusted-clients hardening bundle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,11 @@ CATALOG_TRACK_SEARCH_DISCOGS_ENABLED=false
 # client behind the full required env var set INCLUDING a non-empty parsed
 # redirect-URL list, so a partially-configured client is omitted from the
 # array entirely rather than silently producing a malformed redirect URL.
+# Env values are trimmed of leading/trailing whitespace at read time (#1586)
+# so a trailing newline or space picked up from a paste error in a password
+# manager doesn't register a broken client id. Each configured clientId must
+# be distinct across the three blocks — a collision fails the auth server at
+# boot with a message naming both offending sources (#1579).
 
 # Flowsheet verifier (see flowsheet-digitization/plans/oidc-auth.md).
 # `FLOWSHEET_OIDC_REDIRECT_URLS` is comma-separated; list every allowed
@@ -171,8 +176,12 @@ FLOWSHEET_OIDC_REDIRECT_URLS=http://localhost:8765/auth/callback
 # there is deliberately NO `WXYC_CANARY_OIDC_CLIENT_SECRET` — the canary
 # stops at the /authorize 302 without exchanging the code, so a client
 # secret would only widen the blast radius of a leaked canary env. Redirect
-# URL is hardcoded to https://canary.wxyc.org/authorize-echo (never has to
-# resolve — the canary reads the 302 Location, doesn't follow it). Set on
-# prod only; leave unset locally.
+# URL is hardcoded to https://canary.wxyc.invalid/authorize-echo — the
+# `.invalid` TLD (RFC 2606 §2) guarantees non-resolution, which closes the
+# #1584 exploit surface where a future listener on `canary.wxyc.org` would
+# become a silent redirect target under `skipConsent: true`. The canary
+# reads the 302 Location with `redirect: 'manual'` and doesn't follow it,
+# so the target host never has to resolve. Set on prod only; leave unset
+# locally. Values are trimmed of leading/trailing whitespace at read time.
 # WXYC_CANARY_OIDC_CLIENT_ID=wxyc-canary
 

--- a/shared/authentication/src/auth.definition.ts
+++ b/shared/authentication/src/auth.definition.ts
@@ -218,6 +218,20 @@ export const auth = betterAuth({
       loginPage: buildLoginPage(process.env),
       allowDynamicClientRegistration: false,
       requirePKCE: true,
+      // #1580 — route id_token signing through the JWT plugin's asymmetric
+      // key (RS256 / EdDSA) rather than the default per-client HMAC (HS256).
+      // Better-auth's HS256 path signs with `client.clientSecret` as the
+      // HMAC key (`node_modules/better-auth/dist/plugins/oidc-provider/index.mjs:649`);
+      // for a public client (`type: 'public'`, no `clientSecret`), the call
+      // reduces to `sign(new TextEncoder().encode(undefined))` → zero-length
+      // key → jose throws `JWSInvalid` → 500 out of the token endpoint. The
+      // JWT plugin's asymmetric signer works uniformly for `web` and
+      // `public` clients and needs no per-client secret. This flag requires
+      // the `jwt()` plugin to be registered ahead of `oidcProvider` — the
+      // pin is asserted by `tests/unit/authentication/oidc-provider-public-client-jwt.test.ts`.
+      // Do not flip this to `false` without also removing the wxyc-canary
+      // public trustedClient (see #1578, wxyc-canary#60).
+      useJWTPlugin: true,
       trustedClients: buildTrustedClients(process.env),
       getAdditionalUserInfoClaim: async (userRecord) => {
         try {

--- a/shared/authentication/src/oidc-trusted-clients.ts
+++ b/shared/authentication/src/oidc-trusted-clients.ts
@@ -10,7 +10,14 @@
  *      `process.env` directly — it breaks unit-test injection). The single
  *      production call site in `auth.definition.ts` passes `process.env`
  *      explicitly.
- *   2. Gating the push on the full required-env-var set, INCLUDING a
+ *   2. Trimming each env value once at read time via `readEnv` before the
+ *      truthy check and assignment. GH-secret-to-EC2 workflows can pick up
+ *      a trailing newline or leading space from a paste error in a password
+ *      manager; without a trim, the truthy check passes, the clientId is
+ *      registered with the padding, and better-auth's strict `===` client
+ *      lookup returns invalid_client on the next login (silent failure).
+ *      See #1586 for the failure mode.
+ *   3. Gating the push on the full required-env-var set, INCLUDING a
  *      non-empty parsed `redirectUrls` array. A partially configured client
  *      silently produces a malformed redirect URL or a non-functional
  *      code-exchange (better-auth's authorize endpoint rejects every login
@@ -22,43 +29,79 @@
  * screen is a UX papercut, not a trust boundary. When adding a third-party
  * or less-trusted app, set `skipConsent: false` so the user sees the
  * standard consent screen.
+ *
+ * Duplicate-clientId guard: at the end of the build, every registered
+ * clientId must be unique. If an operator accidentally sets two env vars
+ * to the same clientId, the sequential upsert loop in
+ * `bootstrap-trusted-clients.ts` would clobber one row with the other's
+ * shape (e.g. a wiki.js `type: 'web'` row flips to `type: 'public'` with a
+ * null clientSecret), breaking that login flow silently. Throwing at boot
+ * turns a would-be silent login regression into a loud, fixable startup
+ * failure. See #1579.
  */
 
 import type { Client } from 'better-auth/plugins';
 
+// Extract clientId once per client so both the dedup error message and the
+// `Client` object see the same trimmed value. Also names each source group
+// so the dedup error can point at the two colliding env-var blocks.
+interface Registration {
+  source: string;
+  client: Client;
+}
+
+// Trim once, at read time. Returns undefined for missing OR whitespace-only
+// values so the caller can gate on truthiness against a canonical value.
+const readEnv = (value: string | undefined): string | undefined => {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+};
+
 export function buildTrustedClients(env: NodeJS.ProcessEnv): Client[] {
-  const clients: Client[] = [];
+  const registrations: Registration[] = [];
 
-  if (env.WIKIJS_OIDC_CLIENT_ID && env.WIKIJS_OIDC_CLIENT_SECRET && env.WIKIJS_URL) {
-    clients.push({
-      clientId: env.WIKIJS_OIDC_CLIENT_ID,
-      clientSecret: env.WIKIJS_OIDC_CLIENT_SECRET,
-      redirectUrls: [`${env.WIKIJS_URL}/login/oidc/callback`],
-      name: 'Wiki.js',
-      type: 'web',
-      disabled: false,
-      icon: undefined,
-      metadata: null,
-      skipConsent: true,
-    });
-  }
-
-  if (env.FLOWSHEET_OIDC_CLIENT_ID && env.FLOWSHEET_OIDC_CLIENT_SECRET) {
-    const redirectUrls = (env.FLOWSHEET_OIDC_REDIRECT_URLS || '')
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
-    if (redirectUrls.length > 0) {
-      clients.push({
-        clientId: env.FLOWSHEET_OIDC_CLIENT_ID,
-        clientSecret: env.FLOWSHEET_OIDC_CLIENT_SECRET,
-        redirectUrls,
-        name: 'Flowsheet Verifier',
+  const wikiClientId = readEnv(env.WIKIJS_OIDC_CLIENT_ID);
+  const wikiClientSecret = readEnv(env.WIKIJS_OIDC_CLIENT_SECRET);
+  const wikiUrl = readEnv(env.WIKIJS_URL);
+  if (wikiClientId && wikiClientSecret && wikiUrl) {
+    registrations.push({
+      source: 'Wiki.js',
+      client: {
+        clientId: wikiClientId,
+        clientSecret: wikiClientSecret,
+        redirectUrls: [`${wikiUrl}/login/oidc/callback`],
+        name: 'Wiki.js',
         type: 'web',
         disabled: false,
         icon: undefined,
         metadata: null,
         skipConsent: true,
+      },
+    });
+  }
+
+  const flowsheetClientId = readEnv(env.FLOWSHEET_OIDC_CLIENT_ID);
+  const flowsheetClientSecret = readEnv(env.FLOWSHEET_OIDC_CLIENT_SECRET);
+  if (flowsheetClientId && flowsheetClientSecret) {
+    const redirectUrls = (env.FLOWSHEET_OIDC_REDIRECT_URLS || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (redirectUrls.length > 0) {
+      registrations.push({
+        source: 'Flowsheet Verifier',
+        client: {
+          clientId: flowsheetClientId,
+          clientSecret: flowsheetClientSecret,
+          redirectUrls,
+          name: 'Flowsheet Verifier',
+          type: 'web',
+          disabled: false,
+          icon: undefined,
+          metadata: null,
+          skipConsent: true,
+        },
       });
     }
   }
@@ -69,23 +112,53 @@ export function buildTrustedClients(env: NodeJS.ProcessEnv): Client[] {
   // client: no `client_secret` in the canary env, and the probe stops at the
   // /authorize 302 without exchanging the code — so `type: 'public'` gates the
   // token endpoint's `client_secret` check (better-auth's
-  // `node_modules/.../oidc-provider/index.mjs:541`) to require `code_verifier`
-  // instead. The redirect URL is a placeholder; the canary reads the 302
-  // `Location` with `redirect: 'manual'` and inspects it in-process — no
-  // listener stands up at `canary.wxyc.org/authorize-echo`. See wxyc-canary#60.
-  if (env.WXYC_CANARY_OIDC_CLIENT_ID) {
-    clients.push({
-      clientId: env.WXYC_CANARY_OIDC_CLIENT_ID,
-      clientSecret: undefined,
-      redirectUrls: ['https://canary.wxyc.org/authorize-echo'],
-      name: 'WXYC Canary',
-      type: 'public',
-      disabled: false,
-      icon: undefined,
-      metadata: null,
-      skipConsent: true,
+  // `node_modules/.../oidc-provider/index.mjs:547`) to require `code_verifier`
+  // instead.
+  //
+  // Redirect URL uses the `.invalid` TLD (RFC 2606 §2, reserved for guaranteed
+  // non-resolution) rather than a WXYC-controlled hostname. The canary reads
+  // the 302 `Location` with `redirect: 'manual'` and inspects it in-process,
+  // so the host never has to resolve. Pinning to `.invalid` closes the #1584
+  // exploit surface where a future S3/CDN listener on `canary.wxyc.org` would
+  // become a silent redirect target under `skipConsent: true`. See
+  // wxyc-canary#60 (probe) and wxyc-canary#61 (redirect-URI parameter).
+  const canaryClientId = readEnv(env.WXYC_CANARY_OIDC_CLIENT_ID);
+  if (canaryClientId) {
+    registrations.push({
+      source: 'WXYC Canary',
+      client: {
+        clientId: canaryClientId,
+        clientSecret: undefined,
+        redirectUrls: ['https://canary.wxyc.invalid/authorize-echo'],
+        name: 'WXYC Canary',
+        type: 'public',
+        disabled: false,
+        icon: undefined,
+        metadata: null,
+        skipConsent: true,
+      },
     });
   }
 
-  return clients;
+  assertUniqueClientIds(registrations);
+  return registrations.map((r) => r.client);
+}
+
+// Fails loudly at boot when two configured clients share a clientId. The
+// error names the offending clientId and both source groups so the operator
+// can jump straight to the colliding env vars — without the names, a bare
+// "duplicate clientId" message forces a grep across every WXYC_*_OIDC_CLIENT_ID
+// env var to find the collision.
+function assertUniqueClientIds(registrations: readonly Registration[]): void {
+  const bySeenId = new Map<string, string>();
+  for (const { source, client } of registrations) {
+    const existingSource = bySeenId.get(client.clientId);
+    if (existingSource !== undefined) {
+      throw new Error(
+        `OIDC trustedClients: duplicate clientId "${client.clientId}" registered by both ${existingSource} and ${source}. ` +
+          `Check that WIKIJS_OIDC_CLIENT_ID, FLOWSHEET_OIDC_CLIENT_ID, and WXYC_CANARY_OIDC_CLIENT_ID are all set to distinct values.`
+      );
+    }
+    bySeenId.set(client.clientId, source);
+  }
 }

--- a/tests/unit/authentication/bootstrap-trusted-clients.test.ts
+++ b/tests/unit/authentication/bootstrap-trusted-clients.test.ts
@@ -107,6 +107,25 @@ function flowsheetClient(overrides: Partial<Client> = {}): Client {
   return { ...base, ...overrides };
 }
 
+// Public-client shape (wxyc-canary). Mirrors the actual `Client` type — no
+// `as any`. `clientSecret: undefined` and `type: 'public'` are the two
+// load-bearing coercions in `bootstrap-trusted-clients.ts` (`?? null` on
+// line 67, `?? 'web'` on line 69). See #1585.
+function canaryClient(overrides: Partial<Client> = {}): Client {
+  const base: Client = {
+    clientId: 'wxyc-canary',
+    clientSecret: undefined,
+    redirectUrls: ['https://canary.wxyc.invalid/authorize-echo'],
+    name: 'WXYC Canary',
+    type: 'public',
+    disabled: false,
+    icon: undefined,
+    metadata: null,
+    skipConsent: true,
+  };
+  return { ...base, ...overrides };
+}
+
 describe('bootstrapTrustedClients', () => {
   it('is a no-op when the trustedClients array is empty', async () => {
     const { adapter, calls, rows } = makeFakeAdapter();
@@ -420,6 +439,90 @@ describe('bootstrapTrustedClients', () => {
     const wrapped = thrown as Error & { cause?: unknown };
     expect(wrapped.message).toMatch(/clientId=flowsheet/);
     expect((wrapped.cause as Error | undefined)?.message).toBe('DB unreachable');
+  });
+
+  it('pins the public-client shape on insert: clientSecret null, type "public"', async () => {
+    // #1585 — the bootstrap has two load-bearing coercions for the public-
+    // client shape introduced in #1578:
+    //   line 67: clientSecret: client.clientSecret ?? null
+    //   line 69: type: client.type ?? 'web'
+    // Every existing test uses `clientSecret: 'shh'` and `type: 'web'`, so
+    // the public-client path (`clientSecret: undefined` → null, `type:
+    // 'public'` → 'public') is unpinned. Someone "cleaning up" line 67 to
+    // `?? ''` would give public clients an empty-string HMAC key that
+    // trips #1580 silently; someone dropping the `?? 'web'` on line 69
+    // and passing `type: undefined` at the call site would flip public
+    // clients to `type: undefined` in the DB. Pin the shape here so both
+    // regressions are visible.
+    const { adapter, rows } = makeFakeAdapter();
+
+    const result = await bootstrapTrustedClients(asAdapter(adapter), [canaryClient()]);
+
+    expect(result).toEqual({ created: 1, updated: 0 });
+    const inserted = rows.get('wxyc-canary');
+    assertDefined(inserted, 'wxyc-canary row');
+    // clientSecret must coerce to `null`, NOT to `''` — an empty string
+    // is a valid HMAC key to jose and would sail past the #1580 failure
+    // mode without any test flagging it.
+    expect(inserted.clientSecret).toBeNull();
+    // type must land as literal 'public' — dropping the field or the
+    // `?? 'web'` default would flip this to undefined or 'web'.
+    expect(inserted.type).toBe('public');
+    // Deterministic id preserved for the operator SELECT ... WHERE id
+    // LIKE 'trusted-%' query the module documents.
+    expect(inserted.id).toBe('trusted-wxyc-canary');
+    // Full remaining shape to make sure no other field got clobbered while
+    // the two load-bearing ones were being pinned.
+    expect(inserted).toMatchObject({
+      clientId: 'wxyc-canary',
+      name: 'WXYC Canary',
+      disabled: false,
+      redirectUrls: 'https://canary.wxyc.invalid/authorize-echo',
+      metadata: null,
+      icon: null,
+    });
+  });
+
+  it('pins the public-client shape on update: stale wiki-shape row becomes public shape', async () => {
+    // Symmetric with the wiki/flowsheet drift-tolerant-upsert test. If a
+    // canary row was ever written with a stale non-public shape (e.g., a
+    // partial-config boot that ran before #1580 shipped and mistakenly
+    // registered the canary as `type: 'web'`), the next boot re-upserts
+    // the canonical `type: 'public' + clientSecret: null` shape.
+    const { adapter, calls, rows } = makeFakeAdapter([
+      {
+        id: 'trusted-wxyc-canary',
+        clientId: 'wxyc-canary',
+        clientSecret: 'stale-shh-from-a-past-misconfiguration',
+        name: 'WXYC Canary (old)',
+        type: 'web',
+        disabled: false,
+        redirectUrls: 'https://canary.wxyc.org/authorize-echo',
+        metadata: null,
+        icon: null,
+        userId: null,
+        createdAt: new Date('2026-06-01'),
+        updatedAt: new Date('2026-06-01'),
+      },
+    ]);
+
+    await bootstrapTrustedClients(asAdapter(adapter), [canaryClient()]);
+
+    expect(calls.create).toBe(0);
+    expect(calls.update).toBe(1);
+    const row = rows.get('wxyc-canary');
+    assertDefined(row, 'wxyc-canary row');
+    // Same two load-bearing pins as the create test — asserting them on the
+    // update path too catches a regression that dropped the coercions from
+    // only one of the two branches (they share `buildMutableFields`, but
+    // the pinning is per-branch to make either drift immediately visible).
+    expect(row.clientSecret).toBeNull();
+    expect(row.type).toBe('public');
+    // Redirect URL was also refreshed — proves `buildMutableFields` ran
+    // on the update path with the canary shape, not just the two pinned
+    // fields we're asserting.
+    expect(row.redirectUrls).toBe('https://canary.wxyc.invalid/authorize-echo');
+    expect(row.name).toBe('WXYC Canary');
   });
 
   it('aggregates multiple failures into an AggregateError with a count summary', async () => {

--- a/tests/unit/authentication/build-trusted-clients.test.ts
+++ b/tests/unit/authentication/build-trusted-clients.test.ts
@@ -154,7 +154,7 @@ describe('buildTrustedClients', () => {
       expect(clients[0]).toEqual({
         clientId: 'wxyc-canary',
         clientSecret: undefined,
-        redirectUrls: ['https://canary.wxyc.org/authorize-echo'],
+        redirectUrls: ['https://canary.wxyc.invalid/authorize-echo'],
         name: 'WXYC Canary',
         type: 'public',
         disabled: false,
@@ -241,7 +241,7 @@ describe('buildTrustedClients', () => {
       expect(clients[2]).toEqual({
         clientId: 'wxyc-canary',
         clientSecret: undefined,
-        redirectUrls: ['https://canary.wxyc.org/authorize-echo'],
+        redirectUrls: ['https://canary.wxyc.invalid/authorize-echo'],
         name: 'WXYC Canary',
         type: 'public',
         disabled: false,
@@ -295,6 +295,191 @@ describe('buildTrustedClients', () => {
   describe('neither client', () => {
     it('returns an empty array when no client env vars are set', () => {
       expect(buildTrustedClients({})).toEqual([]);
+    });
+  });
+
+  describe('env-var whitespace trimming', () => {
+    // #1586 — env vars written via GH-secret-to-EC2 workflows can pick up a
+    // trailing newline or space from a paste error in a password manager. The
+    // truthy check passes, the clientId is registered with the padding, and
+    // better-auth's strict `===` client lookup returns invalid_client on the
+    // next login. Silent failure mode — the operator sees a green workflow
+    // and a broken login. Trim before the truthy check and before the
+    // assignment so both the gate and the resulting row use the canonical
+    // value.
+
+    it('trims a trailing newline off WXYC_CANARY_OIDC_CLIENT_ID', () => {
+      const clients = buildTrustedClients({
+        WXYC_CANARY_OIDC_CLIENT_ID: 'wxyc-canary\n',
+      });
+
+      expect(clients).toHaveLength(1);
+      expect(clients[0].clientId).toBe('wxyc-canary');
+    });
+
+    it('trims leading and trailing spaces off WXYC_CANARY_OIDC_CLIENT_ID', () => {
+      const clients = buildTrustedClients({
+        WXYC_CANARY_OIDC_CLIENT_ID: '  wxyc-canary  ',
+      });
+
+      expect(clients).toHaveLength(1);
+      expect(clients[0].clientId).toBe('wxyc-canary');
+    });
+
+    it('treats whitespace-only WXYC_CANARY_OIDC_CLIENT_ID as unset', () => {
+      // '   ' trims to '' — same as unset. Falsy trimmed value gates the
+      // whole block off, so no client is registered.
+      const clients = buildTrustedClients({
+        WXYC_CANARY_OIDC_CLIENT_ID: '   ',
+      });
+
+      expect(clients).toEqual([]);
+    });
+
+    it('trims whitespace off all three wiki.js env vars', () => {
+      const clients = buildTrustedClients({
+        WIKIJS_OIDC_CLIENT_ID: '  wiki-id\n',
+        WIKIJS_OIDC_CLIENT_SECRET: '  wiki-secret  ',
+        WIKIJS_URL: '  https://wiki.wxyc.org  ',
+      });
+
+      expect(clients).toHaveLength(1);
+      expect(clients[0].clientId).toBe('wiki-id');
+      expect(clients[0].clientSecret).toBe('wiki-secret');
+      // Redirect URL is built from the trimmed WIKIJS_URL — no stray spaces
+      // that would send the callback to a malformed origin.
+      expect(clients[0].redirectUrls).toEqual(['https://wiki.wxyc.org/login/oidc/callback']);
+    });
+
+    it('treats whitespace-only WIKIJS_URL as unset (omits the wiki.js entry)', () => {
+      const clients = buildTrustedClients({
+        WIKIJS_OIDC_CLIENT_ID: 'wiki-id',
+        WIKIJS_OIDC_CLIENT_SECRET: 'wiki-secret',
+        WIKIJS_URL: '   ',
+      });
+
+      expect(clients).toEqual([]);
+    });
+
+    it('trims whitespace off flowsheet env vars', () => {
+      const clients = buildTrustedClients({
+        FLOWSHEET_OIDC_CLIENT_ID: '  flowsheet\n',
+        FLOWSHEET_OIDC_CLIENT_SECRET: '  shh  ',
+        FLOWSHEET_OIDC_REDIRECT_URLS: 'https://flowsheet.wxyc.org/auth/callback',
+      });
+
+      expect(clients).toHaveLength(1);
+      expect(clients[0].clientId).toBe('flowsheet');
+      expect(clients[0].clientSecret).toBe('shh');
+    });
+  });
+
+  describe('canary redirect placeholder uses .invalid TLD', () => {
+    // #1584 — RFC 2606 §2 reserves the `.invalid` TLD for guaranteed
+    // non-resolution. The original placeholder `canary.wxyc.org` is a
+    // WXYC-controlled hostname; if anyone ever stood up an S3 static page or
+    // CDN listener there, the `skipConsent: true` bypass would let an
+    // attacker-crafted `/oauth2/authorize` URL silently mint a code and
+    // redirect it to their controlled listener. Pin the `.invalid` TLD
+    // explicitly so a future refactor can't accidentally revert to a
+    // resolvable hostname.
+    it('registers the canary redirect URL against the .invalid TLD', () => {
+      const clients = buildTrustedClients({
+        WXYC_CANARY_OIDC_CLIENT_ID: 'wxyc-canary',
+      });
+
+      expect(clients).toHaveLength(1);
+      expect(clients[0].redirectUrls).toEqual(['https://canary.wxyc.invalid/authorize-echo']);
+    });
+  });
+
+  describe('duplicate clientId guard', () => {
+    // #1579 — buildTrustedClients builds up to three entries from three
+    // env-gated blocks. If two blocks emit the same clientId (operator
+    // accidentally sets WXYC_CANARY_OIDC_CLIENT_ID=wiki-id, for example), the
+    // sequential upsert loop in bootstrap-trusted-clients writes each entry
+    // under the same DB primary key in order — so the second entry's
+    // {type, clientSecret, redirectUrls} clobbers the first. In the wiki-vs-
+    // canary collision case, wiki.js becomes type:'public' with a null
+    // clientSecret, breaking the wiki.js login flow silently. Fail loudly at
+    // boot so the operator sees the misconfiguration before login traffic hits.
+
+    it('throws when two configured clients share a clientId', () => {
+      // Same clientId reused across the canary and wiki.js env-var blocks.
+      expect(() =>
+        buildTrustedClients({
+          WIKIJS_OIDC_CLIENT_ID: 'shared-id',
+          WIKIJS_OIDC_CLIENT_SECRET: 'wiki-secret',
+          WIKIJS_URL: 'https://wiki.wxyc.org',
+          WXYC_CANARY_OIDC_CLIENT_ID: 'shared-id',
+        })
+      ).toThrow(/shared-id/);
+    });
+
+    it('names both offending env-var groups in the error message', () => {
+      // The operator needs to know which env vars collided to fix the paste
+      // error. A bare "duplicate clientId" message forces them to grep every
+      // WXYC_*_OIDC_CLIENT_ID env var to find the collision.
+      let thrown: unknown;
+      try {
+        buildTrustedClients({
+          WIKIJS_OIDC_CLIENT_ID: 'shared-id',
+          WIKIJS_OIDC_CLIENT_SECRET: 'wiki-secret',
+          WIKIJS_URL: 'https://wiki.wxyc.org',
+          WXYC_CANARY_OIDC_CLIENT_ID: 'shared-id',
+        });
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      const err = thrown as Error;
+      expect(err.message).toMatch(/Wiki\.js/);
+      expect(err.message).toMatch(/WXYC Canary/);
+    });
+
+    it('throws on a flowsheet/canary collision (symmetry check)', () => {
+      // The guard treats every client identically, not just wiki-vs-canary.
+      // A future fourth client picks up the same protection for free.
+      expect(() =>
+        buildTrustedClients({
+          FLOWSHEET_OIDC_CLIENT_ID: 'shared-id',
+          FLOWSHEET_OIDC_CLIENT_SECRET: 'shh',
+          FLOWSHEET_OIDC_REDIRECT_URLS: 'https://flowsheet.wxyc.org/auth/callback',
+          WXYC_CANARY_OIDC_CLIENT_ID: 'shared-id',
+        })
+      ).toThrow(/shared-id/);
+    });
+
+    it('does not throw when three distinct clientIds are configured (happy-path regression)', () => {
+      // No behavior change for the correctly-configured case — this is the
+      // one already exercised by "all clients together" but pinned separately
+      // so a regression that always-throws on non-empty input is caught.
+      expect(() =>
+        buildTrustedClients({
+          WIKIJS_OIDC_CLIENT_ID: 'wiki-id',
+          WIKIJS_OIDC_CLIENT_SECRET: 'wiki-secret',
+          WIKIJS_URL: 'https://wiki.wxyc.org',
+          FLOWSHEET_OIDC_CLIENT_ID: 'flowsheet',
+          FLOWSHEET_OIDC_CLIENT_SECRET: 'shh',
+          FLOWSHEET_OIDC_REDIRECT_URLS: 'https://flowsheet.wxyc.org/auth/callback',
+          WXYC_CANARY_OIDC_CLIENT_ID: 'wxyc-canary',
+        })
+      ).not.toThrow();
+    });
+
+    it('detects collisions only after trimming (whitespace-padded matches trim to the same value)', () => {
+      // Belt-and-suspenders: the trim guard from #1586 must apply before the
+      // dedup guard, so a paste-error trailing-space collision surfaces as a
+      // dedup violation instead of silently registering two "distinct" ids
+      // that differ only in trailing whitespace.
+      expect(() =>
+        buildTrustedClients({
+          WIKIJS_OIDC_CLIENT_ID: 'shared-id',
+          WIKIJS_OIDC_CLIENT_SECRET: 'wiki-secret',
+          WIKIJS_URL: 'https://wiki.wxyc.org',
+          WXYC_CANARY_OIDC_CLIENT_ID: 'shared-id\n',
+        })
+      ).toThrow(/shared-id/);
     });
   });
 });

--- a/tests/unit/authentication/oidc-provider-public-client-jwt.test.ts
+++ b/tests/unit/authentication/oidc-provider-public-client-jwt.test.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// #1580 — Better-auth's `oidcProvider` plugin has two id_token signing paths.
+// With `useJWTPlugin: false` (the default), token exchange signs with HS256
+// using `client.clientSecret` as the HMAC key (see
+// `node_modules/better-auth/dist/plugins/oidc-provider/index.mjs:649`). For a
+// public client (`type: 'public'`, no `clientSecret`), that call reduces to
+// `sign(new TextEncoder().encode(undefined))` → zero-length key → jose throws
+// `JWSInvalid` → 500 out of the token endpoint.
+//
+// With `useJWTPlugin: true`, the token exchange delegates to the JWT plugin's
+// asymmetric signer (RS256 / EdDSA), which requires no per-client secret and
+// works uniformly for `web` and `public` clients. The JWT plugin is already
+// registered ahead of `oidcProvider` in `auth.definition.ts`; we just need
+// the flag set.
+//
+// This test pins the flag by source-scan (same technique as the
+// `oidc-provider-schema.test.ts` neighbor). A behavior test would require
+// spinning up the full better-auth instance against a live PG, which is over
+// budget for a unit test. The source-scan catches the regression class that
+// matters: someone flipping the flag off without understanding why it's on.
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+function extractOidcProviderCall(source: string): string {
+  // Slice from `oidcProvider({` through the matching close-brace. Follows
+  // the same brace-counting technique the sibling schema test uses.
+  const anchor = /oidcProvider\(\s*\{/g;
+  const match = anchor.exec(source);
+  if (!match) throw new Error('oidcProvider({ ... }) call not found in auth.definition.ts');
+  const start = match.index + match[0].length;
+  let depth = 1;
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i);
+    }
+  }
+  throw new Error('oidcProvider({ ... }) close not found (unbalanced braces)');
+}
+
+describe('auth.definition.ts oidcProvider public-client id_token signing', () => {
+  const authDefPath = path.resolve(__dirname, '../../../shared/authentication/src/auth.definition.ts');
+  let source: string;
+  let oidcCallBody: string;
+
+  beforeAll(() => {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    source = fs.readFileSync(authDefPath, 'utf-8');
+    const sourceNoComments = stripComments(source);
+    oidcCallBody = extractOidcProviderCall(sourceNoComments);
+  });
+
+  it('sets useJWTPlugin: true so public-client token exchange does not sign HS256 with an empty HMAC key', () => {
+    // Match `useJWTPlugin: true` (with optional whitespace variation). If
+    // this ever flips to `false`, the public-client (`wxyc-canary`) path
+    // regresses to the #1580 500-on-token-exchange failure.
+    expect(oidcCallBody).toMatch(/useJWTPlugin\s*:\s*true/);
+  });
+
+  it('registers the jwt plugin before oidcProvider (required precondition for useJWTPlugin)', () => {
+    // useJWTPlugin: true is a no-op — worse, it 500s at the token endpoint
+    // with "JWT plugin is not enabled" — if the JWT plugin is not in the
+    // plugin chain. Pin the ordering so a future refactor that reorders the
+    // plugin array (or drops jwt()) breaks this test loudly at the source
+    // level rather than at runtime.
+    const jwtIdx = source.search(/\bjwt\s*\(\s*\{/);
+    const oidcIdx = source.search(/\boidcProvider\s*\(\s*\{/);
+    expect(jwtIdx).toBeGreaterThan(-1);
+    expect(oidcIdx).toBeGreaterThan(-1);
+    expect(jwtIdx).toBeLessThan(oidcIdx);
+  });
+});


### PR DESCRIPTION
Five related fixes to the OIDC `trustedClients` config and its bootstrap upsert, all touching `shared/authentication/src/oidc-trusted-clients.ts` and its tests. Each fix is a small, targeted change; the bundle ships as one PR because they all live in the same file and share test infrastructure.

## Summary

- **#1580 — Public-client token exchange 500 (BUG):** Set `useJWTPlugin: true` on the `oidcProvider` plugin so id_token signing goes through the JWT plugin's asymmetric key (RS256 / EdDSA) rather than HS256 with `client.clientSecret`. Prevents the zero-length HMAC key `JWSInvalid` 500 that any wxyc-canary token exchange (or a WIKIJS clientId collision falling through to the same code path) would produce. The JWT plugin is already registered ahead of `oidcProvider`; the fix is a one-line config flag plus a source-scan test that pins both the flag and the plugin ordering.
- **#1586 — Whitespace-trim env vars (BUG):** Trim `WIKIJS_OIDC_CLIENT_{ID,SECRET}`, `WIKIJS_URL`, `FLOWSHEET_OIDC_CLIENT_{ID,SECRET}`, and `WXYC_CANARY_OIDC_CLIENT_ID` once at read time via a shared `readEnv` helper. Closes the silent `invalid_client` failure mode where a GH secret picked up a trailing newline or space from a paste error. Whitespace-only values now gate the block off instead of registering a broken client id.
- **#1584 — Canary redirect uses `.invalid` TLD (SECURITY):** Switch `canary.wxyc.org/authorize-echo` → `canary.wxyc.invalid/authorize-echo`. RFC 2606 §2 reserves the `.invalid` TLD for guaranteed non-resolution. Closes the `skipConsent: true` silent-redirect exploit surface if a future listener ever stood up on the WXYC-controlled host. The `wxyc-canary` `OidcProbeRedirectUri` default should follow in a paired repo PR (wxyc-canary#61).
- **#1579 — Duplicate-clientId guard (BUG):** Fail loudly at boot in `buildTrustedClients` when two configured clients share a clientId. The error names both offending source groups so the operator can jump straight to the colliding env vars. Prevents the sequential bootstrap-upsert clobber that would silently flip Wiki.js to `type: 'public'` on a Wiki+canary id collision. Runs after the whitespace trim so paste-error near-collisions surface as dedup violations rather than silently registering two "distinct" ids that differ only in whitespace.
- **#1585 — Bootstrap public-client shape test coverage (RESILIENCE):** Add a `canaryClient()` fixture and symmetric create + update tests that pin `clientSecret: null` and `type: 'public'` on the inserted / updated row. Regression-tested by flipping `?? null` to `?? ''` in the source and confirming the new tests fail.

Also updates `.env.example` with the RFC 2606 rationale, the trim note, and the dedup-guard note.

## Test plan

- [x] `npm run test:unit` — all 3771 tests green (14 in `bootstrap-trusted-clients.test.ts`, 28 in `build-trusted-clients.test.ts`, 2 in the new `oidc-provider-public-client-jwt.test.ts`).
- [x] `npm run lint` — 0 errors.
- [x] `npm run typecheck` — passes across all workspaces.
- [x] `npm run format:check` — passes.
- [x] Regression check for #1585: flipping `?? null` → `?? ''` on `bootstrap-trusted-clients.ts:67` fails the two new public-client tests as designed.

Closes #1580
Closes #1586
Closes #1584
Closes #1579
Closes #1585