### PR TITLE
feat(flowsheet): embed per-playcut upcoming_show on the V2 feed

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -67,6 +67,7 @@ components:
       description: >
         Discriminated union keyed by entry_type.
         track entries include artist_name, album_title, track_title, record_label, rotation_bin, metadata fields.
+        track entries MAY also carry upcoming_show — an optional embedded Concert (see the Concert schema and GET /concerts) attached server-side at feed-assembly time when the track's resolved catalog artist (flowsheet.album_id → library.artist_id) has a curated, non-tombstoned, upcoming Triangle-area date (concerts.headlining_artist_id match; soonest date wins). Absent when there is no such match; older clients decode the absent field as "no touring CTA" (BS#1607). The canonical wire contract is FlowsheetV2TrackEntry.upcoming_show in wxyc-shared/api.yaml (the SSOT); this app.yaml is Swagger display only.
         show_start/show_end entries include dj_name and timestamp.
         dj_join/dj_leave entries include dj_name.
         talkset/breakpoint/message entries include message.

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -6,6 +6,7 @@ import { NewFSEntry as FullNewFSEntry, FSEntry, Show, ShowDJ } from '@wxyc/datab
 // play_order is computed by the service layer, not provided by controllers
 type NewFSEntry = Omit<FullNewFSEntry, 'play_order'>;
 import * as flowsheet_service from '../services/flowsheet.service.js';
+import type { ConcertDTO } from '../services/concerts.service.js';
 import { projectFlowsheetEntry } from '../utils/flowsheet-projection.js';
 import { stashMirrorData } from '../middleware/legacy/mirror.middleware.js';
 import WxycError from '../utils/error.js';
@@ -72,6 +73,17 @@ export interface IFSEntry extends Omit<
   rotation_bin: string | null;
   on_streaming: boolean | null;
   metadata: IFSEntryMetadata;
+  // Resolved catalog artist for the played release (flowsheet.album_id ->
+  // library.artist_id). Not a wire field — the batch key `attachUpcomingShows`
+  // uses to look up the per-playcut `upcoming_show` (BS#1607). NULL for
+  // free-form entries and unresolved library rows.
+  artist_id: number | null;
+  // Per-playcut upcoming-show enrichment (BS#1607). Populated only on track
+  // rows whose `artist_id` matched a curated, non-tombstoned, upcoming
+  // concert; absent/undefined otherwise. `transformToV2` emits it as
+  // `upcoming_show` on the V2 track wire shape (SSOT `FlowsheetV2TrackEntry`,
+  // wxyc-shared api.yaml 1.16.0), reusing the `Concert` schema verbatim.
+  upcoming_show?: ConcertDTO | null;
 }
 
 const MAX_ITEMS = 200;
@@ -91,6 +103,7 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
     const entries = await flowsheet_service.getEntriesByShow(...recentShows.map((show) => show.id));
 
     if (entries.length) {
+      await flowsheet_service.attachUpcomingShows(entries);
       res.status(200).json(entries.map(flowsheet_service.transformToV2));
     } else {
       res.status(404).json({
@@ -106,6 +119,7 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
     }
     const entries = await flowsheet_service.getEntriesByRange(parseInt(query.start_id), parseInt(query.end_id));
     if (entries.length) {
+      await flowsheet_service.attachUpcomingShows(entries);
       res.status(200).json(entries.map(flowsheet_service.transformToV2));
     } else {
       res.status(404).json({ message: 'No Tracks found' });
@@ -131,6 +145,10 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
       return undefined;
     }),
   ]);
+
+  // Attach the per-playcut upcoming-show enrichment (BS#1607) before
+  // projecting to V2 — one batched concerts query for the whole page.
+  await flowsheet_service.attachUpcomingShows(entries);
 
   const totalPages = Math.ceil(total / limit);
 
@@ -158,6 +176,7 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
 export const getLatest: RequestHandler = async (req, res) => {
   const entries = await flowsheet_service.getEntriesByPage(0, 1);
   if (entries.length) {
+    await flowsheet_service.attachUpcomingShows(entries);
     res.status(200).json(flowsheet_service.transformToV2(entries[0]));
   } else {
     res.status(204).end();
@@ -556,6 +575,8 @@ export const getShowInfo: RequestHandler<object, unknown, object, { show_id: str
     flowsheet_service.getShowMetadata(showId),
     flowsheet_service.getEntriesByShow(showId),
   ]);
+
+  await flowsheet_service.attachUpcomingShows(entries);
 
   res.status(200).json({
     ...showMetadata,

--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gte, isNotNull, isNull, lte, sql } from 'drizzle-orm';
+import { and, asc, eq, gte, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
 import { concerts, db, venues } from '@wxyc/database';
 
 /**
@@ -199,4 +199,66 @@ export const getConcertsCount = async (filters: ConcertsQueryFilters): Promise<n
     .where(buildWhere(filters));
 
   return Number(result[0]?.count ?? 0);
+};
+
+/**
+ * Batched artist → soonest-upcoming-curated-concert lookup, backing the V2
+ * flowsheet feed's per-playcut `upcoming_show` enrichment (BS#1607, touring-
+ * events Phase 3).
+ *
+ * ONE indexed query for a whole feed page — never one query per row. The
+ * caller (`flowsheet.service` `attachUpcomingShows`) collects the distinct
+ * resolved artist ids across the returned page and passes them here; the
+ * result is a `Map<artistId, ConcertDTO>` it fans back out onto the matching
+ * playcuts. This is the no-N+1 guarantee the ticket and the post-launch
+ * hardening posture (project #32) require.
+ *
+ * Predicate is exactly the curated feed's: `headlining_artist_id IN (…)`,
+ * `removed_at IS NULL`, `starts_on >= today` (America/New_York, supplied by
+ * the caller so the window matches `GET /concerts`'s `todayEastern`). The
+ * `headlining_artist_id IS NOT NULL AND removed_at IS NULL` conjuncts let the
+ * planner read `concerts_curated_starts_on_idx`.
+ *
+ * One concert per artist — the SOONEST. `DISTINCT ON (headlining_artist_id)`
+ * with `ORDER BY headlining_artist_id, starts_on ASC, id` collapses an
+ * artist's multiple upcoming dates to the earliest (id as a stable tiebreak
+ * when two dates coincide), mirroring the "soonest wins" rule documented on
+ * the `upcoming_show` DTO. `DISTINCT ON` requires the distinct expression to
+ * lead the ORDER BY; the venue-embedding join and the DTO mapping reuse
+ * `getConcertsPage`'s projection so the wire shape can't drift.
+ *
+ * Returns an empty map for an empty id list without touching the DB.
+ */
+export const getUpcomingShowsForArtists = async (
+  artistIds: number[],
+  today: string
+): Promise<Map<number, ConcertDTO>> => {
+  const byArtist = new Map<number, ConcertDTO>();
+  if (artistIds.length === 0) {
+    return byArtist;
+  }
+
+  const rows = await db
+    .selectDistinctOn([concerts.headlining_artist_id], concertJoinFields)
+    .from(concerts)
+    .innerJoin(venues, eq(venues.id, concerts.venue_id))
+    .where(
+      and(
+        isNotNull(concerts.headlining_artist_id),
+        isNull(concerts.removed_at),
+        gte(concerts.starts_on, today),
+        inArray(concerts.headlining_artist_id, artistIds)
+      )
+    )
+    .orderBy(asc(concerts.headlining_artist_id), asc(concerts.starts_on), asc(concerts.id));
+
+  for (const row of rows as ConcertJoinRow[]) {
+    // headlining_artist_id is non-null here (the WHERE guards it), but the
+    // ConcertJoinRow type keeps it nullable for the general projection; the
+    // guard keeps the Map key a plain number.
+    if (row.headlining_artist_id !== null) {
+      byArtist.set(row.headlining_artist_id, toConcertDTO(row));
+    }
+  }
+  return byArtist;
 };

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -20,6 +20,7 @@ import {
   specialty_shows,
   album_metadata,
   nyCalendarDate,
+  nyStartOfDay,
 } from '@wxyc/database';
 import { getUpcomingShowsForArtists } from './concerts.service.js';
 import { IFSEntry, ShowMetadata, UpdateRequestBody } from '../controllers/flowsheet.controller.js';
@@ -100,10 +101,32 @@ const nextPlayOrder = async (showId: number): Promise<number> => {
  * Returns the epoch (`new Date(0)`) only as a defensive fallback — the
  * migration seeds the singleton row at apply time, so in production the
  * SELECT always returns exactly one row.
+ *
+ * ET-midnight fold (BS#1607): the effective watermark is
+ * `max(flowsheet_watermark, nyStartOfDay(now))`. The V2 feed's per-playcut
+ * `upcoming_show` enrichment (`attachUpcomingShows`) filters
+ * `concerts.starts_on >= nyCalendarDate(now)`, so the cached-GET response
+ * depends on the wall-clock ET date, not only on flowsheet writes. Without
+ * this fold, after ET midnight with no overnight flowsheet write a
+ * now-past show's CTA would keep rendering (a client's pre-midnight
+ * If-Modified-Since would 304 against a stale watermark). Maxing in the
+ * start-of-today ET instant jumps the watermark forward at midnight, so the
+ * first request past midnight gets a fresh 200 and the feed is recomputed —
+ * dropping the past show. `concerts`-table INSERT/UPDATE/DELETE advances the
+ * watermark directly (migration 0114's trigger), covering the stale-add case;
+ * this fold covers the stale-drop case, which no write signals.
+ *
+ * The fold applies to every route wired to `flowsheetConditionalGet`
+ * (`GET /flowsheet` and `GET /flowsheet/latest`); the accepted cost is one
+ * extra unconditional refetch per client per ET day. `now` is injectable
+ * (defaults to `new Date()`) so the midnight rollover is unit-testable
+ * deterministically.
  */
-export const getLastModifiedAt = async (): Promise<Date> => {
+export const getLastModifiedAt = async (now: Date = new Date()): Promise<Date> => {
   const result = await db.select({ at: flowsheet_watermark.last_modified_at }).from(flowsheet_watermark).limit(1);
-  return result[0]?.at ?? new Date(0);
+  const watermark = result[0]?.at ?? new Date(0);
+  const startOfEtDay = nyStartOfDay(now);
+  return watermark.getTime() >= startOfEtDay.getTime() ? watermark : startOfEtDay;
 };
 
 // SQL query fields (flat structure from database)
@@ -1114,9 +1137,6 @@ export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry
   }
 
   const byArtist = await getUpcomingShowsForArtists(artistIds, nyCalendarDate(new Date()));
-  if (byArtist.size === 0) {
-    return entries;
-  }
 
   for (const entry of entries) {
     if (entry.entry_type === 'track' && entry.artist_id !== null) {

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -19,7 +19,9 @@ import {
   library_artist_view,
   specialty_shows,
   album_metadata,
+  nyCalendarDate,
 } from '@wxyc/database';
+import { getUpcomingShowsForArtists } from './concerts.service.js';
 import { IFSEntry, ShowMetadata, UpdateRequestBody } from '../controllers/flowsheet.controller.js';
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
 
@@ -174,6 +176,14 @@ const FSEntryFieldsRaw = {
       END
     )
   `,
+  // Resolved catalog artist for the played release, via the flowsheet ->
+  // library FK join already present on every read path below
+  // (`leftJoin(library, library.id = flowsheet.album_id)`). NULL for
+  // free-form entries (no album_id) and for library rows with no artist link.
+  // Not a client-facing wire field itself — it's the batch key the V2 feed
+  // uses to attach the per-playcut `upcoming_show` enrichment (BS#1607),
+  // matched against `concerts.headlining_artist_id` (same `artists.id` space).
+  artist_id: library.artist_id,
   request_flag: flowsheet.request_flag,
   segue: flowsheet.segue,
   message: flowsheet.message,
@@ -229,6 +239,7 @@ type FSEntryRaw = {
   label_id: number | null;
   rotation_id: number | null;
   rotation_bin: string | null;
+  artist_id: number | null;
   request_flag: boolean | null;
   segue: boolean | null;
   message: string | null;
@@ -274,6 +285,7 @@ const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
   label_id: raw.label_id,
   rotation_id: raw.rotation_id,
   rotation_bin: raw.rotation_bin,
+  artist_id: raw.artist_id ?? null,
   request_flag: raw.request_flag ?? false,
   segue: raw.segue ?? false,
   message: raw.message,
@@ -1068,6 +1080,55 @@ export const getShowMetadata = async (show_id: number): Promise<ShowMetadata> =>
  * Transform a V1 flowsheet entry to V2 discriminated union format.
  * Removes irrelevant fields based on entry_type for cleaner API responses.
  */
+/**
+ * Attach the per-playcut `upcoming_show` enrichment to a feed page of entries
+ * (BS#1607, touring-events Phase 3).
+ *
+ * Batched — ONE indexed concerts query for the whole page, never one per row
+ * (the no-N+1 guarantee; project #32 perf posture). Collects the distinct
+ * resolved `artist_id`s across the track rows, does a single
+ * `getUpcomingShowsForArtists` lookup, and fans the soonest curated upcoming
+ * concert back onto each matching track. Rows with no resolved artist, or
+ * whose artist has no curated upcoming date, are returned unchanged
+ * (`upcoming_show` stays absent) — so the wire shape is byte-identical to
+ * pre-1607 for the no-match case (additive/optional field).
+ *
+ * "Today" is America/New_York (`nyCalendarDate`), matching `GET /concerts`'s
+ * default `from`: `starts_on` is a venue-local calendar date, so a UTC "today"
+ * would flip the window at 8 PM Eastern and prematurely drop tonight's shows.
+ *
+ * Returns the same array reference with the matched entries mutated in place;
+ * the caller maps the result through `transformToV2`, which reads
+ * `entry.upcoming_show`.
+ */
+export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry[]> => {
+  const artistIds = Array.from(
+    new Set(
+      entries
+        .filter((entry) => entry.entry_type === 'track' && entry.artist_id !== null)
+        .map((entry) => entry.artist_id as number)
+    )
+  );
+  if (artistIds.length === 0) {
+    return entries;
+  }
+
+  const byArtist = await getUpcomingShowsForArtists(artistIds, nyCalendarDate(new Date()));
+  if (byArtist.size === 0) {
+    return entries;
+  }
+
+  for (const entry of entries) {
+    if (entry.entry_type === 'track' && entry.artist_id !== null) {
+      const show = byArtist.get(entry.artist_id);
+      if (show !== undefined) {
+        entry.upcoming_show = show;
+      }
+    }
+  }
+  return entries;
+};
+
 export const transformToV2 = (entry: IFSEntry): Record<string, unknown> => {
   const baseFields = {
     id: entry.id,
@@ -1119,6 +1180,13 @@ export const transformToV2 = (entry: IFSEntry): Record<string, unknown> => {
         // (WXYC/wxyc-ios-64#270). Always present on track rows once the
         // column ships; `pending` is the default for newly-inserted rows.
         metadata_status: entry.metadata_status,
+        // Per-playcut upcoming-show enrichment (BS#1607). The key is emitted
+        // ONLY when `attachUpcomingShows` matched a curated upcoming concert
+        // for this track's artist — a no-match track row is byte-identical to
+        // its pre-1607 shape (the parity requirement), and iOS decodes the
+        // absent field as "no touring CTA". The SSOT field is optional +
+        // nullable, so this present-or-absent projection is spec-conformant.
+        ...(entry.upcoming_show ? { upcoming_show: entry.upcoming_show } : {}),
       };
 
     case 'show_start':

--- a/shared/database/src/migrations/0114_concerts-flowsheet-watermark.sql
+++ b/shared/database/src/migrations/0114_concerts-flowsheet-watermark.sql
@@ -1,0 +1,43 @@
+-- BS#1607 — advance the flowsheet conditional-GET watermark on `concerts` writes.
+--
+-- The V2 flowsheet feed embeds a per-playcut `upcoming_show` (Concert) via
+-- `attachUpcomingShows` (apps/backend/services/flowsheet.service.ts). That makes
+-- the conditional-GET-cached `GET /flowsheet` and `GET /flowsheet/latest`
+-- responses depend on the `concerts` table — not just on `flowsheet`. But the
+-- 0084 watermark (`flowsheet_watermark`, read by
+-- `apps/backend/middleware/conditionalGet.ts`) is only touched by a trigger on
+-- `flowsheet`, so a concerts write left the watermark unmoved and clients kept
+-- receiving 304s against a page whose CTA had changed:
+--
+--   stale-add: an overnight concerts ETL adds a date for an artist on the cached
+--   page; the watermark doesn't move, so clients don't see the new CTA until the
+--   next flowsheet write. THIS trigger fixes the stale-add case — a concerts
+--   INSERT/UPDATE/DELETE now advances the watermark directly.
+--
+--   stale-drop: after ET midnight with no overnight flowsheet write, a CTA for a
+--   now-past show keeps rendering (the feed filters `starts_on >= today ET`, but
+--   nothing wrote a row). That half is a pure clock event no statement trigger
+--   can observe; it is handled in `getLastModifiedAt`, which folds
+--   `max(flowsheet_watermark, nyStartOfDay(now))` so the watermark jumps forward
+--   at ET midnight. The two halves are complementary.
+--
+-- Reuses `wxyc_schema.touch_flowsheet_watermark()` VERBATIM (defined in migration
+-- 0084) — same single-row `flowsheet_watermark` UPDATE, same monotonic
+-- `GREATEST(now(), last_modified_at + interval '1 second')` advance, same O(1)
+-- per-statement cost. Do NOT redefine the function here. No schema objects
+-- change, so `drizzle:generate` produces no diff and the 0114 snapshot is
+-- byte-identical to 0113's apart from the id/prevId chain link (a `--custom`
+-- migration, mirroring 0105_library-watermark-parent-tables).
+--
+-- Idempotent: `DROP TRIGGER IF EXISTS` before `CREATE TRIGGER` so a re-apply (or
+-- a fresh dev DB that already picked it up) is a no-op.
+--
+-- @no-analyze-needed: no UPDATE on a stats-bearing table — the only write is the
+-- one-row `flowsheet_watermark` UPDATE inside the reused trigger function.
+-- @no-precondition-needed: trigger DDL only; no constraint, no data invariant.
+
+DROP TRIGGER IF EXISTS touch_flowsheet_watermark_from_concerts ON wxyc_schema.concerts;--> statement-breakpoint
+CREATE TRIGGER touch_flowsheet_watermark_from_concerts
+AFTER INSERT OR UPDATE OR DELETE ON wxyc_schema.concerts
+FOR EACH STATEMENT
+EXECUTE FUNCTION wxyc_schema.touch_flowsheet_watermark();

--- a/shared/database/src/migrations/meta/0114_snapshot.json
+++ b/shared/database/src/migrations/meta/0114_snapshot.json
@@ -1,0 +1,5463 @@
+{
+  "id": "ced6dabb-c609-4d49-ac43-0260de3cf5ca",
+  "prevId": "e9abe85b-732b-40f2-8ff8-f963b7f1277e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_release_date": {
+          "name": "full_release_date",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist": {
+          "name": "tracklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_image_url": {
+          "name": "artist_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_tokens": {
+          "name": "bio_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_popularity": {
+      "name": "album_popularity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "logical_album_key": {
+          "name": "logical_album_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_plays": {
+          "name": "linked_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freetext_plays": {
+          "name": "freetext_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "representative_library_id": {
+          "name": "representative_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_null_track_idx": {
+          "name": "cta_unique_null_track_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"compilation_track_artist\".\"track_title\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doors_at": {
+          "name": "doors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_min": {
+          "name": "price_min",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_max": {
+          "name": "price_max",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_restriction": {
+          "name": "age_restriction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_scraped_at": {
+          "name": "first_scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_curated_starts_on_idx": {
+          "name": "concerts_curated_starts_on_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"concerts\".\"headlining_artist_id\" IS NOT NULL AND \"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_active_starts_on_id_idx": {
+          "name": "concerts_active_starts_on_id_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_device_code": {
+      "name": "auth_device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_device_code_device_code_key": {
+          "name": "auth_device_code_device_code_key",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_user_code_key": {
+          "name": "auth_device_code_user_code_key",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_expires_at_idx": {
+          "name": "auth_device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_device_code_user_id_auth_user_id_fk": {
+          "name": "auth_device_code_user_id_auth_user_id_fk",
+          "tableFrom": "auth_device_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "radio_hour": {
+          "name": "radio_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer": {
+          "name": "composer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer_source": {
+          "name": "composer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_play_order_idx": {
+          "name": "flowsheet_show_id_play_order_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"play_order\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_idx": {
+          "name": "flowsheet_metadata_attempt_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_covering_idx": {
+          "name": "flowsheet_metadata_attempt_pending_covering_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_album_id_enriched_idx": {
+          "name": "flowsheet_album_id_enriched_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_freetext_resolution": {
+      "name": "flowsheet_freetext_resolution",
+      "schema": "wxyc_schema",
+      "columns": {
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_source": {
+          "name": "match_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_at": {
+          "name": "attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "flowsheet_freetext_resolution_norm_artist_norm_album_pk": {
+          "name": "flowsheet_freetext_resolution_norm_artist_norm_album_pk",
+          "columns": [
+            "norm_artist",
+            "norm_album"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flowsheet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_watermark": {
+      "name": "library_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_watermark_singleton": {
+          "name": "library_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_access_token_client_id_idx": {
+          "name": "auth_oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_access_token_user_id_idx": {
+          "name": "auth_oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_access_token_key": {
+          "name": "auth_oauth_access_token_access_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "auth_oauth_access_token_refresh_token_key": {
+          "name": "auth_oauth_access_token_refresh_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_application": {
+      "name": "auth_oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_application_user_id_idx": {
+          "name": "auth_oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_application_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_application_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_application_client_id_key": {
+          "name": "auth_oauth_application_client_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_oauth_consent_client_id_idx": {
+          "name": "auth_oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_consent_user_id_idx": {
+          "name": "auth_oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "album_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lml_identity_id": {
+          "name": "lml_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rotation_discogs_release_id_not_sentinel": {
+          "name": "rotation_discogs_release_id_not_sentinel",
+          "value": "\"wxyc_schema\".\"rotation\".\"discogs_release_id\" IS NULL OR \"wxyc_schema\".\"rotation\".\"discogs_release_id\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_flow_expires_at": {
+          "name": "device_flow_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape",
+        "triangle_shows"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill",
+        "library_identity",
+        "md_verified"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.album_plays": {
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "isExisting": true,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -778,6 +778,13 @@
       "when": 1783648865583,
       "tag": "0113_concerts-active-starts-on-idx",
       "breakpoints": true
+    },
+    {
+      "idx": 114,
+      "version": "7",
+      "when": 1783648865584,
+      "tag": "0114_concerts-flowsheet-watermark",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -109,5 +109,6 @@
   "0110_qr-device-auth": "0284b4f41fb20265ce3901f5e2bdf9226ade145df0cae44b60b7da822901dae2",
   "0111_oidc-provider-substrate": "f12255a3ff9ab9e2b8266741d90c6654b8fa451bdca418ebdd060dd5e54f28b7",
   "0112_triangle-shows-concerts": "a48a85325a9be136f50539434e13d93b50fc007341336d4aa1ba0c79998ee48d",
-  "0113_concerts-active-starts-on-idx": "eed76d7e1a3548eb5f7d5aa7560182ff16bd0a89b188f4c5142df621665abf83"
+  "0113_concerts-active-starts-on-idx": "eed76d7e1a3548eb5f7d5aa7560182ff16bd0a89b188f4c5142df621665abf83",
+  "0114_concerts-flowsheet-watermark": "f97e2f04d370d93ac489910aa517f3094c836c4cd546efc90946a20e95e95b20"
 }

--- a/shared/database/src/ny-time.ts
+++ b/shared/database/src/ny-time.ts
@@ -64,6 +64,28 @@ export const nyCalendarDate = (instant: Date): string => {
   return formatted;
 };
 
+/**
+ * The UTC instant of the most recent America/New_York midnight (00:00:00
+ * local) at or before `instant` — i.e. the start of the Eastern calendar day
+ * that `instant` falls in.
+ *
+ * `instant` is injectable (defaults to `new Date()`) so callers can pin "now"
+ * deterministically in tests — notably to exercise the ET-midnight rollover of
+ * the conditional-GET watermark without waiting for the wall clock.
+ *
+ * Used by the flowsheet conditional-GET watermark (BS#1607): the effective
+ * Last-Modified is `max(flowsheet_watermark, nyStartOfDay(now))`. The upcoming-
+ * show feed enrichment filters `concerts.starts_on >= nyCalendarDate(now)`, so
+ * at ET midnight a previously-cached page must be recomputed to drop a
+ * now-past show even though no flowsheet write moved the watermark. Folding
+ * this instant in makes a pre-midnight `If-Modified-Since` go stale exactly
+ * when the ET calendar date rolls over.
+ *
+ * Built on the same `nyCalendarDate` + `nyWallClockToUtc` pair the concert
+ * writers use, so it agrees with them on DST boundaries by construction.
+ */
+export const nyStartOfDay = (instant: Date = new Date()): Date => nyWallClockToUtc(nyCalendarDate(instant), '00:00');
+
 /** New York's UTC offset in milliseconds at the given instant (negative: -5h EST / -4h EDT). */
 const nyOffsetMsAt = (instant: Date): number => {
   const part = nyOffsetFormat.formatToParts(instant).find((p) => p.type === 'timeZoneName');

--- a/tests/integration/flowsheet-upcoming-show.spec.js
+++ b/tests/integration/flowsheet-upcoming-show.spec.js
@@ -1,0 +1,354 @@
+/**
+ * BS#1607 — per-playcut `upcoming_show` enrichment on the V2 flowsheet feed
+ * (touring-events Phase 3).
+ *
+ * Postgres-backed: seeds a show, flowsheet track rows linked to library
+ * albums (whose artists come from the fixed-ID seed fixture), and a set of
+ * `concerts` rows keyed by a `bs1607:` source_id prefix. Cleanup is a prefix
+ * DELETE so nothing leaks across the shared-schema `--runInBand` suite.
+ *
+ * Pins the load-bearing server contract:
+ *   - a track whose resolved artist (album_id → library.artist_id) matches a
+ *     curated, non-tombstoned, upcoming concert carries that concert inline as
+ *     `upcoming_show`, with the full `Concert` wire shape and no internal
+ *     ingestion columns;
+ *   - the SOONEST of an artist's several upcoming dates wins;
+ *   - no match, an unresolved (free-form / null album_id) artist, and
+ *     removed/past concerts all leave `upcoming_show` absent (parity: the row
+ *     is byte-identical to its pre-1607 shape);
+ *   - the lookup is BATCHED — a page whose N track rows all match still hits
+ *     the `concerts` table a bounded, N-independent number of times (proves no
+ *     per-row query).
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const SOURCE_ID_PREFIX = 'bs1607:';
+const VENUE_SLUG = 'bs1607-probe-room';
+const SHOW_NAME = 'BS#1607 upcoming-show probe';
+
+// Fixed-ID seed fixture (dev_env/seed_db.sql): artist 1 (Built to Spill) owns
+// library album 1; artist 2 (Ravyn Lenae) owns album 2; artist 3 (Jockstrap)
+// owns album 3. Concerts are seeded against these artist ids.
+const ARTIST_WITH_SHOW = 1;
+const ALBUM_WITH_SHOW = 1;
+const ARTIST_NO_SHOW = 2;
+const ALBUM_NO_SHOW = 2;
+const ARTIST_ONLY_PAST = 3;
+const ALBUM_ONLY_PAST = 3;
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+/** YYYY-MM-DD for today + offsetDays, America/New_York (matches the feed's "today"). */
+function isoDate(offsetDays) {
+  const d = new Date(Date.now() + offsetDays * 24 * 60 * 60 * 1000);
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(d);
+}
+
+const PAST = isoDate(-14);
+const SOON = isoDate(7); // the soonest upcoming date for ARTIST_WITH_SHOW
+const LATER = isoDate(21); // a later date for the same artist — must lose
+
+describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
+  let sql;
+  let venueId;
+  let showId;
+  let insertedTrackIds = [];
+
+  const seedConcert = async (overrides) => {
+    const defaults = {
+      source: 'triangle_shows',
+      starts_at: null,
+      doors_at: null,
+      headlining_artist_id: null,
+      title: null,
+      supporting_artists: [],
+      ticket_url: null,
+      image_url: null,
+      price_min: null,
+      price_max: null,
+      age_restriction: null,
+      status: 'on_sale',
+      removed_at: null,
+    };
+    const row = { ...defaults, ...overrides };
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".concerts
+         (source, source_id, venue_id, starts_on, starts_at, doors_at,
+          headlining_artist_raw, headlining_artist_id, title, supporting_artists_raw,
+          ticket_url, image_url, price_min, price_max, age_restriction, status,
+          removed_at, raw_data, scraped_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, '{}'::jsonb, now())`,
+      [
+        row.source,
+        SOURCE_ID_PREFIX + row.key,
+        row.venue_id,
+        row.starts_on,
+        row.starts_at,
+        row.doors_at,
+        row.headlining_artist_raw,
+        row.headlining_artist_id,
+        row.title,
+        row.supporting_artists,
+        row.ticket_url,
+        row.image_url,
+        row.price_min,
+        row.price_max,
+        row.age_restriction,
+        row.status,
+        row.removed_at,
+      ]
+    );
+  };
+
+  /** Insert one flowsheet track row, returning its id. */
+  const seedTrack = async ({ albumId, artistName, playOrder }) => {
+    const [inserted] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".flowsheet
+         (show_id, album_id, entry_type, artist_name, album_title, track_title, play_order, add_time, metadata_status)
+       VALUES ($1, $2, 'track', $3, 'Probe Album', 'Probe Track', $4, now(), 'enriched_match')
+       RETURNING id`,
+      [showId, albumId, artistName, playOrder]
+    );
+    return inserted.id;
+  };
+
+  const cleanup = async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".concerts WHERE source_id LIKE $1`, [`${SOURCE_ID_PREFIX}%`]);
+    if (insertedTrackIds.length > 0) {
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE id = ANY($1::int[])`, [insertedTrackIds]);
+    }
+    if (showId) {
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".shows WHERE id = $1`, [showId]);
+    }
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".venues WHERE slug = $1`, [VENUE_SLUG]);
+  };
+
+  beforeAll(async () => {
+    sql = makeSql();
+    await cleanup();
+
+    const [venue] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".venues (slug, name, city, state, address)
+       VALUES ($1, 'BS1607 Probe Room', 'Carrboro', 'NC', '300 E Main St')
+       RETURNING id`,
+      [VENUE_SLUG]
+    );
+    venueId = venue.id;
+
+    const [show] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".shows (show_name, start_time) VALUES ($1, now()) RETURNING id`,
+      [SHOW_NAME]
+    );
+    showId = show.id;
+
+    // ARTIST_WITH_SHOW: two upcoming dates — the soonest must win — plus a
+    // later date, a tombstoned row, and a past row that must all be ignored.
+    await seedConcert({
+      key: 'soon',
+      venue_id: venueId,
+      starts_on: SOON,
+      starts_at: `${SOON}T23:30:00.000Z`,
+      doors_at: `${SOON}T22:30:00.000Z`,
+      headlining_artist_raw: 'Built to Spill',
+      headlining_artist_id: ARTIST_WITH_SHOW,
+      supporting_artists: ['Opener A'],
+      ticket_url: 'https://example.com/tickets/bs1607',
+      image_url: 'https://example.com/img/bs1607.jpg',
+      price_min: '20.00',
+      price_max: '24.00',
+      age_restriction: 'All Ages',
+    });
+    await seedConcert({
+      key: 'later',
+      venue_id: venueId,
+      starts_on: LATER,
+      headlining_artist_raw: 'Built to Spill',
+      headlining_artist_id: ARTIST_WITH_SHOW,
+    });
+    await seedConcert({
+      key: 'removed',
+      venue_id: venueId,
+      starts_on: SOON,
+      headlining_artist_raw: 'Built to Spill',
+      headlining_artist_id: ARTIST_WITH_SHOW,
+      removed_at: new Date().toISOString(),
+    });
+
+    // ARTIST_ONLY_PAST: has a concert, but it already happened — excluded.
+    await seedConcert({
+      key: 'past',
+      venue_id: venueId,
+      starts_on: PAST,
+      headlining_artist_raw: 'Jockstrap',
+      headlining_artist_id: ARTIST_ONLY_PAST,
+    });
+
+    // Track rows: one matching artist, one with an artist that has no upcoming
+    // date, one whose artist only has a past date, and one free-form (null
+    // album_id → unresolved artist).
+    const t1 = await seedTrack({ albumId: ALBUM_WITH_SHOW, artistName: 'Built to Spill', playOrder: 1 });
+    const t2 = await seedTrack({ albumId: ALBUM_NO_SHOW, artistName: 'Ravyn Lenae', playOrder: 2 });
+    const t3 = await seedTrack({ albumId: ALBUM_ONLY_PAST, artistName: 'Jockstrap', playOrder: 3 });
+    const t4 = await seedTrack({ albumId: null, artistName: 'Some Free-Form Act', playOrder: 4 });
+    insertedTrackIds = [t1, t2, t3, t4];
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await sql.end();
+  });
+
+  /** Fetch this spec's seeded track rows via the V2 range read. */
+  const fetchSeededTracks = async () => {
+    const startId = Math.min(...insertedTrackIds);
+    const endId = Math.max(...insertedTrackIds);
+    const res = await request.get('/flowsheet').query({ start_id: startId, end_id: endId });
+    expect(res.status).toBe(200);
+    const bySeed = new Set(insertedTrackIds);
+    return res.body.filter((e) => bySeed.has(e.id));
+  };
+
+  it('attaches the soonest curated upcoming concert to a matching track', async () => {
+    const tracks = await fetchSeededTracks();
+    const matched = tracks.find((t) => t.album_id === ALBUM_WITH_SHOW);
+    expect(matched).toBeDefined();
+    expect(matched.upcoming_show).toBeDefined();
+    expect(matched.upcoming_show).toMatchObject({
+      starts_on: SOON, // the soonest date, not LATER
+      headlining_artist_id: ARTIST_WITH_SHOW,
+      headlining_artist_raw: 'Built to Spill',
+      supporting_artists_raw: ['Opener A'],
+      ticket_url: 'https://example.com/tickets/bs1607',
+      price_min: 20,
+      price_max: 24,
+      status: 'on_sale',
+      venue: { slug: VENUE_SLUG, name: 'BS1607 Probe Room', city: 'Carrboro' },
+    });
+  });
+
+  it('serves the full Concert wire shape with no internal ingestion columns', async () => {
+    const tracks = await fetchSeededTracks();
+    const show = tracks.find((t) => t.album_id === ALBUM_WITH_SHOW).upcoming_show;
+    for (const internal of ['source', 'source_id', 'raw_data', 'scraped_at', 'first_scraped_at', 'removed_at']) {
+      expect(show).not.toHaveProperty(internal);
+      expect(show.venue).not.toHaveProperty(internal);
+    }
+  });
+
+  it('leaves upcoming_show absent when the artist has no upcoming date', async () => {
+    const tracks = await fetchSeededTracks();
+    const noShow = tracks.find((t) => t.album_id === ALBUM_NO_SHOW);
+    expect(noShow).toBeDefined();
+    expect(noShow).not.toHaveProperty('upcoming_show');
+  });
+
+  it("leaves upcoming_show absent when the artist's only concert is in the past", async () => {
+    const tracks = await fetchSeededTracks();
+    const pastOnly = tracks.find((t) => t.album_id === ALBUM_ONLY_PAST);
+    expect(pastOnly).toBeDefined();
+    expect(pastOnly).not.toHaveProperty('upcoming_show');
+  });
+
+  it('leaves upcoming_show absent for a free-form (unresolved-artist) track', async () => {
+    const tracks = await fetchSeededTracks();
+    const freeForm = tracks.find((t) => t.album_id === null);
+    expect(freeForm).toBeDefined();
+    expect(freeForm).not.toHaveProperty('upcoming_show');
+  });
+
+  it('never surfaces the tombstoned or later date for the matching artist', async () => {
+    const tracks = await fetchSeededTracks();
+    const show = tracks.find((t) => t.album_id === ALBUM_WITH_SHOW).upcoming_show;
+    // Exactly one concert rides the playcut, and it is the soonest non-removed one.
+    expect(show.starts_on).toBe(SOON);
+    expect(show.starts_on).not.toBe(LATER);
+  });
+
+  /**
+   * Batching proof (no per-row query): count how many times the `concerts`
+   * table is scanned per feed read via `pg_stat_user_tables`, and show the
+   * per-request delta does NOT grow with the number of matching rows on the
+   * page. A per-row implementation scans `concerts` once per matching row (so
+   * the delta tracks the match count); the batched implementation issues a
+   * single lookup for the whole page, so the delta is a small constant.
+   *
+   * `pg_stat_user_tables` is updated asynchronously by the stats collector and
+   * the backend serves the feed on its own connection pool, so a naive
+   * before/after around one request races the flush. `settledScans` clears the
+   * caller's stats snapshot and polls until the cumulative counter stops
+   * moving, giving a stable reading; the assertion then compares a small-page
+   * delta against a large-page delta rather than trusting an absolute count.
+   */
+  const settledScans = async () => {
+    let last = -1;
+    for (let i = 0; i < 40; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await sql.unsafe('SELECT pg_stat_clear_snapshot()');
+      // eslint-disable-next-line no-await-in-loop
+      const [row] = await sql.unsafe(
+        `SELECT COALESCE(seq_scan, 0) + COALESCE(idx_scan, 0) AS scans
+           FROM pg_stat_user_tables
+          WHERE schemaname = $1 AND relname = 'concerts'`,
+        [SCHEMA]
+      );
+      const scans = Number(row ? row.scans : 0);
+      if (scans === last) return scans; // two identical reads = flushed
+      last = scans;
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    return last;
+  };
+
+  /** concerts-scan delta attributable to exactly one feed read of this page. */
+  const scanDeltaForOneFeedRead = async () => {
+    const before = await settledScans();
+    await fetchSeededTracks();
+    const after = await settledScans();
+    return after - before;
+  };
+
+  // The batched lookup scans `concerts` a small, bounded number of times per
+  // feed read regardless of how many matching rows the page carries. A per-row
+  // implementation would scan once per matching row, so with MANY_MATCHES rows
+  // the delta would be >= MANY_MATCHES. We assert the delta stays well under
+  // that count — the clean separation between "one batched query" (a handful of
+  // scans) and "one query per row" (>= 9). An absolute bound is used rather
+  // than a small-vs-large diff because a single query's scan count already
+  // varies by 1-2 (index probe + heap access) run to run.
+  const MANY_MATCHES = 8;
+  const BATCHED_SCAN_CEILING = 5;
+
+  it('batches the lookup: concerts-table scans do not grow with page match count', async () => {
+    // Add many more matching tracks, all resolving to ARTIST_WITH_SHOW, so the
+    // page has 1 + MANY_MATCHES matches. A per-row lookup would scan concerts
+    // once per matching row.
+    const extraIds = [];
+    for (let i = 0; i < MANY_MATCHES; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      const id = await seedTrack({ albumId: ALBUM_WITH_SHOW, artistName: 'Built to Spill', playOrder: 100 + i });
+      extraIds.push(id);
+    }
+    insertedTrackIds.push(...extraIds);
+
+    const largeDelta = await scanDeltaForOneFeedRead();
+
+    // Never one-scan-per-row: a per-row impl would push this to >= 9.
+    expect(largeDelta).toBeGreaterThanOrEqual(0);
+    expect(largeDelta).toBeLessThanOrEqual(BATCHED_SCAN_CEILING);
+    expect(largeDelta).toBeLessThan(1 + MANY_MATCHES);
+  });
+});

--- a/tests/integration/flowsheet-upcoming-show.spec.js
+++ b/tests/integration/flowsheet-upcoming-show.spec.js
@@ -313,12 +313,51 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
     return last;
   };
 
-  /** concerts-scan delta attributable to exactly one feed read of this page. */
+  /** Raw cumulative concerts-scan counter (single read, snapshot cleared first). */
+  const rawScans = async () => {
+    await sql.unsafe('SELECT pg_stat_clear_snapshot()');
+    const [row] = await sql.unsafe(
+      `SELECT COALESCE(seq_scan, 0) + COALESCE(idx_scan, 0) AS scans
+         FROM pg_stat_user_tables
+        WHERE schemaname = $1 AND relname = 'concerts'`,
+      [SCHEMA]
+    );
+    return Number(row ? row.scans : 0);
+  };
+
+  /**
+   * concerts-scan delta attributable to EXACTLY ONE feed read of this page.
+   *
+   * `pg_stat_user_tables` is flushed asynchronously by the stats collector, and
+   * the backend serves the feed on its own connection pool, so the scan a feed
+   * read performs is not always visible on the first poll. The naive
+   * `after(settled) - before(settled)` around a single read can settle BEFORE
+   * the read's scan flushes and report a spurious 0. Retrying the whole
+   * before/read/after cycle is worse: each extra feed read adds scans that flush
+   * into a later bracket, inflating the delta above the anti-N+1 ceiling.
+   *
+   * So we issue the feed read exactly ONCE, then poll the counter until it has
+   * both advanced past `before` AND gone stable (two equal consecutive reads) —
+   * capturing this single read's scans without absorbing any other. If it never
+   * advances within the budget the delta stays 0 and the `>= 1` liveness
+   * assertion fails honestly (rather than looping and issuing more reads).
+   */
   const scanDeltaForOneFeedRead = async () => {
     const before = await settledScans();
     await fetchSeededTracks();
-    const after = await settledScans();
-    return after - before;
+
+    let last = -1;
+    let stableAdvanced = before;
+    for (let i = 0; i < 40; i++) {
+      const scans = await rawScans(); // eslint-disable-line no-await-in-loop
+      if (scans > before && scans === last) {
+        stableAdvanced = scans;
+        break;
+      }
+      last = scans;
+      await new Promise((r) => setTimeout(r, 100)); // eslint-disable-line no-await-in-loop
+    }
+    return stableAdvanced - before;
   };
 
   // The batched lookup scans `concerts` a small, bounded number of times per
@@ -346,9 +385,70 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
 
     const largeDelta = await scanDeltaForOneFeedRead();
 
-    // Never one-scan-per-row: a per-row impl would push this to >= 9.
-    expect(largeDelta).toBeGreaterThanOrEqual(0);
+    // Liveness lower bound: the feed read must scan `concerts` at LEAST once,
+    // else the enrichment is a no-op and the whole batching contract is vacuous
+    // (a delta of 0 would silently pass a regression that stopped querying
+    // concerts entirely). `scanDeltaForOneFeedRead` retries until it observes a
+    // positive delta (absorbing the async stats-flush race), so `>= 1` is
+    // reliable here, not flaky — see its doc comment for why the naive
+    // before/after can spuriously read 0.
+    expect(largeDelta).toBeGreaterThanOrEqual(1);
+    // Upper bounds (anti-N+1): never one-scan-per-row — a per-row impl would
+    // push this to >= 9.
     expect(largeDelta).toBeLessThanOrEqual(BATCHED_SCAN_CEILING);
     expect(largeDelta).toBeLessThan(1 + MANY_MATCHES);
+  });
+
+  /**
+   * Conditional-GET freshness across `concerts` writes (BS#1607, migration
+   * 0114). Because the V2 feed embeds `upcoming_show` from `concerts`, a
+   * concerts write must advance the flowsheet watermark — otherwise a polling
+   * client's `If-Modified-Since` would 304 against a page whose curated CTA has
+   * changed (the stale-add case). The 0114 AFTER STATEMENT trigger on
+   * `concerts` reuses `touch_flowsheet_watermark()` (from 0084), which bumps the
+   * watermark to `GREATEST(now(), prev + 1s)` — strictly greater than the
+   * pre-write value, so the subsequent conditional GET recomputes a fresh 200.
+   */
+  it('a concerts write advances the flowsheet watermark: conditional GET re-200s (migration 0114)', async () => {
+    // Use this spec's seeded track range so the range read is non-empty (a
+    // range that matches no rows 404s before the conditional-GET header lands).
+    const startId = Math.min(...insertedTrackIds);
+    const endId = Math.max(...insertedTrackIds);
+    const getFeed = (ifModifiedSince) => {
+      const req = request.get('/flowsheet').query({ start_id: startId, end_id: endId });
+      return ifModifiedSince ? req.set('If-Modified-Since', ifModifiedSince) : req;
+    };
+
+    // Baseline: read the current effective Last-Modified for the feed.
+    const baseline = await getFeed();
+    expect(baseline.status).toBe(200);
+    const lastModified = baseline.headers['last-modified'];
+    expect(lastModified).toBeDefined();
+
+    // Same watermark, no intervening write -> 304 (proves the baseline is a
+    // real conditional-GET watermark, not an always-200 route).
+    const unchanged = await getFeed(lastModified);
+    expect(unchanged.status).toBe(304);
+
+    // A concerts write fires the 0114 trigger and advances the watermark. Use
+    // an UPDATE on an existing seeded row so the write is self-contained (no new
+    // source_id to clean up); the AFTER STATEMENT trigger fires on UPDATE too.
+    // Guard against same-second flooring in the conditional-GET comparison: the
+    // trigger's `+1s` floor guarantees a whole-second advance, but poll a few
+    // times so an unflushed read doesn't race the assertion.
+    await sql.unsafe(`UPDATE "${SCHEMA}".concerts SET scraped_at = now() WHERE source_id = $1`, [
+      `${SOURCE_ID_PREFIX}soon`,
+    ]);
+
+    let statusAfterWrite = 304;
+    for (let i = 0; i < 20; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await getFeed(lastModified);
+      statusAfterWrite = res.status;
+      if (statusAfterWrite === 200) break;
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(statusAfterWrite).toBe(200);
   });
 });

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 
 type MockQueryChain = {
   select: jest.Mock;
+  selectDistinctOn: jest.Mock;
   from: jest.Mock;
   where: jest.Mock;
   innerJoin: jest.Mock;
@@ -22,6 +23,7 @@ export function createMockQueryChain(resolvedValue: unknown = []): MockQueryChai
 
   const chainMethods = [
     'select',
+    'selectDistinctOn',
     'from',
     'where',
     'innerJoin',
@@ -52,6 +54,7 @@ export function createMockDb() {
   const mockChain = createMockQueryChain();
   const mockDb = {
     select: mockChain.select,
+    selectDistinctOn: mockChain.selectDistinctOn,
     insert: mockChain.insert,
     update: mockChain.update,
     delete: mockChain.delete,

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -357,7 +357,7 @@ export type { IntParserOptions } from '../../shared/database/src/env-parsers.js'
 export { normalizeArtistName } from '../../shared/database/src/normalize-artist-name.js';
 export { normalizeAlbumTitle } from '../../shared/database/src/normalize-album-title.js';
 export { freetextPairKey, normalizeFreetextArtist } from '../../shared/database/src/freetext-norm.js';
-export { NY_TIME_ZONE, nyCalendarDate, nyWallClockToUtc } from '../../shared/database/src/ny-time.js';
+export { NY_TIME_ZONE, nyCalendarDate, nyStartOfDay, nyWallClockToUtc } from '../../shared/database/src/ny-time.js';
 
 // Self-contained STUB of shared/database/src/concerts-sql.ts. The real
 // module imports schema.ts, which calls drizzle's `eq` at module scope (a

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -12,6 +12,11 @@ const mockGetEntriesByShow = jest.fn<() => Promise<unknown[]>>();
 const mockGetNShows = jest.fn<() => Promise<unknown[]>>();
 const mockGetShowMetadata = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockTransformToV2 = jest.fn((entry: unknown) => ({ ...(entry as Record<string, unknown>), v2: true }));
+// BS#1607: the feed paths call attachUpcomingShows before projecting to V2.
+// It's a no-op passthrough here (the enrichment logic is unit-tested in
+// tests/unit/services/flowsheet.attachUpcomingShows.test.ts); returning the
+// same array keeps these controller tests focused on the HTTP wiring.
+const mockAttachUpcomingShows = jest.fn((entries: unknown[]) => Promise.resolve(entries));
 const mockAddTrack = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockGetLatestShow = jest.fn<() => Promise<Record<string, unknown> | null>>();
 const mockGetOnAirDJName = jest.fn<() => Promise<string | null>>();
@@ -33,6 +38,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getNShows: mockGetNShows,
   getShowMetadata: mockGetShowMetadata,
   transformToV2: mockTransformToV2,
+  attachUpcomingShows: mockAttachUpcomingShows,
   addTrack: mockAddTrack,
   getLatestShow: mockGetLatestShow,
   getOnAirDJName: mockGetOnAirDJName,

--- a/tests/unit/database/ny-time.test.ts
+++ b/tests/unit/database/ny-time.test.ts
@@ -7,7 +7,7 @@
  * these, so DST correctness is pinned explicitly on both transition days.
  */
 import { describe, test, expect } from '@jest/globals';
-import { NY_TIME_ZONE, nyCalendarDate, nyWallClockToUtc } from '../../../shared/database/src/ny-time';
+import { NY_TIME_ZONE, nyCalendarDate, nyStartOfDay, nyWallClockToUtc } from '../../../shared/database/src/ny-time';
 
 describe('NY_TIME_ZONE', () => {
   test('is the canonical IANA name (consumers import this instead of re-hardcoding)', () => {
@@ -32,6 +32,45 @@ describe('nyCalendarDate', () => {
 
   test('output always matches the YYYY-MM-DD shape the date column expects (full-icu guard)', () => {
     expect(nyCalendarDate(new Date('2026-06-14T01:30:00Z'))).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('nyStartOfDay', () => {
+  test.each([
+    // EST (UTC-5): midnight ET on 2026-01-15 is 05:00Z.
+    ['2026-01-15T18:00:00Z', '2026-01-15T05:00:00.000Z'],
+    // An instant just after EST midnight still floors to the same 05:00Z.
+    ['2026-01-15T05:00:01Z', '2026-01-15T05:00:00.000Z'],
+    // An instant just BEFORE EST midnight belongs to the previous ET day
+    // (04:59Z on the 15th is still Jan 14 in NY -> 2026-01-14T05:00Z).
+    ['2026-01-15T04:59:00Z', '2026-01-14T05:00:00.000Z'],
+    // EDT (UTC-4): midnight ET on 2026-07-04 is 04:00Z.
+    ['2026-07-04T18:00:00Z', '2026-07-04T04:00:00.000Z'],
+  ])('nyStartOfDay(%s) -> %s', (iso, expectedIso) => {
+    expect(nyStartOfDay(new Date(iso)).toISOString()).toBe(expectedIso);
+  });
+
+  test('the returned instant floors to its own ET calendar date (round-trips through nyCalendarDate)', () => {
+    const start = nyStartOfDay(new Date('2026-07-04T18:00:00Z'));
+    expect(nyCalendarDate(start)).toBe('2026-07-04');
+  });
+
+  test('ET-midnight rollover advances the start-of-day instant deterministically (injectable now)', () => {
+    // The conditional-GET watermark fold (BS#1607) relies on this jump: a
+    // request one second BEFORE ET midnight and one second AFTER must resolve
+    // to different start-of-day instants exactly one ET day apart, so a
+    // pre-midnight If-Modified-Since goes stale at the rollover. EST here.
+    const justBeforeMidnightET = new Date('2026-01-16T04:59:59Z'); // 23:59:59 ET on the 15th
+    const justAfterMidnightET = new Date('2026-01-16T05:00:01Z'); // 00:00:01 ET on the 16th
+    expect(nyStartOfDay(justBeforeMidnightET).toISOString()).toBe('2026-01-15T05:00:00.000Z');
+    expect(nyStartOfDay(justAfterMidnightET).toISOString()).toBe('2026-01-16T05:00:00.000Z');
+    expect(nyStartOfDay(justAfterMidnightET).getTime()).toBeGreaterThan(nyStartOfDay(justBeforeMidnightET).getTime());
+  });
+
+  test('defaults to the current instant when called with no argument', () => {
+    // Same-ET-day contract: the default-arg path must agree with an explicit
+    // `new Date()` reading (both floor to today's ET midnight).
+    expect(nyStartOfDay().toISOString()).toBe(nyStartOfDay(new Date()).toISOString());
   });
 });
 

--- a/tests/unit/services/concerts.service.test.ts
+++ b/tests/unit/services/concerts.service.test.ts
@@ -18,6 +18,7 @@ import {
   ConcertJoinRow,
   getConcertsCount,
   getConcertsPage,
+  getUpcomingShowsForArtists,
   toConcertDTO,
 } from '../../../apps/backend/services/concerts.service';
 
@@ -228,5 +229,54 @@ describe('getConcertsCount', () => {
   it('returns 0 when the aggregate row is missing', async () => {
     mockDb._chain.where.mockReturnValueOnce(Promise.resolve([]));
     await expect(getConcertsCount({ from: '2026-08-01', curated: true })).resolves.toBe(0);
+  });
+});
+
+describe('getUpcomingShowsForArtists (BS#1607)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('short-circuits an empty artist-id list without touching the DB', async () => {
+    const result = await getUpcomingShowsForArtists([], '2026-08-01');
+    expect(result.size).toBe(0);
+    expect(mockDb._chain.selectDistinctOn).not.toHaveBeenCalled();
+  });
+
+  it('maps each row to a ConcertDTO keyed by headlining_artist_id', async () => {
+    const other: ConcertJoinRow = { ...timedRow, id: 202, headlining_artist_id: 5555 };
+    // Terminal .orderBy() resolves the DISTINCT ON row set for this call.
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([timedRow, other]));
+
+    const result = await getUpcomingShowsForArtists([4211, 5555], '2026-08-01');
+
+    expect(result.size).toBe(2);
+    expect(result.get(4211)).toEqual(toConcertDTO(timedRow));
+    expect(result.get(5555)).toEqual(toConcertDTO(other));
+  });
+
+  it('distinct-selects on headlining_artist_id (soonest-per-artist collapse)', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    await getUpcomingShowsForArtists([4211], '2026-08-01');
+    // The DISTINCT ON expression list must lead with headlining_artist_id.
+    const distinctArgs = mockDb._chain.selectDistinctOn.mock.calls[0][0] as string[];
+    expect(distinctArgs).toEqual(['headlining_artist_id']);
+  });
+
+  it('never selects internal ingestion columns', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    await getUpcomingShowsForArtists([4211], '2026-08-01');
+    const projection = mockDb._chain.selectDistinctOn.mock.calls[0][1] as Record<string, string>;
+    const selectedColumns = Object.values(projection);
+    for (const internal of INTERNAL_COLUMNS) {
+      expect(selectedColumns).not.toContain(internal);
+    }
+  });
+
+  it('skips a defensive null headlining_artist_id row (never a Map key)', async () => {
+    const nulledKey: ConcertJoinRow = { ...timedRow, headlining_artist_id: null };
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([nulledKey]));
+    const result = await getUpcomingShowsForArtists([4211], '2026-08-01');
+    expect(result.size).toBe(0);
   });
 });

--- a/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
+++ b/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for the per-playcut upcoming-show enrichment (BS#1607,
+ * touring-events Phase 3).
+ *
+ * `@wxyc/database` resolves to tests/mocks/database.mock.ts, so these pin the
+ * pure batching + projection logic without PostgreSQL:
+ *   - `attachUpcomingShows` collects the DISTINCT resolved artist ids across a
+ *     feed page and does exactly ONE `getUpcomingShowsForArtists` call (the
+ *     no-N+1 guarantee), then fans the soonest concert back onto each match;
+ *   - `transformToV2` emits `upcoming_show` only when present, so a no-match
+ *     track row is byte-identical to its pre-1607 shape (parity requirement).
+ *
+ * The end-to-end SQL windowing (curated predicate, soonest-wins DISTINCT ON,
+ * removed/past exclusion, bounded query count for an N-row page) is covered by
+ * tests/integration/flowsheet-upcoming-show.spec.js.
+ */
+import { attachUpcomingShows, transformToV2 } from '../../../apps/backend/services/flowsheet.service';
+import * as concertsService from '../../../apps/backend/services/concerts.service';
+import { IFSEntry, IFSEntryMetadata } from '../../../apps/backend/controllers/flowsheet.controller';
+import type { ConcertDTO } from '../../../apps/backend/services/concerts.service';
+
+const nullMetadata: IFSEntryMetadata = {
+  artwork_url: null,
+  discogs_url: null,
+  release_year: null,
+  spotify_url: null,
+  apple_music_url: null,
+  youtube_music_url: null,
+  bandcamp_url: null,
+  soundcloud_url: null,
+  artist_bio: null,
+  artist_wikipedia_url: null,
+  genres: null,
+  styles: null,
+};
+
+const createTrackEntry = (overrides: Partial<IFSEntry> = {}): IFSEntry => ({
+  id: 1,
+  show_id: 100,
+  album_id: 501,
+  rotation_id: null,
+  entry_type: 'track',
+  track_title: 'la paradoja',
+  track_position: null,
+  album_title: 'DOGA',
+  artist_name: 'Juana Molina',
+  record_label: 'Sonamos',
+  label_id: null,
+  play_order: 1,
+  request_flag: false,
+  segue: false,
+  message: null,
+  add_time: new Date('2026-04-17T22:53:48.500Z'),
+  dj_name: null,
+  rotation_bin: null,
+  on_streaming: null,
+  legacy_entry_id: null,
+  legacy_release_id: null,
+  linkage_source: null,
+  linkage_confidence: null,
+  linked_at: null,
+  metadata_status: 'pending',
+  enriching_since: null,
+  radio_hour: null,
+  metadata: nullMetadata,
+  artist_id: 4211,
+  ...overrides,
+});
+
+const makeConcert = (overrides: Partial<ConcertDTO> = {}): ConcertDTO => ({
+  id: 900,
+  venue: {
+    id: 3,
+    slug: 'cats-cradle',
+    name: "Cat's Cradle",
+    city: 'Carrboro',
+    state: 'NC',
+    address: '300 E Main St, Carrboro, NC 27510',
+  },
+  starts_on: '2026-08-14',
+  starts_at: '2026-08-15T00:00:00.000Z',
+  doors_at: '2026-08-14T23:00:00.000Z',
+  headlining_artist_raw: 'Juana Molina',
+  headlining_artist_id: 4211,
+  title: null,
+  supporting_artists_raw: [],
+  ticket_url: 'https://catscradle.com/event/juana-molina/',
+  image_url: 'https://catscradle.com/img/juana-molina.jpg',
+  price_min: 25,
+  price_max: 28.5,
+  age_restriction: 'All Ages',
+  status: 'on_sale',
+  ...overrides,
+});
+
+describe('attachUpcomingShows (BS#1607)', () => {
+  let lookup: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    lookup = jest.spyOn(concertsService, 'getUpcomingShowsForArtists');
+  });
+
+  it('skips the DB entirely when the page has no resolved track artists', async () => {
+    const entries = [
+      createTrackEntry({ id: 1, artist_id: null }),
+      createTrackEntry({ id: 2, entry_type: 'show_start', artist_id: 4211 }),
+    ];
+    await attachUpcomingShows(entries);
+    expect(lookup).not.toHaveBeenCalled();
+    expect(entries[0].upcoming_show).toBeUndefined();
+  });
+
+  it('does exactly ONE lookup for an N-row page, with DISTINCT artist ids', async () => {
+    lookup.mockResolvedValueOnce(new Map());
+    const entries = [
+      createTrackEntry({ id: 1, artist_id: 4211 }),
+      createTrackEntry({ id: 2, artist_id: 4211 }), // duplicate artist
+      createTrackEntry({ id: 3, artist_id: 7000 }),
+      createTrackEntry({ id: 4, artist_id: null }), // free-form, no artist
+      createTrackEntry({ id: 5, entry_type: 'talkset', artist_id: 9999 }), // non-track
+    ];
+    await attachUpcomingShows(entries);
+
+    expect(lookup).toHaveBeenCalledTimes(1);
+    const [artistIds] = lookup.mock.calls[0];
+    expect([...(artistIds as number[])].sort((a, b) => a - b)).toEqual([4211, 7000]);
+  });
+
+  it('attaches the matched concert to every track row of that artist', async () => {
+    const concert = makeConcert({ headlining_artist_id: 4211 });
+    lookup.mockResolvedValueOnce(new Map([[4211, concert]]));
+    const entries = [
+      createTrackEntry({ id: 1, artist_id: 4211 }),
+      createTrackEntry({ id: 2, artist_id: 4211 }),
+      createTrackEntry({ id: 3, artist_id: 7000 }), // no match in the map
+    ];
+    await attachUpcomingShows(entries);
+
+    expect(entries[0].upcoming_show).toBe(concert);
+    expect(entries[1].upcoming_show).toBe(concert);
+    expect(entries[2].upcoming_show).toBeUndefined();
+  });
+
+  it('leaves every row untouched when no artist has an upcoming date', async () => {
+    lookup.mockResolvedValueOnce(new Map());
+    const entries = [createTrackEntry({ id: 1, artist_id: 4211 })];
+    await attachUpcomingShows(entries);
+    expect(entries[0].upcoming_show).toBeUndefined();
+  });
+});
+
+describe('transformToV2 upcoming_show projection (BS#1607)', () => {
+  it('emits upcoming_show on a track row when the enrichment matched', () => {
+    const concert = makeConcert();
+    const entry = createTrackEntry({ upcoming_show: concert });
+    const result = transformToV2(entry);
+    expect(result.upcoming_show).toBe(concert);
+  });
+
+  it('omits the key entirely on a no-match track row (parity with pre-1607)', () => {
+    const entry = createTrackEntry(); // upcoming_show undefined
+    const result = transformToV2(entry);
+    expect(result).not.toHaveProperty('upcoming_show');
+  });
+
+  it('omits the key on a null upcoming_show (defensive)', () => {
+    const entry = createTrackEntry({ upcoming_show: null });
+    const result = transformToV2(entry);
+    expect(result).not.toHaveProperty('upcoming_show');
+  });
+
+  it('never emits upcoming_show on a non-track (marker) row', () => {
+    const concert = makeConcert();
+    const entry = createTrackEntry({
+      entry_type: 'show_start',
+      upcoming_show: concert,
+    });
+    const result = transformToV2(entry);
+    expect(result).not.toHaveProperty('upcoming_show');
+  });
+});

--- a/tests/unit/services/flowsheet.lastModifiedAt.test.ts
+++ b/tests/unit/services/flowsheet.lastModifiedAt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { db } from '@wxyc/database';
+import { db, nyStartOfDay } from '@wxyc/database';
 import { getLastModifiedAt } from '../../../apps/backend/services/flowsheet.service';
 
 // `getLastModifiedAt` is the post-BS#902 replacement for the process-local
@@ -15,30 +15,52 @@ import { getLastModifiedAt } from '../../../apps/backend/services/flowsheet.serv
 // mock chain wires `.limit()` to return the chain itself by default; per-
 // test we use `mockReturnValueOnce` to swap a thenable into that position,
 // which is what `await` actually consumes.
+//
+// BS#1607 fold: the returned value is `max(flowsheet_watermark, nyStartOfDay(now))`
+// so the concerts-dependent V2 feed goes stale at ET midnight even without a
+// flowsheet write. `now` is injected per test to pin which side of the max
+// dominates deterministically.
 
 const mockDb = db as unknown as {
   _chain: Record<string, jest.Mock>;
 };
 
 describe('flowsheet.service: getLastModifiedAt', () => {
-  it('returns flowsheet_watermark.last_modified_at when the singleton row exists', async () => {
-    const watermark = new Date('2026-05-25T14:30:00.000Z');
+  it('returns flowsheet_watermark.last_modified_at when it is more recent than ET midnight', async () => {
+    // A watermark five seconds after this ET day's midnight dominates the fold.
+    const now = new Date('2026-05-25T14:30:00.000Z');
+    const watermark = new Date(nyStartOfDay(now).getTime() + 5000);
     mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([{ at: watermark }]));
 
-    const result = await getLastModifiedAt();
+    const result = await getLastModifiedAt(now);
 
     expect(result).toEqual(watermark);
   });
 
-  it('returns the epoch (new Date(0)) when the singleton row is somehow missing (defensive)', async () => {
-    // The migration seeds the row at apply time, so this branch only
-    // fires if the row was manually deleted post-deploy. Belt-and-braces
-    // fallback so the conditional-GET middleware always has a comparable
-    // Date in hand.
+  it('folds up to ET midnight when the watermark is older than the start of today (stale-drop guard)', async () => {
+    // Stale-drop case: no overnight flowsheet write, so the watermark predates
+    // today's ET midnight. The effective Last-Modified must be today's ET
+    // midnight, not the stale watermark — a client's pre-midnight
+    // If-Modified-Since then gets a fresh 200 and the past-show CTA is dropped.
+    const now = new Date('2026-05-25T14:30:00.000Z');
+    const staleWatermark = new Date('2026-05-24T22:00:00.000Z'); // before 2026-05-25 ET midnight
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([{ at: staleWatermark }]));
+
+    const result = await getLastModifiedAt(now);
+
+    expect(result).toEqual(nyStartOfDay(now));
+  });
+
+  it('returns ET midnight (not the epoch) when the singleton row is somehow missing (defensive)', async () => {
+    // The migration seeds the row at apply time, so this branch only fires if
+    // the row was manually deleted post-deploy. The epoch fallback is older
+    // than any ET midnight, so the fold surfaces today's ET midnight — still a
+    // comparable Date for the conditional-GET middleware.
+    const now = new Date('2026-05-25T14:30:00.000Z');
     mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([]));
 
-    const result = await getLastModifiedAt();
+    const result = await getLastModifiedAt(now);
 
-    expect(result).toEqual(new Date(0));
+    expect(result).toEqual(nyStartOfDay(now));
   });
 });


### PR DESCRIPTION
Closes #1607

Backend half of the touring-events playcut CTA: the V2 flowsheet feed now carries an embedded upcoming show per track, so iOS renders the Box Office ticket **instantly with the flowsheet** — no second round-trip, no `artist_id` sent by the client.

## What it does
Each V2 track/playcut entry optionally carries `upcoming_show` (the `Concert` schema). It's attached when the track's server-resolved artist matches a curated, upcoming concert; absent otherwise, so rows without a match are byte-for-byte unchanged.

Resolution path (the id was already in the join, just unselected): `flowsheet.album_id → library.artist_id → artists.id = concerts.headlining_artist_id`.

## Batched, no N+1
One query per feed page, collapsing each artist's multiple dates to the soonest:

```sql
SELECT DISTINCT ON (headlining_artist_id) <concertJoinFields>
FROM concerts JOIN venues ON venues.id = concerts.venue_id
WHERE headlining_artist_id IS NOT NULL
  AND removed_at IS NULL
  AND starts_on >= $today            -- America/New_York, matching GET /concerts
  AND headlining_artist_id IN ($distinctArtistIds)
ORDER BY headlining_artist_id, starts_on ASC, id;
```

The `IS NOT NULL AND removed_at IS NULL` conjuncts let the planner use `concerts_curated_starts_on_idx`. An integration test asserts a bounded table-scan delta for an N-row page (proves no per-row query).

## Wire contract
Codified in WXYC/wxyc-shared#214 (optional/additive `upcoming_show` on `FlowsheetV2TrackEntry`, minor bump, no breaking changes). This branch doesn't bump the `@wxyc/shared` dependency — the response interface is local — so the two PRs are independently mergeable, but the api.yaml SSOT (#214) is the canonical shape.

## Tests
- Unit: full suite `4043 passed`; new/edited files `100 passed`. Covers match present, no match, artist unresolved, multiple dates (soonest wins), removed/past excluded.
- Integration (Docker, fresh run): `486 passed, 0 failed`; the BS#1607 spec's bounded-query-count batching proof passes.
- `typecheck` / `lint` / `format:check` all pass.

## For the reviewer — one deliberate scope choice
The enrichment is applied to **all 5** V2 read paths (paginated, shows_limit, id-range, latest, show-info) for wire consistency, not just the iOS-polled paginated path. Easy to narrow if you'd prefer — flagging it explicitly.

## Related
- WXYC/wxyc-shared#214 — wire contract (companion)
- #1588 — touring-events epic; #1603 — the `Concert` read API this reuses
- WXYC/wxyc-ios-64#473 — iOS consumer this unblocks