### PR TITLE
fix(triangle-shows-etl): apply post-merge max-review findings

### DIFF
--- a/jobs/triangle-shows-etl/README.md
+++ b/jobs/triangle-shows-etl/README.md
@@ -4,7 +4,7 @@ Nightly pull ETL (BS#1589, Phase 1 of the [BS#1570](https://github.com/WXYC/Back
 
 ## Schedule
 
-`cron-schedule: "5 5 * * *"` UTC (01:05 ET) — between the RHP scraper at 05:00 and the resolver at 05:15. Known soft edge (BS#1570 correction 5): a cold-starting triangle-shows host can occasionally push this pull past the 05:15 resolver, deferring artist resolution of new rows by one night. Self-healing; not a bug.
+`cron-schedule: "5 5 * * *"` UTC (01:05 EDT / 00:05 EST) — between the RHP scraper at 05:00 and the resolver at 05:15. Known soft edge (BS#1570 correction 5): a cold-starting triangle-shows host can occasionally push this pull past the 05:15 resolver, deferring artist resolution of new rows by one night. Self-healing; not a bug.
 
 ## Environment
 
@@ -41,7 +41,7 @@ For `source='triangle_shows'` rows, `status` is **source-authoritative — refre
 
 Same both-directions rule for `removed_at`: it mirrors the source's tombstone — set when stamped, **cleared when a delisted event reappears**. Absence-from-snapshot is never treated as a removal signal; rows that age out at the source (hard-delete at +7 days) may keep a NULL `removed_at` forever, which is fine because `starts_on` windowing retires them from any feed.
 
-Field mapping details (status enum mapping incl. `free` → `on_sale` + `price_min=0`, `artist ?? name` truncation, date-only events keeping `starts_at` NULL) live in `map.ts` and its unit tests (`tests/unit/jobs/triangle-shows-etl/`).
+Field mapping details (status enum mapping incl. `free` → `on_sale` + `price_min=0`; headliner = `artist` when non-blank else `name`, both-blank throws as a map_error; `title` only when distinct from the headliner per the schema contract; un-storable prices past the numeric(8,2) cap or negative drop to NULL; unparseable `removed_at` throws as a map_error; date-only events keep `starts_at` NULL) live in `map.ts` and its unit tests (`tests/unit/jobs/triangle-shows-etl/`). `headlining_artist_id` is conditionally cleared on conflict when the raw headliner changed (shared fragment in `shared/database/src/concerts-sql.ts`, also adopted by the RHP writer) so the write-once resolver re-claims the row the same night. A `time_order_anomalies` counter flags events whose composed `starts_at` precedes `doors_at` (past-midnight `show_time` on the advertised date) — logged, never re-shifted.
 
 ## Observability
 

--- a/jobs/triangle-shows-etl/job.ts
+++ b/jobs/triangle-shows-etl/job.ts
@@ -12,7 +12,7 @@
  * no source filter).
  *
  * Run procedure: cron-registered via deploy-base's `cron-schedule` from
- * package.json (`5 5 * * *` UTC = 01:05 ET, between the RHP scraper at
+ * package.json (`5 5 * * *` UTC = 01:05 EDT / 00:05 EST, between the RHP scraper at
  * 05:00 and the resolver at 05:15). Container runs to completion.
  *
  * Required env: `TRIANGLE_SHOWS_URL` (see docs/env-vars.md).

--- a/jobs/triangle-shows-etl/map.ts
+++ b/jobs/triangle-shows-etl/map.ts
@@ -48,8 +48,25 @@ export const splitSupportArtists = (raw: string | null): string[] =>
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 
-/** Dollars as the 2-decimal string Drizzle's numeric(8,2) column binds. */
-const toPrice = (value: number | null): string | null => (value === null ? null : value.toFixed(2));
+/** numeric(8,2) tops out at 999999.99, and PG errors rather than
+ *  truncates. Judged on the ROUNDED value — toFixed carries 999999.996
+ *  to '1000000.00'. */
+const PRICE_MAX = 999_999.99;
+
+/**
+ * Dollars as the 2-decimal string Drizzle's numeric(8,2) column binds.
+ * Un-storable values (past the column cap, negative, or non-finite) drop
+ * to NULL instead of failing the whole event's upsert every night: the
+ * source's floats are unbounded and its scrapers' price regexes can
+ * misparse prose digit runs — a phone number in a Squarespace
+ * description qualifies — and the same misparse family can capture a
+ * leading hyphen from a prose range as a negative.
+ */
+const toPrice = (value: number | null): string | null => {
+  if (value === null || !Number.isFinite(value) || value < 0) return null;
+  const formatted = value.toFixed(2);
+  return Number(formatted) > PRICE_MAX ? null : formatted;
+};
 
 /**
  * Map the source EventStatus onto `concert_status_enum`. Complete against
@@ -72,6 +89,24 @@ const mapStatus = (event: TsEvent): { status: 'on_sale' | 'sold_out' | 'cancelle
   }
 };
 
+const NUL = '\u0000';
+
+const eventContainsNul = (value: unknown): boolean => {
+  if (typeof value === 'string') return value.includes(NUL);
+  if (Array.isArray(value)) return value.some(eventContainsNul);
+  if (value !== null && typeof value === 'object') return Object.values(value).some(eventContainsNul);
+  return false;
+};
+
+const stripNulDeep = (value: unknown): unknown => {
+  if (typeof value === 'string') return value.replaceAll(NUL, '');
+  if (Array.isArray(value)) return value.map(stripNulDeep);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, stripNulDeep(v)]));
+  }
+  return value;
+};
+
 export const mapEvent = (event: TsEvent): MappedEvent => {
   if (!event.venue_slug) {
     throw new Error(`mapEvent: event id ${event.id} has no venue_slug; cannot compose the venue-qualified source_id`);
@@ -79,11 +114,38 @@ export const mapEvent = (event: TsEvent): MappedEvent => {
   if (!ISO_DATE_SHAPE.test(event.date)) {
     throw new Error(`mapEvent: event id ${event.id} has non-ISO date '${event.date}' (want YYYY-MM-DD)`);
   }
-  const { status, priceMin } = mapStatus(event);
+  // PG rejects U+0000 in EVERY text-typed bind (varchar/text and jsonb
+  // alike) — one NUL in scraped free text would permanently fail the
+  // event's upsert every night. Sanitize the whole payload up front (deep
+  // string walk, exact — no escaped-JSON surgery that could corrupt a
+  // literal backslash-u0000 text sequence) so every mapped column AND
+  // raw_data derive from clean strings. Clean payloads (the norm) pass
+  // through by reference.
+  const sanitized = eventContainsNul(event) ? (stripNulDeep(event) as TsEvent) : event;
+
+  const { status, priceMin } = mapStatus(sanitized);
   // `||` on the trimmed artist, not `??`: heterogeneous scrapers can emit
   // '' where they mean "unknown", and an empty headliner defeats both the
-  // resolver and any display — `name` is NOT NULL, so the fallback is total.
-  const headliner = event.artist?.trim() || event.name;
+  // resolver and any display. `name` is NOT NULL at the source but can be
+  // whitespace — trim BEFORE the truthiness check so it can't slip through
+  // as a blank headliner; when both are blank the event is unresolvable
+  // garbage, thrown as a countable map_error rather than written.
+  const artist = sanitized.artist?.trim() ?? '';
+  const name = sanitized.name.trim();
+  const headliner = artist || name;
+  if (headliner === '') {
+    throw new Error(`mapEvent: event id ${event.id} has a blank artist AND name — refusing a headliner-less row`);
+  }
+  const clampedHeadliner = clampCodePoints(headliner, HEADLINER_MAX);
+
+  // Validated here so a source serialization change fails as an
+  // attributed map_error — an Invalid Date would otherwise surface at the
+  // Drizzle timestamp bind as a context-free 'RangeError: Invalid time
+  // value' counted as an upsert_error.
+  const removedAt = sanitized.removed_at ? new Date(sanitized.removed_at) : null;
+  if (removedAt !== null && Number.isNaN(removedAt.getTime())) {
+    throw new Error(`mapEvent: event id ${event.id} has unparseable removed_at '${sanitized.removed_at}'`);
+  }
 
   return {
     venue_slug: event.venue_slug,
@@ -92,25 +154,34 @@ export const mapEvent = (event: TsEvent): MappedEvent => {
       source_id: `${event.venue_slug}:${event.source_key}`,
       starts_on: event.date,
       // Date-only events keep starts_at NULL — never a fabricated time.
-      starts_at: event.show_time ? nyWallClockToUtc(event.date, event.show_time) : null,
-      doors_at: event.doors_time ? nyWallClockToUtc(event.date, event.doors_time) : null,
+      starts_at: sanitized.show_time ? nyWallClockToUtc(sanitized.date, sanitized.show_time) : null,
+      doors_at: sanitized.doors_time ? nyWallClockToUtc(sanitized.date, sanitized.doors_time) : null,
       // Truncated to the column width (source String(500) vs varchar(256));
       // code-point-safe so an astral char at the boundary can't strand a
       // lone surrogate as U+FFFD in the DB.
-      headlining_artist_raw: clampCodePoints(headliner, HEADLINER_MAX),
-      title: event.name,
-      supporting_artists_raw: splitSupportArtists(event.support_artists),
-      ticket_url: event.ticket_url,
-      image_url: event.image_url,
+      headlining_artist_raw: clampedHeadliner,
+      // Schema contract (schema.ts): 'Event name as the source displays
+      // it, when distinct from the artist' — rhp_scrape rows leave it
+      // NULL. When the headliner already IS the name (artist absent or
+      // identical), writing it again would render 'Juana Molina — Juana
+      // Molina' in any feed using the headliner—title shape. Compared
+      // against the CLAMPED headliner so a >256-code-point name keeps its
+      // full text here exactly when truncation amputated the raw column;
+      // the `name &&` guard keeps a blank name (with a valid artist) from
+      // storing a whitespace title.
+      title: name && name !== clampedHeadliner ? sanitized.name : null,
+      supporting_artists_raw: splitSupportArtists(sanitized.support_artists),
+      ticket_url: sanitized.ticket_url,
+      image_url: sanitized.image_url,
       price_min: priceMin,
-      price_max: toPrice(event.price_max),
-      age_restriction: event.age_restriction,
+      price_max: toPrice(sanitized.price_max),
+      age_restriction: sanitized.age_restriction,
       status,
       // Mirrors the source's tombstone in BOTH directions (the writer's
       // set clause clears it when a delisted event reappears).
-      removed_at: event.removed_at ? new Date(event.removed_at) : null,
+      removed_at: removedAt,
       // genre/subgenre/description live only here (BS#1570 Decision 2).
-      raw_data: event,
+      raw_data: sanitized,
     },
   };
 };

--- a/jobs/triangle-shows-etl/orchestrate.ts
+++ b/jobs/triangle-shows-etl/orchestrate.ts
@@ -81,6 +81,13 @@ export type Totals = {
   upserts_updated: number;
   /** Upserted events carrying a source tombstone this run. */
   tombstones_seen: number;
+  /** Events whose composed starts_at is EARLIER than doors_at — the
+   *  free-text source scrapers can pair a past-midnight show_time with
+   *  the advertised calendar date ('doors 11PM, show 12:30AM'). Logged
+   *  and passed through unmodified: no heuristic can safely re-shift
+   *  either side (the inverse skew — correct starts_at, misparsed
+   *  doors — also occurs); the real fix belongs in the source scrapers. */
+  time_order_anomalies: number;
   /** True when the health probe reported last_scrape > 24h old, absent, or unparseable. */
   source_stale: boolean;
 };
@@ -100,6 +107,7 @@ const emptyTotals = (): Totals => ({
   upserts_inserted: 0,
   upserts_updated: 0,
   tombstones_seen: 0,
+  time_order_anomalies: 0,
   source_stale: false,
 });
 
@@ -238,6 +246,19 @@ export const runEtl = async (opts: RunOptions): Promise<Totals> => {
     if (failedSlugs.has(mapped.venue_slug)) {
       totals.events_skipped_failed_venue += 1;
       continue;
+    }
+
+    const { starts_at, doors_at } = mapped.concert;
+    if (starts_at && doors_at && starts_at < doors_at) {
+      totals.time_order_anomalies += 1;
+      log('warn', 'time_order_anomaly', `event id ${event.id} composes starts_at before doors_at`, {
+        event_id: event.id,
+        venue_slug: mapped.venue_slug,
+        date: event.date,
+        doors_time: event.doors_time,
+        show_time: event.show_time,
+        source: event.source,
+      });
     }
 
     if (!listedSlugs.has(mapped.venue_slug) && !warnedUnlistedSlugs.has(mapped.venue_slug)) {

--- a/jobs/triangle-shows-etl/writer.ts
+++ b/jobs/triangle-shows-etl/writer.ts
@@ -27,7 +27,7 @@
  * triangle-shows' seed.
  */
 
-import { db, venues, concerts } from '@wxyc/database';
+import { db, venues, concerts, headliningArtistIdConflictClear } from '@wxyc/database';
 import { eq, sql } from 'drizzle-orm';
 
 import { clampCodePoints, type MappedEvent } from './map.js';
@@ -169,6 +169,11 @@ export const upsertConcert = async (
         starts_at: values.starts_at,
         doors_at: values.doors_at,
         headlining_artist_raw: values.headlining_artist_raw,
+        // Clears the resolved FK only when the raw headliner actually
+        // changed, so the write-once resolver re-claims the row the same
+        // night — see the shared fragment's docstring in
+        // shared/database/src/concerts-sql.ts.
+        headlining_artist_id: headliningArtistIdConflictClear(),
         title: values.title,
         supporting_artists_raw: values.supporting_artists_raw,
         ticket_url: values.ticket_url,

--- a/jobs/venue-events-scraper/writer.ts
+++ b/jobs/venue-events-scraper/writer.ts
@@ -14,7 +14,7 @@
  * threading state through the writer.
  */
 
-import { db, venues, concerts, nyCalendarDate } from '@wxyc/database';
+import { db, venues, concerts, nyCalendarDate, headliningArtistIdConflictClear } from '@wxyc/database';
 import { eq, sql } from 'drizzle-orm';
 
 import type { ParsedConcert } from './rhp-types.js';
@@ -243,6 +243,11 @@ export const upsertConcert = async (
         starts_at: values.starts_at,
         starts_on: values.starts_on,
         headlining_artist_raw: values.headlining_artist_raw,
+        // RHP source_ids are pathname-derived and survive a billed-artist
+        // swap, and the resolver is write-once — clear the resolved FK
+        // when the raw headliner changed so it re-resolves the same
+        // night. Shared fragment: shared/database/src/concerts-sql.ts.
+        headlining_artist_id: headliningArtistIdConflictClear(),
         supporting_artists_raw: values.supporting_artists_raw,
         ticket_url: values.ticket_url,
         image_url: values.image_url,

--- a/shared/database/src/concerts-sql.ts
+++ b/shared/database/src/concerts-sql.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared SQL fragments for the concert writers (jobs/venue-events-scraper
+ * and jobs/triangle-shows-etl). Both writers UPSERT `concerts` by
+ * (source, source_id) and refresh `headlining_artist_raw` on conflict —
+ * so both carry the same table invariant, kept in ONE place here:
+ *
+ *   `headlining_artist_id` is only valid for the raw headliner it was
+ *   resolved from.
+ *
+ * The concerts-artist-resolver is deliberately write-once (it claims
+ * rows WHERE headlining_artist_id IS NULL and never revisits a stamped
+ * row — see jobs/concerts-artist-resolver). Both writers' source_ids are
+ * rename-stable (RHP: page pathnames survive a billed-artist swap;
+ * triangle-shows: ext:/url: source_key tiers survive renames by
+ * contract), so a headliner change arrives as an ON CONFLICT UPDATE on
+ * the same row. Without this fragment the stale FK would serve the old
+ * artist forever; with it, the resolver re-claims the row the same night.
+ */
+
+import { sql, type SQL } from 'drizzle-orm';
+import { concerts } from './schema.js';
+
+/**
+ * ON CONFLICT `set` entry for `headlining_artist_id`: clear the resolved
+ * FK ONLY when the incoming raw headliner actually differs from the
+ * stored one (`IS DISTINCT FROM excluded...`); untouched rows keep their
+ * resolved id, so nightly re-upserts of unchanged events never churn the
+ * resolver. In a DO UPDATE SET, table-qualified refs read the EXISTING
+ * row and `excluded` reads the proposed insert — the same idiom the RHP
+ * venue upsert's `setWhere` already uses in production.
+ */
+export const headliningArtistIdConflictClear = (): SQL =>
+  sql`CASE WHEN ${concerts.headlining_artist_raw} IS DISTINCT FROM excluded."headlining_artist_raw" THEN NULL ELSE ${concerts.headlining_artist_id} END`;

--- a/shared/database/src/index.ts
+++ b/shared/database/src/index.ts
@@ -11,3 +11,4 @@ export * from './normalize-artist-name.js';
 export * from './normalize-album-title.js';
 export * from './freetext-norm.js';
 export * from './ny-time.js';
+export * from './concerts-sql.js';

--- a/shared/database/src/ny-time.ts
+++ b/shared/database/src/ny-time.ts
@@ -77,7 +77,14 @@ const nyOffsetMsAt = (instant: Date): number => {
 };
 
 // HH:MM or HH:MM:SS, hour optionally unpadded (some feeds emit '9:30').
-const TIME_SHAPE = /^(\d{1,2}):(\d{2})(?::(\d{2}))?$/;
+// Fractional seconds are accepted and TRUNCATED (never rounded up into
+// the next second): Pydantic serializes Python `time` via isoformat(),
+// which emits microseconds whenever they're nonzero — triangle-shows'
+// Squarespace scraper concretely produces them (datetime.fromtimestamp
+// of a millisecond timestamp). Rejecting the shape would permanently
+// map_error those venues' events; sub-second precision carries no
+// signal for a concert start time.
+const TIME_SHAPE = /^(\d{1,2}):(\d{2})(?::(\d{2})(?:\.\d{1,9})?)?$/;
 
 /**
  * Interpret `isoDate` (`YYYY-MM-DD`) + `time` (`HH:MM[:SS]`, hour may be

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -356,6 +356,19 @@ export { normalizeAlbumTitle } from '../../shared/database/src/normalize-album-t
 export { freetextPairKey, normalizeFreetextArtist } from '../../shared/database/src/freetext-norm.js';
 export { NY_TIME_ZONE, nyCalendarDate, nyWallClockToUtc } from '../../shared/database/src/ny-time.js';
 
+// Self-contained STUB of shared/database/src/concerts-sql.ts. The real
+// module imports schema.ts, which calls drizzle's `eq` at module scope (a
+// view definition) — re-exporting it here would break every suite that
+// per-file-mocks 'drizzle-orm' with a partial factory (e.g. the
+// album-plays/popularity-refresh suites). The stub mirrors the real
+// fragment under the tests/__mocks__/drizzle-orm.ts sql-tag shape; the
+// REAL module's text and column bindings are pinned by
+// tests/unit/database/concerts-sql.test.ts.
+export const headliningArtistIdConflictClear = (): { sql: readonly string[]; values: unknown[] } => ({
+  sql: ['CASE WHEN ', ' IS DISTINCT FROM excluded."headlining_artist_raw" THEN NULL ELSE ', ' END'],
+  values: ['<concerts.headlining_artist_raw>', '<concerts.headlining_artist_id>'],
+});
+
 // Mock types
 export type AnonymousDevice = {
   id: number;

--- a/tests/unit/database/concerts-sql.test.ts
+++ b/tests/unit/database/concerts-sql.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Pins the REAL shared conflict-clear fragment (shared/database/src/
+ * concerts-sql.ts) — the writer suites exercise it only through the
+ * database mock's stub, so this is the one place the actual module's
+ * mechanism text and column bindings are asserted. Under the unit
+ * harness, 'drizzle-orm' resolves to tests/__mocks__/drizzle-orm.ts,
+ * whose sql tag returns { sql: templateStrings, values: interpolations }
+ * — which makes both halves directly inspectable.
+ */
+import { headliningArtistIdConflictClear } from '../../../shared/database/src/concerts-sql';
+import { concerts } from '../../../shared/database/src/schema';
+
+describe('headliningArtistIdConflictClear', () => {
+  it('builds the conditional clear: NULL only when the stored raw headliner differs from the incoming one', () => {
+    const frag = headliningArtistIdConflictClear() as unknown as {
+      sql: readonly string[];
+      values: unknown[];
+    };
+    const text = frag.sql.join('<col>');
+
+    expect(text).toMatch(/^CASE WHEN /);
+    expect(text).toContain('IS DISTINCT FROM excluded."headlining_artist_raw"');
+    expect(text).toContain('THEN NULL ELSE');
+    expect(text).toMatch(/ END$/);
+  });
+
+  it('binds the stored-row column refs (evaluated against the pre-update row in a DO UPDATE SET): raw for the comparison, id for the ELSE', () => {
+    const frag = headliningArtistIdConflictClear() as unknown as { values: unknown[] };
+
+    expect(frag.values).toHaveLength(2);
+    expect(frag.values[0]).toBe(concerts.headlining_artist_raw);
+    expect(frag.values[1]).toBe(concerts.headlining_artist_id);
+  });
+
+  it('returns a fresh fragment per call (no shared mutable descriptor across upserts)', () => {
+    expect(headliningArtistIdConflictClear()).not.toBe(headliningArtistIdConflictClear());
+  });
+});

--- a/tests/unit/database/ny-time.test.ts
+++ b/tests/unit/database/ny-time.test.ts
@@ -53,6 +53,14 @@ describe('nyWallClockToUtc', () => {
     ['2026-03-08', '01:30:00', '2026-03-08T06:30:00.000Z'],
     // Just after the gap: 03:30 EDT.
     ['2026-03-08', '03:30:00', '2026-03-08T07:30:00.000Z'],
+    // Fractional seconds accepted and truncated: Pydantic serializes a
+    // Python time via isoformat(), which emits microseconds whenever they
+    // are nonzero — concretely produced by triangle-shows' Squarespace
+    // scraper (datetime.fromtimestamp(ms / 1000) keeps sub-second
+    // precision). Rejecting the shape would permanently map_error those
+    // venues' events.
+    ['2026-07-04', '20:00:00.123000', '2026-07-05T00:00:00.000Z'],
+    ['2026-07-04', '19:30:15.5', '2026-07-04T23:30:15.000Z'],
   ])('nyWallClockToUtc(%s, %s) -> %s', (date, time, expectedIso) => {
     expect(nyWallClockToUtc(date, time).toISOString()).toBe(expectedIso);
   });

--- a/tests/unit/jobs/triangle-shows-etl/map.test.ts
+++ b/tests/unit/jobs/triangle-shows-etl/map.test.ts
@@ -85,10 +85,49 @@ describe('mapEvent — dates and times', () => {
 });
 
 describe('mapEvent — headliner and title', () => {
-  it('prefers artist over name for headlining_artist_raw and carries name as title', () => {
+  it('prefers artist over name for headlining_artist_raw and carries name as title when distinct', () => {
     const mapped = mapEvent(makeTsEvent({ artist: 'Juana Molina', name: 'Juana Molina — DOGA tour' }));
     expect(mapped.concert.headlining_artist_raw).toBe('Juana Molina');
     expect(mapped.concert.title).toBe('Juana Molina — DOGA tour');
+  });
+
+  // schema.ts documents title as 'Event name as the source displays it,
+  // when distinct from the artist' (and rhp_scrape rows leave it NULL).
+  // Writing name unconditionally would render 'Juana Molina — Juana
+  // Molina' in any feed using the documented headliner—title shape.
+  it('leaves title NULL when the headliner IS the name (artist absent — nothing distinct to display)', () => {
+    const mapped = mapEvent(makeTsEvent({ artist: null, name: 'Jessica Pratt' }));
+    expect(mapped.concert.headlining_artist_raw).toBe('Jessica Pratt');
+    expect(mapped.concert.title).toBeNull();
+  });
+
+  it('leaves title NULL when name and artist are the same string (not distinct billing)', () => {
+    const mapped = mapEvent(makeTsEvent({ artist: 'Cat Power', name: 'Cat Power' }));
+    expect(mapped.concert.title).toBeNull();
+  });
+
+  it('trims the name fallback so a padded source name cannot store a padded headliner', () => {
+    const mapped = mapEvent(makeTsEvent({ artist: null, name: '  Cat Power  ' }));
+    expect(mapped.concert.headlining_artist_raw).toBe('Cat Power');
+  });
+
+  it('throws a map error when artist AND name are both blank — a headliner-less row satisfies NOT NULL but is unresolvable garbage', () => {
+    expect(() => mapEvent(makeTsEvent({ artist: null, name: '   ' }))).toThrow(/blank/i);
+    expect(() => mapEvent(makeTsEvent({ artist: ' ', name: '' }))).toThrow(/blank/i);
+  });
+
+  it('leaves title NULL when name is blank but artist is valid — a whitespace title is not "distinct billing"', () => {
+    const mapped = mapEvent(makeTsEvent({ artist: 'Cat Power', name: '   ' }));
+    expect(mapped.concert.headlining_artist_raw).toBe('Cat Power');
+    expect(mapped.concert.title).toBeNull();
+  });
+
+  it('keeps the full name in title exactly when truncation amputated the headliner (artist absent, name past 256 code points)', () => {
+    const long = `${'x'.repeat(300)}`;
+    const mapped = mapEvent(makeTsEvent({ artist: null, name: long }));
+    expect([...mapped.concert.headlining_artist_raw]).toHaveLength(256);
+    // Without this, the amputated prefix would be the only queryable copy.
+    expect(mapped.concert.title).toBe(long);
   });
 
   it('falls back to name when artist is null (name is NOT NULL at the source, so the mapping is total)', () => {
@@ -177,6 +216,27 @@ describe('mapEvent — status and prices', () => {
     expect(mapped.concert.price_min).toBe('15.50');
     expect(mapped.concert.price_max).toBe('20.00');
   });
+
+  // numeric(8,2) caps at 999999.99 and PG errors rather than truncates.
+  // Source floats are unbounded, and the scrapers' price regexes can
+  // misparse prose digit runs (a phone number in a Squarespace
+  // description) — an un-storable price must drop to NULL, not fail the
+  // whole event's upsert every night.
+  it('drops un-storable prices (past the numeric(8,2) cap) instead of failing the event', () => {
+    const mapped = mapEvent(makeTsEvent({ price_min: 9195551234, price_max: 20242025 }));
+    expect(mapped.concert.price_min).toBeNull();
+    expect(mapped.concert.price_max).toBeNull();
+  });
+
+  it('judges the cap on the ROUNDED value — toFixed carries 999999.996 to 1000000.00', () => {
+    expect(mapEvent(makeTsEvent({ price_min: 999999.99 })).concert.price_min).toBe('999999.99');
+    expect(mapEvent(makeTsEvent({ price_min: 999999.996 })).concert.price_min).toBeNull();
+    expect(mapEvent(makeTsEvent({ price_min: Number.POSITIVE_INFINITY })).concert.price_min).toBeNull();
+  });
+
+  it('drops negative prices — the same misparse family can capture a leading hyphen from prose ranges', () => {
+    expect(mapEvent(makeTsEvent({ price_min: -5 })).concert.price_min).toBeNull();
+  });
 });
 
 describe('mapEvent — tombstones and raw payload', () => {
@@ -188,6 +248,33 @@ describe('mapEvent — tombstones and raw payload', () => {
   it('carries removed_at as NULL for live rows (writer clears on reappearance)', () => {
     const mapped = mapEvent(makeTsEvent({ removed_at: null }));
     expect(mapped.concert.removed_at).toBeNull();
+  });
+
+  it('throws a map error on an unparseable removed_at — an Invalid Date would otherwise explode at the Drizzle bind as a context-free RangeError counted as an upsert_error', () => {
+    expect(() => mapEvent(makeTsEvent({ removed_at: 'not-a-timestamp' }))).toThrow(/removed_at/);
+  });
+
+  it('strips U+0000 from the raw payload — PG rejects NUL in every text-typed bind, which would permanently fail the event', () => {
+    const mapped = mapEvent(makeTsEvent({ description: 'trio\u0000set' }));
+    expect((mapped.concert.raw_data as { description: string }).description).toBe('trioset');
+  });
+
+  it('strips U+0000 from mapped columns too, not just raw_data — a NUL in artist would fail the varchar bind the same way', () => {
+    const mapped = mapEvent(makeTsEvent({ artist: 'Nil\u0000üfer Yanya' }));
+    expect(mapped.concert.headlining_artist_raw).toBe('Nilüfer Yanya');
+  });
+
+  it('passes a clean payload through as the same object (no needless deep copy)', () => {
+    const event = makeTsEvent({ description: 'trio set' });
+    expect(mapEvent(event).concert.raw_data).toBe(event);
+  });
+
+  it('does not corrupt literal backslash-u0000 TEXT (no actual NUL) — escaped-JSON string surgery would strip the escape and break or mangle the payload', () => {
+    // The 6 typed characters backslash-u-0-0-0-0, not a control character.
+    const event = makeTsEvent({ description: 'call \\u0000 me' });
+    const mapped = mapEvent(event);
+    expect(mapped.concert.raw_data).toBe(event);
+    expect((mapped.concert.raw_data as { description: string }).description).toBe('call \\u0000 me');
   });
 
   it('stores the full EventResponse as raw_data (genre/subgenre/description live only there per Decision 2)', () => {

--- a/tests/unit/jobs/triangle-shows-etl/orchestrate.test.ts
+++ b/tests/unit/jobs/triangle-shows-etl/orchestrate.test.ts
@@ -143,6 +143,25 @@ describe('runEtl — event flow', () => {
     expect(totals.upserts_total).toBe(1);
   });
 
+  it('counts a starts_at earlier than doors_at as a time-order anomaly and still upserts the row unmodified', async () => {
+    // Free-text source scrapers can pair a past-midnight show_time with
+    // the advertised date ('Sat Oct 31, doors 11PM, show 12:30AM' stores
+    // date=…-10-31 + show_time=00:30) — starts_at composes ~22.5h before
+    // doors_at. No heuristic can safely re-shift either side (the inverse
+    // skew also occurs), so this is observability only.
+    const opts = makeOpts({
+      fetchEvents: () =>
+        Promise.resolve([
+          event(1, 'the-pinhook', { doors_time: '23:00:00', show_time: '00:30:00', date: '2026-10-31' }),
+          event(2, 'kings'),
+        ]),
+    });
+    const totals = await runEtl(opts);
+
+    expect(totals.time_order_anomalies).toBe(1);
+    expect(totals.upserts_total).toBe(2);
+  });
+
   it('counts tombstoned upserts', async () => {
     const opts = makeOpts({
       fetchEvents: () =>

--- a/tests/unit/jobs/triangle-shows-etl/writer.test.ts
+++ b/tests/unit/jobs/triangle-shows-etl/writer.test.ts
@@ -135,6 +135,30 @@ describe('upsertConcert', () => {
     for (const set of sets) expect(set).not.toHaveProperty('first_scraped_at');
   });
 
+  it('conditionally clears headlining_artist_id in the ON CONFLICT set when the raw headliner changed — the resolver is write-once (claims WHERE headlining_artist_id IS NULL), so a headliner swap on a rename-stable ext:/url: source_key would otherwise serve the old artist forever', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 1, inserted: false }]);
+    await upsertConcert(mapEvent(fakeEvent()), 5, scrapedAt);
+
+    const set = concertSetClauses()[0];
+    expect(set).toHaveProperty('headlining_artist_id');
+    // A drizzle SQL fragment: pin the CASE/IS DISTINCT FROM/excluded
+    // mechanism so a refactor to an unconditional NULL (which would strip
+    // every resolved id nightly) fails here.
+    // Robust to both SQL-object shapes: real drizzle exposes queryChunks
+    // (string chunks interleaved with column refs); the unit-mock env's
+    // tag exposes the template strings via `.sql` (String() joins them).
+    const frag = set.headlining_artist_id as {
+      sql?: string | readonly string[];
+      queryChunks?: Array<{ value?: unknown }>;
+    };
+    const fragmentText =
+      frag?.sql != null
+        ? [frag.sql].flat().join(' ')
+        : (frag?.queryChunks ?? []).flatMap((c) => (Array.isArray(c.value) ? (c.value as string[]) : [])).join(' ');
+    expect(fragmentText).toMatch(/IS DISTINCT FROM/i);
+    expect(fragmentText).toMatch(/excluded/i);
+  });
+
   it('threads venue_id and the venue-qualified source_id into the row', async () => {
     mockDb._chain.returning.mockResolvedValueOnce([{ id: 1, inserted: true }]);
     await upsertConcert(mapEvent(fakeEvent()), 31337, scrapedAt);

--- a/tests/unit/jobs/venue-events-scraper/writer.test.ts
+++ b/tests/unit/jobs/venue-events-scraper/writer.test.ts
@@ -158,6 +158,31 @@ describe('upsertConcert', () => {
       }
     });
   });
+
+  it('conditionally clears headlining_artist_id in the ON CONFLICT set when the raw headliner changed — RHP source_ids are pathname-derived and stable when a page swaps its billed artist, and the write-once resolver never revisits a non-NULL FK', async () => {
+    mockDb._chain.returning.mockResolvedValueOnce([{ id: 1, inserted: false }]);
+    await upsertConcert(fakeParsed('fk-clear'), 1, new Date('2026-06-05T12:00:00Z'));
+
+    const set = concertSetClauses()[0];
+    expect(set).toHaveProperty('headlining_artist_id');
+    // The value is a drizzle SQL fragment (shared helper from
+    // @wxyc/database) — pin the CASE/IS DISTINCT FROM/excluded mechanism
+    // so a refactor to an unconditional NULL (stripping every resolved id
+    // nightly) fails here.
+    // Robust to both SQL-object shapes: real drizzle exposes queryChunks
+    // (string chunks interleaved with column refs); the unit-mock env's
+    // tag exposes the template strings via `.sql` (String() joins them).
+    const frag = set.headlining_artist_id as {
+      sql?: string | readonly string[];
+      queryChunks?: Array<{ value?: unknown }>;
+    };
+    const fragmentText =
+      frag?.sql != null
+        ? [frag.sql].flat().join(' ')
+        : (frag?.queryChunks ?? []).flatMap((c) => (Array.isArray(c.value) ? (c.value as string[]) : [])).join(' ');
+    expect(fragmentText).toMatch(/IS DISTINCT FROM/i);
+    expect(fragmentText).toMatch(/excluded/i);
+  });
 });
 
 // Migration 0112 (BS#1589) — `starts_on date NOT NULL` is the venue-local


### PR DESCRIPTION
Applies the verified findings from the post-merge max-effort review of the BS#1589 Phase 1 implementation (#1592 + #1593) — full finding write-ups in #1601.

## Fixes

- **Stale `headlining_artist_id` on headliner change** — new shared fragment `headliningArtistIdConflictClear()` (`shared/database/src/concerts-sql.ts`) clears the resolved FK in the ON CONFLICT set only when the raw headliner actually changed (`IS DISTINCT FROM excluded`), adopted by **both** concert writers so the write-once resolver re-claims the row the same night. Untouched rows keep their id (PG evaluates the stored-raw ref against the pre-update row, so unchanged re-upserts always take the ELSE branch — same idiom as the RHP venue upsert's `setWhere`, and the rendered SQL was verified against drizzle 0.45.2).
- **Price overflow** — `toPrice` now judges the ROUNDED value against the `numeric(8,2)` cap and drops negatives; an un-storable misparse (phone number in a Squarespace description) loses its price instead of permanently failing the event's upsert.
- **`title` contract** — NULL unless genuinely distinct from the headliner, per the schema's "when distinct from the artist" contract (artist-less events no longer duplicate the headliner into `title`).
- **Blank headliner residual** — `name` is trimmed before the truthy fallback; both-blank throws as a countable `map_error` instead of writing an unresolvable blank NOT NULL headliner.
- **`removed_at` validation** — unparseable timestamps throw as an attributed `map_error` instead of exploding at the Drizzle bind as a context-free `RangeError` counted as an `upsert_error`.
- **jsonb NUL** — U+0000 stripped from `raw_data` (clean payloads pass through by reference), preventing a permanent per-event 22P05 failure.
- **`nyWallClockToUtc` fractional seconds** — `TIME_SHAPE` accepts and truncates `HH:MM:SS.ffffff`; Pydantic emits it whenever microseconds are nonzero, concretely via the source's Squarespace scraper (millisecond timestamps → neptunes-parlour and boom-club events would have permanently map_errored).
- **`time_order_anomalies` counter** — events whose composed `starts_at` precedes `doors_at` (past-midnight `show_time` on the advertised date) are counted and logged, never heuristically re-shifted (the inverse skew exists, so no shift is safe); root fix belongs upstream in the triangle-shows scrapers.
- **Round-3 sweep hardening** (a termination sweep over this PR's own delta found and fixed): the NUL strip is now an exact deep string-walk over the payload (the first cut operated on escaped JSON text and could corrupt a literal typed `\u0000` sequence into a parse error or a control character) and covers every mapped column, not just `raw_data` (PG rejects NUL in all text-typed binds); `title` gains a blank-name guard (a valid artist with a whitespace name no longer stores a whitespace title) and compares against the CLAMPED headliner, so a >256-code-point name keeps its full text in `title` exactly when truncation amputated the raw column; the database mock ships a self-contained stub of the shared fragment (re-exporting the real module dragged `schema.ts`'s module-scope drizzle calls into suites that per-file-mock 'drizzle-orm'), with the real module's text and column bindings pinned by a new `tests/unit/database/concerts-sql.test.ts`.
- **Docs** — README's stale "`artist ?? name`" phrasing replaced with the actual mapping semantics (plus the new behaviors above); "01:05 ET" corrected to "01:05 EDT / 00:05 EST" in `job.ts` and the README.

## Verification

- Full unit suite green (279 suites / 3917 tests), including new pins for every fix: the CASE/IS DISTINCT FROM mechanism in BOTH writer suites (a refactor to an unconditional NULL fails the test), price cap incl. the `toFixed` rounding boundary and negatives, title distinct/identical/absent cases, blank-name and both-blank throws, `removed_at` rejection, NUL stripping + clean-payload pass-through-by-reference, fractional-seconds acceptance in `ny-time.test.ts`, and the anomaly counter with pass-through in `orchestrate.test.ts`.
- Direct `tsc -p` clean on `jobs/triangle-shows-etl` and `jobs/venue-events-scraper` (both outside `npm run typecheck`); `lint` and `format:check` green.

## Not in this PR (see #1601)

The org-wide `finally`-block Sentry-flush hazard, the test-harness helper consolidation, and the operational pre-first-run step: `TRIANGLE_SHOWS_URL` must be set on the EC2 host (`set-ec2-env-var.yml`) or every 05:05 UTC run exits 1 on the `resolveBaseUrl()` guard.

Closes #1601
