### PR TITLE
feat(concerts): public windowless GET /concerts/:id for share pages and deep links (BS#1694)

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -450,7 +450,9 @@ app.get('/healthcheck', async (req, res) => {
 // `shouldHandleError` falls back to a "treat unknown status as 500" rule that
 // captures errors without an explicit status (bare TypeErrors, deserialisation
 // faults) indistinguishably from genuine 5xx faults. The named predicate
-// documents intent and mirrors the backend service's `shouldCaptureExpressError`.
+// documents intent. (It deliberately does NOT mirror the backend's
+// `shouldCaptureExpressError`, which suppresses only the trusted 4xx band its
+// errorHandler echoes — see the predicate's JSDoc for the divergence.)
 Sentry.setupExpressErrorHandler(app, { shouldHandleError: shouldCaptureAuthExpressError });
 
 // Fallback error handler — sanitises response body, forwards full error to

--- a/apps/auth/sentry-error-filter.ts
+++ b/apps/auth/sentry-error-filter.ts
@@ -14,9 +14,16 @@
  * default's `parseInt(... ?? 500)` and get captured as 500s. That's noisy
  * (the failure mode is "auth threw an unexpected exception" — that *should*
  * page) but it's also indistinguishable from genuine 5xx errors. Naming the
- * predicate makes the policy explicit, mirrors `apps/backend/middleware/
- * sentryErrorFilter.ts`, and gives a single place to refine if a noisy class
- * of error emerges.
+ * predicate makes the policy explicit and gives a single place to refine if
+ * a noisy class of error emerges. NOTE: this is deliberately NOT the same
+ * policy as the backend's `shouldCaptureExpressError` (BS#1694 review made
+ * them diverge): the backend suppresses only the trusted integer-4xx band
+ * its errorHandler echoes (`carriedClientStatus`: `expose: true` or the
+ * router's percent-decode URIError, `status` before `statusCode`), while
+ * this filter suppresses ANY sub-500 resolvable status (`statusCode` before
+ * `status`) because better-auth's `APIError`s are the dominant population
+ * here and its fallback handler never echoes messages. Do not edit one
+ * assuming the other matches.
  *
  * Policy: capture iff the error has no resolvable HTTP status, has a NaN
  * status, or has a status of 500 or higher. 4xx errors (validation,

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1692,10 +1692,13 @@ paths:
         upstream — never deleted, never exposed) are served with whatever
         `status` they last carried, so the wxyc.org/shows share page can
         render "this one's passed" and the iOS universal-link fallback can
-        resolve any shared id. Responses are publicly cacheable
-        (`Cache-Control: public, max-age=300`). The canonical wire contract
-        is `/concerts/{id}` in wxyc-shared/api.yaml (the SSOT); this
-        app.yaml is Swagger display only.
+        resolve any shared id. 200 responses are publicly cacheable
+        (`Cache-Control: public, max-age=300`); handler error responses
+        (400/404/5xx) are pinned `no-store` so a shared cache can never
+        hold a miss. (The router-level 400 for an undecodable path escape
+        carries no cache header; 400 is not heuristically cacheable.) The
+        canonical wire contract is `/concerts/{id}` in wxyc-shared/api.yaml
+        (the SSOT); this app.yaml is Swagger display only.
       security: []
       parameters:
         - name: id
@@ -1712,6 +1715,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Concert'
         '400':
-          description: Non-integer id
+          description: Malformed id (non-integer, non-positive, or an undecodable path escape)
         '404':
           description: No concert with this id exists

--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -1681,3 +1681,37 @@ paths:
           description: Invalid query parameters
         '401':
           description: Authentication required
+
+  /concerts/{id}:
+    get:
+      summary: Get a single concert by id (public share/deep-link read)
+      description: >-
+        Public, windowless single-concert read (BS#1694). Unlike the list,
+        this endpoint requires NO authentication and applies NO date window:
+        past concerts and concerts delisted at the source (tombstoned
+        upstream — never deleted, never exposed) are served with whatever
+        `status` they last carried, so the wxyc.org/shows share page can
+        render "this one's passed" and the iOS universal-link fallback can
+        resolve any shared id. Responses are publicly cacheable
+        (`Cache-Control: public, max-age=300`). The canonical wire contract
+        is `/concerts/{id}` in wxyc-shared/api.yaml (the SSOT); this
+        app.yaml is Swagger display only.
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: The concert's serial id
+      responses:
+        '200':
+          description: The concert
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Concert'
+        '400':
+          description: Non-integer id
+        '404':
+          description: No concert with this id exists

--- a/apps/backend/controllers/concerts.controller.ts
+++ b/apps/backend/controllers/concerts.controller.ts
@@ -133,10 +133,24 @@ export const getConcerts: RequestHandler<object, unknown, object, ConcertsQueryP
  * playlist proxy's public-cache pattern at the ~5-minute TTL the spec calls
  * for). Error paths never set it — a shared cache must not pin a 404/400.
  */
+
+/**
+ * PostgreSQL int4 ceiling. `concerts.id` is a serial (int4), so a well-formed
+ * integer above this can never exist — but without a guard it reaches the
+ * Postgres bind, which rejects it with "integer out of range" → an unhandled
+ * 500 (plus Sentry noise) that any unauthenticated URL probe could mint on
+ * this public route. Mapped to 404 (a miss, not a malformed request), before
+ * any query.
+ */
+const MAX_SERIAL_ID = 2_147_483_647;
+
 export const getConcertById: RequestHandler<{ id: string }> = async (req, res) => {
   const id = parsePositiveInt(req.params.id, 'id');
   if (id < 1) {
     throw new WxycError('id must be a positive integer', 400);
+  }
+  if (id > MAX_SERIAL_ID) {
+    throw new WxycError(`No concert with id ${req.params.id}`, 404);
   }
 
   const concert = await concertsService.getConcertById(id);

--- a/apps/backend/controllers/concerts.controller.ts
+++ b/apps/backend/controllers/concerts.controller.ts
@@ -54,16 +54,22 @@ const isValidIsoDate = (value: string): boolean => {
 const todayEastern = (): string => nyCalendarDate(new Date());
 
 /**
- * Parse a positive-integer query param behind an all-digits guard. A bare
+ * Parse a positive-integer param behind an all-digits guard. A bare
  * `parseInt` would accept '1abc' → 1 and '0x10' → 16; requiring the raw
- * value to be all digits (and using an explicit radix) rejects both.
- * Returns 400 on malformed input via `WxycError`.
+ * value to be all digits (and using an explicit radix) rejects both. The
+ * `< 1` rejection makes the name honest — '0' is all-digits but not
+ * positive — so callers need no follow-up check. Returns 400 on malformed
+ * input via `WxycError`.
  */
 const parsePositiveInt = (raw: string, field: string): number => {
   if (!/^\d+$/.test(raw)) {
     throw new WxycError(`${field} must be a positive integer`, 400);
   }
-  return Number.parseInt(raw, 10);
+  const parsed = Number.parseInt(raw, 10);
+  if (parsed < 1) {
+    throw new WxycError(`${field} must be a positive integer`, 400);
+  }
+  return parsed;
 };
 
 export const getConcerts: RequestHandler<object, unknown, object, ConcertsQueryParams> = async (req, res) => {
@@ -72,12 +78,6 @@ export const getConcerts: RequestHandler<object, unknown, object, ConcertsQueryP
   const page = parsePositiveInt(query.page ?? '1', 'page');
   const limit = parsePositiveInt(query.limit ?? String(DEFAULT_LIMIT), 'limit');
 
-  if (page < 1) {
-    throw new WxycError('page must be a positive integer', 400);
-  }
-  if (limit < 1) {
-    throw new WxycError('limit must be a positive integer', 400);
-  }
   if (limit > MAX_LIMIT) {
     throw new WxycError(`limit must be at most ${MAX_LIMIT}`, 400);
   }
@@ -116,42 +116,31 @@ export const getConcerts: RequestHandler<object, unknown, object, ConcertsQueryP
 
 /**
  * `GET /concerts/:id` — public single-concert read (BS#1694, On Tour
- * sharing).
+ * sharing). Contract: `wxyc-shared/api.yaml` v1.18.0 (`/concerts/{id}`,
+ * wxyc-shared#236) — no authentication (the route registers this handler
+ * with no middleware; see concerts.route.ts), no date window, tombstoned
+ * rows served with the `status` they last carried, 404 only for ids with no
+ * row.
  *
- * Contract lives in `wxyc-shared/api.yaml` v1.18.0 (`/concerts/{id}`,
- * wxyc-shared#236): no authentication (the route registers this handler with
- * no middleware — see concerts.route.ts), no date window, tombstoned rows
- * served with the `status` they last carried, 404 only for ids with no row.
+ * The id runs through the same all-digits/positive guard as the list's
+ * page/limit (a bare parseInt would accept '12abc') — 400 before any query.
+ * Ids that pass the guard but cannot exist for an int4 serial (beyond
+ * 2^31-1) resolve to null in the service, which owns that persistence fact,
+ * and surface as the same 404 as any other miss.
  *
- * The id runs through the same all-digits guard as the list's page/limit (a
- * bare parseInt would accept '12abc'), then the `< 1` check the sibling by-id
- * read (`GET /library/rotation/:rotation_id/tracks`) applies — 400 either
- * way, before any query.
- *
- * The 200 carries `Cache-Control: public, max-age=300`: no per-session
- * variance, so the share Worker and CDNs can absorb share-spike traffic (the
- * playlist proxy's public-cache pattern at the ~5-minute TTL the spec calls
- * for). Error paths never set it — a shared cache must not pin a 404/400.
+ * Caching: every response starts pinned `Cache-Control: no-store`; only the
+ * 200 path upgrades to `public, max-age=300` (the playlist proxy's
+ * public-cache pattern at the spec's ~5-minute TTL — no per-session
+ * variance, so the share Worker and CDNs absorb share-spike traffic).
+ * Omitting the header on errors would NOT keep them out of shared caches:
+ * 404 is heuristically cacheable by default (RFC 9110 §15.5.5), and concert
+ * ids are predictable serials, so a header-less 404 could pin a
+ * freshly-shared id as dead at the edge for the CDN's default error TTL.
  */
-
-/**
- * PostgreSQL int4 ceiling. `concerts.id` is a serial (int4), so a well-formed
- * integer above this can never exist — but without a guard it reaches the
- * Postgres bind, which rejects it with "integer out of range" → an unhandled
- * 500 (plus Sentry noise) that any unauthenticated URL probe could mint on
- * this public route. Mapped to 404 (a miss, not a malformed request), before
- * any query.
- */
-const MAX_SERIAL_ID = 2_147_483_647;
-
 export const getConcertById: RequestHandler<{ id: string }> = async (req, res) => {
+  res.set('Cache-Control', 'no-store');
+
   const id = parsePositiveInt(req.params.id, 'id');
-  if (id < 1) {
-    throw new WxycError('id must be a positive integer', 400);
-  }
-  if (id > MAX_SERIAL_ID) {
-    throw new WxycError(`No concert with id ${req.params.id}`, 404);
-  }
 
   const concert = await concertsService.getConcertById(id);
   if (concert === null) {

--- a/apps/backend/controllers/concerts.controller.ts
+++ b/apps/backend/controllers/concerts.controller.ts
@@ -113,3 +113,37 @@ export const getConcerts: RequestHandler<object, unknown, object, ConcertsQueryP
     },
   });
 };
+
+/**
+ * `GET /concerts/:id` — public single-concert read (BS#1694, On Tour
+ * sharing).
+ *
+ * Contract lives in `wxyc-shared/api.yaml` v1.18.0 (`/concerts/{id}`,
+ * wxyc-shared#236): no authentication (the route registers this handler with
+ * no middleware — see concerts.route.ts), no date window, tombstoned rows
+ * served with the `status` they last carried, 404 only for ids with no row.
+ *
+ * The id runs through the same all-digits guard as the list's page/limit (a
+ * bare parseInt would accept '12abc'), then the `< 1` check the sibling by-id
+ * read (`GET /library/rotation/:rotation_id/tracks`) applies — 400 either
+ * way, before any query.
+ *
+ * The 200 carries `Cache-Control: public, max-age=300`: no per-session
+ * variance, so the share Worker and CDNs can absorb share-spike traffic (the
+ * playlist proxy's public-cache pattern at the ~5-minute TTL the spec calls
+ * for). Error paths never set it — a shared cache must not pin a 404/400.
+ */
+export const getConcertById: RequestHandler<{ id: string }> = async (req, res) => {
+  const id = parsePositiveInt(req.params.id, 'id');
+  if (id < 1) {
+    throw new WxycError('id must be a positive integer', 400);
+  }
+
+  const concert = await concertsService.getConcertById(id);
+  if (concert === null) {
+    throw new WxycError(`No concert with id ${id}`, 404);
+  }
+
+  res.set('Cache-Control', 'public, max-age=300');
+  res.status(200).json(concert);
+};

--- a/apps/backend/middleware/errorHandler.ts
+++ b/apps/backend/middleware/errorHandler.ts
@@ -7,29 +7,46 @@ function hasStatusCode(error: Error): error is WxycError | LmlClientError {
 }
 
 /**
- * 4xx status carried by errors thrown from Express internals and standard
- * middleware: the router's percent-decode failure is a `URIError` with
- * `status: 400` (and no `statusCode`), while http-errors-style throwers
- * (body-parser) set both aliases, sometimes string-encoded. Only the
- * integer 4xx band is trusted — those are by construction client-input
- * errors whose messages are safe to echo (and Express 5's `res.status()`
- * throws on non-integer codes). Foreign errors carrying a 5xx (or no)
- * status stay on the generic-500 path so internals never leak. Without
- * this mapping, a malformed escape in a path segment (`GET /concerts/%ZZ`,
- * unauthenticated-reachable since the BS#1694 public by-id route) surfaced
- * as a probe-mintable 500.
+ * TRUSTED 4xx status carried by errors thrown from Express internals and
+ * standard middleware: the router's percent-decode failure is a `URIError`
+ * with `status: 400` (and no `statusCode`), while http-errors-style
+ * throwers (body-parser) set both aliases, sometimes string-encoded, plus
+ * `expose: true` for the 4xx band. Without this mapping, a malformed escape
+ * in a path segment (`GET /concerts/%ZZ`, unauthenticated-reachable since
+ * the BS#1694 public by-id route) surfaced as a probe-mintable 500.
+ *
+ * A 4xx number alone is NOT proof the error is client-caused or its message
+ * client-safe: upstream SDK errors (groq-sdk `APIError` et al.) mirror the
+ * provider's HTTP status onto `.status` and embed the raw provider body in
+ * `message` — echoing those would leak provider/org/quota internals to
+ * unauthenticated-tier callers and misreport our own dependency failures as
+ * the caller's 4xx. So echo requires the integer 4xx band (Express 5's
+ * `res.status()` throws on non-integers) AND a trust signal: `expose: true`
+ * (the http-errors convention — set exactly when the thrower deems the
+ * message response-safe) or the router's own percent-decode `URIError`
+ * (message derived from the request path). Everything else — foreign 5xx,
+ * no status, untrusted 4xx — stays on the generic-500 path so internals
+ * never leak.
  *
  * SHARED CLASSIFIER — `shouldCaptureExpressError` (sentryErrorFilter.ts)
  * imports this so the response tier and the Sentry-capture tier resolve the
- * `status`/`statusCode` aliases with byte-identical precedence: whatever
- * answers as an echoed 4xx is capture-suppressed, and whatever answers as a
- * generic 500 is captured. Diverging reads would let a 500-answered failure
- * hide from monitoring.
+ * aliases and the trust gate identically: whatever answers as an echoed 4xx
+ * is capture-suppressed, and whatever answers as a generic 500 is captured.
+ * Diverging reads would let a 500-answered failure hide from monitoring.
  */
 export function carriedClientStatus(error: Error): number | null {
   const raw = (error as { status?: number | string }).status ?? (error as { statusCode?: number | string }).statusCode;
   const numeric = typeof raw === 'string' ? parseInt(raw, 10) : raw;
-  return typeof numeric === 'number' && Number.isInteger(numeric) && numeric >= 400 && numeric < 500 ? numeric : null;
+  if (typeof numeric !== 'number' || !Number.isInteger(numeric) || numeric < 400 || numeric >= 500) {
+    return null;
+  }
+  if ((error as { expose?: boolean }).expose === true) {
+    return numeric;
+  }
+  if (error instanceof URIError && numeric === 400) {
+    return numeric;
+  }
+  return null;
 }
 
 function errorHandler(err: any, req: Request, res: Response, next: NextFunction) {

--- a/apps/backend/middleware/errorHandler.ts
+++ b/apps/backend/middleware/errorHandler.ts
@@ -6,6 +6,32 @@ function hasStatusCode(error: Error): error is WxycError | LmlClientError {
   return error instanceof WxycError || error instanceof LmlClientError;
 }
 
+/**
+ * 4xx status carried by errors thrown from Express internals and standard
+ * middleware: the router's percent-decode failure is a `URIError` with
+ * `status: 400` (and no `statusCode`), while http-errors-style throwers
+ * (body-parser) set both aliases, sometimes string-encoded. Only the
+ * integer 4xx band is trusted — those are by construction client-input
+ * errors whose messages are safe to echo (and Express 5's `res.status()`
+ * throws on non-integer codes). Foreign errors carrying a 5xx (or no)
+ * status stay on the generic-500 path so internals never leak. Without
+ * this mapping, a malformed escape in a path segment (`GET /concerts/%ZZ`,
+ * unauthenticated-reachable since the BS#1694 public by-id route) surfaced
+ * as a probe-mintable 500.
+ *
+ * SHARED CLASSIFIER — `shouldCaptureExpressError` (sentryErrorFilter.ts)
+ * imports this so the response tier and the Sentry-capture tier resolve the
+ * `status`/`statusCode` aliases with byte-identical precedence: whatever
+ * answers as an echoed 4xx is capture-suppressed, and whatever answers as a
+ * generic 500 is captured. Diverging reads would let a 500-answered failure
+ * hide from monitoring.
+ */
+export function carriedClientStatus(error: Error): number | null {
+  const raw = (error as { status?: number | string }).status ?? (error as { statusCode?: number | string }).statusCode;
+  const numeric = typeof raw === 'string' ? parseInt(raw, 10) : raw;
+  return typeof numeric === 'number' && Number.isInteger(numeric) && numeric >= 400 && numeric < 500 ? numeric : null;
+}
+
 function errorHandler(err: any, req: Request, res: Response, next: NextFunction) {
   // prettier-ignore
   const error = err instanceof Error
@@ -15,6 +41,13 @@ function errorHandler(err: any, req: Request, res: Response, next: NextFunction)
   if (hasStatusCode(error)) {
     console.error(`[${req.method} ${req.url}] ${error.name} ${error.statusCode}: ${error.message}`);
     res.status(error.statusCode).json({ message: error.message });
+    return;
+  }
+
+  const clientStatus = carriedClientStatus(error);
+  if (clientStatus !== null) {
+    console.error(`[${req.method} ${req.url}] ${error.name} ${clientStatus}: ${error.message}`);
+    res.status(clientStatus).json({ message: error.message });
   } else {
     console.error(`[${req.method} ${req.url}] Unhandled error:`, error);
     res.status(500).json({ message: 'Internal server error' });

--- a/apps/backend/middleware/sentryErrorFilter.ts
+++ b/apps/backend/middleware/sentryErrorFilter.ts
@@ -1,4 +1,5 @@
 import { LmlClientError } from '@wxyc/lml-client';
+import { carriedClientStatus } from './errorHandler.js';
 
 /**
  * Decides whether `Sentry.setupExpressErrorHandler` should auto-capture an
@@ -17,7 +18,13 @@ import { LmlClientError } from '@wxyc/lml-client';
  */
 export function shouldCaptureExpressError(error: Error): boolean {
   if (error instanceof LmlClientError) return false;
-  const statusCode = (error as { statusCode?: number | string }).statusCode;
-  const numeric = typeof statusCode === 'string' ? parseInt(statusCode, 10) : statusCode;
-  return numeric === undefined || Number.isNaN(numeric) || numeric >= 500;
+  // Suppress exactly the integer-4xx band that errorHandler echoes as a
+  // client error — via the SAME `carriedClientStatus` helper, so the two
+  // tiers can never classify one error divergently. This covers WxycError's
+  // `statusCode`, http-errors' dual aliases, and Express's own `status`
+  // (router percent-decode URIErrors carry ONLY `status: 400`, and are
+  // unauthenticated-reachable via the public GET /concerts/:id — BS#1694 —
+  // so missing the alias would spam Sentry with client-input noise).
+  // Everything else renders as a generic 500 and MUST be captured.
+  return carriedClientStatus(error) === null;
 }

--- a/apps/backend/middleware/sentryErrorFilter.ts
+++ b/apps/backend/middleware/sentryErrorFilter.ts
@@ -1,4 +1,5 @@
 import { LmlClientError } from '@wxyc/lml-client';
+import WxycError from '../utils/error.js';
 import { carriedClientStatus } from './errorHandler.js';
 
 /**
@@ -17,14 +18,23 @@ import { carriedClientStatus } from './errorHandler.js';
  * cascade from the catalog-search 503 incident).
  */
 export function shouldCaptureExpressError(error: Error): boolean {
+  // Sentry passes the RAW pipeline value; errorHandler wraps non-Error
+  // throwables in `new Error(String(err))` — dropping any carried status —
+  // so they always render as generic 500s. Normalize identically: a
+  // next()'d plain object with a trusted-looking 4xx must still be
+  // captured, or its 500 response would be invisible to monitoring.
+  if (!(error instanceof Error)) return true;
   if (error instanceof LmlClientError) return false;
-  // Suppress exactly the integer-4xx band that errorHandler echoes as a
-  // client error — via the SAME `carriedClientStatus` helper, so the two
-  // tiers can never classify one error divergently. This covers WxycError's
-  // `statusCode`, http-errors' dual aliases, and Express's own `status`
-  // (router percent-decode URIErrors carry ONLY `status: 400`, and are
-  // unauthenticated-reachable via the public GET /concerts/:id — BS#1694 —
-  // so missing the alias would spam Sentry with client-input noise).
-  // Everything else renders as a generic 500 and MUST be captured.
+  // Application errors keep their own rule: errorHandler echoes a WxycError
+  // at any status, and only the 5xx band is Sentry-worthy.
+  if (error instanceof WxycError) return error.statusCode >= 500;
+  // Foreign errors: suppress exactly the trusted 4xx band that errorHandler
+  // echoes as a client error — via the SAME `carriedClientStatus` helper
+  // (integer 4xx + `expose: true` or the router's percent-decode URIError,
+  // which is unauthenticated-reachable via the public GET /concerts/:id —
+  // BS#1694 — and must not spam Sentry). Everything else renders as a
+  // generic 500 and MUST be captured — including upstream-SDK errors
+  // (groq-sdk) whose 4xx `.status` mirrors the provider: a rotated API key
+  // or provider rate-limiting is a dependency failure, not client noise.
   return carriedClientStatus(error) === null;
 }

--- a/apps/backend/routes/concerts.route.ts
+++ b/apps/backend/routes/concerts.route.ts
@@ -4,8 +4,16 @@ import * as concertsController from '../controllers/concerts.controller.js';
 
 export const concerts_route = Router();
 
-// Anonymous session auth (any valid JWT, no permission scope) — matches the
-// /proxy iOS read surfaces. See BS#1603.
-concerts_route.use(requirePermissions({}));
+// List: anonymous session auth (any valid JWT, no permission scope) — matches
+// the /proxy iOS read surfaces. See BS#1603. Applied per-route rather than
+// router-wide so the by-id read below can opt out (the config route's
+// public/authed split is the in-repo precedent; BS#1682 tracks the same tier
+// question for /library/genres).
+concerts_route.get('/', requirePermissions({}), concertsController.getConcerts);
 
-concerts_route.get('/', concertsController.getConcerts);
+// By-id: deliberately PUBLIC — no auth middleware of any kind (BS#1694,
+// wxyc-shared#236). Consumed by the wxyc.org/shows/<id> share Worker (which
+// has no sane path to minting anonymous sessions) and the iOS universal-link
+// fallback; responses are publicly cacheable, so no per-session variance is
+// permitted here anyway.
+concerts_route.get('/:id', concertsController.getConcertById);

--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -262,6 +262,40 @@ export const getConcertsCount = async (filters: ConcertsQueryFilters): Promise<n
 };
 
 /**
+ * Single-concert read backing the public `GET /concerts/:id` (BS#1694, On
+ * Tour sharing; contract `wxyc-shared/api.yaml` v1.18.0, wxyc-shared#236).
+ * Reuses the list's exact projection (`concertPageFields`, BS#1624 genres
+ * LEFT JOIN included) and the same `toConcertDTO` mapper, so the by-id wire
+ * shape can never drift from `getConcertsPage`'s.
+ *
+ * Deliberately WINDOWLESS — the one place `buildWhere` is NOT used: no
+ * `starts_on` bound and no `removed_at IS NULL` conjunct. The share page and
+ * the iOS universal-link fallback render past and source-delisted
+ * (tombstoned) shows as "this one's passed" with whatever `status` the row
+ * last carried, so those rows must come back rather than 404. The leak
+ * barrier is untouched: the explicit select list never includes `removed_at`
+ * or the other ingestion columns, so a tombstoned row is served without
+ * exposing that it is one.
+ *
+ * Resolves null when no row matches (or when the venue INNER JOIN drops a
+ * dangling `venue_id` — same strictness as the list; a Concert without its
+ * embedded Venue can't satisfy the contract). The controller maps null → 404.
+ */
+export const getConcertById = async (id: number): Promise<ConcertDTO | null> => {
+  const rows = await db
+    .select(concertPageFields)
+    .from(concerts)
+    .innerJoin(venues, eq(venues.id, concerts.venue_id))
+    .leftJoin(artists, eq(artists.id, concerts.headlining_artist_id))
+    .leftJoin(artist_metadata, eq(artist_metadata.discogs_artist_id, effectiveHeadlinerDiscogsId))
+    .where(eq(concerts.id, id))
+    .limit(1);
+
+  const row = (rows as ConcertJoinRow[])[0];
+  return row === undefined ? null : toConcertDTO(row);
+};
+
+/**
  * Adds the canonical catalog artist name to the concerts ⋈ venues projection
  * for the `upcoming_show` name arm. Sourced via the LEFT JOIN to `artists`, so
  * a resolved concert keys its name-map entry off the artist's CURRENT catalog

--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -261,6 +261,9 @@ export const getConcertsCount = async (filters: ConcertsQueryFilters): Promise<n
   return Number(result[0]?.count ?? 0);
 };
 
+/** PostgreSQL int4 ceiling — the largest id a `serial` column can hold. */
+const MAX_SERIAL_ID = 2_147_483_647;
+
 /**
  * Single-concert read backing the public `GET /concerts/:id` (BS#1694, On
  * Tour sharing; contract `wxyc-shared/api.yaml` v1.18.0, wxyc-shared#236).
@@ -277,11 +280,23 @@ export const getConcertsCount = async (filters: ConcertsQueryFilters): Promise<n
  * or the other ingestion columns, so a tombstoned row is served without
  * exposing that it is one.
  *
- * Resolves null when no row matches (or when the venue INNER JOIN drops a
- * dangling `venue_id` — same strictness as the list; a Concert without its
- * embedded Venue can't satisfy the contract). The controller maps null → 404.
+ * Resolves null when no row matches, when the venue INNER JOIN drops a
+ * dangling `venue_id` (same strictness as the list; a Concert without its
+ * embedded Venue can't satisfy the contract), or when the id is impossible
+ * for the int4 serial (non-integral, < 1, or > 2^31-1) — short-circuited
+ * below, before any query. The controller maps null → 404.
  */
 export const getConcertById = async (id: number): Promise<ConcertDTO | null> => {
+  // `concerts.id` is a serial (int4): an id outside (0, MAX_SERIAL_ID] — or a
+  // non-integer — can never match a row, and without this short-circuit it
+  // would reach the Postgres bind, which rejects it ("integer out of range")
+  // as an unhandled error. The service owns that persistence fact so EVERY
+  // caller (the public route today, the share-page BFF chain tomorrow) gets
+  // miss semantics instead of a bind 500.
+  if (!Number.isInteger(id) || id < 1 || id > MAX_SERIAL_ID) {
+    return null;
+  }
+
   const rows = await db
     .select(concertPageFields)
     .from(concerts)

--- a/tests/integration/concerts-by-id.spec.js
+++ b/tests/integration/concerts-by-id.spec.js
@@ -264,25 +264,58 @@ describe('GET /concerts/:id (BS#1694)', () => {
   });
 
   describe('misses', () => {
-    it('returns 404 in the standard error shape for an id with no row', async () => {
-      const res = await request.get('/concerts/2100000000');
+    /**
+     * A guaranteed-missing id derived from the live table (MAX + 1) rather
+     * than a hardcoded literal — the schema is shared across suites, so a
+     * fixed value would silently flip to 200 if any other spec ever seeded
+     * an explicit high id.
+     */
+    const missingId = async () => {
+      const [{ next_id: nextId }] = await sql.unsafe(
+        `SELECT COALESCE(MAX(id), 0) + 1 AS next_id FROM "${SCHEMA}".concerts`
+      );
+      return nextId;
+    };
+
+    // Misses must never be edge-cached: 404 is heuristically cacheable by
+    // default (RFC 9110 §15.5.5), so without the explicit no-store a CDN
+    // could pin "dead" onto an id minutes before its row lands (concert ids
+    // are predictable serials). The explicit directive enforces what
+    // omission only implied.
+    it('returns 404 pinned no-store in the standard error shape for an id with no row', async () => {
+      const res = await request.get(`/concerts/${await missingId()}`);
       expect(res.status).toBe(404);
       expect(res.body).toHaveProperty('message');
+      expect(res.headers['cache-control']).toBe('no-store');
     });
 
     it('returns 404 (not a bind 500) for an all-digits id beyond the int4 serial range', async () => {
       const res = await request.get('/concerts/99999999999999');
       expect(res.status).toBe(404);
       expect(res.body).toHaveProperty('message');
+      expect(res.headers['cache-control']).toBe('no-store');
     });
 
     it.each([['abc'], ['12abc'], ['0']])(
-      'returns 400 in the standard error shape for non-integer id %s',
+      'returns 400 pinned no-store in the standard error shape for non-integer id %s',
       async (id) => {
         const res = await request.get(`/concerts/${id}`);
         expect(res.status).toBe(400);
         expect(res.body).toHaveProperty('message');
+        expect(res.headers['cache-control']).toBe('no-store');
       }
     );
+
+    // A malformed percent-escape fails URL-decoding inside the Express
+    // router itself — before any controller runs. That URIError carries
+    // `status: 400` (not `statusCode`), which the errorHandler must answer
+    // as a clean client error: pre-fix it surfaced as a 500 plus a Sentry
+    // capture, mintable by any unauthenticated probe on this public route
+    // (a share link truncated mid-escape is enough).
+    it('returns 400 in the standard error shape for a malformed percent-escape', async () => {
+      const res = await request.get('/concerts/%ZZ');
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty('message');
+    });
   });
 });

--- a/tests/integration/concerts-by-id.spec.js
+++ b/tests/integration/concerts-by-id.spec.js
@@ -1,0 +1,282 @@
+/**
+ * BS#1694 — public `GET /concerts/:id` (On Tour sharing).
+ *
+ * Postgres-backed sibling of concerts.spec.js (BS#1603), keyed by a
+ * `bs1694:` source_id prefix so cleanup is a prefix DELETE and nothing leaks
+ * across runs.
+ *
+ * Pins the by-id contract from `wxyc-shared/api.yaml` v1.18.0
+ * (`/concerts/{id}`, wxyc-shared#236):
+ *   - PUBLIC: a request with NO Authorization header succeeds — the share
+ *     Worker and CDNs cannot mint anonymous sessions (the point of the
+ *     ticket). The list stays behind anonymous-session auth, unchanged.
+ *   - Serialization parity: the 200 body is the EXACT object the list
+ *     endpoint emits for the same row (asserted by deep-equality against the
+ *     list response, not duplicated literals).
+ *   - WINDOWLESS: past rows and `removed_at`-tombstoned rows are served with
+ *     whatever `status` they last carried — while remaining excluded from
+ *     the list (the deliberate divergence).
+ *   - Leak barrier holds: internal ingestion columns (removed_at above all,
+ *     since tombstoned rows are now reachable) never reach the payload.
+ *   - 404 for nonexistent ids, 400 for non-integer ids — both in the
+ *     standard `{ message }` error shape.
+ *   - `Cache-Control: public, max-age=300` on the 200 path.
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+const { createAuthRequest } = require('../utils/test_helpers');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const SOURCE_ID_PREFIX = 'bs1694:';
+const VENUE_SLUG = 'bs1694-probe-room';
+const ARTIST_NAME = 'BS#1694 Probe Headliner';
+// Synthetic Discogs id for the resolved headliner; high enough to avoid
+// colliding with any real artists/artist_metadata row in the CI clone.
+const ARTIST_DISCOGS_ID = 91694001;
+const ARTIST_GENRES = ['Folk, World, & Country'];
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+/** YYYY-MM-DD for today + offsetDays, in America/New_York (matches the list's default `from`). */
+function isoDate(offsetDays) {
+  const d = new Date(Date.now() + offsetDays * 24 * 60 * 60 * 1000);
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(d);
+}
+
+const PAST = isoDate(-45); // long gone — invisible to the list's default window
+const IN_15 = isoDate(15); // upcoming, resolved + enriched headliner
+const IN_22 = isoDate(22); // tombstoned (removed_at set) — list-invisible, by-id-visible
+
+const INTERNAL_COLUMNS = ['source', 'source_id', 'raw_data', 'scraped_at', 'first_scraped_at', 'removed_at'];
+
+describe('GET /concerts/:id (BS#1694)', () => {
+  let auth;
+  let sql;
+  let artistId;
+  let upcomingId;
+  let pastId;
+  let removedId;
+
+  /** Seeds one concert row and returns its serial id. */
+  const seedConcert = async (overrides) => {
+    const defaults = {
+      source: 'triangle_shows',
+      starts_at: null,
+      doors_at: null,
+      headlining_artist_id: null,
+      title: null,
+      supporting_artists: [],
+      ticket_url: null,
+      image_url: null,
+      event_url: null,
+      price_min: null,
+      price_max: null,
+      age_restriction: null,
+      status: 'on_sale',
+      removed_at: null,
+    };
+    const row = { ...defaults, ...overrides };
+    const [inserted] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".concerts
+         (source, source_id, venue_id, starts_on, starts_at, doors_at,
+          headlining_artist_raw, headlining_artist_id, title, supporting_artists_raw,
+          ticket_url, image_url, price_min, price_max, age_restriction, status,
+          removed_at, event_url, raw_data, scraped_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, '{}'::jsonb, now())
+       RETURNING id`,
+      [
+        row.source,
+        SOURCE_ID_PREFIX + row.key,
+        row.venue_id,
+        row.starts_on,
+        row.starts_at,
+        row.doors_at,
+        row.headlining_artist_raw,
+        row.headlining_artist_id,
+        row.title,
+        row.supporting_artists,
+        row.ticket_url,
+        row.image_url,
+        row.price_min,
+        row.price_max,
+        row.age_restriction,
+        row.status,
+        row.removed_at,
+        row.event_url,
+      ]
+    );
+    return inserted.id;
+  };
+
+  const cleanup = async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".concerts WHERE source_id LIKE $1`, [`${SOURCE_ID_PREFIX}%`]);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".venues WHERE slug = $1`, [VENUE_SLUG]);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".artist_metadata WHERE discogs_artist_id = $1`, [ARTIST_DISCOGS_ID]);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".artists WHERE artist_name = $1`, [ARTIST_NAME]);
+  };
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = makeSql();
+    await cleanup(); // idempotent across re-runs (shared schema, --runInBand)
+
+    const [venue] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".venues (slug, name, city, state, address)
+       VALUES ($1, 'BS1694 Probe Room', 'Chapel Hill', 'NC', '100 E Franklin St')
+       RETURNING id`,
+      [VENUE_SLUG]
+    );
+    const venueId = venue.id;
+
+    const [artist] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters, discogs_artist_id)
+       VALUES ($1, $1, 'ZZ', $2) RETURNING id`,
+      [ARTIST_NAME, ARTIST_DISCOGS_ID]
+    );
+    artistId = artist.id;
+
+    // Genre enrichment for the resolved headliner (BS#1624 projection) — the
+    // parity test below proves the by-id read carries the same enrichment
+    // fields as the list.
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles)
+       VALUES ($1, $2, $3)`,
+      [ARTIST_DISCOGS_ID, ARTIST_GENRES, []]
+    );
+
+    // Upcoming, fully-populated, resolved headliner: the serialization-parity
+    // row (starts_at at 23:30Z stays the same ET calendar date, so the derive
+    // trigger's recomputed starts_on remains IN_15).
+    upcomingId = await seedConcert({
+      key: 'upcoming',
+      venue_id: venueId,
+      starts_on: IN_15,
+      starts_at: `${IN_15}T23:30:00.000Z`,
+      doors_at: `${IN_15}T22:30:00.000Z`,
+      headlining_artist_raw: ARTIST_NAME,
+      headlining_artist_id: artistId,
+      supporting_artists: ['Probe Opener'],
+      ticket_url: 'https://example.com/tickets/bs1694',
+      image_url: 'https://example.com/img/bs1694.jpg',
+      event_url: 'https://example.com/venue/event/bs1694',
+      price_min: '18.00',
+      price_max: '22.00',
+      age_restriction: 'All Ages',
+    });
+
+    // Long-past row: outside every list window, but the share page must still
+    // render it ("this one's passed").
+    pastId = await seedConcert({
+      key: 'past',
+      venue_id: venueId,
+      starts_on: PAST,
+      headlining_artist_raw: 'Bygone Probe Act',
+    });
+
+    // Tombstoned row: removed_at set, status as the source last carried it.
+    removedId = await seedConcert({
+      key: 'removed',
+      venue_id: venueId,
+      starts_on: IN_22,
+      headlining_artist_raw: 'Delisted Probe Act',
+      status: 'cancelled',
+      removed_at: new Date().toISOString(),
+    });
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await sql.end();
+  });
+
+  describe('public access (no session)', () => {
+    it('serves a request with NO Authorization header', async () => {
+      // Plain requester — no bearer of any kind. This is the point of the
+      // ticket: the share Worker and CDNs cannot mint anonymous sessions.
+      const res = await request.get(`/concerts/${upcomingId}`);
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(upcomingId);
+    });
+
+    it('marks the response publicly cacheable with a 5-minute TTL', async () => {
+      const res = await request.get(`/concerts/${upcomingId}`);
+      expect(res.headers['cache-control']).toBe('public, max-age=300');
+    });
+  });
+
+  describe('serialization parity with the list', () => {
+    it('emits the exact Concert object GET /concerts serializes for the same row', async () => {
+      // The list's rendering is the reference — fetched, not re-derived, so
+      // this cannot drift into a second hand-maintained shape.
+      const list = await auth.get('/concerts').query({ from: IN_15, to: IN_15, limit: 100 });
+      expect(list.status).toBe(200);
+      const reference = list.body.concerts.find((c) => c.id === upcomingId);
+      expect(reference).toBeDefined();
+      // Sanity that the reference row exercises the full shape, enrichment
+      // included (genres via the BS#1624 LEFT JOIN).
+      expect(reference.genres).toEqual(ARTIST_GENRES);
+
+      const byId = await request.get(`/concerts/${upcomingId}`);
+      expect(byId.status).toBe(200);
+      expect(byId.body).toEqual(reference);
+    });
+  });
+
+  describe('windowless reads', () => {
+    it('serves a long-past concert the list will never emit', async () => {
+      const res = await request.get(`/concerts/${pastId}`);
+      expect(res.status).toBe(200);
+      expect(res.body.starts_on).toBe(PAST);
+      expect(res.body.headlining_artist_raw).toBe('Bygone Probe Act');
+    });
+
+    it('serves a tombstoned concert with the status it last carried', async () => {
+      const res = await request.get(`/concerts/${removedId}`);
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('cancelled');
+      expect(res.body.starts_on).toBe(IN_22);
+    });
+
+    it('keeps the tombstoned row excluded from the list (the deliberate divergence)', async () => {
+      const list = await auth.get('/concerts').query({ from: IN_22, to: IN_22, limit: 100 });
+      expect(list.status).toBe(200);
+      expect(list.body.concerts.find((c) => c.id === removedId)).toBeUndefined();
+    });
+
+    it('never leaks internal ingestion columns — removed_at above all', async () => {
+      const res = await request.get(`/concerts/${removedId}`);
+      for (const internal of INTERNAL_COLUMNS) {
+        expect(res.body).not.toHaveProperty(internal);
+        expect(res.body.venue).not.toHaveProperty(internal);
+      }
+    });
+  });
+
+  describe('misses', () => {
+    it('returns 404 in the standard error shape for an id with no row', async () => {
+      const res = await request.get('/concerts/2100000000');
+      expect(res.status).toBe(404);
+      expect(res.body).toHaveProperty('message');
+    });
+
+    it.each([['abc'], ['12abc'], ['0']])(
+      'returns 400 in the standard error shape for non-integer id %s',
+      async (id) => {
+        const res = await request.get(`/concerts/${id}`);
+        expect(res.status).toBe(400);
+        expect(res.body).toHaveProperty('message');
+      }
+    );
+  });
+});

--- a/tests/integration/concerts-by-id.spec.js
+++ b/tests/integration/concerts-by-id.spec.js
@@ -270,6 +270,12 @@ describe('GET /concerts/:id (BS#1694)', () => {
       expect(res.body).toHaveProperty('message');
     });
 
+    it('returns 404 (not a bind 500) for an all-digits id beyond the int4 serial range', async () => {
+      const res = await request.get('/concerts/99999999999999');
+      expect(res.status).toBe(404);
+      expect(res.body).toHaveProperty('message');
+    });
+
     it.each([['abc'], ['12abc'], ['0']])(
       'returns 400 in the standard error shape for non-integer id %s',
       async (id) => {

--- a/tests/integration/concerts-by-id.spec.js
+++ b/tests/integration/concerts-by-id.spec.js
@@ -297,7 +297,7 @@ describe('GET /concerts/:id (BS#1694)', () => {
     });
 
     it.each([['abc'], ['12abc'], ['0']])(
-      'returns 400 pinned no-store in the standard error shape for non-integer id %s',
+      'returns 400 pinned no-store in the standard error shape for malformed id %s',
       async (id) => {
         const res = await request.get(`/concerts/${id}`);
         expect(res.status).toBe(400);

--- a/tests/unit/controllers/concerts.controller.test.ts
+++ b/tests/unit/controllers/concerts.controller.test.ts
@@ -302,6 +302,22 @@ describe('concerts.controller getConcertById', () => {
     expect(res.set).not.toHaveBeenCalled();
   });
 
+  // Ids beyond the int4 serial ceiling are well-formed integers that can
+  // never exist. Without this guard the Postgres bind rejects them with
+  // "integer out of range" → an unhandled 500 (plus Sentry noise) that any
+  // unauthenticated URL probe could mint on this public route. They are a
+  // miss, not a malformed request: 404, before any query.
+  it.each([
+    ['2147483648'], // int4 max + 1
+    ['99999999999999'],
+  ])('maps out-of-int4-range id=%s to a 404 without querying', async (id) => {
+    setId(id);
+
+    await expect(invoke()).rejects.toMatchObject({ statusCode: 404 });
+    expect(mockGetConcertById).not.toHaveBeenCalled();
+    expect(res.set).not.toHaveBeenCalled();
+  });
+
   it('propagates service failures to the error handler', async () => {
     const failure = new Error('db unavailable');
     mockGetConcertById.mockRejectedValue(failure);

--- a/tests/unit/controllers/concerts.controller.test.ts
+++ b/tests/unit/controllers/concerts.controller.test.ts
@@ -269,15 +269,29 @@ describe('concerts.controller getConcertById', () => {
 
   it('marks the 200 publicly cacheable with the ~5-minute TTL the spec calls for', async () => {
     await invoke();
-    expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=300');
+    // The public directive must be the FINAL Cache-Control written — it
+    // overrides the no-store default the handler pins first.
+    expect(res.set).toHaveBeenLastCalledWith('Cache-Control', 'public, max-age=300');
   });
 
-  it('maps a service null to a 404 WxycError and never sets Cache-Control', async () => {
+  // Omitting Cache-Control does NOT keep a 404 out of shared caches: 404 is
+  // heuristically cacheable by default (RFC 9110 §15.5.5), and the CDN tier
+  // this route is built for caches header-less 404s for minutes — long
+  // enough to pin a freshly-shared id as dead at the edge. Every response
+  // therefore starts explicitly `no-store`; only the 200 path upgrades to
+  // the public directive.
+  it('pins the no-store default before anything can throw', async () => {
+    await invoke();
+    expect(res.set).toHaveBeenNthCalledWith(1, 'Cache-Control', 'no-store');
+  });
+
+  it('maps a service null to a 404 WxycError with Cache-Control pinned no-store', async () => {
     mockGetConcertById.mockResolvedValue(null);
     setId('999999');
 
     await expect(invoke()).rejects.toMatchObject({ statusCode: 404 });
-    expect(res.set).not.toHaveBeenCalled();
+    expect(res.set).toHaveBeenCalledWith('Cache-Control', 'no-store');
+    expect(res.set).not.toHaveBeenCalledWith('Cache-Control', 'public, max-age=300');
     expect(res.json).not.toHaveBeenCalled();
   });
 
@@ -299,24 +313,15 @@ describe('concerts.controller getConcertById', () => {
       message: 'id must be a positive integer',
     });
     expect(mockGetConcertById).not.toHaveBeenCalled();
-    expect(res.set).not.toHaveBeenCalled();
+    expect(res.set).toHaveBeenCalledWith('Cache-Control', 'no-store');
+    expect(res.set).not.toHaveBeenCalledWith('Cache-Control', 'public, max-age=300');
   });
 
-  // Ids beyond the int4 serial ceiling are well-formed integers that can
-  // never exist. Without this guard the Postgres bind rejects them with
-  // "integer out of range" → an unhandled 500 (plus Sentry noise) that any
-  // unauthenticated URL probe could mint on this public route. They are a
-  // miss, not a malformed request: 404, before any query.
-  it.each([
-    ['2147483648'], // int4 max + 1
-    ['99999999999999'],
-  ])('maps out-of-int4-range id=%s to a 404 without querying', async (id) => {
-    setId(id);
-
-    await expect(invoke()).rejects.toMatchObject({ statusCode: 404 });
-    expect(mockGetConcertById).not.toHaveBeenCalled();
-    expect(res.set).not.toHaveBeenCalled();
-  });
+  // Out-of-int4-range ids (e.g. '2147483648') are well-formed integers that
+  // can never exist; the SERVICE owns that persistence fact and resolves
+  // them to null (see concerts.service.test.ts), which the null → 404
+  // mapping above already covers at this tier. The full wire behavior is
+  // pinned end-to-end in tests/integration/concerts-by-id.spec.js.
 
   it('propagates service failures to the error handler', async () => {
     const failure = new Error('db unavailable');

--- a/tests/unit/controllers/concerts.controller.test.ts
+++ b/tests/unit/controllers/concerts.controller.test.ts
@@ -1,24 +1,33 @@
 /**
- * Unit tests for `GET /concerts` (BS#1603, on-tour Phase 2).
+ * Unit tests for `GET /concerts` (BS#1603, on-tour Phase 2) and the public
+ * `GET /concerts/:id` (BS#1694, On Tour sharing).
  *
  * Service is mocked; these tests pin the controller contract: query-param
  * validation (page/limit/curated/from/to), the 1-indexed page → offset math,
- * the default `starts_on` window ("today forward", America/New_York), and
- * the `ConcertsResponse` wire shape (`concerts` + `PaginationInfo`).
+ * the default `starts_on` window ("today forward", America/New_York), the
+ * `ConcertsResponse` wire shape (`concerts` + `PaginationInfo`), and the
+ * by-id contract (id validation, null → 404, `Cache-Control: public` on the
+ * 200 path only).
  */
 import { jest } from '@jest/globals';
 import type { Request, Response, NextFunction } from 'express';
 
 const mockGetConcertsPage = jest.fn<() => Promise<unknown[]>>();
 const mockGetConcertsCount = jest.fn<() => Promise<number>>();
+const mockGetConcertById = jest.fn<() => Promise<unknown>>();
 
 jest.mock('../../../apps/backend/services/concerts.service', () => ({
   getConcertsPage: mockGetConcertsPage,
   getConcertsCount: mockGetConcertsCount,
+  getConcertById: mockGetConcertById,
 }));
 
 import { nyCalendarDate } from '@wxyc/database';
-import { getConcerts, ConcertsQueryParams } from '../../../apps/backend/controllers/concerts.controller';
+import {
+  getConcertById,
+  getConcerts,
+  ConcertsQueryParams,
+} from '../../../apps/backend/controllers/concerts.controller';
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -205,6 +214,97 @@ describe('concerts.controller getConcerts', () => {
   it('propagates service failures to the error handler', async () => {
     const failure = new Error('db unavailable');
     mockGetConcertsPage.mockRejectedValue(failure);
+    await expect(invoke()).rejects.toThrow(failure);
+  });
+});
+
+/**
+ * `GET /concerts/:id` (BS#1694) — public, windowless single-concert read per
+ * `wxyc-shared/api.yaml` v1.18.0 (`/concerts/{id}`, wxyc-shared#236). The
+ * service is mocked, so these pin the controller half of the contract: the
+ * all-digits id guard (same strictness as the list's page/limit — a bare
+ * parseInt would coerce '12abc'), null → 404 WxycError, and public
+ * cacheability on the 200 path only (an error response must never pick up the
+ * public Cache-Control, or a shared cache could pin a 404/400 for 5 minutes).
+ * Auth-tier wiring (no middleware) is pinned in the route + integration tests;
+ * windowless/tombstone semantics are pinned against real SQL in
+ * tests/integration/concerts-by-id.spec.js.
+ */
+describe('concerts.controller getConcertById', () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  const mockNext = jest.fn<NextFunction>();
+
+  const invoke = () => getConcertById(req as Request, res as Response, mockNext);
+
+  const concert = {
+    id: 4821,
+    venue: { id: 3, slug: 'cats-cradle', name: "Cat's Cradle", city: 'Carrboro', state: 'NC', address: null },
+    starts_on: '2026-08-14',
+    status: 'on_sale',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetConcertById.mockResolvedValue(concert);
+    req = { params: { id: '4821' } };
+    res = {
+      status: jest.fn().mockReturnThis() as unknown as Response['status'],
+      json: jest.fn() as unknown as Response['json'],
+      set: jest.fn().mockReturnThis() as unknown as Response['set'],
+    };
+  });
+
+  const setId = (id: string) => {
+    req.params = { id };
+  };
+
+  it('serves the concert the service resolves, verbatim', async () => {
+    await invoke();
+
+    expect(mockGetConcertById).toHaveBeenCalledWith(4821);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(concert);
+  });
+
+  it('marks the 200 publicly cacheable with the ~5-minute TTL the spec calls for', async () => {
+    await invoke();
+    expect(res.set).toHaveBeenCalledWith('Cache-Control', 'public, max-age=300');
+  });
+
+  it('maps a service null to a 404 WxycError and never sets Cache-Control', async () => {
+    mockGetConcertById.mockResolvedValue(null);
+    setId('999999');
+
+    await expect(invoke()).rejects.toMatchObject({ statusCode: 404 });
+    expect(res.set).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['abc'],
+    // trailing-garbage / radix inputs a bare parseInt would coerce
+    ['12abc'],
+    ['0x10'],
+    ['-1'],
+    ['1.5'],
+    [''],
+    // 0 is all-digits but not a valid serial id — reject before the query
+    ['0'],
+  ])('rejects id=%s with a 400 WxycError without querying', async (id) => {
+    setId(id);
+
+    await expect(invoke()).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'id must be a positive integer',
+    });
+    expect(mockGetConcertById).not.toHaveBeenCalled();
+    expect(res.set).not.toHaveBeenCalled();
+  });
+
+  it('propagates service failures to the error handler', async () => {
+    const failure = new Error('db unavailable');
+    mockGetConcertById.mockRejectedValue(failure);
     await expect(invoke()).rejects.toThrow(failure);
   });
 });

--- a/tests/unit/middleware/errorHandler.test.ts
+++ b/tests/unit/middleware/errorHandler.test.ts
@@ -74,8 +74,15 @@ describe('errorHandler middleware', () => {
    * (body-parser). Rendering those as 500s turns any malformed escape in a
    * public path segment (`GET /concerts/%ZZ` — BS#1694 made the first such
    * unauthenticated param route) into a probe-mintable fake internal error.
-   * Only the 4xx band is trusted and echoed; foreign 5xx-status errors stay
-   * on the generic-500 path so internals never leak.
+   *
+   * Echo requires TRUST, not just a 4xx number: upstream SDK errors
+   * (groq-sdk APIError et al.) mirror the provider's HTTP status onto
+   * `.status` and embed the raw provider body in `message` — echoing those
+   * would leak provider/org/quota internals to unauthenticated-tier callers
+   * and misreport our own dependency failures as the caller's 4xx. Trusted =
+   * `expose: true` (the http-errors convention body-parser follows) or the
+   * router's own percent-decode URIError. Everything else stays on the
+   * generic-500 path.
    */
   describe('foreign errors carrying an HTTP status (express/router/body-parser convention)', () => {
     it('answers the carried 4xx status for a router percent-decode URIError (status, no statusCode)', () => {
@@ -88,9 +95,10 @@ describe('errorHandler middleware', () => {
       expect(jsonMock).toHaveBeenCalledWith({ message: "Failed to decode param '%ZZ'" });
     });
 
-    it('answers a 4xx carried as statusCode (http-errors convention, e.g. body-parser)', () => {
+    it('answers a 4xx carried as statusCode when the error declares expose (http-errors, e.g. body-parser)', () => {
       const { res, statusMock, jsonMock } = mockResponse();
-      const error = Object.assign(new Error('request entity too large'), { statusCode: 413 });
+      // Real body-parser shape: SyntaxError with status+statusCode+expose:true.
+      const error = Object.assign(new Error('request entity too large'), { statusCode: 413, expose: true });
 
       errorHandler(error, mockReq, res, mockNext);
 
@@ -100,12 +108,33 @@ describe('errorHandler middleware', () => {
 
     it('parses a string-encoded 4xx status (express convention)', () => {
       const { res, statusMock, jsonMock } = mockResponse();
-      const error = Object.assign(new Error('bad escape'), { status: '400' });
+      const error = Object.assign(new Error('bad escape'), { status: '400', expose: true });
 
       errorHandler(error, mockReq, res, mockNext);
 
       expect(statusMock).toHaveBeenCalledWith(400);
       expect(jsonMock).toHaveBeenCalledWith({ message: 'bad escape' });
+    });
+
+    // The groq-sdk APIError shape: integer `.status` mirroring the provider's
+    // HTTP status, no `statusCode`, no `expose`, message embedding the raw
+    // provider body. POST /request/parse rethrows these raw (parseOnly), so
+    // without the trust gate an anonymous-session caller would receive the
+    // provider's org/model/quota internals as a 429 — and Sentry would treat
+    // it as client noise. It must stay a generic 500 (captured).
+    it('does NOT echo an untrusted 4xx (no expose, not a URIError) — e.g. an upstream SDK error', () => {
+      const { res, statusMock, jsonMock } = mockResponse();
+      const error = Object.assign(
+        new Error(
+          '429 {"error":{"message":"Rate limit reached for model llama-3.3-70b-versatile in organization org_01abc"}}'
+        ),
+        { status: 429 }
+      );
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(statusMock).toHaveBeenCalledWith(500);
+      expect(jsonMock).toHaveBeenCalledWith({ message: 'Internal server error' });
     });
 
     it('keeps foreign 5xx-status errors on the generic 500 path (no internals leak)', () => {

--- a/tests/unit/middleware/errorHandler.test.ts
+++ b/tests/unit/middleware/errorHandler.test.ts
@@ -66,4 +66,96 @@ describe('errorHandler middleware', () => {
     expect(consoleSpy).toHaveBeenCalledWith('[GET /flowsheet/latest] Unhandled error:', error);
     consoleSpy.mockRestore();
   });
+
+  /**
+   * Express internals and standard middleware throw errors that carry a
+   * numeric `status` (the router's percent-decode failure — URIError with
+   * `status: 400` and NO `statusCode`) or an http-errors-style `statusCode`
+   * (body-parser). Rendering those as 500s turns any malformed escape in a
+   * public path segment (`GET /concerts/%ZZ` — BS#1694 made the first such
+   * unauthenticated param route) into a probe-mintable fake internal error.
+   * Only the 4xx band is trusted and echoed; foreign 5xx-status errors stay
+   * on the generic-500 path so internals never leak.
+   */
+  describe('foreign errors carrying an HTTP status (express/router/body-parser convention)', () => {
+    it('answers the carried 4xx status for a router percent-decode URIError (status, no statusCode)', () => {
+      const { res, statusMock, jsonMock } = mockResponse();
+      const error = Object.assign(new URIError("Failed to decode param '%ZZ'"), { status: 400 });
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({ message: "Failed to decode param '%ZZ'" });
+    });
+
+    it('answers a 4xx carried as statusCode (http-errors convention, e.g. body-parser)', () => {
+      const { res, statusMock, jsonMock } = mockResponse();
+      const error = Object.assign(new Error('request entity too large'), { statusCode: 413 });
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(statusMock).toHaveBeenCalledWith(413);
+      expect(jsonMock).toHaveBeenCalledWith({ message: 'request entity too large' });
+    });
+
+    it('parses a string-encoded 4xx status (express convention)', () => {
+      const { res, statusMock, jsonMock } = mockResponse();
+      const error = Object.assign(new Error('bad escape'), { status: '400' });
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(statusMock).toHaveBeenCalledWith(400);
+      expect(jsonMock).toHaveBeenCalledWith({ message: 'bad escape' });
+    });
+
+    it('keeps foreign 5xx-status errors on the generic 500 path (no internals leak)', () => {
+      const { res, statusMock, jsonMock } = mockResponse();
+      const error = Object.assign(new Error('SELECT * FROM users failed'), { status: 503 });
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(statusMock).toHaveBeenCalledWith(500);
+      expect(jsonMock).toHaveBeenCalledWith({ message: 'Internal server error' });
+    });
+
+    // Express 5's res.status() throws a RangeError on non-integer codes, so a
+    // fractional carried status must fall through to the generic 500 instead
+    // of detonating inside the error handler itself.
+    it('ignores a non-integer carried status rather than passing it to res.status', () => {
+      const { res, statusMock, jsonMock } = mockResponse();
+      const error = Object.assign(new Error('weird status'), { status: 404.5 });
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(statusMock).toHaveBeenCalledWith(500);
+      expect(jsonMock).toHaveBeenCalledWith({ message: 'Internal server error' });
+    });
+
+    // `status` wins over `statusCode` when both are present — the SAME
+    // precedence shouldCaptureExpressError uses (it imports the same helper),
+    // so the response tier and the Sentry tier can never classify one error
+    // divergently. With status=503 taking precedence, this error is a
+    // generic 500 AND Sentry-captured; the sibling sentryErrorFilter test
+    // pins the capture half.
+    it('classifies a both-alias error by `status` first, matching the Sentry filter', () => {
+      const { res, statusMock, jsonMock } = mockResponse();
+      const error = Object.assign(new Error('conflicted'), { statusCode: 404, status: 503 });
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(statusMock).toHaveBeenCalledWith(500);
+      expect(jsonMock).toHaveBeenCalledWith({ message: 'Internal server error' });
+    });
+
+    it('logs the carried-status client error as a single line, not an unhandled dump', () => {
+      const { res } = mockResponse();
+      const error = Object.assign(new URIError("Failed to decode param '%2'"), { status: 400 });
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      errorHandler(error, mockReq, res, mockNext);
+
+      expect(consoleSpy).toHaveBeenCalledWith("[GET /flowsheet/latest] URIError 400: Failed to decode param '%2'");
+      consoleSpy.mockRestore();
+    });
+  });
 });

--- a/tests/unit/middleware/sentryErrorFilter.test.ts
+++ b/tests/unit/middleware/sentryErrorFilter.test.ts
@@ -30,4 +30,38 @@ describe('shouldCaptureExpressError', () => {
     const stringClient = Object.assign(new Error('e'), { statusCode: '404' });
     expect(shouldCaptureExpressError(stringClient)).toBe(false);
   });
+
+  // Express internals set `status`, not `statusCode` — the router's
+  // percent-decode URIError (status: 400, no statusCode) is unauthenticated-
+  // reachable via the public GET /concerts/:id (BS#1694) and must not spam
+  // Sentry any more than a WxycError 400 does.
+  it('reads the `status` alias when `statusCode` is absent (router decode errors)', () => {
+    const decodeError = Object.assign(new URIError("Failed to decode param '%ZZ'"), { status: 400 });
+    expect(shouldCaptureExpressError(decodeError)).toBe(false);
+
+    const stringStatus = Object.assign(new Error('e'), { status: '404' });
+    expect(shouldCaptureExpressError(stringStatus)).toBe(false);
+
+    const serverStatus = Object.assign(new Error('e'), { status: 503 });
+    expect(shouldCaptureExpressError(serverStatus)).toBe(true);
+  });
+
+  // Suppression is exactly the 4xx band the errorHandler echoes (it shares
+  // carriedClientStatus). Anything else that still renders as a generic 500 —
+  // a 1xx-3xx-status oddity, a sub-400 statusCode — MUST be captured, or the
+  // production 500 is invisible to monitoring.
+  it('captures errors whose carried status is outside the echoed 4xx band', () => {
+    const redirectish = Object.assign(new Error('upstream said not-modified'), { status: 304 });
+    expect(shouldCaptureExpressError(redirectish)).toBe(true);
+
+    const subFourHundred = Object.assign(new Error('e'), { statusCode: 300 });
+    expect(shouldCaptureExpressError(subFourHundred)).toBe(true);
+  });
+
+  // Both-alias divergence: `status` wins (same helper as errorHandler), so
+  // this error answers as a generic 500 — and is captured accordingly.
+  it('classifies a both-alias error by `status` first, matching errorHandler', () => {
+    const conflicted = Object.assign(new Error('conflicted'), { statusCode: 404, status: 503 });
+    expect(shouldCaptureExpressError(conflicted)).toBe(true);
+  });
 });

--- a/tests/unit/middleware/sentryErrorFilter.test.ts
+++ b/tests/unit/middleware/sentryErrorFilter.test.ts
@@ -23,12 +23,21 @@ describe('shouldCaptureExpressError', () => {
     expect(shouldCaptureExpressError(new Error('unexpected'))).toBe(true);
   });
 
+  // Capture tracks the RESPONSE: suppression applies exactly to the errors
+  // errorHandler echoes as trusted client 4xxs (it shares carriedClientStatus,
+  // which requires `expose: true` — the http-errors convention — or the
+  // router's URIError). A bare string statusCode without expose renders as a
+  // generic 500, so it MUST be captured; the 5xx string form was never
+  // suppressed.
   it('handles statusCode encoded as a string (express convention)', () => {
     const stringStatus = Object.assign(new Error('e'), { statusCode: '504' });
     expect(shouldCaptureExpressError(stringStatus)).toBe(true);
 
-    const stringClient = Object.assign(new Error('e'), { statusCode: '404' });
-    expect(shouldCaptureExpressError(stringClient)).toBe(false);
+    const exposedStringClient = Object.assign(new Error('e'), { statusCode: '404', expose: true });
+    expect(shouldCaptureExpressError(exposedStringClient)).toBe(false);
+
+    const untrustedStringClient = Object.assign(new Error('e'), { statusCode: '404' });
+    expect(shouldCaptureExpressError(untrustedStringClient)).toBe(true);
   });
 
   // Express internals set `status`, not `statusCode` — the router's
@@ -39,17 +48,17 @@ describe('shouldCaptureExpressError', () => {
     const decodeError = Object.assign(new URIError("Failed to decode param '%ZZ'"), { status: 400 });
     expect(shouldCaptureExpressError(decodeError)).toBe(false);
 
-    const stringStatus = Object.assign(new Error('e'), { status: '404' });
-    expect(shouldCaptureExpressError(stringStatus)).toBe(false);
+    const exposedClient = Object.assign(new Error('e'), { status: '404', expose: true });
+    expect(shouldCaptureExpressError(exposedClient)).toBe(false);
 
     const serverStatus = Object.assign(new Error('e'), { status: 503 });
     expect(shouldCaptureExpressError(serverStatus)).toBe(true);
   });
 
-  // Suppression is exactly the 4xx band the errorHandler echoes (it shares
-  // carriedClientStatus). Anything else that still renders as a generic 500 —
-  // a 1xx-3xx-status oddity, a sub-400 statusCode — MUST be captured, or the
-  // production 500 is invisible to monitoring.
+  // Suppression is exactly the trusted 4xx band the errorHandler echoes.
+  // Anything that still renders as a generic 500 — a 1xx-3xx-status oddity,
+  // a sub-400 statusCode — MUST be captured, or the production 500 is
+  // invisible to monitoring.
   it('captures errors whose carried status is outside the echoed 4xx band', () => {
     const redirectish = Object.assign(new Error('upstream said not-modified'), { status: 304 });
     expect(shouldCaptureExpressError(redirectish)).toBe(true);
@@ -58,10 +67,40 @@ describe('shouldCaptureExpressError', () => {
     expect(shouldCaptureExpressError(subFourHundred)).toBe(true);
   });
 
+  // The groq-sdk APIError shape (integer `.status` 429/401, no statusCode,
+  // no expose, provider body in message) renders as a generic 500 and MUST
+  // be captured: a rotated GROQ_API_KEY or sustained provider rate-limiting
+  // is a server-side dependency failure, not client noise. This was main's
+  // behavior (statusCode undefined → captured); the status-alias read must
+  // not regress it.
+  it('captures untrusted upstream-SDK 4xx errors (no expose) that render as 500s', () => {
+    const groqRateLimit = Object.assign(new Error('429 Rate limit reached for model X in organization org_01abc'), {
+      status: 429,
+    });
+    expect(shouldCaptureExpressError(groqRateLimit)).toBe(true);
+
+    const groqBadKey = Object.assign(new Error('401 Invalid API Key'), { status: 401 });
+    expect(shouldCaptureExpressError(groqBadKey)).toBe(true);
+  });
+
   // Both-alias divergence: `status` wins (same helper as errorHandler), so
   // this error answers as a generic 500 — and is captured accordingly.
   it('classifies a both-alias error by `status` first, matching errorHandler', () => {
-    const conflicted = Object.assign(new Error('conflicted'), { statusCode: 404, status: 503 });
+    const conflicted = Object.assign(new Error('conflicted'), { statusCode: 404, status: 503, expose: true });
     expect(shouldCaptureExpressError(conflicted)).toBe(true);
+  });
+
+  // Sentry's expressErrorHandler passes the RAW pipeline value, but
+  // errorHandler wraps non-Error throwables in `new Error(String(err))` —
+  // dropping any carried status — before classifying, so every non-Error
+  // renders as a generic 500. The filter must normalize the same way, or a
+  // next()'d plain object with a trusted-looking 4xx would be 500-answered
+  // yet capture-suppressed: invisible to monitoring.
+  it('captures non-Error throwables regardless of carried properties (they render as 500s)', () => {
+    const plainWithStatus = { status: 400, expose: true, message: 'looks legit' } as unknown as Error;
+    expect(shouldCaptureExpressError(plainWithStatus)).toBe(true);
+
+    expect(shouldCaptureExpressError('string throw' as unknown as Error)).toBe(true);
+    expect(shouldCaptureExpressError(undefined as unknown as Error)).toBe(true);
   });
 });

--- a/tests/unit/routes/concerts.route.test.ts
+++ b/tests/unit/routes/concerts.route.test.ts
@@ -1,10 +1,13 @@
 /**
- * Route-wiring tests for /concerts (BS#1603).
+ * Route-wiring tests for /concerts (BS#1603, BS#1694).
  *
  * The @wxyc/authentication mock's `requirePermissions` returns 401 when the
- * Authorization header is missing, so these pin that the route group is
- * actually mounted behind the middleware (anonymous session auth — any
- * bearer token, no permission scope — matching the /proxy read surfaces).
+ * Authorization header is missing, so these pin the auth tier of each route:
+ * the list stays behind anonymous-session auth (any bearer token, no
+ * permission scope — matching the /proxy read surfaces), while the by-id
+ * read is deliberately PUBLIC (no auth middleware at all) so the
+ * `wxyc.org/shows/<id>` share Worker and the iOS universal-link fallback can
+ * call it without minting a session (BS#1694 / wxyc-shared#236).
  */
 import { jest } from '@jest/globals';
 import express from 'express';
@@ -12,10 +15,12 @@ import request from 'supertest';
 
 const mockGetConcertsPage = jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]);
 const mockGetConcertsCount = jest.fn<() => Promise<number>>().mockResolvedValue(0);
+const mockGetConcertById = jest.fn<() => Promise<unknown>>().mockResolvedValue(null);
 
 jest.mock('../../../apps/backend/services/concerts.service', () => ({
   getConcertsPage: mockGetConcertsPage,
   getConcertsCount: mockGetConcertsCount,
+  getConcertById: mockGetConcertById,
 }));
 
 import { concerts_route } from '../../../apps/backend/routes/concerts.route';
@@ -28,8 +33,10 @@ describe('concerts route', () => {
   beforeEach(() => {
     mockGetConcertsPage.mockClear();
     mockGetConcertsCount.mockClear();
+    mockGetConcertById.mockClear();
     mockGetConcertsPage.mockResolvedValue([]);
     mockGetConcertsCount.mockResolvedValue(0);
+    mockGetConcertById.mockResolvedValue(null);
   });
 
   it('GET /concerts requires an Authorization header', async () => {
@@ -45,5 +52,28 @@ describe('concerts route', () => {
       concerts: [],
       pagination: { page: 1, limit: 50, total: 0, hasMore: false },
     });
+  });
+
+  // BS#1694 — the whole point of the by-id route: a request WITHOUT any
+  // Authorization header reaches the controller. The share page (a Cloudflare
+  // Worker) and CDNs have no sane path to minting anonymous sessions.
+  it('GET /concerts/:id serves a request with NO Authorization header', async () => {
+    const concert = { id: 42 };
+    mockGetConcertById.mockResolvedValue(concert);
+
+    const response = await request(app).get('/concerts/42');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(concert);
+    expect(mockGetConcertById).toHaveBeenCalledWith(42);
+  });
+
+  it('GET /concerts/:id does not disturb the list route (list still 401s bare)', async () => {
+    mockGetConcertById.mockResolvedValue({ id: 7 });
+    await request(app).get('/concerts/7');
+
+    const bareList = await request(app).get('/concerts');
+    expect(bareList.status).toBe(401);
+    expect(mockGetConcertsPage).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/services/concerts.service.test.ts
+++ b/tests/unit/services/concerts.service.test.ts
@@ -312,6 +312,27 @@ describe('getConcertById', () => {
     await expect(getConcertById(999999)).resolves.toBeNull();
   });
 
+  // `concerts.id` is an int4 serial, so ids outside (0, 2^31-1] — and
+  // non-integers — can never match a row. The service owns that persistence
+  // fact and short-circuits to null BEFORE the query: the Postgres int4 bind
+  // would otherwise reject the value ("integer out of range") as an unhandled
+  // 500, and the service's `id: number` signature must stay total for
+  // non-route callers (the share-page BFF chain) that skip the controller's
+  // parse guard.
+  it.each([
+    ['int4 max + 1', 2_147_483_648],
+    ['far beyond int4', 99_999_999_999_999],
+    ['zero', 0],
+    ['negative', -7],
+    ['non-integer', 3.5],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['NaN', Number.NaN],
+  ])('short-circuits an impossible id (%s) to null without querying', async (_label, id) => {
+    await expect(getConcertById(id)).resolves.toBeNull();
+
+    expect(mockDb._chain.select).not.toHaveBeenCalled();
+  });
+
   it('selects the shared list projection — never the internal ingestion columns', async () => {
     mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([timedRow]));
 

--- a/tests/unit/services/concerts.service.test.ts
+++ b/tests/unit/services/concerts.service.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the concerts read service (BS#1603).
+ * Unit tests for the concerts read service (BS#1603, BS#1694).
  *
  * `@wxyc/database` resolves to tests/mocks/database.mock.ts, so these pin
  * the pieces that don't need PostgreSQL:
@@ -8,15 +8,20 @@
  *     key set: no internal ingestion columns.
  *   - The select projection never references the internal columns, so they
  *     can't reach the response regardless of the mapper.
+ *   - `getConcertById` — first-row → DTO via the same mapper as the list,
+ *     empty → null, and the shared leak-barrier projection.
  *
  * Windowing behavior (date-only rows, curated predicate, pagination against
- * real SQL) is covered by tests/integration/concerts.spec.js.
+ * real SQL) is covered by tests/integration/concerts.spec.js; the by-id
+ * read's WINDOWLESS semantics (past + tombstoned rows served) are covered by
+ * tests/integration/concerts-by-id.spec.js.
  */
 import { db } from '@wxyc/database';
 import {
   ConcertDTO,
   ConcertJoinRow,
   __resetUpcomingShowsMapsCacheForTests,
+  getConcertById,
   getConcertsCount,
   getConcertsPage,
   getUpcomingShowsMaps,
@@ -277,6 +282,49 @@ describe('getConcertsCount', () => {
   it('returns 0 when the aggregate row is missing', async () => {
     mockDb._chain.where.mockReturnValueOnce(Promise.resolve([]));
     await expect(getConcertsCount({ from: '2026-08-01', curated: true })).resolves.toBe(0);
+  });
+});
+
+/**
+ * BS#1694 — single-concert read behind the public `GET /concerts/:id`. The
+ * load-bearing property here is SHAPE PARITY with the list: the same
+ * projection and the same `toConcertDTO` mapper, asserted by comparing the
+ * result to `toConcertDTO(row)` rather than to hand-written literals. The
+ * windowless half of the contract (no `starts_on` bound, no `removed_at`
+ * filter) is real-SQL behavior, pinned in
+ * tests/integration/concerts-by-id.spec.js.
+ */
+describe('getConcertById', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('maps the found row through toConcertDTO — the exact list serialization', async () => {
+    // Terminal .limit(1) resolves the row set for this call.
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([timedRow]));
+
+    await expect(getConcertById(101)).resolves.toEqual(toConcertDTO(timedRow));
+  });
+
+  it('resolves null when no row matches the id', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([]));
+
+    await expect(getConcertById(999999)).resolves.toBeNull();
+  });
+
+  it('selects the shared list projection — never the internal ingestion columns', async () => {
+    mockDb._chain.limit.mockReturnValueOnce(Promise.resolve([timedRow]));
+
+    await getConcertById(101);
+
+    const projection = mockDb._chain.select.mock.calls[0][0] as Record<string, string>;
+    const selectedColumns = Object.values(projection);
+    for (const internal of INTERNAL_COLUMNS) {
+      expect(selectedColumns).not.toContain(internal);
+    }
+    // Parity pin: the by-id projection carries the BS#1624 genres join, so a
+    // by-id read can never lag the list's enrichment fields.
+    expect(Object.keys(projection)).toContain('genres');
   });
 });
 


### PR DESCRIPTION
## Problem

The On Tour sharing plan needs a single-concert read that a public web page can call: the `wxyc.org/shows/<id>` share page (Cloudflare Worker) renders OG tags from it, and the iOS app uses it as the universal-link fallback when a shared id isn't in the loaded window. Today `/concerts` is list-only, sits behind `requirePermissions({})` (anonymous-session JWT a Worker can't sanely mint), and windows to `starts_on >= today` with `removed_at IS NULL` — all three properties wrong for that consumer.

## Approach

Implements `GET /concerts/{id}` exactly per the contract merged in WXYC/wxyc-shared#237 (`api.yaml` v1.18.0, ticket WXYC/wxyc-shared#236):

- **Public**: the route registers the handler with **no** auth middleware. The router-wide `requirePermissions({})` moves to a per-route guard on the list (the `config.route.ts` public/authed split is the in-repo precedent), so the list's anonymous-session tier is byte-for-byte unchanged while the by-id read opts out entirely.
- **Windowless**: `getConcertById` is the one concerts query that does NOT go through `buildWhere` — no `starts_on` bound, no `removed_at` filter. Past and source-delisted (tombstoned) rows return with whatever `status` they last carried, so the share page can render "this one's passed"; 404 only for ids with no row.
- **Same shape as the list**: the query reuses `concertPageFields` (BS#1624 genres LEFT JOIN included) and `toConcertDTO`, so the by-id serialization structurally cannot drift from `GET /concerts`. The leak barrier holds — the shared explicit select list never projects `removed_at`, `source`, `source_id`, `raw_data`, or scrape timestamps, which matters more now that tombstoned rows are reachable.
- **Edge-cacheable, miss-safe**: `Cache-Control: public, max-age=300` on the 200 path (the playlist proxy's public-cache pattern at the spec's ~5-minute TTL); every handler error path is explicitly pinned `no-store`. Omission would not have kept misses out of shared caches — 404 is heuristically cacheable by default (RFC 9110 §15.5.5) and concert ids are predictable serials, so a header-less 404 could pin a freshly-shared id as dead at the edge.
- **Id validation**: the list's all-digits `parsePositiveInt` guard, which now also enforces the positivity its name promises — `/concerts/12abc`, `/concerts/0x10`, `/concerts/0` are 400s in the standard `{ message }` error shape, before any query. Ids that pass the guard but are impossible for the int4 serial (`/concerts/99999999999999`) short-circuit to null inside `concertsService.getConcertById` — the service owns the persistence fact, stays total for future non-route callers (the share-page BFF chain), and the controller 404s them like any other miss instead of letting the Postgres bind mint a 500.
- **App-wide errorHandler hardening** (surfaced by making this the app's first unauthenticated `:param` route): the Express router's percent-decode failure (`GET /concerts/%ZZ` — a share link truncated mid-escape) throws a `URIError` carrying `status: 400` but no `statusCode`, which the errorHandler rendered as a 500 and Sentry captured. `errorHandler` now answers TRUSTED integer-4xx errors with their status and message — trusted means `expose: true` (the http-errors convention body-parser follows) or the router's own percent-decode `URIError`. Untrusted 4xx shapes (upstream SDK errors like groq-sdk's `APIError`, whose `.status` mirrors the provider and whose message embeds the raw provider body) keep the generic 500 and stay Sentry-captured, byte-identical to main — so nothing about our provider/org/quota internals can leak through an echoed message. `shouldCaptureExpressError` shares the same classifier (plus the same non-Error-throwable normalization as the handler's wrap) so the response tier and the Sentry tier can never classify one error divergently. Heads-up for the BS#845 alarm owners: malformed-JSON / oversized-body mutations on `/flowsheet` now correctly answer their true 4xx (400/413) instead of 500, entering the `MutationClientError` counted band — previously those were near-invisible (500 to client, Sentry-suppressed, unmetered). The auth app's twin filter keeps its own deliberately broader policy; its "mirrors the backend" comments were rewritten to document the divergence.
- `app.yaml` gains the path for Swagger display parity (the SSOT stays `wxyc-shared/api.yaml`; no generated-type changes needed — the `Concert` schema itself is untouched).

No schema changes, no migrations; list endpoint semantics unchanged (its integration spec runs untouched-green).

## Tests

TDD throughout — all new tests written and observed failing before the implementation.

- **Route wiring** (`tests/unit/routes/concerts.route.test.ts`): by-id serves with NO Authorization header; the list still 401s bare — the auth restructure can't silently widen it.
- **Controller** (`tests/unit/controllers/concerts.controller.test.ts`): parsed id passthrough, null → 404 `WxycError`, parameterized non-integer/zero rejections without querying, the no-store default pinned first with the public directive as the final Cache-Control on 200s only, service-failure propagation.
- **Service** (`tests/unit/services/concerts.service.test.ts`): found row maps through `toConcertDTO` (the exact list serialization), empty → null, parameterized impossible-id short-circuits (0, negative, non-integer, > int4, Infinity, NaN → null without touching the db), projection excludes internal columns and carries `genres`.
- **Middleware** (`tests/unit/middleware/errorHandler.test.ts`, `sentryErrorFilter.test.ts`): carried-4xx echo for the router URIError shape and http-errors shape, string-encoded statuses, non-integer statuses ignored, foreign 5xx stays generic-500, and capture-suppression pinned to exactly the echoed 4xx band with shared alias precedence.
- **Integration** (`tests/integration/concerts-by-id.spec.js`, Postgres-backed): unauthenticated 200; deep-equality of the by-id body against the list endpoint's own serialization of the same row (fetched, not re-derived); long-past row served; tombstoned row served with its `status` intact while staying excluded from the list; internal-column leak barrier; 404 (derived MAX(id)+1 miss), out-of-int4-range 404, and 400 shapes all pinned `no-store`; the `%ZZ` router-decode 400; `Cache-Control: public, max-age=300` on the 200.

Local gates: `typecheck`, `lint` (0 errors), `format:check`, `build`, unit suite (4637 passed), full integration suite against the Docker CI sandbox (533 passed, 8 standard-mode skips; the single failure is the pre-existing order-dependent `requestLine.spec.js` flake, which passes solo against this branch's image).

## References

- Contract: WXYC/wxyc-shared#236, merged via WXYC/wxyc-shared#237
- Parent epic: #1588 (On Tour); consumers: WXYC/wxyc-ios-64#537, WXYC/wxyc-links-registry#1
- Permission-tier precedent discussion: #1682

Closes #1694

