### PR TITLE
chore(flowsheet-metadata-backfill): gate the nightly cron with a never-firing schedule

### DIFF
--- a/jobs/flowsheet-metadata-backfill/package.json
+++ b/jobs/flowsheet-metadata-backfill/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@wxyc/flowsheet-metadata-backfill",
-  "cron-schedule": "0 6 * * *",
+  "cron-schedule": "0 0 31 2 *",
   "version": "1.0.0",
-  "description": "WXYC recurring metadata drift-repair: enrich flowsheet track rows where LML metadata enrichment never ran (#631 / #638 / #641). Runs once nightly at 06:00 UTC; orchestrator's cooperative pause defers when DJs are active.",
+  "description": "WXYC recurring metadata drift-repair: enrich flowsheet track rows where LML metadata enrichment never ran (#631 / #638 / #641). GATED (never-firing schedule) while the BS#1631 backfill runs and until the BS#1591 play-priority drain lands; formerly nightly 06:00 UTC; orchestrator's cooperative pause defers when DJs are active.",
   "type": "module",
   "main": "./dist/job.js",
   "scripts": {


### PR DESCRIPTION
Closes #1668.

Gates the `flowsheet-metadata-backfill` nightly cron at its deploy-time source of truth: `cron-schedule` in `jobs/flowsheet-metadata-backfill/package.json` → `0 0 31 2 *` (Feb 31, never fires). The crontab entry stays installed — deploy verification greps for the `CRON_ID`, and re-enabling later is a one-line revert or the `BACKFILL_CRON_SCHEDULE` repo variable (BS#914).

**Why here and not the crontab:** `deploy-base.yml`'s crontab install (line ~526) greps out the existing line by `CRON_ID` and appends a fresh, ungated one — so the 2026-07-16 04:06 UTC deploy (PR #1664 merge) silently erased the `#RESUME-GATE` prefix ops had installed 35 minutes earlier, and the cron fired at 06:00 into the LML contention documented in #1668. Any comment-prefix gate dies on the next merge to `main`.

**Interim state on wxyc-ec2** (already applied by hand): the live crontab line carries the same never-firing schedule and today's stuck container was `docker stop`ped cleanly. This PR makes that state deploy-proof.

**Testing:** `jest --config jest.unit.config.ts tests/unit/scripts/resolve-cron-schedule.test.ts` — 5/5 pass (the test reads the package default dynamically); `scripts/resolve-cron-schedule.sh flowsheet-metadata-backfill` prints the gated schedule, and the env-override path still wins when set.

## Related
- WXYC/Backend-Service#1591 (durable replacement: play-priority drain)
- WXYC/Backend-Service#1011, WXYC/Backend-Service#895 (retire/retune tickets)
- WXYC/Backend-Service#1631 (the backfill this protects)