### PR TITLE
fix(search): escape ILIKE wildcards in suggest/labels user input

### DIFF
--- a/apps/backend/services/labels.service.ts
+++ b/apps/backend/services/labels.service.ts
@@ -1,5 +1,6 @@
 import { eq, sql } from 'drizzle-orm';
 import { db, labels, Label } from '@wxyc/database';
+import { ilikeEscaped } from '../utils/sql-like.js';
 
 export const getAllLabels = async (): Promise<Label[]> => {
   return await db.select().from(labels);
@@ -32,7 +33,7 @@ export const createLabel = async (labelName: string, parentLabelId?: number): Pr
 export const searchLabels = async (query: string, limit = 10): Promise<Label[]> => {
   const searchQuery = sql`
     SELECT * FROM ${labels}
-    WHERE ${labels.label_name} ILIKE ${query + '%'}
+    WHERE ${ilikeEscaped(labels.label_name, query, 'prefix')}
     ORDER BY ${labels.label_name}
     LIMIT ${limit}
   `;

--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -20,6 +20,7 @@ import { runCatalogTrackSearchCascade, type TaggedLibraryViewEntry } from './lib
 import type { ArtistMatchHint, ArtistSearchAliasSource } from './requestLine/types.js';
 import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 import WxycError from '../utils/error.js';
+import { ilikeEscaped } from '../utils/sql-like.js';
 
 export type CatalogSort = 'artist' | 'album' | 'plays' | 'date';
 export type CatalogOrder = 'asc' | 'desc';
@@ -518,7 +519,7 @@ function buildColumnMatch(field: CatalogField, value: string, exact: boolean): S
   if (exact) {
     return sql`${col} = ${value}`;
   }
-  return sql`${col} ILIKE ${'%' + value + '%'}`;
+  return ilikeEscaped(col, value, 'contains');
 }
 
 function buildAllFieldMatch(value: string, exact: boolean): SQL {
@@ -536,8 +537,7 @@ function buildAllFieldMatch(value: string, exact: boolean): SQL {
   // UNION ALL design (BS#1318) alias-only hits surface from branch (b)'s
   // INNER JOIN against the `alias_hits` CTE, not from an OR predicate
   // injected into this fragment.
-  const pattern = '%' + value + '%';
-  return sql`(${library_artist_view.artist_name} ILIKE ${pattern} OR ${library_artist_view.album_title} ILIKE ${pattern} OR ${library_artist_view.label} ILIKE ${pattern})`;
+  return sql`(${ilikeEscaped(library_artist_view.artist_name, value, 'contains')} OR ${ilikeEscaped(library_artist_view.album_title, value, 'contains')} OR ${ilikeEscaped(library_artist_view.label, value, 'contains')})`;
 }
 
 function buildFilterClause(params: LibraryQueryParams): SQL | null {

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -48,6 +48,7 @@ import { checkLibraryArtistNameHealth } from './library-artist-name-assertion.se
 import { getConfig as getCatalogTrackSearchConfig } from '../config/catalogTrackSearch.js';
 import { getConfig as getCatalogSearchAliasConfig } from '../config/catalogSearchAlias.js';
 import { isCompilationArtist } from './requestLine/matching/index.js';
+import { ilikeEscaped } from '../utils/sql-like.js';
 
 /**
  * Catalog freshness watermark for the conditional-GET path (BS#1467 / Epic F
@@ -1502,9 +1503,6 @@ export type ArtistInGenreSearchRow = {
   code_number: number;
 };
 
-/** Escape LIKE/ILIKE metacharacters so user input matches literally. */
-const escapeLikePattern = (value: string): string => value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
-
 /**
  * Prefix search for artists in a genre (catalog add-entry autocomplete).
  * `code_number` is the artist's number within that genre (`artist_genre_code`).
@@ -1523,8 +1521,6 @@ export const searchArtistsInGenre = async (
 
   // Escape %/_ so e.g. q='%a' can't short the prefix-search contract into a
   // contains-anything scan (review issue 14).
-  const pattern = escapeLikePattern(prefix) + '%';
-
   return db
     .select({
       id: artists.id,
@@ -1534,7 +1530,7 @@ export const searchArtistsInGenre = async (
     })
     .from(artists)
     .innerJoin(genre_artist_crossreference, eq(genre_artist_crossreference.artist_id, artists.id))
-    .where(and(eq(genre_artist_crossreference.genre_id, genre_id), sql`${artists.artist_name} ILIKE ${pattern}`))
+    .where(and(eq(genre_artist_crossreference.genre_id, genre_id), ilikeEscaped(artists.artist_name, prefix, 'prefix')))
     .orderBy(asc(artists.artist_name))
     .limit(cappedLimit);
 };
@@ -2052,7 +2048,7 @@ async function searchLibraryByTrackUncachedOrThrow(query: string): Promise<Tagge
                 compilation_track_artist.library_id,
                 rows.map((r) => r.id)
               ),
-              sql`${compilation_track_artist.track_title} ILIKE ${'%' + query + '%'}`
+              ilikeEscaped(compilation_track_artist.track_title, query, 'contains')
             )
           )) as Array<{ library_id: number }>);
   const ctaCovered = new Set(ctaRows.map((r) => r.library_id));
@@ -2314,8 +2310,7 @@ export async function searchLibraryByCTARaw(
 
   await checkLibraryArtistNameHealth();
 
-  const likePattern = `%${trimmed}%`;
-  const matchPredicate = sql`(${compilation_track_artist.track_title} ILIKE ${likePattern} OR ${compilation_track_artist.artist_name} ILIKE ${likePattern})`;
+  const matchPredicate = sql`(${ilikeEscaped(compilation_track_artist.track_title, trimmed, 'contains')} OR ${ilikeEscaped(compilation_track_artist.artist_name, trimmed, 'contains')})`;
   const streamingPredicate = on_streaming !== undefined ? sql` AND ${library.on_streaming} = ${on_streaming}` : sql``;
 
   // Raw SQL because we need both the library_artist_view projection and the

--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -6,6 +6,7 @@ import {
   type FlowsheetField,
   type SearchCondition,
 } from './search-parser.service.js';
+import { ilikeEscaped } from '../utils/sql-like.js';
 
 export type SearchParams = {
   q: string;
@@ -236,7 +237,7 @@ function buildColumnMatch(column: string, value: string, exact: boolean): SQL {
   if (exact) {
     return sql`${col} = ${value}`;
   }
-  return sql`${col} ILIKE ${'%' + value + '%'}`;
+  return ilikeEscaped(col, value, 'contains');
 }
 
 /**
@@ -263,8 +264,7 @@ function buildAllFieldMatch(value: string, exact: boolean): SQL {
   }
   // Trigram fallback: short queries, pure-punctuation strings, and any other
   // input that the tsvector path would tokenize away.
-  const pattern = '%' + value + '%';
-  return sql`(${flowsheet.artist_name} ILIKE ${pattern} OR ${flowsheet.track_title} ILIKE ${pattern} OR ${flowsheet.album_title} ILIKE ${pattern} OR ${flowsheet.record_label} ILIKE ${pattern})`;
+  return sql`(${ilikeEscaped(flowsheet.artist_name, value, 'contains')} OR ${ilikeEscaped(flowsheet.track_title, value, 'contains')} OR ${ilikeEscaped(flowsheet.album_title, value, 'contains')} OR ${ilikeEscaped(flowsheet.record_label, value, 'contains')})`;
 }
 
 function buildDjNameMatch(value: string, exact: boolean): SQL {
@@ -280,7 +280,7 @@ function buildDjNameMatch(value: string, exact: boolean): SQL {
   if (exact) {
     return sql`${flowsheet.dj_name} = ${value}`;
   }
-  return sql`${flowsheet.dj_name} ILIKE ${'%' + value + '%'}`;
+  return ilikeEscaped(flowsheet.dj_name, value, 'contains');
 }
 
 function buildDateMatch(value: string): SQL {

--- a/apps/backend/services/suggest.service.ts
+++ b/apps/backend/services/suggest.service.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm';
 import { db, artists, library, flowsheet, library_artist_view, compilation_track_artist } from '@wxyc/database';
+import { ilikeEscaped } from '../utils/sql-like.js';
 
 export type SuggestTrackResult = {
   track_title: string;
@@ -22,7 +23,7 @@ export async function suggestArtists(prefix: string, limit = 5): Promise<string[
     SELECT ${artists.artist_name} AS artist_name, SUM(COALESCE(${library.plays}, 0)) AS total_plays
     FROM ${artists}
     JOIN ${library} ON ${library.artist_id} = ${artists.id}
-    WHERE ${artists.artist_name} ILIKE ${prefix + '%'}
+    WHERE ${ilikeEscaped(artists.artist_name, prefix, 'prefix')}
     GROUP BY ${artists.artist_name}
     ORDER BY total_plays DESC
     LIMIT ${limit}
@@ -47,8 +48,8 @@ export async function suggestTracks(prefix: string, artistName: string, limit = 
       ${flowsheet.album_title} AS album_title,
       ${flowsheet.record_label} AS record_label
     FROM ${flowsheet}
-    WHERE ${flowsheet.artist_name} ILIKE ${artistName}
-      AND ${flowsheet.track_title} ILIKE ${prefix + '%'}
+    WHERE ${ilikeEscaped(flowsheet.artist_name, artistName, 'exact')}
+      AND ${ilikeEscaped(flowsheet.track_title, prefix, 'prefix')}
       AND ${flowsheet.entry_type} = 'track'
     ORDER BY ${flowsheet.track_title}, ${flowsheet.add_time} DESC
     LIMIT ${limit}
@@ -69,8 +70,8 @@ export async function suggestTracks(prefix: string, artistName: string, limit = 
            ${library.label} AS record_label
     FROM ${compilation_track_artist}
     JOIN ${library} ON ${library.id} = ${compilation_track_artist.library_id}
-    WHERE ${compilation_track_artist.artist_name} ILIKE ${artistName}
-      AND ${compilation_track_artist.track_title} ILIKE ${prefix + '%'}
+    WHERE ${ilikeEscaped(compilation_track_artist.artist_name, artistName, 'exact')}
+      AND ${ilikeEscaped(compilation_track_artist.track_title, prefix, 'prefix')}
     LIMIT ${limit}
   `;
 
@@ -100,8 +101,8 @@ export async function getTrackDetails(artistName: string, trackTitle: string): P
   const flowsheetQuery = sql`
     SELECT ${flowsheet.album_title} AS album_title, ${flowsheet.record_label} AS record_label
     FROM ${flowsheet}
-    WHERE ${flowsheet.artist_name} ILIKE ${artistName}
-      AND ${flowsheet.track_title} ILIKE ${trackTitle}
+    WHERE ${ilikeEscaped(flowsheet.artist_name, artistName, 'exact')}
+      AND ${ilikeEscaped(flowsheet.track_title, trackTitle, 'exact')}
       AND ${flowsheet.entry_type} = 'track'
     ORDER BY ${flowsheet.add_time} DESC
     LIMIT 1
@@ -119,7 +120,7 @@ export async function getTrackDetails(artistName: string, trackTitle: string): P
     SELECT ${library_artist_view.album_title} AS album_title,
            ${library_artist_view.label} AS record_label
     FROM ${library_artist_view}
-    WHERE ${library_artist_view.artist_name} ILIKE ${artistName}
+    WHERE ${ilikeEscaped(library_artist_view.artist_name, artistName, 'exact')}
     ORDER BY ${library_artist_view.album_title}
     LIMIT 1
   `;

--- a/apps/backend/utils/sql-like.ts
+++ b/apps/backend/utils/sql-like.ts
@@ -1,0 +1,51 @@
+import { sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+
+/**
+ * Escape the LIKE/ILIKE metacharacters (`%`, `_`) and the escape character
+ * itself (`\`) in user-supplied text so that it is matched literally rather
+ * than being silently reinterpreted as a wildcard pattern.
+ *
+ * This is a correctness fix, not an injection fix — Drizzle's `sql` tag already
+ * parameterizes the value, so `%`/`_` can never break out of the string. But an
+ * unescaped `%` still turns `suggestArtists("a%")` into "every artist starting
+ * with a", and an unescaped `_` turns a short label query into a table scan.
+ *
+ * The backslash is escaped first (implicitly, by including it in the character
+ * class) so that a literal `\` in the input can't combine with a following
+ * metacharacter. Pair the result with an explicit `ESCAPE '\'` clause on the
+ * ILIKE — see {@link ilikeEscaped}. (Postgres already defaults the LIKE escape
+ * character to backslash, but stating it keeps the intent legible.)
+ */
+export const escapeLikePattern = (value: string): string => value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+
+/** Wildcard placement for {@link ilikeEscaped}. */
+export type LikeWrap =
+  /** `value%` — starts-with (autocomplete prefix). */
+  | 'prefix'
+  /** `%value` — ends-with. */
+  | 'suffix'
+  /** `%value%` — substring search (default). */
+  | 'contains'
+  /** `value` — whole-value match, still case-insensitive. */
+  | 'exact';
+
+/**
+ * Build a case-insensitive `ILIKE` predicate whose right-hand pattern treats
+ * the caller's user-supplied `value` literally: metacharacters are escaped
+ * (see {@link escapeLikePattern}) and an explicit `ESCAPE '\'` clause is
+ * attached so the escaping is honored regardless of server defaults.
+ *
+ * `column` may be a Drizzle column or any `sql` fragment.
+ */
+export function ilikeEscaped(column: SQLWrapper, value: string, wrap: LikeWrap = 'contains'): SQL {
+  const escaped = escapeLikePattern(value);
+  const pattern =
+    wrap === 'prefix'
+      ? `${escaped}%`
+      : wrap === 'suffix'
+        ? `%${escaped}`
+        : wrap === 'contains'
+          ? `%${escaped}%`
+          : escaped;
+  return sql`${column} ILIKE ${pattern} ESCAPE '\\'`;
+}

--- a/tests/unit/services/labels.service.test.ts
+++ b/tests/unit/services/labels.service.test.ts
@@ -1,4 +1,12 @@
+// Use the real drizzle-orm `sql` tag (the unit suite auto-mocks it) so
+// searchLabels builds a real SQL object we can compile with PgDialect and
+// inspect the escaped ILIKE pattern + ESCAPE clause.
+jest.unmock('drizzle-orm');
+
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { db, createMockQueryChain } from '../../mocks/database.mock';
+
+const dialect = new PgDialect();
 
 // Reset mocks before each test
 beforeEach(() => {
@@ -104,6 +112,18 @@ describe('labels.service', () => {
       const result = await searchLabels('Nonexistent');
 
       expect(result).toEqual([]);
+    });
+
+    it('treats a _ in the query literally (escapes wildcards, adds ESCAPE)', async () => {
+      (db.execute as jest.Mock).mockResolvedValue([]);
+
+      await searchLabels('_a');
+
+      const stmt = (db.execute as jest.Mock).mock.calls[0][0];
+      const { sql: text, params } = dialect.sqlToQuery(stmt);
+      // "_a" -> escaped "\_a" -> prefix pattern "\_a%".
+      expect(params).toContain('\\_a%');
+      expect(text).toContain("ESCAPE '\\'");
     });
   });
 });

--- a/tests/unit/services/search.service.escape.test.ts
+++ b/tests/unit/services/search.service.escape.test.ts
@@ -1,0 +1,66 @@
+// Use the real drizzle-orm `sql` tag (the unit suite auto-mocks it) so
+// searchFlowsheet builds a real SQL object we can compile with PgDialect and
+// assert the escaped ILIKE patterns + ESCAPE clause reach db.execute. Mirrors
+// the escaping regression tests in suggest.service.test.ts / labels.service.test.ts,
+// extended to the flowsheet search service's multi-column trigram fallback.
+jest.unmock('drizzle-orm');
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { db } from '../../mocks/database.mock';
+
+const dialect = new PgDialect();
+
+/** Compile the SQL text + bound params for the Nth db.execute call (0 = data query). */
+const compiledExecuteCall = (n = 0) => {
+  const stmt = (db.execute as jest.Mock).mock.calls[n][0];
+  return dialect.sqlToQuery(stmt);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+import { searchFlowsheet } from '../../../apps/backend/services/search.service';
+
+/** searchFlowsheet issues the data query first, then the count query. */
+const mockDataAndCount = () => {
+  (db.execute as jest.Mock).mockResolvedValueOnce([]).mockResolvedValueOnce([{ total: 0 }]);
+};
+
+describe('search.service ILIKE wildcard escaping', () => {
+  it('escapes a % across all four columns of the all-field trigram fallback (with ESCAPE)', async () => {
+    mockDataAndCount();
+
+    // "%a" is 2 chars -> shouldUseTsvector() is false -> trigram fallback path,
+    // which ORs an ILIKE across artist/track/album/label.
+    await searchFlowsheet({ q: '%a', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    const { sql: text, params } = compiledExecuteCall(0);
+    // "%a" -> escaped "\%a" -> contains pattern "%\%a%" (only the wrapping %s are wildcards).
+    const contains = params.filter((p) => p === '%\\%a%');
+    // One bound param per column: artist_name, track_title, album_title, record_label.
+    expect(contains).toHaveLength(4);
+    expect(text).toContain("ESCAPE '\\'");
+  });
+
+  it('escapes a % in a field-scoped (artist:) contains match (with ESCAPE)', async () => {
+    mockDataAndCount();
+
+    await searchFlowsheet({ q: 'artist:%a', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    const { sql: text, params } = compiledExecuteCall(0);
+    expect(params).toContain('%\\%a%');
+    expect(text).toContain("ESCAPE '\\'");
+  });
+
+  it('escapes a _ in a dj-name (dj:) contains match (with ESCAPE)', async () => {
+    mockDataAndCount();
+
+    await searchFlowsheet({ q: 'dj:_a', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    const { sql: text, params } = compiledExecuteCall(0);
+    // "_a" -> escaped "\_a" -> contains pattern "%\_a%".
+    expect(params).toContain('%\\_a%');
+    expect(text).toContain("ESCAPE '\\'");
+  });
+});

--- a/tests/unit/services/suggest.service.test.ts
+++ b/tests/unit/services/suggest.service.test.ts
@@ -1,4 +1,19 @@
+// Use the real drizzle-orm `sql` tag (the unit suite auto-mocks it) so the
+// service builds a real SQL object we can compile with PgDialect and inspect
+// the escaped ILIKE patterns + ESCAPE clause. The mock @wxyc/database tables
+// are plain string maps, which the real `sql` tag binds as params — fine here.
+jest.unmock('drizzle-orm');
+
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { db } from '../../mocks/database.mock';
+
+const dialect = new PgDialect();
+
+/** Extract the compiled SQL text + bound params for the Nth db.execute call. */
+const compiledExecuteCall = (n = 0) => {
+  const stmt = (db.execute as jest.Mock).mock.calls[n][0];
+  return dialect.sqlToQuery(stmt);
+};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -33,6 +48,26 @@ describe('suggest.service', () => {
       const result = await suggestArtists('Aut', 1);
 
       expect(result).toEqual(['Autechre']);
+    });
+
+    it('treats a % in the prefix literally (escapes wildcards, adds ESCAPE)', async () => {
+      (db.execute as jest.Mock).mockResolvedValue([]);
+
+      await suggestArtists('A%');
+
+      const { sql: text, params } = compiledExecuteCall();
+      // Prefix "A%" -> escaped "A\%" -> pattern "A\%%" (only the trailing % is a wildcard).
+      expect(params).toContain('A\\%%');
+      expect(text).toContain("ESCAPE '\\'");
+    });
+
+    it('treats a _ in the prefix literally', async () => {
+      (db.execute as jest.Mock).mockResolvedValue([]);
+
+      await suggestArtists('Hot_');
+
+      const { params } = compiledExecuteCall();
+      expect(params).toContain('Hot\\_%');
     });
   });
 
@@ -75,6 +110,19 @@ describe('suggest.service', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].album_title).toBe('Confield');
+    });
+
+    it('escapes wildcards in both the track prefix and the artist name', async () => {
+      (db.execute as jest.Mock).mockResolvedValue([]);
+
+      await suggestTracks('%', 'AC_DC');
+
+      const { sql: text, params } = compiledExecuteCall();
+      // Prefix "%" must not become a bare wildcard that ignores the LIMIT contract.
+      expect(params).toContain('\\%%');
+      // Artist name is a full-value (exact) ILIKE: escaped, no added wildcards.
+      expect(params).toContain('AC\\_DC');
+      expect(text).toContain("ESCAPE '\\'");
     });
 
     it('skips compilation query when flowsheet results meet limit', async () => {
@@ -131,6 +179,22 @@ describe('suggest.service', () => {
       const result = await getTrackDetails('Unknown Artist', 'Unknown Track');
 
       expect(result).toBeNull();
+    });
+
+    it('escapes wildcards in the artist name and track title (full-value ILIKE)', async () => {
+      (db.execute as jest.Mock).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      await getTrackDetails('AC_DC', '100%');
+
+      const flowsheet = compiledExecuteCall(0);
+      expect(flowsheet.params).toContain('AC\\_DC');
+      expect(flowsheet.params).toContain('100\\%');
+      expect(flowsheet.sql).toContain("ESCAPE '\\'");
+
+      // Library fallback also escapes the artist name.
+      const library = compiledExecuteCall(1);
+      expect(library.params).toContain('AC\\_DC');
+      expect(library.sql).toContain("ESCAPE '\\'");
     });
   });
 });

--- a/tests/unit/utils/sql-like.test.ts
+++ b/tests/unit/utils/sql-like.test.ts
@@ -1,0 +1,65 @@
+// The unit suite auto-mocks drizzle-orm (tests/__mocks__/drizzle-orm.ts) so
+// `sql` returns a plain `{ sql, values }` shape. This suite needs the real
+// tag + dialect to compile fragments and inspect the escaped patterns/ESCAPE
+// clause the helper emits.
+jest.unmock('drizzle-orm');
+
+import { sql } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { escapeLikePattern, ilikeEscaped } from '../../../apps/backend/utils/sql-like';
+
+const dialect = new PgDialect();
+
+describe('escapeLikePattern', () => {
+  it('escapes a literal percent so it cannot act as a wildcard', () => {
+    // "100%" is a real track title; without escaping it matches "100" + anything.
+    expect(escapeLikePattern('100%')).toBe('100\\%');
+  });
+
+  it('escapes a literal underscore so it cannot act as a single-char wildcard', () => {
+    // "Hot_Soup" is a real band name; "_" would otherwise match any character.
+    expect(escapeLikePattern('Hot_Soup')).toBe('Hot\\_Soup');
+  });
+
+  it('escapes the backslash escape character itself', () => {
+    expect(escapeLikePattern('a\\b')).toBe('a\\\\b');
+  });
+
+  it('escapes the backslash before the wildcard it precedes (ordering matters)', () => {
+    // Raw input "\%" must become "\\" + "\%" = "\\\%", never "\\%" (which would
+    // re-introduce an active wildcard after a single escaped backslash).
+    expect(escapeLikePattern('\\%')).toBe('\\\\\\%');
+  });
+
+  it('leaves ordinary (including diacritic-bearing) text untouched', () => {
+    expect(escapeLikePattern('Nilüfer Yanya')).toBe('Nilüfer Yanya');
+  });
+});
+
+describe('ilikeEscaped', () => {
+  it('emits an explicit ESCAPE clause', () => {
+    const { sql: text } = dialect.sqlToQuery(ilikeEscaped(sql`x`, 'a%'));
+    expect(text).toContain("ESCAPE '\\'");
+  });
+
+  it("defaults to a substring ('contains') pattern with the value escaped", () => {
+    const { params } = dialect.sqlToQuery(ilikeEscaped(sql`x`, '100%'));
+    // %  + escaped("100%") + %  =>  %100\%%
+    expect(params).toContain('%100\\%%');
+  });
+
+  it('prefix wrap appends only a trailing wildcard', () => {
+    const { params } = dialect.sqlToQuery(ilikeEscaped(sql`x`, 'a%', 'prefix'));
+    expect(params).toContain('a\\%%');
+  });
+
+  it('suffix wrap prepends only a leading wildcard', () => {
+    const { params } = dialect.sqlToQuery(ilikeEscaped(sql`x`, 'a%', 'suffix'));
+    expect(params).toContain('%a\\%');
+  });
+
+  it('exact wrap adds no wildcards but still escapes user metacharacters', () => {
+    const { params } = dialect.sqlToQuery(ilikeEscaped(sql`x`, 'AC_DC', 'exact'));
+    expect(params).toContain('AC\\_DC');
+  });
+});


### PR DESCRIPTION
## Problem

User-supplied text containing the ILIKE metacharacters `%` and `_` was interpolated unescaped into ILIKE patterns in the suggest and labels services. This is not SQL injection (Drizzle's `sql` tag parameterizes the value) but a correctness bug: the user's literal text is silently reinterpreted as a wildcard pattern. `suggestArtists("a%")` matched every artist starting with "a", `searchLabels("_a")` enumerated short labels, and a literal `%`/`_` in a real track title ("100%") or band name ("Hot_Soup") quietly broke autocomplete and search. Auditing `grep -rn ILIKE apps/backend/services/` surfaced the same shape in the flowsheet/catalog search services and the CTA library search, which are fixed here too.

## Fix

Add a centralized helper `apps/backend/utils/sql-like.ts`:

- `escapeLikePattern(value)` — escapes `\`, `%`, `_` (backslash first, so a literal `\` can't combine with a following metacharacter).
- `ilikeEscaped(column, value, wrap)` — builds a case-insensitive `ILIKE` predicate with the value escaped and an explicit `ESCAPE '\'` clause; `wrap` is `prefix` / `suffix` / `contains` / `exact`.

Every user-input ILIKE site now routes through the helper. The previously-local `escapeLikePattern` in `library.service.ts` (only site already escaping) is removed in favor of the shared helper and now also carries the explicit `ESCAPE` clause.

## Sites fixed

- `apps/backend/services/suggest.service.ts` — artist prefix; flowsheet artist (exact) + track prefix; compilation-fallback artist (exact) + track prefix; track-details artist + title (exact); library-fallback artist (exact)
- `apps/backend/services/labels.service.ts` — label-name prefix
- `apps/backend/services/library.service.ts` — `searchArtistsInGenre` prefix (was already escaped; now via shared helper + explicit `ESCAPE`); CTA-coverage `track_title` contains-filter; `searchLibraryByCTARaw` track + artist contains
- `apps/backend/services/search.service.ts` — `buildColumnMatch`; all-field trigram fallback (4 columns); `buildDjNameMatch`
- `apps/backend/services/library-search.service.ts` — `buildColumnMatch`; all-field trigram fallback (3 columns)

Not fixed (literal patterns, not user input): `shared/database/src/library-tiebreak.ts` `'vinyl%'` / `'digital%'`.

## Tests

- New `tests/unit/utils/sql-like.test.ts` — `escapeLikePattern` treats `%`, `_`, `\` literally (incl. ordering), leaves diacritic text untouched; `ilikeEscaped` emits `ESCAPE '\'` and wraps correctly per mode.
- Extended `suggest.service.test.ts` / `labels.service.test.ts` — compile the built SQL (real drizzle `sql` via `jest.unmock` + `PgDialect`) and assert the escaped pattern + `ESCAPE` clause reach `db.execute` for `%`/`_` inputs.

Local checks: `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check`, and `npm run test:unit` (294 suites / 4294 tests) all pass. Integration tests were not run (shared Postgres in use by parallel worktrees).

Closes #1124