### PR TITLE
feat(concerts): clean-name LML gate + unresolved-headliner name-set export (BS#1614 PR 1)

### DIFF
--- a/jobs/triangle-shows-etl/headliner.ts
+++ b/jobs/triangle-shows-etl/headliner.ts
@@ -1,0 +1,209 @@
+/**
+ * Clean-headliner extraction (BS#1604) + the clean-name LML gate (BS#1614).
+ *
+ * Extracted from map.ts so this module stays free of `@wxyc/database`
+ * (whose client throws at import time without DB_* env vars) — the
+ * BS#1614 name-set export script filters text dumps anywhere, without DB
+ * credentials. map.ts re-exports `extractHeadliner`, so ETL-side
+ * consumers are unchanged.
+ *
+ * triangle-shows' `artist` field is byte-identical to the event `name`
+ * in practice — the full marquee/billing string, not a clean performer —
+ * which starves the exact-match `concerts-artist-resolver` (9/259
+ * distinct billings resolved). Until the upstream `headliner` field
+ * (WXYC/triangle-shows#18) covers the corpus, derive a clean headliner
+ * here. TRIANGLE_SHOWS-SPECIFIC by design: RHP headliners are already
+ * clean, and the shared resolver stays untouched.
+ *
+ * Conservative by contract: prefer under-stripping — a billing left
+ * dirty just stays unresolved (today's behavior), while over-stripping
+ * can mangle a legitimate name into a WRONG resolution. `&`/`and` are
+ * never treated as support delimiters (Andy Frasco & The U.N), and a
+ * leading single mixed-case parenthetical word is kept ((Sandy) Alex
+ * G) — only tag-shaped parentheticals strip. Idempotent: every rule
+ * removes its own trigger, and the empty-result fallback returns a
+ * string none of the rules re-fire on.
+ *
+ * `isCleanHeadliner` (BS#1614) sits beside the extractor ON PURPOSE: the
+ * gate that decides which stored names are LML-eligible must evolve in
+ * the same file as the extraction rules it composes with, so the two
+ * can't drift apart (the constraint recorded on WXYC/Backend-Service#1614).
+ */
+
+/** Leading `(...)`/`[...]` group plus trailing whitespace; content captured
+ *  so `isStrippableLeadingTag` can rule on it. Anchored — only LEADING
+ *  parentheticals are candidates; trailing ones (`!!! (Chk Chk Chk)`) are
+ *  part of the name. */
+const LEADING_TAG = /^[([]([^)\]]*)[)\]]\s*/;
+
+/**
+ * Ticketing/venue noise phrases that mark a mixed-case leading parenthetical
+ * as strippable even when it isn't all-caps or digit-bearing (`(Sold Out)`,
+ * `(Moved to the Ritz)`, `(Record Shop)`). Word-boundary anchored, not a
+ * bare substring, so a band name that merely CONTAINS a noise word
+ * (`(Free Energy)`, `(Moved by Music)`) stays attached — the conservative
+ * contract prefers leaving an unknown parenthetical over guessing it's a
+ * tag. Deliberately small and phrase-specific.
+ */
+const NOISE_PATTERNS = [
+  /\bsold[\s-]?out\b/,
+  /\blow tix\b/,
+  /\brecord shop\b/,
+  /\bmoved to\b/,
+  /\bcancell?ed\b/,
+  /\bpostponed\b/,
+  /\brescheduled\b/,
+];
+
+/**
+ * Venue tags look like `(Record Shop)`, `(LOW TIX)`, `(18+)`, `(SOLD
+ * OUT)`, `[MOVED TO THE RITZ]` — all-caps, digit/age-gate-bearing, or a
+ * recognizable ticketing/venue noise phrase. A leading parenthetical that
+ * is merely multi-word is NOT enough: a real multi-word band name can lead
+ * a billing (`(Free Energy) Truth Club`), and the conservative contract
+ * prefers keeping it over guessing it's a tag. The `toLowerCase` half of
+ * the all-caps test keeps caseless scripts from counting as "all caps".
+ */
+const isStrippableLeadingTag = (content: string): boolean => {
+  const tag = content.trim();
+  if (tag === '') return true; // pure noise, e.g. '()'
+  if (/\d/.test(tag)) return true; // digit / age-gate: (18+)
+  const letters = tag.replace(/[^\p{L}]+/gu, '');
+  if (letters.length >= 2 && letters === letters.toUpperCase() && letters !== letters.toLowerCase()) return true;
+  const lower = tag.toLowerCase();
+  return NOISE_PATTERNS.some((pattern) => pattern.test(lower));
+};
+
+/** `An Evening With: X` / `An Evening With X` — the framing is never the
+ *  performer. Requires a colon or whitespace after `with` so a band name
+ *  merely STARTING with the phrase (`An Evening Withering`) is untouched. */
+const AN_EVENING_WITH = /^an evening with[:\s]+/i;
+
+/** `<Promoter> Presents: X` — colon REQUIRED: `X Presents Y` without one
+ *  is too weak a signal (plausibly a name), and `[^:]*` keeps the strip
+ *  from eating past other colon structure in the billing. */
+const PRESENTS_PREFIX = /^[^:]*\bpresents\s*:\s*/i;
+
+/**
+ * Support-act tails: ` w/ X`, ` // X // Y`, ` feat. X`, ` ft. X`,
+ * ` featuring X`. Every delimiter requires LEADING whitespace so
+ * slash-bearing names (`AC/DC`) never split; `w/`+`//` allow a missing
+ * space after the token (`w/Magick Potion` occurs in the wild) while the
+ * word-shaped forms require one so a name merely containing the letters
+ * (`Featherweight`) is safe. Plain ` with `, `&`, `and`, `+` are NOT
+ * delimiters — far too common inside legitimate names. The `w/(?!o(?:ut)?\b)`
+ * negative lookahead keeps `w/` from firing on the abbreviations `w/o` and
+ * `w/out` — those mean "without" and belong to the name (`Angel w/o Wings`),
+ * not a support delimiter.
+ */
+const SUPPORT_TAIL = /\s+(?:w\/(?!o(?:ut)?\b)|\/\/)\s*\S.*$|\s+(?:feat\.|ft\.|featuring)\s+\S.*$/i;
+
+/** Punctuation a tail/prefix strip can leave dangling (`Foo -` after
+ *  `Foo - w/ Bar`). Terminal `!`/`?`/`.` are kept — they end real names. */
+const TRAILING_DANGLE = /[\s,;:\-–—]+$/;
+
+/**
+ * The full cleanup pass over a trimmed billing. May return `''` when the
+ * billing was pure tag/framing noise — `extractHeadliner` maps that back
+ * to the verbatim input (better stored than dropped), while
+ * `isCleanHeadliner` uses the raw `''` to reject the residue outright.
+ */
+const cleanBilling = (original: string): string => {
+  let cleaned = original;
+  let stripped = false;
+  // Strip the support-act tail FIRST. `PRESENTS_PREFIX` (below) is greedy
+  // to the last colon, so running it before the tail strip lets a promoter
+  // clause buried in a support tail eat the real headliner
+  // (`Deerhoof w/ Hopscotch Presents: Late Night Set` -> `Late Night Set`).
+  // Removing the tail up front leaves the leading fixpoint only the
+  // headliner + its framing to work on.
+  const afterTail = cleaned.replace(SUPPORT_TAIL, '');
+  if (afterTail !== cleaned) {
+    cleaned = afterTail;
+    stripped = true;
+  }
+  // Leading structures repeat and stack — `(LOW TIX) (18+) An Evening
+  // With: X` — so strip to a fixpoint. Terminates: every pass that
+  // doesn't break strictly shortens the string.
+  for (;;) {
+    const before = cleaned;
+    const tag = LEADING_TAG.exec(cleaned);
+    if (tag && isStrippableLeadingTag(tag[1])) {
+      cleaned = cleaned.slice(tag[0].length).trimStart();
+    }
+    cleaned = cleaned.replace(AN_EVENING_WITH, '').replace(PRESENTS_PREFIX, '').trimStart();
+    if (cleaned === before) break;
+    stripped = true;
+  }
+  // Only clean a dangling separator when a strip actually fired — otherwise
+  // a verbatim name that legitimately ends in punctuation (`Sleep Token —`)
+  // would be silently altered.
+  if (stripped) cleaned = cleaned.replace(TRAILING_DANGLE, '');
+  return cleaned.trim();
+};
+
+/**
+ * Derive a clean headliner from a billing string. Exported for the unit
+ * suite. Returns the trimmed input unchanged when no rule fires, and
+ * falls back to the trimmed input when cleanup empties the string (a
+ * pure-tag billing like `(SOLD OUT)` is still better stored verbatim
+ * than dropped — it just stays unresolved, exactly like today).
+ */
+export const extractHeadliner = (billing: string): string => {
+  const original = billing.trim();
+  const cleaned = cleanBilling(original);
+  return cleaned === '' ? original : cleaned;
+};
+
+/**
+ * Multi-act billing markers the extractor deliberately leaves in place
+ * (BS#1614). Keyed by reason so the export script's measurement can
+ * report a per-delimiter breakdown; `HARD_BILLING_DELIMITERS` is the
+ * derived union the gate tests.
+ *
+ * Spacing is load-bearing: ` / ` and ` + ` require whitespace on both
+ * sides so `AC/DC` / `DIIV/Horsegirl` never gate; ` with ` requires
+ * surrounding whitespace so `With Honor` / `Withered Hand` never gate.
+ * `&`/`and` are deliberately ABSENT: the BS#1613 prod-sample analysis
+ * found that bucket dominated by real single acts (`AJ Lee & Blue
+ * Summit`, `Nick Cave and the Bad Seeds`), and under LML#759's
+ * verify-before-mint model a genuine `&` co-bill can't exact-form-match
+ * a Discogs artist — it just returns not_found. Excluding the bucket
+ * would trade real recall for one saved API call.
+ */
+export const BILLING_DELIMITER_PATTERNS = {
+  comma: /,/,
+  plus: /\s\+\s/,
+  slash: /\s\/\s/,
+  with: /\swith\s/i,
+} as const;
+
+/**
+ * Literal union of `BILLING_DELIMITER_PATTERNS` (a derived `new RegExp`
+ * would trip security/detect-non-literal-regexp for no safety gain on a
+ * compile-time const tuple). The unit suite pins this literal to the
+ * per-reason record so the two cannot drift.
+ */
+export const HARD_BILLING_DELIMITERS = /,|\s\+\s|\s\/\s|\swith\s/i;
+
+/**
+ * Is a stored headliner name eligible for the LML#759 bare-name resolve
+ * pass (BS#1614)?
+ *
+ * Clean means: extraction has nothing left to do on it (`cleanBilling`
+ * fixpoint — which also rejects pure-tag billings whose cleanup empties
+ * to `''`, the case `extractHeadliner`'s verbatim fallback would hide),
+ * and it carries no hard multi-act delimiter.
+ *
+ * This is an API-BUDGET gate, not a correctness gate: under
+ * verify-before-mint a dirty name that slips through wastes one Discogs
+ * call and lands `not_found`, while a clean name wrongly gated just
+ * stays unresolved (status quo). Both failure modes are cheap, so the
+ * gate stays simpler than the extractor.
+ */
+export const isCleanHeadliner = (name: string): boolean => {
+  const trimmed = name.trim();
+  if (trimmed === '') return false;
+  if (cleanBilling(trimmed) !== trimmed) return false;
+  return !HARD_BILLING_DELIMITERS.test(trimmed);
+};

--- a/jobs/triangle-shows-etl/map.ts
+++ b/jobs/triangle-shows-etl/map.ts
@@ -14,7 +14,20 @@
  */
 
 import { nyCalendarDate, nyWallClockToUtc, type NewConcert } from '@wxyc/database';
+import { extractHeadliner } from './headliner.js';
 import type { TsEvent } from './types.js';
+
+// Clean-headliner extraction (BS#1604) + the BS#1614 clean-name LML gate
+// live in headliner.ts — a deliberately DB-free module so the BS#1614
+// name-set export script can import them without tripping
+// `@wxyc/database`'s import-time env guard. Re-exported here so ETL-side
+// consumers keep one import surface.
+export {
+  extractHeadliner,
+  isCleanHeadliner,
+  HARD_BILLING_DELIMITERS,
+  BILLING_DELIMITER_PATTERNS,
+} from './headliner.js';
 
 /** Code-point-safe truncation (`String.prototype.slice` counts UTF-16 code
  *  units and can strand half a surrogate pair as U+FFFD in the DB). Lives
@@ -47,142 +60,6 @@ export const splitSupportArtists = (raw: string | null): string[] =>
     .split(',')
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
-
-/* ------------------------------------------------------------------ *
- * Clean-headliner extraction (BS#1604)                                *
- *                                                                     *
- * triangle-shows' `artist` field is byte-identical to the event       *
- * `name` in practice — the full marquee/billing string, not a clean   *
- * performer — which starves the exact-match `concerts-artist-resolver`*
- * (9/259 distinct billings resolved). Until the upstream `headliner`  *
- * field (WXYC/triangle-shows#18) covers the corpus, derive a clean    *
- * headliner here. TRIANGLE_SHOWS-SPECIFIC by design: RHP headliners   *
- * are already clean, and the shared resolver stays untouched.         *
- *                                                                     *
- * Conservative by contract: prefer under-stripping — a billing left   *
- * dirty just stays unresolved (today's behavior), while over-stripping*
- * can mangle a legitimate name into a WRONG resolution. `&`/`and` are *
- * never treated as support delimiters (Andy Frasco & The U.N), and a  *
- * leading single mixed-case parenthetical word is kept ((Sandy) Alex  *
- * G) — only tag-shaped parentheticals strip. Idempotent: every rule   *
- * removes its own trigger, and the empty-result fallback returns a    *
- * string none of the rules re-fire on.                                *
- * ------------------------------------------------------------------ */
-
-/** Leading `(...)`/`[...]` group plus trailing whitespace; content captured
- *  so `isStrippableLeadingTag` can rule on it. Anchored — only LEADING
- *  parentheticals are candidates; trailing ones (`!!! (Chk Chk Chk)`) are
- *  part of the name. */
-const LEADING_TAG = /^[([]([^)\]]*)[)\]]\s*/;
-
-/**
- * Ticketing/venue noise phrases that mark a mixed-case leading parenthetical
- * as strippable even when it isn't all-caps or digit-bearing (`(Sold Out)`,
- * `(Moved to the Ritz)`, `(Record Shop)`). Word-boundary anchored, not a
- * bare substring, so a band name that merely CONTAINS a noise word
- * (`(Free Energy)`, `(Moved by Music)`) stays attached — the conservative
- * contract prefers leaving an unknown parenthetical over guessing it's a
- * tag. Deliberately small and phrase-specific.
- */
-const NOISE_PATTERNS = [
-  /\bsold[\s-]?out\b/,
-  /\blow tix\b/,
-  /\brecord shop\b/,
-  /\bmoved to\b/,
-  /\bcancell?ed\b/,
-  /\bpostponed\b/,
-  /\brescheduled\b/,
-];
-
-/**
- * Venue tags look like `(Record Shop)`, `(LOW TIX)`, `(18+)`, `(SOLD
- * OUT)`, `[MOVED TO THE RITZ]` — all-caps, digit/age-gate-bearing, or a
- * recognizable ticketing/venue noise phrase. A leading parenthetical that
- * is merely multi-word is NOT enough: a real multi-word band name can lead
- * a billing (`(Free Energy) Truth Club`), and the conservative contract
- * prefers keeping it over guessing it's a tag. The `toLowerCase` half of
- * the all-caps test keeps caseless scripts from counting as "all caps".
- */
-const isStrippableLeadingTag = (content: string): boolean => {
-  const tag = content.trim();
-  if (tag === '') return true; // pure noise, e.g. '()'
-  if (/\d/.test(tag)) return true; // digit / age-gate: (18+)
-  const letters = tag.replace(/[^\p{L}]+/gu, '');
-  if (letters.length >= 2 && letters === letters.toUpperCase() && letters !== letters.toLowerCase()) return true;
-  const lower = tag.toLowerCase();
-  return NOISE_PATTERNS.some((pattern) => pattern.test(lower));
-};
-
-/** `An Evening With: X` / `An Evening With X` — the framing is never the
- *  performer. Requires a colon or whitespace after `with` so a band name
- *  merely STARTING with the phrase (`An Evening Withering`) is untouched. */
-const AN_EVENING_WITH = /^an evening with[:\s]+/i;
-
-/** `<Promoter> Presents: X` — colon REQUIRED: `X Presents Y` without one
- *  is too weak a signal (plausibly a name), and `[^:]*` keeps the strip
- *  from eating past other colon structure in the billing. */
-const PRESENTS_PREFIX = /^[^:]*\bpresents\s*:\s*/i;
-
-/**
- * Support-act tails: ` w/ X`, ` // X // Y`, ` feat. X`, ` ft. X`,
- * ` featuring X`. Every delimiter requires LEADING whitespace so
- * slash-bearing names (`AC/DC`) never split; `w/`+`//` allow a missing
- * space after the token (`w/Magick Potion` occurs in the wild) while the
- * word-shaped forms require one so a name merely containing the letters
- * (`Featherweight`) is safe. Plain ` with `, `&`, `and`, `+` are NOT
- * delimiters — far too common inside legitimate names. The `w/(?!o(?:ut)?\b)`
- * negative lookahead keeps `w/` from firing on the abbreviations `w/o` and
- * `w/out` — those mean "without" and belong to the name (`Angel w/o Wings`),
- * not a support delimiter.
- */
-const SUPPORT_TAIL = /\s+(?:w\/(?!o(?:ut)?\b)|\/\/)\s*\S.*$|\s+(?:feat\.|ft\.|featuring)\s+\S.*$/i;
-
-/** Punctuation a tail/prefix strip can leave dangling (`Foo -` after
- *  `Foo - w/ Bar`). Terminal `!`/`?`/`.` are kept — they end real names. */
-const TRAILING_DANGLE = /[\s,;:\-–—]+$/;
-
-/**
- * Derive a clean headliner from a billing string. Exported for the unit
- * suite. Returns the trimmed input unchanged when no rule fires, and
- * falls back to the trimmed input when cleanup empties the string (a
- * pure-tag billing like `(SOLD OUT)` is still better stored verbatim
- * than dropped — it just stays unresolved, exactly like today).
- */
-export const extractHeadliner = (billing: string): string => {
-  const original = billing.trim();
-  let cleaned = original;
-  let stripped = false;
-  // Strip the support-act tail FIRST. `PRESENTS_PREFIX` (below) is greedy
-  // to the last colon, so running it before the tail strip lets a promoter
-  // clause buried in a support tail eat the real headliner
-  // (`Deerhoof w/ Hopscotch Presents: Late Night Set` -> `Late Night Set`).
-  // Removing the tail up front leaves the leading fixpoint only the
-  // headliner + its framing to work on.
-  const afterTail = cleaned.replace(SUPPORT_TAIL, '');
-  if (afterTail !== cleaned) {
-    cleaned = afterTail;
-    stripped = true;
-  }
-  // Leading structures repeat and stack — `(LOW TIX) (18+) An Evening
-  // With: X` — so strip to a fixpoint. Terminates: every pass that
-  // doesn't break strictly shortens the string.
-  for (;;) {
-    const before = cleaned;
-    const tag = LEADING_TAG.exec(cleaned);
-    if (tag && isStrippableLeadingTag(tag[1])) {
-      cleaned = cleaned.slice(tag[0].length).trimStart();
-    }
-    cleaned = cleaned.replace(AN_EVENING_WITH, '').replace(PRESENTS_PREFIX, '').trimStart();
-    if (cleaned === before) break;
-    stripped = true;
-  }
-  // Only clean a dangling separator when a strip actually fired — otherwise
-  // a verbatim name that legitimately ends in punctuation (`Sleep Token —`)
-  // would be silently altered.
-  if (stripped) cleaned = cleaned.replace(TRAILING_DANGLE, '');
-  cleaned = cleaned.trim();
-  return cleaned === '' ? original : cleaned;
-};
 
 /** numeric(8,2) tops out at 999999.99, and PG errors rather than
  *  truncates. Judged on the ROUNDED value — toFixed carries 999999.996

--- a/scripts/export-unresolved-headliners.ts
+++ b/scripts/export-unresolved-headliners.ts
@@ -1,0 +1,50 @@
+/**
+ * BS#1614 PR 1: export the clean unresolved concert-headliner name set —
+ * the handoff file for LML#759's drain script, plus the fresh
+ * measurement replacing the stale 2026-07-11 142/252 split.
+ *
+ * Deliberately DB-free (imports only jobs/triangle-shows-etl/headliner.ts,
+ * never `@wxyc/database`): the dump comes from a one-line psql on the
+ * prod host, and this script filters it anywhere, no credentials needed.
+ *
+ * Usage:
+ *   1. Dump distinct unresolved upcoming headliner names on the prod host
+ *      (read-only; upcoming-only so no Discogs budget is ever spent on
+ *      past shows):
+ *
+ *        psql "$DATABASE_URL" -At -c "SELECT DISTINCT headlining_artist_raw FROM wxyc_schema.concerts WHERE headlining_artist_id IS NULL AND headlining_artist_raw IS NOT NULL AND removed_at IS NULL AND starts_on >= CURRENT_DATE ORDER BY 1" > unresolved-headliners.txt
+ *
+ *   2. Filter locally:
+ *
+ *        npx tsx scripts/export-unresolved-headliners.ts unresolved-headliners.txt > clean-names.txt
+ *
+ *      (or pipe the dump on stdin and omit the file argument.)
+ *
+ * stdout: the sorted clean-name list, one per line — LML#759's input.
+ * stderr: the measurement summary + the gated-out names per reason, for
+ *         the BS#1614 comment.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import { formatSummary, summarizeHeadlinerDump } from './lib/headliner-export.js';
+
+const source = process.argv[2];
+// fd 0 = stdin; readFileSync on it blocks until EOF, which is exactly the
+// pipe semantics we want for `psql ... | tsx <this script>`.
+const raw = readFileSync(source ?? 0, 'utf8');
+const summary = summarizeHeadlinerDump(raw.split(/\r?\n/));
+
+if (summary.distinctRaw === 0) {
+  console.error('export-unresolved-headliners: no names in input — is the dump empty?');
+  process.exit(1);
+}
+
+process.stdout.write(summary.clean.join('\n') + '\n');
+
+console.error(formatSummary(summary));
+for (const [reason, names] of Object.entries(summary.gated)) {
+  if (names.length === 0) continue;
+  console.error(`\ngated (${reason}):`);
+  for (const name of names) console.error(`  ${name}`);
+}

--- a/scripts/lib/headliner-export.ts
+++ b/scripts/lib/headliner-export.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure filter half of scripts/export-unresolved-headliners.ts (BS#1614
+ * PR 1). Kept separate from the CLI entry so the unit suite imports it
+ * without side effects, and kept out of jobs/triangle-shows-etl/ because
+ * the reasons taxonomy is an export-measurement concern, not an ETL one.
+ *
+ * Pipeline per dump line (one `headlining_artist_raw` per line):
+ * trim/dedupe -> `extractHeadliner` (normalizes rows scraped before
+ * BS#1604 deployed; idempotent on already-clean rows) ->
+ * `isCleanHeadliner` gate -> clean list or per-reason gated bucket.
+ * Everything dedupes on the EXTRACTED form, so a legacy `(SOLD OUT) X`
+ * row and its re-scraped `X` sibling collapse to one entry.
+ */
+
+import {
+  extractHeadliner,
+  isCleanHeadliner,
+  BILLING_DELIMITER_PATTERNS,
+} from '../../jobs/triangle-shows-etl/headliner.js';
+
+/**
+ * Why a name was withheld from the LML-eligible set: one of the hard
+ * billing delimiters, or `extraction_residue` — the post-extraction gate
+ * failed with no delimiter present, which (extraction being idempotent)
+ * is exactly the pure-tag fallback case (`(SOLD OUT)`, `(18+)`).
+ */
+export type GateReason = keyof typeof BILLING_DELIMITER_PATTERNS | 'extraction_residue';
+
+export type HeadlinerDumpSummary = {
+  /** Raw dump lines, blanks included. */
+  totalLines: number;
+  /** Distinct trimmed non-empty raw names. */
+  distinctRaw: number;
+  /** Distinct raws that `extractHeadliner` changed (pre-BS#1604 legacy shapes). */
+  extractionChanged: number;
+  /** Sorted distinct extracted names passing `isCleanHeadliner` — the LML#759 handoff. */
+  clean: string[];
+  /** Sorted distinct extracted names withheld, bucketed by first-matching reason. */
+  gated: Record<GateReason, string[]>;
+};
+
+export const summarizeHeadlinerDump = (lines: string[]): HeadlinerDumpSummary => {
+  const distinct = [...new Set(lines.map((line) => line.trim()).filter((line) => line !== ''))];
+
+  let extractionChanged = 0;
+  const clean = new Set<string>();
+  const gatedSeen = new Set<string>();
+  const gated: Record<GateReason, string[]> = {
+    comma: [],
+    plus: [],
+    slash: [],
+    with: [],
+    extraction_residue: [],
+  };
+
+  for (const raw of distinct) {
+    const extracted = extractHeadliner(raw);
+    if (extracted !== raw) extractionChanged += 1;
+    if (isCleanHeadliner(extracted)) {
+      clean.add(extracted);
+      continue;
+    }
+    if (gatedSeen.has(extracted)) continue;
+    gatedSeen.add(extracted);
+    const delimiter = (Object.entries(BILLING_DELIMITER_PATTERNS) as [GateReason, RegExp][]).find(([, pattern]) =>
+      pattern.test(extracted)
+    );
+    gated[delimiter?.[0] ?? 'extraction_residue'].push(extracted);
+  }
+
+  for (const names of Object.values(gated)) names.sort();
+
+  return {
+    totalLines: lines.length,
+    distinctRaw: distinct.length,
+    extractionChanged,
+    clean: [...clean].sort(),
+    gated,
+  };
+};
+
+/** The measurement block posted to WXYC/Backend-Service#1614 (stderr). */
+export const formatSummary = (summary: HeadlinerDumpSummary): string => {
+  const gatedTotal = Object.values(summary.gated).reduce((count, names) => count + names.length, 0);
+  return [
+    `input lines: ${summary.totalLines}`,
+    `distinct raw names: ${summary.distinctRaw}`,
+    `changed by extraction: ${summary.extractionChanged}`,
+    `clean (LML-eligible): ${summary.clean.length}`,
+    `gated out: ${gatedTotal}`,
+    ...Object.entries(summary.gated).map(([reason, names]) => `  ${reason}: ${names.length}`),
+  ].join('\n');
+};

--- a/tests/unit/jobs/triangle-shows-etl/headliner.test.ts
+++ b/tests/unit/jobs/triangle-shows-etl/headliner.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for the clean-name LML gate (BS#1614 PR 1).
+ *
+ * `isCleanHeadliner` decides which stored headliner names are eligible for
+ * the LML#759 bare-name resolve pass. It is an API-BUDGET gate, not a
+ * correctness gate: under LML's verify-before-mint design a co-bill string
+ * can't exact-form-match a Discogs artist, so a dirty name that slips
+ * through wastes one Discogs call and lands `not_found` — while a clean
+ * name wrongly gated just stays unresolved (status quo). Both failure
+ * modes are cheap, which is why the gate can be simpler than the
+ * extractor.
+ *
+ * The extraction suite for `extractHeadliner` itself lives in map.test.ts
+ * (imported through map.ts's re-export, which doubles as the re-export
+ * regression test).
+ */
+import {
+  BILLING_DELIMITER_PATTERNS,
+  HARD_BILLING_DELIMITERS,
+  extractHeadliner,
+  isCleanHeadliner,
+} from '../../../../jobs/triangle-shows-etl/headliner';
+
+describe('HARD_BILLING_DELIMITERS', () => {
+  it('is exactly the union of BILLING_DELIMITER_PATTERNS (literal pinned against the record)', () => {
+    // The union is a literal regex (security/detect-non-literal-regexp);
+    // this pin is what keeps it and the per-reason record from drifting.
+    const derived = Object.values(BILLING_DELIMITER_PATTERNS)
+      .map((pattern) => pattern.source)
+      .join('|');
+    expect(HARD_BILLING_DELIMITERS.source).toBe(derived);
+    expect(HARD_BILLING_DELIMITERS.flags).toBe('i');
+  });
+});
+
+describe('isCleanHeadliner — clean single-artist names pass', () => {
+  it.each([
+    // The BS#1614 prod residual's sample population — the exact names the
+    // gate exists to let through.
+    'Wishy',
+    "L'Rain",
+    'REZN',
+    'glaive',
+    'The Tubs',
+    'SiM',
+    'Popsicle',
+    // `&` / `and` are NOT billing delimiters: the BS#1613 prod-sample
+    // analysis found that bucket dominated by real single acts, and under
+    // verify-before-mint a genuine `&` co-bill just returns not_found.
+    'AJ Lee & Blue Summit',
+    'Nick Cave and the Bad Seeds',
+    'Duke Ellington & John Coltrane',
+    'Iron and Wine',
+    '...And You Will Know Us by the Trail of Dead',
+    // Shapes the extractor deliberately preserves stay clean.
+    '(Sandy) Alex G',
+    '!!! (Chk Chk Chk)',
+    'Owen (solo)',
+    'Godspeed You! Black Emperor',
+    // Slash / `with` / `w/o` only count with the delimiter's exact spacing.
+    'AC/DC',
+    'DIIV/Horsegirl',
+    'Angel w/o Wings',
+    'With Honor',
+    'Withered Hand',
+  ])('isCleanHeadliner(%j) === true', (name) => {
+    expect(isCleanHeadliner(name)).toBe(true);
+  });
+});
+
+describe('isCleanHeadliner — hard billing delimiters gate', () => {
+  it.each([
+    // Comma anywhere.
+    ['Wishy, special guest TBA', 'comma'],
+    ['Built to Spill, Prism Bitch, Itchy Kitty', 'comma'],
+    // Space-delimited ` + `.
+    ['Sylvan Esso + Flock of Dimes', 'plus'],
+    // Space-delimited ` / ` (AC/DC-style names have no spaces and pass).
+    ['Magic City Hippies / Flipturn', 'slash'],
+    // Plain word ` with `. Deliberate contrast with extraction's
+    // must-not-strip contract: extractHeadliner keeps `Elvis Costello with
+    // Steve Nieve` verbatim (over-stripping could mangle a real name); the
+    // gate merely WITHHOLDS it from the LML send, which costs nothing.
+    ['Elvis Costello with Steve Nieve', 'with'],
+    ['Built to Spill with Prism Bitch', 'with'],
+  ])('isCleanHeadliner(%j) === false (%s)', (name) => {
+    expect(isCleanHeadliner(name)).toBe(false);
+  });
+});
+
+describe('isCleanHeadliner — extraction residue gates', () => {
+  it.each([
+    // Names extraction would still change are by definition not clean —
+    // covers legacy rows scraped before BS#1604 deployed.
+    '(SOLD OUT) Jessica Pratt',
+    'Deerhoof w/ Sword II',
+    'Mdou Moctar feat. Mikey Coltun',
+    '(LOW TIX) An Evening With: Deerhoof',
+    // Pure-tag billings: extractHeadliner's empty-cleanup fallback returns
+    // them VERBATIM (better stored than dropped), so the fixpoint test
+    // alone would wrongly call them clean. The gate must still reject —
+    // these are ticketing residue, not artist names.
+    '(SOLD OUT)',
+    '(18+)',
+    'An Evening With:',
+    // Blank input is never clean.
+    '',
+    '   ',
+  ])('isCleanHeadliner(%j) === false', (name) => {
+    expect(isCleanHeadliner(name)).toBe(false);
+  });
+});
+
+describe('isCleanHeadliner — composition with extractHeadliner', () => {
+  it.each([
+    // Extraction output of a strippable billing is clean...
+    ['(SOLD OUT) Jessica Pratt', true],
+    ['Wednesday w/Truth Club', true],
+    ['(LOW TIX) (18+) An Evening With: Deerhoof w/ Sword II', true],
+    // ...but extraction never strips hard delimiters, so a comma/`+`
+    // billing stays gated even after extraction.
+    ['Wishy, special guest TBA', false],
+    ['Sylvan Esso + Flock of Dimes', false],
+  ])('isCleanHeadliner(extractHeadliner(%j)) === %j', (billing, expected) => {
+    expect(isCleanHeadliner(extractHeadliner(billing))).toBe(expected);
+  });
+});

--- a/tests/unit/scripts/export-unresolved-headliners.test.ts
+++ b/tests/unit/scripts/export-unresolved-headliners.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for the BS#1614 name-set export filter (PR 1).
+ *
+ * `summarizeHeadlinerDump` is the pure half of
+ * scripts/export-unresolved-headliners.ts: raw dump lines (one
+ * `headlining_artist_raw` per line, psql -At output) -> the clean-name
+ * list handed to LML#759's drain script, plus the gated-out breakdown
+ * that becomes the fresh measurement posted to BS#1614.
+ */
+import { summarizeHeadlinerDump, formatSummary } from '../../../scripts/lib/headliner-export';
+
+const DUMP = [
+  '(SOLD OUT) Jessica Pratt', // legacy pre-BS#1604 row: extraction cleans it
+  'Jessica Pratt', // post-extraction duplicate of the same artist
+  'Wishy, special guest TBA', // comma billing
+  'REZN + Yawning Man', // ` + ` billing
+  'Magic City Hippies / Flipturn', // ` / ` billing
+  'Elvis Costello with Steve Nieve', // plain ` with ` billing
+  '(18+)', // pure ticketing tag (extraction fallback returns it verbatim)
+  'Duke Ellington & John Coltrane', // `&` act — clean by design
+  '', // blank lines dropped
+  '   ',
+  'Wishy',
+];
+
+describe('summarizeHeadlinerDump', () => {
+  const summary = summarizeHeadlinerDump(DUMP);
+
+  it('emits the sorted distinct clean-name list, deduped on the extracted form', () => {
+    // '(SOLD OUT) Jessica Pratt' and 'Jessica Pratt' collapse to one entry.
+    expect(summary.clean).toEqual(['Duke Ellington & John Coltrane', 'Jessica Pratt', 'Wishy']);
+  });
+
+  it('counts lines, distinct raws, and extraction-changed raws', () => {
+    expect(summary.totalLines).toBe(11);
+    expect(summary.distinctRaw).toBe(9); // trimmed non-empty distinct
+    expect(summary.extractionChanged).toBe(1); // only the (SOLD OUT) row
+  });
+
+  it('buckets gated-out names by first-matching reason', () => {
+    expect(summary.gated.comma).toEqual(['Wishy, special guest TBA']);
+    expect(summary.gated.plus).toEqual(['REZN + Yawning Man']);
+    expect(summary.gated.slash).toEqual(['Magic City Hippies / Flipturn']);
+    expect(summary.gated.with).toEqual(['Elvis Costello with Steve Nieve']);
+    expect(summary.gated.extraction_residue).toEqual(['(18+)']);
+  });
+
+  it('is stable under a re-run over its own clean output (idempotent handoff)', () => {
+    const again = summarizeHeadlinerDump(summary.clean);
+    expect(again.clean).toEqual(summary.clean);
+    expect(Object.values(again.gated).flat()).toEqual([]);
+  });
+
+  it('handles an empty dump', () => {
+    const empty = summarizeHeadlinerDump([]);
+    expect(empty.clean).toEqual([]);
+    expect(empty.totalLines).toBe(0);
+    expect(empty.distinctRaw).toBe(0);
+  });
+});
+
+describe('formatSummary', () => {
+  it('renders the measurement block with counts and the gated breakdown', () => {
+    const text = formatSummary(summarizeHeadlinerDump(DUMP));
+    expect(text).toContain('distinct raw names: 9');
+    expect(text).toContain('clean (LML-eligible): 3');
+    expect(text).toContain('gated out: 5');
+    expect(text).toContain('comma: 1');
+    expect(text).toContain('plus: 1');
+    expect(text).toContain('slash: 1');
+    expect(text).toContain('with: 1');
+    expect(text).toContain('extraction_residue: 1');
+  });
+});


### PR DESCRIPTION
PR 1 of 3 for WXYC/Backend-Service#1614 (see the delivery plan recorded there) — the unblocked deliverable that feeds WXYC/library-metadata-lookup#759's drain: the clean-name gate and the name-set export. Does not close the issue.

## What

- **`jobs/triangle-shows-etl/headliner.ts` (new)** — the BS#1604 clean-headliner extraction cluster moves here from `map.ts`, verbatim except for one internal split: `cleanBilling` (the full cleanup pass, may return `''`) is separated from `extractHeadliner`'s verbatim fallback so the new gate can see the pure-tag-emptied case the fallback hides. `map.ts` re-exports everything, so ETL consumers and the existing extraction test suite are unchanged — the untouched `map.test.ts` passing through the re-export is the behavioral regression proof.
- **`isCleanHeadliner` (new)** — decides which stored headliner names are eligible for the LML#759 bare-name resolve pass. Clean = extraction fixpoint (which also rejects pure ticketing tags like `(SOLD OUT)`) AND no hard billing delimiter (`,`, ` + `, ` / `, plain ` with `). `&`/`and` are deliberately **not** delimiters: the BS#1613 prod-sample analysis found that bucket dominated by real single acts, and under LML#759's verify-before-mint model a genuine co-bill can't exact-form-match a Discogs artist — it just returns `not_found`. The gate is an API-budget measure, not a correctness one; both failure directions are cheap, which is why it can be simpler than the extractor.
- **`scripts/export-unresolved-headliners.ts` + `scripts/lib/headliner-export.ts` (new)** — dump-to-handoff filter: distinct unresolved upcoming `headlining_artist_raw` lines (one-line read-only psql, documented in the script header) → `extractHeadliner` → gate → sorted clean-name list on stdout (LML#759's drain input) with the per-reason gated breakdown on stderr (the fresh measurement for BS#1614, replacing the stale 2026-07-11 142/252 split). Deliberately DB-free — which is the reason for the `headliner.ts` extraction: `@wxyc/database`'s client throws at import time without `DB_*` env vars.

## Why the module move

The BS#1614 constraint requires the gate to be the *same code* as the extraction rules it composes with (no re-derived heuristic that can drift from the measurement). Keeping them in one module while making that module importable without DB credentials meant lifting the whole cluster out of `map.ts`.

## Testing

- New `headliner.test.ts`: gate positives (the prod residual's sample names, `&`/`and` acts, `(Sandy) Alex G` / `AC/DC` / `w/o` shape edges), delimiter negatives, extraction-residue negatives (incl. the pure-tag fallback case), extract∘gate composition, and a literal-vs-record drift pin for `HARD_BILLING_DELIMITERS`.
- New `export-unresolved-headliners.test.ts`: dedupe-on-extracted-form, counts, per-reason buckets, idempotent re-run over its own output, empty dump.
- Existing `map.test.ts` (extraction suite) untouched and green through the re-export.
- Local CI: `typecheck`, `lint` (0 errors, no new-file warnings), `format:check`, `build`, full unit suite (285 suites / 4117 tests), `ci:testmock`, plus direct `tsc` on the job workspace and the scripts (both outside root typecheck scope).

## Related

- WXYC/Backend-Service#1614 — parent ticket (PR 2: lml-client function; PR 3: migration + writer job — both gated on the LML#759 drain report).
- WXYC/library-metadata-lookup#759 — consumes this PR's export as its drain input.
- Extraction substrate: BS#1604 (WXYC/Backend-Service#1604), WXYC/triangle-shows#18.
