### PR TITLE
fix(lml-client): host-guard mislabeled streaming URLs at the LML ingestion boundary (BS#1710)

### DIFF
--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -41,6 +41,15 @@ export type {
   StreamingCheckSources,
 } from '@wxyc/shared/dtos';
 
+// BS#1710: streaming-URL host guard. Enforces "a `spotify_url` field must
+// hold a Spotify URL" (and the Apple analogue) at the LML response boundary
+// — `sanitizeLookupStreamingUrls` is applied in `postLookup` +
+// `bulkLookupMetadata` below so every downstream writer + serve seam is
+// covered at one chokepoint. Imported (not just re-exported) so it's in
+// local scope for those callsites.
+import { isSpotifyUrl, isAppleMusicUrl, sanitizeLookupStreamingUrls } from './streaming-url-guard.js';
+export { isSpotifyUrl, isAppleMusicUrl, sanitizeLookupStreamingUrls };
+
 class LmlClientError extends Error {
   constructor(
     message: string,
@@ -525,7 +534,12 @@ async function postLookup(
         options?.timeoutMs
       );
 
-      const parsed = (await response.json()) as LookupResponse;
+      // BS#1710: enforce the streaming-URL host invariant at this untrusted
+      // boundary. LML's `artwork.spotify_url` can carry a non-Spotify URL
+      // (Deezer/Apple/…) sourced from the library `streaming_links` artifact;
+      // null it here so no downstream writer persists it under the Spotify
+      // slot and the writers' `?? searchUrls.spotify_url` fallback wins.
+      const parsed = sanitizeLookupStreamingUrls((await response.json()) as LookupResponse);
 
       // cache_stats schema is freeform today (additionalProperties: true). Until
       // wxyc-shared#86 tightens the type, treat it as a loose record and only
@@ -675,6 +689,12 @@ export async function bulkLookupMetadata(
             console.warn('lml.client: failed to project cache_stats onto bulk span', err);
           }
         }
+      }
+
+      // BS#1710: same streaming-URL host invariant as postLookup, applied to
+      // each per-item verdict's nested LookupResponse (null on `status: error`).
+      for (const item of parsed.results ?? []) {
+        if (item.lookup != null) sanitizeLookupStreamingUrls(item.lookup);
       }
 
       return { results: parsed.results };

--- a/shared/lml-client/src/streaming-url-guard.ts
+++ b/shared/lml-client/src/streaming-url-guard.ts
@@ -34,17 +34,37 @@ function hostIsUnder(host: string, apex: string): boolean {
 }
 
 /**
+ * Parse `url` to a lowercased hostname, or `null` if it isn't a usable
+ * absolute URL. Returns `null` for a non-string or an unparseable value.
+ *
+ * Rejects any raw backslash up front — before `new URL()` sees it — to close
+ * a parser differential: for the http(s) special schemes WHATWG folds `\` to
+ * `/`, so `https://spotify.com\@evil.example/x` parses to hostname
+ * `spotify.com` and would pass the host check, yet the guard's keep-or-null
+ * contract persists that raw string verbatim, and a downstream URL parser that
+ * keeps the backslash resolves the same string to host `evil.example` — the
+ * "Spotify" button would then open `evil.example`. A genuine streaming URL
+ * never contains a raw backslash (it would be percent-encoded as `%5C`), so
+ * rejecting closes the differential at zero cost to real data (BS#1710).
+ */
+function safeHostname(url: string): string | null {
+  if (url.includes('\\')) return null;
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * True iff `url` parses to an absolute URL whose host is `spotify.com`
  * or a subdomain (`open.spotify.com`, `www.spotify.com`, …). Case-folds
  * the host; returns false for nullish, non-string, or unparseable input.
  */
 export function isSpotifyUrl(url: string | null | undefined): boolean {
   if (typeof url !== 'string') return false;
-  try {
-    return hostIsUnder(new URL(url).hostname.toLowerCase(), 'spotify.com');
-  } catch {
-    return false;
-  }
+  const host = safeHostname(url);
+  return host !== null && hostIsUnder(host, 'spotify.com');
 }
 
 /**
@@ -55,11 +75,8 @@ export function isSpotifyUrl(url: string | null | undefined): boolean {
  */
 export function isAppleMusicUrl(url: string | null | undefined): boolean {
   if (typeof url !== 'string') return false;
-  try {
-    return hostIsUnder(new URL(url).hostname.toLowerCase(), 'apple.com');
-  } catch {
-    return false;
-  }
+  const host = safeHostname(url);
+  return host !== null && hostIsUnder(host, 'apple.com');
 }
 
 /**

--- a/shared/lml-client/src/streaming-url-guard.ts
+++ b/shared/lml-client/src/streaming-url-guard.ts
@@ -1,0 +1,85 @@
+/**
+ * Streaming-URL host guard (BS#1710).
+ *
+ * LML's `results[].artwork.spotify_url` is populated from the library
+ * `streaming_links.spotify_url` artifact column, which for a subset of
+ * releases literally stores a NON-Spotify URL (Deezer, Apple Music,
+ * Bandcamp, …). Backend-Service persists and serves that value verbatim,
+ * and iOS binds it to a hardwired green "Spotify" button — so the button
+ * opens Deezer. See https://github.com/WXYC/Backend-Service/issues/1710.
+ *
+ * The invariant these guards enforce is purely about the field name: a
+ * value stored under `spotify_url` must be a Spotify URL, and a value
+ * under `apple_music_url` must be an Apple URL. `sanitizeLookupStreamingUrls`
+ * applies it at the LML response boundary — the single chokepoint every
+ * downstream writer (enrichment-worker + the backfill/reenrichment jobs)
+ * and the request-path serve read from — so a mislabeled URL never reaches
+ * a persisted `spotify_url`/`apple_music_url` column. A rejected value falls
+ * to `null`; the writers' `?? searchUrls.spotify_url` fallback then persists
+ * a real `open.spotify.com/search/…` URL instead.
+ *
+ * This does NOT heal rows already persisted before the guard shipped —
+ * BS persistence is fill-only, so an existing bad value survives. Those
+ * need the separate overwrite migration (BS#1710 fix #3).
+ */
+import type { LookupResponse } from '@wxyc/shared/dtos';
+
+/**
+ * True iff `host` is `apex` or a subdomain of it. The leading-dot check
+ * rejects suffix spoofs like `spotify.com.evil.example` (whose host ends
+ * in `.evil.example`, not `.spotify.com`).
+ */
+function hostIsUnder(host: string, apex: string): boolean {
+  return host === apex || host.endsWith(`.${apex}`);
+}
+
+/**
+ * True iff `url` parses to an absolute URL whose host is `spotify.com`
+ * or a subdomain (`open.spotify.com`, `www.spotify.com`, …). Case-folds
+ * the host; returns false for nullish, non-string, or unparseable input.
+ */
+export function isSpotifyUrl(url: string | null | undefined): boolean {
+  if (typeof url !== 'string') return false;
+  try {
+    return hostIsUnder(new URL(url).hostname.toLowerCase(), 'spotify.com');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True iff `url` parses to an absolute URL whose host is `apple.com` or a
+ * subdomain (`music.apple.com`, `itunes.apple.com`, `geo.music.apple.com`).
+ * Every Apple Music link lives under `apple.com`, so the apex covers the
+ * legacy iTunes and geo-redirect hosts too.
+ */
+export function isAppleMusicUrl(url: string | null | undefined): boolean {
+  if (typeof url !== 'string') return false;
+  try {
+    return hostIsUnder(new URL(url).hostname.toLowerCase(), 'apple.com');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Enforce the field-name/host invariant on every result's artwork: a
+ * `spotify_url` that isn't a Spotify host and an `apple_music_url` that
+ * isn't an Apple host are set to `null`. Mutates `response` in place (the
+ * caller owns the freshly-parsed object) and returns it for convenience.
+ * Other streaming slots are left untouched — only these two are rendered
+ * under hardwired service-specific buttons in the iOS app.
+ */
+export function sanitizeLookupStreamingUrls(response: LookupResponse): LookupResponse {
+  for (const item of response.results ?? []) {
+    const artwork = item.artwork;
+    if (!artwork) continue;
+    if (artwork.spotify_url != null && !isSpotifyUrl(artwork.spotify_url)) {
+      artwork.spotify_url = null;
+    }
+    if (artwork.apple_music_url != null && !isAppleMusicUrl(artwork.apple_music_url)) {
+      artwork.apple_music_url = null;
+    }
+  }
+  return response;
+}

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -433,6 +433,54 @@ describe('lml.client', () => {
 
       expect(result).toEqual(lookupResponse);
     });
+
+    // BS#1710: the client sanitizes streaming URLs at the response boundary so
+    // no downstream writer persists a non-Spotify URL under the spotify_url
+    // slot (iOS binds it to a hardwired green "Spotify" button).
+    it('nulls a non-Spotify URL sitting in artwork.spotify_url (BS#1710)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              {
+                library_item: { id: 1580 },
+                artwork: {
+                  spotify_url: 'https://www.deezer.com/album/254381182',
+                  apple_music_url: 'https://music.apple.com/us/album/foo/1',
+                },
+              },
+            ],
+            search_type: 'direct',
+            song_not_found: false,
+            found_on_compilation: false,
+          }),
+      } as unknown as globalThis.Response);
+
+      const result = await lookupMetadata('Kid 606', 'Down With The Scene');
+
+      expect(result.results[0].artwork?.spotify_url).toBeNull();
+      // A genuine Apple URL in its own slot is preserved.
+      expect(result.results[0].artwork?.apple_music_url).toBe('https://music.apple.com/us/album/foo/1');
+    });
+
+    it('preserves a genuine Spotify URL (BS#1710)', async () => {
+      const url = 'https://open.spotify.com/album/abc123';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [{ library_item: { id: 1 }, artwork: { spotify_url: url } }],
+            search_type: 'direct',
+            song_not_found: false,
+            found_on_compilation: false,
+          }),
+      } as unknown as globalThis.Response);
+
+      const result = await lookupMetadata('Autechre', 'Confield');
+
+      expect(result.results[0].artwork?.spotify_url).toBe(url);
+    });
   });
 
   describe('lookupBySong', () => {
@@ -589,6 +637,38 @@ describe('lml.client', () => {
         [2, 'error'],
       ]);
       expect(result.results[2].message).toBe('TimeoutError');
+    });
+
+    // BS#1710: the bulk seam sanitizes each per-item verdict's nested
+    // LookupResponse — the album-level backfill (BS#1041) writes through here.
+    it('nulls a non-Spotify URL in a per-item verdict artwork.spotify_url (BS#1710)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              {
+                index: 0,
+                status: 'match',
+                lookup: {
+                  results: [
+                    {
+                      library_item: { id: 1580 },
+                      artwork: { spotify_url: 'https://www.deezer.com/album/254381182' },
+                    },
+                  ],
+                },
+              },
+              { index: 1, status: 'error', lookup: null, message: 'TimeoutError' },
+            ],
+          }),
+      } as unknown as globalThis.Response);
+
+      const result = await bulkLookupMetadata([itemFor('Kid 606', 'x'), itemFor('y', 'z')]);
+
+      expect(result.results[0].lookup?.results[0].artwork?.spotify_url).toBeNull();
+      // A null `lookup` (status: error) is passed through untouched.
+      expect(result.results[1].lookup).toBeNull();
     });
 
     it('rejects empty items locally without hitting the wire', async () => {

--- a/tests/unit/shared/lml-client/streaming-url-guard.test.ts
+++ b/tests/unit/shared/lml-client/streaming-url-guard.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the streaming-URL host guard (BS#1710).
+ *
+ * LML's `results[].artwork.spotify_url` is sourced from the library
+ * `streaming_links.spotify_url` artifact column, which for a subset of
+ * releases literally stores a NON-Spotify URL (Deezer/Apple/Bandcamp/…).
+ * BS persists and serves that value verbatim, and iOS binds it to a
+ * hardwired green "Spotify" button. The guard enforces the field-name
+ * invariant — a value in the `spotify_url` slot must be a Spotify URL —
+ * at the untrusted-upstream boundary, before any writer persists it.
+ */
+import type { LookupResponse } from '@wxyc/lml-client';
+import { isSpotifyUrl, isAppleMusicUrl, sanitizeLookupStreamingUrls } from '@wxyc/lml-client';
+
+describe('isSpotifyUrl', () => {
+  it.each([
+    ['open.spotify.com album', 'https://open.spotify.com/album/abc123'],
+    ['open.spotify.com search (synthesized fallback)', 'https://open.spotify.com/search/kid%20606'],
+    ['bare spotify.com apex', 'https://spotify.com/album/abc'],
+    ['www.spotify.com', 'https://www.spotify.com/album/abc'],
+    ['case-insensitive host', 'HTTPS://OPEN.SPOTIFY.COM/album/abc'],
+  ])('accepts a Spotify-host URL (%s)', (_label, url) => {
+    expect(isSpotifyUrl(url)).toBe(true);
+  });
+
+  it.each([
+    ['Deezer (the pinned Kid 606 pollution)', 'https://www.deezer.com/album/254381182'],
+    ['Apple Music', 'https://music.apple.com/us/album/foo/123'],
+    ['Bandcamp', 'https://artist.bandcamp.com/album/foo'],
+    ['Qobuz', 'https://www.qobuz.com/album/foo'],
+    ['host-suffix spoof', 'https://spotify.com.evil.example/album/abc'],
+    ['substring-not-host spoof', 'https://evil.example/spotify.com/album'],
+    ['not a URL', 'not a url'],
+    ['empty string', ''],
+  ])('rejects a non-Spotify URL (%s)', (_label, url) => {
+    expect(isSpotifyUrl(url)).toBe(false);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('rejects nullish input (%s)', (_label, input) => {
+    expect(isSpotifyUrl(input)).toBe(false);
+  });
+});
+
+describe('isAppleMusicUrl', () => {
+  it.each([
+    ['music.apple.com', 'https://music.apple.com/us/album/foo/123'],
+    ['itunes.apple.com legacy', 'https://itunes.apple.com/us/album/foo/123'],
+    ['geo.music.apple.com', 'https://geo.music.apple.com/us/album/foo'],
+    ['bare apple.com apex', 'https://apple.com/foo'],
+  ])('accepts an Apple-host URL (%s)', (_label, url) => {
+    expect(isAppleMusicUrl(url)).toBe(true);
+  });
+
+  it.each([
+    ['Spotify', 'https://open.spotify.com/album/abc'],
+    ['Deezer', 'https://www.deezer.com/album/254381182'],
+    ['host-suffix spoof', 'https://apple.com.evil.example/foo'],
+    ['null', null],
+  ])('rejects a non-Apple URL (%s)', (_label, url) => {
+    expect(isAppleMusicUrl(url)).toBe(false);
+  });
+});
+
+describe('sanitizeLookupStreamingUrls', () => {
+  // The guard only reads `results[].artwork.{spotify_url,apple_music_url}`;
+  // a minimal cast keeps the fixture legible without a full LibraryCatalogItem.
+  const build = (artwork: Record<string, unknown> | undefined): LookupResponse => ({
+    results: [{ library_item: { id: 1 }, artwork }],
+    search_type: 'direct',
+    song_not_found: false,
+    found_on_compilation: false,
+  });
+
+  it('nulls a Deezer URL sitting in the spotify_url slot (the reported bug)', () => {
+    const resp = build({ spotify_url: 'https://www.deezer.com/album/254381182' });
+    const out = sanitizeLookupStreamingUrls(resp);
+    expect(out.results[0].artwork?.spotify_url).toBeNull();
+  });
+
+  it('nulls a mislabeled non-Apple URL in the apple_music_url slot', () => {
+    const resp = build({ apple_music_url: 'https://www.deezer.com/album/1' });
+    const out = sanitizeLookupStreamingUrls(resp);
+    expect(out.results[0].artwork?.apple_music_url).toBeNull();
+  });
+
+  it('preserves a genuine Spotify URL', () => {
+    const url = 'https://open.spotify.com/album/abc123';
+    const resp = build({ spotify_url: url });
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.spotify_url).toBe(url);
+  });
+
+  it('preserves a genuine Apple Music URL', () => {
+    const url = 'https://music.apple.com/us/album/foo/123';
+    const resp = build({ apple_music_url: url });
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.apple_music_url).toBe(url);
+  });
+
+  it('leaves other streaming slots untouched (only spotify/apple are host-guarded)', () => {
+    const resp = build({
+      spotify_url: 'https://open.spotify.com/album/ok',
+      bandcamp_url: 'https://artist.bandcamp.com/album/foo',
+      soundcloud_url: 'https://soundcloud.com/artist/track',
+    });
+    const out = sanitizeLookupStreamingUrls(resp).results[0].artwork;
+    expect(out?.bandcamp_url).toBe('https://artist.bandcamp.com/album/foo');
+    expect(out?.soundcloud_url).toBe('https://soundcloud.com/artist/track');
+  });
+
+  it('tolerates a result item with no artwork', () => {
+    const resp = build(undefined);
+    expect(() => sanitizeLookupStreamingUrls(resp)).not.toThrow();
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork).toBeUndefined();
+  });
+
+  it('tolerates an empty results array', () => {
+    const resp = build({ spotify_url: 'x' });
+    resp.results = [];
+    expect(sanitizeLookupStreamingUrls(resp).results).toEqual([]);
+  });
+
+  it('leaves an already-null spotify_url as null (idempotent)', () => {
+    const resp = build({ spotify_url: null });
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.spotify_url).toBeNull();
+  });
+});

--- a/tests/unit/shared/lml-client/streaming-url-guard.test.ts
+++ b/tests/unit/shared/lml-client/streaming-url-guard.test.ts
@@ -30,6 +30,18 @@ describe('isSpotifyUrl', () => {
     ['Qobuz', 'https://www.qobuz.com/album/foo'],
     ['host-suffix spoof', 'https://spotify.com.evil.example/album/abc'],
     ['substring-not-host spoof', 'https://evil.example/spotify.com/album'],
+    // WHATWG folds `\` to `/` for http(s), so `new URL(...).hostname` reads
+    // `spotify.com` and the naive host check would ACCEPT — but the raw string
+    // (persisted verbatim) resolves to `evil.example` under a parser that keeps
+    // the backslash. The guard must reject the raw backslash (BS#1710).
+    ['backslash-authority spoof', 'https://spotify.com\\@evil.example/x'],
+    ['backslash after subdomain', 'https://open.spotify.com\\@evil.example/x'],
+    // Tab/CR/LF need no special handling: unlike `\`, WHATWG strips them and
+    // resolves the authority to the real (evil) host, so the guard already
+    // rejects them. Characterized here so the backslash-only carve-out is
+    // documented, not accidental.
+    ['tab in authority (WHATWG resolves to evil host)', 'https://open.spotify.com\t@evil.example/x'],
+    ['newline in authority (WHATWG resolves to evil host)', 'https://open.spotify.com\n@evil.example/x'],
     ['not a URL', 'not a url'],
     ['empty string', ''],
   ])('rejects a non-Spotify URL (%s)', (_label, url) => {
@@ -58,6 +70,7 @@ describe('isAppleMusicUrl', () => {
     ['Spotify', 'https://open.spotify.com/album/abc'],
     ['Deezer', 'https://www.deezer.com/album/254381182'],
     ['host-suffix spoof', 'https://apple.com.evil.example/foo'],
+    ['backslash-authority spoof', 'https://apple.com\\@evil.example/foo'],
     ['null', null],
   ])('rejects a non-Apple URL (%s)', (_label, url) => {
     expect(isAppleMusicUrl(url)).toBe(false);
@@ -84,6 +97,14 @@ describe('sanitizeLookupStreamingUrls', () => {
     const resp = build({ apple_music_url: 'https://www.deezer.com/album/1' });
     const out = sanitizeLookupStreamingUrls(resp);
     expect(out.results[0].artwork?.apple_music_url).toBeNull();
+  });
+
+  it('nulls a backslash-authority spoof in the spotify_url slot (parser differential)', () => {
+    // `new URL(...).hostname` folds this to `spotify.com`, but the raw string
+    // persisted verbatim resolves to `evil.example` under a backslash-preserving
+    // parser — the guard must null it, not persist it under the Spotify button.
+    const resp = build({ spotify_url: 'https://spotify.com\\@evil.example/x' });
+    expect(sanitizeLookupStreamingUrls(resp).results[0].artwork?.spotify_url).toBeNull();
   });
 
   it('preserves a genuine Spotify URL', () => {


### PR DESCRIPTION
## What

Enforce the invariant "a `spotify_url` field must hold a Spotify URL (and `apple_music_url` an Apple URL)" at the single untrusted-upstream chokepoint — the `@wxyc/lml-client` response boundary.

LML's `results[].artwork.spotify_url` is sourced from the library `streaming_links.spotify_url` artifact column, which for a subset of releases literally stores a **non-Spotify** URL (Deezer/Apple/Bandcamp/Qobuz/Tidal). Backend-Service persists and serves it verbatim, and iOS binds it to a hardwired green "Spotify" button — so the button opens Deezer. Pinned live writer: library release **id=1580** → LML returns `artwork.spotify_url = https://www.deezer.com/album/254381182`.

`sanitizeLookupStreamingUrls` nulls a mislabeled URL in `postLookup` and per-item in `bulkLookupMetadata`, so **every** downstream writer (enrichment-worker + the backfill/reenrichment jobs) and the fresh-LML serve path is covered in one place. A nulled value lets the writers' existing `?? searchUrls.spotify_url` fallback persist a real `open.spotify.com/search/…` URL instead.

## Why this seam

- The **live** writer (`apps/enrichment-worker`) obtains `artwork` via `lookupMetadata` → `postLookup`, **not** through `metadata.service.ts` — a guard placed only in the service would miss it. The lml-client response boundary is the one chokepoint all writers + the serve path share.
- Placed in `@wxyc/lml-client` (the leaf); `@wxyc/metadata` depends on it, so putting the helper upstream would form a dependency cycle.
- Host matching parses the URL and checks the registrable apex (`spotify.com`/`apple.com`), so suffix spoofs like `spotify.com.evil.example` are rejected.

## Changes

- `shared/lml-client/src/streaming-url-guard.ts` (new) — `isSpotifyUrl` / `isAppleMusicUrl` / `sanitizeLookupStreamingUrls`.
- `shared/lml-client/src/index.ts` — apply the sanitize in `postLookup` + `bulkLookupMetadata`; re-export the helpers.
- `tests/unit/shared/lml-client/streaming-url-guard.test.ts` (new, 31 cases) + seam tests in `tests/unit/services/lml.client.test.ts`.

## Scope / out of scope

Ingestion boundary only. BS persistence is fill-only, so this does **not** heal the ~68K `flowsheet` + ~3.9K `album_metadata` rows already persisted. Tracked follow-ups (parent #1710): the DB-read serve seams (`proxy.controller` persisted branch, `flowsheet.service`), an overwrite migration for existing rows, upstream artifact cleanup (LML#573 territory), and the iOS host-gate (separate repo).

## Testing

`npm run typecheck` / `lint` / `format:check` / `test:unit` (4784/4784) all pass locally.

Closes #1712
Part of #1710
