### PR TITLE
feat(jobs): nightly concerts-genre-enrichment job + one-time backfill (BS#1624)

### DIFF
--- a/Dockerfile.concerts-genre-enrichment
+++ b/Dockerfile.concerts-genre-enrichment
@@ -1,0 +1,44 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+ARG NPM_TOKEN
+WORKDIR /concerts-genre-enrichment-builder
+
+COPY ./.npmrc ./
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./shared/lml-client ./shared/lml-client
+COPY ./jobs/concerts-genre-enrichment ./jobs/concerts-genre-enrichment
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-client --workspace=@wxyc/concerts-genre-enrichment
+
+#Production stage
+FROM node:24-alpine AS prod
+
+ARG NPM_TOKEN
+WORKDIR /concerts-genre-enrichment
+
+COPY ./.npmrc ./
+COPY ./package* ./
+COPY ./jobs/concerts-genre-enrichment/package* ./jobs/concerts-genre-enrichment/
+COPY ./shared/database/package* ./shared/database/
+COPY ./shared/lml-client/package* ./shared/lml-client/
+
+# `@wxyc/lml-client` declares `@wxyc/shared` as a registry dependency
+# (GitHub Packages, `@wxyc:registry` in `.npmrc`). Without NPM_TOKEN +
+# .npmrc the prod stage's npm install 401s on @wxyc/shared. Mirrors the
+# pattern in Dockerfile.concerts-artist-lml-resolver.
+RUN npm install --omit=dev && rm -f .npmrc
+
+COPY --from=builder ./concerts-genre-enrichment-builder/jobs/concerts-genre-enrichment/dist ./jobs/concerts-genre-enrichment/dist
+COPY --from=builder ./concerts-genre-enrichment-builder/shared/database/dist ./shared/database/dist
+COPY --from=builder ./concerts-genre-enrichment-builder/shared/lml-client/dist ./shared/lml-client/dist
+
+# Identifies the connection in pg_stat_activity during incident triage.
+ENV DB_APPLICATION_NAME=wxyc-concerts-genre-enrichment
+
+# ENTRYPOINT + empty CMD so docker-level args (e.g. `--backfill`, `--dry-run`)
+# pass through to the job rather than replacing the launcher.
+ENTRYPOINT ["node", "/concerts-genre-enrichment/jobs/concerts-genre-enrichment/dist/job.js"]
+CMD []

--- a/jobs/concerts-genre-enrichment/README.md
+++ b/jobs/concerts-genre-enrichment/README.md
@@ -1,0 +1,48 @@
+# concerts-genre-enrichment (BS#1624)
+
+Nightly cron that enriches **resolved concert headliners** with artist-level Discogs **genres** (and styles), so `GET /concerts` can project `Concert.genres` (wxyc-shared#221) for the iOS On Tour tab (wxyc-ios-64#474 R2).
+
+## What it does
+
+1. Load candidates: RESOLVED headliners (`concerts.headlining_discogs_artist_id`, or a library `headlining_artist_id` whose `artists.discogs_artist_id` is known) that have **no** `artist_metadata` row yet — deduped by Discogs artist id.
+2. Page them through LML's bulk artist-genres endpoint (`POST /api/v1/artists/genres/bulk`, LML#781).
+3. UPSERT `genres`/`styles` into `artist_metadata` keyed on the Discogs artist id, `ON CONFLICT DO NOTHING`.
+
+The effective Discogs id — `COALESCE(headlining_discogs_artist_id, artists.discogs_artist_id)` — is the exact expression the `GET /concerts` projection joins `artist_metadata` on (`apps/backend/services/concerts.service.ts`), so enrichment writes and the read join resolve genres through the same key.
+
+## Scheduling
+
+Chained **after** the artist resolvers: 05:15 UTC strict/alias (`concerts-artist-resolver`) and 05:35 UTC LML (`concerts-artist-lml-resolver`). Default `cron-schedule`: `45 5 * * *` UTC. It only ever sees headliners those passes resolved.
+
+## Modes
+
+| Invocation                    | Candidate window                                                               | Writes                             |
+| ----------------------------- | ------------------------------------------------------------------------------ | ---------------------------------- |
+| `node dist/job.js` (nightly)  | upcoming-only (`starts_on >= today`, venue-local Eastern)                      | yes                                |
+| `node dist/job.js --backfill` | **all dates** — the one-time deploy backfill over existing resolved headliners | yes                                |
+| `node dist/job.js --dry-run`  | (either)                                                                       | no — enumerate + log the plan only |
+
+**Idempotency.** The candidate query anti-joins `artist_metadata` (`WHERE am.discogs_artist_id IS NULL`) and the writer is `ON CONFLICT DO NOTHING`, so a re-run — including a re-run of the one-time backfill — enriches nothing already enriched and never overwrites a collected row. A page whose LML call throws is skipped and its artists are re-selected next run (the anti-join is the retry substrate; there is no attempt-at marker).
+
+## One-time backfill at deploy
+
+```bash
+# built + pushed by the deploy pipeline as an ECR image; run once at deploy:
+docker run --rm --env-file .env <image> --backfill
+```
+
+Run off-peak. Re-running is a no-op.
+
+## Env
+
+| Var                                    | Default | Meaning                                                                              |
+| -------------------------------------- | ------- | ------------------------------------------------------------------------------------ |
+| `CONCERTS_GENRE_ENRICH_PAGE_SIZE`      | 10      | artists per LML page (hard cap `ARTIST_GENRES_BATCH_CAP` = 25)                       |
+| `CONCERTS_GENRE_ENRICH_MAX_CONCURRENT` | 1       | limiter concurrency                                                                  |
+| `CONCERTS_GENRE_ENRICH_RATE_PER_MIN`   | 20      | limiter page rate                                                                    |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`       | 60      | cooperative-pause probe window (`0` disables)                                        |
+| `LIBRARY_METADATA_URL`, `LML_API_KEY`  | —       | LML endpoint + server-to-server bearer (merged at the `@wxyc/lml-client` chokepoint) |
+
+## LML contract (reconciled — LML#847)
+
+The LML call is isolated behind `fetchArtistGenresBulk` in `@wxyc/lml-client`, reconciled against the shipped `POST /api/v1/artists/genres/bulk` endpoint (LML#781, merged as LML#847) and the wxyc-shared `ArtistGenres*` contract (#235): request `{ artist_name, discogs_artist_id? }[]` under the `artists` envelope key; response per-artist `{ genres: string[], styles: string[], source }`, index-aligned with the request. `fetchArtistGenresBulk` enforces `results.length === artists.length` before returning (throws `LmlClientError(502)` on a misaligned array), so the orchestrator's positional zip can never mis-attribute a genre set. Per-request cap `ARTIST_GENRES_BATCH_CAP` = 25. LML's `source` discriminator routes the write: `unavailable` (LML couldn't reach Discogs) is skipped and left retryable; `cache`/`discogs_api`/`not_found` persist. Every test mocks the LML call; nothing here hits a live endpoint.

--- a/jobs/concerts-genre-enrichment/job.ts
+++ b/jobs/concerts-genre-enrichment/job.ts
@@ -1,0 +1,171 @@
+/**
+ * Nightly cron: enrich resolved concert headliners with artist-level Discogs
+ * genres via LML's bulk artist-genres endpoint (BS#1624, LML#781).
+ *
+ * Chained after the concert artist resolvers (05:15 UTC strict/alias, 05:35 UTC
+ * LML) so it only ever sees headliners those passes have resolved. For each
+ * resolved headliner lacking an `artist_metadata` row it calls
+ * `POST /api/v1/artists/genres/bulk` and persists `genres`/`styles` keyed on the
+ * Discogs artist id — the key `GET /concerts` projects onto `Concert.genres`.
+ * Default schedule `45 5 * * *` UTC.
+ *
+ * Modes:
+ *   - default (nightly): upcoming-only candidate window (venue-local Eastern
+ *     date), so genre budget is never spent on past shows the feed won't serve.
+ *   - `--backfill`: drop the window and front-fill every existing resolved
+ *     headliner — the one-time deploy backfill. Idempotent: the candidate
+ *     anti-join + `ON CONFLICT DO NOTHING` make a re-run a no-op.
+ *   - `--dry-run`: enumerate + log the plan; no LML calls, no writes.
+ *
+ * Enrichment runs nightly server-to-server with the LML API key (merged at the
+ * `@wxyc/lml-client` chokepoint from `LML_API_KEY`); it is never on any
+ * listener hot path.
+ *
+ * The LML endpoint path + field names are the shipped LML#781 contract (merged
+ * as LML#847), carried by `fetchArtistGenresBulk`, which enforces 1:1 index
+ * alignment of the response before returning. LML's `source` discriminator
+ * routes the write: `unavailable` (couldn't reach Discogs) is skipped and left
+ * retryable; `cache`/`discogs_api`/`not_found` persist.
+ *
+ * Run procedure: see jobs/concerts-genre-enrichment/README.md.
+ */
+
+import { sql } from 'drizzle-orm';
+import { closeDatabaseConnection, db, requireNonNegativeInt, requirePositiveInt } from '@wxyc/database';
+import { ARTIST_GENRES_BATCH_CAP, fetchArtistGenresBulk } from '@wxyc/lml-client';
+import { defaultLmlLimiter } from './lml-limiter.js';
+import { loadEnrichmentCandidates } from './query.js';
+import { runEnrichment, type Totals } from './orchestrate.js';
+import { upsertArtistGenres } from './writer.js';
+import { captureError, closeLogger, initLogger, log } from './logger.js';
+
+const JOB_NAME = 'concerts-genre-enrichment';
+
+// -- Env knobs ---------------------------------------------------------------
+
+/** Artists per LML page. Hard-capped at `ARTIST_GENRES_BATCH_CAP`. */
+export const PAGE_SIZE_ENV = 'CONCERTS_GENRE_ENRICH_PAGE_SIZE';
+export const PAGE_SIZE_DEFAULT = 10;
+
+/** Cooperative-pause lookback window (seconds). `0` disables the probe. */
+export const LIVE_ACTIVITY_LOOKBACK_ENV = 'LIVE_ACTIVITY_LOOKBACK_SECONDS';
+export const LIVE_ACTIVITY_LOOKBACK_DEFAULT = 60;
+
+/** Sleep between re-probes when DJ activity is detected. */
+export const LIVE_ACTIVITY_PAUSE_MS_DEFAULT = 30_000;
+
+export interface EnrichJobOptions {
+  pageSize: number;
+  liveActivityLookbackSeconds: number;
+  liveActivityPauseMs: number;
+  backfill: boolean;
+  dryRun: boolean;
+}
+
+export const enrichJobOptions = (
+  env: NodeJS.ProcessEnv = process.env,
+  args: string[] = process.argv
+): EnrichJobOptions => {
+  const ctx = { context: JOB_NAME };
+  const pageSize = requirePositiveInt(env[PAGE_SIZE_ENV], PAGE_SIZE_ENV, PAGE_SIZE_DEFAULT, ctx);
+  if (pageSize > ARTIST_GENRES_BATCH_CAP) {
+    // Fail fast at parse time with an actionable message — the client would
+    // otherwise throw the same ceiling per page after the run started.
+    throw new Error(
+      `[${JOB_NAME}] ${PAGE_SIZE_ENV}=${pageSize} exceeds the LML per-request cap of ${ARTIST_GENRES_BATCH_CAP}.`
+    );
+  }
+  return {
+    pageSize,
+    liveActivityLookbackSeconds: requireNonNegativeInt(
+      env[LIVE_ACTIVITY_LOOKBACK_ENV],
+      LIVE_ACTIVITY_LOOKBACK_ENV,
+      LIVE_ACTIVITY_LOOKBACK_DEFAULT,
+      { ...ctx, note: 'Use 0 to disable the live-activity probe.' }
+    ),
+    liveActivityPauseMs: LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+    backfill: args.includes('--backfill'),
+    dryRun: args.includes('--dry-run'),
+  };
+};
+
+// -- Cooperative pause -------------------------------------------------------
+
+/** Probe `flowsheet` for a track row added in the last `lookbackSeconds`.
+ * Returns `true` when activity is detected. `0` disables the probe.
+ * Mirrors `jobs/concerts-artist-lml-resolver/job.ts`. */
+export const checkLiveActivity = async (lookbackSeconds: number): Promise<boolean> => {
+  if (lookbackSeconds <= 0) return false;
+  const rows = (await db.execute(sql`
+    SELECT 1
+    FROM "wxyc_schema"."flowsheet"
+    WHERE "entry_type" = 'track'
+      AND "add_time" > now() - (interval '1 second' * ${lookbackSeconds})
+    LIMIT 1
+  `)) as unknown as Array<unknown>;
+  return rows.length > 0;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Loop: probe → if active, sleep pauseMs → re-probe. Returns when quiet. */
+export const awaitQuietWindow = async (lookbackSeconds: number, pauseMs: number): Promise<void> => {
+  while (await checkLiveActivity(lookbackSeconds)) {
+    log('info', 'live_activity_pause', `live DJ activity within ${lookbackSeconds}s; deferring ${pauseMs}ms`, {
+      lookback_seconds: lookbackSeconds,
+      pause_ms: pauseMs,
+    });
+    await sleep(pauseMs);
+  }
+};
+
+// -- Entrypoint ----------------------------------------------------------------
+
+export const runJob = async (options: EnrichJobOptions): Promise<Totals> => {
+  log('info', 'started', `${JOB_NAME} starting`, {
+    page_size: options.pageSize,
+    backfill: options.backfill,
+    live_activity_lookback_seconds: options.liveActivityLookbackSeconds,
+    dry_run: options.dryRun,
+  });
+
+  return await runEnrichment(
+    {
+      loadCandidates: () => loadEnrichmentCandidates(options.backfill),
+      fetchGenres: (items) => fetchArtistGenresBulk(items, { limiter: defaultLmlLimiter, caller: JOB_NAME }),
+      upsert: upsertArtistGenres,
+      awaitQuiet: () => awaitQuietWindow(options.liveActivityLookbackSeconds, options.liveActivityPauseMs),
+    },
+    {
+      pageSize: options.pageSize,
+      dryRun: options.dryRun,
+    }
+  );
+};
+
+const main = async (): Promise<void> => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+
+  try {
+    const options = enrichJobOptions();
+    const totals = await runJob(options);
+    log('info', 'finished', `${JOB_NAME} done`, { ...totals });
+  } catch (err) {
+    captureError(err, 'main');
+    log('error', 'failed', `${JOB_NAME} failed: ${err instanceof Error ? err.message : String(err)}`, {
+      error_message: err instanceof Error ? err.message : String(err),
+      error_name: err instanceof Error ? err.name : null,
+    });
+    process.exitCode = 1;
+  } finally {
+    await closeLogger();
+    await closeDatabaseConnection();
+  }
+};
+
+// Guard the auto-invoke so jest's module load doesn't fire a stray run against
+// the mocked DB. Jest sets NODE_ENV='test'; production runs leave it unset (the
+// Dockerfile sets no NODE_ENV), and any non-'test' value executes main().
+if (process.env.NODE_ENV !== 'test') {
+  void main();
+}

--- a/jobs/concerts-genre-enrichment/lml-limiter.ts
+++ b/jobs/concerts-genre-enrichment/lml-limiter.ts
@@ -1,0 +1,47 @@
+/**
+ * Concurrency + rate-limit gate for jobs/concerts-genre-enrichment (BS#1624).
+ *
+ * Mirrors jobs/concerts-artist-lml-resolver/lml-limiter.ts with job-scoped
+ * env names (CONCERTS_GENRE_ENRICH_*) and the same stricter-than-runtime
+ * defaults (concurrency=1, rate=20/min). Copying the file keeps this job's
+ * blast-radius story identical to the other cron jobs' without coupling any of
+ * them to another's build graph.
+ *
+ * Rate accounting note: `fetchArtistGenresBulk` takes ONE token per BATCH (LML
+ * paces its own fan-out inside the request), and the job sends pages serially,
+ * so concurrency never exceeds 1 in practice — the token bucket only prevents
+ * hot-looping through cheap pages faster than 20 pages/min.
+ *
+ * The underlying primitives (Semaphore, TokenBucket, LmlLimiter,
+ * createLmlLimiter) live in @wxyc/lml-client post-BS#887.
+ */
+
+import { type LmlLimiter, Semaphore, TokenBucket, createLmlLimiter as createSharedLmlLimiter } from '@wxyc/lml-client';
+
+export { type LmlLimiter, Semaphore, TokenBucket };
+
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  // Number() (not parseInt) so partial-parse strings like "20banana" surface
+  // as NaN and get rejected rather than silently coercing.
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  console.warn(`lml-limiter: ${name}=${raw} is invalid (must be positive number); using fallback ${fallback}`);
+  return fallback;
+};
+
+export const createLmlLimiter = (config?: { maxConcurrent?: number; ratePerMinute?: number }): LmlLimiter =>
+  createSharedLmlLimiter({
+    maxConcurrent: config?.maxConcurrent ?? envInt('CONCERTS_GENRE_ENRICH_MAX_CONCURRENT', 1),
+    ratePerMinute: config?.ratePerMinute ?? envInt('CONCERTS_GENRE_ENRICH_RATE_PER_MIN', 20),
+  });
+
+/**
+ * Module-level singleton consumed by job.ts. Reads CONCERTS_GENRE_ENRICH_*
+ * from env at module load — mutating process.env after the first import of
+ * this module does NOT reconfigure the singleton. Tests that exercise
+ * different limits must call `createLmlLimiter()` directly with explicit
+ * config.
+ */
+export const defaultLmlLimiter: LmlLimiter = createLmlLimiter();

--- a/jobs/concerts-genre-enrichment/logger.ts
+++ b/jobs/concerts-genre-enrichment/logger.ts
@@ -1,0 +1,96 @@
+/**
+ * Observability for concerts-genre-enrichment: Sentry init + JSON logs.
+ *
+ * Every log line carries the four tags `repo`, `tool`, `step`, `run_id` so
+ * downstream consumers (CloudWatch / Loki) can filter by step without a regex
+ * over free-form prose. Sentry stays inactive when SENTRY_DSN is unset (the
+ * @sentry/node SDK silently no-ops in that case), so this module is safe to
+ * call from any environment.
+ *
+ * Mirrors `jobs/concerts-artist-lml-resolver/logger.ts` verbatim — the
+ * contract is identical, and the duplication is the established pattern for
+ * keeping each job's build graph independent of the others.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  /** Optional run id; a random UUID is generated when omitted. */
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+// `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+/**
+ * Initialize Sentry and the structured logger. Call once at the top of the
+ * entrypoint, before any other logic. Returns the resolved `run_id` so the
+ * caller can pass it to subprocesses or persist it for cross-system tracing.
+ */
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+/**
+ * Emit a JSON log line. `info`/`warn` go to stdout, `error` goes to stderr
+ * so container log shippers can split streams by severity.
+ *
+ * Silently no-ops when called before `initLogger()` so unit tests that
+ * exercise library functions directly (without invoking the entrypoint)
+ * don't have to thread an init call through every fixture.
+ */
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+/** Capture an exception to Sentry with the current run's tags + an extra `step`. */
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+/** Flush pending Sentry events. Call from the entrypoint's `finally`. */
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/concerts-genre-enrichment/orchestrate.ts
+++ b/jobs/concerts-genre-enrichment/orchestrate.ts
@@ -1,0 +1,182 @@
+/**
+ * Orchestrator for jobs/concerts-genre-enrichment (BS#1624).
+ *
+ * Unit of work: `(resolved headliner artist → Discogs genres → artist_metadata
+ * row)`. Loads the candidate artists (resolved headliners lacking a genre row),
+ * pages them through LML's bulk artist-genres endpoint (LML#781), and UPSERTs
+ * the verdicts. Verdict routing keys on LML's `source`: `cache`/`discogs_api`/
+ * `not_found` persist a row (an empty-genre `not_found` is a legitimate
+ * "enriched, no genres" terminal row); `unavailable` — LML couldn't reach
+ * Discogs (no token, saturation breaker open, transient failure) — is skipped
+ * so the artist keeps no row and is retried, never negative-cached.
+ *
+ * Retryability: a page whose LML call THROWS (transport failure / timeout /
+ * 5xx) is skipped with nothing written; those artists keep no `artist_metadata`
+ * row and are re-selected on the next run (the candidate anti-join is the
+ * retry substrate — there is no attempt-at marker to manage, unlike the
+ * resolver). A per-artist `unavailable` verdict is treated the same way (no row
+ * written → retried). A row IS written for a confirmed genre-less artist
+ * (`not_found` / empty `cache` verdict) — that is the terminal negative-cache.
+ *
+ * Dep-injected so the unit suite drives the loop without PG or LML — see
+ * tests/unit/jobs/concerts-genre-enrichment/orchestrate.test.ts. The LML
+ * request/response shape is the shipped LML#781 contract carried by
+ * `fetchArtistGenresBulk` (@wxyc/lml-client).
+ */
+
+import type { ArtistGenresBulkResponse, ArtistGenresRequestItem } from '@wxyc/lml-client';
+import type { EnrichmentCandidate } from './query.js';
+import type { ArtistGenresRow } from './writer.js';
+import { captureError, log } from './logger.js';
+
+export type Totals = {
+  /** Resolved-but-unenriched artists loaded (deduped by Discogs id). */
+  candidates: number;
+  /** LML pages that received a response. */
+  pages: number;
+  /** Artist verdicts received across all responded pages. */
+  fetched: number;
+  /** Of `fetched`, how many carried >= 1 genre. */
+  with_genres: number;
+  /** Of `fetched`, verdicts with `source: 'unavailable'` — skipped, left retryable. */
+  unavailable_skipped: number;
+  /** `artist_metadata` rows actually inserted (a re-run over an enriched set → 0). */
+  enriched: number;
+  /** Page-level transport failures (per artist) + write failures. */
+  errors: number;
+  /** Set when a whole page came back `unavailable` (breaker open) and the run stopped short. */
+  stopped_early: boolean;
+};
+
+export const emptyTotals = (): Totals => ({
+  candidates: 0,
+  pages: 0,
+  fetched: 0,
+  with_genres: 0,
+  unavailable_skipped: 0,
+  enriched: 0,
+  errors: 0,
+  stopped_early: false,
+});
+
+export interface EnrichDeps {
+  /** Resolved headliners lacking a genre row (deduped by Discogs id). */
+  loadCandidates: () => Promise<EnrichmentCandidate[]>;
+  /** One LML page. The client validates 1:1 index alignment before returning. */
+  fetchGenres: (items: ArtistGenresRequestItem[]) => Promise<ArtistGenresBulkResponse>;
+  /** Persist a batch of verdicts (ON CONFLICT DO NOTHING); returns rows inserted. */
+  upsert: (rows: ArtistGenresRow[]) => Promise<{ inserted: number }>;
+  /** Cooperative pause — awaited before each page. */
+  awaitQuiet?: () => Promise<void>;
+}
+
+export interface EnrichOptions {
+  pageSize: number;
+  dryRun: boolean;
+}
+
+const chunk = <T>(arr: T[], size: number): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+};
+
+export const runEnrichment = async (deps: EnrichDeps, options: EnrichOptions): Promise<Totals> => {
+  const totals = emptyTotals();
+
+  const candidates = await deps.loadCandidates();
+  totals.candidates = candidates.length;
+
+  const pages = chunk(candidates, options.pageSize);
+  log('info', 'enumerated', `${candidates.length} resolved headliners need genres`, {
+    candidates: candidates.length,
+    planned_pages: pages.length,
+    page_size: options.pageSize,
+  });
+
+  if (options.dryRun) {
+    log('info', 'dry_run_plan', `(dry-run) would send ${pages.length} pages of up to ${options.pageSize} artists`, {
+      planned_pages: pages.length,
+    });
+    return totals;
+  }
+
+  for (const page of pages) {
+    if (deps.awaitQuiet) await deps.awaitQuiet();
+
+    let response: ArtistGenresBulkResponse;
+    try {
+      response = await deps.fetchGenres(
+        page.map((c) => ({ artist_name: c.artist_name, discogs_artist_id: c.discogs_artist_id }))
+      );
+    } catch (err) {
+      // Transport failure: nothing written, the whole page's artists keep no
+      // row and are re-selected next run (the candidate anti-join is the retry
+      // substrate). Never abort the run over one page.
+      totals.errors += page.length;
+      log('warn', 'page_failed', `fetchArtistGenresBulk threw; page of ${page.length} left retryable`, {
+        page_size: page.length,
+        first_discogs_artist_id: page[0]?.discogs_artist_id ?? null,
+        error_message: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+      });
+      captureError(err, 'page_failed', { page_size: page.length });
+      continue;
+    }
+    totals.pages += 1;
+
+    // Zip verdicts to candidates positionally (the client already validated
+    // results.length === page.length, so this is safe). Build the write batch.
+    const rows: ArtistGenresRow[] = [];
+    let pageUnavailable = 0;
+    for (let i = 0; i < page.length; i++) {
+      const verdict = response.results[i];
+      totals.fetched += 1;
+      // `unavailable` = LML couldn't reach Discogs (no token / breaker open /
+      // transient). Skip the write so the artist keeps no `artist_metadata` row
+      // and the candidate anti-join re-selects it next run. Persisting even the
+      // empty verdict would negative-cache a couldn't-ask permanently. A
+      // `not_found` verdict, by contrast, is a genuine "Discogs has no genres"
+      // and DOES persist (an empty row is a real, terminal negative-cache).
+      if (verdict.source === 'unavailable') {
+        totals.unavailable_skipped += 1;
+        pageUnavailable += 1;
+        continue;
+      }
+      const genres = verdict.genres ?? [];
+      const styles = verdict.styles ?? [];
+      if (genres.length > 0) totals.with_genres += 1;
+      rows.push({ discogs_artist_id: page[i].discogs_artist_id, genres, styles });
+    }
+
+    // A page that comes back entirely `unavailable` means LML's Discogs breaker
+    // is open (no token / saturation) and short-circuited every verdict; later
+    // pages would just waste round-trips against the same open breaker. Stop the
+    // run — the whole candidate set stays retryable via the anti-join, and `rows`
+    // is empty so there is nothing to write. (Mirrors concerts-artist-lml-
+    // resolver's all-escalation early-stop.)
+    if (page.length > 0 && pageUnavailable === page.length) {
+      totals.stopped_early = true;
+      log('info', 'stopped_early', `page of ${page.length} came back all-unavailable (breaker open); stopping run`, {
+        page_size: page.length,
+        pages_done: totals.pages,
+      });
+      break;
+    }
+
+    try {
+      const { inserted } = await deps.upsert(rows);
+      totals.enriched += inserted;
+    } catch (err) {
+      // A write failure leaves the page's artists unenriched (no row →
+      // retryable next run). Count and continue.
+      totals.errors += rows.length;
+      log('warn', 'upsert_failed', `artist_metadata UPSERT threw for a page of ${rows.length}`, {
+        page_size: rows.length,
+        error_message: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+      });
+      captureError(err, 'upsert_failed', { page_size: rows.length });
+    }
+  }
+
+  return totals;
+};

--- a/jobs/concerts-genre-enrichment/package.json
+++ b/jobs/concerts-genre-enrichment/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@wxyc/concerts-genre-enrichment",
+  "cron-schedule": "45 5 * * *",
+  "version": "1.0.0",
+  "description": "WXYC nightly cron (BS#1624): enrich resolved concert headliners with artist-level Discogs genres via LML's bulk artist-genres endpoint (LML#781), persisting genres/styles on artist_metadata keyed by Discogs artist id (the key GET /concerts projects onto Concert.genres). Runs after the 05:15/05:35 artist resolvers; --backfill front-fills existing resolved headliners once (idempotent); cooperative pause defers when DJs are active.",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_concerts_genre_enrichment:ci -f ../../Dockerfile.concerts-genre-enrichment ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.66.0",
+    "@wxyc/database": "^1.0.0",
+    "@wxyc/lml-client": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/concerts-genre-enrichment/query.ts
+++ b/jobs/concerts-genre-enrichment/query.ts
@@ -1,0 +1,97 @@
+/**
+ * Candidate query for jobs/concerts-genre-enrichment (BS#1624).
+ *
+ * Selects RESOLVED concert headliners that lack a persisted genre row — one
+ * per distinct Discogs artist id. "Resolved" spans both concert resolution
+ * lanes:
+ *   - the offline LML pass (BS#1614) writes `concerts.headlining_discogs_artist_id`
+ *     directly;
+ *   - the strict/alias resolver (BS#1372) writes `concerts.headlining_artist_id`
+ *     (a library FK), which reaches a Discogs id through `artists.discogs_artist_id`.
+ * The effective id is `COALESCE(headlining_discogs_artist_id, artists.discogs_artist_id)`
+ * — the exact expression the `GET /concerts` projection keys `artist_metadata`
+ * on (`apps/backend/services/concerts.service.ts`), so enrichment and read
+ * resolve genres through the same key.
+ *
+ * Idempotency + data-safety: the anti-join `artist_metadata am ... WHERE
+ * am.discogs_artist_id IS NULL` selects ONLY artists with no row yet, so a
+ * re-run (or the one-time backfill re-run) picks up nothing already enriched
+ * and never rewrites a collected row. `DISTINCT ON (discogs_artist_id)`
+ * collapses an artist playing multiple venues to one LML call.
+ *
+ * Window: the nightly run is upcoming-only (`starts_on >= today` in the
+ * venue-local Eastern date the read path windows on — never server-clock
+ * `CURRENT_DATE`; mirrors the resolver's candidate window), so genre budget is
+ * never spent on past shows the feed won't serve. The one-time deploy backfill
+ * (`--backfill`) drops the window to front-fill every existing resolved
+ * headliner regardless of date.
+ *
+ * Schema-qualified refs honour `WXYC_SCHEMA_NAME` (parallel Jest workers
+ * override it so each worker targets its own schema). Mirrors
+ * `jobs/concerts-artist-lml-resolver/targets.ts`.
+ */
+
+import { sql } from 'drizzle-orm';
+import { db } from '@wxyc/database';
+
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const CONCERTS_TABLE = sql.raw(`"${SCHEMA}"."concerts"`);
+const ARTISTS_TABLE = sql.raw(`"${SCHEMA}"."artists"`);
+const ARTIST_METADATA_TABLE = sql.raw(`"${SCHEMA}"."artist_metadata"`);
+
+/** One artist still needing genre enrichment. */
+export type EnrichmentCandidate = { discogs_artist_id: number; artist_name: string };
+
+/**
+ * Normalize `db.execute(sql\`...\`)` results across drizzle-orm driver shapes.
+ * postgres-js returns an array; node-postgres returns `{ rows }`. Anything else
+ * means the driver contract changed under us — fail LOUD rather than degrade
+ * into a healthy-looking zero-work no-op. Mirrors
+ * `jobs/concerts-artist-lml-resolver/targets.ts`.
+ */
+const describeShape = (result: unknown): string => {
+  if (result === null) return 'null';
+  if (result === undefined) return 'undefined';
+  if (typeof result !== 'object') return typeof result;
+  return `object{${Object.keys(result).join(',')}}`;
+};
+
+const unwrapRows = <T>(result: unknown): T[] => {
+  if (Array.isArray(result)) return result as T[];
+  if (result && typeof result === 'object' && Array.isArray((result as { rows?: unknown }).rows)) {
+    return (result as { rows: T[] }).rows;
+  }
+  throw new Error(`concerts-genre-enrichment: unrecognized db.execute() result shape: ${describeShape(result)}`);
+};
+
+/**
+ * Load the enrichment candidate set.
+ *
+ * @param backfill - when true, drop the upcoming-only `starts_on` window so the
+ *   one-time deploy backfill covers every existing resolved headliner.
+ */
+export const loadEnrichmentCandidates = async (backfill = false): Promise<EnrichmentCandidate[]> => {
+  // Interpolated as a whole `sql` fragment, not a bind param — it's DDL-shaped
+  // (a WHERE conjunct), and both branches are compile-time constants we control.
+  const windowClause = backfill ? sql`` : sql`AND "c"."starts_on" >= (now() AT TIME ZONE 'America/New_York')::date`;
+
+  const result: unknown = await db.execute(sql`
+    SELECT DISTINCT ON (eff."discogs_artist_id")
+      eff."discogs_artist_id" AS discogs_artist_id,
+      eff."artist_name" AS artist_name
+    FROM (
+      SELECT
+        COALESCE("c"."headlining_discogs_artist_id", "a"."discogs_artist_id") AS discogs_artist_id,
+        COALESCE("a"."artist_name", "c"."headlining_artist_raw") AS artist_name
+      FROM ${CONCERTS_TABLE} "c"
+      LEFT JOIN ${ARTISTS_TABLE} "a" ON "a"."id" = "c"."headlining_artist_id"
+      WHERE "c"."removed_at" IS NULL
+        ${windowClause}
+        AND COALESCE("c"."headlining_discogs_artist_id", "a"."discogs_artist_id") IS NOT NULL
+    ) eff
+    LEFT JOIN ${ARTIST_METADATA_TABLE} "am" ON "am"."discogs_artist_id" = eff."discogs_artist_id"
+    WHERE "am"."discogs_artist_id" IS NULL
+    ORDER BY eff."discogs_artist_id" ASC
+  `);
+  return unwrapRows<EnrichmentCandidate>(result);
+};

--- a/jobs/concerts-genre-enrichment/tsconfig.json
+++ b/jobs/concerts-genre-enrichment/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }, { "path": "../../shared/lml-client" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/concerts-genre-enrichment/tsup.config.ts
+++ b/jobs/concerts-genre-enrichment/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/jobs/concerts-genre-enrichment/writer.ts
+++ b/jobs/concerts-genre-enrichment/writer.ts
@@ -1,0 +1,45 @@
+/**
+ * Writer for jobs/concerts-genre-enrichment (BS#1624).
+ *
+ * Batch UPSERT of artist-level genres into `artist_metadata`, keyed on the
+ * Discogs artist id. `ON CONFLICT DO NOTHING` is the idempotency + data-safety
+ * guarantee: the candidate query already excludes artists that have a row, so a
+ * conflict here can only be a concurrent writer (another pod, or the nightly
+ * cron racing the one-time backfill) — and in that case the existing row wins
+ * and is never overwritten (the collected-data rule).
+ *
+ * Empty `genres`/`styles` arrays are persisted verbatim (not coalesced to
+ * NULL): an artist LML resolved to "no Discogs genres" gets a row, so the
+ * anti-join in query.ts won't re-select it every night. The row's presence —
+ * not its contents — is what makes the enrichment idempotent.
+ */
+
+import { artist_metadata, db } from '@wxyc/database';
+
+/** One artist's resolved genres/styles, ready to persist. */
+export type ArtistGenresRow = {
+  discogs_artist_id: number;
+  genres: string[];
+  styles: string[];
+};
+
+/**
+ * Insert the batch, skipping any Discogs id that already has a row. Returns the
+ * count actually inserted (a re-run over an already-enriched set returns 0 —
+ * the idempotency signal the tests assert on).
+ */
+export const upsertArtistGenres = async (rows: ArtistGenresRow[]): Promise<{ inserted: number }> => {
+  if (rows.length === 0) return { inserted: 0 };
+  const inserted = await db
+    .insert(artist_metadata)
+    .values(
+      rows.map((r) => ({
+        discogs_artist_id: r.discogs_artist_id,
+        genres: r.genres,
+        styles: r.styles,
+      }))
+    )
+    .onConflictDoNothing({ target: artist_metadata.discogs_artist_id })
+    .returning({ discogs_artist_id: artist_metadata.discogs_artist_id });
+  return { inserted: inserted.length };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -815,6 +815,22 @@
         "drizzle-orm": "^0.45.0"
       }
     },
+    "jobs/concerts-genre-enrichment": {
+      "name": "@wxyc/concerts-genre-enrichment",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.66.0",
+        "@wxyc/database": "^1.0.0",
+        "@wxyc/lml-client": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/flowsheet-artwork-repair": {
       "name": "@wxyc/flowsheet-artwork-repair",
       "version": "1.0.0",
@@ -6497,6 +6513,10 @@
     },
     "node_modules/@wxyc/concerts-artist-resolver": {
       "resolved": "jobs/concerts-artist-resolver",
+      "link": true
+    },
+    "node_modules/@wxyc/concerts-genre-enrichment": {
+      "resolved": "jobs/concerts-genre-enrichment",
       "link": true
     },
     "node_modules/@wxyc/database": {

--- a/tests/integration/concerts-genre-enrichment.spec.js
+++ b/tests/integration/concerts-genre-enrichment.spec.js
@@ -1,0 +1,325 @@
+/**
+ * Integration tests for the concerts genre-enrichment pipeline (BS#1624)
+ * against a REAL Postgres (migration 0121 `artist_metadata` + the read-path
+ * LEFT JOIN in apps/backend/services/concerts.service.ts).
+ *
+ * Two halves, both DB-backed:
+ *
+ *  1. The nightly enrichment's DB contract, validating the SQL the job issues:
+ *     - candidate selection (`jobs/concerts-genre-enrichment/query.ts`): the
+ *       COALESCE(headlining_discogs_artist_id, artists.discogs_artist_id)
+ *       effective-id, the `artist_metadata` anti-join (unenriched only), the
+ *       DISTINCT-ON dedupe, the upcoming-only window, and the `--backfill`
+ *       window that drops it;
+ *     - the UPSERT (`jobs/concerts-genre-enrichment/writer.ts`): ON CONFLICT
+ *       DO NOTHING idempotency — a re-run inserts 0 and never overwrites.
+ *  2. The read projection: `GET /concerts` emits `genres` for a resolved +
+ *     enriched headliner and `null` when unresolved or un-enriched.
+ *
+ * Pure SQL for half 1 — does NOT import the TS job (the integration runner is
+ * babel-jest with no TS support); the SQL here mirrors query.ts / writer.ts and
+ * must follow when they change. Mirrors the sibling
+ * `concerts-artist-lml-resolver-writer.spec.js` in shape.
+ *
+ * WXYC-representative headliners (Juana Molina, Stereolab, Chuquimamani-Condori)
+ * per the org fixture convention. Needs CI to run: requires the Docker
+ * integration DB (the `pg` marker tier).
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const SOURCE_ID_PREFIX = 'bs1624:';
+const VENUE_SLUG = 'bs1624-probe-room';
+
+// Stable, high Discogs ids so they never collide with seeded fixture data.
+const DISCOGS_ENRICHED = 91624001; // Lane A (library FK), already has an artist_metadata row.
+const DISCOGS_EXTERNAL = 91624002; // Lane B (headlining_discogs_artist_id only), unenriched.
+const DISCOGS_LIBRARY_UNENRICHED = 91624003; // Lane A (library FK), unenriched.
+const DISCOGS_PAST = 91624004; // Lane B, unenriched, PAST show (nightly excludes; backfill includes).
+// Ids used only by the idempotency half, so they can't perturb the other tests.
+const DISCOGS_UPSERT_A = 91624901;
+const DISCOGS_UPSERT_B = 91624902;
+
+const ARTIST_ENRICHED = 'Juana Molina'; // library artist, resolved + enriched
+const ARTIST_LIBRARY_UNENRICHED = 'Stereolab'; // library artist, resolved, not yet enriched
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+/** YYYY-MM-DD for today + offsetDays, in America/New_York (matches the job + read window). */
+function isoDate(offsetDays) {
+  const d = new Date(Date.now() + offsetDays * 24 * 60 * 60 * 1000);
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(d);
+}
+
+const IN_10 = isoDate(10);
+const IN_15 = isoDate(15);
+const IN_20 = isoDate(20);
+const PAST = isoDate(-30);
+
+/**
+ * Candidate query — a faithful mirror of
+ * `jobs/concerts-genre-enrichment/query.ts#loadEnrichmentCandidates`, scoped by
+ * the test source_id prefix so a shared schema's other rows can't perturb the
+ * assertion (the real query is unscoped).
+ */
+async function loadCandidates(sql, { backfill = false } = {}) {
+  const windowClause = backfill ? sql`` : sql`AND c."starts_on" >= (now() AT TIME ZONE 'America/New_York')::date`;
+  return sql`
+    SELECT DISTINCT ON (eff.discogs_artist_id)
+      eff.discogs_artist_id AS discogs_artist_id,
+      eff.artist_name AS artist_name
+    FROM (
+      SELECT
+        COALESCE(c."headlining_discogs_artist_id", a."discogs_artist_id") AS discogs_artist_id,
+        COALESCE(a."artist_name", c."headlining_artist_raw") AS artist_name
+      FROM ${sql(SCHEMA)}."concerts" c
+      LEFT JOIN ${sql(SCHEMA)}."artists" a ON a."id" = c."headlining_artist_id"
+      WHERE c."removed_at" IS NULL
+        ${windowClause}
+        AND COALESCE(c."headlining_discogs_artist_id", a."discogs_artist_id") IS NOT NULL
+        AND c."source_id" LIKE ${SOURCE_ID_PREFIX + '%'}
+    ) eff
+    LEFT JOIN ${sql(SCHEMA)}."artist_metadata" am ON am."discogs_artist_id" = eff.discogs_artist_id
+    WHERE am."discogs_artist_id" IS NULL
+    ORDER BY eff.discogs_artist_id ASC
+  `;
+}
+
+/** UPSERT mirror of `jobs/concerts-genre-enrichment/writer.ts#upsertArtistGenres`. */
+async function upsertArtistGenres(sql, rows) {
+  if (rows.length === 0) return [];
+  return sql`
+    INSERT INTO ${sql(SCHEMA)}."artist_metadata" ${sql(rows, 'discogs_artist_id', 'genres', 'styles')}
+    ON CONFLICT ("discogs_artist_id") DO NOTHING
+    RETURNING "discogs_artist_id"
+  `;
+}
+
+describe('concerts genre enrichment (BS#1624)', () => {
+  let auth;
+  let sql;
+  let venueId;
+  let enrichedArtistId;
+  let libraryUnenrichedArtistId;
+
+  const seedConcert = async (o) => {
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".concerts
+         (source, source_id, venue_id, starts_on, headlining_artist_raw,
+          headlining_artist_id, headlining_discogs_artist_id, removed_at, raw_data, scraped_at)
+       VALUES ('triangle_shows', $1, $2, $3, $4, $5, $6, $7, '{}'::jsonb, now())`,
+      [
+        SOURCE_ID_PREFIX + o.key,
+        o.venue_id,
+        o.starts_on,
+        o.headlining_artist_raw,
+        o.headlining_artist_id ?? null,
+        o.headlining_discogs_artist_id ?? null,
+        o.removed_at ?? null,
+      ]
+    );
+  };
+
+  const cleanup = async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".concerts WHERE source_id LIKE $1`, [`${SOURCE_ID_PREFIX}%`]);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".venues WHERE slug = $1`, [VENUE_SLUG]);
+    // Delete by the test's synthetic discogs_artist_id, NOT by name: the CI seed
+    // clone already contains real artists with these WXYC names (Juana Molina,
+    // Stereolab) whose `library` rows FK-reference `artists.id`, so a name-based
+    // delete hits those seed rows (library_artist_id_artists_id_fk violation).
+    // The synthetic ids (9162400x) exist only in this test.
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".artists WHERE discogs_artist_id = ANY($1)`, [
+      [DISCOGS_ENRICHED, DISCOGS_LIBRARY_UNENRICHED],
+    ]);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".artist_metadata WHERE discogs_artist_id = ANY($1)`, [
+      [
+        DISCOGS_ENRICHED,
+        DISCOGS_EXTERNAL,
+        DISCOGS_LIBRARY_UNENRICHED,
+        DISCOGS_PAST,
+        DISCOGS_UPSERT_A,
+        DISCOGS_UPSERT_B,
+      ],
+    ]);
+  };
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = makeSql();
+    await cleanup();
+
+    const [venue] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".venues (slug, name, city, state, address)
+       VALUES ($1, 'BS1624 Probe Room', 'Carrboro', 'NC', '300 E Main St') RETURNING id`,
+      [VENUE_SLUG]
+    );
+    venueId = venue.id;
+
+    // Library artist, resolved + ENRICHED (has an artist_metadata row).
+    const [a1] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters, discogs_artist_id)
+       VALUES ($1, $1, 'ZZ', $2) RETURNING id`,
+      [ARTIST_ENRICHED, DISCOGS_ENRICHED]
+    );
+    enrichedArtistId = a1.id;
+
+    // Library artist, resolved but NOT yet enriched.
+    const [a2] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters, discogs_artist_id)
+       VALUES ($1, $1, 'ZZ', $2) RETURNING id`,
+      [ARTIST_LIBRARY_UNENRICHED, DISCOGS_LIBRARY_UNENRICHED]
+    );
+    libraryUnenrichedArtistId = a2.id;
+
+    // The enriched artist's persisted genres (what GET /concerts should surface).
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles)
+       VALUES ($1, $2, $3)`,
+      [DISCOGS_ENRICHED, ['Rock', 'Electronic'], ['Folktronica']]
+    );
+
+    // Lane A, resolved + enriched, upcoming.
+    await seedConcert({
+      key: 'enriched-library',
+      venue_id: venueId,
+      starts_on: IN_10,
+      headlining_artist_raw: ARTIST_ENRICHED,
+      headlining_artist_id: enrichedArtistId,
+    });
+    // Lane A, resolved, unenriched, upcoming.
+    await seedConcert({
+      key: 'unenriched-library',
+      venue_id: venueId,
+      starts_on: IN_10,
+      headlining_artist_raw: ARTIST_LIBRARY_UNENRICHED,
+      headlining_artist_id: libraryUnenrichedArtistId,
+    });
+    // Lane B (external Discogs id only), unenriched, upcoming — TWO shows for
+    // the SAME artist to prove DISTINCT-ON dedupe.
+    await seedConcert({
+      key: 'external-a',
+      venue_id: venueId,
+      starts_on: IN_15,
+      headlining_artist_raw: 'Chuquimamani-Condori',
+      headlining_discogs_artist_id: DISCOGS_EXTERNAL,
+    });
+    await seedConcert({
+      key: 'external-b',
+      venue_id: venueId,
+      starts_on: IN_20,
+      headlining_artist_raw: 'Chuquimamani-Condori',
+      headlining_discogs_artist_id: DISCOGS_EXTERNAL,
+    });
+    // Unresolved headliner — no id either lane; never a candidate, genres null.
+    await seedConcert({
+      key: 'unresolved',
+      venue_id: venueId,
+      starts_on: IN_10,
+      headlining_artist_raw: 'Some Unresolved Billing & Another',
+    });
+    // Lane B, unenriched, PAST — nightly excludes (upcoming-only), backfill includes.
+    await seedConcert({
+      key: 'external-past',
+      venue_id: venueId,
+      starts_on: PAST,
+      headlining_artist_raw: 'Long Gone Touring Act',
+      headlining_discogs_artist_id: DISCOGS_PAST,
+    });
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await sql.end();
+  });
+
+  describe('candidate selection (mirror of query.ts)', () => {
+    it('selects resolved + unenriched headliners (both lanes), deduped, excluding enriched/unresolved', async () => {
+      const rows = await loadCandidates(sql);
+      const ids = rows.map((r) => Number(r.discogs_artist_id));
+
+      // Included: Lane B external (once, despite two shows) + Lane A unenriched library.
+      expect(ids).toContain(DISCOGS_EXTERNAL);
+      expect(ids).toContain(DISCOGS_LIBRARY_UNENRICHED);
+      // Excluded: already enriched (has artist_metadata row), unresolved (no id),
+      // and the past show (outside the nightly upcoming window).
+      expect(ids).not.toContain(DISCOGS_ENRICHED);
+      expect(ids).not.toContain(DISCOGS_PAST);
+      // DISTINCT-ON dedupe: the two external shows collapse to one candidate.
+      expect(ids.filter((id) => id === DISCOGS_EXTERNAL)).toHaveLength(1);
+    });
+
+    it('carries a usable name — the canonical artists.artist_name for a library headliner', async () => {
+      const rows = await loadCandidates(sql);
+      const libraryRow = rows.find((r) => Number(r.discogs_artist_id) === DISCOGS_LIBRARY_UNENRICHED);
+      expect(libraryRow.artist_name).toBe(ARTIST_LIBRARY_UNENRICHED);
+    });
+
+    it('--backfill drops the upcoming-only window and includes the past resolved headliner', async () => {
+      const nightly = (await loadCandidates(sql)).map((r) => Number(r.discogs_artist_id));
+      const backfill = (await loadCandidates(sql, { backfill: true })).map((r) => Number(r.discogs_artist_id));
+      expect(nightly).not.toContain(DISCOGS_PAST);
+      expect(backfill).toContain(DISCOGS_PAST);
+    });
+  });
+
+  describe('UPSERT idempotency (mirror of writer.ts)', () => {
+    it('inserts new rows, and a re-run inserts 0 without overwriting a collected row', async () => {
+      const rows = [
+        { discogs_artist_id: DISCOGS_UPSERT_A, genres: ['Jazz'], styles: ['Big Band'] },
+        { discogs_artist_id: DISCOGS_UPSERT_B, genres: [], styles: [] },
+      ];
+
+      const firstRun = await upsertArtistGenres(sql, rows);
+      expect(firstRun).toHaveLength(2);
+
+      // Re-run the same batch (idempotency): ON CONFLICT DO NOTHING → 0 inserts.
+      const secondRun = await upsertArtistGenres(sql, rows);
+      expect(secondRun).toHaveLength(0);
+
+      // A conflicting re-run with DIFFERENT genres must NOT overwrite the row.
+      await upsertArtistGenres(sql, [{ discogs_artist_id: DISCOGS_UPSERT_A, genres: ['Pop'], styles: ['Synth-pop'] }]);
+      const [persisted] = await sql.unsafe(
+        `SELECT genres, styles FROM "${SCHEMA}".artist_metadata WHERE discogs_artist_id = $1`,
+        [DISCOGS_UPSERT_A]
+      );
+      expect(persisted.genres).toEqual(['Jazz']);
+      expect(persisted.styles).toEqual(['Big Band']);
+    });
+  });
+
+  describe('GET /concerts genres projection', () => {
+    it('emits the joined genres array for a resolved + enriched headliner', async () => {
+      const res = await auth.get(`/concerts?from=${IN_10}&to=${IN_10}`).expect(200);
+      const enriched = res.body.concerts.find((c) => c.headlining_artist_raw === ARTIST_ENRICHED);
+      expect(enriched).toBeDefined();
+      expect(enriched.genres).toEqual(['Rock', 'Electronic']);
+    });
+
+    it('emits null genres for a resolved-but-unenriched headliner', async () => {
+      const res = await auth.get(`/concerts?from=${IN_10}&to=${IN_10}`).expect(200);
+      const unenriched = res.body.concerts.find((c) => c.headlining_artist_raw === ARTIST_LIBRARY_UNENRICHED);
+      expect(unenriched).toBeDefined();
+      expect(unenriched.genres).toBeNull();
+    });
+
+    it('emits null genres for an unresolved headliner', async () => {
+      const res = await auth.get(`/concerts?from=${IN_10}&to=${IN_10}`).expect(200);
+      const unresolved = res.body.concerts.find((c) => c.headlining_artist_raw === 'Some Unresolved Billing & Another');
+      expect(unresolved).toBeDefined();
+      expect(unresolved.genres).toBeNull();
+    });
+  });
+});

--- a/tests/unit/jobs/concerts-genre-enrichment/orchestrate.test.ts
+++ b/tests/unit/jobs/concerts-genre-enrichment/orchestrate.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Unit tests for jobs/concerts-genre-enrichment orchestrate.ts (BS#1624).
+ *
+ * The orchestrator is the unit-testable seam: load candidates → serial pages
+ * → fetch genres → UPSERT, over a dep-injected candidate loader, a fake
+ * `fetchGenres` (the LML#781 contract), and a fake `upsert`. This suite pins:
+ *
+ *   - only unenriched candidates flow to LML (the loader is the anti-join;
+ *     an empty candidate set makes zero LML calls);
+ *   - paging respects pageSize; verdicts zip to candidates positionally;
+ *   - empty genres still produce a persisted row (terminal "no genres" state);
+ *   - dry-run enumerates but never calls LML or the writer;
+ *   - a thrown LML page is counted + skipped, the run continues (retryable);
+ *   - a thrown UPSERT is counted + skipped, the run continues;
+ *   - the cooperative pause is awaited before each page.
+ *
+ * WXYC-representative artists (Juana Molina, Jessica Pratt, Stereolab, …) per
+ * the org fixture convention.
+ */
+import { jest } from '@jest/globals';
+
+import type { ArtistGenresBulkResponse, ArtistGenresRequestItem, ArtistGenresSource } from '@wxyc/lml-client';
+import {
+  runEnrichment,
+  type EnrichDeps,
+  type EnrichOptions,
+} from '../../../../jobs/concerts-genre-enrichment/orchestrate';
+import type { EnrichmentCandidate } from '../../../../jobs/concerts-genre-enrichment/query';
+import type { ArtistGenresRow } from '../../../../jobs/concerts-genre-enrichment/writer';
+
+type FetchGenresFn = EnrichDeps['fetchGenres'];
+type UpsertFn = EnrichDeps['upsert'];
+type LoadCandidatesFn = EnrichDeps['loadCandidates'];
+
+const candidate = (discogs_artist_id: number, artist_name: string): EnrichmentCandidate => ({
+  discogs_artist_id,
+  artist_name,
+});
+
+/**
+ * An LML response echoing one `{ genres, styles, source }` verdict per input
+ * item. `source` defaults to `'cache'` so genre-content fixtures needn't spell
+ * it out; the source-routing tests pass it explicitly.
+ */
+const genresResponse = (
+  verdicts: Array<{ genres: string[]; styles: string[]; source?: ArtistGenresSource }>
+): ArtistGenresBulkResponse => ({
+  results: verdicts.map((v) => ({ genres: v.genres, styles: v.styles, source: v.source ?? 'cache' })),
+});
+
+const makeDeps = (
+  candidates: EnrichmentCandidate[],
+  overrides: Partial<EnrichDeps> = {}
+): {
+  deps: EnrichDeps;
+  loadCandidates: jest.Mock<LoadCandidatesFn>;
+  fetchGenres: jest.Mock<FetchGenresFn>;
+  upsert: jest.Mock<UpsertFn>;
+  awaitQuiet: jest.Mock<() => Promise<void>>;
+  writes: ArtistGenresRow[];
+} => {
+  const writes: ArtistGenresRow[] = [];
+  const loadCandidates =
+    (overrides.loadCandidates as jest.Mock<LoadCandidatesFn>) ??
+    jest.fn<LoadCandidatesFn>().mockResolvedValue(candidates);
+  // Default fetch: every artist resolves to a single genre keyed by its id.
+  const fetchGenres =
+    (overrides.fetchGenres as jest.Mock<FetchGenresFn>) ??
+    jest
+      .fn<FetchGenresFn>()
+      .mockImplementation((items: ArtistGenresRequestItem[]) =>
+        Promise.resolve(genresResponse(items.map(() => ({ genres: ['Rock'], styles: ['Indie Rock'] }))))
+      );
+  const upsert =
+    (overrides.upsert as jest.Mock<UpsertFn>) ??
+    jest.fn<UpsertFn>().mockImplementation((rows: ArtistGenresRow[]) => {
+      writes.push(...rows);
+      return Promise.resolve({ inserted: rows.length });
+    });
+  const awaitQuiet =
+    (overrides.awaitQuiet as jest.Mock<() => Promise<void>>) ??
+    jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  const deps: EnrichDeps = { loadCandidates, fetchGenres, upsert, awaitQuiet };
+  return { deps, loadCandidates, fetchGenres, upsert, awaitQuiet, writes };
+};
+
+const options = (over: Partial<EnrichOptions> = {}): EnrichOptions => ({ pageSize: 10, dryRun: false, ...over });
+
+describe('runEnrichment (BS#1624)', () => {
+  it('fetches genres only for the loaded (unenriched) candidates and persists them', async () => {
+    const { deps, fetchGenres, upsert, writes } = makeDeps([
+      candidate(100, 'Juana Molina'),
+      candidate(200, 'Jessica Pratt'),
+    ]);
+
+    const totals = await runEnrichment(deps, options());
+
+    expect(fetchGenres).toHaveBeenCalledTimes(1);
+    // Request items carry both name and discogs id (the LML#781 request shape).
+    expect(fetchGenres.mock.calls[0][0]).toEqual([
+      { artist_name: 'Juana Molina', discogs_artist_id: 100 },
+      { artist_name: 'Jessica Pratt', discogs_artist_id: 200 },
+    ]);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(writes).toEqual([
+      { discogs_artist_id: 100, genres: ['Rock'], styles: ['Indie Rock'] },
+      { discogs_artist_id: 200, genres: ['Rock'], styles: ['Indie Rock'] },
+    ]);
+    expect(totals).toMatchObject({ candidates: 2, pages: 1, fetched: 2, with_genres: 2, enriched: 2, errors: 0 });
+  });
+
+  it('makes zero LML calls when no candidate needs enrichment (anti-join drained)', async () => {
+    const { deps, fetchGenres, upsert } = makeDeps([]);
+
+    const totals = await runEnrichment(deps, options());
+
+    expect(fetchGenres).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+    expect(totals).toMatchObject({ candidates: 0, pages: 0, enriched: 0 });
+  });
+
+  it('pages candidates by pageSize and zips verdicts to candidates positionally', async () => {
+    const { deps, fetchGenres, writes } = makeDeps(
+      [candidate(1, 'Stereolab'), candidate(2, 'Cat Power'), candidate(3, 'Chuquimamani-Condori')],
+      {
+        fetchGenres: jest
+          .fn<FetchGenresFn>()
+          .mockResolvedValueOnce(
+            genresResponse([
+              { genres: ['Electronic'], styles: [] },
+              { genres: ['Rock'], styles: [] },
+            ])
+          )
+          .mockResolvedValueOnce(genresResponse([{ genres: ['Jazz'], styles: ['Big Band'] }])),
+      }
+    );
+
+    const totals = await runEnrichment(deps, options({ pageSize: 2 }));
+
+    expect(fetchGenres).toHaveBeenCalledTimes(2);
+    expect(writes).toEqual([
+      { discogs_artist_id: 1, genres: ['Electronic'], styles: [] },
+      { discogs_artist_id: 2, genres: ['Rock'], styles: [] },
+      { discogs_artist_id: 3, genres: ['Jazz'], styles: ['Big Band'] },
+    ]);
+    expect(totals).toMatchObject({ candidates: 3, pages: 2, fetched: 3, enriched: 3 });
+  });
+
+  it('persists a row even when LML returns empty genres (terminal "no genres" state)', async () => {
+    const { deps, writes } = makeDeps([candidate(300, 'Obscure Touring Act')], {
+      fetchGenres: jest.fn<FetchGenresFn>().mockResolvedValue(genresResponse([{ genres: [], styles: [] }])),
+    });
+
+    const totals = await runEnrichment(deps, options());
+
+    expect(writes).toEqual([{ discogs_artist_id: 300, genres: [], styles: [] }]);
+    expect(totals).toMatchObject({ fetched: 1, with_genres: 0, enriched: 1 });
+  });
+
+  it('skips `unavailable` verdicts (left retryable) but persists `not_found`', async () => {
+    // A page mixing sources: `cache` + `not_found` persist (the latter an empty
+    // negative-cache row); `unavailable` — LML couldn't reach Discogs — is
+    // skipped so the artist keeps no row and the candidate anti-join re-selects
+    // it next run. Persisting the couldn't-ask would negative-cache it forever.
+    const { deps, upsert, writes } = makeDeps(
+      [candidate(1, 'Cached Act'), candidate(2, 'Couldnt Ask Act'), candidate(3, 'Confirmed Empty Act')],
+      {
+        fetchGenres: jest.fn<FetchGenresFn>().mockResolvedValue(
+          genresResponse([
+            { genres: ['Rock'], styles: [], source: 'cache' },
+            { genres: [], styles: [], source: 'unavailable' },
+            { genres: [], styles: [], source: 'not_found' },
+          ])
+        ),
+      }
+    );
+
+    const totals = await runEnrichment(deps, options());
+
+    // Only the cache + not_found artists are written; the unavailable one is not.
+    expect(writes).toEqual([
+      { discogs_artist_id: 1, genres: ['Rock'], styles: [] },
+      { discogs_artist_id: 3, genres: [], styles: [] },
+    ]);
+    expect(writes.some((w) => w.discogs_artist_id === 2)).toBe(false);
+    expect(totals).toMatchObject({ fetched: 3, unavailable_skipped: 1, with_genres: 1, enriched: 2 });
+    expect(upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops early when a whole page comes back `unavailable` (breaker open)', async () => {
+    // Page 1 (all unavailable) means LML's Discogs breaker is open; paging
+    // further would just waste round-trips. The run stops and every remaining
+    // candidate stays retryable via the anti-join.
+    const { deps, fetchGenres, upsert, writes } = makeDeps(
+      [candidate(1, 'A'), candidate(2, 'B'), candidate(3, 'C'), candidate(4, 'D')],
+      {
+        fetchGenres: jest
+          .fn<FetchGenresFn>()
+          .mockResolvedValueOnce(
+            genresResponse([
+              { genres: [], styles: [], source: 'unavailable' },
+              { genres: [], styles: [], source: 'unavailable' },
+            ])
+          )
+          .mockResolvedValueOnce(genresResponse([{ genres: ['Rock'], styles: [] }])),
+      }
+    );
+
+    const totals = await runEnrichment(deps, options({ pageSize: 2 }));
+
+    // Only page 1 ran; page 2 was never fetched and nothing was written.
+    expect(fetchGenres).toHaveBeenCalledTimes(1);
+    expect(upsert).not.toHaveBeenCalled();
+    expect(writes).toEqual([]);
+    expect(totals).toMatchObject({
+      candidates: 4,
+      pages: 1,
+      fetched: 2,
+      unavailable_skipped: 2,
+      enriched: 0,
+      stopped_early: true,
+    });
+  });
+
+  it('does NOT stop early on a page only partially `unavailable`', async () => {
+    // One unavailable verdict among three must not trip the all-unavailable
+    // breaker guard — the run pages to completion.
+    const { deps, fetchGenres } = makeDeps([candidate(1, 'A'), candidate(2, 'B'), candidate(3, 'C')], {
+      fetchGenres: jest.fn<FetchGenresFn>().mockResolvedValue(
+        genresResponse([
+          { genres: ['Rock'], styles: [], source: 'cache' },
+          { genres: [], styles: [], source: 'unavailable' },
+          { genres: ['Jazz'], styles: [], source: 'cache' },
+        ])
+      ),
+    });
+
+    const totals = await runEnrichment(deps, options({ pageSize: 3 }));
+
+    expect(fetchGenres).toHaveBeenCalledTimes(1);
+    expect(totals).toMatchObject({ pages: 1, unavailable_skipped: 1, enriched: 2, stopped_early: false });
+  });
+
+  it('dry-run enumerates but never calls LML or the writer', async () => {
+    const { deps, fetchGenres, upsert } = makeDeps([candidate(1, 'Juana Molina')]);
+
+    const totals = await runEnrichment(deps, options({ dryRun: true }));
+
+    expect(fetchGenres).not.toHaveBeenCalled();
+    expect(upsert).not.toHaveBeenCalled();
+    expect(totals).toMatchObject({ candidates: 1, pages: 0, enriched: 0 });
+  });
+
+  it('counts a thrown LML page as errors and continues to the next page', async () => {
+    const { deps, upsert, writes } = makeDeps([candidate(1, 'A'), candidate(2, 'B'), candidate(3, 'C')], {
+      fetchGenres: jest
+        .fn<FetchGenresFn>()
+        .mockRejectedValueOnce(new Error('LML 503'))
+        .mockResolvedValueOnce(genresResponse([{ genres: ['Rock'], styles: [] }])),
+    });
+
+    const totals = await runEnrichment(deps, options({ pageSize: 2 }));
+
+    // Page 1 (2 artists) threw → counted as 2 errors, nothing written; page 2
+    // (1 artist) succeeded.
+    expect(totals).toMatchObject({ candidates: 3, pages: 1, fetched: 1, enriched: 1, errors: 2 });
+    expect(writes).toEqual([{ discogs_artist_id: 3, genres: ['Rock'], styles: [] }]);
+    expect(upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts a thrown UPSERT as errors and continues', async () => {
+    const { deps } = makeDeps([candidate(1, 'A'), candidate(2, 'B')], {
+      upsert: jest.fn<UpsertFn>().mockRejectedValue(new Error('deadlock')),
+    });
+
+    const totals = await runEnrichment(deps, options());
+
+    expect(totals).toMatchObject({ candidates: 2, pages: 1, fetched: 2, enriched: 0, errors: 2 });
+  });
+
+  it('awaits the cooperative pause before each page', async () => {
+    const { deps, awaitQuiet } = makeDeps([candidate(1, 'A'), candidate(2, 'B'), candidate(3, 'C')]);
+
+    await runEnrichment(deps, options({ pageSize: 1 }));
+
+    // One await per page (3 pages).
+    expect(awaitQuiet).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
Closes #1624 — **split 3 of 3**, the final link of the On Tour R2 genre-filter train (`LML#781 → BS#1624 → iOS#491`). Depends on #1687 (`@wxyc/lml-client` boundary) and #1688 (`artist_metadata` table + projection).

> **Diff note:** this PR's diff currently shows all 25 files (splits 1 + 2 + 3) because #1687 and #1688 aren't in `main` yet. Once they merge, this rebases onto `main` and reduces to the **14 job-only files**. The net-new-for-this-split files are everything under `jobs/concerts-genre-enrichment/`, `Dockerfile.concerts-genre-enrichment`, `package-lock.json`, `tests/integration/concerts-genre-enrichment.spec.js`, and `tests/unit/jobs/concerts-genre-enrichment/orchestrate.test.ts`.

## What this does

Nightly cron `concerts-genre-enrichment` that enriches **resolved concert headliners** with artist-level Discogs **genres** (and styles), so `GET /concerts` projects `Concert.genres` for the iOS On Tour tab.

- Loads resolved headliners lacking an `artist_metadata` row (deduped by Discogs artist id), pages them (25/batch) through LML's bulk artist-genres endpoint via `fetchArtistGenresBulk` (#1687), and UPSERTs `ON CONFLICT DO NOTHING`. The candidate anti-join is the retry substrate — no attempt-at marker.
- Modes: default nightly (upcoming-only window), one-time `--backfill` (all dates), `--dry-run`.
- Cooperative live-DJ pause; never on any listener hot path (runs server-to-server with `LML_API_KEY`).
- LML's `source` discriminator routes the write: `unavailable` (couldn't reach Discogs) is **skipped and left retryable**; `cache`/`discogs_api`/`not_found` persist (an empty `not_found` row is a real negative-cache).

## Why this is the split that carries the deploy gate

This is the only split that calls LML at runtime, so it's the only one gated on **LML#847 reaching LML production** (it is on LML staging now; LML prod is the `prod` branch). Merged before then, a nightly run simply throws per page and leaves those artists retryable (caught, no data written) — operationally noisy, not corrupting. #1687 and #1688 are inert/backward-compatible and can land first.

## Verification

The branch is byte-for-byte identical to the pre-split combined branch that already passed full CI (unit 4582, Migration Dry-Run prod-shaped, Integration-Tests, lint/typecheck). Every test mocks the LML call; nothing here hits a live endpoint.

## Split map (BS#1624)

| Split | Scope | Files | Base | Mergeable now? | Gated on LML prod? |
|---|---|---|---|---|---|
| 1 · #1687 | `@wxyc/lml-client` boundary | 2 | `main` | yes | no |
| 2 · #1688 | `artist_metadata` table + `GET /concerts` projection | 9 | `main` | yes | no |
| **3 · this PR** | nightly enrichment job | 14 | `main` | after 1 + 2 | **yes** — merge after LML#847 reaches LML production |

Splits 1 and 2 are independent (disjoint files) and can merge in either order, immediately. This split depends on both and rebases onto `main` after they land.
