### PR TITLE
fix(concerts): fall back to stdin on empty-string arg in headliner export (BS#1614 follow-up)

### DIFF
--- a/scripts/export-unresolved-headliners.ts
+++ b/scripts/export-unresolved-headliners.ts
@@ -31,8 +31,11 @@ import { formatSummary, summarizeHeadlinerDump } from './lib/headliner-export.js
 
 const source = process.argv[2];
 // fd 0 = stdin; readFileSync on it blocks until EOF, which is exactly the
-// pipe semantics we want for `psql ... | tsx <this script>`.
-const raw = readFileSync(source ?? 0, 'utf8');
+// pipe semantics we want for `psql ... | tsx <this script>`. `||` not `??`
+// so an empty-string arg (e.g. an unset shell var expanded into the
+// invocation) also falls back to stdin instead of readFileSync('') throwing
+// a raw ENOENT.
+const raw = readFileSync(source || 0, 'utf8');
 const summary = summarizeHeadlinerDump(raw.split(/\r?\n/));
 
 if (summary.distinctRaw === 0) {


### PR DESCRIPTION
Follow-up to the merged #1617 (BS#1614 PR 1). A post-merge `/code-review max` pass on that PR flagged one robustness edge in the new export CLI; the fix was reviewed and approved in the loop but raced the squash-merge, so it never landed on `main`. This PR carries just that one-line change.

## What

`scripts/export-unresolved-headliners.ts` read its dump from `readFileSync(source ?? 0, 'utf8')`, where `source = process.argv[2]` and `0` is fd 0 (stdin). With `??`, only a missing arg (`undefined`) falls back to stdin — an **empty-string** arg stays `''`, and `readFileSync('', 'utf8')` throws a raw `ENOENT` with a full Node stack instead of reading the piped input the operator intended. That happens whenever an unset shell var is expanded into the invocation, e.g. `FILE=""; psql ... | npx tsx scripts/export-unresolved-headliners.ts "$FILE"`.

Switching `??` to `||` makes `''` (falsy but non-nullish) also fall back to fd 0, matching the missing-arg case. An empty-string path is never a valid file, so `||` is strictly safer here with no behavior change for a real path argument.

## Testing

The change is confined to the CLI entry (not the unit-tested pure `summarizeHeadlinerDump` half). Verified against the sibling review worktree: the 48 `headliner` + `export-unresolved-headliners` unit tests pass, direct `tsc` on the script is clean, and `prettier --check` passes. Byte-identical to the version reviewed on #1617.

## Related

- #1617 — the merged parent PR this follows up.
- WXYC/Backend-Service#1614 — parent ticket.
