### PR TITLE
feat(flowsheet): widen V2 upcoming_show match to free-text plays and unresolved concerts (BS#1613)

### DIFF
--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -1,5 +1,5 @@
 import { and, asc, eq, gte, isNotNull, isNull, lte, sql } from 'drizzle-orm';
-import { artists, concerts, db, normalizeArtistName, venues } from '@wxyc/database';
+import { artists, concerts, db, normalizeFreetextArtist, venues } from '@wxyc/database';
 
 /**
  * Concerts read service — backs `GET /concerts` (BS#1603, touring-events
@@ -241,10 +241,12 @@ type UpcomingShowJoinRow = ConcertJoinRow & { artist_name: string | null };
  *     join would drop every UNRESOLVED concert (`headlining_artist_id IS
  *     NULL`), which is precisely the set BS#1613's name arm exists to recover.
  *
- * Predicate: `removed_at IS NULL AND starts_on >= today` (America/New_York,
- * supplied by the caller so the window matches `GET /concerts`'s
- * `todayEastern`). No `headlining_artist_id IS NOT NULL` conjunct — unlike
- * BS#1607's id-only lookup, this must include unresolved concerts. Reads the
+ * Predicate: `buildWhere({ from: today, curated: false })` — `removed_at IS NULL
+ * AND starts_on >= today` (America/New_York, supplied by the caller so the
+ * window matches `GET /concerts`'s `todayEastern`). Reusing the shared builder
+ * keeps this feed from drifting off the page/count queries; `curated: false`
+ * omits the `headlining_artist_id IS NOT NULL` conjunct — unlike BS#1607's
+ * id-only lookup, this must include unresolved concerts. Reads the
  * `concerts_active_starts_on_id_idx` (non-tombstoned, `starts_on`-first).
  *
  * Returns two maps, each collapsed to the SOONEST concert per key by
@@ -253,13 +255,21 @@ type UpcomingShowJoinRow = ConcertJoinRow & { artist_name: string | null };
  * `upcoming_show` DTO without a `DISTINCT ON`:
  *   - `byArtistId` — RESOLVED rows only (`headlining_artist_id` non-null),
  *     keyed by that id. The precise arm; matches album-linked plays.
- *   - `byNormName` — keyed by `normalizeArtistName(...)`: the canonical
- *     `artists.artist_name` for a resolved row (so a free-text play typed with
- *     the current name matches even when the concert resolved via an alias of
- *     an older name), else the scraped `headlining_artist_raw`. A billing/
- *     co-bill raw normalizes to its ENTIRE string — an inert key no
- *     one-artist-per-entry flowsheet play equals — so it is stored but never
- *     matched (see the BS#1613 ticket's "no clean-name filter" rationale).
+ *   - `byNormName` — keyed by `normalizeFreetextArtist(...)` (the free-text
+ *     match SSOT: `normalizeArtistName` + collapse internal whitespace + trim,
+ *     so incidental spacing in a scraped raw or a DJ's free-text entry can't
+ *     split the key): the canonical `artists.artist_name` for a resolved row
+ *     (so a free-text play typed with the current name matches even when the
+ *     concert resolved via an alias of an older name), else the scraped
+ *     `headlining_artist_raw`. Both sides of the match run this one function, so
+ *     the two keys are provably drift-free. A billing/co-bill raw normalizes to
+ *     its ENTIRE string — an inert key no one-artist-per-entry flowsheet play
+ *     equals — so it is stored but never matched (see the BS#1613 ticket's "no
+ *     clean-name filter" rationale). RESIDUAL (accepted; #1614 is the real
+ *     lever): two DISTINCT artists sharing a normalized name (homonyms, e.g. two
+ *     bands named `Wire`) collapse to one key — the soonest wins and can attach
+ *     to a play of the other. Low-harm for a "Touring Soon" CTA, not engineered
+ *     around here.
  *
  * The venue-embedding join and DTO mapping reuse `getConcertsPage`'s projection
  * so the wire shape can't drift.
@@ -275,23 +285,31 @@ export const getUpcomingShowsMaps = async (
     .from(concerts)
     .innerJoin(venues, eq(venues.id, concerts.venue_id))
     .leftJoin(artists, eq(artists.id, concerts.headlining_artist_id))
-    .where(and(isNull(concerts.removed_at), gte(concerts.starts_on, today)))
+    .where(buildWhere({ from: today, curated: false }))
     .orderBy(asc(concerts.starts_on), asc(concerts.id));
 
   for (const row of rows as UpcomingShowJoinRow[]) {
-    const dto = toConcertDTO(row);
+    const artistId = row.headlining_artist_id;
 
-    // id arm — resolved rows only; first write wins → soonest.
-    if (row.headlining_artist_id !== null && !byArtistId.has(row.headlining_artist_id)) {
-      byArtistId.set(row.headlining_artist_id, dto);
+    // name arm — canonical name for resolved rows (falling back to the raw only
+    // on the impossible dangling-FK miss, since `artists.artist_name` is NOT
+    // NULL), the scraped raw for unresolved rows.
+    const nameSource = artistId !== null && row.artist_name !== null ? row.artist_name : row.headlining_artist_raw;
+    const nameKey = normalizeFreetextArtist(nameSource);
+
+    // First write wins per key → the soonest date (rows arrive starts_on ASC).
+    // id arm is resolved rows only; name arm skips the inert empty key.
+    const needsId = artistId !== null && !byArtistId.has(artistId);
+    const needsName = nameKey !== '' && !byNormName.has(nameKey);
+    if (!needsId && !needsName) {
+      continue; // a later date for an already-seen artist AND name — build no DTO
     }
 
-    // name arm — canonical name for resolved rows (falling back to the raw if
-    // the LEFT JOIN somehow found no artists row), raw for unresolved rows.
-    const nameSource =
-      row.headlining_artist_id !== null && row.artist_name !== null ? row.artist_name : row.headlining_artist_raw;
-    const nameKey = normalizeArtistName(nameSource);
-    if (nameKey !== '' && !byNormName.has(nameKey)) {
+    const dto = toConcertDTO(row);
+    if (needsId && artistId !== null) {
+      byArtistId.set(artistId, dto);
+    }
+    if (needsName) {
       byNormName.set(nameKey, dto);
     }
   }

--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -1,5 +1,5 @@
-import { and, asc, eq, gte, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
-import { concerts, db, venues } from '@wxyc/database';
+import { and, asc, eq, gte, isNotNull, isNull, lte, sql } from 'drizzle-orm';
+import { artists, concerts, db, normalizeArtistName, venues } from '@wxyc/database';
 
 /**
  * Concerts read service — backs `GET /concerts` (BS#1603, touring-events
@@ -208,63 +208,93 @@ export const getConcertsCount = async (filters: ConcertsQueryFilters): Promise<n
 };
 
 /**
- * Batched artist → soonest-upcoming-curated-concert lookup, backing the V2
- * flowsheet feed's per-playcut `upcoming_show` enrichment (BS#1607, touring-
- * events Phase 3).
- *
- * ONE indexed query for a whole feed page — never one query per row. The
- * caller (`flowsheet.service` `attachUpcomingShows`) collects the distinct
- * resolved artist ids across the returned page and passes them here; the
- * result is a `Map<artistId, ConcertDTO>` it fans back out onto the matching
- * playcuts. This is the no-N+1 guarantee the ticket and the post-launch
- * hardening posture (project #32) require.
- *
- * Predicate is exactly the curated feed's: `headlining_artist_id IN (…)`,
- * `removed_at IS NULL`, `starts_on >= today` (America/New_York, supplied by
- * the caller so the window matches `GET /concerts`'s `todayEastern`). The
- * `headlining_artist_id IS NOT NULL AND removed_at IS NULL` conjuncts let the
- * planner read `concerts_curated_starts_on_idx`.
- *
- * One concert per artist — the SOONEST. `DISTINCT ON (headlining_artist_id)`
- * with `ORDER BY headlining_artist_id, starts_on ASC, id` collapses an
- * artist's multiple upcoming dates to the earliest (id as a stable tiebreak
- * when two dates coincide), mirroring the "soonest wins" rule documented on
- * the `upcoming_show` DTO. `DISTINCT ON` requires the distinct expression to
- * lead the ORDER BY; the venue-embedding join and the DTO mapping reuse
- * `getConcertsPage`'s projection so the wire shape can't drift.
- *
- * Returns an empty map for an empty id list without touching the DB.
+ * Adds the canonical catalog artist name to the concerts ⋈ venues projection
+ * for the `upcoming_show` name arm. Sourced via the LEFT JOIN to `artists`, so
+ * a resolved concert keys its name-map entry off the artist's CURRENT catalog
+ * name (which may differ from the possibly-stale scraped raw), while an
+ * unresolved concert leaves this null and falls back to the raw.
  */
-export const getUpcomingShowsForArtists = async (
-  artistIds: number[],
+const upcomingShowJoinFields = {
+  ...concertJoinFields,
+  artist_name: artists.artist_name,
+};
+
+/** `ConcertJoinRow` plus the LEFT-joined canonical artist name (null when unresolved). */
+type UpcomingShowJoinRow = ConcertJoinRow & { artist_name: string | null };
+
+/**
+ * Batched upcoming-concert lookup backing the V2 flowsheet feed's per-playcut
+ * `upcoming_show` enrichment (BS#1607, widened by BS#1613; touring-events
+ * Phase 3).
+ *
+ * ONE indexed query for a whole feed page — never one query per row. The caller
+ * (`flowsheet.service` `attachUpcomingShows`) invokes this once and fans the
+ * two returned maps back onto the page's tracks. This is the no-N+1 guarantee
+ * the ticket and the post-launch hardening posture (project #32) require.
+ *
+ * JOIN shape:
+ *   - INNER JOIN `venues` — strict, exactly as `getConcertsPage`; keeps the
+ *     DTO's `venue` non-null. A concert with a dangling `venue_id` is dropped
+ *     (it can't render a CTA anyway).
+ *   - LEFT JOIN `artists` on `headlining_artist_id` — only to source the
+ *     canonical name for the name arm's key. It MUST be a left join: an inner
+ *     join would drop every UNRESOLVED concert (`headlining_artist_id IS
+ *     NULL`), which is precisely the set BS#1613's name arm exists to recover.
+ *
+ * Predicate: `removed_at IS NULL AND starts_on >= today` (America/New_York,
+ * supplied by the caller so the window matches `GET /concerts`'s
+ * `todayEastern`). No `headlining_artist_id IS NOT NULL` conjunct — unlike
+ * BS#1607's id-only lookup, this must include unresolved concerts. Reads the
+ * `concerts_active_starts_on_id_idx` (non-tombstoned, `starts_on`-first).
+ *
+ * Returns two maps, each collapsed to the SOONEST concert per key by
+ * first-write-wins over rows ordered `starts_on ASC, id ASC` (id as a stable
+ * tiebreak when two dates coincide) — mirroring the "soonest wins" rule on the
+ * `upcoming_show` DTO without a `DISTINCT ON`:
+ *   - `byArtistId` — RESOLVED rows only (`headlining_artist_id` non-null),
+ *     keyed by that id. The precise arm; matches album-linked plays.
+ *   - `byNormName` — keyed by `normalizeArtistName(...)`: the canonical
+ *     `artists.artist_name` for a resolved row (so a free-text play typed with
+ *     the current name matches even when the concert resolved via an alias of
+ *     an older name), else the scraped `headlining_artist_raw`. A billing/
+ *     co-bill raw normalizes to its ENTIRE string — an inert key no
+ *     one-artist-per-entry flowsheet play equals — so it is stored but never
+ *     matched (see the BS#1613 ticket's "no clean-name filter" rationale).
+ *
+ * The venue-embedding join and DTO mapping reuse `getConcertsPage`'s projection
+ * so the wire shape can't drift.
+ */
+export const getUpcomingShowsMaps = async (
   today: string
-): Promise<Map<number, ConcertDTO>> => {
-  const byArtist = new Map<number, ConcertDTO>();
-  if (artistIds.length === 0) {
-    return byArtist;
-  }
+): Promise<{ byArtistId: Map<number, ConcertDTO>; byNormName: Map<string, ConcertDTO> }> => {
+  const byArtistId = new Map<number, ConcertDTO>();
+  const byNormName = new Map<string, ConcertDTO>();
 
   const rows = await db
-    .selectDistinctOn([concerts.headlining_artist_id], concertJoinFields)
+    .select(upcomingShowJoinFields)
     .from(concerts)
     .innerJoin(venues, eq(venues.id, concerts.venue_id))
-    .where(
-      and(
-        isNotNull(concerts.headlining_artist_id),
-        isNull(concerts.removed_at),
-        gte(concerts.starts_on, today),
-        inArray(concerts.headlining_artist_id, artistIds)
-      )
-    )
-    .orderBy(asc(concerts.headlining_artist_id), asc(concerts.starts_on), asc(concerts.id));
+    .leftJoin(artists, eq(artists.id, concerts.headlining_artist_id))
+    .where(and(isNull(concerts.removed_at), gte(concerts.starts_on, today)))
+    .orderBy(asc(concerts.starts_on), asc(concerts.id));
 
-  for (const row of rows as ConcertJoinRow[]) {
-    // headlining_artist_id is non-null here (the WHERE guards it), but the
-    // ConcertJoinRow type keeps it nullable for the general projection; the
-    // guard keeps the Map key a plain number.
-    if (row.headlining_artist_id !== null) {
-      byArtist.set(row.headlining_artist_id, toConcertDTO(row));
+  for (const row of rows as UpcomingShowJoinRow[]) {
+    const dto = toConcertDTO(row);
+
+    // id arm — resolved rows only; first write wins → soonest.
+    if (row.headlining_artist_id !== null && !byArtistId.has(row.headlining_artist_id)) {
+      byArtistId.set(row.headlining_artist_id, dto);
+    }
+
+    // name arm — canonical name for resolved rows (falling back to the raw if
+    // the LEFT JOIN somehow found no artists row), raw for unresolved rows.
+    const nameSource =
+      row.headlining_artist_id !== null && row.artist_name !== null ? row.artist_name : row.headlining_artist_raw;
+    const nameKey = normalizeArtistName(nameSource);
+    if (nameKey !== '' && !byNormName.has(nameKey)) {
+      byNormName.set(nameKey, dto);
     }
   }
-  return byArtist;
+
+  return { byArtistId, byNormName };
 };

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -19,7 +19,7 @@ import {
   library_artist_view,
   specialty_shows,
   album_metadata,
-  normalizeArtistName,
+  normalizeFreetextArtist,
   nyCalendarDate,
   nyStartOfDay,
 } from '@wxyc/database';
@@ -1115,11 +1115,13 @@ export const getShowMetadata = async (show_id: number): Promise<ShowMetadata> =>
  *   1. id arm — `byArtistId.get(artist_id)`: the album-resolved catalog artist
  *      (`flowsheet.album_id → library.artist_id`) matched a resolved concert.
  *      Precise; the sole BS#1607 path, kept as-is (regression-guarded).
- *   2. name arm (BS#1613) — `byNormName.get(normalizeArtistName(artist_name))`:
+ *   2. name arm (BS#1613) — `byNormName.get(normalizeFreetextArtist(artist_name))`:
  *      catches FREE-TEXT plays (no `album_id`, so no `artist_id`) and CLEAN
  *      UNRESOLVED concerts (touring artists absent from our catalog). Uses the
- *      SAME normalizer as the concert side, so the two keys are provably
- *      produced by one function — drift would be a silent no-match.
+ *      free-text match SSOT (`normalizeArtistName` + collapse internal
+ *      whitespace + trim) — the SAME normalizer the concert side keys with, so
+ *      incidental spacing can't split the key and the two sides are provably
+ *      drift-free.
  *
  * The name arm keys only on a non-empty `artist_name` (`?.trim()`), so a blank
  * free-text name can't form a `''` key that collides. Rows that match neither
@@ -1155,7 +1157,7 @@ export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry
     const byId = entry.artist_id !== null ? byArtistId.get(entry.artist_id) : undefined;
     const byName =
       byId === undefined && entry.artist_name?.trim()
-        ? byNormName.get(normalizeArtistName(entry.artist_name))
+        ? byNormName.get(normalizeFreetextArtist(entry.artist_name))
         : undefined;
     const show = byId ?? byName;
     if (show !== undefined) {

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -19,10 +19,11 @@ import {
   library_artist_view,
   specialty_shows,
   album_metadata,
+  normalizeArtistName,
   nyCalendarDate,
   nyStartOfDay,
 } from '@wxyc/database';
-import { getUpcomingShowsForArtists } from './concerts.service.js';
+import { getUpcomingShowsMaps } from './concerts.service.js';
 import { IFSEntry, ShowMetadata, UpdateRequestBody } from '../controllers/flowsheet.controller.js';
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
 
@@ -1105,16 +1106,25 @@ export const getShowMetadata = async (show_id: number): Promise<ShowMetadata> =>
  */
 /**
  * Attach the per-playcut `upcoming_show` enrichment to a feed page of entries
- * (BS#1607, touring-events Phase 3).
+ * (BS#1607, widened to a hybrid id-arm ∪ name-arm match in BS#1613; touring-
+ * events Phase 3).
  *
- * Batched — ONE indexed concerts query for the whole page, never one per row
- * (the no-N+1 guarantee; project #32 perf posture). Collects the distinct
- * resolved `artist_id`s across the track rows, does a single
- * `getUpcomingShowsForArtists` lookup, and fans the soonest curated upcoming
- * concert back onto each matching track. Rows with no resolved artist, or
- * whose artist has no curated upcoming date, are returned unchanged
- * (`upcoming_show` stays absent) — so the wire shape is byte-identical to
- * pre-1607 for the no-match case (additive/optional field).
+ * Batched — ONE indexed concerts query for the whole page via
+ * `getUpcomingShowsMaps`, never one per row (the no-N+1 guarantee; project #32
+ * perf posture). Each track row resolves through two arms, id first:
+ *   1. id arm — `byArtistId.get(artist_id)`: the album-resolved catalog artist
+ *      (`flowsheet.album_id → library.artist_id`) matched a resolved concert.
+ *      Precise; the sole BS#1607 path, kept as-is (regression-guarded).
+ *   2. name arm (BS#1613) — `byNormName.get(normalizeArtistName(artist_name))`:
+ *      catches FREE-TEXT plays (no `album_id`, so no `artist_id`) and CLEAN
+ *      UNRESOLVED concerts (touring artists absent from our catalog). Uses the
+ *      SAME normalizer as the concert side, so the two keys are provably
+ *      produced by one function — drift would be a silent no-match.
+ *
+ * The name arm keys only on a non-empty `artist_name` (`?.trim()`), so a blank
+ * free-text name can't form a `''` key that collides. Rows that match neither
+ * arm are returned unchanged (`upcoming_show` stays absent) — the wire shape is
+ * byte-identical to pre-1607 for the no-match case (additive/optional field).
  *
  * "Today" is America/New_York (`nyCalendarDate`), matching `GET /concerts`'s
  * default `from`: `starts_on` is a venue-local calendar date, so a UTC "today"
@@ -1125,25 +1135,31 @@ export const getShowMetadata = async (show_id: number): Promise<ShowMetadata> =>
  * `entry.upcoming_show`.
  */
 export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry[]> => {
-  const artistIds = Array.from(
-    new Set(
-      entries
-        .filter((entry) => entry.entry_type === 'track' && entry.artist_id !== null)
-        .map((entry) => entry.artist_id as number)
-    )
+  // Skip the DB only when NO track row could match either arm: a track matches
+  // the id arm with a non-null artist_id, or the name arm with a non-empty
+  // artist_name. (Almost every track carries a name, so this mainly short-
+  // circuits all-marker pages.)
+  const hasMatchableTrack = entries.some(
+    (entry) => entry.entry_type === 'track' && (entry.artist_id !== null || !!entry.artist_name?.trim())
   );
-  if (artistIds.length === 0) {
+  if (!hasMatchableTrack) {
     return entries;
   }
 
-  const byArtist = await getUpcomingShowsForArtists(artistIds, nyCalendarDate(new Date()));
+  const { byArtistId, byNormName } = await getUpcomingShowsMaps(nyCalendarDate(new Date()));
 
   for (const entry of entries) {
-    if (entry.entry_type === 'track' && entry.artist_id !== null) {
-      const show = byArtist.get(entry.artist_id);
-      if (show !== undefined) {
-        entry.upcoming_show = show;
-      }
+    if (entry.entry_type !== 'track') {
+      continue;
+    }
+    const byId = entry.artist_id !== null ? byArtistId.get(entry.artist_id) : undefined;
+    const byName =
+      byId === undefined && entry.artist_name?.trim()
+        ? byNormName.get(normalizeArtistName(entry.artist_name))
+        : undefined;
+    const show = byId ?? byName;
+    if (show !== undefined) {
+      entry.upcoming_show = show;
     }
   }
   return entries;

--- a/tests/integration/flowsheet-upcoming-show.spec.js
+++ b/tests/integration/flowsheet-upcoming-show.spec.js
@@ -74,6 +74,16 @@ const LATER = isoDate(21); // a later date for the same artist — must lose
 const NAME_SOON = isoDate(4);
 const NAME_LATER = isoDate(25);
 
+// BS#1613 RESOLVED name-arm probe: artist 6 (Bjork) with a scraped raw ('Björk',
+// diacritic) that DIFFERS from the canonical catalog name ('Bjork'). A free-text
+// play typed 'Bjork' can only attach if the name arm keys off the LEFT-JOINed
+// canonical `artists.artist_name`, not the raw — so this fixture fails loudly if
+// that join ever regresses (which the mocked unit tests can't catch).
+const ARTIST_RESOLVED_NAME = 6;
+const RESOLVED_CANONICAL_NAME = 'Bjork';
+const RESOLVED_SCRAPED_RAW = 'Björk';
+const RESOLVED_NAME_DATE = isoDate(6);
+
 describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
   let sql;
   let venueId;
@@ -238,6 +248,16 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
       starts_on: NAME_LATER,
       headlining_artist_raw: 'THE TUBS',
     });
+    // A RESOLVED concert (headlining_artist_id set) whose scraped raw differs
+    // from the canonical catalog name — exercises the real LEFT JOIN sourcing
+    // the name-arm key off artists.artist_name.
+    await seedConcert({
+      key: 'resolved-name',
+      venue_id: venueId,
+      starts_on: RESOLVED_NAME_DATE,
+      headlining_artist_raw: RESOLVED_SCRAPED_RAW,
+      headlining_artist_id: ARTIST_RESOLVED_NAME,
+    });
 
     // Track rows: one matching artist, one with an artist that has no upcoming
     // date, one whose artist only has a past date, and one free-form (null
@@ -250,7 +270,10 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
     const t5 = await seedTrack({ albumId: null, artistName: 'Wishy', playOrder: 5 });
     const t6 = await seedTrack({ albumId: null, artistName: 'Circle Jerks', playOrder: 6 });
     const t7 = await seedTrack({ albumId: null, artistName: 'The Tubs', playOrder: 7 });
-    insertedTrackIds = [t1, t2, t3, t4, t5, t6, t7];
+    // Free-text play typed with the CANONICAL name of a resolved concert whose
+    // scraped raw differs — must attach via the canonical name-arm key.
+    const t8 = await seedTrack({ albumId: null, artistName: RESOLVED_CANONICAL_NAME, playOrder: 8 });
+    insertedTrackIds = [t1, t2, t3, t4, t5, t6, t7, t8];
   });
 
   afterAll(async () => {
@@ -351,6 +374,23 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
     expect(tubs.upcoming_show).toBeDefined();
     expect(tubs.upcoming_show.starts_on).toBe(NAME_SOON);
     expect(tubs.upcoming_show.starts_on).not.toBe(NAME_LATER);
+  });
+
+  it('attaches a RESOLVED concert to a free-text play via the LEFT-JOINed canonical name (not the raw)', async () => {
+    const tracks = await fetchSeededTracks();
+    // The play is typed with the canonical catalog name 'Bjork'; the resolved
+    // concert's scraped raw is 'Björk' (diacritic). Matching proves the name-arm
+    // key is sourced from artists.artist_name via the LEFT JOIN — if that join
+    // regressed, the key would fall back to the raw 'Björk' and this would miss.
+    const bjork = tracks.find((t) => t.album_id === null && t.artist_name === RESOLVED_CANONICAL_NAME);
+    expect(bjork).toBeDefined();
+    expect(bjork.upcoming_show).toBeDefined();
+    expect(bjork.upcoming_show).toMatchObject({
+      starts_on: RESOLVED_NAME_DATE,
+      headlining_artist_id: ARTIST_RESOLVED_NAME, // the resolved concert
+      headlining_artist_raw: RESOLVED_SCRAPED_RAW, // whose raw differs from canonical
+      venue: { slug: VENUE_SLUG },
+    });
   });
 
   it('never surfaces the tombstoned or later date for the matching artist', async () => {

--- a/tests/integration/flowsheet-upcoming-show.spec.js
+++ b/tests/integration/flowsheet-upcoming-show.spec.js
@@ -13,12 +13,20 @@
  *     `upcoming_show`, with the full `Concert` wire shape and no internal
  *     ingestion columns;
  *   - the SOONEST of an artist's several upcoming dates wins;
- *   - no match, an unresolved (free-form / null album_id) artist, and
- *     removed/past concerts all leave `upcoming_show` absent (parity: the row
- *     is byte-identical to its pre-1607 shape);
+ *   - no match, an unresolved (free-form / null album_id) artist with no
+ *     matching concert, and removed/past concerts all leave `upcoming_show`
+ *     absent (parity: the row is byte-identical to its pre-1607 shape);
  *   - the lookup is BATCHED — a page whose N track rows all match still hits
  *     the `concerts` table a bounded, N-independent number of times (proves no
  *     per-row query).
+ *
+ * BS#1613 widens the match to a name arm alongside the id arm, also pinned here:
+ *   - a FREE-TEXT play (null album_id, so no resolved artist_id) attaches a
+ *     clean UNRESOLVED concert (headlining_artist_id null) by normalized name;
+ *   - a billing-string concert raw (`Circle Jerks & Municipal Waste`) is an
+ *     inert key — it does not attach to a single-artist play (`Circle Jerks`);
+ *   - the name arm collapses two unresolved concerts whose raws normalize to
+ *     the same key to the SOONEST date.
  */
 
 const postgres = require('postgres');
@@ -60,6 +68,11 @@ function isoDate(offsetDays) {
 const PAST = isoDate(-14);
 const SOON = isoDate(7); // the soonest upcoming date for ARTIST_WITH_SHOW
 const LATER = isoDate(21); // a later date for the same artist — must lose
+
+// BS#1613 name-arm dates: two upcoming dates for one normalized name key, to
+// prove the name arm also collapses to the soonest.
+const NAME_SOON = isoDate(4);
+const NAME_LATER = isoDate(25);
 
 describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
   let sql;
@@ -196,14 +209,48 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
       headlining_artist_id: ARTIST_ONLY_PAST,
     });
 
+    // BS#1613 name-arm fixtures — all UNRESOLVED (headlining_artist_id null),
+    // so they can't be reached by the id arm; the name arm is the only path.
+    // A clean single name absent from our catalog (the recall #1613 adds).
+    await seedConcert({
+      key: 'freetext-clean',
+      venue_id: venueId,
+      starts_on: SOON,
+      headlining_artist_raw: 'Wishy',
+    });
+    // A billing string — normalizes to its entire self, an inert map key.
+    await seedConcert({
+      key: 'billing',
+      venue_id: venueId,
+      starts_on: SOON,
+      headlining_artist_raw: 'Circle Jerks & Municipal Waste',
+    });
+    // Two dates whose raws normalize to the same key ('tubs') — soonest wins.
+    await seedConcert({
+      key: 'name-soon',
+      venue_id: venueId,
+      starts_on: NAME_SOON,
+      headlining_artist_raw: 'The Tubs',
+    });
+    await seedConcert({
+      key: 'name-later',
+      venue_id: venueId,
+      starts_on: NAME_LATER,
+      headlining_artist_raw: 'THE TUBS',
+    });
+
     // Track rows: one matching artist, one with an artist that has no upcoming
     // date, one whose artist only has a past date, and one free-form (null
-    // album_id → unresolved artist).
+    // album_id → unresolved artist) with no matching concert.
     const t1 = await seedTrack({ albumId: ALBUM_WITH_SHOW, artistName: 'Built to Spill', playOrder: 1 });
     const t2 = await seedTrack({ albumId: ALBUM_NO_SHOW, artistName: 'Ravyn Lenae', playOrder: 2 });
     const t3 = await seedTrack({ albumId: ALBUM_ONLY_PAST, artistName: 'Jockstrap', playOrder: 3 });
     const t4 = await seedTrack({ albumId: null, artistName: 'Some Free-Form Act', playOrder: 4 });
-    insertedTrackIds = [t1, t2, t3, t4];
+    // BS#1613 free-text plays (null album_id → null artist_id): match by name.
+    const t5 = await seedTrack({ albumId: null, artistName: 'Wishy', playOrder: 5 });
+    const t6 = await seedTrack({ albumId: null, artistName: 'Circle Jerks', playOrder: 6 });
+    const t7 = await seedTrack({ albumId: null, artistName: 'The Tubs', playOrder: 7 });
+    insertedTrackIds = [t1, t2, t3, t4, t5, t6, t7];
   });
 
   afterAll(async () => {
@@ -262,11 +309,48 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
     expect(pastOnly).not.toHaveProperty('upcoming_show');
   });
 
-  it('leaves upcoming_show absent for a free-form (unresolved-artist) track', async () => {
+  it('leaves upcoming_show absent for a free-form track with no matching concert', async () => {
     const tracks = await fetchSeededTracks();
-    const freeForm = tracks.find((t) => t.album_id === null);
+    // Several tracks now share a null album_id (the BS#1613 free-text plays), so
+    // key on the artist name that has no concert.
+    const freeForm = tracks.find((t) => t.album_id === null && t.artist_name === 'Some Free-Form Act');
     expect(freeForm).toBeDefined();
     expect(freeForm).not.toHaveProperty('upcoming_show');
+  });
+
+  // --- BS#1613 name arm ---
+
+  it('attaches a clean unresolved concert to a free-text play by normalized name', async () => {
+    const tracks = await fetchSeededTracks();
+    const freeText = tracks.find((t) => t.album_id === null && t.artist_name === 'Wishy');
+    expect(freeText).toBeDefined();
+    expect(freeText.upcoming_show).toBeDefined();
+    expect(freeText.upcoming_show).toMatchObject({
+      starts_on: SOON,
+      headlining_artist_raw: 'Wishy',
+      headlining_artist_id: null, // unresolved — matched purely by name
+      venue: { slug: VENUE_SLUG },
+    });
+  });
+
+  it('does not attach a billing-string concert to a single-artist free-text play (inert key)', async () => {
+    const tracks = await fetchSeededTracks();
+    // The concert raw is 'Circle Jerks & Municipal Waste'; the play is
+    // 'Circle Jerks'. The billing string normalizes to its entire self, so the
+    // single-act play never equals it.
+    const cj = tracks.find((t) => t.album_id === null && t.artist_name === 'Circle Jerks');
+    expect(cj).toBeDefined();
+    expect(cj).not.toHaveProperty('upcoming_show');
+  });
+
+  it('collapses two same-normalized-name unresolved concerts to the SOONEST', async () => {
+    const tracks = await fetchSeededTracks();
+    // 'The Tubs' and 'THE TUBS' both normalize to 'tubs'; only NAME_SOON rides.
+    const tubs = tracks.find((t) => t.album_id === null && t.artist_name === 'The Tubs');
+    expect(tubs).toBeDefined();
+    expect(tubs.upcoming_show).toBeDefined();
+    expect(tubs.upcoming_show.starts_on).toBe(NAME_SOON);
+    expect(tubs.upcoming_show.starts_on).not.toBe(NAME_LATER);
   });
 
   it('never surfaces the tombstoned or later date for the matching artist', async () => {

--- a/tests/unit/services/concerts.service.test.ts
+++ b/tests/unit/services/concerts.service.test.ts
@@ -333,6 +333,27 @@ describe('getUpcomingShowsMaps (BS#1613)', () => {
     expect(byNormName.has('municipal waste')).toBe(false);
   });
 
+  it('collapses stray + doubled whitespace in the name key (free-text SSOT)', async () => {
+    // A DJ free-text play and a scraped raw routinely differ only in incidental
+    // whitespace ('J Dilla' vs 'J  Dilla' vs ' J Dilla '). The name arm keys
+    // free-text plays, so it must use the free-text normalizer (collapse internal
+    // whitespace + trim) — the same SSOT `flowsheet_freetext_resolution` uses —
+    // not the bare `normalizeArtistName`, which leaves the doubled/edge spaces in
+    // place and silently splits the key.
+    const messy: UpcomingRow = {
+      ...unresolvedCleanRow,
+      id: 402,
+      headlining_artist_raw: ' J  Dilla ',
+      starts_on: '2026-08-11',
+    };
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([messy]));
+    const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    // Collapsed + trimmed → a play typed 'J Dilla' (single space) matches.
+    expect(byNormName.get('j dilla')).toEqual(toConcertDTO(messy));
+    // The un-collapsed variant is NOT a key (would be a silent no-match).
+    expect(byNormName.has(' j  dilla ')).toBe(false);
+  });
+
   it('collapses multiple dates for one name key to the SOONEST (first row wins)', async () => {
     // Rows arrive ordered starts_on ASC (the query's ORDER BY), so the first
     // occurrence of a key is the soonest.

--- a/tests/unit/services/concerts.service.test.ts
+++ b/tests/unit/services/concerts.service.test.ts
@@ -18,7 +18,7 @@ import {
   ConcertJoinRow,
   getConcertsCount,
   getConcertsPage,
-  getUpcomingShowsForArtists,
+  getUpcomingShowsMaps,
   toConcertDTO,
 } from '../../../apps/backend/services/concerts.service';
 
@@ -249,51 +249,131 @@ describe('getConcertsCount', () => {
   });
 });
 
-describe('getUpcomingShowsForArtists (BS#1607)', () => {
+/**
+ * BS#1613 widens the `upcoming_show` match from the id-only join to a hybrid
+ * id-arm ∪ name-arm. `getUpcomingShowsMaps` loads every upcoming, non-tombstoned
+ * concert once (not filtered to a passed id list) and returns two maps:
+ *   - `byArtistId` — resolved rows only, keyed by `headlining_artist_id`;
+ *   - `byNormName` — resolved rows keyed by the CANONICAL artist name (from the
+ *     LEFT JOIN to `artists`), unresolved rows keyed by the raw. Billing-string
+ *     raws normalize to their entire string — inert keys, not false positives.
+ * Both maps are first-write-wins over rows ordered `starts_on ASC, id`, so each
+ * key holds the SOONEST upcoming concert.
+ *
+ * These fixtures carry the extra `artist_name` (the canonical name the LEFT
+ * JOIN sources) that `ConcertJoinRow` doesn't; the row shape is a superset.
+ */
+describe('getUpcomingShowsMaps (BS#1613)', () => {
+  type UpcomingRow = ConcertJoinRow & { artist_name: string | null };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('short-circuits an empty artist-id list without touching the DB', async () => {
-    const result = await getUpcomingShowsForArtists([], '2026-08-01');
-    expect(result.size).toBe(0);
-    expect(mockDb._chain.selectDistinctOn).not.toHaveBeenCalled();
+  // Resolved: headlining_artist_id set; artist_name is the canonical catalog
+  // name, which can differ from the scraped raw (here, diacritic vs not).
+  const resolvedRow: UpcomingRow = {
+    ...timedRow,
+    id: 301,
+    headlining_artist_id: 4211,
+    headlining_artist_raw: 'Nilufer Yanya', // scraped, no diacritic
+    artist_name: 'Nilüfer Yanya', // canonical catalog name
+    starts_on: '2026-08-14',
+  };
+
+  // Unresolved, clean single name (the recall #1613 adds): keys off the raw.
+  const unresolvedCleanRow: UpcomingRow = {
+    ...timedRow,
+    id: 302,
+    headlining_artist_id: null,
+    headlining_artist_raw: 'Wishy',
+    artist_name: null,
+    starts_on: '2026-08-20',
+  };
+
+  // Unresolved billing string: keys off its ENTIRE normalized string — inert.
+  const billingRow: UpcomingRow = {
+    ...timedRow,
+    id: 303,
+    headlining_artist_id: null,
+    headlining_artist_raw: 'Circle Jerks & Municipal Waste',
+    artist_name: null,
+    starts_on: '2026-08-22',
+  };
+
+  it('builds byArtistId from resolved rows only, keyed by headlining_artist_id', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([resolvedRow, unresolvedCleanRow]));
+    const { byArtistId } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byArtistId.size).toBe(1); // the unresolved row is not in the id map
+    expect(byArtistId.get(4211)).toEqual(toConcertDTO(resolvedRow));
   });
 
-  it('maps each row to a ConcertDTO keyed by headlining_artist_id', async () => {
-    const other: ConcertJoinRow = { ...timedRow, id: 202, headlining_artist_id: 5555 };
-    // Terminal .orderBy() resolves the DISTINCT ON row set for this call.
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([timedRow, other]));
-
-    const result = await getUpcomingShowsForArtists([4211, 5555], '2026-08-01');
-
-    expect(result.size).toBe(2);
-    expect(result.get(4211)).toEqual(toConcertDTO(timedRow));
-    expect(result.get(5555)).toEqual(toConcertDTO(other));
+  it('keys a resolved row in byNormName off the CANONICAL name, not the raw', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([resolvedRow]));
+    const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    // canonical 'Nilüfer Yanya' → 'nilüfer yanya'; the diacritic-free raw
+    // 'Nilufer Yanya' → 'nilufer yanya' is NOT the key.
+    expect(byNormName.get('nilüfer yanya')).toEqual(toConcertDTO(resolvedRow));
+    expect(byNormName.has('nilufer yanya')).toBe(false);
   });
 
-  it('distinct-selects on headlining_artist_id (soonest-per-artist collapse)', async () => {
+  it('keys an unresolved clean row in byNormName off the raw name', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([unresolvedCleanRow]));
+    const { byArtistId, byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byArtistId.size).toBe(0); // unresolved → absent from the id map
+    expect(byNormName.get('wishy')).toEqual(toConcertDTO(unresolvedCleanRow));
+  });
+
+  it('keys a billing-string raw off its ENTIRE normalized string (inert key)', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([billingRow]));
+    const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byNormName.get('circle jerks & municipal waste')).toEqual(toConcertDTO(billingRow));
+    // The individual acts are NOT keys, so a single-artist play can't match.
+    expect(byNormName.has('circle jerks')).toBe(false);
+    expect(byNormName.has('municipal waste')).toBe(false);
+  });
+
+  it('collapses multiple dates for one name key to the SOONEST (first row wins)', async () => {
+    // Rows arrive ordered starts_on ASC (the query's ORDER BY), so the first
+    // occurrence of a key is the soonest.
+    const soon: UpcomingRow = { ...unresolvedCleanRow, id: 400, starts_on: '2026-08-10' };
+    const later: UpcomingRow = { ...unresolvedCleanRow, id: 401, starts_on: '2026-09-10' };
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([soon, later]));
+    const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byNormName.get('wishy')).toEqual(toConcertDTO(soon));
+  });
+
+  it('collapses multiple dates for one artist id to the SOONEST (first row wins)', async () => {
+    const soon: UpcomingRow = { ...resolvedRow, id: 500, starts_on: '2026-08-10' };
+    const later: UpcomingRow = { ...resolvedRow, id: 501, starts_on: '2026-09-10' };
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([soon, later]));
+    const { byArtistId } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byArtistId.get(4211)).toEqual(toConcertDTO(soon));
+  });
+
+  it('LEFT JOINs artists so a resolved row can source its canonical name', async () => {
     mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
-    await getUpcomingShowsForArtists([4211], '2026-08-01');
-    // The DISTINCT ON expression list must lead with headlining_artist_id.
-    const distinctArgs = mockDb._chain.selectDistinctOn.mock.calls[0][0] as string[];
-    expect(distinctArgs).toEqual(['headlining_artist_id']);
+    await getUpcomingShowsMaps('2026-08-01');
+    // The join to artists must be a LEFT join — an INNER join would silently
+    // drop every unresolved concert (headlining_artist_id IS NULL), which is
+    // exactly the set the name arm exists to recover.
+    expect(mockDb._chain.leftJoin).toHaveBeenCalled();
   });
 
   it('never selects internal ingestion columns', async () => {
     mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
-    await getUpcomingShowsForArtists([4211], '2026-08-01');
-    const projection = mockDb._chain.selectDistinctOn.mock.calls[0][1] as Record<string, string>;
+    await getUpcomingShowsMaps('2026-08-01');
+    const projection = mockDb._chain.select.mock.calls[0][0] as Record<string, string>;
     const selectedColumns = Object.values(projection);
     for (const internal of INTERNAL_COLUMNS) {
       expect(selectedColumns).not.toContain(internal);
     }
   });
 
-  it('skips a defensive null headlining_artist_id row (never a Map key)', async () => {
-    const nulledKey: ConcertJoinRow = { ...timedRow, headlining_artist_id: null };
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([nulledKey]));
-    const result = await getUpcomingShowsForArtists([4211], '2026-08-01');
-    expect(result.size).toBe(0);
+  it('returns two empty maps for an empty upcoming set', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    const { byArtistId, byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byArtistId.size).toBe(0);
+    expect(byNormName.size).toBe(0);
   });
 });

--- a/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
+++ b/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
@@ -183,6 +183,19 @@ describe('attachUpcomingShows (BS#1607 id arm + BS#1613 name arm)', () => {
     expect(entries[0].upcoming_show).toBeUndefined();
   });
 
+  it('matches a free-text play whose name carries stray/doubled whitespace (free-text SSOT key)', async () => {
+    // The concert side keys 'J Dilla' → 'j dilla'. A DJ free-texts ' J  Dilla '
+    // (leading/trailing + doubled spaces). Both sides run the SAME free-text
+    // normalizer (collapse internal whitespace + trim), so the play still
+    // resolves to 'j dilla' and matches — the bare `normalizeArtistName` would
+    // leave ' j  dilla ' and silently miss.
+    const concert = makeConcert({ headlining_artist_id: null, headlining_artist_raw: 'J Dilla' });
+    lookup.mockResolvedValueOnce(maps(new Map(), new Map([['j dilla', concert]])));
+    const entries = [createTrackEntry({ id: 1, artist_id: null, artist_name: ' J  Dilla ' })];
+    await attachUpcomingShows(entries);
+    expect(entries[0].upcoming_show).toBe(concert);
+  });
+
   // --- precedence + guards ---
 
   it('prefers the id arm over the name arm when a row matches both', async () => {

--- a/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
+++ b/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
@@ -1,17 +1,18 @@
 /**
- * Unit tests for the per-playcut upcoming-show enrichment (BS#1607,
- * touring-events Phase 3).
+ * Unit tests for the per-playcut upcoming-show enrichment (BS#1607, widened to
+ * a hybrid id-arm ∪ name-arm match in BS#1613, touring-events Phase 3).
  *
  * `@wxyc/database` resolves to tests/mocks/database.mock.ts, so these pin the
- * pure batching + projection logic without PostgreSQL:
- *   - `attachUpcomingShows` collects the DISTINCT resolved artist ids across a
- *     feed page and does exactly ONE `getUpcomingShowsForArtists` call (the
- *     no-N+1 guarantee), then fans the soonest concert back onto each match;
+ * pure batching + fan-out logic without PostgreSQL:
+ *   - `attachUpcomingShows` does exactly ONE `getUpcomingShowsMaps` call for a
+ *     feed page (the no-N+1 guarantee), then fans the soonest concert onto each
+ *     track via the id arm (album-resolved `artist_id`) with a normalized-name
+ *     arm fallback (free-text plays + clean unresolved concerts, BS#1613);
  *   - `transformToV2` emits `upcoming_show` only when present, so a no-match
  *     track row is byte-identical to its pre-1607 shape (parity requirement).
  *
- * The end-to-end SQL windowing (curated predicate, soonest-wins DISTINCT ON,
- * removed/past exclusion, bounded query count for an N-row page) is covered by
+ * The end-to-end SQL windowing (removed/past exclusion, canonical-name key,
+ * soonest-wins collapse, bounded query count for an N-row page) is covered by
  * tests/integration/flowsheet-upcoming-show.spec.js.
  */
 import { attachUpcomingShows, transformToV2 } from '../../../apps/backend/services/flowsheet.service';
@@ -94,47 +95,54 @@ const makeConcert = (overrides: Partial<ConcertDTO> = {}): ConcertDTO => ({
   ...overrides,
 });
 
-describe('attachUpcomingShows (BS#1607)', () => {
+/** Build the {byArtistId, byNormName} return of getUpcomingShowsMaps. */
+const maps = (byArtistId: Map<number, ConcertDTO> = new Map(), byNormName: Map<string, ConcertDTO> = new Map()) => ({
+  byArtistId,
+  byNormName,
+});
+
+describe('attachUpcomingShows (BS#1607 id arm + BS#1613 name arm)', () => {
   let lookup: jest.SpyInstance;
 
   beforeEach(() => {
     jest.restoreAllMocks();
-    lookup = jest.spyOn(concertsService, 'getUpcomingShowsForArtists');
+    lookup = jest.spyOn(concertsService, 'getUpcomingShowsMaps');
   });
 
-  it('skips the DB entirely when the page has no resolved track artists', async () => {
+  it('skips the DB when no track row carries an artist id or a non-empty name', async () => {
     const entries = [
-      createTrackEntry({ id: 1, artist_id: null }),
-      createTrackEntry({ id: 2, entry_type: 'show_start', artist_id: 4211 }),
+      createTrackEntry({ id: 1, entry_type: 'show_start', artist_id: 4211 }), // marker
+      createTrackEntry({ id: 2, artist_id: null, artist_name: '   ' }), // blank free text
     ];
     await attachUpcomingShows(entries);
     expect(lookup).not.toHaveBeenCalled();
-    expect(entries[0].upcoming_show).toBeUndefined();
+    expect(entries[1].upcoming_show).toBeUndefined();
   });
 
-  it('does exactly ONE lookup for an N-row page, with DISTINCT artist ids', async () => {
-    lookup.mockResolvedValueOnce(new Map());
+  it('does exactly ONE getUpcomingShowsMaps call for an N-row page, with a today date', async () => {
+    lookup.mockResolvedValueOnce(maps());
     const entries = [
       createTrackEntry({ id: 1, artist_id: 4211 }),
       createTrackEntry({ id: 2, artist_id: 4211 }), // duplicate artist
-      createTrackEntry({ id: 3, artist_id: 7000 }),
-      createTrackEntry({ id: 4, artist_id: null }), // free-form, no artist
-      createTrackEntry({ id: 5, entry_type: 'talkset', artist_id: 9999 }), // non-track
+      createTrackEntry({ id: 3, artist_id: null, artist_name: 'Wishy' }), // free-text
+      createTrackEntry({ id: 4, entry_type: 'talkset', artist_id: 9999 }), // non-track
     ];
     await attachUpcomingShows(entries);
 
     expect(lookup).toHaveBeenCalledTimes(1);
-    const [artistIds] = lookup.mock.calls[0];
-    expect([...(artistIds as number[])].sort((a, b) => a - b)).toEqual([4211, 7000]);
+    const [today] = lookup.mock.calls[0];
+    expect(today).toMatch(/^\d{4}-\d{2}-\d{2}$/); // America/New_York calendar date
   });
 
-  it('attaches the matched concert to every track row of that artist', async () => {
+  // --- id arm (BS#1607 regression guard) ---
+
+  it('attaches via the id arm to every catalog track row of that artist', async () => {
     const concert = makeConcert({ headlining_artist_id: 4211 });
-    lookup.mockResolvedValueOnce(new Map([[4211, concert]]));
+    lookup.mockResolvedValueOnce(maps(new Map([[4211, concert]])));
     const entries = [
-      createTrackEntry({ id: 1, artist_id: 4211 }),
-      createTrackEntry({ id: 2, artist_id: 4211 }),
-      createTrackEntry({ id: 3, artist_id: 7000 }), // no match in the map
+      createTrackEntry({ id: 1, artist_id: 4211, artist_name: 'Juana Molina' }),
+      createTrackEntry({ id: 2, artist_id: 4211, artist_name: 'Juana Molina' }),
+      createTrackEntry({ id: 3, artist_id: 7000, artist_name: 'Someone Else' }), // no map entry
     ];
     await attachUpcomingShows(entries);
 
@@ -143,11 +151,70 @@ describe('attachUpcomingShows (BS#1607)', () => {
     expect(entries[2].upcoming_show).toBeUndefined();
   });
 
-  it('leaves every row untouched when no artist has an upcoming date', async () => {
-    lookup.mockResolvedValueOnce(new Map());
-    const entries = [createTrackEntry({ id: 1, artist_id: 4211 })];
+  // --- name arm (BS#1613) ---
+
+  it('attaches via the name arm to a free-text play of a resolved artist', async () => {
+    const concert = makeConcert({ headlining_artist_id: 4211 });
+    // Free-text play: no album_id → artist_id null; matched on canonical name.
+    lookup.mockResolvedValueOnce(maps(new Map(), new Map([['juana molina', concert]])));
+    const entries = [createTrackEntry({ id: 1, artist_id: null, artist_name: 'Juana Molina' })];
+    await attachUpcomingShows(entries);
+    expect(entries[0].upcoming_show).toBe(concert);
+  });
+
+  it('attaches a clean unresolved concert to a free-text play by name (null headlining_artist_id)', async () => {
+    const concert = makeConcert({ headlining_artist_id: null, headlining_artist_raw: 'Wishy' });
+    lookup.mockResolvedValueOnce(maps(new Map(), new Map([['wishy', concert]])));
+    const entries = [createTrackEntry({ id: 1, artist_id: null, artist_name: 'Wishy' })];
+    await attachUpcomingShows(entries);
+    expect(entries[0].upcoming_show).toBe(concert);
+    expect(entries[0].upcoming_show?.headlining_artist_id).toBeNull();
+  });
+
+  it('does not attach a billing-string concert to a single-artist play (inert key)', async () => {
+    const concert = makeConcert({
+      headlining_artist_id: null,
+      headlining_artist_raw: 'Circle Jerks & Municipal Waste',
+    });
+    // The map is keyed by the ENTIRE normalized billing string.
+    lookup.mockResolvedValueOnce(maps(new Map(), new Map([['circle jerks & municipal waste', concert]])));
+    const entries = [createTrackEntry({ id: 1, artist_id: null, artist_name: 'Circle Jerks' })];
     await attachUpcomingShows(entries);
     expect(entries[0].upcoming_show).toBeUndefined();
+  });
+
+  // --- precedence + guards ---
+
+  it('prefers the id arm over the name arm when a row matches both', async () => {
+    const byIdConcert = makeConcert({ id: 900, headlining_artist_id: 4211 });
+    const byNameConcert = makeConcert({ id: 901, headlining_artist_id: null, headlining_artist_raw: 'Juana Molina' });
+    lookup.mockResolvedValueOnce(maps(new Map([[4211, byIdConcert]]), new Map([['juana molina', byNameConcert]])));
+    const entries = [createTrackEntry({ id: 1, artist_id: 4211, artist_name: 'Juana Molina' })];
+    await attachUpcomingShows(entries);
+    expect(entries[0].upcoming_show).toBe(byIdConcert); // id arm wins
+  });
+
+  it('never matches a whitespace-only free-text name (no empty-string key collision)', async () => {
+    const stray = makeConcert();
+    // A hypothetical stray '' key must never be reached by a blank name.
+    lookup.mockResolvedValueOnce(maps(new Map(), new Map([['', stray]])));
+    const entries = [
+      createTrackEntry({ id: 1, artist_id: 4211, artist_name: 'Juana Molina' }), // matchable → DB runs
+      createTrackEntry({ id: 2, artist_id: null, artist_name: '   ' }), // blank free text
+    ];
+    await attachUpcomingShows(entries);
+    expect(entries[1].upcoming_show).toBeUndefined();
+  });
+
+  it('leaves every row untouched when both maps are empty', async () => {
+    lookup.mockResolvedValueOnce(maps());
+    const entries = [
+      createTrackEntry({ id: 1, artist_id: 4211 }),
+      createTrackEntry({ id: 2, artist_id: null, artist_name: 'Wishy' }),
+    ];
+    await attachUpcomingShows(entries);
+    expect(entries[0].upcoming_show).toBeUndefined();
+    expect(entries[1].upcoming_show).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

BS#1607 attached the per-playcut `upcoming_show` CTA on the V2 flowsheet feed **only** via the album-resolved id join (`flowsheet.album_id → library.artist_id = concerts.headlining_artist_id`). Measured on prod 2026-07-11, that left two recall gaps this PR closes with **no LML dependency**:

- **Free-text plays** (`album_id IS NULL`, so no resolved `artist_id`) never matched — the CTA was invisible for any DJ-typed play, even of a currently-touring artist.
- **Unresolved concerts** (no `headlining_artist_id`) never participated — the clean single-name ones (`Wishy`, `L'Rain`, `The Tubs`, …) are real touring artists simply absent from our catalog.

The match becomes a hybrid **id arm ∪ name arm**.

## What changed

- **`apps/backend/services/concerts.service.ts`** — replaced `getUpcomingShowsForArtists(artistIds, today)` with `getUpcomingShowsMaps(today)`. One indexed query (`concerts` INNER JOIN `venues` LEFT JOIN `artists`, reading the existing `concerts_active_starts_on_id_idx`) returning `{ byArtistId, byNormName }`. Resolved rows key `byNormName` off the **canonical** `artists.artist_name` (so a free-text play typed with the current name matches even when the concert resolved via an alias of an older name); unresolved rows key off `headlining_artist_raw`. Both maps are first-write-wins over rows ordered `starts_on ASC, id`, so each key holds the **soonest** concert.
- **`apps/backend/services/flowsheet.service.ts`** — `attachUpcomingShows` fans out **id arm first, name arm fallback** via the same `normalizeArtistName` twin used concert-side. Short-circuits the DB only when no track row carries an id *or* a non-empty name; guards the name arm on `artist_name?.trim()` so a blank name can't form a `''` collision key.

### Deliberate non-changes

- **No clean/billing-string filter.** Matching is exact normalized-string equality on both sides, so a billing/co-bill raw (`Circle Jerks & Municipal Waste`) normalizes to its **entire** string — an inert map key no one-artist-per-entry play equals. Filtering it removes nothing and adds a predicate + parity tests for no benefit. (`and`/`&` are **not** multi-act markers — `AJ Lee & Blue Summit`, `Nick Cave and the Bad Seeds` are single acts.)
- **No migration.** Reads the existing partial index.
- **No `wxyc-shared/api.yaml` change.** `upcoming_show` stays optional/nullable, so no-match rows are byte-identical to pre-1607.

### Accepted residual

Two *distinct* artists sharing a normalized name (homonyms) will match. A clean filter wouldn't address this; identity-grade resolution is the offline-LML sibling (WXYC/Backend-Service#1614), out of scope here. Acceptable for a low-harm "Touring Soon" CTA.

## Testing

All local checks green (`typecheck`, `lint`, `format:check`, `test:unit` — 4068 passed, and `ci:testmock` — 490 integration passed).

- **Unit** (`concerts.service.test.ts`, `flowsheet.attachUpcomingShows.test.ts`): byArtistId/byNormName construction (canonical vs raw key), soonest-wins by both id and name, billing-string inert key, id-vs-name precedence, empty-name guard, one-lookup-per-page.
- **Integration** (`flowsheet-upcoming-show.spec.js`, extended): free-text play attaches a clean unresolved concert by name; billing-string concert does **not** attach to a single-artist play; two unresolved concerts normalizing to the same key collapse to the soonest; the BS#1607 bounded-scan (one concerts query per feed page) still holds over `getUpcomingShowsMaps`.

Closes #1613.