### PR TITLE
fix(mirror): delete tubafrenzy row by legacy_entry_id, not MAX(ID)/play_order

### DIFF
--- a/apps/backend/middleware/legacy/flowsheet.mirror.ts
+++ b/apps/backend/middleware/legacy/flowsheet.mirror.ts
@@ -343,21 +343,34 @@ export const updateEntry = createHttpMirrorMiddleware<FSEntry>(async (_req, entr
   await mirrorUpdateEntry(tubafrenzyId, body);
 });
 
-export const deleteEntry = createBackendMirrorMiddleware<FSEntry>(async (req, removed) => {
-  const statements: string[] = [];
+export const deleteEntry = createBackendMirrorMiddleware<FSEntry>(async (_req, removed) => {
+  // Delete by the tubafrenzy surrogate key persisted on the row at insert
+  // (`legacy_entry_id` — the same identity uses #1/#3 key their `ON CONFLICT`
+  // on; see addEntry's persist above and `shared/database/src/schema.ts`).
+  // BS#1101.
+  //
+  // The prior implementation resolved the show via `MAX(ID)` and matched the
+  // row positionally by `SEQUENCE_WITHIN_SHOW = play_order`. Both predicates
+  // are wrong:
+  //   - `MAX(ID)` is the newest tubafrenzy show, not the deleted entry's, so
+  //     correcting an older show deletes from the wrong show.
+  //   - Even for the right show, tubafrenzy's `SEQUENCE_WITHIN_SHOW` (assigned
+  //     at insert as `MAX(SEQUENCE_WITHIN_SHOW)+1` into `@SEQ_NUM`; see addEntry
+  //     above) and BS `play_order` are assigned independently and diverge — BS
+  //     `play_order` counts lifecycle markers tubafrenzy never materializes as
+  //     entry rows — so the positional predicate misses even in the happy path.
+  //
+  // When `legacy_entry_id` is null — a residual pre-mirror row, or a row whose
+  // mirror POST failed — there is no safe target, so no-op (return no
+  // statements) rather than guess. The middleware skips the enqueue on empty.
+  // Log the skip: a failed insert-mirror leaves a tubafrenzy row this delete
+  // can never reach, so the residual is at least countable in the logs.
+  if (removed.legacy_entry_id == null) {
+    console.warn('[mirror] Skipping tubafrenzy delete: no legacy_entry_id on removed row', removed.id);
+    return [];
+  }
 
-  // Resolve the RADIO_SHOW_ID first
-  statements.push(`SET @RS_ID := (SELECT IFNULL(MAX(ID), 0) FROM ${RADIO_SHOW_TABLE});`);
-
-  // Delete by RADIO_SHOW_ID and SEQUENCE_WITHIN_SHOW
-  statements.push(
-    `DELETE FROM ${FLOWSHEET_ENTRY_TABLE}
-      WHERE RADIO_SHOW_ID = @RS_ID
-        AND SEQUENCE_WITHIN_SHOW = ${safeSqlNum(removed.play_order)}
-      LIMIT 1;`
-  );
-
-  return statements;
+  return [`DELETE FROM ${FLOWSHEET_ENTRY_TABLE} WHERE ID = ${safeSqlNum(removed.legacy_entry_id)} LIMIT 1;`];
 });
 
 /*

--- a/apps/backend/middleware/legacy/mirror.middleware.ts
+++ b/apps/backend/middleware/legacy/mirror.middleware.ts
@@ -37,10 +37,16 @@ export const createBackendMirrorMiddleware =
           const mirrorOn = await isMirrorEnabled(req);
           if (!mirrorOn) return;
 
+          const statements = await createCommand(req, data);
+          // An empty statement list means "nothing to mirror" (e.g. deleteEntry
+          // of a row with no tubafrenzy id). Skip the enqueue rather than push an
+          // empty `START TRANSACTION; COMMIT;` for the SSH executor to run.
+          if (statements.length === 0) return;
+
           console.log('Enqueuing mirror work...');
 
           const queue = MirrorCommandQueue.instance();
-          queue.enqueue(await createCommand(req, data));
+          queue.enqueue(statements);
         } catch (e) {
           console.error('Error in mirror middleware:', e);
           Sentry.captureException(e, { tags: { subsystem: 'legacy-mirror', variant: 'sql' } });

--- a/tests/unit/middleware/legacy/delete-entry-legacy-id.test.ts
+++ b/tests/unit/middleware/legacy/delete-entry-legacy-id.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for the legacy `deleteEntry` mirror keying on the tubafrenzy surrogate
+ * key (BS#1101).
+ *
+ * The prior implementation resolved the target row positionally:
+ *
+ *   SET @RS_ID := (SELECT IFNULL(MAX(ID), 0) FROM FLOWSHEET_RADIO_SHOW_PROD);
+ *   DELETE FROM FLOWSHEET_ENTRY_PROD
+ *     WHERE RADIO_SHOW_ID = @RS_ID AND SEQUENCE_WITHIN_SHOW = <play_order> LIMIT 1;
+ *
+ * Both predicates are wrong:
+ *
+ *  - `MAX(ID)` is the newest tubafrenzy show, not the deleted entry's show, so
+ *    correcting an older show deletes from the wrong show (cross-show).
+ *  - Even for the right show, tubafrenzy's `SEQUENCE_WITHIN_SHOW` (assigned at
+ *    insert as `MAX(SEQUENCE_WITHIN_SHOW)+1`) and BS `play_order` are assigned
+ *    independently and diverge — BS `play_order` counts lifecycle markers that
+ *    tubafrenzy never materializes as entry rows — so the positional predicate
+ *    misses even in the happy path (within-show miss).
+ *
+ * The fix keys the DELETE on `legacy_entry_id`, the ID tubafrenzy assigned and
+ * BS persisted on the row at insert. These tests drive the real middleware and
+ * assert on the SQL it enqueues to the mirror command queue — the SSH/SQL path
+ * itself is not observable in CI, so the generated statement is the contract.
+ */
+
+// --- Mocks (hoisted per-module) ---
+
+const mockEnqueue = jest.fn();
+jest.mock('../../../../apps/backend/middleware/legacy/commandqueue.mirror', () => ({
+  MirrorCommandQueue: {
+    instance: jest.fn(() => ({ enqueue: mockEnqueue })),
+  },
+}));
+
+// The delete path reads no HTTP mirror helpers, but flowsheet.mirror.ts imports
+// the module at load; stub it so the import graph resolves without a real client.
+jest.mock('../../../../apps/backend/middleware/legacy/http.mirror', () => ({
+  mirrorCreateEntry: jest.fn(),
+  mirrorCreateShow: jest.fn(),
+  mirrorSignoffShow: jest.fn(),
+  mirrorUpdateEntry: jest.fn(),
+  cacheEntryId: jest.fn(),
+  cacheShowId: jest.fn(),
+  getCachedEntryId: jest.fn(),
+  getCachedShowId: jest.fn(),
+  clearEntryIdMap: jest.fn(),
+  clearShowIdMap: jest.fn(),
+  mapEntryToTubafrenzy: jest.fn(),
+  mapShowToTubafrenzy: jest.fn(),
+  mapUpdateToTubafrenzy: jest.fn(),
+}));
+
+jest.mock('@wxyc/database', () => ({
+  db: {},
+  user: {},
+  flowsheet: { id: 'id', legacy_entry_id: 'legacy_entry_id', show_id: 'show_id' },
+  shows: { id: 'id', legacy_show_id: 'legacy_show_id' },
+}));
+
+jest.mock('drizzle-orm', () => ({
+  eq: jest.fn((...args: unknown[]) => args),
+  desc: jest.fn(),
+  asc: jest.fn(),
+}));
+
+jest.mock('posthog-node', () => ({
+  PostHog: jest.fn().mockImplementation(() => ({
+    isFeatureEnabled: jest.fn().mockResolvedValue(true),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('../../../../apps/backend/middleware/legacy/rotation-match.mirror', () => ({
+  isActiveRotationMatch: jest.fn().mockResolvedValue(false),
+}));
+
+import { runMiddleware } from './http-mirror-harness';
+
+// Import the middleware AFTER all mocks are set up
+import { flowsheetMirror } from '../../../../apps/backend/middleware/legacy/flowsheet.mirror';
+import { createBackendMirrorMiddleware } from '../../../../apps/backend/middleware/legacy/mirror.middleware';
+
+// The single transaction body the mirror enqueued this run, or undefined if it
+// never enqueued (no-op).
+function enqueuedSql(): string | undefined {
+  if (mockEnqueue.mock.calls.length === 0) return undefined;
+  const [statements] = mockEnqueue.mock.calls[mockEnqueue.mock.calls.length - 1];
+  return (statements as string[]).join('\n');
+}
+
+const baseRemovedEntry = {
+  id: 42,
+  show_id: 100,
+  album_id: null,
+  rotation_id: null,
+  legacy_entry_id: 555 as number | null,
+  entry_type: 'track',
+  track_title: 'la paradoja',
+  album_title: 'DOGA',
+  artist_name: 'Juana Molina',
+  record_label: 'Sonamos',
+  play_order: 3,
+  request_flag: false,
+  segue: false,
+  message: null as string | null,
+  add_time: new Date('2024-02-01T12:00:00Z').toISOString(),
+};
+
+describe('deleteEntry mirror keys on legacy_entry_id (BS#1101)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes by the tubafrenzy surrogate ID, not the positional predicate', async () => {
+    await runMiddleware(flowsheetMirror.deleteEntry, { ...baseRemovedEntry, legacy_entry_id: 555 });
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    const sql = enqueuedSql();
+    expect(sql).toContain('DELETE FROM FLOWSHEET_ENTRY_PROD');
+    expect(sql).toContain('WHERE ID = 555');
+  });
+
+  it('does not resolve the show via MAX(ID) or match by SEQUENCE_WITHIN_SHOW (cross-show + within-show fix)', async () => {
+    // play_order = 3 but the tubafrenzy row's SEQUENCE_WITHIN_SHOW would be 1;
+    // keying on legacy_entry_id must ignore play_order entirely.
+    await runMiddleware(flowsheetMirror.deleteEntry, { ...baseRemovedEntry, play_order: 3, legacy_entry_id: 555 });
+    const sql = enqueuedSql();
+    expect(sql).not.toContain('MAX(ID)');
+    expect(sql).not.toContain('RADIO_SHOW_ID');
+    expect(sql).not.toContain('SEQUENCE_WITHIN_SHOW');
+    // The diverging play_order value must not leak into the statement.
+    expect(sql).not.toContain('= 3');
+  });
+
+  it('no-ops (enqueues nothing) when legacy_entry_id is null — no safe target to guess', async () => {
+    await runMiddleware(flowsheetMirror.deleteEntry, { ...baseRemovedEntry, legacy_entry_id: null });
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('coerces legacy_entry_id to a safe integer literal', async () => {
+    await runMiddleware(flowsheetMirror.deleteEntry, { ...baseRemovedEntry, legacy_entry_id: 171792 });
+    const sql = enqueuedSql();
+    expect(sql).toContain('WHERE ID = 171792');
+  });
+});
+
+// Direct coverage for the factory guard the null-legacy_entry_id case relies on:
+// a backend mirror handler that returns no statements must not enqueue an empty
+// `START TRANSACTION; COMMIT;` for the SSH executor. deleteEntry exercises this
+// transitively; this asserts the guard independent of deleteEntry's logic
+// (changeOrder's `return []` hard guard leans on the same behavior).
+describe('createBackendMirrorMiddleware skips the enqueue on an empty statement list', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not enqueue when the command builder returns []', async () => {
+    const emptyMirror = createBackendMirrorMiddleware<typeof baseRemovedEntry>(() => Promise.resolve<string[]>([]));
+    await runMiddleware(emptyMirror, baseRemovedEntry);
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('enqueues when the command builder returns statements', async () => {
+    const nonEmptyMirror = createBackendMirrorMiddleware<typeof baseRemovedEntry>(() => Promise.resolve(['SELECT 1;']));
+    await runMiddleware(nonEmptyMirror, baseRemovedEntry);
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(enqueuedSql()).toContain('SELECT 1;');
+  });
+});

--- a/tests/unit/middleware/legacy/flowsheet.mirror.test.ts
+++ b/tests/unit/middleware/legacy/flowsheet.mirror.test.ts
@@ -272,20 +272,11 @@ describe('flowsheet.mirror SQL generation', () => {
       });
     });
 
-    describe('deleteEntry SQL', () => {
-      it('generates DELETE statement by RADIO_SHOW_ID and SEQUENCE_WITHIN_SHOW', () => {
-        const entry = createMockEntry({ play_order: 3 });
-        const sql = `DELETE FROM ${FLOWSHEET_ENTRY_TABLE}
-      WHERE RADIO_SHOW_ID = @RS_ID
-        AND SEQUENCE_WITHIN_SHOW = ${safeSqlNum(entry.play_order)}
-      LIMIT 1;`;
-
-        expect(sql).toContain('DELETE FROM');
-        expect(sql).toContain('RADIO_SHOW_ID = @RS_ID');
-        expect(sql).toContain('SEQUENCE_WITHIN_SHOW = 3');
-        expect(sql).toContain('LIMIT 1');
-      });
-    });
+    // deleteEntry SQL keys on the tubafrenzy surrogate `legacy_entry_id`, not
+    // the positional `RADIO_SHOW_ID`/`SEQUENCE_WITHIN_SHOW` predicate this block
+    // used to assert (BS#1101). The real coverage — which drives the middleware
+    // and inspects the enqueued statement — lives in
+    // `delete-entry-legacy-id.test.ts`.
   });
 
   describe('SQL value escaping', () => {


### PR DESCRIPTION
Closes #1101.

## Problem

The legacy `deleteEntry` mirror ([`flowsheet.mirror.ts`](https://github.com/WXYC/Backend-Service/blob/851e6b48aaa7c076eccdfc61f90f828a8a197dd8/apps/backend/middleware/legacy/flowsheet.mirror.ts#L346-L361)) resolved the target row positionally:

```sql
SET @RS_ID := (SELECT IFNULL(MAX(ID), 0) FROM FLOWSHEET_RADIO_SHOW_PROD);
DELETE FROM FLOWSHEET_ENTRY_PROD
  WHERE RADIO_SHOW_ID = @RS_ID AND SEQUENCE_WITHIN_SHOW = <play_order> LIMIT 1;
```

Both predicates are wrong, which produces **two distinct failure modes**:

- **Cross-show wrong deletion** (issue description): `MAX(ID)` is the newest tubafrenzy show, not the deleted entry's. Deleting a correction to an older show wipes whatever row in the *current* show shares that `SEQUENCE_WITHIN_SHOW` slot. Per-show `play_order` reset (#693) makes the collision likely.
- **Within-show miss** ([staging repro](https://github.com/WXYC/Backend-Service/issues/1101#issuecomment-4988337890)): even when `@RS_ID` resolves to the **correct** show, tubafrenzy's `SEQUENCE_WITHIN_SHOW` (assigned at insert as `MAX(SEQUENCE_WITHIN_SHOW)+1`) and BS `play_order` are assigned independently and diverge — BS `play_order` counts lifecycle markers tubafrenzy never materializes as entry rows — so the positional predicate misses in the happy path, leaving a stray row in the wxyc.info archive.

## Fix

Key the DELETE on `legacy_entry_id` — the surrogate key tubafrenzy assigned, persisted on the row at insert (`addEntry`) and carried on the deleted row via the mirror stash (BS#1513):

```sql
DELETE FROM FLOWSHEET_ENTRY_PROD WHERE ID = <legacy_entry_id> LIMIT 1;
```

When `legacy_entry_id` is null (residual pre-mirror rows, or rows whose mirror POST failed) there is no safe target, so the handler returns no statements and `createBackendMirrorMiddleware` now **skips the enqueue on an empty statement list** rather than run an empty `START TRANSACTION; COMMIT;` over SSH.

This single fix resolves both failure modes (neither `MAX(ID)` nor `play_order` is consulted anymore).

## Tests

- New `tests/unit/middleware/legacy/delete-entry-legacy-id.test.ts` drives the real middleware and asserts the enqueued SQL keys on `ID` and never emits `MAX(ID)` / `RADIO_SHOW_ID` / `SEQUENCE_WITHIN_SHOW` / the diverging `play_order`, plus the null → no-op case.
- The prior tautological `deleteEntry SQL` block (which hand-asserted the removed positional shape) is dropped in favour of the real coverage.

**On the AC's requested integration test:** the delete-mirror path executes SQL over SSH against tubafrenzy's MySQL, which the integration harness has no equivalent of (the mock only covers the HTTP mirror path). The "only the targeted row was removed" assertion isn't observable in CI, so the generated-statement unit assertion is the faithful level for this logic.

## Unblocks

[WXYC/auto-dj-orchestrator#27](https://github.com/WXYC/auto-dj-orchestrator/issues/27) AC#2 — the auto-DJ deploy validation's add-then-delete no longer leaves a permanent stray "Auto DJ" play in the archive.

## Local checks

`typecheck` clean · `lint` 0 errors · `format:check` clean · `test:unit` 4380/4380 pass.