### PR TITLE
fix(library-search): keep track cascade on missing=false + NULL-safe alias dedupe

### DIFF
--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -183,11 +183,15 @@ export async function searchLibrary(
     const queryWhereAliasOff = buildWhereClause(conditions);
     const branchAWhere = combineWhere(queryWhereAliasOff, filterWhere);
     // Branch (b): the row satisfies `filterWhere` AND its artist_id has an
-    // alias hit AND the row would NOT have matched branch (a). When
-    // queryWhereAliasOff is null (defensive — aliasActive gates on
-    // hasAllFieldCondition so this is unreachable today), the NOT becomes
-    // vacuously false and (b) emits nothing, which is what we want.
-    const dedupeWhere = queryWhereAliasOff ? sql`NOT ${queryWhereAliasOff}` : sql`FALSE`;
+    // alias hit AND the row would NOT have matched branch (a). Uses the
+    // NULL-safe `IS NOT TRUE` rather than `NOT (...)` (BS#1557): `label` is
+    // nullable, so an alias-only hit on a NULL-label row makes
+    // queryWhereAliasOff evaluate to NULL — `NOT NULL` is NULL (dropped from
+    // both arms), but `NULL IS NOT TRUE` is TRUE (kept in b), which is exactly
+    // the alias-only row the feature exists to surface. When queryWhereAliasOff
+    // is null (defensive — aliasActive gates on hasAllFieldCondition so this is
+    // unreachable today), (b) emits nothing, which is what we want.
+    const dedupeWhere = queryWhereAliasOff ? sql`(${queryWhereAliasOff}) IS NOT TRUE` : sql`FALSE`;
     const branchBWhere = combineWhere(dedupeWhere, filterWhere);
 
     const orderBy = sql`${SORT_COLUMNS_UNQUALIFIED[params.sort]} ${orderDirection}, ${SECONDARY_SORT_UNQUALIFIED[params.sort]} ASC, id ASC`;
@@ -331,8 +335,11 @@ export async function searchLibrary(
   // LML's `Semaphore(5) + TokenBucket(50/min)` chokepoint; pagination beyond
   // page 0 stays empty so clients don't scroll a bounded fallback list.
   if (params.page !== 0) return { results, total };
-  // Cascade rows carry no date_lost/date_found — skip when missing filter is set.
-  if (params.missing !== undefined) return { results, total };
+  // Cascade rows carry no date_lost/date_found, so they can never be
+  // known-missing — skip the cascade only for `missing=true` (BS#1552).
+  // `missing=false` (dj-site's default "hide lost records" filter) still runs
+  // it: cascade rows are, by construction, non-missing and must surface.
+  if (params.missing === true) return { results, total };
   const trimmed = params.q.trim();
   if (!passesCascadeGate(trimmed, conditions)) return { results, total };
 

--- a/tests/unit/services/library-search-alias.test.ts
+++ b/tests/unit/services/library-search-alias.test.ts
@@ -322,6 +322,53 @@ describe('catalog search — alias-aware LATERAL JOIN (PR 5)', () => {
       expect(renderedCount).not.toContain('alias_hits');
     });
 
+    it('flag on: branch-B dedupe predicate is NULL-safe so alias-only NULL-label rows survive (BS#1557)', async () => {
+      // BS#1557 regression pin. `queryWhereAliasOff` is
+      // `(artist ILIKE q OR album ILIKE q OR label ILIKE q)`. `library.label`
+      // is nullable, so for an alias-only hit whose matched album has a NULL
+      // label the predicate evaluates to NULL (FALSE OR FALSE OR NULL). The
+      // old dedupe `NOT (queryWhereAliasOff)` is then `NOT NULL = NULL`, which
+      // drops the row from branch B — exactly the row the alias path exists to
+      // surface. The fix uses the NULL-safe `(queryWhereAliasOff) IS NOT TRUE`.
+      //
+      // The mocked DB can't exercise Postgres three-valued logic, so the
+      // load-bearing assertion is on the rendered dedupe predicate: it must be
+      // the `IS NOT TRUE` form. We also confirm a NULL-label alias-only row the
+      // mock returns still projects through unharmed.
+      process.env.CATALOG_SEARCH_ALIAS_ENABLED = 'true';
+      resetCatalogSearchAliasConfig();
+      stubGenreFormatLookups();
+
+      const nullLabelAliasRow = {
+        ...baseQueryRow,
+        label: null,
+        alias_max_sim: 0.81,
+        alias_matched_variant: 'Thee Oh Sees',
+        alias_matched_source: 'discogs_name_variation',
+      };
+      db.execute.mockReset();
+      db.execute.mockResolvedValueOnce([nullLabelAliasRow]).mockResolvedValueOnce([{ total: 1 }]);
+
+      const { results } = await searchCatalogQuery(baseQueryParams);
+
+      const dataCall = db.execute.mock.calls[0]?.[0];
+      const countCall = db.execute.mock.calls[1]?.[0];
+      const renderedData = JSON.stringify(dataCall ?? '');
+      const renderedCount = JSON.stringify(countCall ?? '');
+
+      // The NULL-safe dedupe form must be present in both arms of the UNION.
+      expect(renderedData).toContain('IS NOT TRUE');
+      expect(renderedCount).toContain('IS NOT TRUE');
+
+      // The NULL-label alias-only row still surfaces with its alias hint.
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(42);
+      expect(results[0].label).toBe('');
+      expect(results[0].matched_via_alias).toEqual([
+        { matched_variant: 'Thee Oh Sees', source: 'discogs_name_variation' },
+      ]);
+    });
+
     it('flag on: emits ALT1 UNION ALL shape with alias_hits CTE (BS#1318)', async () => {
       // BS#1318 regression pin: the alias-aware catalog path must use the
       // CTE + UNION ALL form, not the LATERAL JOIN. The LATERAL had a 3-6.5×

--- a/tests/unit/services/library-search.missing-cascade.test.ts
+++ b/tests/unit/services/library-search.missing-cascade.test.ts
@@ -1,0 +1,112 @@
+import { jest } from '@jest/globals';
+import { db } from '../../mocks/database.mock';
+
+// BS#1552 regression pin. `GET /library/query` must only skip the track-title
+// cascade when `missing=true` (cascade rows carry no date_lost/date_found, so
+// they can never be known-missing). `missing=false` is the dj-site catalog's
+// default "hide lost records" filter — the cascade rows are, by construction,
+// non-missing albums and MUST still run, or catalog track-title search is dead
+// on that surface. The pre-fix guard `if (params.missing !== undefined)` killed
+// the cascade for both truthy and falsy `missing`.
+
+const mockRunCatalogTrackSearchCascade = jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]);
+
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  runCatalogTrackSearchCascade: mockRunCatalogTrackSearchCascade,
+}));
+
+type SpanLike = { setAttribute: jest.Mock; setAttributes: jest.Mock };
+type SpanOpts = { name: string; op: string; attributes?: Record<string, unknown> };
+const spanInstance: SpanLike = { setAttribute: jest.fn(), setAttributes: jest.fn() };
+const mockStartSpan = jest.fn(
+  <T>(_opts: SpanOpts, callback: (span: SpanLike) => T | Promise<T>): Promise<T> =>
+    Promise.resolve(callback(spanInstance))
+);
+jest.mock('@sentry/node', () => ({
+  startSpan: <T>(opts: SpanOpts, callback: (span: SpanLike) => T | Promise<T>): Promise<T> =>
+    mockStartSpan(opts, callback),
+  getActiveSpan: () => spanInstance,
+}));
+
+import { searchLibrary } from '../../../apps/backend/services/library-search.service';
+
+const PARAMS = {
+  q: 'vi scose poise',
+  page: 0,
+  limit: 20,
+  sort: 'artist' as const,
+  order: 'asc' as const,
+};
+
+// A cascade-only hit — a present, non-missing album that matches only through
+// the track-title cascade (no direct artist/album/label match on the primary
+// SELECT). Shaped as the `TaggedLibraryViewEntry` that
+// `runCatalogTrackSearchCascade` returns.
+const cascadeHit = {
+  id: 314,
+  add_date: '2024-03-01',
+  album_title: 'DOGA',
+  artist_name: 'Juana Molina',
+  code_letters: 'JU',
+  code_number: 1,
+  code_artist_number: 4,
+  format_name: 'CD',
+  genre_name: 'Rock',
+  label: 'Sonamos',
+  label_id: null,
+  rotation_bin: null,
+  plays: 12,
+  on_streaming: true,
+  album_artist: null,
+};
+
+function primeEmptyPrimary(): void {
+  // Two `db.execute` calls in `searchLibrary` (data + count via Promise.all).
+  // Empty data + total=0 forces the post-empty branch where the cascade gate
+  // (and the `missing` guard) is consulted.
+  db.execute.mockReset();
+  db.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0 }]);
+}
+
+describe('searchLibrary missing-filter cascade guard (BS#1552)', () => {
+  beforeEach(() => {
+    mockStartSpan.mockClear();
+    mockRunCatalogTrackSearchCascade.mockReset();
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([]);
+  });
+
+  it('missing=false still runs the cascade and returns the cascade-only hit', async () => {
+    primeEmptyPrimary();
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([cascadeHit]);
+
+    const { results, total } = await searchLibrary({ ...PARAMS, missing: false });
+
+    expect(mockRunCatalogTrackSearchCascade).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(314);
+    expect(total).toBe(1);
+  });
+
+  it('missing=true still skips the cascade (existing behavior preserved)', async () => {
+    primeEmptyPrimary();
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([cascadeHit]);
+
+    const { results, total } = await searchLibrary({ ...PARAMS, missing: true });
+
+    expect(mockRunCatalogTrackSearchCascade).not.toHaveBeenCalled();
+    expect(mockStartSpan).not.toHaveBeenCalled();
+    expect(results).toHaveLength(0);
+    expect(total).toBe(0);
+  });
+
+  it('missing omitted still runs the cascade (unchanged)', async () => {
+    primeEmptyPrimary();
+    mockRunCatalogTrackSearchCascade.mockResolvedValue([cascadeHit]);
+
+    const { results } = await searchLibrary({ ...PARAMS });
+
+    expect(mockRunCatalogTrackSearchCascade).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(314);
+  });
+});


### PR DESCRIPTION
Two independent bugs in the catalog `/library/query` path (`apps/backend/services/library-search.service.ts`), delivered together as one PR.

## BS#1552 — `missing=false` silently disabled the track-title cascade

The post-empty CTA/LML track-title cascade was short-circuited whenever the `missing` filter was present (`if (params.missing !== undefined) return { results, total }`), including `missing=false`. Skipping is only correct for `missing=true`: cascade rows carry no `date_lost`/`date_found`, so they can never be known-missing. `missing=false` is dj-site's default "hide lost records" filter, so the guard silently killed catalog track-title search on that surface.

Fix: gate the skip on `params.missing === true`. `missing=false` cascade rows are non-missing by construction and now surface (they are not missing-filtered in-memory, per the issue's guidance).

## BS#1557 — alias-UNION branch-B dedupe dropped alias-only rows with NULL label

Pre-existing bug introduced by BS#1318 (alias-UNION search path), independent of #1154. Branch B's dedupe predicate used `NOT (queryWhereAliasOff)`. `library.label` is nullable, so for an alias-only hit whose matched album has a NULL label the predicate evaluates to NULL (`FALSE OR FALSE OR NULL`); `NOT NULL` is NULL, so the row is dropped from both arms of the UNION and the outer `DISTINCT ON` can never resurrect it — exactly the row the alias path exists to surface.

Fix: replace with the NULL-safe `(queryWhereAliasOff) IS NOT TRUE`, which is TRUE for the NULL case.

## Tests

- `tests/unit/services/library-search.missing-cascade.test.ts` (new): `missing=false` runs the cascade and returns the cascade-only hit; `missing=true` still skips it; `missing` omitted still runs it.
- `tests/unit/services/library-search-alias.test.ts`: added a NULL-label alias-only case asserting the rendered branch-B dedupe is the NULL-safe `IS NOT TRUE` form and the row projects through with its alias hint.

Both are red before the fix, green after.

## Local checks

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run test:unit` — 294 suites / 4283 tests pass

Note: the issue also flags the same 3VL class in `buildConditionFragment`'s negated `NOT (...)` handling for user `NOT foo` queries. That is a separate code path with its own test surface; left out of scope here to keep the PR tight and is worth a follow-up.

Closes #1552
Closes #1557