### PR TITLE
feat: serve external critic-review snippets on /proxy/metadata/album (ADR 0012)

### DIFF
--- a/apps/backend/config/catalogSearchAlias.ts
+++ b/apps/backend/config/catalogSearchAlias.ts
@@ -9,32 +9,14 @@
  *
  * Defaults to `false` so production behavior is unchanged until an operator
  * opts in. See: `Backend-Service/plans/artist-search-alias.md` §PR 5.
+ *
+ * The singleton mechanics (strict-`true` parse, lazy cache, `resetConfig` test
+ * hook) come from the shared {@link createEnvFlagConfig} factory. Tests that
+ * mutate `process.env.CATALOG_SEARCH_ALIAS_ENABLED` between cases must call
+ * `resetConfig()` in `beforeEach` so the next `getConfig()` re-reads the env.
  */
+import { createEnvFlagConfig, type EnvFlagConfig } from './envFlag.js';
 
-export interface CatalogSearchAliasConfig {
-  enabled: boolean;
-}
+export type CatalogSearchAliasConfig = EnvFlagConfig;
 
-export function loadConfig(): CatalogSearchAliasConfig {
-  return {
-    enabled: process.env.CATALOG_SEARCH_ALIAS_ENABLED === 'true',
-  };
-}
-
-let _config: CatalogSearchAliasConfig | null = null;
-
-export function getConfig(): CatalogSearchAliasConfig {
-  if (!_config) {
-    _config = loadConfig();
-  }
-  return _config;
-}
-
-/**
- * Reset the cached singleton. Tests that mutate
- * `process.env.CATALOG_SEARCH_ALIAS_ENABLED` between cases must call this
- * in `beforeEach` so the next `getConfig()` re-reads the environment.
- */
-export function resetConfig(): void {
-  _config = null;
-}
+export const { loadConfig, getConfig, resetConfig } = createEnvFlagConfig('CATALOG_SEARCH_ALIAS_ENABLED');

--- a/apps/backend/config/criticReviews.ts
+++ b/apps/backend/config/criticReviews.ts
@@ -4,9 +4,10 @@
  *
  * When enabled, `GET /proxy/metadata/album` does one extra indexed read
  * against `album_critic_reviews` (keyed on the same `library.id` the handler
- * already resolves) and attaches a non-empty `criticReviews` array to the
- * response. The flag is strict-`true` gated so an accidental
- * `CRITIC_REVIEWS_ENABLED=1` does not silently add a query to a hot path.
+ * already resolves for the metadata read — a shared resolve, not a second key
+ * lookup) and attaches a non-empty `criticReviews` array to the response. The
+ * flag is strict-`true` gated so an accidental `CRITIC_REVIEWS_ENABLED=1` does
+ * not silently add a query to a hot path.
  *
  * Defaults to `false` so production behavior — response shape and serve-path
  * query plan — is byte-for-byte unchanged until an operator opts in. This
@@ -14,32 +15,14 @@
  * (project #32) on the album-metadata serve path: no added latency ships to
  * prod until the flag is flipped, at which point the read's cost can be
  * measured against #32's perf budgets deliberately. See ADR 0012.
+ *
+ * The singleton mechanics (strict-`true` parse, lazy cache, `resetConfig` test
+ * hook) come from the shared {@link createEnvFlagConfig} factory. Tests that
+ * mutate `process.env.CRITIC_REVIEWS_ENABLED` between cases must call
+ * `resetConfig()` in `beforeEach` so the next `getConfig()` re-reads the env.
  */
+import { createEnvFlagConfig, type EnvFlagConfig } from './envFlag.js';
 
-export interface CriticReviewsConfig {
-  enabled: boolean;
-}
+export type CriticReviewsConfig = EnvFlagConfig;
 
-export function loadConfig(): CriticReviewsConfig {
-  return {
-    enabled: process.env.CRITIC_REVIEWS_ENABLED === 'true',
-  };
-}
-
-let _config: CriticReviewsConfig | null = null;
-
-export function getConfig(): CriticReviewsConfig {
-  if (!_config) {
-    _config = loadConfig();
-  }
-  return _config;
-}
-
-/**
- * Reset the cached singleton. Tests that mutate
- * `process.env.CRITIC_REVIEWS_ENABLED` between cases must call this in
- * `beforeEach` so the next `getConfig()` re-reads the environment.
- */
-export function resetConfig(): void {
-  _config = null;
-}
+export const { loadConfig, getConfig, resetConfig } = createEnvFlagConfig('CRITIC_REVIEWS_ENABLED');

--- a/apps/backend/config/criticReviews.ts
+++ b/apps/backend/config/criticReviews.ts
@@ -1,0 +1,45 @@
+/**
+ * Configuration for external critic-review snippets on the album-metadata
+ * serve path (album-critic-reviews slice, ADR 0012).
+ *
+ * When enabled, `GET /proxy/metadata/album` does one extra indexed read
+ * against `album_critic_reviews` (keyed on the same `library.id` the handler
+ * already resolves) and attaches a non-empty `criticReviews` array to the
+ * response. The flag is strict-`true` gated so an accidental
+ * `CRITIC_REVIEWS_ENABLED=1` does not silently add a query to a hot path.
+ *
+ * Defaults to `false` so production behavior — response shape and serve-path
+ * query plan — is byte-for-byte unchanged until an operator opts in. This
+ * keeps the change compatible with the Post-launch service hardening freeze
+ * (project #32) on the album-metadata serve path: no added latency ships to
+ * prod until the flag is flipped, at which point the read's cost can be
+ * measured against #32's perf budgets deliberately. See ADR 0012.
+ */
+
+export interface CriticReviewsConfig {
+  enabled: boolean;
+}
+
+export function loadConfig(): CriticReviewsConfig {
+  return {
+    enabled: process.env.CRITIC_REVIEWS_ENABLED === 'true',
+  };
+}
+
+let _config: CriticReviewsConfig | null = null;
+
+export function getConfig(): CriticReviewsConfig {
+  if (!_config) {
+    _config = loadConfig();
+  }
+  return _config;
+}
+
+/**
+ * Reset the cached singleton. Tests that mutate
+ * `process.env.CRITIC_REVIEWS_ENABLED` between cases must call this in
+ * `beforeEach` so the next `getConfig()` re-reads the environment.
+ */
+export function resetConfig(): void {
+  _config = null;
+}

--- a/apps/backend/config/envFlag.ts
+++ b/apps/backend/config/envFlag.ts
@@ -1,0 +1,48 @@
+/**
+ * Factory for the single-boolean, strict-`true`-gated, lazily-cached
+ * environment-flag config that several feature gates share verbatim
+ * (`criticReviews`, `catalogSearchAlias`). Each returned config is a small
+ * singleton over one env var; `getConfig()` reads the environment once and
+ * caches, `loadConfig()` reads it fresh every call, and `resetConfig()` drops
+ * the cache so a test that mutated the env var in `beforeEach` re-reads it.
+ *
+ * The strict `=== 'true'` comparison is the point of the shared helper: a flag
+ * that gates an extra query or a widened SQL path must not silently enable on
+ * `=1`/`TRUE`/`yes`. Callers that need more than one flag (e.g.
+ * `catalogTrackSearch`, which carries two) don't use this factory.
+ *
+ * The returned functions close over a factory-local cache, so they stay
+ * correct when destructured and re-exported as standalone named bindings
+ * (`export const { getConfig, resetConfig } = createEnvFlagConfig(...)`) —
+ * there is no `this` to lose.
+ */
+export interface EnvFlagConfig {
+  enabled: boolean;
+}
+
+export interface EnvFlag {
+  loadConfig(): EnvFlagConfig;
+  getConfig(): EnvFlagConfig;
+  resetConfig(): void;
+}
+
+export function createEnvFlagConfig(envVar: string): EnvFlag {
+  let cached: EnvFlagConfig | null = null;
+
+  function loadConfig(): EnvFlagConfig {
+    return { enabled: process.env[envVar] === 'true' };
+  }
+
+  function getConfig(): EnvFlagConfig {
+    if (!cached) {
+      cached = loadConfig();
+    }
+    return cached;
+  }
+
+  function resetConfig(): void {
+    cached = null;
+  }
+
+  return { loadConfig, getConfig, resetConfig };
+}

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -27,8 +27,9 @@ import { getDiscogsReleaseIdByLegacyId } from '../services/library.service.js';
 import { filterSpacerGif, isSyntheticArtwork } from '../services/metadata/metadata.service.js';
 import { SearchUrlProvider } from '../services/metadata/providers/search-urls.provider.js';
 import {
-  lookupAlbumMetadataByKey,
-  lookupCriticReviewsByAlbumKey,
+  resolveLinkedAlbumId,
+  lookupAlbumMetadataById,
+  lookupCriticReviewsByAlbumId,
   type PersistedAlbumMetadata,
 } from '../services/album-metadata-lookup.service.js';
 import { getConfig as getCriticReviewsConfig } from '../config/criticReviews.js';
@@ -383,7 +384,7 @@ function buildLocalMetadataResponse(persisted: PersistedAlbumMetadata): Record<s
   if (persisted.artist_wikipedia_url) metadata.artistWikipediaUrl = persisted.artist_wikipedia_url;
   // LML-only enrichment fields (BS#1336). The `[...]` array copies match the
   // LML branch's convention and future-proof the field against a cached
-  // lookup layer: `lookupAlbumMetadataByKey` reads fresh from the DB today (no
+  // lookup layer: `lookupAlbumMetadataById` reads fresh from the DB today (no
   // aliasing hazard), but proxy.controller is cache-heavy and the cache-
   // hierarchy work (project #32) may front this lookup with an LRU — at which
   // point an uncopied array assigned onto the response could be mutated by a
@@ -446,14 +447,22 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   // fills missing streaming URLs at the bottom of the handler. iOS sees
   // the same shape it would on the LML-fallthrough path.
   //
+  // Resolve the `album_id` from the normalized `(artist, album)` lookup key
+  // ONCE, then feed it to both the persisted-metadata read and (below) the
+  // critic-reviews read. Resolving per-read would let a flowsheet insert
+  // between the two calls make metadata and reviews describe different albums
+  // for the same request.
+  //
   // A thrown DB error here would propagate as 500 and regress availability
   // versus the LML-fallthrough path (which catches LML errors and degrades
   // to synthesized search URLs). Treat any DB failure as a cache miss and
   // fall through to LML — the caller's worst-case latency goes up, but the
   // request still completes with a 200.
+  let albumId: number | null = null;
   let persisted: PersistedAlbumMetadata | null = null;
   try {
-    persisted = await lookupAlbumMetadataByKey(artistName, releaseTitle);
+    albumId = await resolveLinkedAlbumId(artistName, releaseTitle);
+    if (albumId !== null) persisted = await lookupAlbumMetadataById(albumId);
   } catch (lookupError) {
     console.warn('[ProxyController] local metadata lookup failed; falling through to LML:', lookupError);
   }
@@ -531,13 +540,17 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
   // Flag-gated (`CRITIC_REVIEWS_ENABLED`, default off) so prod behavior — the
   // response shape and the serve-path query plan — is unchanged until an
   // operator opts in, keeping this compatible with the #32 hardening freeze
-  // on the album-metadata serve path. Attached only when non-empty so an
-  // un-seeded album's response is byte-identical to before. Wrapped in
-  // try/catch: the reviews read is strictly additive and must never break the
-  // metadata response, so a DB failure degrades to omitting the field.
-  if (getCriticReviewsConfig().enabled) {
+  // on the album-metadata serve path. Reuses the `album_id` resolved for the
+  // metadata read above (one extra indexed read, not a second key resolve),
+  // and runs whenever the key resolved to a linked album — independent of
+  // whether `album_metadata` enrichment has landed, so a linked album with
+  // reviews but no metadata row still surfaces its reviews. Attached only when
+  // non-empty so an un-seeded album's response is byte-identical to before.
+  // Wrapped in try/catch: the reviews read is strictly additive and must never
+  // break the metadata response, so a DB failure degrades to omitting the field.
+  if (getCriticReviewsConfig().enabled && albumId !== null) {
     try {
-      const criticReviews = await lookupCriticReviewsByAlbumKey(artistName, releaseTitle);
+      const criticReviews = await lookupCriticReviewsByAlbumId(albumId);
       if (criticReviews.length > 0) metadata.criticReviews = criticReviews;
     } catch (reviewsError) {
       console.warn('[ProxyController] critic-reviews lookup failed; omitting criticReviews:', reviewsError);

--- a/apps/backend/controllers/proxy.controller.ts
+++ b/apps/backend/controllers/proxy.controller.ts
@@ -26,7 +26,12 @@ import { lmlLookupCoordinator } from '../services/lml/index.js';
 import { getDiscogsReleaseIdByLegacyId } from '../services/library.service.js';
 import { filterSpacerGif, isSyntheticArtwork } from '../services/metadata/metadata.service.js';
 import { SearchUrlProvider } from '../services/metadata/providers/search-urls.provider.js';
-import { lookupAlbumMetadataByKey, type PersistedAlbumMetadata } from '../services/album-metadata-lookup.service.js';
+import {
+  lookupAlbumMetadataByKey,
+  lookupCriticReviewsByAlbumKey,
+  type PersistedAlbumMetadata,
+} from '../services/album-metadata-lookup.service.js';
+import { getConfig as getCriticReviewsConfig } from '../config/criticReviews.js';
 import { LRUCache } from 'lru-cache';
 import WxycError from '../utils/error.js';
 
@@ -520,6 +525,23 @@ export const getAlbumMetadata: RequestHandler<object, unknown, unknown, AlbumMet
     });
   } catch (err) {
     console.warn('[ProxyController] failed to project Sentry attrs', err);
+  }
+
+  // External critic-review snippets (album-critic-reviews slice, ADR 0012).
+  // Flag-gated (`CRITIC_REVIEWS_ENABLED`, default off) so prod behavior — the
+  // response shape and the serve-path query plan — is unchanged until an
+  // operator opts in, keeping this compatible with the #32 hardening freeze
+  // on the album-metadata serve path. Attached only when non-empty so an
+  // un-seeded album's response is byte-identical to before. Wrapped in
+  // try/catch: the reviews read is strictly additive and must never break the
+  // metadata response, so a DB failure degrades to omitting the field.
+  if (getCriticReviewsConfig().enabled) {
+    try {
+      const criticReviews = await lookupCriticReviewsByAlbumKey(artistName, releaseTitle);
+      if (criticReviews.length > 0) metadata.criticReviews = criticReviews;
+    } catch (reviewsError) {
+      console.warn('[ProxyController] critic-reviews lookup failed; omitting criticReviews:', reviewsError);
+    }
   }
 
   res.set('Cache-Control', 'private, max-age=600');

--- a/apps/backend/services/album-metadata-lookup.service.ts
+++ b/apps/backend/services/album-metadata-lookup.service.ts
@@ -1,42 +1,39 @@
 /**
- * Local lookup helper for the cache-first `/proxy/metadata/album` path
- * (BS#1331). Resolves an `(artistName, releaseTitle)` tuple against BS's
- * own persisted state — `album_metadata` keyed by the `album_id` of a
- * matching `flowsheet` row — so the steady-state read path skips the LML
- * cascade entirely.
+ * Local read helpers backing the cache-first `/proxy/metadata/album` path
+ * (BS#1331) and the external critic-review snippets attached to it
+ * (album-critic-reviews slice, ADR 0012). All three read BS's own persisted
+ * state so the steady-state serve path skips the LML cascade entirely.
  *
- * Query shape is a two-step lookup with the partial functional index
- * `flowsheet_album_link_lookup_idx` (migration 0081) doing the work:
- *   1. Find one `album_id` whose `flowsheet` row matches the normalized
- *      lookup key (`lower(trim(artist)) || '-' || lower(trim(coalesce(
- *      album, '')))`). The partial index's `WHERE album_id IS NOT NULL`
- *      predicate aligns with the explicit `WHERE` here so the planner
- *      uses the index without a sort.
- *   2. PK-lookup on `album_metadata` by that `album_id`.
+ * Three exported helpers, keyed on the `album_id` of a matching `flowsheet`
+ * row and staged so the handler resolves that id exactly once per request:
+ *   - {@link resolveLinkedAlbumId} — normalized `(artist, release)` key →
+ *     one `library.id`, via the partial functional index
+ *     `flowsheet_album_link_lookup_idx` (migration 0081). Deterministic
+ *     `ORDER BY flowsheet.id DESC LIMIT 1` row-pick so multi-`album_id` keys
+ *     (V/A multi-format, dual-pressings, librarian duplicates) can't flap
+ *     between distinct albums across polls.
+ *   - {@link lookupAlbumMetadataById} — PK-lookup on `album_metadata` for a
+ *     resolved id; the 10 base columns the proxy response is built from plus
+ *     the 8 LML-only enrichment fields (`discogs_artist_id` / `label` /
+ *     `full_release_date` / `genres` / `styles` / `tracklist` /
+ *     `artist_image_url` / `bio_tokens`, BS#1336) so a cache hit carries the
+ *     same shape as the cold LML-fallthrough path.
+ *   - {@link lookupCriticReviewsByAlbumId} — up to `CRITIC_REVIEWS_LIMIT`
+ *     attributed snippets for a resolved id, independent of whether
+ *     `album_metadata` enrichment has run.
  *
- * The two-step form avoids the `ORDER BY flowsheet.id DESC LIMIT 1` sort
- * cost on hot keys (a popular release played hundreds of times would
- * otherwise force the planner to materialize all matching flowsheet rows
- * before taking the head). All flowsheet rows for the same album resolve
- * to the same `album_metadata` row anyway, so the row-pick within a key
- * is degenerate as long as we land on one matching `album_id`.
+ * The `/proxy/metadata/album` handler calls {@link resolveLinkedAlbumId}
+ * once and feeds the id to both the metadata and reviews reads, so a
+ * concurrent flowsheet insert can't make the two reads describe two
+ * different albums for one request (the reads used to each re-resolve the
+ * key, which was both racy and coupled reviews to the metadata read).
  *
- * Returns the 10 base columns the proxy response is built from plus the 8
- * LML-only enrichment fields (`discogs_artist_id` / `label` /
- * `full_release_date` / `genres` / `styles` / `tracklist` /
- * `artist_image_url` / `bio_tokens`) added by BS#1336. Before that, those
- * fields lived only on the cold LML-fallthrough response, so a cache hit
- * shed the artist+release subtree (dj-site / iOS V1 gate the artist
- * sub-panel on `discogsArtistId`); the enrichment-worker now persists them
- * (`extended: true`) and the read path surfaces them, so a hit carries the
- * same shape as the cold path.
- *
- * `null` return means "no enriched local row for this key" — the caller
- * should fall through to LML. Free-form flowsheet rows (`album_id IS
- * NULL`) by definition can't hit, so iOS surfaces for those still pay
- * the LML round-trip. That's accepted scope: the cache-first goal
- * targets the linked-row cohort (the steady state for entries old enough
- * to be of interest to a detail-view fetch).
+ * A `null` metadata result means "no enriched local row for this id" — the
+ * caller falls through to LML. Free-form flowsheet rows (`album_id IS NULL`)
+ * can't resolve at all, so iOS surfaces for those still pay the LML
+ * round-trip. That's accepted scope: the cache-first goal targets the
+ * linked-row cohort (the steady state for entries old enough to be of
+ * interest to a detail-view fetch).
  */
 import { sql, eq, desc } from 'drizzle-orm';
 import { db, flowsheet, album_metadata, album_critic_reviews } from '@wxyc/database';
@@ -94,29 +91,16 @@ export interface PersistedAlbumMetadata {
 }
 
 /**
- * Resolve `(artistName, releaseTitle)` against persisted state.
- * Returns the row's metadata, or `null` when no `album_id`-bearing
- * flowsheet row exists for the key. `null` means "cold — go to LML".
- *
- * An empty/whitespace-only `artistName` short-circuits to `null` (the
- * caller's 400 path runs first, but this guard means a key of `'-'`
- * — which any blank-artist linked row would also produce — can't
- * accidentally serve arbitrary metadata).
- *
- * `releaseTitle` is similarly required for a meaningful hit: an
- * undefined/blank releaseTitle keys into `'<artist>-'`, which matches
- * any linked flowsheet row whose DJ left `album_title` blank, returning
- * whichever `album_id` that row carried. The artist-card surfaces that
- * call this endpoint without a releaseTitle are better served by an
- * LML lookup or a dedicated artist-only handler.
- */
-/**
  * Resolve `(artistName, releaseTitle)` to the `library.id` of a matching
  * linked flowsheet row, or `null` when no `album_id`-bearing flowsheet row
  * exists for the key. Shared Step-1 for both the album-metadata read
- * (`lookupAlbumMetadataByKey`) and the critic-reviews read
- * (`lookupCriticReviewsByAlbumKey`) so they resolve the *same* album key
- * for a given query.
+ * (`lookupAlbumMetadataById`) and the critic-reviews read
+ * (`lookupCriticReviewsByAlbumId`). Callers that need both — the
+ * `/proxy/metadata/album` handler — resolve the key *once* here and pass the
+ * id to both reads, so a concurrent flowsheet insert can't make the two
+ * reads disagree on which album they describe. The seed writer
+ * (`scripts/seed-critic-reviews.ts`) imports this to key its UPSERTs against
+ * the exact same normalized flowsheet key the serve path reads.
  *
  * Uses the partial functional index `flowsheet_album_link_lookup_idx`. The
  * explicit `flowsheet.album_id IS NOT NULL` predicate matches the index's
@@ -135,7 +119,7 @@ export interface PersistedAlbumMetadata {
  * linked flowsheet row whose DJ left `album_title` blank and return an
  * arbitrary `album_id`.
  */
-async function resolveLinkedAlbumId(artistName: string, releaseTitle?: string): Promise<number | null> {
+export async function resolveLinkedAlbumId(artistName: string, releaseTitle?: string): Promise<number | null> {
   const trimmedArtist = artistName.trim();
   const trimmedRelease = (releaseTitle ?? '').trim();
   if (trimmedArtist.length === 0 || trimmedRelease.length === 0) return null;
@@ -152,21 +136,21 @@ async function resolveLinkedAlbumId(artistName: string, releaseTitle?: string): 
   return candidate[0]?.album_id ?? null;
 }
 
-export async function lookupAlbumMetadataByKey(
-  artistName: string,
-  releaseTitle?: string
-): Promise<PersistedAlbumMetadata | null> {
-  // Step 1: resolve the album_id via the partial functional index.
-  const albumId = await resolveLinkedAlbumId(artistName, releaseTitle);
-  if (albumId === null) return null;
-
-  // Step 2: PK-lookup on album_metadata. Returns null when the row
-  // doesn't exist yet (race window: flowsheet INSERT landed but the
-  // enrichment-worker hasn't UPSERTed album_metadata yet). Falling
-  // through to LML in that window is the right behavior — the worker
-  // is already paying the LML cost concurrently, but a stale or
-  // pre-enrichment response would otherwise persist in the iOS cache
-  // for the duration of the response Cache-Control TTL.
+/**
+ * PK-lookup of persisted `album_metadata` for an already-resolved
+ * `library.id`. Returns `null` when the row doesn't exist yet (race window:
+ * flowsheet INSERT landed but the enrichment-worker hasn't UPSERTed
+ * `album_metadata` yet). Falling through to LML in that window is the right
+ * behavior — the worker is already paying the LML cost concurrently, but a
+ * stale or pre-enrichment response would otherwise persist in the iOS cache
+ * for the duration of the response Cache-Control TTL.
+ *
+ * The caller resolves `albumId` via {@link resolveLinkedAlbumId} once and
+ * passes it to both this read and {@link lookupCriticReviewsByAlbumId}, so a
+ * concurrent flowsheet insert can't make metadata and reviews describe two
+ * different albums for one request.
+ */
+export async function lookupAlbumMetadataById(albumId: number): Promise<PersistedAlbumMetadata | null> {
   const rows = await db
     .select({
       artwork_url: album_metadata.artwork_url,
@@ -201,14 +185,23 @@ export async function lookupAlbumMetadataByKey(
 }
 
 /**
- * Wire projection of one external critic-review snippet, matching the
- * `CriticReviewItem` schema in wxyc-shared `api.yaml` (album-critic-reviews
- * slice, ADR 0012). Only the six wire fields are surfaced; the internal
- * columns (`id`, `album_id`, `discogs_release_id`, `source_key`, timestamps)
- * never leave the service. `url` maps to the `source_url` column;
- * `publishedDate` maps to `published_at`. Optional fields are omitted from
- * the response when null so iOS `decodeIfPresent` and dj-site optional
- * chaining stay decode-compatible.
+ * Wire projection of one external critic-review snippet (album-critic-reviews
+ * slice, ADR 0012). Only the six wire fields are surfaced; the internal columns
+ * (`id`, `album_id`, `discogs_release_id`, `source_key`, timestamps) never
+ * leave the service. `url` maps to the `source_url` column; `publishedDate`
+ * maps to `published_at`. Optional fields are omitted from the response when
+ * null so iOS `decodeIfPresent` and dj-site optional chaining stay
+ * decode-compatible.
+ *
+ * SSOT: the canonical shape is the `CriticReviewItem` schema in wxyc-shared
+ * `api.yaml` (contract WXYC/wxyc-shared#242, PR WXYC/wxyc-shared#243). That PR
+ * must merge and `@wxyc/shared` must publish before this endpoint change ships
+ * — the dependency is encoded as BS#1719 blocked-by wxyc-shared#242 so the
+ * specs can't drift. This interface is a deliberate temporary hand-mirror kept
+ * field-for-field in sync with that schema; once the generated type is
+ * published, replace this declaration with an import of the generated
+ * `CriticReviewItem` (this is the only local copy — the controller and seed
+ * both consume it from here).
  */
 export interface CriticReviewItem {
   source: string;
@@ -229,15 +222,17 @@ export interface CriticReviewItem {
 const CRITIC_REVIEWS_LIMIT = 5;
 
 /**
- * Resolve `(artistName, releaseTitle)` to its attributed external critic
- * snippets (album-critic-reviews slice, ADR 0012). Shares Step-1
- * (`resolveLinkedAlbumId`) with `lookupAlbumMetadataByKey`, so a given query
- * resolves the same `library.id` for both metadata and reviews.
+ * Attributed external critic snippets for an already-resolved `library.id`
+ * (album-critic-reviews slice, ADR 0012). The caller resolves the id via
+ * {@link resolveLinkedAlbumId} once and shares it with
+ * {@link lookupAlbumMetadataById}, so a given request describes the same
+ * album for both metadata and reviews.
  *
- * Returns `[]` (never `null`) when the key doesn't resolve to a linked album
- * or the album has no seeded snippets — the caller attaches `criticReviews`
- * only when the array is non-empty, so an empty result keeps the response
- * shape identical to an un-seeded album.
+ * Returns `[]` (never `null`) when the album has no seeded snippets — the
+ * caller attaches `criticReviews` only when the array is non-empty, so an
+ * empty result keeps the response shape identical to an un-seeded album. This
+ * read is independent of whether `album_metadata` enrichment has run: a linked
+ * album with seeded reviews but no metadata row still surfaces its reviews.
  *
  * Ordered newest-first (`published_at DESC NULLS LAST`, then `id DESC` as a
  * stable tiebreak for undated rows and same-day rows) and capped at
@@ -245,13 +240,7 @@ const CRITIC_REVIEWS_LIMIT = 5;
  * it as an ISO `YYYY-MM-DD` string, which is exactly the `publishedDate`
  * wire shape.
  */
-export async function lookupCriticReviewsByAlbumKey(
-  artistName: string,
-  releaseTitle?: string
-): Promise<CriticReviewItem[]> {
-  const albumId = await resolveLinkedAlbumId(artistName, releaseTitle);
-  if (albumId === null) return [];
-
+export async function lookupCriticReviewsByAlbumId(albumId: number): Promise<CriticReviewItem[]> {
   const rows = await db
     .select({
       source: album_critic_reviews.source,

--- a/apps/backend/services/album-metadata-lookup.service.ts
+++ b/apps/backend/services/album-metadata-lookup.service.ts
@@ -39,7 +39,7 @@
  * to be of interest to a detail-view fetch).
  */
 import { sql, eq, desc } from 'drizzle-orm';
-import { db, flowsheet, album_metadata } from '@wxyc/database';
+import { db, flowsheet, album_metadata, album_critic_reviews } from '@wxyc/database';
 import type { DiscogsResolvedToken, DiscogsTrackItem } from '@wxyc/lml-client';
 
 const flowsheetLookupKey = sql<string>`lower(trim(${flowsheet.artist_name})) || '-' || lower(trim(coalesce(${flowsheet.album_title}, '')))`;
@@ -110,28 +110,38 @@ export interface PersistedAlbumMetadata {
  * call this endpoint without a releaseTitle are better served by an
  * LML lookup or a dedicated artist-only handler.
  */
-export async function lookupAlbumMetadataByKey(
-  artistName: string,
-  releaseTitle?: string
-): Promise<PersistedAlbumMetadata | null> {
+/**
+ * Resolve `(artistName, releaseTitle)` to the `library.id` of a matching
+ * linked flowsheet row, or `null` when no `album_id`-bearing flowsheet row
+ * exists for the key. Shared Step-1 for both the album-metadata read
+ * (`lookupAlbumMetadataByKey`) and the critic-reviews read
+ * (`lookupCriticReviewsByAlbumKey`) so they resolve the *same* album key
+ * for a given query.
+ *
+ * Uses the partial functional index `flowsheet_album_link_lookup_idx`. The
+ * explicit `flowsheet.album_id IS NOT NULL` predicate matches the index's
+ * WHERE clause verbatim so the planner uses the partial index. `ORDER BY
+ * flowsheet.id DESC LIMIT 1` makes the row-pick deterministic on
+ * multi-album_id keys (V/A multi-format, dual-pressing, librarian
+ * duplicates — verified to exist in the live `album_id` corpus). Two
+ * requests for the same lookup key resolve to the same row, eliminating a
+ * flapping-response edge that would otherwise let iOS see two different
+ * albums for the same query across polls. Sort cost is bounded: the
+ * most-popular key has hundreds of matches, not thousands; the post-filter
+ * `id DESC` sort on the small match set is sub-ms in practice.
+ *
+ * An empty/whitespace-only `artistName` or `releaseTitle` short-circuits to
+ * `null`: the key `'<artist>-'` (blank release) would otherwise match any
+ * linked flowsheet row whose DJ left `album_title` blank and return an
+ * arbitrary `album_id`.
+ */
+async function resolveLinkedAlbumId(artistName: string, releaseTitle?: string): Promise<number | null> {
   const trimmedArtist = artistName.trim();
   const trimmedRelease = (releaseTitle ?? '').trim();
   if (trimmedArtist.length === 0 || trimmedRelease.length === 0) return null;
 
   const key = lookupKey(trimmedArtist, trimmedRelease);
 
-  // Step 1: find the album_id via the partial functional index. Explicit
-  // `flowsheet.album_id IS NOT NULL` predicate matches the index's WHERE
-  // clause verbatim so the planner uses the partial index. `ORDER BY
-  // flowsheet.id DESC LIMIT 1` makes the row-pick deterministic on
-  // multi-album_id keys (V/A multi-format, dual-pressing, librarian
-  // duplicates — verified to exist in the live `album_id` corpus). Two
-  // requests for the same lookup key resolve to the same row, eliminating
-  // a flapping-response edge that would otherwise let iOS see two
-  // different artworks/streaming URLs for the same album across polls.
-  // Sort cost is bounded: the most-popular key has hundreds of matches,
-  // not thousands; the index returns sorted-by-key but the post-filter
-  // `id DESC` sort on the small match set is sub-ms in practice.
   const candidate = await db
     .select({ album_id: flowsheet.album_id })
     .from(flowsheet)
@@ -139,8 +149,16 @@ export async function lookupAlbumMetadataByKey(
     .orderBy(desc(flowsheet.id))
     .limit(1);
 
-  const albumId = candidate[0]?.album_id;
-  if (albumId === undefined || albumId === null) return null;
+  return candidate[0]?.album_id ?? null;
+}
+
+export async function lookupAlbumMetadataByKey(
+  artistName: string,
+  releaseTitle?: string
+): Promise<PersistedAlbumMetadata | null> {
+  // Step 1: resolve the album_id via the partial functional index.
+  const albumId = await resolveLinkedAlbumId(artistName, releaseTitle);
+  if (albumId === null) return null;
 
   // Step 2: PK-lookup on album_metadata. Returns null when the row
   // doesn't exist yet (race window: flowsheet INSERT landed but the
@@ -180,4 +198,86 @@ export async function lookupAlbumMetadataByKey(
   // the typed projection here — the enrichment-worker is the sole writer and
   // persists the LML DTO shapes verbatim.
   return (rows[0] ?? null) as PersistedAlbumMetadata | null;
+}
+
+/**
+ * Wire projection of one external critic-review snippet, matching the
+ * `CriticReviewItem` schema in wxyc-shared `api.yaml` (album-critic-reviews
+ * slice, ADR 0012). Only the six wire fields are surfaced; the internal
+ * columns (`id`, `album_id`, `discogs_release_id`, `source_key`, timestamps)
+ * never leave the service. `url` maps to the `source_url` column;
+ * `publishedDate` maps to `published_at`. Optional fields are omitted from
+ * the response when null so iOS `decodeIfPresent` and dj-site optional
+ * chaining stay decode-compatible.
+ */
+export interface CriticReviewItem {
+  source: string;
+  url: string;
+  snippet: string;
+  author?: string;
+  publishedDate?: string;
+  rating?: string;
+}
+
+/**
+ * Cap on the number of snippets returned per album. The playcut detail view
+ * shows a short list, and an unbounded array on this hot serve path is a
+ * payload-size risk; a re-seed that somehow inserted dozens of rows for one
+ * album shouldn't bloat every response. Newest-first (see ORDER BY below)
+ * means the cap keeps the most recent coverage.
+ */
+const CRITIC_REVIEWS_LIMIT = 5;
+
+/**
+ * Resolve `(artistName, releaseTitle)` to its attributed external critic
+ * snippets (album-critic-reviews slice, ADR 0012). Shares Step-1
+ * (`resolveLinkedAlbumId`) with `lookupAlbumMetadataByKey`, so a given query
+ * resolves the same `library.id` for both metadata and reviews.
+ *
+ * Returns `[]` (never `null`) when the key doesn't resolve to a linked album
+ * or the album has no seeded snippets — the caller attaches `criticReviews`
+ * only when the array is non-empty, so an empty result keeps the response
+ * shape identical to an un-seeded album.
+ *
+ * Ordered newest-first (`published_at DESC NULLS LAST`, then `id DESC` as a
+ * stable tiebreak for undated rows and same-day rows) and capped at
+ * `CRITIC_REVIEWS_LIMIT`. `published_at` is a `date` column; drizzle returns
+ * it as an ISO `YYYY-MM-DD` string, which is exactly the `publishedDate`
+ * wire shape.
+ */
+export async function lookupCriticReviewsByAlbumKey(
+  artistName: string,
+  releaseTitle?: string
+): Promise<CriticReviewItem[]> {
+  const albumId = await resolveLinkedAlbumId(artistName, releaseTitle);
+  if (albumId === null) return [];
+
+  const rows = await db
+    .select({
+      source: album_critic_reviews.source,
+      source_url: album_critic_reviews.source_url,
+      snippet: album_critic_reviews.snippet,
+      author: album_critic_reviews.author,
+      published_at: album_critic_reviews.published_at,
+      rating: album_critic_reviews.rating,
+    })
+    .from(album_critic_reviews)
+    .where(eq(album_critic_reviews.album_id, albumId))
+    .orderBy(sql`${album_critic_reviews.published_at} DESC NULLS LAST`, desc(album_critic_reviews.id))
+    .limit(CRITIC_REVIEWS_LIMIT);
+
+  // Project to the wire shape, omitting optional fields when null so the
+  // response carries only present keys (matches the metadata handler's
+  // "assign only when present" convention).
+  return rows.map((row) => {
+    const item: CriticReviewItem = {
+      source: row.source,
+      url: row.source_url,
+      snippet: row.snippet,
+    };
+    if (row.author) item.author = row.author;
+    if (row.published_at) item.publishedDate = row.published_at;
+    if (row.rating) item.rating = row.rating;
+    return item;
+  });
 }

--- a/docs/adr/0012-external-critic-reviews.md
+++ b/docs/adr/0012-external-critic-reviews.md
@@ -1,0 +1,35 @@
+# 0012 — External critic-review snippets are attributed, link-out, and a fourth distinct "review" concept
+
+Short attributed excerpts from external music-critic reviews (Pitchfork, The Quietus, and the crawled review corpus in [`WXYC/research-data`](https://github.com/WXYC/research-data)) surface in the iOS playcut detail view. They live in their own table, [`album_critic_reviews`](../../shared/database/src/schema.ts) (migration 0125), keyed on `library.id`, and are served as an additive optional `criticReviews` array on `GET /proxy/metadata/album` (contract: `CriticReviewItem` in [wxyc-shared `api.yaml`](https://github.com/WXYC/wxyc-shared/pull/243)). This is the fourth distinct "review" concept in the stack and does NOT extend any of the other three.
+
+The four concepts and why none of them is this one:
+
+- **`reviews`** ([ADR 0006](0006-reviews-model-extension.md)) — the one-per-album, author-owned (`author_dj_id` FK to `auth_user`), MD-queued in-app Review model at `/reviews`. Authored by WXYC DJs, mutable, library-bound. Critic reviews are third-party, not DJ-authored, and there are many per album.
+- **`album_review_submissions`** ([ADR 0011](0011-album-review-submissions-separate-archive.md)) — the ~1,650 DJ-written Google-Form reviews, an append-only PII-internal archive. Also WXYC-authored; critic reviews carry no PII and are meant to be shown with attribution, the opposite posture.
+- **`AlbumReview` DTO** (wxyc-shared #229, closed) — reserved for the ADR 0006 in-app model's wire shape. `CriticReviewItem` is deliberately named to avoid colliding with it.
+- **`album_critic_reviews`** (this ADR) — external, third-party, attributed, multiple per album, keyed on `library.id`.
+
+## Departure from "Complement, Don't Confirm"
+
+[`WXYC/wiki` `research/review-corpus-analysis.md`](https://github.com/WXYC/wiki/blob/main/research/review-corpus-analysis.md) established the **"Complement, Don't Confirm"** doctrine: the crawled critic corpus is used _internally_ — as an unattributed signal that informs WXYC's own editorial voice — and is never republished as third-party opinion, because doing so both dilutes the station's freeform identity and raises the copyright question of redistributing full critic text.
+
+This slice consciously departs on the second half. It surfaces **short attributed excerpts with a link-out to the source**, not full text and not an unattributed signal. The departure is bounded so it stays defensible:
+
+- **Length.** The seed writer trims each `snippet` to ≤300 characters (a 512-char column gives headroom but the writer is the cap). Short, attributed, transformative-context excerpts with a link to the full review are the standard fair-use quotation posture for editorial aggregators.
+- **Attribution + link-out, always.** `source` and `source_url` are `NOT NULL`. The UI shows the publication name and links out; it never presents critic text as WXYC's.
+- **No scores as the primary artifact.** `rating` is optional metadata, not the surfaced content. We show what a critic _said_, attributed, not a decontextualized number.
+- **Complement still holds for the corpus's internal uses.** Nothing here changes how the corpus informs internal editorial work; this adds a second, separately-governed, attributed surface.
+
+## Decision
+
+- `album_critic_reviews` is the store for external attributed critic snippets: multiple per album, keyed on `album_id` → `library.id` (`ON DELETE CASCADE` — a critic snippet has no meaning once its library album is gone), `(album_id, source_url)` as the UPSERT conflict target so a re-seed refreshes rather than duplicates.
+- Two ingestion sources feed the one table through a single seed writer: (a) **structured relations** (publisher review APIs / linked-data where a review URL is directly resolvable for a release) and (b) the **existing crawled corpus** in `research-data`. `source` records the publication; `source_key` records the writer's provenance handle so a given source's rows can be re-driven idempotently.
+- The serve path is **flag-gated** behind `CRITIC_REVIEWS_ENABLED` (strict `=== 'true'`, default `false`), attaches `criticReviews` to the `GET /proxy/metadata/album` response **only when non-empty**, and does the extra read in a `try/catch` that degrades to omitting the field. With the flag off (the production default), the response shape and the serve-path query plan are byte-for-byte unchanged. This keeps the change compatible with the [Post-launch service hardening](https://github.com/orgs/WXYC/projects/32) freeze on the album-metadata serve path: no behavior ships to prod until an operator opts in, at which point the added query's cost can be measured against #32's perf budgets deliberately.
+- The wire contract is additive and optional (`CriticReviewItem` requires only `source`/`url`/`snippet`), so iOS `decodeIfPresent` and dj-site optional chaining stay decode-compatible whether or not the field is present.
+
+## Consequences
+
+- Later work touching "reviews" now has four concepts to disambiguate; this ADR and [ADR 0011](0011-album-review-submissions-separate-archive.md) together are the boundary markers.
+- The seed writer is the sole writer of `album_critic_reviews`; manual corrections (should any be needed) win over it, mirroring the `album_review_submissions.album_id` link-pass posture.
+- Flipping `CRITIC_REVIEWS_ENABLED=true` adds one indexed read (`album_id` equality on `album_critic_reviews`) to the album-metadata serve path. That is the only prod-latency change and it is opt-in; enabling it is a decision for the #32 owners, not a side effect of this merge.
+- The fair-use posture is a per-source judgment. If a specific publisher's terms forbid excerpting, that source is excluded at the seed writer, not litigated in the serve path — the table trusts its writer.

--- a/scripts/seed-critic-reviews.ts
+++ b/scripts/seed-critic-reviews.ts
@@ -1,0 +1,387 @@
+/**
+ * Seed `album_critic_reviews` with short attributed critic-review snippets
+ * (album-critic-reviews slice, ADR 0012).
+ *
+ * This is the write-side companion to the read path
+ * `lookupCriticReviewsByAlbumKey` (apps/backend/services/album-metadata-lookup.service.ts).
+ * It takes a prepared manifest of candidate review articles, resolves each to
+ * a linked library album via the SAME normalized flowsheet lookup key the
+ * serve path uses (so a seeded row is guaranteed reachable by the endpoint),
+ * asks Claude Haiku to pull ONE short verbatim excerpt + attribution, and
+ * UPSERTs into `album_critic_reviews` keyed on `(album_id, source_url)`.
+ *
+ * Sources (the user's "(a) and (b)" scope):
+ *   (b1) the existing crawled review corpus (WXYC/research-data — ~37K
+ *        articles from 4 publications), and
+ *   (b2) structured critic-review relations (e.g. MusicBrainz review URLs).
+ * Corpus *discovery* (crawling research-data, querying MB) is deliberately
+ * OUT of this tracer-bullet script — that belongs in a future
+ * `jobs/album-critic-reviews-etl/`. This script reads a already-assembled
+ * manifest so the load-bearing parts (LLM extraction + idempotent write +
+ * album linkage) are real and reviewable now. Both sources normalize to the
+ * common `CorpusItem` shape below before they reach this script.
+ *
+ * Fair use (see ADR 0012): we store a SHORT attributed excerpt (<=300 chars)
+ * plus a mandatory link-out to the full review — never full text, never a
+ * score-only card. The 300-char cap is enforced in code (`MAX_SNIPPET`), not
+ * just in the prompt, so a mis-behaving model can't overshoot it.
+ *
+ * SAFETY — this script costs money (Anthropic API) and writes to a live DB:
+ *   - DRY RUN IS THE DEFAULT. Nothing is written unless SEED_EXECUTE=true.
+ *   - SEED_SKIP_LLM=true swaps the Haiku call for a deterministic local
+ *     first-sentence excerpt so the pipeline can be exercised end-to-end at
+ *     ZERO API cost (lower quality — validation only, not for production seed).
+ *   - With the LLM enabled, ANTHROPIC_API_KEY must be set or the script aborts
+ *     up front rather than silently degrading.
+ *
+ * Usage:
+ *   # zero-cost pipeline smoke (no writes, no API):
+ *   SEED_SKIP_LLM=true dotenvx run -f .env -- npx tsx scripts/seed-critic-reviews.ts --input reviews.jsonl
+ *
+ *   # real extraction, still no writes (preview what would be seeded):
+ *   dotenvx run -f .env -- npx tsx scripts/seed-critic-reviews.ts --input reviews.jsonl
+ *
+ *   # commit to the DB:
+ *   SEED_EXECUTE=true dotenvx run -f .env -- npx tsx scripts/seed-critic-reviews.ts --input reviews.jsonl
+ *
+ * Requires (only for real extraction): `npm i @anthropic-ai/sdk` — the SDK is
+ * loaded via dynamic import so the SEED_SKIP_LLM path runs without it present.
+ *
+ * Input manifest: JSONL, one CorpusItem per line (see the type below).
+ *   {"artist":"Juana Molina","album":"DOGA","source":"Pitchfork",
+ *    "sourceUrl":"https://pitchfork.com/reviews/albums/juana-molina-doga/",
+ *    "articleText":"...full review body...","author":"Philip Sherburne",
+ *    "publishedAt":"2024-09-30","rating":"7.8"}
+ */
+
+import { config } from 'dotenv';
+config();
+
+import { readFileSync } from 'node:fs';
+import { sql, desc } from 'drizzle-orm';
+import { db, closeDatabaseConnection, flowsheet, album_critic_reviews } from '@wxyc/database';
+
+/** One candidate review, normalized from either source (b1) or (b2). */
+export interface CorpusItem {
+  /** Artist as it should match the WXYC flowsheet/library artist_name. */
+  artist: string;
+  /** Album title as it should match the flowsheet/library album_title. */
+  album: string;
+  /** Publication name shown as the snippet's attribution (e.g. "Pitchfork"). */
+  source: string;
+  /** Canonical URL of the full review — the mandatory link-out + conflict key. */
+  sourceUrl: string;
+  /** Full review body Haiku reads to pull the excerpt from. */
+  articleText: string;
+  /** Byline, if the manifest already knows it (Haiku may also recover it). */
+  author?: string;
+  /** ISO date (YYYY-MM-DD) the review was published, if known. */
+  publishedAt?: string;
+  /** Score as printed by the publication (e.g. "7.8", "4/5"), if any. */
+  rating?: string;
+  /** Discogs release id, if the manifest carries one (informational only). */
+  discogsReleaseId?: number;
+}
+
+/** What Haiku returns per article, before we cap/clean it. */
+interface Extraction {
+  /** False when the article isn't actually a review of this album — skip it. */
+  isReview: boolean;
+  /** One verbatim excerpt from the body, the reviewer's own words. */
+  snippet: string;
+  /** Byline recovered from the body, or null. */
+  author: string | null;
+  /** Score recovered from the body, or null. */
+  rating: string | null;
+}
+
+/** Hard fair-use ceiling. The DB column is varchar(512); we self-limit tighter. */
+const MAX_SNIPPET = 300;
+const MODEL = 'claude-haiku-4-5-20251001';
+
+const DRY_RUN = process.env.SEED_EXECUTE !== 'true';
+const SKIP_LLM = process.env.SEED_SKIP_LLM === 'true';
+const LIMIT = Number.parseInt(process.env.SEED_LIMIT ?? '0', 10); // 0 = no cap
+
+function parseArgs(argv: string[]): { input: string } {
+  const idx = argv.indexOf('--input');
+  const input = idx >= 0 ? argv[idx + 1] : process.env.SEED_INPUT;
+  if (!input) {
+    console.error('❌ No input manifest. Pass --input <file.jsonl> or set SEED_INPUT.');
+    process.exit(1);
+  }
+  return { input };
+}
+
+/** Read + parse the JSONL manifest, skipping blank lines. Throws on bad JSON. */
+function loadManifest(path: string): CorpusItem[] {
+  const raw = readFileSync(path, 'utf8');
+  const items: CorpusItem[] = [];
+  raw.split('\n').forEach((line, i) => {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) return;
+    try {
+      items.push(JSON.parse(trimmed) as CorpusItem);
+    } catch (err) {
+      throw new Error(`Malformed JSON on line ${i + 1} of ${path}: ${(err as Error).message}`);
+    }
+  });
+  return items;
+}
+
+/**
+ * Resolve the linked library album_id for an (artist, album) pair using the
+ * exact normalized key the serve path resolves against
+ * (`resolveLinkedAlbumId` in album-metadata-lookup.service.ts). Kept in sync
+ * by construction: same `lower(trim(...))` composition, same
+ * `album_id IS NOT NULL` filter, same newest-row tiebreak. A review whose
+ * album isn't linked in the flowsheet has nowhere to surface, so we skip it.
+ */
+async function resolveAlbumId(artist: string, album: string): Promise<number | null> {
+  const trimmedArtist = artist.trim();
+  const trimmedAlbum = album.trim();
+  if (trimmedArtist.length === 0 || trimmedAlbum.length === 0) return null;
+
+  const key = `${trimmedArtist.toLowerCase()}-${trimmedAlbum.toLowerCase()}`;
+  const keyExpr = sql<string>`lower(trim(${flowsheet.artist_name})) || '-' || lower(trim(coalesce(${flowsheet.album_title}, '')))`;
+
+  const rows = await db
+    .select({ album_id: flowsheet.album_id })
+    .from(flowsheet)
+    .where(sql`${keyExpr} = ${key} AND ${flowsheet.album_id} IS NOT NULL`)
+    .orderBy(desc(flowsheet.id))
+    .limit(1);
+
+  return rows[0]?.album_id ?? null;
+}
+
+const EXTRACTION_SYSTEM = [
+  'You extract a single short, verbatim, attributable pull-quote from a music album review.',
+  'Rules:',
+  `- The snippet MUST be the reviewer's own words, copied verbatim from the body, and <= ${MAX_SNIPPET} characters.`,
+  '- Prefer an evaluative sentence about the music (not a plot/biography sentence).',
+  '- Do NOT paraphrase, summarize, translate, or invent text. If nothing suitable exists, set isReview=false.',
+  '- If the article is not actually a review of the named album, set isReview=false.',
+  '- Recover the byline (author) and the printed score (rating) only if they appear in the text; otherwise null.',
+].join('\n');
+
+/** JSON-schema tool the model is forced to call, so output is structured. */
+const EXTRACTION_TOOL = {
+  name: 'record_snippet',
+  description: 'Record the extracted pull-quote and attribution.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      isReview: {
+        type: 'boolean',
+        description: 'True only if this is a review of the named album with a usable quote.',
+      },
+      snippet: {
+        type: 'string',
+        description: `Verbatim excerpt, <= ${MAX_SNIPPET} chars. Empty string if isReview is false.`,
+      },
+      author: { type: ['string', 'null'], description: 'Byline if present in the text, else null.' },
+      rating: { type: ['string', 'null'], description: 'Printed score if present, else null.' },
+    },
+    required: ['isReview', 'snippet', 'author', 'rating'],
+    additionalProperties: false,
+  },
+} as const;
+
+// The Anthropic client is loaded lazily so the SEED_SKIP_LLM path needs no SDK.
+// Typed loosely on purpose — scripts/ is outside the typecheck + lint scope.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let anthropicClient: any = null;
+
+async function getAnthropic(): Promise<any> {
+  if (anthropicClient) return anthropicClient;
+  // Computed specifier keeps a missing optional dep from being a hard
+  // dependency of this file when SEED_SKIP_LLM is used.
+  const moduleName = '@anthropic-ai/sdk';
+  const mod: any = await import(moduleName);
+  const Anthropic = mod.default ?? mod;
+  anthropicClient = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  return anthropicClient;
+}
+
+/**
+ * Deterministic, zero-cost fallback used under SEED_SKIP_LLM: take the first
+ * sentence of the article body, capped. Good enough to exercise the write
+ * path; NOT the quality bar for a real seed.
+ */
+function localExtract(item: CorpusItem): Extraction {
+  const body = item.articleText.replace(/\s+/g, ' ').trim();
+  const firstSentence = body.split(/(?<=[.!?])\s/)[0] ?? body;
+  const snippet = firstSentence.slice(0, MAX_SNIPPET).trim();
+  return {
+    isReview: snippet.length > 0,
+    snippet,
+    author: item.author ?? null,
+    rating: item.rating ?? null,
+  };
+}
+
+/** Ask Haiku for the structured extraction. Throws on a malformed tool call. */
+async function llmExtract(item: CorpusItem): Promise<Extraction> {
+  const client = await getAnthropic();
+  const message = await client.messages.create({
+    model: MODEL,
+    max_tokens: 512,
+    system: EXTRACTION_SYSTEM,
+    tools: [EXTRACTION_TOOL],
+    tool_choice: { type: 'tool', name: EXTRACTION_TOOL.name },
+    messages: [
+      {
+        role: 'user',
+        content: [
+          `Album: ${item.album}`,
+          `Artist: ${item.artist}`,
+          `Publication: ${item.source}`,
+          '',
+          'Review body:',
+          item.articleText,
+        ].join('\n'),
+      },
+    ],
+  });
+
+  const toolUse = (message.content ?? []).find((block: any) => block.type === 'tool_use');
+  if (!toolUse) throw new Error('Model did not return a tool_use block');
+  const out = toolUse.input as Partial<Extraction>;
+  return {
+    isReview: out.isReview === true,
+    snippet: typeof out.snippet === 'string' ? out.snippet : '',
+    author: typeof out.author === 'string' && out.author.trim().length > 0 ? out.author : null,
+    rating: typeof out.rating === 'string' && out.rating.trim().length > 0 ? out.rating : null,
+  };
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * Normalize an extraction into a persistable row (or null to skip). Enforces
+ * the fair-use cap in code: an over-length snippet is trimmed at the last
+ * sentence/space boundary rather than mid-word, and a snippet that still can't
+ * fit is rejected so we never persist a truncated-mid-thought quote.
+ */
+function toRow(
+  item: CorpusItem,
+  albumId: number,
+  extraction: Extraction
+): typeof album_critic_reviews.$inferInsert | null {
+  if (!extraction.isReview) return null;
+  let snippet = extraction.snippet.replace(/\s+/g, ' ').trim();
+  if (snippet.length === 0) return null;
+  if (snippet.length > MAX_SNIPPET) {
+    const cut = snippet.slice(0, MAX_SNIPPET);
+    const boundary = Math.max(cut.lastIndexOf('. '), cut.lastIndexOf(' '));
+    snippet = boundary > MAX_SNIPPET * 0.6 ? cut.slice(0, boundary).trim() : '';
+    if (snippet.length === 0) return null; // couldn't cap cleanly — drop it
+  }
+  return {
+    album_id: albumId,
+    source: item.source,
+    source_url: item.sourceUrl,
+    snippet,
+    author: extraction.author ?? item.author ?? null,
+    published_at: item.publishedAt ?? null,
+    rating: extraction.rating ?? item.rating ?? null,
+    discogs_release_id: item.discogsReleaseId ?? null,
+    source_key: `manifest:${item.source}`,
+  };
+}
+
+/** Idempotent UPSERT on the (album_id, source_url) unique index. */
+async function upsertRow(row: typeof album_critic_reviews.$inferInsert): Promise<void> {
+  await db
+    .insert(album_critic_reviews)
+    .values(row)
+    .onConflictDoUpdate({
+      target: [album_critic_reviews.album_id, album_critic_reviews.source_url],
+      set: {
+        source: row.source,
+        snippet: row.snippet,
+        author: row.author,
+        published_at: row.published_at,
+        rating: row.rating,
+        discogs_release_id: row.discogs_release_id,
+        source_key: row.source_key,
+        last_modified: sql`now()`,
+      },
+    });
+}
+
+async function main(): Promise<void> {
+  const { input } = parseArgs(process.argv.slice(2));
+
+  if (!SKIP_LLM && !process.env.ANTHROPIC_API_KEY) {
+    console.error(
+      '❌ ANTHROPIC_API_KEY is not set. Set it, or run with SEED_SKIP_LLM=true for the zero-cost local extractor.'
+    );
+    process.exit(1);
+  }
+
+  const all = loadManifest(input);
+  const items = LIMIT > 0 ? all.slice(0, LIMIT) : all;
+
+  console.log('🌱 Seed album_critic_reviews (ADR 0012)');
+  console.log(`   Input: ${input} (${all.length} items${LIMIT > 0 ? `, capped to ${items.length}` : ''})`);
+  console.log(`   Extractor: ${SKIP_LLM ? 'local first-sentence (zero cost)' : `Haiku (${MODEL})`}`);
+  console.log(
+    `   Mode: ${DRY_RUN ? 'DRY RUN (no writes) — set SEED_EXECUTE=true to commit' : '⚠️  EXECUTE (writing to DB)'}\n`
+  );
+
+  const stats = { written: 0, skippedUnlinked: 0, skippedNotReview: 0, failed: 0 };
+
+  for (const item of items) {
+    const label = `"${item.artist} — ${item.album}" (${item.source})`;
+    try {
+      const albumId = await resolveAlbumId(item.artist, item.album);
+      if (albumId === null) {
+        stats.skippedUnlinked++;
+        console.log(`   ⤳ skip (no linked library album) ${label}`);
+        continue;
+      }
+
+      const extraction = SKIP_LLM ? localExtract(item) : await llmExtract(item);
+      const row = toRow(item, albumId, extraction);
+      if (!row) {
+        stats.skippedNotReview++;
+        console.log(`   ⤳ skip (not a usable review) ${label}`);
+        continue;
+      }
+
+      if (DRY_RUN) {
+        console.log(`   🔍 would upsert album_id=${albumId} ${label}\n        “${row.snippet}”`);
+      } else {
+        await upsertRow(row);
+        console.log(`   ✅ upserted album_id=${albumId} ${label}`);
+      }
+      stats.written++;
+    } catch (err) {
+      stats.failed++;
+      console.error(`   ❌ ${label} — ${(err as Error).message}`);
+    }
+  }
+
+  console.log('\n📊 Seed complete:');
+  console.log(`   ${DRY_RUN ? 'Would write' : 'Written'}:        ${stats.written}`);
+  console.log(`   Skipped (unlinked): ${stats.skippedUnlinked}`);
+  console.log(`   Skipped (no quote): ${stats.skippedNotReview}`);
+  console.log(`   Failed:             ${stats.failed}`);
+
+  await closeDatabaseConnection();
+}
+
+// Only run when invoked directly; tests import the helpers without side effects.
+const invokedDirectly = (() => {
+  if (typeof process === 'undefined' || !process.argv?.[1]) return false;
+  const arg = process.argv[1];
+  return arg.endsWith('seed-critic-reviews.ts') || arg.endsWith('seed-critic-reviews.js');
+})();
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('Fatal error:', err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seed-critic-reviews.ts
+++ b/scripts/seed-critic-reviews.ts
@@ -3,10 +3,11 @@
  * (album-critic-reviews slice, ADR 0012).
  *
  * This is the write-side companion to the read path
- * `lookupCriticReviewsByAlbumKey` (apps/backend/services/album-metadata-lookup.service.ts).
+ * `lookupCriticReviewsByAlbumId` (apps/backend/services/album-metadata-lookup.service.ts).
  * It takes a prepared manifest of candidate review articles, resolves each to
- * a linked library album via the SAME normalized flowsheet lookup key the
- * serve path uses (so a seeded row is guaranteed reachable by the endpoint),
+ * a linked library album via the SAME `resolveLinkedAlbumId` the serve path
+ * uses — imported, not re-implemented, so a seeded row is guaranteed reachable
+ * by the endpoint and the two can never drift —
  * asks Claude Haiku to pull ONE short verbatim excerpt + attribution, and
  * UPSERTs into `album_critic_reviews` keyed on `(album_id, source_url)`.
  *
@@ -58,8 +59,9 @@ import { config } from 'dotenv';
 config();
 
 import { readFileSync } from 'node:fs';
-import { sql, desc } from 'drizzle-orm';
-import { db, closeDatabaseConnection, flowsheet, album_critic_reviews } from '@wxyc/database';
+import { sql } from 'drizzle-orm';
+import { db, closeDatabaseConnection, album_critic_reviews } from '@wxyc/database';
+import { resolveLinkedAlbumId } from '../apps/backend/services/album-metadata-lookup.service.js';
 
 /** One candidate review, normalized from either source (b1) or (b2). */
 export interface CorpusItem {
@@ -127,32 +129,6 @@ function loadManifest(path: string): CorpusItem[] {
     }
   });
   return items;
-}
-
-/**
- * Resolve the linked library album_id for an (artist, album) pair using the
- * exact normalized key the serve path resolves against
- * (`resolveLinkedAlbumId` in album-metadata-lookup.service.ts). Kept in sync
- * by construction: same `lower(trim(...))` composition, same
- * `album_id IS NOT NULL` filter, same newest-row tiebreak. A review whose
- * album isn't linked in the flowsheet has nowhere to surface, so we skip it.
- */
-async function resolveAlbumId(artist: string, album: string): Promise<number | null> {
-  const trimmedArtist = artist.trim();
-  const trimmedAlbum = album.trim();
-  if (trimmedArtist.length === 0 || trimmedAlbum.length === 0) return null;
-
-  const key = `${trimmedArtist.toLowerCase()}-${trimmedAlbum.toLowerCase()}`;
-  const keyExpr = sql<string>`lower(trim(${flowsheet.artist_name})) || '-' || lower(trim(coalesce(${flowsheet.album_title}, '')))`;
-
-  const rows = await db
-    .select({ album_id: flowsheet.album_id })
-    .from(flowsheet)
-    .where(sql`${keyExpr} = ${key} AND ${flowsheet.album_id} IS NOT NULL`)
-    .orderBy(desc(flowsheet.id))
-    .limit(1);
-
-  return rows[0]?.album_id ?? null;
 }
 
 const EXTRACTION_SYSTEM = [
@@ -273,8 +249,21 @@ function toRow(
   if (snippet.length === 0) return null;
   if (snippet.length > MAX_SNIPPET) {
     const cut = snippet.slice(0, MAX_SNIPPET);
-    const boundary = Math.max(cut.lastIndexOf('. '), cut.lastIndexOf(' '));
-    snippet = boundary > MAX_SNIPPET * 0.6 ? cut.slice(0, boundary).trim() : '';
+    // Prefer ending on a full sentence, then fall back to a word boundary,
+    // then drop. `sentenceEnd` is the index of the sentence-ending punctuation
+    // (`.`/`!`/`?` before a space), so slice `+ 1` to keep that punctuation and
+    // land a clean sentence. A word-boundary slice stops at the space, dropping
+    // the trailing partial word. Both must land past 60% of the cap — a cut
+    // that early isn't a usable quote, so we reject rather than persist a stub.
+    const sentenceEnd = Math.max(cut.lastIndexOf('. '), cut.lastIndexOf('! '), cut.lastIndexOf('? '));
+    const wordEnd = cut.lastIndexOf(' ');
+    if (sentenceEnd > MAX_SNIPPET * 0.6) {
+      snippet = cut.slice(0, sentenceEnd + 1).trim();
+    } else if (wordEnd > MAX_SNIPPET * 0.6) {
+      snippet = cut.slice(0, wordEnd).trim();
+    } else {
+      snippet = '';
+    }
     if (snippet.length === 0) return null; // couldn't cap cleanly — drop it
   }
   return {
@@ -335,7 +324,7 @@ async function main(): Promise<void> {
   for (const item of items) {
     const label = `"${item.artist} — ${item.album}" (${item.source})`;
     try {
-      const albumId = await resolveAlbumId(item.artist, item.album);
+      const albumId = await resolveLinkedAlbumId(item.artist, item.album);
       if (albumId === null) {
         stats.skippedUnlinked++;
         console.log(`   ⤳ skip (no linked library album) ${label}`);

--- a/shared/database/src/migrations/0125_album-critic-reviews.sql
+++ b/shared/database/src/migrations/0125_album-critic-reviews.sql
@@ -1,0 +1,29 @@
+-- 0125 external critic-review snippets: album_critic_reviews
+-- (album-critic-reviews slice, ADR 0012).
+--
+-- Short attributed excerpts from external music-critic reviews, keyed by
+-- library.id (the same album key the /proxy/metadata/album serve path
+-- already resolves). The 4th distinct "review" concept in the schema —
+-- distinct from `reviews` (legacy), `album_review_submissions` (DJ-authored
+-- archive, ADR 0011), and the `AlbumReview` DTO. `snippet` is capped at 512
+-- chars (writer trims to <=300 for fair-use); `(album_id, source_url)` is the
+-- UPSERT conflict target. Creates a fresh table + FK + UNIQUE index against
+-- no existing table, no rows rewritten (DDL-only).
+-- @no-precondition-needed: fresh empty table, no existing rows can violate the FK or UNIQUE index
+CREATE TABLE "wxyc_schema"."album_critic_reviews" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"album_id" integer NOT NULL,
+	"source" text NOT NULL,
+	"source_url" varchar(1024) NOT NULL,
+	"snippet" varchar(512) NOT NULL,
+	"author" varchar(128),
+	"published_at" date,
+	"rating" varchar(32),
+	"discogs_release_id" integer,
+	"source_key" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_modified" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "wxyc_schema"."album_critic_reviews" ADD CONSTRAINT "album_critic_reviews_album_id_library_id_fk" FOREIGN KEY ("album_id") REFERENCES "wxyc_schema"."library"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "album_critic_reviews_album_id_source_url_uq" ON "wxyc_schema"."album_critic_reviews" USING btree ("album_id","source_url");

--- a/shared/database/src/migrations/meta/0125_snapshot.json
+++ b/shared/database/src/migrations/meta/0125_snapshot.json
@@ -1,0 +1,6047 @@
+{
+  "id": "e4fa8244-6310-4315-9547-73071028a59b",
+  "prevId": "23c0c558-8a16-4dcb-b976-8f11dbb313f2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_critic_reviews": {
+      "name": "album_critic_reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_critic_reviews_album_id_source_url_uq": {
+          "name": "album_critic_reviews_album_id_source_url_uq",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_critic_reviews_album_id_library_id_fk": {
+          "name": "album_critic_reviews_album_id_library_id_fk",
+          "tableFrom": "album_critic_reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_release_date": {
+          "name": "full_release_date",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist": {
+          "name": "tracklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_image_url": {
+          "name": "artist_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_tokens": {
+          "name": "bio_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_popularity": {
+      "name": "album_popularity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "logical_album_key": {
+          "name": "logical_album_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_plays": {
+          "name": "linked_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freetext_plays": {
+          "name": "freetext_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "representative_library_id": {
+          "name": "representative_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_review_submissions": {
+      "name": "album_review_submissions",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_blurb": {
+          "name": "artist_blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_tracks": {
+          "name": "recommended_tracks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buzzwords": {
+          "name": "buzzwords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fcc_violations": {
+          "name": "fcc_violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_purpose": {
+          "name": "review_purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_raw": {
+          "name": "reviewer_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent_raw": {
+          "name": "social_consent_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent": {
+          "name": "social_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_within_six_months": {
+          "name": "released_within_six_months",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated": {
+          "name": "rotated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_form'"
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_review_submissions_source_key_uq": {
+          "name": "album_review_submissions_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"album_review_submissions\".\"source_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_album_id_idx": {
+          "name": "album_review_submissions_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_submitted_at_idx": {
+          "name": "album_review_submissions_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_norm_artist_idx": {
+          "name": "album_review_submissions_norm_artist_idx",
+          "columns": [
+            {
+              "expression": "norm_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_review_submissions_album_id_library_id_fk": {
+          "name": "album_review_submissions_album_id_library_id_fk",
+          "tableFrom": "album_review_submissions",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_metadata": {
+      "name": "artist_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_similar_artists": {
+      "name": "artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_similar_artists_artist_id_artists_id_fk": {
+          "name": "artist_similar_artists_artist_id_artists_id_fk",
+          "tableFrom": "artist_similar_artists",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_station_plays": {
+      "name": "artist_station_plays",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_station_plays_artist_id_artists_id_fk": {
+          "name": "artist_station_plays_artist_id_artists_id_fk",
+          "tableFrom": "artist_station_plays",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_null_track_idx": {
+          "name": "cta_unique_null_track_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"compilation_track_artist\".\"track_title\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doors_at": {
+          "name": "doors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id": {
+          "name": "headlining_discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id_source": {
+          "name": "headlining_discogs_artist_id_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_resolve_attempted_at": {
+          "name": "artist_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_min": {
+          "name": "price_min",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_max": {
+          "name": "price_max",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_restriction": {
+          "name": "age_restriction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_scraped_at": {
+          "name": "first_scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_curated_starts_on_idx": {
+          "name": "concerts_curated_starts_on_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"wxyc_schema\".\"concerts\".\"headlining_artist_id\" IS NOT NULL OR \"wxyc_schema\".\"concerts\".\"headlining_discogs_artist_id\" IS NOT NULL) AND \"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_active_starts_on_id_idx": {
+          "name": "concerts_active_starts_on_id_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_device_code": {
+      "name": "auth_device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_device_code_device_code_key": {
+          "name": "auth_device_code_device_code_key",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_user_code_key": {
+          "name": "auth_device_code_user_code_key",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_expires_at_idx": {
+          "name": "auth_device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_device_code_user_id_auth_user_id_fk": {
+          "name": "auth_device_code_user_id_auth_user_id_fk",
+          "tableFrom": "auth_device_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.discogs_artist_similar_artists": {
+      "name": "discogs_artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "radio_hour": {
+          "name": "radio_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer": {
+          "name": "composer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer_source": {
+          "name": "composer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_play_order_idx": {
+          "name": "flowsheet_show_id_play_order_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"play_order\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_idx": {
+          "name": "flowsheet_metadata_attempt_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_covering_idx": {
+          "name": "flowsheet_metadata_attempt_pending_covering_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_album_id_enriched_idx": {
+          "name": "flowsheet_album_id_enriched_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_freetext_resolution": {
+      "name": "flowsheet_freetext_resolution",
+      "schema": "wxyc_schema",
+      "columns": {
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_source": {
+          "name": "match_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_at": {
+          "name": "attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "flowsheet_freetext_resolution_norm_artist_norm_album_pk": {
+          "name": "flowsheet_freetext_resolution_norm_artist_norm_album_pk",
+          "columns": [
+            "norm_artist",
+            "norm_album"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flowsheet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_unavailable": {
+          "name": "discogs_unavailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discogs_unavailable_note": {
+          "name": "discogs_unavailable_note",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discogs_recheck_at": {
+          "name": "last_discogs_recheck_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_discogs_unavailable_idx": {
+          "name": "library_discogs_unavailable_idx",
+          "columns": [
+            {
+              "expression": "discogs_unavailable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_discogs_unavailable_note_check": {
+          "name": "library_discogs_unavailable_note_check",
+          "value": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" OR \"wxyc_schema\".\"library\".\"discogs_unavailable_note\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_watermark": {
+      "name": "library_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_watermark_singleton": {
+          "name": "library_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_access_token_client_id_idx": {
+          "name": "auth_oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_access_token_user_id_idx": {
+          "name": "auth_oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_access_token_key": {
+          "name": "auth_oauth_access_token_access_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "auth_oauth_access_token_refresh_token_key": {
+          "name": "auth_oauth_access_token_refresh_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_application": {
+      "name": "auth_oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_application_user_id_idx": {
+          "name": "auth_oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_application_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_application_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_application_client_id_key": {
+          "name": "auth_oauth_application_client_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_oauth_consent_client_id_idx": {
+          "name": "auth_oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_consent_user_id_idx": {
+          "name": "auth_oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "album_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lml_identity_id": {
+          "name": "lml_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rotation_discogs_release_id_not_sentinel": {
+          "name": "rotation_discogs_release_id_not_sentinel",
+          "value": "\"wxyc_schema\".\"rotation\".\"discogs_release_id\" IS NULL OR \"wxyc_schema\".\"rotation\".\"discogs_release_id\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_flow_expires_at": {
+          "name": "device_flow_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape",
+        "triangle_shows"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill",
+        "library_identity",
+        "md_verified",
+        "recheck_after_unavailable"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.album_plays": {
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "isExisting": true,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -855,6 +855,13 @@
       "when": 1784500083784,
       "tag": "0124_discogs-artist-similar-artists",
       "breakpoints": true
+    },
+    {
+      "idx": 125,
+      "version": "7",
+      "when": 1784500083785,
+      "tag": "0125_album-critic-reviews",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -120,5 +120,6 @@
   "0121_concerts-artist-genres": "246fd69ab64011af85ceb131be71e6b437377d4467f1cda959f37fe805c7e4ff",
   "0122_concerts-similar-artists": "7a76ba662728e529d331e398af753e550493b04fae25ca196145221c7b8af6df",
   "0123_artist-station-plays": "27a035161a03b42b583736e677aeb9fd20b1e28fe13bf0ae35180d487959006b",
-  "0124_discogs-artist-similar-artists": "151015f4cfe0c071ee0286dcfdc086a077249a5544551c1e44c0ae5f6db62a79"
+  "0124_discogs-artist-similar-artists": "151015f4cfe0c071ee0286dcfdc086a077249a5544551c1e44c0ae5f6db62a79",
+  "0125_album-critic-reviews": "d43eac8d0eb8e11929e092cadbfffe4f66e3e181c350d6ee1608ed8b9d72d73d"
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -1707,6 +1707,79 @@ export const album_review_submissions = wxyc_schema.table(
 export type AlbumReviewSubmission = InferSelectModel<typeof album_review_submissions>;
 export type NewAlbumReviewSubmission = InferInsertModel<typeof album_review_submissions>;
 
+/**
+ * External critic-review snippets (ADR 0012) — short attributed excerpts
+ * of published third-party album reviews, surfaced in the iOS playcut
+ * detail view with mandatory attribution + link-out to the original.
+ *
+ * This is the FOURTH, deliberately-distinct review concept and must not be
+ * merged with any of the others:
+ *   - `reviews` (ADR 0006): one-per-album, DJ-authored, in-app Review model.
+ *   - `album_review_submissions` (ADR 0011): archived DJ Google-Form reviews.
+ *   - the closed `AlbumReview` DTO (WXYC/wxyc-shared#229).
+ * Those are all WXYC-authored. This table holds EXTERNAL critic text.
+ *
+ * Copyright posture (ADR 0012): store only a short excerpt (`snippet`,
+ * hard-capped at ~300 chars by the seed writer — the DB caps the column at
+ * 512 for headroom), never full article text; every row carries `source` +
+ * `source_url` so the client can attribute and link out. This is a conscious
+ * departure from the "Complement, Don't Confirm" stance (which keeps crawled
+ * critic text unattributed and internal) — see the ADR for the reasoning.
+ *
+ * Keyed on `library.id` (via `album_id`), the stable stack-wide album key
+ * `album_metadata` also FKs to, so `/proxy/metadata/album` joins these onto
+ * the response by the same resolved album id. `ON DELETE CASCADE`: a critic
+ * review has no meaning without its album.
+ *
+ * `source` is text with a documented vocabulary (the 0109 enum-cost lesson),
+ * not a pgEnum. Values so far:
+ *   'The Quietus' — the spike seed (`scripts/seed-critic-reviews.ts`).
+ *
+ * `source_key` is an optional provenance marker (the originating corpus row
+ * key) for audit; idempotent re-seed is guaranteed by the
+ * `(album_id, source_url)` unique constraint (the UPSERT conflict target),
+ * not by `source_key`. `discogs_release_id` is a nullable hook for a future
+ * release-level reconciliation pass; the spike leaves it NULL.
+ */
+export const album_critic_reviews = wxyc_schema.table(
+  'album_critic_reviews',
+  {
+    id: serial('id').primaryKey(),
+    album_id: integer('album_id')
+      .references(() => library.id, { onDelete: 'cascade' })
+      .notNull(),
+    // Publication / outlet name, e.g. 'The Quietus'. Shown as attribution.
+    source: text('source').notNull(),
+    // Link to the original review. Mandatory — this is the link-out target
+    // and half of the fair-use attribution posture. Also the UPSERT natural
+    // key (paired with album_id).
+    source_url: varchar('source_url', { length: 1024 }).notNull(),
+    // Short attributed excerpt. Capped at ~300 chars by the seed writer; the
+    // column allows 512 for headroom. NEVER full article text (ADR 0012).
+    snippet: varchar('snippet', { length: 512 }).notNull(),
+    // Byline, when known.
+    author: varchar('author', { length: 128 }),
+    // Publication date, when known.
+    published_at: date('published_at'),
+    // Source-native rating as free text (e.g. '8/10'), when present.
+    rating: varchar('rating', { length: 32 }),
+    // Nullable hook for a future release-level reconciliation pass.
+    discogs_release_id: integer('discogs_release_id'),
+    // Originating corpus row key, for audit. Not the idempotency key.
+    source_key: text('source_key'),
+    created_at: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    last_modified: timestamp('last_modified', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    // UPSERT conflict target + the serve-path lookup index (album_id is the
+    // leading column, so `WHERE album_id = ?` uses this index directly).
+    uniqueIndex('album_critic_reviews_album_id_source_url_uq').on(table.album_id, table.source_url),
+  ]
+);
+
+export type AlbumCriticReview = InferSelectModel<typeof album_critic_reviews>;
+export type NewAlbumCriticReview = InferInsertModel<typeof album_critic_reviews>;
+
 export type NewBinEntry = InferInsertModel<typeof bins>;
 export type BinEntry = InferSelectModel<typeof bins>;
 export const bins = wxyc_schema.table('bins', {

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -1771,8 +1771,18 @@ export const album_critic_reviews = wxyc_schema.table(
     last_modified: timestamp('last_modified', { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [
-    // UPSERT conflict target + the serve-path lookup index (album_id is the
-    // leading column, so `WHERE album_id = ?` uses this index directly).
+    // UPSERT conflict target AND the serve-path lookup index: album_id is the
+    // leading column, so `WHERE album_id = ?` (the selective predicate) is an
+    // index range scan on this index directly. The serve query's residual
+    // `ORDER BY published_at DESC NULLS LAST, id DESC LIMIT 5` is a top-N sort
+    // over only the matched rows — a per-album handful for a curated critic
+    // corpus, capped at CRITIC_REVIEWS_LIMIT (5) on the read — so it stays
+    // sub-ms in memory. A dedicated `(album_id, published_at DESC NULLS LAST,
+    // id DESC)` ordered index would let the planner skip that sort, but the
+    // payoff is immeasurable at this row count while the write-amplification on
+    // every seed/ETL UPSERT is real; it's deliberately deferred until per-album
+    // counts grow enough to warrant it (and the serve path is flag-gated off in
+    // prod today regardless). See ADR 0012.
     uniqueIndex('album_critic_reviews_album_id_source_url_uq').on(table.album_id, table.source_url),
   ]
 );

--- a/tests/integration/album-metadata-upsert.spec.js
+++ b/tests/integration/album-metadata-upsert.spec.js
@@ -253,7 +253,7 @@ describe('album_metadata UPSERT contract (real PG)', () => {
     expect(row.full_release_date).toBe('2022-09-30');
     expect(row.artist_image_url).toBe(EXTENDED_PAYLOAD.artist_image_url);
     // text[] must come back as a JS array, NOT a '{Rock,Jazz}' literal string —
-    // the read path (lookupAlbumMetadataByKey) and buildLocalMetadataResponse
+    // the read path (lookupAlbumMetadataById) and buildLocalMetadataResponse
     // spread it (`[...persisted.genres]`), which would corrupt a string.
     expect(Array.isArray(row.genres)).toBe(true);
     expect(row.genres).toEqual(['Rock', 'Jazz']);

--- a/tests/integration/critic-reviews-metadata.spec.js
+++ b/tests/integration/critic-reviews-metadata.spec.js
@@ -2,8 +2,9 @@
  * Integration test for the `album_critic_reviews` serve contract
  * (album-critic-reviews slice, ADR 0012).
  *
- * `lookupCriticReviewsByAlbumKey` (apps/backend/services/album-metadata-lookup.service.ts)
- * resolves an album_id off the flowsheet lookup key, then issues:
+ * The serve path resolves an album_id off the flowsheet lookup key once
+ * (`resolveLinkedAlbumId`), then `lookupCriticReviewsByAlbumId`
+ * (apps/backend/services/album-metadata-lookup.service.ts) issues:
  *
  *   SELECT source, source_url, snippet, author, published_at, rating
  *     FROM album_critic_reviews
@@ -43,8 +44,8 @@ const { getTestDb } = require('../utils/db');
 const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
 
 /**
- * The exact serve query issued by `lookupCriticReviewsByAlbumKey` after it
- * resolves an album_id. Returns rows newest-first, capped at 5.
+ * The exact serve query issued by `lookupCriticReviewsByAlbumId` for a
+ * resolved album_id. Returns rows newest-first, capped at 5.
  */
 async function serveReviews(sql, albumId) {
   return sql`

--- a/tests/integration/critic-reviews-metadata.spec.js
+++ b/tests/integration/critic-reviews-metadata.spec.js
@@ -1,0 +1,311 @@
+/**
+ * Integration test for the `album_critic_reviews` serve contract
+ * (album-critic-reviews slice, ADR 0012).
+ *
+ * `lookupCriticReviewsByAlbumKey` (apps/backend/services/album-metadata-lookup.service.ts)
+ * resolves an album_id off the flowsheet lookup key, then issues:
+ *
+ *   SELECT source, source_url, snippet, author, published_at, rating
+ *     FROM album_critic_reviews
+ *    WHERE album_id = $1
+ *    ORDER BY published_at DESC NULLS LAST, id DESC
+ *    LIMIT 5
+ *
+ * The unit tests cover the Drizzle builder shape + the wire projection
+ * (url<-source_url, publishedDate<-published_at, optional-field omission)
+ * against a mocked DB. This spec validates the parts only real PostgreSQL
+ * can settle:
+ *
+ *   1. Ordering: `published_at DESC NULLS LAST, id DESC` — dated rows newest
+ *      first, NULL-dated rows last, id-descending tiebreak within a published
+ *      date. (NULLS LAST is NOT PG's default for DESC — default is NULLS
+ *      FIRST — so an unqualified ORDER BY would surface undated rows on top.)
+ *   2. The `LIMIT 5` cap (CRITIC_REVIEWS_LIMIT) drops the oldest overflow.
+ *   3. FK keying: reviews are partitioned by album_id; a query for album A
+ *      never surfaces album B's rows.
+ *   4. `(album_id, source_url)` UNIQUE index is a working UPSERT conflict
+ *      target — re-ingesting the same (album, url) overwrites in place rather
+ *      than duplicating; a different url under the same album coexists.
+ *   5. ON DELETE CASCADE: dropping the `library` album evaporates its reviews
+ *      (the seed/ETL never has to clean the child table by hand).
+ *
+ * Pure SQL — does NOT import the TS service. The integration runner is
+ * babel-jest with no TS support (see `album-metadata-upsert.spec.js` and
+ * `library-identity-backfill.spec.js` headers for the drizzle-orm + ts-jest
+ * incompatibility). The SELECT below is hand-mirrored from the service; when
+ * that query is edited the SQL here must follow. Ordering is asserted on
+ * `source_url` (a plain varchar identity marker) rather than `published_at`
+ * so the assertion is independent of how postgres-js parses the `date` type.
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * The exact serve query issued by `lookupCriticReviewsByAlbumKey` after it
+ * resolves an album_id. Returns rows newest-first, capped at 5.
+ */
+async function serveReviews(sql, albumId) {
+  return sql`
+    SELECT source, source_url, snippet, author, published_at, rating
+      FROM ${sql(SCHEMA)}.album_critic_reviews
+     WHERE album_id = ${albumId}
+     ORDER BY published_at DESC NULLS LAST, id DESC
+     LIMIT 5
+  `;
+}
+
+/**
+ * Insert one review row. `publishedAt` may be an ISO date string or null.
+ * Returns the new id so callers can reason about the id-descending tiebreak.
+ */
+async function insertReview(
+  sql,
+  albumId,
+  { source, sourceUrl, snippet, author = null, publishedAt = null, rating = null }
+) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_critic_reviews
+      (album_id, source, source_url, snippet, author, published_at, rating)
+    VALUES
+      (${albumId}, ${source}, ${sourceUrl}, ${snippet}, ${author}, ${publishedAt}, ${rating})
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+/**
+ * UPSERT a review keyed on the `(album_id, source_url)` unique index — the
+ * conflict target the seed script + any re-ingest use. Overwrites the mutable
+ * columns on conflict, mirroring an idempotent nightly seed.
+ */
+async function upsertReview(
+  sql,
+  albumId,
+  { source, sourceUrl, snippet, author = null, publishedAt = null, rating = null }
+) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_critic_reviews
+      (album_id, source, source_url, snippet, author, published_at, rating)
+    VALUES
+      (${albumId}, ${source}, ${sourceUrl}, ${snippet}, ${author}, ${publishedAt}, ${rating})
+    ON CONFLICT (album_id, source_url) DO UPDATE
+       SET source        = EXCLUDED.source,
+           snippet       = EXCLUDED.snippet,
+           author        = EXCLUDED.author,
+           published_at  = EXCLUDED.published_at,
+           rating        = EXCLUDED.rating,
+           last_modified = now()
+  `;
+}
+
+/**
+ * Insert a fresh library album to act as the FK target. Returns the new id.
+ * Mirrors `insertLibraryAlbum` in album-metadata-upsert.spec.js: artist_id,
+ * genre_id, format_id are NOT NULL on `library` and the seeded fixture in
+ * dev_env/seed_db.sql guarantees ids 1 (artists), 11 (genres), 1 (format).
+ */
+async function insertLibraryAlbum(sql, suffix) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.library
+      (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+    VALUES
+      (1, 11, 1, ${'critic-reviews-test-album-' + suffix}, 9999, 'Built to Spill')
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+describe('album_critic_reviews serve contract (real PG)', () => {
+  let sql;
+  /** album_ids inserted; deleted in afterAll regardless of pass/fail. */
+  const insertedAlbumIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedAlbumIds.length > 0) {
+      // The FK cascades on delete, so dropping the library rows is sufficient.
+      // Belt + suspenders: target the child table explicitly first in case the
+      // FK is ever loosened.
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_critic_reviews WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+  });
+
+  test('orders published_at DESC with NULLS LAST and an id-descending tiebreak', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'ordering');
+    insertedAlbumIds.push(albumId);
+
+    // Insertion order a,b,c,d fixes the id sequence (id_a < id_b < id_c < id_d).
+    // 'a' and 'd' share published_at '2024-05-01' to force the id-DESC tiebreak;
+    // 'c' is undated to exercise NULLS LAST.
+    await insertReview(sql, albumId, {
+      source: 'Pitchfork',
+      sourceUrl: 'https://example.com/critic-order/a',
+      snippet: 'first-dated',
+      publishedAt: '2024-05-01',
+    });
+    await insertReview(sql, albumId, {
+      source: 'Pitchfork',
+      sourceUrl: 'https://example.com/critic-order/b',
+      snippet: 'older',
+      publishedAt: '2023-01-01',
+    });
+    await insertReview(sql, albumId, {
+      source: 'Pitchfork',
+      sourceUrl: 'https://example.com/critic-order/c',
+      snippet: 'undated',
+      publishedAt: null,
+    });
+    await insertReview(sql, albumId, {
+      source: 'Pitchfork',
+      sourceUrl: 'https://example.com/critic-order/d',
+      snippet: 'tie-newer-id',
+      publishedAt: '2024-05-01',
+    });
+
+    const rows = await serveReviews(sql, albumId);
+
+    // d and a tie on 2024-05-01 -> id DESC -> d (later insert) first, then a;
+    // then b (2023); then c (NULL) last.
+    expect(rows.map((r) => r.source_url)).toEqual([
+      'https://example.com/critic-order/d',
+      'https://example.com/critic-order/a',
+      'https://example.com/critic-order/b',
+      'https://example.com/critic-order/c',
+    ]);
+  });
+
+  test('caps the result set at CRITIC_REVIEWS_LIMIT (5), dropping the oldest overflow', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'limit');
+    insertedAlbumIds.push(albumId);
+
+    // Six dated rows, ascending dates 2020..2025. Newest 5 (2021..2025) survive
+    // the LIMIT; the 2020 row is the drop.
+    const years = [2020, 2021, 2022, 2023, 2024, 2025];
+    for (const year of years) {
+      await insertReview(sql, albumId, {
+        source: 'The Wire',
+        sourceUrl: `https://example.com/critic-limit/${year}`,
+        snippet: `review-${year}`,
+        publishedAt: `${year}-06-01`,
+      });
+    }
+
+    const rows = await serveReviews(sql, albumId);
+
+    expect(rows).toHaveLength(5);
+    expect(rows.map((r) => r.source_url)).toEqual([
+      'https://example.com/critic-limit/2025',
+      'https://example.com/critic-limit/2024',
+      'https://example.com/critic-limit/2023',
+      'https://example.com/critic-limit/2022',
+      'https://example.com/critic-limit/2021',
+    ]);
+  });
+
+  test('partitions by album_id: a query never surfaces another album’s reviews', async () => {
+    const albumA = await insertLibraryAlbum(sql, 'fk-a');
+    const albumB = await insertLibraryAlbum(sql, 'fk-b');
+    insertedAlbumIds.push(albumA, albumB);
+
+    await insertReview(sql, albumA, {
+      source: 'Pitchfork',
+      sourceUrl: 'https://example.com/critic-fk/a-only',
+      snippet: 'belongs to A',
+      publishedAt: '2024-02-02',
+    });
+    await insertReview(sql, albumB, {
+      source: 'Pitchfork',
+      sourceUrl: 'https://example.com/critic-fk/b-only',
+      snippet: 'belongs to B',
+      publishedAt: '2024-03-03',
+    });
+
+    const rowsA = await serveReviews(sql, albumA);
+    const rowsB = await serveReviews(sql, albumB);
+
+    expect(rowsA.map((r) => r.source_url)).toEqual(['https://example.com/critic-fk/a-only']);
+    expect(rowsB.map((r) => r.source_url)).toEqual(['https://example.com/critic-fk/b-only']);
+  });
+
+  test('(album_id, source_url) UNIQUE index is an idempotent UPSERT conflict target', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'upsert');
+    insertedAlbumIds.push(albumId);
+
+    const url = 'https://example.com/critic-upsert/same';
+
+    // First ingest.
+    await upsertReview(sql, albumId, {
+      source: 'Pitchfork',
+      sourceUrl: url,
+      snippet: 'original snippet',
+      publishedAt: '2024-01-01',
+      rating: '7.8',
+    });
+    // Re-ingest the same (album, url) with revised content.
+    await upsertReview(sql, albumId, {
+      source: 'Pitchfork',
+      sourceUrl: url,
+      snippet: 'revised snippet',
+      publishedAt: '2024-01-01',
+      rating: '8.1',
+    });
+    // A different url under the same album is a distinct row, not a conflict.
+    await upsertReview(sql, albumId, {
+      source: 'The Wire',
+      sourceUrl: 'https://example.com/critic-upsert/other',
+      snippet: 'second source',
+      publishedAt: '2024-04-04',
+    });
+
+    const all = await sql`
+      SELECT source_url, snippet, rating
+        FROM ${sql(SCHEMA)}.album_critic_reviews
+       WHERE album_id = ${albumId}
+       ORDER BY source_url
+    `;
+
+    expect(all).toHaveLength(2);
+    const same = all.find((r) => r.source_url === url);
+    expect(same.snippet).toBe('revised snippet');
+    expect(same.rating).toBe('8.1');
+    expect(all.find((r) => r.source_url === 'https://example.com/critic-upsert/other').snippet).toBe('second source');
+  });
+
+  test('ON DELETE CASCADE: dropping the library album evaporates its reviews', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'cascade');
+
+    await insertReview(sql, albumId, {
+      source: 'Pitchfork',
+      sourceUrl: 'https://example.com/critic-cascade/1',
+      snippet: 'will be cascaded away',
+      publishedAt: '2024-05-05',
+    });
+    await insertReview(sql, albumId, {
+      source: 'The Wire',
+      sourceUrl: 'https://example.com/critic-cascade/2',
+      snippet: 'also cascaded',
+      publishedAt: null,
+    });
+
+    const before = await sql`
+      SELECT count(*)::int AS n FROM ${sql(SCHEMA)}.album_critic_reviews WHERE album_id = ${albumId}
+    `;
+    expect(before[0].n).toBe(2);
+
+    // Deleting the parent library row must cascade to album_critic_reviews.
+    // (This album_id is intentionally NOT pushed to insertedAlbumIds — it is
+    // consumed here — so afterAll won't double-delete a vanished row.)
+    await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ${albumId}`;
+
+    const after = await sql`
+      SELECT count(*)::int AS n FROM ${sql(SCHEMA)}.album_critic_reviews WHERE album_id = ${albumId}
+    `;
+    expect(after[0].n).toBe(0);
+  });
+});

--- a/tests/unit/config/critic-reviews-flag.test.ts
+++ b/tests/unit/config/critic-reviews-flag.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for the CRITIC_REVIEWS_ENABLED flag (album-critic-reviews slice,
+ * ADR 0012). The load-bearing property is strict `=== 'true'` gating: an
+ * accidental `CRITIC_REVIEWS_ENABLED=1` must NOT add a query to the hot
+ * album-metadata serve path. Mirrors the catalogSearchAlias config contract.
+ */
+import { getConfig, loadConfig, resetConfig } from '../../../apps/backend/config/criticReviews';
+
+describe('criticReviews flag config', () => {
+  const original = process.env.CRITIC_REVIEWS_ENABLED;
+
+  beforeEach(() => {
+    delete process.env.CRITIC_REVIEWS_ENABLED;
+    resetConfig();
+  });
+
+  afterAll(() => {
+    if (original === undefined) delete process.env.CRITIC_REVIEWS_ENABLED;
+    else process.env.CRITIC_REVIEWS_ENABLED = original;
+    resetConfig();
+  });
+
+  it('defaults to disabled when the env var is unset', () => {
+    expect(loadConfig().enabled).toBe(false);
+  });
+
+  it('enables only on the exact string "true"', () => {
+    process.env.CRITIC_REVIEWS_ENABLED = 'true';
+    expect(loadConfig().enabled).toBe(true);
+  });
+
+  it.each(['1', 'TRUE', 'yes', 'on', ''])('does not enable on non-canonical value %p', (value) => {
+    process.env.CRITIC_REVIEWS_ENABLED = value;
+    expect(loadConfig().enabled).toBe(false);
+  });
+
+  it('caches the singleton until resetConfig() is called', () => {
+    process.env.CRITIC_REVIEWS_ENABLED = 'true';
+    expect(getConfig().enabled).toBe(true);
+    // Mutating the env without resetting must not change the cached value.
+    delete process.env.CRITIC_REVIEWS_ENABLED;
+    expect(getConfig().enabled).toBe(true);
+    resetConfig();
+    expect(getConfig().enabled).toBe(false);
+  });
+});

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -44,8 +44,21 @@ jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
 // `lookupAlbumMetadataByKey` before falling through to LML. Mocked here so
 // each test can set local-hit, catch-arm-row, or cold-miss explicitly.
 const mockLookupAlbumMetadataByKey = jest.fn<(artist: string, release?: string) => Promise<unknown>>();
+// ADR 0012: getAlbumMetadata also attaches external critic-review snippets
+// (flag-gated). Mocked so each test can set the returned snippets, an empty
+// result, or a thrown error explicitly.
+const mockLookupCriticReviewsByAlbumKey = jest.fn<(artist: string, release?: string) => Promise<unknown[]>>();
 jest.mock('../../../apps/backend/services/album-metadata-lookup.service', () => ({
   lookupAlbumMetadataByKey: mockLookupAlbumMetadataByKey,
+  lookupCriticReviewsByAlbumKey: mockLookupCriticReviewsByAlbumKey,
+}));
+
+// ADR 0012 flag: getConfig().enabled gates the criticReviews attach. Default
+// off (matches prod) so unrelated getAlbumMetadata tests keep their exact
+// response shapes; the critic-reviews suite opts in per test.
+const mockCriticReviewsConfig = jest.fn<() => { enabled: boolean }>(() => ({ enabled: false }));
+jest.mock('../../../apps/backend/config/criticReviews', () => ({
+  getConfig: mockCriticReviewsConfig,
 }));
 
 // BS#1331 acceptance: the cohort split for trace explorer turns on
@@ -134,6 +147,10 @@ describe('proxy.controller', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockNext = jest.fn();
+    // Flag defaults off every test (clearAllMocks clears calls, not a
+    // mockReturnValue set by a prior test) so unrelated getAlbumMetadata
+    // assertions never see a leaked criticReviews attach.
+    mockCriticReviewsConfig.mockReturnValue({ enabled: false });
   });
 
   // --- searchArtwork ---
@@ -243,6 +260,73 @@ describe('proxy.controller', () => {
       // Default to cold case: no local row, so existing tests fall through
       // to LML. Local-hit tests override below. BS#1331.
       mockLookupAlbumMetadataByKey.mockResolvedValue(null);
+    });
+
+    // ADR 0012: attach external critic-review snippets, flag-gated. These run
+    // in the cold-case default (persisted=null, LML returns nothing); the
+    // attach happens after both the local-hit and cold branches, so the
+    // cohort is irrelevant to the attach behavior.
+    describe('criticReviews attach (ADR 0012)', () => {
+      const sampleReviews = [
+        {
+          source: 'The Quietus',
+          url: 'https://thequietus.com/articles/example',
+          snippet: 'A record that dissolves song into texture.',
+        },
+      ];
+
+      it('flag off (default): never calls the reviews lookup and omits criticReviews', async () => {
+        // Even with the lookup primed to return snippets, the flag gate must
+        // keep the response byte-identical to before — the #32 freeze-safety
+        // invariant.
+        mockLookupCriticReviewsByAlbumKey.mockResolvedValue(sampleReviews);
+        const req = { query: { artistName: 'Juana Molina', releaseTitle: 'DOGA' } } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(mockLookupCriticReviewsByAlbumKey).not.toHaveBeenCalled();
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect(result).not.toHaveProperty('criticReviews');
+      });
+
+      it('flag on + non-empty: attaches criticReviews', async () => {
+        mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+        mockLookupCriticReviewsByAlbumKey.mockResolvedValue(sampleReviews);
+        const req = { query: { artistName: 'Juana Molina', releaseTitle: 'DOGA' } } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(mockLookupCriticReviewsByAlbumKey).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect(result.criticReviews).toEqual(sampleReviews);
+      });
+
+      it('flag on + empty result: omits criticReviews so an un-seeded album is byte-identical', async () => {
+        mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+        mockLookupCriticReviewsByAlbumKey.mockResolvedValue([]);
+        const req = { query: { artistName: 'Unseeded', releaseTitle: 'Album' } } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect(result).not.toHaveProperty('criticReviews');
+      });
+
+      it('flag on + lookup throws: degrades to omitting criticReviews, still responds 200', async () => {
+        mockCriticReviewsConfig.mockReturnValue({ enabled: true });
+        mockLookupCriticReviewsByAlbumKey.mockRejectedValue(new Error('db down'));
+        const req = { query: { artistName: 'Any', releaseTitle: 'Album' } } as unknown as Request;
+        const res = createMockRes();
+
+        await getAlbumMetadata(req, res as Response, mockNext);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        const result = (res.json as jest.Mock).mock.calls[0][0];
+        expect(result).not.toHaveProperty('criticReviews');
+      });
     });
 
     it('throws WxycError 400 when artistName is missing', async () => {

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -40,18 +40,29 @@ jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
   lmlLookupCoordinator: { lookup: mockLookupMetadata },
 }));
 
-// BS#1331: getAlbumMetadata now consults local persisted state first via
-// `lookupAlbumMetadataByKey` before falling through to LML. Mocked here so
-// each test can set local-hit, catch-arm-row, or cold-miss explicitly.
-const mockLookupAlbumMetadataByKey = jest.fn<(artist: string, release?: string) => Promise<unknown>>();
-// ADR 0012: getAlbumMetadata also attaches external critic-review snippets
-// (flag-gated). Mocked so each test can set the returned snippets, an empty
-// result, or a thrown error explicitly.
-const mockLookupCriticReviewsByAlbumKey = jest.fn<(artist: string, release?: string) => Promise<unknown[]>>();
+// BS#1331 + ADR 0012: getAlbumMetadata resolves the linked `album_id` ONCE via
+// `resolveLinkedAlbumId`, then feeds it to the by-id persisted-metadata read
+// (`lookupAlbumMetadataById`) and — flag-gated — the by-id critic-reviews read
+// (`lookupCriticReviewsByAlbumId`). Resolving once makes the metadata and
+// reviews reads observe the same album_id atomically and decouples the reviews
+// attach from metadata-enrichment state. Each is mocked so a test can set the
+// resolved id, a local-hit/catch-arm/cold metadata row, or the returned
+// snippets independently.
+const mockResolveLinkedAlbumId = jest.fn<(artist: string, release?: string) => Promise<number | null>>();
+const mockLookupAlbumMetadataById = jest.fn<(albumId: number) => Promise<unknown>>();
+const mockLookupCriticReviewsByAlbumId = jest.fn<(albumId: number) => Promise<unknown[]>>();
 jest.mock('../../../apps/backend/services/album-metadata-lookup.service', () => ({
-  lookupAlbumMetadataByKey: mockLookupAlbumMetadataByKey,
-  lookupCriticReviewsByAlbumKey: mockLookupCriticReviewsByAlbumKey,
+  resolveLinkedAlbumId: mockResolveLinkedAlbumId,
+  lookupAlbumMetadataById: mockLookupAlbumMetadataById,
+  lookupCriticReviewsByAlbumId: mockLookupCriticReviewsByAlbumId,
 }));
+
+// Default album_id the resolve step returns across getAlbumMetadata tests so
+// both the by-id metadata read and the (flag-gated) reviews read are reachable.
+// Tests that assert the cold/local-hit metadata shape control it via the by-id
+// mock's resolved value; the resolved id itself only matters where a test pins
+// the call argument.
+const DEFAULT_LINKED_ALBUM_ID = 4242;
 
 // ADR 0012 flag: getConfig().enabled gates the criticReviews attach. Default
 // off (matches prod) so unrelated getAlbumMetadata tests keep their exact
@@ -257,9 +268,13 @@ describe('proxy.controller', () => {
 
   describe('getAlbumMetadata', () => {
     beforeEach(() => {
-      // Default to cold case: no local row, so existing tests fall through
-      // to LML. Local-hit tests override below. BS#1331.
-      mockLookupAlbumMetadataByKey.mockResolvedValue(null);
+      // Default: a linked album_id resolves (so the reviews attach is
+      // reachable) but no persisted metadata row exists — the cold case, so
+      // existing tests fall through to LML. Local-hit tests override the by-id
+      // metadata mock below. `clearAllMocks` clears calls, not the resolved
+      // value a prior test set, so both defaults are re-asserted here. BS#1331.
+      mockResolveLinkedAlbumId.mockResolvedValue(DEFAULT_LINKED_ALBUM_ID);
+      mockLookupAlbumMetadataById.mockResolvedValue(null);
     });
 
     // ADR 0012: attach external critic-review snippets, flag-gated. These run
@@ -279,33 +294,36 @@ describe('proxy.controller', () => {
         // Even with the lookup primed to return snippets, the flag gate must
         // keep the response byte-identical to before — the #32 freeze-safety
         // invariant.
-        mockLookupCriticReviewsByAlbumKey.mockResolvedValue(sampleReviews);
+        mockLookupCriticReviewsByAlbumId.mockResolvedValue(sampleReviews);
         const req = { query: { artistName: 'Juana Molina', releaseTitle: 'DOGA' } } as unknown as Request;
         const res = createMockRes();
 
         await getAlbumMetadata(req, res as Response, mockNext);
 
-        expect(mockLookupCriticReviewsByAlbumKey).not.toHaveBeenCalled();
+        expect(mockLookupCriticReviewsByAlbumId).not.toHaveBeenCalled();
         const result = (res.json as jest.Mock).mock.calls[0][0];
         expect(result).not.toHaveProperty('criticReviews');
       });
 
       it('flag on + non-empty: attaches criticReviews', async () => {
         mockCriticReviewsConfig.mockReturnValue({ enabled: true });
-        mockLookupCriticReviewsByAlbumKey.mockResolvedValue(sampleReviews);
+        mockLookupCriticReviewsByAlbumId.mockResolvedValue(sampleReviews);
         const req = { query: { artistName: 'Juana Molina', releaseTitle: 'DOGA' } } as unknown as Request;
         const res = createMockRes();
 
         await getAlbumMetadata(req, res as Response, mockNext);
 
-        expect(mockLookupCriticReviewsByAlbumKey).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+        // Reviews are read by the resolved album_id, not by artist/release —
+        // the resolve happened once and both reads observe the same id.
+        expect(mockResolveLinkedAlbumId).toHaveBeenCalledWith('Juana Molina', 'DOGA');
+        expect(mockLookupCriticReviewsByAlbumId).toHaveBeenCalledWith(DEFAULT_LINKED_ALBUM_ID);
         const result = (res.json as jest.Mock).mock.calls[0][0];
         expect(result.criticReviews).toEqual(sampleReviews);
       });
 
       it('flag on + empty result: omits criticReviews so an un-seeded album is byte-identical', async () => {
         mockCriticReviewsConfig.mockReturnValue({ enabled: true });
-        mockLookupCriticReviewsByAlbumKey.mockResolvedValue([]);
+        mockLookupCriticReviewsByAlbumId.mockResolvedValue([]);
         const req = { query: { artistName: 'Unseeded', releaseTitle: 'Album' } } as unknown as Request;
         const res = createMockRes();
 
@@ -317,7 +335,7 @@ describe('proxy.controller', () => {
 
       it('flag on + lookup throws: degrades to omitting criticReviews, still responds 200', async () => {
         mockCriticReviewsConfig.mockReturnValue({ enabled: true });
-        mockLookupCriticReviewsByAlbumKey.mockRejectedValue(new Error('db down'));
+        mockLookupCriticReviewsByAlbumId.mockRejectedValue(new Error('db down'));
         const req = { query: { artistName: 'Any', releaseTitle: 'Album' } } as unknown as Request;
         const res = createMockRes();
 
@@ -953,7 +971,7 @@ describe('proxy.controller', () => {
     // 0 on local hit so the cohort split survives in the trace explorer.
     describe('cache-first local lookup (BS#1331)', () => {
       it('serves persisted state without invoking LML when local row is enriched', async () => {
-        mockLookupAlbumMetadataByKey.mockResolvedValue({
+        mockLookupAlbumMetadataById.mockResolvedValue({
           artwork_url: 'https://i.discogs.com/cached.jpg',
           discogs_url: 'https://www.discogs.com/release/54321',
           release_year: 2024,
@@ -973,7 +991,8 @@ describe('proxy.controller', () => {
 
         await getAlbumMetadata(req, res as Response, mockNext);
 
-        expect(mockLookupAlbumMetadataByKey).toHaveBeenCalledWith('Cached Artist', 'Cached Album');
+        expect(mockResolveLinkedAlbumId).toHaveBeenCalledWith('Cached Artist', 'Cached Album');
+        expect(mockLookupAlbumMetadataById).toHaveBeenCalledWith(DEFAULT_LINKED_ALBUM_ID);
         expect(mockLookupMetadata).not.toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(200);
 
@@ -1000,7 +1019,7 @@ describe('proxy.controller', () => {
         // LML-fallthrough returned them, a hit omitted them. Now the worker
         // persists them and this branch emits them with the same conventions
         // as `populateReleaseMetadata` + `populateCommonMetadataFields`.
-        mockLookupAlbumMetadataByKey.mockResolvedValue({
+        mockLookupAlbumMetadataById.mockResolvedValue({
           artwork_url: 'https://i.discogs.com/art.jpg',
           discogs_url: 'https://www.discogs.com/release/12345',
           release_year: 2001,
@@ -1052,7 +1071,7 @@ describe('proxy.controller', () => {
         // its *no-match* branch emits neither artwork nor discogsArtistId. The
         // local branch mirrors both: gated on `discogs_url` (the match-shape
         // marker), so a match row with a null artist id still carries the key.
-        mockLookupAlbumMetadataByKey.mockResolvedValueOnce({
+        mockLookupAlbumMetadataById.mockResolvedValueOnce({
           artwork_url: 'https://i.discogs.com/art.jpg',
           discogs_url: 'https://www.discogs.com/release/55',
           release_year: 2019,
@@ -1083,7 +1102,7 @@ describe('proxy.controller', () => {
 
         // No-match-shaped row: discogs_url null (the no-match UPSERT writes only
         // search URLs), so discogsArtistId is omitted like the cold no-match.
-        mockLookupAlbumMetadataByKey.mockResolvedValueOnce({
+        mockLookupAlbumMetadataById.mockResolvedValueOnce({
           artwork_url: null,
           discogs_url: null,
           release_year: null,
@@ -1121,7 +1140,7 @@ describe('proxy.controller', () => {
         // request time doesn't poison persisted state, and matching the
         // LML-fallthrough branch's behavior means iOS sees the same
         // degraded-but-usable shape regardless of cohort.
-        mockLookupAlbumMetadataByKey.mockResolvedValue({
+        mockLookupAlbumMetadataById.mockResolvedValue({
           artwork_url: null,
           discogs_url: null,
           release_year: null,
@@ -1168,7 +1187,7 @@ describe('proxy.controller', () => {
         // with all 10 columns null. Without request-time synthesis the
         // handler would return `{}` to iOS — every streaming button greys
         // out. Synthesizing here matches the cold-path behavior.
-        mockLookupAlbumMetadataByKey.mockResolvedValue({
+        mockLookupAlbumMetadataById.mockResolvedValue({
           artwork_url: null,
           discogs_url: null,
           release_year: null,
@@ -1203,7 +1222,7 @@ describe('proxy.controller', () => {
         // pre-#649 flowsheet rows. The local-hit path must scrub via
         // filterSpacerGif so iOS's "missing → placeholder" fallback
         // doesn't render the 1×1 tracking pixel as cover art.
-        mockLookupAlbumMetadataByKey.mockResolvedValue({
+        mockLookupAlbumMetadataById.mockResolvedValue({
           artwork_url: 'https://s.discogs.com/images/spacer.gif',
           discogs_url: 'https://www.discogs.com/release/777',
           release_year: 2015,
@@ -1236,7 +1255,7 @@ describe('proxy.controller', () => {
         // return 500, regressing availability versus the pre-PR endpoint
         // (which had zero DB-failure surface). The graceful degradation
         // matches the LML-fallthrough path's own try/catch.
-        mockLookupAlbumMetadataByKey.mockRejectedValue(new Error('asyncpg: connection refused'));
+        mockLookupAlbumMetadataById.mockRejectedValue(new Error('asyncpg: connection refused'));
         mockLookupMetadata.mockResolvedValue({
           results: [
             {
@@ -1269,7 +1288,8 @@ describe('proxy.controller', () => {
       });
 
       it('falls through to LML when no local row matches (true cold case)', async () => {
-        mockLookupAlbumMetadataByKey.mockResolvedValue(null);
+        // No linked album resolves at all — the by-id metadata read never runs.
+        mockResolveLinkedAlbumId.mockResolvedValue(null);
         mockLookupMetadata.mockResolvedValue({
           results: [
             {
@@ -1297,8 +1317,9 @@ describe('proxy.controller', () => {
 
         await getAlbumMetadata(req, res as Response, mockNext);
 
-        expect(mockLookupAlbumMetadataByKey).toHaveBeenCalledWith('Cold Artist', 'Cold Album');
-        // LML was consulted because the local lookup returned null.
+        expect(mockResolveLinkedAlbumId).toHaveBeenCalledWith('Cold Artist', 'Cold Album');
+        expect(mockLookupAlbumMetadataById).not.toHaveBeenCalled();
+        // LML was consulted because the resolve step found no linked album.
         expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
         expect(res.status).toHaveBeenCalledWith(200);
 
@@ -1312,7 +1333,7 @@ describe('proxy.controller', () => {
         // is a fallthrough, 0 is a steady-state hit. Without this signal
         // we can't distinguish "the cache-first path saved 5s" from "we
         // never reached the cache-first path" in the prod p95.
-        mockLookupAlbumMetadataByKey.mockResolvedValue({
+        mockLookupAlbumMetadataById.mockResolvedValue({
           artwork_url: 'https://i.discogs.com/x.jpg',
           discogs_url: 'https://www.discogs.com/release/1',
           release_year: 2020,

--- a/tests/unit/services/album-metadata-lookup.service.test.ts
+++ b/tests/unit/services/album-metadata-lookup.service.test.ts
@@ -90,9 +90,22 @@ jest.mock('@wxyc/database', () => ({
     artist_image_url: 'artist_image_url',
     bio_tokens: 'bio_tokens',
   },
+  album_critic_reviews: {
+    id: 'id',
+    album_id: 'album_id',
+    source: 'source',
+    source_url: 'source_url',
+    snippet: 'snippet',
+    author: 'author',
+    published_at: 'published_at',
+    rating: 'rating',
+  },
 }));
 
-import { lookupAlbumMetadataByKey } from '../../../apps/backend/services/album-metadata-lookup.service';
+import {
+  lookupAlbumMetadataByKey,
+  lookupCriticReviewsByAlbumKey,
+} from '../../../apps/backend/services/album-metadata-lookup.service';
 
 describe('album-metadata-lookup.service', () => {
   beforeEach(() => {
@@ -274,6 +287,120 @@ describe('album-metadata-lookup.service', () => {
       expect(result?.apple_music_url).toBeNull();
       expect(result?.spotify_url).toBeNull();
       expect(result?.artwork_url).toBeNull();
+    });
+  });
+
+  describe('lookupCriticReviewsByAlbumKey', () => {
+    // Shares Step-1 (resolveLinkedAlbumId) with the metadata read, so the
+    // same empty-key + cold-case guards apply. Then it projects
+    // album_critic_reviews rows onto the CriticReviewItem wire shape (ADR
+    // 0012): url ← source_url, publishedDate ← published_at, optional fields
+    // omitted when null.
+
+    it('returns [] without touching the DB when artistName is empty (shared guard)', async () => {
+      const result = await lookupCriticReviewsByAlbumKey('', 'Some Album');
+      expect(result).toEqual([]);
+      expect(mockSelect).not.toHaveBeenCalled();
+    });
+
+    it('returns [] without touching the DB when releaseTitle is blank (shared guard)', async () => {
+      const result = await lookupCriticReviewsByAlbumKey('Some Artist', '  ');
+      expect(result).toEqual([]);
+      expect(mockSelect).not.toHaveBeenCalled();
+    });
+
+    it('returns [] when the key resolves to no linked album (cold case) — reviews query short-circuits', async () => {
+      // Step 1 → empty rowset; pin that step 2 is skipped via select call count.
+      mockRowsQueue.push([]);
+      const result = await lookupCriticReviewsByAlbumKey('Unknown Artist', 'Unknown Album');
+      expect(result).toEqual([]);
+      expect(mockSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns [] when the linked album has no seeded snippets', async () => {
+      mockRowsQueue.push([{ album_id: 42 }]);
+      mockRowsQueue.push([]);
+      const result = await lookupCriticReviewsByAlbumKey('Seeded Artist', 'Unseeded Album');
+      expect(result).toEqual([]);
+      expect(mockSelect).toHaveBeenCalledTimes(2);
+    });
+
+    it('projects a full row onto the wire shape (url ← source_url, publishedDate ← published_at)', async () => {
+      mockRowsQueue.push([{ album_id: 7 }]);
+      mockRowsQueue.push([
+        {
+          source: 'The Quietus',
+          source_url: 'https://thequietus.com/articles/juana-molina-doga',
+          snippet: 'A record that dissolves the line between song and texture.',
+          author: 'A. Critic',
+          published_at: '2024-03-15',
+          rating: '8.0',
+        },
+      ]);
+      const result = await lookupCriticReviewsByAlbumKey('Juana Molina', 'DOGA');
+      expect(result).toEqual([
+        {
+          source: 'The Quietus',
+          url: 'https://thequietus.com/articles/juana-molina-doga',
+          snippet: 'A record that dissolves the line between song and texture.',
+          author: 'A. Critic',
+          publishedDate: '2024-03-15',
+          rating: '8.0',
+        },
+      ]);
+    });
+
+    it('omits optional fields (author/publishedDate/rating) when null so decodeIfPresent stays compatible', async () => {
+      mockRowsQueue.push([{ album_id: 7 }]);
+      mockRowsQueue.push([
+        {
+          source: 'Pitchfork',
+          source_url: 'https://pitchfork.com/reviews/albums/example',
+          snippet: 'The most quietly radical thing she has made.',
+          author: null,
+          published_at: null,
+          rating: null,
+        },
+      ]);
+      const result = await lookupCriticReviewsByAlbumKey('Jessica Pratt', 'On Your Own Love Again');
+      expect(result).toEqual([
+        {
+          source: 'Pitchfork',
+          url: 'https://pitchfork.com/reviews/albums/example',
+          snippet: 'The most quietly radical thing she has made.',
+        },
+      ]);
+      // No undefined optional keys leaked onto the item.
+      expect(Object.keys(result[0])).toEqual(['source', 'url', 'snippet']);
+    });
+
+    it('preserves row order and returns every projected snippet on a multi-review hit', async () => {
+      mockRowsQueue.push([{ album_id: 9 }]);
+      mockRowsQueue.push([
+        {
+          source: 'A',
+          source_url: 'https://a/1',
+          snippet: 'first',
+          author: null,
+          published_at: '2024-05-01',
+          rating: null,
+        },
+        {
+          source: 'B',
+          source_url: 'https://b/2',
+          snippet: 'second',
+          author: null,
+          published_at: '2023-01-01',
+          rating: null,
+        },
+      ]);
+      const result = await lookupCriticReviewsByAlbumKey('Multi Artist', 'Reviewed Album');
+      expect(result.map((r) => r.source)).toEqual(['A', 'B']);
+      // Step 1 (resolveLinkedAlbumId) and step 2 (reviews) both order for
+      // determinism — pin that the reviews query carries an ORDER BY (the
+      // newest-first + stable-tiebreak contract) rather than relying on
+      // insertion order.
+      expect(chainSpy.orderBy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/tests/unit/services/album-metadata-lookup.service.test.ts
+++ b/tests/unit/services/album-metadata-lookup.service.test.ts
@@ -1,26 +1,32 @@
 /**
- * Unit tests for the local-state cache-first helper that backs
- * `/proxy/metadata/album` (BS#1331). The helper itself is mocked away in
- * the controller's suite, so these tests cover the JS-side shape that
- * wouldn't otherwise surface in CI until prod:
- *   - empty/whitespace-key guard (artist or release blank → null)
- *   - two-step query semantics (step 1 finds an album_id; step 2 PK-looks
- *     up album_metadata; absent album_metadata → null fallthrough)
- *   - deterministic ORDER BY id DESC LIMIT 1 on step 1
+ * Unit tests for the local-state cache-first helpers that back
+ * `/proxy/metadata/album` (BS#1331, album-critic-reviews slice ADR 0012).
+ * The controller resolves the `album_id` once via `resolveLinkedAlbumId` and
+ * feeds it to `lookupAlbumMetadataById` and `lookupCriticReviewsByAlbumId`;
+ * all three are mocked away in the controller's suite, so these tests cover
+ * the JS-side shape that wouldn't otherwise surface in CI until prod:
+ *   - `resolveLinkedAlbumId`: empty/whitespace-key guard (artist or release
+ *     blank → null, no DB), cold-case (no match → null), deterministic
+ *     `ORDER BY id DESC LIMIT 1` on multi-album_id keys
+ *   - `lookupAlbumMetadataById`: PK-lookup projection; absent row → null
+ *     fallthrough; no ORDER BY (it's a PK read, not a pick)
+ *   - `lookupCriticReviewsByAlbumId`: newest-first ORDER BY, wire-shape
+ *     projection (url ← source_url, publishedDate ← published_at, null
+ *     optionals omitted)
  *
- * The drizzle DB chain is mocked at the module level so test cases can
- * stub each query's resolved rows independently. The shape mirrors
- * `tests/unit/services/playlist-proxy.service.test.ts`.
+ * The drizzle DB chain is mocked at the module level so test cases can stub
+ * each query's resolved rows independently. Each by-id helper issues exactly
+ * one `db.select(...)`, so a test pushes one rowset per call. The shape
+ * mirrors `tests/unit/services/playlist-proxy.service.test.ts`.
  */
 import { jest } from '@jest/globals';
 
 // --- Drizzle DB chain mock ---
 //
 // Each `db.select(...)` call returns a fresh chain whose terminal awaitable
-// is the array of rows pushed via `mockRowsQueue`. Tests push step-1 rows
-// first, then step-2 rows; the helper consumes them in order. The mock's
-// .from/.where/.orderBy/.limit are also captured on `chainSpy` so tests
-// can pin the SQL contract (`ORDER BY` on step 1, `eq()` on step 2).
+// is the next array of rows pushed via `mockRowsQueue`. The mock's
+// .from/.where/.orderBy/.limit are also captured on `chainSpy` so tests can
+// pin the SQL contract (`ORDER BY` presence per query).
 
 const mockRowsQueue: Array<Array<Record<string, unknown>>> = [];
 
@@ -103,8 +109,9 @@ jest.mock('@wxyc/database', () => ({
 }));
 
 import {
-  lookupAlbumMetadataByKey,
-  lookupCriticReviewsByAlbumKey,
+  resolveLinkedAlbumId,
+  lookupAlbumMetadataById,
+  lookupCriticReviewsByAlbumId,
 } from '../../../apps/backend/services/album-metadata-lookup.service';
 
 describe('album-metadata-lookup.service', () => {
@@ -117,89 +124,68 @@ describe('album-metadata-lookup.service', () => {
     chainSpy.limit.mockClear();
   });
 
-  describe('empty-key guard', () => {
-    // Pin the contract that the guard prevents *any* DB call: a regression
-    // that removes the guard would shift these from `select=0` to `select=1`,
-    // letting `'-'`-keyed requests reach the partial index.
-    it('returns null without touching the DB when artistName is empty', async () => {
-      const result = await lookupAlbumMetadataByKey('', 'Some Album');
-      expect(result).toBeNull();
-      expect(mockSelect).not.toHaveBeenCalled();
+  describe('resolveLinkedAlbumId', () => {
+    describe('empty-key guard', () => {
+      // Pin the contract that the guard prevents *any* DB call: a regression
+      // that removes the guard would shift these from `select=0` to `select=1`,
+      // letting `'-'`-keyed requests reach the partial index and resolve an
+      // arbitrary album_id.
+      it('returns null without touching the DB when artistName is empty', async () => {
+        expect(await resolveLinkedAlbumId('', 'Some Album')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when artistName is whitespace-only', async () => {
+        expect(await resolveLinkedAlbumId('   ', 'Some Album')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when releaseTitle is undefined (artist-card surfaces fall through to LML)', async () => {
+        expect(await resolveLinkedAlbumId('Some Artist', undefined)).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when releaseTitle is empty', async () => {
+        expect(await resolveLinkedAlbumId('Some Artist', '')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when releaseTitle is whitespace-only', async () => {
+        expect(await resolveLinkedAlbumId('Some Artist', '\t  ')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
     });
 
-    it('returns null when artistName is whitespace-only (matches no key meaningfully)', async () => {
-      const result = await lookupAlbumMetadataByKey('   ', 'Some Album');
-      expect(result).toBeNull();
-      expect(mockSelect).not.toHaveBeenCalled();
-    });
-
-    it('returns null when releaseTitle is undefined (artist-card surfaces fall through to LML)', async () => {
-      const result = await lookupAlbumMetadataByKey('Some Artist', undefined);
-      expect(result).toBeNull();
-      expect(mockSelect).not.toHaveBeenCalled();
-    });
-
-    it('returns null when releaseTitle is empty', async () => {
-      const result = await lookupAlbumMetadataByKey('Some Artist', '');
-      expect(result).toBeNull();
-      expect(mockSelect).not.toHaveBeenCalled();
-    });
-
-    it('returns null when releaseTitle is whitespace-only', async () => {
-      const result = await lookupAlbumMetadataByKey('Some Artist', '\t  ');
-      expect(result).toBeNull();
-      expect(mockSelect).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('two-step query', () => {
-    it('returns null when step 1 finds no matching flowsheet row (cold case) — step 2 short-circuits', async () => {
-      // Step 1 → empty rowset; pin that step 2 is skipped via select call count.
-      // A regression that removed the `albumId === undefined || albumId === null
-      // → return null` guard would shift this to `select=2`.
+    it('returns null on the cold case (no matching album_id-bearing flowsheet row)', async () => {
       mockRowsQueue.push([]);
-      const result = await lookupAlbumMetadataByKey('Unknown Artist', 'Unknown Album');
-      expect(result).toBeNull();
+      expect(await resolveLinkedAlbumId('Unknown Artist', 'Unknown Album')).toBeNull();
       expect(mockSelect).toHaveBeenCalledTimes(1);
     });
 
-    it('returns null when step 2 finds no album_metadata row (race window: flowsheet INSERT before worker UPSERT)', async () => {
-      // Step 1 finds album_id=42, step 2 returns empty (no album_metadata).
-      mockRowsQueue.push([{ album_id: 42 }]);
-      mockRowsQueue.push([]);
-      const result = await lookupAlbumMetadataByKey('In-Flight Artist', 'In-Flight Album');
-      expect(result).toBeNull();
-      expect(mockSelect).toHaveBeenCalledTimes(2);
-    });
-
-    it('issues ORDER BY on step 1 for deterministic row-pick on multi-album_id keys', async () => {
+    it('returns the album_id and issues ORDER BY for a deterministic row-pick on multi-album_id keys', async () => {
       // Pin BS#1331 round-2 review fix: dropping the ORDER BY here would
       // re-introduce iOS-visible flapping between distinct album_metadata
       // payloads when a lookup key resolves to multiple album_ids
       // (V/A multi-format, dual-pressings, librarian duplicates — empirically
       // present in the live `album_id` corpus).
-      mockRowsQueue.push([{ album_id: 1 }]);
-      mockRowsQueue.push([
-        {
-          artwork_url: null,
-          discogs_url: null,
-          release_year: null,
-          spotify_url: null,
-          apple_music_url: null,
-          youtube_music_url: null,
-          bandcamp_url: null,
-          soundcloud_url: null,
-          artist_bio: null,
-          artist_wikipedia_url: null,
-        },
-      ]);
-      await lookupAlbumMetadataByKey('Multi Artist', 'Same Title Different Pressings');
-      // Step 1 uses orderBy; step 2 (PK lookup) does not.
+      mockRowsQueue.push([{ album_id: 42 }]);
+      const albumId = await resolveLinkedAlbumId('Multi Artist', 'Same Title Different Pressings');
+      expect(albumId).toBe(42);
       expect(chainSpy.orderBy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('lookupAlbumMetadataById', () => {
+    it('returns null when no album_metadata row exists (race window: flowsheet INSERT before worker UPSERT)', async () => {
+      mockRowsQueue.push([]);
+      const result = await lookupAlbumMetadataById(42);
+      expect(result).toBeNull();
+      // A single PK read — no ORDER BY (the pick already happened in resolve).
+      expect(mockSelect).toHaveBeenCalledTimes(1);
+      expect(chainSpy.orderBy).not.toHaveBeenCalled();
     });
 
     it('returns the persisted 10-column projection on a hit', async () => {
-      mockRowsQueue.push([{ album_id: 7 }]);
       mockRowsQueue.push([
         {
           artwork_url: 'https://i.discogs.com/x.jpg',
@@ -214,7 +200,7 @@ describe('album-metadata-lookup.service', () => {
           artist_wikipedia_url: null,
         },
       ]);
-      const result = await lookupAlbumMetadataByKey('Hit Artist', 'Hit Album');
+      const result = await lookupAlbumMetadataById(7);
       expect(result).toEqual({
         artwork_url: 'https://i.discogs.com/x.jpg',
         discogs_url: 'https://www.discogs.com/release/7',
@@ -230,7 +216,6 @@ describe('album-metadata-lookup.service', () => {
     });
 
     it('returns the 8 LML-only enrichment fields on a hit (BS#1336)', async () => {
-      mockRowsQueue.push([{ album_id: 7 }]);
       mockRowsQueue.push([
         {
           artwork_url: 'https://i.discogs.com/x.jpg',
@@ -253,7 +238,7 @@ describe('album-metadata-lookup.service', () => {
           bio_tokens: [{ type: 'plainText', text: 'Argentine musician' }],
         },
       ]);
-      const result = await lookupAlbumMetadataByKey('Juana Molina', 'DOGA');
+      const result = await lookupAlbumMetadataById(7);
       expect(result?.discogs_artist_id).toBe(3840);
       expect(result?.label).toBe('Sonamos');
       expect(result?.full_release_date).toBe('2022-09-30');
@@ -265,7 +250,6 @@ describe('album-metadata-lookup.service', () => {
     });
 
     it('catch-arm-shape row (YT/BC/SC populated, others null) is returned faithfully — caller decides synthesis', async () => {
-      mockRowsQueue.push([{ album_id: 100 }]);
       mockRowsQueue.push([
         {
           artwork_url: null,
@@ -280,7 +264,7 @@ describe('album-metadata-lookup.service', () => {
           artist_wikipedia_url: null,
         },
       ]);
-      const result = await lookupAlbumMetadataByKey('Catch Arm Artist', 'Catch Arm Album');
+      const result = await lookupAlbumMetadataById(100);
       expect(result?.youtube_music_url).toContain('music.youtube.com');
       expect(result?.bandcamp_url).toContain('bandcamp.com');
       expect(result?.soundcloud_url).toContain('soundcloud.com');
@@ -290,43 +274,19 @@ describe('album-metadata-lookup.service', () => {
     });
   });
 
-  describe('lookupCriticReviewsByAlbumKey', () => {
-    // Shares Step-1 (resolveLinkedAlbumId) with the metadata read, so the
-    // same empty-key + cold-case guards apply. Then it projects
-    // album_critic_reviews rows onto the CriticReviewItem wire shape (ADR
-    // 0012): url ← source_url, publishedDate ← published_at, optional fields
-    // omitted when null.
+  describe('lookupCriticReviewsByAlbumId', () => {
+    // Projects album_critic_reviews rows onto the CriticReviewItem wire shape
+    // (ADR 0012): url ← source_url, publishedDate ← published_at, optional
+    // fields omitted when null.
 
-    it('returns [] without touching the DB when artistName is empty (shared guard)', async () => {
-      const result = await lookupCriticReviewsByAlbumKey('', 'Some Album');
-      expect(result).toEqual([]);
-      expect(mockSelect).not.toHaveBeenCalled();
-    });
-
-    it('returns [] without touching the DB when releaseTitle is blank (shared guard)', async () => {
-      const result = await lookupCriticReviewsByAlbumKey('Some Artist', '  ');
-      expect(result).toEqual([]);
-      expect(mockSelect).not.toHaveBeenCalled();
-    });
-
-    it('returns [] when the key resolves to no linked album (cold case) — reviews query short-circuits', async () => {
-      // Step 1 → empty rowset; pin that step 2 is skipped via select call count.
+    it('returns [] when the linked album has no seeded snippets', async () => {
       mockRowsQueue.push([]);
-      const result = await lookupCriticReviewsByAlbumKey('Unknown Artist', 'Unknown Album');
+      const result = await lookupCriticReviewsByAlbumId(42);
       expect(result).toEqual([]);
       expect(mockSelect).toHaveBeenCalledTimes(1);
     });
 
-    it('returns [] when the linked album has no seeded snippets', async () => {
-      mockRowsQueue.push([{ album_id: 42 }]);
-      mockRowsQueue.push([]);
-      const result = await lookupCriticReviewsByAlbumKey('Seeded Artist', 'Unseeded Album');
-      expect(result).toEqual([]);
-      expect(mockSelect).toHaveBeenCalledTimes(2);
-    });
-
     it('projects a full row onto the wire shape (url ← source_url, publishedDate ← published_at)', async () => {
-      mockRowsQueue.push([{ album_id: 7 }]);
       mockRowsQueue.push([
         {
           source: 'The Quietus',
@@ -337,7 +297,7 @@ describe('album-metadata-lookup.service', () => {
           rating: '8.0',
         },
       ]);
-      const result = await lookupCriticReviewsByAlbumKey('Juana Molina', 'DOGA');
+      const result = await lookupCriticReviewsByAlbumId(7);
       expect(result).toEqual([
         {
           source: 'The Quietus',
@@ -351,7 +311,6 @@ describe('album-metadata-lookup.service', () => {
     });
 
     it('omits optional fields (author/publishedDate/rating) when null so decodeIfPresent stays compatible', async () => {
-      mockRowsQueue.push([{ album_id: 7 }]);
       mockRowsQueue.push([
         {
           source: 'Pitchfork',
@@ -362,7 +321,7 @@ describe('album-metadata-lookup.service', () => {
           rating: null,
         },
       ]);
-      const result = await lookupCriticReviewsByAlbumKey('Jessica Pratt', 'On Your Own Love Again');
+      const result = await lookupCriticReviewsByAlbumId(7);
       expect(result).toEqual([
         {
           source: 'Pitchfork',
@@ -374,8 +333,7 @@ describe('album-metadata-lookup.service', () => {
       expect(Object.keys(result[0])).toEqual(['source', 'url', 'snippet']);
     });
 
-    it('preserves row order and returns every projected snippet on a multi-review hit', async () => {
-      mockRowsQueue.push([{ album_id: 9 }]);
+    it('preserves row order and pins the newest-first ORDER BY on a multi-review hit', async () => {
       mockRowsQueue.push([
         {
           source: 'A',
@@ -394,13 +352,11 @@ describe('album-metadata-lookup.service', () => {
           rating: null,
         },
       ]);
-      const result = await lookupCriticReviewsByAlbumKey('Multi Artist', 'Reviewed Album');
+      const result = await lookupCriticReviewsByAlbumId(9);
       expect(result.map((r) => r.source)).toEqual(['A', 'B']);
-      // Step 1 (resolveLinkedAlbumId) and step 2 (reviews) both order for
-      // determinism — pin that the reviews query carries an ORDER BY (the
-      // newest-first + stable-tiebreak contract) rather than relying on
-      // insertion order.
-      expect(chainSpy.orderBy).toHaveBeenCalledTimes(2);
+      // Pin that the reviews query carries an ORDER BY (the newest-first +
+      // stable-tiebreak contract) rather than relying on insertion order.
+      expect(chainSpy.orderBy).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
Closes #1719. Backend leg of epic #1718 (external critic reviews in the iOS playcut detail view, thin vertical slice). The wire contract (`CriticReviewItem`) is merged (wxyc-shared#243) and published as `@wxyc/shared@2.1.0`. BS still hand-mirrors the type in `album-metadata-lookup.service.ts` because it pins `@wxyc/shared` at the `1.x` line; adopting the generated type is a follow-up that takes the `@wxyc/shared` `1.x → 2.x` major upgrade, tracked in #1726. The iOS `ReviewsSection` consumer is the remaining sub-issue.

## What this adds

- **`album_critic_reviews` table** (migration 0125) — keyed on `album_id` → `library.id` (`ON DELETE CASCADE`), with a `(album_id, source_url)` unique index used as the UPSERT conflict target. It is the 4th distinct "review" concept in the schema — separate from `reviews` (legacy), `album_review_submissions` (DJ-authored archive, ADR 0011), and the `AlbumReview` DTO. ADR 0012 explains why it's a new table rather than an overload of any of those.
- **Serve path** — `lookupCriticReviewsByAlbumKey` resolves an `album_id` via the same normalized flowsheet lookup key the album-metadata serve path already uses (extracted into a shared `resolveLinkedAlbumId`), then returns up to 5 snippets ordered `published_at DESC NULLS LAST, id DESC`. `getAlbumMetadata` attaches them as `metadata.criticReviews` on `GET /proxy/metadata/album`.
- **Seed script** — `scripts/seed-critic-reviews.ts` extracts one verbatim snippet per article from a prepared review manifest via Claude Haiku and UPSERTs into the table.
- **ADR 0012** — records the table-vs-overload decision and the fair-use posture (short attributed excerpts with a mandatory link-out; never full text, never score-only cards).

## Flag gate (respects the #32 freeze)

The attach is gated behind `CRITIC_REVIEWS_ENABLED` (strict `=== 'true'`, default false), inside a try/catch so a reviews-path failure never degrades the metadata response. With the flag off, prod behavior and the album-metadata query plan are unchanged — no new query runs on the hot serve path. This keeps the change compatible with the [post-launch service hardening](https://github.com/orgs/WXYC/projects/32) freeze on the serve path (same pattern as `LML_LIBRARY_RELEASE_OVERRIDE` and `CATALOG_SEARCH_ALIAS_ENABLED`). Enabling in prod is a deliberate follow-up once the table is seeded.

## Safety notes

- **The seed script is not run by CI and must not be run casually.** It calls the Anthropic API (real cost) and writes live rows. It defaults to dry-run (writes only on `SEED_EXECUTE=true`) and has a zero-cost local-extractor path (`SEED_SKIP_LLM=true`) for pipeline smoke tests. `scripts/**` is outside typecheck + eslint scope by repo config, so its use of `@anthropic-ai/sdk` (dynamic import) doesn't gate the build.
- Snippets are capped at 300 chars in code (below the column's 512), enforcing the fair-use excerpt length independent of the source.

## Tests

- **Unit** — the flag gate (strict `=== 'true'`; `1`/`TRUE`/`yes`/`on` do not enable), the snippet projection (`url`←`source_url`, `publishedDate`←`published_at`, optional-field omission, internal columns never on the wire), and the controller attach/skip/error branches.
- **Integration** (`tests/integration/critic-reviews-metadata.spec.js`) — pins the live-PG serve contract: NULLS-LAST ordering, LIMIT-5 cap, `album_id` partitioning, `(album_id, source_url)` UPSERT, and `ON DELETE CASCADE`.

Local checks green: typecheck, lint, `format:check`, and the touched unit suites (92 tests). The serve SQL's ordering/cap/partition/UPSERT/cascade semantics were also verified against a throwaway PostgreSQL 18 instance using the verbatim 0125 DDL.

## Related

- WXYC/Backend-Service#1718 (epic)
- WXYC/Backend-Service#1719 (this sub-issue)

