### PR TITLE
Adopt @wxyc/shared 2.x; replace hand-mirrored CriticReviewItem with the generated type

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^10.66.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.12.0",
+    "@wxyc/shared": "^2.1.0",
     "better-auth": "^1.6.23",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,7 +24,7 @@
     "@wxyc/legacy-mirror": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^1.15.0",
+    "@wxyc/shared": "^2.1.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.18.1",

--- a/apps/backend/services/album-metadata-lookup.service.ts
+++ b/apps/backend/services/album-metadata-lookup.service.ts
@@ -37,6 +37,7 @@
  */
 import { sql, eq, desc } from 'drizzle-orm';
 import { db, flowsheet, album_metadata, album_critic_reviews } from '@wxyc/database';
+import type { CriticReviewItem } from '@wxyc/shared/dtos';
 import type { DiscogsResolvedToken, DiscogsTrackItem } from '@wxyc/lml-client';
 
 const flowsheetLookupKey = sql<string>`lower(trim(${flowsheet.artist_name})) || '-' || lower(trim(coalesce(${flowsheet.album_title}, '')))`;
@@ -185,34 +186,6 @@ export async function lookupAlbumMetadataById(albumId: number): Promise<Persiste
 }
 
 /**
- * Wire projection of one external critic-review snippet (album-critic-reviews
- * slice, ADR 0012). Only the six wire fields are surfaced; the internal columns
- * (`id`, `album_id`, `discogs_release_id`, `source_key`, timestamps) never
- * leave the service. `url` maps to the `source_url` column; `publishedDate`
- * maps to `published_at`. Optional fields are omitted from the response when
- * null so iOS `decodeIfPresent` and dj-site optional chaining stay
- * decode-compatible.
- *
- * SSOT: the canonical shape is the `CriticReviewItem` schema in wxyc-shared
- * `api.yaml` (contract WXYC/wxyc-shared#242, PR WXYC/wxyc-shared#243). That PR
- * must merge and `@wxyc/shared` must publish before this endpoint change ships
- * — the dependency is encoded as BS#1719 blocked-by wxyc-shared#242 so the
- * specs can't drift. This interface is a deliberate temporary hand-mirror kept
- * field-for-field in sync with that schema; once the generated type is
- * published, replace this declaration with an import of the generated
- * `CriticReviewItem` (this is the only local copy — the controller and seed
- * both consume it from here).
- */
-export interface CriticReviewItem {
-  source: string;
-  url: string;
-  snippet: string;
-  author?: string;
-  publishedDate?: string;
-  rating?: string;
-}
-
-/**
  * Cap on the number of snippets returned per album. The playcut detail view
  * shows a short list, and an unbounded array on this hot serve path is a
  * payload-size risk; a re-seed that somehow inserted dozens of rows for one
@@ -239,6 +212,15 @@ const CRITIC_REVIEWS_LIMIT = 5;
  * `CRITIC_REVIEWS_LIMIT`. `published_at` is a `date` column; drizzle returns
  * it as an ISO `YYYY-MM-DD` string, which is exactly the `publishedDate`
  * wire shape.
+ *
+ * The return type is the generated `CriticReviewItem` from `@wxyc/shared`
+ * (SSOT: the schema of the same name in wxyc-shared `api.yaml`, contract
+ * WXYC/wxyc-shared#242). Only the six wire fields are surfaced; the internal
+ * columns (`id`, `album_id`, `discogs_release_id`, `source_key`, timestamps)
+ * never leave the service. `url` projects from the `source_url` column and
+ * `publishedDate` from `published_at`; optional fields are omitted when null
+ * so iOS `decodeIfPresent` and dj-site optional chaining stay
+ * decode-compatible.
  */
 export async function lookupCriticReviewsByAlbumId(albumId: number): Promise<CriticReviewItem[]> {
   const rows = await db

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "@sentry/node": "^10.66.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.12.0",
+        "@wxyc/shared": "^2.1.0",
         "better-auth": "^1.6.23",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -352,7 +352,7 @@
         "@wxyc/legacy-mirror": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^1.15.0",
+        "@wxyc/shared": "^2.1.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.18.1",
@@ -6685,9 +6685,9 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "1.16.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.16.0/270ba285feff65253fc48224d8fd03ea952007f0",
-      "integrity": "sha512-oq/U4QWVAP0EhhAap++XklJHPCpRbDF7eIlNJgKMfylEkS4s32uzNH+ltuV+/8NaqNFCiKgZZa+ArrqQ06j0WQ==",
+      "version": "2.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/2.1.0/755f9464dc07af6f1273f9aefc83a441152acd35",
+      "integrity": "sha512-Zn2ONPJqXtrbBkg4Xf20fGUZZ76d9pUM60NxrrKRMLjJULk2tfP9hYwRKKzNN+PnfObLoVOHdsbeHSQIal6AXA==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"
@@ -14899,7 +14899,7 @@
         "@aws-sdk/client-ses": "^3.1089.0",
         "@sentry/node": "^10.66.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^1.12.0",
+        "@wxyc/shared": "^2.1.0",
         "better-auth": "^1.6.23",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -15189,7 +15189,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^10.66.0",
-        "@wxyc/shared": "^1.16.0"
+        "@wxyc/shared": "^2.1.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-ses": "^3.1089.0",
     "@sentry/node": "^10.66.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^1.12.0",
+    "@wxyc/shared": "^2.1.0",
     "better-auth": "^1.6.23",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.66.0",
-    "@wxyc/shared": "^1.16.0"
+    "@wxyc/shared": "^2.1.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/tests/unit/controllers/proxy.controller.test.ts
+++ b/tests/unit/controllers/proxy.controller.test.ts
@@ -1032,7 +1032,7 @@ describe('proxy.controller', () => {
         // id=1580). The host guard must not serve them under the hardwired iOS
         // "Spotify"/"Apple Music" button; not setting them lets the request-time
         // fallback synthesize a real open.spotify.com/search URL instead.
-        mockLookupAlbumMetadataByKey.mockResolvedValue({
+        mockLookupAlbumMetadataById.mockResolvedValue({
           artwork_url: 'https://i.discogs.com/cached.jpg',
           discogs_url: 'https://www.discogs.com/release/1580',
           release_year: 2024,


### PR DESCRIPTION
Adopts the `@wxyc/shared` 2.x line and deletes the hand-mirrored `CriticReviewItem` in favor of the generated type, per #1726.

## Changes

- Bump `@wxyc/shared` `^1.x` → `^2.1.0` in all four consuming workspaces (`apps/backend`, `apps/auth`, `shared/authentication`, `shared/lml-client`) and refresh the lockfile.
- Delete the deliberate temporary hand-mirror `export interface CriticReviewItem` in `apps/backend/services/album-metadata-lookup.service.ts` (introduced in #1721 while BS was pinned to 1.x) and import the generated type from `@wxyc/shared/dtos` instead. SSOT is the `CriticReviewItem` schema in wxyc-shared `api.yaml` (contract WXYC/wxyc-shared#242).

## Breaking-change reconciliation (2.0.0)

The only 2.0.0 break — `OnAirDJ.id` retyped `number` → `string | null` (WXYC/wxyc-shared#211) — required no code changes: the backend has typed its on-air DJ shape inline since #1547 and never imports the generated `OnAirDJ`. Typecheck is green with no source edits beyond the type swap.

## Behavior

Behavior-preserving; no wire-shape change to `GET /proxy/metadata/album`. The generated interface is field-for-field identical to the deleted mirror (required `source`/`url`/`snippet`; optional `author`/`publishedDate`/`rating`). The projection still maps `url` ← `source_url`, `publishedDate` ← `published_at`, omits null optionals, and caps at `CRITIC_REVIEWS_LIMIT`. `CRITIC_REVIEWS_ENABLED` remains off in prod.

Also includes a one-line fix (separate commit) for a pre-existing unit-test failure on `main`: the BS#1714 spotify-url suppression spec referenced the nonexistent `mockLookupAlbumMetadataByKey` (should be `mockLookupAlbumMetadataById`), a ReferenceError introduced by 9ffde959 which was pushed directly to `main` where `test.yml` does not run.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` green
- `npm run test:unit`: 328 suites / 4941 tests green (includes the mock-name fix)
- `npm run ci:testmock` (Docker-isolated CI mirror): 61/61 integration suites green, including `tests/integration/critic-reviews-metadata.spec.js` which pins the serve contract

Closes #1726
