### PR TITLE
perf(flowsheet): cache upcoming_show maps to bound the hot-path concerts scan (BS#1616)

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -9,6 +9,7 @@ import {
   resolveRadioHour,
   type BackendEntryType,
 } from '../utils/flowsheet-transform.js';
+import { __resetUpcomingShowsMapsCacheForTests } from '../services/concerts.service.js';
 
 const ETL_NOTIFY_KEY = process.env.ETL_NOTIFY_KEY ?? '';
 
@@ -41,6 +42,28 @@ export const internal_route = Router();
  */
 function authenticateInternal(key: string | undefined): boolean {
   return !!ETL_NOTIFY_KEY && key === ETL_NOTIFY_KEY;
+}
+
+/**
+ * POST /internal/test/reset-upcoming-shows-cache — dev/test-only.
+ *
+ * The `upcoming_show` map cache (BS#1616) lives in THIS server process, so the
+ * out-of-process integration spec (which talks to the backend over HTTP) can't
+ * clear it with an in-process helper. It resets through this endpoint instead,
+ * to get a genuine cold read for the anti-N+1 batching + cache-hit assertions.
+ *
+ * Registered ONLY when NODE_ENV is development/test — the route does not exist in
+ * production. Mirrors the `isDevOrTest` gate in internal-bans.route.ts and the
+ * auth server's `/auth/test/*` surface. No auth key: it only clears an ephemeral
+ * in-memory cache (no data at risk) and the route is absent in prod anyway.
+ */
+const isDevOrTest = process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
+
+if (isDevOrTest) {
+  internal_route.post('/test/reset-upcoming-shows-cache', (_req, res) => {
+    __resetUpcomingShowsMapsCacheForTests();
+    res.sendStatus(204);
+  });
 }
 
 /**

--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -1,5 +1,7 @@
 import { and, asc, eq, gte, isNotNull, isNull, lte, or, sql } from 'drizzle-orm';
 import { artist_metadata, artists, concerts, db, normalizeFreetextArtist, venues } from '@wxyc/database';
+import { LRUCache } from 'lru-cache';
+import * as Sentry from '@sentry/node';
 
 /**
  * Concerts read service — backs `GET /concerts` (BS#1603, on-tour
@@ -368,3 +370,81 @@ export const getUpcomingShowsMaps = async (
 
   return { byArtistId, byNormName };
 };
+
+/** Resolved return of {@link getUpcomingShowsMaps}, aliased for the cache below. */
+type UpcomingShowsMaps = Awaited<ReturnType<typeof getUpcomingShowsMaps>>;
+
+/**
+ * Per-process cache of the two `upcoming_show` maps (BS#1616).
+ *
+ * {@link getUpcomingShowsMaps} runs on the hot V2 flowsheet read path — including
+ * `getLatest`, the single-entry "now playing" tick the iOS/Android apps and the
+ * uptime canary poll continuously — and each call scans the entire unbounded
+ * upcoming-concerts set (`removed_at IS NULL AND starts_on >= today`, no upper
+ * bound) to rebuild the maps. This cache amortizes that: continuous polling
+ * collapses from one full-catalog scan PER read to ~one rebuild per TTL.
+ *
+ * Keyed on the ET `today` string (`nyCalendarDate`, supplied by the caller), so a
+ * midnight roll produces a miss and rebuilds rather than serving a just-passed
+ * show as upcoming. `max: 2` holds today plus a briefly-overlapping yesterday
+ * across the roll; `ttl: 60_000` keeps the amortization benefit (~1 rebuild/min
+ * regardless of poll rate) while surfacing a rare manual concert edit within a
+ * minute — `concerts` otherwise mutates only via the nightly ETL, so intra-day
+ * staleness cost is ~zero.
+ *
+ * The cached VALUE is the `Promise<Maps>`, not the resolved maps, so concurrent
+ * cold callers atomically share one in-flight build (the get/set is synchronous
+ * on Node's single thread). A rejected build is evicted, never cached (see the
+ * wrapper). Per-process only — like the LML lookup coordinator's cache,
+ * cross-instance coalescing is out of scope; session stickiness collapses most
+ * same-key bursts.
+ */
+const upcomingShowsMapsCache = new LRUCache<string, Promise<UpcomingShowsMaps>>({
+  max: 2,
+  ttl: 60_000,
+});
+
+/**
+ * Cached wrapper around {@link getUpcomingShowsMaps} for the hot read path
+ * (`flowsheet.service` `attachUpcomingShows`). A cold miss builds and `.set`s the
+ * in-flight promise synchronously so concurrent callers coalesce onto it; a warm
+ * hit returns the settled promise for the rest of the TTL.
+ *
+ * INVARIANT — the returned maps, and the `ConcertDTO` instances inside them, are
+ * handed out BY REFERENCE to every caller within the TTL and MUST be treated as
+ * read-only. The sole consumer, `attachUpcomingShows`, only reads them (it shares
+ * a `ConcertDTO` onto `entry.upcoming_show`; `transformToV2` spreads it into a
+ * fresh response object and never mutates it). Never mutate a returned map or DTO.
+ *
+ * Error handling: the ORIGINAL promise is returned, so a build failure rejects to
+ * the caller (→ Express error handler) exactly as the uncached builder did. A
+ * SEPARATE `.catch` evicts the rejected entry so the error is not cached — the
+ * next call issues a fresh query. Both consumers handle the rejection, so there
+ * is no unhandled-rejection footgun.
+ */
+export const getUpcomingShowsMapsCached = (today: string): Promise<UpcomingShowsMaps> => {
+  const hit = upcomingShowsMapsCache.get(today);
+  // Boolean attribute is safe via the late setAttribute path (the numeric
+  // string-typing trap of BS#1070/#1081 only affects avg/p50 aggregations on
+  // numbers). Lets prod confirm getLatest's hit ratio — i.e. that it stopped
+  // scanning `concerts` on every poll.
+  Sentry.getActiveSpan()?.setAttribute('concerts.upcoming_maps.cache_hit', hit !== undefined);
+  if (hit !== undefined) {
+    return hit;
+  }
+  const build = getUpcomingShowsMaps(today);
+  upcomingShowsMapsCache.set(today, build);
+  build.catch(() => upcomingShowsMapsCache.delete(today)); // evict on failure; never cache an error
+  return build;
+};
+
+/**
+ * Test-only hook to clear the module-scoped cache between cases — mirrors the
+ * `__reset…ForTests` helpers in `library.service` / `proxy.controller`. Any suite
+ * that exercises the real wrapper (the cache unit tests; the out-of-process
+ * integration spec, via the test-gated `/internal/test/reset-upcoming-shows-cache`
+ * endpoint) must reset it, or a warm entry leaks a prior case's maps.
+ */
+export function __resetUpcomingShowsMapsCacheForTests(): void {
+  upcomingShowsMapsCache.clear();
+}

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -23,7 +23,7 @@ import {
   nyCalendarDate,
   nyStartOfDay,
 } from '@wxyc/database';
-import { getUpcomingShowsMaps } from './concerts.service.js';
+import { getUpcomingShowsMapsCached } from './concerts.service.js';
 import { IFSEntry, ShowMetadata, UpdateRequestBody } from '../controllers/flowsheet.controller.js';
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
 
@@ -1116,8 +1116,11 @@ export const getShowMetadata = async (show_id: number): Promise<ShowMetadata> =>
  * events Phase 3).
  *
  * Batched — ONE indexed concerts query for the whole page via
- * `getUpcomingShowsMaps`, never one per row (the no-N+1 guarantee; project #32
- * perf posture). Each track row resolves through two arms, id first:
+ * `getUpcomingShowsMapsCached`, never one per row (the no-N+1 guarantee; project
+ * #32 perf posture). And that query only fires on a cold build: the wrapper
+ * memoizes the maps per ET day for a short TTL (BS#1616), so the hot poll path
+ * (`getLatest`) skips the concerts scan entirely on warm reads. Each track row
+ * resolves through two arms, id first:
  *   1. id arm — `byArtistId.get(artist_id)`: the album-resolved catalog artist
  *      (`flowsheet.album_id → library.artist_id`) matched a resolved concert.
  *      Precise; the sole BS#1607 path, kept as-is (regression-guarded).
@@ -1154,7 +1157,7 @@ export const attachUpcomingShows = async (entries: IFSEntry[]): Promise<IFSEntry
     return entries;
   }
 
-  const { byArtistId, byNormName } = await getUpcomingShowsMaps(nyCalendarDate(new Date()));
+  const { byArtistId, byNormName } = await getUpcomingShowsMapsCached(nyCalendarDate(new Date()));
 
   for (const entry of entries) {
     if (entry.entry_type !== 'track') {

--- a/tests/integration/flowsheet-upcoming-show.spec.js
+++ b/tests/integration/flowsheet-upcoming-show.spec.js
@@ -159,6 +159,18 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
     await sql.unsafe(`DELETE FROM "${SCHEMA}".venues WHERE slug = $1`, [VENUE_SLUG]);
   };
 
+  /**
+   * Clear the SERVER's per-process `upcoming_show` map cache (BS#1616). The cache
+   * lives in the backend process, out of this out-of-process test's reach, so we
+   * clear it through the dev/test-only `/internal/test/reset-upcoming-shows-cache`
+   * endpoint (the CI-profile backend runs NODE_ENV=test, so the route exists).
+   * Used to force a genuine cold feed read.
+   */
+  const resetUpcomingShowsCache = async () => {
+    const res = await request.post('/internal/test/reset-upcoming-shows-cache');
+    expect(res.status).toBe(204);
+  };
+
   beforeAll(async () => {
     sql = makeSql();
     await cleanup();
@@ -274,6 +286,12 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
     // scraped raw differs — must attach via the canonical name-arm key.
     const t8 = await seedTrack({ albumId: null, artistName: RESOLVED_CANONICAL_NAME, playOrder: 8 });
     insertedTrackIds = [t1, t2, t3, t4, t5, t6, t7, t8];
+
+    // A prior spec file's /flowsheet read may have warmed the server's
+    // upcoming_show map cache (BS#1616) before these concerts existed. Clear it
+    // so the first read in this file rebuilds against the seeded fixtures rather
+    // than serving a stale, concert-free map for the same ET `today` key.
+    await resetUpcomingShowsCache();
   });
 
   afterAll(async () => {
@@ -409,33 +427,13 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
    * the delta tracks the match count); the batched implementation issues a
    * single lookup for the whole page, so the delta is a small constant.
    *
-   * `pg_stat_user_tables` is updated asynchronously by the stats collector and
-   * the backend serves the feed on its own connection pool, so a naive
-   * before/after around one request races the flush. `settledScans` clears the
-   * caller's stats snapshot and polls until the cumulative counter stops
-   * moving, giving a stable reading; the assertion then compares a small-page
-   * delta against a large-page delta rather than trusting an absolute count.
+   * `pg_stat_user_tables` is updated asynchronously by each backend and the
+   * server serves the feed on its own connection pool, so a naive before/after
+   * around one request races the flush. `drainedScans` clears the caller's stats
+   * snapshot and polls until the cumulative counter has held STILL for a
+   * sustained run of reads (not just two — see below), giving a fully drained
+   * reading; the assertions then bound the drained cold and warm deltas.
    */
-  const settledScans = async () => {
-    let last = -1;
-    for (let i = 0; i < 40; i++) {
-      // eslint-disable-next-line no-await-in-loop
-      await sql.unsafe('SELECT pg_stat_clear_snapshot()');
-      // eslint-disable-next-line no-await-in-loop
-      const [row] = await sql.unsafe(
-        `SELECT COALESCE(seq_scan, 0) + COALESCE(idx_scan, 0) AS scans
-           FROM pg_stat_user_tables
-          WHERE schemaname = $1 AND relname = 'concerts'`,
-        [SCHEMA]
-      );
-      const scans = Number(row ? row.scans : 0);
-      if (scans === last) return scans; // two identical reads = flushed
-      last = scans;
-      // eslint-disable-next-line no-await-in-loop
-      await new Promise((r) => setTimeout(r, 100));
-    }
-    return last;
-  };
 
   /** Raw cumulative concerts-scan counter (single read, snapshot cleared first). */
   const rawScans = async () => {
@@ -449,39 +447,58 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
     return Number(row ? row.scans : 0);
   };
 
-  /**
-   * concerts-scan delta attributable to EXACTLY ONE feed read of this page.
-   *
-   * `pg_stat_user_tables` is flushed asynchronously by the stats collector, and
-   * the backend serves the feed on its own connection pool, so the scan a feed
-   * read performs is not always visible on the first poll. The naive
-   * `after(settled) - before(settled)` around a single read can settle BEFORE
-   * the read's scan flushes and report a spurious 0. Retrying the whole
-   * before/read/after cycle is worse: each extra feed read adds scans that flush
-   * into a later bracket, inflating the delta above the anti-N+1 ceiling.
-   *
-   * So we issue the feed read exactly ONCE, then poll the counter until it has
-   * both advanced past `before` AND gone stable (two equal consecutive reads) —
-   * capturing this single read's scans without absorbing any other. If it never
-   * advances within the budget the delta stays 0 and the `>= 1` liveness
-   * assertion fails honestly (rather than looping and issuing more reads).
-   */
-  const scanDeltaForOneFeedRead = async () => {
-    const before = await settledScans();
-    await fetchSeededTracks();
+  // `pg_stat_user_tables` is flushed asynchronously per backend (no more often
+  // than ~1s, PGSTAT_MIN_INTERVAL), and one maps build bumps the concerts
+  // counter by SEVERAL (seq/idx probe + heap access, BS#1661). Two helpers read
+  // the cumulative counter drained to a SUSTAINED quiescent value — a longer run
+  // of consecutive equal reads (STABLE × GAP_MS > the 1s flush floor) waits the
+  // whole flush out, so no trailing increment leaks into a later bracket.
+  const STABLE = 6; // consecutive equal reads ⇒ the flush has fully settled
+  const GAP_MS = 200; // STABLE × GAP_MS = 1.2s > the ~1s stats-flush floor
+  const MAX_POLLS = 80;
 
+  /** Drained counter with no advancement requirement (a quiescent baseline). */
+  const quiescedScans = async () => {
     let last = -1;
-    let stableAdvanced = before;
-    for (let i = 0; i < 40; i++) {
+    let run = 0;
+    for (let i = 0; i < MAX_POLLS; i++) {
       const scans = await rawScans(); // eslint-disable-line no-await-in-loop
-      if (scans > before && scans === last) {
-        stableAdvanced = scans;
-        break;
+      if (scans === last) run += 1;
+      else {
+        last = scans;
+        run = 1;
       }
-      last = scans;
-      await new Promise((r) => setTimeout(r, 100)); // eslint-disable-line no-await-in-loop
+      if (run >= STABLE) return scans;
+      await new Promise((r) => setTimeout(r, GAP_MS)); // eslint-disable-line no-await-in-loop
     }
-    return stableAdvanced - before;
+    return last;
+  };
+
+  /**
+   * Drained counter AFTER it has advanced past `baseline`. A read's scan flushes
+   * ~1s late, so a plain quiesce right after the read can latch onto the
+   * PRE-flush plateau (counter still at `baseline`) and declare "drained" before
+   * the read's increments ever appear — they then surface in a later bracket. So
+   * we only begin counting stability once the counter has moved past `baseline`,
+   * guaranteeing this read's whole (multi-increment, atomic-per-commit) flush is
+   * captured here and nothing bleeds forward. If it never advances (a regression
+   * that stopped querying concerts), it exhausts the budget and returns
+   * `baseline`, so the caller's `>= 1` liveness assertion fails honestly.
+   */
+  const drainedScansAbove = async (baseline) => {
+    let last = -1;
+    let run = 0;
+    for (let i = 0; i < MAX_POLLS; i++) {
+      const scans = await rawScans(); // eslint-disable-line no-await-in-loop
+      if (scans > baseline && scans === last) run += 1;
+      else {
+        last = scans;
+        run = 1;
+      }
+      if (scans > baseline && run >= STABLE) return scans;
+      await new Promise((r) => setTimeout(r, GAP_MS)); // eslint-disable-line no-await-in-loop
+    }
+    return last;
   };
 
   // The batched lookup scans `concerts` a small, bounded number of times per
@@ -499,7 +516,7 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
   const MANY_MATCHES = 12;
   const BATCHED_SCAN_CEILING = 7;
 
-  it('batches the lookup: concerts-table scans do not grow with page match count', async () => {
+  it('cold read batches the lookup (bounded scans, no per-row query); warm reads are served from cache (no per-read rebuild)', async () => {
     // Add many more matching tracks, all resolving to ARTIST_WITH_SHOW, so the
     // page has 1 + MANY_MATCHES matches. A per-row lookup would scan concerts
     // once per matching row.
@@ -511,23 +528,55 @@ describe('V2 flowsheet upcoming_show enrichment (BS#1607)', () => {
     }
     insertedTrackIds.push(...extraIds);
 
-    const largeDelta = await scanDeltaForOneFeedRead();
+    // Force a genuine COLD read: clear the server's per-process map cache so this
+    // read rebuilds and actually scans `concerts`. Without the reset, a mid-suite
+    // read is warm (BS#1616 memoizes the maps across reads) and scans nothing —
+    // which would make the anti-N+1 assertion below vacuous.
+    await resetUpcomingShowsCache();
 
-    // Liveness lower bound: the feed read must scan `concerts` at LEAST once,
+    // COLD read. `beforeCold` is a quiesced baseline; `afterCold` waits for the
+    // counter to ADVANCE past it and then settle, so this rebuild's whole flush
+    // (which surfaces ~1s late) is captured here and none of its increments
+    // bleed into the warm bracket below.
+    const beforeCold = await quiescedScans();
+    await fetchSeededTracks();
+    const afterCold = await drainedScansAbove(beforeCold);
+    const coldDelta = afterCold - beforeCold;
+
+    // Liveness lower bound: the cold read must scan `concerts` at LEAST once,
     // else the enrichment is a no-op and the whole batching contract is vacuous
     // (a delta of 0 would silently pass a regression that stopped querying
-    // concerts entirely). `scanDeltaForOneFeedRead` retries until it observes a
-    // positive delta (absorbing the async stats-flush race), so `>= 1` is
-    // reliable here, not flaky — see its doc comment for why the naive
-    // before/after can spuriously read 0.
-    expect(largeDelta).toBeGreaterThanOrEqual(1);
+    // concerts entirely).
+    expect(coldDelta).toBeGreaterThanOrEqual(1);
     // Upper bounds (anti-N+1): never one-scan-per-row — a per-row impl would
     // push this to >= 1 + MANY_MATCHES (13). The `< 1 + MANY_MATCHES` assertion
     // is the load-bearing anti-N+1 guarantee; BATCHED_SCAN_CEILING is the
     // tighter "still just a handful of scans" bound, with headroom for planner
     // variance (BS#1661).
-    expect(largeDelta).toBeLessThanOrEqual(BATCHED_SCAN_CEILING);
-    expect(largeDelta).toBeLessThan(1 + MANY_MATCHES);
+    expect(coldDelta).toBeLessThanOrEqual(BATCHED_SCAN_CEILING);
+    expect(coldDelta).toBeLessThan(1 + MANY_MATCHES);
+
+    // Cache proof (BS#1616): the cold read above warmed the per-day map cache.
+    // Further reads of the same page/today — with NO reset between — are served
+    // entirely from that cache and issue ZERO `concerts` queries (confirmed by
+    // statement logging during development). `pg_stat_user_tables` flushes
+    // asynchronously (~1s) and one build bumps the counter by several (BS#1661),
+    // so a strict "== 0" on the warm bracket races that flush: a cold increment
+    // can slip past `afterCold` into it. That slip is bounded by ONE build
+    // (< BATCHED_SCAN_CEILING) and is INDEPENDENT of how many warm reads we do —
+    // whereas a cache that rebuilt per read would scan WARM_READS times. So we
+    // do WARM_READS (> the ceiling) reads and assert the whole warm bracket
+    // stayed under a single build's worth: cleanly separates "served from cache"
+    // (< ceiling, just flush bleed) from "rebuilt each read" (>= WARM_READS).
+    // The deterministic per-call proof (one build cold, zero warm) is in the
+    // mocked unit tests (concerts.service.test.ts). This is the hot-path win —
+    // getLatest stops scanning concerts on every poll — proven end-to-end.
+    const WARM_READS = 10; // > BATCHED_SCAN_CEILING, so a per-read rebuild overshoots the bound
+    for (let i = 0; i < WARM_READS; i++) {
+      await fetchSeededTracks(); // eslint-disable-line no-await-in-loop
+    }
+    const afterWarm = await quiescedScans();
+    expect(afterWarm - afterCold).toBeLessThan(BATCHED_SCAN_CEILING);
   });
 
   /**

--- a/tests/unit/services/concerts.service.test.ts
+++ b/tests/unit/services/concerts.service.test.ts
@@ -16,9 +16,11 @@ import { db } from '@wxyc/database';
 import {
   ConcertDTO,
   ConcertJoinRow,
+  __resetUpcomingShowsMapsCacheForTests,
   getConcertsCount,
   getConcertsPage,
   getUpcomingShowsMaps,
+  getUpcomingShowsMapsCached,
   toConcertDTO,
 } from '../../../apps/backend/services/concerts.service';
 
@@ -425,5 +427,85 @@ describe('getUpcomingShowsMaps (BS#1613)', () => {
     const { byArtistId, byNormName } = await getUpcomingShowsMaps('2026-08-01');
     expect(byArtistId.size).toBe(0);
     expect(byNormName.size).toBe(0);
+  });
+});
+
+/**
+ * BS#1616 — `getUpcomingShowsMaps` runs on the hot V2 flowsheet read path
+ * (including `getLatest`, the single-entry "now playing" tick the iOS/Android
+ * apps and the uptime canary poll continuously), and each call scans the entire
+ * unbounded upcoming-concerts set to rebuild the two maps.
+ * `getUpcomingShowsMapsCached` wraps the pure builder in a per-process,
+ * promise-valued LRU keyed on the ET `today` string (`max: 2`, `ttl: 60s`) so
+ * repeat reads within the TTL are served without re-querying `concerts`. The
+ * builder itself stays pure and is pinned by the suite above; these pin only the
+ * cache behavior.
+ *
+ * Build count == `db.select` call count: the builder issues exactly one
+ * `db.select(...)` per invocation, and the DB mock aliases `db.select` to
+ * `mockDb._chain.select`, so a warm hit (no build) leaves the counter fixed. The
+ * cache is module-scoped, so `__resetUpcomingShowsMapsCacheForTests()` runs in
+ * `beforeEach` to keep a prior case's maps from leaking into the next.
+ */
+describe('getUpcomingShowsMapsCached (BS#1616 per-process map cache)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetUpcomingShowsMapsCacheForTests();
+  });
+
+  it('builds once on a cold miss', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    await getUpcomingShowsMapsCached('2026-08-01');
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a warm hit within the TTL without re-querying (identical maps reference)', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    const first = await getUpcomingShowsMapsCached('2026-08-01');
+    const second = await getUpcomingShowsMapsCached('2026-08-01');
+    // Same object reference proves the second call resolved the cached promise,
+    // not a fresh build.
+    expect(second).toBe(first);
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebuilds after __resetUpcomingShowsMapsCacheForTests clears the cache', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
+    await getUpcomingShowsMapsCached('2026-08-01');
+    __resetUpcomingShowsMapsCacheForTests();
+    await getUpcomingShowsMapsCached('2026-08-01');
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(2);
+  });
+
+  it('rebuilds for a distinct today key (date roll → miss)', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
+    await getUpcomingShowsMapsCached('2026-08-01');
+    await getUpcomingShowsMapsCached('2026-08-02'); // a different ET calendar day
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces two concurrent cold calls into a single build', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    const [a, b] = await Promise.all([
+      getUpcomingShowsMapsCached('2026-08-01'),
+      getUpcomingShowsMapsCached('2026-08-01'),
+    ]);
+    // Both callers awaited the same in-flight promise → same resolved object.
+    expect(a).toBe(b);
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache a rejected build — the next call retries', async () => {
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.reject(new Error('boom')))
+      .mockReturnValueOnce(Promise.resolve([]));
+    await expect(getUpcomingShowsMapsCached('2026-08-01')).rejects.toThrow('boom');
+    // The failed promise was evicted, so this is a fresh cold miss (not a cached
+    // error): the builder runs again and resolves.
+    await expect(getUpcomingShowsMapsCached('2026-08-01')).resolves.toEqual({
+      byArtistId: new Map(),
+      byNormName: new Map(),
+    });
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
+++ b/tests/unit/services/flowsheet.attachUpcomingShows.test.ts
@@ -4,8 +4,8 @@
  *
  * `@wxyc/database` resolves to tests/mocks/database.mock.ts, so these pin the
  * pure batching + fan-out logic without PostgreSQL:
- *   - `attachUpcomingShows` does exactly ONE `getUpcomingShowsMaps` call for a
- *     feed page (the no-N+1 guarantee), then fans the soonest concert onto each
+ *   - `attachUpcomingShows` does exactly ONE `getUpcomingShowsMapsCached` call
+ *     for a feed page (the no-N+1 guarantee), then fans the soonest concert onto each
  *     track via the id arm (album-resolved `artist_id`) with a normalized-name
  *     arm fallback (free-text plays + clean unresolved concerts, BS#1613);
  *   - `transformToV2` emits `upcoming_show` only when present, so a no-match
@@ -106,7 +106,11 @@ describe('attachUpcomingShows (BS#1607 id arm + BS#1613 name arm)', () => {
 
   beforeEach(() => {
     jest.restoreAllMocks();
-    lookup = jest.spyOn(concertsService, 'getUpcomingShowsMaps');
+    // attachUpcomingShows now calls the cached wrapper (BS#1616), so intercept
+    // that — spying on the pure builder would no longer see the call. The spy
+    // fully replaces the wrapper, so the real LRU is never exercised here (no
+    // cache reset needed); the cache itself is pinned in concerts.service.test.ts.
+    lookup = jest.spyOn(concertsService, 'getUpcomingShowsMapsCached');
   });
 
   it('skips the DB when no track row carries an artist id or a non-empty name', async () => {
@@ -119,7 +123,7 @@ describe('attachUpcomingShows (BS#1607 id arm + BS#1613 name arm)', () => {
     expect(entries[1].upcoming_show).toBeUndefined();
   });
 
-  it('does exactly ONE getUpcomingShowsMaps call for an N-row page, with a today date', async () => {
+  it('does exactly ONE getUpcomingShowsMapsCached call for an N-row page, with a today date', async () => {
     lookup.mockResolvedValueOnce(maps());
     const entries = [
       createTrackEntry({ id: 1, artist_id: 4211 }),


### PR DESCRIPTION
## Problem

`attachUpcomingShows` runs on every V2 flowsheet read — including `getLatest`, the single-entry "now playing" tick that the iOS/Android apps and the uptime canary poll continuously. Each call rebuilt two in-memory maps (`byArtistId`, `byNormName`) by scanning the **entire unbounded** upcoming-concerts set (`removed_at IS NULL AND starts_on >= today`, no upper bound). The cost was frequency times full-scan on the hottest read path in the service.

## Fix

Wrap `getUpcomingShowsMaps` in a per-process promise-in-LRU cache, `getUpcomingShowsMapsCached`, keyed on the ET `today` string (`nyCalendarDate`), `max: 2`, `ttl: 60_000`. Continuous polling collapses from one full-catalog scan per read to about one rebuild per minute regardless of poll rate.

- The cached value is the in-flight `Promise`, so concurrent cold callers coalesce onto a single build (the get/set is synchronous on Node's single thread).
- A rejected build is evicted and never cached — the next call issues a fresh query.
- The returned maps and the `ConcertDTO`s inside them are handed out by reference within the TTL and are read-only for the sole consumer, so there is no defensive copy.
- `concerts` otherwise mutates only via the nightly ETL, so intra-day staleness cost is about zero; a rare manual edit surfaces within the TTL. The ET-`today` key means a midnight roll misses and rebuilds rather than serving a just-passed show.
- A boolean `concerts.upcoming_maps.cache_hit` span attribute (safe via late `setAttribute` per BS#1070/#1081) lets prod confirm getLatest's hit ratio.

A dev/test-only `POST /internal/test/reset-upcoming-shows-cache` endpoint (gated on `NODE_ENV`, absent in production, mirroring the `isDevOrTest` gate in `internal-bans.route.ts`) lets the out-of-process integration spec force a genuine cold read.

## Testing

- **Unit** (`concerts.service.test.ts`): 6 new cases — cold miss builds, warm hit skips the build, reset re-builds, distinct `today` key re-builds, two concurrent cold callers coalesce onto one build, and a rejected build is not cached (retries on the next call).
- **Integration** (`flowsheet-upcoming-show.spec.js`): reset → cold → warm proof end-to-end against the real server. The cold read batches the lookup (bounded `concerts` scans regardless of matching-row count — the anti-N+1 guarantee), and warm reads are served from the cache without rebuilding.
- The warm-read proof asserts that 10 warm reads together scan `concerts` **less than one rebuild's worth** rather than exactly zero: `pg_stat_user_tables` flushes asynchronously and one build bumps the counter by several (seq/idx/heap, BS#1661), so an exact-zero assertion races the flush. That the cache issues zero warm queries was confirmed via statement logging (one `concerts` query across reset + cold + five warm reads); a per-read rebuild would scan ≥10, which the bound catches unmistakably.
- Full local gate green: typecheck, lint (0 errors), format:check, 4592 unit tests, 521 integration tests (Docker CI mirror).

Closes #1616