### PR TITLE
fix(flowsheet): normalize the '' synthetic-match discogs_url sentinel to null on the read projection

### DIFF
--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -226,7 +226,13 @@ const FSEntryFieldsRaw = {
   // entries (album_id IS NULL) miss the join and fall through to the
   // inline flowsheet values.
   artwork_url: sql<string | null>`coalesce(${album_metadata.artwork_url}, ${flowsheet.artwork_url})`,
-  discogs_url: sql<string | null>`coalesce(${album_metadata.discogs_url}, ${flowsheet.discogs_url})`,
+  // discogs_url additionally NULLIFs the '' synthetic-match sentinel LML
+  // persists for streaming-only/artist-only matches (LML#401/#487) so it
+  // never reaches the wire (BS#1628). NULLIF wraps the COALESCE — an ''
+  // verdict in album_metadata stays authoritative over a stale inline URL
+  // rather than falling through to it. The persisted '' is deliberate
+  // (BS#1185 keys off it); only the projection normalizes.
+  discogs_url: sql<string | null>`nullif(coalesce(${album_metadata.discogs_url}, ${flowsheet.discogs_url}), '')`,
   release_year: sql<number | null>`coalesce(${album_metadata.release_year}, ${flowsheet.release_year})`,
   spotify_url: sql<string | null>`coalesce(${album_metadata.spotify_url}, ${flowsheet.spotify_url})`,
   apple_music_url: sql<string | null>`coalesce(${album_metadata.apple_music_url}, ${flowsheet.apple_music_url})`,

--- a/tests/integration/metadata.spec.js
+++ b/tests/integration/metadata.spec.js
@@ -572,6 +572,141 @@ describe('V2 flowsheet genres/styles projection (BS#1441)', () => {
   });
 });
 
+describe('discogs_url synthetic-match sentinel normalization (BS#1628)', () => {
+  // LML synthesizes `(release_id=0, release_url='')` results for streaming-only
+  // and artist-only matches (LML#401/#487), and the enrichment worker persists
+  // that `release_url` verbatim — so synthetic-match rows hold `discogs_url=''`
+  // on disk. That empty string is a deliberate persisted sentinel (BS#1185 keys
+  // off it); it must NOT reach the wire, where clients would render a dead
+  // Discogs link. The read projection normalizes it:
+  // `nullif(coalesce(album_metadata, flowsheet), '')` — coalesce first, so an
+  // `''` verdict in album_metadata stays authoritative over a stale inline
+  // flowsheet URL (Epic D semantics), then nullif for the wire.
+  //
+  // Real (non-empty) discogs_url passthrough is already pinned by the BS#897
+  // block above (SENTINEL.discogs_url asserted toEqual on the wire).
+  //
+  // As in the BS#897/BS#1441 blocks, force LML to 500 so the runtime
+  // fire-and-forget enrichment lands in the catch arm, which writes only the
+  // 3 synthesized search URLs — it can neither clobber the seeded
+  // album_metadata row (ON CONFLICT DO NOTHING) nor touch discogs_url on the
+  // flowsheet inline columns.
+
+  let sql;
+  let mockApiAvailable = false;
+  const SENTINEL_ALBUM_ID = 5; // real library.id; same hygiene as BS#897/BS#1441
+  const STALE_INLINE_URL = 'https://bs1628.example.com/stale-inline-discogs';
+  const SEEDED_ARTWORK_URL = 'https://bs1628.example.com/apple-probe-artwork.jpg';
+
+  beforeAll(async () => {
+    sql = makeSql();
+    mockApiAvailable = await isMockApiAvailable();
+  });
+
+  afterAll(async () => {
+    if (sql) await sql.end();
+  });
+
+  beforeEach(async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".album_metadata WHERE album_id = ${SENTINEL_ALBUM_ID}`);
+    if (mockApiAvailable) await resetMockApi();
+    await fls_util.join_show(getTestDjId(), global.secondary_access_token);
+  });
+
+  afterEach(async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".album_metadata WHERE album_id = ${SENTINEL_ALBUM_ID}`);
+    if (mockApiAvailable) await resetMockApi();
+    await fls_util.leave_show(getTestDjId(), global.secondary_access_token);
+  });
+
+  test("free-form row persisted with discogs_url='' projects null on the wire; disk keeps ''", async () => {
+    if (!mockApiAvailable) {
+      console.warn('Skipping: mock API server not available for LML failure simulation');
+      return;
+    }
+    await simulateError('lml', '/api/v1/lookup', 500);
+
+    // Free-form add (no album_id) — the read path's LEFT JOIN misses
+    // album_metadata and coalesce falls through to the inline columns.
+    const addRes = await request
+      .post('/flowsheet')
+      .set('Authorization', global.secondary_access_token)
+      .send({
+        artist_name: 'Chuquimamani-Condori',
+        album_title: 'Edits',
+        track_title: 'BS1628 synthetic sentinel track',
+      })
+      .expect(201);
+
+    // Stamp the worker's synthetic-match persist shape directly (the worker
+    // writes `artwork.release_url ?? null` and `''` passes `??` untouched).
+    // The catch-arm fire-and-forget only sets the 3 search URL columns, so
+    // this cannot be clobbered regardless of landing order.
+    await sql`
+      UPDATE ${sql(`${SCHEMA}.flowsheet`)}
+         SET discogs_url = '', metadata_status = 'enriched_match'
+       WHERE id = ${addRes.body.id}
+    `;
+
+    const getRes = await request.get('/flowsheet').query({ limit: 10 }).send().expect(200);
+    const entry = getRes.body.entries.find((e) => e.id === addRes.body.id);
+    expect(entry).toBeDefined();
+
+    // Wire: normalized to null — never the empty-string sentinel.
+    expect(entry.discogs_url).toBeNull();
+
+    // Disk: the persisted sentinel survives untouched — BS#1628 is
+    // read-path-only and must not mutate the stored column.
+    const rows = await sql`
+      SELECT discogs_url FROM ${sql(`${SCHEMA}.flowsheet`)} WHERE id = ${addRes.body.id}
+    `;
+    expect(rows[0].discogs_url).toBe('');
+  });
+
+  test("album_metadata discogs_url='' verdict projects null and masks a stale inline URL", async () => {
+    if (!mockApiAvailable) {
+      console.warn('Skipping: mock API server not available for LML failure simulation');
+      return;
+    }
+    await simulateError('lml', '/api/v1/lookup', 500);
+
+    // Seed the LML#487 synthetic shape: artwork found via the Apple probe,
+    // but no Discogs release — discogs_url holds the '' sentinel.
+    await sql`
+      INSERT INTO ${sql(`${SCHEMA}.album_metadata`)} (album_id, artwork_url, discogs_url)
+      VALUES (${SENTINEL_ALBUM_ID}, ${SEEDED_ARTWORK_URL}, '')
+    `;
+
+    const addRes = await request
+      .post('/flowsheet')
+      .set('Authorization', global.secondary_access_token)
+      .send({
+        album_id: SENTINEL_ALBUM_ID,
+        track_title: 'BS1628 linked sentinel track',
+      })
+      .expect(201);
+
+    // A stale real URL on the inline column (pre-D3 enrichment relic). The
+    // album_metadata '' verdict is newer and authoritative: coalesce picks it
+    // BEFORE nullif runs, so the wire shows null — not this stale URL.
+    await sql`
+      UPDATE ${sql(`${SCHEMA}.flowsheet`)}
+         SET discogs_url = ${STALE_INLINE_URL}
+       WHERE id = ${addRes.body.id}
+    `;
+
+    const getRes = await request.get('/flowsheet').query({ limit: 10 }).send().expect(200);
+    const entry = getRes.body.entries.find((e) => e.id === addRes.body.id);
+    expect(entry).toBeDefined();
+
+    // The join hit the seeded row (artwork projects), and the '' verdict
+    // normalized to null rather than falling through to the stale inline URL.
+    expect(entry.artwork_url).toEqual(SEEDED_ARTWORK_URL);
+    expect(entry.discogs_url).toBeNull();
+    expect(entry.discogs_url).not.toEqual(STALE_INLINE_URL);
+  });
+});
+
 describe('Metadata Service Initialization', () => {
   test('Backend healthcheck passes (metadata service initialized)', async () => {
     // Body conforms to HealthCheckResponse from @wxyc/shared (#804).


### PR DESCRIPTION
## Summary

The v2 `/flowsheet` response emitted `discogs_url: ""` for synthetic-artwork / artist-only matches (~9% of recent entries at capture time). LML synthesizes `(release_id=0, release_url="")` results for these matches (LML#401/#487), the enrichment worker persists that `release_url` verbatim (`''` passes `??` untouched), and the read projection's `coalesce(album_metadata.discogs_url, flowsheet.discogs_url)` only skips `NULL` — so the internal sentinel leaked onto the public contract, where truthiness-checking clients would render a dead Discogs link.

This wraps the projection in `NULLIF` at the wire boundary (`apps/backend/services/flowsheet.service.ts`, the single `FSEntryFieldsRaw` projection feeding all V1 + V2 flowsheet reads):

```ts
discogs_url: sql<string | null>`nullif(coalesce(${album_metadata.discogs_url}, ${flowsheet.discogs_url}), '')`,
```

### Design choice: NULLIF wraps the COALESCE

`nullif(coalesce(am, fs), '')` — not `coalesce(nullif(am,''), nullif(fs,''))`. An `''` verdict in `album_metadata` is the newer enrichment verdict and stays authoritative: it projects `null` rather than falling through to a stale pre-D3 inline flowsheet URL. This matches Epic D's album_metadata-wins semantics, and the second integration test pins it.

### Scope

Read-path only, per the ticket constraints: no migration, no write-path change, no persisted-state change. The stored `''` remains the deliberate cross-service synthetic-match sentinel (BS#1185 keys off it). This brings `/flowsheet` to parity with `/proxy/metadata/album`'s `buildLocalMetadataResponse`, which already gates on truthiness.

**Residual surfaces (out of scope, noting for the record):** the mutation echoes (`projectFlowsheetEntry`) and the CDC `liveFs:update` SSE broadcast (`pickClientFacingColumns`) project the raw row and can still carry `''` — e.g. an `updateEntry` echo on an already-enriched synthetic row, or the SSE event fired by the worker's own UPDATE. The GET feed (this PR) is the surface every client reconciles against. If those echoes should be normalized too, that's a small follow-up in `apps/backend/utils/flowsheet-projection.ts`.

## Tests

Two integration tests in `tests/integration/metadata.spec.js` (new BS#1628 block, modeled on the sibling BS#897/BS#1441 blocks):

- **Free-form row** persisted with `discogs_url=''` projects `null` on the wire while a direct SQL read confirms the disk still holds `''` (pins the read-path-only invariant).
- **Linked row** with an `album_metadata` `''` verdict projects `null` and masks a stale real inline URL; the seeded `artwork_url` proves the join hit the row (pins the NULLIF-wraps-COALESCE ordering).

Red→green verified: both tests fail with `Received: ""` on main's projection and pass with the fix.

## Local checks

- `typecheck`, `lint`, `format:check`: clean
- Unit: 4172/4172 across 287 suites
- Integration (full suite, fresh `ci:testmock`-equivalent env): 500 passed / 8 skipped / 2 failures, both confirmed flakes that pass on a fresh-env re-run — the documented BS#1613 `flowsheet-upcoming-show` scan-count planner variance, and a transient `requestLine` downstream-mock hiccup (neither touches this diff's paths)

Closes #1628