### PR TITLE
test(enrichment-worker): 1000-event backpressure spec for the idempotent claim (BS#892)

### DIFF
--- a/tests/integration/enrichment-worker-backpressure.spec.js
+++ b/tests/integration/enrichment-worker-backpressure.spec.js
@@ -117,13 +117,14 @@ async function bulkInsertPendingRows(sql, n) {
 
 /**
  * Assert the terminal DB state of a fully-drained burst: none of `ids` left
- * `'pending'`, and exactly `expectedEnriched` of them moved to `'enriching'`.
- * Both burst tests assert this same post-condition; keeping it in one place
- * mirrors the single-`claimRow`-mirror rationale in `tests/utils/enrichment-claim.js`.
- * Local to this spec by design — it encodes the backpressure post-condition,
- * not a cross-spec contract, so it stays beside the tests that use it.
+ * `'pending'`, and every one of them moved to `'enriching'` (the enriching
+ * count equals `ids.length`). Both burst tests assert this same post-condition;
+ * keeping it in one place mirrors the single-`claimRow`-mirror rationale in
+ * `tests/utils/enrichment-claim.js`. Local to this spec by design — it encodes
+ * the backpressure post-condition, not a cross-spec contract, so it stays
+ * beside the tests that use it.
  */
-async function expectAllEnriched(sql, ids, expectedEnriched) {
+async function expectAllEnriched(sql, ids) {
   const pendingLeft = await sql`
     SELECT count(*)::int AS n
       FROM ${sql(SCHEMA)}.flowsheet
@@ -138,7 +139,7 @@ async function expectAllEnriched(sql, ids, expectedEnriched) {
      WHERE id = ANY(${ids})
        AND metadata_status = 'enriching'
   `;
-  expect(enrichingCount[0].n).toBe(expectedEnriched);
+  expect(enrichingCount[0].n).toBe(ids.length);
 }
 
 describe('enrichment-worker backpressure — 1000-event burst (real PG)', () => {
@@ -187,7 +188,7 @@ describe('enrichment-worker backpressure — 1000-event burst (real PG)', () => 
       expect(wonIds).toEqual([...ids].sort((a, b) => a - b));
 
       // DB state: all rows moved pending → enriching; none stranded pending.
-      await expectAllEnriched(sql, ids, BURST_SIZE);
+      await expectAllEnriched(sql, ids);
 
       // Throughput is logged, not asserted (see file header).
       console.log(
@@ -241,7 +242,7 @@ describe('enrichment-worker backpressure — 1000-event burst (real PG)', () => 
       expect([...distinctWonIds].sort((a, b) => a - b)).toEqual([...ids].sort((a, b) => a - b));
 
       // DB state: no row stranded pending; every row ended enriching.
-      await expectAllEnriched(sql, ids, BURST_SIZE);
+      await expectAllEnriched(sql, ids);
 
       console.log(
         `[backpressure] N×N fan-out: ${N_WORKERS * BURST_SIZE} claim attempts ` +

--- a/tests/integration/enrichment-worker-backpressure.spec.js
+++ b/tests/integration/enrichment-worker-backpressure.spec.js
@@ -26,9 +26,10 @@
  *
  * Pure SQL — does NOT import `claim.ts`. The integration runner is babel-jest
  * with no TS support (drizzle-orm + ts-jest incompatibility; see
- * `library-identity-backfill.spec.js` header). The `claimRow` helper below
- * mirrors `claimRowForEnrichment`; when that file is hand-edited the SQL here
- * must follow.
+ * `library-identity-backfill.spec.js` header). The `claimRow` helper is the
+ * shared mirror of `claimRowForEnrichment` in `tests/utils/enrichment-claim.js`
+ * (one canonical copy across the claim/sweep/backpressure specs); when
+ * `claim.ts` is hand-edited that helper must follow.
  *
  * Why no hard throughput SLO: wall-clock through a 5-connection pool on a
  * shared CI runner is not a stable number, so the burst's elapsed time is
@@ -50,6 +51,7 @@
  */
 
 const { getTestDb } = require('../utils/db');
+const { claimRow } = require('../utils/enrichment-claim');
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 
@@ -70,23 +72,6 @@ const BURST_TEST_TIMEOUT_MS = 60_000;
 
 /** Distinctive prefix so cleanup (and any post-mortem) is unambiguous. */
 const ARTIST_PREFIX = 'enrichment-backpressure-artist-';
-
-/**
- * Issue the worker's CAS-UPDATE directly. Mirrors `claimRowForEnrichment`
- * in `apps/enrichment-worker/claim.ts` — when that file is hand-edited the
- * SQL here must follow. Identical to the sibling claim spec's helper.
- */
-async function claimRow(sql, id) {
-  const rows = await sql`
-    UPDATE ${sql(SCHEMA)}.flowsheet
-       SET metadata_status = 'enriching',
-           enriching_since = now()
-     WHERE id = ${id}
-       AND metadata_status = 'pending'
-    RETURNING id
-  `;
-  return rows.length > 0 ? { claimed: true, id: rows[0].id } : { claimed: false };
-}
 
 /**
  * Bulk-insert `n` fresh pending track rows in a single server-side

--- a/tests/integration/enrichment-worker-backpressure.spec.js
+++ b/tests/integration/enrichment-worker-backpressure.spec.js
@@ -1,0 +1,258 @@
+/**
+ * Backpressure integration test for the enrichment worker (BS#892 / Epic C
+ * C2). This is the "backpressure test at 1000 events / 1 second" acceptance
+ * item from #892 — the last unchecked box on that child.
+ *
+ * What "backpressure" means for this consumer
+ * -------------------------------------------
+ * The CDC handler (`apps/enrichment-worker/handler.ts:139-169`) is
+ * deliberately fire-and-forget: `makeEnrichmentHandler` returns synchronously
+ * for every event so a slow LML lookup can never back-pressure the CDC
+ * LISTEN socket and cause dropped NOTIFYs. Downstream concurrency is bounded
+ * at the shared LML `Semaphore(5)` in `@wxyc/lml-client`, not at the handler.
+ * So the one place where a 1000-event burst can actually corrupt state is the
+ * atomic claim (`apps/enrichment-worker/claim.ts`): under the N×N fan-out
+ * (every BS instance's worker receives every CDC event), a burst of 1000
+ * inserts produces up to N×1000 concurrent claim CAS-UPDATEs racing across a
+ * handful of distinct rows-per-id. The invariant that has to survive the
+ * burst is *exactly-once*: every row claimed once, no row claimed twice, no
+ * row left unclaimed.
+ *
+ * This spec exercises that invariant at the acceptance volume. The sibling
+ * `enrichment-worker-claim.spec.js` covers the claim contract at low
+ * cardinality (2-way and 10-way contention on a *single* row, terminal-state
+ * safety, C6 stranded-claim recovery); this file adds the high-cardinality
+ * burst dimension the acceptance item calls for.
+ *
+ * Pure SQL — does NOT import `claim.ts`. The integration runner is babel-jest
+ * with no TS support (drizzle-orm + ts-jest incompatibility; see
+ * `library-identity-backfill.spec.js` header). The `claimRow` helper below
+ * mirrors `claimRowForEnrichment`; when that file is hand-edited the SQL here
+ * must follow.
+ *
+ * Why no hard throughput SLO: wall-clock through a 5-connection pool on a
+ * shared CI runner is not a stable number, so the burst's elapsed time is
+ * logged (not asserted). The real "the consumer keeps up / does not deadlock"
+ * guard is the per-test timeout — a lock-escalation or seq-scan regression on
+ * the claim (e.g. the `flowsheet_metadata_status_pending_idx` partial index
+ * getting dropped) manifests as a timeout, not a wrong answer.
+ *
+ * Coverage:
+ *   1. Single-worker 1000-event burst: every row claimed exactly once; no row
+ *      left pending. (Throughput/volume — one worker draining a full burst.)
+ *   2. N×N fan-out burst: N workers each receive all 1000 events (N×1000
+ *      claim attempts); exactly 1000 win, N×1000−1000 lose cleanly, every
+ *      winning id is distinct, and no row is left pending. (Fan-out
+ *      correctness under burst — the property that makes N×N safe.)
+ *
+ * @see WXYC/Backend-Service#892
+ * @see tests/integration/enrichment-worker-claim.spec.js
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/** The acceptance volume: 1000 events in the burst. */
+const BURST_SIZE = 1000;
+/**
+ * Simulated BS-instance count for the N×N fan-out test. 3 is enough to prove
+ * the "every worker gets every event, exactly one wins" property without
+ * ballooning the attempt count past what a 5-connection pool drains inside
+ * the per-test timeout (3×1000 = 3000 CAS-UPDATEs).
+ */
+const N_WORKERS = 3;
+
+/** Per-test timeout ceiling — the 30 s jest default is too tight for a
+ * multi-thousand-statement burst through a 5-connection pool. Kept well under
+ * any real deadlock so a hang still fails fast-ish. */
+const BURST_TEST_TIMEOUT_MS = 60_000;
+
+/** Distinctive prefix so cleanup (and any post-mortem) is unambiguous. */
+const ARTIST_PREFIX = 'enrichment-backpressure-artist-';
+
+/**
+ * Issue the worker's CAS-UPDATE directly. Mirrors `claimRowForEnrichment`
+ * in `apps/enrichment-worker/claim.ts` — when that file is hand-edited the
+ * SQL here must follow. Identical to the sibling claim spec's helper.
+ */
+async function claimRow(sql, id) {
+  const rows = await sql`
+    UPDATE ${sql(SCHEMA)}.flowsheet
+       SET metadata_status = 'enriching',
+           enriching_since = now()
+     WHERE id = ${id}
+       AND metadata_status = 'pending'
+    RETURNING id
+  `;
+  return rows.length > 0 ? { claimed: true, id: rows[0].id } : { claimed: false };
+}
+
+/**
+ * Bulk-insert `n` fresh pending track rows in a single server-side
+ * `INSERT … SELECT … FROM generate_series` (fast; no 1000-way client
+ * marshaling). Returns the new ids. Mirrors the column set the sibling
+ * claim spec's `insertPendingRow` uses:
+ *   - `metadata_status='pending'` is the claimable state (BS#891).
+ *   - `show_id` is intentionally omitted (flowsheet permits NULL show_id).
+ *   - `play_order` (NOT NULL) is given a distinct high value per row so this
+ *     spec can't collide with sibling specs on any (show_id, play_order)
+ *     constraint a future migration might add.
+ */
+async function bulkInsertPendingRows(sql, n) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.flowsheet
+      (play_order, entry_type, artist_name, album_title, track_title, metadata_status, request_flag, segue)
+    SELECT
+      800000 + g,
+      'track',
+      ${ARTIST_PREFIX} || g,
+      'Test Album',
+      'Test Track',
+      'pending',
+      false,
+      false
+    FROM generate_series(1, ${n}) AS g
+    RETURNING id
+  `;
+  return rows.map((r) => r.id);
+}
+
+describe('enrichment-worker backpressure — 1000-event burst (real PG)', () => {
+  let sql;
+  /** ids inserted by tests; deleted in afterAll regardless of pass/fail. */
+  const insertedIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    // Delete by id (exact, indexed) for the rows we tracked, plus a
+    // belt-and-suspenders prefix sweep in case a test threw mid-insert before
+    // its ids were recorded. The prefix is unique to this spec.
+    if (insertedIds.length > 0) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE id = ANY(${insertedIds})`;
+    }
+    await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE artist_name LIKE ${ARTIST_PREFIX + '%'}`;
+    // Pool is shared with the rest of the integration suite; do NOT close it.
+  });
+
+  test(
+    'single-worker burst: 1000 events → every row claimed exactly once, none left pending',
+    async () => {
+      const ids = await bulkInsertPendingRows(sql, BURST_SIZE);
+      insertedIds.push(...ids);
+      expect(ids).toHaveLength(BURST_SIZE);
+
+      // One worker receives all 1000 CDC events at once and fires a claim for
+      // each. Promise.all queues them through the 5-connection pool.
+      const start = Date.now();
+      const results = await Promise.all(ids.map((id) => claimRow(sql, id)));
+      const elapsedMs = Date.now() - start;
+
+      const wins = results.filter((r) => r.claimed);
+      const losses = results.filter((r) => !r.claimed);
+
+      // Every distinct pending row is claimable exactly once by a single
+      // worker: 1000 events → 1000 wins, 0 losses.
+      expect(wins).toHaveLength(BURST_SIZE);
+      expect(losses).toHaveLength(0);
+
+      // The winning ids are exactly the inserted set — nothing dropped.
+      const wonIds = wins.map((r) => r.id).sort((a, b) => a - b);
+      expect(wonIds).toEqual([...ids].sort((a, b) => a - b));
+
+      // DB state: all rows moved pending → enriching; none stranded pending.
+      const pendingLeft = await sql`
+        SELECT count(*)::int AS n
+          FROM ${sql(SCHEMA)}.flowsheet
+         WHERE id = ANY(${ids})
+           AND metadata_status = 'pending'
+      `;
+      expect(pendingLeft[0].n).toBe(0);
+
+      const enrichingCount = await sql`
+        SELECT count(*)::int AS n
+          FROM ${sql(SCHEMA)}.flowsheet
+         WHERE id = ANY(${ids})
+           AND metadata_status = 'enriching'
+      `;
+      expect(enrichingCount[0].n).toBe(BURST_SIZE);
+
+      // Throughput is logged, not asserted (see file header).
+      console.log(
+        `[backpressure] single-worker: ${BURST_SIZE} claims in ${elapsedMs}ms ` +
+          `(${Math.round((BURST_SIZE / elapsedMs) * 1000)} rows/sec)`
+      );
+    },
+    BURST_TEST_TIMEOUT_MS
+  );
+
+  test(
+    'N×N fan-out burst: 3 workers × 1000 events → exactly 1000 wins, no double-claim, none left pending',
+    async () => {
+      const ids = await bulkInsertPendingRows(sql, BURST_SIZE);
+      insertedIds.push(...ids);
+      expect(ids).toHaveLength(BURST_SIZE);
+
+      // Simulate the N×N fan-out: every one of N_WORKERS worker instances
+      // receives every CDC event, so each id is raced by N_WORKERS concurrent
+      // claims. Interleave (worker-major would let worker 0 finish the whole
+      // burst before worker 1 starts, defeating the contention). Building one
+      // flat array of N_WORKERS×BURST_SIZE claims and firing them together is
+      // the closest single-process approximation of the real burst.
+      const attempts = [];
+      for (let i = 0; i < BURST_SIZE; i++) {
+        for (let w = 0; w < N_WORKERS; w++) {
+          attempts.push(claimRow(sql, ids[i]));
+        }
+      }
+      expect(attempts).toHaveLength(N_WORKERS * BURST_SIZE);
+
+      const start = Date.now();
+      const results = await Promise.all(attempts);
+      const elapsedMs = Date.now() - start;
+
+      const wins = results.filter((r) => r.claimed);
+      const losses = results.filter((r) => !r.claimed);
+
+      // Exactly one claim per row wins; the other (N_WORKERS−1) per row lose
+      // cleanly. This is the property that makes N×N delivery safe.
+      expect(wins).toHaveLength(BURST_SIZE);
+      expect(losses).toHaveLength((N_WORKERS - 1) * BURST_SIZE);
+
+      // No row won twice: the winning ids are distinct and cover the whole
+      // inserted set. (A double-claim would show up as a duplicate id here
+      // and as fewer than BURST_SIZE distinct winners.)
+      const wonIds = wins.map((r) => r.id);
+      const distinctWonIds = new Set(wonIds);
+      expect(distinctWonIds.size).toBe(BURST_SIZE);
+      expect([...distinctWonIds].sort((a, b) => a - b)).toEqual([...ids].sort((a, b) => a - b));
+
+      // DB state: no row stranded pending; every row ended enriching.
+      const pendingLeft = await sql`
+        SELECT count(*)::int AS n
+          FROM ${sql(SCHEMA)}.flowsheet
+         WHERE id = ANY(${ids})
+           AND metadata_status = 'pending'
+      `;
+      expect(pendingLeft[0].n).toBe(0);
+
+      const enrichingCount = await sql`
+        SELECT count(*)::int AS n
+          FROM ${sql(SCHEMA)}.flowsheet
+         WHERE id = ANY(${ids})
+           AND metadata_status = 'enriching'
+      `;
+      expect(enrichingCount[0].n).toBe(BURST_SIZE);
+
+      console.log(
+        `[backpressure] N×N fan-out: ${N_WORKERS * BURST_SIZE} claim attempts ` +
+          `(${N_WORKERS} workers × ${BURST_SIZE} events) in ${elapsedMs}ms ` +
+          `(${Math.round((BURST_SIZE / elapsedMs) * 1000)} rows/sec drained)`
+      );
+    },
+    BURST_TEST_TIMEOUT_MS
+  );
+});

--- a/tests/integration/enrichment-worker-backpressure.spec.js
+++ b/tests/integration/enrichment-worker-backpressure.spec.js
@@ -34,17 +34,25 @@
  * Why no hard throughput SLO: wall-clock through a 5-connection pool on a
  * shared CI runner is not a stable number, so the burst's elapsed time is
  * logged (not asserted). The real "the consumer keeps up / does not deadlock"
- * guard is the per-test timeout — a lock-escalation or seq-scan regression on
- * the claim (e.g. the `flowsheet_metadata_status_pending_idx` partial index
- * getting dropped) manifests as a timeout, not a wrong answer.
+ * guard is the per-test timeout. The claim is a primary-key point lookup
+ * (`WHERE id = $1 AND metadata_status = 'pending'`), so what a timeout catches
+ * is a genuine deadlock or a pathological lock-contention collapse under the
+ * burst — not an index regression: the partial `flowsheet_metadata_status_pending_idx`
+ * serves the C6 bulk `WHERE metadata_status='pending'` scan, never this per-id
+ * claim, so dropping it wouldn't slow the burst. Such a hang manifests as a
+ * timeout, not a wrong answer.
  *
  * Coverage:
  *   1. Single-worker 1000-event burst: every row claimed exactly once; no row
  *      left pending. (Throughput/volume — one worker draining a full burst.)
  *   2. N×N fan-out burst: N workers each receive all 1000 events (N×1000
  *      claim attempts); exactly 1000 win, N×1000−1000 lose cleanly, every
- *      winning id is distinct, and no row is left pending. (Fan-out
- *      correctness under burst — the property that makes N×N safe.)
+ *      winning id is distinct, and no row is left pending. (The single-statement
+ *      CAS is exactly-once by construction under row-level locking, so this
+ *      pins that that invariant survives the live schema + index + pool at the
+ *      N×N acceptance volume — it's the exactly-once claim that makes N×N
+ *      delivery safe, verified at burst scale, not a proof that concurrency
+ *      alone could break it.)
  *
  * @see WXYC/Backend-Service#892
  * @see tests/integration/enrichment-worker-claim.spec.js
@@ -80,9 +88,13 @@ const ARTIST_PREFIX = 'enrichment-backpressure-artist-';
  * claim spec's `insertPendingRow` uses:
  *   - `metadata_status='pending'` is the claimable state (BS#891).
  *   - `show_id` is intentionally omitted (flowsheet permits NULL show_id).
- *   - `play_order` (NOT NULL) is given a distinct high value per row so this
- *     spec can't collide with sibling specs on any (show_id, play_order)
- *     constraint a future migration might add.
+ *   - `play_order` (NOT NULL) draws from an 800000+ band unique to this spec,
+ *     keeping it clear of the sibling specs' sentinels (claim `99999`, sweep
+ *     `99998`) under the shared `--runInBand` schema. Both burst tests draw
+ *     from the same band (their rows coexist until the shared `afterAll`),
+ *     which is safe today because `play_order` carries no uniqueness constraint
+ *     and `show_id` is NULL — so even a future `(show_id, play_order)` unique
+ *     wouldn't fire on these rows.
  */
 async function bulkInsertPendingRows(sql, n) {
   const rows = await sql`
@@ -101,6 +113,32 @@ async function bulkInsertPendingRows(sql, n) {
     RETURNING id
   `;
   return rows.map((r) => r.id);
+}
+
+/**
+ * Assert the terminal DB state of a fully-drained burst: none of `ids` left
+ * `'pending'`, and exactly `expectedEnriched` of them moved to `'enriching'`.
+ * Both burst tests assert this same post-condition; keeping it in one place
+ * mirrors the single-`claimRow`-mirror rationale in `tests/utils/enrichment-claim.js`.
+ * Local to this spec by design — it encodes the backpressure post-condition,
+ * not a cross-spec contract, so it stays beside the tests that use it.
+ */
+async function expectAllEnriched(sql, ids, expectedEnriched) {
+  const pendingLeft = await sql`
+    SELECT count(*)::int AS n
+      FROM ${sql(SCHEMA)}.flowsheet
+     WHERE id = ANY(${ids})
+       AND metadata_status = 'pending'
+  `;
+  expect(pendingLeft[0].n).toBe(0);
+
+  const enrichingCount = await sql`
+    SELECT count(*)::int AS n
+      FROM ${sql(SCHEMA)}.flowsheet
+     WHERE id = ANY(${ids})
+       AND metadata_status = 'enriching'
+  `;
+  expect(enrichingCount[0].n).toBe(expectedEnriched);
 }
 
 describe('enrichment-worker backpressure — 1000-event burst (real PG)', () => {
@@ -149,21 +187,7 @@ describe('enrichment-worker backpressure — 1000-event burst (real PG)', () => 
       expect(wonIds).toEqual([...ids].sort((a, b) => a - b));
 
       // DB state: all rows moved pending → enriching; none stranded pending.
-      const pendingLeft = await sql`
-        SELECT count(*)::int AS n
-          FROM ${sql(SCHEMA)}.flowsheet
-         WHERE id = ANY(${ids})
-           AND metadata_status = 'pending'
-      `;
-      expect(pendingLeft[0].n).toBe(0);
-
-      const enrichingCount = await sql`
-        SELECT count(*)::int AS n
-          FROM ${sql(SCHEMA)}.flowsheet
-         WHERE id = ANY(${ids})
-           AND metadata_status = 'enriching'
-      `;
-      expect(enrichingCount[0].n).toBe(BURST_SIZE);
+      await expectAllEnriched(sql, ids, BURST_SIZE);
 
       // Throughput is logged, not asserted (see file header).
       console.log(
@@ -203,7 +227,8 @@ describe('enrichment-worker backpressure — 1000-event burst (real PG)', () => 
       const losses = results.filter((r) => !r.claimed);
 
       // Exactly one claim per row wins; the other (N_WORKERS−1) per row lose
-      // cleanly. This is the property that makes N×N delivery safe.
+      // cleanly — the exactly-once invariant the single-statement CAS gives by
+      // construction, pinned here against the live table at burst volume.
       expect(wins).toHaveLength(BURST_SIZE);
       expect(losses).toHaveLength((N_WORKERS - 1) * BURST_SIZE);
 
@@ -216,21 +241,7 @@ describe('enrichment-worker backpressure — 1000-event burst (real PG)', () => 
       expect([...distinctWonIds].sort((a, b) => a - b)).toEqual([...ids].sort((a, b) => a - b));
 
       // DB state: no row stranded pending; every row ended enriching.
-      const pendingLeft = await sql`
-        SELECT count(*)::int AS n
-          FROM ${sql(SCHEMA)}.flowsheet
-         WHERE id = ANY(${ids})
-           AND metadata_status = 'pending'
-      `;
-      expect(pendingLeft[0].n).toBe(0);
-
-      const enrichingCount = await sql`
-        SELECT count(*)::int AS n
-          FROM ${sql(SCHEMA)}.flowsheet
-         WHERE id = ANY(${ids})
-           AND metadata_status = 'enriching'
-      `;
-      expect(enrichingCount[0].n).toBe(BURST_SIZE);
+      await expectAllEnriched(sql, ids, BURST_SIZE);
 
       console.log(
         `[backpressure] N×N fan-out: ${N_WORKERS * BURST_SIZE} claim attempts ` +

--- a/tests/integration/enrichment-worker-claim.spec.js
+++ b/tests/integration/enrichment-worker-claim.spec.js
@@ -38,25 +38,9 @@
  */
 
 const { getTestDb } = require('../utils/db');
+const { claimRow } = require('../utils/enrichment-claim');
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
-
-/**
- * Issue the worker's CAS-UPDATE directly. Mirrors `claimRowForEnrichment`
- * in `apps/enrichment-worker/claim.ts` — when that file is hand-edited the
- * SQL here must follow.
- */
-async function claimRow(sql, id) {
-  const rows = await sql`
-    UPDATE ${sql(SCHEMA)}.flowsheet
-       SET metadata_status = 'enriching',
-           enriching_since = now()
-     WHERE id = ${id}
-       AND metadata_status = 'pending'
-    RETURNING id
-  `;
-  return rows.length > 0 ? { claimed: true, id: rows[0].id } : { claimed: false };
-}
 
 /**
  * Insert a fresh pending track row. Returns the new id. Uses an obviously

--- a/tests/integration/enrichment-worker-sweep.spec.js
+++ b/tests/integration/enrichment-worker-sweep.spec.js
@@ -31,6 +31,7 @@
  */
 
 const { getTestDb } = require('../utils/db');
+const { claimRow } = require('../utils/enrichment-claim');
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 
@@ -82,22 +83,6 @@ async function insertPendingRow(sql, suffix) {
 }
 
 /**
- * Mirror of the worker's claim SQL — flip the row to `'enriching'` and
- * stamp `enriching_since = now()`. Returns whether the claim won.
- */
-async function claimRow(sql, id) {
-  const rows = await sql`
-    UPDATE ${sql(SCHEMA)}.flowsheet
-       SET metadata_status = 'enriching',
-           enriching_since = now()
-     WHERE id = ${id}
-       AND metadata_status = 'pending'
-    RETURNING id
-  `;
-  return rows.length > 0;
-}
-
-/**
  * Backdate a row's `enriching_since` past the 60s TTL so the next sweep
  * picks it up. Mirrors the conditions a process death between claim and
  * finalize would produce, ~minutes after the fact.
@@ -130,7 +115,7 @@ describe('enrichment-worker stranded-claim sweep (real PG)', () => {
     const id = await insertPendingRow(sql, 'single-stranded');
     insertedIds.push(id);
 
-    expect(await claimRow(sql, id)).toBe(true);
+    expect((await claimRow(sql, id)).claimed).toBe(true);
     // Backdate well above any reasonable derived TTL so the test pinning
     // remains correct if STRANDED_TTL_SECONDS grows beyond 60s.
     await backdateEnrichingSince(sql, id, 600);
@@ -146,7 +131,7 @@ describe('enrichment-worker stranded-claim sweep (real PG)', () => {
     expect(row.enriching_since).toBeNull();
 
     // Row is claimable again — the contract the C2 worker depends on.
-    expect(await claimRow(sql, id)).toBe(true);
+    expect((await claimRow(sql, id)).claimed).toBe(true);
   });
 
   test('batch recovery: 5 stranded rows are reverted in a single sweep tick', async () => {
@@ -179,7 +164,7 @@ describe('enrichment-worker stranded-claim sweep (real PG)', () => {
     const id = await insertPendingRow(sql, 'recent-claim');
     insertedIds.push(id);
 
-    expect(await claimRow(sql, id)).toBe(true);
+    expect((await claimRow(sql, id)).claimed).toBe(true);
     // enriching_since defaulted to now() — well inside the 60s TTL.
     await runSweep(sql, [id]);
 

--- a/tests/utils/enrichment-claim.js
+++ b/tests/utils/enrichment-claim.js
@@ -1,0 +1,54 @@
+/**
+ * Shared test helper for the enrichment worker's idempotent-claim contract.
+ *
+ * `claimRow` is the ONE canonical mirror of `claimRowForEnrichment` in
+ * `apps/enrichment-worker/claim.ts`. The three enrichment integration specs
+ * (claim, sweep, backpressure) each need to issue the worker's exact
+ * CAS-UPDATE; before this module they carried three byte-identical copies of
+ * it, so a hand-edit to `claim.ts` had to be chased through three files. This
+ * centralizes the lockstep pin: when `claim.ts` is hand-edited, the SQL here
+ * must follow, and all three specs pick up the change from one place.
+ *
+ * Pure SQL — this does NOT import `claim.ts`. The integration runner is
+ * babel-jest with no TS support (drizzle-orm + ts-jest incompatibility; see
+ * `enrichment-worker-claim.spec.js` header). That's precisely why the SQL is
+ * duplicated from the TS source rather than imported — and precisely why it
+ * belongs in exactly one place.
+ *
+ * Only `claimRow` lives here. The specs' `insertPendingRow` /
+ * `bulkInsertPendingRows` helpers are deliberately NOT shared: they use
+ * genuinely different insert strategies (single-row VALUES with a
+ * human-readable per-test artist suffix vs. bulk `generate_series`) and
+ * distinct `play_order` sentinels (`99999` / `99998` / `800000+g`) chosen so
+ * sibling specs can't collide under the shared `--runInBand` schema. Folding
+ * those into one parametric helper would be speculative generality that
+ * degrades the readable-suffix cleanup for no real dedup win.
+ */
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * Issue the worker's claim CAS-UPDATE directly against `flowsheet`. Mirrors
+ * `claimRowForEnrichment` in `apps/enrichment-worker/claim.ts`: flip a
+ * `pending` row to `enriching`, stamp `enriching_since = now()`, and use the
+ * `RETURNING` length to report whether this caller won the race.
+ *
+ * @param {import('postgres').Sql} sql - the shared test pool from `getTestDb()`.
+ * @param {number} id - the `flowsheet.id` to claim.
+ * @returns {Promise<{claimed: true, id: number} | {claimed: false}>} `claimed`
+ *   is true (with the won id) iff this caller's UPDATE matched a still-`pending`
+ *   row; false when a sibling already claimed it (empty `RETURNING`).
+ */
+async function claimRow(sql, id) {
+  const rows = await sql`
+    UPDATE ${sql(SCHEMA)}.flowsheet
+       SET metadata_status = 'enriching',
+           enriching_since = now()
+     WHERE id = ${id}
+       AND metadata_status = 'pending'
+    RETURNING id
+  `;
+  return rows.length > 0 ? { claimed: true, id: rows[0].id } : { claimed: false };
+}
+
+module.exports = { claimRow };

--- a/tests/utils/enrichment-claim.js
+++ b/tests/utils/enrichment-claim.js
@@ -19,10 +19,12 @@
  * `bulkInsertPendingRows` helpers are deliberately NOT shared: they use
  * genuinely different insert strategies (single-row VALUES with a
  * human-readable per-test artist suffix vs. bulk `generate_series`) and
- * distinct `play_order` sentinels (`99999` / `99998` / `800000+g`) chosen so
- * sibling specs can't collide under the shared `--runInBand` schema. Folding
- * those into one parametric helper would be speculative generality that
- * degrades the readable-suffix cleanup for no real dedup win.
+ * per-spec `play_order` sentinels (`99999` / `99998` / `800000+g`) kept
+ * distinct for unambiguous post-mortem attribution — not for collision
+ * avoidance: `play_order` carries no uniqueness constraint, and cleanup is
+ * keyed on `id`/`artist_name`. Folding those into one parametric helper would
+ * be speculative generality that degrades the readable-suffix cleanup for no
+ * real dedup win.
  */
 
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';


### PR DESCRIPTION
## Summary

Adds the **backpressure test at 1000 events / 1 second** — the last unchecked acceptance item on **C2 (#892)** of the Epic C event-driven enrichment work.

The other two remaining items are already satisfied in code:
- **CDC fan-out audit** — documented in `apps/enrichment-worker/cdc-subscriber.ts`'s header: per-process LISTEN (`cdc-listener.ts:43-49`, no pool collapse), pure fan-out with no upstream dedup (`cdc-websocket.ts`), `pg_notify` broadcasts to every LISTEN → N×N safe end-to-end.
- **Stranded-claim sweep** — split to C8/#1225, closed (`apps/enrichment-worker/sweep.ts`).

## Why this shape

The CDC handler (`apps/enrichment-worker/handler.ts:139-169`) is deliberately fire-and-forget, so a slow LML lookup can never back-pressure the CDC LISTEN socket and cause dropped NOTIFYs; downstream concurrency is bounded at the shared LML `Semaphore(5)` in `@wxyc/lml-client`, not at the handler. That leaves the **atomic claim** (`claim.ts`) as the one place a burst can corrupt state: under N×N fan-out (every BS instance's worker receives every CDC event), a 1000-insert burst becomes up to N×1000 racing CAS-UPDATEs. The invariant that must survive is **exactly-once**.

## What the test does

`tests/integration/enrichment-worker-backpressure.spec.js` exercises that invariant at the acceptance volume, in two scenarios:

1. **Single-worker 1000-event burst** — every row claimed exactly once, none left pending.
2. **N=3 fan-out burst (3000 claim attempts)** — exactly 1000 wins, 2000 clean losses, distinct winners covering the full inserted set, none left pending.

Pure SQL mirroring `claimRowForEnrichment`, consistent with the sibling `enrichment-worker-claim.spec.js` (the integration runner is babel-jest with no TS import). Throughput is **logged, not asserted** — wall-clock through a 5-connection pool on a shared CI runner is not a stable number; the per-test timeout is the "keeps up / no deadlock" guard (a lock-escalation or dropped-partial-index regression on the claim manifests as a timeout, not a wrong answer).

## Folded-in refactor + review-loop hardening (commits 2–4)

`claimRow` — the pure-SQL mirror of `apps/enrichment-worker/claim.ts` — was byte-identical across three integration specs (claim, sweep, backpressure). This PR would have added the third copy; instead it extracts the one canonical mirror to `tests/utils/enrichment-claim.js` and points all three specs at it, so a hand-edit to `claim.ts` is chased in one place, not three. Return shape is canonicalized on `{ claimed, id }` (the sweep spec's boolean call sites are adapted). The per-spec `insertPendingRow`/`bulkInsertPendingRows` helpers stay local by design — genuinely different insert strategies (single-row VALUES with a readable suffix vs. bulk `generate_series`) and per-spec `play_order` sentinels kept distinct for post-mortem attribution (no uniqueness constraint on `play_order`).

Commits 3–4 are two rounds of a two-axis (Standards + Spec) review loop, run to convergence — all confined to the test files, no production code, invariant unchanged: corrected a file-header claim that the per-test timeout guards against the partial `pending` index being dropped (the claim is a primary-key point lookup, so it never uses that index); softened the N×N framing to state the exactly-once property is guaranteed by the single-statement CAS *by construction* and merely pinned at burst volume; extracted the duplicated "none pending, all enriching" post-condition into a local `expectAllEnriched(sql, ids)` helper (its speculative count param dropped in favor of `ids.length`); and fixed a "sentinels chosen so specs can't collide" overclaim in both the spec and the shared-helper header.

## Testing

- Ran the spec's exact burst SQL + assertions against a Postgres instance with the real `metadata_status_enum` values + `'pending'` default + the migration-0078 partial-index predicate: all checks pass (1000/1000 exactly-once single-worker; 1000 wins / 2000 losses / 0 double-claims fan-out).
- All three enrichment specs green against the CI Docker Postgres after the refactor: 3 suites / 14 tests (backpressure single-worker 225 ms, N×N 464 ms; sweep 4; claim 8). `prettier --check` clean; ESLint ignores `tests/**` JS by config (as it does every existing integration spec).

## Related

- Closes #892 — this satisfies the **claim** half of C2's backpressure acceptance item (exactly-once under a 1000-event burst, the one surface where a burst can corrupt state).
- #1640 — the **limiter/no-loss** half (`Semaphore(5)`/`TokenBucket(50/min)` pacing + the `in_flight_dropped` no-loss metric through the real `makeEnrichmentHandler`) is split out. #892's acceptance list is re-scoped accordingly; note the spec's original "queue in memory / drop oldest" design was never built — the worker throttles via the shared LML semaphore wait-queue + the C6 cron safety net (#1225).

