### PR TITLE
chore(gitignore): fix .DS_STORE casing so the pattern matches on case-sensitive filesystems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ coverage
 dist
 mirror-logs
 .env
-.DS_STORE
+.DS_Store
 .cache
 *.tsbuildinfo
 .claude/worktrees/


### PR DESCRIPTION
## Summary

Line 7 of `.gitignore` read `.DS_STORE` (all caps), which is not the real name of the macOS Finder metadata file (`.DS_Store`). It has only been matching because git sets `core.ignorecase=true` on macOS's case-insensitive filesystem — verified via `git check-ignore -v`. On any case-sensitive checkout (Linux, case-sensitive APFS) the pattern silently stops matching and Finder droppings surface as untracked files.

One-character fix: correct the entry's casing to `.DS_Store`.

No `.DS_Store` file is currently tracked (`git ls-files | grep -i ds_store` is empty), so no `git rm` companion is needed.