### PR TITLE
fix(artwork): retry NSFW model load after a transient failure instead of caching the rejection

### DIFF
--- a/apps/backend/services/artwork/nsfw.ts
+++ b/apps/backend/services/artwork/nsfw.ts
@@ -28,11 +28,22 @@ async function getModel(): Promise<nsfwjs.NSFWJS> {
   if (model) return model;
   if (modelLoading) return modelLoading;
 
-  modelLoading = nsfwjs.load().then((m) => {
-    model = m;
-    console.log('[NSFWClassifier] Model loaded');
-    return m;
-  });
+  modelLoading = nsfwjs
+    .load()
+    .then((m) => {
+      model = m;
+      console.log('[NSFWClassifier] Model loaded');
+      return m;
+    })
+    .catch((err) => {
+      // Don't memoize the rejection (#1121): a transient first-load failure
+      // (cold-start GPU init, network blip, OOM) would otherwise wedge the
+      // slot on a rejected promise and 500 every subsequent classify() for the
+      // life of the process. Reset the in-flight slot so the next call retries,
+      // and re-throw so the current caller still sees the error.
+      modelLoading = null;
+      throw err;
+    });
 
   return modelLoading;
 }
@@ -76,7 +87,15 @@ export async function classify(imageBuffer: Buffer): Promise<NSFWResult> {
 
 /**
  * Preloads the NSFW model. Call at server startup to avoid cold-start latency.
+ *
+ * A transient load failure here must not crash the server (#1121): swallow and
+ * log it, leaving the in-flight slot reset so the lazy classify() path retries
+ * the load on the first real request.
  */
 export async function preloadModel(): Promise<void> {
-  await getModel();
+  try {
+    await getModel();
+  } catch (err) {
+    console.error('[NSFWClassifier] Model preload failed; will retry lazily on first classify()', err);
+  }
 }

--- a/tests/unit/services/artwork.nsfw.test.ts
+++ b/tests/unit/services/artwork.nsfw.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for the NSFW artwork classifier's model loader.
+ *
+ * Regression coverage for #1121: a transient first-load failure must NOT be
+ * cached forever. The in-flight slot has to reset on rejection so the next
+ * call retries the load, and preloadModel() must swallow the failure so a
+ * cold-start blip can't crash the server.
+ */
+import { jest } from '@jest/globals';
+
+// --- Mocks ---
+
+const mockLoad = jest.fn<() => Promise<unknown>>();
+const mockClassify = jest.fn<() => Promise<Array<{ className: string; probability: number }>>>();
+const mockDispose = jest.fn();
+const mockTensor3d = jest.fn<() => { dispose: () => void }>();
+const mockSharp = jest.fn<() => unknown>();
+const mockToBuffer = jest.fn<() => Promise<{ data: Buffer; info: { height: number; width: number } }>>();
+
+jest.mock('nsfwjs', () => ({
+  load: mockLoad,
+}));
+
+jest.mock('@tensorflow/tfjs', () => ({
+  tensor3d: mockTensor3d,
+}));
+
+jest.mock('sharp', () => ({
+  __esModule: true,
+  default: mockSharp,
+}));
+
+const NSFW_MODULE = '../../../apps/backend/services/artwork/nsfw';
+
+async function loadNsfwModule() {
+  jest.resetModules();
+  return import(NSFW_MODULE);
+}
+
+describe('NSFW model loader (#1121)', () => {
+  beforeEach(() => {
+    mockLoad.mockReset();
+    mockClassify.mockReset();
+    mockDispose.mockReset();
+    mockTensor3d.mockReset();
+    mockSharp.mockReset();
+    mockToBuffer.mockReset();
+
+    // Happy-path decode + inference defaults; individual tests override load().
+    mockClassify.mockResolvedValue([{ className: 'Neutral', probability: 0.99 }]);
+    mockToBuffer.mockResolvedValue({ data: Buffer.alloc(3), info: { height: 1, width: 1 } });
+    mockTensor3d.mockReturnValue({ dispose: mockDispose });
+    mockSharp.mockReturnValue({
+      removeAlpha: () => ({ raw: () => ({ toBuffer: mockToBuffer }) }),
+    });
+  });
+
+  it('retries the model load on the next call after a transient first-load failure', async () => {
+    mockLoad
+      .mockRejectedValueOnce(new Error('transient GPU init failure'))
+      .mockResolvedValue({ classify: mockClassify });
+
+    const { classify } = await loadNsfwModule();
+
+    // First call surfaces the load failure to the caller.
+    await expect(classify(Buffer.from('art'))).rejects.toThrow('transient GPU init failure');
+
+    // Second call must re-attempt the load (not replay the cached rejection).
+    await expect(classify(Buffer.from('art'))).resolves.toBe('sfw');
+
+    expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches the model after a successful load (no redundant reload)', async () => {
+    mockLoad.mockResolvedValue({ classify: mockClassify });
+
+    const { classify } = await loadNsfwModule();
+
+    await expect(classify(Buffer.from('art'))).resolves.toBe('sfw');
+    await expect(classify(Buffer.from('art'))).resolves.toBe('sfw');
+
+    expect(mockLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it('preloadModel() does not throw on a transient load failure', async () => {
+    mockLoad.mockRejectedValueOnce(new Error('cold-start blip'));
+
+    const { preloadModel } = await loadNsfwModule();
+
+    await expect(preloadModel()).resolves.toBeUndefined();
+  });
+
+  it('lazy classify() recovers after a failed preloadModel()', async () => {
+    mockLoad.mockRejectedValueOnce(new Error('cold-start blip')).mockResolvedValue({ classify: mockClassify });
+
+    const { preloadModel, classify } = await loadNsfwModule();
+
+    await preloadModel(); // swallows the failure, resets the in-flight slot
+
+    await expect(classify(Buffer.from('art'))).resolves.toBe('sfw');
+    expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Problem

`getModel()` in the NSFW classifier deduped concurrent model loads with a `modelLoading: Promise | null` slot, but the promise chain had a success-only `.then` and no `.catch`. If the first `nsfwjs.load()` rejected — cold-start GPU init failure, a transient network blip pulling the model, or OOM under load — `modelLoading` was permanently left holding a rejected promise. Every subsequent `classify(...)` returned that same rejected promise, so `/proxy/artwork/search` 500'd for the lifetime of the process; the only recovery was a full restart.

## Fix

- `getModel()` now attaches a `.catch` to the load chain that resets `modelLoading = null` and re-throws. The current caller still sees the error, but the in-flight slot is cleared so the next call retries the load instead of replaying the cached rejection. The success path (memoized `model`, concurrent-caller dedup) is unchanged.
- `preloadModel()` (called at server startup) now swallows and logs a transient load failure instead of letting it crash the server, leaving the lazy `classify()` path to retry on the first real request.

## Tests

New unit suite `tests/unit/services/artwork.nsfw.test.ts` (mocks `nsfwjs` / `@tensorflow/tfjs` / `sharp`):

- first-load rejection is retried on the next `classify()` call and succeeds (`load` called twice) — the regression guard
- a successful load is still cached (no redundant reload)
- `preloadModel()` does not throw on a transient failure
- lazy `classify()` recovers after a failed `preloadModel()`

Red before the fix (3 of 4 failing), green after. Local checks: typecheck, lint (0 errors), `test:unit` (294 suites / 4283 tests) all pass; Prettier clean.

Closes #1121