### PR TITLE
feat: GET /album-reviews read endpoint with PII-barrier projection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ Express 5 application with these route groups:
 | `/config`       | Public app bootstrap configuration                         |
 | `/proxy`        | iOS proxy endpoints (anonymous auth + rate limit)          |
 | `/library`      | Music library catalog                                      |
+| `/album-reviews` | Form-review archive reads (ADR 0011; anon-JWT, PII-excluding projection) |
 | `/flowsheet`    | V1 flowsheet (legacy)                                      |
 | `/v2/flowsheet` | V2 flowsheet (uses `@wxyc/shared` DTOs)                    |
 | `/djs`          | DJ profiles and management                                 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,20 +60,20 @@ npm workspaces:
 
 Express 5 application with these route groups:
 
-| Route           | Purpose                                                    |
-| --------------- | ---------------------------------------------------------- |
-| `/config`       | Public app bootstrap configuration                         |
-| `/proxy`        | iOS proxy endpoints (anonymous auth + rate limit)          |
-| `/library`      | Music library catalog                                      |
+| Route            | Purpose                                                                  |
+| ---------------- | ------------------------------------------------------------------------ |
+| `/config`        | Public app bootstrap configuration                                       |
+| `/proxy`         | iOS proxy endpoints (anonymous auth + rate limit)                        |
+| `/library`       | Music library catalog                                                    |
 | `/album-reviews` | Form-review archive reads (ADR 0011; anon-JWT, PII-excluding projection) |
-| `/flowsheet`    | V1 flowsheet (legacy)                                      |
-| `/v2/flowsheet` | V2 flowsheet (uses `@wxyc/shared` DTOs)                    |
-| `/djs`          | DJ profiles and management                                 |
-| `/request`      | Song request line                                          |
-| `/schedule`     | Schedule management                                        |
-| `/events`       | SSE for real-time updates                                  |
-| `/healthcheck`  | Health check                                               |
-| `/internal`     | Internal endpoints (ETL notifications, tubafrenzy webhook) |
+| `/flowsheet`     | V1 flowsheet (legacy)                                                    |
+| `/v2/flowsheet`  | V2 flowsheet (uses `@wxyc/shared` DTOs)                                  |
+| `/djs`           | DJ profiles and management                                               |
+| `/request`       | Song request line                                                        |
+| `/schedule`      | Schedule management                                                      |
+| `/events`        | SSE for real-time updates                                                |
+| `/healthcheck`   | Health check                                                             |
+| `/internal`      | Internal endpoints (ETL notifications, tubafrenzy webhook)               |
 
 Code is organized as controllers (HTTP handling) → services (business logic) → database (Drizzle queries).
 

--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -22,6 +22,7 @@ import { ses_events_route } from './routes/ses-events.route.js';
 import { proxy_route } from './routes/proxy.route.js';
 import { playlist_route } from './routes/playlist.route.js';
 import { concerts_route } from './routes/concerts.route.js';
+import { album_reviews_route } from './routes/album-reviews.route.js';
 import { startPlaylistProxy, stopPlaylistProxy } from './services/playlist-proxy.service.js';
 import { startAlbumPlaysRefresh, stopAlbumPlaysRefresh } from './services/album-plays-refresh.service.js';
 import {
@@ -98,6 +99,9 @@ app.use('/playlists', playlist_route);
 
 // On Tour concerts feed (anonymous auth, pure DB read) — BS#1603
 app.use('/concerts', concerts_route);
+
+// Form-review archive read (anonymous auth, pure DB read) — ADR 0011
+app.use('/album-reviews', album_reviews_route);
 
 // Business logic routes
 app.use('/labels', labels_route);

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -624,6 +624,105 @@ components:
             hasMore:
               type: boolean
 
+    AlbumReview:
+      type: object
+      description: >-
+        One archived DJ album review from the WXYC album-review Google Form,
+        synced nightly by the album-reviews ETL (ADR 0011). Distinct from
+        the in-app Review model reserved at /reviews (ADR 0006). Reviewer
+        identity (reviewer_raw, social_consent_raw) is never exposed. This
+        block is Swagger display only; the SSOT is wxyc-shared/api.yaml.
+      required:
+        - id
+        - album_id
+        - artist_name
+        - album_title
+        - record_label
+        - artist_blurb
+        - review
+        - recommended_tracks
+        - buzzwords
+        - fcc_violations
+        - review_purpose
+        - rotated
+        - released_within_six_months
+        - social_consent
+        - submitted_at
+      properties:
+        id:
+          type: integer
+        album_id:
+          type: integer
+          nullable: true
+          description: WXYC library album id when the free-text artist/album resolved to exactly one catalog row; null otherwise.
+        artist_name:
+          type: string
+          nullable: true
+        album_title:
+          type: string
+          nullable: true
+        record_label:
+          type: string
+          nullable: true
+        artist_blurb:
+          type: string
+          nullable: true
+        review:
+          type: string
+          nullable: true
+        recommended_tracks:
+          type: string
+          nullable: true
+          description: Raw recommended-tracks text, including the form's `!`-rating notation.
+        buzzwords:
+          type: string
+          nullable: true
+        fcc_violations:
+          type: string
+          nullable: true
+          description: Verbatim reviewer answer; blank (unanswered) is distinct from "None"/"N/A".
+        review_purpose:
+          type: string
+          nullable: true
+        rotated:
+          type: boolean
+          nullable: true
+        released_within_six_months:
+          type: boolean
+          nullable: true
+        social_consent:
+          type: boolean
+          nullable: true
+        submitted_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    AlbumReviewsResponse:
+      type: object
+      required:
+        - album_reviews
+        - pagination
+      properties:
+        album_reviews:
+          type: array
+          items:
+            $ref: '#/components/schemas/AlbumReview'
+        pagination:
+          type: object
+          required:
+            - page
+            - limit
+          properties:
+            page:
+              type: integer
+            limit:
+              type: integer
+            total:
+              type: integer
+            hasMore:
+              type: boolean
+
 security:
   - BearerAuth: []
 
@@ -1677,6 +1776,55 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConcertsResponse'
+        '400':
+          description: Invalid query parameters
+        '401':
+          description: Authentication required
+
+  /album-reviews:
+    get:
+      summary: List archived DJ album-review submissions
+      description: >-
+        Album-review submissions from the WXYC album-review Google Form
+        archive (ADR 0011), ordered by submitted_at descending (nulls
+        last), paginated. Filterable by linked library album or by artist
+        name (normalized exact match). Deliberately not /reviews, which is
+        reserved for the in-app Review model (ADR 0006). Requires anonymous
+        session auth. Reviewer names are never included in responses. This
+        block is Swagger display only; the SSOT is wxyc-shared/api.yaml.
+      parameters:
+        - name: album_id
+          in: query
+          schema:
+            type: integer
+          description: Return only submissions linked to this library album id.
+        - name: artist
+          in: query
+          schema:
+            type: string
+          description: Artist-name filter; matched against the submission's normalized artist name (case-insensitive, leading-"the"-insensitive).
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number (1-indexed)
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+          description: Page size
+      responses:
+        '200':
+          description: Paginated list of album-review submissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AlbumReviewsResponse'
         '400':
           description: Invalid query parameters
         '401':

--- a/apps/backend/controllers/album-reviews.controller.ts
+++ b/apps/backend/controllers/album-reviews.controller.ts
@@ -1,0 +1,96 @@
+import { RequestHandler } from 'express';
+import * as albumReviewsService from '../services/album-reviews.service.js';
+import WxycError from '../utils/error.js';
+
+/**
+ * `GET /album-reviews` — form-review archive read (album-reviews-sheet-sync
+ * plan / ADR 0011).
+ *
+ * Contract lives in `wxyc-shared/api.yaml` (`AlbumReviewsResponse`,
+ * contract PR wxyc-shared#230). Pagination follows the spec's
+ * `PaginationParams` conventions: 1-indexed `page`, `limit` capped at 100;
+ * the response carries a `PaginationInfo` object alongside the
+ * `album_reviews`. Reviewer identity never appears in responses — the
+ * service's projection is the PII barrier (see album-reviews.service.ts).
+ */
+
+export type AlbumReviewsQueryParams = {
+  album_id?: string;
+  artist?: string;
+  page?: string;
+  limit?: string;
+};
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const MAX_ARTIST_LENGTH = 256;
+
+/**
+ * Parse a positive-integer query param behind an all-digits guard. A bare
+ * `parseInt` would accept '1abc' → 1 and '0x10' → 16; requiring the raw
+ * value to be all digits (and using an explicit radix) rejects both.
+ * Returns 400 on malformed input via `WxycError`.
+ */
+const parsePositiveInt = (raw: string, field: string): number => {
+  if (!/^\d+$/.test(raw)) {
+    throw new WxycError(`${field} must be a positive integer`, 400);
+  }
+  return Number.parseInt(raw, 10);
+};
+
+export const getAlbumReviews: RequestHandler<object, unknown, object, AlbumReviewsQueryParams> = async (req, res) => {
+  const { query } = req;
+
+  const page = parsePositiveInt(query.page ?? '1', 'page');
+  const limit = parsePositiveInt(query.limit ?? String(DEFAULT_LIMIT), 'limit');
+
+  if (page < 1) {
+    throw new WxycError('page must be a positive integer', 400);
+  }
+  if (limit < 1) {
+    throw new WxycError('limit must be a positive integer', 400);
+  }
+  if (limit > MAX_LIMIT) {
+    throw new WxycError(`limit must be at most ${MAX_LIMIT}`, 400);
+  }
+
+  let album_id: number | undefined;
+  if (query.album_id !== undefined) {
+    album_id = parsePositiveInt(query.album_id, 'album_id');
+    if (album_id < 1) {
+      throw new WxycError('album_id must be a positive integer', 400);
+    }
+  }
+
+  let artist: string | undefined;
+  if (query.artist !== undefined) {
+    // The typeof guard matters: Express's query parser turns a repeated
+    // param (?artist=a&artist=b) into an array despite the declared type,
+    // and an array must 400 here rather than reach the service's
+    // normalize call.
+    if (typeof query.artist !== 'string' || query.artist.trim() === '') {
+      throw new WxycError('artist must be a non-empty string', 400);
+    }
+    if (query.artist.length > MAX_ARTIST_LENGTH) {
+      throw new WxycError(`artist must be at most ${MAX_ARTIST_LENGTH} characters`, 400);
+    }
+    artist = query.artist;
+  }
+
+  const offset = (page - 1) * limit;
+  const filters = { album_id, artist };
+  const [album_reviews, total] = await Promise.all([
+    albumReviewsService.getAlbumReviewsPage(filters, limit, offset),
+    albumReviewsService.getAlbumReviewsCount(filters),
+  ]);
+
+  res.status(200).json({
+    album_reviews,
+    pagination: {
+      page,
+      limit,
+      total,
+      hasMore: offset + album_reviews.length < total,
+    },
+  });
+};

--- a/apps/backend/routes/album-reviews.route.ts
+++ b/apps/backend/routes/album-reviews.route.ts
@@ -1,0 +1,12 @@
+import { requirePermissions } from '@wxyc/authentication';
+import { Router } from 'express';
+import * as albumReviewsController from '../controllers/album-reviews.controller.js';
+
+export const album_reviews_route = Router();
+
+// Anonymous session auth (any valid JWT, no permission scope) — matches the
+// /concerts and /proxy iOS read surfaces. See ADR 0011 / the
+// album-reviews-sheet-sync plan.
+album_reviews_route.use(requirePermissions({}));
+
+album_reviews_route.get('/', albumReviewsController.getAlbumReviews);

--- a/apps/backend/services/album-reviews.service.ts
+++ b/apps/backend/services/album-reviews.service.ts
@@ -1,0 +1,175 @@
+import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
+import { album_review_submissions, db, normalizeArtistName } from '@wxyc/database';
+
+/**
+ * Album-review archive read service — backs `GET /album-reviews`
+ * (album-reviews-sheet-sync plan / ADR 0011). Pure DB reads over the
+ * `album_review_submissions` table that `jobs/album-reviews-etl/`
+ * populates nightly from the "Album Review Responses" Google Form; no
+ * LML calls, no writes.
+ *
+ * PII rule: `reviewer_raw` holds real names (the form promised "your
+ * name will not be shared") and `social_consent_raw` carries
+ * name-adjacent asides. Both are stored for internal curation and are
+ * NEVER emitted here — see the projection note below.
+ */
+
+/**
+ * Wire shape mirroring `AlbumReview` in `wxyc-shared/api.yaml` (the
+ * cross-repo SSOT; contract added by wxyc-shared#230). Local alias pending
+ * a published `@wxyc/shared` that carries it — once the dependency pin in
+ * `apps/backend/package.json` reaches that version, this should be
+ * replaced with `import type { AlbumReview } from '@wxyc/shared/dtos'`.
+ * Same sequencing as the concerts `ConcertDTO` alias.
+ */
+export type AlbumReviewDTO = {
+  id: number;
+  album_id: number | null;
+  artist_name: string | null;
+  album_title: string | null;
+  record_label: string | null;
+  artist_blurb: string | null;
+  review: string | null;
+  recommended_tracks: string | null;
+  buzzwords: string | null;
+  fcc_violations: string | null;
+  review_purpose: string | null;
+  rotated: boolean | null;
+  released_within_six_months: boolean | null;
+  social_consent: boolean | null;
+  // ISO-8601 date-time string (or null), matching the SSOT `AlbumReview`
+  // type (format: date-time). The Drizzle row surfaces the column as
+  // `Date`; `toAlbumReviewDTO` serializes it so the local alias aligns
+  // with the generated `@wxyc/shared` shape (see the alias note above).
+  submitted_at: string | null;
+};
+
+export type AlbumReviewsQueryFilters = {
+  /** Exact match on the best-effort library link. */
+  album_id?: number;
+  /** Raw artist-name filter; matched as `norm_artist = normalizeArtistName(artist)`. */
+  artist?: string;
+};
+
+/**
+ * Flat row produced by the explicit select below. Exported for the
+ * `toAlbumReviewDTO` unit tests.
+ */
+export type AlbumReviewRow = {
+  id: number;
+  album_id: number | null;
+  artist_name: string | null;
+  album_title: string | null;
+  record_label: string | null;
+  artist_blurb: string | null;
+  review: string | null;
+  recommended_tracks: string | null;
+  buzzwords: string | null;
+  fcc_violations: string | null;
+  review_purpose: string | null;
+  rotated: boolean | null;
+  released_within_six_months: boolean | null;
+  social_consent: boolean | null;
+  submitted_at: Date | null;
+};
+
+// Explicit select list — THE PROJECTION IS THE PII LEAK BARRIER (the
+// concerts.service precedent): `reviewer_raw` and `social_consent_raw`
+// are never selected, so reviewer identity cannot reach the response no
+// matter what the DTO mapper does. The internal ETL bookkeeping columns
+// (source, source_key, norm_artist, norm_album, add_date, last_modified)
+// are excluded for the same reason. Do NOT replace this with a bare
+// `select()` — a full-row select would silently re-open the leak.
+const albumReviewFields = {
+  id: album_review_submissions.id,
+  album_id: album_review_submissions.album_id,
+  artist_name: album_review_submissions.artist_name,
+  album_title: album_review_submissions.album_title,
+  record_label: album_review_submissions.record_label,
+  artist_blurb: album_review_submissions.artist_blurb,
+  review: album_review_submissions.review,
+  recommended_tracks: album_review_submissions.recommended_tracks,
+  buzzwords: album_review_submissions.buzzwords,
+  fcc_violations: album_review_submissions.fcc_violations,
+  review_purpose: album_review_submissions.review_purpose,
+  rotated: album_review_submissions.rotated,
+  released_within_six_months: album_review_submissions.released_within_six_months,
+  social_consent: album_review_submissions.social_consent,
+  submitted_at: album_review_submissions.submitted_at,
+};
+
+/** Maps a projected row to the `AlbumReview` wire shape. Explicit field
+ *  list (never a spread) so a wider row cannot smuggle extra keys onto
+ *  the wire — the second layer behind the projection barrier above. */
+export const toAlbumReviewDTO = (row: AlbumReviewRow): AlbumReviewDTO => ({
+  id: row.id,
+  album_id: row.album_id,
+  artist_name: row.artist_name,
+  album_title: row.album_title,
+  record_label: row.record_label,
+  artist_blurb: row.artist_blurb,
+  review: row.review,
+  recommended_tracks: row.recommended_tracks,
+  buzzwords: row.buzzwords,
+  fcc_violations: row.fcc_violations,
+  review_purpose: row.review_purpose,
+  rotated: row.rotated,
+  released_within_six_months: row.released_within_six_months,
+  social_consent: row.social_consent,
+  // Drizzle surfaces the `timestamptz` column as `Date`; the SSOT wire
+  // type is an ISO-8601 date-time string (see the DTO note above).
+  submitted_at: row.submitted_at === null ? null : row.submitted_at.toISOString(),
+});
+
+/**
+ * Shared WHERE builder so the page and count queries can never drift.
+ *
+ * `album_id` is an exact match on the link column; `artist` normalizes
+ * TS-side via `normalizeArtistName` (lowercase, leading-"The"-strip — the
+ * migration-0092 SSOT) and compares against the persisted `norm_artist`,
+ * so the filter is an equality that reads
+ * `album_review_submissions_norm_artist_idx`. Returns `undefined` (no
+ * WHERE clause) when no filters are set.
+ */
+const buildWhere = ({ album_id, artist }: AlbumReviewsQueryFilters): SQL | undefined => {
+  const conditions: SQL[] = [];
+  if (album_id !== undefined) {
+    conditions.push(eq(album_review_submissions.album_id, album_id));
+  }
+  if (artist !== undefined) {
+    conditions.push(eq(album_review_submissions.norm_artist, normalizeArtistName(artist)));
+  }
+  return conditions.length === 0 ? undefined : and(...conditions);
+};
+
+/**
+ * One page of submissions, newest first: `submitted_at DESC NULLS LAST`
+ * (the rare timestamp-less row sorts to the end, not the top — plain
+ * DESC would put NULLs first in Postgres) with `id DESC` as a stable
+ * tiebreak.
+ */
+export const getAlbumReviewsPage = async (
+  filters: AlbumReviewsQueryFilters,
+  limit: number,
+  offset: number
+): Promise<AlbumReviewDTO[]> => {
+  const rows = await db
+    .select(albumReviewFields)
+    .from(album_review_submissions)
+    .where(buildWhere(filters))
+    .orderBy(sql`${album_review_submissions.submitted_at} DESC NULLS LAST`, desc(album_review_submissions.id))
+    .limit(limit)
+    .offset(offset);
+
+  return (rows as AlbumReviewRow[]).map(toAlbumReviewDTO);
+};
+
+/** Total row count for the same filters, for `PaginationInfo`. */
+export const getAlbumReviewsCount = async (filters: AlbumReviewsQueryFilters): Promise<number> => {
+  const result = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(album_review_submissions)
+    .where(buildWhere(filters));
+
+  return Number(result[0]?.count ?? 0);
+};

--- a/tests/e2e/album-reviews-pipeline.test.ts
+++ b/tests/e2e/album-reviews-pipeline.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Album-Reviews Pipeline E2E Tests (ADR 0011)
+ *
+ * The full sheet → DB → link → API pipeline, end to end against a live
+ * stack. Where the integration spec (`tests/integration/album-reviews.spec.js`)
+ * seeds `album_review_submissions` with raw SQL and exercises only the
+ * read endpoint, this suite runs the REAL ingestion:
+ *
+ *   1. Run the album-reviews ETL orchestrator against an in-memory sheet
+ *      fixture — real header mapping + real UPSERT writer + real link
+ *      pass — via `tests/e2e/support/album-reviews-fixture-run.ts`.
+ *   2. Run it AGAIN, asserting the idempotent-nightly acceptance
+ *      criterion: inserted=0, updated=0, everything `unchanged`.
+ *   3. Read the rows back through the live `GET /album-reviews`,
+ *      asserting the wire shape, the link-pass `album_id`, the artist
+ *      filter, and — load-bearing — that reviewer PII never reaches the
+ *      wire even though the ingested rows carry it in the DB.
+ *
+ * Prerequisites (the e2e Docker profile — `npm run e2e:env`):
+ *   - e2e-db   reachable at E2E_DB_PORT (default 5434)
+ *   - e2e-auth reachable at E2E_AUTH_PORT (default 8084)
+ *   - e2e-backend reachable at E2E_BACKEND_PORT (default 8085), AUTH_BYPASS=false
+ *
+ * Run: npm run test:e2e -- tests/e2e/album-reviews-pipeline.test.ts
+ */
+
+import { execSync } from 'child_process';
+import postgres from 'postgres';
+
+const DB_PORT = process.env.E2E_DB_PORT || '5434';
+const DB_NAME = process.env.DB_NAME || 'e2edb';
+const DB_USER = process.env.DB_USERNAME || 'e2euser';
+const DB_PASSWORD = process.env.DB_PASSWORD || 'e2epassword';
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+const BASE_URL = process.env.E2E_BASE_URL || `http://localhost:${process.env.E2E_BACKEND_PORT || '8085'}`;
+const AUTH_URL = process.env.E2E_AUTH_URL || `http://localhost:${process.env.E2E_AUTH_PORT || '8084'}/auth`;
+
+// The fixture rows' deterministic source keys: `form:` + the UTC instant of
+// the sheet's ET wall-clock timestamp (EDT for the March row, EST for the
+// January row) — the same derivation map.ts performs.
+const JUANA_SOURCE_KEY = 'form:2021-03-15T17:45:12.000Z';
+const PRATT_SOURCE_KEY = 'form:2015-01-21T03:10:05.000Z';
+const ALL_SOURCE_KEYS = [JUANA_SOURCE_KEY, PRATT_SOURCE_KEY];
+
+// ZZ ownership markers on the FK scaffolding (artists/genres/format), so
+// cleanup can only ever delete this suite's own rows.
+const LINK_ARTIST = 'Juana Molina';
+const PROBE_GENRE = 'E2E AR Probe Genre';
+const PROBE_FORMAT = 'E2E AR Probe Format';
+
+const jobEnv = {
+  ...process.env,
+  DB_HOST: 'localhost',
+  DB_PORT,
+  DB_NAME,
+  DB_USERNAME: DB_USER,
+  DB_PASSWORD,
+  WXYC_SCHEMA_NAME: SCHEMA,
+  // Neutralize Sentry in the child job: without this, an inherited
+  // SENTRY_DSN would flush fixture-run telemetry to production Sentry and
+  // add the 2s Sentry.close() drain to every runNode.
+  SENTRY_DSN: '',
+  SENTRY_TRACES_SAMPLE_RATE: '0',
+};
+
+// stdio:'pipe' captures the child's output; on a non-zero exit execSync
+// throws with that output buffered on the error, not printed. Surface it so
+// a fixture drift is diagnosable from the failure message.
+const runNode = (script: string): string => {
+  try {
+    return execSync(`npx tsx ${script}`, {
+      env: jobEnv,
+      cwd: process.cwd(),
+      stdio: 'pipe',
+      timeout: 120000,
+    }).toString();
+  } catch (err) {
+    const e = err as { stdout?: Buffer; stderr?: Buffer };
+    const stdout = e.stdout?.toString() ?? '';
+    const stderr = e.stderr?.toString() ?? '';
+    throw new Error(`child failed: npx tsx ${script}\n--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`, {
+      cause: err,
+    });
+  }
+};
+
+type EtlTotals = {
+  fetched: number;
+  valid: number;
+  skipped_invalid: number;
+  fallback_keys: number;
+  duplicate_key_skipped: number;
+  inserted: number;
+  updated: number;
+  unchanged: number;
+  linked: number;
+  link_ambiguous: number;
+  link_unmatched: number;
+};
+
+/** The driver prints the run totals as the last JSON line on stdout;
+ *  logger lines precede it, so scan from the end for a parseable object
+ *  carrying the counter keys. */
+const parseTotals = (stdout: string): EtlTotals => {
+  const lines = stdout.split('\n').filter((l) => l.trim() !== '');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(lines[i]) as Record<string, unknown>;
+      if (typeof parsed === 'object' && parsed !== null && 'inserted' in parsed && 'linked' in parsed) {
+        return parsed as EtlTotals;
+      }
+    } catch {
+      // not a JSON line — keep scanning
+    }
+  }
+  throw new Error(`album-reviews-fixture-run: no totals JSON found in stdout:\n${stdout}`);
+};
+
+/**
+ * Anonymous session → JWT. `/album-reviews` is gated by
+ * `requirePermissions({})`, which verifies a JWT against JWKS — so the
+ * anonymous *session* token from `/sign-in/anonymous` must be exchanged at
+ * `/auth/token` for the JWT the backend will honour.
+ */
+async function getAnonymousJwt(): Promise<string> {
+  const signIn = await fetch(`${AUTH_URL}/sign-in/anonymous`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!signIn.ok) throw new Error(`anonymous sign-in failed: ${signIn.status} ${await signIn.text().catch(() => '')}`);
+  const sessionToken =
+    signIn.headers.get('set-auth-token') || ((await signIn.json().catch(() => ({}))) as { token?: string }).token;
+  if (!sessionToken) throw new Error('no session token from anonymous sign-in');
+
+  const tokenRes = await fetch(`${AUTH_URL}/token`, { headers: { Authorization: `Bearer ${sessionToken}` } });
+  if (!tokenRes.ok)
+    throw new Error(`token exchange failed: ${tokenRes.status} ${await tokenRes.text().catch(() => '')}`);
+  const jwt = ((await tokenRes.json()) as { token?: string }).token;
+  if (!jwt) throw new Error('no JWT returned from /auth/token');
+  return jwt;
+}
+
+let pg: ReturnType<typeof postgres>;
+let authToken: string;
+let libraryId: number;
+let firstRun: EtlTotals;
+let secondRun: EtlTotals;
+
+interface SubmissionRow {
+  id: number;
+  source_key: string;
+  album_id: number | null;
+  reviewer_raw: string | null;
+  norm_artist: string | null;
+}
+
+/** This suite's submission rows, straight from the DB. */
+const ingestedRows = async (): Promise<SubmissionRow[]> =>
+  pg<SubmissionRow[]>`
+    SELECT id, source_key, album_id, reviewer_raw, norm_artist
+    FROM ${pg(SCHEMA)}.album_review_submissions
+    WHERE source_key = ANY(${ALL_SOURCE_KEYS})
+    ORDER BY source_key ASC
+  `;
+
+const cleanup = async (): Promise<void> => {
+  await pg`DELETE FROM ${pg(SCHEMA)}.album_review_submissions WHERE source_key = ANY(${ALL_SOURCE_KEYS})`;
+  await pg`DELETE FROM ${pg(SCHEMA)}.library
+            WHERE artist_id IN (SELECT id FROM ${pg(SCHEMA)}.artists WHERE artist_name = ${LINK_ARTIST} AND code_letters = 'ZZ')`;
+  await pg`DELETE FROM ${pg(SCHEMA)}.artists WHERE artist_name = ${LINK_ARTIST} AND code_letters = 'ZZ'`;
+  await pg`DELETE FROM ${pg(SCHEMA)}.genres WHERE genre_name = ${PROBE_GENRE}`;
+  await pg`DELETE FROM ${pg(SCHEMA)}.format WHERE format_name = ${PROBE_FORMAT}`;
+};
+
+beforeAll(async () => {
+  pg = postgres(`postgres://${DB_USER}:${DB_PASSWORD}@localhost:${DB_PORT}/${DB_NAME}`, { max: 1, onnotice: () => {} });
+  await cleanup(); // idempotent across re-runs on the shared e2e schema
+
+  // FK scaffolding so the link pass has a SINGLETON library match for the
+  // Juana Molina / DOGA fixture row. The Jessica Pratt row deliberately has
+  // no library twin — the negative link arm.
+  const [genre] = await pg`INSERT INTO ${pg(SCHEMA)}.genres (genre_name) VALUES (${PROBE_GENRE}) RETURNING id`;
+  const [format] = await pg`INSERT INTO ${pg(SCHEMA)}.format (format_name) VALUES (${PROBE_FORMAT}) RETURNING id`;
+  const [artist] = await pg`
+    INSERT INTO ${pg(SCHEMA)}.artists (artist_name, alphabetical_name, code_letters)
+    VALUES (${LINK_ARTIST}, ${LINK_ARTIST}, 'ZZ') RETURNING id
+  `;
+  const [lib] = await pg`
+    INSERT INTO ${pg(SCHEMA)}.library (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+    VALUES (${(artist as { id: number }).id}, ${(genre as { id: number }).id}, ${(format as { id: number }).id},
+            'DOGA', 9201, ${LINK_ARTIST})
+    RETURNING id
+  `;
+  libraryId = (lib as { id: number }).id;
+
+  authToken = await getAnonymousJwt();
+
+  // 1. Ingest the fixture sheet (map → upsert → link), twice: the second
+  // run pins nightly idempotency against an unchanged sheet.
+  firstRun = parseTotals(runNode('tests/e2e/support/album-reviews-fixture-run.ts'));
+  secondRun = parseTotals(runNode('tests/e2e/support/album-reviews-fixture-run.ts'));
+}, 180000);
+
+afterAll(async () => {
+  await cleanup();
+  await pg.end();
+});
+
+describe('ingest step (album-reviews-etl → album_review_submissions)', () => {
+  it('lands both valid fixture rows and drops the formula-residue junk row', async () => {
+    expect(firstRun).toMatchObject({
+      fetched: 3,
+      valid: 2,
+      skipped_invalid: 1,
+      fallback_keys: 0,
+      inserted: 2,
+      updated: 0,
+      unchanged: 0,
+    });
+    const rows = await ingestedRows();
+    expect(rows.map((r) => r.source_key)).toEqual([PRATT_SOURCE_KEY, JUANA_SOURCE_KEY]);
+  });
+
+  it('keeps reviewer PII in the DB (internal curation) — the wire assertions below prove it stays there', async () => {
+    const rows = await ingestedRows();
+    const juana = rows.find((r) => r.source_key === JUANA_SOURCE_KEY);
+    expect(juana?.reviewer_raw).toBe('A Real Name, 3/15/21');
+  });
+
+  it('is idempotent on the second run against an unchanged sheet', () => {
+    expect(secondRun).toMatchObject({ inserted: 0, updated: 0, unchanged: 2 });
+  });
+});
+
+describe('link step (singleton library match)', () => {
+  it('links the row with exactly one library match and leaves the other unmatched', async () => {
+    expect(firstRun).toMatchObject({ linked: 1, link_ambiguous: 0, link_unmatched: 1 });
+    const rows = await ingestedRows();
+    const juana = rows.find((r) => r.source_key === JUANA_SOURCE_KEY);
+    const pratt = rows.find((r) => r.source_key === PRATT_SOURCE_KEY);
+    expect(juana?.album_id).toBe(libraryId);
+    expect(pratt?.album_id).toBeNull();
+  });
+});
+
+describe('read step (GET /album-reviews)', () => {
+  const getAlbumReviews = async (query: string): Promise<any> => {
+    const res = await fetch(`${BASE_URL}/album-reviews?${query}`, {
+      headers: { Authorization: `Bearer ${authToken}` },
+    });
+    expect(res.status).toBe(200);
+    return res.json();
+  };
+
+  it('returns 401 without a bearer token', async () => {
+    const res = await fetch(`${BASE_URL}/album-reviews`);
+    expect(res.status).toBe(401);
+  });
+
+  it('round-trips the linked row through the artist filter with the full wire shape', async () => {
+    const body = await getAlbumReviews('artist=juana%20molina&limit=100');
+    const rows = (body.album_reviews as any[]).filter((r) => r.album_id === libraryId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      album_id: libraryId,
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      record_label: 'Sonamos',
+      review: 'Hypnotic layered loops; a late-night staple.',
+      recommended_tracks: '1, 3 (!!!!), 5',
+      buzzwords: 'hypnotic, electronic, folk',
+      fcc_violations: 'None',
+      review_purpose: 'Rotation',
+      rotated: true,
+      released_within_six_months: true,
+      social_consent: true,
+      submitted_at: '2021-03-15T17:45:12.000Z',
+    });
+  });
+
+  it('serves the unlinked row through the album_id-less listing', async () => {
+    const body = await getAlbumReviews('artist=jessica%20pratt&limit=100');
+    const rows = (body.album_reviews as any[]).filter((r) => r.artist_name === 'Jessica Pratt');
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    const pratt = rows.find((r) => r.album_title === 'On Your Own Love Again');
+    expect(pratt).toBeDefined();
+    expect(pratt.album_id).toBeNull();
+    expect(pratt.rotated).toBe(false);
+    expect(pratt.submitted_at).toBe('2015-01-21T03:10:05.000Z');
+  });
+
+  it('NEVER exposes reviewer PII on the wire — the rows carry it in the DB', async () => {
+    // The ingest step proved reviewer_raw is populated in the DB; this is
+    // the wire-level exclusion (absent keys, not nulls).
+    const body = await getAlbumReviews(`album_id=${libraryId}&limit=100`);
+    expect((body.album_reviews as any[]).length).toBeGreaterThanOrEqual(1);
+    for (const row of body.album_reviews as any[]) {
+      for (const internal of [
+        'reviewer_raw',
+        'social_consent_raw',
+        'source',
+        'source_key',
+        'norm_artist',
+        'norm_album',
+        'add_date',
+        'last_modified',
+      ]) {
+        expect(row).not.toHaveProperty(internal);
+      }
+    }
+  });
+});

--- a/tests/e2e/support/album-reviews-fixture-run.ts
+++ b/tests/e2e/support/album-reviews-fixture-run.ts
@@ -1,0 +1,115 @@
+/**
+ * E2E fixture driver for the album-reviews ETL pipeline (ADR 0011).
+ *
+ * Runs the REAL orchestrator (`runEtl`) with the REAL header mapping
+ * (`resolveHeaderIndexes`/`mapRow`, invoked inside `runEtl`), the REAL DB
+ * writer (`upsertSubmission`) and the REAL link pass (`linkSubmissions`) —
+ * only the network fetch is swapped for an in-memory sheet fixture. That
+ * exercises the map → upsert → link chain against a real Postgres exactly
+ * as production does, minus the live Google Sheets HTTP (the same seam the
+ * unit fetch suite covers; see venue-events-fixture-run.ts for the
+ * pattern).
+ *
+ * Invoked as a child process by `tests/e2e/album-reviews-pipeline.test.ts`,
+ * so `@wxyc/database` binds to whatever DB_* the parent passes in the env.
+ * Prints the run totals as JSON on stdout (the last line) and exits
+ * non-zero if the orchestrator's run guards throw.
+ *
+ * The fixture mirrors the live sheet's shape: the dead long-form
+ * "Buzzwords about the album" column sits BEFORE the live `Buzzwords`
+ * column (the exact-match trap map.ts exists to sidestep), one row is
+ * formula residue with no artist/album (validity-filter target), and the
+ * timestamps cover the sheet's M/D/YYYY ET wall-clock format.
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { runEtl } from '../../../jobs/album-reviews-etl/orchestrate.js';
+import { upsertSubmission } from '../../../jobs/album-reviews-etl/writer.js';
+import { linkSubmissions } from '../../../jobs/album-reviews-etl/link.js';
+import { initLogger, closeLogger } from '../../../jobs/album-reviews-etl/logger.js';
+
+const HEADERS = [
+  'Timestamp',
+  'Artist Name',
+  'Album Name',
+  'Record Label',
+  'Please write a short 1-2 sentences about the artist',
+  'Please write your review here',
+  'Please identify at least 2 recommended tracks',
+  'Name of reviewer, and date',
+  'List any FCC violations by track number',
+  // Dead long-form column — 0 responses on the live sheet; must NOT be
+  // confused with the live short `Buzzwords` column below.
+  'Buzzwords about the album (examples include: jazzy, ambient, harsh)',
+  'Buzzwords',
+  'Are you comfortable with us sharing this review on social media?',
+  'Was this album released within the last 6 months?',
+  'What is this review for?',
+  'rotated? (y/n)',
+];
+
+// Row 1: EDT wall clock (2021-03-15 13:45:12 ET = 17:45:12 UTC); the
+// library row the e2e test seeds makes this the singleton link target.
+// Row 2: EST wall clock (2015-01-20 22:10:05 ET = 2015-01-21 03:10:05 UTC);
+// no matching library row → link_unmatched.
+// Row 3: formula residue (no artist/album) → skipped_invalid.
+const DATA_ROWS: string[][] = [
+  [
+    '3/15/2021 13:45:12',
+    'Juana Molina',
+    'DOGA',
+    'Sonamos',
+    'Argentine electronic-folk auteur.',
+    'Hypnotic layered loops; a late-night staple.',
+    '1, 3 (!!!!), 5',
+    'A Real Name, 3/15/21',
+    'None',
+    '',
+    'hypnotic, electronic, folk',
+    'Yes, but remove my name',
+    'Yes',
+    'Rotation',
+    'y',
+  ],
+  [
+    '1/20/2015 22:10:05',
+    'Jessica Pratt',
+    'On Your Own Love Again',
+    'Drag City',
+    'Whispered folk miniatures out of Los Angeles.',
+    'Timeless. Back, Baby is the anchor.',
+    '2 (!!!), 4',
+    'Another Real Name, 1/20/15',
+    '',
+    '',
+    'folk, intimate',
+    'No',
+    'No',
+    'New DJ Assignment',
+    'n',
+  ],
+  ['B1163='],
+];
+
+const SHEET_FIXTURE: string[][] = [HEADERS, ...DATA_ROWS];
+
+const main = async (): Promise<void> => {
+  initLogger({ repo: 'Backend-Service', tool: 'album-reviews-fixture-run' });
+  try {
+    const totals = await runEtl({
+      fetchRows: () => Promise.resolve(SHEET_FIXTURE),
+      upsertSubmission,
+      linkPass: () => linkSubmissions(),
+      dryRun: false,
+    });
+    process.stdout.write(`${JSON.stringify(totals)}\n`);
+  } finally {
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
+};
+
+main().catch((error) => {
+  process.stderr.write(`${(error as Error).stack || String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/tests/integration/album-reviews.spec.js
+++ b/tests/integration/album-reviews.spec.js
@@ -1,0 +1,353 @@
+/**
+ * `GET /album-reviews` (album-reviews-sheet-sync plan / ADR 0011).
+ *
+ * Postgres-backed: direct SQL seeds a library album (with its FK
+ * scaffolding) and a deterministic set of `album_review_submissions` rows
+ * keyed by an `itest-ar:` source_key prefix, so cleanup is a prefix DELETE
+ * and nothing leaks across runs — the same idiom as concerts.spec.js.
+ *
+ * Pins the load-bearing server contract:
+ *   - anonymous-session auth (bearer required — AUTH_BYPASS still enforces
+ *     the header);
+ *   - PII exclusion ON THE WIRE: response objects carry no `reviewer_raw`
+ *     or `social_consent_raw` keys (nor any internal ETL column) even
+ *     though the seeded rows populate both — the projection barrier;
+ *   - ordering by `submitted_at` DESC NULLS LAST (the timestamp-less row
+ *     sorts last, not first);
+ *   - `album_id` exact filter and `artist` normalized filter
+ *     (case-insensitive, leading-"The"-insensitive);
+ *   - page/limit pagination with PaginationInfo;
+ *   - param-validation 400s.
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const SOURCE_KEY_PREFIX = 'itest-ar:';
+const ARTIST_NAME = 'Juana Molina';
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+/** ISO instant for now - offsetDays. Ordering is on the instant itself. */
+function isoInstant(offsetDays) {
+  return new Date(Date.now() - offsetDays * 24 * 60 * 60 * 1000).toISOString();
+}
+
+const NEWEST = isoInstant(10); // Juana review 2 (multi-review pair, newest)
+const MIDDLE = isoInstant(50); // Jessica Pratt review
+const OLDEST = isoInstant(100); // Juana review 1 (fully populated row)
+
+describe('GET /album-reviews (ADR 0011)', () => {
+  let auth;
+  let sql;
+  let libraryId;
+  const seededIds = {};
+
+  const seedSubmission = async (key, overrides) => {
+    const defaults = {
+      album_id: null,
+      artist_name: null,
+      album_title: null,
+      record_label: null,
+      artist_blurb: null,
+      review: null,
+      recommended_tracks: null,
+      buzzwords: null,
+      fcc_violations: null,
+      review_purpose: null,
+      reviewer_raw: null,
+      social_consent_raw: null,
+      social_consent: null,
+      released_within_six_months: null,
+      rotated: null,
+      submitted_at: null,
+      norm_artist: null,
+      norm_album: null,
+    };
+    const row = { ...defaults, ...overrides };
+    const [inserted] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".album_review_submissions
+         (album_id, artist_name, album_title, record_label, artist_blurb, review,
+          recommended_tracks, buzzwords, fcc_violations, review_purpose,
+          reviewer_raw, social_consent_raw, social_consent,
+          released_within_six_months, rotated, submitted_at,
+          source, source_key, norm_artist, norm_album)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
+               'google_form', $17, $18, $19)
+       RETURNING id`,
+      [
+        row.album_id,
+        row.artist_name,
+        row.album_title,
+        row.record_label,
+        row.artist_blurb,
+        row.review,
+        row.recommended_tracks,
+        row.buzzwords,
+        row.fcc_violations,
+        row.review_purpose,
+        row.reviewer_raw,
+        row.social_consent_raw,
+        row.social_consent,
+        row.released_within_six_months,
+        row.rotated,
+        row.submitted_at,
+        SOURCE_KEY_PREFIX + key,
+        row.norm_artist,
+        row.norm_album,
+      ]
+    );
+    seededIds[key] = inserted.id;
+  };
+
+  const cleanup = async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".album_review_submissions WHERE source_key LIKE $1`, [
+      `${SOURCE_KEY_PREFIX}%`,
+    ]);
+    // Library rows created by a previous (possibly failed) run: owned via
+    // the ZZ-coded probe artist, so the sweep can never touch fixture data.
+    await sql.unsafe(
+      `DELETE FROM "${SCHEMA}".library
+        WHERE artist_id IN (SELECT id FROM "${SCHEMA}".artists WHERE artist_name = $1 AND code_letters = 'ZZ')`,
+      [ARTIST_NAME]
+    );
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".artists WHERE artist_name = $1 AND code_letters = 'ZZ'`, [ARTIST_NAME]);
+  };
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = makeSql();
+    await cleanup(); // idempotent across re-runs (shared schema, --runInBand)
+
+    // FK scaffolding for the album_id filter: artists → library. genre_id /
+    // format_id are NOT NULL FKs; the seed DB fixture guarantees at least
+    // one row in each (dev_env/seed_db.sql).
+    const [genre] = await sql.unsafe(`SELECT id FROM "${SCHEMA}".genres ORDER BY id LIMIT 1`);
+    const [format] = await sql.unsafe(`SELECT id FROM "${SCHEMA}".format ORDER BY id LIMIT 1`);
+    const [artist] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters)
+       VALUES ($1, $1, 'ZZ') RETURNING id`,
+      [ARTIST_NAME]
+    );
+    const [lib] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+       VALUES ($1, $2, $3, 'DOGA', 9101, $4) RETURNING id`,
+      [artist.id, genre.id, format.id, ARTIST_NAME]
+    );
+    libraryId = lib.id;
+
+    // Fully populated linked review — the wire-shape row. reviewer_raw and
+    // social_consent_raw are deliberately set: the PII assertions below
+    // prove they never reach the wire.
+    await seedSubmission('juana-1', {
+      album_id: libraryId,
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      record_label: 'Sonamos',
+      artist_blurb: 'Argentine electronic-folk auteur.',
+      review: 'Hypnotic layered loops; a late-night staple.',
+      recommended_tracks: '1, 3 (!!!!), 5',
+      buzzwords: 'hypnotic, electronic, folk',
+      fcc_violations: 'None',
+      review_purpose: 'Rotation',
+      reviewer_raw: 'A Real Name, 3/15/21',
+      social_consent_raw: 'Yes, but remove my name',
+      social_consent: true,
+      released_within_six_months: true,
+      rotated: true,
+      submitted_at: OLDEST,
+      norm_artist: 'juana molina',
+      norm_album: 'doga',
+    });
+
+    // Second review of the SAME album (the multi-review invariant that
+    // separates this archive from ADR 0006's one-per-album reviews).
+    await seedSubmission('juana-2', {
+      album_id: libraryId,
+      artist_name: 'Juana Molina',
+      album_title: 'DOGA',
+      review: 'Still hypnotic on the hundredth listen.',
+      submitted_at: NEWEST,
+      norm_artist: 'juana molina',
+      norm_album: 'doga',
+    });
+
+    // Unlinked review (album_id NULL — the ~unmatched cohort).
+    await seedSubmission('pratt', {
+      artist_name: 'Jessica Pratt',
+      album_title: 'On Your Own Love Again',
+      review: 'Whispered folk miniatures. Timeless.',
+      submitted_at: MIDDLE,
+      norm_artist: 'jessica pratt',
+      norm_album: 'on your own love again',
+    });
+
+    // Timestamp-less review (the nots: fallback cohort) — must sort LAST
+    // under submitted_at DESC NULLS LAST, and is the artist-filter target.
+    await seedSubmission('stereolab', {
+      artist_name: 'Stereolab',
+      album_title: 'Dots and Loops',
+      review: 'Motorik lounge-pop; side two is all peaks.',
+      submitted_at: null,
+      norm_artist: 'stereolab',
+      norm_album: 'dots and loops',
+    });
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await sql.end();
+  });
+
+  /** Reviews from a response body that belong to this spec's seed. */
+  const seeded = (body) => {
+    const ids = new Set(Object.values(seededIds));
+    return body.album_reviews.filter((r) => ids.has(r.id));
+  };
+
+  describe('auth', () => {
+    it('returns 401 without an Authorization header', async () => {
+      const res = await request.get('/album-reviews');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('default listing', () => {
+    it('orders by submitted_at DESC with the timestamp-less row LAST (NULLS LAST)', async () => {
+      const res = await auth.get('/album-reviews').query({ limit: 100 });
+      expect(res.status).toBe(200);
+
+      const rows = seeded(res.body);
+      expect(rows.map((r) => r.id)).toEqual([
+        seededIds['juana-2'], // newest instant
+        seededIds['pratt'],
+        seededIds['juana-1'], // oldest instant
+        seededIds['stereolab'], // null submitted_at — last, not first
+      ]);
+      expect(rows[3].submitted_at).toBeNull();
+    });
+
+    it('serves the full AlbumReview wire shape with no PII and no internal columns', async () => {
+      const res = await auth.get('/album-reviews').query({ limit: 100 });
+      const full = seeded(res.body).find((r) => r.id === seededIds['juana-1']);
+
+      expect(full).toEqual({
+        id: seededIds['juana-1'],
+        album_id: libraryId,
+        artist_name: 'Juana Molina',
+        album_title: 'DOGA',
+        record_label: 'Sonamos',
+        artist_blurb: 'Argentine electronic-folk auteur.',
+        review: 'Hypnotic layered loops; a late-night staple.',
+        recommended_tracks: '1, 3 (!!!!), 5',
+        buzzwords: 'hypnotic, electronic, folk',
+        fcc_violations: 'None',
+        review_purpose: 'Rotation',
+        rotated: true,
+        released_within_six_months: true,
+        social_consent: true,
+        submitted_at: OLDEST,
+      });
+
+      // The load-bearing PII assertion: the seeded row HAS reviewer_raw and
+      // social_consent_raw in the DB; the wire object must not carry the
+      // keys at all (absent, not null).
+      for (const row of seeded(res.body)) {
+        for (const internal of [
+          'reviewer_raw',
+          'social_consent_raw',
+          'source',
+          'source_key',
+          'norm_artist',
+          'norm_album',
+          'add_date',
+          'last_modified',
+        ]) {
+          expect(row).not.toHaveProperty(internal);
+        }
+      }
+    });
+  });
+
+  describe('album_id filter', () => {
+    it('returns exactly the submissions linked to the album — multi-review rows stay distinct', async () => {
+      const res = await auth.get('/album-reviews').query({ album_id: String(libraryId), limit: 100 });
+      expect(res.status).toBe(200);
+
+      const rows = seeded(res.body);
+      expect(rows.map((r) => r.id)).toEqual([seededIds['juana-2'], seededIds['juana-1']]);
+      for (const row of rows) {
+        expect(row.album_id).toBe(libraryId);
+      }
+    });
+  });
+
+  describe('artist filter (normalized exact match)', () => {
+    it('matches case-insensitively', async () => {
+      const res = await auth.get('/album-reviews').query({ artist: 'STEREOLAB', limit: 100 });
+      expect(res.status).toBe(200);
+      const rows = seeded(res.body);
+      expect(rows.map((r) => r.id)).toEqual([seededIds['stereolab']]);
+    });
+
+    it('strips a leading "The " (normalizeArtistName SSOT)', async () => {
+      const res = await auth.get('/album-reviews').query({ artist: 'The Stereolab', limit: 100 });
+      expect(res.status).toBe(200);
+      expect(seeded(res.body).map((r) => r.id)).toEqual([seededIds['stereolab']]);
+    });
+
+    it('returns no seeded rows for an unknown artist', async () => {
+      const res = await auth.get('/album-reviews').query({ artist: 'No Such Probe Artist', limit: 100 });
+      expect(res.status).toBe(200);
+      expect(seeded(res.body)).toEqual([]);
+    });
+  });
+
+  describe('pagination', () => {
+    it('pages through the album_id window with PaginationInfo', async () => {
+      const window = { album_id: String(libraryId) };
+
+      const page1 = await auth.get('/album-reviews').query({ ...window, page: 1, limit: 1 });
+      expect(page1.status).toBe(200);
+      expect(page1.body.album_reviews).toHaveLength(1);
+      expect(page1.body.album_reviews[0].id).toBe(seededIds['juana-2']);
+      expect(page1.body.pagination).toEqual({ page: 1, limit: 1, total: 2, hasMore: true });
+
+      const page2 = await auth.get('/album-reviews').query({ ...window, page: 2, limit: 1 });
+      expect(page2.status).toBe(200);
+      expect(page2.body.album_reviews).toHaveLength(1);
+      expect(page2.body.album_reviews[0].id).toBe(seededIds['juana-1']);
+      expect(page2.body.pagination).toEqual({ page: 2, limit: 1, total: 2, hasMore: false });
+    });
+  });
+
+  describe('validation', () => {
+    it.each([
+      ['page', '0'],
+      ['page', 'abc'],
+      ['limit', '0'],
+      ['limit', '101'],
+      ['album_id', '0'],
+      ['album_id', 'abc'],
+      ['album_id', '3.5'],
+      ['artist', ''],
+      ['artist', 'a'.repeat(257)],
+    ])('returns 400 for invalid %s', async (param, value) => {
+      const res = await auth.get('/album-reviews').query({ [param]: value });
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty('message');
+    });
+  });
+});

--- a/tests/unit/controllers/album-reviews.controller.test.ts
+++ b/tests/unit/controllers/album-reviews.controller.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Unit tests for `GET /album-reviews` (album-reviews-sheet-sync plan /
+ * ADR 0011).
+ *
+ * Service is mocked; these tests pin the controller contract: query-param
+ * validation (album_id/artist/page/limit), the 1-indexed page → offset
+ * math, defaults (page 1, limit 50) and the limit cap (100), and the
+ * `AlbumReviewsResponse` wire shape (`album_reviews` + `PaginationInfo`).
+ */
+import { jest } from '@jest/globals';
+import type { Request, Response, NextFunction } from 'express';
+
+const mockGetAlbumReviewsPage = jest.fn<() => Promise<unknown[]>>();
+const mockGetAlbumReviewsCount = jest.fn<() => Promise<number>>();
+
+jest.mock('../../../apps/backend/services/album-reviews.service', () => ({
+  getAlbumReviewsPage: mockGetAlbumReviewsPage,
+  getAlbumReviewsCount: mockGetAlbumReviewsCount,
+}));
+
+import { getAlbumReviews, AlbumReviewsQueryParams } from '../../../apps/backend/controllers/album-reviews.controller';
+
+describe('album-reviews.controller getAlbumReviews', () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  const mockNext = jest.fn<NextFunction>();
+
+  const invoke = () => getAlbumReviews(req as Request, res as Response, mockNext);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAlbumReviewsPage.mockResolvedValue([]);
+    mockGetAlbumReviewsCount.mockResolvedValue(0);
+    req = { query: {} };
+    res = {
+      status: jest.fn().mockReturnThis() as unknown as Response['status'],
+      json: jest.fn() as unknown as Response['json'],
+    };
+  });
+
+  const setQuery = (query: AlbumReviewsQueryParams) => {
+    req.query = query;
+  };
+
+  describe('defaults', () => {
+    it('serves page 1, limit 50, with no filters', async () => {
+      await invoke();
+
+      expect(mockGetAlbumReviewsPage).toHaveBeenCalledWith({ album_id: undefined, artist: undefined }, 50, 0);
+      expect(mockGetAlbumReviewsCount).toHaveBeenCalledWith({ album_id: undefined, artist: undefined });
+    });
+
+    it('responds with the AlbumReviewsResponse shape', async () => {
+      const album_reviews = [{ id: 1 }, { id: 2 }];
+      mockGetAlbumReviewsPage.mockResolvedValue(album_reviews);
+      mockGetAlbumReviewsCount.mockResolvedValue(2);
+
+      await invoke();
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        album_reviews,
+        pagination: { page: 1, limit: 50, total: 2, hasMore: false },
+      });
+    });
+  });
+
+  describe('pagination', () => {
+    it('translates 1-indexed page to offset and reports hasMore', async () => {
+      const pageRows = Array.from({ length: 10 }, (_, i) => ({ id: i }));
+      mockGetAlbumReviewsPage.mockResolvedValue(pageRows);
+      mockGetAlbumReviewsCount.mockResolvedValue(35);
+      setQuery({ page: '2', limit: '10' });
+
+      await invoke();
+
+      expect(mockGetAlbumReviewsPage).toHaveBeenCalledWith(expect.anything(), 10, 10);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pagination: { page: 2, limit: 10, total: 35, hasMore: true },
+        })
+      );
+    });
+
+    it('reports hasMore=false on the final page', async () => {
+      mockGetAlbumReviewsPage.mockResolvedValue([{ id: 30 }]);
+      mockGetAlbumReviewsCount.mockResolvedValue(21);
+      setQuery({ page: '3', limit: '10' });
+
+      await invoke();
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pagination: expect.objectContaining({ hasMore: false }),
+        })
+      );
+    });
+
+    it.each([
+      ['0', 'page must be a positive integer'],
+      ['-1', 'page must be a positive integer'],
+      ['abc', 'page must be a positive integer'],
+      // radix-less / trailing-garbage inputs a bare parseInt would coerce
+      ['1abc', 'page must be a positive integer'],
+      ['0x10', 'page must be a positive integer'],
+    ])('rejects page=%s with a 400 WxycError', async (page, message) => {
+      setQuery({ page });
+      await expect(invoke()).rejects.toThrow(message);
+      expect(mockGetAlbumReviewsPage).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['0', 'limit must be a positive integer'],
+      ['-5', 'limit must be a positive integer'],
+      ['abc', 'limit must be a positive integer'],
+      ['20xyz', 'limit must be a positive integer'],
+      ['0x10', 'limit must be a positive integer'],
+      ['101', 'limit must be at most 100'],
+    ])('rejects limit=%s with a 400 WxycError', async (limit, message) => {
+      setQuery({ limit });
+      await expect(invoke()).rejects.toThrow(message);
+      expect(mockGetAlbumReviewsPage).not.toHaveBeenCalled();
+    });
+
+    it('accepts the maximum limit of 100', async () => {
+      setQuery({ limit: '100' });
+      await invoke();
+      expect(mockGetAlbumReviewsPage).toHaveBeenCalledWith(expect.anything(), 100, 0);
+    });
+
+    it('accepts a valid all-digits page/limit', async () => {
+      setQuery({ page: '2', limit: '20' });
+      await invoke();
+      expect(mockGetAlbumReviewsPage).toHaveBeenCalledWith(expect.anything(), 20, 20);
+    });
+  });
+
+  describe('album_id filter', () => {
+    it('passes a parsed album_id through to the service', async () => {
+      setQuery({ album_id: '42' });
+      await invoke();
+      expect(mockGetAlbumReviewsPage).toHaveBeenCalledWith({ album_id: 42, artist: undefined }, 50, 0);
+      expect(mockGetAlbumReviewsCount).toHaveBeenCalledWith({ album_id: 42, artist: undefined });
+    });
+
+    it.each([
+      ['0', 'album_id must be a positive integer'],
+      ['-7', 'album_id must be a positive integer'],
+      ['abc', 'album_id must be a positive integer'],
+      ['3.5', 'album_id must be a positive integer'],
+      ['7abc', 'album_id must be a positive integer'],
+      ['0x10', 'album_id must be a positive integer'],
+    ])('rejects album_id=%s with a 400 WxycError', async (album_id, message) => {
+      setQuery({ album_id });
+      await expect(invoke()).rejects.toThrow(message);
+      expect(mockGetAlbumReviewsPage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('artist filter', () => {
+    it('passes the raw artist string through to the service (service owns normalization)', async () => {
+      setQuery({ artist: 'Juana Molina' });
+      await invoke();
+      expect(mockGetAlbumReviewsPage).toHaveBeenCalledWith({ album_id: undefined, artist: 'Juana Molina' }, 50, 0);
+      expect(mockGetAlbumReviewsCount).toHaveBeenCalledWith({ album_id: undefined, artist: 'Juana Molina' });
+    });
+
+    it.each([
+      ['an empty string', ''],
+      ['a whitespace-only string', '   '],
+    ])('rejects %s with a 400 WxycError', async (_label, artist) => {
+      setQuery({ artist });
+      await expect(invoke()).rejects.toThrow('artist must be a non-empty string');
+      expect(mockGetAlbumReviewsPage).not.toHaveBeenCalled();
+    });
+
+    it('rejects an artist longer than 256 characters', async () => {
+      setQuery({ artist: 'a'.repeat(257) });
+      await expect(invoke()).rejects.toThrow('artist must be at most 256 characters');
+      expect(mockGetAlbumReviewsPage).not.toHaveBeenCalled();
+    });
+
+    it('accepts an artist of exactly 256 characters', async () => {
+      const artist = 'a'.repeat(256);
+      setQuery({ artist });
+      await invoke();
+      expect(mockGetAlbumReviewsPage).toHaveBeenCalledWith(expect.objectContaining({ artist }), 50, 0);
+    });
+
+    it('rejects a repeated artist param (array) instead of coercing it', async () => {
+      // Express's query parser turns ?artist=a&artist=b into an array; the
+      // typed param says string, so the runtime guard must 400 rather than
+      // pass an array into the service's normalize call.
+      setQuery({ artist: ['Stereolab', 'Cat Power'] as unknown as string });
+      await expect(invoke()).rejects.toThrow('artist must be a non-empty string');
+      expect(mockGetAlbumReviewsPage).not.toHaveBeenCalled();
+    });
+  });
+
+  it('propagates service failures to the error handler', async () => {
+    const failure = new Error('db unavailable');
+    mockGetAlbumReviewsPage.mockRejectedValue(failure);
+    await expect(invoke()).rejects.toThrow(failure);
+  });
+});

--- a/tests/unit/routes/album-reviews.route.test.ts
+++ b/tests/unit/routes/album-reviews.route.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Route-wiring tests for /album-reviews (album-reviews-sheet-sync plan /
+ * ADR 0011).
+ *
+ * The @wxyc/authentication mock's `requirePermissions` returns 401 when the
+ * Authorization header is missing, so these pin that the route group is
+ * actually mounted behind the middleware (anonymous session auth — any
+ * bearer token, no permission scope — matching the /concerts and /proxy
+ * read surfaces).
+ */
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+const mockGetAlbumReviewsPage = jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]);
+const mockGetAlbumReviewsCount = jest.fn<() => Promise<number>>().mockResolvedValue(0);
+
+jest.mock('../../../apps/backend/services/album-reviews.service', () => ({
+  getAlbumReviewsPage: mockGetAlbumReviewsPage,
+  getAlbumReviewsCount: mockGetAlbumReviewsCount,
+}));
+
+import { album_reviews_route } from '../../../apps/backend/routes/album-reviews.route';
+
+const app = express();
+app.use(express.json());
+app.use('/album-reviews', album_reviews_route);
+
+describe('album-reviews route', () => {
+  beforeEach(() => {
+    mockGetAlbumReviewsPage.mockClear();
+    mockGetAlbumReviewsCount.mockClear();
+    mockGetAlbumReviewsPage.mockResolvedValue([]);
+    mockGetAlbumReviewsCount.mockResolvedValue(0);
+  });
+
+  it('GET /album-reviews requires an Authorization header', async () => {
+    const response = await request(app).get('/album-reviews');
+    expect(response.status).toBe(401);
+    expect(mockGetAlbumReviewsPage).not.toHaveBeenCalled();
+  });
+
+  it('GET /album-reviews serves an authenticated request', async () => {
+    const response = await request(app).get('/album-reviews').set('Authorization', 'Bearer test-token');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      album_reviews: [],
+      pagination: { page: 1, limit: 50, total: 0, hasMore: false },
+    });
+  });
+});

--- a/tests/unit/services/album-reviews.service.test.ts
+++ b/tests/unit/services/album-reviews.service.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for the album-reviews read service (album-reviews-sheet-sync
+ * plan / ADR 0011).
+ *
+ * `@wxyc/database` resolves to tests/mocks/database.mock.ts, so these pin
+ * the pieces that don't need PostgreSQL:
+ *   - `toAlbumReviewDTO` — ISO serialization of `submitted_at`, null
+ *     passthrough, and (the PII leak barrier) the exact wire key set: no
+ *     `reviewer_raw`, no `social_consent_raw`, no internal ETL columns.
+ *   - The select projection never references the PII/internal columns, so
+ *     they can't reach the response regardless of the mapper.
+ *   - `buildWhere` parity: the page and count queries receive structurally
+ *     identical WHERE trees for the same filters, and the artist filter is
+ *     applied as `norm_artist = normalizeArtistName(param)`.
+ *
+ * Real SQL behavior (ordering NULLS LAST, filters, pagination) is covered
+ * by tests/integration/album-reviews.spec.js.
+ */
+import { and, eq } from 'drizzle-orm';
+import { album_review_submissions, db, normalizeArtistName } from '@wxyc/database';
+import {
+  AlbumReviewDTO,
+  AlbumReviewRow,
+  getAlbumReviewsCount,
+  getAlbumReviewsPage,
+  toAlbumReviewDTO,
+} from '../../../apps/backend/services/album-reviews.service';
+
+/**
+ * Compile-time pin: `AlbumReviewDTO` must match the SSOT `AlbumReview`
+ * schema in `wxyc-shared/api.yaml` (the album-review contract PR,
+ * wxyc-shared#230). The published `@wxyc/shared` at this worktree's pin
+ * does not yet export an `AlbumReview` DTO, so we assert against a
+ * hand-mirrored shape derived from the api.yaml schema. When
+ * `@wxyc/shared` publishes `AlbumReview`, replace `ApiYamlAlbumReview`
+ * below with `import type { AlbumReview } from '@wxyc/shared/dtos'` — the
+ * two-way `Equal` assertion then fails loudly if the local alias drifts
+ * from the SSOT (`submitted_at` a nullable date-time string, the three
+ * normalized flags nullable booleans, everything free-text nullable).
+ */
+type ApiYamlAlbumReview = {
+  id: number;
+  album_id: number | null;
+  artist_name: string | null;
+  album_title: string | null;
+  record_label: string | null;
+  artist_blurb: string | null;
+  review: string | null;
+  recommended_tracks: string | null;
+  buzzwords: string | null;
+  fcc_violations: string | null;
+  review_purpose: string | null;
+  rotated: boolean | null;
+  released_within_six_months: boolean | null;
+  social_consent: boolean | null;
+  submitted_at: string | null;
+};
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+// Fails to compile if AlbumReviewDTO and the api.yaml-derived shape diverge
+// in either direction (extra key, missing key, or type mismatch).
+type _AlbumReviewDtoMatchesSsot = Expect<Equal<AlbumReviewDTO, ApiYamlAlbumReview>>;
+// Reference the alias so `noUnusedLocals`/lint keep the assertion live.
+const _albumReviewDtoTypeGuard: _AlbumReviewDtoMatchesSsot = true;
+
+const mockDb = db as unknown as { _chain: Record<string, jest.Mock> };
+
+/** Columns that must NEVER appear in the projection or on the wire.
+ *  reviewer_raw/social_consent_raw are the PII pair the form's "your name
+ *  will not be shared" promise protects; the rest are internal ETL
+ *  bookkeeping. */
+const PII_COLUMNS = ['reviewer_raw', 'social_consent_raw'];
+const INTERNAL_COLUMNS = [...PII_COLUMNS, 'source', 'source_key', 'norm_artist', 'norm_album', 'add_date', 'last_modified'];
+
+const WIRE_KEYS = [
+  'id',
+  'album_id',
+  'artist_name',
+  'album_title',
+  'record_label',
+  'artist_blurb',
+  'review',
+  'recommended_tracks',
+  'buzzwords',
+  'fcc_violations',
+  'review_purpose',
+  'rotated',
+  'released_within_six_months',
+  'social_consent',
+  'submitted_at',
+];
+
+const timestampedRow: AlbumReviewRow = {
+  id: 301,
+  album_id: 7042,
+  artist_name: 'Juana Molina',
+  album_title: 'DOGA',
+  record_label: 'Sonamos',
+  artist_blurb: 'Argentine electronic-folk auteur; ex-sitcom star turned loop-pedal visionary.',
+  review: 'Hypnotic layered loops; a late-night staple. Play la paradoja first.',
+  recommended_tracks: '1, 3 (!!!!), 5',
+  buzzwords: 'hypnotic, electronic, folk',
+  fcc_violations: 'None',
+  review_purpose: 'Rotation',
+  rotated: true,
+  released_within_six_months: true,
+  social_consent: true,
+  submitted_at: new Date('2026-03-15T17:45:12.000Z'),
+};
+
+const nulledRow: AlbumReviewRow = {
+  id: 302,
+  album_id: null,
+  artist_name: 'Jessica Pratt',
+  album_title: 'On Your Own Love Again',
+  record_label: null,
+  artist_blurb: null,
+  review: 'Whispered folk miniatures. Timeless.',
+  recommended_tracks: null,
+  buzzwords: null,
+  fcc_violations: null,
+  review_purpose: null,
+  rotated: null,
+  released_within_six_months: null,
+  social_consent: null,
+  submitted_at: null,
+};
+
+describe('AlbumReviewDTO structural pin', () => {
+  it('matches the api.yaml-derived AlbumReview shape (compile-time assertion)', () => {
+    // The real check is the `_AlbumReviewDtoMatchesSsot` type above, which
+    // fails to compile on drift; this keeps a runtime reference to the guard.
+    expect(_albumReviewDtoTypeGuard).toBe(true);
+  });
+});
+
+describe('toAlbumReviewDTO', () => {
+  it('serializes the submitted_at instant to an ISO-8601 string (SSOT date-time shape)', () => {
+    const dto = toAlbumReviewDTO(timestampedRow);
+    expect(dto.submitted_at).toBe('2026-03-15T17:45:12.000Z');
+    expect(typeof dto.submitted_at).toBe('string');
+  });
+
+  it('passes nulls through for a sparse row (null submitted_at and flags)', () => {
+    const dto = toAlbumReviewDTO(nulledRow);
+    expect(dto.album_id).toBeNull();
+    expect(dto.record_label).toBeNull();
+    expect(dto.rotated).toBeNull();
+    expect(dto.released_within_six_months).toBeNull();
+    expect(dto.social_consent).toBeNull();
+    expect(dto.submitted_at).toBeNull();
+  });
+
+  it('emits exactly the AlbumReview wire keys — no PII, no internal columns', () => {
+    const dto = toAlbumReviewDTO(timestampedRow);
+    expect(Object.keys(dto).sort()).toEqual([...WIRE_KEYS].sort());
+    for (const internal of INTERNAL_COLUMNS) {
+      expect(dto).not.toHaveProperty(internal);
+    }
+  });
+
+  it('drops PII even when a wider row leaks extra properties into the mapper', () => {
+    // The projection is the real barrier; this pins the second layer — the
+    // mapper is an explicit field list, not a spread, so a row that somehow
+    // carried reviewer_raw still cannot reach the wire.
+    const leakyRow = {
+      ...timestampedRow,
+      reviewer_raw: 'A Real Name, 3/15/26',
+      social_consent_raw: 'Yes, but remove my name',
+    } as AlbumReviewRow;
+    const dto = toAlbumReviewDTO(leakyRow);
+    expect(dto).not.toHaveProperty('reviewer_raw');
+    expect(dto).not.toHaveProperty('social_consent_raw');
+  });
+});
+
+describe('getAlbumReviewsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('selects a projection that never references the PII or internal columns', async () => {
+    // Terminal .offset() resolves the row set for this call.
+    mockDb._chain.offset.mockReturnValueOnce(Promise.resolve([timestampedRow]));
+
+    const result = await getAlbumReviewsPage({}, 50, 0);
+
+    expect(result).toEqual([toAlbumReviewDTO(timestampedRow)]);
+    // The mocked table objects map each column to its name, so the
+    // projection's values are column-name strings we can inspect.
+    const projection = mockDb._chain.select.mock.calls[0][0] as Record<string, string>;
+    const selectedColumns = Object.values(projection);
+    for (const internal of INTERNAL_COLUMNS) {
+      expect(selectedColumns).not.toContain(internal);
+    }
+    // And it selects exactly the wire fields, keyed by their wire names.
+    expect(Object.keys(projection).sort()).toEqual([...WIRE_KEYS].sort());
+  });
+
+  it('applies the artist filter as norm_artist = normalizeArtistName(param)', async () => {
+    mockDb._chain.offset.mockReturnValueOnce(Promise.resolve([]));
+
+    await getAlbumReviewsPage({ artist: 'The Stereolab' }, 50, 0);
+
+    const whereArg = mockDb._chain.where.mock.calls[0][0] as unknown;
+    // normalizeArtistName lowercases and strips the leading "The ".
+    expect(normalizeArtistName('The Stereolab')).toBe('stereolab');
+    expect(whereArg).toEqual(and(eq(album_review_submissions.norm_artist, 'stereolab')));
+  });
+
+  it('applies the album_id filter as an exact match', async () => {
+    mockDb._chain.offset.mockReturnValueOnce(Promise.resolve([]));
+
+    await getAlbumReviewsPage({ album_id: 7042 }, 50, 0);
+
+    const whereArg = mockDb._chain.where.mock.calls[0][0] as unknown;
+    expect(whereArg).toEqual(and(eq(album_review_submissions.album_id, 7042)));
+  });
+
+  it('passes no WHERE clause when there are no filters', async () => {
+    mockDb._chain.offset.mockReturnValueOnce(Promise.resolve([]));
+
+    await getAlbumReviewsPage({}, 50, 0);
+
+    expect(mockDb._chain.where.mock.calls[0][0]).toBeUndefined();
+  });
+});
+
+describe('getAlbumReviewsCount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the count from the first row', async () => {
+    // Terminal .where() resolves the aggregate row for this call.
+    mockDb._chain.where.mockReturnValueOnce(Promise.resolve([{ count: 42 }]));
+    await expect(getAlbumReviewsCount({})).resolves.toBe(42);
+  });
+
+  it('returns 0 when the aggregate row is missing', async () => {
+    mockDb._chain.where.mockReturnValueOnce(Promise.resolve([]));
+    await expect(getAlbumReviewsCount({ album_id: 7042 })).resolves.toBe(0);
+  });
+});
+
+describe('buildWhere parity (page vs count)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('page and count receive structurally identical WHERE trees for the same filters', async () => {
+    const filters = { album_id: 7042, artist: 'Cat Power' };
+
+    mockDb._chain.offset.mockReturnValueOnce(Promise.resolve([]));
+    await getAlbumReviewsPage(filters, 50, 0);
+    const pageWhere = mockDb._chain.where.mock.calls[0][0] as unknown;
+
+    mockDb._chain.where.mockReturnValueOnce(Promise.resolve([{ count: 0 }]));
+    await getAlbumReviewsCount(filters);
+    const countWhere = mockDb._chain.where.mock.calls[1][0] as unknown;
+
+    expect(pageWhere).toEqual(countWhere);
+    expect(pageWhere).toEqual(
+      and(eq(album_review_submissions.album_id, 7042), eq(album_review_submissions.norm_artist, 'cat power'))
+    );
+  });
+});

--- a/tests/unit/services/album-reviews.service.test.ts
+++ b/tests/unit/services/album-reviews.service.test.ts
@@ -72,7 +72,15 @@ const mockDb = db as unknown as { _chain: Record<string, jest.Mock> };
  *  will not be shared" promise protects; the rest are internal ETL
  *  bookkeeping. */
 const PII_COLUMNS = ['reviewer_raw', 'social_consent_raw'];
-const INTERNAL_COLUMNS = [...PII_COLUMNS, 'source', 'source_key', 'norm_artist', 'norm_album', 'add_date', 'last_modified'];
+const INTERNAL_COLUMNS = [
+  ...PII_COLUMNS,
+  'source',
+  'source_key',
+  'norm_artist',
+  'norm_album',
+  'add_date',
+  'last_modified',
+];
 
 const WIRE_KEYS = [
   'id',


### PR DESCRIPTION
Closes #1677 (PR 3 of 3). Stacked on #1678 — retarget to `main` and rebase after #1678 merges. Contract: WXYC/wxyc-shared#229 / #230.

Read surface for the album-review archive, mirroring the concerts stack:

- **Route**: `routes/album-reviews.route.ts`, mounted at `/album-reviews` with `requirePermissions({})` (anon-JWT read posture — the iOS surface convention). Deliberately not `/reviews`, which ADR 0006 reserves for the in-app Review model.
- **Controller**: hand-rolled param validation (`album_id` all-digits int, `artist` non-empty ≤256 chars with repeated-param rejection, `page`/`limit` defaults 1/50 cap 100), `Promise.all([page, count])`, `{ album_reviews, pagination }` per the wxyc-shared `AlbumReviewsResponse` shape.
- **Service**: the explicit `select({...})` projection is the **PII leak barrier** — `reviewer_raw` and `social_consent_raw` are never selected, so reviewer identity cannot reach the wire regardless of the DTO mapper (the form promised names would not be shared). Shared `buildWhere` for page/count parity; `artist` filter matches `norm_artist = normalizeArtistName(param)` on the `…_norm_artist_idx`; order `submitted_at DESC NULLS LAST, id DESC`. Local `AlbumReviewDTO` alias with the concerts-style TODO to switch to `@wxyc/shared/dtos` once the pin carries wxyc-shared#230's types.
- **Docs**: app.yaml Swagger-display mirror + CLAUDE.md route-table row.

## Tests

Unit (controller 400-families/defaults/caps, route auth wiring, service projection-key-set PII assertion + buildWhere parity + compile-time shape pin against api.yaml), `tests/integration/album-reviews.spec.js` (17 cases: 401, wire-shape equality, PII keys absent while DB rows carry them, filters incl. case/leading-The insensitivity, NULLS-LAST ordering, pagination, validation 400s), and `tests/e2e/album-reviews-pipeline.test.ts` (8 cases: real `runEtl` + writer + link with only the sheet fetch stubbed, run twice for idempotency, then a live GET round-trip with wire-level PII exclusion).

The e2e suite is what surfaced the two driver-boundary bugs now fixed in #1678 (raw-Date setWhere binding, `ANY()` array splat) — it is the first test to run the actual TS writer/link path against real PostgreSQL.

Local gate: typecheck, format, 4,593 unit tests, migrations validator; integration spec 17/17 and e2e 8/8 against the Dockerized stack.