### PR TITLE
fix(flowsheet): read-time host guard for persisted mislabeled streaming URLs (BS#1714)

### DIFF
--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -19,6 +19,8 @@ import {
   resolveEntity as lmlResolveEntity,
   searchLibrary,
   envInt,
+  isSpotifyUrl,
+  isAppleMusicUrl,
   LmlClientError,
 } from '@wxyc/lml-client';
 import type { DiscogsMatchResult, DiscogsReleaseMetadata, DiscogsTrackItem, LookupResponse } from '@wxyc/lml-client';
@@ -369,8 +371,14 @@ function buildLocalMetadataResponse(persisted: PersistedAlbumMetadata): Record<s
   // real year or null, but check for both shapes defensively (mirrors
   // populateReleaseMetadata + extractAlbumMetadata, #1002).
   if (persisted.release_year) metadata.releaseYear = persisted.release_year;
-  if (persisted.spotify_url) metadata.spotifyUrl = persisted.spotify_url;
-  if (persisted.apple_music_url) metadata.appleMusicUrl = persisted.apple_music_url;
+  // BS#1714: a persisted `spotify_url`/`apple_music_url` mislabeled at the LML
+  // boundary before #1712 shipped (e.g. a Deezer URL under `spotify_url`) is
+  // suppressed rather than served under the hardwired iOS "Spotify"/"Apple
+  // Music" button. Not setting it leaves the L508-509 fallback to synthesize a
+  // real `open.spotify.com/search/…` URL — the same degradation the fresh-LML
+  // branch already emits.
+  if (isSpotifyUrl(persisted.spotify_url)) metadata.spotifyUrl = persisted.spotify_url;
+  if (isAppleMusicUrl(persisted.apple_music_url)) metadata.appleMusicUrl = persisted.apple_music_url;
   if (persisted.youtube_music_url) metadata.youtubeMusicUrl = persisted.youtube_music_url;
   if (persisted.bandcamp_url) metadata.bandcampUrl = persisted.bandcamp_url;
   if (persisted.soundcloud_url) metadata.soundcloudUrl = persisted.soundcloud_url;

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -23,6 +23,7 @@ import {
   nyCalendarDate,
   nyStartOfDay,
 } from '@wxyc/database';
+import { isSpotifyUrl, isAppleMusicUrl } from '@wxyc/lml-client';
 import { getUpcomingShowsMapsCached } from './concerts.service.js';
 import { IFSEntry, ShowMetadata, UpdateRequestBody } from '../controllers/flowsheet.controller.js';
 import { PgSelectQueryBuilder, QueryBuilder } from 'drizzle-orm/pg-core';
@@ -258,7 +259,7 @@ const FSEntryFieldsRaw = {
 };
 
 // Raw result type from SQL query
-type FSEntryRaw = {
+export type FSEntryRaw = {
   id: number;
   show_id: number | null;
   album_id: number | null;
@@ -301,65 +302,82 @@ type FSEntryRaw = {
   radio_hour: Date | null;
 };
 
-/** Transform flat SQL result to nested IFSEntry structure */
-const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => ({
-  id: raw.id,
-  show_id: raw.show_id,
-  album_id: raw.album_id,
-  legacy_entry_id: raw.legacy_entry_id ?? null,
-  legacy_release_id: raw.legacy_release_id ?? null,
-  entry_type: raw.entry_type as FSEntry['entry_type'],
-  artist_name: raw.artist_name,
-  album_title: raw.album_title,
-  track_title: raw.track_title,
-  track_position: raw.track_position,
-  record_label: raw.record_label,
-  label_id: raw.label_id,
-  rotation_id: raw.rotation_id,
-  rotation_bin: raw.rotation_bin,
-  artist_id: raw.artist_id ?? null,
-  request_flag: raw.request_flag ?? false,
-  segue: raw.segue ?? false,
-  message: raw.message,
-  play_order: raw.play_order ?? 0,
-  add_time: raw.add_time ?? new Date(),
-  dj_name: raw.dj_name,
-  linkage_source: raw.linkage_source,
-  linkage_confidence: raw.linkage_confidence,
-  linked_at: raw.linked_at,
-  // Metadata columns (on FSEntry since they're on the flowsheet table)
-  artwork_url: raw.artwork_url,
-  discogs_url: raw.discogs_url,
-  release_year: raw.release_year,
-  spotify_url: raw.spotify_url,
-  apple_music_url: raw.apple_music_url,
-  youtube_music_url: raw.youtube_music_url,
-  bandcamp_url: raw.bandcamp_url,
-  soundcloud_url: raw.soundcloud_url,
-  artist_bio: raw.artist_bio,
-  artist_wikipedia_url: raw.artist_wikipedia_url,
-  on_streaming: raw.on_streaming ?? null,
-  metadata_status: raw.metadata_status,
-  enriching_since: raw.enriching_since,
-  radio_hour: raw.radio_hour ?? null,
-  // Nested metadata view (used by transformToV2). genres/styles are
-  // album_metadata-only fields (BS#1441) and so live here, NOT as top-level
-  // IFSEntry/FSEntry fields (that type mirrors the flowsheet table).
-  metadata: {
+/**
+ * Transform flat SQL result to nested IFSEntry structure.
+ *
+ * Exported so the BS#1714 serve-seam host guard can be unit-tested directly:
+ * this is the single producer of every IFSEntry that reaches the `/flowsheet`
+ * (top-level fields) and `/v2/flowsheet` (`transformToV2`, nested `metadata`)
+ * read paths, so guarding the two hardwired streaming URLs here covers both.
+ */
+export const transformToIFSEntry = (raw: FSEntryRaw): IFSEntry => {
+  // BS#1714: suppress a persisted `spotify_url`/`apple_music_url` whose host
+  // isn't Spotify/Apple (mislabeled at the LML boundary before #1712 shipped)
+  // so it never reaches the hardwired iOS "Spotify"/"Apple Music" button. No
+  // synthesized fallback exists at this seam, so a mislabeled value drops to
+  // null. Applied once and reused for both the top-level field and the nested
+  // `metadata` object below.
+  const spotify_url = isSpotifyUrl(raw.spotify_url) ? raw.spotify_url : null;
+  const apple_music_url = isAppleMusicUrl(raw.apple_music_url) ? raw.apple_music_url : null;
+  return {
+    id: raw.id,
+    show_id: raw.show_id,
+    album_id: raw.album_id,
+    legacy_entry_id: raw.legacy_entry_id ?? null,
+    legacy_release_id: raw.legacy_release_id ?? null,
+    entry_type: raw.entry_type as FSEntry['entry_type'],
+    artist_name: raw.artist_name,
+    album_title: raw.album_title,
+    track_title: raw.track_title,
+    track_position: raw.track_position,
+    record_label: raw.record_label,
+    label_id: raw.label_id,
+    rotation_id: raw.rotation_id,
+    rotation_bin: raw.rotation_bin,
+    artist_id: raw.artist_id ?? null,
+    request_flag: raw.request_flag ?? false,
+    segue: raw.segue ?? false,
+    message: raw.message,
+    play_order: raw.play_order ?? 0,
+    add_time: raw.add_time ?? new Date(),
+    dj_name: raw.dj_name,
+    linkage_source: raw.linkage_source,
+    linkage_confidence: raw.linkage_confidence,
+    linked_at: raw.linked_at,
+    // Metadata columns (on FSEntry since they're on the flowsheet table)
     artwork_url: raw.artwork_url,
     discogs_url: raw.discogs_url,
     release_year: raw.release_year,
-    spotify_url: raw.spotify_url,
-    apple_music_url: raw.apple_music_url,
+    spotify_url,
+    apple_music_url,
     youtube_music_url: raw.youtube_music_url,
     bandcamp_url: raw.bandcamp_url,
     soundcloud_url: raw.soundcloud_url,
     artist_bio: raw.artist_bio,
     artist_wikipedia_url: raw.artist_wikipedia_url,
-    genres: raw.genres,
-    styles: raw.styles,
-  },
-});
+    on_streaming: raw.on_streaming ?? null,
+    metadata_status: raw.metadata_status,
+    enriching_since: raw.enriching_since,
+    radio_hour: raw.radio_hour ?? null,
+    // Nested metadata view (used by transformToV2). genres/styles are
+    // album_metadata-only fields (BS#1441) and so live here, NOT as top-level
+    // IFSEntry/FSEntry fields (that type mirrors the flowsheet table).
+    metadata: {
+      artwork_url: raw.artwork_url,
+      discogs_url: raw.discogs_url,
+      release_year: raw.release_year,
+      spotify_url,
+      apple_music_url,
+      youtube_music_url: raw.youtube_music_url,
+      bandcamp_url: raw.bandcamp_url,
+      soundcloud_url: raw.soundcloud_url,
+      artist_bio: raw.artist_bio,
+      artist_wikipedia_url: raw.artist_wikipedia_url,
+      genres: raw.genres,
+      styles: raw.styles,
+    },
+  };
+};
 
 /**
  * Resolve the DJ name for a show using the priority:

--- a/apps/backend/utils/flowsheet-projection.ts
+++ b/apps/backend/utils/flowsheet-projection.ts
@@ -1,4 +1,5 @@
 import type { FSEntry } from '@wxyc/database';
+import { isSpotifyUrl, isAppleMusicUrl } from '@wxyc/lml-client';
 
 /**
  * Client-facing flowsheet-row projection (BS#1513).
@@ -87,6 +88,11 @@ export type ClientFacingFSEntry = Pick<FSEntry, (typeof CLIENT_FACING_FLOWSHEET_
  * internal column. Written as an explicit field-by-field object literal (rather
  * than a loop) so that TypeScript enforces the shape against `ClientFacingFSEntry`
  * and a schema change that renames a client-facing column is a compile error.
+ *
+ * BS#1714: `spotify_url` / `apple_music_url` are host-guarded on the way out — a
+ * value whose host isn't Spotify/Apple (mislabeled at the LML boundary before
+ * #1712 shipped) is dropped to `null` rather than emitted under the hardwired
+ * iOS "Spotify"/"Apple Music" button. Every other column passes through as-is.
  */
 export function projectFlowsheetEntry(row: FSEntry): ClientFacingFSEntry {
   return {
@@ -112,8 +118,10 @@ export function projectFlowsheetEntry(row: FSEntry): ClientFacingFSEntry {
     artwork_url: row.artwork_url,
     discogs_url: row.discogs_url,
     release_year: row.release_year,
-    spotify_url: row.spotify_url,
-    apple_music_url: row.apple_music_url,
+    // BS#1714: null a non-Spotify/non-Apple value; leave a nullish or genuine
+    // value untouched — same `!= null &&` shape as `sanitizeLookupStreamingUrls`.
+    spotify_url: row.spotify_url != null && !isSpotifyUrl(row.spotify_url) ? null : row.spotify_url,
+    apple_music_url: row.apple_music_url != null && !isAppleMusicUrl(row.apple_music_url) ? null : row.apple_music_url,
     youtube_music_url: row.youtube_music_url,
     bandcamp_url: row.bandcamp_url,
     soundcloud_url: row.soundcloud_url,
@@ -130,7 +138,12 @@ export function projectFlowsheetEntry(row: FSEntry): ClientFacingFSEntry {
  * apply. It loops the same `CLIENT_FACING_FLOWSHEET_COLUMNS` allow-list — one
  * list, zero drift with the typed projector — and copies only the columns
  * actually present on the row, so a partial row is not padded with invented
- * keys. Values pass through untouched (an ISO-string date stays an ISO string).
+ * keys. Values pass through untouched (an ISO-string date stays an ISO string),
+ * with the sole exception of the BS#1714 host guard below: a `spotify_url` /
+ * `apple_music_url` that is present but whose host isn't Spotify/Apple is nulled
+ * (the same suppression {@link projectFlowsheetEntry} applies), so the CDC
+ * `liveFs:update` SSE never carries a mislabeled URL under the hardwired iOS
+ * "Spotify"/"Apple Music" button. A column absent from the row stays absent.
  */
 export function pickClientFacingColumns(row: Record<string, unknown>): Record<string, unknown> {
   const projected: Record<string, unknown> = {};
@@ -139,6 +152,17 @@ export function pickClientFacingColumns(row: Record<string, unknown>): Record<st
       // eslint-disable-next-line security/detect-object-injection -- keys are the fixed allow-list const, not caller input
       projected[column] = row[column];
     }
+  }
+  // BS#1714 host guard. Values arrive as parsed JSON (`unknown`); the guards
+  // narrow a non-string to `false`, so the cast to the `string | null` these
+  // columns actually hold is safe. Only null a key that is present — a partial
+  // row that omitted it stays omitted (the "not padded with invented keys"
+  // contract above).
+  if (Object.hasOwn(projected, 'spotify_url') && !isSpotifyUrl(projected.spotify_url as string | null)) {
+    projected.spotify_url = null;
+  }
+  if (Object.hasOwn(projected, 'apple_music_url') && !isAppleMusicUrl(projected.apple_music_url as string | null)) {
+    projected.apple_music_url = null;
   }
   return projected;
 }

--- a/plans/bs1714-serve-seam-host-guard.md
+++ b/plans/bs1714-serve-seam-host-guard.md
@@ -1,0 +1,52 @@
+# BS#1714 — read-time serve-seam host guard for already-persisted mislabeled streaming URLs
+
+## Problem
+
+The ingestion-boundary guard (#1712 / PR #1713, merged) stops _new_ mislabeled streaming URLs from being persisted, but BS persistence is fill-only: the ~68K `flowsheet` + ~3.9K `album_metadata` rows already holding a non-Spotify URL in `spotify_url` (or non-Apple in `apple_music_url`) are unaffected and still served verbatim — iOS still binds them to the hardwired green "Spotify" button, which opens Deezer/Apple/Bandcamp/Qobuz/Tidal. This is interim read-time protection until the #1715 overwrite migration heals the data.
+
+## End state
+
+At every serve seam that emits a _persisted_ `spotify_url`/`apple_music_url`, a value whose host isn't Spotify/Apple is suppressed (dropped to `null`, or falls through to the already-computed `open.spotify.com/search/…` synthesized fallback where one exists) rather than passed through. Host-matching logic is not re-implemented: every seam calls `isSpotifyUrl` / `isAppleMusicUrl` from `@wxyc/lml-client` (shipped in #1712), which URL-parse and apex-match the host (rejecting suffix spoofs like `spotify.com.evil.example` and — post-PR #1713 — raw-backslash authority spoofs).
+
+## Scope: the serve seams (grounded against the current code)
+
+Only seams that read **persisted** rows need guarding. The fresh-LML branch (`proxy.controller.ts` L224–225, reading `artwork` from `lookupMetadata`→`postLookup`) and the enrichment write path (`enrichment.service.ts`) are already covered by #1712's ingestion sanitize, so they are **out of scope** here.
+
+1. **`apps/backend/controllers/proxy.controller.ts` — `buildLocalMetadataResponse` (L372–373).** Reads `persisted.spotify_url` / `persisted.apple_music_url` from `album_metadata`. Guard each read; when the value fails the host check it is simply not set on `metadata`, so the existing fallback at L508–509 (`if (!metadata.spotifyUrl) metadata.spotifyUrl = fallbackUrls.spotifyUrl`) synthesizes the `open.spotify.com/search/…` URL. Net effect: mislabeled → synthesized Spotify search URL, matching the fresh-LML branch's degradation. Serves `/proxy/metadata/album`.
+
+2. **`apps/backend/services/flowsheet.service.ts` — `transformToIFSEntry` (L305–362).** The single producer of every `IFSEntry`. `raw.spotify_url` currently feeds both the top-level field (L334) and the nested `metadata` object (L352); `raw.apple_music_url` likewise (L335, L353). Sanitize once into two locals at the top of the transform and use them in all four positions. This transitively covers the `transformToV2` seam at L1223–1224 (`entry.metadata?.spotify_url`) because every `IFSEntry` that reaches `transformToV2` came through `transformToIFSEntry` (verified: the only three producers are `raw.map(transformToIFSEntry)` at L464/478/500). No synthesized fallback exists at this seam, so a mislabeled value drops to `null` — iOS then renders no Spotify button, or falls to the `/proxy/metadata` fetch path (which synthesizes). Serves `/flowsheet` + `/v2/flowsheet` reads.
+
+3. **`apps/backend/utils/flowsheet-projection.ts` — `projectFlowsheetEntry` (L115–116)** _(not enumerated in the ticket; discovered by seam trace)._ Reads `row.spotify_url` / `row.apple_music_url` straight off a raw `FSEntry`. Feeds the mutation-handler responses (`addEntry`/`updateEntry`/`changeOrder`/`deleteEntry`) and the DJ peek (`getPlaylistsForDJ`) — the `/flowsheet` + `/v2/flowsheet` mutation 200s named in the ticket's AC. Guard both reads → `null` on mismatch.
+
+4. **`apps/backend/utils/flowsheet-projection.ts` — `pickClientFacingColumns` (L135–144)** _(not enumerated in the ticket; discovered by seam trace)._ JSON-tolerant sibling projecting the CDC `to_jsonb(NEW)` payload the anonymous `liveFs:update` SSE broadcast forwards (BS#1534) — iOS consumes this for real-time flowsheet updates and renders inline streaming metadata off it (branches on `metadata_status`, wxyc-ios-64#270). Values arrive as `unknown` (parsed JSON); after the allow-list copy, null the two streaming keys if present and failing the host check. The guards type-narrow non-strings to `false`, so passing `unknown` is runtime-safe.
+
+## Why include seams 3 & 4 beyond the ticket's list
+
+The ticket's acceptance criterion is behavioral — "a persisted non-Spotify `spotify_url` … is not emitted under the Spotify field by `/proxy/metadata/*`, `/flowsheet`, and `/v2/flowsheet`." The mutation responses and the `liveFs:update` SSE are `/flowsheet`+`/v2/flowsheet`-family surfaces that emit persisted streaming URLs; leaving them unguarded would half-close the invariant and invite a regression. Same one-line-per-field guard, same shared helpers — no new host logic, low marginal cost.
+
+## Non-goals
+
+- No writes / no data migration — that is the sibling #1715 (durable fix).
+- No change to `youtube_music_url` / `bandcamp_url` / `soundcloud_url` — the bug is specific to the two service-branded buttons iOS hardwires to `spotify_url` / `apple_music_url`. (A future generalization could host-gate all five; out of scope for this interim fix and for the shipped #1712 helpers, which only expose Spotify/Apple predicates.)
+- No new host-matching code — reuse `@wxyc/lml-client` helpers only.
+
+## TDD plan
+
+Failing-first unit tests, one per seam, then implement:
+
+- **flowsheet-projection.test.ts** (new or extend): `projectFlowsheetEntry` and `pickClientFacingColumns` — genuine `open.spotify.com/album/…` passes; Deezer-in-`spotify_url` → `null`; `music.apple.com` in `apple_music_url` passes; a non-Apple in `apple_music_url` → `null`; suffix spoof `spotify.com.evil.example` → `null`; genuine values on the other three streaming fields untouched.
+- **flowsheet.service** V2 read path: exercise `transformToIFSEntry` output (via the exported read fn or `transformToV2`) — mislabeled `spotify_url` suppressed on both the top-level field and the nested `metadata`; genuine passes; nested seam (L1223) reflects the sanitized value.
+- **proxy.controller** `getAlbumMetadata`: with `lookupAlbumMetadataByKey` mocked to return a persisted Deezer `spotify_url`, the response's `spotifyUrl` is the synthesized `open.spotify.com/search/…` fallback (not the Deezer URL); a genuine persisted Spotify URL passes through unchanged. Follow the existing proxy.controller test mock pattern.
+
+Parameterize the shared reject/accept cases where the existing suite already parameterizes.
+
+## Acceptance criteria (from #1714)
+
+- [ ] A persisted non-Spotify `spotify_url` (e.g. the Deezer URL on release id=1580) is not emitted under the Spotify field by `/proxy/metadata/*`, `/flowsheet`, and `/v2/flowsheet` (incl. the mutation 200s and the `liveFs:update` SSE).
+- [ ] Genuine Spotify/Apple URLs pass through unchanged.
+- [ ] Unit coverage at each seam.
+- [ ] `npm run typecheck` / `lint` / `format:check` / `test:unit` all pass.
+
+## Risk / rollback
+
+Pure read-path suppression; no writes, no schema change, no migration. Worst case a genuine-but-oddly-hosted Spotify/Apple URL is dropped to `null` — but the apex-match accepts every `*.spotify.com` / `*.apple.com` host, and the fallback path already synthesizes a working search URL, so the degradation is graceful. Revert = revert the PR.

--- a/tests/integration/metadata.spec.js
+++ b/tests/integration/metadata.spec.js
@@ -334,8 +334,12 @@ describe('album_metadata COALESCE projection (BS#897)', () => {
     artwork_url: 'https://bs897.example.com/artwork.jpg',
     discogs_url: 'https://bs897.example.com/discogs',
     release_year: 1979,
-    spotify_url: 'https://bs897.example.com/spotify',
-    apple_music_url: 'https://bs897.example.com/apple',
+    // BS#1714: the read-time serve-seam host guard (transformToIFSEntry) nulls a
+    // spotify_url whose host isn't Spotify (and apple_music_url off Apple), so
+    // these two sentinels must be genuine hosts to survive the projection —
+    // the other eight columns carry the arbitrary bs897.example.com host.
+    spotify_url: 'https://open.spotify.com/album/bs897sentinel',
+    apple_music_url: 'https://music.apple.com/us/album/bs897sentinel',
     youtube_music_url: 'https://bs897.example.com/youtube',
     bandcamp_url: 'https://bs897.example.com/bandcamp',
     soundcloud_url: 'https://bs897.example.com/soundcloud',

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -25,15 +25,28 @@ class MockLmlClientError extends Error {
   }
 }
 
-jest.mock('@wxyc/lml-client', () => ({
-  lookupMetadata: mockLookupMetadata,
-  getRelease: mockGetRelease,
-  getArtistDetails: mockGetArtistDetails,
-  resolveEntity: mockResolveEntity,
-  searchLibrary: mockSearchLibrary,
-  envInt: (_name: string, fallback: number) => fallback,
-  LmlClientError: MockLmlClientError,
-}));
+jest.mock('@wxyc/lml-client', () => {
+  // BS#1714: buildLocalMetadataResponse now host-guards the persisted
+  // spotify_url/apple_music_url via these predicates. Pass the REAL
+  // (side-effect-free, type-only-dep) implementations through from the guard
+  // submodule so the suppression behaves exactly as in production — requiring
+  // the whole `@wxyc/lml-client` index would needlessly load Sentry + the HTTP
+  // client the rest of this factory deliberately stubs.
+  const { isSpotifyUrl, isAppleMusicUrl } = jest.requireActual<
+    typeof import('../../../shared/lml-client/src/streaming-url-guard')
+  >('../../../shared/lml-client/src/streaming-url-guard');
+  return {
+    lookupMetadata: mockLookupMetadata,
+    getRelease: mockGetRelease,
+    getArtistDetails: mockGetArtistDetails,
+    resolveEntity: mockResolveEntity,
+    searchLibrary: mockSearchLibrary,
+    envInt: (_name: string, fallback: number) => fallback,
+    isSpotifyUrl,
+    isAppleMusicUrl,
+    LmlClientError: MockLmlClientError,
+  };
+});
 
 // Backend code paths now route through the LmlLookupCoordinator (BS#885).
 jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
@@ -908,6 +921,47 @@ describe('proxy.controller', () => {
         expect(result.artistBio).toBe('A cached bio of the artist.');
         expect(result.artistWikipediaUrl).toBe('https://en.wikipedia.org/wiki/CachedArtist');
         expect(res.set).toHaveBeenCalledWith('Cache-Control', 'private, max-age=600');
+      });
+
+      it('suppresses a persisted mislabeled spotify_url/apple_music_url, synthesizing the search fallback (BS#1714)', async () => {
+        // Pre-#1712 fill-only persistence left non-Spotify/non-Apple URLs under
+        // these two columns (e.g. a Deezer URL under spotify_url on release
+        // id=1580). The host guard must not serve them under the hardwired iOS
+        // "Spotify"/"Apple Music" button; not setting them lets the request-time
+        // fallback synthesize a real open.spotify.com/search URL instead.
+        mockLookupAlbumMetadataByKey.mockResolvedValue({
+          artwork_url: 'https://i.discogs.com/cached.jpg',
+          discogs_url: 'https://www.discogs.com/release/1580',
+          release_year: 2024,
+          spotify_url: 'https://www.deezer.com/album/254381182',
+          apple_music_url: 'https://tidal.com/browse/album/254381182',
+          youtube_music_url: 'https://music.youtube.com/playlist?list=cachedyt',
+          bandcamp_url: 'https://artist.bandcamp.com/album/cached',
+          soundcloud_url: 'https://soundcloud.com/artist/cached-album',
+          artist_bio: 'A cached bio of the artist.',
+          artist_wikipedia_url: 'https://en.wikipedia.org/wiki/CachedArtist',
+        });
+
+        const req = {
+          query: { artistName: 'Cached Artist', releaseTitle: 'Cached Album', trackTitle: 'Cached Track' },
+        } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(mockLookupMetadata).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        // Mislabeled → dropped, then synthesized (never the Deezer/Tidal URL).
+        expect(result.spotifyUrl).not.toBe('https://www.deezer.com/album/254381182');
+        expect(result.spotifyUrl).toContain('open.spotify.com/search');
+        expect(result.appleMusicUrl).not.toBe('https://tidal.com/browse/album/254381182');
+        expect(result.appleMusicUrl).toContain('music.apple.com/search');
+        // The other three streaming slots are untouched by the guard.
+        expect(result.youtubeMusicUrl).toBe('https://music.youtube.com/playlist?list=cachedyt');
+        expect(result.bandcampUrl).toBe('https://artist.bandcamp.com/album/cached');
+        expect(result.soundcloudUrl).toBe('https://soundcloud.com/artist/cached-album');
       });
 
       it('emits the 8 LML-only fields on a local hit, matching the cold extended-mode shape (BS#1336)', async () => {

--- a/tests/unit/services/flowsheet.transformToIFSEntry.host-guard.test.ts
+++ b/tests/unit/services/flowsheet.transformToIFSEntry.host-guard.test.ts
@@ -1,0 +1,102 @@
+import { transformToIFSEntry, type FSEntryRaw } from '../../../apps/backend/services/flowsheet.service';
+
+/**
+ * BS#1714. `transformToIFSEntry` is the single producer of every IFSEntry that
+ * reaches the `/flowsheet` read (top-level `spotify_url`/`apple_music_url`) and
+ * the `/v2/flowsheet` read (`transformToV2`, nested `metadata`). Fill-only
+ * persistence left non-Spotify/non-Apple URLs under those two columns before
+ * #1712's ingestion guard shipped; this seam host-guards them so a mislabeled
+ * value never reaches the hardwired iOS "Spotify"/"Apple Music" button. Both the
+ * top-level field and the nested `metadata` copy must be suppressed together.
+ */
+
+const makeRaw = (overrides: Partial<FSEntryRaw> = {}): FSEntryRaw => ({
+  id: 1,
+  show_id: 100,
+  album_id: null,
+  entry_type: 'track',
+  artist_name: 'Juana Molina',
+  album_title: 'DOGA',
+  track_title: 'la paradoja',
+  track_position: null,
+  record_label: 'Sonamos',
+  label_id: null,
+  rotation_id: null,
+  rotation_bin: null,
+  artist_id: null,
+  request_flag: false,
+  segue: false,
+  message: null,
+  play_order: 1,
+  legacy_entry_id: null,
+  legacy_release_id: null,
+  add_time: new Date('2026-04-17T22:53:48.500Z'),
+  dj_name: null,
+  linkage_source: null,
+  linkage_confidence: null,
+  linked_at: null,
+  artwork_url: null,
+  discogs_url: null,
+  release_year: null,
+  spotify_url: null,
+  apple_music_url: null,
+  youtube_music_url: null,
+  bandcamp_url: null,
+  soundcloud_url: null,
+  artist_bio: null,
+  artist_wikipedia_url: null,
+  genres: null,
+  styles: null,
+  on_streaming: null,
+  metadata_status: 'enriched_match',
+  enriching_since: null,
+  radio_hour: null,
+  ...overrides,
+});
+
+describe('transformToIFSEntry streaming-URL host guard (BS#1714)', () => {
+  it('suppresses a mislabeled spotify_url on both the top-level field and nested metadata', () => {
+    const entry = transformToIFSEntry(makeRaw({ spotify_url: 'https://www.deezer.com/album/254381182' }));
+    expect(entry.spotify_url).toBeNull();
+    expect(entry.metadata.spotify_url).toBeNull();
+  });
+
+  it('suppresses a mislabeled apple_music_url on both the top-level field and nested metadata', () => {
+    const entry = transformToIFSEntry(makeRaw({ apple_music_url: 'https://tidal.com/browse/album/254381182' }));
+    expect(entry.apple_music_url).toBeNull();
+    expect(entry.metadata.apple_music_url).toBeNull();
+  });
+
+  it('drops a suffix-spoof host to null', () => {
+    const entry = transformToIFSEntry(makeRaw({ spotify_url: 'https://open.spotify.com.evil.example/album/1' }));
+    expect(entry.spotify_url).toBeNull();
+    expect(entry.metadata.spotify_url).toBeNull();
+  });
+
+  it('passes a genuine Spotify/Apple URL through on both positions', () => {
+    const entry = transformToIFSEntry(
+      makeRaw({
+        spotify_url: 'https://open.spotify.com/album/genuine',
+        apple_music_url: 'https://music.apple.com/us/album/genuine',
+      })
+    );
+    expect(entry.spotify_url).toBe('https://open.spotify.com/album/genuine');
+    expect(entry.metadata.spotify_url).toBe('https://open.spotify.com/album/genuine');
+    expect(entry.apple_music_url).toBe('https://music.apple.com/us/album/genuine');
+    expect(entry.metadata.apple_music_url).toBe('https://music.apple.com/us/album/genuine');
+  });
+
+  it('leaves the other three streaming fields untouched when spotify_url is mislabeled', () => {
+    const entry = transformToIFSEntry(
+      makeRaw({
+        spotify_url: 'https://www.deezer.com/album/1',
+        youtube_music_url: 'https://music.youtube.com/playlist?list=yt',
+        bandcamp_url: 'https://artist.bandcamp.com/album/x',
+        soundcloud_url: 'https://soundcloud.com/artist/x',
+      })
+    );
+    expect(entry.youtube_music_url).toBe('https://music.youtube.com/playlist?list=yt');
+    expect(entry.bandcamp_url).toBe('https://artist.bandcamp.com/album/x');
+    expect(entry.soundcloud_url).toBe('https://soundcloud.com/artist/x');
+  });
+});

--- a/tests/unit/utils/flowsheet-projection.test.ts
+++ b/tests/unit/utils/flowsheet-projection.test.ts
@@ -84,6 +84,52 @@ describe('projectFlowsheetEntry (BS#1513)', () => {
     expect(projected.entry_type).toBe('talkset');
     expect(projected).not.toHaveProperty('search_doc');
   });
+
+  // BS#1714: fill-only persistence left non-Spotify/non-Apple URLs under the
+  // spotify_url/apple_music_url columns before #1712's ingestion guard shipped.
+  // The projector host-guards them so iOS never binds a Deezer URL to the
+  // hardwired green "Spotify" button.
+  describe('BS#1714 streaming-URL host guard', () => {
+    it('drops a non-Spotify spotify_url to null (Deezer under the Spotify field)', () => {
+      const projected = projectFlowsheetEntry(
+        makeFullFlowsheetRow({ spotify_url: 'https://www.deezer.com/album/254381182' })
+      );
+      expect(projected.spotify_url).toBeNull();
+    });
+
+    it('drops a non-Apple apple_music_url to null', () => {
+      const projected = projectFlowsheetEntry(
+        makeFullFlowsheetRow({ apple_music_url: 'https://tidal.com/browse/album/254381182' })
+      );
+      expect(projected.apple_music_url).toBeNull();
+    });
+
+    it('drops a suffix-spoof host to null (spotify.com.evil.example)', () => {
+      const projected = projectFlowsheetEntry(
+        makeFullFlowsheetRow({ spotify_url: 'https://open.spotify.com.evil.example/album/1' })
+      );
+      expect(projected.spotify_url).toBeNull();
+    });
+
+    it('passes a genuine Spotify/Apple URL through unchanged', () => {
+      const projected = projectFlowsheetEntry(
+        makeFullFlowsheetRow({
+          spotify_url: 'https://open.spotify.com/album/genuine',
+          apple_music_url: 'https://music.apple.com/us/album/genuine',
+        })
+      );
+      expect(projected.spotify_url).toBe('https://open.spotify.com/album/genuine');
+      expect(projected.apple_music_url).toBe('https://music.apple.com/us/album/genuine');
+    });
+
+    it('leaves the other three streaming fields untouched when spotify_url is mislabeled', () => {
+      const row = makeFullFlowsheetRow({ spotify_url: 'https://www.deezer.com/album/1' });
+      const projected = projectFlowsheetEntry(row);
+      expect(projected.youtube_music_url).toBe(row.youtube_music_url);
+      expect(projected.bandcamp_url).toBe(row.bandcamp_url);
+      expect(projected.soundcloud_url).toBe(row.soundcloud_url);
+    });
+  });
 });
 
 describe('pickClientFacingColumns (BS#1534)', () => {
@@ -117,5 +163,35 @@ describe('pickClientFacingColumns (BS#1534)', () => {
     const picked = pickClientFacingColumns(JSON.parse('{"id":7,"__proto__":{"polluted":true}}'));
     expect(picked).toEqual({ id: 7 });
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  // BS#1714: the same host guard on the parsed-JSON CDC `liveFs:update` payload.
+  describe('BS#1714 streaming-URL host guard', () => {
+    it('nulls a present-but-mislabeled spotify_url (Deezer) while keeping the key', () => {
+      const picked = pickClientFacingColumns({ id: 7, spotify_url: 'https://www.deezer.com/album/1' });
+      expect(picked.spotify_url).toBeNull();
+      expect('spotify_url' in picked).toBe(true);
+    });
+
+    it('nulls a present-but-mislabeled apple_music_url', () => {
+      const picked = pickClientFacingColumns({ id: 7, apple_music_url: 'https://tidal.com/browse/album/1' });
+      expect(picked.apple_music_url).toBeNull();
+    });
+
+    it('passes a genuine Spotify/Apple URL through unchanged', () => {
+      const picked = pickClientFacingColumns({
+        id: 7,
+        spotify_url: 'https://open.spotify.com/album/genuine',
+        apple_music_url: 'https://music.apple.com/us/album/genuine',
+      });
+      expect(picked.spotify_url).toBe('https://open.spotify.com/album/genuine');
+      expect(picked.apple_music_url).toBe('https://music.apple.com/us/album/genuine');
+    });
+
+    it('does not invent a streaming key that was absent from the partial row', () => {
+      const picked = pickClientFacingColumns({ id: 7, artist_name: 'Jessica Pratt' });
+      expect(picked).not.toHaveProperty('spotify_url');
+      expect(picked).not.toHaveProperty('apple_music_url');
+    });
   });
 });


### PR DESCRIPTION
## Problem

The ingestion-boundary host guard (#1712 / PR #1713) stops *new* mislabeled streaming URLs from being persisted, but BS persistence is fill-only — the ~68K `flowsheet` + ~3.9K `album_metadata` rows already holding a non-Spotify URL under `spotify_url` (or non-Apple under `apple_music_url`) were still **served** verbatim, so iOS kept binding e.g. a Deezer URL to the hardwired green "Spotify" button. This PR adds interim **read-time** suppression at the DB-read serve seams so already-persisted bad rows stop surfacing under the wrong button immediately, without waiting on the durable overwrite job (#1715).

## Approach

Reuse the `isSpotifyUrl` / `isAppleMusicUrl` helpers from `@wxyc/lml-client` (added in #1712) at each serve seam that emits a persisted row — no re-implementation of host matching, one source of truth for the apex-match logic.

### Seams guarded

| Seam | Surface | Behavior |
|---|---|---|
| `proxy.controller.buildLocalMetadataResponse` | `/proxy/metadata/album` persisted branch (sole consumer of `album-metadata-lookup.service`'s `PersistedAlbumMetadata`) | A suppressed value falls through to the already-synthesized `open.spotify.com/search` / `music.apple.com/search` fallback |
| `flowsheet.service.transformToIFSEntry` | the single producer of every `IFSEntry` reaching `/flowsheet` (top-level field) and `/v2/flowsheet` (`transformToV2`'s nested `metadata`) | sanitized once into two locals reused in both positions; exported alongside `FSEntryRaw` for direct unit coverage |
| `flowsheet-projection.projectFlowsheetEntry` | mutation-response (`addEntry`/`updateEntry`/`deleteEntry`/`changeOrder`) + DJ peek | present non-matching host → `null` |
| `flowsheet-projection.pickClientFacingColumns` | CDC `liveFs:update` SSE | present non-matching host → `null` |

The two nullish-passthrough projectors match `sanitizeLookupStreamingUrls`'s `!= null` shape — a nullish or genuine value is left untouched, only a present non-matching host is dropped to `null`.

### Deliberately out of scope

The fresh-LML serve branches (`proxy.controller` L226, `metadata.service.extractAlbumMetadata`, `enrichment.service` writes) are already clean: `sanitizeLookupStreamingUrls` runs inside the LML client on every single (`index.ts:542`) and bulk (`index.ts:697`) lookup, so any consumer of an LML result — including the cold-fallthrough serve branch and the enrichment writer — receives sanitized data. This is a read-only interim guard; the durable data heal is the sibling overwrite job (#1715).

## Testing

- New: `tests/unit/services/flowsheet.transformToIFSEntry.host-guard.test.ts` (both top-level + nested `metadata` positions, suffix-spoof, genuine passthrough, other three streaming fields untouched).
- Extended: `tests/unit/utils/flowsheet-projection.test.ts` (guard under both `projectFlowsheetEntry` and `pickClientFacingColumns`) and `tests/unit/controllers/proxy.controller.test.ts` (persisted Deezer/Tidal URL suppressed, search fallback synthesized, LML not called).
- Full local gate green: `typecheck`, `lint` (0 errors), `format:check`, `test:unit` (4805 passing).

## Acceptance criteria

- [x] A persisted non-Spotify `spotify_url` is not emitted under the Spotify field by `/proxy/metadata/*`, `/flowsheet`, and `/v2/flowsheet` (incl. mutation 200s + the `liveFs:update` SSE).
- [x] Genuine Spotify/Apple URLs pass through unchanged.
- [x] Unit coverage at each seam.

Part of #1710. Sibling of the overwrite-job follow-up (#1715). Depends on #1712 (helpers, already merged).

Closes #1714
