### PR TITLE
feat(lml-client): add fetchArtistGenresBulk for the artist-genres endpoint (BS#1624)

### DIFF
--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -1255,6 +1255,173 @@ export async function resolveArtistNamesBulk(
 }
 
 /**
+ * Wire shape for `POST /api/v1/artists/genres/bulk` (LML#781, BS#1624).
+ *
+ * Reconciled against LML#781's shipped OpenAPI shape (merged as LML#847) and
+ * the wxyc-shared `ArtistGenres*` contract (wxyc-shared#235):
+ *   - Request: a batch of `{ artist_name, discogs_artist_id? }` under `artists`.
+ *   - Response: per-artist `{ genres: string[], styles: string[], source }`,
+ *     index-aligned with the request. `ARTIST_GENRES_BATCH_CAP` (25) mirrors
+ *     LML's router cap.
+ *
+ * Defined locally rather than imported from `@wxyc/shared/dtos` because the
+ * `ArtistGenres*` schemas — though merged into wxyc-shared/api.yaml (#235) —
+ * are not yet in a published `@wxyc/shared` release. Swap these interfaces for
+ * the generated `@wxyc/shared/dtos` types once that package publishes the
+ * schemas; same deferred-adoption path as `ArtistResolveBulkResponse`.
+ */
+
+/** One artist to resolve genres for. `discogs_artist_id` strengthens LML's match when known. */
+export interface ArtistGenresRequestItem {
+  artist_name: string;
+  discogs_artist_id?: number;
+}
+
+/**
+ * Provenance of one artist's genre/style verdict — the retry-vs-negative-cache
+ * discriminator (mirrors `ArtistGenresSource` in wxyc-shared/api.yaml #235):
+ *   - `cache`       — served from the discogs-cache genre/style rows.
+ *   - `discogs_api` — cache miss; the Discogs API fallback produced genres.
+ *   - `not_found`   — Discogs answered; the artist has no genre data. Safe to
+ *                     negative-cache (persist an empty row).
+ *   - `unavailable` — LML could not consult Discogs (no token, saturation
+ *                     breaker open, or a transient fetch failure). RETRY — the
+ *                     consumer must NOT negative-cache a couldn't-ask.
+ */
+export type ArtistGenresSource = 'cache' | 'discogs_api' | 'not_found' | 'unavailable';
+
+/**
+ * Genre/style verdict for one input artist, index-aligned with the request's
+ * `artists` array. Both arrays are always present (possibly empty) — LML may
+ * know the Discogs genre taxonomy for an artist but not the finer-grained
+ * styles, or neither. `source` disambiguates an empty verdict: a confirmed
+ * "no genres" (persist) versus a transient "couldn't ask" (retry).
+ */
+export interface ArtistGenresResultItem {
+  genres: string[];
+  styles: string[];
+  source: ArtistGenresSource;
+}
+
+export interface ArtistGenresBulkRequest {
+  artists: ArtistGenresRequestItem[];
+}
+
+export interface ArtistGenresBulkResponse {
+  /** One verdict per input artist, in input order. */
+  results: ArtistGenresResultItem[];
+}
+
+/**
+ * LML's per-request cap on `fetchArtistGenresBulk` (LML#781), matching the
+ * endpoint's router cap (`_GENRES_INPUT_CAP`). Callers page against this constant.
+ */
+export const ARTIST_GENRES_BATCH_CAP = 25;
+
+/** Per-artist slice of the batch-size-scaled default socket timeout (ms). */
+const ARTIST_GENRES_PER_ITEM_TIMEOUT_MS = 2000;
+
+/** Fixed slack on top of the per-item budget — connection setup + serialization. */
+const ARTIST_GENRES_TIMEOUT_SLACK_MS = 20_000;
+
+/**
+ * Bulk-resolve artist genres/styles via LML's `POST /api/v1/artists/genres/bulk`
+ * (LML#781). Discogs `genres`/`styles` taxonomy for each input artist,
+ * aggregated (majority-take) across the artist's releases in the LML
+ * discogs-cache. Returns one verdict per input artist in input order.
+ *
+ * Consumer: the concerts genre enrichment (BS#1624) — persists the result on
+ * `artist_metadata` keyed by Discogs artist id, projected onto `Concert.genres`.
+ * Runs nightly server-to-server with the LML API key; never in a listener hot
+ * path.
+ *
+ * Wiring mirrors `resolveArtistNamesBulk` (its sibling offline-batch endpoint):
+ * one limiter token per BATCH (LML paces its own fan-out internally); a
+ * batch-size-scaled socket timeout; a `http.client` span with `lml.bulk.size`.
+ * The default `limiter` is the process-wide runtime pool — a big batch can hold
+ * a permit for the whole socket, so any offline caller MUST pass a dedicated
+ * `options.limiter` (the documented consumer does).
+ *
+ * Client-side validation rejects empty + oversize batches before the wire call;
+ * the response is validated to be an index-aligned 1:1 array before return so a
+ * consumer that zips verdicts to artists positionally can never mis-attribute a
+ * genre set. All failures throw `LmlClientError`.
+ *
+ * @param artists - Artists to resolve (1..=`ARTIST_GENRES_BATCH_CAP`).
+ * @param options.timeoutMs - Override the batch-size-scaled default socket timeout (ms).
+ * @param options.limiter - Override the default runtime limiter (see the token note above).
+ * @param options.caller - Caller-class label projected onto the span as `lml.caller`.
+ */
+export async function fetchArtistGenresBulk(
+  artists: ArtistGenresRequestItem[],
+  options?: { timeoutMs?: number; limiter?: LmlLimiter; caller?: string }
+): Promise<ArtistGenresBulkResponse> {
+  if (artists.length === 0) {
+    throw new LmlClientError('fetchArtistGenresBulk requires at least 1 artist.', 400);
+  }
+  if (artists.length > ARTIST_GENRES_BATCH_CAP) {
+    throw new LmlClientError(
+      `fetchArtistGenresBulk exceeded the cap of ${ARTIST_GENRES_BATCH_CAP} artists (received ${artists.length}).`,
+      400
+    );
+  }
+
+  const timeoutMs =
+    options?.timeoutMs ?? artists.length * ARTIST_GENRES_PER_ITEM_TIMEOUT_MS + ARTIST_GENRES_TIMEOUT_SLACK_MS;
+
+  const body: ArtistGenresBulkRequest = { artists };
+
+  const activeLimiter = options?.limiter ?? defaultLimiter;
+  return activeLimiter.run(async () => {
+    return await Sentry.startSpan({ name: 'lml.artists.genres.bulk', op: 'http.client' }, async (span) => {
+      try {
+        span.setAttributes({
+          'lml.queue_depth': activeLimiter.state().queueDepth,
+          'lml.bulk.size': artists.length,
+          'lml.caller': options?.caller ?? 'unknown',
+        });
+      } catch (err) {
+        console.warn('lml.client: failed to project queue_depth + bulk.size + caller onto genres span', err);
+      }
+
+      const response = await lmlFetch(
+        '/api/v1/artists/genres/bulk',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        },
+        timeoutMs
+      );
+
+      let parsed: ArtistGenresBulkResponse;
+      try {
+        parsed = (await response.json()) as ArtistGenresBulkResponse;
+      } catch (err) {
+        throw new LmlClientError(
+          `fetchArtistGenresBulk: LML returned an unparseable body: ${(err as Error).message}`,
+          502
+        );
+      }
+
+      // Positional contract: `results[i]` is the verdict for `artists[i]`. A
+      // short / long / reordered / missing array would let the consumer write
+      // one artist's genres onto another's Discogs id. Fail loud at the
+      // chokepoint (mirrors `resolveArtistNamesBulk`).
+      if (!Array.isArray(parsed.results) || parsed.results.length !== artists.length) {
+        const got = Array.isArray(parsed.results) ? `${parsed.results.length} result(s)` : 'a non-array results field';
+        throw new LmlClientError(
+          `fetchArtistGenresBulk: LML returned ${got} for ${artists.length} artist(s); expected an index-aligned 1:1 array`,
+          502
+        );
+      }
+
+      return parsed;
+    });
+  });
+}
+
+/**
  * Check whether the LML service is configured.
  */
 export function isLmlConfigured(): boolean {

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -1301,6 +1301,14 @@ export interface ArtistGenresResultItem {
   genres: string[];
   styles: string[];
   source: ArtistGenresSource;
+  /**
+   * Echoed back from the request by LML (LML#781) for index verification. When
+   * present on both sides, the alignment guard asserts it matches the request
+   * item at the same index — turning the positional contract from a length
+   * check into an identity check. Optional: a name-only request item has no id
+   * for LML to echo.
+   */
+  discogs_artist_id?: number;
 }
 
 export interface ArtistGenresBulkRequest {
@@ -1343,9 +1351,11 @@ const ARTIST_GENRES_TIMEOUT_SLACK_MS = 20_000;
  * `options.limiter` (the documented consumer does).
  *
  * Client-side validation rejects empty + oversize batches before the wire call;
- * the response is validated to be an index-aligned 1:1 array before return so a
- * consumer that zips verdicts to artists positionally can never mis-attribute a
- * genre set. All failures throw `LmlClientError`.
+ * the response is validated to be an index-aligned 1:1 array before return — by
+ * length AND, wherever the request supplied a Discogs id, by LML's echoed
+ * `discogs_artist_id` at each index — so a consumer that zips verdicts to
+ * artists positionally can never mis-attribute a genre set. All failures throw
+ * `LmlClientError`.
  *
  * @param artists - Artists to resolve (1..=`ARTIST_GENRES_BATCH_CAP`).
  * @param options.timeoutMs - Override the batch-size-scaled default socket timeout (ms).
@@ -1405,15 +1415,35 @@ export async function fetchArtistGenresBulk(
       }
 
       // Positional contract: `results[i]` is the verdict for `artists[i]`. A
-      // short / long / reordered / missing array would let the consumer write
-      // one artist's genres onto another's Discogs id. Fail loud at the
+      // short / long / missing array — or a null body — would let the consumer
+      // write one artist's genres onto another's Discogs id. Fail loud at the
       // chokepoint (mirrors `resolveArtistNamesBulk`).
-      if (!Array.isArray(parsed.results) || parsed.results.length !== artists.length) {
-        const got = Array.isArray(parsed.results) ? `${parsed.results.length} result(s)` : 'a non-array results field';
+      if (parsed == null || !Array.isArray(parsed.results) || parsed.results.length !== artists.length) {
+        const got =
+          parsed != null && Array.isArray(parsed.results)
+            ? `${parsed.results.length} result(s)`
+            : 'a non-array results field';
         throw new LmlClientError(
           `fetchArtistGenresBulk: LML returned ${got} for ${artists.length} artist(s); expected an index-aligned 1:1 array`,
           502
         );
+      }
+
+      // Defense-in-depth beyond length: when both the request item and the
+      // echoed verdict carry a Discogs id, they MUST match at this index. LML
+      // echoes `discogs_artist_id` for exactly this check (LML#781); a mismatch
+      // means the array was reordered under us, which the length check alone
+      // can't catch. The consumer (BS#1624) zips genres to Discogs ids
+      // positionally, so a silent reorder would mis-attribute a genre set.
+      for (let i = 0; i < artists.length; i++) {
+        const sent = artists[i].discogs_artist_id;
+        const echoed = parsed.results[i].discogs_artist_id;
+        if (sent != null && echoed != null && sent !== echoed) {
+          throw new LmlClientError(
+            `fetchArtistGenresBulk: LML echoed discogs_artist_id ${echoed} at index ${i} but the request sent ${sent}; the results array is misordered`,
+            502
+          );
+        }
       }
 
       return parsed;

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -33,6 +33,9 @@ import {
   resolveArtistNamesBulk,
   ARTIST_RESOLVE_BATCH_CAP,
   type ArtistResolveResult,
+  fetchArtistGenresBulk,
+  ARTIST_GENRES_BATCH_CAP,
+  type ArtistGenresSource,
   LmlClientError,
   checkStreamingAvailability,
   searchLibrary,
@@ -1048,6 +1051,123 @@ describe('lml.client', () => {
       const err = await resolveArtistNamesBulk(['Wishy']).catch((e) => e);
       expect(err).toBeInstanceOf(LmlClientError);
       expect((err as LmlClientError).statusCode).toBe(413);
+    });
+  });
+
+  describe('fetchArtistGenresBulk (BS#1624 / LML#781)', () => {
+    // Index-aligned genre/style verdict; both arrays always present per contract.
+    // `source` defaults to 'cache'; the pass-through test varies it explicitly.
+    const genreResult = (genres: string[], styles: string[], source: ArtistGenresSource = 'cache') => ({
+      genres,
+      styles,
+      source,
+    });
+
+    const okBatch = (count: number) =>
+      ({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: Array.from({ length: count }, () => genreResult(['Rock'], ['Indie Rock'])) }),
+      }) as unknown as globalThis.Response;
+
+    beforeEach(() => {
+      // Reset the process-wide default limiter so the timeout tests draw from a
+      // full TokenBucket (mirrors the resolveArtistNamesBulk block's guard).
+      _resetLmlClientLimitersForTest();
+    });
+
+    it('POSTs to /api/v1/artists/genres/bulk wrapping items in an {artists} envelope', async () => {
+      mockFetch.mockResolvedValue(okBatch(2));
+
+      await fetchArtistGenresBulk([
+        { artist_name: 'Juana Molina', discogs_artist_id: 100 },
+        { artist_name: 'Jessica Pratt' },
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://lml.test:8000/api/v1/artists/genres/bulk');
+      expect(init.method).toBe('POST');
+      const body = JSON.parse(init.body as string) as { artists: unknown[] };
+      expect(body.artists).toEqual([
+        { artist_name: 'Juana Molina', discogs_artist_id: 100 },
+        { artist_name: 'Jessica Pratt' },
+      ]);
+    });
+
+    it('returns genre/style verdicts index-aligned with the input artists, passing `source` through', async () => {
+      // Vary `source` across the batch: the consumer's retry-vs-negative-cache
+      // routing (BS#1624 skips `unavailable`) depends on it surviving the client.
+      const mockResponse = {
+        results: [
+          genreResult(['Electronic'], ['Experimental'], 'cache'),
+          genreResult([], [], 'unavailable'),
+          genreResult(['Jazz'], [], 'discogs_api'),
+        ],
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as unknown as globalThis.Response);
+
+      const result = await fetchArtistGenresBulk([
+        { artist_name: 'Chuquimamani-Condori', discogs_artist_id: 1 },
+        { artist_name: 'Stereolab', discogs_artist_id: 2 },
+        { artist_name: 'Duke Ellington & John Coltrane', discogs_artist_id: 3 },
+      ]);
+
+      expect(result.results).toHaveLength(3);
+      expect(result.results[0]).toEqual({ genres: ['Electronic'], styles: ['Experimental'], source: 'cache' });
+      expect(result.results[1]).toEqual({ genres: [], styles: [], source: 'unavailable' });
+      expect(result.results[2]).toEqual({ genres: ['Jazz'], styles: [], source: 'discogs_api' });
+    });
+
+    it('rejects an empty batch client-side before the wire call', async () => {
+      await expect(fetchArtistGenresBulk([])).rejects.toThrow(/at least 1 artist/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects an over-cap batch client-side before the wire call', async () => {
+      const artists = Array.from({ length: ARTIST_GENRES_BATCH_CAP + 1 }, (_, i) => ({ artist_name: `A${i}` }));
+      await expect(fetchArtistGenresBulk(artists)).rejects.toThrow(/cap of 25 artists/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws LmlClientError(502) when the response array length is misaligned with the request', async () => {
+      // Two artists in, one verdict back — a positional mis-attribution hazard.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [genreResult(['Rock'], [])] }),
+      } as unknown as globalThis.Response);
+
+      const err = await fetchArtistGenresBulk([{ artist_name: 'Cat Power' }, { artist_name: 'Stereolab' }]).catch(
+        (e) => e
+      );
+      expect(err).toBeInstanceOf(LmlClientError);
+      expect((err as LmlClientError).statusCode).toBe(502);
+      expect((err as LmlClientError).message).toMatch(/index-aligned 1:1 array/);
+    });
+
+    it('projects lml.bulk.size + caller onto the span', async () => {
+      mockFetch.mockResolvedValue(okBatch(1));
+
+      await fetchArtistGenresBulk([{ artist_name: 'Juana Molina' }], { caller: 'concerts-genre-enrichment' });
+
+      expect(mockSpanSetAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({ 'lml.bulk.size': 1, 'lml.caller': 'concerts-genre-enrichment' })
+      );
+    });
+
+    it('surfaces a 5xx as LmlClientError(502)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+      } as unknown as globalThis.Response);
+
+      const err = await fetchArtistGenresBulk([{ artist_name: 'Juana Molina' }]).catch((e) => e);
+      expect(err).toBeInstanceOf(LmlClientError);
+      expect((err as LmlClientError).statusCode).toBe(502);
     });
   });
 

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -1148,6 +1148,42 @@ describe('lml.client', () => {
       expect((err as LmlClientError).message).toMatch(/index-aligned 1:1 array/);
     });
 
+    it('throws LmlClientError(502) when LML echoes a discogs_artist_id out of order (same length, reordered)', async () => {
+      // Right length, but the echoed ids don't line up with the request order —
+      // a length-only check would miss it and mis-attribute genres. The client
+      // verifies the echoed `discogs_artist_id` per index (LML#781).
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              { genres: ['Rock'], styles: [], source: 'cache', discogs_artist_id: 2 },
+              { genres: ['Jazz'], styles: [], source: 'cache', discogs_artist_id: 1 },
+            ],
+          }),
+      } as unknown as globalThis.Response);
+
+      const err = await fetchArtistGenresBulk([
+        { artist_name: 'Cat Power', discogs_artist_id: 1 },
+        { artist_name: 'Stereolab', discogs_artist_id: 2 },
+      ]).catch((e) => e);
+      expect(err).toBeInstanceOf(LmlClientError);
+      expect((err as LmlClientError).statusCode).toBe(502);
+      expect((err as LmlClientError).message).toMatch(/misordered/);
+    });
+
+    it('throws LmlClientError(502), not a raw TypeError, when a 200 body is null', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(null),
+      } as unknown as globalThis.Response);
+
+      const err = await fetchArtistGenresBulk([{ artist_name: 'Juana Molina' }]).catch((e) => e);
+      expect(err).toBeInstanceOf(LmlClientError);
+      expect((err as LmlClientError).statusCode).toBe(502);
+      expect((err as LmlClientError).message).toMatch(/index-aligned 1:1 array/);
+    });
+
     it('projects lml.bulk.size + caller onto the span', async () => {
       mockFetch.mockResolvedValue(okBatch(1));
 


### PR DESCRIPTION
Part of #1624 — **split 1 of 3** of the On Tour R2 genre-filter middle link.

## What this does

Adds the client boundary for LML's bulk artist-genres endpoint — `fetchArtistGenresBulk` in `@wxyc/lml-client`:

- **Contract.** Request `{ artist_name, discogs_artist_id? }[]` under the `artists` envelope key (LML#781, shipped as LML#847; wxyc-shared#235); per-artist `{ genres: string[], styles: string[], source }` response, **index-aligned** with the request.
- **Index-alignment guard.** Enforces `results.length === artists.length` before returning (throws `LmlClientError(502)` on a misaligned array), so a positional zip downstream can never mis-attribute a genre set.
- **`source` discriminator.** `cache` / `discogs_api` / `not_found` / `unavailable`, surfaced via the `ArtistGenresSource` type — the retry-vs-negative-cache signal consumed by split 3.
- **Cap.** `ARTIST_GENRES_BATCH_CAP` = 25.

Types are kept local to `@wxyc/lml-client` pending an `@wxyc/shared` release that carries wxyc-shared#235's generated schemas — a follow-up swap, not a blocker.

## Why split out

Inert on its own: nothing calls `fetchArtistGenresBulk` until the enrichment job (split 3). Reviewing the contract boundary in isolation keeps it small (~290 lines) and independent of the migration and the job.

## Verification

- `typecheck`, scoped `eslint` (0 errors), scoped `prettier --check` — clean.
- `test:unit` `lml.client.test.ts` — 91 passed (index-alignment + `source` pass-through).

## Split map (BS#1624)

| Split | Scope | Files | Base | Mergeable now? | Gated on LML prod? |
|---|---|---|---|---|---|
| **1 · this PR** | `@wxyc/lml-client` boundary | 2 | `main` | yes | no |
| 2 · #1688 | `artist_metadata` table + `GET /concerts` projection | 9 | `main` | yes | no |
| 3 · #1686 | nightly enrichment job | 14 | `main` | after 1 + 2 | **yes** — merge after LML#847 reaches LML production |

Splits 1 and 2 are independent (disjoint files) and can merge in either order, immediately. Split 3 depends on both and rebases onto `main` after they land; it also carries the deploy gate (the only split that calls LML at runtime).
