### PR TITLE
fix(cdc): constant-time WebSocket auth via Bearer header, drop secret-in-URL

### DIFF
--- a/apps/backend/services/cdc/cdc-websocket.ts
+++ b/apps/backend/services/cdc/cdc-websocket.ts
@@ -2,9 +2,11 @@
  * CDC WebSocket server for Backend-Service.
  *
  * Attaches to the existing Express HTTP server via the 'upgrade' event,
- * filtered to the /cdc path. Authenticates connections via CDC_SECRET
- * query parameter. Fans out PostgreSQL CDC events (received via the shared
- * dispatcher's `onCdcEvent`) to all connected WebSocket clients.
+ * filtered to the /cdc path. Authenticates connections against CDC_SECRET via
+ * an `Authorization: Bearer` header, compared in constant time (BS#1136); a
+ * deprecated `?key=` query-parameter path is kept for one deploy. Fans out
+ * PostgreSQL CDC events (received via the shared dispatcher's `onCdcEvent`) to
+ * all connected WebSocket clients.
  *
  * The LISTEN startup itself lives in `dispatcher.ts` (BS#1187): the
  * dispatcher always runs so in-process subscribers like
@@ -39,12 +41,63 @@
 import { Server as HttpServer, IncomingMessage } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { URL } from 'url';
+import { timingSafeEqual } from 'crypto';
 import * as Sentry from '@sentry/node';
 import { onCdcEvent } from '@wxyc/database';
 import type { CdcEvent } from '@wxyc/database';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const CDC_PATH = '/cdc';
+
+/**
+ * Constant-time string comparison (BS#1136). The previous auth used
+ * `key !== secret`, a short-circuiting per-character compare that leaks the
+ * secret one byte at a time to a timing attack against the upgrade endpoint.
+ *
+ * `crypto.timingSafeEqual` runs in time independent of where the first
+ * differing byte is, but throws if the two buffers differ in length. We
+ * length-guard first and report a plain non-match — a length mismatch is
+ * already a non-match, and revealing only the length (not the contents) is
+ * the standard, accepted trade-off for a fixed-length shared secret.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+/**
+ * Extracts the caller-supplied CDC secret from an upgrade request (BS#1136).
+ *
+ * Preferred: `Authorization: Bearer <secret>`. Headers are not written to
+ * access logs or Sentry's request-context capture by default, so the secret
+ * does not leak to log-retention systems the way a `?key=` query parameter
+ * does (query strings land in CloudFront / nginx / EC2 access logs, browser
+ * history, and request snapshots even under TLS).
+ *
+ * Deprecated (removed after one deploy): `?key=<secret>` in the URL. Kept only
+ * so an in-flight consumer can migrate to the header without a lockstep
+ * deploy; every use logs a deprecation warning. The secret value itself is
+ * never logged. Returns `null` when neither is present.
+ */
+function extractCdcSecret(request: IncomingMessage, url: URL): string | null {
+  const authHeader = request.headers.authorization;
+  if (authHeader) {
+    const match = /^Bearer (.+)$/i.exec(authHeader);
+    if (match) return match[1];
+  }
+
+  const key = url.searchParams.get('key');
+  if (key) {
+    console.warn(
+      '[cdc-ws] DEPRECATED: CDC secret supplied via the ?key= query parameter — migrate to the Authorization: Bearer header (BS#1136). Query strings leak to access logs; this path will be removed after one deploy.'
+    );
+    return key;
+  }
+
+  return null;
+}
 
 /**
  * Per-client outbound-buffer ceiling, in bytes. A consumer that exceeds
@@ -102,10 +155,11 @@ function safeSend(client: WebSocket, msg: string): boolean {
 
 /**
  * Sets up the CDC WebSocket server on the given HTTP server.
- * Handles upgrade requests to /cdc, authenticates via query parameter,
- * and registers a fan-out handler against the shared CDC dispatcher.
- * No-ops (with the canonical `[cdc-ws]` disabled log) when CDC_SECRET
- * is unset — deploy verification matches the same log line.
+ * Handles upgrade requests to /cdc, authenticates via the
+ * `Authorization: Bearer` header (constant-time compare; deprecated `?key=`
+ * shim for one deploy), and registers a fan-out handler against the shared
+ * CDC dispatcher. No-ops (with the canonical `[cdc-ws]` disabled log) when
+ * CDC_SECRET is unset — deploy verification matches the same log line.
  */
 export async function setupCdcWebSocket(server: HttpServer): Promise<void> {
   const secret = process.env.CDC_SECRET;
@@ -124,9 +178,12 @@ export async function setupCdcWebSocket(server: HttpServer): Promise<void> {
       return;
     }
 
-    const key = url.searchParams.get('key');
-    if (!key || key !== secret) {
-      console.warn('[cdc-ws] Rejected connection: invalid key');
+    // Auth (BS#1136): prefer the `Authorization: Bearer` header, fall back to
+    // the deprecated `?key=` query parameter for one deploy, and compare with a
+    // constant-time check. Never log the presented secret.
+    const provided = extractCdcSecret(request, url);
+    if (!provided || !constantTimeEqual(provided, secret)) {
+      console.warn('[cdc-ws] Rejected connection: invalid credentials');
       socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
       socket.destroy();
       return;

--- a/apps/backend/services/cdc/cdc-websocket.ts
+++ b/apps/backend/services/cdc/cdc-websocket.ts
@@ -84,7 +84,12 @@ export function constantTimeEqual(a: string, b: string): boolean {
 function extractCdcSecret(request: IncomingMessage, url: URL): string | null {
   const authHeader = request.headers.authorization;
   if (authHeader) {
-    const match = /^Bearer (.+)$/i.exec(authHeader);
+    // `\s+` (not a literal single space) matches the repo's Bearer-parsing
+    // convention (`authenticateBearer` in apps/backend/routes/internal.route.ts,
+    // `auth.middleware.ts`) and RFC 7235's `1*SP` between scheme and token, so a
+    // tab- or multi-space-separated header authenticates instead of spuriously
+    // 403ing or capturing leading whitespace into the compared secret.
+    const match = /^Bearer\s+(.+)$/i.exec(authHeader);
     if (match) return match[1];
   }
 

--- a/docs/cdc.md
+++ b/docs/cdc.md
@@ -4,7 +4,19 @@ WebSocket endpoint at `/cdc` that broadcasts all database changes via PostgreSQL
 
 ## Endpoint
 
-`ws://host:8080/cdc?key=<CDC_SECRET>` — requires `CDC_SECRET` environment variable.
+`ws://host:8080/cdc` — requires `CDC_SECRET` environment variable.
+
+### Authentication (BS#1136)
+
+Present the shared secret in an `Authorization: Bearer <CDC_SECRET>` header. The upgrade handler compares it against `CDC_SECRET` with `crypto.timingSafeEqual` (length-guarded, constant time). A missing or wrong secret gets a `403 Forbidden` and the socket is destroyed; the presented secret is never logged.
+
+```ts
+new WebSocket('ws://host:8080/cdc', { headers: { Authorization: `Bearer ${CDC_SECRET}` } });
+```
+
+The header path replaces the old `?key=<CDC_SECRET>` query parameter, which leaked the secret to every HTTP-aware intermediary on the path (CloudFront / nginx / EC2 access logs, browser history, request snapshots) even under TLS, and used a non-constant-time `!==` compare vulnerable to a byte-at-a-time timing attack.
+
+**Deprecated shim, removed after one deploy:** the upgrade handler still accepts `?key=<CDC_SECRET>` for backwards compatibility, but every use logs a `[cdc-ws] DEPRECATED: … ?key= …` warning. Migrate any out-of-band consumer to the header, then delete the `?key=` branch in `apps/backend/services/cdc/cdc-websocket.ts` (`extractCdcSecret`). The in-repo consumer (`scripts/sync/reconcile.ts`) already uses the header.
 
 ## Event format
 

--- a/scripts/sync/reconcile.ts
+++ b/scripts/sync/reconcile.ts
@@ -704,10 +704,14 @@ async function processSseFrame(
 // --- WebSocket CDC client (used for Backend-Service direction) ---
 
 function connectCdc(label: string, wsUrl: string, tableHandlers: Record<string, (event: CdcEvent) => Promise<void>>) {
-  const url = `${wsUrl}?key=${CDC_SECRET}`;
   logInfo(`[${label}] Connecting to ${wsUrl}...`);
 
-  const ws = new WebSocket(url);
+  // Auth via the `Authorization: Bearer` header (BS#1136), not a `?key=` query
+  // parameter — the query string leaks the secret to access logs. The header
+  // is compared in constant time by the CDC WebSocket upgrade handler.
+  const ws = new WebSocket(wsUrl, {
+    headers: { Authorization: `Bearer ${CDC_SECRET}` },
+  });
   let reconnectDelay = 1000;
 
   ws.on('open', () => {

--- a/tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts
+++ b/tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts
@@ -647,6 +647,22 @@ describe('CDC WebSocket upgrade auth (BS#1136)', () => {
     });
   });
 
+  it('accepts a Bearer header whose scheme/token separator is a tab or multiple spaces (RFC 7235 1*SP)', async () => {
+    await withCdcSecret(SECRET, async () => {
+      const server = makeServer();
+      await setupCdcWebSocket(server);
+      const handler = getUpgradeHandler(server);
+
+      for (const sep of ['\t', '  ', ' \t ']) {
+        wssHandleUpgradeMock.mockClear();
+        const socket = makeSocket();
+        handler(makeUpgradeRequest({ authorization: `Bearer${sep}${SECRET}` }), socket, Buffer.alloc(0));
+        expect(wssHandleUpgradeMock).toHaveBeenCalledTimes(1);
+        expect(socket.destroy).not.toHaveBeenCalled();
+      }
+    });
+  });
+
   it('rejects a wrong Bearer secret without calling handleUpgrade', async () => {
     await withCdcSecret(SECRET, async () => {
       const server = makeServer();

--- a/tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts
+++ b/tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts
@@ -47,10 +47,26 @@ jest.mock('@sentry/node', () => ({
   captureMessage: (...args: unknown[]) => captureMessageMock(...args),
 }));
 
+// Partial-mock `crypto` so the BS#1136 auth test can prove the compare goes
+// through `timingSafeEqual` (constant time). The real implementation is
+// preserved via `jest.fn(actual.timingSafeEqual)`, so behaviour is unchanged;
+// `jest.spyOn` can't be used because `timingSafeEqual` is non-configurable on
+// the native module object.
+jest.mock('crypto', () => {
+  const actual = jest.requireActual<typeof import('crypto')>('crypto');
+  return {
+    ...actual,
+    timingSafeEqual: jest.fn(actual.timingSafeEqual),
+  };
+});
+
 // Captured server-level handlers so tests can drive the `'connection'` event
 // against a synthetic client. Reset in `beforeEach`.
 const wssHandlers: Record<string, Array<(...args: unknown[]) => void>> = {};
 const wssClients = new Set<unknown>();
+// Shared `handleUpgrade` mock so the BS#1136 auth tests can assert whether a
+// given upgrade request was accepted (handleUpgrade called) or rejected.
+const wssHandleUpgradeMock = jest.fn();
 
 jest.mock('ws', () => {
   const WebSocketServer = jest.fn().mockImplementation(() => {
@@ -60,7 +76,7 @@ jest.mock('ws', () => {
       },
       close: jest.fn(),
       clients: wssClients,
-      handleUpgrade: jest.fn(),
+      handleUpgrade: wssHandleUpgradeMock,
       emit: jest.fn(),
     };
   });
@@ -71,9 +87,14 @@ jest.mock('ws', () => {
 });
 
 import type { Server as HttpServer } from 'http';
+import { timingSafeEqual } from 'crypto';
 import { onCdcErrorEvent, onCdcEvent, onCdcOversizedEvent, startCdcListener, stopCdcListener } from '@wxyc/database';
 import { WebSocketServer } from 'ws';
-import { setupCdcWebSocket, shutdownCdcWebSocket } from '../../../../../../apps/backend/services/cdc/cdc-websocket';
+import {
+  setupCdcWebSocket,
+  shutdownCdcWebSocket,
+  constantTimeEqual,
+} from '../../../../../../apps/backend/services/cdc/cdc-websocket';
 import { startCdcDispatcher, shutdownCdcDispatcher } from '../../../../../../apps/backend/services/cdc/dispatcher';
 
 const makeServer = (): HttpServer => {
@@ -136,6 +157,7 @@ function resetSharedMocks(): void {
   for (const k of Object.keys(wssHandlers)) delete wssHandlers[k];
   wssClients.clear();
   captureMessageMock.mockReset();
+  wssHandleUpgradeMock.mockReset();
 }
 
 describe('startCdcDispatcher (BS#1187)', () => {
@@ -525,6 +547,206 @@ describe('CDC WebSocket back-pressure and ping/pong (BS#1134)', () => {
           expect.stringMatching(/pong|heartbeat/i),
           expect.objectContaining({ level: 'warning' })
         );
+      });
+    });
+  });
+});
+
+/**
+ * BS#1136 — constant-time WebSocket auth via the `Authorization: Bearer`
+ * header, with a one-deploy `?key=` backwards-compatibility shim.
+ *
+ * Pins:
+ *   (a) the secret compare goes through `crypto.timingSafeEqual` (constant
+ *       time), rejects a wrong secret, and never throws on a length mismatch;
+ *   (b) a connection presenting the correct secret in an `Authorization:
+ *       Bearer` header is accepted (`handleUpgrade` called);
+ *   (c) the deprecated `?key=` query-string path still authenticates for one
+ *       deploy but emits a deprecation warning; the header wins when both are
+ *       present; the bearer secret is never written to any log.
+ */
+describe('constantTimeEqual (BS#1136)', () => {
+  it('returns true for identical strings', () => {
+    expect(constantTimeEqual('s3cr3t-value-123', 's3cr3t-value-123')).toBe(true);
+  });
+
+  it('returns false for different strings of equal length', () => {
+    expect(constantTimeEqual('s3cr3t-value-123', 's3cr3t-value-124')).toBe(false);
+  });
+
+  it('returns false (without throwing) when the lengths differ', () => {
+    // A naive `crypto.timingSafeEqual` throws on unequal-length buffers; the
+    // length guard must swallow that and report a plain non-match.
+    expect(() => constantTimeEqual('short', 'a-considerably-longer-secret')).not.toThrow();
+    expect(constantTimeEqual('short', 'a-considerably-longer-secret')).toBe(false);
+  });
+
+  it('delegates the equal-length compare to crypto.timingSafeEqual', () => {
+    (timingSafeEqual as jest.Mock).mockClear();
+    constantTimeEqual('s3cr3t-value-123', 's3cr3t-value-123');
+    expect(timingSafeEqual as jest.Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reach crypto.timingSafeEqual on a length mismatch (guards before the call)', () => {
+    (timingSafeEqual as jest.Mock).mockClear();
+    expect(constantTimeEqual('short', 'a-considerably-longer-secret')).toBe(false);
+    expect(timingSafeEqual as jest.Mock).not.toHaveBeenCalled();
+  });
+});
+
+describe('CDC WebSocket upgrade auth (BS#1136)', () => {
+  const SECRET = 'super-secret-cdc-value';
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSharedMocks();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    await shutdownCdcWebSocket();
+  });
+
+  /** Pull the `'upgrade'` handler `setupCdcWebSocket` registered on the HTTP server. */
+  function getUpgradeHandler(server: HttpServer): (req: unknown, socket: unknown, head: unknown) => void {
+    const call = (server.on as jest.Mock).mock.calls.find((c) => c[0] === 'upgrade');
+    expect(call).toBeDefined();
+    return call![1] as (req: unknown, socket: unknown, head: unknown) => void;
+  }
+
+  function makeUpgradeRequest(opts: { authorization?: string; query?: string }): unknown {
+    return {
+      url: `/cdc${opts.query ?? ''}`,
+      headers: {
+        host: 'localhost:8080',
+        ...(opts.authorization ? { authorization: opts.authorization } : {}),
+      },
+    };
+  }
+
+  function makeSocket(): { write: jest.Mock; destroy: jest.Mock } {
+    return { write: jest.fn(), destroy: jest.fn() };
+  }
+
+  it('accepts a connection authenticated via the Authorization: Bearer header', async () => {
+    await withCdcSecret(SECRET, async () => {
+      const server = makeServer();
+      await setupCdcWebSocket(server);
+      const handler = getUpgradeHandler(server);
+      const socket = makeSocket();
+
+      handler(makeUpgradeRequest({ authorization: `Bearer ${SECRET}` }), socket, Buffer.alloc(0));
+
+      expect(wssHandleUpgradeMock).toHaveBeenCalledTimes(1);
+      expect(socket.destroy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects a wrong Bearer secret without calling handleUpgrade', async () => {
+    await withCdcSecret(SECRET, async () => {
+      const server = makeServer();
+      await setupCdcWebSocket(server);
+      const handler = getUpgradeHandler(server);
+      const socket = makeSocket();
+
+      handler(makeUpgradeRequest({ authorization: 'Bearer not-the-secret' }), socket, Buffer.alloc(0));
+
+      expect(wssHandleUpgradeMock).not.toHaveBeenCalled();
+      expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('403'));
+      expect(socket.destroy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('rejects a request that carries no credentials', async () => {
+    await withCdcSecret(SECRET, async () => {
+      const server = makeServer();
+      await setupCdcWebSocket(server);
+      const handler = getUpgradeHandler(server);
+      const socket = makeSocket();
+
+      handler(makeUpgradeRequest({}), socket, Buffer.alloc(0));
+
+      expect(wssHandleUpgradeMock).not.toHaveBeenCalled();
+      expect(socket.destroy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('never writes the bearer secret to a log line', async () => {
+    await withCdcSecret(SECRET, async () => {
+      const server = makeServer();
+      await setupCdcWebSocket(server);
+      const handler = getUpgradeHandler(server);
+
+      handler(makeUpgradeRequest({ authorization: 'Bearer leak-me-if-you-can' }), makeSocket(), Buffer.alloc(0));
+
+      const logged = [...consoleWarnSpy.mock.calls, ...consoleLogSpy.mock.calls].flat().map(String).join(' ');
+      expect(logged).not.toContain('leak-me-if-you-can');
+    });
+  });
+
+  describe('deprecated ?key= backwards-compatibility shim', () => {
+    it('still accepts the correct secret supplied in the query string', async () => {
+      await withCdcSecret(SECRET, async () => {
+        const server = makeServer();
+        await setupCdcWebSocket(server);
+        const handler = getUpgradeHandler(server);
+        const socket = makeSocket();
+
+        handler(makeUpgradeRequest({ query: `?key=${SECRET}` }), socket, Buffer.alloc(0));
+
+        expect(wssHandleUpgradeMock).toHaveBeenCalledTimes(1);
+        expect(socket.destroy).not.toHaveBeenCalled();
+      });
+    });
+
+    it('emits a deprecation warning when the query-string path is used', async () => {
+      await withCdcSecret(SECRET, async () => {
+        const server = makeServer();
+        await setupCdcWebSocket(server);
+        const handler = getUpgradeHandler(server);
+
+        handler(makeUpgradeRequest({ query: `?key=${SECRET}` }), makeSocket(), Buffer.alloc(0));
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringMatching(/deprecat/i));
+      });
+    });
+
+    it('rejects a wrong secret supplied in the query string', async () => {
+      await withCdcSecret(SECRET, async () => {
+        const server = makeServer();
+        await setupCdcWebSocket(server);
+        const handler = getUpgradeHandler(server);
+        const socket = makeSocket();
+
+        handler(makeUpgradeRequest({ query: '?key=wrong' }), socket, Buffer.alloc(0));
+
+        expect(wssHandleUpgradeMock).not.toHaveBeenCalled();
+        expect(socket.destroy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('prefers the Authorization header over the query string (no deprecation warning)', async () => {
+      await withCdcSecret(SECRET, async () => {
+        const server = makeServer();
+        await setupCdcWebSocket(server);
+        const handler = getUpgradeHandler(server);
+        const socket = makeSocket();
+
+        // Correct header + wrong query → accepted on the header, and the
+        // deprecated-path warning must not fire because ?key= was never read.
+        handler(
+          makeUpgradeRequest({ authorization: `Bearer ${SECRET}`, query: '?key=wrong' }),
+          socket,
+          Buffer.alloc(0)
+        );
+
+        expect(wssHandleUpgradeMock).toHaveBeenCalledTimes(1);
+        expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringMatching(/deprecat/i));
       });
     });
   });


### PR DESCRIPTION
## Problem

The CDC WebSocket upgrade handler (`apps/backend/services/cdc/cdc-websocket.ts`) had two auth weaknesses:

1. **Non-constant-time compare** — `if (!key || key !== secret)`, a short-circuiting per-character comparison that leaks the secret one byte at a time to a timing attack against the upgrade endpoint.
2. **Secret in the URL** — the secret rode in the `?key=` query string, which lands in plaintext in every HTTP-aware intermediary on the path (CloudFront / nginx / EC2 access logs, browser history, Sentry request snapshots) even under TLS.

## Fix

- Authenticate via an `Authorization: Bearer <CDC_SECRET>` header, compared with `crypto.timingSafeEqual` (length-guarded so it never throws on a length mismatch, and reports a plain non-match). The presented secret is never written to a log line.
- Keep the `?key=` query-string path working for **one deploy** as a backwards-compatibility shim, emitting a `[cdc-ws] DEPRECATED` warning on every use. The `Authorization` header wins when both are present. The `?key=` branch (`extractCdcSecret`) should be deleted after this rolls out.
- Update the sole in-repo consumer, `scripts/sync/reconcile.ts` (`connectCdc`), to send the header instead of the query parameter.
- Update `docs/cdc.md` with the new auth shape and the shim-removal note.

The tubafrenzy SSE path in `reconcile.ts` (`connectSse`) is unchanged — it hits tubafrenzy's `/playlists/cdcStream`, a different service, not this endpoint.

## Tests

Added to `tests/unit/apps/backend/services/cdc/cdc-websocket.test.ts` (TDD, red first):

- `constantTimeEqual`: equal → true, unequal same-length → false, different-length → false without throwing, delegates to `crypto.timingSafeEqual` on the equal-length path and guards before the call on a length mismatch.
- Upgrade auth: Bearer header accepted (`handleUpgrade` called); wrong Bearer secret and missing credentials rejected with `403` + `socket.destroy()`; the bearer secret is never logged; the deprecated `?key=` path still authenticates but emits a deprecation warning; wrong `?key=` rejected; the header is preferred over the query string (no deprecation warning when the header is used).

## Local checks

- `npm run typecheck` — pass
- `npm run lint` — 0 errors
- `npm run test:unit` — 4292 passed (31 in the CDC suite)
- `prettier --check` on changed files — clean

Integration tests were not run (shared Postgres in use by parallel worktrees); the unit tests drive the real upgrade handler with a synthetic request/socket.

## Consumers in other repos

No other repo consumes this endpoint with the `?key=` parameter that I could find — the only known consumer is the in-repo reconciliation monitor, which this PR updates. The one-deploy `?key=` shim covers any out-of-band operator still using the old URL. If an external consumer exists, it must switch to the `Authorization: Bearer` header before the shim is removed.

Closes #1136