### PR TITLE
feat(concerts): emit station_recommended from rotation membership of the resolved headliner

### DIFF
--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -7,7 +7,9 @@ import {
   concerts,
   db,
   discogs_artist_similar_artists,
+  library,
   normalizeFreetextArtist,
+  rotation,
   type SimilarArtistNeighbor,
   venues,
 } from '@wxyc/database';
@@ -93,6 +95,16 @@ export type ConcertDTO = {
   // id OR the nightly enrichment hasn't run. Same optional-and-nullable discipline
   // as `genres`/`similar_artists` (not in the api.yaml `required` set).
   station_plays?: number | null;
+  // True when the resolved headliner (`headlining_artist_id`) has at least one
+  // WXYC library release that has been in rotation, any rotation row past or
+  // present (BS#1731, On Tour "For You" tier redesign — supersedes the
+  // `station_plays` play-count signal per wxyc-ios-64#576). Sourced from an
+  // EXISTS over `rotation` JOIN `library`, computed in every page/by-id read
+  // (never null there). Discogs-only headliners (`headlining_artist_id IS
+  // NULL`) always read false. Optional (not in the api.yaml `required` set,
+  // wxyc-shared#244) so the `upcoming_show` embed can omit it — see
+  // `station_plays` for the identical discipline.
+  station_recommended?: boolean;
 };
 
 export type ConcertsQueryFilters = {
@@ -144,6 +156,11 @@ export type ConcertJoinRow = {
   // omits it (the #1616 embed boundary), so its rows leave it undefined and
   // `toConcertDTO` coalesces to null.
   station_plays?: number | null;
+  // Optional: only the `getConcertsPage` / `getConcertById` projection selects the
+  // `station_recommended` EXISTS subquery. The `getUpcomingShowsMaps` embed omits
+  // it, so its rows leave it undefined and `toConcertDTO` passes that through
+  // (the field is omitted on the wire there, not coalesced to false).
+  station_recommended?: boolean;
 };
 
 // Explicit select list — the projection is the leak barrier: internal
@@ -217,6 +234,11 @@ export const toConcertDTO = (row: ConcertJoinRow): ConcertDTO => ({
   // Same null-safe discipline (BS#1702): undefined on the embed projection, null
   // for a headliner with no in-library id or no station-plays enrichment row.
   station_plays: row.station_plays ?? null,
+  // NOT coalesced (BS#1731): the page/by-id projection's EXISTS always supplies a
+  // concrete boolean, so `?? false` would never fire there anyway; on the embed
+  // projection `row.station_recommended` is `undefined` and must stay that way so
+  // `JSON.stringify` omits the key rather than asserting "not recommended".
+  station_recommended: row.station_recommended,
 });
 
 /**
@@ -259,10 +281,11 @@ const buildWhere = ({ from, to, curated }: ConcertsQueryFilters) => {
 const effectiveHeadlinerDiscogsId = sql`COALESCE(${concerts.headlining_discogs_artist_id}, ${artists.discogs_artist_id})`;
 
 // Page projection: the shared concerts⋈venues fields plus the LEFT-joined
-// artist-level genres (BS#1624), affinity neighbors (BS#1626 + BS#1701), and
-// station plays (BS#1702). Kept separate from `concertJoinFields` so the
-// `getUpcomingShowsMaps` / count paths (which don't join the enrichment tables)
-// can't accidentally reference those tables' columns.
+// artist-level genres (BS#1624), affinity neighbors (BS#1626 + BS#1701),
+// station plays (BS#1702), and the station-recommended EXISTS (BS#1731). Kept
+// separate from `concertJoinFields` so the `getUpcomingShowsMaps` / count paths
+// (which don't join the enrichment tables) can't accidentally reference those
+// tables' columns.
 //
 // `similar_artists` COALESCEs the two enrichment lanes (BS#1701): the library
 // lane (`artist_similar_artists`, keyed on `headlining_artist_id`) wins over the
@@ -277,6 +300,17 @@ const concertPageFields = {
     SimilarArtistNeighbor[] | null
   >`COALESCE(${artist_similar_artists.neighbors}, ${discogs_artist_similar_artists.neighbors})`,
   station_plays: artist_station_plays.plays,
+  // Station-recommended (BS#1731): a scalar EXISTS, not a joined table, so it
+  // lands in both `getConcertsPage` and `getConcertById` automatically without
+  // a `.leftJoin` (and so cannot trigger the BS#1694 "table … is not part of
+  // the query" hazard). Always a real boolean — never null — since EXISTS
+  // itself never returns NULL; a NULL `headlining_artist_id` (Discogs-only
+  // headliner) simply never correlates a match, so it reads false.
+  station_recommended: sql<boolean>`EXISTS (
+    SELECT 1 FROM ${rotation}
+    JOIN ${library} ON ${library.id} = ${rotation.album_id}
+    WHERE ${library.artist_id} = ${concerts.headlining_artist_id}
+  )`,
 };
 
 /**

--- a/tests/integration/concerts.spec.js
+++ b/tests/integration/concerts.spec.js
@@ -377,3 +377,184 @@ describe('GET /concerts (BS#1603)', () => {
     });
   });
 });
+
+/**
+ * BS#1731 — `Concert.station_recommended`: true iff the resolved headliner
+ * (`headlining_artist_id`) has ≥1 `library` release with ≥1 `rotation` row
+ * (any bin, regardless of `kill_date`), false/omitted otherwise.
+ *
+ * Isolated from the BS#1603 describe above (own venue/source_id prefix) so
+ * these seeds can't perturb that block's exact-array ordering/pagination
+ * assertions.
+ */
+describe('GET /concerts station_recommended (BS#1731)', () => {
+  const VENUE_SLUG = 'bs1731-probe-room';
+  const SOURCE_ID_PREFIX = 'bs1731:';
+  const ROTATED_ARTIST_NAME = 'BS#1731 Rotation-Backed Probe Artist';
+  const UNROTATED_ARTIST_NAME = 'BS#1731 Unrotated Probe Artist';
+  const DISCOGS_ONLY_ARTIST_RAW = 'BS#1731 Discogs-Only Probe Artist';
+  const DISCOGS_ONLY_ARTIST_DISCOGS_ID = 91731001;
+  const STARTS_ON = isoDate(15);
+
+  let auth;
+  let sql;
+  let libraryId;
+
+  const insertConcert = async (venueId, key, overrides) => {
+    const defaults = {
+      source: 'triangle_shows',
+      starts_at: null,
+      doors_at: null,
+      headlining_artist_id: null,
+      headlining_discogs_artist_id: null,
+      title: null,
+      supporting_artists: [],
+      ticket_url: null,
+      image_url: null,
+      event_url: null,
+      price_min: null,
+      price_max: null,
+      age_restriction: null,
+      status: 'on_sale',
+      removed_at: null,
+    };
+    const row = { ...defaults, ...overrides };
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".concerts
+         (source, source_id, venue_id, starts_on, starts_at, doors_at,
+          headlining_artist_raw, headlining_artist_id, headlining_discogs_artist_id,
+          title, supporting_artists_raw, ticket_url, image_url, price_min, price_max,
+          age_restriction, status, removed_at, event_url, raw_data, scraped_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, '{}'::jsonb, now())`,
+      [
+        row.source,
+        SOURCE_ID_PREFIX + key,
+        venueId,
+        STARTS_ON,
+        row.starts_at,
+        row.doors_at,
+        row.headlining_artist_raw,
+        row.headlining_artist_id,
+        row.headlining_discogs_artist_id,
+        row.title,
+        row.supporting_artists,
+        row.ticket_url,
+        row.image_url,
+        row.price_min,
+        row.price_max,
+        row.age_restriction,
+        row.status,
+        row.removed_at,
+        row.event_url,
+      ]
+    );
+  };
+
+  const cleanup = async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".concerts WHERE source_id LIKE $1`, [`${SOURCE_ID_PREFIX}%`]);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".venues WHERE slug = $1`, [VENUE_SLUG]);
+    await sql.unsafe(
+      `DELETE FROM "${SCHEMA}".rotation WHERE album_id IN (SELECT id FROM "${SCHEMA}".library WHERE artist_id IN (SELECT id FROM "${SCHEMA}".artists WHERE artist_name = $1))`,
+      [ROTATED_ARTIST_NAME]
+    );
+    await sql.unsafe(
+      `DELETE FROM "${SCHEMA}".library WHERE artist_id IN (SELECT id FROM "${SCHEMA}".artists WHERE artist_name = $1)`,
+      [ROTATED_ARTIST_NAME]
+    );
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".artists WHERE artist_name IN ($1, $2)`, [
+      ROTATED_ARTIST_NAME,
+      UNROTATED_ARTIST_NAME,
+    ]);
+  };
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = makeSql();
+    await cleanup(); // idempotent across re-runs (shared schema, --runInBand)
+
+    const [venue] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".venues (slug, name, city, state, address)
+       VALUES ($1, 'BS1731 Probe Room', 'Carrboro', 'NC', '300 E Main St')
+       RETURNING id`,
+      [VENUE_SLUG]
+    );
+    const venueId = venue.id;
+
+    const [rotatedArtist] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters)
+       VALUES ($1, $1, 'ZZ') RETURNING id`,
+      [ROTATED_ARTIST_NAME]
+    );
+    const [unrotatedArtist] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters)
+       VALUES ($1, $1, 'ZZ') RETURNING id`,
+      [UNROTATED_ARTIST_NAME]
+    );
+
+    // Rotation-linked library release for the rotated artist: the true case.
+    const [libraryRow] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library (artist_id, genre_id, format_id, album_title, code_number)
+       VALUES ($1, (SELECT id FROM "${SCHEMA}".genres LIMIT 1), (SELECT id FROM "${SCHEMA}".format LIMIT 1), $2, 1)
+       RETURNING id`,
+      [rotatedArtist.id, `${ROTATED_ARTIST_NAME} LP`]
+    );
+    libraryId = libraryRow.id;
+    await sql.unsafe(`INSERT INTO "${SCHEMA}".rotation (album_id, rotation_bin) VALUES ($1, 'H')`, [libraryId]);
+
+    await insertConcert(venueId, 'rotated', {
+      headlining_artist_raw: ROTATED_ARTIST_NAME,
+      headlining_artist_id: rotatedArtist.id,
+    });
+    // Resolved headliner with no library/rotation row at all: the false case.
+    await insertConcert(venueId, 'unrotated', {
+      headlining_artist_raw: UNROTATED_ARTIST_NAME,
+      headlining_artist_id: unrotatedArtist.id,
+    });
+    // Discogs-only resolution (headlining_artist_id NULL): false/omitted by
+    // construction, since the EXISTS correlates on headlining_artist_id.
+    await insertConcert(venueId, 'discogs-only', {
+      headlining_artist_raw: DISCOGS_ONLY_ARTIST_RAW,
+      headlining_discogs_artist_id: DISCOGS_ONLY_ARTIST_DISCOGS_ID,
+    });
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await sql.end();
+  });
+
+  const findByRaw = (body, raw) => body.concerts.find((c) => c.headlining_artist_raw === raw);
+
+  it('emits true for a headliner with a rotation-linked library release', async () => {
+    const res = await auth.get('/concerts').query({ from: STARTS_ON, to: STARTS_ON, limit: 100 });
+    expect(res.status).toBe(200);
+    const concert = findByRaw(res.body, ROTATED_ARTIST_NAME);
+    expect(concert).toBeDefined();
+    expect(concert.station_recommended).toBe(true);
+  });
+
+  it('emits false for a resolved headliner with no rotation row', async () => {
+    const res = await auth.get('/concerts').query({ from: STARTS_ON, to: STARTS_ON, limit: 100 });
+    expect(res.status).toBe(200);
+    const concert = findByRaw(res.body, UNROTATED_ARTIST_NAME);
+    expect(concert).toBeDefined();
+    expect(concert.station_recommended).toBe(false);
+  });
+
+  it('emits false or omits the field for a Discogs-only resolved headliner', async () => {
+    const res = await auth.get('/concerts').query({ from: STARTS_ON, to: STARTS_ON, limit: 100 });
+    expect(res.status).toBe(200);
+    const concert = findByRaw(res.body, DISCOGS_ONLY_ARTIST_RAW);
+    expect(concert).toBeDefined();
+    expect(concert.headlining_artist_id).toBeNull();
+    expect(concert.station_recommended === false || concert.station_recommended === undefined).toBe(true);
+  });
+
+  it('agrees between GET /concerts and GET /concerts/:id for the rotated headliner', async () => {
+    const res = await auth.get('/concerts').query({ from: STARTS_ON, to: STARTS_ON, limit: 100 });
+    const concert = findByRaw(res.body, ROTATED_ARTIST_NAME);
+    const byId = await auth.get(`/concerts/${concert.id}`);
+    expect(byId.status).toBe(200);
+    expect(byId.body.station_recommended).toBe(true);
+  });
+});

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -74,6 +74,7 @@ export const user_activity = {};
 export const labels = {};
 export const library = {
   id: 'id',
+  artist_id: 'artist_id',
   legacy_release_id: 'legacy_release_id',
   on_streaming: 'on_streaming',
   artwork_url: 'artwork_url',

--- a/tests/unit/services/concerts.service.test.ts
+++ b/tests/unit/services/concerts.service.test.ts
@@ -75,6 +75,10 @@ type ApiYamlConcert = {
   // BS#1702: the station-affinity play count as an optional + nullable integer,
   // same discipline as `genres`/`similar_artists`.
   station_plays?: number | null;
+  // BS#1731 (wxyc-shared#244): rotation-membership signal for the "For You"
+  // station-affinity tier. Optional, NOT nullable — the page/by-id projection's
+  // EXISTS always yields a concrete boolean; only the embed omits the key.
+  station_recommended?: boolean;
 };
 
 type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
@@ -124,6 +128,8 @@ const timedRow: ConcertJoinRow = {
   // Resolved + enriched headliner: the LEFT JOIN to `artist_station_plays`
   // produced an all-time play count (BS#1702).
   station_plays: 312,
+  // Resolved headliner with a rotation-linked library release (BS#1731).
+  station_recommended: true,
 };
 
 const dateOnlyRow: ConcertJoinRow = {
@@ -147,6 +153,8 @@ const dateOnlyRow: ConcertJoinRow = {
   genres: null,
   similar_artists: null,
   station_plays: null,
+  // Unresolved headliner: the EXISTS correlation never matches → false (BS#1731).
+  station_recommended: false,
 };
 
 describe('ConcertDTO structural pin', () => {
@@ -275,6 +283,28 @@ describe('toConcertDTO', () => {
     expect(dto.station_plays).toBeNull();
   });
 
+  // BS#1731 — station_recommended comes from the EXISTS(rotation ⋈ library)
+  // subquery in the page/by-id projection: true for a rotation-linked resolved
+  // headliner, false for an unrotated or unresolved one, and OMITTED (not
+  // coalesced to false) when the embed projection doesn't select it.
+  it('passes station_recommended: true through for a rotation-linked headliner', () => {
+    const dto = toConcertDTO(timedRow);
+    expect(dto.station_recommended).toBe(true);
+  });
+
+  it('passes station_recommended: false through for an unrotated/unresolved headliner', () => {
+    const dto = toConcertDTO(dateOnlyRow);
+    expect(dto.station_recommended).toBe(false);
+  });
+
+  it('omits station_recommended (not false) when the row lacks the key (embed projection)', () => {
+    const { station_recommended: _drop, ...without } = timedRow;
+    void _drop;
+    const dto = toConcertDTO(without);
+    expect(dto.station_recommended).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(dto))).not.toHaveProperty('station_recommended');
+  });
+
   it('emits exactly the Concert wire keys — no internal ingestion columns', () => {
     const dto = toConcertDTO(timedRow);
     expect(Object.keys(dto).sort()).toEqual(
@@ -298,6 +328,7 @@ describe('toConcertDTO', () => {
         'genres',
         'similar_artists',
         'station_plays',
+        'station_recommended',
       ].sort()
     );
     for (const internal of INTERNAL_COLUMNS) {
@@ -325,6 +356,9 @@ describe('getConcertsPage', () => {
     for (const internal of INTERNAL_COLUMNS) {
       expect(selectedColumns).not.toContain(internal);
     }
+    // BS#1731 — the station_recommended EXISTS is part of the shared page
+    // projection, so it must always be selected here.
+    expect(Object.keys(projection)).toContain('station_recommended');
   });
 });
 
@@ -403,11 +437,13 @@ describe('getConcertById', () => {
     for (const internal of INTERNAL_COLUMNS) {
       expect(selectedColumns).not.toContain(internal);
     }
-    // Parity pin: the by-id projection carries the BS#1624 genres and BS#1702
-    // station_plays joins, so a by-id read can never lag the list's enrichment
-    // fields (the BS#1694 lockstep-join invariant).
+    // Parity pin: the by-id projection carries the BS#1624 genres, BS#1702
+    // station_plays, and BS#1731 station_recommended fields, so a by-id read
+    // can never lag the list's enrichment fields (the BS#1694 lockstep-join
+    // invariant).
     expect(Object.keys(projection)).toContain('genres');
     expect(Object.keys(projection)).toContain('station_plays');
+    expect(Object.keys(projection)).toContain('station_recommended');
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds an EXISTS(`rotation` JOIN `library`) subquery to `concertPageFields` (shared by `getConcertsPage`/`getConcertById`) so `GET /concerts` and `GET /concerts/:id` emit `station_recommended: boolean` — true when the resolved headliner (`headlining_artist_id`) has a WXYC rotation-linked library release.
- Deliberately not added to the `upcoming_show` embed projection (`getUpcomingShowsMaps`); those rows leave the field `undefined` so it's omitted on the wire rather than asserting `false`.
- Discogs-only resolved headliners (no `headlining_artist_id`) never correlate a match, so the field reads `false`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors, pre-existing warnings only)
- [x] `npm run format:check`
- [x] `npm run test:unit`
- [x] `npm run ci:testmock` (Docker-isolated integration suite, incl. new `GET /concerts station_recommended (BS#1731)` block: rotation-linked headliner → true, resolved-but-unrotated → false, Discogs-only → false/omitted, and page/by-id parity) — 61/62 suites passed (1 skipped by design), 574/582 tests passed (8 skipped)

Closes #1731