### PR TITLE
feat(lml-client): resolveArtistNamesBulk bulk bare-name artist resolution (BS#1614 PR 2)

### DIFF
--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -1016,6 +1016,197 @@ export async function refreshForIdentities(
 }
 
 /**
+ * Wire shape for `POST /api/v1/artists/resolve/bulk` (LML#759, BS#1614).
+ *
+ * Mirrors `ArtistResolveBulkRequest` / `ArtistResolveBulkResponse` /
+ * `ArtistResolveResult` and the three verdict enums in `wxyc-shared/api.yaml`
+ * (PR A, wxyc-shared#218). Defined locally rather than imported from
+ * `@wxyc/shared/dtos` so this wrapper compiles against the currently-shipped
+ * shared bundle; the types move to `@wxyc/shared/dtos` once the OpenAPI codegen
+ * catches up. Same pattern used by `EntityResolveResponse`,
+ * `ReleaseIdentityResolveRequest`, and `BulkCacheRefreshRequest` during their
+ * own ramp-ups.
+ *
+ * Resolution model is verify-before-mint: `method` has exactly two values
+ * because the discogs-cache is a pair-wise-filtered sample of Discogs — cache
+ * legs corroborate (and equality legs can veto a mint into `ambiguous`) but
+ * never decide. `escalation_unavailable` is the one RETRYABLE unresolved reason
+ * ("couldn't ask," not "asked and missed"); consumers must not apply a no-match
+ * TTL to it.
+ */
+
+/** What decided a resolved verdict: an `identity_store` short-circuit vs a live `api_search`. */
+export type ArtistResolveMethod = 'identity_store' | 'api_search';
+
+/**
+ * A discogs-cache candidate-generation leg that produced >= 1 candidate for the
+ * input's identity-match form. Corroboration + conflict detection only, never a
+ * verdict: the four equality legs can veto a mint into `ambiguous`; fuzzy
+ * `cache_trigram` neighbors never veto.
+ */
+export type ArtistResolveCacheLeg =
+  | 'cache_exact'
+  | 'cache_member'
+  | 'cache_alias'
+  | 'cache_name_variation'
+  | 'cache_trigram';
+
+/**
+ * Why a name did not resolve. `not_found` / `ambiguous` are terminal;
+ * `escalation_unavailable` (breaker open / outage / 429 / 5xx-after-retries) is
+ * RETRYABLE — the caller must not stamp a no-match TTL on it.
+ */
+export type ArtistResolveUnresolvedReason = 'not_found' | 'ambiguous' | 'escalation_unavailable';
+
+/**
+ * Verdict for one input name, index-aligned with the request's `names`. Exactly
+ * one of `discogs_artist_id` (resolved) or `unresolved_reason` is present;
+ * `cache_corroboration` is always present (may be empty). `candidate_count` is
+ * always serialized — `null` means "not measured" (the API tier did not run:
+ * identity_store short-circuit or escalation_unavailable), never zero-as-unknown.
+ */
+export interface ArtistResolveResult {
+  /** Verbatim echo of the input name at this index. */
+  name: string;
+  /** The resolved Discogs artist id. Present iff resolved. */
+  discogs_artist_id?: number;
+  /**
+   * Raw Discogs artist title, disambiguation suffix included (e.g. `Popsicle (2)`).
+   * Present iff resolved via `api_search` — `identity_store` rows store no title.
+   */
+  canonical_name?: string;
+  /** What decided the resolution. Present iff resolved. */
+  method?: ArtistResolveMethod;
+  /**
+   * Cache legs that produced candidates for this name's identity-match form, on
+   * both verdict kinds. Empty when no leg produced candidates and always empty
+   * on `identity_store` short-circuits.
+   */
+  cache_corroboration: ArtistResolveCacheLeg[];
+  /** Why the name did not resolve. Present iff unresolved. */
+  unresolved_reason?: ArtistResolveUnresolvedReason;
+  /**
+   * Exact-form candidates the API tier observed (1 on resolved, 0 on
+   * not_found; on ambiguous >= 2 for an overloaded family or exactly 1 for an
+   * equality-leg cache conflict). `null` when the API tier did not run.
+   */
+  candidate_count: number | null;
+}
+
+export interface ArtistResolveBulkRequest {
+  names: string[];
+  /** Run every tier identically but skip the `entity.identity` write-back. */
+  dry_run?: boolean;
+}
+
+export interface ArtistResolveBulkResponse {
+  /** One verdict per input name, in input order. */
+  results: ArtistResolveResult[];
+}
+
+/**
+ * LML's per-request hard cap on `resolveArtistNamesBulk` (LML#759). Keeps a
+ * fully-escalating batch within the shared 50/min Discogs budget (~25 live
+ * calls, ~30 s); callers page against this constant. LML returns 413 on
+ * overflow. Hard contract, not a tunable.
+ */
+export const ARTIST_RESOLVE_BATCH_CAP = 25;
+
+/**
+ * Per-name slice of the batch-size-scaled default timeout. LML processes the
+ * API leg serially at the shared 50/min Discogs budget (~1.2 s/name) plus
+ * retries/backoff, so the socket budget must grow with batch size or a
+ * successful full-escalation batch reads as a transport timeout.
+ */
+const ARTIST_RESOLVE_PER_NAME_TIMEOUT_MS = 5000;
+
+/**
+ * Fixed slack on top of the per-name budget — connection setup, the PG
+ * candidate pre-pass, and response serialization, independent of batch size.
+ */
+const ARTIST_RESOLVE_TIMEOUT_SLACK_MS = 30_000;
+
+/**
+ * Bulk-resolve bare artist names to Discogs artist identities via LML's
+ * `POST /api/v1/artists/resolve/bulk` (LML#759). Verify-before-mint: LML reads
+ * `entity.identity`, generates discogs-cache corroboration candidates, then
+ * runs a single-page live Discogs API artist search, minting only on exactly
+ * one exact-form candidate with no equality-leg cache conflict. Returns one
+ * verdict per input name in input order (`ArtistResolveResult`).
+ *
+ * Consumer: the concerts headliner backfill (BS#1614) — touring artists absent
+ * from the WXYC library that the pure-SQL strict/alias resolver can't reach.
+ *
+ * Wiring decisions (mirroring `bulkLookupMetadata`):
+ *
+ * - **One limiter token per batch, not per name.** LML paces its own serial
+ *   Discogs fan-out internally; the BS-side limiter mirrors that same shared
+ *   ceiling, so token-per-batch is the correct accounting.
+ * - **Timeout scales with batch size.** `names.length ×
+ *   ARTIST_RESOLVE_PER_NAME_TIMEOUT_MS (5000) + ARTIST_RESOLVE_TIMEOUT_SLACK_MS
+ *   (30_000)` — ~35 s for a 1-name page, ~155 s at the 25 cap. A fixed 30 s
+ *   default (this endpoint's `/lookup` siblings) would misclassify a successful
+ *   full-escalation batch as a transport timeout. Override via
+ *   `options.timeoutMs`. Offline-only caller; a long socket is cheap.
+ * - **Span op mirrors `bulkLookupMetadata`** (`http.client`); `lml.bulk.size` is
+ *   the batch attribute. No `cache_stats` projection — this endpoint doesn't
+ *   return the `/lookup` cache-counter block.
+ *
+ * Client-side validation rejects empty + oversize batches before the wire call
+ * — a 400/413 round-trip costs a TCP RTT for no information gain.
+ *
+ * @param names - Bare artist names (1..=25), sent verbatim.
+ * @param options.dryRun - Run every tier but skip the `entity.identity` write-back.
+ */
+export async function resolveArtistNamesBulk(
+  names: string[],
+  options?: { timeoutMs?: number; limiter?: LmlLimiter; caller?: string; dryRun?: boolean }
+): Promise<ArtistResolveBulkResponse> {
+  if (names.length === 0) {
+    throw new LmlClientError('resolveArtistNamesBulk requires at least 1 name.', 400);
+  }
+  if (names.length > ARTIST_RESOLVE_BATCH_CAP) {
+    throw new LmlClientError(
+      `resolveArtistNamesBulk exceeded the cap of ${ARTIST_RESOLVE_BATCH_CAP} names (received ${names.length}).`,
+      400
+    );
+  }
+
+  const timeoutMs =
+    options?.timeoutMs ?? names.length * ARTIST_RESOLVE_PER_NAME_TIMEOUT_MS + ARTIST_RESOLVE_TIMEOUT_SLACK_MS;
+
+  const body: ArtistResolveBulkRequest = { names };
+  if (options?.dryRun) body.dry_run = true;
+
+  const activeLimiter = options?.limiter ?? defaultLimiter;
+  return activeLimiter.run(async () => {
+    return await Sentry.startSpan({ name: 'lml.artists.resolve.bulk', op: 'http.client' }, async (span) => {
+      try {
+        span.setAttributes({
+          'lml.queue_depth': activeLimiter.state().queueDepth,
+          'lml.bulk.size': names.length,
+          'lml.caller': options?.caller ?? 'unknown',
+        });
+      } catch (err) {
+        console.warn('lml.client: failed to project queue_depth + bulk.size + caller onto resolve span', err);
+      }
+
+      const response = await lmlFetch(
+        '/api/v1/artists/resolve/bulk',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+        timeoutMs
+      );
+
+      return (await response.json()) as ArtistResolveBulkResponse;
+    });
+  });
+}
+
+/**
  * Check whether the LML service is configured.
  */
 export function isLmlConfigured(): boolean {

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -1141,7 +1141,12 @@ const ARTIST_RESOLVE_TIMEOUT_SLACK_MS = 30_000;
  *
  * - **One limiter token per batch, not per name.** LML paces its own serial
  *   Discogs fan-out internally; the BS-side limiter mirrors that same shared
- *   ceiling, so token-per-batch is the correct accounting.
+ *   ceiling, so token-per-batch is the correct accounting. The default
+ *   `limiter` is the process-wide runtime pool (`LML_CLIENT_*`); a full
+ *   25-name batch can hold one of its 5 permits for the entire ~155 s socket,
+ *   so any runtime/interactive caller MUST pass a dedicated `options.limiter`
+ *   (the documented offline consumer does). Defaulting to the runtime pool is
+ *   the sibling convention, not an invitation to run big batches on it.
  * - **Timeout scales with batch size.** `names.length ×
  *   ARTIST_RESOLVE_PER_NAME_TIMEOUT_MS (5000) + ARTIST_RESOLVE_TIMEOUT_SLACK_MS
  *   (30_000)` — ~35 s for a 1-name page, ~155 s at the 25 cap. A fixed 30 s
@@ -1151,11 +1156,29 @@ const ARTIST_RESOLVE_TIMEOUT_SLACK_MS = 30_000;
  * - **Span op mirrors `bulkLookupMetadata`** (`http.client`); `lml.bulk.size` is
  *   the batch attribute. No `cache_stats` projection — this endpoint doesn't
  *   return the `/lookup` cache-counter block.
+ * - **No `X-Caller-Budget-Ms`.** That header is a `/lookup`-family construct
+ *   (it lets LML short-circuit its empty-results cascade); this endpoint does
+ *   not honor it, so — unlike the sibling — no `budgetMs` option is offered.
  *
  * Client-side validation rejects empty + oversize batches before the wire call
- * — a 400/413 round-trip costs a TCP RTT for no information gain.
+ * — a 400/413 round-trip costs a TCP RTT for no information gain. The response
+ * is then validated to be an index-aligned 1:1 array before return; a length or
+ * shape violation throws `LmlClientError(…, 502)` rather than handing a
+ * mis-aligned batch to a consumer that zips verdicts to names positionally.
+ *
+ * Errors (all `LmlClientError`):
+ *   - Empty / >25 names: thrown client-side (`400`) before the wire call.
+ *   - Timeout: `504` (AbortController fired; rethrown from `lmlFetch`).
+ *   - 5xx: `502`. Other non-2xx (incl. a wire `413` if LML's cap ever drops
+ *     below 25): the upstream status is passed through.
+ *   - Network failure, or a malformed / mis-aligned response body: `502`.
+ * Note `escalation_unavailable` is NOT an error — it arrives as a 200-body
+ * verdict and is RETRYABLE; consumers must not stamp a no-match TTL on it.
  *
  * @param names - Bare artist names (1..=25), sent verbatim.
+ * @param options.timeoutMs - Override the batch-size-scaled default socket timeout (ms).
+ * @param options.limiter - Override the default runtime limiter (see the token bullet above).
+ * @param options.caller - Caller-class label projected onto the span as `lml.caller`.
  * @param options.dryRun - Run every tier but skip the `entity.identity` write-back.
  */
 export async function resolveArtistNamesBulk(
@@ -1201,7 +1224,23 @@ export async function resolveArtistNamesBulk(
         timeoutMs
       );
 
-      return (await response.json()) as ArtistResolveBulkResponse;
+      const parsed = (await response.json()) as ArtistResolveBulkResponse;
+
+      // The whole contract is positional: `results[i]` is the verdict for
+      // `names[i]` (`ArtistResolveResult` carries no `index` field, unlike
+      // `BulkLookupResultItem`). A short, long, reordered, or missing array
+      // would let a consumer silently mis-attribute a `discogs_artist_id` to
+      // the wrong name and write it. Fail loud at the chokepoint instead.
+      if (!Array.isArray(parsed.results) || parsed.results.length !== names.length) {
+        throw new LmlClientError(
+          `resolveArtistNamesBulk: LML returned ${
+            Array.isArray(parsed.results) ? parsed.results.length : 'a non-array'
+          } result(s) for ${names.length} name(s); expected an index-aligned 1:1 array`,
+          502
+        );
+      }
+
+      return parsed;
     });
   });
 }

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -1107,8 +1107,10 @@ export interface ArtistResolveBulkResponse {
 /**
  * LML's per-request hard cap on `resolveArtistNamesBulk` (LML#759). Keeps a
  * fully-escalating batch within the shared 50/min Discogs budget (~25 live
- * calls, ~30 s); callers page against this constant. LML returns 413 on
- * overflow. Hard contract, not a tunable.
+ * calls ≈ 30 s of rate-limited Discogs time — distinct from, and shorter than,
+ * the ~155 s socket timeout below, which adds retry/backoff + transport slack
+ * on top of that floor); callers page against this constant. LML returns 413
+ * on overflow. Hard contract, not a tunable.
  */
 export const ARTIST_RESOLVE_BATCH_CAP = 25;
 
@@ -1224,7 +1226,19 @@ export async function resolveArtistNamesBulk(
         timeoutMs
       );
 
-      const parsed = (await response.json()) as ArtistResolveBulkResponse;
+      let parsed: ArtistResolveBulkResponse;
+      try {
+        parsed = (await response.json()) as ArtistResolveBulkResponse;
+      } catch (err) {
+        // A 200 with an unparseable body (truncated stream, or an HTML error
+        // page a proxy slipped in front of LML) would otherwise throw a bare
+        // SyntaxError that escapes the `LmlClientError` contract this function's
+        // JSDoc promises. Wrap it so consumers see one error type.
+        throw new LmlClientError(
+          `resolveArtistNamesBulk: LML returned an unparseable body: ${(err as Error).message}`,
+          502
+        );
+      }
 
       // The whole contract is positional: `results[i]` is the verdict for
       // `names[i]` (`ArtistResolveResult` carries no `index` field, unlike
@@ -1232,10 +1246,9 @@ export async function resolveArtistNamesBulk(
       // would let a consumer silently mis-attribute a `discogs_artist_id` to
       // the wrong name and write it. Fail loud at the chokepoint instead.
       if (!Array.isArray(parsed.results) || parsed.results.length !== names.length) {
+        const got = Array.isArray(parsed.results) ? `${parsed.results.length} result(s)` : 'a non-array results field';
         throw new LmlClientError(
-          `resolveArtistNamesBulk: LML returned ${
-            Array.isArray(parsed.results) ? parsed.results.length : 'a non-array'
-          } result(s) for ${names.length} name(s); expected an index-aligned 1:1 array`,
+          `resolveArtistNamesBulk: LML returned ${got} for ${names.length} name(s); expected an index-aligned 1:1 array`,
           502
         );
       }

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -774,11 +774,26 @@ describe('lml.client', () => {
       candidate_count: 1,
     });
 
-    it('sends POST to /api/v1/artists/resolve/bulk wrapping names in a {names} envelope', async () => {
-      mockFetch.mockResolvedValue({
+    // The wrapper validates results.length === names.length, so request-shape
+    // tests that don't care about the verdicts must still return an index-
+    // aligned 1:1 body rather than a bare `{ results: [] }`.
+    const okBatch = (names: string[]) =>
+      ({
         ok: true,
-        json: () => Promise.resolve({ results: [] }),
-      } as unknown as globalThis.Response);
+        json: () => Promise.resolve({ results: names.map((n, i) => resolvedResult(n, 1000 + i)) }),
+      }) as unknown as globalThis.Response;
+
+    beforeEach(() => {
+      // Reset the process-wide default limiter so the setTimeout-spy timeout
+      // tests below draw from a full TokenBucket. Without this, a depleted
+      // shared bucket sends TokenBucket.consume(1) down the slow path, adding a
+      // stray setTimeout call and a real ~1.2 s sleep — a latent flake the
+      // BS#906 block already guards against with the same reset-before-each.
+      _resetLmlClientLimitersForTest();
+    });
+
+    it('sends POST to /api/v1/artists/resolve/bulk wrapping names in a {names} envelope', async () => {
+      mockFetch.mockResolvedValue(okBatch(['Wishy', "L'Rain"]));
 
       await resolveArtistNamesBulk(['Wishy', "L'Rain"]);
 
@@ -793,10 +808,7 @@ describe('lml.client', () => {
     });
 
     it('forwards dry_run: true onto the body when options.dryRun is set', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ results: [] }),
-      } as unknown as globalThis.Response);
+      mockFetch.mockResolvedValue(okBatch(['Wishy']));
 
       await resolveArtistNamesBulk(['Wishy'], { dryRun: true });
 
@@ -839,13 +851,8 @@ describe('lml.client', () => {
       // Resolved verdict: every field survives the passthrough, incl. the two
       // api_search-only fields (canonical_name, cache_corroboration) the wrapper
       // must not drop if a future refactor ever introduces a projection step.
-      expect(result.results[0]).toMatchObject({
-        discogs_artist_id: 7315154,
-        canonical_name: 'Wishy',
-        method: 'api_search',
-        cache_corroboration: ['cache_exact'],
-        candidate_count: 1,
-      });
+      // toEqual (not toMatchObject) so a dropped OR an added junk field fails.
+      expect(result.results[0]).toEqual(resolvedResult('Wishy', 7315154));
       expect(result.results[1]).toMatchObject({ unresolved_reason: 'not_found', candidate_count: 0 });
       // Ambiguous verdict: corroboration legs (incl. a fuzzy cache_trigram
       // neighbor) pass through alongside the reason and count.
@@ -856,6 +863,34 @@ describe('lml.client', () => {
       });
       // escalation_unavailable carries candidate_count: null (not measured — never zero-as-unknown).
       expect(result.results[3]).toMatchObject({ unresolved_reason: 'escalation_unavailable', candidate_count: null });
+    });
+
+    it('throws (502) when LML returns fewer results than names — the contract is positional', async () => {
+      // 2 names in, 1 verdict back: index alignment is broken. The wrapper must
+      // reject rather than let a consumer zip results[1] to the wrong name.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [resolvedResult('Wishy', 7315154)] }),
+      } as unknown as globalThis.Response);
+
+      const err = await resolveArtistNamesBulk(['Wishy', "L'Rain"]).catch((e) => e);
+      expect(err).toBeInstanceOf(LmlClientError);
+      expect((err as LmlClientError).statusCode).toBe(502);
+      expect((err as Error).message).toMatch(/1 result\(s\) for 2 name\(s\)/);
+    });
+
+    it('throws (502) when LML returns a non-array results field', async () => {
+      // A malformed 200 body ({results: null}) would otherwise NPE deep in a
+      // consumer's `.results.map(...)`; localize it to an LmlClientError here.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: null }),
+      } as unknown as globalThis.Response);
+
+      const err = await resolveArtistNamesBulk(['Wishy']).catch((e) => e);
+      expect(err).toBeInstanceOf(LmlClientError);
+      expect((err as LmlClientError).statusCode).toBe(502);
+      expect((err as Error).message).toMatch(/non-array/);
     });
 
     it('rejects empty names locally without hitting the wire', async () => {
@@ -875,10 +910,7 @@ describe('lml.client', () => {
 
     it('includes Authorization: Bearer <key> when LML_API_KEY is set', async () => {
       process.env.LML_API_KEY = 'test-secret';
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ results: [] }),
-      } as unknown as globalThis.Response);
+      mockFetch.mockResolvedValue(okBatch(['Wishy']));
 
       await resolveArtistNamesBulk(['Wishy']);
 
@@ -887,35 +919,29 @@ describe('lml.client', () => {
     });
 
     it('consumes exactly one limiter token per batch (not one per name)', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ results: [] }),
-      } as unknown as globalThis.Response);
-
-      // The real pin here is the mockFetch call count (== 2, one HTTP request
-      // per batch): a regression that fanned out to one request+token PER NAME
-      // would fire 50 requests, not 2. The timing assertion is only a weak
-      // secondary — with a 60-token bucket even a hypothetical consume(25)-per-
-      // batch (25 + 25 = 50 ≤ 60) would not block, so `elapsed < 500` alone
-      // cannot distinguish per-batch from per-name token accounting. Same
-      // documented caveat as the bulkLookupMetadata token-per-batch test.
       const limiter = createLmlLimiter({ maxConcurrent: 4, ratePerMinute: 60 });
       const names = Array.from({ length: 25 }, (_, i) => `Artist ${i}`);
+      mockFetch.mockResolvedValue(okBatch(names));
 
       const start = Date.now();
       await resolveArtistNamesBulk(names, { limiter });
       await resolveArtistNamesBulk(names, { limiter });
       const elapsed = Date.now() - start;
 
+      // The fetch call count (== 2, one HTTP request per batch) catches the
+      // gross regression: one request+token PER NAME would fire 50 requests.
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(elapsed).toBeLessThan(500);
+      // Token-accounting pin the fetch-count can't give: 2 batches of 25 names
+      // consume 2 tokens total (one per batch). A `consume(names.length)`
+      // regression would drain ~50 of the 60-token bucket, leaving ~10 — which
+      // the fetch-count and the (non-blocking, 50 ≤ 60) timing assertion both
+      // miss. ~58 remaining (minus negligible continuous refill) proves 1/batch.
+      expect(limiter.state().availableTokens).toBeGreaterThan(55);
     });
 
     it('wraps the call in a Sentry span (lml.artists.resolve.bulk / http.client) with bulk.size', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ results: [] }),
-      } as unknown as globalThis.Response);
+      mockFetch.mockResolvedValue(okBatch(['Wishy', "L'Rain", '(Sandy) Alex G']));
 
       await resolveArtistNamesBulk(['Wishy', "L'Rain", '(Sandy) Alex G']);
 
@@ -925,10 +951,7 @@ describe('lml.client', () => {
     });
 
     it('projects lml.caller onto the span when caller is provided', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ results: [] }),
-      } as unknown as globalThis.Response);
+      mockFetch.mockResolvedValue(okBatch(['Wishy']));
 
       await resolveArtistNamesBulk(['Wishy'], { caller: 'concerts-artist-lml-resolver' });
 
@@ -939,10 +962,7 @@ describe('lml.client', () => {
     });
 
     it("projects lml.caller='unknown' when caller is not provided (flag-of-shame)", async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ results: [] }),
-      } as unknown as globalThis.Response);
+      mockFetch.mockResolvedValue(okBatch(['Wishy']));
 
       await resolveArtistNamesBulk(['Wishy']);
 
@@ -964,12 +984,9 @@ describe('lml.client', () => {
       [ARTIST_RESOLVE_BATCH_CAP, 155000],
     ])('scales the default timeout with batch size: %i names → %i ms', async (count, expectedMs) => {
       const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ results: [] }),
-      } as unknown as globalThis.Response);
-
       const names = Array.from({ length: count }, (_, i) => `Artist ${i}`);
+      mockFetch.mockResolvedValue(okBatch(names));
+
       await resolveArtistNamesBulk(names);
 
       expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === expectedMs)).toHaveLength(1);
@@ -978,10 +995,7 @@ describe('lml.client', () => {
 
     it('honors options.timeoutMs as a per-call override', async () => {
       const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ results: [] }),
-      } as unknown as globalThis.Response);
+      mockFetch.mockResolvedValue(okBatch(['Wishy', "L'Rain"]));
 
       await resolveArtistNamesBulk(['Wishy', "L'Rain"], { timeoutMs: 5000 });
 
@@ -991,14 +1005,19 @@ describe('lml.client', () => {
       setTimeoutSpy.mockRestore();
     });
 
-    it('throws LmlClientError on non-2xx response (e.g. 413 over-cap at the wire)', async () => {
+    it('throws LmlClientError, passing the upstream status through (413 over-cap at the wire)', async () => {
+      // The client caps at 25 locally, so a wire 413 can only arise if LML's
+      // cap ever drops below 25 — pin that lmlFetch passes <500 statuses
+      // through (413, not a collapsed 502) so a caller could branch on it.
       mockFetch.mockResolvedValue({
         ok: false,
         status: 413,
         statusText: 'Payload Too Large',
       } as unknown as globalThis.Response);
 
-      await expect(resolveArtistNamesBulk(['Wishy'])).rejects.toThrow(LmlClientError);
+      const err = await resolveArtistNamesBulk(['Wishy']).catch((e) => e);
+      expect(err).toBeInstanceOf(LmlClientError);
+      expect((err as LmlClientError).statusCode).toBe(413);
     });
   });
 

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -30,6 +30,9 @@ import {
   resolveEntity,
   refreshForIdentities,
   REFRESH_FOR_IDENTITIES_BATCH_CAP,
+  resolveArtistNamesBulk,
+  ARTIST_RESOLVE_BATCH_CAP,
+  type ArtistResolveResult,
   LmlClientError,
   checkStreamingAvailability,
   searchLibrary,
@@ -755,6 +758,222 @@ describe('lml.client', () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+  });
+
+  describe('resolveArtistNamesBulk (BS#1614 / LML#759)', () => {
+    // A resolved-via-api_search verdict, mirroring the wxyc-shared#218
+    // ArtistResolveResult contract: discogs_artist_id + method + canonical_name,
+    // required cache_corroboration, candidate_count = 1.
+    const resolvedResult = (name: string, id: number): ArtistResolveResult => ({
+      name,
+      discogs_artist_id: id,
+      canonical_name: name,
+      method: 'api_search',
+      cache_corroboration: ['cache_exact'],
+      candidate_count: 1,
+    });
+
+    it('sends POST to /api/v1/artists/resolve/bulk wrapping names in a {names} envelope', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await resolveArtistNamesBulk(['Wishy', "L'Rain"]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://lml.test:8000/api/v1/artists/resolve/bulk');
+      expect(init.method).toBe('POST');
+      const body = JSON.parse(init.body as string) as { names: string[]; dry_run?: boolean };
+      expect(body.names).toEqual(['Wishy', "L'Rain"]);
+      // dry_run stays off the wire unless explicitly requested.
+      expect(body.dry_run).toBeUndefined();
+    });
+
+    it('forwards dry_run: true onto the body when options.dryRun is set', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await resolveArtistNamesBulk(['Wishy'], { dryRun: true });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string) as { dry_run?: boolean };
+      expect(body.dry_run).toBe(true);
+    });
+
+    it('returns verdicts index-aligned with input, passing resolved + unresolved fields through', async () => {
+      const mockResponse = {
+        results: [
+          resolvedResult('Wishy', 7315154),
+          {
+            name: 'Some Co-Bill & Another',
+            cache_corroboration: [],
+            unresolved_reason: 'not_found',
+            candidate_count: 0,
+          },
+          {
+            name: 'Popsicle',
+            cache_corroboration: ['cache_exact', 'cache_trigram'],
+            unresolved_reason: 'ambiguous',
+            candidate_count: 2,
+          },
+          {
+            name: 'Never Asked',
+            cache_corroboration: [],
+            unresolved_reason: 'escalation_unavailable',
+            candidate_count: null,
+          },
+        ],
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as unknown as globalThis.Response);
+
+      const result = await resolveArtistNamesBulk(['Wishy', 'Some Co-Bill & Another', 'Popsicle', 'Never Asked']);
+
+      expect(result.results.map((r) => r.name)).toEqual(['Wishy', 'Some Co-Bill & Another', 'Popsicle', 'Never Asked']);
+      expect(result.results[0]).toMatchObject({ discogs_artist_id: 7315154, method: 'api_search', candidate_count: 1 });
+      expect(result.results[1]).toMatchObject({ unresolved_reason: 'not_found', candidate_count: 0 });
+      expect(result.results[2].unresolved_reason).toBe('ambiguous');
+      // escalation_unavailable carries candidate_count: null (not measured — never zero-as-unknown).
+      expect(result.results[3]).toMatchObject({ unresolved_reason: 'escalation_unavailable', candidate_count: null });
+    });
+
+    it('rejects empty names locally without hitting the wire', async () => {
+      await expect(resolveArtistNamesBulk([])).rejects.toThrow(/at least 1 name/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects oversize batches (> 25) locally without hitting the wire', async () => {
+      const names = Array.from({ length: ARTIST_RESOLVE_BATCH_CAP + 1 }, (_, i) => `Artist ${i}`);
+      await expect(resolveArtistNamesBulk(names)).rejects.toThrow(/cap of 25 names/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('exports ARTIST_RESOLVE_BATCH_CAP as the LML#759 hard contract value (25)', () => {
+      expect(ARTIST_RESOLVE_BATCH_CAP).toBe(25);
+    });
+
+    it('includes Authorization: Bearer <key> when LML_API_KEY is set', async () => {
+      process.env.LML_API_KEY = 'test-secret';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await resolveArtistNamesBulk(['Wishy']);
+
+      const headers = (mockFetch.mock.calls.at(-1)?.[1]?.headers ?? {}) as Record<string, string>;
+      expect(headers).toMatchObject({ Authorization: 'Bearer test-secret', 'Content-Type': 'application/json' });
+    });
+
+    it('consumes exactly one limiter token per batch (not one per name)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      // Same shape as the bulkLookupMetadata token-per-batch pin: a 25-name
+      // batch consuming 25 tokens would drain a small bucket; one token per
+      // batch keeps two back-to-back pages fast.
+      const limiter = createLmlLimiter({ maxConcurrent: 4, ratePerMinute: 60 });
+      const names = Array.from({ length: 25 }, (_, i) => `Artist ${i}`);
+
+      const start = Date.now();
+      await resolveArtistNamesBulk(names, { limiter });
+      await resolveArtistNamesBulk(names, { limiter });
+      const elapsed = Date.now() - start;
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it('wraps the call in a Sentry span (lml.artists.resolve.bulk / http.client) with bulk.size', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await resolveArtistNamesBulk(['Wishy', "L'Rain", '(Sandy) Alex G']);
+
+      expect(mockStartSpan).toHaveBeenCalledTimes(1);
+      expect(mockStartSpan.mock.calls[0][0]).toEqual({ name: 'lml.artists.resolve.bulk', op: 'http.client' });
+      expect(mockSpanSetAttributes).toHaveBeenCalledWith(expect.objectContaining({ 'lml.bulk.size': 3 }));
+    });
+
+    it('projects lml.caller onto the span when caller is provided', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await resolveArtistNamesBulk(['Wishy'], { caller: 'concerts-artist-lml-resolver' });
+
+      const callerCalls = mockSpanSetAttributes.mock.calls.filter(
+        (args) => (args[0] as Record<string, unknown>)?.['lml.caller'] === 'concerts-artist-lml-resolver'
+      );
+      expect(callerCalls).toHaveLength(1);
+    });
+
+    it("projects lml.caller='unknown' when caller is not provided (flag-of-shame)", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await resolveArtistNamesBulk(['Wishy']);
+
+      const callerCalls = mockSpanSetAttributes.mock.calls.filter(
+        (args) => (args[0] as Record<string, unknown>)?.['lml.caller'] === 'unknown'
+      );
+      expect(callerCalls).toHaveLength(1);
+    });
+
+    it('scales the default timeout with batch size (names.length × 5000 + 30000)', async () => {
+      // The API leg runs serially at the shared 50/min budget (~1.2s/name)
+      // plus retries. A fixed 30s default would misclassify a successful
+      // full-escalation batch as a transport timeout, so the budget must
+      // scale. 3 names → 3×5000 + 30000 = 45000 ms.
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await resolveArtistNamesBulk(['Wishy', "L'Rain", '(Sandy) Alex G']);
+
+      const scaledCalls = setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 45000);
+      expect(scaledCalls).toHaveLength(1);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('honors options.timeoutMs as a per-call override', async () => {
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await resolveArtistNamesBulk(['Wishy', "L'Rain"], { timeoutMs: 5000 });
+
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 5000)).toHaveLength(1);
+      // The scaled default (2×5000 + 30000 = 40000) must NOT be scheduled when overridden.
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 40000)).toHaveLength(0);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('throws LmlClientError on non-2xx response (e.g. 413 over-cap at the wire)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 413,
+        statusText: 'Payload Too Large',
+      } as unknown as globalThis.Response);
+
+      await expect(resolveArtistNamesBulk(['Wishy'])).rejects.toThrow(LmlClientError);
     });
   });
 

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -836,9 +836,24 @@ describe('lml.client', () => {
       const result = await resolveArtistNamesBulk(['Wishy', 'Some Co-Bill & Another', 'Popsicle', 'Never Asked']);
 
       expect(result.results.map((r) => r.name)).toEqual(['Wishy', 'Some Co-Bill & Another', 'Popsicle', 'Never Asked']);
-      expect(result.results[0]).toMatchObject({ discogs_artist_id: 7315154, method: 'api_search', candidate_count: 1 });
+      // Resolved verdict: every field survives the passthrough, incl. the two
+      // api_search-only fields (canonical_name, cache_corroboration) the wrapper
+      // must not drop if a future refactor ever introduces a projection step.
+      expect(result.results[0]).toMatchObject({
+        discogs_artist_id: 7315154,
+        canonical_name: 'Wishy',
+        method: 'api_search',
+        cache_corroboration: ['cache_exact'],
+        candidate_count: 1,
+      });
       expect(result.results[1]).toMatchObject({ unresolved_reason: 'not_found', candidate_count: 0 });
-      expect(result.results[2].unresolved_reason).toBe('ambiguous');
+      // Ambiguous verdict: corroboration legs (incl. a fuzzy cache_trigram
+      // neighbor) pass through alongside the reason and count.
+      expect(result.results[2]).toMatchObject({
+        unresolved_reason: 'ambiguous',
+        cache_corroboration: ['cache_exact', 'cache_trigram'],
+        candidate_count: 2,
+      });
       // escalation_unavailable carries candidate_count: null (not measured — never zero-as-unknown).
       expect(result.results[3]).toMatchObject({ unresolved_reason: 'escalation_unavailable', candidate_count: null });
     });
@@ -877,9 +892,13 @@ describe('lml.client', () => {
         json: () => Promise.resolve({ results: [] }),
       } as unknown as globalThis.Response);
 
-      // Same shape as the bulkLookupMetadata token-per-batch pin: a 25-name
-      // batch consuming 25 tokens would drain a small bucket; one token per
-      // batch keeps two back-to-back pages fast.
+      // The real pin here is the mockFetch call count (== 2, one HTTP request
+      // per batch): a regression that fanned out to one request+token PER NAME
+      // would fire 50 requests, not 2. The timing assertion is only a weak
+      // secondary — with a 60-token bucket even a hypothetical consume(25)-per-
+      // batch (25 + 25 = 50 ≤ 60) would not block, so `elapsed < 500` alone
+      // cannot distinguish per-batch from per-name token accounting. Same
+      // documented caveat as the bulkLookupMetadata token-per-batch test.
       const limiter = createLmlLimiter({ maxConcurrent: 4, ratePerMinute: 60 });
       const names = Array.from({ length: 25 }, (_, i) => `Artist ${i}`);
 
@@ -933,21 +952,27 @@ describe('lml.client', () => {
       expect(callerCalls).toHaveLength(1);
     });
 
-    it('scales the default timeout with batch size (names.length × 5000 + 30000)', async () => {
-      // The API leg runs serially at the shared 50/min budget (~1.2s/name)
-      // plus retries. A fixed 30s default would misclassify a successful
-      // full-escalation batch as a transport timeout, so the budget must
-      // scale. 3 names → 3×5000 + 30000 = 45000 ms.
+    // The API leg runs serially at the shared 50/min budget (~1.2s/name) plus
+    // retries. A fixed 30s default would misclassify a successful full-escalation
+    // batch as a transport timeout, so the budget scales: names.length × 5000 +
+    // 30000. The 1-name floor (35000) and the 25-name cap (155000) are the two
+    // boundaries the JSDoc advertises; the 3-name point (45000) pins the slope,
+    // so together they'd catch an operator-precedence slip like × (5000 + 30000).
+    it.each([
+      [1, 35000],
+      [3, 45000],
+      [ARTIST_RESOLVE_BATCH_CAP, 155000],
+    ])('scales the default timeout with batch size: %i names → %i ms', async (count, expectedMs) => {
       const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
       mockFetch.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ results: [] }),
       } as unknown as globalThis.Response);
 
-      await resolveArtistNamesBulk(['Wishy', "L'Rain", '(Sandy) Alex G']);
+      const names = Array.from({ length: count }, (_, i) => `Artist ${i}`);
+      await resolveArtistNamesBulk(names);
 
-      const scaledCalls = setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 45000);
-      expect(scaledCalls).toHaveLength(1);
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === expectedMs)).toHaveLength(1);
       setTimeoutSpy.mockRestore();
     });
 

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -817,6 +817,18 @@ describe('lml.client', () => {
     });
 
     it('returns verdicts index-aligned with input, passing resolved + unresolved fields through', async () => {
+      // An identity_store short-circuit: resolved, but the API tier never ran —
+      // so no canonical_name (identity rows store no title), empty
+      // cache_corroboration, and candidate_count: null. Distinct verdict shape
+      // from the api_search resolvedResult; pinned so a future projection can't
+      // silently mangle the identity_store branch.
+      const identityStoreResult: ArtistResolveResult = {
+        name: 'Cindy Lee',
+        discogs_artist_id: 4720512,
+        method: 'identity_store',
+        cache_corroboration: [],
+        candidate_count: null,
+      };
       const mockResponse = {
         results: [
           resolvedResult('Wishy', 7315154),
@@ -838,6 +850,7 @@ describe('lml.client', () => {
             unresolved_reason: 'escalation_unavailable',
             candidate_count: null,
           },
+          identityStoreResult,
         ],
       };
       mockFetch.mockResolvedValue({
@@ -845,9 +858,10 @@ describe('lml.client', () => {
         json: () => Promise.resolve(mockResponse),
       } as unknown as globalThis.Response);
 
-      const result = await resolveArtistNamesBulk(['Wishy', 'Some Co-Bill & Another', 'Popsicle', 'Never Asked']);
+      const names = ['Wishy', 'Some Co-Bill & Another', 'Popsicle', 'Never Asked', 'Cindy Lee'];
+      const result = await resolveArtistNamesBulk(names);
 
-      expect(result.results.map((r) => r.name)).toEqual(['Wishy', 'Some Co-Bill & Another', 'Popsicle', 'Never Asked']);
+      expect(result.results.map((r) => r.name)).toEqual(names);
       // Resolved verdict: every field survives the passthrough, incl. the two
       // api_search-only fields (canonical_name, cache_corroboration) the wrapper
       // must not drop if a future refactor ever introduces a projection step.
@@ -863,6 +877,8 @@ describe('lml.client', () => {
       });
       // escalation_unavailable carries candidate_count: null (not measured — never zero-as-unknown).
       expect(result.results[3]).toMatchObject({ unresolved_reason: 'escalation_unavailable', candidate_count: null });
+      // identity_store short-circuit survives whole (no canonical_name/reason added).
+      expect(result.results[4]).toEqual(identityStoreResult);
     });
 
     it('throws (502) when LML returns fewer results than names — the contract is positional', async () => {
@@ -891,6 +907,20 @@ describe('lml.client', () => {
       expect(err).toBeInstanceOf(LmlClientError);
       expect((err as LmlClientError).statusCode).toBe(502);
       expect((err as Error).message).toMatch(/non-array/);
+    });
+
+    it('throws (502 LmlClientError) when a 200 body is unparseable — not a raw SyntaxError', async () => {
+      // The JSDoc promises "all LmlClientError"; a non-JSON 200 (truncated
+      // stream / proxy HTML page) must not escape as a bare SyntaxError.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+      } as unknown as globalThis.Response);
+
+      const err = await resolveArtistNamesBulk(['Wishy']).catch((e) => e);
+      expect(err).toBeInstanceOf(LmlClientError);
+      expect((err as LmlClientError).statusCode).toBe(502);
+      expect((err as Error).message).toMatch(/unparseable body/);
     });
 
     it('rejects empty names locally without hitting the wire', async () => {


### PR DESCRIPTION
PR 2 of 3 for WXYC/Backend-Service#1614 (delivery plan recorded on the issue). Adds the `@wxyc/lml-client` wrapper for LML#759's bulk bare-name artist-resolution endpoint. **Does not close the issue** — PR 3 (migration + writer job) lands last and closes it.

## What

- **`resolveArtistNamesBulk(names, options?)` (new)** — wraps `POST /api/v1/artists/resolve/bulk` through the existing `lmlFetch` chokepoint (bearer merged there; no new auth plumbing). Returns one `ArtistResolveResult` per input name in input order.
- **Local wire types (new)** — `ArtistResolveResult`, `ArtistResolveBulkRequest`/`Response`, and the three enums (`ArtistResolveMethod`, `ArtistResolveCacheLeg`, `ArtistResolveUnresolvedReason`), plus `ARTIST_RESOLVE_BATCH_CAP = 25`. Defined directly above the function and exported from the module root — the same ramp-up pattern as `ReleaseIdentityResolveRequest` / `BulkCacheRefreshRequest`, keeping BS unblocked on the wxyc-shared#218 → publish → version-bump chain. They mirror the **merged** wxyc-shared#218 (`api.yaml` 1.18.0) contract exactly, including `candidate_count: number | null` (null = not measured, never zero) and required `cache_corroboration` on both verdict kinds.

## Wiring (mirrors `bulkLookupMetadata`)

- **One limiter token per batch, not per name** — LML paces its own serial Discogs fan-out; the BS limiter mirrors that shared ceiling. Default limiter unless `options.limiter`.
- **Batch-size-scaled timeout** — `names.length × 5000 + 30_000` (~35 s for 1 name, ~155 s at the 25 cap), overridable via `options.timeoutMs`. A fixed 30 s default (this endpoint's `/lookup` siblings) would misclassify a successful full-escalation batch as a transport timeout. Offline-only caller; a long socket is cheap.
- **Sentry span** `lml.artists.resolve.bulk` (`http.client`) with `lml.bulk.size` / `lml.queue_depth` / `lml.caller`. No `cache_stats` projection — this endpoint doesn't return the `/lookup` cache-counter block.
- **Client-side cap** — throw-before-wire on 0 and >25 names (a 400/413 round-trip costs an RTT for no information gain).
- `escalation_unavailable` is passed through verbatim as the retryable verdict; the no-match-TTL policy that consumes it lives in PR 3's writer job.

## Tests

New `resolveArtistNamesBulk` block in `tests/unit/services/lml.client.test.ts` (TDD, written red first): cap enforcement (0 / 26), `ARTIST_RESOLVE_BATCH_CAP === 25`, auth-header presence, `{names}` + `dry_run` body shape, token-per-batch, span name/op/`lml.bulk.size`/`lml.caller`, the batch-size-scaled default timeout + `timeoutMs` override, index-aligned verdict passthrough (resolved / not_found / ambiguous / escalation_unavailable with `candidate_count: null`), and 413 non-2xx mapping.

## Safety / CI

- Local gates green: `typecheck`, `lint` (0 errors), `format:check`, `test:unit` (285 suites / 4132 tests), and `@wxyc/lml-client` build (incl. `.d.ts`).
- Purely additive: a new unused export with no runtime wiring, so the Docker integration suite (runtime paths only) is unaffected.

## Merge gate

Per the plan, PR 2 is **authored early but merges only when LML#759 PR C (the live endpoint) is deployed** — the wrapper's wire contract needs the endpoint live before merge. The drain report + live drain gate PR 3, not this PR.

## Related

- WXYC/Backend-Service#1614 — parent epic (PR 1: #1617 merged; PR 3: migration + writer job, gated on the LML#759 drain report)
- WXYC/library-metadata-lookup#759 — the endpoint this wraps
- WXYC/wxyc-shared#218 — the merged wire contract (`api.yaml` 1.18.0) these local types mirror