### PR TITLE
ci: add buildx registry layer caching to deploy-base.yml

### DIFF
--- a/.github/ecr-lifecycle-policy.json
+++ b/.github/ecr-lifecycle-policy.json
@@ -1,0 +1,30 @@
+{
+  "rules": [
+    {
+      "rulePriority": 1,
+      "description": "Expire untagged images (superseded buildcache/sha layers) after 1 day",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 1
+      },
+      "action": {
+        "type": "expire"
+      }
+    },
+    {
+      "rulePriority": 2,
+      "description": "Keep only the most recent 20 sha-* tagged images",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPrefixList": ["sha-"],
+        "countType": "imageCountMoreThan",
+        "countNumber": 20
+      },
+      "action": {
+        "type": "expire"
+      }
+    }
+  ]
+}

--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -267,6 +267,18 @@ jobs:
           aws ecr describe-repositories --repository-names $TARGET_APP --region $AWS_REGION 2>/dev/null || \
             aws ecr create-repository --repository-name $TARGET_APP --region $AWS_REGION
 
+      - name: Apply ECR Lifecycle Policy
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          TARGET_APP=${{ matrix.target }}
+          aws ecr put-lifecycle-policy \
+            --repository-name "$TARGET_APP" \
+            --region "$AWS_REGION" \
+            --lifecycle-policy-text file://.github/ecr-lifecycle-policy.json
+
       - name: Check if image exists in ECR
         id: check_image
         env:
@@ -286,39 +298,47 @@ jobs:
             echo "image_exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build Image
+      - name: Compute Image Tags
         if: steps.check_image.outputs.image_exists == 'false'
+        id: image_tags
         run: |
           TARGET_APP=${{ matrix.target }}
-
-          docker build --platform linux/amd64 --build-arg NPM_TOKEN=${{ secrets.NPM_TOKEN }} -f Dockerfile.${TARGET_APP} -t ${TARGET_APP}:ci .
-
-      - name: Tag and Push Image
-        if: steps.check_image.outputs.image_exists == 'false'
-        run: |
-          TARGET_APP=${{ matrix.target }}
-          TAG=${{ steps.determine_version.outputs.deploy_version }}
+          DEPLOY_TAG=${{ steps.determine_version.outputs.deploy_version }}
           SHA_TAG="sha-${{ github.sha }}"
-
           IMAGE_URI="${{ secrets.AWS_ECR_URI }}/${TARGET_APP}"
 
-          echo "Tagging Docker image..."
-          docker tag ${TARGET_APP}:ci $IMAGE_URI:$TAG
-
-          echo "Pushing Docker image to ECR..."
-          docker push $IMAGE_URI:$TAG
+          TAGS="$IMAGE_URI:$DEPLOY_TAG
+          $IMAGE_URI:$SHA_TAG"
 
           # Always push SHA tag for cache invalidation detection
-          echo "Tagging Docker image with SHA..."
-          docker tag ${TARGET_APP}:ci $IMAGE_URI:$SHA_TAG
-          docker push $IMAGE_URI:$SHA_TAG
-
           if [[ "${{ inputs.version }}" == "latest" || -z "${{ inputs.version }}" ]]; then
-          echo "Tagging Docker image with 'latest'..."
-          docker tag ${TARGET_APP}:ci $IMAGE_URI:latest
-          echo "Pushing Docker image to ECR with 'latest' tag..."
-          docker push $IMAGE_URI:latest
+            TAGS="$TAGS
+          $IMAGE_URI:latest"
           fi
+
+          {
+            echo "tags<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      # image-manifest=true,oci-mediatypes=true is required — ECR rejects the
+      # default BuildKit cache-manifest media type on cache-to. Don't switch
+      # to type=gha: its 10GB-per-repo cap thrashes across ~38 images' caches;
+      # ECR registry cache scales per-repo instead. See docs/deploy.md.
+      - name: Build and Push Image
+        if: steps.check_image.outputs.image_exists == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.${{ matrix.target }}
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            NPM_TOKEN=${{ secrets.NPM_TOKEN }}
+          tags: ${{ steps.image_tags.outputs.tags }}
+          cache-from: type=registry,ref=${{ secrets.AWS_ECR_URI }}/${{ matrix.target }}:buildcache
+          cache-to: type=registry,ref=${{ secrets.AWS_ECR_URI }}/${{ matrix.target }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
   migrate:
     needs: [handle-git-tags, setup]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ CLAUDE.md is a router for the always-loaded reference card. Topic depth lives in
 - **[`docs/env-vars.md`](docs/env-vars.md)** — Full environment-variable reference (Backend, DB, Auth, Email, Sentry, Slack, ETL, mirror queue, cross-cache-identity flags)
 - **[`docs/replication.md`](docs/replication.md)** — Local PostgreSQL logical-replication setup and operation
 - **[`docs/cdc.md`](docs/cdc.md)** — CDC WebSocket endpoint, event format, reconciliation monitor
-- **[`docs/deploy.md`](docs/deploy.md)** — Deploy cadence, migration-chain risk, deploy-wedge anatomy, CI workflow pin maintenance (permissions, gha/v1 pins, caller-callee permissions trap from #857)
+- **[`docs/deploy.md`](docs/deploy.md)** — Deploy cadence, migration-chain risk, deploy-wedge anatomy, buildx registry layer caching (ECR manifest requirement, lifecycle policy), CI workflow pin maintenance (permissions, gha/v1 pins, caller-callee permissions trap from #857)
 - **[`docs/authentication.md`](docs/authentication.md)** — Roles, permissions matrix, JWT payload, `requirePermissions` middleware flow, `AUTH_BYPASS`, better-auth role-mismatch gotcha
 - **[`docs/testing.md`](docs/testing.md)** — Unit + integration + CI-mock test setup, jest configs, CI workflow job list
 - **[`docs/dev-db-fixture.md`](docs/dev-db-fixture.md)** — Dev DB seed pipeline (`seed_db.sql` + `seed-clone.sql`), `LOAD_CLONE_FIXTURE` gate, `predev` rebuild hook, `db:stop` volume drop

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -26,6 +26,18 @@ The other defenses in [Project #26 — Migration Deploy Hardening](https://githu
 
 **Practical rule of thumb**: when a PR that touches `shared/database/src/migrations/**` merges, verify the auto-deploy on that push succeeded within 24 hours. If it didn't, run `deploy-manual.yml` to clear the wedge before another migration PR merges on top. The rule is advisory — don't gate merges on cadence, since PR authors don't necessarily own deploys.
 
+## Build image caching
+
+<!-- @rule id=deploy-buildx-registry-cache enforced-by=none added=2026-07-21 incidents=#run-29874378612 -->
+
+`build` (in `deploy-base.yml`) uses `docker/build-push-action@v6` with a registry-backed buildx cache instead of a plain `docker build`: `cache-from`/`cache-to` point at a `:buildcache` tag in each target's own ECR repository (`type=registry`, `mode=max`). This matters because the matrix is Turbo-affected-scoped (`setup` → Detect Build Target, `TURBO_SCM_BASE=github.event.before`) and per-target version-skips a rebuild if its tag already exists in ECR (`Check if image exists in ECR`) — both guards make a **leaf** change (one app/job, or none) cheap regardless of caching. A change to a shared dependency (`shared/database`, `shared/authentication`, `shared/lml-client`, a `@wxyc/shared` bump, or `package-lock.json`) sits above every target in Turbo's graph, so all ~38 targets are marked affected and each gets a **new** version tag that can't hit the ECR-exists skip — every image rebuilds. The registry cache is what makes that full-fleet rebuild reuse unchanged layers instead of recomputing all of them from scratch, as happened in the ~23 min `f065761d` deploy ([run 29874378612](https://github.com/WXYC/Backend-Service/actions/runs/29874378612)).
+
+`cache-to` **must** set `image-manifest=true,oci-mediatypes=true` — ECR rejects the default BuildKit cache-manifest media type and only accepts a cache exported as an OCI image manifest; omitting these options makes the cache push fail. Don't switch to `type=gha`: GitHub Actions cache is capped at 10 GB per repo, and ~38 images' layer caches would thrash/evict each other well below that ceiling — ECR registry cache scales per-repo instead. The three-tag push contract (`:${DEPLOY_TAG}`, `:sha-${github.sha}`, conditional `:latest`) is unchanged, just moved from manual `docker tag`/`docker push` calls into the action's `tags:` list.
+
+The `npm ci` layer still busts on any `package-lock.json` change — exactly the fleet-wide shared-dep case — so per-target layer caching alone doesn't help the single most expensive layer; it's still recomputed once per target. Collapsing that into a single shared base image every `Dockerfile.<target>` builds `FROM` is a candidate follow-up if the registry cache alone doesn't cut wall-clock enough (BS#1738's suggested-approach step 2), not yet implemented.
+
+**ECR storage**: the `:buildcache` tag holds the live cache manifest per repo; `.github/ecr-lifecycle-policy.json` (applied via `Apply ECR Lifecycle Policy`, run every `build` invocation so a newly-created repository picks it up on its first build) expires untagged images (the dangling layers left behind each time `:buildcache` is retagged) after 1 day and caps `sha-*` tags at the 20 most recent per repo. The `buildcache` tag itself is never matched by either rule, since it's always tagged and never has the `sha-` prefix.
+
 ## CI workflow pin maintenance
 
 Three classes of pin in `.github/workflows/*.yml` exist for supply-chain reasons (mirrors WXYC/request-o-matic#124's free-tier hardening; see WXYC/wiki#67 for the org-wide rollout). They will bit-rot and need occasional bumps:


### PR DESCRIPTION
## Summary

- `build` now uses `docker/build-push-action@v6` with an ECR registry-backed buildx cache (`cache-from`/`cache-to`, `mode=max`, `image-manifest=true,oci-mediatypes=true` — required for ECR to accept the cache export) instead of a plain `docker build`, so a shared-dependency change that marks every app/job Turbo-affected reuses unchanged layers instead of rebuilding all ~38 images from scratch.
- Added `.github/ecr-lifecycle-policy.json`, applied per-repository via a new `Apply ECR Lifecycle Policy` step, expiring superseded untagged cache layers after 1 day and capping `sha-*` tags at the 20 most recent.
- Preserves the existing three-tag push contract (`:${DEPLOY_TAG}`, `:sha-${github.sha}`, conditional `:latest`), the Turbo affected-target scoping, and the "image exists in ECR" version skip.
- Documented the caching behavior, the ECR manifest requirement, and the lifecycle policy in `docs/deploy.md`.

Closes #1738

## Test plan

- [x] `actionlint .github/workflows/*.yml` — same baseline shellcheck/action-metadata info findings as `main`, no new error-level findings
- [x] `npm run format:check`, `npm run lint` (0 errors), `npm run typecheck` — all pass
- [ ] On merge: verify a shared-dep deploy shows cache hits and reduced wall-clock vs. the ~23 min baseline ([run 29874378612](https://github.com/WXYC/Backend-Service/actions/runs/29874378612))
- [ ] On merge: verify a leaf-change deploy still builds only its one target and is no slower than today