### PR TITLE
feat(flowsheet): project artist_id onto the V2 track wire shape (BS#1625)

### DIFF
--- a/apps/backend/app.yaml
+++ b/apps/backend/app.yaml
@@ -67,6 +67,7 @@ components:
       description: >
         Discriminated union keyed by entry_type.
         track entries include artist_name, album_title, track_title, record_label, rotation_bin, metadata fields.
+        track entries also carry artist_id — the resolved WXYC catalog artist id (flowsheet.album_id → library.artist_id), additive and nullable (null for free-form entries and library rows with no artist link). Shares the artists.id keyspace with concerts.headlining_artist_id / upcoming_show so on-device features (the On Tour likes match) can intersect a liked playcut against concert headliners (BS#1625). Canonical wire contract: FlowsheetV2TrackEntry.artist_id in wxyc-shared/api.yaml (the SSOT).
         track entries MAY also carry upcoming_show — an optional embedded Concert (see the Concert schema and GET /concerts) attached server-side at feed-assembly time when the track's resolved catalog artist (flowsheet.album_id → library.artist_id) has a curated, non-tombstoned, upcoming Triangle-area date (concerts.headlining_artist_id match; soonest date wins). Absent when there is no such match; older clients decode the absent field as "no touring CTA" (BS#1607). The canonical wire contract is FlowsheetV2TrackEntry.upcoming_show in wxyc-shared/api.yaml (the SSOT); this app.yaml is Swagger display only.
         show_start/show_end entries include dj_name and timestamp.
         dj_join/dj_leave entries include dj_name.

--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -74,9 +74,10 @@ export interface IFSEntry extends Omit<
   on_streaming: boolean | null;
   metadata: IFSEntryMetadata;
   // Resolved catalog artist for the played release (flowsheet.album_id ->
-  // library.artist_id). Not a wire field — the batch key `attachUpcomingShows`
-  // uses to look up the per-playcut `upcoming_show` (BS#1607). NULL for
-  // free-form entries and unresolved library rows.
+  // library.artist_id). The batch key `attachUpcomingShows` uses to look up the
+  // per-playcut `upcoming_show` (BS#1607), and since BS#1625 also projected
+  // onto the V2 track wire shape as `artist_id`. NULL for free-form entries and
+  // unresolved library rows.
   artist_id: number | null;
   // Per-playcut upcoming-show enrichment (BS#1607). Populated only on track
   // rows whose `artist_id` matched a curated, non-tombstoned, upcoming

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -204,9 +204,11 @@ const FSEntryFieldsRaw = {
   // library FK join already present on every read path below
   // (`leftJoin(library, library.id = flowsheet.album_id)`). NULL for
   // free-form entries (no album_id) and for library rows with no artist link.
-  // Not a client-facing wire field itself — it's the batch key the V2 feed
-  // uses to attach the per-playcut `upcoming_show` enrichment (BS#1607),
-  // matched against `concerts.headlining_artist_id` (same `artists.id` space).
+  // Two roles: (1) the batch key the V2 feed uses to attach the per-playcut
+  // `upcoming_show` enrichment (BS#1607), matched against
+  // `concerts.headlining_artist_id` (same `artists.id` space); and (2) since
+  // BS#1625, a client-facing wire field — `transformToV2` projects it onto
+  // the V2 track shape as `artist_id` for the iOS On Tour likes match.
   artist_id: library.artist_id,
   request_flag: flowsheet.request_flag,
   segue: flowsheet.segue,
@@ -1197,6 +1199,15 @@ export const transformToV2 = (entry: IFSEntry): Record<string, unknown> => {
         ...baseFields,
         album_id: entry.album_id,
         rotation_id: entry.rotation_id,
+        // Resolved catalog artist id (flowsheet.album_id -> library.artist_id),
+        // already computed on the read path (FSEntryFieldsRaw). Additive,
+        // nullable wire field (BS#1625): null for free-form entries (no
+        // album_id) and library rows with no artist link. Shares the artists.id
+        // keyspace with concerts.headlining_artist_id / upcoming_show, so the
+        // iOS On Tour likes match can intersect a liked playcut against
+        // concert headliners. SSOT: FlowsheetV2TrackEntry.artist_id (wxyc-shared
+        // api.yaml 1.19.0).
+        artist_id: entry.artist_id ?? null,
         artist_name: entry.artist_name,
         album_title: entry.album_title,
         track_title: entry.track_title,

--- a/tests/unit/services/flowsheet.service.test.ts
+++ b/tests/unit/services/flowsheet.service.test.ts
@@ -170,6 +170,33 @@ describe('flowsheet.service', () => {
         expect(result.label_id).toBe(42);
       });
 
+      it('projects the resolved catalog artist_id on a library-linked track (BS#1625)', () => {
+        const entry = createBaseEntry({
+          entry_type: 'track',
+          artist_name: 'Juana Molina',
+          album_title: 'Halo',
+          album_id: 1,
+          artist_id: 501,
+        });
+
+        const result = transformToV2(entry);
+
+        expect(result.artist_id).toBe(501);
+      });
+
+      it('projects artist_id as null for a free-text track with no album_id (BS#1625)', () => {
+        const entry = createBaseEntry({
+          entry_type: 'track',
+          artist_name: 'Some Unlinked Artist',
+          album_id: null,
+          artist_id: null,
+        });
+
+        const result = transformToV2(entry);
+
+        expect(result.artist_id).toBeNull();
+      });
+
       it.each([
         { value: true, description: 'true' },
         { value: false, description: 'false' },


### PR DESCRIPTION
## What

Projects the already-computed resolved catalog artist id onto the V2 flowsheet track wire shape as `artist_id`. One line in `transformToV2`'s track case (`artist_id: entry.artist_id ?? null`) — the value comes from `FSEntryFieldsRaw.artist_id` (`flowsheet.album_id → library.artist_id`), which the read path already selects to power `upcoming_show` (BS#1607). No new joins, no new query shape, no behavior change for existing consumers.

## Why

Unblocks the iOS On Tour on-device likes feature ([WXYC/wxyc-ios-64#492](https://github.com/WXYC/wxyc-ios-64/issues/492)): hearts on playcut rows need catalog artist ids so a liked artist can be matched against `concerts.headlining_artist_id` / `Concert.similar_artists` — the same `artists.id` keyspace.

## Scope

- `transformToV2` track case: emits `artist_id` (null for free-form rows with no `album_id` and library rows with no linked artist — the missed join already yields null).
- The two stale "not a wire field" comments on `IFSEntry.artist_id` and `FSEntryFieldsRaw.artist_id` are corrected — it now has both roles (batch key **and** wire field).
- `app.yaml` Swagger prose note (display-only; SSOT is wxyc-shared).
- Unit tests: linked track projects the id; free-text track projects null.

Does **not** touch the mutation/peek echoes (`projectFlowsheetEntry` → `FlowsheetEntryResponse`) — `artist_id` here is a `library`-join value, not a `flowsheet` column, so `CLIENT_FACING_FLOWSHEET_COLUMNS` correctly stays unchanged.

## Contract-first

SSOT is [WXYC/wxyc-shared#239](https://github.com/WXYC/wxyc-shared/pull/239) (`FlowsheetV2TrackEntry.artist_id`, api.yaml 1.19.0; issue [#238](https://github.com/WXYC/wxyc-shared/issues/238)). BS emits an untyped `Record<string, unknown>`, so there is no build-time coupling — but that PR should merge first to keep the SSOT ahead of the emitter.

## Governance

Frozen-surface pre-clearance approved in this issue ([Post-launch service hardening](https://github.com/orgs/WXYC/projects/32) exception). Structurally identical to the `upcoming_show` addition to the same surface (BS#1607). Parent epic: [#1588](https://github.com/WXYC/Backend-Service/issues/1588).

## Local checks

typecheck ✅ · lint (0 errors) ✅ · format ✅ · full unit suite (313 suites / 4680 tests) ✅ · wxyc-shared `oasdiff breaking`: no breaking changes ✅

Closes #1625
