### PR TITLE
fix(webhook): name stub shows from payload djHandle and heal nameless open shows

### DIFF
--- a/apps/backend/routes/internal.route.ts
+++ b/apps/backend/routes/internal.route.ts
@@ -110,7 +110,8 @@ interface ResolvedShow {
    * (degraded `Start of show: ${time}` instead of leaking a real name).
    *
    * Null when the show has no resolvable name from either source
-   * (stub shows pre-ETL-fill; legacy rows with no primary_dj_id and no
+   * (stub shows created before the payload carried `djHandle` (BS#1723)
+   * and not yet ETL-filled; legacy rows with no primary_dj_id and no
    * legacy_dj_name).
    */
   dj_name: string | null;
@@ -118,15 +119,31 @@ interface ResolvedShow {
 
 /**
  * Look up a show by legacy_show_id, creating a stub if it doesn't exist.
- * Uses onConflictDoNothing + re-select for concurrent-insert safety.
+ * Uses an insert-or-fill upsert + re-select for concurrent-insert safety:
+ * DO NOTHING when no handle is carried, otherwise ON CONFLICT DO UPDATE
+ * fills `legacy_dj_name` so a lost concurrent-insert race can't drop it.
  *
  * Also resolves the show's display dj_name via a LEFT JOIN to auth_user on
  * `shows.primary_dj_id` — same query path, no extra round-trip. The webhook
  * INSERT writes this onto marker rows so the v2 wire honours the
  * FLOWSHEET_DJ_NAME_NON_NULL contract (BS#1371).
+ *
+ * `legacyDjHandle` is the optional `entry.djHandle` from sign-on/sign-off
+ * marker payloads (tubafrenzy#607, always DJ_HANDLE — never the real name).
+ * When present it names the stub at creation, and heals an existing show
+ * whose name resolves to null — the sign-on race where the BREAKPOINT
+ * delivery creates the stub before the START_OF_SHOW delivery carries the
+ * handle. Without it, `on_air` reports null (= confirmed automation,
+ * "AUTO DJ" on iOS) until the flowsheet ETL's next half-hourly tick (BS#1723).
+ * Normalized with the same `truncate(_, 128)` the ETL applies, so the next
+ * ETL `IS DISTINCT FROM` pass sees an identical byte sequence. A non-null
+ * resolved name always wins — the heal never overwrites (BS#1371/#1449
+ * convention), and `legacy_dj_name IS NULL` in the WHERE guards against a
+ * concurrent ETL write between the probe and the UPDATE.
  */
-async function resolveShow(legacyShowId: number): Promise<ResolvedShow | null> {
+async function resolveShow(legacyShowId: number, legacyDjHandle: string | null): Promise<ResolvedShow | null> {
   if (!legacyShowId) return null;
+  const handle = truncate(legacyDjHandle, 128);
 
   const selectShow = () =>
     db
@@ -140,10 +157,45 @@ async function resolveShow(legacyShowId: number): Promise<ResolvedShow | null> {
       .limit(1);
 
   const existing = await selectShow();
-  if (existing.length > 0) return { id: existing[0].id, dj_name: existing[0].dj_name };
+  if (existing.length > 0) {
+    if (existing[0].dj_name === null && handle !== null) {
+      await db
+        .update(shows)
+        .set({ legacy_dj_name: handle })
+        .where(and(eq(shows.id, existing[0].id), isNull(shows.legacy_dj_name)));
+      const [reread] = await selectShow();
+      return reread ? { id: reread.id, dj_name: reread.dj_name } : { id: existing[0].id, dj_name: existing[0].dj_name };
+    }
+    return { id: existing[0].id, dj_name: existing[0].dj_name };
+  }
 
   // Create a stub show — the ETL will fill in details (end_time, show_name) later.
-  await db.insert(shows).values({ legacy_show_id: legacyShowId, start_time: new Date() }).onConflictDoNothing();
+  //
+  // Conflict arm: the two sign-on deliveries can interleave so tightly that
+  // BOTH probes above see no row; if the handle-bearing delivery then loses
+  // the INSERT race to the nameless one, a bare DO NOTHING would discard the
+  // handle and re-open the BS#1723 window until the next ETL tick. When we
+  // carry a handle, fill legacy_dj_name atomically instead — same
+  // never-overwrite `IS NULL` guard as the heal above, same
+  // onConflictDoUpdate-on-legacy_show_id shape as the flowsheet ETL's shows
+  // upsert. With no handle there is nothing to fill; keep DO NOTHING.
+  const stubValues = {
+    legacy_show_id: legacyShowId,
+    start_time: new Date(),
+    ...(handle !== null && { legacy_dj_name: handle }),
+  };
+  if (handle !== null) {
+    await db
+      .insert(shows)
+      .values(stubValues)
+      .onConflictDoUpdate({
+        target: shows.legacy_show_id,
+        set: { legacy_dj_name: handle },
+        setWhere: isNull(shows.legacy_dj_name),
+      });
+  } else {
+    await db.insert(shows).values(stubValues).onConflictDoNothing();
+  }
 
   const [row] = await selectShow();
   return row ? { id: row.id, dj_name: row.dj_name } : null;
@@ -215,7 +267,7 @@ internal_route.post('/flowsheet-webhook', async (req, res) => {
       const rawLibraryId = entry.libraryReleaseId ?? 0;
       const rawRotationId = entry.rotationReleaseId ?? 0;
       const [show, albumId, rotationId] = await Promise.all([
-        resolveShow(entry.radioShowId),
+        resolveShow(entry.radioShowId, typeof entry.djHandle === 'string' ? entry.djHandle : null),
         resolveAlbumId(rawLibraryId),
         resolveRotationId(rawRotationId),
       ]);

--- a/tests/unit/routes/internal.route.test.ts
+++ b/tests/unit/routes/internal.route.test.ts
@@ -732,6 +732,211 @@ describe('POST /internal/flowsheet-webhook', () => {
     expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'show_start', dj_name: 'Aubrey' }));
   });
 
+  // -- Stub-show naming + heal from payload djHandle (BS#1723) --
+  //
+  // tubafrenzy#607 adds an optional `entry.djHandle` (the show's DJ_HANDLE) to
+  // sign-on/sign-off marker payloads. resolveShow uses it two ways: a stub
+  // `shows` row is created WITH `legacy_dj_name`, and an existing open show
+  // whose name resolves to NULL is healed in place. The heal path is the one
+  // that fixes the live bug: at sign-on the BREAKPOINT delivery precedes the
+  // START_OF_SHOW delivery, so the stub already exists (nameless) when the
+  // handle arrives. Without this, `on_air` reports `null` (= confirmed
+  // automation, "AUTO DJ" on iOS) until the */30 flowsheet-ETL tick.
+  //
+  // Mock-order note: the heal adds a `db.update(shows)` (no terminal await —
+  // the bare chain resolves) plus ONE extra `selectShow()` re-select. Under
+  // `Promise.all`, resolveAlbumId's SELECT dispatches before resolveShow's
+  // continuation runs, so the re-select consumes mockLimit position 3 (after
+  // show-select and album-select), then the sibling-marker probe is position
+  // 4. All `db.update(...)` calls share one mock chain, so heal assertions
+  // inspect the `.set()` payload — `legacy_dj_name` is a key only the shows
+  // heal writes.
+
+  const allUpdateSetCalls = (): Record<string, unknown>[] => {
+    const setMock = (mockChain as unknown as { set: jest.Mock }).set;
+    return setMock.mock.calls.map((c) => c[0] as Record<string, unknown>);
+  };
+
+  const mockOnConflictDoUpdate = (mockChain as unknown as { onConflictDoUpdate: jest.Mock }).onConflictDoUpdate;
+
+  it('creates the stub show WITH legacy_dj_name when the payload carries djHandle', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([]) // resolveShow: no existing show
+      .mockResolvedValueOnce([]) // resolveAlbumId (unlinked)
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'ovni' }]) // post-insert re-select
+      .mockResolvedValueOnce([]); // sibling-marker probe (nothing to heal)
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]); // fresh flowsheet INSERT
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9, djHandle: 'ovni' } });
+
+    expect(res.status).toBe(200);
+    // First .values() call is the shows stub INSERT, second is the flowsheet INSERT.
+    expect(mockValues.mock.calls[0]![0]).toEqual(
+      expect.objectContaining({ legacy_show_id: 1001, legacy_dj_name: 'ovni' })
+    );
+    expect(mockValues.mock.calls[1]![0]).toEqual(
+      expect.objectContaining({ entry_type: 'show_start', dj_name: 'ovni' })
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('arms the stub INSERT with an ON CONFLICT DO UPDATE fill so a lost concurrent-insert race still names the show', async () => {
+    // The sequential sign-on race is healed by the existing-row branch, but
+    // the two sign-on deliveries can also interleave so BOTH probes see no
+    // row. Then the handle-bearing delivery can lose the INSERT race; a bare
+    // onConflictDoNothing would discard the handle and leave the stub
+    // nameless until the next ETL tick. The conflict arm must fill
+    // legacy_dj_name (guarded by a never-overwrite setWhere) instead.
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([]) // resolveShow: no existing show at probe time
+      .mockResolvedValueOnce([]) // resolveAlbumId
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'ovni' }]) // post-insert re-select
+      .mockResolvedValueOnce([]); // sibling-marker probe
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9, djHandle: 'ovni' } });
+
+    expect(res.status).toBe(200);
+    // `target` matters: a non-unique conflict target would make PG reject the
+    // INSERT ("no unique or exclusion constraint...") and 500 the webhook.
+    expect(mockOnConflictDoUpdate.mock.calls.map((c) => c[0])).toEqual([
+      expect.objectContaining({
+        target: 'legacy_show_id',
+        set: { legacy_dj_name: 'ovni' },
+        setWhere: expect.anything(),
+      }),
+    ]);
+  });
+
+  it('creates the stub show WITHOUT legacy_dj_name when djHandle is absent (pins pre-#1723 behavior)', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([]) // resolveShow: no existing show
+      .mockResolvedValueOnce([]) // resolveAlbumId
+      .mockResolvedValueOnce([{ id: 9999, dj_name: null }]); // post-insert re-select (still nameless)
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9 } });
+
+    expect(res.status).toBe(200);
+    expect(mockValues.mock.calls[0]![0]).toEqual(expect.objectContaining({ legacy_show_id: 1001 }));
+    expect(mockValues.mock.calls[0]![0]).not.toHaveProperty('legacy_dj_name');
+    expect(mockValues.mock.calls[1]![0]).toEqual(expect.objectContaining({ entry_type: 'show_start', dj_name: null }));
+    // No handle → nothing to fill on conflict; the stub INSERT stays DO NOTHING.
+    expect(mockOnConflictDoUpdate).not.toHaveBeenCalled();
+  });
+
+  it('heals a nameless existing show from djHandle and names the marker INSERT (the sign-on race)', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: null }]) // resolveShow: stub exists, nameless
+      .mockResolvedValueOnce([]) // resolveAlbumId
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'ovni' }]) // post-heal re-select
+      .mockResolvedValueOnce([]); // sibling-marker probe
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9, djHandle: 'ovni' } });
+
+    expect(res.status).toBe(200);
+    expect(allUpdateSetCalls()).toEqual([{ legacy_dj_name: 'ovni' }]);
+    expect(mockValues.mock.calls[0]![0]).toEqual(
+      expect.objectContaining({ entry_type: 'show_start', dj_name: 'ovni' })
+    );
+  });
+
+  it('issues NO shows heal when the show already resolves a name (never overwrite)', async () => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: 'Aubrey' }]) // already named
+      .mockResolvedValueOnce([]) // resolveAlbumId
+      .mockResolvedValueOnce([]); // sibling-marker probe
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9, djHandle: 'ovni' } });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'show_start', dj_name: 'Aubrey' }));
+  });
+
+  it.each([
+    ['blank', ''],
+    ['whitespace', '   '],
+    ['non-string', 12345],
+  ])('treats a %s djHandle as absent: no heal, no extra re-select', async (_label, badHandle) => {
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: null }]) // nameless show
+      .mockResolvedValueOnce([]); // resolveAlbumId
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9, djHandle: badHandle } });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    // No heal → no post-heal re-select; nameless show → no sibling probe.
+    expect(mockLimit).toHaveBeenCalledTimes(2);
+    expect(lastInsertValues()).toEqual(expect.objectContaining({ entry_type: 'show_start', dj_name: null }));
+  });
+
+  it('truncates an over-long djHandle to 128 chars on stub create (ETL byte-parity)', async () => {
+    const expected = 'x'.repeat(128);
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([]) // no existing show
+      .mockResolvedValueOnce([]) // resolveAlbumId
+      .mockResolvedValueOnce([{ id: 9999, dj_name: expected }]) // post-insert re-select
+      .mockResolvedValueOnce([]); // sibling-marker probe
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9, djHandle: `  ${'x'.repeat(200)}  ` } });
+
+    expect(res.status).toBe(200);
+    expect(mockValues.mock.calls[0]![0]).toEqual(expect.objectContaining({ legacy_dj_name: expected }));
+  });
+
+  it('truncates an over-long djHandle to 128 chars on the heal path', async () => {
+    const expected = 'x'.repeat(128);
+    mockLimit.mockReset();
+    mockLimit
+      .mockResolvedValueOnce([{ id: 9999, dj_name: null }]) // nameless show
+      .mockResolvedValueOnce([]) // resolveAlbumId
+      .mockResolvedValueOnce([{ id: 9999, dj_name: expected }]) // post-heal re-select
+      .mockResolvedValueOnce([]); // sibling-marker probe
+    mockReturning.mockResolvedValueOnce([{ id: 5555 }]);
+
+    const res = await request(app)
+      .post('/internal/flowsheet-webhook')
+      .set('X-Internal-Key', 'test-secret-key')
+      .send({ action: 'create', entry: { ...validEntry, flowsheetEntryType: 9, djHandle: 'x'.repeat(200) } });
+
+    expect(res.status).toBe(200);
+    expect(allUpdateSetCalls()).toEqual([{ legacy_dj_name: expected }]);
+  });
+
   // -- Delete --
 
   it('returns 200 for valid delete', async () => {


### PR DESCRIPTION
Closes #1723

## What

`resolveShow` now accepts the optional `entry.djHandle` that WXYC/tubafrenzy#607 adds to START_OF_SHOW / END_OF_SHOW webhook payloads, and uses it two ways:

- **Heal**: when the existing show's COALESCE-resolved name is null and a handle arrived, `UPDATE shows SET legacy_dj_name = <handle> WHERE id = <id> AND legacy_dj_name IS NULL`, then re-select. This is the path that fixes the live bug — tubafrenzy creates the BREAKPOINT entry before START_OF_SHOW, so the nameless stub already exists when the handle arrives.
- **Named stub create**: the stub INSERT includes `legacy_dj_name` when a handle is present (covers delivery reordering / lost breakpoint delivery).

Downstream comes free: `markerDjName` resolves non-null so the `show_start` flowsheet row is born named, `on_air` reports `{dj_name}` instead of `null` ("confirmed automation" → false "AUTO DJ" on iOS), and `/flowsheet/djs-on-air` is non-empty within one webhook delivery of a sign-on instead of up to ~30 minutes later at the next flowsheet-ETL tick.

## Design notes

- The handle is normalized with the same `truncate(_, 128)` the flowsheet ETL applies to `show.djHandle`, so the next ETL `IS DISTINCT FROM` pass sees an identical byte sequence — no churn.
- A non-null resolved name always wins (operator edits, ETL fills, `dj_name_override`, account `user.djName`) — the heal never overwrites, same convention the #1371/#1449 tests pin. The `legacy_dj_name IS NULL` guard in the WHERE also protects against a concurrent ETL write between the probe and the UPDATE.
- The heal targets `shows`; the `flowsheet_watermark` trigger is on `flowsheet`, so this is watermark-safe (probe-before-write, same shape as #1444).
- Blank/whitespace/non-string `djHandle` is treated as absent. No 'Anonymous' filtering (parity with ETL + backfill convention; display filtering stays read-side).
- Old tubafrenzy payloads (`djHandle` undefined) behave exactly as before, so this deploys safely ahead of the emitter.

## Deploy order

This PR merges and deploys **first**; WXYC/tubafrenzy#607 (PR to follow) is blocked on it. Old BS ignores unknown JSON keys, so the emitter is safe either way, but the fix only goes live once both are deployed.

## Testing

TDD: eight new tests in `tests/unit/routes/internal.route.test.ts` (heal fires exactly when the show resolves null and a handle is present; stub INSERT carries `legacy_dj_name`; no-handle path pins today's behavior; never-overwrite; blank/whitespace/non-string handles treated as absent with no extra queries; >128-char handles truncated on both paths), each observed failing before the implementation change. Full `npm run test:unit` green (4,934 tests), typecheck clean, lint 0 errors, rebased on `main` @ `6f698bd1`.

## Post-deploy verification

At the next real sign-on: `GET /flowsheet?limit=3` shows `on_air: {"dj_name": ...}` within the first minutes of the show, and `GET /flowsheet/djs-on-air` is non-empty.
