### PR TITLE
fix(library): harden PATCH /library/:id input validation + enrichment repair

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -736,17 +736,20 @@ export const updateAlbum: RequestHandler<{ id: string }, unknown, UpdateAlbumReq
     return;
   }
 
-  // Identity-affecting edits invalidate the LML enrichment columns and
-  // re-fire the same pipeline addAlbum runs (issue 12); otherwise
-  // on_streaming / artwork_url / canonical_entity stay bound to the OLD
-  // (artist, title) identity and no drain job repairs them.
+  // Identity-affecting edits re-fire the same LML pipeline addAlbum runs (issue
+  // 12), so on_streaming / artwork_url / canonical_entity can be rebound to the
+  // NEW (artist, title) identity. We do NOT null those columns up front:
+  // enrichAlbumAfterIdentityChange overwrites each one only on a successful
+  // lookup (refill-then-swap), so an unconfigured LML or a no-match re-lookup
+  // leaves the prior — still-better-than-blank — enrichment intact rather than
+  // permanently wiping it with no repair path (BS#1549).
   const identityChanged =
     (updates.artist_id !== undefined && updates.artist_id !== existing.artist_id) ||
     (updates.album_title !== undefined && updates.album_title !== existing.album_title) ||
     ('alternate_artist_name' in body &&
       (updates.alternate_artist_name ?? null) !== (existing.alternate_artist_name ?? null));
 
-  const updated = await libraryService.updateAlbumInDB(albumId, updates, { resetEnrichment: identityChanged });
+  const updated = await libraryService.updateAlbumInDB(albumId, updates);
   if (!updated) {
     throw new WxycError('Album not found', 404);
   }

--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -569,6 +569,11 @@ const UPDATABLE_ALBUM_FIELDS = [
   'disc_quantity',
 ] as const;
 
+// `album_title`, `alternate_artist_name`, and `label` are all `varchar(128)`
+// in the library schema. Reject over-length input as a 400 rather than letting
+// it reach the UPDATE and trip PG 22001 ("value too long") → 500 (#1551).
+const MAX_ALBUM_TEXT_LENGTH = 128;
+
 /**
  * PATCH /library/:id with true partial semantics (PR #1154 review issues
  * 5–8, 10–13): only fields present in the body are validated and written, so
@@ -596,14 +601,22 @@ export const updateAlbum: RequestHandler<{ id: string }, unknown, UpdateAlbumReq
     if (typeof body.album_title !== 'string' || body.album_title.trim() === '') {
       throw new WxycError('album_title must be a non-empty string', 400);
     }
-    updates.album_title = body.album_title.trim();
+    const trimmedTitle = body.album_title.trim();
+    if (trimmedTitle.length > MAX_ALBUM_TEXT_LENGTH) {
+      throw new WxycError(`album_title must be ${MAX_ALBUM_TEXT_LENGTH} characters or fewer`, 400);
+    }
+    updates.album_title = trimmedTitle;
   }
 
   if ('alternate_artist_name' in body) {
     if (body.alternate_artist_name !== null && typeof body.alternate_artist_name !== 'string') {
       throw new WxycError('alternate_artist_name must be a string or null', 400);
     }
-    updates.alternate_artist_name = body.alternate_artist_name?.trim() || null;
+    const trimmedAlternate = body.alternate_artist_name?.trim() || null;
+    if (trimmedAlternate !== null && trimmedAlternate.length > MAX_ALBUM_TEXT_LENGTH) {
+      throw new WxycError(`alternate_artist_name must be ${MAX_ALBUM_TEXT_LENGTH} characters or fewer`, 400);
+    }
+    updates.alternate_artist_name = trimmedAlternate;
   }
 
   if (body.disc_quantity !== undefined) {
@@ -616,6 +629,14 @@ export const updateAlbum: RequestHandler<{ id: string }, unknown, UpdateAlbumReq
   if (body.format_id !== undefined) {
     if (!Number.isInteger(body.format_id) || body.format_id < 1) {
       throw new WxycError('format_id must be a positive integer', 400);
+    }
+    // Validate against the format table so a stale/guessed id surfaces as 400
+    // instead of a PG 23503 → 500 (mirrors the label_id guard). This runs
+    // before the label upsert below, so a bad format_id can't strand an orphan
+    // labels row on the failure path (#1550).
+    const formatRow = await libraryService.getFormatById(body.format_id);
+    if (!formatRow) {
+      throw new WxycError('format_id does not reference an existing format', 400);
     }
     updates.format_id = body.format_id;
   }
@@ -667,6 +688,9 @@ export const updateAlbum: RequestHandler<{ id: string }, unknown, UpdateAlbumReq
       // long-stable label_id (issue 6). Clearing must be explicit.
       throw new WxycError('label must be a non-empty string; clear the label by sending label_id: null', 400);
     }
+    if (trimmedLabel !== undefined && trimmedLabel.length > MAX_ALBUM_TEXT_LENGTH) {
+      throw new WxycError(`label must be ${MAX_ALBUM_TEXT_LENGTH} characters or fewer`, 400);
+    }
 
     if (labelIdProvided && body.label_id === null) {
       if (trimmedLabel) {
@@ -693,6 +717,23 @@ export const updateAlbum: RequestHandler<{ id: string }, unknown, UpdateAlbumReq
       updates.label_id = resolvedLabel.id;
       updates.label = trimmedLabel;
     }
+  }
+
+  // Short-circuit a no-op edit: updateAlbumInDB always SETs last_modified =
+  // NOW(), which fires the touch_library_watermark trigger and advances the
+  // catalog conditional-GET watermark — forcing every iOS / dj-site poller to
+  // re-download the full catalog for a write that changed nothing (#1555). A
+  // PATCH resolves to no-op when every computed update already equals the
+  // stored value (e.g. `{artist_id: <same>}`, or a dj-site "Save" that
+  // resubmits the unchanged record). Compare against the already-fetched row
+  // and return it unchanged rather than running the UPDATE.
+  const effectiveChange = (Object.keys(updates) as Array<keyof libraryService.UpdateAlbumRow>).some(
+    (key) => updates[key] !== existing[key as keyof typeof existing]
+  );
+  if (!effectiveChange) {
+    const album = await libraryService.getAlbumFromDB(albumId);
+    res.status(200).json(album);
+    return;
   }
 
   // Identity-affecting edits invalidate the LML enrichment columns and
@@ -830,11 +871,22 @@ export const searchLibraryQueryEndpoint: RequestHandler<object, unknown, unknown
   }
   const q = req.query.q ?? '';
 
+  // Express's `simple` query parser yields a string[] for a repeated key, and
+  // parseInt(['1','2']) stringifies to '1,2' → 1, silently coercing instead of
+  // erroring. Reject repeated page/limit keys the same way `q` is rejected
+  // above, so a malformed request fails loudly rather than paginating wrong
+  // (#1553).
+  if (req.query.page !== undefined && typeof req.query.page !== 'string') {
+    throw new WxycError('page must be a single string value', 400);
+  }
   const page = parseInt(req.query.page ?? '0');
   if (isNaN(page) || page < 0) {
     throw new WxycError('page must be a non-negative integer', 400);
   }
 
+  if (req.query.limit !== undefined && typeof req.query.limit !== 'string') {
+    throw new WxycError('limit must be a single string value', 400);
+  }
   const limit = parseInt(req.query.limit ?? String(DEFAULT_LIMIT));
   if (isNaN(limit) || limit < 1) {
     throw new WxycError('limit must be a positive integer', 400);

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -5,6 +5,7 @@ import type { ReconciledIdentity, TrackMatchHint } from '@wxyc/shared/dtos';
 import { RotationAddRequest } from '../controllers/library.controller.js';
 import { db } from '@wxyc/database';
 import {
+  AlbumFormat,
   Artist,
   NewAlbum,
   NewAlbumFormat,
@@ -220,6 +221,17 @@ export const getFormatsFromDB = async () => {
 export const insertFormat = async (new_format: NewAlbumFormat) => {
   const response = await db.insert(format).values(new_format).returning();
   return response[0];
+};
+
+/**
+ * Look up a single format row by id. Used by PATCH /library/:id to validate an
+ * incoming `format_id` against the `format` table so a stale/guessed id
+ * surfaces as a 400 instead of tripping the NOT NULL FK (PG 23503) → 500
+ * (BS#1550), mirroring `labelsService.getLabelById`.
+ */
+export const getFormatById = async (id: number): Promise<AlbumFormat | undefined> => {
+  const result = await db.select().from(format).where(eq(format.id, id)).limit(1);
+  return result[0];
 };
 
 export interface Rotation {

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -1665,11 +1665,7 @@ export type UpdateAlbumRow = {
   code_number?: number;
 };
 
-export const updateAlbumInDB = async (
-  album_id: number,
-  updates: UpdateAlbumRow,
-  opts?: { resetEnrichment?: boolean }
-) => {
+export const updateAlbumInDB = async (album_id: number, updates: UpdateAlbumRow) => {
   const set: Record<string, unknown> = { last_modified: sql`NOW()` };
   for (const key of [
     'album_title',
@@ -1685,18 +1681,15 @@ export const updateAlbumInDB = async (
   ] as const) {
     if (updates[key] !== undefined) set[key] = updates[key];
   }
-  // Identity-affecting edits invalidate LML-derived columns: the old
-  // on_streaming / artwork / canonical-entity linkage belongs to the previous
-  // (artist, title) identity. The controller re-fires enrichment after the
-  // write; nulling first means a failed lookup leaves the row visibly
-  // unenriched instead of silently bound to the wrong identity.
-  if (opts?.resetEnrichment) {
-    set.on_streaming = null;
-    set.artwork_url = null;
-    set.canonical_entity_id = null;
-    set.canonical_entity_confidence = null;
-    set.canonical_entity_resolved_at = null;
-  }
+  // Deliberately NOT nulling the LML-derived columns (on_streaming /
+  // artwork_url / canonical_entity_*) here. The old reset-then-maybe-refill
+  // shape permanently wiped enrichment whenever the post-write re-lookup was
+  // skipped (LML unconfigured) or found no match (transient outage, or a
+  // freeform-radio artist with no Discogs "direct" match) — and no recurring
+  // job repairs those columns (BS#1549). The controller now re-fires
+  // enrichment and overwrites each column only on a successful lookup
+  // (refill-then-swap), so a failed/empty lookup leaves the prior values
+  // intact instead of stranding the row blank.
   const result = await db.update(library).set(set).where(eq(library.id, album_id)).returning({ id: library.id });
   return result[0];
 };

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -21,6 +21,18 @@ const mockResolveRotationPickerSource = jest.fn<(rotationId: number) => Promise<
 type RotationTrackMock = { position: string; title: string; duration: string | null; artists: string[] };
 const mockGetRotationTracksFromRelease = jest.fn<(releaseId: number) => Promise<RotationTrackMock[] | null>>();
 
+// PATCH /library/:id (updateAlbum) surface.
+const mockGetLibraryRowById = jest.fn<(id: number) => Promise<Record<string, unknown> | undefined>>();
+const mockUpdateAlbumInDB =
+  jest.fn<(id: number, updates: Record<string, unknown>, opts?: unknown) => Promise<{ id: number } | undefined>>();
+const mockGetFormatById = jest.fn<(id: number) => Promise<{ id: number; format_name: string } | undefined>>();
+const mockArtistExistsInGenre = jest.fn<(artistId: number, genreId: number) => Promise<boolean>>();
+const mockAlbumCodeNumberTaken = jest.fn<(artistId: number, code: number, exclude: number) => Promise<boolean>>();
+const mockUpdateOnStreaming = jest.fn<() => Promise<unknown>>();
+const mockUpdateArtworkUrl = jest.fn<() => Promise<unknown>>();
+const mockGetLabelById = jest.fn<(id: number) => Promise<{ id: number; label_name: string } | undefined>>();
+const mockSearchLibrary = jest.fn<() => Promise<{ results: unknown[]; total: number }>>();
+
 jest.mock('../../../apps/backend/services/library.service', () => ({
   getAlbumFromDB: mockGetAlbumFromDB,
   markAlbumMissing: mockMarkAlbumMissing,
@@ -37,8 +49,8 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   addToRotation: jest.fn(),
   killRotationInDB: jest.fn(),
   insertAlbum: mockInsertAlbum,
-  updateArtworkUrl: jest.fn(),
-  updateOnStreaming: jest.fn(),
+  updateArtworkUrl: mockUpdateArtworkUrl,
+  updateOnStreaming: mockUpdateOnStreaming,
   updateCanonicalEntity: mockUpdateCanonicalEntity,
   mapLookupToCanonicalEntity: mockMapLookupToCanonicalEntity,
   artistIdFromName: mockArtistIdFromName,
@@ -51,13 +63,25 @@ jest.mock('../../../apps/backend/services/library.service', () => ({
   getGenresFromDB: jest.fn(),
   insertGenre: jest.fn(),
   insertFormat: jest.fn(),
+  getFormatById: mockGetFormatById,
   isISODate: jest.fn(),
   resolveRotationPickerSource: mockResolveRotationPickerSource,
   getRotationTracksFromRelease: mockGetRotationTracksFromRelease,
+  getLibraryRowById: mockGetLibraryRowById,
+  updateAlbumInDB: mockUpdateAlbumInDB,
+  artistExistsInGenre: mockArtistExistsInGenre,
+  albumCodeNumberTaken: mockAlbumCodeNumberTaken,
 }));
 
 jest.mock('../../../apps/backend/services/labels.service', () => ({
   createLabel: mockCreateLabel,
+  getLabelById: mockGetLabelById,
+}));
+
+jest.mock('../../../apps/backend/services/library-search.service', () => ({
+  parseEnumQueryList: () => undefined,
+  parseRotationBinsQueryList: () => undefined,
+  searchLibrary: mockSearchLibrary,
 }));
 
 const mockLookupMetadata = jest.fn<() => Promise<unknown>>();
@@ -95,6 +119,8 @@ import {
   searchForAlbum,
   addAlbum,
   getRotationTracks,
+  updateAlbum,
+  searchLibraryQueryEndpoint,
 } from '../../../apps/backend/controllers/library.controller';
 
 function mockResponse(): Response {
@@ -562,6 +588,172 @@ describe('library.controller', () => {
       const res = mockResponse();
 
       await expect(getRotationTracks(req, res, next)).rejects.toThrow('upstream timeout');
+    });
+  });
+
+  describe('updateAlbum', () => {
+    const existingRow = {
+      id: 42,
+      artist_id: 7,
+      genre_id: 11,
+      format_id: 1,
+      album_title: 'DOGA',
+      label: 'Sonamos',
+      label_id: 10,
+      alternate_artist_name: null,
+      disc_quantity: 1,
+      code_number: 3,
+      artist_name: 'Juana Molina',
+    };
+
+    const reqFor = (body: Record<string, unknown>) => ({ params: { id: '42' }, body }) as unknown as Request;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockIsLmlConfigured.mockReturnValue(false);
+      mockGetLibraryRowById.mockResolvedValue(existingRow);
+      mockUpdateAlbumInDB.mockResolvedValue({ id: 42 });
+      mockGetFormatById.mockResolvedValue({ id: 1, format_name: 'CD' });
+      mockGetAlbumFromDB.mockResolvedValue(fullAlbum);
+      mockGetArtistNameById.mockResolvedValue('Juana Molina');
+      mockArtistExistsInGenre.mockResolvedValue(true);
+    });
+
+    describe('format_id existence guard (#1550)', () => {
+      it('returns 400 when format_id does not reference an existing format', async () => {
+        mockGetFormatById.mockResolvedValue(undefined);
+        const res = mockResponse();
+
+        await expect(updateAlbum(reqFor({ format_id: 99999999 }), res, next)).rejects.toThrow(
+          'format_id does not reference an existing format'
+        );
+        expect(mockUpdateAlbumInDB).not.toHaveBeenCalled();
+      });
+
+      it('does not create an orphan label when an invalid format_id is combined with a new label', async () => {
+        mockGetFormatById.mockResolvedValue(undefined);
+        const res = mockResponse();
+
+        await expect(updateAlbum(reqFor({ format_id: 99999999, label: 'Brand New Label' }), res, next)).rejects.toThrow(
+          'format_id does not reference an existing format'
+        );
+        // format_id is validated before the label upsert, so no labels row is stranded.
+        expect(mockCreateLabel).not.toHaveBeenCalled();
+        expect(mockUpdateAlbumInDB).not.toHaveBeenCalled();
+      });
+
+      it('accepts a format_id that references an existing format', async () => {
+        mockGetFormatById.mockResolvedValue({ id: 2, format_name: 'Vinyl' });
+        const res = mockResponse();
+
+        await updateAlbum(reqFor({ format_id: 2 }), res, next);
+
+        expect(mockGetFormatById).toHaveBeenCalledWith(2);
+        expect(mockUpdateAlbumInDB).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+    });
+
+    describe('over-length string guards (#1551)', () => {
+      it('returns 400 for an over-length album_title (>128 chars)', async () => {
+        const res = mockResponse();
+
+        await expect(updateAlbum(reqFor({ album_title: 'a'.repeat(129) }), res, next)).rejects.toThrow(
+          'album_title must be 128 characters or fewer'
+        );
+        expect(mockUpdateAlbumInDB).not.toHaveBeenCalled();
+      });
+
+      it('returns 400 for an over-length alternate_artist_name (>128 chars)', async () => {
+        const res = mockResponse();
+
+        await expect(updateAlbum(reqFor({ alternate_artist_name: 'a'.repeat(129) }), res, next)).rejects.toThrow(
+          'alternate_artist_name must be 128 characters or fewer'
+        );
+        expect(mockUpdateAlbumInDB).not.toHaveBeenCalled();
+      });
+
+      it('returns 400 for an over-length label (>128 chars) without upserting it', async () => {
+        const res = mockResponse();
+
+        await expect(updateAlbum(reqFor({ label: 'a'.repeat(129) }), res, next)).rejects.toThrow(
+          'label must be 128 characters or fewer'
+        );
+        expect(mockCreateLabel).not.toHaveBeenCalled();
+        expect(mockUpdateAlbumInDB).not.toHaveBeenCalled();
+      });
+
+      it('accepts an exactly-128-char album_title', async () => {
+        const res = mockResponse();
+
+        await updateAlbum(reqFor({ album_title: 'a'.repeat(128) }), res, next);
+
+        expect(mockUpdateAlbumInDB).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+    });
+
+    describe('no-op short-circuit (#1555)', () => {
+      it('returns 200 without running the UPDATE when artist_id is unchanged', async () => {
+        const res = mockResponse();
+
+        await updateAlbum(reqFor({ artist_id: 7 }), res, next);
+
+        expect(mockUpdateAlbumInDB).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith(fullAlbum);
+      });
+
+      it('returns 200 without running the UPDATE when the submitted album_title equals the stored value', async () => {
+        const res = mockResponse();
+
+        await updateAlbum(reqFor({ album_title: 'DOGA' }), res, next);
+
+        expect(mockUpdateAlbumInDB).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      it('runs the UPDATE when a field actually changes', async () => {
+        const res = mockResponse();
+
+        await updateAlbum(reqFor({ album_title: 'A Different Title' }), res, next);
+
+        expect(mockUpdateAlbumInDB).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+    });
+  });
+
+  describe('searchLibraryQueryEndpoint', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockSearchLibrary.mockResolvedValue({ results: [], total: 0 });
+    });
+
+    it('returns 400 when the page key is repeated (Express yields string[]) (#1553)', async () => {
+      const req = { query: { page: ['1', '2'] } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(searchLibraryQueryEndpoint(req, res, next)).rejects.toThrow('page must be a single string value');
+      expect(mockSearchLibrary).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the limit key is repeated (Express yields string[]) (#1553)', async () => {
+      const req = { query: { limit: ['1', '2'] } } as unknown as Request;
+      const res = mockResponse();
+
+      await expect(searchLibraryQueryEndpoint(req, res, next)).rejects.toThrow('limit must be a single string value');
+      expect(mockSearchLibrary).not.toHaveBeenCalled();
+    });
+
+    it('accepts single-valued page/limit and returns 200', async () => {
+      const req = { query: { page: '1', limit: '10' } } as unknown as Request;
+      const res = mockResponse();
+
+      await searchLibraryQueryEndpoint(req, res, next);
+
+      expect(mockSearchLibrary).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
     });
   });
 });

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -722,6 +722,62 @@ describe('library.controller', () => {
         expect(res.status).toHaveBeenCalledWith(200);
       });
     });
+
+    describe('enrichment repair on identity change (#1549)', () => {
+      it('does not null enrichment columns when LML is unconfigured', async () => {
+        mockIsLmlConfigured.mockReturnValue(false);
+        const res = mockResponse();
+
+        await updateAlbum(reqFor({ album_title: 'A New Title' }), res, next);
+
+        // Two-arg call, no resetEnrichment flag: updateAlbumInDB never NULLs
+        // on_streaming / artwork_url / canonical_entity_*.
+        expect(mockUpdateAlbumInDB).toHaveBeenCalledWith(42, expect.objectContaining({ album_title: 'A New Title' }));
+        expect(mockUpdateAlbumInDB.mock.calls[0]).toHaveLength(2);
+        // LML unconfigured -> no re-enrichment fired, so nothing is wiped or rewritten.
+        expect(mockUpdateOnStreaming).not.toHaveBeenCalled();
+        expect(mockUpdateArtworkUrl).not.toHaveBeenCalled();
+        expect(mockUpdateCanonicalEntity).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      it('preserves prior enrichment when the identity re-lookup finds no match', async () => {
+        mockIsLmlConfigured.mockReturnValue(true);
+        mockCheckStreamingAvailability.mockResolvedValue({ on_streaming: null });
+        mockLookupMetadata.mockResolvedValue(null); // no match: coordinator returns null
+        const res = mockResponse();
+
+        await updateAlbum(reqFor({ album_title: 'A New Title' }), res, next);
+        // Drain the fire-and-forget canonical-entity lookup before asserting.
+        await new Promise((r) => setImmediate(r));
+
+        expect(mockUpdateAlbumInDB).toHaveBeenCalledWith(42, expect.objectContaining({ album_title: 'A New Title' }));
+        expect(mockUpdateAlbumInDB.mock.calls[0]).toHaveLength(2);
+        // A no-match re-lookup writes nothing, so the prior artwork / streaming /
+        // canonical values survive the edit instead of being NULLed-and-abandoned.
+        expect(mockUpdateOnStreaming).not.toHaveBeenCalled();
+        expect(mockUpdateArtworkUrl).not.toHaveBeenCalled();
+        expect(mockUpdateCanonicalEntity).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      it('swaps in the newly looked-up artwork/streaming when the re-lookup matches', async () => {
+        mockIsLmlConfigured.mockReturnValue(true);
+        mockCheckStreamingAvailability.mockResolvedValue({ on_streaming: true });
+        mockLookupMetadata.mockResolvedValue({
+          search_type: 'direct',
+          results: [{ artwork: { artwork_url: 'https://i.discogs.com/new.jpg' } }],
+        });
+        const res = mockResponse();
+
+        await updateAlbum(reqFor({ album_title: 'A New Title' }), res, next);
+        await new Promise((r) => setImmediate(r));
+
+        expect(mockUpdateOnStreaming).toHaveBeenCalledWith(42, true);
+        expect(mockUpdateArtworkUrl).toHaveBeenCalledWith(42, 'https://i.discogs.com/new.jpg');
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+    });
   });
 
   describe('searchLibraryQueryEndpoint', () => {


### PR DESCRIPTION
Closes five sibling bugs from the PR #1154 catalog-editing review, all funnelling through `apps/backend/controllers/library.controller.ts` + `apps/backend/services/library.service.ts`. Structured as two commits for review legibility.

## Commit 1 — validation guards (#1550 / #1551 / #1553 / #1555)

- **#1550** — `PATCH /library/:id` `format_id` had only a `Number.isInteger`/`>= 1` shape check, so a nonexistent id tripped the `NOT NULL` FK (PG 23503) → 500 and, because the label upsert runs first, stranded an orphan `labels` row. Added `libraryService.getFormatById` and a `format`-row-exists guard mirroring the `label_id`→`getLabelById`→400 guard. It runs before the label upsert, so a bad `format_id` returns 400 with no orphan label written.
- **#1551** — `album_title` / `alternate_artist_name` / `label` are all `varchar(128)`; an over-length value tripped PG 22001 → 500. Added `<= 128` length checks (400 with a clear message) alongside the existing non-empty checks. Scoped to PATCH per the acceptance criteria; `addAlbum` has the same gap and is left for the #1556 cleanup tracker.
- **#1553** — repeated `page`/`limit` query keys (Express's `simple` parser yields `string[]`) silently coerced through `parseInt` (`['1','2']` → `1`) instead of erroring. Now rejected with 400, mirroring the existing `q` array guard.
- **#1555** — a no-op PATCH still ran the UPDATE, and `updateAlbumInDB` always SETs `last_modified = NOW()`, firing the `touch_library_watermark` trigger and busting the full-catalog conditional-GET watermark (Epic F / BS#1467). Now short-circuits to returning the current row when every computed update already equals the stored value (e.g. `{artist_id: <same>}`, or a dj-site "Save" of an unchanged record). A real edit still advances the watermark.

## Commit 2 — enrichment data-loss fix (#1549)

An identity-changing PATCH called `updateAlbumInDB(..., { resetEnrichment: true })`, which unconditionally NULLed `on_streaming` / `artwork_url` / `canonical_entity_*`. The repairing re-lookup is gated on `identityChanged && isLmlConfigured()` and re-persists each column only on a successful match, so the columns were destroyed and never restored whenever LML is unconfigured (dev/test/misdeploy) or the lookup finds no match (a transient outage, or a freeform-radio artist with no Discogs "direct" match). No recurring job repairs them, so the row stayed blank in the catalog UI.

Switched to **refill-then-swap**: removed the `resetEnrichment` reset (and the now-dead option from `updateAlbumInDB`); `enrichAlbumAfterIdentityChange` already overwrites each column only when the new lookup yields a value. An unconfigured LML or a no-match re-lookup now leaves the prior enrichment intact.

## Tests

All unit (mocked-DB), matching the existing controller test patterns in `tests/unit/controllers/library.controller.test.ts`:

- format_id existence guard: 400 on nonexistent id; no orphan label on the failure path; accepts a valid id.
- over-length guards: 400 for over-length `album_title` / `alternate_artist_name` / `label` (no upsert); accepts exactly 128 chars.
- no-op short-circuit: unchanged `artist_id` / `album_title` return 200 without running the UPDATE; a real change still runs it.
- repeated `page`/`limit` keys: 400; single-valued still 200.
- #1549: LML-unconfigured and no-match identity edits leave enrichment untouched (two-arg `updateAlbumInDB`, no writes); a matching re-lookup swaps in the new artwork/streaming.

Full local checks pass: `npm run typecheck` (clean), `npm run lint` (0 errors), `npm run test:unit` (4295 passed). Integration tests were intentionally not run to avoid a shared-Postgres collision with parallel worktrees; #1549's suggested integration coverage (mock LML unconfigured / mock lookup null) is fully exercised at the unit level above.

Closes #1549
Closes #1550
Closes #1551
Closes #1553
Closes #1555