### PR TITLE
fix(concerts): join artist_similar_artists on the public by-id read (BS#1694 hotfix)

### DIFF
--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -331,12 +331,20 @@ export const getConcertById = async (id: number): Promise<ConcertDTO | null> => 
     return null;
   }
 
+  // Join set MUST stay identical to `getConcertsPage`: both select
+  // `concertPageFields`, and Drizzle throws at runtime ("table … is not part
+  // of the query") if the projection references a table the query never
+  // joined. BS#1626 adding `similar_artists` to the shared projection while
+  // this query was in flight is exactly how the by-id read 500'd on every
+  // row-returning request (BS#1694 hotfix) — the by-id spec's
+  // serialization-parity test is the regression guard.
   const rows = await db
     .select(concertPageFields)
     .from(concerts)
     .innerJoin(venues, eq(venues.id, concerts.venue_id))
     .leftJoin(artists, eq(artists.id, concerts.headlining_artist_id))
     .leftJoin(artist_metadata, eq(artist_metadata.discogs_artist_id, effectiveHeadlinerDiscogsId))
+    .leftJoin(artist_similar_artists, eq(artist_similar_artists.artist_id, concerts.headlining_artist_id))
     .where(eq(concerts.id, id))
     .limit(1);
 


### PR DESCRIPTION
Production hotfix for the route shipped by #1695: every row-capable request to the public GET /concerts/:id has returned 500 since the merge deployed. Root cause is a semantic merge conflict, not the #1695 review commits: BS#1626 (12f3be8a) widened the shared concertPageFields projection with similar_artists (artist_similar_artists.neighbors) while the #1695 branch — tested green at its pre-#1626 base — was in flight. The merged tree pairs the widened projection with a by-id query that never joins artist_similar_artists, and Drizzle throws at runtime for exactly that ("table … is not part of the query"). Misses were unaffected (guard-path 404s never execute the projection), which is why the overflow probe 404'd cleanly while ids 1–3000 all 500'd.

Fix: mirror getConcertsPage's LEFT JOIN on artist_similar_artists (artist_id = headlining_artist_id) in getConcertById, with a comment pinning the invariant that the two queries' join sets must match the shared projection.

Verification: fresh containerized CI-mirror run (ci:env on a non-conflicting port + ci:test) — 58/58 suites, 543 passed / 8 standard-mode skips, including concerts-by-id.spec.js whose serialization-parity test is the regression guard for this exact failure. typecheck, lint, format:check, and unit (4678/4678) all green.

Refs #1694, #1695, and the BS#1626 projection commit 12f3be8a.