### PR TITLE
fix(auth): case-insensitive Bearer scheme parsing per RFC 6750

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -25,7 +25,7 @@ The `shared/authentication` workspace package wraps better-auth and provides JWT
 
 **`requirePermissions` middleware flow:**
 
-1. Extract Bearer token from `Authorization` header
+1. Extract Bearer token from `Authorization` header via the shared `parseBearerToken` helper — the Bearer scheme is matched case-insensitively per RFC 6750 §2.1 (`bearer`/`Bearer`/`BEARER`), and a bare `Bearer` with no token is rejected with 401. The same helper serves the `AUTH_BYPASS` branch so the two cannot drift (BS#1125).
 2. Verify against JWKS endpoint (`BETTER_AUTH_JWKS_URL`)
 3. Check issuer and audience claims
 4. Validate role exists in `WXYCRoles`

--- a/shared/authentication/src/auth.middleware.ts
+++ b/shared/authentication/src/auth.middleware.ts
@@ -31,6 +31,30 @@ function getJWKS() {
   return _jwks;
 }
 
+/**
+ * Extract the token from an `Authorization` header carrying the Bearer scheme.
+ *
+ * The scheme name is case-insensitive per RFC 6750 §2.1 (`bearer`, `Bearer`,
+ * and `BEARER` are equivalent), and one or more whitespace characters may
+ * separate the scheme from the token. Returns the trimmed token, or `null`
+ * when the header is absent, does not carry the Bearer scheme, or carries the
+ * scheme with no token (e.g. a bare `Bearer`).
+ *
+ * Shared by both the production and AUTH_BYPASS branches of
+ * `requirePermissions` so the two parsers cannot drift apart again (BS#1125).
+ */
+export function parseBearerToken(authHeader: string | undefined): string | null {
+  if (!authHeader) {
+    return null;
+  }
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  if (!match) {
+    return null;
+  }
+  const token = match[1].trim();
+  return token.length > 0 ? token : null;
+}
+
 async function verify(token: string) {
   const issuer = process.env.BETTER_AUTH_ISSUER;
   const audience = process.env.BETTER_AUTH_AUDIENCE;
@@ -78,11 +102,10 @@ export function requirePermissions(required: RequiredPermissions) {
       if (!authHeader) {
         return res.status(401).json({ error: 'Unauthorized: Missing Authorization header.' });
       }
-      const match = authHeader.match(/^Bearer\s+(.+)$/i);
-      if (!match) {
+      const token = parseBearerToken(authHeader);
+      if (!token) {
         return res.status(401).json({ error: 'Unauthorized: Missing token in Authorization header.' });
       }
-      const token = match[1].trim();
       // Try to decode the JWT so req.auth is populated for controllers.
       // If the token is not a valid JWT (e.g. integration tests pass a raw
       // user ID), fall back to using the token value as the user ID directly.
@@ -111,10 +134,10 @@ export function requirePermissions(required: RequiredPermissions) {
       return res.status(401).json({ error: 'Unauthorized: Missing Authorization header.' });
     }
 
-    // Extract token from Authorization header
-    // Support both "Bearer <token>" and plain "<token>" formats
-    // Tests may use plain format, but Bearer format is standard
-    const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7).trim() : authHeader.trim();
+    // Parse the Bearer token with the same case-insensitive helper the bypass
+    // branch uses (BS#1125), so the two paths cannot diverge on scheme casing
+    // or malformed-header handling (RFC 6750 §2.1).
+    const token = parseBearerToken(authHeader);
 
     if (!token) {
       return res.status(401).json({ error: 'Unauthorized: Missing token in Authorization header.' });

--- a/tests/unit/authentication/auth.middleware.test.ts
+++ b/tests/unit/authentication/auth.middleware.test.ts
@@ -139,6 +139,35 @@ describe('requirePermissions middleware', () => {
       expect(res.status).toHaveBeenCalledWith(401);
       expect(next).not.toHaveBeenCalled();
     });
+
+    // RFC 6750 §2.1: the Bearer scheme is case-insensitive. The production
+    // branch must strip the scheme regardless of case and hand jwtVerify only
+    // the token — not the whole "<scheme> <token>" string (BS#1125).
+    it.each(['bearer', 'Bearer', 'BEARER', 'BeArEr'])(
+      'should strip the "%s" scheme and verify the bare token',
+      async (scheme) => {
+        mockJwtPayload({ role: 'dj' });
+        const { req, res, next } = createMocks(`${scheme} valid.jwt.token`);
+        const middleware = requirePermissions({ catalog: ['read'] });
+
+        await middleware(req, res, next);
+
+        expect(mockedJwtVerify).toHaveBeenCalledWith('valid.jwt.token', expect.anything(), expect.anything());
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should return 401 for a bare "Bearer" with no token, without calling jwtVerify', async () => {
+      const { req, res, next } = createMocks('Bearer');
+      const middleware = requirePermissions({ catalog: ['read'] });
+
+      await middleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(mockedJwtVerify).not.toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
   });
 
   describe('role normalization', () => {

--- a/tests/unit/authentication/parse-bearer-token.test.ts
+++ b/tests/unit/authentication/parse-bearer-token.test.ts
@@ -1,0 +1,59 @@
+// Mock jose so importing auth.middleware (which imports jose at module scope)
+// doesn't pull the real ESM module into the pure-helper test.
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn(() => jest.fn()),
+  jwtVerify: jest.fn(),
+  decodeJwt: jest.fn(),
+}));
+
+import { parseBearerToken } from '../../../shared/authentication/src/auth.middleware';
+
+describe('parseBearerToken', () => {
+  it('parses a canonical "Bearer <token>" header', () => {
+    expect(parseBearerToken('Bearer abc.def.ghi')).toBe('abc.def.ghi');
+  });
+
+  it('parses a lowercase "bearer" scheme (RFC 6750 §2.1 case-insensitive)', () => {
+    expect(parseBearerToken('bearer abc.def.ghi')).toBe('abc.def.ghi');
+  });
+
+  it('parses an uppercase "BEARER" scheme', () => {
+    expect(parseBearerToken('BEARER abc.def.ghi')).toBe('abc.def.ghi');
+  });
+
+  it('parses a mixed-case "BeArEr" scheme', () => {
+    expect(parseBearerToken('BeArEr abc.def.ghi')).toBe('abc.def.ghi');
+  });
+
+  it('tolerates multiple whitespace characters between scheme and token', () => {
+    expect(parseBearerToken('Bearer   abc.def.ghi')).toBe('abc.def.ghi');
+  });
+
+  it('trims trailing whitespace from the token', () => {
+    expect(parseBearerToken('Bearer abc.def.ghi   ')).toBe('abc.def.ghi');
+  });
+
+  it('returns null for undefined (missing header)', () => {
+    expect(parseBearerToken(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseBearerToken('')).toBeNull();
+  });
+
+  it('returns null for a bare "Bearer" with no token', () => {
+    expect(parseBearerToken('Bearer')).toBeNull();
+  });
+
+  it('returns null for "Bearer " with only trailing whitespace', () => {
+    expect(parseBearerToken('Bearer   ')).toBeNull();
+  });
+
+  it('returns null for a plain token with no Bearer scheme', () => {
+    expect(parseBearerToken('abc.def.ghi')).toBeNull();
+  });
+
+  it('returns null for a non-Bearer scheme (e.g. Basic)', () => {
+    expect(parseBearerToken('Basic dXNlcjpwYXNz')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`requirePermissions` parsed the `Authorization` header two different ways. The production branch used `authHeader.startsWith('Bearer ')` (case-sensitive, single-space); the AUTH_BYPASS branch used `^Bearer\s+(.+)$/i`. RFC 6750 §2.1 makes the Bearer scheme case-insensitive, so a header arriving as `bearer <token>` (lowercased by an intermediate proxy or a non-normalizing client SDK) had the entire `bearer <token>` string handed to `jwtVerify`, failing verification with a confusing 401 — and the two branches diverged in behavior, complicating test diagnostics.

## Fix

Extract a shared `parseBearerToken(authHeader)` helper into `shared/authentication/src/auth.middleware.ts` and call it from both the production and bypass branches, so the two parsers cannot drift again:

- Case-insensitive scheme (`bearer`/`Bearer`/`BEARER`), whitespace-tolerant between scheme and token, per RFC 6750 §2.1.
- Rejects a bare `Bearer` (no token) → `null`, so both branches return the same 401 for malformed headers.
- Returns `null` for a missing / non-Bearer header.

Drops the production branch's undocumented plain-token fallback (`authHeader.trim()` when no `Bearer` prefix), which is not load-bearing: the CI integration suite runs under `AUTH_BYPASS=true` + `NODE_ENV=test` (the bypass branch, already strict) and always sends `Authorization: Bearer <token>` (prefix baked into `tests/setup/integration.setup.js`); real clients always send the Bearer scheme.

## Tests

- New `tests/unit/authentication/parse-bearer-token.test.ts` — pure-helper coverage of `bearer`/`Bearer`/`BEARER`/mixed-case, multi-whitespace, trailing-whitespace trim, and every rejection path (missing, empty, bare `Bearer`, plain token, non-Bearer scheme).
- `tests/unit/authentication/auth.middleware.test.ts` — added a parameterized case proving lowercase/uppercase/mixed schemes strip to the bare token before `jwtVerify`, plus a bare-`Bearer` → 401 (no `jwtVerify` call) regression case. These fail on the pre-fix code (whole `bearer <token>` string reaches `jwtVerify`) and pass after.

## Local checks

`npm run typecheck`, `npm run lint` (0 errors), `npm run format:check`, and `npm run test:unit` (294 suites / 4296 tests) all pass. Integration tests were not run locally (shared Postgres :5432 in use); CI will exercise them.

Closes #1125