### PR TITLE
chore(check-auth-tables-doc): tree-walk schema, richer exit codes, extracted main-module helper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,14 @@ jobs:
               - 'jobs/**'
               - 'shared/**'
               - 'tests/**'
+              # `scripts/**` covers the ESM static-check + operator scripts
+              # (`scripts/check-*.mjs`, `scripts/lib/*.mjs`, etc.). Prior to
+              # BS#1590 R4-5 an edit here didn't trigger `lint-and-typecheck`
+              # or `unit-tests`, which meant a broken ES-module import in a
+              # script had no CI signal — the script's own pre-push hook
+              # would still run in dev, but a script-only PR could green-CI
+              # its way to `main` with the module unloadable.
+              - 'scripts/**'
               - 'dev_env/mock-api-server/**'
               - 'package.json'
               - 'package-lock.json'
@@ -185,12 +193,12 @@ jobs:
 
   # Auth-tables doc drift (BS#1573). Runs unconditionally on every PR
   # rather than behind a paths filter: the script is zero-dep, ~1s, and
-  # gating `Integration-Tests` on it (via `needs:` below) needs this job
-  # to reach a terminal state on every PR. A paths-filter `if:` would
-  # leave it skipped on unrelated PRs — GHA treats a skipped `needs:` as
-  # satisfied, but the cognitive load of tracking that vs. a required
-  # check that could silently pass isn't worth the second saved. No
-  # `npm ci`; the script has no dependencies.
+  # this job is a required status check on `main` (BS#1587), which means
+  # every PR needs it to reach a terminal state. A paths-filter `if:`
+  # would leave it skipped on unrelated PRs, and branch protection treats
+  # a required check reporting `conclusion=skipped` as passing — a silent
+  # bypass this whole check was written to close. No `npm ci`; the script
+  # has no dependencies.
   auth-tables-doc-drift:
     runs-on: ubuntu-latest
     steps:
@@ -268,23 +276,18 @@ jobs:
   # The services block starts PostgreSQL even when skipped -- this is unavoidable with GHA
   # service containers but harmless (starts in seconds, job exits immediately).
   Integration-Tests:
-    needs: [detect-changes, lint-and-typecheck, auth-tables-doc-drift]
-    # Pattern: "always-run + explicit failing pre-step" to convert upstream
-    # dep failures into a real job failure. `Integration-Tests` is a required
-    # status check on `main`; `auth-tables-doc-drift` is not. On this repo,
-    # branch protection treats a required check that reports `conclusion=skipped`
-    # as passing (empirically confirmed: `Migration Dry-Run (prod-shaped data)`
-    # reports skipped and does not block merge). So the intuitive fix — a
-    # `needs:` dep + `if: !failure() && !cancelled()` — silently bypasses:
-    # doc-drift fails -> Integration-Tests reports `skipped` -> merge allowed.
+    needs: [detect-changes, lint-and-typecheck]
+    # Run when lint-and-typecheck succeeds or was skipped (no src changes).
+    # This ensures the required check reports status on docs-only PRs.
     #
-    # Instead: run the job unconditionally (`always() && !cancelled()`), and
-    # have its first step explicitly fail when a critical `needs:` dep failed.
-    # A failing step fails the job, so `conclusion=failure` propagates to
-    # branch protection as red. See BS#1573 for the incident that motivated
-    # gating this check; the branch-protection admin-side follow-up is to add
-    # `auth-tables-doc-drift` directly to `required_status_checks.contexts`.
-    if: ${{ always() && !cancelled() }}
+    # `auth-tables-doc-drift` is enforced directly via
+    # `required_status_checks.contexts` on `main` (BS#1587), so it no longer
+    # needs to gate `Integration-Tests` via `needs:` + a synthetic failing
+    # step. That prior scaffold (BS#1577 R4) worked around the branch-protection
+    # quirk where a required check reporting `conclusion=skipped` was treated
+    # as passing; with doc-drift a direct required context, its own failure
+    # blocks merge regardless of Integration-Tests' result.
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -317,33 +320,6 @@ jobs:
       BETTER_AUTH_AUDIENCE: http://localhost:8083
       BETTER_AUTH_SECRET: ci-test-secret-key-for-jwt-signing
     steps:
-      # See the comment on `if:` above for why this step exists. Do not
-      # remove without understanding the branch-protection-vs-skipped-check
-      # interaction it papers over.
-      #
-      # WARNING: if you add anything to `Integration-Tests`' `needs:` list,
-      # extend this `if:` disjunction to cover it too. A required-check gate
-      # that doesn't enumerate every upstream it depends on will silently
-      # skip when that upstream fails/cancels/skips-unexpectedly, and the
-      # whole point of this scaffold is to make those failures loud.
-      #
-      # `auth-tables-doc-drift` runs unconditionally (see the R2 refactor)
-      # so a `skipped` result there means something went wrong — treat it
-      # as bad. `lint-and-typecheck` and `detect-changes` legitimately don't
-      # run in some states (paths filter false / n/a for detect-changes),
-      # so only fail on their explicit failure or cancellation.
-      - name: Enforce upstream gate
-        if: >-
-          ${{ needs.auth-tables-doc-drift.result != 'success'
-              || contains(fromJson('["failure", "cancelled"]'), needs.lint-and-typecheck.result)
-              || contains(fromJson('["failure", "cancelled"]'), needs.detect-changes.result) }}
-        run: |
-          echo "::error::Required upstream job failed; failing Integration-Tests to surface the block to branch protection."
-          echo "  detect-changes:        ${{ needs.detect-changes.result }}"
-          echo "  auth-tables-doc-drift: ${{ needs.auth-tables-doc-drift.result }}"
-          echo "  lint-and-typecheck:    ${{ needs.lint-and-typecheck.result }}"
-          exit 1
-
       - name: Skip notification
         if: env.RUN_TESTS != 'true'
         run: echo "No relevant changes detected, skipping integration tests"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Drizzle ORM with PostgreSQL (`postgres-js` driver).
 
 <!-- auth-tables-list:end -->
 
-The list above is enforced against `shared/database/src/schema.ts` by `scripts/check-auth-tables-doc.mjs` (BS#1573). Adding a new `auth_*` `pgTable(...)` requires updating the sentinel-fenced line; the CI job will fail otherwise.
+The list above is enforced against every `.ts` file under `shared/database/src/` by `scripts/check-auth-tables-doc.mjs` (BS#1573). Adding a new `auth_*` `pgTable(...)` — in `schema.ts` today or a sibling file if the schema is ever split (BS#1581) — requires updating the sentinel-fenced line; the CI job will fail otherwise.
 
 **Domain tables** (custom schema): `dj_stats`, `schedule`, `shift_covers`, `artists`, and flowsheet-related tables.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ CLAUDE.md is the always-loaded reference card; topic depth lives in `docs/*.md`.
 
 - `npm run check:doc-budget` — **warn-only.** Warns if CLAUDE.md exceeds its char budget. When it fires, extract to `docs/` rather than growing CLAUDE.md.
 - `npm run check:doc-rules` — **warn-only.** Surfaces `<!-- @rule -->` markers in `docs/*.md` that are stale (unenforced + old, enforced + verbose, or past `review-after`). Convention documented in [`docs/migrations.md`](docs/migrations.md#rule-annotation-convention).
-- `npm run check:auth-tables-doc` — **hard-fail.** Enforces the sentinel-fenced `auth_*` table list in CLAUDE.md against `shared/database/src/schema.ts`. A mismatch is always a bug (see BS#1573 for the drift incidents that motivated it); do not paper over failures with `|| true` in the hook. If your diff legitimately changes the set of auth tables, edit the sentinel-fenced line in CLAUDE.md to match the schema.
+- `npm run check:auth-tables-doc` — **hard-fail.** Enforces the sentinel-fenced `auth_*` table list in CLAUDE.md against every `.ts` file under `shared/database/src/` (BS#1581 tree walk; skips only `migrations/`). A mismatch is always a bug (see BS#1573 for the drift incidents that motivated it); do not paper over failures with `|| true` in the hook. If your diff legitimately changes the set of auth tables, edit the sentinel-fenced line in CLAUDE.md to match the schema.
 
 ### Branching
 

--- a/scripts/check-auth-tables-doc.mjs
+++ b/scripts/check-auth-tables-doc.mjs
@@ -28,12 +28,16 @@
  * to unrelated schema growth.
  *
  * Detection strategy:
- *   - Schema: walk every `.ts` file under `shared/database/src/` (excluding
- *     `migrations/`) and regex `pgTable\(\s*'(auth_[…]+)'` for every
- *     declaration. Walking a directory instead of a single hard-coded path
- *     survives a future split of `schema.ts` into `schema/auth.ts`,
- *     `schema/domain.ts`, etc. (BS#1581) — the check keeps working with no
- *     config file to remember to update.
+ *   - Schema: walk every `.ts` file under `shared/database/src/` (skipping
+ *     only `migrations/`, which is SQL-only) and regex
+ *     `pgTable\(\s*'(auth_[…]+)'` for every declaration. Walking a
+ *     directory instead of a single hard-coded path survives a future
+ *     split of `schema.ts` into `schema/auth.ts`, `schema/domain.ts`,
+ *     etc. (BS#1581) — the check keeps working with no config file to
+ *     remember to update. A conservative skip list here would silently
+ *     drop a future auth_* declaration in a subdir, reintroducing the
+ *     exact silent-bypass class this check closes; only skip dirs with
+ *     a technical reason (SQL only, etc.).
  *   - Doc: locate the fenced block between `<!-- auth-tables-list:begin -->`
  *     and `<!-- auth-tables-list:end -->`; extract every backtick-quoted
  *     `auth_*` token from the body.
@@ -74,7 +78,13 @@ const SCRIPT_REPO_ROOT = resolve(__dirname, '..');
 // `schema/auth.ts`, `schema/domain.ts`, etc. keeps working without a config
 // file to remember to update.
 const SCHEMA_ROOT_REL = 'shared/database/src';
-const SCHEMA_SKIP_DIRS = new Set(['migrations', 'legacy', 'types']);
+// Skip only `migrations/` — SQL files, no pgTable(...) calls, would be
+// filtered out by the extension check anyway but skipping saves a large
+// directory walk. Everything else under the schema root is a candidate;
+// speculative skip entries (e.g. `legacy/`, `types/`) would silently drop
+// a future auth_* declaration in one of those subdirs, reintroducing the
+// exact silent-bypass class this check was written to close (F14).
+const SCHEMA_SKIP_DIRS = new Set(['migrations']);
 const DOC_REL = 'CLAUDE.md';
 const SENTINEL_BEGIN = '<!-- auth-tables-list:begin -->';
 const SENTINEL_END = '<!-- auth-tables-list:end -->';
@@ -103,11 +113,62 @@ const DOC_TOKEN_RE = /`(auth_[A-Za-z0-9_]+)`/g;
 
 // Strip JS/TS line and block comments before regex extraction. A
 // commented-out `// pgTable('auth_legacy', ...)` is not a declared table.
-// Not a full JS parser — no template-literal or string tracking — but the
-// schema file has no `//` or `/*` sequences inside strings today, and the
-// worst case (over-strip) still fails safely on the diff step.
+//
+// Tracks single-quote, double-quote, and backtick string state so a `//`
+// or `/*` sequence inside a string literal isn't treated as a comment.
+// Without that tracking, a schema line like
+// `const url = 'https://example.com'; export const authX = pgTable('auth_x', ...);`
+// would have everything from the `//` onward stripped, silently dropping
+// the real `pgTable` call — reintroducing the exact silent-bypass class
+// this whole PR was written to close (F13). Handles simple backslash
+// escapes inside strings; not a full JS parser (template-literal
+// `${...}` interpolation is scanned as opaque string content) but
+// sufficient for the schema tree's declaration style.
 function stripJsComments(source) {
-  return source.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+  let out = '';
+  let i = 0;
+  const n = source.length;
+  while (i < n) {
+    const c = source[i];
+    const next = source[i + 1];
+    // String literal — scan to matching quote, respecting backslash escapes.
+    if (c === "'" || c === '"' || c === '`') {
+      const quote = c;
+      out += c;
+      i += 1;
+      while (i < n) {
+        const sc = source[i];
+        if (sc === '\\' && i + 1 < n) {
+          out += sc + source[i + 1];
+          i += 2;
+          continue;
+        }
+        out += sc;
+        i += 1;
+        if (sc === quote) break;
+        // Bail out of an unterminated string at EOL for single/double quotes
+        // (backticks legitimately span lines). Prevents an unclosed quote
+        // from swallowing the rest of the file.
+        if (sc === '\n' && quote !== '`') break;
+      }
+      continue;
+    }
+    // Line comment — drop to end of line (but keep the newline).
+    if (c === '/' && next === '/') {
+      while (i < n && source[i] !== '\n') i += 1;
+      continue;
+    }
+    // Block comment — drop through the closing `*/`.
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) i += 1;
+      i += 2; // skip past `*/` (safe past EOF; loop condition guards)
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
 }
 
 // Strip HTML comments from a markdown body. A backticked `auth_*` inside

--- a/scripts/check-auth-tables-doc.mjs
+++ b/scripts/check-auth-tables-doc.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
  * Static check: the "Auth tables" one-liner in `CLAUDE.md` matches the set of
- * `auth_*` tables declared as `pgTable('auth_...', ...)` in
- * `shared/database/src/schema.ts` (BS#1573).
+ * `auth_*` tables declared as `pgTable('auth_...', ...)` under
+ * `shared/database/src/**` (BS#1573).
  *
  * Why this exists: in the ~30 days before it was written, the doc list rotted
  * twice in silence.
@@ -28,7 +28,12 @@
  * to unrelated schema growth.
  *
  * Detection strategy:
- *   - Schema: regex `pgTable\(\s*'(auth_[a-z0-9_]+)'` for every declaration.
+ *   - Schema: walk every `.ts` file under `shared/database/src/` (excluding
+ *     `migrations/`) and regex `pgTable\(\s*'(auth_[…]+)'` for every
+ *     declaration. Walking a directory instead of a single hard-coded path
+ *     survives a future split of `schema.ts` into `schema/auth.ts`,
+ *     `schema/domain.ts`, etc. (BS#1581) — the check keeps working with no
+ *     config file to remember to update.
  *   - Doc: locate the fenced block between `<!-- auth-tables-list:begin -->`
  *     and `<!-- auth-tables-list:end -->`; extract every backtick-quoted
  *     `auth_*` token from the body.
@@ -40,14 +45,21 @@
  *
  * Exit codes:
  *   0 — sets match
- *   1 — sets differ, sentinels missing/duplicated/inverted, schema has zero
- *       auth_* tables, or one of the required files is missing
+ *   2 — sentinel/config error (missing/duplicate/inverted sentinels in
+ *       CLAUDE.md, or one of the required paths is missing)
+ *   3 — schema and doc disagree (drift)
+ *   4 — schema regex found zero auth_* tables (probably a moved/renamed file
+ *       or a broken import; the repo always has at least `auth_user`)
+ *
+ * The exit-code split (BS#1583) lets a CI operator distinguish "the check is
+ * broken" (2 or 4 — inspect the script/schema layout) from "someone forgot
+ * to update the doc" (3 — edit CLAUDE.md). Historically both mapped to 1.
  */
 
-import { readFileSync, statSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
+import { isInvokedDirectly } from './lib/main-module.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Prefer cwd as repo root (so tests can point at a temp tree); fall back to
@@ -55,10 +67,24 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT_CWD = process.cwd();
 const SCRIPT_REPO_ROOT = resolve(__dirname, '..');
 
-const SCHEMA_REL = 'shared/database/src/schema.ts';
+// Directory to scan for schema declarations. Everything under this dir with
+// a `.ts` extension is candidate source; `migrations/` is skipped explicitly
+// (SQL only, no pgTable calls). Was a single hard-coded file until BS#1581 —
+// switched to a directory walk so a future split of `schema.ts` into
+// `schema/auth.ts`, `schema/domain.ts`, etc. keeps working without a config
+// file to remember to update.
+const SCHEMA_ROOT_REL = 'shared/database/src';
+const SCHEMA_SKIP_DIRS = new Set(['migrations', 'legacy', 'types']);
 const DOC_REL = 'CLAUDE.md';
 const SENTINEL_BEGIN = '<!-- auth-tables-list:begin -->';
 const SENTINEL_END = '<!-- auth-tables-list:end -->';
+
+// Exit-code taxonomy (BS#1583). Named constants so switch-arms and tests
+// don't hand-write literals.
+export const EXIT_OK = 0;
+export const EXIT_CONFIG = 2;
+export const EXIT_DRIFT = 3;
+export const EXIT_ZERO_TABLES = 4;
 
 // pgTable('auth_<name>', ...) — the string literal is the DB table name and
 // is what the CLAUDE.md list enumerates. The JS export symbol (which may
@@ -67,7 +93,8 @@ const SENTINEL_END = '<!-- auth-tables-list:end -->';
 // Character class matches [A-Za-z0-9_] to catch camelCased tables (e.g.
 // `auth_UserV2`), and quote class includes backticks to catch template-literal
 // args (`pgTable(\`auth_new\`, ...)`. Mirrors the shape in
-// `scripts/schema-shape-report.mjs`.
+// `scripts/schema-shape-report.mjs` (search for `pgTable` there — line
+// numbers drift; the name is stable).
 const PG_TABLE_RE = /pgTable\(\s*['"`](auth_[A-Za-z0-9_]+)['"`]/g;
 
 // Backtick-quoted `auth_<name>` token inside the sentinel-fenced doc block.
@@ -89,6 +116,14 @@ function stripHtmlComments(body) {
   return body.replace(/<!--[\s\S]*?-->/g, '');
 }
 
+// Strip triple-backtick fenced code blocks from a markdown body. Prevents a
+// documentation example that happens to embed the sentinel comment (or a
+// bogus `auth_*` token) from being counted as either a real sentinel or a
+// real doc claim. Handles both ``` and ```lang forms (R4-6).
+function stripFencedCodeBlocks(source) {
+  return source.replace(/```[\s\S]*?```/g, '');
+}
+
 function fileExists(abs) {
   try {
     return statSync(abs).isFile();
@@ -97,8 +132,19 @@ function fileExists(abs) {
   }
 }
 
+function dirExists(abs) {
+  try {
+    return statSync(abs).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 function pickRepoRoot() {
-  const layoutMatches = (root) => fileExists(join(root, SCHEMA_REL)) && fileExists(join(root, DOC_REL));
+  // A repo root is one that has both the schema dir and CLAUDE.md at the
+  // expected paths. Nothing else is required — the walk below discovers
+  // whatever .ts files live inside.
+  const layoutMatches = (root) => dirExists(join(root, SCHEMA_ROOT_REL)) && fileExists(join(root, DOC_REL));
   if (layoutMatches(REPO_ROOT_CWD)) return REPO_ROOT_CWD;
   // R3-5: when the test harness pins us to a temp root, don't silently fall
   // back to the real script-parent repo. A test that deletes one of the
@@ -114,7 +160,33 @@ function pickRepoRoot() {
   return REPO_ROOT_CWD;
 }
 
-function extractSchemaTables(source) {
+/**
+ * Recursively collect every `.ts` file under `root`, skipping directory
+ * names in SCHEMA_SKIP_DIRS. Returns absolute paths.
+ */
+function collectSchemaFiles(root) {
+  const out = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (SCHEMA_SKIP_DIRS.has(entry.name)) continue;
+        walk(join(dir, entry.name));
+      } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+        out.push(join(dir, entry.name));
+      }
+    }
+  };
+  walk(root);
+  return out.sort();
+}
+
+export function extractSchemaTables(source) {
   // Strip comments first so commented-out `pgTable(...)` calls (or
   // pseudo-declarations inside `/* ... */` block comments) don't inflate
   // the schema set. Line numbers below are computed from the stripped
@@ -138,6 +210,32 @@ function extractSchemaTables(source) {
 }
 
 /**
+ * Walk `schemaRoot` for `.ts` files and merge every `pgTable('auth_…')`
+ * declaration into a single set. The value stored in `lineByTable` is
+ * `{ relPath, lineNo }` so the drift-report can point at the exact file
+ * that declares each table (relevant once schema.ts gets split — BS#1581).
+ */
+function extractSchemaTablesFromTree(schemaRoot, repoRoot) {
+  const files = collectSchemaFiles(schemaRoot);
+  const tables = new Set();
+  const lineByTable = new Map();
+  for (const abs of files) {
+    const source = readFileSync(abs, 'utf8');
+    const { tables: fileTables, lineByTable: fileLines } = extractSchemaTables(source);
+    for (const t of fileTables) tables.add(t);
+    for (const [t, lineNo] of fileLines) {
+      if (!lineByTable.has(t)) {
+        // Relative to the repo root so error messages stay copy-pasteable
+        // regardless of where the check was invoked from.
+        const relPath = abs.startsWith(repoRoot + '/') ? abs.slice(repoRoot.length + 1) : abs;
+        lineByTable.set(t, { relPath, lineNo });
+      }
+    }
+  }
+  return { tables, lineByTable };
+}
+
+/**
  * Count non-overlapping occurrences of `needle` in `haystack`. Used to
  * assert exactly one begin/end sentinel — a duplicated sentinel silently
  * redefines the fenced block otherwise (F6).
@@ -152,27 +250,31 @@ function countOccurrences(haystack, needle) {
   return count;
 }
 
-function extractDocBlock(source) {
-  const beginCount = countOccurrences(source, SENTINEL_BEGIN);
-  const endCount = countOccurrences(source, SENTINEL_END);
+export function extractDocBlock(source) {
+  // Strip fenced code blocks first so a documentation example that embeds
+  // the sentinel (```md ... <!-- auth-tables-list:begin --> ... ```) doesn't
+  // inflate the sentinel count and trip the duplicate branch (R4-6).
+  const stripped = stripFencedCodeBlocks(source);
+  const beginCount = countOccurrences(stripped, SENTINEL_BEGIN);
+  const endCount = countOccurrences(stripped, SENTINEL_END);
   if (beginCount === 0 || endCount === 0) {
     return { ok: false, reason: 'missing' };
   }
   if (beginCount > 1 || endCount > 1) {
     return { ok: false, reason: 'duplicate', beginCount, endCount };
   }
-  const begin = source.indexOf(SENTINEL_BEGIN);
-  const end = source.indexOf(SENTINEL_END);
+  const begin = stripped.indexOf(SENTINEL_BEGIN);
+  const end = stripped.indexOf(SENTINEL_END);
   if (end < begin) {
     return { ok: false, reason: 'inverted' };
   }
   const bodyStart = begin + SENTINEL_BEGIN.length;
-  const body = source.slice(bodyStart, end);
-  const lineNo = source.slice(0, begin).split('\n').length;
+  const body = stripped.slice(bodyStart, end);
+  const lineNo = stripped.slice(0, begin).split('\n').length;
   return { ok: true, body, lineNo };
 }
 
-function extractDocTables(body) {
+export function extractDocTables(body) {
   // Strip HTML comments so a TODO like
   // `<!-- also list \`auth_ghost\` once BS#9999 lands -->` doesn't get
   // parsed as a real doc claim (F4).
@@ -186,39 +288,38 @@ function extractDocTables(body) {
   return tables;
 }
 
-function main(repoRoot) {
-  const schemaPath = join(repoRoot, SCHEMA_REL);
+export function main(repoRoot) {
+  const schemaRoot = join(repoRoot, SCHEMA_ROOT_REL);
   const docPath = join(repoRoot, DOC_REL);
 
-  if (!fileExists(schemaPath)) {
-    console.error(`check-auth-tables-doc: cannot find ${SCHEMA_REL} (looked in ${repoRoot})`);
-    return 1;
+  if (!dirExists(schemaRoot)) {
+    console.error(`check-auth-tables-doc: cannot find ${SCHEMA_ROOT_REL} (looked in ${repoRoot})`);
+    return EXIT_CONFIG;
   }
   if (!fileExists(docPath)) {
     console.error(`check-auth-tables-doc: cannot find ${DOC_REL} (looked in ${repoRoot})`);
-    return 1;
+    return EXIT_CONFIG;
   }
 
-  const schemaSource = readFileSync(schemaPath, 'utf8');
   const docSource = readFileSync(docPath, 'utf8');
 
-  const { tables: schemaTables, lineByTable: schemaLineByTable } = extractSchemaTables(schemaSource);
+  const { tables: schemaTables, lineByTable: schemaLineByTable } = extractSchemaTablesFromTree(schemaRoot, repoRoot);
 
   // F3: hard-fail if the schema regex found zero tables. This repo will
   // always have at least `auth_user`. A zero-match usually means the regex
-  // is broken (renamed import, quote-style change) or the schema file
-  // moved. Without this guard, an empty schema set silently matches an
-  // empty doc set — the exact BS#1571 failure shape.
+  // is broken (renamed import, quote-style change) or the whole schema
+  // tree moved. Without this guard, an empty schema set silently matches
+  // an empty doc set — the exact BS#1571 failure shape.
   if (schemaTables.size === 0) {
     console.error(
-      `check-auth-tables-doc: found zero auth_* pgTable(...) declarations in ${SCHEMA_REL}.\n` +
+      `check-auth-tables-doc: found zero auth_* pgTable(...) declarations under ${SCHEMA_ROOT_REL}.\n` +
         `       this repo always has at least auth_user; a zero match probably means:\n` +
-        `         - the schema file was moved or split (SCHEMA_REL is hard-coded)\n` +
+        `         - the schema tree was moved or renamed (SCHEMA_ROOT_REL is hard-coded)\n` +
         `         - pgTable was renamed at the import site (e.g. \`import { pgTable as pt }\`)\n` +
-        `         - the file was drained without landing new tables somewhere else\n` +
+        `         - every schema file was drained without landing new tables somewhere else\n` +
         `       failing loudly rather than silently agreeing with an empty doc set.`
     );
-    return 1;
+    return EXIT_ZERO_TABLES;
   }
 
   const block = extractDocBlock(docSource);
@@ -253,13 +354,18 @@ function main(repoRoot) {
       );
     } else {
       // Defensive: a new `reason` value was added to extractDocBlock but this
-      // switch wasn't updated. Throw with the raw reason so the caller sees
-      // exactly what the parser reported, rather than a silently mislabelled
-      // "missing sentinel" message that sends operators looking for the wrong
-      // thing (R3-3).
-      throw new Error(`check-auth-tables-doc: unrecognized block failure reason: ${JSON.stringify(block.reason)}`);
+      // switch wasn't updated. Print a clean error + exit rather than a raw
+      // Node stack trace so the failure UX matches every other branch above
+      // (R4-8). The stack still names the file for anyone who wants it via
+      // `node --stack-trace-limit`.
+      console.error(
+        `check-auth-tables-doc: unrecognized block failure reason: ${JSON.stringify(block.reason)}.\n` +
+          `       this is a bug — extractDocBlock returned a reason the CLI switch\n` +
+          `       doesn't handle. add a branch above or remove the unhandled reason\n` +
+          `       from extractDocBlock.`
+      );
     }
-    return 1;
+    return EXIT_CONFIG;
   }
 
   const docTables = extractDocTables(block.body);
@@ -269,20 +375,20 @@ function main(repoRoot) {
 
   if (missingInDoc.length === 0 && extraInDoc.length === 0) {
     console.log(
-      `PASS: ${schemaTables.size} auth_* table(s) in ${SCHEMA_REL} match the CLAUDE.md sentinel-fenced list.`
+      `PASS: ${schemaTables.size} auth_* table(s) under ${SCHEMA_ROOT_REL} match the CLAUDE.md sentinel-fenced list.`
     );
-    return 0;
+    return EXIT_OK;
   }
 
   console.error('');
-  console.error(`FAIL: the auth-tables list in ${DOC_REL} has drifted from ${SCHEMA_REL}.`);
+  console.error(`FAIL: the auth-tables list in ${DOC_REL} has drifted from ${SCHEMA_ROOT_REL}.`);
   console.error(`      (fix by editing the sentinel-fenced line in ${DOC_REL}:${block.lineNo})`);
   console.error('');
   if (missingInDoc.length > 0) {
     console.error(`  missing from ${DOC_REL} (declared in schema but not documented):`);
     for (const t of missingInDoc) {
-      const ln = schemaLineByTable.get(t);
-      console.error(`    - ${t}   (${SCHEMA_REL}:${ln})`);
+      const loc = schemaLineByTable.get(t);
+      console.error(`    - ${t}   (${loc.relPath}:${loc.lineNo})`);
     }
     console.error('');
   }
@@ -294,20 +400,9 @@ function main(repoRoot) {
     console.error('');
   }
   console.error(`  BS#1573 for the rationale; BS#1571 / BS#1572 for the incidents that motivated the check.`);
-  return 1;
+  return EXIT_DRIFT;
 }
 
-import { realpathSync } from 'node:fs';
-const invokedDirectly = (() => {
-  try {
-    return realpathSync(resolve(process.argv[1] ?? '')) === realpathSync(fileURLToPath(import.meta.url));
-  } catch {
-    return false;
-  }
-})();
-
-if (invokedDirectly) {
+if (isInvokedDirectly(import.meta.url)) {
   process.exit(main(pickRepoRoot()));
 }
-
-export { extractSchemaTables, extractDocBlock, extractDocTables, main };

--- a/scripts/check-bulk-update-analyze.mjs
+++ b/scripts/check-bulk-update-analyze.mjs
@@ -49,6 +49,7 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { resolve, relative, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
+import { isInvokedDirectly } from './lib/main-module.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Cwd-relative root (so tests can run the script against a synthetic tree).
@@ -270,16 +271,7 @@ function main(repoRoot) {
   return strict ? 1 : 0;
 }
 
-import { realpathSync } from 'node:fs';
-const invokedDirectly = (() => {
-  try {
-    return realpathSync(resolve(process.argv[1] ?? '')) === realpathSync(fileURLToPath(import.meta.url));
-  } catch {
-    return false;
-  }
-})();
-
-if (invokedDirectly) {
+if (isInvokedDirectly(import.meta.url)) {
   // Prefer the cwd as repo root (so tests can run against a temp tree); fall
   // back to the script's parent dir if cwd doesn't have the expected layout.
   const probeRoot = (root) =>

--- a/scripts/check-legacy-entry-id-writes.mjs
+++ b/scripts/check-legacy-entry-id-writes.mjs
@@ -45,10 +45,11 @@
  *   2 — an allowlisted file no longer contains the pattern (stale allowlist).
  */
 
-import { readFileSync, readdirSync, statSync, realpathSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, relative, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
+import { isInvokedDirectly } from './lib/main-module.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -175,19 +176,6 @@ function main() {
   console.log(`PASS: ${matched.length} source file(s) reference legacy_entry_id; all in the allowlist.`);
 }
 
-// Node ESM "is main module" idiom. realpathSync canonicalizes both sides so
-// macOS's /tmp -> /private/tmp symlink doesn't make a self-invocation look
-// like an import (which would skip main() and silently exit 0).
-const invokedDirectly = (() => {
-  try {
-    const argvPath = realpathSync(resolve(process.argv[1] ?? ''));
-    const selfPath = realpathSync(fileURLToPath(import.meta.url));
-    return argvPath === selfPath;
-  } catch {
-    return false;
-  }
-})();
-
-if (invokedDirectly) {
+if (isInvokedDirectly(import.meta.url)) {
   main();
 }

--- a/scripts/lib/main-module.mjs
+++ b/scripts/lib/main-module.mjs
@@ -1,0 +1,44 @@
+/**
+ * Node ESM "am I invoked directly?" helper. Reused across the zero-dep static
+ * checks under `scripts/` (`check-auth-tables-doc.mjs`,
+ * `check-bulk-update-analyze.mjs`, `check-legacy-entry-id-writes.mjs`) — each
+ * one used to hand-roll the same ~10 lines of `realpathSync` + `fileURLToPath`
+ * boilerplate.
+ *
+ * Why realpathSync on both sides: macOS's `/tmp` -> `/private/tmp` symlink
+ * (and any similar dev-loop path) can make a legitimate self-invocation look
+ * like an ES-module import, which would skip the entry point and silently
+ * exit 0. Canonicalizing both `process.argv[1]` and `import.meta.url` before
+ * comparison avoids that trap.
+ *
+ * The helper stays zero-dep (no npm, only `node:` builtins) so a script that
+ * imports it doesn't drag in a workspace resolve — the whole point of the
+ * `scripts/*.mjs` family is to run before `npm ci` in the pre-push hook.
+ */
+
+import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Returns `true` when the script whose `import.meta.url` is passed in was
+ * invoked directly (e.g. `node scripts/foo.mjs`), and `false` when it was
+ * loaded as an import (e.g. from a test that dynamic-imports the module).
+ *
+ * Failures during path canonicalization (missing argv[1], broken symlink,
+ * permission error) are swallowed and treated as "not invoked directly" so a
+ * script that gets imported in an unusual environment doesn't crash before
+ * its exports are usable.
+ *
+ * @param {string} importMetaUrl — pass `import.meta.url` verbatim.
+ * @returns {boolean}
+ */
+export function isInvokedDirectly(importMetaUrl) {
+  try {
+    const argvPath = realpathSync(resolve(process.argv[1] ?? ''));
+    const selfPath = realpathSync(fileURLToPath(importMetaUrl));
+    return argvPath === selfPath;
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/scripts/check-auth-tables-doc.test.ts
+++ b/tests/unit/scripts/check-auth-tables-doc.test.ts
@@ -2,8 +2,8 @@
  * Tests for `scripts/check-auth-tables-doc.mjs` (BS#1573).
  *
  * The script compares:
- *   - the set of `auth_*` string literals passed to `pgTable(...)` in
- *     `shared/database/src/schema.ts`
+ *   - the set of `auth_*` string literals passed to `pgTable(...)` under
+ *     `shared/database/src/**` (walks the tree since BS#1581)
  *   - the set of backtick-quoted `auth_*` tokens between the sentinel
  *     comments `<!-- auth-tables-list:begin -->` and
  *     `<!-- auth-tables-list:end -->` in `CLAUDE.md`
@@ -25,6 +25,14 @@ import { spawnSync } from 'child_process';
 
 const repoRoot = path.resolve(__dirname, '../../..');
 const scriptPath = path.join(repoRoot, 'scripts/check-auth-tables-doc.mjs');
+
+// Exit-code taxonomy (BS#1583). Mirrors the constants exported from the
+// script. Tests assert the categorical code so a wording change in the
+// human-readable stderr doesn't invalidate the categorical guarantee.
+const EXIT_OK = 0;
+const EXIT_CONFIG = 2;
+const EXIT_DRIFT = 3;
+const EXIT_ZERO_TABLES = 4;
 
 interface ExecResult {
   stdout: string;
@@ -67,13 +75,24 @@ function runAgainstRepo(): ExecResult {
  * Build a synthetic repo layout with just the two files the script reads:
  * `CLAUDE.md` and `shared/database/src/schema.ts`. All test fixtures below
  * use the same shape so the assertions stay focused on the diff logic.
+ * Callers can pass `extraSchemaFiles` to simulate a split schema layout
+ * (BS#1581).
  */
-function setupTempRepo(files: { claudeMd: string; schemaTs: string }): string {
+function setupTempRepo(files: {
+  claudeMd: string;
+  schemaTs: string;
+  extraSchemaFiles?: Record<string, string>;
+}): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'auth-tables-doc-'));
   fs.writeFileSync(path.join(root, 'CLAUDE.md'), files.claudeMd);
   const schemaDir = path.join(root, 'shared/database/src');
   fs.mkdirSync(schemaDir, { recursive: true });
   fs.writeFileSync(path.join(schemaDir, 'schema.ts'), files.schemaTs);
+  for (const [rel, contents] of Object.entries(files.extraSchemaFiles ?? {})) {
+    const abs = path.join(schemaDir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, contents);
+  }
   return root;
 }
 
@@ -102,63 +121,72 @@ describe('check-auth-tables-doc.mjs', () => {
     // A regression that adds an `auth_*` pgTable without updating the CLAUDE.md
     // sentinel-fenced list (or vice versa) would flip this to non-zero.
     const { status } = runAgainstRepo();
-    expect(status).toBe(0);
+    expect(status).toBe(EXIT_OK);
   });
 
   describe('isolated fixtures', () => {
-    let tmpRoot: string;
+    // F10 (BS#1582): track every tmpRoot the test body creates and clean them
+    // all in afterEach. The prior single-variable form only cleaned the last
+    // root a test assigned, which was fine for the current cases but would
+    // leak dirs the moment someone added a test that makes two of them.
+    const tmpRoots: string[] = [];
+    const trackTmpRepo: typeof setupTempRepo = (files) => {
+      const root = setupTempRepo(files);
+      tmpRoots.push(root);
+      return root;
+    };
     afterEach(() => {
-      if (tmpRoot) {
-        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      for (const root of tmpRoots.splice(0)) {
+        fs.rmSync(root, { recursive: true, force: true });
       }
     });
 
     it('passes when doc list and schema pgTables match exactly', () => {
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_user', 'auth_session', 'auth_account']),
         schemaTs: schemaWith(['auth_user', 'auth_session', 'auth_account']),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(0);
+      expect(status).toBe(EXIT_OK);
       expect(stderr).toBe('');
     });
 
     it('fails when a table is present in schema but missing from the doc', () => {
       // The July 2026 shape: `auth_oauth_consent` is in schema.ts but the
-      // author forgot to add it to the CLAUDE.md list.
-      tmpRoot = setupTempRepo({
+      // author forgot to add it to the CLAUDE.md list. Assert the exit code
+      // and the specific table token — the surrounding phrasing ("missing
+      // from...") isn't load-bearing (BS#1583 / F12).
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_user', 'auth_session']),
         schemaTs: schemaWith(['auth_user', 'auth_session', 'auth_oauth_consent']),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(1);
+      expect(status).toBe(EXIT_DRIFT);
       expect(stderr).toMatch(/auth_oauth_consent/);
-      expect(stderr).toMatch(/missing/i);
     });
 
     it('fails when the doc lists a table that is not in the schema', () => {
       // Inverse drift: doc claims a table that no pgTable(...) declares.
       // Could happen from a stale doc after a table was removed.
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_user', 'auth_session', 'auth_ghost']),
         schemaTs: schemaWith(['auth_user', 'auth_session']),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(1);
+      expect(status).toBe(EXIT_DRIFT);
       expect(stderr).toMatch(/auth_ghost/);
-      expect(stderr).toMatch(/extra/i);
     });
 
     it('ignores non-auth_* pgTables in the schema (scope: auth_* only)', () => {
       // Domain tables (`wxyc_*`, `user_activity`, `anonymous_devices`, etc.)
       // have their own list and their own drift risk. The check is tightly
       // scoped to auth_* to avoid coupling to unrelated schema growth.
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_user', 'auth_session']),
         schemaTs: schemaWith(['auth_user', 'auth_session'], ['user_activity', 'anonymous_devices', 'wxyc_flowsheet']),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(0);
+      expect(status).toBe(EXIT_OK);
       expect(stderr).toBe('');
     });
 
@@ -166,7 +194,7 @@ describe('check-auth-tables-doc.mjs', () => {
       // The oidcProvider plugin's modelName mapping means the DB table is
       // `auth_oauth_consent` while the export is `oauthConsent`. The doc lists
       // the DB name, so the check must extract the string literal argument.
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_oauth_consent']),
         schemaTs: [
           `import { pgTable, text } from 'drizzle-orm/pg-core';`,
@@ -176,18 +204,18 @@ describe('check-auth-tables-doc.mjs', () => {
         ].join('\n'),
       });
       const { status } = runOnRoot(tmpRoot);
-      expect(status).toBe(0);
+      expect(status).toBe(EXIT_OK);
     });
 
     it('fails clearly when the sentinel comments are missing', () => {
       // If the sentinels are stripped, the parser has no durable target.
       // Fail loudly rather than silently allow an empty "doc set".
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: '**Auth tables**: `auth_user`.\n',
         schemaTs: schemaWith(['auth_user']),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(1);
+      expect(status).toBe(EXIT_CONFIG);
       expect(stderr).toMatch(/sentinel/i);
     });
 
@@ -197,7 +225,7 @@ describe('check-auth-tables-doc.mjs', () => {
     // are realistic patterns that would silently drop tables from the schema
     // set and hide drift. Mirrors `scripts/schema-shape-report.mjs`.
     it('extracts uppercase table names from pgTable literals', () => {
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_user', 'auth_UserV2']),
         schemaTs: [
           `import { pgTable, text } from 'drizzle-orm/pg-core';`,
@@ -208,12 +236,12 @@ describe('check-auth-tables-doc.mjs', () => {
         ].join('\n'),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(0);
+      expect(status).toBe(EXIT_OK);
       expect(stderr).toBe('');
     });
 
     it('extracts table names from backtick-quoted pgTable literals', () => {
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_user', 'auth_new']),
         schemaTs: [
           `import { pgTable, text } from 'drizzle-orm/pg-core';`,
@@ -224,15 +252,16 @@ describe('check-auth-tables-doc.mjs', () => {
         ].join('\n'),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(0);
+      expect(status).toBe(EXIT_OK);
       expect(stderr).toBe('');
     });
 
-    // F3: hard-fail when the schema regex matches zero tables. If the doc is
-    // also empty, both sets agree at 0-vs-0 and the check silently "passes"
-    // (the BS#1571 shape). This repo will always have at least `auth_user`.
+    // F3 (BS#1583): hard-fail with exit-code 4 when the schema regex matches
+    // zero tables. If the doc is also empty, both sets agree at 0-vs-0 and
+    // the check silently "passes" (the BS#1571 shape). This repo will always
+    // have at least `auth_user`.
     it('fails when zero auth_* pgTables are found in the schema', () => {
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: [
           '# CLAUDE.md',
           '',
@@ -249,7 +278,7 @@ describe('check-auth-tables-doc.mjs', () => {
         ].join('\n'),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(1);
+      expect(status).toBe(EXIT_ZERO_TABLES);
       expect(stderr).toMatch(/zero|no.*auth_/i);
     });
 
@@ -257,7 +286,7 @@ describe('check-auth-tables-doc.mjs', () => {
     // extraction. A backticked `auth_*` token inside `<!-- ... -->` is a
     // human note or TODO, not a claim about a real table.
     it('ignores auth_* tokens inside HTML comments in the doc body', () => {
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: [
           '# CLAUDE.md',
           '',
@@ -270,7 +299,7 @@ describe('check-auth-tables-doc.mjs', () => {
         schemaTs: schemaWith(['auth_user']),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(0);
+      expect(status).toBe(EXIT_OK);
       expect(stderr).toBe('');
     });
 
@@ -278,7 +307,7 @@ describe('check-auth-tables-doc.mjs', () => {
     // `// pgTable('auth_legacy', ...)` call should not be counted as a
     // declared table.
     it('ignores pgTable calls inside line comments in the schema', () => {
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_user']),
         schemaTs: [
           `import { pgTable, text } from 'drizzle-orm/pg-core';`,
@@ -289,12 +318,12 @@ describe('check-auth-tables-doc.mjs', () => {
         ].join('\n'),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(0);
+      expect(status).toBe(EXIT_OK);
       expect(stderr).toBe('');
     });
 
     it('ignores pgTable calls inside block comments in the schema', () => {
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_user']),
         schemaTs: [
           `import { pgTable, text } from 'drizzle-orm/pg-core';`,
@@ -307,7 +336,7 @@ describe('check-auth-tables-doc.mjs', () => {
         ].join('\n'),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(0);
+      expect(status).toBe(EXIT_OK);
       expect(stderr).toBe('');
     });
 
@@ -315,7 +344,7 @@ describe('check-auth-tables-doc.mjs', () => {
     // The prior `indexOf` picks the first occurrence and slices to the
     // first END — everything past that vanishes. Fail loudly instead.
     it('fails when the begin sentinel appears more than once', () => {
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: [
           '# CLAUDE.md',
           '',
@@ -331,12 +360,12 @@ describe('check-auth-tables-doc.mjs', () => {
         schemaTs: schemaWith(['auth_user']),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(1);
+      expect(status).toBe(EXIT_CONFIG);
       expect(stderr).toMatch(/duplicate|more than one|multiple.*sentinel/i);
     });
 
     it('fails when the end sentinel appears more than once', () => {
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: [
           '# CLAUDE.md',
           '',
@@ -350,7 +379,7 @@ describe('check-auth-tables-doc.mjs', () => {
         schemaTs: schemaWith(['auth_user']),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(1);
+      expect(status).toBe(EXIT_CONFIG);
       expect(stderr).toMatch(/duplicate|more than one|multiple.*sentinel/i);
     });
 
@@ -358,7 +387,7 @@ describe('check-auth-tables-doc.mjs', () => {
     // sentinels — surface a message that names the actual problem
     // ("inverted") so a reader isn't chasing a phantom "missing" error.
     it('fails with an inverted-order message when end appears before begin', () => {
-      tmpRoot = setupTempRepo({
+      const tmpRoot = trackTmpRepo({
         claudeMd: [
           '# CLAUDE.md',
           '',
@@ -370,7 +399,7 @@ describe('check-auth-tables-doc.mjs', () => {
         schemaTs: schemaWith(['auth_user']),
       });
       const { status, stderr } = runOnRoot(tmpRoot);
-      expect(status).toBe(1);
+      expect(status).toBe(EXIT_CONFIG);
       // R3-4: assert the distinctive "inverted sentinel comments" wording
       // rather than a permissive alternation. The permissive form would
       // accept the generic "missing sentinel comments" fallback too — the
@@ -378,31 +407,118 @@ describe('check-auth-tables-doc.mjs', () => {
       expect(stderr).toMatch(/inverted sentinel comments/);
     });
 
-    // R3-6: cover the "cannot find <required file>" exit-1 branches. This
-    // is the surface a caller sees when the script is invoked from a
-    // directory that looks-close-but-isn't the repo (e.g. a partial checkout,
-    // or a stale scratch tree that lost CLAUDE.md). Without this test the
-    // fallback branches in pickRepoRoot + main are untested.
-    it('exits 1 with a clear message when CLAUDE.md is missing from the repo root', () => {
-      tmpRoot = setupTempRepo({
+    // R4-6 (BS#1590): sentinels that appear inside a triple-backtick fenced
+    // code block are documentation examples, not real sentinels. The prior
+    // indexOf-based counter would trip the duplicate branch on a CLAUDE.md
+    // that documents this very check. Strip fenced blocks before counting.
+    it('ignores sentinels inside triple-backtick fenced code blocks', () => {
+      const tmpRoot = trackTmpRepo({
+        claudeMd: [
+          '# CLAUDE.md',
+          '',
+          '<!-- auth-tables-list:begin -->',
+          '**Auth tables**: `auth_user`.',
+          '<!-- auth-tables-list:end -->',
+          '',
+          '## How this check works',
+          '',
+          '```md',
+          '<!-- auth-tables-list:begin -->',
+          '**Auth tables**: `auth_ghost`, `auth_example`.',
+          '<!-- auth-tables-list:end -->',
+          '```',
+          '',
+        ].join('\n'),
+        schemaTs: schemaWith(['auth_user']),
+      });
+      const { status, stderr } = runOnRoot(tmpRoot);
+      expect(status).toBe(EXIT_OK);
+      expect(stderr).toBe('');
+    });
+
+    // R3-6 + R4-9 (BS#1590): the "cannot find <required file>" exit branches
+    // must report the resolved repo root in the error and produce no stdout.
+    // If pickRepoRoot silently regressed (e.g. someone flipped a fallback to
+    // cwd), the assertions here would catch the drift because the reported
+    // path would no longer include the temp-root dir.
+    it('exits with EXIT_CONFIG and a clear message when CLAUDE.md is missing from the repo root', () => {
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_user']),
         schemaTs: schemaWith(['auth_user']),
       });
       fs.rmSync(path.join(tmpRoot, 'CLAUDE.md'));
-      const { status, stderr } = runOnRoot(tmpRoot, { forceCwd: true });
-      expect(status).toBe(1);
+      const { status, stdout, stderr } = runOnRoot(tmpRoot, { forceCwd: true });
+      expect(status).toBe(EXIT_CONFIG);
+      expect(stdout).toBe('');
       expect(stderr).toMatch(/cannot find CLAUDE\.md/);
+      // R4-9: assert the resolved path portion of the "looked in <path>"
+      // suffix names the temp root. Uses fs.realpathSync because macOS
+      // resolves /var/folders/... symlinks to /private/var/folders/... in
+      // the script's process.cwd() readout.
+      const canonical = fs.realpathSync(tmpRoot);
+      expect(stderr).toContain(`looked in ${canonical}`);
     });
 
-    it('exits 1 with a clear message when shared/database/src/schema.ts is missing', () => {
-      tmpRoot = setupTempRepo({
+    it('exits with EXIT_CONFIG and a clear message when shared/database/src is missing', () => {
+      const tmpRoot = trackTmpRepo({
         claudeMd: docWith(['auth_user']),
         schemaTs: schemaWith(['auth_user']),
       });
-      fs.rmSync(path.join(tmpRoot, 'shared/database/src/schema.ts'));
-      const { status, stderr } = runOnRoot(tmpRoot, { forceCwd: true });
-      expect(status).toBe(1);
-      expect(stderr).toMatch(/cannot find shared\/database\/src\/schema\.ts/);
+      fs.rmSync(path.join(tmpRoot, 'shared/database/src'), { recursive: true });
+      const { status, stdout, stderr } = runOnRoot(tmpRoot, { forceCwd: true });
+      expect(status).toBe(EXIT_CONFIG);
+      expect(stdout).toBe('');
+      expect(stderr).toMatch(/cannot find shared\/database\/src/);
+      const canonical = fs.realpathSync(tmpRoot);
+      expect(stderr).toContain(`looked in ${canonical}`);
+    });
+
+    // BS#1581 (F7): the schema regex walks the tree, so a legitimate split
+    // of `schema.ts` into `schema/auth.ts`, `schema/domain.ts`, etc. keeps
+    // working with no config file to remember to update. This test writes
+    // an `auth_*` declaration into a sibling file and asserts the check
+    // still finds it.
+    it('discovers auth_* pgTables declared in a sibling schema file', () => {
+      const tmpRoot = trackTmpRepo({
+        claudeMd: docWith(['auth_user', 'auth_split_out']),
+        schemaTs: schemaWith(['auth_user']),
+        extraSchemaFiles: {
+          'schema/oauth.ts': [
+            `import { pgTable, text } from 'drizzle-orm/pg-core';`,
+            '',
+            `export const splitOut = pgTable('auth_split_out', { id: text('id') });`,
+            '',
+          ].join('\n'),
+        },
+      });
+      const { status, stderr } = runOnRoot(tmpRoot);
+      expect(status).toBe(EXIT_OK);
+      expect(stderr).toBe('');
+    });
+
+    it('reports the file that declared each missing table in the drift error', () => {
+      // Companion to the split-schema test: when a table declared in a
+      // sibling file is missing from the doc, the drift report should name
+      // that sibling file (not the original schema.ts) so operators can
+      // navigate to the actual declaration.
+      const tmpRoot = trackTmpRepo({
+        claudeMd: docWith(['auth_user']),
+        schemaTs: schemaWith(['auth_user']),
+        extraSchemaFiles: {
+          'schema/oauth.ts': [
+            `import { pgTable, text } from 'drizzle-orm/pg-core';`,
+            '',
+            `export const splitOut = pgTable('auth_split_out', { id: text('id') });`,
+            '',
+          ].join('\n'),
+        },
+      });
+      const { status, stderr } = runOnRoot(tmpRoot);
+      expect(status).toBe(EXIT_DRIFT);
+      expect(stderr).toMatch(/auth_split_out/);
+      // The relative path portion of the location marker should include the
+      // sibling file, not schema.ts.
+      expect(stderr).toMatch(/shared\/database\/src\/schema\/oauth\.ts:/);
     });
   });
 });

--- a/tests/unit/scripts/check-auth-tables-doc.test.ts
+++ b/tests/unit/scripts/check-auth-tables-doc.test.ts
@@ -340,6 +340,62 @@ describe('check-auth-tables-doc.mjs', () => {
       expect(stderr).toBe('');
     });
 
+    // F13: the naive line-comment stripper treats any `//` as a comment,
+    // including `//` inside string literals. A real `pgTable(...)` sharing
+    // a line with a URL literal would be silently dropped from the schema
+    // set — the exact class of silent-bypass this whole PR was written to
+    // close. Regression guard: schema file with a URL literal on the same
+    // line as an auth_ pgTable declaration must still be discovered.
+    it('extracts pgTable calls on the same line as a `//`-containing string literal', () => {
+      const tmpRoot = trackTmpRepo({
+        claudeMd: docWith(['auth_user', 'auth_provider']),
+        schemaTs: [
+          `import { pgTable, text } from 'drizzle-orm/pg-core';`,
+          '',
+          `export const authUser = pgTable('auth_user', { id: text('id') });`,
+          // URL literal immediately before an auth_ pgTable on the same line.
+          // The naive comment stripper would delete from `//example.com...`
+          // to end-of-line, taking the pgTable call with it.
+          `const providerUrl = 'https://example.com'; export const authProvider = pgTable('auth_provider', { id: text('id') });`,
+          '',
+        ].join('\n'),
+      });
+      const { status, stderr } = runOnRoot(tmpRoot);
+      expect(status).toBe(EXIT_OK);
+      expect(stderr).toBe('');
+    });
+
+    // F14: SCHEMA_SKIP_DIRS must not include speculative directory names.
+    // Skipping a subdirectory that later gains an auth_* pgTable would
+    // silently drop it from the schema set — the exact silent-bypass class
+    // this PR closes. `migrations/` is the only justified skip (SQL only,
+    // no pgTable calls). Sibling subdirs must be walked. Regression guard:
+    // an auth_ pgTable in a `legacy/` or `types/` subdirectory is
+    // discovered by the tree walk.
+    it('discovers auth_* pgTables declared under any non-migrations subdirectory', () => {
+      const tmpRoot = trackTmpRepo({
+        claudeMd: docWith(['auth_user', 'auth_legacy_thing', 'auth_type_thing']),
+        schemaTs: schemaWith(['auth_user']),
+        extraSchemaFiles: {
+          'legacy/tables.ts': [
+            `import { pgTable, text } from 'drizzle-orm/pg-core';`,
+            '',
+            `export const legacyThing = pgTable('auth_legacy_thing', { id: text('id') });`,
+            '',
+          ].join('\n'),
+          'types/tables.ts': [
+            `import { pgTable, text } from 'drizzle-orm/pg-core';`,
+            '',
+            `export const typeThing = pgTable('auth_type_thing', { id: text('id') });`,
+            '',
+          ].join('\n'),
+        },
+      });
+      const { status, stderr } = runOnRoot(tmpRoot);
+      expect(status).toBe(EXIT_OK);
+      expect(stderr).toBe('');
+    });
+
     // F6: duplicate begin/end sentinels are a silent redefinition risk.
     // The prior `indexOf` picks the first occurrence and slices to the
     // first END — everything past that vanishes. Fail loudly instead.


### PR DESCRIPTION
## Summary

Bundle of follow-up polish from the BS#1577 review rounds, plus the workflow simplification that BS#1587's branch-protection half unlocked.

- Walk `shared/database/src/**/*.ts` for `pgTable('auth_*')` declarations instead of hard-coding `schema.ts` — a legitimate split of the schema file (`schema/auth.ts`, `schema/oauth.ts`, etc.) now keeps working with no config file to update. Drift errors name the exact file each missing table was declared in.
- Extract `scripts/lib/main-module.mjs::isInvokedDirectly(importMetaUrl)` and consume it from all three ESM static-check scripts. One authoritative implementation replaces the ~10-line `realpathSync` + `fileURLToPath` incantation duplicated three times.
- Split exit codes: 2 = sentinel/config error, 3 = drift, 4 = zero auth_* tables in schema. CI operators triaging a red PR can now distinguish "someone forgot to update CLAUDE.md" from "the check itself is broken." Tests assert the categorical code + at least one load-bearing token (table name) rather than the surrounding prose.
- Strip triple-backtick fenced code blocks before sentinel counting — a documentation example that embeds the sentinel no longer trips the duplicate branch.
- Replace the defensive `throw new Error(...)` in the block-parser switch with a `console.error(...)` clean-exit path so the failure UX matches every other branch.
- Assert the `looked in <path>` portion of the missing-file errors + stdout emptiness in the tests, and lock down `stderr === ''` on the positive-path tests (asymmetric-baseline fix).
- Track tmp roots in an array in the test harness so multiple `setupTempRepo` calls per test no longer leak.
- Add `scripts/**` to the `src:` paths filter so a script edit triggers `lint-and-typecheck` and `unit-tests`.
- BS#1587's branch-protection half is live (`auth-tables-doc-drift` is now a required status check on `main` directly), so rip out the R4 workaround: drop `auth-tables-doc-drift` from `Integration-Tests` `needs:`, remove the `Enforce upstream gate` step, restore the pre-R4 `if:` shape.

## Ticket status

- **Closes #1581** — schema-file split resilience via tree-walk.
- **Closes #1582** — F9 shared main-module helper + F10 tmp-root array.
- **Closes #1583** — F11 exit-code taxonomy (2/3/4), F12 robust stderr assertions, F14 exit-code table refreshed, F15 stable cross-reference.
- **Closes #1587** — branch-protection admin change already landed upstream; this PR removes the workflow scaffold it superseded.
- **Closes #1590** — R4-5 (`scripts/**` in paths filter), R4-6 (fenced-block awareness), R4-8 (clean exit on unhandled reason), R4-9 (path-in-error + stdout-empty assertions), R4-10 (`stderr === ''` on positive paths), R4-12 (scaffold removal), R4-13 (WARNING moot with the scaffold gone).

Explicitly deferred (not addressed here):

- **R4-7** — `stripJsComments` naive about `//` and `/*` inside string literals. No such case in `shared/database/src/schema.ts` today; the module docstring already flags the known-known. Skip until a real case appears.
- **R4-11** — a test for the defensive unhandled-reason branch would require exposing that branch as a public seam. The throw is now a clean `console.error` + exit; the branch is a bug-catch for future maintenance and its "no test" cost is proportional.

## Test plan

- [x] `npm run lint` (0 errors)
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npx jest --config jest.unit.config.ts` (270 suites / 3758 tests pass; `tests/unit/scripts/check-auth-tables-doc.test.ts` alone is 21 cases including the new split-schema + fenced-block + path-in-error cases)
- [x] `node scripts/check-auth-tables-doc.mjs` end-to-end (PASS: 12 auth_* tables match)
- [x] End-to-end drift injection: edit CLAUDE.md to break a sentinel-fenced token, run the check, confirm exit code 3 + readable diff naming the schema file and line number
- [x] YAML round-trip parse of the modified `.github/workflows/test.yml`
- [ ] CI green (the check should still fail loudly on a broken sentinel; the workflow rewrite should preserve `Integration-Tests` status reporting on docs-only PRs)