### PR TITLE
fix(triangle-shows-etl): make splitSupportArtists array-tolerant (BS#1621)

### DIFF
--- a/jobs/triangle-shows-etl/map.ts
+++ b/jobs/triangle-shows-etl/map.ts
@@ -53,12 +53,14 @@ export type MappedEvent = {
   concert: Omit<NewConcert, 'venue_id' | 'scraped_at'>;
 };
 
-/** Split the source's single comma-joined string into the `text[]` shape
- *  `concerts.supporting_artists_raw` expects: trimmed, empties dropped. */
-export const splitSupportArtists = (raw: string | null): string[] =>
-  (raw ?? '')
-    .split(',')
-    .map((s) => s.trim())
+/** Normalize the source's support-artist field into the `text[]` shape
+ *  `concerts.supporting_artists_raw` expects: trimmed, empties dropped.
+ *  Accepts both the legacy single comma-joined string and the JSON array
+ *  the source flips to (WXYC/triangle-shows#39) — the feed is untrusted, so
+ *  a non-string array element is coerced away rather than crashing the ETL. */
+export const splitSupportArtists = (raw: string | string[] | null): string[] =>
+  (Array.isArray(raw) ? raw : (raw ?? '').split(','))
+    .map((s) => (typeof s === 'string' ? s.trim() : ''))
     .filter((s) => s.length > 0);
 
 /** numeric(8,2) tops out at 999999.99, and PG errors rather than

--- a/jobs/triangle-shows-etl/types.ts
+++ b/jobs/triangle-shows-etl/types.ts
@@ -26,8 +26,13 @@ export type TsEvent = {
    * and non-blank, falling back to the local heuristic (BS#1604).
    */
   headliner?: string | null;
-  /** Single comma-joined string at the source, not a list. */
-  support_artists: string | null;
+  /**
+   * Support-artist billing. Historically a single comma-joined string;
+   * WXYC/triangle-shows#39 flips it to a JSON array (lossless — a comma
+   * inside a name no longer corrupts). `splitSupportArtists` tolerates
+   * both shapes so the consumer can deploy ahead of the source flip.
+   */
+  support_artists: string | string[] | null;
   /** Venue-local calendar date, `YYYY-MM-DD`. */
   date: string;
   doors_time: string | null;

--- a/tests/unit/jobs/triangle-shows-etl/map.test.ts
+++ b/tests/unit/jobs/triangle-shows-etl/map.test.ts
@@ -365,6 +365,25 @@ describe('splitSupportArtists', () => {
     expect(splitSupportArtists(input)).toEqual(expected);
   });
 
+  it('passes an already-clean array through unchanged', () => {
+    expect(splitSupportArtists(['Stereolab', 'Cat Power'])).toEqual(['Stereolab', 'Cat Power']);
+  });
+
+  it('trims and drops empties in array input', () => {
+    expect(splitSupportArtists(['Nilüfer Yanya ', '', 'Hermanos Gutiérrez'])).toEqual([
+      'Nilüfer Yanya',
+      'Hermanos Gutiérrez',
+    ]);
+  });
+
+  it('drops non-string elements a malformed feed array could carry', () => {
+    // The feed is untrusted external JSON; a null slot must not crash the ETL.
+    expect(splitSupportArtists(['Juana Molina', null, 'Jessica Pratt'] as string[])).toEqual([
+      'Juana Molina',
+      'Jessica Pratt',
+    ]);
+  });
+
   it('is what mapEvent feeds supporting_artists_raw', () => {
     const mapped = mapEvent(makeTsEvent({ support_artists: 'Stereolab, Cat Power' }));
     expect(mapped.concert.supporting_artists_raw).toEqual(['Stereolab', 'Cat Power']);


### PR DESCRIPTION
Closes #1621.

## Problem

`jobs/triangle-shows-etl` reads `support_artists` as a comma-joined **string** and splits it in `splitSupportArtists`. WXYC/triangle-shows#39 flips that field to a JSON **array** (lossless multi-name capture — a comma inside a support name no longer corrupts). The instant that ships, `raw` is `["A","B"]` and `Array.prototype.split` does not exist → `TypeError: raw.split is not a function` → the ETL hard-throws on every `triangle_shows` event.

triangle-shows (Railway/Cloud Run) and Backend-Service (EC2) deploy independently, so the producer flip cannot be made atomic with a consumer change. The consumer must be made tolerant **first** — this PR does that.

## Change

`splitSupportArtists` now accepts `string | string[] | null`:

- **Array** → normalized (trim, drop empties) and passed through.
- **String** → comma-split exactly as before (byte-identical on today's production input).
- **Non-string array element** (e.g. a `null` slot) → coerced away rather than crashing, since the feed is untrusted external JSON. This closes the same crash class the ticket exists to prevent, one level down.

`types.ts` `support_artists` widened to `string | string[] | null` to match.

## Tests

Built test-first (red→green per behavior), each RED reproducing a real failure before the fix:

- `splitSupportArtists("A, B")` → `["A","B"]` — regression-asserted, existing string rows untouched.
- `["Stereolab","Cat Power"]` passes through; `["Nilüfer Yanya ", "", "Hermanos Gutiérrez"]` → `["Nilüfer Yanya","Hermanos Gutiérrez"]`.
- `["Juana Molina", null, "Jessica Pratt"]` → `["Juana Molina","Jessica Pratt"]` (malformed-feed hardening).
- `null` → `[]` (existing).

Local gate all green: `format:check`, `typecheck` (exit 0), `lint` (exit 0), and the full triangle-shows-etl unit suite (216/216).

## Deploy ordering

**This must merge and deploy before the triangle-shows array flip (PR-A under WXYC/triangle-shows#39).** It exists solely to make that deploy ordering safe.

## Related

- WXYC/triangle-shows#39 — the upstream flip this unblocks.
- #1618 — the junction capture that ultimately consumes the array; this shim keeps its ETL green through the transition.