### PR TITLE
feat(concerts): persist + project Concert.artist_bio

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^10.66.0",
     "@wxyc/authentication": "^1.0.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^2.1.0",
+    "@wxyc/shared": "^2.3.0",
     "better-auth": "^1.6.23",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -24,7 +24,7 @@
     "@wxyc/legacy-mirror": "^1.0.0",
     "@wxyc/lml-client": "^1.0.0",
     "@wxyc/metadata": "^1.0.0",
-    "@wxyc/shared": "^2.1.0",
+    "@wxyc/shared": "^2.3.0",
     "async-mutex": "^0.5.0",
     "aws-jwt-verify": "^5.2.1",
     "axios": "^1.18.1",

--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -77,6 +77,13 @@ export type ConcertDTO = {
   // compatibly; mirrored here as `genres?` to keep the compile-time
   // `Equal<ConcertDTO, ApiYamlConcert>` pin in concerts.service.test.ts honest.
   genres?: string[] | null;
+  // Raw Discogs artist bio/profile text for the resolved headlining artist
+  // (BS#1734, On Tour R3 "About the Artist"), sourced from `artist_metadata`
+  // via the same null-safe LEFT JOIN as `genres`. Stored and served RAW — no
+  // `cleanDiscogsBio` — matching `album_metadata.artist_bio` /
+  // `flowsheet.artist_bio` precedent (iOS's `DiscogsMarkupParser` renders the
+  // raw markup). Same optional-and-nullable discipline as `genres`.
+  artist_bio?: string | null;
   // Top-K affinity neighbors of the resolved headlining artist (BS#1626, On Tour
   // R3b; extended BS#1701), COALESCEd from the two enrichment lanes: the library
   // lane (`artist_similar_artists`, keyed on `headlining_artist_id`) and the
@@ -146,6 +153,11 @@ export type ConcertJoinRow = {
   // and selects this. The `getUpcomingShowsMaps` projection omits it, so its
   // rows leave it undefined and `toConcertDTO` coalesces to null.
   genres?: string[] | null;
+  // Optional: only the `getConcertsPage` projection LEFT-joins `artist_metadata`
+  // and selects this (BS#1734, same join as `genres`). The `getUpcomingShowsMaps`
+  // projection omits it, so its rows leave it undefined and `toConcertDTO`
+  // coalesces to null.
+  artist_bio?: string | null;
   // Optional: only the `getConcertsPage` projection LEFT-joins the two
   // similar-artists lanes and selects the COALESCEd value. The
   // `getUpcomingShowsMaps` embed omits it (the #1616 hot-path guard), so its rows
@@ -228,6 +240,9 @@ export const toConcertDTO = (row: ConcertJoinRow): ConcertDTO => ({
   // `upcoming_show` embed) leaves `genres` undefined → null on the wire; a
   // resolved-but-unenriched headliner surfaces as null too (no joined row).
   genres: row.genres ?? null,
+  // Same null-safe discipline (BS#1734): undefined on the embed projection,
+  // null for a headliner in neither lane or with no enrichment row.
+  artist_bio: row.artist_bio ?? null,
   // Same null-safe discipline (BS#1626 + BS#1701): undefined on the embed
   // projection, null for a headliner in neither lane or with no enrichment row.
   similar_artists: row.similar_artists ?? null,
@@ -296,6 +311,7 @@ const effectiveHeadlinerDiscogsId = sql`COALESCE(${concerts.headlining_discogs_a
 const concertPageFields = {
   ...concertJoinFields,
   genres: artist_metadata.genres,
+  artist_bio: artist_metadata.artist_bio,
   similar_artists: sql<
     SimilarArtistNeighbor[] | null
   >`COALESCE(${artist_similar_artists.neighbors}, ${discogs_artist_similar_artists.neighbors})`,

--- a/jobs/concerts-genre-enrichment/README.md
+++ b/jobs/concerts-genre-enrichment/README.md
@@ -1,14 +1,16 @@
-# concerts-genre-enrichment (BS#1624)
+# concerts-genre-enrichment (BS#1624 + BS#1734)
 
-Nightly cron that enriches **resolved concert headliners** with artist-level Discogs **genres** (and styles), so `GET /concerts` can project `Concert.genres` (wxyc-shared#221) for the iOS On Tour tab (wxyc-ios-64#474 R2).
+Nightly cron that enriches **resolved concert headliners** with artist-level Discogs **genres** (and styles), so `GET /concerts` can project `Concert.genres` (wxyc-shared#221) for the iOS On Tour tab (wxyc-ios-64#474 R2). Extended (BS#1734) to also carry the raw Discogs artist **bio**, projected as `Concert.artist_bio` (wxyc-shared#247).
 
 ## What it does
 
 1. Load candidates: RESOLVED headliners (`concerts.headlining_discogs_artist_id`, or a library `headlining_artist_id` whose `artists.discogs_artist_id` is known) that have **no** `artist_metadata` row yet — deduped by Discogs artist id.
-2. Page them through LML's bulk artist-genres endpoint (`POST /api/v1/artists/genres/bulk`, LML#781).
-3. UPSERT `genres`/`styles` into `artist_metadata` keyed on the Discogs artist id, `ON CONFLICT DO NOTHING`.
+2. Page them through LML's bulk artist-genres endpoint (`POST /api/v1/artists/genres/bulk`, LML#781; `bio` added LML#889).
+3. UPSERT `genres`/`styles`/`artist_bio` into `artist_metadata` keyed on the Discogs artist id, `ON CONFLICT DO NOTHING`.
 
-The effective Discogs id — `COALESCE(headlining_discogs_artist_id, artists.discogs_artist_id)` — is the exact expression the `GET /concerts` projection joins `artist_metadata` on (`apps/backend/services/concerts.service.ts`), so enrichment writes and the read join resolve genres through the same key.
+The effective Discogs id — `COALESCE(headlining_discogs_artist_id, artists.discogs_artist_id)` — is the exact expression the `GET /concerts` projection joins `artist_metadata` on (`apps/backend/services/concerts.service.ts`), so enrichment writes and the read join resolve genres/bio through the same key.
+
+`artist_bio` is stored **raw** — no `cleanDiscogsBio` — matching `album_metadata.artist_bio` / `flowsheet.artist_bio` precedent; cleaning (if any) is a read-time-only concern.
 
 ## Scheduling
 
@@ -16,11 +18,14 @@ Chained **after** the artist resolvers: 05:15 UTC strict/alias (`concerts-artist
 
 ## Modes
 
-| Invocation                    | Candidate window                                                               | Writes                             |
-| ----------------------------- | ------------------------------------------------------------------------------ | ---------------------------------- |
-| `node dist/job.js` (nightly)  | upcoming-only (`starts_on >= today`, venue-local Eastern)                      | yes                                |
-| `node dist/job.js --backfill` | **all dates** — the one-time deploy backfill over existing resolved headliners | yes                                |
-| `node dist/job.js --dry-run`  | (either)                                                                       | no — enumerate + log the plan only |
+| Invocation                        | Candidate window                                                                                              | Writes                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `node dist/job.js` (nightly)      | upcoming-only (`starts_on >= today`, venue-local Eastern), rows with **no** metadata row                      | genres/styles/bio                  |
+| `node dist/job.js --backfill`     | **all dates** — the one-time deploy backfill over existing resolved headliners, rows with **no** metadata row | genres/styles/bio                  |
+| `node dist/job.js --bio-backfill` | rows that **already have** genres/styles but `artist_bio IS NULL` (BS#1734)                                   | bio only, fill-null                |
+| `node dist/job.js --dry-run`      | (any of the above)                                                                                            | no — enumerate + log the plan only |
+
+`--backfill` and `--bio-backfill` are mutually exclusive (different candidate sets, different writers) — the job fails fast if both are passed.
 
 **Idempotency.** The candidate query anti-joins `artist_metadata` (`WHERE am.discogs_artist_id IS NULL`) and the writer is `ON CONFLICT DO NOTHING`, so a re-run — including a re-run of the one-time backfill — enriches nothing already enriched and never overwrites a collected row. A page whose LML call throws is skipped and its artists are re-selected next run (the anti-join is the retry substrate; there is no attempt-at marker).
 
@@ -32,6 +37,16 @@ docker run --rm --env-file .env <image> --backfill
 ```
 
 Run off-peak. Re-running is a no-op.
+
+## One-time bio backfill (BS#1734)
+
+The nightly candidate query (and `--backfill`) only ever select artists with **no** `artist_metadata` row, so genres-only rows created by BS#1624's live nightly runs before the `artist_bio` column shipped never pick up a bio from either. Run this once, after the migration deploys, to fill them:
+
+```bash
+docker run --rm --env-file .env <image> --bio-backfill
+```
+
+Selects `discogs_artist_id` from `artist_metadata WHERE artist_bio IS NULL`, re-queries the same LML bulk endpoint, and writes via a fill-null-only `INSERT ... ON CONFLICT DO UPDATE ... WHERE artist_bio IS NULL` (`writer.ts#applyBioBackfill`) — never touches `genres`/`styles`, never overwrites a bio already present. Idempotent; re-running only re-attempts rows still `NULL` (including artists LML genuinely has no Discogs profile text for — a responded `null` bio is written as a terminal answer, not left for retry; only a `source: 'unavailable'` verdict stays retryable).
 
 ## Env
 
@@ -45,4 +60,4 @@ Run off-peak. Re-running is a no-op.
 
 ## LML contract (reconciled — LML#847)
 
-The LML call is isolated behind `fetchArtistGenresBulk` in `@wxyc/lml-client`, reconciled against the shipped `POST /api/v1/artists/genres/bulk` endpoint (LML#781, merged as LML#847) and the wxyc-shared `ArtistGenres*` contract (#235): request `{ artist_name, discogs_artist_id? }[]` under the `artists` envelope key; response per-artist `{ genres: string[], styles: string[], source }`, index-aligned with the request. `fetchArtistGenresBulk` enforces `results.length === artists.length` before returning (throws `LmlClientError(502)` on a misaligned array), so the orchestrator's positional zip can never mis-attribute a genre set. Per-request cap `ARTIST_GENRES_BATCH_CAP` = 25. LML's `source` discriminator routes the write: `unavailable` (LML couldn't reach Discogs) is skipped and left retryable; `cache`/`discogs_api`/`not_found` persist. Every test mocks the LML call; nothing here hits a live endpoint.
+The LML call is isolated behind `fetchArtistGenresBulk` in `@wxyc/lml-client`, reconciled against the shipped `POST /api/v1/artists/genres/bulk` endpoint (LML#781, merged as LML#847) and the wxyc-shared `ArtistGenres*` contract (#235): request `{ artist_name, discogs_artist_id? }[]` under the `artists` envelope key; response per-artist `{ genres: string[], styles: string[], source, bio? }`, index-aligned with the request. `bio` (BS#1734, LML#889) is the raw Discogs artist `profile` text — nullable, independent of `source`. `fetchArtistGenresBulk` enforces `results.length === artists.length` before returning (throws `LmlClientError(502)` on a misaligned array), so the orchestrator's positional zip can never mis-attribute a genre set. Per-request cap `ARTIST_GENRES_BATCH_CAP` = 25. LML's `source` discriminator routes the write: `unavailable` (LML couldn't reach Discogs) is skipped and left retryable; `cache`/`discogs_api`/`not_found` persist. Every test mocks the LML call; nothing here hits a live endpoint.

--- a/jobs/concerts-genre-enrichment/README.md
+++ b/jobs/concerts-genre-enrichment/README.md
@@ -46,7 +46,7 @@ The nightly candidate query (and `--backfill`) only ever select artists with **n
 docker run --rm --env-file .env <image> --bio-backfill
 ```
 
-Selects `discogs_artist_id` from `artist_metadata WHERE artist_bio IS NULL`, re-queries the same LML bulk endpoint, and writes via a fill-null-only `INSERT ... ON CONFLICT DO UPDATE ... WHERE artist_bio IS NULL` (`writer.ts#applyBioBackfill`) — never touches `genres`/`styles`, never overwrites a bio already present. Idempotent; re-running only re-attempts rows still `NULL` (including artists LML genuinely has no Discogs profile text for — a responded `null` bio is written as a terminal answer, not left for retry; only a `source: 'unavailable'` verdict stays retryable).
+Selects `discogs_artist_id` from `artist_metadata WHERE artist_bio IS NULL`, re-queries the same LML bulk endpoint, and writes via a fill-null-only `INSERT ... ON CONFLICT DO UPDATE ... WHERE artist_bio IS NULL` (`writer.ts#applyBioBackfill`) — never touches `genres`/`styles`, never overwrites a bio already present. Only a verdict with a real (non-empty) bio is written; that row then has `artist_bio IS NOT NULL` and is terminal. Two verdict shapes leave the row `NULL`-retryable and are re-attempted on a re-run: `source: 'unavailable'` (LML couldn't reach Discogs — transient) and a responded-but-blank profile (Discogs genuinely has no bio — persistent). Because there is no attempt marker, a blank-profile artist stays in the candidate set indefinitely, so **this is a one-time manual pass, not a no-op-on-re-run cron** — re-running it re-queries every blank-profile artist (bounded and rate-limited, but not free). A `bio_attempted_at` marker would be required for a true no-op re-run; that is deferred as out of scope.
 
 ## Env
 

--- a/jobs/concerts-genre-enrichment/bio-backfill.ts
+++ b/jobs/concerts-genre-enrichment/bio-backfill.ts
@@ -12,10 +12,22 @@
  * UPDATE. Deliberately does NOT touch genres/styles on these rows (BS#1624
  * already populated them) and does NOT widen the nightly candidate anti-join.
  *
+ * Only a verdict carrying a real (non-empty) bio is written — that row then has
+ * `artist_bio IS NOT NULL` and drops out of the candidate set for good. Two
+ * verdict shapes are skipped and leave the row `NULL`-retryable: `source:
+ * 'unavailable'` (LML couldn't reach Discogs — transient) and a responded but
+ * blank/absent profile (Discogs genuinely has no bio). Writing the latter as
+ * NULL would achieve nothing (the candidate query keys on `artist_bio IS
+ * NULL`), so the skip avoids a pointless self-UPDATE. The consequence: a
+ * blank-profile artist is re-attempted on every re-run — this pass does NOT
+ * converge to a no-op re-run, which is acceptable for a one-time MANUAL job
+ * (bounded, rate-limited) but is why it must never be scheduled as a cron. True
+ * convergence would need a `bio_attempted_at` marker (deferred, out of scope).
+ *
  * Same page/fetch/skip-unavailable/stop-early control flow as `orchestrate.ts`
  * (kept as a sibling function rather than folded in, since the two write
  * completely different columns via different statements) — see that file for
- * the retry-vs-terminal rationale this mirrors.
+ * the breaker-open early-stop rationale this mirrors.
  *
  * Dep-injected so the unit suite drives the loop without PG or LML — see
  * tests/unit/jobs/concerts-genre-enrichment/bio-backfill.test.ts.
@@ -37,6 +49,8 @@ export type BioBackfillTotals = {
   updated: number;
   /** Of `fetched`, verdicts with `source: 'unavailable'` — skipped, left retryable. */
   unavailable_skipped: number;
+  /** Of `fetched`, responded verdicts with a blank/absent bio — skipped, left `NULL`-retryable. */
+  no_bio_skipped: number;
   /** Page-level transport failures (per artist) + write failures. */
   errors: number;
   /** Set when a whole page came back `unavailable` (breaker open) and the run stopped short. */
@@ -49,6 +63,7 @@ export const emptyBioBackfillTotals = (): BioBackfillTotals => ({
   fetched: 0,
   updated: 0,
   unavailable_skipped: 0,
+  no_bio_skipped: 0,
   errors: 0,
   stopped_early: false,
 });
@@ -129,16 +144,26 @@ export const runBioBackfill = async (
     for (let i = 0; i < page.length; i++) {
       const verdict = response.results[i];
       totals.fetched += 1;
-      // `unavailable` = LML couldn't reach Discogs. Skip the write so the row
-      // keeps `artist_bio IS NULL` and the candidate query re-selects it next
-      // run. A responded verdict (even a null bio — a blank Discogs profile is
-      // a real terminal answer) writes.
+      // `unavailable` = LML couldn't reach Discogs (transient). Skip the write so
+      // the row keeps `artist_bio IS NULL` and the candidate query re-selects it
+      // next run — and count it toward `pageUnavailable` so an all-unavailable
+      // page trips the breaker-open early stop below.
       if (verdict.source === 'unavailable') {
         totals.unavailable_skipped += 1;
         pageUnavailable += 1;
         continue;
       }
-      rows.push({ discogs_artist_id: page[i].discogs_artist_id, artist_bio: verdict.bio ?? null });
+      // Responded, but Discogs has no profile text. Writing NULL would be a
+      // pointless self-UPDATE (the candidate query keys on `artist_bio IS
+      // NULL`), so skip it — the row stays NULL-retryable, exactly like a
+      // populated-bio artist stays terminal. NOT a breaker signal, so this does
+      // NOT count toward `pageUnavailable`.
+      const bio = verdict.bio ?? null;
+      if (bio === null || bio === '') {
+        totals.no_bio_skipped += 1;
+        continue;
+      }
+      rows.push({ discogs_artist_id: page[i].discogs_artist_id, artist_bio: bio });
     }
 
     // A page that comes back entirely `unavailable` means LML's Discogs breaker

--- a/jobs/concerts-genre-enrichment/bio-backfill.ts
+++ b/jobs/concerts-genre-enrichment/bio-backfill.ts
@@ -1,0 +1,174 @@
+/**
+ * Bio backfill orchestrator for jobs/concerts-genre-enrichment (BS#1734).
+ *
+ * The nightly candidate query (query.ts `loadEnrichmentCandidates`) anti-joins
+ * on "no `artist_metadata` row at all", so it never revisits an artist BS#1624
+ * already enriched with genres/styles — meaning rows created before the
+ * `artist_bio` column shipped never pick up a bio from the nightly run or from
+ * `--backfill` (same anti-join). This is the one-time pass that fills them:
+ * `loadBioBackfillCandidates` selects `discogs_artist_id WHERE artist_bio IS
+ * NULL`, re-queries the SAME LML bulk artist-genres endpoint (bio rides
+ * genres/styles, LML#889), and `applyBioBackfill` writes a fill-null-only
+ * UPDATE. Deliberately does NOT touch genres/styles on these rows (BS#1624
+ * already populated them) and does NOT widen the nightly candidate anti-join.
+ *
+ * Same page/fetch/skip-unavailable/stop-early control flow as `orchestrate.ts`
+ * (kept as a sibling function rather than folded in, since the two write
+ * completely different columns via different statements) — see that file for
+ * the retry-vs-terminal rationale this mirrors.
+ *
+ * Dep-injected so the unit suite drives the loop without PG or LML — see
+ * tests/unit/jobs/concerts-genre-enrichment/bio-backfill.test.ts.
+ */
+
+import type { ArtistGenresBulkResponse, ArtistGenresRequestItem } from '@wxyc/lml-client';
+import type { EnrichmentCandidate } from './query.js';
+import type { BioBackfillRow } from './writer.js';
+import { captureError, log } from './logger.js';
+
+export type BioBackfillTotals = {
+  /** `artist_metadata` rows lacking a bio (deduped by Discogs id). */
+  candidates: number;
+  /** LML pages that received a response. */
+  pages: number;
+  /** Artist verdicts received across all responded pages. */
+  fetched: number;
+  /** `artist_metadata` rows actually updated (a re-run over a filled set → 0). */
+  updated: number;
+  /** Of `fetched`, verdicts with `source: 'unavailable'` — skipped, left retryable. */
+  unavailable_skipped: number;
+  /** Page-level transport failures (per artist) + write failures. */
+  errors: number;
+  /** Set when a whole page came back `unavailable` (breaker open) and the run stopped short. */
+  stopped_early: boolean;
+};
+
+export const emptyBioBackfillTotals = (): BioBackfillTotals => ({
+  candidates: 0,
+  pages: 0,
+  fetched: 0,
+  updated: 0,
+  unavailable_skipped: 0,
+  errors: 0,
+  stopped_early: false,
+});
+
+export interface BioBackfillDeps {
+  /** Existing `artist_metadata` rows lacking a bio (deduped by Discogs id). */
+  loadCandidates: () => Promise<EnrichmentCandidate[]>;
+  /** One LML page. The client validates 1:1 index alignment before returning. */
+  fetchGenres: (items: ArtistGenresRequestItem[]) => Promise<ArtistGenresBulkResponse>;
+  /** Fill-null bio UPDATE (never overwrites a populated value); returns rows updated. */
+  applyBioBackfill: (rows: BioBackfillRow[]) => Promise<{ updated: number }>;
+  /** Cooperative pause — awaited before each page. */
+  awaitQuiet?: () => Promise<void>;
+}
+
+export interface BioBackfillOptions {
+  pageSize: number;
+  dryRun: boolean;
+}
+
+const chunk = <T>(arr: T[], size: number): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+};
+
+export const runBioBackfill = async (
+  deps: BioBackfillDeps,
+  options: BioBackfillOptions
+): Promise<BioBackfillTotals> => {
+  const totals = emptyBioBackfillTotals();
+
+  const candidates = await deps.loadCandidates();
+  totals.candidates = candidates.length;
+
+  const pages = chunk(candidates, options.pageSize);
+  log('info', 'bio_backfill_enumerated', `${candidates.length} artist_metadata rows need a bio backfill`, {
+    candidates: candidates.length,
+    planned_pages: pages.length,
+    page_size: options.pageSize,
+  });
+
+  if (options.dryRun) {
+    log(
+      'info',
+      'bio_backfill_dry_run_plan',
+      `(dry-run) would send ${pages.length} pages of up to ${options.pageSize} artists`,
+      { planned_pages: pages.length }
+    );
+    return totals;
+  }
+
+  for (const page of pages) {
+    if (deps.awaitQuiet) await deps.awaitQuiet();
+
+    let response: ArtistGenresBulkResponse;
+    try {
+      response = await deps.fetchGenres(
+        page.map((c) => ({ artist_name: c.artist_name, discogs_artist_id: c.discogs_artist_id }))
+      );
+    } catch (err) {
+      // Transport failure: nothing written, the whole page's artists keep
+      // `artist_bio IS NULL` and are re-selected next run (the candidate query
+      // is the retry substrate).
+      totals.errors += page.length;
+      log('warn', 'bio_backfill_page_failed', `fetchArtistGenresBulk threw; page of ${page.length} left retryable`, {
+        page_size: page.length,
+        first_discogs_artist_id: page[0]?.discogs_artist_id ?? null,
+        error_message: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+      });
+      captureError(err, 'bio_backfill_page_failed', { page_size: page.length });
+      continue;
+    }
+    totals.pages += 1;
+
+    const rows: BioBackfillRow[] = [];
+    let pageUnavailable = 0;
+    for (let i = 0; i < page.length; i++) {
+      const verdict = response.results[i];
+      totals.fetched += 1;
+      // `unavailable` = LML couldn't reach Discogs. Skip the write so the row
+      // keeps `artist_bio IS NULL` and the candidate query re-selects it next
+      // run. A responded verdict (even a null bio — a blank Discogs profile is
+      // a real terminal answer) writes.
+      if (verdict.source === 'unavailable') {
+        totals.unavailable_skipped += 1;
+        pageUnavailable += 1;
+        continue;
+      }
+      rows.push({ discogs_artist_id: page[i].discogs_artist_id, artist_bio: verdict.bio ?? null });
+    }
+
+    // A page that comes back entirely `unavailable` means LML's Discogs breaker
+    // is open; later pages would just waste round-trips. Stop the run — the
+    // whole candidate set stays retryable, and `rows` is empty so there is
+    // nothing to write. Mirrors orchestrate.ts's identical guard.
+    if (page.length > 0 && pageUnavailable === page.length) {
+      totals.stopped_early = true;
+      log(
+        'info',
+        'bio_backfill_stopped_early',
+        `page of ${page.length} came back all-unavailable (breaker open); stopping run`,
+        { page_size: page.length, pages_done: totals.pages }
+      );
+      break;
+    }
+
+    try {
+      const { updated } = await deps.applyBioBackfill(rows);
+      totals.updated += updated;
+    } catch (err) {
+      // A write failure leaves the page's rows at `artist_bio IS NULL` (retryable).
+      totals.errors += rows.length;
+      log('warn', 'bio_backfill_update_failed', `artist_metadata bio UPDATE threw for a page of ${rows.length}`, {
+        page_size: rows.length,
+        error_message: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+      });
+      captureError(err, 'bio_backfill_update_failed', { page_size: rows.length });
+    }
+  }
+
+  return totals;
+};

--- a/jobs/concerts-genre-enrichment/job.ts
+++ b/jobs/concerts-genre-enrichment/job.ts
@@ -1,13 +1,14 @@
 /**
  * Nightly cron: enrich resolved concert headliners with artist-level Discogs
- * genres via LML's bulk artist-genres endpoint (BS#1624, LML#781).
+ * genres + bio via LML's bulk artist-genres endpoint (BS#1624, LML#781;
+ * `bio` added BS#1734, LML#889).
  *
  * Chained after the concert artist resolvers (05:15 UTC strict/alias, 05:35 UTC
  * LML) so it only ever sees headliners those passes have resolved. For each
  * resolved headliner lacking an `artist_metadata` row it calls
- * `POST /api/v1/artists/genres/bulk` and persists `genres`/`styles` keyed on the
- * Discogs artist id — the key `GET /concerts` projects onto `Concert.genres`.
- * Default schedule `45 5 * * *` UTC.
+ * `POST /api/v1/artists/genres/bulk` and persists `genres`/`styles`/`artist_bio`
+ * keyed on the Discogs artist id — the key `GET /concerts` projects onto
+ * `Concert.genres`/`Concert.artist_bio`. Default schedule `45 5 * * *` UTC.
  *
  * Modes:
  *   - default (nightly): upcoming-only candidate window (venue-local Eastern
@@ -15,7 +16,12 @@
  *   - `--backfill`: drop the window and front-fill every existing resolved
  *     headliner — the one-time deploy backfill. Idempotent: the candidate
  *     anti-join + `ON CONFLICT DO NOTHING` make a re-run a no-op.
- *   - `--dry-run`: enumerate + log the plan; no LML calls, no writes.
+ *   - `--bio-backfill` (BS#1734, mutually exclusive with the above): a SEPARATE
+ *     one-time pass over pre-existing genres-only `artist_metadata` rows (the
+ *     nightly anti-join never revisits a row that already exists, so these
+ *     rows would otherwise never pick up a bio). See `bio-backfill.ts`.
+ *   - `--dry-run`: enumerate + log the plan; no LML calls, no writes. Applies
+ *     to whichever mode is selected.
  *
  * Enrichment runs nightly server-to-server with the LML API key (merged at the
  * `@wxyc/lml-client` chokepoint from `LML_API_KEY`); it is never on any
@@ -34,9 +40,10 @@ import { sql } from 'drizzle-orm';
 import { closeDatabaseConnection, db, requireNonNegativeInt, requirePositiveInt } from '@wxyc/database';
 import { ARTIST_GENRES_BATCH_CAP, fetchArtistGenresBulk } from '@wxyc/lml-client';
 import { defaultLmlLimiter } from './lml-limiter.js';
-import { loadEnrichmentCandidates } from './query.js';
+import { loadBioBackfillCandidates, loadEnrichmentCandidates } from './query.js';
 import { runEnrichment, type Totals } from './orchestrate.js';
-import { upsertArtistGenres } from './writer.js';
+import { runBioBackfill, type BioBackfillTotals } from './bio-backfill.js';
+import { applyBioBackfill, upsertArtistGenres } from './writer.js';
 import { captureError, closeLogger, initLogger, log } from './logger.js';
 
 const JOB_NAME = 'concerts-genre-enrichment';
@@ -59,6 +66,7 @@ export interface EnrichJobOptions {
   liveActivityLookbackSeconds: number;
   liveActivityPauseMs: number;
   backfill: boolean;
+  bioBackfill: boolean;
   dryRun: boolean;
 }
 
@@ -75,6 +83,14 @@ export const enrichJobOptions = (
       `[${JOB_NAME}] ${PAGE_SIZE_ENV}=${pageSize} exceeds the LML per-request cap of ${ARTIST_GENRES_BATCH_CAP}.`
     );
   }
+  const backfill = args.includes('--backfill');
+  const bioBackfill = args.includes('--bio-backfill');
+  if (backfill && bioBackfill) {
+    // Two different one-time modes over two different candidate sets and two
+    // different writers — running both in one invocation would conflate their
+    // totals/logging. Run them as separate invocations instead.
+    throw new Error(`[${JOB_NAME}] --backfill and --bio-backfill are mutually exclusive; run them separately.`);
+  }
   return {
     pageSize,
     liveActivityLookbackSeconds: requireNonNegativeInt(
@@ -84,7 +100,8 @@ export const enrichJobOptions = (
       { ...ctx, note: 'Use 0 to disable the live-activity probe.' }
     ),
     liveActivityPauseMs: LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
-    backfill: args.includes('--backfill'),
+    backfill,
+    bioBackfill,
     dryRun: args.includes('--dry-run'),
   };
 };
@@ -143,12 +160,34 @@ export const runJob = async (options: EnrichJobOptions): Promise<Totals> => {
   );
 };
 
+/** `--bio-backfill` mode (BS#1734) — see `bio-backfill.ts` module docblock. */
+export const runBioBackfillJob = async (options: EnrichJobOptions): Promise<BioBackfillTotals> => {
+  log('info', 'bio_backfill_started', `${JOB_NAME} bio backfill starting`, {
+    page_size: options.pageSize,
+    live_activity_lookback_seconds: options.liveActivityLookbackSeconds,
+    dry_run: options.dryRun,
+  });
+
+  return await runBioBackfill(
+    {
+      loadCandidates: loadBioBackfillCandidates,
+      fetchGenres: (items) => fetchArtistGenresBulk(items, { limiter: defaultLmlLimiter, caller: JOB_NAME }),
+      applyBioBackfill,
+      awaitQuiet: () => awaitQuietWindow(options.liveActivityLookbackSeconds, options.liveActivityPauseMs),
+    },
+    {
+      pageSize: options.pageSize,
+      dryRun: options.dryRun,
+    }
+  );
+};
+
 const main = async (): Promise<void> => {
   initLogger({ repo: 'Backend-Service', tool: JOB_NAME });
 
   try {
     const options = enrichJobOptions();
-    const totals = await runJob(options);
+    const totals = options.bioBackfill ? await runBioBackfillJob(options) : await runJob(options);
     log('info', 'finished', `${JOB_NAME} done`, { ...totals });
   } catch (err) {
     captureError(err, 'main');

--- a/jobs/concerts-genre-enrichment/orchestrate.ts
+++ b/jobs/concerts-genre-enrichment/orchestrate.ts
@@ -145,7 +145,12 @@ export const runEnrichment = async (deps: EnrichDeps, options: EnrichOptions): P
       const genres = verdict.genres ?? [];
       const styles = verdict.styles ?? [];
       if (genres.length > 0) totals.with_genres += 1;
-      rows.push({ discogs_artist_id: page[i].discogs_artist_id, genres, styles });
+      rows.push({
+        discogs_artist_id: page[i].discogs_artist_id,
+        genres,
+        styles,
+        artist_bio: verdict.bio ?? null,
+      });
     }
 
     // A page that comes back entirely `unavailable` means LML's Discogs breaker

--- a/jobs/concerts-genre-enrichment/query.ts
+++ b/jobs/concerts-genre-enrichment/query.ts
@@ -95,3 +95,32 @@ export const loadEnrichmentCandidates = async (backfill = false): Promise<Enrich
   `);
   return unwrapRows<EnrichmentCandidate>(result);
 };
+
+/**
+ * Bio-backfill candidates (BS#1734): existing `artist_metadata` rows the
+ * nightly genres enrichment (BS#1624) created BEFORE the `artist_bio` column
+ * shipped, so `artist_bio IS NULL` on a row that already has genres/styles.
+ * The anti-join in `loadEnrichmentCandidates` above never revisits these rows
+ * — it only selects artists with NO row at all — so this is the one-time
+ * pass that fills them (`jobs/concerts-genre-enrichment/bio-backfill.ts`).
+ *
+ * Name resolution mirrors the candidate query's `eff` subquery: a library
+ * artist's canonical `artists.artist_name`, or the raw headliner billing off
+ * any concert row that resolved to this Discogs id (the `artist_metadata` row
+ * only exists because some concert resolved to it, at either lane).
+ */
+export const loadBioBackfillCandidates = async (): Promise<EnrichmentCandidate[]> => {
+  const result: unknown = await db.execute(sql`
+    SELECT DISTINCT ON (am."discogs_artist_id")
+      am."discogs_artist_id" AS discogs_artist_id,
+      COALESCE("a"."artist_name", "c"."headlining_artist_raw") AS artist_name
+    FROM ${ARTIST_METADATA_TABLE} am
+    LEFT JOIN ${ARTISTS_TABLE} "a" ON "a"."discogs_artist_id" = am."discogs_artist_id"
+    LEFT JOIN ${CONCERTS_TABLE} "c" ON "c"."headlining_discogs_artist_id" = am."discogs_artist_id"
+      OR "c"."headlining_artist_id" = "a"."id"
+    WHERE am."artist_bio" IS NULL
+      AND COALESCE("a"."artist_name", "c"."headlining_artist_raw") IS NOT NULL
+    ORDER BY am."discogs_artist_id" ASC
+  `);
+  return unwrapRows<EnrichmentCandidate>(result);
+};

--- a/jobs/concerts-genre-enrichment/query.ts
+++ b/jobs/concerts-genre-enrichment/query.ts
@@ -105,19 +105,37 @@ export const loadEnrichmentCandidates = async (backfill = false): Promise<Enrich
  * pass that fills them (`jobs/concerts-genre-enrichment/bio-backfill.ts`).
  *
  * Name resolution mirrors the candidate query's `eff` subquery: a library
- * artist's canonical `artists.artist_name`, or the raw headliner billing off
- * any concert row that resolved to this Discogs id (the `artist_metadata` row
- * only exists because some concert resolved to it, at either lane).
+ * artist's canonical `artists.artist_name`, or — for a Discogs-only touring
+ * artist with no `artists` row — the raw headliner billing from its most-recent
+ * NON-removed concert. That billing comes from a `LATERAL … ORDER BY starts_on
+ * DESC, id DESC LIMIT 1` rather than a bare OR-join, so the pick is
+ * deterministic (freshest billing wins a tie, not an arbitrary row) and the
+ * lookup returns exactly one concert per artist instead of fanning `am` out
+ * across every matching concert. `am.discogs_artist_id` is the PK, so the result
+ * is already one row per artist — no `DISTINCT ON` needed.
+ *
+ * A blank-profile artist that a prior run wrote NULL for stays a candidate:
+ * there is no attempt marker, so `--bio-backfill` does not converge to a true
+ * no-op re-run. That is acceptable for a one-time manual pass (see
+ * `bio-backfill.ts`); it must not be scheduled as a recurring cron.
  */
 export const loadBioBackfillCandidates = async (): Promise<EnrichmentCandidate[]> => {
   const result: unknown = await db.execute(sql`
-    SELECT DISTINCT ON (am."discogs_artist_id")
+    SELECT
       am."discogs_artist_id" AS discogs_artist_id,
       COALESCE("a"."artist_name", "c"."headlining_artist_raw") AS artist_name
     FROM ${ARTIST_METADATA_TABLE} am
     LEFT JOIN ${ARTISTS_TABLE} "a" ON "a"."discogs_artist_id" = am."discogs_artist_id"
-    LEFT JOIN ${CONCERTS_TABLE} "c" ON "c"."headlining_discogs_artist_id" = am."discogs_artist_id"
-      OR "c"."headlining_artist_id" = "a"."id"
+    LEFT JOIN LATERAL (
+      SELECT "cc"."headlining_artist_raw"
+      FROM ${CONCERTS_TABLE} "cc"
+      WHERE ("cc"."headlining_discogs_artist_id" = am."discogs_artist_id"
+             OR "cc"."headlining_artist_id" = "a"."id")
+        AND "cc"."removed_at" IS NULL
+        AND "cc"."headlining_artist_raw" IS NOT NULL
+      ORDER BY "cc"."starts_on" DESC NULLS LAST, "cc"."id" DESC
+      LIMIT 1
+    ) "c" ON TRUE
     WHERE am."artist_bio" IS NULL
       AND COALESCE("a"."artist_name", "c"."headlining_artist_raw") IS NOT NULL
     ORDER BY am."discogs_artist_id" ASC

--- a/jobs/concerts-genre-enrichment/writer.ts
+++ b/jobs/concerts-genre-enrichment/writer.ts
@@ -14,13 +14,15 @@
  * not its contents — is what makes the enrichment idempotent.
  */
 
+import { sql } from 'drizzle-orm';
 import { artist_metadata, db } from '@wxyc/database';
 
-/** One artist's resolved genres/styles, ready to persist. */
+/** One artist's resolved genres/styles/bio, ready to persist. */
 export type ArtistGenresRow = {
   discogs_artist_id: number;
   genres: string[];
   styles: string[];
+  artist_bio: string | null;
 };
 
 /**
@@ -37,9 +39,53 @@ export const upsertArtistGenres = async (rows: ArtistGenresRow[]): Promise<{ ins
         discogs_artist_id: r.discogs_artist_id,
         genres: r.genres,
         styles: r.styles,
+        artist_bio: r.artist_bio,
       }))
     )
     .onConflictDoNothing({ target: artist_metadata.discogs_artist_id })
     .returning({ discogs_artist_id: artist_metadata.discogs_artist_id });
   return { inserted: inserted.length };
+};
+
+/** One artist's re-fetched bio, ready to fill onto an existing row. */
+export type BioBackfillRow = {
+  discogs_artist_id: number;
+  artist_bio: string | null;
+};
+
+/**
+ * Fill-null bio backfill (BS#1734) for pre-existing genres-only `artist_metadata`
+ * rows: an `INSERT ... ON CONFLICT DO UPDATE` whose `set` only ever writes
+ * `artist_bio`/`updated_at`, and whose `setWhere` restricts the UPDATE to rows
+ * whose `artist_bio` is currently NULL — the row always already exists (it was
+ * created by `upsertArtistGenres` above), so the INSERT branch never actually
+ * fires; `genres`/`styles` values are structurally required by `.values()` but
+ * are discarded by the DO UPDATE's `set` (never overwritten). Idempotent and
+ * re-run-safe: a row already carrying a bio, or a fixed-by-a-previous-page row,
+ * silently drops out of `setWhere` and `updated` reports its true count.
+ * Mirrors the fill-null pattern in `jobs/flowsheet-linked-reenrichment` (the
+ * structural donor for `album_metadata`).
+ */
+export const applyBioBackfill = async (rows: BioBackfillRow[]): Promise<{ updated: number }> => {
+  if (rows.length === 0) return { updated: 0 };
+  const updated = await db
+    .insert(artist_metadata)
+    .values(
+      rows.map((r) => ({
+        discogs_artist_id: r.discogs_artist_id,
+        genres: [] as string[],
+        styles: [] as string[],
+        artist_bio: r.artist_bio,
+      }))
+    )
+    .onConflictDoUpdate({
+      target: artist_metadata.discogs_artist_id,
+      set: {
+        artist_bio: sql`excluded."artist_bio"`,
+        updated_at: sql`NOW()`,
+      },
+      setWhere: sql`${artist_metadata.artist_bio} IS NULL`,
+    })
+    .returning({ discogs_artist_id: artist_metadata.discogs_artist_id });
+  return { updated: updated.length };
 };

--- a/jobs/concerts-genre-enrichment/writer.ts
+++ b/jobs/concerts-genre-enrichment/writer.ts
@@ -65,6 +65,11 @@ export type BioBackfillRow = {
  * silently drops out of `setWhere` and `updated` reports its true count.
  * Mirrors the fill-null pattern in `jobs/flowsheet-linked-reenrichment` (the
  * structural donor for `album_metadata`).
+ *
+ * Callers pass ONLY verdicts carrying a real (non-empty) bio — `bio-backfill.ts`
+ * skips blank/absent and `unavailable` verdicts upstream, so this statement
+ * never writes a NULL bio (which would be a no-op self-UPDATE the `setWhere`
+ * would still count).
  */
 export const applyBioBackfill = async (rows: BioBackfillRow[]): Promise<{ updated: number }> => {
   if (rows.length === 0) return { updated: 0 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "@sentry/node": "^10.66.0",
         "@wxyc/authentication": "^1.0.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^2.1.0",
+        "@wxyc/shared": "^2.3.0",
         "better-auth": "^1.6.23",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
@@ -352,7 +352,7 @@
         "@wxyc/legacy-mirror": "^1.0.0",
         "@wxyc/lml-client": "^1.0.0",
         "@wxyc/metadata": "^1.0.0",
-        "@wxyc/shared": "^2.1.0",
+        "@wxyc/shared": "^2.3.0",
         "async-mutex": "^0.5.0",
         "aws-jwt-verify": "^5.2.1",
         "axios": "^1.18.1",
@@ -6685,9 +6685,9 @@
       "link": true
     },
     "node_modules/@wxyc/shared": {
-      "version": "2.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/2.1.0/755f9464dc07af6f1273f9aefc83a441152acd35",
-      "integrity": "sha512-Zn2ONPJqXtrbBkg4Xf20fGUZZ76d9pUM60NxrrKRMLjJULk2tfP9hYwRKKzNN+PnfObLoVOHdsbeHSQIal6AXA==",
+      "version": "2.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/2.3.0/bfb5ca611cfa2fd263081e6e0eef410136fafeb4",
+      "integrity": "sha512-7zP4RDJ5lrvmvJrCf7JEhMdYLMCLI3vU5qO72XyhvmICjwG8W8WxReHJkg5qqv67cT01+16BXle8B77tv6IzHg==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"
@@ -14899,7 +14899,7 @@
         "@aws-sdk/client-ses": "^3.1089.0",
         "@sentry/node": "^10.66.0",
         "@wxyc/database": "^1.0.0",
-        "@wxyc/shared": "^2.1.0",
+        "@wxyc/shared": "^2.3.0",
         "better-auth": "^1.6.23",
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9"
@@ -15189,7 +15189,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "^10.66.0",
-        "@wxyc/shared": "^2.1.0"
+        "@wxyc/shared": "^2.3.0"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/shared/authentication/package.json
+++ b/shared/authentication/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-ses": "^3.1089.0",
     "@sentry/node": "^10.66.0",
     "@wxyc/database": "^1.0.0",
-    "@wxyc/shared": "^2.1.0",
+    "@wxyc/shared": "^2.3.0",
     "better-auth": "^1.6.23",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"

--- a/shared/database/src/migrations/0127_concerts-artist-bio.sql
+++ b/shared/database/src/migrations/0127_concerts-artist-bio.sql
@@ -1,0 +1,21 @@
+-- 0127 artist_metadata.artist_bio (BS#1734, On Tour R3 "About the Artist").
+--
+-- Adds the raw Discogs artist bio/profile text alongside the BS#1624
+-- genres/styles columns on `artist_metadata`, so `GET /concerts` can project
+-- `Concert.artist_bio` (wxyc-shared#247) via the same null-safe LEFT JOIN
+-- `genres` already uses. Stored RAW — no `cleanDiscogsBio` — matching
+-- `album_metadata.artist_bio` / `flowsheet.artist_bio` precedent; cleaning (if
+-- any) is a read-time-only concern, and iOS's `DiscogsMarkupParser` renders
+-- the raw markup as tappable links.
+--
+-- Population: `jobs/concerts-genre-enrichment/` threads `bio` from the same
+-- LML bulk artist-genres endpoint (LML#889) into NET-NEW `artist_metadata`
+-- rows going forward. Pre-existing genres-only rows (created by BS#1624
+-- before this column shipped) are NOT touched by the nightly run — the
+-- candidate anti-join only selects artists with no row at all — and need the
+-- one-time `--bio-backfill` pass (see jobs/concerts-genre-enrichment/README.md).
+--
+-- Lock behavior: additive nullable column, no rows rewritten (DDL-only).
+-- No precondition guard required: NULL trivially satisfies every existing row
+-- (-- @no-precondition-needed).
+ALTER TABLE "wxyc_schema"."artist_metadata" ADD COLUMN "artist_bio" text;

--- a/shared/database/src/migrations/meta/0127_snapshot.json
+++ b/shared/database/src/migrations/meta/0127_snapshot.json
@@ -1,0 +1,6053 @@
+{
+  "id": "4a4e98e4-9dfe-4f76-9624-5c155f547485",
+  "prevId": "f17be2bd-418e-4924-a2aa-568a64b699a9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_account_provider_account_key": {
+          "name": "auth_account_provider_account_key",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_critic_reviews": {
+      "name": "album_critic_reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_critic_reviews_album_id_source_url_uq": {
+          "name": "album_critic_reviews_album_id_source_url_uq",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_critic_reviews_album_id_library_id_fk": {
+          "name": "album_critic_reviews_album_id_library_id_fk",
+          "tableFrom": "album_critic_reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_metadata": {
+      "name": "album_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_release_date": {
+          "name": "full_release_date",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracklist": {
+          "name": "tracklist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_image_url": {
+          "name": "artist_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio_tokens": {
+          "name": "bio_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "album_metadata_album_id_library_id_fk": {
+          "name": "album_metadata_album_id_library_id_fk",
+          "tableFrom": "album_metadata",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_popularity": {
+      "name": "album_popularity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "logical_album_key": {
+          "name": "logical_album_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_plays": {
+          "name": "linked_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freetext_plays": {
+          "name": "freetext_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "representative_library_id": {
+          "name": "representative_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.album_review_submissions": {
+      "name": "album_review_submissions",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_blurb": {
+          "name": "artist_blurb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_tracks": {
+          "name": "recommended_tracks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buzzwords": {
+          "name": "buzzwords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fcc_violations": {
+          "name": "fcc_violations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_purpose": {
+          "name": "review_purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_raw": {
+          "name": "reviewer_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent_raw": {
+          "name": "social_consent_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_consent": {
+          "name": "social_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_within_six_months": {
+          "name": "released_within_six_months",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated": {
+          "name": "rotated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_form'"
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_review_submissions_source_key_uq": {
+          "name": "album_review_submissions_source_key_uq",
+          "columns": [
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"album_review_submissions\".\"source_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_album_id_idx": {
+          "name": "album_review_submissions_album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_submitted_at_idx": {
+          "name": "album_review_submissions_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_review_submissions_norm_artist_idx": {
+          "name": "album_review_submissions_norm_artist_idx",
+          "columns": [
+            {
+              "expression": "norm_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_review_submissions_album_id_library_id_fk": {
+          "name": "album_review_submissions_album_id_library_id_fk",
+          "tableFrom": "album_review_submissions",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymous_devices": {
+      "name": "anonymous_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "anonymous_devices_device_id_key": {
+          "name": "anonymous_devices_device_id_key",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_crossreference": {
+      "name": "artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist_id": {
+          "name": "target_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_crossref_source_target": {
+          "name": "artist_crossref_source_target",
+          "columns": [
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_crossreference_source_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_source_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "source_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_crossreference_target_artist_id_artists_id_fk": {
+          "name": "artist_crossreference_target_artist_id_artists_id_fk",
+          "tableFrom": "artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "target_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_library_crossreference": {
+      "name": "artist_library_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_id_artist_id": {
+          "name": "library_id_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_library_crossreference_artist_id_artists_id_fk": {
+          "name": "artist_library_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_library_crossreference_library_id_library_id_fk": {
+          "name": "artist_library_crossreference_library_id_library_id_fk",
+          "tableFrom": "artist_library_crossreference",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_metadata": {
+      "name": "artist_metadata",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_search_alias": {
+      "name": "artist_search_alias",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_artist_id": {
+          "name": "related_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_subject_id": {
+          "name": "external_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_object_id": {
+          "name": "external_object_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_search_alias_variant_trgm_idx": {
+          "name": "artist_search_alias_variant_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"variant\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_search_alias_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_search_alias_related_artist_id_artists_id_fk": {
+          "name": "artist_search_alias_related_artist_id_artists_id_fk",
+          "tableFrom": "artist_search_alias",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "related_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "artist_search_alias_pkey": {
+          "name": "artist_search_alias_pkey",
+          "columns": [
+            "artist_id",
+            "source",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "artist_search_alias_confidence_range": {
+          "name": "artist_search_alias_confidence_range",
+          "value": "\"wxyc_schema\".\"artist_search_alias\".\"confidence\" BETWEEN 0 AND 1"
+        },
+        "artist_search_alias_variant_nonblank": {
+          "name": "artist_search_alias_variant_nonblank",
+          "value": "length(trim(\"wxyc_schema\".\"artist_search_alias\".\"variant\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_similar_artists": {
+      "name": "artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_similar_artists_artist_id_artists_id_fk": {
+          "name": "artist_similar_artists_artist_id_artists_id_fk",
+          "tableFrom": "artist_similar_artists",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artist_station_plays": {
+      "name": "artist_station_plays",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "artist_station_plays_artist_id_artists_id_fk": {
+          "name": "artist_station_plays_artist_id_artists_id_fk",
+          "tableFrom": "artist_station_plays",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.artists": {
+      "name": "artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artist_name_trgm_idx": {
+          "name": "artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "code_letters_idx": {
+          "name": "code_letters_idx",
+          "columns": [
+            {
+              "expression": "code_letters",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.banned_fingerprints": {
+      "name": "banned_fingerprints",
+      "schema": "wxyc_schema",
+      "columns": {
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ban_expires_at": {
+          "name": "ban_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_by_user_id": {
+          "name": "banned_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "banned_fingerprints_ban_expires_at_idx": {
+          "name": "banned_fingerprints_ban_expires_at_idx",
+          "columns": [
+            {
+              "expression": "ban_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"banned_fingerprints\".\"ban_expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banned_fingerprints_banned_by_user_id_auth_user_id_fk": {
+          "name": "banned_fingerprints_banned_by_user_id_auth_user_id_fk",
+          "tableFrom": "banned_fingerprints",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "banned_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.bins": {
+      "name": "bins",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bins_dj_id_auth_user_id_fk": {
+          "name": "bins_dj_id_auth_user_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bins_album_id_library_id_fk": {
+          "name": "bins_album_id_library_id_fk",
+          "tableFrom": "bins",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.compilation_track_artist": {
+      "name": "compilation_track_artist",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cta_library_id_idx": {
+          "name": "cta_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_artist_name_idx": {
+          "name": "cta_artist_name_idx",
+          "columns": [
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_idx": {
+          "name": "cta_unique_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cta_unique_null_track_idx": {
+          "name": "cta_unique_null_track_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"wxyc_schema\".\"compilation_track_artist\".\"track_title\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compilation_track_artist_library_id_library_id_fk": {
+          "name": "compilation_track_artist_library_id_library_id_fk",
+          "tableFrom": "compilation_track_artist",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.concerts": {
+      "name": "concerts",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "concert_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_on": {
+          "name": "starts_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doors_at": {
+          "name": "doors_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_raw": {
+          "name": "headlining_artist_raw",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_artist_id": {
+          "name": "headlining_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id": {
+          "name": "headlining_discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headlining_discogs_artist_id_source": {
+          "name": "headlining_discogs_artist_id_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_resolve_attempted_at": {
+          "name": "artist_resolve_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supporting_artists_raw": {
+          "name": "supporting_artists_raw",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_min": {
+          "name": "price_min",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_max": {
+          "name": "price_max",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_restriction": {
+          "name": "age_restriction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "concert_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'on_sale'"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scraped_at": {
+          "name": "scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_scraped_at": {
+          "name": "first_scraped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "concerts_source_source_id_idx": {
+          "name": "concerts_source_source_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_venue_starts_at_idx": {
+          "name": "concerts_venue_starts_at_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_headlining_artist_starts_at_idx": {
+          "name": "concerts_headlining_artist_starts_at_idx",
+          "columns": [
+            {
+              "expression": "headlining_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_curated_starts_on_idx": {
+          "name": "concerts_curated_starts_on_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"wxyc_schema\".\"concerts\".\"headlining_artist_id\" IS NOT NULL OR \"wxyc_schema\".\"concerts\".\"headlining_discogs_artist_id\" IS NOT NULL) AND \"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "concerts_active_starts_on_id_idx": {
+          "name": "concerts_active_starts_on_id_idx",
+          "columns": [
+            {
+              "expression": "starts_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"concerts\".\"removed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "concerts_venue_id_venues_id_fk": {
+          "name": "concerts_venue_id_venues_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "venues",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "concerts_headlining_artist_id_artists_id_fk": {
+          "name": "concerts_headlining_artist_id_artists_id_fk",
+          "tableFrom": "concerts",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "headlining_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.cronjob_runs": {
+      "name": "cronjob_runs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_device_code": {
+      "name": "auth_device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_device_code_device_code_key": {
+          "name": "auth_device_code_device_code_key",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_user_code_key": {
+          "name": "auth_device_code_user_code_key",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_device_code_expires_at_idx": {
+          "name": "auth_device_code_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_device_code_user_id_auth_user_id_fk": {
+          "name": "auth_device_code_user_id_auth_user_id_fk",
+          "tableFrom": "auth_device_code",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.discogs_artist_similar_artists": {
+      "name": "discogs_artist_similar_artists",
+      "schema": "wxyc_schema",
+      "columns": {
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "neighbors": {
+          "name": "neighbors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.dj_stats": {
+      "name": "dj_stats",
+      "schema": "wxyc_schema",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shows_covered": {
+          "name": "shows_covered",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dj_stats_user_id_auth_user_id_fk": {
+          "name": "dj_stats_user_id_auth_user_id_fk",
+          "tableFrom": "dj_stats",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet": {
+      "name": "flowsheet",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_entry_id": {
+          "name": "legacy_entry_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "flowsheet_entry_type",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'track'"
+        },
+        "track_title": {
+          "name": "track_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_position": {
+          "name": "track_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_order": {
+          "name": "play_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_flag": {
+          "name": "request_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "segue": {
+          "name": "segue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_time": {
+          "name": "add_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "radio_hour": {
+          "name": "radio_hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_url": {
+          "name": "spotify_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube_music_url": {
+          "name": "youtube_music_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_url": {
+          "name": "bandcamp_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud_url": {
+          "name": "soundcloud_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_bio": {
+          "name": "artist_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_wikipedia_url": {
+          "name": "artist_wikipedia_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_source": {
+          "name": "linkage_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkage_confidence": {
+          "name": "linkage_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer": {
+          "name": "composer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composer_source": {
+          "name": "composer_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_link_attempted_at": {
+          "name": "legacy_link_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_attempt_at": {
+          "name": "metadata_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_status": {
+          "name": "metadata_status",
+          "type": "metadata_status_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "enriching_since": {
+          "name": "enriching_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"track_title\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"dj_name\", '')), 'B') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'C') || setweight(to_tsvector('simple', coalesce(\"record_label\", '')), 'D')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "flowsheet_legacy_entry_id_idx": {
+          "name": "flowsheet_legacy_entry_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_legacy_release_id_idx": {
+          "name": "flowsheet_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_artist_name_trgm_idx": {
+          "name": "flowsheet_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_title_trgm_idx": {
+          "name": "flowsheet_track_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"track_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_title_trgm_idx": {
+          "name": "flowsheet_album_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_record_label_trgm_idx": {
+          "name": "flowsheet_record_label_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"record_label\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_track_add_time_idx": {
+          "name": "flowsheet_track_add_time_idx",
+          "columns": [
+            {
+              "expression": "\"add_time\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_search_doc_idx": {
+          "name": "flowsheet_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "flowsheet_album_link_lookup_idx": {
+          "name": "flowsheet_album_link_lookup_idx",
+          "columns": [
+            {
+              "expression": "(lower(trim(\"artist_name\")) || '-' || lower(trim(coalesce(\"album_title\", ''))))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_idx": {
+          "name": "flowsheet_show_id_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_show_id_play_order_idx": {
+          "name": "flowsheet_show_id_play_order_idx",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"play_order\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_updated_at_idx": {
+          "name": "flowsheet_updated_at_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_idx": {
+          "name": "flowsheet_metadata_attempt_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_attempt_pending_covering_idx": {
+          "name": "flowsheet_metadata_attempt_pending_covering_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_pending_idx": {
+          "name": "flowsheet_metadata_status_pending_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"entry_type\" = 'track' AND \"wxyc_schema\".\"flowsheet\".\"artist_name\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_metadata_status_enriching_stale_idx": {
+          "name": "flowsheet_metadata_status_enriching_stale_idx",
+          "columns": [
+            {
+              "expression": "enriching_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"metadata_status\" = 'enriching'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flowsheet_album_id_enriched_idx": {
+          "name": "flowsheet_album_id_enriched_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet\".\"album_id\" IS NOT NULL AND \"wxyc_schema\".\"flowsheet\".\"metadata_attempt_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_show_id_shows_id_fk": {
+          "name": "flowsheet_show_id_shows_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_album_id_library_id_fk": {
+          "name": "flowsheet_album_id_library_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_rotation_id_rotation_id_fk": {
+          "name": "flowsheet_rotation_id_rotation_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "rotation",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "rotation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "flowsheet_label_id_labels_id_fk": {
+          "name": "flowsheet_label_id_labels_id_fk",
+          "tableFrom": "flowsheet",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_freetext_resolution": {
+      "name": "flowsheet_freetext_resolution",
+      "schema": "wxyc_schema",
+      "columns": {
+        "norm_artist": {
+          "name": "norm_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "norm_album": {
+          "name": "norm_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_source": {
+          "name": "match_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_at": {
+          "name": "attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "flowsheet_freetext_resolution_norm_artist_norm_album_pk": {
+          "name": "flowsheet_freetext_resolution_norm_artist_norm_album_pk",
+          "columns": [
+            "norm_artist",
+            "norm_album"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_linkage_review": {
+      "name": "flowsheet_linkage_review",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "flowsheet_id": {
+          "name": "flowsheet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_library_ids": {
+          "name": "candidate_library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_confidences": {
+          "name": "candidate_confidences",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_action": {
+          "name": "suggested_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_decision": {
+          "name": "reviewed_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flowsheet_linkage_review_unreviewed_idx": {
+          "name": "flowsheet_linkage_review_unreviewed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"flowsheet_linkage_review\".\"reviewed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk": {
+          "name": "flowsheet_linkage_review_flowsheet_id_flowsheet_id_fk",
+          "tableFrom": "flowsheet_linkage_review",
+          "tableTo": "flowsheet",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "flowsheet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flowsheet_linkage_review_flowsheet_id_unique": {
+          "name": "flowsheet_linkage_review_flowsheet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flowsheet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.flowsheet_watermark": {
+      "name": "flowsheet_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "flowsheet_watermark_singleton": {
+          "name": "flowsheet_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.format": {
+      "name": "format",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genre_artist_crossreference": {
+      "name": "genre_artist_crossreference",
+      "schema": "wxyc_schema",
+      "columns": {
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_genre_key": {
+          "name": "artist_genre_key",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "genre_artist_crossreference_artist_id_artists_id_fk": {
+          "name": "genre_artist_crossreference_artist_id_artists_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "genre_artist_crossreference_genre_id_genres_id_fk": {
+          "name": "genre_artist_crossreference_genre_id_genres_id_fk",
+          "tableFrom": "genre_artist_crossreference",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.genres": {
+      "name": "genres",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_invitation": {
+      "name": "auth_invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_invitation_email_idx": {
+          "name": "auth_invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_invitation_organization_id_auth_organization_id_fk": {
+          "name": "auth_invitation_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_invitation_inviter_id_auth_user_id_fk": {
+          "name": "auth_invitation_inviter_id_auth_user_id_fk",
+          "tableFrom": "auth_invitation",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_jwks": {
+      "name": "auth_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.labels": {
+      "name": "labels",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label_name": {
+          "name": "label_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_label_id": {
+          "name": "parent_label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_label_name_unique": {
+          "name": "labels_label_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "label_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library": {
+      "name": "library",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_id": {
+          "name": "format_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alternate_artist_name": {
+          "name": "alternate_artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_volume_letters": {
+          "name": "code_volume_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disc_quantity": {
+          "name": "disc_quantity",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "legacy_release_id": {
+          "name": "legacy_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_lost": {
+          "name": "date_lost",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_found": {
+          "name": "date_found",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_id": {
+          "name": "canonical_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_confidence": {
+          "name": "canonical_entity_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_entity_resolved_at": {
+          "name": "canonical_entity_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_unavailable": {
+          "name": "discogs_unavailable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discogs_unavailable_note": {
+          "name": "discogs_unavailable_note",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_discogs_recheck_at": {
+          "name": "last_discogs_recheck_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_doc": {
+          "name": "search_doc",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('simple', coalesce(\"artist_name\", '')), 'A') || setweight(to_tsvector('simple', coalesce(\"album_title\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "title_trgm_idx": {
+          "name": "title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_title\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "genre_id_idx": {
+          "name": "genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "format_id_idx": {
+          "name": "format_id_idx",
+          "columns": [
+            {
+              "expression": "format_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_id_idx": {
+          "name": "artist_id_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_legacy_release_id_idx": {
+          "name": "library_legacy_release_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_artist_trgm_idx": {
+          "name": "album_artist_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"album_artist\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_artist_name_trgm_idx": {
+          "name": "library_artist_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"artist_name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_search_doc_idx": {
+          "name": "library_search_doc_idx",
+          "columns": [
+            {
+              "expression": "\"search_doc\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "library_canonical_entity_id_idx": {
+          "name": "library_canonical_entity_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_discogs_unavailable_idx": {
+          "name": "library_discogs_unavailable_idx",
+          "columns": [
+            {
+              "expression": "discogs_unavailable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artist_id_artists_id_fk": {
+          "name": "library_artist_id_artists_id_fk",
+          "tableFrom": "library",
+          "tableTo": "artists",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_genre_id_genres_id_fk": {
+          "name": "library_genre_id_genres_id_fk",
+          "tableFrom": "library",
+          "tableTo": "genres",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_format_id_format_id_fk": {
+          "name": "library_format_id_format_id_fk",
+          "tableFrom": "library",
+          "tableTo": "format",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "format_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "library_label_id_labels_id_fk": {
+          "name": "library_label_id_labels_id_fk",
+          "tableFrom": "library",
+          "tableTo": "labels",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_discogs_unavailable_note_check": {
+          "name": "library_discogs_unavailable_note_check",
+          "value": "\"wxyc_schema\".\"library\".\"discogs_unavailable\" OR \"wxyc_schema\".\"library\".\"discogs_unavailable_note\" IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity": {
+      "name": "library_identity",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distinct_unresolved_sources": {
+          "name": "distinct_unresolved_sources",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        (CASE WHEN \"discogs_master_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"discogs_release_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_group_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_release_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"musicbrainz_recording_mbid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"wikidata_qid\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"spotify_id\" IS NULL THEN 1 ELSE 0 END)\n      + (CASE WHEN \"apple_music_id\" IS NULL THEN 1 ELSE 0 END)\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "library_identity_audit_idx": {
+          "name": "library_identity_audit_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"distinct_unresolved_sources\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_identity_library_id_library_id_fk": {
+          "name": "library_identity_library_id_library_id_fk",
+          "tableFrom": "library_identity",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_confidence_range": {
+          "name": "library_identity_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_history": {
+      "name": "library_identity_history",
+      "schema": "wxyc_schema",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discogs_master_id": {
+          "name": "discogs_master_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_group_mbid": {
+          "name": "musicbrainz_release_group_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_release_mbid": {
+          "name": "musicbrainz_release_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_recording_mbid": {
+          "name": "musicbrainz_recording_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_id": {
+          "name": "spotify_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_sources": {
+          "name": "agreement_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_category": {
+          "name": "reason_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_identity_source": {
+      "name": "library_identity_source",
+      "schema": "wxyc_schema",
+      "columns": {
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "boost_sources": {
+          "name": "boost_sources",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "library_identity_source_library_id_library_id_fk": {
+          "name": "library_identity_source_library_id_library_id_fk",
+          "tableFrom": "library_identity_source",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "library_identity_source_library_id_source_pk": {
+          "name": "library_identity_source_library_id_source_pk",
+          "columns": [
+            "library_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_identity_source_confidence_range": {
+          "name": "library_identity_source_confidence_range",
+          "value": "\"wxyc_schema\".\"library_identity_source\".\"confidence\" BETWEEN 0 AND 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.library_watermark": {
+      "name": "library_watermark",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "library_watermark_singleton": {
+          "name": "library_watermark_singleton",
+          "value": "\"id\" = true"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_member": {
+      "name": "auth_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_member_org_user_key": {
+          "name": "auth_member_org_user_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_member_organization_id_auth_organization_id_fk": {
+          "name": "auth_member_organization_id_auth_organization_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_member_user_id_auth_user_id_fk": {
+          "name": "auth_member_user_id_auth_user_id_fk",
+          "tableFrom": "auth_member",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_access_token": {
+      "name": "auth_oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_access_token_client_id_idx": {
+          "name": "auth_oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_access_token_user_id_idx": {
+          "name": "auth_oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_access_token_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_access_token_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_access_token_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_access_token",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_access_token_access_token_key": {
+          "name": "auth_oauth_access_token_access_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "auth_oauth_access_token_refresh_token_key": {
+          "name": "auth_oauth_access_token_refresh_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_application": {
+      "name": "auth_oauth_application",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_urls": {
+          "name": "redirect_urls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_oauth_application_user_id_idx": {
+          "name": "auth_oauth_application_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_application_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_application_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_application",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_oauth_application_client_id_key": {
+          "name": "auth_oauth_application_client_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_oauth_consent": {
+      "name": "auth_oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "consent_given": {
+          "name": "consent_given",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_oauth_consent_client_id_idx": {
+          "name": "auth_oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_oauth_consent_user_id_idx": {
+          "name": "auth_oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk": {
+          "name": "auth_oauth_consent_client_id_auth_oauth_application_client_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_oauth_application",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_oauth_consent_user_id_auth_user_id_fk": {
+          "name": "auth_oauth_consent_user_id_auth_user_id_fk",
+          "tableFrom": "auth_oauth_consent",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_organization": {
+      "name": "auth_organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_organization_slug_key": {
+          "name": "auth_organization_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.reviews": {
+      "name": "reviews",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reviews_album_id_library_id_fk": {
+          "name": "reviews_album_id_library_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_album_id_unique": {
+          "name": "reviews_album_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "album_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.rotation": {
+      "name": "rotation",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_rotation_id": {
+          "name": "legacy_rotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_library_release_id": {
+          "name": "legacy_library_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_label": {
+          "name": "record_label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id": {
+          "name": "discogs_release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_release_id_source": {
+          "name": "discogs_release_id_source",
+          "type": "discogs_release_id_source_enum",
+          "typeSchema": "wxyc_schema",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tubafrenzy_paste'"
+        },
+        "tracklist_lookup_attempted_at": {
+          "name": "tracklist_lookup_attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lml_identity_id": {
+          "name": "lml_identity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "album_id_idx": {
+          "name": "album_id_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rotation_legacy_rotation_id_idx": {
+          "name": "rotation_legacy_rotation_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_rotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rotation_album_id_library_id_fk": {
+          "name": "rotation_album_id_library_id_fk",
+          "tableFrom": "rotation",
+          "tableTo": "library",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rotation_discogs_release_id_not_sentinel": {
+          "name": "rotation_discogs_release_id_not_sentinel",
+          "value": "\"wxyc_schema\".\"rotation\".\"discogs_release_id\" IS NULL OR \"wxyc_schema\".\"rotation\".\"discogs_release_id\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.schedule": {
+      "name": "schedule",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_duration": {
+          "name": "show_duration",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id": {
+          "name": "assigned_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_dj_id2": {
+          "name": "assigned_dj_id2",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_specialty_id_specialty_shows_id_fk": {
+          "name": "schedule_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedule_assigned_dj_id2_auth_user_id_fk": {
+          "name": "schedule_assigned_dj_id2_auth_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "assigned_dj_id2"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_flow_expires_at": {
+          "name": "device_flow_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_session_token_key": {
+          "name": "auth_session_token_key",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shift_covers": {
+      "name": "shift_covers",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shift_timestamp": {
+          "name": "shift_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_dj_id": {
+          "name": "cover_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "covered": {
+          "name": "covered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shift_covers_schedule_id_schedule_id_fk": {
+          "name": "shift_covers_schedule_id_schedule_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "schedule",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shift_covers_cover_dj_id_auth_user_id_fk": {
+          "name": "shift_covers_cover_dj_id_auth_user_id_fk",
+          "tableFrom": "shift_covers",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "cover_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.show_djs": {
+      "name": "show_djs",
+      "schema": "wxyc_schema",
+      "columns": {
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dj_id": {
+          "name": "dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "show_djs_show_id_dj_id_unique": {
+          "name": "show_djs_show_id_dj_id_unique",
+          "columns": [
+            {
+              "expression": "show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dj_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "show_djs_show_id_shows_id_fk": {
+          "name": "show_djs_show_id_shows_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "show_djs_dj_id_auth_user_id_fk": {
+          "name": "show_djs_dj_id_auth_user_id_fk",
+          "tableFrom": "show_djs",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.shows": {
+      "name": "shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_dj_id": {
+          "name": "primary_dj_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specialty_id": {
+          "name": "specialty_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_show_id": {
+          "name": "legacy_show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_name": {
+          "name": "legacy_dj_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_dj_id": {
+          "name": "legacy_dj_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name_override": {
+          "name": "dj_name_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_name": {
+          "name": "show_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "shows_legacy_show_id_idx": {
+          "name": "shows_legacy_show_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_show_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shows_primary_dj_id_auth_user_id_fk": {
+          "name": "shows_primary_dj_id_auth_user_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "primary_dj_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shows_specialty_id_specialty_shows_id_fk": {
+          "name": "shows_specialty_id_specialty_shows_id_fk",
+          "tableFrom": "shows",
+          "tableTo": "specialty_shows",
+          "schemaTo": "wxyc_schema",
+          "columnsFrom": [
+            "specialty_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.specialty_shows": {
+      "name": "specialty_shows",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specialty_name": {
+          "name": "specialty_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dj_name": {
+          "name": "dj_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_skin": {
+          "name": "app_skin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'modern-light'"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "auth_user_email_key": {
+          "name": "auth_user_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_username_key": {
+          "name": "auth_user_username_key",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity": {
+      "name": "user_activity",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_activity_user_id_auth_user_id_fk": {
+          "name": "user_activity_user_id_auth_user_id_fk",
+          "tableFrom": "user_activity",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "wxyc_schema.venues": {
+      "name": "venues",
+      "schema": "wxyc_schema",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_slug_idx": {
+          "name": "venues_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "wxyc_schema.concert_source_enum": {
+      "name": "concert_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "rhp_scrape",
+        "triangle_shows"
+      ]
+    },
+    "wxyc_schema.concert_status_enum": {
+      "name": "concert_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "on_sale",
+        "sold_out",
+        "cancelled",
+        "rescheduled"
+      ]
+    },
+    "wxyc_schema.discogs_release_id_source_enum": {
+      "name": "discogs_release_id_source_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "tubafrenzy_paste",
+        "lml_offline_backfill",
+        "discogs_direct_backfill",
+        "library_identity",
+        "md_verified",
+        "recheck_after_unavailable"
+      ]
+    },
+    "wxyc_schema.flowsheet_entry_type": {
+      "name": "flowsheet_entry_type",
+      "schema": "wxyc_schema",
+      "values": [
+        "track",
+        "show_start",
+        "show_end",
+        "dj_join",
+        "dj_leave",
+        "talkset",
+        "breakpoint",
+        "message"
+      ]
+    },
+    "public.freq_enum": {
+      "name": "freq_enum",
+      "schema": "public",
+      "values": [
+        "S",
+        "L",
+        "M",
+        "H",
+        "N"
+      ]
+    },
+    "wxyc_schema.metadata_status_enum": {
+      "name": "metadata_status_enum",
+      "schema": "wxyc_schema",
+      "values": [
+        "pending",
+        "enriching",
+        "enriched_match",
+        "enriched_no_match",
+        "failed_no_retry"
+      ]
+    }
+  },
+  "schemas": {
+    "wxyc_schema": "wxyc_schema"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "wxyc_schema.library_artist_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_letters": {
+          "name": "code_letters",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_genre_code": {
+          "name": "artist_genre_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_number": {
+          "name": "code_number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_name": {
+          "name": "format_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_name": {
+          "name": "genre_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "add_date": {
+          "name": "add_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_streaming": {
+          "name": "on_streaming",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_artist": {
+          "name": "album_artist",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "artwork_url": {
+          "name": "artwork_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_artist_id": {
+          "name": "discogs_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz_artist_id": {
+          "name": "musicbrainz_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_qid": {
+          "name": "wikidata_qid",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_artist_id": {
+          "name": "spotify_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apple_music_artist_id": {
+          "name": "apple_music_artist_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp_id": {
+          "name": "bandcamp_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"artists\".\"code_letters\", \"wxyc_schema\".\"genre_artist_crossreference\".\"artist_genre_code\", \"wxyc_schema\".\"library\".\"code_number\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"format\".\"format_name\", \"wxyc_schema\".\"genres\".\"genre_name\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"add_date\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"library\".\"on_streaming\", \"wxyc_schema\".\"library\".\"album_artist\", \"wxyc_schema\".\"library\".\"plays\", \"wxyc_schema\".\"library\".\"artwork_url\", \"wxyc_schema\".\"artists\".\"discogs_artist_id\", \"wxyc_schema\".\"artists\".\"musicbrainz_artist_id\", \"wxyc_schema\".\"artists\".\"wikidata_qid\", \"wxyc_schema\".\"artists\".\"spotify_artist_id\", \"wxyc_schema\".\"artists\".\"apple_music_artist_id\", \"wxyc_schema\".\"artists\".\"bandcamp_id\", \"wxyc_schema\".\"library\".\"artist_id\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\" inner join \"wxyc_schema\".\"format\" on \"wxyc_schema\".\"format\".\"id\" = \"wxyc_schema\".\"library\".\"format_id\" inner join \"wxyc_schema\".\"genres\" on \"wxyc_schema\".\"genres\".\"id\" = \"wxyc_schema\".\"library\".\"genre_id\" inner join \"wxyc_schema\".\"genre_artist_crossreference\" on (\"wxyc_schema\".\"genre_artist_crossreference\".\"artist_id\" = \"wxyc_schema\".\"library\".\"artist_id\" and \"wxyc_schema\".\"genre_artist_crossreference\".\"genre_id\" = \"wxyc_schema\".\"library\".\"genre_id\") left join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"rotation\".\"album_id\" = \"wxyc_schema\".\"library\".\"id\" AND (\"wxyc_schema\".\"rotation\".\"kill_date\" > CURRENT_DATE OR \"wxyc_schema\".\"rotation\".\"kill_date\" IS NULL)",
+      "name": "library_artist_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.rotation_library_view": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_bin": {
+          "name": "rotation_bin",
+          "type": "freq_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_title": {
+          "name": "album_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alphabetical_name": {
+          "name": "alphabetical_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kill_date": {
+          "name": "kill_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"wxyc_schema\".\"library\".\"id\", \"wxyc_schema\".\"rotation\".\"id\", \"wxyc_schema\".\"library\".\"label\", \"wxyc_schema\".\"library\".\"label_id\", \"wxyc_schema\".\"rotation\".\"rotation_bin\", \"wxyc_schema\".\"library\".\"album_title\", \"wxyc_schema\".\"artists\".\"artist_name\", \"wxyc_schema\".\"artists\".\"alphabetical_name\", \"wxyc_schema\".\"rotation\".\"kill_date\" from \"wxyc_schema\".\"library\" inner join \"wxyc_schema\".\"rotation\" on \"wxyc_schema\".\"library\".\"id\" = \"wxyc_schema\".\"rotation\".\"album_id\" inner join \"wxyc_schema\".\"artists\" on \"wxyc_schema\".\"artists\".\"id\" = \"wxyc_schema\".\"library\".\"artist_id\"",
+      "name": "rotation_library_view",
+      "schema": "wxyc_schema",
+      "isExisting": false,
+      "materialized": false
+    },
+    "wxyc_schema.album_plays": {
+      "columns": {
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "album_plays",
+      "schema": "wxyc_schema",
+      "isExisting": true,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/database/src/migrations/meta/_journal.json
+++ b/shared/database/src/migrations/meta/_journal.json
@@ -869,6 +869,13 @@
       "when": 1784591961446,
       "tag": "0126_tribute-context-fk-repair",
       "breakpoints": true
+    },
+    {
+      "idx": 127,
+      "version": "7",
+      "when": 1784666353897,
+      "tag": "0127_concerts-artist-bio",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/database/src/migrations/meta/applied-hashes.json
+++ b/shared/database/src/migrations/meta/applied-hashes.json
@@ -122,5 +122,6 @@
   "0123_artist-station-plays": "27a035161a03b42b583736e677aeb9fd20b1e28fe13bf0ae35180d487959006b",
   "0124_discogs-artist-similar-artists": "151015f4cfe0c071ee0286dcfdc086a077249a5544551c1e44c0ae5f6db62a79",
   "0125_album-critic-reviews": "d43eac8d0eb8e11929e092cadbfffe4f66e3e181c350d6ee1608ed8b9d72d73d",
-  "0126_tribute-context-fk-repair": "58e230fde235f58ec8936c6e02f4dc296441440a3297bd915dcf8d1b0675481a"
+  "0126_tribute-context-fk-repair": "58e230fde235f58ec8936c6e02f4dc296441440a3297bd915dcf8d1b0675481a",
+  "0127_concerts-artist-bio": "2a296921ec432d68934c0427a7fe8ce95375df8afc6327f0a69a5f3dbfd7f13a"
 }

--- a/shared/database/src/schema.ts
+++ b/shared/database/src/schema.ts
@@ -1396,12 +1396,16 @@ export const album_metadata = wxyc_schema.table('album_metadata', {
  * `artist_metadata` row, calls LML's bulk artist-genres endpoint (LML#781),
  * and UPSERTs `ON CONFLICT DO NOTHING` — never overwriting a collected row.
  * Both `genres` and `styles` are nullable `text[]` (LML may resolve one and
- * not the other).
+ * not the other). `artist_bio` (BS#1734) rides the same endpoint (LML#889)
+ * and is stored RAW — no `cleanDiscogsBio` at write time, matching
+ * `album_metadata.artist_bio` / `flowsheet.artist_bio` precedent; cleaning is
+ * a read-time-only concern.
  */
 export const artist_metadata = wxyc_schema.table('artist_metadata', {
   discogs_artist_id: integer('discogs_artist_id').primaryKey().notNull(),
   genres: text('genres').array(),
   styles: text('styles').array(),
+  artist_bio: text('artist_bio'),
   updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
 });
 

--- a/shared/lml-client/package.json
+++ b/shared/lml-client/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/node": "^10.66.0",
-    "@wxyc/shared": "^2.1.0"
+    "@wxyc/shared": "^2.3.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -1329,6 +1329,13 @@ export interface ArtistGenresResultItem {
    * for LML to echo.
    */
   discogs_artist_id?: number;
+  /**
+   * The Discogs artist `profile` text, raw (BS#1734 / LML#889). Null for
+   * name-only inputs, uncached ids, blank profiles, and not-found tombstones;
+   * independent of `source` — a `cache`/`not_found` verdict may still carry a
+   * real bio.
+   */
+  bio?: string | null;
 }
 
 export interface ArtistGenresBulkRequest {

--- a/tests/integration/concerts-by-id.spec.js
+++ b/tests/integration/concerts-by-id.spec.js
@@ -35,6 +35,7 @@ const ARTIST_NAME = 'BS#1694 Probe Headliner';
 // colliding with any real artists/artist_metadata row in the CI clone.
 const ARTIST_DISCOGS_ID = 91694001;
 const ARTIST_GENRES = ['Folk, World, & Country'];
+const ARTIST_BIO = 'BS#1694 probe headliner biography text.';
 
 function makeSql() {
   return postgres({
@@ -146,13 +147,13 @@ describe('GET /concerts/:id (BS#1694)', () => {
     );
     artistId = artist.id;
 
-    // Genre enrichment for the resolved headliner (BS#1624 projection) — the
-    // parity test below proves the by-id read carries the same enrichment
-    // fields as the list.
+    // Genre + bio enrichment for the resolved headliner (BS#1624 / BS#1734
+    // projections) — the parity test below proves the by-id read carries the
+    // same enrichment fields as the list.
     await sql.unsafe(
-      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles)
-       VALUES ($1, $2, $3)`,
-      [ARTIST_DISCOGS_ID, ARTIST_GENRES, []]
+      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles, artist_bio)
+       VALUES ($1, $2, $3, $4)`,
+      [ARTIST_DISCOGS_ID, ARTIST_GENRES, [], ARTIST_BIO]
     );
 
     // Upcoming, fully-populated, resolved headliner: the serialization-parity
@@ -224,8 +225,9 @@ describe('GET /concerts/:id (BS#1694)', () => {
       const reference = list.body.concerts.find((c) => c.id === upcomingId);
       expect(reference).toBeDefined();
       // Sanity that the reference row exercises the full shape, enrichment
-      // included (genres via the BS#1624 LEFT JOIN).
+      // included (genres via the BS#1624 LEFT JOIN, artist_bio via BS#1734).
       expect(reference.genres).toEqual(ARTIST_GENRES);
+      expect(reference.artist_bio).toBe(ARTIST_BIO);
 
       const byId = await request.get(`/concerts/${upcomingId}`);
       expect(byId.status).toBe(200);

--- a/tests/integration/concerts-genre-enrichment.spec.js
+++ b/tests/integration/concerts-genre-enrichment.spec.js
@@ -45,6 +45,7 @@ const DISCOGS_UPSERT_B = 91624902;
 
 const ARTIST_ENRICHED = 'Juana Molina'; // library artist, resolved + enriched
 const ARTIST_LIBRARY_UNENRICHED = 'Stereolab'; // library artist, resolved, not yet enriched
+const ARTIST_BIO = 'Argentine singer-songwriter known for genre-blurring electro-folk records.';
 
 function makeSql() {
   return postgres({
@@ -102,7 +103,7 @@ async function loadCandidates(sql, { backfill = false } = {}) {
 async function upsertArtistGenres(sql, rows) {
   if (rows.length === 0) return [];
   return sql`
-    INSERT INTO ${sql(SCHEMA)}."artist_metadata" ${sql(rows, 'discogs_artist_id', 'genres', 'styles')}
+    INSERT INTO ${sql(SCHEMA)}."artist_metadata" ${sql(rows, 'discogs_artist_id', 'genres', 'styles', 'artist_bio')}
     ON CONFLICT ("discogs_artist_id") DO NOTHING
     RETURNING "discogs_artist_id"
   `;
@@ -184,11 +185,11 @@ describe('concerts genre enrichment (BS#1624)', () => {
     );
     libraryUnenrichedArtistId = a2.id;
 
-    // The enriched artist's persisted genres (what GET /concerts should surface).
+    // The enriched artist's persisted genres + bio (what GET /concerts should surface).
     await sql.unsafe(
-      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles)
-       VALUES ($1, $2, $3)`,
-      [DISCOGS_ENRICHED, ['Rock', 'Electronic'], ['Folktronica']]
+      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles, artist_bio)
+       VALUES ($1, $2, $3, $4)`,
+      [DISCOGS_ENRICHED, ['Rock', 'Electronic'], ['Folktronica'], ARTIST_BIO]
     );
 
     // Lane A, resolved + enriched, upcoming.
@@ -278,8 +279,13 @@ describe('concerts genre enrichment (BS#1624)', () => {
   describe('UPSERT idempotency (mirror of writer.ts)', () => {
     it('inserts new rows, and a re-run inserts 0 without overwriting a collected row', async () => {
       const rows = [
-        { discogs_artist_id: DISCOGS_UPSERT_A, genres: ['Jazz'], styles: ['Big Band'] },
-        { discogs_artist_id: DISCOGS_UPSERT_B, genres: [], styles: [] },
+        {
+          discogs_artist_id: DISCOGS_UPSERT_A,
+          genres: ['Jazz'],
+          styles: ['Big Band'],
+          artist_bio: 'A big band jazz outfit.',
+        },
+        { discogs_artist_id: DISCOGS_UPSERT_B, genres: [], styles: [], artist_bio: null },
       ];
 
       const firstRun = await upsertArtistGenres(sql, rows);
@@ -289,14 +295,17 @@ describe('concerts genre enrichment (BS#1624)', () => {
       const secondRun = await upsertArtistGenres(sql, rows);
       expect(secondRun).toHaveLength(0);
 
-      // A conflicting re-run with DIFFERENT genres must NOT overwrite the row.
-      await upsertArtistGenres(sql, [{ discogs_artist_id: DISCOGS_UPSERT_A, genres: ['Pop'], styles: ['Synth-pop'] }]);
+      // A conflicting re-run with DIFFERENT genres/bio must NOT overwrite the row.
+      await upsertArtistGenres(sql, [
+        { discogs_artist_id: DISCOGS_UPSERT_A, genres: ['Pop'], styles: ['Synth-pop'], artist_bio: 'A different bio.' },
+      ]);
       const [persisted] = await sql.unsafe(
-        `SELECT genres, styles FROM "${SCHEMA}".artist_metadata WHERE discogs_artist_id = $1`,
+        `SELECT genres, styles, artist_bio FROM "${SCHEMA}".artist_metadata WHERE discogs_artist_id = $1`,
         [DISCOGS_UPSERT_A]
       );
       expect(persisted.genres).toEqual(['Jazz']);
       expect(persisted.styles).toEqual(['Big Band']);
+      expect(persisted.artist_bio).toBe('A big band jazz outfit.');
     });
   });
 
@@ -320,6 +329,29 @@ describe('concerts genre enrichment (BS#1624)', () => {
       const unresolved = res.body.concerts.find((c) => c.headlining_artist_raw === 'Some Unresolved Billing & Another');
       expect(unresolved).toBeDefined();
       expect(unresolved.genres).toBeNull();
+    });
+  });
+
+  describe('GET /concerts artist_bio projection (BS#1734)', () => {
+    it('emits the joined artist_bio for a resolved + enriched headliner', async () => {
+      const res = await auth.get(`/concerts?from=${IN_10}&to=${IN_10}`).expect(200);
+      const enriched = res.body.concerts.find((c) => c.headlining_artist_raw === ARTIST_ENRICHED);
+      expect(enriched).toBeDefined();
+      expect(enriched.artist_bio).toBe(ARTIST_BIO);
+    });
+
+    it('emits null artist_bio for a resolved-but-unenriched headliner', async () => {
+      const res = await auth.get(`/concerts?from=${IN_10}&to=${IN_10}`).expect(200);
+      const unenriched = res.body.concerts.find((c) => c.headlining_artist_raw === ARTIST_LIBRARY_UNENRICHED);
+      expect(unenriched).toBeDefined();
+      expect(unenriched.artist_bio).toBeNull();
+    });
+
+    it('emits null artist_bio for an unresolved headliner', async () => {
+      const res = await auth.get(`/concerts?from=${IN_10}&to=${IN_10}`).expect(200);
+      const unresolved = res.body.concerts.find((c) => c.headlining_artist_raw === 'Some Unresolved Billing & Another');
+      expect(unresolved).toBeDefined();
+      expect(unresolved.artist_bio).toBeNull();
     });
   });
 });

--- a/tests/integration/concerts-genre-enrichment.spec.js
+++ b/tests/integration/concerts-genre-enrichment.spec.js
@@ -47,6 +47,14 @@ const ARTIST_ENRICHED = 'Juana Molina'; // library artist, resolved + enriched
 const ARTIST_LIBRARY_UNENRICHED = 'Stereolab'; // library artist, resolved, not yet enriched
 const ARTIST_BIO = 'Argentine singer-songwriter known for genre-blurring electro-folk records.';
 
+// BS#1734 bio-backfill fixtures: genres-only artist_metadata rows with artist_bio NULL.
+const DISCOGS_BIO_NULL_LIB = 91624005; // library headliner (name via artists.artist_name), genres-only, bio NULL
+const DISCOGS_BIO_NULL_EXT = 91624006; // Discogs-only headliner (name via freshest non-removed concert), bio NULL
+const DISCOGS_BIO_FILL = 91624007; // dedicated mutable null-bio row for the fill test
+const ARTIST_BIO_NULL_LIB = 'Hermanos Gutiérrez';
+const ARTIST_BIO_FILL = 'Nilüfer Yanya';
+const BIO_EXT_ACTIVE_RAW = 'Csillagrablók'; // freshest ACTIVE billing for the Discogs-only headliner
+
 function makeSql() {
   return postgres({
     host: process.env.DB_HOST || 'localhost',
@@ -109,6 +117,49 @@ async function upsertArtistGenres(sql, rows) {
   `;
 }
 
+/**
+ * Bio-backfill candidate mirror of
+ * `jobs/concerts-genre-enrichment/query.ts#loadBioBackfillCandidates` (BS#1734),
+ * scoped to the test's synthetic ids so the shared CI schema's other null-bio
+ * rows can't perturb the assertions (the real query is unscoped). Exercises the
+ * `LATERAL … LIMIT 1` name resolution: freshest NON-removed concert billing.
+ */
+async function loadBioBackfillCandidates(sql, ids) {
+  return sql`
+    SELECT
+      am."discogs_artist_id" AS discogs_artist_id,
+      COALESCE(a."artist_name", c."headlining_artist_raw") AS artist_name
+    FROM ${sql(SCHEMA)}."artist_metadata" am
+    LEFT JOIN ${sql(SCHEMA)}."artists" a ON a."discogs_artist_id" = am."discogs_artist_id"
+    LEFT JOIN LATERAL (
+      SELECT cc."headlining_artist_raw"
+      FROM ${sql(SCHEMA)}."concerts" cc
+      WHERE (cc."headlining_discogs_artist_id" = am."discogs_artist_id"
+             OR cc."headlining_artist_id" = a."id")
+        AND cc."removed_at" IS NULL
+        AND cc."headlining_artist_raw" IS NOT NULL
+      ORDER BY cc."starts_on" DESC NULLS LAST, cc."id" DESC
+      LIMIT 1
+    ) c ON TRUE
+    WHERE am."artist_bio" IS NULL
+      AND COALESCE(a."artist_name", c."headlining_artist_raw") IS NOT NULL
+      AND am."discogs_artist_id" = ANY(${ids})
+    ORDER BY am."discogs_artist_id" ASC
+  `;
+}
+
+/** Fill-null bio UPDATE mirror of `writer.ts#applyBioBackfill` (BS#1734). */
+async function applyBioBackfill(sql, rows) {
+  if (rows.length === 0) return [];
+  return sql`
+    INSERT INTO ${sql(SCHEMA)}."artist_metadata" ${sql(rows, 'discogs_artist_id', 'genres', 'styles', 'artist_bio')}
+    ON CONFLICT ("discogs_artist_id") DO UPDATE
+      SET "artist_bio" = excluded."artist_bio", "updated_at" = NOW()
+      WHERE ${sql(SCHEMA)}."artist_metadata"."artist_bio" IS NULL
+    RETURNING "discogs_artist_id"
+  `;
+}
+
 describe('concerts genre enrichment (BS#1624)', () => {
   let auth;
   let sql;
@@ -143,7 +194,7 @@ describe('concerts genre enrichment (BS#1624)', () => {
     // delete hits those seed rows (library_artist_id_artists_id_fk violation).
     // The synthetic ids (9162400x) exist only in this test.
     await sql.unsafe(`DELETE FROM "${SCHEMA}".artists WHERE discogs_artist_id = ANY($1)`, [
-      [DISCOGS_ENRICHED, DISCOGS_LIBRARY_UNENRICHED],
+      [DISCOGS_ENRICHED, DISCOGS_LIBRARY_UNENRICHED, DISCOGS_BIO_NULL_LIB, DISCOGS_BIO_FILL],
     ]);
     await sql.unsafe(`DELETE FROM "${SCHEMA}".artist_metadata WHERE discogs_artist_id = ANY($1)`, [
       [
@@ -153,6 +204,9 @@ describe('concerts genre enrichment (BS#1624)', () => {
         DISCOGS_PAST,
         DISCOGS_UPSERT_A,
         DISCOGS_UPSERT_B,
+        DISCOGS_BIO_NULL_LIB,
+        DISCOGS_BIO_NULL_EXT,
+        DISCOGS_BIO_FILL,
       ],
     ]);
   };
@@ -239,6 +293,73 @@ describe('concerts genre enrichment (BS#1624)', () => {
       headlining_artist_raw: 'Long Gone Touring Act',
       headlining_discogs_artist_id: DISCOGS_PAST,
     });
+
+    // --- BS#1734 bio-backfill fixtures: genres-only rows with artist_bio NULL. ---
+
+    // Library headliner: has an artists row (name resolves via artists.artist_name)
+    // and an artist_metadata row WITH genres but a NULL bio.
+    const [a3] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters, discogs_artist_id)
+       VALUES ($1, $1, 'ZZ', $2) RETURNING id`,
+      [ARTIST_BIO_NULL_LIB, DISCOGS_BIO_NULL_LIB]
+    );
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles, artist_bio)
+       VALUES ($1, $2, $3, NULL)`,
+      [DISCOGS_BIO_NULL_LIB, ['Ambient'], []]
+    );
+    await seedConcert({
+      key: 'bio-null-lib',
+      venue_id: venueId,
+      starts_on: IN_15,
+      headlining_artist_raw: ARTIST_BIO_NULL_LIB,
+      headlining_artist_id: a3.id,
+    });
+
+    // Discogs-only headliner: NO artists row, genres-only artist_metadata row with
+    // NULL bio. Name must resolve to the freshest NON-removed concert billing —
+    // three concerts prove both the removed_at exclusion and the DESC ordering:
+    //   IN_20 REMOVED (latest date, but excluded), IN_15 ACTIVE (the winner),
+    //   IN_10 ACTIVE (older, loses the tie-break).
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles, artist_bio)
+       VALUES ($1, $2, $3, NULL)`,
+      [DISCOGS_BIO_NULL_EXT, [], []]
+    );
+    await seedConcert({
+      key: 'bio-ext-removed',
+      venue_id: venueId,
+      starts_on: IN_20,
+      headlining_artist_raw: 'Stale Removed Billing',
+      headlining_discogs_artist_id: DISCOGS_BIO_NULL_EXT,
+      removed_at: '2020-01-01T00:00:00Z',
+    });
+    await seedConcert({
+      key: 'bio-ext-active',
+      venue_id: venueId,
+      starts_on: IN_15,
+      headlining_artist_raw: BIO_EXT_ACTIVE_RAW,
+      headlining_discogs_artist_id: DISCOGS_BIO_NULL_EXT,
+    });
+    await seedConcert({
+      key: 'bio-ext-active-older',
+      venue_id: venueId,
+      starts_on: IN_10,
+      headlining_artist_raw: 'Older Active Billing',
+      headlining_discogs_artist_id: DISCOGS_BIO_NULL_EXT,
+    });
+
+    // Dedicated mutable null-bio row for the fill test (kept off the load-test ids).
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters, discogs_artist_id)
+       VALUES ($1, $1, 'ZZ', $2) RETURNING id`,
+      [ARTIST_BIO_FILL, DISCOGS_BIO_FILL]
+    );
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles, artist_bio)
+       VALUES ($1, $2, $3, NULL)`,
+      [DISCOGS_BIO_FILL, ['Jazz'], []]
+    );
   });
 
   afterAll(async () => {
@@ -352,6 +473,57 @@ describe('concerts genre enrichment (BS#1624)', () => {
       const unresolved = res.body.concerts.find((c) => c.headlining_artist_raw === 'Some Unresolved Billing & Another');
       expect(unresolved).toBeDefined();
       expect(unresolved.artist_bio).toBeNull();
+    });
+  });
+
+  describe('bio backfill (mirror of query.ts + writer.ts, BS#1734)', () => {
+    it('selects genres-only null-bio rows, resolves a deterministic non-removed name, excludes populated bios', async () => {
+      const rows = await loadBioBackfillCandidates(sql, [DISCOGS_ENRICHED, DISCOGS_BIO_NULL_LIB, DISCOGS_BIO_NULL_EXT]);
+      const byId = new Map(rows.map((r) => [Number(r.discogs_artist_id), r.artist_name]));
+
+      // A row that already carries a bio is not a candidate.
+      expect(byId.has(DISCOGS_ENRICHED)).toBe(false);
+      // Library headliner → canonical artists.artist_name.
+      expect(byId.get(DISCOGS_BIO_NULL_LIB)).toBe(ARTIST_BIO_NULL_LIB);
+      // Discogs-only headliner → freshest ACTIVE billing: not the later-dated but
+      // REMOVED concert (proves removed_at exclusion), not the older active one
+      // (proves the starts_on DESC tie-break).
+      expect(byId.get(DISCOGS_BIO_NULL_EXT)).toBe(BIO_EXT_ACTIVE_RAW);
+    });
+
+    it('fills a null bio, never overwrites a populated one, and a re-run over the filled row updates 0', async () => {
+      // Fill the dedicated null-bio row AND attempt to clobber the already-populated one.
+      const first = await applyBioBackfill(sql, [
+        { discogs_artist_id: DISCOGS_BIO_FILL, genres: [], styles: [], artist_bio: 'A freshly resolved bio.' },
+        { discogs_artist_id: DISCOGS_ENRICHED, genres: [], styles: [], artist_bio: 'MUST NOT overwrite.' },
+      ]);
+      const firstIds = first.map((r) => Number(r.discogs_artist_id));
+      // Only the NULL row is updated; the setWhere blocks the populated one.
+      expect(firstIds).toContain(DISCOGS_BIO_FILL);
+      expect(firstIds).not.toContain(DISCOGS_ENRICHED);
+
+      const [filled] = await sql.unsafe(
+        `SELECT artist_bio FROM "${SCHEMA}".artist_metadata WHERE discogs_artist_id = $1`,
+        [DISCOGS_BIO_FILL]
+      );
+      expect(filled.artist_bio).toBe('A freshly resolved bio.');
+      const [untouched] = await sql.unsafe(
+        `SELECT artist_bio FROM "${SCHEMA}".artist_metadata WHERE discogs_artist_id = $1`,
+        [DISCOGS_ENRICHED]
+      );
+      expect(untouched.artist_bio).toBe(ARTIST_BIO);
+
+      // Re-run over the now-filled row → 0 updates (setWhere excludes non-null),
+      // and the stored bio is unchanged.
+      const second = await applyBioBackfill(sql, [
+        { discogs_artist_id: DISCOGS_BIO_FILL, genres: [], styles: [], artist_bio: 'A different bio (v2).' },
+      ]);
+      expect(second).toHaveLength(0);
+      const [afterRerun] = await sql.unsafe(
+        `SELECT artist_bio FROM "${SCHEMA}".artist_metadata WHERE discogs_artist_id = $1`,
+        [DISCOGS_BIO_FILL]
+      );
+      expect(afterRerun.artist_bio).toBe('A freshly resolved bio.');
     });
   });
 });

--- a/tests/integration/concerts.spec.js
+++ b/tests/integration/concerts.spec.js
@@ -35,6 +35,7 @@ const ARTIST_NAME = 'BS#1603 Touring Probe Artist';
 const ARTIST_DISCOGS_ID = 91624001;
 const ARTIST_GENRES = ['Rock', 'Electronic'];
 const ARTIST_STYLES = ['Indie Rock'];
+const ARTIST_BIO = 'A touring probe artist known for genre-blending live sets.';
 
 function makeSql() {
   return postgres({
@@ -142,14 +143,15 @@ describe('GET /concerts (BS#1603)', () => {
     );
     artistId = artist.id;
 
-    // Enrichment output for the resolved headliner: the BS#1624 genres
-    // projection LEFT JOINs artist_metadata on COALESCE(headlining_discogs_
-    // artist_id, artists.discogs_artist_id). Seeding a row here proves genres
-    // surface on the wire; the un-enriched rows below prove the null-safe miss.
+    // Enrichment output for the resolved headliner: the BS#1624 genres /
+    // BS#1734 artist_bio projection LEFT JOINs artist_metadata on
+    // COALESCE(headlining_discogs_artist_id, artists.discogs_artist_id).
+    // Seeding a row here proves genres/artist_bio surface on the wire; the
+    // un-enriched rows below prove the null-safe miss.
     await sql.unsafe(
-      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles)
-       VALUES ($1, $2, $3)`,
-      [ARTIST_DISCOGS_ID, ARTIST_GENRES, ARTIST_STYLES]
+      `INSERT INTO "${SCHEMA}".artist_metadata (discogs_artist_id, genres, styles, artist_bio)
+       VALUES ($1, $2, $3, $4)`,
+      [ARTIST_DISCOGS_ID, ARTIST_GENRES, ARTIST_STYLES, ARTIST_BIO]
     );
 
     // Past row — excluded by the default "today forward" window.
@@ -311,6 +313,22 @@ describe('GET /concerts (BS#1603)', () => {
       const unenriched = rows.find((c) => c.headlining_artist_raw === 'Date-Only Billing');
       expect(unenriched).toBeDefined();
       expect(unenriched.genres).toBeNull();
+    });
+  });
+
+  describe('artist_bio projection (BS#1734)', () => {
+    it('surfaces artist_metadata.artist_bio on a resolved headliner and leaves un-enriched rows null', async () => {
+      const res = await auth.get('/concerts').query({ limit: 100 });
+      expect(res.status).toBe(200);
+      const rows = seeded(res.body);
+
+      const enriched = rows.find((c) => c.headlining_artist_raw === ARTIST_NAME);
+      expect(enriched).toBeDefined();
+      expect(enriched.artist_bio).toBe(ARTIST_BIO);
+
+      const unenriched = rows.find((c) => c.headlining_artist_raw === 'Date-Only Billing');
+      expect(unenriched).toBeDefined();
+      expect(unenriched.artist_bio).toBeNull();
     });
   });
 

--- a/tests/unit/jobs/concerts-genre-enrichment/bio-backfill.test.ts
+++ b/tests/unit/jobs/concerts-genre-enrichment/bio-backfill.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for jobs/concerts-genre-enrichment bio-backfill.ts (BS#1734).
+ *
+ * Same dep-injected seam as orchestrate.test.ts (candidate loader, fake
+ * `fetchGenres`, fake `applyBioBackfill`). This suite pins:
+ *
+ *   - candidates page through LML and a bio verdict updates the row;
+ *   - a null-bio verdict still updates (a blank Discogs profile is a real
+ *     terminal answer, not a retry signal);
+ *   - `unavailable` verdicts are skipped (left retryable);
+ *   - a whole-page `unavailable` stops the run early;
+ *   - dry-run enumerates but never calls LML or the writer;
+ *   - a thrown LML page / writer call is counted + skipped, the run continues;
+ *   - the cooperative pause is awaited before each page.
+ *
+ * WXYC-representative artists per the org fixture convention.
+ */
+import { jest } from '@jest/globals';
+
+import type { ArtistGenresBulkResponse, ArtistGenresRequestItem, ArtistGenresSource } from '@wxyc/lml-client';
+import {
+  runBioBackfill,
+  type BioBackfillDeps,
+  type BioBackfillOptions,
+} from '../../../../jobs/concerts-genre-enrichment/bio-backfill';
+import type { EnrichmentCandidate } from '../../../../jobs/concerts-genre-enrichment/query';
+import type { BioBackfillRow } from '../../../../jobs/concerts-genre-enrichment/writer';
+
+type FetchGenresFn = BioBackfillDeps['fetchGenres'];
+type ApplyFn = BioBackfillDeps['applyBioBackfill'];
+type LoadCandidatesFn = BioBackfillDeps['loadCandidates'];
+
+const candidate = (discogs_artist_id: number, artist_name: string): EnrichmentCandidate => ({
+  discogs_artist_id,
+  artist_name,
+});
+
+const genresResponse = (
+  verdicts: Array<{ bio?: string | null; source?: ArtistGenresSource }>
+): ArtistGenresBulkResponse => ({
+  results: verdicts.map((v) => ({ genres: [], styles: [], source: v.source ?? 'cache', bio: v.bio ?? null })),
+});
+
+const makeDeps = (
+  candidates: EnrichmentCandidate[],
+  overrides: Partial<BioBackfillDeps> = {}
+): {
+  deps: BioBackfillDeps;
+  loadCandidates: jest.Mock<LoadCandidatesFn>;
+  fetchGenres: jest.Mock<FetchGenresFn>;
+  applyBioBackfill: jest.Mock<ApplyFn>;
+  awaitQuiet: jest.Mock<() => Promise<void>>;
+  writes: BioBackfillRow[];
+} => {
+  const writes: BioBackfillRow[] = [];
+  const loadCandidates =
+    (overrides.loadCandidates as jest.Mock<LoadCandidatesFn>) ??
+    jest.fn<LoadCandidatesFn>().mockResolvedValue(candidates);
+  const fetchGenres =
+    (overrides.fetchGenres as jest.Mock<FetchGenresFn>) ??
+    jest
+      .fn<FetchGenresFn>()
+      .mockImplementation((items: ArtistGenresRequestItem[]) =>
+        Promise.resolve(genresResponse(items.map(() => ({ bio: 'A touring act.' }))))
+      );
+  const applyBioBackfill =
+    (overrides.applyBioBackfill as jest.Mock<ApplyFn>) ??
+    jest.fn<ApplyFn>().mockImplementation((rows: BioBackfillRow[]) => {
+      writes.push(...rows);
+      return Promise.resolve({ updated: rows.length });
+    });
+  const awaitQuiet =
+    (overrides.awaitQuiet as jest.Mock<() => Promise<void>>) ??
+    jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  const deps: BioBackfillDeps = { loadCandidates, fetchGenres, applyBioBackfill, awaitQuiet };
+  return { deps, loadCandidates, fetchGenres, applyBioBackfill, awaitQuiet, writes };
+};
+
+const options = (over: Partial<BioBackfillOptions> = {}): BioBackfillOptions => ({
+  pageSize: 10,
+  dryRun: false,
+  ...over,
+});
+
+describe('runBioBackfill (BS#1734)', () => {
+  it('fetches bios for the loaded candidates and persists them', async () => {
+    const { deps, fetchGenres, applyBioBackfill, writes } = makeDeps([
+      candidate(100, 'Juana Molina'),
+      candidate(200, 'Jessica Pratt'),
+    ]);
+
+    const totals = await runBioBackfill(deps, options());
+
+    expect(fetchGenres).toHaveBeenCalledTimes(1);
+    expect(fetchGenres.mock.calls[0][0]).toEqual([
+      { artist_name: 'Juana Molina', discogs_artist_id: 100 },
+      { artist_name: 'Jessica Pratt', discogs_artist_id: 200 },
+    ]);
+    expect(applyBioBackfill).toHaveBeenCalledTimes(1);
+    expect(writes).toEqual([
+      { discogs_artist_id: 100, artist_bio: 'A touring act.' },
+      { discogs_artist_id: 200, artist_bio: 'A touring act.' },
+    ]);
+    expect(totals).toMatchObject({ candidates: 2, pages: 1, fetched: 2, updated: 2, errors: 0 });
+  });
+
+  it('makes zero LML calls when no row needs a bio', async () => {
+    const { deps, fetchGenres, applyBioBackfill } = makeDeps([]);
+
+    const totals = await runBioBackfill(deps, options());
+
+    expect(fetchGenres).not.toHaveBeenCalled();
+    expect(applyBioBackfill).not.toHaveBeenCalled();
+    expect(totals).toMatchObject({ candidates: 0, pages: 0, updated: 0 });
+  });
+
+  it('updates a row with a null bio (a blank Discogs profile is terminal, not a retry signal)', async () => {
+    const { deps, writes } = makeDeps([candidate(300, 'Obscure Touring Act')], {
+      fetchGenres: jest.fn<FetchGenresFn>().mockResolvedValue(genresResponse([{ bio: null }])),
+    });
+
+    const totals = await runBioBackfill(deps, options());
+
+    expect(writes).toEqual([{ discogs_artist_id: 300, artist_bio: null }]);
+    expect(totals).toMatchObject({ fetched: 1, updated: 1 });
+  });
+
+  it('skips `unavailable` verdicts (left retryable)', async () => {
+    const { deps, applyBioBackfill, writes } = makeDeps([candidate(1, 'Cached Act'), candidate(2, 'Couldnt Ask Act')], {
+      fetchGenres: jest.fn<FetchGenresFn>().mockResolvedValue(
+        genresResponse([
+          { bio: 'Has a bio.', source: 'cache' },
+          { bio: null, source: 'unavailable' },
+        ])
+      ),
+    });
+
+    const totals = await runBioBackfill(deps, options());
+
+    expect(writes).toEqual([{ discogs_artist_id: 1, artist_bio: 'Has a bio.' }]);
+    expect(writes.some((w) => w.discogs_artist_id === 2)).toBe(false);
+    expect(totals).toMatchObject({ fetched: 2, unavailable_skipped: 1, updated: 1 });
+    expect(applyBioBackfill).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops early when a whole page comes back `unavailable` (breaker open)', async () => {
+    const { deps, fetchGenres, applyBioBackfill, writes } = makeDeps(
+      [candidate(1, 'A'), candidate(2, 'B'), candidate(3, 'C')],
+      {
+        fetchGenres: jest
+          .fn<FetchGenresFn>()
+          .mockResolvedValueOnce(genresResponse([{ source: 'unavailable' }, { source: 'unavailable' }]))
+          .mockResolvedValueOnce(genresResponse([{ bio: 'A touring act.' }])),
+      }
+    );
+
+    const totals = await runBioBackfill(deps, options({ pageSize: 2 }));
+
+    expect(fetchGenres).toHaveBeenCalledTimes(1);
+    expect(applyBioBackfill).not.toHaveBeenCalled();
+    expect(writes).toEqual([]);
+    expect(totals).toMatchObject({
+      candidates: 3,
+      pages: 1,
+      fetched: 2,
+      unavailable_skipped: 2,
+      updated: 0,
+      stopped_early: true,
+    });
+  });
+
+  it('dry-run enumerates but never calls LML or the writer', async () => {
+    const { deps, fetchGenres, applyBioBackfill } = makeDeps([candidate(1, 'Juana Molina')]);
+
+    const totals = await runBioBackfill(deps, options({ dryRun: true }));
+
+    expect(fetchGenres).not.toHaveBeenCalled();
+    expect(applyBioBackfill).not.toHaveBeenCalled();
+    expect(totals).toMatchObject({ candidates: 1, pages: 0, updated: 0 });
+  });
+
+  it('counts a thrown LML page as errors and continues to the next page', async () => {
+    const { deps, applyBioBackfill, writes } = makeDeps([candidate(1, 'A'), candidate(2, 'B'), candidate(3, 'C')], {
+      fetchGenres: jest
+        .fn<FetchGenresFn>()
+        .mockRejectedValueOnce(new Error('LML 503'))
+        .mockResolvedValueOnce(genresResponse([{ bio: 'A touring act.' }])),
+    });
+
+    const totals = await runBioBackfill(deps, options({ pageSize: 2 }));
+
+    expect(totals).toMatchObject({ candidates: 3, pages: 1, fetched: 1, updated: 1, errors: 2 });
+    expect(writes).toEqual([{ discogs_artist_id: 3, artist_bio: 'A touring act.' }]);
+    expect(applyBioBackfill).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts a thrown writer call as errors and continues', async () => {
+    const { deps } = makeDeps([candidate(1, 'A'), candidate(2, 'B')], {
+      applyBioBackfill: jest.fn<ApplyFn>().mockRejectedValue(new Error('deadlock')),
+    });
+
+    const totals = await runBioBackfill(deps, options());
+
+    expect(totals).toMatchObject({ candidates: 2, pages: 1, fetched: 2, updated: 0, errors: 2 });
+  });
+
+  it('awaits the cooperative pause before each page', async () => {
+    const { deps, awaitQuiet } = makeDeps([candidate(1, 'A'), candidate(2, 'B'), candidate(3, 'C')]);
+
+    await runBioBackfill(deps, options({ pageSize: 1 }));
+
+    expect(awaitQuiet).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/unit/jobs/concerts-genre-enrichment/bio-backfill.test.ts
+++ b/tests/unit/jobs/concerts-genre-enrichment/bio-backfill.test.ts
@@ -4,9 +4,9 @@
  * Same dep-injected seam as orchestrate.test.ts (candidate loader, fake
  * `fetchGenres`, fake `applyBioBackfill`). This suite pins:
  *
- *   - candidates page through LML and a bio verdict updates the row;
- *   - a null-bio verdict still updates (a blank Discogs profile is a real
- *     terminal answer, not a retry signal);
+ *   - candidates page through LML and a real bio verdict updates the row;
+ *   - a responded-but-blank bio is skipped, not written (a NULL self-UPDATE
+ *     achieves nothing; the row stays NULL-retryable — no attempt marker);
  *   - `unavailable` verdicts are skipped (left retryable);
  *   - a whole-page `unavailable` stops the run early;
  *   - dry-run enumerates but never calls LML or the writer;
@@ -114,15 +114,28 @@ describe('runBioBackfill (BS#1734)', () => {
     expect(totals).toMatchObject({ candidates: 0, pages: 0, updated: 0 });
   });
 
-  it('updates a row with a null bio (a blank Discogs profile is terminal, not a retry signal)', async () => {
+  it('skips a responded-but-blank bio, leaving the row NULL-retryable (no attempt marker)', async () => {
     const { deps, writes } = makeDeps([candidate(300, 'Obscure Touring Act')], {
       fetchGenres: jest.fn<FetchGenresFn>().mockResolvedValue(genresResponse([{ bio: null }])),
     });
 
     const totals = await runBioBackfill(deps, options());
 
-    expect(writes).toEqual([{ discogs_artist_id: 300, artist_bio: null }]);
-    expect(totals).toMatchObject({ fetched: 1, updated: 1 });
+    // A blank profile is not written (a NULL self-UPDATE would achieve nothing);
+    // the row keeps `artist_bio IS NULL` and is re-selected on a future run.
+    expect(writes).toEqual([]);
+    expect(totals).toMatchObject({ fetched: 1, no_bio_skipped: 1, updated: 0 });
+  });
+
+  it('skips an empty-string bio the same way as a null bio', async () => {
+    const { deps, writes } = makeDeps([candidate(301, 'Blank Profile Act')], {
+      fetchGenres: jest.fn<FetchGenresFn>().mockResolvedValue(genresResponse([{ bio: '' }])),
+    });
+
+    const totals = await runBioBackfill(deps, options());
+
+    expect(writes).toEqual([]);
+    expect(totals).toMatchObject({ fetched: 1, no_bio_skipped: 1, updated: 0 });
   });
 
   it('skips `unavailable` verdicts (left retryable)', async () => {

--- a/tests/unit/jobs/concerts-genre-enrichment/orchestrate.test.ts
+++ b/tests/unit/jobs/concerts-genre-enrichment/orchestrate.test.ts
@@ -38,14 +38,20 @@ const candidate = (discogs_artist_id: number, artist_name: string): EnrichmentCa
 });
 
 /**
- * An LML response echoing one `{ genres, styles, source }` verdict per input
- * item. `source` defaults to `'cache'` so genre-content fixtures needn't spell
- * it out; the source-routing tests pass it explicitly.
+ * An LML response echoing one `{ genres, styles, source, bio }` verdict per
+ * input item. `source` defaults to `'cache'` so genre-content fixtures needn't
+ * spell it out; the source-routing tests pass it explicitly. `bio` defaults to
+ * `null` so pre-BS#1734 fixtures don't need updating.
  */
 const genresResponse = (
-  verdicts: Array<{ genres: string[]; styles: string[]; source?: ArtistGenresSource }>
+  verdicts: Array<{ genres: string[]; styles: string[]; source?: ArtistGenresSource; bio?: string | null }>
 ): ArtistGenresBulkResponse => ({
-  results: verdicts.map((v) => ({ genres: v.genres, styles: v.styles, source: v.source ?? 'cache' })),
+  results: verdicts.map((v) => ({
+    genres: v.genres,
+    styles: v.styles,
+    source: v.source ?? 'cache',
+    bio: v.bio ?? null,
+  })),
 });
 
 const makeDeps = (
@@ -103,10 +109,28 @@ describe('runEnrichment (BS#1624)', () => {
     ]);
     expect(upsert).toHaveBeenCalledTimes(1);
     expect(writes).toEqual([
-      { discogs_artist_id: 100, genres: ['Rock'], styles: ['Indie Rock'] },
-      { discogs_artist_id: 200, genres: ['Rock'], styles: ['Indie Rock'] },
+      { discogs_artist_id: 100, genres: ['Rock'], styles: ['Indie Rock'], artist_bio: null },
+      { discogs_artist_id: 200, genres: ['Rock'], styles: ['Indie Rock'], artist_bio: null },
     ]);
     expect(totals).toMatchObject({ candidates: 2, pages: 1, fetched: 2, with_genres: 2, enriched: 2, errors: 0 });
+  });
+
+  it('threads the LML bio verdict through to the persisted row (BS#1734)', async () => {
+    const { deps, writes } = makeDeps([candidate(100, 'Juana Molina'), candidate(200, 'Jessica Pratt')], {
+      fetchGenres: jest.fn<FetchGenresFn>().mockResolvedValue(
+        genresResponse([
+          { genres: ['Rock'], styles: [], bio: 'Argentine singer-songwriter.' },
+          { genres: ['Rock'], styles: [] }, // no bio on this verdict → null
+        ])
+      ),
+    });
+
+    await runEnrichment(deps, options());
+
+    expect(writes).toEqual([
+      { discogs_artist_id: 100, genres: ['Rock'], styles: [], artist_bio: 'Argentine singer-songwriter.' },
+      { discogs_artist_id: 200, genres: ['Rock'], styles: [], artist_bio: null },
+    ]);
   });
 
   it('makes zero LML calls when no candidate needs enrichment (anti-join drained)', async () => {
@@ -139,9 +163,9 @@ describe('runEnrichment (BS#1624)', () => {
 
     expect(fetchGenres).toHaveBeenCalledTimes(2);
     expect(writes).toEqual([
-      { discogs_artist_id: 1, genres: ['Electronic'], styles: [] },
-      { discogs_artist_id: 2, genres: ['Rock'], styles: [] },
-      { discogs_artist_id: 3, genres: ['Jazz'], styles: ['Big Band'] },
+      { discogs_artist_id: 1, genres: ['Electronic'], styles: [], artist_bio: null },
+      { discogs_artist_id: 2, genres: ['Rock'], styles: [], artist_bio: null },
+      { discogs_artist_id: 3, genres: ['Jazz'], styles: ['Big Band'], artist_bio: null },
     ]);
     expect(totals).toMatchObject({ candidates: 3, pages: 2, fetched: 3, enriched: 3 });
   });
@@ -153,7 +177,7 @@ describe('runEnrichment (BS#1624)', () => {
 
     const totals = await runEnrichment(deps, options());
 
-    expect(writes).toEqual([{ discogs_artist_id: 300, genres: [], styles: [] }]);
+    expect(writes).toEqual([{ discogs_artist_id: 300, genres: [], styles: [], artist_bio: null }]);
     expect(totals).toMatchObject({ fetched: 1, with_genres: 0, enriched: 1 });
   });
 
@@ -179,8 +203,8 @@ describe('runEnrichment (BS#1624)', () => {
 
     // Only the cache + not_found artists are written; the unavailable one is not.
     expect(writes).toEqual([
-      { discogs_artist_id: 1, genres: ['Rock'], styles: [] },
-      { discogs_artist_id: 3, genres: [], styles: [] },
+      { discogs_artist_id: 1, genres: ['Rock'], styles: [], artist_bio: null },
+      { discogs_artist_id: 3, genres: [], styles: [], artist_bio: null },
     ]);
     expect(writes.some((w) => w.discogs_artist_id === 2)).toBe(false);
     expect(totals).toMatchObject({ fetched: 3, unavailable_skipped: 1, with_genres: 1, enriched: 2 });
@@ -264,7 +288,7 @@ describe('runEnrichment (BS#1624)', () => {
     // Page 1 (2 artists) threw → counted as 2 errors, nothing written; page 2
     // (1 artist) succeeded.
     expect(totals).toMatchObject({ candidates: 3, pages: 1, fetched: 1, enriched: 1, errors: 2 });
-    expect(writes).toEqual([{ discogs_artist_id: 3, genres: ['Rock'], styles: [] }]);
+    expect(writes).toEqual([{ discogs_artist_id: 3, genres: ['Rock'], styles: [], artist_bio: null }]);
     expect(upsert).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/services/concerts.service.test.ts
+++ b/tests/unit/services/concerts.service.test.ts
@@ -31,8 +31,9 @@ import {
 
 /**
  * Compile-time pin: `ConcertDTO` must match the SSOT `Concert` schema in
- * `wxyc-shared/api.yaml` v1.17.0 (event_url added in 1.17.0 / BS#1609). The published `@wxyc/shared` at this
- * worktree's pin (`^1.15.0`) does not yet export a `Concert` DTO, so we
+ * `wxyc-shared/api.yaml` v1.20.0 (artist_bio added in 1.20.0 / BS#1734,
+ * wxyc-shared#247). The published `@wxyc/shared` at this worktree's pin
+ * (`^2.3.0`) does not yet export a `Concert` DTO, so we
  * assert against a hand-mirrored shape derived from the api.yaml operation.
  * When `@wxyc/shared` publishes `Concert`, replace `ApiYamlConcert` below
  * with `import type { Concert } from '@wxyc/shared/dtos'` — the two-way
@@ -69,6 +70,9 @@ type ApiYamlConcert = {
   // BS#1624 / wxyc-shared#221: nullable AND optional (not in the api.yaml
   // `required` set), so `genres?: string[] | null`.
   genres?: string[] | null;
+  // BS#1734 / wxyc-shared#247: raw Discogs artist bio, same optional +
+  // nullable discipline as `genres`.
+  artist_bio?: string | null;
   // BS#1626 / wxyc-shared#222: the `SimilarArtist` schema (`{ artist_id, weight }`)
   // as an optional + nullable array, same discipline as `genres`.
   similar_artists?: { artist_id: number; weight: number }[] | null;
@@ -119,6 +123,9 @@ const timedRow: ConcertJoinRow = {
   // Resolved + enriched headliner: the LEFT JOIN to `artist_metadata` produced
   // a genres array (BS#1624).
   genres: ['Rock', 'Electronic'],
+  // Resolved + enriched headliner: the same LEFT JOIN produced a raw Discogs
+  // bio (BS#1734).
+  artist_bio: 'Nilüfer Yanya is a British singer-songwriter and guitarist from London.',
   // Resolved + enriched headliner: the LEFT JOIN to `artist_similar_artists`
   // produced an affinity-neighbor array (BS#1626).
   similar_artists: [
@@ -149,8 +156,10 @@ const dateOnlyRow: ConcertJoinRow = {
   age_restriction: null,
   venue_address: null,
   // Unresolved headliner (headlining_artist_id null): the LEFT JOINs miss, so
-  // the projection yields NULL genres, similar_artists, and station_plays.
+  // the projection yields NULL genres, artist_bio, similar_artists, and
+  // station_plays.
   genres: null,
+  artist_bio: null,
   similar_artists: null,
   station_plays: null,
   // Unresolved headliner: the EXISTS correlation never matches → false (BS#1731).
@@ -242,6 +251,25 @@ describe('toConcertDTO', () => {
     expect(dto.genres).toBeNull();
   });
 
+  // BS#1734 — artist_bio comes from the same LEFT JOIN to artist_metadata as
+  // genres. Present for a resolved + enriched headliner; null when unresolved
+  // or the enrichment hasn't run.
+  it('passes the joined artist_bio through for a resolved, enriched headliner', () => {
+    const dto = toConcertDTO(timedRow);
+    expect(dto.artist_bio).toBe('Nilüfer Yanya is a British singer-songwriter and guitarist from London.');
+  });
+
+  it('emits null artist_bio for an unresolved headliner (LEFT JOIN miss)', () => {
+    expect(toConcertDTO(dateOnlyRow).artist_bio).toBeNull();
+  });
+
+  it('coalesces an undefined row.artist_bio (projection without the join) to null', () => {
+    const { artist_bio: _drop, ...withoutBio } = timedRow;
+    void _drop;
+    const dto = toConcertDTO(withoutBio);
+    expect(dto.artist_bio).toBeNull();
+  });
+
   // BS#1626 — similar_artists come from the LEFT JOIN to artist_similar_artists.
   // Present for a resolved + enriched headliner; null when unresolved or the
   // enrichment hasn't run; null when the embed projection omits the join.
@@ -326,6 +354,7 @@ describe('toConcertDTO', () => {
         'age_restriction',
         'status',
         'genres',
+        'artist_bio',
         'similar_artists',
         'station_plays',
         'station_recommended',
@@ -437,11 +466,12 @@ describe('getConcertById', () => {
     for (const internal of INTERNAL_COLUMNS) {
       expect(selectedColumns).not.toContain(internal);
     }
-    // Parity pin: the by-id projection carries the BS#1624 genres, BS#1702
-    // station_plays, and BS#1731 station_recommended fields, so a by-id read
-    // can never lag the list's enrichment fields (the BS#1694 lockstep-join
-    // invariant).
+    // Parity pin: the by-id projection carries the BS#1624 genres, BS#1734
+    // artist_bio, BS#1702 station_plays, and BS#1731 station_recommended
+    // fields, so a by-id read can never lag the list's enrichment fields (the
+    // BS#1694 lockstep-join invariant).
     expect(Object.keys(projection)).toContain('genres');
+    expect(Object.keys(projection)).toContain('artist_bio');
     expect(Object.keys(projection)).toContain('station_plays');
     expect(Object.keys(projection)).toContain('station_recommended');
   });


### PR DESCRIPTION
## Summary

- Migration 0127 adds `artist_metadata.artist_bio`, mirroring BS#1624's `genres`/`styles` columns; `jobs/concerts-genre-enrichment` threads `bio` from LML's bulk artist-genres endpoint (LML#889) into net-new rows via `upsertArtistGenres`.
- `apps/backend/services/concerts.service.ts` projects `artist_bio` onto `Concert.artist_bio` on both `getConcertsPage` and `getConcertById` (never on the `getUpcomingShowsMaps` embed, matching `genres`'s existing #1616 hot-path boundary). Bio is stored and served **raw** — no `cleanDiscogsBio` — matching `album_metadata.artist_bio` / `flowsheet.artist_bio` precedent.
- New `--bio-backfill` mode (`bio-backfill.ts` + `writer.ts#applyBioBackfill`) one-time-fills the pre-existing genres-only `artist_metadata` rows the nightly candidate anti-join never revisits, via a fill-null-only `INSERT ... ON CONFLICT DO UPDATE ... WHERE artist_bio IS NULL` (never touches `genres`/`styles`, never overwrites a populated bio).
- Bumps `@wxyc/shared` to `^2.3.0` across `apps/backend`, `apps/auth`, `shared/lml-client`, `shared/authentication` for the `Concert.artist_bio` SSOT contract (wxyc-shared#247); `package-lock.json` synced.

## Test plan

- [x] `npm run typecheck` — clean (root workspaces + direct `tsc` on `jobs/concerts-genre-enrichment` and `tests/tsconfig.json`, filtered to touched files — pre-existing unrelated errors elsewhere untouched)
- [x] `npm run lint` — 0 errors (pre-existing warning classes only, no new categories)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 329 suites / 4970 tests pass
- [x] `npm run ci:testmock` (Docker CI mirror) — all 6 `concerts*` integration specs pass, including new `artist_bio` coverage in `concerts.spec.js`, `concerts-by-id.spec.js`, `concerts-genre-enrichment.spec.js`; 2 unrelated pre-existing flakes (`flowsheet-upcoming-show.spec.js` known scan-count variance, `requestLine.spec.js` timing) untouched by this change
- [x] `npm run lint:migrations` — clean

Closes #1734