### PR TITLE
fix(search): cap /flowsheet/search count and degrade on count failure

### DIFF
--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { sql, type SQL } from 'drizzle-orm';
 import { db, flowsheet } from '@wxyc/database';
 import {
@@ -55,6 +56,22 @@ type SearchResultRow = {
 };
 
 type CountRow = { total: number };
+
+/**
+ * Upper bound on the exact count reported by /flowsheet/search (BS#1681).
+ *
+ * An unbounded `COUNT(*)` over the `entry_type = 'track'` set is a parallel seq
+ * scan of the whole 3.3 GB / ~2M-row flowsheet heap — ~12s in prod, well past
+ * the 5s HTTP `statement_timeout`, which 500'd the endpoint for every query
+ * (the empty default listing and broad terms like "the" match nearly every
+ * row). Wrapping the count in a `LIMIT COUNT_CAP + 1` derived table bounds the
+ * work to at most this many matching rows regardless of selectivity (33-105ms
+ * measured), at the cost of reporting `COUNT_CAP + 1` as a "10000+" sentinel
+ * once the true match set exceeds the cap. Deep offset pagination past the cap
+ * was never meaningful for the multi-million-row historical archive, and the
+ * forward path (cursor mode) doesn't depend on `total` at all.
+ */
+export const COUNT_CAP = 10000;
 
 export type SearchResult = {
   id: number;
@@ -148,12 +165,35 @@ export async function searchFlowsheet(
     ${limitClause}
   `;
 
-  const countQuery = sql`SELECT COUNT(*)::int AS total ${fullWhere}`;
+  // Capped count (BS#1681): `COUNT(*)` over a `LIMIT COUNT_CAP + 1` derived
+  // table stops scanning once the cap is reached, bounding cost regardless of
+  // how many rows the predicate actually matches.
+  const countQuery = sql`SELECT COUNT(*)::int AS total FROM (SELECT 1 ${fullWhere} LIMIT ${COUNT_CAP + 1}) AS capped`;
 
-  const [dataRows, countRows] = await Promise.all([db.execute(dataQuery), db.execute(countQuery)]);
+  // allSettled, not all: the count is now cheap enough that it should never
+  // time out, but if it (or a future predicate) does, the data page is already
+  // in hand — degrade to a lower-bound total rather than 500-ing the whole
+  // request the way the pre-BS#1681 `Promise.all` did.
+  const [dataSettled, countSettled] = await Promise.allSettled([db.execute(dataQuery), db.execute(countQuery)]);
 
-  const results = (dataRows as unknown as SearchResultRow[]).map(transformRow);
-  const total = (countRows as unknown as CountRow[])[0]?.total ?? 0;
+  if (dataSettled.status === 'rejected') {
+    // No data page means nothing to serve — a data-query failure stays fatal
+    // and propagates to the error handler as a 500.
+    throw dataSettled.reason;
+  }
+
+  const results = (dataSettled.value as unknown as SearchResultRow[]).map(transformRow);
+
+  let total: number;
+  if (countSettled.status === 'fulfilled') {
+    total = (countSettled.value as unknown as CountRow[])[0]?.total ?? 0;
+  } else {
+    // Lower bound on the true total: everything up to and including this page.
+    // In cursor mode `offset` is 0, so this collapses to the current page size.
+    total = offset + results.length;
+    Sentry.captureException(countSettled.reason);
+    console.error('flowsheet search count query failed; returning lower-bound total', countSettled.reason);
+  }
 
   // nextCursor only when cursor mode is active AND we got a full page —
   // a short page means there are no more rows.

--- a/apps/backend/services/search.service.ts
+++ b/apps/backend/services/search.service.ts
@@ -188,10 +188,16 @@ export async function searchFlowsheet(
   if (countSettled.status === 'fulfilled') {
     total = (countSettled.value as unknown as CountRow[])[0]?.total ?? 0;
   } else {
-    // Lower bound on the true total: everything up to and including this page.
-    // In cursor mode `offset` is 0, so this collapses to the current page size.
+    // Best-effort total when the count is unavailable: the rows we've already
+    // paged past plus this page. Exact for a partial final page, a lower bound
+    // for a full page, and — only in the rare empty-page-past-end offset case —
+    // an over-estimate bounded by `offset`. In cursor mode `offset` is 0, so
+    // this collapses to the current page size.
     total = offset + results.length;
-    Sentry.captureException(countSettled.reason);
+    Sentry.captureException(countSettled.reason, {
+      tags: { subsystem: 'flowsheet-search' },
+      extra: { q, page, limit },
+    });
     console.error('flowsheet search count query failed; returning lower-bound total', countSettled.reason);
   }
 

--- a/tests/unit/services/search.service.count-cap.test.ts
+++ b/tests/unit/services/search.service.count-cap.test.ts
@@ -1,0 +1,151 @@
+// BS#1681: the exact `COUNT(*)` over the full track set is an unbounded parallel
+// seq scan (measured 12.3s / 1.97M rows in prod) that blows past the 5s HTTP
+// `statement_timeout`, and because it ran in a `Promise.all` alongside the data
+// query, its rejection 500'd the whole endpoint — including the 4ms data page
+// that was already in hand. Two fixes, tested here:
+//   1. Cap the count with a `LIMIT COUNT_CAP + 1` subquery so cost is bounded
+//      regardless of selectivity (33-105ms in prod).
+//   2. Run data + count via `Promise.allSettled` so a count failure degrades to
+//      a lower-bound total instead of failing the request.
+//
+// Uses the real drizzle-orm `sql` tag (compiled with PgDialect) to assert the
+// cap reaches the count query, mirroring search.service.escape.test.ts.
+jest.unmock('drizzle-orm');
+
+// @sentry/node's exports aren't spy-able (non-configurable ESM namespace), so
+// stub the one function the service uses with a module factory.
+jest.mock('@sentry/node', () => ({ captureException: jest.fn() }));
+
+import * as Sentry from '@sentry/node';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { db } from '../../mocks/database.mock';
+
+const dialect = new PgDialect();
+
+/** Compile the SQL text + bound params for the Nth db.execute call (0 = data, 1 = count). */
+const compiledExecuteCall = (n: number) => {
+  const stmt = (db.execute as jest.Mock).mock.calls[n][0];
+  return dialect.sqlToQuery(stmt);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+import { searchFlowsheet, COUNT_CAP } from '../../../apps/backend/services/search.service';
+
+const makeRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 1,
+  play_date: new Date('2024-06-15T14:30:00Z'),
+  artist_name: 'Juana Molina',
+  track_title: 'la paradoja',
+  album_title: 'DOGA',
+  record_label: 'Sonamos',
+  show_id: 100,
+  dj_name: 'DJ Test',
+  ...overrides,
+});
+
+/** searchFlowsheet issues the data query first, then the count query. */
+const mockDataAndCount = (rows: ReturnType<typeof makeRow>[] = [], total = 0) => {
+  (db.execute as jest.Mock).mockResolvedValueOnce(rows).mockResolvedValueOnce([{ total }]);
+};
+
+describe('BS#1681 fix #1: capped count query', () => {
+  it('wraps the count in a LIMIT COUNT_CAP + 1 subquery (empty query)', async () => {
+    mockDataAndCount();
+
+    await searchFlowsheet({ q: '', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    const { sql: text, params } = compiledExecuteCall(1);
+    const lower = text.toLowerCase();
+    expect(lower).toContain('count(*)');
+    // The unbounded `COUNT(*) FROM flowsheet` is replaced by a bounded
+    // `COUNT(*) FROM (SELECT 1 ... LIMIT $n)` derived table.
+    expect(lower).toMatch(/from\s*\(\s*select 1/);
+    expect(lower).toContain('limit');
+    expect(params).toContain(COUNT_CAP + 1);
+  });
+
+  it('caps the count for a broad tsvector query too (q=the)', async () => {
+    mockDataAndCount();
+
+    await searchFlowsheet({ q: 'the', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    const { sql: text, params } = compiledExecuteCall(1);
+    const lower = text.toLowerCase();
+    expect(lower).toMatch(/from\s*\(\s*select 1/);
+    // The broad predicate is preserved inside the capped derived table.
+    expect(lower).toContain('websearch_to_tsquery');
+    expect(params).toContain(COUNT_CAP + 1);
+  });
+
+  it('leaves the data query (call 0) unbounded by the count cap', async () => {
+    mockDataAndCount();
+
+    await searchFlowsheet({ q: '', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    const { params } = compiledExecuteCall(0);
+    // Data query is limited by the caller's `limit` (50), not the count cap.
+    expect(params).toContain(50);
+    expect(params).not.toContain(COUNT_CAP + 1);
+  });
+
+  it('returns the capped count value verbatim from the count query', async () => {
+    // When the true match set exceeds the cap the count query returns
+    // COUNT_CAP + 1; the service passes it through unchanged.
+    mockDataAndCount([makeRow()], COUNT_CAP + 1);
+
+    const result = await searchFlowsheet({ q: '', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    expect(result.total).toBe(COUNT_CAP + 1);
+  });
+});
+
+describe('BS#1681 fix #2: count failure degrades instead of 500-ing', () => {
+  it('resolves with the data page and a lower-bound total when the count query rejects', async () => {
+    const captureException = Sentry.captureException as unknown as jest.Mock;
+    const rows = [makeRow({ id: 1 }), makeRow({ id: 2 })];
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce(rows) // data query succeeds
+      .mockRejectedValueOnce(new Error('canceling statement due to statement timeout')); // count fails
+
+    const result = await searchFlowsheet({ q: 'the', page: 2, limit: 10, sort: 'date', order: 'desc' });
+
+    // Data is served, not dropped.
+    expect(result.results).toHaveLength(2);
+    // Lower bound: offset (page * limit) + rows on this page.
+    expect(result.total).toBe(2 * 10 + 2);
+    // The swallowed failure is still reported so we retain visibility.
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('still throws when the DATA query fails — nothing to serve is fatal', async () => {
+    (db.execute as jest.Mock)
+      .mockRejectedValueOnce(new Error('data boom')) // data query fails
+      .mockResolvedValueOnce([{ total: 5 }]); // count succeeds
+
+    await expect(searchFlowsheet({ q: 'the', page: 0, limit: 50, sort: 'date', order: 'desc' })).rejects.toThrow(
+      'data boom'
+    );
+  });
+
+  it('uses results.length as the lower bound in cursor mode (offset is 0)', async () => {
+    const rows = Array.from({ length: 5 }, (_, i) => makeRow({ id: i + 1 }));
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce(rows)
+      .mockRejectedValueOnce(new Error('canceling statement due to statement timeout'));
+
+    const result = await searchFlowsheet({
+      q: '',
+      page: 3,
+      limit: 50,
+      sort: 'date',
+      order: 'desc',
+      cursor: '2024-06-16T00:00:00.000Z_999',
+    });
+
+    // Cursor mode zeroes the offset, so the lower bound is just this page's rows.
+    expect(result.total).toBe(5);
+  });
+});

--- a/tests/unit/services/search.service.count-cap.test.ts
+++ b/tests/unit/services/search.service.count-cap.test.ts
@@ -100,6 +100,19 @@ describe('BS#1681 fix #1: capped count query', () => {
 
     expect(result.total).toBe(COUNT_CAP + 1);
   });
+
+  it('does not report to Sentry when the count query succeeds', async () => {
+    // The degradation capture must stay inside the count-failure branch — a
+    // regression that fired it unconditionally would spam Sentry on every
+    // successful search (the hot, high-volume default listing).
+    const captureException = Sentry.captureException as unknown as jest.Mock;
+    mockDataAndCount([makeRow()], 42);
+
+    const result = await searchFlowsheet({ q: '', page: 0, limit: 50, sort: 'date', order: 'desc' });
+
+    expect(result.total).toBe(42);
+    expect(captureException).not.toHaveBeenCalled();
+  });
 });
 
 describe('BS#1681 fix #2: count failure degrades instead of 500-ing', () => {


### PR DESCRIPTION
## Problem

`GET /flowsheet/search` returned **500 for every query** in production — the empty default "recent playlists" listing and every search term alike — while sibling flowsheet endpoints stayed healthy. This left dj-site's entire `/playlists` archive rendering only the shell.

Root cause (from prod Sentry + direct DB inspection): `searchFlowsheet` ran the data query and an **unbounded exact `COUNT(*)`** in a `Promise.all`. The data query is cheap (~4 ms — it rides the `flowsheet_track_add_time_idx` partial index and stops at `LIMIT`), but the count is a **parallel seq scan of the whole 3.3 GB / ~2M-row `flowsheet` heap**:

- empty `q` → counts the entire `entry_type='track'` set (1,976,630 rows): **12.3 s**
- `q=the` → matches nearly every row via the GIN tsvector index: also over budget

Both blow past the app's 5 s HTTP `statement_timeout` (`shared/database/src/client.ts`), and the rejected count rejected the whole `Promise.all` — so the 4 ms data page that was already in hand never went out. CI's tiny compose DB counts instantly, which is why this only surfaced at prod scale.

## Fix

1. **Cap the count.** The count is now `COUNT(*) FROM (SELECT 1 … LIMIT COUNT_CAP + 1)` (`COUNT_CAP = 10000`). The scan stops once the cap is reached, bounding cost regardless of selectivity. Measured in prod under the app's real 5 s cap: empty `q` → **23.7 ms**, `q=the` → **78.2 ms**. Match sets larger than the cap report `10001` as a "10,000+" sentinel.
2. **Degrade instead of 500-ing.** Data + count now run via `Promise.allSettled`. If the count fails (a future slow predicate, a lock, a transient DB hiccup), the endpoint returns the data page with a lower-bound `total` (`offset + page rows`) and reports the failure to Sentry, rather than failing the whole request. A **data**-query failure stays fatal — nothing to serve.

`total`/`totalPages` remain required integers, so `PlaylistSearchResponse` is unchanged (no api.yaml change). The one behavioral consequence: offset pagination now caps at ~201 pages for match sets over 10k — never meaningful over the multi-million-row historical archive, and cursor mode (the forward path) doesn't use `total`.

## Verification

- New unit tests (`tests/unit/services/search.service.count-cap.test.ts`, 7 tests): assert the cap reaches the compiled count SQL (via `PgDialect`, mirroring the existing escape test), the broad-tsquery predicate is preserved inside the cap, the data query is untouched by the cap, and the `allSettled` degradation returns a lower-bound total + Sentry capture. Full unit suite: **4555 passing**.
- Prod SQL verified directly with the app's 5 s `statement_timeout` enforced (see timings above).

## Follow-up (separate issue)

Prod inspection also surfaced a DB-hygiene problem beyond this endpoint: the `flowsheet` table shows **never** vacuumed/analyzed (all four `pg_stat_user_tables` timestamps NULL) with a stale planner estimate (822k vs actual 1.97M). That degrades plans well past search and is filed separately.

Closes #1681
