### PR TITLE
test(flowsheet): stop the upcoming_show scan-count ceiling flaking on planner variance

### DIFF
--- a/tests/integration/flowsheet-upcoming-show.spec.js
+++ b/tests/integration/flowsheet-upcoming-show.spec.js
@@ -487,13 +487,17 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
   // The batched lookup scans `concerts` a small, bounded number of times per
   // feed read regardless of how many matching rows the page carries. A per-row
   // implementation would scan once per matching row, so with MANY_MATCHES rows
-  // the delta would be >= MANY_MATCHES. We assert the delta stays well under
+  // the delta would be >= 1 + MANY_MATCHES. We assert the delta stays well under
   // that count — the clean separation between "one batched query" (a handful of
-  // scans) and "one query per row" (>= 9). An absolute bound is used rather
-  // than a small-vs-large diff because a single query's scan count already
-  // varies by 1-2 (index probe + heap access) run to run.
-  const MANY_MATCHES = 8;
-  const BATCHED_SCAN_CEILING = 5;
+  // scans) and "one query per row" (>= 1 + MANY_MATCHES). An absolute bound is
+  // used rather than a small-vs-large diff because a single query's scan count
+  // already varies run to run (BS#1661: seq_scan-vs-idx_scan + index probe +
+  // heap access observed at 4-6). The ceiling carries one unit of headroom above
+  // that observed max, and MANY_MATCHES is set high enough that the per-row
+  // threshold (13) stays far above the ceiling — so the anti-N+1 contract still
+  // reads cleanly without the ceiling flaking on planner variance.
+  const MANY_MATCHES = 12;
+  const BATCHED_SCAN_CEILING = 7;
 
   it('batches the lookup: concerts-table scans do not grow with page match count', async () => {
     // Add many more matching tracks, all resolving to ARTIST_WITH_SHOW, so the
@@ -518,7 +522,10 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
     // before/after can spuriously read 0.
     expect(largeDelta).toBeGreaterThanOrEqual(1);
     // Upper bounds (anti-N+1): never one-scan-per-row — a per-row impl would
-    // push this to >= 9.
+    // push this to >= 1 + MANY_MATCHES (13). The `< 1 + MANY_MATCHES` assertion
+    // is the load-bearing anti-N+1 guarantee; BATCHED_SCAN_CEILING is the
+    // tighter "still just a handful of scans" bound, with headroom for planner
+    // variance (BS#1661).
     expect(largeDelta).toBeLessThanOrEqual(BATCHED_SCAN_CEILING);
     expect(largeDelta).toBeLessThan(1 + MANY_MATCHES);
   });


### PR DESCRIPTION
The integration assertion `flowsheet-upcoming-show.spec.js` › "batches the lookup: concerts-table scans do not grow with page match count" (BS#1607) used a tight absolute `BATCHED_SCAN_CEILING = 5`, which flakes to `6` on Postgres planner variance (`seq_scan`-vs-`idx_scan` + index probe + heap — the test's own comment already notes a 1-2 run-to-run swing). It just failed twice on the unrelated PR #1659 (a catalog-controller change nowhere near the flowsheet read path).

Fix: raise `BATCHED_SCAN_CEILING` to 7 (one unit above the observed max of 6) and `MANY_MATCHES` to 12 so the per-row N+1 threshold (13) stays far above the ceiling. The load-bearing guarantee remains `expect(largeDelta).toBeLessThan(1 + MANY_MATCHES)`; the absolute ceiling is the secondary "still just a handful of scans" bound, now with planner headroom. Test-only change, no production behavior affected.

Closes #1661