### PR TITLE
fix(flowsheet-linked-reenrichment): run post-lane ANALYZE under a raised statement_timeout

### DIFF
--- a/jobs/flowsheet-linked-reenrichment/README.md
+++ b/jobs/flowsheet-linked-reenrichment/README.md
@@ -83,18 +83,19 @@ DROP INDEX CONCURRENTLY IF EXISTS wxyc_schema.flowsheet_linked_reenrichment_idx;
 
 ## Environment variables
 
-| Var                                 | Default  | Purpose                                                      |
-| ----------------------------------- | -------- | ------------------------------------------------------------ |
-| `LINKED_REENRICH_BULK_BATCH_SIZE`   | `5`      | Items per Lane B bulk-lookup request (LML cap 100).          |
-| `LINKED_REENRICH_BULK_RATE_PER_MIN` | `1`      | Lane B batches per minute.                                   |
-| `LINKED_REENRICH_BULK_BUDGET_MS`    | `25000`  | Per-item LML `X-Caller-Budget-Ms`.                           |
-| `LINKED_REENRICH_FLIP_BATCH_SIZE`   | `5000`   | Rows per flip UPDATE transaction.                            |
-| `LINKED_REENRICH_FLIP_TIMEOUT_MS`   | `300000` | Statement timeout per flip batch.                            |
-| `LINKED_REENRICH_READ_TIMEOUT_MS`   | `300000` | Statement timeout for count/enumerate/resolve SELECTs.       |
-| `LINKED_REENRICH_ALBUM_AFTER_ID`    | `0`      | Lane B resume cursor.                                        |
-| `LIVE_ACTIVITY_LOOKBACK_SECONDS`    | `300`    | Cooperative-pause lookback; `0` disables.                    |
-| `LIBRARY_METADATA_URL`              | —        | LML base URL. Required for `--execute` (Lane B).             |
-| `DB_*`, `SENTRY_*`                  | —        | Standard DB + observability config (see `docs/env-vars.md`). |
+| Var                                  | Default  | Purpose                                                                                                                                                     |
+| ------------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LINKED_REENRICH_BULK_BATCH_SIZE`    | `5`      | Items per Lane B bulk-lookup request (LML cap 100).                                                                                                         |
+| `LINKED_REENRICH_BULK_RATE_PER_MIN`  | `1`      | Lane B batches per minute.                                                                                                                                  |
+| `LINKED_REENRICH_BULK_BUDGET_MS`     | `25000`  | Per-item LML `X-Caller-Budget-Ms`.                                                                                                                          |
+| `LINKED_REENRICH_FLIP_BATCH_SIZE`    | `5000`   | Rows per flip UPDATE transaction.                                                                                                                           |
+| `LINKED_REENRICH_FLIP_TIMEOUT_MS`    | `300000` | Statement timeout per flip batch.                                                                                                                           |
+| `LINKED_REENRICH_READ_TIMEOUT_MS`    | `300000` | Statement timeout for count/enumerate/resolve SELECTs.                                                                                                      |
+| `LINKED_REENRICH_ANALYZE_TIMEOUT_MS` | `300000` | Statement timeout for the post-lane `ANALYZE` (own raised-timeout tx; the 5s connection default cancels ANALYZE on the 2.6M-row flowsheet — BS#1638 run 1). |
+| `LINKED_REENRICH_ALBUM_AFTER_ID`     | `0`      | Lane B resume cursor.                                                                                                                                       |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`     | `300`    | Cooperative-pause lookback; `0` disables.                                                                                                                   |
+| `LIBRARY_METADATA_URL`               | —        | LML base URL. Required for `--execute` (Lane B).                                                                                                            |
+| `DB_*`, `SENTRY_*`                   | —        | Standard DB + observability config (see `docs/env-vars.md`).                                                                                                |
 
 ## References
 

--- a/jobs/flowsheet-linked-reenrichment/job.ts
+++ b/jobs/flowsheet-linked-reenrichment/job.ts
@@ -54,7 +54,7 @@
  * (out-of-band partial index pre-flight, off-peak window, resume knobs).
  */
 
-import { sql } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import {
   album_metadata,
   db,
@@ -111,6 +111,12 @@ export const FLIP_TIMEOUT_DEFAULT = 5 * 60 * 1000;
  * margin even if that pre-flight was skipped and the scan degrades. */
 export const READ_TIMEOUT_ENV = 'LINKED_REENRICH_READ_TIMEOUT_MS';
 export const READ_TIMEOUT_DEFAULT = 5 * 60 * 1000;
+
+/** Statement timeout for the post-lane ANALYZE. Runs in its own raised-timeout
+ * transaction because ANALYZE on the 2.6M-row flowsheet exceeds the 5s
+ * connection default (BS#1638 prod run 1 aborted here). 5min is a wide margin. */
+export const ANALYZE_TIMEOUT_ENV = 'LINKED_REENRICH_ANALYZE_TIMEOUT_MS';
+export const ANALYZE_TIMEOUT_DEFAULT = 5 * 60 * 1000;
 
 /** Resume cursor for Lane B's residual-album enumeration. The summary log's
  * `last_album_id` carries the value to resume a stopped run from. Lane A's
@@ -391,15 +397,41 @@ export const awaitQuietWindow = async (lookbackSeconds: number, pauseMs: number)
 
 // -- ANALYZE -----------------------------------------------------------------
 
-export const analyzeFlowsheet = async (): Promise<void> => {
-  log('info', 'analyze_started', 'ANALYZE flowsheet');
-  await db.execute(sql`ANALYZE "wxyc_schema"."flowsheet"`);
+/**
+ * Run an ANALYZE inside a transaction that raises `statement_timeout` off the
+ * @wxyc/database 5s connection default (same wrapper the flip batches use).
+ * ANALYZE on the 2.6M-row `flowsheet` runs well past 5s, so on the raw
+ * connection it is cancelled — which aborted the whole job after Lane A on
+ * BS#1638 prod run 1. A stats refresh is an optimization, not correctness, so
+ * a failure here is swallowed (logged + Sentry) rather than allowed to abort a
+ * data lane that already committed. ANALYZE is permitted inside a transaction
+ * block (unlike VACUUM).
+ */
+const runAnalyze = async (
+  table: 'flowsheet' | 'album_metadata',
+  analyzeStmt: SQL,
+  timeoutMs: number
+): Promise<void> => {
+  log('info', 'analyze_started', `ANALYZE ${table}`);
+  try {
+    await db.transaction(async (tx) => {
+      await tx.execute(sql.raw(`SET LOCAL statement_timeout = '${timeoutMs}ms'`));
+      await tx.execute(analyzeStmt);
+    });
+  } catch (err) {
+    log('warn', 'analyze_failed', `ANALYZE ${table} failed (non-fatal)`, {
+      table,
+      error_message: err instanceof Error ? err.message : String(err),
+    });
+    captureError(err, 'analyze_failed', { table });
+  }
 };
 
-export const analyzeAlbumMetadata = async (): Promise<void> => {
-  log('info', 'analyze_started', 'ANALYZE album_metadata');
-  await db.execute(sql`ANALYZE "wxyc_schema"."album_metadata"`);
-};
+export const analyzeFlowsheet = (timeoutMs: number = ANALYZE_TIMEOUT_DEFAULT): Promise<void> =>
+  runAnalyze('flowsheet', sql`ANALYZE "wxyc_schema"."flowsheet"`, timeoutMs);
+
+export const analyzeAlbumMetadata = (timeoutMs: number = ANALYZE_TIMEOUT_DEFAULT): Promise<void> =>
+  runAnalyze('album_metadata', sql`ANALYZE "wxyc_schema"."album_metadata"`, timeoutMs);
 
 // -- Lane B: per-batch orchestration -----------------------------------------
 
@@ -593,6 +625,7 @@ export interface ReenrichmentOptions {
   flipBatchSize: number;
   flipTimeoutMs: number;
   readTimeoutMs: number;
+  analyzeTimeoutMs: number;
   albumAfterId: number;
   liveActivityLookbackSeconds: number;
   liveActivityPauseMs: number;
@@ -623,6 +656,7 @@ export const resolveOptions = (
     flipBatchSize: requirePositiveInt(env[FLIP_BATCH_SIZE_ENV], FLIP_BATCH_SIZE_ENV, FLIP_BATCH_SIZE_DEFAULT, ctx),
     flipTimeoutMs: requirePositiveInt(env[FLIP_TIMEOUT_ENV], FLIP_TIMEOUT_ENV, FLIP_TIMEOUT_DEFAULT, ctx),
     readTimeoutMs: requirePositiveInt(env[READ_TIMEOUT_ENV], READ_TIMEOUT_ENV, READ_TIMEOUT_DEFAULT, ctx),
+    analyzeTimeoutMs: requirePositiveInt(env[ANALYZE_TIMEOUT_ENV], ANALYZE_TIMEOUT_ENV, ANALYZE_TIMEOUT_DEFAULT, ctx),
     albumAfterId: requireNonNegativeInt(env[ALBUM_AFTER_ID_ENV], ALBUM_AFTER_ID_ENV, 0, {
       ...ctx,
       note: 'Resume cursor — the summary log of the previous run carries last_album_id.',
@@ -685,7 +719,7 @@ export const runReenrichment = async (options: ReenrichmentOptions): Promise<Ree
       options.liveActivityLookbackSeconds,
       options.liveActivityPauseMs
     );
-    if (summary.lane_a_flipped > 0) await analyzeFlowsheet();
+    if (summary.lane_a_flipped > 0) await analyzeFlowsheet(options.analyzeTimeoutMs);
   }
 
   // ---- Lane B: LML re-lookup for the residual albums ----------------------
@@ -753,7 +787,7 @@ export const runReenrichment = async (options: ReenrichmentOptions): Promise<Ree
   // Lane A; because Lane A already flipped the pre-populated albums, this
   // pass touches only Lane B's new matches.
   if (summary.upserts > 0) {
-    await analyzeAlbumMetadata();
+    await analyzeAlbumMetadata(options.analyzeTimeoutMs);
     // Scope-verifying SELECT before the Lane B UPDATE lane (spec: "Run the
     // scope-verifying SELECT before each UPDATE lane"), mirroring Lane A's
     // pre-flip count. After the ANALYZE above, the still-`enriched_no_match`
@@ -771,7 +805,7 @@ export const runReenrichment = async (options: ReenrichmentOptions): Promise<Ree
       options.liveActivityLookbackSeconds,
       options.liveActivityPauseMs
     );
-    if (summary.lane_b_flipped > 0) await analyzeFlowsheet();
+    if (summary.lane_b_flipped > 0) await analyzeFlowsheet(options.analyzeTimeoutMs);
   }
 
   summary.flipped_from_album_metadata = summary.lane_a_flipped + summary.lane_b_flipped;

--- a/tests/unit/jobs/flowsheet-linked-reenrichment/job.test.ts
+++ b/tests/unit/jobs/flowsheet-linked-reenrichment/job.test.ts
@@ -400,13 +400,28 @@ describe('upsertAlbumMatchFillNull', () => {
 // ---------------------------------------------------------------------------
 
 describe('ANALYZE', () => {
-  it('analyzeFlowsheet issues ANALYZE flowsheet', async () => {
-    await analyzeFlowsheet();
+  // BS#1638 prod run 1: ANALYZE ran on the raw connection under the @wxyc/database
+  // 5s statement_timeout and was cancelled on the 2.6M-row flowsheet, aborting the
+  // whole job after Lane A. Both ANALYZEs must run inside a transaction that raises
+  // statement_timeout (mirroring the flip batches), and a stats-refresh failure must
+  // never abort a completed data lane.
+  it('analyzeFlowsheet issues ANALYZE flowsheet inside a raised-timeout transaction', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+    await analyzeFlowsheet(300_000);
     expect(renderSql(findExecuteCallMatching(/ANALYZE/i)?.[0])).toMatch(/flowsheet/i);
+    expect((db.transaction as jest.Mock).mock.calls.length).toBe(1);
+    expect(renderSql(findExecuteCallMatching(/SET\s+LOCAL\s+statement_timeout/i)?.[0])).toMatch(/300000ms/);
   });
-  it('analyzeAlbumMetadata issues ANALYZE album_metadata', async () => {
-    await analyzeAlbumMetadata();
+  it('analyzeAlbumMetadata issues ANALYZE album_metadata inside a raised-timeout transaction', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+    await analyzeAlbumMetadata(300_000);
     expect(renderSql(findExecuteCallMatching(/ANALYZE/i)?.[0])).toMatch(/album_metadata/i);
+    expect(renderSql(findExecuteCallMatching(/SET\s+LOCAL\s+statement_timeout/i)?.[0])).toMatch(/300000ms/);
+  });
+  it('is non-fatal: a failing ANALYZE is swallowed (a stats refresh must not abort a completed lane)', async () => {
+    (db.transaction as jest.Mock).mockRejectedValueOnce(new Error('canceling statement due to statement timeout'));
+    await expect(analyzeFlowsheet(300_000)).resolves.toBeUndefined();
+    expect(Sentry.captureException).toHaveBeenCalled();
   });
 });
 
@@ -696,11 +711,13 @@ describe('runReenrichment', () => {
       .mockResolvedValueOnce([{ id: 1 }, { id: 2 }]) // lane A UPDATE → 2
       .mockResolvedValueOnce([]) // SET LOCAL (lane A flip batch 2)
       .mockResolvedValueOnce([]) // lane A UPDATE → 0
+      .mockResolvedValueOnce([]) // SET LOCAL (ANALYZE flowsheet, lane A)
       .mockResolvedValueOnce([]) // ANALYZE flowsheet (lane A)
       .mockResolvedValueOnce([]) // SET LOCAL (enumerate)
       .mockResolvedValueOnce([{ album_id: 7 }]) // residual → 1 album
       .mockResolvedValueOnce([]) // SET LOCAL (resolveAlbums)
       .mockResolvedValueOnce([{ album_id: 7, artist_name: 'Chuquimamani-Condori', album_title: 'Edits' }]) // resolve
+      .mockResolvedValueOnce([]) // SET LOCAL (ANALYZE album_metadata)
       .mockResolvedValueOnce([]) // ANALYZE album_metadata
       .mockResolvedValueOnce([]) // SET LOCAL (lane B scope count)
       .mockResolvedValueOnce([{ count: 1 }]) // lane B scope count
@@ -708,6 +725,7 @@ describe('runReenrichment', () => {
       .mockResolvedValueOnce([{ id: 9 }]) // lane B UPDATE → 1
       .mockResolvedValueOnce([]) // SET LOCAL (lane B flip batch 2)
       .mockResolvedValueOnce([]) // lane B UPDATE → 0
+      .mockResolvedValueOnce([]) // SET LOCAL (ANALYZE flowsheet, lane B)
       .mockResolvedValueOnce([]); // ANALYZE flowsheet (lane B)
 
     mockBulkLookupMetadata.mockResolvedValue({ results: [{ index: 0, status: 'match', lookup: lookupWithArtwork() }] });


### PR DESCRIPTION
Closes #1648.

## Problem

The first prod run of `jobs/flowsheet-linked-reenrichment` (BS#1638) failed with exit 1 **after Lane A had already committed its 15,231-row flip** — Lane B (the ~314-album LML re-lookup) never ran.

`analyzeFlowsheet()` / `analyzeAlbumMetadata()` ran `ANALYZE` on the raw connection, which `@wxyc/database` pins to a 5s `statement_timeout`. `ANALYZE` on the 2.6M-row `flowsheet` exceeds 5s and is cancelled, aborting the whole job. (Confirmed: table owner == connection user, so not permissions; a manual `SET statement_timeout=300s; ANALYZE …` succeeds.) The flip batches already dodge this by wrapping in a transaction with a raised `SET LOCAL statement_timeout`; the ANALYZE path did not.

## Change

- Both ANALYZE calls now run inside a transaction that raises `statement_timeout` (new `LINKED_REENRICH_ANALYZE_TIMEOUT_MS` knob, default 5min) — the same `SET LOCAL` wrapper the flip batches use.
- The stats refresh is **non-fatal**: a data lane that already committed must not be aborted because ANALYZE failed. On failure it logs `analyze_failed` + captures to Sentry instead of throwing.
- Unit tests: raised-timeout transaction on both ANALYZEs + the non-fatal path; existing `runReenrichment` orchestration sequences updated for the extra `SET LOCAL` execute per ANALYZE.

## Verification

- `npx jest … job.test.ts` → 41/41.
- `tsc --noEmit -p jobs/flowsheet-linked-reenrichment/tsconfig.json` clean; eslint 0 errors; prettier clean.

## Rollout

Lane A is already committed on prod (cohort 22,773 → 7,542 remaining). After this deploys, a re-run no-ops Lane A (0 to flip) and completes Lane B cleanly.

Refs #1638, #1443.