### PR TITLE
feat(#1672): streaming-url-upgrade one-shot job

### DIFF
--- a/Dockerfile.streaming-url-upgrade
+++ b/Dockerfile.streaming-url-upgrade
@@ -1,0 +1,56 @@
+#Build stage
+FROM node:24-alpine AS builder
+
+ARG NPM_TOKEN
+WORKDIR /streaming-url-upgrade-builder
+
+COPY ./.npmrc ./
+COPY ./package.json ./package-lock.json ./
+COPY ./tsconfig.base.json ./
+COPY ./shared/database ./shared/database
+COPY ./shared/lml-client ./shared/lml-client
+COPY ./jobs/streaming-url-upgrade ./jobs/streaming-url-upgrade
+
+RUN npm ci && npm run build --workspace=@wxyc/database --workspace=@wxyc/lml-client --workspace=@wxyc/streaming-url-upgrade
+
+#Production stage
+FROM node:24-alpine AS prod
+
+ARG NPM_TOKEN
+WORKDIR /streaming-url-upgrade
+
+COPY ./.npmrc ./
+COPY ./package* ./
+COPY ./jobs/streaming-url-upgrade/package* ./jobs/streaming-url-upgrade/
+COPY ./shared/database/package* ./shared/database/
+COPY ./shared/lml-client/package* ./shared/lml-client/
+
+# `@wxyc/lml-client` declares `@wxyc/shared` as a registry dependency
+# (GitHub Packages, `@wxyc:registry` in `.npmrc`). Without NPM_TOKEN +
+# .npmrc the prod stage's npm install 401s on @wxyc/shared.
+RUN npm install --omit=dev && rm -f .npmrc
+
+COPY --from=builder ./streaming-url-upgrade-builder/jobs/streaming-url-upgrade/dist ./jobs/streaming-url-upgrade/dist
+COPY --from=builder ./streaming-url-upgrade-builder/shared/database/dist ./shared/database/dist
+COPY --from=builder ./streaming-url-upgrade-builder/shared/lml-client/dist ./shared/lml-client/dist
+
+# The candidate SELECTs walk `flowsheet` (2.6M rows) with no covering
+# index; the API's tight 5s default statement timeout is too aggressive
+# for the batch scans as the cursor advances.
+ENV DB_STATEMENT_TIMEOUT_MS=300000
+
+# Async commit: the LIKE search-shape guard makes any work lost to an RDS
+# crash naturally re-runnable (an unwritten row is still search-shaped and
+# re-selected), so the RPO trade-off is safe.
+ENV DB_SYNCHRONOUS_COMMIT=off
+
+# Identifies the connection in pg_stat_activity during triage.
+ENV DB_APPLICATION_NAME=wxyc-streaming-url-upgrade
+
+# ENTRYPOINT + empty CMD so docker-level args (`--execute`, `--dry-run`)
+# pass through to the job rather than replacing the launcher — the
+# Dockerfile.apple-music-url-backfill pattern. With `CMD ["npm", "start"]`,
+# `docker run <image> --execute` would REPLACE the CMD and npm would never
+# run.
+ENTRYPOINT ["node", "/streaming-url-upgrade/jobs/streaming-url-upgrade/dist/job.js"]
+CMD []

--- a/jobs/streaming-url-upgrade/README.md
+++ b/jobs/streaming-url-upgrade/README.md
@@ -1,0 +1,205 @@
+# streaming-url-upgrade
+
+One-shot remediation for BS#1672. Re-queries LML for every `album_metadata` / `flowsheet` row whose `spotify_url` or `bandcamp_url` was persisted as a provider **search** URL, then overwrites ONLY the still-search-shaped columns with the verified link LML now returns. **Dry-run is the default; writes require `--execute`.**
+
+## Problem
+
+When LML can't verify a direct provider link, the enrichment worker persists a **search** URL — the byte-identical output of `@wxyc/metadata`'s `synthesizeSearchUrls` — as a fallback:
+
+- Spotify: `https://open.spotify.com/search/<query>`
+- Bandcamp: `https://bandcamp.com/search?q=<query>`
+
+(Apple is never persisted as a search URL — BS#1192 synthesizes no Apple fallback — so it is out of scope here.)
+
+Once LML's streaming-availability drain lands a verified link for that release, BS never re-queries, so the search-URL placeholder becomes **permanent**. This job re-runs the same lookup and upgrades the placeholder to the verified link, one column at a time.
+
+**Candidate predicate** (identical in the job's phase-start COUNT, its batch SELECT, and the scope-confirm SQL below):
+
+```
+spotify_url LIKE 'https://open.spotify.com/search/%'  OR  bandcamp_url LIKE 'https://bandcamp.com/search?q=%'
+```
+
+A row is a candidate if **either** column is search-shaped. One LML lookup can upgrade **both** columns on that row via two independent guarded UPDATEs.
+
+```sql
+-- Confirm scope BEFORE running (org data-safety rule). Same predicates the job uses.
+SELECT COUNT(*) FROM wxyc_schema.album_metadata am
+LEFT JOIN wxyc_schema.library l ON l.id = am.album_id
+LEFT JOIN wxyc_schema.artists a ON l.artist_id = a.id
+WHERE (am.spotify_url LIKE 'https://open.spotify.com/search/%'
+       OR am.bandcamp_url LIKE 'https://bandcamp.com/search?q=%')
+  AND COALESCE(a.artist_name, l.artist_name) IS NOT NULL;
+
+SELECT COUNT(*) FROM wxyc_schema.flowsheet f
+WHERE f.entry_type = 'track'
+  AND (f.spotify_url LIKE 'https://open.spotify.com/search/%'
+       OR f.bandcamp_url LIKE 'https://bandcamp.com/search?q=%')
+  AND f.artist_name IS NOT NULL
+  AND f.add_time >= '2026-05-01';
+```
+
+Per candidate the job runs up to TWO LML lookups (artist + album + song, `extended: true`): the second fires only when the first returned no verified URL for **any** still-pending column, after `UPGRADE_SECOND_PASS_DELAY_MS`, to catch LML's eventual-consistency streaming fill. Repeat (artist, album, track) triples are served from an in-run cache.
+
+**Never-downgrade guard**: each UPDATE carries `<column> LIKE '<search-prefix>%'` in its WHERE. If a verified link appeared between SELECT and UPDATE, the UPDATE matches 0 rows (counted `skipped_not_search`) — a verified link is never overwritten, and a search URL is never written over a search URL (`extractStreamingUrls` coerces still-search-shaped LML output to null).
+
+## Scope
+
+- **album_metadata**: full table.
+- **flowsheet**: `entry_type = 'track'` since `2026-05-01` (`UPGRADE_FLOWSHEET_SINCE`). The 1.34M deep tail before that date is deferred.
+- **Services**: `spotify` + `bandcamp`. YouTube columns are schema-ready but **excluded** until LML#833 lands its YouTube drain. SoundCloud dropped (0 verified links in the corpus).
+
+## Gate — DO NOT `--execute` yet
+
+The write-run is gated on both provider drains completing in LML production:
+
+- **LML#831** — Spotify streaming-URL drain (OPEN)
+- **LML#832** — Bandcamp streaming-URL drain (OPEN)
+
+Until both drain, LML still returns the same search-shaped fallbacks and the re-query is a no-op that just re-confirms the placeholder. Build / typecheck / **dry-run** are fine now; `--execute` waits for the gate.
+
+## Pre-flight checklist
+
+1. **LML#831 + LML#832 drained to LML production.** A dry-run's `would_upgrade` count doubling as a live probe is the cheap way to confirm links are now verifiable before `--execute`.
+
+2. **Sibling cron is stopped.** All backfill/upgrade jobs share the `UPGRADE_LML_*` token bucket AND LML's global Discogs ceiling. Concurrent runs trip the BS#994 outage pattern.
+
+   ```bash
+   docker ps -a --filter name=flowsheet-metadata-backfill-cron --format '{{.Status}}'
+   # Must show: Exited (running is not)
+   ```
+
+3. **Run off-peak, outside the 06:00 UTC flood window** (coordinate with BS#1591). The cooperative pause defers batches while DJs are active, but scheduling around the flood is still on the operator.
+
+4. **Optional, recommended for the flowsheet phase: build the partial index out-of-band.** The flowsheet WHERE has no covering index; without one each batch SELECT degrades toward a heap scan as the cursor advances.
+
+   ```sql
+   CREATE INDEX CONCURRENTLY IF NOT EXISTS flowsheet_search_url_upgrade_idx
+     ON wxyc_schema.flowsheet (id)
+     WHERE entry_type = 'track'
+       AND artist_name IS NOT NULL
+       AND (spotify_url LIKE 'https://open.spotify.com/search/%'
+            OR bandcamp_url LIKE 'https://bandcamp.com/search?q=%');
+   ```
+
+   `CONCURRENTLY` takes only a `ShareUpdateExclusiveLock`, so DJs keep inserting while it builds. Drop it after the run (see Post-run). `album_metadata` needs no index.
+
+5. **Snapshot the verified rows** so the post-run never-downgrade spot-check is a mechanical diff:
+
+   ```sql
+   CREATE TABLE wxyc_schema.upgrade_prerun_fs AS
+     SELECT id, spotify_url, bandcamp_url FROM wxyc_schema.flowsheet
+     WHERE spotify_url IS NOT NULL OR bandcamp_url IS NOT NULL;
+   CREATE TABLE wxyc_schema.upgrade_prerun_am AS
+     SELECT album_id, spotify_url, bandcamp_url FROM wxyc_schema.album_metadata
+     WHERE spotify_url IS NOT NULL OR bandcamp_url IS NOT NULL;
+   ```
+
+## Run procedure
+
+```bash
+# 1. Build & push image (the Dockerfile.<target> filename IS the deploy registration).
+gh workflow run deploy-manual.yml --ref main \
+  -f target=streaming-url-upgrade -f version=latest
+
+# 2. SSH to EC2. Tee logs to a file BEFORE relying on `docker logs` —
+# `--rm` removes the container on exit and the structured summary line is
+# unrecoverable afterwards. `--name` is load-bearing for the kill-switch.
+ssh wxyc-ec2
+
+# 3. DRY-RUN FIRST (the default — no flag needed). Full paced LML sweep,
+# candidate + would_upgrade counts, ZERO writes.
+docker run --rm --name streaming-url-upgrade --env-file .env \
+  <ECR-URI>/streaming-url-upgrade:<tag> 2>&1 \
+  | tee /tmp/streaming-url-upgrade-dryrun-$(date +%Y%m%d-%H%M%S).log
+
+# 4. Review the dry-run summary (see Post-run jq), then — ONLY after the
+# LML#831/#832 gate — execute:
+docker run --rm --name streaming-url-upgrade --env-file .env \
+  <ECR-URI>/streaming-url-upgrade:<tag> --execute 2>&1 \
+  | tee /tmp/streaming-url-upgrade-$(date +%Y%m%d-%H%M%S).log
+```
+
+For a bounded pilot, add `-e UPGRADE_MAX_ROWS_PER_TABLE=50`.
+
+> **Env-var read timing**: `lml-fetch.ts` reads `UPGRADE_LML_PER_CALL_TIMEOUT_MS` and `lml-limiter.ts` reads `UPGRADE_LML_MAX_CONCURRENT` / `UPGRADE_LML_RATE_PER_MIN` at module load. Pass env vars via `--env-file`/`-e` so they're visible to PID 1; exporting inside the container after start is silently ignored.
+
+## Pacing & wall-clock estimate
+
+Serial rows behind Sem(1) + TB(20/min). A first-pass hit costs 1 token; an unresolved candidate costs 2 tokens + the 15 s second-pass delay, so throughput ranges ~7–20 candidates/min depending on hit rate. Size the run from the dry-run's candidate counts before `--execute`.
+
+## Kill-switch
+
+```bash
+# Up to 10 min grace so the in-flight row drains, the structured `stopped`
+# line (with resume cursors) is emitted, Sentry flushes, and the DB pool
+# closes. Docker's default 10 s grace would SIGKILL first.
+docker stop -t 600 streaming-url-upgrade
+```
+
+The SIGTERM handler flips a cooperative-stop flag checked between rows (and inside every sleep), so a single in-flight LML lookup is the longest wait. Repeated SIGTERM/SIGINT are idempotent; the escape hatch for a wedged LML call is `docker kill` (SIGKILL — skips the `finally` arm, so Sentry may lose the last seconds).
+
+## Resumability & idempotency
+
+- Upgraded columns drop out of the WHERE (no longer search-shaped), so plain re-runs are always safe and only re-visit still-search-shaped columns.
+- To skip already-swept rows after a `stopped`/`failed` run, pass the summary line's per-phase `last_id` cursors: `-e UPGRADE_ALBUM_AFTER_ID=<n> -e UPGRADE_FLOWSHEET_AFTER_ID=<n>`. A cursored resume also skips any rows counted `lml_error` below the cursor — those still match the predicate, so a final plain re-run WITHOUT cursors picks them back up.
+- Never-downgrade is enforced in the UPDATE's WHERE (`... AND <column> LIKE '<search-prefix>%'`), not just app logic — a verified URL that appears mid-run makes the UPDATE match 0 rows (counted `skipped_not_search`).
+
+## Post-run
+
+1. **Source the counts** from the `finished` / `stopped` / `failed` summary line (`-R` + `fromjson?` skips the non-JSON env-validation warns). Each phase carries per-service `spotify` / `bandcamp` sub-objects:
+
+   ```bash
+   cat /tmp/streaming-url-upgrade-*.log | \
+     jq -rR 'fromjson? | select(.step=="finished" or .step=="stopped" or .step=="failed") |
+       "step=\(.step) dry_run=\(.dry_run)\n" +
+       "am:  cand=\(.album_metadata.candidates) scanned=\(.album_metadata.scanned) lml_err=\(.album_metadata.lml_error) last_id=\(.album_metadata.last_id)\n" +
+       "  spotify:  upgraded=\(.album_metadata.spotify.upgraded) would=\(.album_metadata.spotify.would_upgrade) still_search=\(.album_metadata.spotify.still_search) skipped=\(.album_metadata.spotify.skipped_not_search) db_err=\(.album_metadata.spotify.db_error)\n" +
+       "  bandcamp: upgraded=\(.album_metadata.bandcamp.upgraded) would=\(.album_metadata.bandcamp.would_upgrade) still_search=\(.album_metadata.bandcamp.still_search) skipped=\(.album_metadata.bandcamp.skipped_not_search) db_err=\(.album_metadata.bandcamp.db_error)\n" +
+       "fs:  cand=\(.flowsheet.candidates) scanned=\(.flowsheet.scanned) lml_err=\(.flowsheet.lml_error) last_id=\(.flowsheet.last_id)\n" +
+       "  spotify:  upgraded=\(.flowsheet.spotify.upgraded) would=\(.flowsheet.spotify.would_upgrade) still_search=\(.flowsheet.spotify.still_search) skipped=\(.flowsheet.spotify.skipped_not_search) db_err=\(.flowsheet.spotify.db_error)\n" +
+       "  bandcamp: upgraded=\(.flowsheet.bandcamp.upgraded) would=\(.flowsheet.bandcamp.would_upgrade) still_search=\(.flowsheet.bandcamp.still_search) skipped=\(.flowsheet.bandcamp.skipped_not_search) db_err=\(.flowsheet.bandcamp.db_error)"'
+   ```
+
+   Document the totals as a comment on BS#1672.
+
+2. **Never-downgrade spot-check** (acceptance criterion): diff against the pre-run snapshot — a verified (non-search) URL must never have changed. Both counts must be 0, then drop the snapshot tables.
+
+   ```sql
+   SELECT COUNT(*) FROM wxyc_schema.upgrade_prerun_fs s
+   JOIN wxyc_schema.flowsheet f USING (id)
+   WHERE (s.spotify_url  NOT LIKE 'https://open.spotify.com/search/%' AND f.spotify_url  IS DISTINCT FROM s.spotify_url)
+      OR (s.bandcamp_url NOT LIKE 'https://bandcamp.com/search?q=%'  AND f.bandcamp_url IS DISTINCT FROM s.bandcamp_url);
+
+   SELECT COUNT(*) FROM wxyc_schema.upgrade_prerun_am s
+   JOIN wxyc_schema.album_metadata a USING (album_id)
+   WHERE (s.spotify_url  NOT LIKE 'https://open.spotify.com/search/%' AND a.spotify_url  IS DISTINCT FROM s.spotify_url)
+      OR (s.bandcamp_url NOT LIKE 'https://bandcamp.com/search?q=%'  AND a.bandcamp_url IS DISTINCT FROM s.bandcamp_url);
+
+   DROP TABLE wxyc_schema.upgrade_prerun_fs, wxyc_schema.upgrade_prerun_am;
+   ```
+
+3. **Drop the one-shot index**:
+
+   ```sql
+   DROP INDEX CONCURRENTLY IF EXISTS wxyc_schema.flowsheet_search_url_upgrade_idx;
+   ```
+
+## Environment variables
+
+| Variable                          | Default      | Notes                                                                     |
+| --------------------------------- | ------------ | ------------------------------------------------------------------------- |
+| `LIBRARY_METADATA_URL`            | (required)   | LML endpoint                                                              |
+| `UPGRADE_BATCH_SIZE`              | 100          | Rows per SELECT                                                           |
+| `UPGRADE_MAX_ROWS_PER_TABLE`      | 0            | 0 = unlimited; positive cap bounds a pilot run per phase                  |
+| `UPGRADE_SECOND_PASS_DELAY_MS`    | 15000        | Delay before the second lookup (eventual-consistency fill); 0 = immediate |
+| `UPGRADE_FLOWSHEET_SINCE`         | `2026-05-01` | `YYYY-MM-DD` floor on flowsheet `add_time`; the deep tail is deferred     |
+| `UPGRADE_ALBUM_AFTER_ID`          | 0            | Resume cursor for the album_metadata phase                                |
+| `UPGRADE_FLOWSHEET_AFTER_ID`      | 0            | Resume cursor for the flowsheet phase                                     |
+| `UPGRADE_LML_MAX_CONCURRENT`      | 1            | Semaphore permit count (shared knob across the backfill/upgrade family)   |
+| `UPGRADE_LML_RATE_PER_MIN`        | 20           | Token bucket rate                                                         |
+| `UPGRADE_LML_PER_CALL_TIMEOUT_MS` | 35000        | Per-LML-call timeout (ms)                                                 |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`  | 60           | Set 0 to disable the cooperative pause                                    |
+| `LIVE_ACTIVITY_PAUSE_MS`          | 30000        | Pause duration when DJ activity detected (ms)                             |
+| `SENTRY_DSN`                      | (optional)   | Sentry error reporting                                                    |
+
+CLI flags: `--execute` (write mode), `--dry-run` (explicit no-op, the default; passing both fails fast).

--- a/jobs/streaming-url-upgrade/env.ts
+++ b/jobs/streaming-url-upgrade/env.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared env-var parser for the streaming-url-upgrade job.
+ *
+ * `Number(raw)` (not `parseInt`) so partial-parse strings like "35000banana"
+ * surface as NaN and get rejected instead of silently coercing to 35000.
+ * `Number.isSafeInteger` guards against precision-lost large values
+ * (2^53+1 silently rounds to 2^53 and isInteger returns true).
+ *
+ * Invalid values fall back with a `console.warn` — the JSON logger isn't
+ * available at module-load time (which is when these readers fire). A
+ * future cleanup could route through the structured logger after init.
+ */
+export const envInt = (name: string, fallback: number, prefix = 'env'): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
+  console.warn(`${prefix}: ${name}=${raw} is invalid (must be positive safe integer); using fallback ${fallback}`);
+  return fallback;
+};

--- a/jobs/streaming-url-upgrade/job.ts
+++ b/jobs/streaming-url-upgrade/job.ts
@@ -1,0 +1,91 @@
+/**
+ * One-shot streaming-URL upgrade remediation (BS#1672).
+ *
+ * Backend-Service persisted LML's write-time streaming *search*-URL
+ * fallbacks (`@wxyc/metadata` `synthesizeSearchUrls`) verbatim into
+ * `spotify_url` / `bandcamp_url` and never re-queries, so a row that could
+ * now resolve to a verified album link stays a search URL forever. With the
+ * LML-side drains landed (LML#831 Spotify, LML#832 Bandcamp), a re-query
+ * resolves many of them. This job re-queries LML for every `album_metadata`
+ * / `flowsheet` row whose `spotify_url` OR `bandcamp_url` is search-shaped,
+ * and overwrites ONLY the still-search-shaped columns (never a verified
+ * link — the UPDATE's SQL LIKE guard enforces never-downgrade).
+ *
+ * DRY-RUN IS THE DEFAULT. The container performs the full paced LML
+ * sweep and reports candidates / would-upgrade counts with zero writes;
+ * pass `--execute` to write. Run via deploy-manual.yml
+ * (target=streaming-url-upgrade, version=latest), then SSH to EC2 and:
+ *
+ *   docker run --rm --name streaming-url-upgrade --env-file .env \
+ *     <ECR-URI>/streaming-url-upgrade:<tag>            # dry-run
+ *   docker run --rm --name streaming-url-upgrade --env-file .env \
+ *     <ECR-URI>/streaming-url-upgrade:<tag> --execute  # writes
+ *
+ * See jobs/streaming-url-upgrade/README.md for the full run procedure
+ * (off-peak window, sibling-cron pre-flight, `docker stop -t 600`,
+ * post-run audit).
+ *
+ * SIGTERM/SIGINT handling: the signal handler flips the orchestrator's
+ * cooperative-stop flag; the run finishes its in-flight row, emits a
+ * structured `stopped` log line with per-phase resume cursors, then falls
+ * through to the `finally` arm. `process.on` (not `process.once`) is
+ * deliberate — every SIGTERM/SIGINT just re-flips the already-true flag
+ * (idempotent). Force-exit is SIGKILL (`docker kill`).
+ */
+
+import { closeDatabaseConnection } from '@wxyc/database';
+import { requestStop, resolveDryRun, runUpgrade } from './orchestrate.js';
+import { lookupMetadata } from './lml-fetch.js';
+import { initLogger, log, captureError, closeLogger, errorMessage } from './logger.js';
+
+const JOB_NAME = 'streaming-url-upgrade';
+
+/**
+ * Fail-fast on missing LML configuration. Without this, every candidate's
+ * lookup would throw at the client's `baseUrl()` and the orchestrator
+ * would grind through the whole cohort emitting `lml_error` events.
+ */
+const requireLmlConfigured = (): void => {
+  if (!process.env.LIBRARY_METADATA_URL) {
+    throw new Error('LIBRARY_METADATA_URL is not configured; aborting before any rows are scanned.');
+  }
+};
+
+const registerSignalHandlers = (): void => {
+  const onSignal = (signal: NodeJS.Signals) => {
+    log('warn', 'signal', `received ${signal}; requesting graceful stop`, { signal });
+    requestStop();
+  };
+  process.on('SIGTERM', onSignal);
+  process.on('SIGINT', onSignal);
+};
+
+const main = async () => {
+  initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
+  registerSignalHandlers();
+  try {
+    const dryRun = resolveDryRun();
+    requireLmlConfigured();
+    log('info', 'init', `${JOB_NAME} initialized`, { dry_run: dryRun });
+    const result = await runUpgrade({
+      lookup: lookupMetadata,
+      dryRun,
+    });
+    // runUpgrade catches its own loop exceptions to preserve the summary
+    // log + span; propagate the failure through the exit code so a
+    // wrapping script's `$?` check doesn't believe a sustained-outage run
+    // succeeded.
+    if (result.failed) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    log('error', 'failed', `${JOB_NAME} failed`, { error_message: errorMessage(error) });
+    captureError(error, 'failed');
+    process.exitCode = 1;
+  } finally {
+    await closeDatabaseConnection();
+    await closeLogger();
+  }
+};
+
+void main();

--- a/jobs/streaming-url-upgrade/lml-fetch.ts
+++ b/jobs/streaming-url-upgrade/lml-fetch.ts
@@ -1,0 +1,29 @@
+/**
+ * Thin LML shim for streaming-url-upgrade (BS#1672).
+ *
+ * Shim over @wxyc/lml-client.lookupMetadata with `extended: true` — the
+ * job re-runs the same full `/api/v1/lookup` (artist + album + song,
+ * extended) path the enrichment worker used when it persisted the search
+ * URL, so the re-query has the same shot at a verified link. Response-level
+ * dedup lives in the orchestrator's URL cache (keyed on artist+album+track),
+ * not here.
+ *
+ * Timeout: UPGRADE_LML_PER_CALL_TIMEOUT_MS, default 35 s — clears LML#370's
+ * 25.25 s per-item cascade-exhaustion cap plus headroom, so a legitimately
+ * slow resolve is not cut off and miscounted as lml_error. Reads the env var
+ * at module load; see README note on env-var timing.
+ */
+
+import { lookupMetadata as sharedLookupMetadata, type LookupResponse } from '@wxyc/lml-client';
+import { envInt } from './env.js';
+import { defaultLmlLimiter } from './lml-limiter.js';
+
+const TIMEOUT_MS = envInt('UPGRADE_LML_PER_CALL_TIMEOUT_MS', 35_000, 'lml-fetch');
+
+export const lookupMetadata = async (artist: string, album?: string, track?: string): Promise<LookupResponse> =>
+  sharedLookupMetadata(artist, album, track, {
+    extended: true,
+    limiter: defaultLmlLimiter,
+    timeoutMs: TIMEOUT_MS,
+    caller: 'streaming-url-upgrade',
+  });

--- a/jobs/streaming-url-upgrade/lml-limiter.ts
+++ b/jobs/streaming-url-upgrade/lml-limiter.ts
@@ -1,0 +1,27 @@
+/**
+ * Concurrency + rate-limit gate for streaming-url-upgrade's LML calls.
+ *
+ * Mirrors jobs/apple-music-url-backfill/lml-limiter.ts: same Sem(1) +
+ * TB(20/min) envelope so a one-shot drain shares LML's 50/min Discogs budget
+ * gently with real-time traffic. The 2026-05-21 incident (BS#994)
+ * established that a serial loop alone is insufficient — the token bucket
+ * caps burst rate independent of orchestrator speed.
+ *
+ * Reads UPGRADE_LML_* env vars — a distinct knob from the BACKFILL_LML_*
+ * family so this job's rate can be tuned without touching the apple backfill.
+ * The LML/Discogs budget is still shared, so the pre-flight is the same:
+ * verify no sibling backfill/cron container is running before executing.
+ */
+
+import { type LmlLimiter, Semaphore, TokenBucket, createLmlLimiter as createSharedLmlLimiter } from '@wxyc/lml-client';
+import { envInt } from './env.js';
+
+export { type LmlLimiter, Semaphore, TokenBucket };
+
+export const createLmlLimiter = (config?: { maxConcurrent?: number; ratePerMinute?: number }): LmlLimiter =>
+  createSharedLmlLimiter({
+    maxConcurrent: config?.maxConcurrent ?? envInt('UPGRADE_LML_MAX_CONCURRENT', 1, 'lml-limiter'),
+    ratePerMinute: config?.ratePerMinute ?? envInt('UPGRADE_LML_RATE_PER_MIN', 20, 'lml-limiter'),
+  });
+
+export const defaultLmlLimiter: LmlLimiter = createLmlLimiter();

--- a/jobs/streaming-url-upgrade/logger.ts
+++ b/jobs/streaming-url-upgrade/logger.ts
@@ -1,0 +1,81 @@
+/**
+ * Observability for streaming-url-upgrade: Sentry init + JSON logs.
+ *
+ * Mirrors jobs/apple-music-url-backfill/logger.ts verbatim — the contract is
+ * identical, the duplication keeps the one-shot job's build graph
+ * independent of the sibling job packages.
+ */
+
+import * as Sentry from '@sentry/node';
+import { randomUUID } from 'crypto';
+
+export type LoggerConfig = {
+  repo: string;
+  tool: string;
+  runId?: string;
+};
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+type BaseTags = { repo: string; tool: string; run_id: string };
+
+let baseTags: BaseTags | null = null;
+
+export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
+  if (raw === undefined) return 0;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  return parsed;
+};
+
+export const initLogger = (config: LoggerConfig): string => {
+  const runId = config.runId ?? randomUUID();
+  baseTags = { repo: config.repo, tool: config.tool, run_id: runId };
+
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    release: process.env.SENTRY_RELEASE,
+    environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: resolveTracesSampleRate(),
+  });
+  Sentry.setTag('repo', config.repo);
+  Sentry.setTag('tool', config.tool);
+  Sentry.setTag('run_id', runId);
+
+  return runId;
+};
+
+export const log = (level: LogLevel, step: string, message: string, fields: Record<string, unknown> = {}): void => {
+  if (!baseTags) return;
+  const line =
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      step,
+      message,
+      ...baseTags,
+      ...fields,
+    }) + '\n';
+  if (level === 'error') {
+    process.stderr.write(line);
+  } else {
+    process.stdout.write(line);
+  }
+};
+
+export const captureError = (error: unknown, step: string, extra: Record<string, unknown> = {}): void => {
+  Sentry.captureException(error, { tags: { step }, extra });
+};
+
+/**
+ * Defend against non-Error throws (`throw 'string'`, `throw { code: x }`) —
+ * `(err as Error).message` would emit `undefined` and the JSON logger would
+ * drop the key. The canonical safe pattern from
+ * flowsheet-metadata-backfill/orchestrate.ts.
+ */
+export const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
+export const closeLogger = async (): Promise<void> => {
+  await Sentry.close(2000);
+  baseTags = null;
+};

--- a/jobs/streaming-url-upgrade/orchestrate.ts
+++ b/jobs/streaming-url-upgrade/orchestrate.ts
@@ -228,18 +228,30 @@ const normalize = (s: string | null | undefined): string => (s ?? '').trim().nor
 const cacheKey = (artist: string, album: string | null | undefined, track: string | null | undefined): string =>
   normalize(artist) + '\0' + normalize(album) + '\0' + normalize(track);
 
+/** Service → column name, derived from SERVICE_CONFIGS (no per-service branch). */
+const COLUMN_BY_SERVICE: Record<UpgradeService, 'spotify_url' | 'bandcamp_url'> = Object.fromEntries(
+  SERVICE_CONFIGS.map((cfg) => [cfg.service, cfg.column])
+) as Record<UpgradeService, 'spotify_url' | 'bandcamp_url'>;
+
 /** Current value of a service's column on the candidate row. */
-const rowColumnValue = (row: CandidateRow, service: UpgradeService): string | null =>
-  service === 'spotify' ? row.spotify_url : row.bandcamp_url;
+const rowColumnValue = (row: CandidateRow, service: UpgradeService): string | null => {
+  const value = (row as Record<string, unknown>)[COLUMN_BY_SERVICE[service]];
+  return typeof value === 'string' ? value : null;
+};
 
 /**
- * The search-shaped OR predicate, built from SERVICE_CONFIGS so the SQL LIKE
- * clauses can never drift from the write-side guard. `alias` is the table
- * alias (`am` / `f`).
+ * The search-shaped OR predicate, built by iterating SERVICE_CONFIGS so the
+ * SQL LIKE clauses can never drift from the write-side guard OR silently omit
+ * a newly-appended service. `alias` is the table alias (`am` / `f`).
  */
-const searchShapedOr = (alias: 'am' | 'f') =>
-  sql`(${sql.raw(`${alias}."spotify_url"`)} LIKE ${SERVICE_CONFIGS[0].searchPrefix + '%'}
-    OR ${sql.raw(`${alias}."bandcamp_url"`)} LIKE ${SERVICE_CONFIGS[1].searchPrefix + '%'})`;
+const searchShapedOr = (alias: 'am' | 'f') => {
+  const [first, ...rest] = SERVICE_CONFIGS;
+  let clause = sql`${sql.raw(`${alias}."${first.column}"`)} LIKE ${first.searchPrefix + '%'}`;
+  for (const cfg of rest) {
+    clause = sql`${clause} OR ${sql.raw(`${alias}."${cfg.column}"`)} LIKE ${cfg.searchPrefix + '%'}`;
+  }
+  return sql`(${clause})`;
+};
 
 /**
  * Shared WHERE fragments so the phase-start COUNT and the batch SELECT can

--- a/jobs/streaming-url-upgrade/orchestrate.ts
+++ b/jobs/streaming-url-upgrade/orchestrate.ts
@@ -1,0 +1,700 @@
+/**
+ * Two-phase orchestrator for the streaming-url-upgrade remediation
+ * (BS#1672).
+ *
+ * Phase A iterates `album_metadata`, phase B iterates `flowsheet` — album
+ * first so the flowsheet phase's LML re-queries land on an already-warm LML
+ * album cache. A candidate in either phase is a row whose `spotify_url` OR
+ * `bandcamp_url` currently holds a provider *search* URL (LIKE the exact
+ * `@wxyc/metadata` search prefix; see resolve.ts SERVICE_CONFIGS). This is a
+ * shape-driven cohort, not the absence-driven one the apple backfill used —
+ * no `IS NULL` / discogs signal.
+ *
+ * Per candidate: one LML lookup (cached), then up to a SECOND lookup that
+ * fires only when the first returned no verified URL for any still-pending
+ * column — it catches LML#706's eventually-consistent streaming
+ * post-process. A single lookup can upgrade BOTH columns on one row; each
+ * column is a separate guarded UPDATE (resolve.ts `applyUpgrade`) so a raced
+ * write to one never blocks the other.
+ *
+ * Dry-run (the job default; see `resolveDryRun`) performs the same paced
+ * lookups but NEVER calls the apply seam — candidate and would-upgrade
+ * counts come out of the summary log with zero writes.
+ *
+ * Never-downgrade: `extractStreamingUrls` drops a value that is empty, absent,
+ * or itself search-shaped (no search→search rewrite), and `applyUpgrade`'s
+ * `<column> LIKE '<search-prefix>%'` guard makes a row that got verified
+ * between SELECT and UPDATE a counted no-op (`skipped_not_search`).
+ *
+ * Dedup: an in-run URL cache keyed on normalized (artist, album, track),
+ * storing the per-service verified-URL set. The track component is
+ * load-bearing (LML links can be per-track). Album-phase keys use an empty
+ * track and never collide with flowsheet keys.
+ *
+ * Resumability: id-cursor iteration per phase; `UPGRADE_ALBUM_AFTER_ID` /
+ * `UPGRADE_FLOWSHEET_AFTER_ID` resume from the summary log's per-phase
+ * `last_id`. Re-runs are idempotent — upgraded rows stop being search-shaped
+ * and drop out of the WHERE, and the apply guard no-ops a racing fill.
+ *
+ * Cooperative pause, SIGTERM stop, and loadBatch retry mirror
+ * `jobs/apple-music-url-backfill/orchestrate.ts`.
+ */
+
+import * as Sentry from '@sentry/node';
+import { sql } from 'drizzle-orm';
+import {
+  db,
+  checkLiveActivity as defaultCheckLiveActivity,
+  LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT,
+  LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+  requireNonNegativeInt,
+  requirePositiveInt,
+  type CheckLiveActivityFn,
+} from '@wxyc/database';
+import type { LookupResponse } from '@wxyc/lml-client';
+import {
+  applyUpgrade,
+  extractStreamingUrls,
+  isSearchShaped,
+  SERVICE_CONFIGS,
+  type ApplyOutcome,
+  type ApplyTarget,
+  type UpgradeService,
+} from './resolve.js';
+import { captureError, errorMessage, log } from './logger.js';
+
+const JOB_NAME = 'streaming-url-upgrade';
+
+export const BATCH_SIZE = 100;
+
+/**
+ * Delay between the two passes. LML#706's background streaming post-process
+ * typically fills the album cache within seconds of the first lookup; 15 s
+ * clears it with headroom without doubling the per-candidate wall clock.
+ */
+export const SECOND_PASS_DELAY_MS = 15_000;
+
+/**
+ * Flowsheet is scoped by recency — the 1.34M deep tail is deferred (BS#1672).
+ * The default matches the AC1 audit window; override with
+ * UPGRADE_FLOWSHEET_SINCE (set an old date like '1900-01-01' for full scope).
+ */
+export const FLOWSHEET_SINCE_DEFAULT = '2026-05-01';
+
+const SCHEMA = (process.env.WXYC_SCHEMA_NAME || 'wxyc_schema').replace(/"/g, '""');
+const ALBUM_METADATA_TABLE = sql.raw(`"${SCHEMA}"."album_metadata"`);
+const FLOWSHEET_TABLE = sql.raw(`"${SCHEMA}"."flowsheet"`);
+const LIBRARY_TABLE = sql.raw(`"${SCHEMA}"."library"`);
+const ARTISTS_TABLE = sql.raw(`"${SCHEMA}"."artists"`);
+
+/**
+ * Retry budget for the per-batch SELECT — a transient RDS failover should
+ * not abort a multi-hour drain. Same shape as apple-music-url-backfill.
+ */
+const LOAD_BATCH_MAX_ATTEMPTS = 3;
+const LOAD_BATCH_BACKOFF_MS = [500, 2000];
+
+/**
+ * Dry-run is the DEFAULT: writes require the explicit `--execute` flag.
+ * `--dry-run` is accepted as an explicit no-op for self-documenting run
+ * commands; passing both is a fat-finger worth failing fast on.
+ */
+export const resolveDryRun = (argv: string[] = process.argv): boolean => {
+  const execute = argv.includes('--execute');
+  const dryRun = argv.includes('--dry-run');
+  if (execute && dryRun) {
+    throw new Error('Contradictory flags: pass either --execute or --dry-run (the default), not both.');
+  }
+  return !execute;
+};
+
+export const resolveBatchSize = (raw: string | undefined = process.env.UPGRADE_BATCH_SIZE): number =>
+  requirePositiveInt(raw, 'UPGRADE_BATCH_SIZE', BATCH_SIZE);
+
+export const resolveSecondPassDelayMs = (raw: string | undefined = process.env.UPGRADE_SECOND_PASS_DELAY_MS): number =>
+  requireNonNegativeInt(raw, 'UPGRADE_SECOND_PASS_DELAY_MS', SECOND_PASS_DELAY_MS, {
+    unit: 'ms',
+    note: 'Use 0 to fire the second pass immediately.',
+  });
+
+export const resolveMaxRowsPerTable = (raw: string | undefined = process.env.UPGRADE_MAX_ROWS_PER_TABLE): number =>
+  requireNonNegativeInt(raw, 'UPGRADE_MAX_ROWS_PER_TABLE', 0, {
+    note: 'Use 0 for unlimited; a positive cap bounds a sample/pilot run.',
+  });
+
+export const resolveAfterId = (envName: string, raw: string | undefined): number =>
+  requireNonNegativeInt(raw, envName, 0, {
+    note: 'Resume cursor — the summary log of the previous run carries the per-phase last_id.',
+  });
+
+/**
+ * Flowsheet recency cutoff (`add_time >= <since>`). Validated as YYYY-MM-DD;
+ * an unparseable value falls back to the default with a warn (the JSON logger
+ * isn't up at module-load time). Not injectable through requireNonNegativeInt
+ * since it's a date, not a count.
+ */
+export const resolveFlowsheetSince = (raw: string | undefined = process.env.UPGRADE_FLOWSHEET_SINCE): string => {
+  if (raw === undefined || raw === '') return FLOWSHEET_SINCE_DEFAULT;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    console.warn(
+      `orchestrate: UPGRADE_FLOWSHEET_SINCE=${raw} is not YYYY-MM-DD; using default ${FLOWSHEET_SINCE_DEFAULT}`
+    );
+    return FLOWSHEET_SINCE_DEFAULT;
+  }
+  return raw;
+};
+
+export const resolveLiveActivityLookback = (
+  raw: string | undefined = process.env.LIVE_ACTIVITY_LOOKBACK_SECONDS
+): number =>
+  requireNonNegativeInt(raw, 'LIVE_ACTIVITY_LOOKBACK_SECONDS', LIVE_ACTIVITY_LOOKBACK_SECONDS_DEFAULT, {
+    unit: 's',
+    note: 'Use 0 to disable the cooperative pause.',
+  });
+
+export const resolveLiveActivityPauseMs = (raw: string | undefined = process.env.LIVE_ACTIVITY_PAUSE_MS): number =>
+  requireNonNegativeInt(raw, 'LIVE_ACTIVITY_PAUSE_MS', LIVE_ACTIVITY_PAUSE_MS_DEFAULT, { unit: 'ms' });
+
+export type LookupFn = (artist: string, album?: string, track?: string) => Promise<LookupResponse>;
+export type ApplyFn = (target: ApplyTarget, id: number, service: UpgradeService, url: string) => Promise<ApplyOutcome>;
+
+type CandidateRow = {
+  id: number;
+  artist_name: string;
+  album_title: string | null;
+  track_title?: string | null;
+  spotify_url: string | null;
+  bandcamp_url: string | null;
+};
+
+/** Per-service tallies within a phase. */
+export type ServiceTotals = {
+  /** Rows where this column was search-shaped (i.e. a pending upgrade). */
+  candidates: number;
+  upgraded: number;
+  would_upgrade: number;
+  still_search: number;
+  skipped_not_search: number;
+  db_error: number;
+};
+
+export type PhaseTotals = {
+  /** Rows matching the OR predicate (search-shaped on at least one column). */
+  candidates: number;
+  scanned: number;
+  /** Row-level: the LML lookup for the row failed (no column processed). */
+  lml_error: number;
+  cache_hits: number;
+  second_pass_attempts: number;
+  second_pass_resolved: number;
+  last_id: number;
+  spotify: ServiceTotals;
+  bandcamp: ServiceTotals;
+};
+
+export type RunResult = {
+  album_metadata: PhaseTotals;
+  flowsheet: PhaseTotals;
+  dryRun: boolean;
+  stopped: boolean;
+  /** True iff loadBatch retry exhaustion (or an uncaught loop error) ended
+   * the run — job.ts maps this to process.exitCode=1. */
+  failed: boolean;
+};
+
+/** Cooperative cancellation flag for graceful shutdown on SIGTERM. */
+let stopRequested = false;
+export const requestStop = (): void => {
+  stopRequested = true;
+};
+/** Test-only seam to reset the singleton between tests. */
+export const __resetStopForTesting = (): void => {
+  stopRequested = false;
+};
+
+/** Stop-aware sleep: returns early if stopRequested flips during the wait. */
+const stopAwareSleep = async (ms: number): Promise<void> => {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (stopRequested) return;
+    const remaining = deadline - Date.now();
+    const tick = Math.min(500, remaining);
+    await new Promise<void>((resolve) => setTimeout(resolve, tick));
+  }
+};
+
+/** Normalized dedup key. Track is part of the key on purpose (per-track links). */
+const normalize = (s: string | null | undefined): string => (s ?? '').trim().normalize('NFKC').toLowerCase();
+const cacheKey = (artist: string, album: string | null | undefined, track: string | null | undefined): string =>
+  normalize(artist) + '\0' + normalize(album) + '\0' + normalize(track);
+
+/** Current value of a service's column on the candidate row. */
+const rowColumnValue = (row: CandidateRow, service: UpgradeService): string | null =>
+  service === 'spotify' ? row.spotify_url : row.bandcamp_url;
+
+/**
+ * The search-shaped OR predicate, built from SERVICE_CONFIGS so the SQL LIKE
+ * clauses can never drift from the write-side guard. `alias` is the table
+ * alias (`am` / `f`).
+ */
+const searchShapedOr = (alias: 'am' | 'f') =>
+  sql`(${sql.raw(`${alias}."spotify_url"`)} LIKE ${SERVICE_CONFIGS[0].searchPrefix + '%'}
+    OR ${sql.raw(`${alias}."bandcamp_url"`)} LIKE ${SERVICE_CONFIGS[1].searchPrefix + '%'})`;
+
+/**
+ * Shared WHERE fragments so the phase-start COUNT and the batch SELECT can
+ * never drift apart (the count IS the "SELECT with the same predicate first"
+ * the issue's data-safety constraint asks for).
+ */
+const albumWhere = (afterId: number) => sql`
+  WHERE ${searchShapedOr('am')}
+    AND COALESCE(a."artist_name", l."artist_name") IS NOT NULL
+    AND am."album_id" > ${afterId}
+`;
+
+const flowsheetWhere = (afterId: number, since: string) => sql`
+  WHERE f."entry_type" = 'track'
+    AND ${searchShapedOr('f')}
+    AND f."artist_name" IS NOT NULL
+    AND f."add_time" >= ${since}
+    AND f."id" > ${afterId}
+`;
+
+const albumFrom = sql`
+  FROM ${ALBUM_METADATA_TABLE} am
+  JOIN ${LIBRARY_TABLE} l ON l."id" = am."album_id"
+  LEFT JOIN ${ARTISTS_TABLE} a ON l."artist_id" = a."id"
+`;
+
+const flowsheetFrom = sql`
+  FROM ${FLOWSHEET_TABLE} f
+`;
+
+const countCandidates = async (target: ApplyTarget, afterId: number, since: string): Promise<number> => {
+  const query =
+    target === 'album_metadata'
+      ? sql`SELECT COUNT(*)::int AS count ${albumFrom} ${albumWhere(afterId)}`
+      : sql`SELECT COUNT(*)::int AS count ${flowsheetFrom} ${flowsheetWhere(afterId, since)}`;
+  const rows = (await db.execute(query)) as unknown as Array<{ count: number | string }>;
+  return Number(rows?.[0]?.count ?? 0);
+};
+
+const loadBatchOnce = async (
+  target: ApplyTarget,
+  afterId: number,
+  batchSize: number,
+  since: string
+): Promise<CandidateRow[]> => {
+  const query =
+    target === 'album_metadata'
+      ? sql`
+          SELECT
+            am."album_id" AS "id",
+            COALESCE(a."artist_name", l."artist_name") AS "artist_name",
+            l."album_title" AS "album_title",
+            am."spotify_url" AS "spotify_url",
+            am."bandcamp_url" AS "bandcamp_url"
+          ${albumFrom}
+          ${albumWhere(afterId)}
+          ORDER BY am."album_id" ASC
+          LIMIT ${batchSize}
+        `
+      : sql`
+          SELECT
+            f."id",
+            f."artist_name",
+            f."album_title",
+            f."track_title",
+            f."spotify_url",
+            f."bandcamp_url"
+          ${flowsheetFrom}
+          ${flowsheetWhere(afterId, since)}
+          ORDER BY f."id" ASC
+          LIMIT ${batchSize}
+        `;
+  const rows = (await db.execute(query)) as unknown as CandidateRow[];
+  return rows ?? [];
+};
+
+/**
+ * loadBatch with transient-error retry. Honors stopRequested so shutdown
+ * isn't blocked by retry backoffs; exhausting retries throws the most recent
+ * error (the caller distinguishes stop from failure via the flag).
+ */
+const loadBatch = async (
+  target: ApplyTarget,
+  afterId: number,
+  batchSize: number,
+  since: string
+): Promise<CandidateRow[]> => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < LOAD_BATCH_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await loadBatchOnce(target, afterId, batchSize, since);
+    } catch (error) {
+      lastError = error;
+      if (stopRequested || attempt + 1 >= LOAD_BATCH_MAX_ATTEMPTS) throw error;
+      const backoff = LOAD_BATCH_BACKOFF_MS[attempt] ?? LOAD_BATCH_BACKOFF_MS[LOAD_BATCH_BACKOFF_MS.length - 1];
+      log('warn', 'load_batch_retry', `loadBatch attempt ${attempt + 1} failed; retrying in ${backoff}ms`, {
+        target,
+        attempt: attempt + 1,
+        after_id: afterId,
+        backoff_ms: backoff,
+        error_message: errorMessage(error),
+      });
+      await stopAwareSleep(backoff);
+      if (stopRequested) throw error;
+    }
+  }
+  // Unreachable: the loop either returns or throws. Kept for TS narrowing.
+  throw lastError;
+};
+
+const emptyServiceTotals = (): ServiceTotals => ({
+  candidates: 0,
+  upgraded: 0,
+  would_upgrade: 0,
+  still_search: 0,
+  skipped_not_search: 0,
+  db_error: 0,
+});
+
+const emptyPhaseTotals = (): PhaseTotals => ({
+  candidates: 0,
+  scanned: 0,
+  lml_error: 0,
+  cache_hits: 0,
+  second_pass_attempts: 0,
+  second_pass_resolved: 0,
+  last_id: 0,
+  spotify: emptyServiceTotals(),
+  bandcamp: emptyServiceTotals(),
+});
+
+type StreamingUrlSet = Record<UpgradeService, string | null>;
+
+type PhaseDeps = {
+  lookup: LookupFn;
+  apply: ApplyFn;
+  dryRun: boolean;
+  secondPassDelayMs: number;
+  urlCache: Map<string, StreamingUrlSet>;
+};
+
+/**
+ * Drive a single candidate through (cached) lookup → two-pass resolution →
+ * per-service guarded apply. Catches lookup AND apply errors so one bad row
+ * (or one bad column) cannot abort the run. Mutates the phase totals
+ * directly (row-level counters + per-service tallies); the caller owns
+ * scanned/last_id.
+ */
+const processCandidate = async (
+  target: ApplyTarget,
+  row: CandidateRow,
+  totals: PhaseTotals,
+  deps: PhaseDeps
+): Promise<void> => {
+  const pending = SERVICE_CONFIGS.filter((cfg) => isSearchShaped(cfg.service, rowColumnValue(row, cfg.service)));
+  if (pending.length === 0) return; // predicate guarantees ≥1, but stay defensive
+  for (const cfg of pending) totals[cfg.service].candidates += 1;
+
+  const key = cacheKey(row.artist_name, row.album_title, row.track_title);
+
+  let urls: StreamingUrlSet;
+  const cached = deps.urlCache.get(key);
+  if (cached) {
+    totals.cache_hits += 1;
+    urls = cached;
+  } else {
+    const album = row.album_title ?? undefined;
+    const track = row.track_title ?? undefined;
+    try {
+      urls = extractStreamingUrls(await deps.lookup(row.artist_name, album, track));
+      // Second pass fires only when the first resolved nothing for any
+      // still-pending column — LML#706's fill lands shortly after.
+      if (pending.every((cfg) => urls[cfg.service] === null)) {
+        totals.second_pass_attempts += 1;
+        await stopAwareSleep(deps.secondPassDelayMs);
+        urls = extractStreamingUrls(await deps.lookup(row.artist_name, album, track));
+        if (pending.some((cfg) => urls[cfg.service] !== null)) totals.second_pass_resolved += 1;
+      }
+    } catch (error) {
+      log('warn', 'lml_error', `LML lookup failed for ${target} id=${row.id}`, {
+        target,
+        row_id: row.id,
+        error_message: errorMessage(error),
+      });
+      captureError(error, 'lml_error', {
+        target,
+        row_id: row.id,
+        artist: row.artist_name,
+        album: row.album_title ?? null,
+        track: row.track_title ?? null,
+      });
+      totals.lml_error += 1;
+      return;
+    }
+    deps.urlCache.set(key, urls);
+  }
+
+  for (const cfg of pending) {
+    const service = cfg.service;
+    const st = totals[service];
+    const verified = urls[service];
+    if (verified === null) {
+      st.still_search += 1;
+      continue;
+    }
+    if (deps.dryRun) {
+      st.would_upgrade += 1;
+      continue;
+    }
+    try {
+      const outcome = await deps.apply(target, row.id, service, verified);
+      if (outcome === 'upgraded') st.upgraded += 1;
+      else st.skipped_not_search += 1;
+    } catch (error) {
+      log('warn', 'db_error', `${target} ${service} UPDATE failed for id=${row.id}`, {
+        target,
+        service,
+        row_id: row.id,
+        error_message: errorMessage(error),
+      });
+      captureError(error, 'db_error', { target, service, row_id: row.id, url: verified });
+      st.db_error += 1;
+    }
+  }
+};
+
+export const runUpgrade = async (opts: {
+  lookup: LookupFn;
+  apply?: ApplyFn;
+  dryRun: boolean;
+  batchSize?: number;
+  maxRowsPerTable?: number;
+  secondPassDelayMs?: number;
+  albumAfterId?: number;
+  flowsheetAfterId?: number;
+  flowsheetSince?: string;
+  liveActivityLookbackSeconds?: number;
+  liveActivityPauseMs?: number;
+  checkLiveActivity?: CheckLiveActivityFn;
+}): Promise<RunResult> => {
+  const dryRun = opts.dryRun;
+  const batchSize = opts.batchSize ?? resolveBatchSize();
+  const maxRowsPerTable = opts.maxRowsPerTable ?? resolveMaxRowsPerTable();
+  const secondPassDelayMs = opts.secondPassDelayMs ?? resolveSecondPassDelayMs();
+  const albumAfterId =
+    opts.albumAfterId ?? resolveAfterId('UPGRADE_ALBUM_AFTER_ID', process.env.UPGRADE_ALBUM_AFTER_ID);
+  const flowsheetAfterId =
+    opts.flowsheetAfterId ?? resolveAfterId('UPGRADE_FLOWSHEET_AFTER_ID', process.env.UPGRADE_FLOWSHEET_AFTER_ID);
+  const flowsheetSince = opts.flowsheetSince ?? resolveFlowsheetSince();
+  const liveActivityLookbackSeconds = opts.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
+  const liveActivityPauseMs = opts.liveActivityPauseMs ?? resolveLiveActivityPauseMs();
+  const probe = opts.checkLiveActivity ?? defaultCheckLiveActivity;
+
+  const deps: PhaseDeps = {
+    lookup: opts.lookup,
+    apply: opts.apply ?? applyUpgrade,
+    dryRun,
+    secondPassDelayMs,
+    urlCache: new Map<string, StreamingUrlSet>(),
+  };
+
+  // On probe error: log + capture + assume no activity. A transient RDS
+  // error in the probe SELECT shouldn't abort the drain.
+  const safeProbe = async (): Promise<boolean> => {
+    try {
+      return await probe(liveActivityLookbackSeconds);
+    } catch (error) {
+      log('warn', 'probe_error', 'checkLiveActivity threw; assuming no activity', {
+        error_message: errorMessage(error),
+      });
+      captureError(error, 'probe_error');
+      return false;
+    }
+  };
+
+  // Returns true iff the run should stop (SIGTERM observed during the wait).
+  const waitForQuietPeriod = async (): Promise<boolean> => {
+    if (liveActivityLookbackSeconds <= 0) return false;
+    let active = await safeProbe();
+    while (active) {
+      if (stopRequested) return true;
+      log('info', 'live_activity_pause', `live flowsheet activity detected; pausing ${liveActivityPauseMs}ms`, {
+        lookback_seconds: liveActivityLookbackSeconds,
+        pause_ms: liveActivityPauseMs,
+      });
+      await stopAwareSleep(liveActivityPauseMs);
+      active = await safeProbe();
+    }
+    return stopRequested;
+  };
+
+  log('info', 'started', `${JOB_NAME} starting`, {
+    dry_run: dryRun,
+    batch_size: batchSize,
+    max_rows_per_table: maxRowsPerTable,
+    second_pass_delay_ms: secondPassDelayMs,
+    album_after_id: albumAfterId,
+    flowsheet_after_id: flowsheetAfterId,
+    flowsheet_since: flowsheetSince,
+    live_activity_lookback_seconds: liveActivityLookbackSeconds,
+    live_activity_pause_ms: liveActivityPauseMs,
+  });
+
+  const result: RunResult = {
+    album_metadata: emptyPhaseTotals(),
+    flowsheet: emptyPhaseTotals(),
+    dryRun,
+    stopped: false,
+    failed: false,
+  };
+  // Pre-seed the resume cursors so a run stopped before a phase starts still
+  // logs the operator's own cursor back out (not a misleading 0).
+  result.album_metadata.last_id = albumAfterId;
+  result.flowsheet.last_id = flowsheetAfterId;
+  let failure: { error: unknown } | null = null;
+
+  const runPhase = async (target: ApplyTarget, afterId: number): Promise<void> => {
+    const totals = result[target];
+    totals.last_id = afterId;
+
+    totals.candidates = await countCandidates(target, afterId, flowsheetSince);
+    log('info', 'phase_started', `${target} phase: ${totals.candidates} candidates`, {
+      target,
+      candidates: totals.candidates,
+      after_id: afterId,
+    });
+
+    let lastId = afterId;
+    let batchIndex = 0;
+    while (true) {
+      if (stopRequested || (await waitForQuietPeriod())) {
+        result.stopped = true;
+        return;
+      }
+      if (maxRowsPerTable > 0 && totals.scanned >= maxRowsPerTable) {
+        log('info', 'phase_capped', `${target} phase capped at ${maxRowsPerTable} rows`, {
+          target,
+          max_rows_per_table: maxRowsPerTable,
+          last_id: lastId,
+        });
+        return;
+      }
+
+      let rows: CandidateRow[];
+      try {
+        rows = await loadBatch(target, lastId, batchSize, flowsheetSince);
+      } catch (error) {
+        if (stopRequested) {
+          result.stopped = true;
+        } else {
+          failure = { error };
+        }
+        return;
+      }
+      if (rows.length === 0) return;
+
+      batchIndex += 1;
+      const batchStart = Date.now();
+      const before = JSON.parse(JSON.stringify(totals)) as PhaseTotals;
+
+      for (const row of rows) {
+        await processCandidate(target, row, totals, deps);
+        totals.scanned += 1;
+        lastId = row.id;
+        totals.last_id = row.id;
+        if (stopRequested) {
+          result.stopped = true;
+          break;
+        }
+        if (maxRowsPerTable > 0 && totals.scanned >= maxRowsPerTable) break;
+      }
+
+      log('info', 'batch_done', `${target} batch ${batchIndex} done`, {
+        target,
+        batch_index: batchIndex,
+        wall_clock_ms: Date.now() - batchStart,
+        last_id: lastId,
+        scanned: totals.scanned - before.scanned,
+        lml_error: totals.lml_error - before.lml_error,
+        cache_hits: totals.cache_hits - before.cache_hits,
+        spotify_upgraded: totals.spotify.upgraded - before.spotify.upgraded,
+        spotify_would_upgrade: totals.spotify.would_upgrade - before.spotify.would_upgrade,
+        spotify_still_search: totals.spotify.still_search - before.spotify.still_search,
+        bandcamp_upgraded: totals.bandcamp.upgraded - before.bandcamp.upgraded,
+        bandcamp_would_upgrade: totals.bandcamp.would_upgrade - before.bandcamp.would_upgrade,
+        bandcamp_still_search: totals.bandcamp.still_search - before.bandcamp.still_search,
+        total_scanned: totals.scanned,
+      });
+
+      if (result.stopped) return;
+    }
+  };
+
+  try {
+    await runPhase('album_metadata', albumAfterId);
+    if (!result.stopped && !failure) {
+      await runPhase('flowsheet', flowsheetAfterId);
+    }
+  } catch (error) {
+    // Defensive: processCandidate catches its own errors, so this arm only
+    // fires on a programming error. Preserve the summary either way.
+    failure = { error };
+  } finally {
+    result.failed = failure !== null;
+
+    // Summary span carrying numeric attributes (BS#1081 typing-trap
+    // workaround) — emitted even on stop/fail so partial-run telemetry is
+    // queryable in Sentry's trace explorer.
+    Sentry.startSpan(
+      {
+        name: 'streaming_url_upgrade.run.summary',
+        attributes: {
+          'upgrade.dry_run': dryRun,
+          'upgrade.album.candidates': result.album_metadata.candidates,
+          'upgrade.album.spotify_upgraded': result.album_metadata.spotify.upgraded,
+          'upgrade.album.spotify_would_upgrade': result.album_metadata.spotify.would_upgrade,
+          'upgrade.album.bandcamp_upgraded': result.album_metadata.bandcamp.upgraded,
+          'upgrade.album.bandcamp_would_upgrade': result.album_metadata.bandcamp.would_upgrade,
+          'upgrade.album.last_id': result.album_metadata.last_id,
+          'upgrade.flowsheet.candidates': result.flowsheet.candidates,
+          'upgrade.flowsheet.spotify_upgraded': result.flowsheet.spotify.upgraded,
+          'upgrade.flowsheet.spotify_would_upgrade': result.flowsheet.spotify.would_upgrade,
+          'upgrade.flowsheet.bandcamp_upgraded': result.flowsheet.bandcamp.upgraded,
+          'upgrade.flowsheet.bandcamp_would_upgrade': result.flowsheet.bandcamp.would_upgrade,
+          'upgrade.flowsheet.last_id': result.flowsheet.last_id,
+          'upgrade.stopped': result.stopped,
+          'upgrade.failed': result.failed,
+        },
+      },
+      () => {
+        /* attributes set at creation */
+      }
+    );
+
+    // Distinct steps so a runbook jq filter can differentiate:
+    //   'finished' — both phases drained (or capped) cleanly
+    //   'stopped'  — SIGTERM caused a clean early break (resume via last_id)
+    //   'failed'   — retry exhaustion / uncaught error; last_id still logged
+    const step = failure ? 'failed' : result.stopped ? 'stopped' : 'finished';
+    const level = failure ? 'error' : 'info';
+    log(level, step, `${JOB_NAME} ${step}`, {
+      dry_run: dryRun,
+      album_metadata: { ...result.album_metadata },
+      flowsheet: { ...result.flowsheet },
+      stopped: result.stopped,
+      failed: result.failed,
+      ...(failure ? { error_message: errorMessage(failure.error) } : {}),
+    });
+    if (failure) {
+      captureError(failure.error, 'failed', {
+        album_last_id: result.album_metadata.last_id,
+        flowsheet_last_id: result.flowsheet.last_id,
+      });
+    }
+  }
+
+  return result;
+};

--- a/jobs/streaming-url-upgrade/package.json
+++ b/jobs/streaming-url-upgrade/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@wxyc/streaming-url-upgrade",
+  "job-type": "one-shot",
+  "version": "1.0.0",
+  "description": "One-shot remediation: re-query LML for album_metadata + flowsheet rows whose spotify_url or bandcamp_url was persisted as a provider SEARCH URL, then overwrite ONLY the still-search-shaped columns with the verified link LML now returns. Never downgrades a verified link (SQL LIKE guard). Dry-run by default; pass --execute to write. Gated on LML#831 (Spotify drain) + LML#832 (Bandcamp drain). BS#1672.",
+  "type": "module",
+  "main": "./dist/job.js",
+  "scripts": {
+    "start": "node dist/job.js",
+    "build": "tsup --minify",
+    "clean": "rm -rf dist",
+    "docker:build": "docker build -t wxyc_streaming_url_upgrade:ci -f ../../Dockerfile.streaming-url-upgrade ../../",
+    "dev": "tsup --watch"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/node": "^10.66.0",
+    "@wxyc/database": "^1.0.0",
+    "@wxyc/lml-client": "^1.0.0"
+  },
+  "peerDependencies": {
+    "drizzle-orm": "^0.45.0"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/jobs/streaming-url-upgrade/resolve.ts
+++ b/jobs/streaming-url-upgrade/resolve.ts
@@ -41,8 +41,15 @@
  * YouTube Music (`youtube_music_url`) and SoundCloud (`soundcloud_url`) are
  * deliberately OUT of scope: the AC1 prod audit (2026-07-20) found zero
  * verified rows for either across 3.6M+ column-values, and only spotify +
- * bandcamp have a drain ticket. YouTube can be added here once LML#833 lands
- * (append a ServiceConfig); SoundCloud has no path to verified links.
+ * bandcamp have a drain ticket. YouTube can be added once LML#833 lands, but
+ * "append a ServiceConfig" is NOT the whole edit: extend `UpgradeService`,
+ * append to `SERVICE_CONFIGS` (both `isSearchShaped` and `extractStreamingUrls`
+ * derive from the list), and add the new column to orchestrate.ts's
+ * `CandidateRow` + both batch-SELECT column lists so its rows are fetched.
+ * The read/write column here is derived from `SERVICE_CONFIGS`, and the
+ * per-target guard-column maps below are `satisfies Record<UpgradeService, …>`
+ * so the compiler forces every new service to be wired in — no silent
+ * wrong-column write. SoundCloud has no path to verified links.
  */
 
 import { and, eq, like, sql } from 'drizzle-orm';
@@ -118,20 +125,31 @@ export const applyUpgrade = async (
   service: UpgradeService,
   url: string
 ): Promise<ApplyOutcome> => {
-  const pattern = CONFIG_BY_SERVICE[service].searchPrefix + '%';
+  const { column, searchPrefix } = CONFIG_BY_SERVICE[service];
+  const pattern = searchPrefix + '%';
+  // Column name is derived from SERVICE_CONFIGS so the write always targets
+  // the SAME column the guard checks — never a spotify-vs-else fall-through.
+  const set = { [column]: url } as Partial<Record<'spotify_url' | 'bandcamp_url', string>>;
 
   let updated: Array<{ id: number }>;
   if (target === 'album_metadata') {
-    const guardColumn = service === 'spotify' ? album_metadata.spotify_url : album_metadata.bandcamp_url;
-    const set = service === 'spotify' ? { spotify_url: url } : { bandcamp_url: url };
+    // `satisfies Record<UpgradeService, …>` makes the map exhaustive: a new
+    // service added to UpgradeService fails the build here until wired in.
+    const guardColumn = (
+      { spotify: album_metadata.spotify_url, bandcamp: album_metadata.bandcamp_url } satisfies Record<
+        UpgradeService,
+        unknown
+      >
+    )[service];
     updated = await db
       .update(album_metadata)
       .set({ ...set, updated_at: sql`NOW()` })
       .where(and(eq(album_metadata.album_id, id), like(guardColumn, pattern)))
       .returning({ id: album_metadata.album_id });
   } else {
-    const guardColumn = service === 'spotify' ? flowsheet.spotify_url : flowsheet.bandcamp_url;
-    const set = service === 'spotify' ? { spotify_url: url } : { bandcamp_url: url };
+    const guardColumn = (
+      { spotify: flowsheet.spotify_url, bandcamp: flowsheet.bandcamp_url } satisfies Record<UpgradeService, unknown>
+    )[service];
     updated = await db
       .update(flowsheet)
       .set(set)

--- a/jobs/streaming-url-upgrade/resolve.ts
+++ b/jobs/streaming-url-upgrade/resolve.ts
@@ -1,0 +1,143 @@
+/**
+ * Write-side of the streaming-url-upgrade remediation (BS#1672).
+ *
+ * Backend-Service persisted LML's write-time streaming fallbacks verbatim:
+ * when a lookup could not resolve a verified Spotify/Bandcamp link, LML
+ * synthesized a provider *search* URL (`@wxyc/metadata` `synthesizeSearchUrls`
+ * + `search-urls.provider.ts`) and BS stored it. Those rows never re-query,
+ * so a search URL that could now resolve to a verified album link stays a
+ * search URL forever. With the LML-side drains landed (LML#831 Spotify,
+ * LML#832 Bandcamp), a re-query resolves many of them; this module applies
+ * what the re-query returns.
+ *
+ * Three invariants, all load-bearing:
+ *
+ *   1. One column at a time: `applyUpgrade` sets exactly the one target
+ *      streaming column (plus the `updated_at` bump on album_metadata — the
+ *      writer convention from apps/enrichment-worker/enrich.ts; flowsheet's
+ *      BEFORE UPDATE trigger `bump_flowsheet_updated_at` owns its own stamp,
+ *      migration 0084). A single LML lookup can upgrade both spotify and
+ *      bandcamp on one row, but each is a separate guarded UPDATE so a raced
+ *      write to one column never blocks the other.
+ *
+ *   2. Never-downgrade, enforced in SQL: the WHERE carries
+ *      `<column> LIKE '<search-prefix>%'` — this job only ever overwrites a
+ *      *search-shaped* value. A verified link that appeared between the
+ *      orchestrator's SELECT and this UPDATE (enrichment worker, a parallel
+ *      run, manual fix) no longer matches the LIKE, so it is left untouched
+ *      and reported as 'skipped_not_search' rather than clobbered. This is
+ *      the shape-predicate analogue of the apple-music-url-backfill's
+ *      `IS NULL` guard (BS#1631).
+ *
+ *   3. No search→search: `extractStreamingUrls` returns a URL only when it
+ *      is present, non-empty, AND not itself search-shaped, so a lookup that
+ *      still falls back to a search URL is treated as "no upgrade" — the row
+ *      stays search-shaped and is retried on a later run instead of being
+ *      rewritten with an equivalent search URL.
+ *
+ * Errors propagate — the orchestrator's catch arm counts them as
+ * 'db_error' and continues.
+ *
+ * YouTube Music (`youtube_music_url`) and SoundCloud (`soundcloud_url`) are
+ * deliberately OUT of scope: the AC1 prod audit (2026-07-20) found zero
+ * verified rows for either across 3.6M+ column-values, and only spotify +
+ * bandcamp have a drain ticket. YouTube can be added here once LML#833 lands
+ * (append a ServiceConfig); SoundCloud has no path to verified links.
+ */
+
+import { and, eq, like, sql } from 'drizzle-orm';
+import { album_metadata, db, flowsheet } from '@wxyc/database';
+import type { LookupResponse } from '@wxyc/lml-client';
+
+export type ApplyTarget = 'album_metadata' | 'flowsheet';
+export type UpgradeService = 'spotify' | 'bandcamp';
+export type ApplyOutcome = 'upgraded' | 'skipped_not_search';
+
+export interface ServiceConfig {
+  service: UpgradeService;
+  /** The streaming column on both album_metadata and flowsheet. */
+  column: 'spotify_url' | 'bandcamp_url';
+  /**
+   * The exact search-URL prefix LML synthesizes for this service — byte-
+   * identical to `@wxyc/metadata` `synthesizeSearchUrls` /
+   * `search-urls.provider.ts`, confirmed against prod (BS#1672 AC1: exactly
+   * one prefix per service, no historical variants). A value starting with
+   * this prefix is upgradeable; anything else is a verified link (or a
+   * foreign-provider link — see BS#1710) and is left alone.
+   */
+  searchPrefix: string;
+}
+
+export const SERVICE_CONFIGS: readonly ServiceConfig[] = [
+  { service: 'spotify', column: 'spotify_url', searchPrefix: 'https://open.spotify.com/search/' },
+  { service: 'bandcamp', column: 'bandcamp_url', searchPrefix: 'https://bandcamp.com/search?q=' },
+] as const;
+
+const CONFIG_BY_SERVICE: Record<UpgradeService, ServiceConfig> = Object.fromEntries(
+  SERVICE_CONFIGS.map((c) => [c.service, c])
+) as Record<UpgradeService, ServiceConfig>;
+
+/**
+ * True iff `url` is the search-URL fallback for `service`. The candidate
+ * predicate (orchestrator) and this write guard both key on it, so a row's
+ * "is upgradeable" verdict can never drift between SELECT and UPDATE.
+ */
+export const isSearchShaped = (service: UpgradeService, url: string | null | undefined): boolean =>
+  !!url && url.startsWith(CONFIG_BY_SERVICE[service].searchPrefix);
+
+/**
+ * Read the verified streaming URL per in-scope service off the top-1 lookup
+ * result's artwork block.
+ *
+ * Top-1 only — mirroring what the enrichment worker persisted from the
+ * original lookup; a URL on a lower-ranked (different-release) result is not
+ * evidence about THIS row's release. A value that is empty, absent, or still
+ * search-shaped coerces to null so the job never writes a blank or another
+ * search URL into the column.
+ */
+export const extractStreamingUrls = (response: LookupResponse): Record<UpgradeService, string | null> => {
+  const artwork = response.results?.[0]?.artwork;
+  const out = {} as Record<UpgradeService, string | null>;
+  for (const cfg of SERVICE_CONFIGS) {
+    const value = artwork ? (artwork as Record<string, unknown>)[cfg.column] : null;
+    out[cfg.service] = typeof value === 'string' && value !== '' && !isSearchShaped(cfg.service, value) ? value : null;
+  }
+  return out;
+};
+
+/**
+ * Overwrite a single still-search-shaped streaming column with the verified
+ * `url`. `id` is `album_metadata.album_id` or `flowsheet.id` per `target`.
+ * Returns 'skipped_not_search' when the guarded UPDATE matches 0 rows (the
+ * column was verified — or otherwise stopped being search-shaped — since the
+ * orchestrator's SELECT).
+ */
+export const applyUpgrade = async (
+  target: ApplyTarget,
+  id: number,
+  service: UpgradeService,
+  url: string
+): Promise<ApplyOutcome> => {
+  const pattern = CONFIG_BY_SERVICE[service].searchPrefix + '%';
+
+  let updated: Array<{ id: number }>;
+  if (target === 'album_metadata') {
+    const guardColumn = service === 'spotify' ? album_metadata.spotify_url : album_metadata.bandcamp_url;
+    const set = service === 'spotify' ? { spotify_url: url } : { bandcamp_url: url };
+    updated = await db
+      .update(album_metadata)
+      .set({ ...set, updated_at: sql`NOW()` })
+      .where(and(eq(album_metadata.album_id, id), like(guardColumn, pattern)))
+      .returning({ id: album_metadata.album_id });
+  } else {
+    const guardColumn = service === 'spotify' ? flowsheet.spotify_url : flowsheet.bandcamp_url;
+    const set = service === 'spotify' ? { spotify_url: url } : { bandcamp_url: url };
+    updated = await db
+      .update(flowsheet)
+      .set(set)
+      .where(and(eq(flowsheet.id, id), like(guardColumn, pattern)))
+      .returning({ id: flowsheet.id });
+  }
+
+  return updated.length === 0 ? 'skipped_not_search' : 'upgraded';
+};

--- a/jobs/streaming-url-upgrade/tsconfig.json
+++ b/jobs/streaming-url-upgrade/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "references": [{ "path": "../../shared/database" }],
+  "include": ["."],
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/jobs/streaming-url-upgrade/tsup.config.ts
+++ b/jobs/streaming-url-upgrade/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig((options) => ({
+  entry: ['job.ts'],
+  format: ['esm'],
+  outDir: 'dist',
+  clean: true,
+  onSuccess: options.watch ? 'node ./dist/job.js' : undefined,
+  minify: !options.watch,
+
+  esbuildOptions(options) {
+    options.alias = {
+      '@': resolve(__dirname),
+    };
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1128,6 +1128,22 @@
       "name": "@wxyc/rotation-release-id-pollution-check",
       "version": "1.0.0"
     },
+    "jobs/streaming-url-upgrade": {
+      "name": "@wxyc/streaming-url-upgrade",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.66.0",
+        "@wxyc/database": "^1.0.0",
+        "@wxyc/lml-client": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "drizzle-orm": "^0.45.0"
+      }
+    },
     "jobs/triangle-shows-etl": {
       "name": "@wxyc/triangle-shows-etl",
       "version": "1.0.0",
@@ -6667,6 +6683,10 @@
         "better-auth": "^1.5.0",
         "typescript": "^5.0.0 || ^6.0.0"
       }
+    },
+    "node_modules/@wxyc/streaming-url-upgrade": {
+      "resolved": "jobs/streaming-url-upgrade",
+      "link": true
     },
     "node_modules/@wxyc/triangle-shows-etl": {
       "resolved": "jobs/triangle-shows-etl",

--- a/tests/__mocks__/drizzle-orm.ts
+++ b/tests/__mocks__/drizzle-orm.ts
@@ -23,3 +23,4 @@ export const gte = jest.fn((a, b) => ({ gte: [a, b] }));
 export const lte = jest.fn((a, b) => ({ lte: [a, b] }));
 export const exists = jest.fn((sub) => ({ exists: sub }));
 export const notExists = jest.fn((sub) => ({ notExists: sub }));
+export const like = jest.fn((col, pattern) => ({ like: [col, pattern] }));

--- a/tests/unit/jobs/streaming-url-upgrade/lml-fetch.test.ts
+++ b/tests/unit/jobs/streaming-url-upgrade/lml-fetch.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Payload pin for the streaming-url-upgrade LML shim (BS#1672).
+ *
+ * The job re-runs the same full `/api/v1/lookup` with artist + album + song
+ * and `extended: true` the enrichment worker walked when it persisted the
+ * search URL. This suite pins the shim's pass-through so a dropped `extended`
+ * flag (or a swallowed track title, which would change which per-track URL
+ * LML verifies) breaks CI instead of silently degrading the re-query. Mock
+ * pattern mirrors tests/unit/jobs/apple-music-url-backfill/lml-fetch.test.ts.
+ */
+
+const emptyResponse = {
+  results: [],
+  search_type: 'none',
+  song_not_found: true,
+};
+
+describe('jobs/streaming-url-upgrade/lml-fetch payload contract', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  const loadModule = async (
+    mockLookup: jest.Mock
+  ): Promise<typeof import('../../../../jobs/streaming-url-upgrade/lml-fetch.js')> => {
+    // Mock the local limiter module — we only care about the args passed to
+    // sharedLookupMetadata. Avoids stubbing all of @wxyc/lml-client's
+    // exports (Semaphore, TokenBucket, createLmlLimiter) that lml-limiter.ts
+    // pulls in at module load.
+    jest.doMock('../../../../jobs/streaming-url-upgrade/lml-limiter.js', () => ({
+      defaultLmlLimiter: { run: jest.fn() },
+    }));
+    jest.doMock('@wxyc/lml-client', () => ({
+      lookupMetadata: mockLookup,
+    }));
+    return import('../../../../jobs/streaming-url-upgrade/lml-fetch.js');
+  };
+
+  it('forwards artist + album + song positionally and sets extended: true (the issue contract)', async () => {
+    const mockLookup = jest.fn().mockResolvedValue(emptyResponse);
+
+    const { lookupMetadata } = await loadModule(mockLookup);
+    await lookupMetadata('Jessica Pratt', 'On Your Own Love Again', 'Back, Baby');
+
+    expect(mockLookup).toHaveBeenCalledWith(
+      'Jessica Pratt',
+      'On Your Own Love Again',
+      'Back, Baby',
+      expect.objectContaining({ extended: true, caller: 'streaming-url-upgrade' })
+    );
+  });
+
+  it('album-phase shape: album without track still carries extended: true', async () => {
+    const mockLookup = jest.fn().mockResolvedValue(emptyResponse);
+
+    const { lookupMetadata } = await loadModule(mockLookup);
+    await lookupMetadata('Juana Molina', 'DOGA');
+
+    expect(mockLookup).toHaveBeenCalledWith(
+      'Juana Molina',
+      'DOGA',
+      undefined,
+      expect.objectContaining({ extended: true })
+    );
+  });
+
+  it('passes the default 35_000ms per-call timeout when UPGRADE_LML_PER_CALL_TIMEOUT_MS is unset', async () => {
+    delete process.env.UPGRADE_LML_PER_CALL_TIMEOUT_MS;
+    const mockLookup = jest.fn().mockResolvedValue(emptyResponse);
+
+    const { lookupMetadata } = await loadModule(mockLookup);
+    await lookupMetadata('Stereolab', 'Aluminum Tunes');
+
+    expect(mockLookup).toHaveBeenCalledWith(
+      'Stereolab',
+      'Aluminum Tunes',
+      undefined,
+      expect.objectContaining({ timeoutMs: 35_000 })
+    );
+  });
+
+  it('routes through the job-owned limiter (shared UPGRADE_LML_* envelope)', async () => {
+    const mockLookup = jest.fn().mockResolvedValue(emptyResponse);
+
+    const { lookupMetadata } = await loadModule(mockLookup);
+    await lookupMetadata('Chuquimamani-Condori', 'Edits', 'Call Your Name');
+
+    const options = mockLookup.mock.calls[0]?.[3] as { limiter?: unknown };
+    expect(options.limiter).toBeDefined();
+  });
+});

--- a/tests/unit/jobs/streaming-url-upgrade/orchestrate.test.ts
+++ b/tests/unit/jobs/streaming-url-upgrade/orchestrate.test.ts
@@ -1,0 +1,653 @@
+/**
+ * Unit tests for streaming-url-upgrade orchestrate.ts (BS#1672).
+ *
+ * Pins the behaviors the remediation depends on:
+ *
+ *   1. Candidate selection predicates for both phases — a row is a candidate
+ *      iff spotify_url OR bandcamp_url is search-shaped (LIKE the provider
+ *      search prefix). No apple_music_url / discogs signal (this job is
+ *      shape-driven, not absence-driven).
+ *      - album_metadata: (spotify_url LIKE … OR bandcamp_url LIKE …) AND the
+ *        album_id cursor AND artist_name IS NOT NULL.
+ *      - flowsheet: entry_type='track' AND the same OR-pair AND artist_name
+ *        IS NOT NULL AND add_time >= cutoff AND the id cursor.
+ *   2. Dry-run (the default mode wired by job.ts) performs LML lookups but
+ *      ZERO writes; would_upgrade rows are counted per service.
+ *   3. Multi-column: ONE lookup can upgrade both spotify and bandcamp on a
+ *      single row via two independent guarded UPDATEs.
+ *   4. Never-downgrade: a row that stopped being search-shaped between SELECT
+ *      and UPDATE reports skipped_not_search (apply seam's LIKE guard), and
+ *      extractStreamingUrls never surfaces a search→search "upgrade".
+ *   5. Second-pass logic: a second LML lookup fires only when the first
+ *      returned no verified URL for any still-pending column (LML#706 fill).
+ *   6. Resumability: UPGRADE_*_AFTER_ID cursors narrow the SELECT; per-phase
+ *      last_id resume cursors ride out on the run result.
+ *   7. Error arms (lml_error row-level / db_error per-service) count and
+ *      continue; loadBatch retry exhaustion flags failed=true.
+ *   8. Cooperative pause and SIGTERM stop mirror the sibling backfills.
+ */
+import { jest } from '@jest/globals';
+
+import { db, checkLiveActivity as mockCheckLiveActivity } from '@wxyc/database';
+import type { LookupResponse } from '@wxyc/lml-client';
+import {
+  BATCH_SIZE,
+  FLOWSHEET_SINCE_DEFAULT,
+  SECOND_PASS_DELAY_MS,
+  requestStop,
+  resolveAfterId,
+  resolveBatchSize,
+  resolveDryRun,
+  resolveFlowsheetSince,
+  resolveMaxRowsPerTable,
+  resolveSecondPassDelayMs,
+  runUpgrade,
+  __resetStopForTesting,
+  type ApplyFn,
+  type LookupFn,
+} from '../../../../jobs/streaming-url-upgrade/orchestrate';
+
+type SqlLike = { sql?: string | string[]; values?: unknown[]; raw?: string };
+/**
+ * Render the tests/__mocks__/drizzle-orm.ts sql-tag shape ({ sql: strings,
+ * values }) to a flat string, recursing into nested fragments and sql.raw
+ * identifiers so predicate and cursor assertions can see the composed query.
+ */
+const renderSql = (value: unknown): string => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  const obj = value as SqlLike;
+  if (typeof obj.raw === 'string') return obj.raw;
+  if (Array.isArray(obj.sql)) {
+    const values = obj.values ?? [];
+    return obj.sql.map((chunk, i) => chunk + (i < values.length ? renderSql(values[i]) : '')).join('');
+  }
+  if (typeof obj.sql === 'string') return obj.sql;
+  return '';
+};
+
+const SPOTIFY_SEARCH = 'https://open.spotify.com/search/Juana%20Molina%20DOGA';
+const BANDCAMP_SEARCH = 'https://bandcamp.com/search?q=Juana%20Molina%20DOGA';
+const SPOTIFY_VERIFIED = 'https://open.spotify.com/album/5aBcDeFgHiJkLmNoPqRsT';
+const BANDCAMP_VERIFIED = 'https://juanamolina.bandcamp.com/album/doga';
+
+const lookupResult = (spotify: string | null, bandcamp: string | null): LookupResponse => ({
+  results: [
+    {
+      library_item: { id: 1 },
+      artwork: {
+        release_id: 100,
+        release_url: 'https://www.discogs.com/release/100',
+        spotify_url: spotify,
+        bandcamp_url: bandcamp,
+      },
+    },
+  ],
+  search_type: 'direct',
+});
+
+/** Both columns resolve to verified links. */
+const withBoth: LookupResponse = lookupResult(SPOTIFY_VERIFIED, BANDCAMP_VERIFIED);
+/** Neither column resolves (still search-shaped upstream → coerced null). */
+const withNeither: LookupResponse = lookupResult(null, null);
+/** Only spotify resolves. */
+const withSpotifyOnly: LookupResponse = lookupResult(SPOTIFY_VERIFIED, null);
+
+const albumRow = (
+  id: number,
+  overrides: { artist?: string; album?: string; spotify_url?: string | null; bandcamp_url?: string | null } = {}
+) => ({
+  id,
+  artist_name: overrides.artist ?? 'Juana Molina',
+  album_title: overrides.album ?? 'DOGA',
+  spotify_url: 'spotify_url' in overrides ? overrides.spotify_url : SPOTIFY_SEARCH,
+  bandcamp_url: 'bandcamp_url' in overrides ? overrides.bandcamp_url : BANDCAMP_SEARCH,
+});
+
+const flowsheetRow = (
+  id: number,
+  overrides: {
+    artist?: string;
+    album?: string;
+    track?: string;
+    spotify_url?: string | null;
+    bandcamp_url?: string | null;
+  } = {}
+) => ({
+  id,
+  artist_name: overrides.artist ?? 'Jessica Pratt',
+  album_title: overrides.album ?? 'On Your Own Love Again',
+  track_title: overrides.track ?? 'Back, Baby',
+  spotify_url: 'spotify_url' in overrides ? overrides.spotify_url : SPOTIFY_SEARCH,
+  bandcamp_url: 'bandcamp_url' in overrides ? overrides.bandcamp_url : BANDCAMP_SEARCH,
+});
+
+/**
+ * Queue db.execute results in call order: phase A count, phase A batches
+ * (until empty), phase B count, phase B batches (until empty).
+ */
+const queueExecute = (...results: unknown[]): void => {
+  const mock = db.execute as jest.Mock;
+  for (const result of results) {
+    mock.mockResolvedValueOnce(result as never);
+  }
+};
+
+/** Both phases empty — for tests that only exercise resolvers/edges. */
+const emptyRun = (): void => {
+  queueExecute([{ count: 0 }], [], [{ count: 0 }], []);
+};
+
+const baseOpts = (lookup: LookupFn, apply?: ApplyFn) => ({
+  lookup,
+  ...(apply ? { apply } : {}),
+  dryRun: false,
+  batchSize: 100,
+  secondPassDelayMs: 0,
+  liveActivityLookbackSeconds: 0,
+});
+
+describe('resolveDryRun', () => {
+  it('defaults to dry-run when no flag is passed', () => {
+    expect(resolveDryRun(['node', 'job.js'])).toBe(true);
+  });
+
+  it('explicit --dry-run stays dry-run', () => {
+    expect(resolveDryRun(['node', 'job.js', '--dry-run'])).toBe(true);
+  });
+
+  it('--execute switches writes on', () => {
+    expect(resolveDryRun(['node', 'job.js', '--execute'])).toBe(false);
+  });
+
+  it('throws on contradictory flags', () => {
+    expect(() => resolveDryRun(['node', 'job.js', '--execute', '--dry-run'])).toThrow(/contradictory/i);
+  });
+});
+
+describe('env resolvers', () => {
+  it('resolveBatchSize falls back to BATCH_SIZE and parses positive integers', () => {
+    expect(resolveBatchSize(undefined)).toBe(BATCH_SIZE);
+    expect(resolveBatchSize('200')).toBe(200);
+    expect(() => resolveBatchSize('0')).toThrow(/UPGRADE_BATCH_SIZE/);
+  });
+
+  it('resolveSecondPassDelayMs falls back to SECOND_PASS_DELAY_MS and accepts 0', () => {
+    expect(resolveSecondPassDelayMs(undefined)).toBe(SECOND_PASS_DELAY_MS);
+    expect(resolveSecondPassDelayMs('0')).toBe(0);
+    expect(resolveSecondPassDelayMs('5000')).toBe(5000);
+  });
+
+  it('resolveMaxRowsPerTable defaults to 0 (unlimited) and accepts positive caps', () => {
+    expect(resolveMaxRowsPerTable(undefined)).toBe(0);
+    expect(resolveMaxRowsPerTable('250')).toBe(250);
+  });
+
+  it('resolveAfterId defaults to 0 and rejects negatives', () => {
+    expect(resolveAfterId('UPGRADE_ALBUM_AFTER_ID', undefined)).toBe(0);
+    expect(resolveAfterId('UPGRADE_ALBUM_AFTER_ID', '150')).toBe(150);
+    expect(() => resolveAfterId('UPGRADE_ALBUM_AFTER_ID', '-1')).toThrow(/UPGRADE_ALBUM_AFTER_ID/);
+  });
+
+  it('resolveFlowsheetSince defaults and validates YYYY-MM-DD', () => {
+    expect(resolveFlowsheetSince(undefined)).toBe(FLOWSHEET_SINCE_DEFAULT);
+    expect(resolveFlowsheetSince('')).toBe(FLOWSHEET_SINCE_DEFAULT);
+    expect(resolveFlowsheetSince('2026-01-15')).toBe('2026-01-15');
+    expect(resolveFlowsheetSince('nonsense')).toBe(FLOWSHEET_SINCE_DEFAULT);
+  });
+});
+
+describe('runUpgrade — candidate selection predicates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetStopForTesting();
+  });
+
+  it('album_metadata SELECT: (spotify_url LIKE OR bandcamp_url LIKE) search prefixes, no apple signal', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    await runUpgrade(baseOpts(lookup, apply));
+
+    const batchSql = renderSql((db.execute as jest.Mock).mock.calls[1]?.[0]);
+    expect(batchSql).toMatch(/album_metadata/);
+    expect(batchSql).toMatch(/"spotify_url" LIKE/);
+    expect(batchSql).toMatch(/"bandcamp_url" LIKE/);
+    expect(batchSql).toMatch(/open\.spotify\.com\/search\//);
+    expect(batchSql).toMatch(/bandcamp\.com\/search\?q=/);
+    expect(batchSql).not.toMatch(/apple_music_url/);
+    expect(batchSql).toMatch(/ORDER BY/);
+  });
+
+  it('flowsheet SELECT: entry_type=track AND OR-pair AND artist_name IS NOT NULL AND add_time cutoff', async () => {
+    queueExecute([{ count: 0 }], [], [{ count: 1 }], [flowsheetRow(9)], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    await runUpgrade({ ...baseOpts(lookup, apply), flowsheetSince: '2026-05-01' });
+
+    const batchSql = renderSql((db.execute as jest.Mock).mock.calls[3]?.[0]);
+    expect(batchSql).toMatch(/flowsheet/);
+    expect(batchSql).toMatch(/entry_type.*track/s);
+    expect(batchSql).toMatch(/"spotify_url" LIKE/);
+    expect(batchSql).toMatch(/"bandcamp_url" LIKE/);
+    expect(batchSql.toLowerCase()).toMatch(/artist_name.*is not null/s);
+    expect(batchSql).toMatch(/add_time/);
+    expect(batchSql).toMatch(/2026-05-01/);
+  });
+
+  it('count queries share the batch predicates and populate per-phase candidate totals', async () => {
+    queueExecute([{ count: 7 }], [], [{ count: 3 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    const countASql = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]);
+    expect(countASql).toMatch(/COUNT/i);
+    expect(countASql).toMatch(/"spotify_url" LIKE/);
+    expect(result.album_metadata.candidates).toBe(7);
+    expect(result.flowsheet.candidates).toBe(3);
+  });
+
+  it('processes album_metadata fully before flowsheet', async () => {
+    queueExecute(
+      [{ count: 1 }],
+      [albumRow(5, { artist: 'Stereolab', album: 'Aluminum Tunes' })],
+      [],
+      [{ count: 1 }],
+      [flowsheetRow(9)],
+      []
+    );
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    await runUpgrade(baseOpts(lookup, apply));
+
+    expect(lookup.mock.calls[0]?.[0]).toBe('Stereolab');
+    expect(lookup.mock.calls[1]?.[0]).toBe('Jessica Pratt');
+    expect(apply.mock.calls[0]?.[0]).toBe('album_metadata');
+    expect(apply.mock.calls[apply.mock.calls.length - 1]?.[0]).toBe('flowsheet');
+  });
+
+  it('flowsheet lookups carry the row track_title', async () => {
+    queueExecute([{ count: 0 }], [], [{ count: 1 }], [flowsheetRow(9)], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    await runUpgrade(baseOpts(lookup, apply));
+
+    expect(lookup).toHaveBeenCalledWith('Jessica Pratt', 'On Your Own Love Again', 'Back, Baby');
+  });
+
+  it('ID cursor advances across batches and the loop terminates on an empty batch', async () => {
+    queueExecute([{ count: 3 }], [albumRow(10), albumRow(20)], [albumRow(30)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withNeither);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade({ ...baseOpts(lookup, apply), batchSize: 2 });
+
+    const secondBatchSql = renderSql((db.execute as jest.Mock).mock.calls[2]?.[0]);
+    expect(secondBatchSql).toMatch(/20/);
+    expect(result.album_metadata.scanned).toBe(3);
+    expect(result.album_metadata.last_id).toBe(30);
+  });
+});
+
+describe('runUpgrade — multi-column upgrade', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetStopForTesting();
+  });
+
+  it('one lookup upgrades BOTH spotify and bandcamp on a row (two guarded UPDATEs)', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledTimes(2);
+    expect(apply).toHaveBeenCalledWith('album_metadata', 5, 'spotify', SPOTIFY_VERIFIED);
+    expect(apply).toHaveBeenCalledWith('album_metadata', 5, 'bandcamp', BANDCAMP_VERIFIED);
+    expect(result.album_metadata.spotify.upgraded).toBe(1);
+    expect(result.album_metadata.bandcamp.upgraded).toBe(1);
+  });
+
+  it('only upgrades the columns that were search-shaped on the row', async () => {
+    // bandcamp already verified on the row → not a pending column; spotify search-shaped.
+    queueExecute([{ count: 1 }], [albumRow(5, { bandcamp_url: BANDCAMP_VERIFIED })], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledWith('album_metadata', 5, 'spotify', SPOTIFY_VERIFIED);
+    expect(result.album_metadata.spotify.candidates).toBe(1);
+    expect(result.album_metadata.bandcamp.candidates).toBe(0);
+    expect(result.album_metadata.spotify.upgraded).toBe(1);
+    expect(result.album_metadata.bandcamp.upgraded).toBe(0);
+  });
+
+  it('a lookup that resolves only spotify leaves bandcamp counted still_search', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withSpotifyOnly);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledWith('album_metadata', 5, 'spotify', SPOTIFY_VERIFIED);
+    expect(result.album_metadata.spotify.upgraded).toBe(1);
+    expect(result.album_metadata.bandcamp.still_search).toBe(1);
+  });
+});
+
+describe('runUpgrade — dry-run', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetStopForTesting();
+  });
+
+  it('performs lookups but ZERO writes: would_upgrade counted per service', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 1 }], [flowsheetRow(9)], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+
+    const result = await runUpgrade({
+      lookup,
+      dryRun: true,
+      batchSize: 100,
+      secondPassDelayMs: 0,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    expect(lookup).toHaveBeenCalledTimes(2);
+    expect(db.update as jest.Mock).not.toHaveBeenCalled();
+    expect(db.insert as jest.Mock).not.toHaveBeenCalled();
+    expect(result.album_metadata.spotify.would_upgrade).toBe(1);
+    expect(result.album_metadata.bandcamp.would_upgrade).toBe(1);
+    expect(result.flowsheet.spotify.would_upgrade).toBe(1);
+    expect(result.album_metadata.spotify.upgraded).toBe(0);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it('counts still_search rows in dry-run', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withNeither);
+
+    const result = await runUpgrade({
+      lookup,
+      dryRun: true,
+      batchSize: 100,
+      secondPassDelayMs: 0,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    expect(db.update as jest.Mock).not.toHaveBeenCalled();
+    expect(result.album_metadata.spotify.still_search).toBe(1);
+    expect(result.album_metadata.bandcamp.still_search).toBe(1);
+    expect(result.album_metadata.spotify.would_upgrade).toBe(0);
+  });
+});
+
+describe('runUpgrade — second-pass logic', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetStopForTesting();
+  });
+
+  it('skips the second lookup when the first returns a URL', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(result.album_metadata.second_pass_attempts).toBe(0);
+  });
+
+  it('fires a second lookup when the first returns nothing; second URL upgrades', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValueOnce(withNeither).mockResolvedValueOnce(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(lookup).toHaveBeenCalledTimes(2);
+    expect(result.album_metadata.second_pass_attempts).toBe(1);
+    expect(result.album_metadata.second_pass_resolved).toBe(1);
+    expect(result.album_metadata.spotify.upgraded).toBe(1);
+  });
+
+  it('counts still_search when both passes return no URL', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withNeither);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(lookup).toHaveBeenCalledTimes(2);
+    expect(result.album_metadata.spotify.still_search).toBe(1);
+    expect(apply).not.toHaveBeenCalled();
+  });
+});
+
+describe('runUpgrade — dedup cache (keyed on artist+album+track)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetStopForTesting();
+  });
+
+  it('re-uses a resolved URL set for repeat (artist, album, track) triples', async () => {
+    queueExecute([{ count: 0 }], [], [{ count: 2 }], [flowsheetRow(9), flowsheetRow(11)], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledTimes(4); // 2 rows × 2 columns
+    expect(result.flowsheet.cache_hits).toBe(1);
+    expect(result.flowsheet.spotify.upgraded).toBe(2);
+  });
+
+  it('does NOT share a URL across rows with different track titles', async () => {
+    queueExecute(
+      [{ count: 0 }],
+      [],
+      [{ count: 2 }],
+      [
+        flowsheetRow(9, { artist: 'Chuquimamani-Condori', album: 'Edits', track: 'Call Your Name' }),
+        flowsheetRow(11, { artist: 'Chuquimamani-Condori', album: 'Edits', track: 'Prayer' }),
+      ],
+      []
+    );
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(lookup).toHaveBeenCalledTimes(2);
+    expect(result.flowsheet.cache_hits).toBe(0);
+  });
+
+  it('caches a both-passes-null verdict so repeat triples skip LML entirely', async () => {
+    queueExecute([{ count: 0 }], [], [{ count: 2 }], [flowsheetRow(9), flowsheetRow(11)], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withNeither);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(lookup).toHaveBeenCalledTimes(2); // two passes for row 9 only
+    expect(result.flowsheet.cache_hits).toBe(1);
+    expect(result.flowsheet.spotify.still_search).toBe(2);
+  });
+});
+
+describe('runUpgrade — never-overwrite (raced verify)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetStopForTesting();
+  });
+
+  it('a row verified between SELECT and UPDATE reports skipped_not_search, not a write', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withSpotifyOnly);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('skipped_not_search');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(result.album_metadata.spotify.skipped_not_search).toBe(1);
+    expect(result.album_metadata.spotify.upgraded).toBe(0);
+  });
+});
+
+describe('runUpgrade — resumability', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetStopForTesting();
+  });
+
+  it('albumAfterId and flowsheetAfterId narrow the respective SELECTs', async () => {
+    queueExecute([{ count: 0 }], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    await runUpgrade({ ...baseOpts(lookup, apply), albumAfterId: 123, flowsheetAfterId: 456 });
+
+    const albumBatchSql = renderSql((db.execute as jest.Mock).mock.calls[1]?.[0]);
+    const flowsheetBatchSql = renderSql((db.execute as jest.Mock).mock.calls[3]?.[0]);
+    expect(albumBatchSql).toMatch(/123/);
+    expect(flowsheetBatchSql).toMatch(/456/);
+  });
+
+  it('maxRowsPerTable caps a phase but the next phase still runs', async () => {
+    queueExecute([{ count: 3 }], [albumRow(10), albumRow(20), albumRow(30)], [{ count: 1 }], [flowsheetRow(9)], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade({ ...baseOpts(lookup, apply), maxRowsPerTable: 2 });
+
+    expect(result.album_metadata.scanned).toBe(2);
+    expect(result.album_metadata.last_id).toBe(20);
+    expect(result.flowsheet.scanned).toBe(1);
+  });
+});
+
+describe('runUpgrade — error arms', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetStopForTesting();
+  });
+
+  it('lml_error: lookup throws → no apply, row-level counter increments, loop continues', async () => {
+    queueExecute(
+      [{ count: 2 }],
+      [albumRow(5), albumRow(6, { artist: 'Sessa', album: 'Pequena Vertigem de Amor' })],
+      [],
+      [{ count: 0 }],
+      []
+    );
+    const lookup = jest.fn<LookupFn>().mockRejectedValueOnce(new Error('LML timeout')).mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(result.album_metadata.lml_error).toBe(1);
+    expect(result.album_metadata.spotify.upgraded).toBe(1);
+    expect(result.album_metadata.scanned).toBe(2);
+  });
+
+  it('db_error: apply throws → per-service counter increments, loop continues', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    // spotify UPDATE throws, bandcamp UPDATE succeeds
+    const apply = jest
+      .fn<ApplyFn>()
+      .mockRejectedValueOnce(new Error('connection reset'))
+      .mockResolvedValueOnce('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(result.album_metadata.spotify.db_error).toBe(1);
+    expect(result.album_metadata.bandcamp.upgraded).toBe(1);
+    expect(result.album_metadata.scanned).toBe(1);
+  });
+
+  it('loadBatch retry exhaustion marks the run failed (exit-code path) without throwing', async () => {
+    const err = new Error('sustained outage');
+    (db.execute as jest.Mock).mockReset();
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ count: 1 }] as never);
+    (db.execute as jest.Mock).mockRejectedValue(err as never);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(result.failed).toBe(true);
+    expect(result.album_metadata.scanned).toBe(0);
+  }, 30_000);
+});
+
+describe('runUpgrade — cooperative pause', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetStopForTesting();
+  });
+
+  it('defers when live activity is detected, continues when quiet', async () => {
+    (mockCheckLiveActivity as jest.Mock).mockResolvedValueOnce(true as never).mockResolvedValue(false as never);
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade({
+      ...baseOpts(lookup, apply),
+      liveActivityLookbackSeconds: 60,
+      liveActivityPauseMs: 0,
+      checkLiveActivity: mockCheckLiveActivity,
+    });
+
+    expect((mockCheckLiveActivity as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(result.album_metadata.spotify.upgraded).toBe(1);
+  });
+
+  it('skips the probe when liveActivityLookbackSeconds=0', async () => {
+    emptyRun();
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    await runUpgrade({ ...baseOpts(lookup, apply), checkLiveActivity: mockCheckLiveActivity });
+
+    expect(mockCheckLiveActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe('runUpgrade — cooperative stop (SIGTERM)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetStopForTesting();
+  });
+  afterEach(() => {
+    __resetStopForTesting();
+  });
+
+  it('finishes the in-flight row then stops; result.stopped=true', async () => {
+    queueExecute([{ count: 2 }], [albumRow(5), albumRow(6)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockImplementation(() => {
+      requestStop();
+      return Promise.resolve(withBoth);
+    });
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(result.stopped).toBe(true);
+    expect(result.album_metadata.scanned).toBe(1);
+    expect(result.album_metadata.spotify.upgraded).toBe(1);
+  });
+});

--- a/tests/unit/jobs/streaming-url-upgrade/orchestrate.test.ts
+++ b/tests/unit/jobs/streaming-url-upgrade/orchestrate.test.ts
@@ -46,6 +46,7 @@ import {
   type ApplyFn,
   type LookupFn,
 } from '../../../../jobs/streaming-url-upgrade/orchestrate';
+import { SERVICE_CONFIGS } from '../../../../jobs/streaming-url-upgrade/resolve';
 
 type SqlLike = { sql?: string | string[]; values?: unknown[]; raw?: string };
 /**
@@ -218,6 +219,24 @@ describe('runUpgrade — candidate selection predicates', () => {
     expect(batchSql).toMatch(/bandcamp\.com\/search\?q=/);
     expect(batchSql).not.toMatch(/apple_music_url/);
     expect(batchSql).toMatch(/ORDER BY/);
+  });
+
+  it('candidate predicate emits one LIKE clause per SERVICE_CONFIGS entry (derived, not hardcoded)', async () => {
+    // Guards the refactor that builds searchShapedOr from SERVICE_CONFIGS: a
+    // service appended to the list must appear in the SELECT WHERE, so this
+    // asserts every configured column + search prefix is present rather than
+    // a fixed spotify/bandcamp pair.
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    await runUpgrade(baseOpts(lookup, apply));
+
+    const batchSql = renderSql((db.execute as jest.Mock).mock.calls[1]?.[0]);
+    for (const cfg of SERVICE_CONFIGS) {
+      expect(batchSql).toContain(`"${cfg.column}" LIKE`);
+      expect(batchSql).toContain(cfg.searchPrefix);
+    }
   });
 
   it('flowsheet SELECT: entry_type=track AND OR-pair AND artist_name IS NOT NULL AND add_time cutoff', async () => {

--- a/tests/unit/jobs/streaming-url-upgrade/resolve.test.ts
+++ b/tests/unit/jobs/streaming-url-upgrade/resolve.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for streaming-url-upgrade resolve.ts (BS#1672).
+ *
+ * Pins the write-side contract of the upgrade pass:
+ *
+ *   1. `isSearchShaped` recognizes ONLY a service's own search-URL prefix
+ *      — the shape predicate that decides which columns are upgradeable.
+ *   2. `extractStreamingUrls` reads ONLY the top-1 result's artwork block,
+ *      returns the verified URL per service, and coerces absent / null /
+ *      empty-string / (defensively) a still-search-shaped value to null so
+ *      the job never overwrites a search URL with another search URL.
+ *   3. `applyUpgrade` writes ONLY the one target column (plus the
+ *      `updated_at` bump on album_metadata; flowsheet's trigger owns its
+ *      own bump) — never any other metadata column.
+ *   4. Never-downgrade is enforced in the UPDATE's WHERE clause
+ *      (`... AND <column> LIKE '<search-prefix>%'`), not just application
+ *      logic: a row whose column was verified between the SELECT and this
+ *      UPDATE matches 0 rows and reports 'skipped_not_search'.
+ */
+import { jest } from '@jest/globals';
+
+import { db, album_metadata, flowsheet } from '@wxyc/database';
+import type { LookupResponse } from '@wxyc/lml-client';
+import { applyUpgrade, extractStreamingUrls, isSearchShaped } from '../../../../jobs/streaming-url-upgrade/resolve';
+
+const mockDb = db as unknown as {
+  update: jest.Mock;
+  insert: jest.Mock;
+  _chain: {
+    set: jest.Mock;
+    where: jest.Mock;
+    returning: jest.Mock;
+  };
+};
+
+const SPOTIFY_SEARCH = 'https://open.spotify.com/search/jessica%20pratt';
+const SPOTIFY_VERIFIED = 'https://open.spotify.com/album/6xB8dRegF2Cglc7lqZWmZ4';
+const BANDCAMP_SEARCH = 'https://bandcamp.com/search?q=jessica%20pratt';
+const BANDCAMP_VERIFIED = 'https://jessicapratt.bandcamp.com/album/on-your-own-love-again';
+
+const artworkWith = (overrides: Record<string, unknown>) => ({
+  release_id: 6543210,
+  release_url: 'https://www.discogs.com/release/6543210',
+  artwork_url: 'https://i.discogs.com/jessica-pratt.jpg',
+  release_year: 2015,
+  spotify_url: SPOTIFY_VERIFIED,
+  apple_music_url: null,
+  youtube_music_url: null,
+  bandcamp_url: BANDCAMP_VERIFIED,
+  soundcloud_url: null,
+  ...overrides,
+});
+
+const responseWith = (overrides: Record<string, unknown>): LookupResponse => ({
+  results: [{ library_item: { id: 1 }, artwork: artworkWith(overrides) }],
+  search_type: 'direct',
+  song_not_found: false,
+});
+
+describe('isSearchShaped', () => {
+  it('recognizes each service by its own search-URL prefix', () => {
+    expect(isSearchShaped('spotify', SPOTIFY_SEARCH)).toBe(true);
+    expect(isSearchShaped('bandcamp', BANDCAMP_SEARCH)).toBe(true);
+  });
+
+  it('is false for a verified (non-search) URL', () => {
+    expect(isSearchShaped('spotify', SPOTIFY_VERIFIED)).toBe(false);
+    expect(isSearchShaped('bandcamp', BANDCAMP_VERIFIED)).toBe(false);
+  });
+
+  it('is false for null / undefined / empty', () => {
+    expect(isSearchShaped('spotify', null)).toBe(false);
+    expect(isSearchShaped('spotify', undefined)).toBe(false);
+    expect(isSearchShaped('spotify', '')).toBe(false);
+  });
+
+  it('does not cross services: a spotify search URL is not bandcamp-search-shaped', () => {
+    expect(isSearchShaped('bandcamp', SPOTIFY_SEARCH)).toBe(false);
+    expect(isSearchShaped('spotify', BANDCAMP_SEARCH)).toBe(false);
+  });
+});
+
+describe('extractStreamingUrls', () => {
+  it('returns the top-1 verified URL per service', () => {
+    expect(extractStreamingUrls(responseWith({}))).toEqual({
+      spotify: SPOTIFY_VERIFIED,
+      bandcamp: BANDCAMP_VERIFIED,
+    });
+  });
+
+  it('returns nulls when results are empty', () => {
+    expect(
+      extractStreamingUrls({ results: [], search_type: 'none', song_not_found: true } as unknown as LookupResponse)
+    ).toEqual({ spotify: null, bandcamp: null });
+  });
+
+  it('returns nulls when the top-1 result has no artwork block', () => {
+    expect(
+      extractStreamingUrls({
+        results: [{ library_item: { id: 1 }, artwork: null }],
+        search_type: 'direct',
+      } as unknown as LookupResponse)
+    ).toEqual({ spotify: null, bandcamp: null });
+  });
+
+  it('nulls a service whose URL is null or absent', () => {
+    expect(extractStreamingUrls(responseWith({ spotify_url: null }))).toEqual({
+      spotify: null,
+      bandcamp: BANDCAMP_VERIFIED,
+    });
+  });
+
+  it('coerces an empty-string URL to null', () => {
+    expect(extractStreamingUrls(responseWith({ bandcamp_url: '' }))).toEqual({
+      spotify: SPOTIFY_VERIFIED,
+      bandcamp: null,
+    });
+  });
+
+  it('never returns a still-search-shaped URL (no search→search upgrade)', () => {
+    expect(extractStreamingUrls(responseWith({ spotify_url: SPOTIFY_SEARCH, bandcamp_url: BANDCAMP_SEARCH }))).toEqual({
+      spotify: null,
+      bandcamp: null,
+    });
+  });
+
+  it('ignores URLs on non-top-1 results', () => {
+    const secondHasUrl = {
+      results: [
+        { library_item: { id: 1 }, artwork: { release_id: 1, release_url: 'x' } },
+        { library_item: { id: 2 }, artwork: artworkWith({}) },
+      ],
+      search_type: 'direct',
+    } as unknown as LookupResponse;
+    expect(extractStreamingUrls(secondHasUrl)).toEqual({ spotify: null, bandcamp: null });
+  });
+});
+
+describe('applyUpgrade', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb._chain.returning.mockResolvedValue([{ id: 42 }]);
+  });
+
+  it('flowsheet spotify: sets ONLY spotify_url (trigger owns updated_at) and returns upgraded', async () => {
+    const outcome = await applyUpgrade('flowsheet', 42, 'spotify', SPOTIFY_VERIFIED);
+
+    expect(outcome).toBe('upgraded');
+    expect(mockDb.update).toHaveBeenCalledWith(flowsheet);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs).toEqual({ spotify_url: SPOTIFY_VERIFIED });
+  });
+
+  it('flowsheet bandcamp: sets ONLY bandcamp_url', async () => {
+    await applyUpgrade('flowsheet', 42, 'bandcamp', BANDCAMP_VERIFIED);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs).toEqual({ bandcamp_url: BANDCAMP_VERIFIED });
+  });
+
+  it('album_metadata spotify: sets spotify_url plus the updated_at bump and nothing else', async () => {
+    const outcome = await applyUpgrade('album_metadata', 7, 'spotify', SPOTIFY_VERIFIED);
+
+    expect(outcome).toBe('upgraded');
+    expect(mockDb.update).toHaveBeenCalledWith(album_metadata);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs.spotify_url).toBe(SPOTIFY_VERIFIED);
+    expect(Object.keys(setArgs).sort()).toEqual(['spotify_url', 'updated_at']);
+  });
+
+  it('album_metadata bandcamp: sets bandcamp_url plus updated_at', async () => {
+    await applyUpgrade('album_metadata', 7, 'bandcamp', BANDCAMP_VERIFIED);
+    const setArgs = mockDb._chain.set.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArgs.bandcamp_url).toBe(BANDCAMP_VERIFIED);
+    expect(Object.keys(setArgs).sort()).toEqual(['bandcamp_url', 'updated_at']);
+  });
+
+  it.each([
+    {
+      target: 'album_metadata' as const,
+      idColumn: 'album_id',
+      service: 'spotify' as const,
+      column: 'spotify_url',
+      prefix: 'https://open.spotify.com/search/%',
+    },
+    {
+      target: 'flowsheet' as const,
+      idColumn: 'id',
+      service: 'spotify' as const,
+      column: 'spotify_url',
+      prefix: 'https://open.spotify.com/search/%',
+    },
+    {
+      target: 'flowsheet' as const,
+      idColumn: 'id',
+      service: 'bandcamp' as const,
+      column: 'bandcamp_url',
+      prefix: 'https://bandcamp.com/search?q=%',
+    },
+  ])(
+    '$target $service: WHERE is id-equality AND <column> LIKE <search-prefix> (the never-downgrade guard lives in SQL)',
+    async ({ target, idColumn, service, column, prefix }) => {
+      await applyUpgrade(target, 42, service, 'https://verified.example/x');
+
+      const whereCall = mockDb._chain.where.mock.calls[0]?.[0];
+      expect(whereCall).toEqual({
+        and: [{ eq: [idColumn, 42] }, { like: [column, prefix] }],
+      });
+    }
+  );
+
+  it.each(['album_metadata', 'flowsheet'] as const)(
+    '%s: returns skipped_not_search when the UPDATE matches 0 rows (column was verified since the SELECT)',
+    async (target) => {
+      mockDb._chain.returning.mockResolvedValue([]);
+      const outcome = await applyUpgrade(target, 42, 'spotify', SPOTIFY_VERIFIED);
+      expect(outcome).toBe('skipped_not_search');
+    }
+  );
+
+  it('never touches any other table (no inserts, single update)', async () => {
+    await applyUpgrade('flowsheet', 42, 'spotify', SPOTIFY_VERIFIED);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/jobs/streaming-url-upgrade/runbook-log-contract.test.ts
+++ b/tests/unit/jobs/streaming-url-upgrade/runbook-log-contract.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Log-contract pin for streaming-url-upgrade (BS#1672).
+ *
+ * The README's post-run jq sources the run totals from the summary line's
+ * NESTED per-phase objects (`.album_metadata.candidates`,
+ * `.flowsheet.last_id`, the per-service `.album_metadata.spotify.upgraded`,
+ * ...) plus the top-level `dry_run`. Renaming any contracted field without
+ * updating the runbook would silently break the post-run procedure — this
+ * suite makes that a CI failure instead. Mirrors
+ * tests/unit/jobs/apple-music-url-backfill/runbook-log-contract.test.ts.
+ *
+ * Contracted shapes:
+ *   - `step: 'phase_started'` per phase: target (string), candidates
+ *     (number), after_id (number).
+ *   - `step: 'batch_done'` per batch: target, batch_index, wall_clock_ms,
+ *     last_id, per-batch deltas (scanned / lml_error / cache_hits /
+ *     {spotify,bandcamp}_{upgraded,would_upgrade,still_search}),
+ *     total_scanned.
+ *   - `step: 'finished' | 'stopped' | 'failed'` once: dry_run (boolean),
+ *     album_metadata + flowsheet (objects, each carrying numeric candidates /
+ *     scanned / lml_error / cache_hits / last_id and per-service spotify +
+ *     bandcamp objects), stopped + failed (booleans), error_message on
+ *     failed.
+ */
+import { jest } from '@jest/globals';
+
+import { db } from '@wxyc/database';
+import type { LookupResponse } from '@wxyc/lml-client';
+import {
+  requestStop,
+  runUpgrade,
+  __resetStopForTesting,
+  type ApplyFn,
+  type LookupFn,
+} from '../../../../jobs/streaming-url-upgrade/orchestrate';
+import { initLogger, closeLogger } from '../../../../jobs/streaming-url-upgrade/logger';
+
+type JsonLine = Record<string, unknown>;
+
+const captureJson = (stream: 'stdout' | 'stderr'): JsonLine[] => {
+  const lines: JsonLine[] = [];
+  jest.spyOn(process[stream], 'write').mockImplementation((chunk: unknown) => {
+    const text = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString();
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        lines.push(JSON.parse(line) as JsonLine);
+      } catch {
+        // ignore non-JSON
+      }
+    }
+    return true;
+  });
+  return lines;
+};
+
+const SPOTIFY_SEARCH = 'https://open.spotify.com/search/Stereolab';
+const BANDCAMP_SEARCH = 'https://bandcamp.com/search?q=Stereolab';
+const SPOTIFY_VERIFIED = 'https://open.spotify.com/album/5aBcDeFgHiJkLmNoPqRsT';
+const BANDCAMP_VERIFIED = 'https://stereolab.bandcamp.com/album/aluminum-tunes';
+
+const lookupResult = (spotify: string | null, bandcamp: string | null): LookupResponse => ({
+  results: [
+    {
+      library_item: { id: 1 },
+      artwork: { release_id: 1, release_url: 'u', spotify_url: spotify, bandcamp_url: bandcamp },
+    },
+  ],
+  search_type: 'direct',
+});
+const withBoth: LookupResponse = lookupResult(SPOTIFY_VERIFIED, BANDCAMP_VERIFIED);
+const withNeither: LookupResponse = lookupResult(null, null);
+
+const albumRow = (id: number, artist = 'Stereolab', album = 'Aluminum Tunes') => ({
+  id,
+  artist_name: artist,
+  album_title: album,
+  spotify_url: SPOTIFY_SEARCH,
+  bandcamp_url: BANDCAMP_SEARCH,
+});
+
+const flowsheetRow = (id: number) => ({
+  id,
+  artist_name: 'Jessica Pratt',
+  album_title: 'On Your Own Love Again',
+  track_title: 'Back, Baby',
+  spotify_url: SPOTIFY_SEARCH,
+  bandcamp_url: BANDCAMP_SEARCH,
+});
+
+const queueExecute = (...results: unknown[]): void => {
+  for (const result of results) {
+    (db.execute as jest.Mock).mockResolvedValueOnce(result as never);
+  }
+};
+
+const baseOpts = (lookup: LookupFn, apply: ApplyFn) => ({
+  lookup,
+  apply,
+  dryRun: false,
+  batchSize: 100,
+  secondPassDelayMs: 0,
+  liveActivityLookbackSeconds: 0,
+});
+
+const expectServiceTotalsShape = (svc: unknown): void => {
+  const st = svc as Record<string, unknown>;
+  expect(typeof st.candidates).toBe('number');
+  expect(typeof st.upgraded).toBe('number');
+  expect(typeof st.would_upgrade).toBe('number');
+  expect(typeof st.still_search).toBe('number');
+  expect(typeof st.skipped_not_search).toBe('number');
+  expect(typeof st.db_error).toBe('number');
+};
+
+/** The nested per-phase fields the README's jq interpolates. */
+const expectPhaseTotalsShape = (phase: unknown): void => {
+  const totals = phase as Record<string, unknown>;
+  expect(typeof totals.candidates).toBe('number');
+  expect(typeof totals.scanned).toBe('number');
+  expect(typeof totals.lml_error).toBe('number');
+  expect(typeof totals.cache_hits).toBe('number');
+  expect(typeof totals.last_id).toBe('number');
+  expectServiceTotalsShape(totals.spotify);
+  expectServiceTotalsShape(totals.bandcamp);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // mockReset wipes any unconsumed mockResolvedValueOnce queue from an
+  // earlier test (clearAllMocks only clears call history).
+  (db.execute as jest.Mock).mockReset();
+  __resetStopForTesting();
+  delete process.env.SENTRY_DSN;
+  initLogger({ repo: 'Backend-Service', tool: 'streaming-url-upgrade', runId: 'test-run' });
+});
+
+afterEach(async () => {
+  __resetStopForTesting();
+  jest.restoreAllMocks();
+  await closeLogger();
+});
+
+describe('runbook log contract — phase_started', () => {
+  it('emits one phase_started per phase, album_metadata first, with numeric candidates + after_id', async () => {
+    queueExecute([{ count: 2 }], [albumRow(5)], [], [{ count: 1 }], [flowsheetRow(9)], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const stdoutLines = captureJson('stdout');
+    await runUpgrade(baseOpts(lookup, apply));
+
+    const phaseStarted = stdoutLines.filter((l) => l.step === 'phase_started');
+    expect(phaseStarted.map((l) => l.target)).toEqual(['album_metadata', 'flowsheet']);
+    expect(phaseStarted[0].candidates).toBe(2);
+    expect(phaseStarted[1].candidates).toBe(1);
+    expect(typeof phaseStarted[0].after_id).toBe('number');
+  });
+});
+
+describe('runbook log contract — batch_done', () => {
+  it('emits one batch_done per batch with the contracted numeric fields and base tags', async () => {
+    queueExecute([{ count: 2 }], [albumRow(5), albumRow(6, 'Juana Molina', 'DOGA')], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const stdoutLines = captureJson('stdout');
+    await runUpgrade(baseOpts(lookup, apply));
+
+    const batchDone = stdoutLines.filter((l) => l.step === 'batch_done');
+    expect(batchDone.length).toBe(1);
+
+    const rec = batchDone[0];
+    expect(rec.target).toBe('album_metadata');
+    expect(typeof rec.batch_index).toBe('number');
+    expect(typeof rec.wall_clock_ms).toBe('number');
+    expect(typeof rec.last_id).toBe('number');
+    expect(typeof rec.total_scanned).toBe('number');
+    expect(rec.repo).toBe('Backend-Service');
+    expect(rec.tool).toBe('streaming-url-upgrade');
+    expect(rec.run_id).toBe('test-run');
+    expect(rec.scanned).toBe(2);
+    expect(rec.spotify_upgraded).toBe(2);
+    expect(rec.bandcamp_upgraded).toBe(2);
+    expect(typeof rec.lml_error).toBe('number');
+    expect(typeof rec.cache_hits).toBe('number');
+    expect(typeof rec.spotify_still_search).toBe('number');
+    expect(typeof rec.bandcamp_would_upgrade).toBe('number');
+  });
+});
+
+describe('runbook log contract — finished', () => {
+  it('carries dry_run plus the nested per-phase objects the README jq interpolates', async () => {
+    // Row 6 is a DIFFERENT album than row 5 — same-key rows would be served
+    // from the dedup cache and never reach the second-pass mocks below.
+    queueExecute(
+      [{ count: 2 }],
+      [albumRow(5), albumRow(6, 'Juana Molina', 'DOGA')],
+      [],
+      [{ count: 1 }],
+      [flowsheetRow(9)],
+      []
+    );
+    const lookup = jest
+      .fn<LookupFn>()
+      .mockResolvedValueOnce(withBoth)
+      .mockResolvedValueOnce(withNeither)
+      .mockResolvedValueOnce(withNeither)
+      .mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const stdoutLines = captureJson('stdout');
+    await runUpgrade(baseOpts(lookup, apply));
+
+    const finished = stdoutLines.find((l) => l.step === 'finished');
+    expect(finished).toBeDefined();
+    expect(finished?.dry_run).toBe(false);
+    expect(finished?.stopped).toBe(false);
+    expect(finished?.failed).toBe(false);
+
+    expectPhaseTotalsShape(finished?.album_metadata);
+    expectPhaseTotalsShape(finished?.flowsheet);
+
+    const am = finished?.album_metadata as Record<string, unknown>;
+    const fs = finished?.flowsheet as Record<string, unknown>;
+    // Row 5 upgraded on pass 1; row 6 null on both passes → still_search.
+    expect(am.candidates).toBe(2);
+    expect((am.spotify as Record<string, unknown>).upgraded).toBe(1);
+    expect((am.spotify as Record<string, unknown>).still_search).toBe(1);
+    expect(am.last_id).toBe(6);
+    // Flowsheet row 9 upgraded.
+    expect(fs.candidates).toBe(1);
+    expect((fs.spotify as Record<string, unknown>).upgraded).toBe(1);
+    expect(fs.last_id).toBe(9);
+  });
+
+  it('dry-run finished line reports dry_run=true and would_upgrade instead of upgraded', async () => {
+    queueExecute([{ count: 1 }], [albumRow(5)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+
+    const stdoutLines = captureJson('stdout');
+    await runUpgrade({ lookup, dryRun: true, batchSize: 100, secondPassDelayMs: 0, liveActivityLookbackSeconds: 0 });
+
+    const finished = stdoutLines.find((l) => l.step === 'finished');
+    expect(finished?.dry_run).toBe(true);
+    const am = finished?.album_metadata as Record<string, unknown>;
+    expect((am.spotify as Record<string, unknown>).would_upgrade).toBe(1);
+    expect((am.spotify as Record<string, unknown>).upgraded).toBe(0);
+  });
+});
+
+describe('runbook log contract — stopped step', () => {
+  it('emits step=stopped (not finished) on SIGTERM-induced early break, with resume cursors', async () => {
+    queueExecute([{ count: 2 }], [albumRow(5), albumRow(6)], [], [{ count: 0 }], []);
+    const lookup = jest.fn<LookupFn>().mockImplementation(() => {
+      requestStop(); // simulate SIGTERM while row 5 is in flight
+      return Promise.resolve(withBoth);
+    });
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const stdoutLines = captureJson('stdout');
+    const result = await runUpgrade(baseOpts(lookup, apply));
+
+    expect(stdoutLines.find((l) => l.step === 'finished')).toBeUndefined();
+    const stopped = stdoutLines.find((l) => l.step === 'stopped');
+    expect(stopped).toBeDefined();
+    expect(stopped?.stopped).toBe(true);
+    expect(stopped?.dry_run).toBe(false);
+    expectPhaseTotalsShape(stopped?.album_metadata);
+    expectPhaseTotalsShape(stopped?.flowsheet);
+    expect((stopped?.album_metadata as Record<string, unknown>).last_id).toBe(5);
+    expect(result.stopped).toBe(true);
+  });
+});
+
+describe('runbook log contract — failed step', () => {
+  it('emits step=failed with error_message and per-phase last_id when loadBatch exhausts retries', async () => {
+    const err = new Error('sustained outage');
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ count: 1 }] as never);
+    (db.execute as jest.Mock).mockRejectedValue(err as never);
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(withBoth);
+    const apply = jest.fn<ApplyFn>().mockResolvedValue('upgraded');
+
+    const stdoutLines = captureJson('stdout');
+    const stderrLines = captureJson('stderr');
+    await runUpgrade(baseOpts(lookup, apply));
+
+    const failed = [...stdoutLines, ...stderrLines].find((l) => l.step === 'failed');
+    expect(failed).toBeDefined();
+    expect(failed?.failed).toBe(true);
+    expect(failed?.error_message).toMatch(/sustained outage/);
+    expectPhaseTotalsShape(failed?.album_metadata);
+    expectPhaseTotalsShape(failed?.flowsheet);
+  }, 30_000);
+});


### PR DESCRIPTION
Closes #1672.

## What

One-shot remediation job (`jobs/streaming-url-upgrade/`, `job-type: one-shot`) that re-queries LML for `album_metadata` + `flowsheet` rows whose `spotify_url` or `bandcamp_url` was persisted as a provider **search** URL, then overwrites ONLY the still-search-shaped columns with the verified link LML now returns. **Dry-run is the default; `--execute` writes.**

## Why

When LML can't verify a direct provider link, the enrichment worker persists a search URL — the byte-identical output of `@wxyc/metadata`'s `synthesizeSearchUrls` (`https://open.spotify.com/search/…`, `https://bandcamp.com/search?q=…`). Once LML's streaming drain lands a verified link, BS never re-queries, so the placeholder is permanent. This job upgrades those placeholders. (Apple is out of scope — BS#1192 synthesizes no Apple fallback.)

## Design

- **Shape-driven candidate predicate**: a row is a candidate when *either* column is search-shaped (`<column> LIKE '<search-prefix>%'`). One LML lookup can upgrade *both* columns via two independent guarded UPDATEs.
- **Never-downgrade guard in SQL**: each UPDATE carries `<column> LIKE '<search-prefix>%'` in its WHERE. A verified link that appears mid-run makes the UPDATE match zero rows (counted `skipped_not_search`); `extractStreamingUrls` coerces still-search-shaped LML output to null, so a search URL is never written over a search URL either.
- Forked from `jobs/apple-music-url-backfill` (BS#1631): preserves two-phase resume cursors, second-pass eventual-consistency fill, cooperative DJ-activity pause, cooperative SIGTERM stop, in-run dedup cache, and the structured runbook log contract — now **per-service** (`spotify` / `bandcamp` sub-objects on each phase).

## Scope

- `album_metadata`: full table.
- `flowsheet`: `entry_type = 'track'` since `2026-05-01` (`UPGRADE_FLOWSHEET_SINCE`); the 1.34M deep tail is deferred.
- Services `spotify` + `bandcamp`. YouTube columns are schema-ready but **excluded** until LML#833; SoundCloud dropped (0 verified links in the corpus).

## Deploy registration

The `Dockerfile.streaming-url-upgrade` filename *is* the registration — `deploy-base` validates `jobs/<target>` exists and builds `Dockerfile.<target>`. No workflow enumeration edit needed.

## Gate — execute-run NOT lifted by this PR

The write-run stays gated on **LML#831** (Spotify drain) + **LML#832** (Bandcamp drain), both OPEN. Until both land, LML still returns the same search-shaped fallbacks and the re-query is a no-op. This PR ships build + typecheck + dry-run capability only.

## Tests

- 66 job unit tests across 4 suites (orchestrate, resolve, lml-fetch payload contract, runbook-log contract): shape predicates, multi-column upgrade, the never-downgrade guard, dry-run, second-pass, dedup cache, resume cursors, per-service error arms, cooperative pause/stop.
- Job typecheck clean (`jobs/streaming-url-upgrade/tsconfig.json`, EXIT 0).
- TDD: failing tests preceded implementation per repo mandate.