### PR TITLE
fix(rate-limit): key unauthenticated callers per-IP instead of a shared bucket

### DIFF
--- a/apps/backend/middleware/rate-limit-key.ts
+++ b/apps/backend/middleware/rate-limit-key.ts
@@ -1,0 +1,34 @@
+import type { Request } from 'express';
+
+// Namespace prefixes keep the authenticated-user key space and the
+// unauthenticated per-IP key space from colliding, so a caller cannot set
+// their user id to a victim's IP and poison that bucket (BS#1127).
+const USER_KEY_PREFIX = 'user:';
+const IP_KEY_PREFIX = 'ip:';
+
+// Mirrors apps/auth/rate-limit-key.ts: key on the nginx-set `x-real-ip`
+// header, never `req.ip`. Under `trust proxy: true` (apps/backend/app.ts)
+// `req.ip` reads the client-controlled X-Forwarded-For, which must not
+// influence rate-limit bucketing — see BS#774, BS#1048.
+const clientIpFromRequest = (req: Pick<Request, 'headers' | 'socket'>): string => {
+  const raw = req.headers['x-real-ip'];
+  const realIp = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof realIp === 'string' && realIp.length > 0) return realIp;
+  return req.socket.remoteAddress ?? 'unknown';
+};
+
+/**
+ * Compute the rate-limit bucket key for a request.
+ *
+ * Authenticated callers key on their user id (namespaced `user:`).
+ * Unauthenticated callers key on their client IP (namespaced `ip:`) instead
+ * of a single shared `'unknown'` bucket, so one anonymous client's traffic
+ * can no longer exhaust the limit for every other unauthenticated caller
+ * (BS#1127).
+ */
+export const rateLimitKeyFromRequest = (req: Request): string => {
+  if (req.auth?.id) {
+    return `${USER_KEY_PREFIX}${req.auth.id}`;
+  }
+  return `${IP_KEY_PREFIX}${clientIpFromRequest(req)}`;
+};

--- a/apps/backend/middleware/rateLimiting.ts
+++ b/apps/backend/middleware/rateLimiting.ts
@@ -1,5 +1,6 @@
 import rateLimit, { Options, MemoryStore } from 'express-rate-limit';
 import { Request, Response, NextFunction } from 'express';
+import { rateLimitKeyFromRequest } from './rate-limit-key';
 
 // Environment-based configuration
 const isTestEnv = process.env.NODE_ENV === 'test' || process.env.USE_MOCK_SERVICES === 'true';
@@ -50,13 +51,9 @@ export const songRequestRateLimit = shouldEnableRateLimiting
       standardHeaders: true,
       legacyHeaders: false,
       store: songRequestStore,
-      keyGenerator: (req: Request) => {
-        // Use user ID (set by requirePermissions middleware, which runs before this)
-        if (req.auth?.id) {
-          return req.auth.id;
-        }
-        return 'unknown';
-      },
+      // Authenticated callers key on their user id; unauthenticated callers
+      // key per-client-IP instead of a single shared bucket (BS#1127).
+      keyGenerator: rateLimitKeyFromRequest,
       handler: (_req: Request, res: Response) => {
         res.status(429).json({
           message: 'Too many requests. Please wait before submitting more song requests.',
@@ -84,12 +81,9 @@ export const proxyRateLimit = shouldEnableRateLimiting
       standardHeaders: true,
       legacyHeaders: false,
       store: proxyStore,
-      keyGenerator: (req: Request) => {
-        if (req.auth?.id) {
-          return req.auth.id;
-        }
-        return 'unknown';
-      },
+      // Authenticated callers key on their user id; unauthenticated callers
+      // key per-client-IP instead of a single shared bucket (BS#1127).
+      keyGenerator: rateLimitKeyFromRequest,
       handler: (_req: Request, res: Response) => {
         res.status(429).json({
           message: 'Too many proxy requests. Please try again shortly.',

--- a/tests/unit/middleware/rate-limit-key.test.ts
+++ b/tests/unit/middleware/rate-limit-key.test.ts
@@ -1,0 +1,77 @@
+import { Request } from 'express';
+import { rateLimitKeyFromRequest } from '../../../apps/backend/middleware/rate-limit-key';
+
+const makeReq = (overrides: {
+  auth?: { id?: string };
+  headers?: Record<string, string | string[] | undefined>;
+  remoteAddress?: string | undefined;
+}) =>
+  ({
+    auth: overrides.auth,
+    headers: overrides.headers ?? {},
+    socket: { remoteAddress: overrides.remoteAddress },
+  }) as unknown as Request;
+
+describe('rateLimitKeyFromRequest', () => {
+  it('keys an authenticated caller on their user id, namespaced', () => {
+    const key = rateLimitKeyFromRequest(makeReq({ auth: { id: 'user-123' }, remoteAddress: '10.0.0.1' }));
+    expect(key).toBe('user:user-123');
+  });
+
+  it('gives two different unauthenticated IPs independent buckets', () => {
+    const keyA = rateLimitKeyFromRequest(makeReq({ headers: { 'x-real-ip': '203.0.113.7' } }));
+    const keyB = rateLimitKeyFromRequest(makeReq({ headers: { 'x-real-ip': '198.51.100.2' } }));
+
+    expect(keyA).toBe('ip:203.0.113.7');
+    expect(keyB).toBe('ip:198.51.100.2');
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it('never collapses unauthenticated callers into a single shared bucket', () => {
+    // The BS#1127 bug: every anonymous caller shared the literal 'unknown'
+    // key, so one client's traffic rate-limited everyone. Distinct IPs must
+    // never map to the same key.
+    const keys = ['203.0.113.7', '198.51.100.2', '192.0.2.9'].map((ip) =>
+      rateLimitKeyFromRequest(makeReq({ headers: { 'x-real-ip': ip } }))
+    );
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('ignores client-supplied X-Forwarded-For — only X-Real-IP is trusted (BS#774/#1048)', () => {
+    const key = rateLimitKeyFromRequest(
+      makeReq({
+        headers: { 'x-forwarded-for': '1.2.3.4', 'x-real-ip': '203.0.113.7' },
+        remoteAddress: '10.0.0.1',
+      })
+    );
+    expect(key).toBe('ip:203.0.113.7');
+  });
+
+  it('falls back to the socket address when X-Real-IP is missing', () => {
+    const key = rateLimitKeyFromRequest(makeReq({ headers: {}, remoteAddress: '10.0.0.1' }));
+    expect(key).toBe('ip:10.0.0.1');
+  });
+
+  it('uses the first value when X-Real-IP is an array (Node header-parsing edge case)', () => {
+    const key = rateLimitKeyFromRequest(
+      makeReq({ headers: { 'x-real-ip': ['203.0.113.7', '203.0.113.8'] }, remoteAddress: '10.0.0.1' })
+    );
+    expect(key).toBe('ip:203.0.113.7');
+  });
+
+  it('falls back to ip:unknown only when neither X-Real-IP nor a socket address is available', () => {
+    const key = rateLimitKeyFromRequest(makeReq({ headers: {}, remoteAddress: undefined }));
+    expect(key).toBe('ip:unknown');
+  });
+
+  it('cannot let an attacker collide the user and IP key spaces', () => {
+    // A caller who sets their user id to a victim's IP must land in a
+    // different bucket than that IP's anonymous traffic — the namespace
+    // prefixes guarantee it.
+    const spoofedUserKey = rateLimitKeyFromRequest(makeReq({ auth: { id: '203.0.113.7' } }));
+    const victimIpKey = rateLimitKeyFromRequest(makeReq({ headers: { 'x-real-ip': '203.0.113.7' } }));
+    expect(spoofedUserKey).toBe('user:203.0.113.7');
+    expect(victimIpKey).toBe('ip:203.0.113.7');
+    expect(spoofedUserKey).not.toBe(victimIpKey);
+  });
+});

--- a/tests/unit/middleware/rateLimiting.test.ts
+++ b/tests/unit/middleware/rateLimiting.test.ts
@@ -12,12 +12,23 @@ jest.mock('express-rate-limit', () => {
   return { __esModule: true, default: mockRateLimit, MemoryStore };
 });
 
-describe('songRequestRateLimit keyGenerator', () => {
-  let keyGenerator: (req: Request) => string;
+const makeReq = (overrides: {
+  auth?: { id?: string };
+  headers?: Record<string, string | string[] | undefined>;
+  remoteAddress?: string | undefined;
+}) =>
+  ({
+    auth: overrides.auth,
+    headers: overrides.headers ?? {},
+    socket: { remoteAddress: overrides.remoteAddress },
+  }) as unknown as Request;
+
+describe('rate limiter keyGenerators', () => {
+  let keyGenerators: ((req: Request) => string)[];
 
   beforeAll(async () => {
     capturedConfigs = [];
-    // Force rate limiting to be active so the config is captured
+    // Force rate limiting to be active so the configs are captured
     process.env.TEST_RATE_LIMITING = 'true';
     // Re-import after mock is in place
     jest.resetModules();
@@ -35,27 +46,39 @@ describe('songRequestRateLimit keyGenerator', () => {
 
     await import('../../../apps/backend/middleware/rateLimiting');
 
-    const songRequestConfig = capturedConfigs.find((c) => typeof c.keyGenerator === 'function');
-    expect(songRequestConfig).toBeDefined();
-    keyGenerator = songRequestConfig.keyGenerator as (req: Request) => string;
+    keyGenerators = capturedConfigs
+      .map((c) => c.keyGenerator)
+      .filter((k): k is (req: Request) => string => typeof k === 'function');
   });
 
   afterAll(() => {
     delete process.env.TEST_RATE_LIMITING;
   });
 
-  it('returns user ID when req.auth.id is set', () => {
-    const req = { auth: { id: 'user-123' }, ip: '10.0.0.1' } as unknown as Request;
-    expect(keyGenerator(req)).toBe('user-123');
+  it('wires a keyGenerator into both the song-request and proxy limiters', () => {
+    expect(keyGenerators.length).toBe(2);
   });
 
-  it('returns "unknown" when req.auth is undefined', () => {
-    const req = { auth: undefined, ip: '192.168.1.42' } as unknown as Request;
-    expect(keyGenerator(req)).toBe('unknown');
-  });
+  // Both limiters share the same per-request key policy (BS#1127), so assert
+  // the behaviour against each captured keyGenerator.
+  describe.each([[0], [1]])('keyGenerator #%i', (idx) => {
+    it('keys an authenticated caller on their namespaced user id', () => {
+      const req = makeReq({ auth: { id: 'user-123' }, headers: { 'x-real-ip': '203.0.113.7' } });
+      expect(keyGenerators[idx](req)).toBe('user:user-123');
+    });
 
-  it('returns "unknown" when req.auth.id is missing', () => {
-    const req = { auth: {}, ip: '10.0.0.5' } as unknown as Request;
-    expect(keyGenerator(req)).toBe('unknown');
+    it('gives two different unauthenticated IPs independent buckets', () => {
+      const keyA = keyGenerators[idx](makeReq({ headers: { 'x-real-ip': '203.0.113.7' } }));
+      const keyB = keyGenerators[idx](makeReq({ headers: { 'x-real-ip': '198.51.100.2' } }));
+      expect(keyA).toBe('ip:203.0.113.7');
+      expect(keyB).toBe('ip:198.51.100.2');
+      expect(keyA).not.toBe(keyB);
+    });
+
+    it('never returns the shared literal "unknown" bucket for an unauthenticated caller', () => {
+      const key = keyGenerators[idx](makeReq({ headers: { 'x-real-ip': '192.0.2.9' } }));
+      expect(key).not.toBe('unknown');
+      expect(key).toBe('ip:192.0.2.9');
+    });
   });
 });


### PR DESCRIPTION
## Problem

`songRequestRateLimit` and `proxyRateLimit` both returned the constant string `'unknown'` from their `keyGenerator` whenever `req.auth?.id` was missing. Every unauthenticated caller therefore shared a single rate-limit bucket per limiter — one client could exhaust the global anonymous limit and rate-limit (DoS) all other unauthenticated traffic, and per-caller fairness was lost.

## Fix

Extract a shared `rateLimitKeyFromRequest` (`apps/backend/middleware/rate-limit-key.ts`) and wire both limiters to it:

- Authenticated callers key on their user id, namespaced `user:<id>`.
- Unauthenticated callers key on their client IP, namespaced `ip:<ip>` — independent buckets per client rather than one shared `'unknown'`.
- The IP is read from the nginx-set `x-real-ip` header with a `socket.remoteAddress` fallback, mirroring the auth service's `rateLimitKeyFromRequest` (`apps/auth/rate-limit-key.ts`). It deliberately does **not** use `req.ip`, which under `trust proxy: true` reads the client-controlled `X-Forwarded-For` and must not influence bucketing (BS#774, BS#1048).
- The `user:` / `ip:` prefixes keep the two key spaces from colliding, so a caller who sets their user id to a victim's IP lands in a different bucket than that IP's anonymous traffic.

## Tests

- New `tests/unit/middleware/rate-limit-key.test.ts`: two distinct unauthenticated IPs get independent buckets; distinct IPs never collapse into one bucket; authenticated requests key on the namespaced user id; X-Forwarded-For is ignored in favor of X-Real-IP; socket fallback; `ip:unknown` only when no IP is available at all; user/IP key spaces cannot collide.
- Updated `tests/unit/middleware/rateLimiting.test.ts`: asserts both the song-request and proxy limiters wire the shared keyGenerator and never emit the shared `'unknown'` bucket for unauthenticated callers.

Local checks: `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check`, and `npm run test:unit` (4291 passing) all green. Integration tests not run (shared Postgres in use by parallel worktrees).

Closes #1127