### PR TITLE
fix(concerts): preserve image_url on re-upsert instead of clobbering with null

### DIFF
--- a/jobs/triangle-shows-etl/writer.ts
+++ b/jobs/triangle-shows-etl/writer.ts
@@ -27,7 +27,7 @@
  * triangle-shows' seed.
  */
 
-import { db, venues, concerts, headliningArtistIdConflictClear } from '@wxyc/database';
+import { db, venues, concerts, headliningArtistIdConflictClear, imageUrlConflictCoalesce } from '@wxyc/database';
 import { eq, sql } from 'drizzle-orm';
 
 import { clampCodePoints, type MappedEvent } from './map.js';
@@ -177,13 +177,11 @@ export const upsertConcert = async (
         title: values.title,
         supporting_artists_raw: values.supporting_artists_raw,
         ticket_url: values.ticket_url,
-        // Incoming-first COALESCE (BS#1742): a fresh scrape's image wins
-        // when present, falling back to the stored value only when the
-        // scrape came back null — a later image-less pass must never
-        // clobber a poster a previous pass captured. Argument order is the
-        // OPPOSITE of `jobs/flowsheet-linked-reenrichment/job.ts`'s
-        // keep-existing-first `album_metadata.artwork_url` COALESCE.
-        image_url: sql`COALESCE(excluded."image_url", ${concerts.image_url})`,
+        // Incoming-first COALESCE (BS#1742) — a fresh scrape's image wins,
+        // falling back to the stored value only when this pass came back
+        // null. Shared with the RHP writer; see the fragment's docstring in
+        // shared/database/src/concerts-sql.ts.
+        image_url: imageUrlConflictCoalesce(),
         event_url: values.event_url,
         price_min: values.price_min,
         price_max: values.price_max,

--- a/jobs/triangle-shows-etl/writer.ts
+++ b/jobs/triangle-shows-etl/writer.ts
@@ -177,7 +177,13 @@ export const upsertConcert = async (
         title: values.title,
         supporting_artists_raw: values.supporting_artists_raw,
         ticket_url: values.ticket_url,
-        image_url: values.image_url,
+        // Incoming-first COALESCE (BS#1742): a fresh scrape's image wins
+        // when present, falling back to the stored value only when the
+        // scrape came back null — a later image-less pass must never
+        // clobber a poster a previous pass captured. Argument order is the
+        // OPPOSITE of `jobs/flowsheet-linked-reenrichment/job.ts`'s
+        // keep-existing-first `album_metadata.artwork_url` COALESCE.
+        image_url: sql`COALESCE(excluded."image_url", ${concerts.image_url})`,
         event_url: values.event_url,
         price_min: values.price_min,
         price_max: values.price_max,

--- a/jobs/venue-events-scraper/writer.ts
+++ b/jobs/venue-events-scraper/writer.ts
@@ -14,7 +14,14 @@
  * threading state through the writer.
  */
 
-import { db, venues, concerts, nyCalendarDate, headliningArtistIdConflictClear } from '@wxyc/database';
+import {
+  db,
+  venues,
+  concerts,
+  nyCalendarDate,
+  headliningArtistIdConflictClear,
+  imageUrlConflictCoalesce,
+} from '@wxyc/database';
 import { eq, sql } from 'drizzle-orm';
 
 import type { ParsedConcert } from './rhp-types.js';
@@ -222,7 +229,8 @@ export const upsertConcert = async (
     image_url: parsed.image_url,
     // The venue's own event-detail page (BS#1609). Parsed all along but
     // dropped at write time until this column existed; refreshes on every
-    // pass like ticket_url/image_url so a moved page URL propagates.
+    // pass like ticket_url so a moved page URL propagates. (image_url is the
+    // exception — it's COALESCE-guarded in the set clause below, BS#1742.)
     event_url: parsed.event_page_url,
     raw_data: parsed.raw,
     scraped_at: new Date(scrapedAtIso),
@@ -254,13 +262,11 @@ export const upsertConcert = async (
         headlining_artist_id: headliningArtistIdConflictClear(),
         supporting_artists_raw: values.supporting_artists_raw,
         ticket_url: values.ticket_url,
-        // Incoming-first COALESCE (BS#1742): a fresh scrape's image wins
-        // when present, falling back to the stored value only when the
-        // scrape came back null — a later image-less pass must never
-        // clobber a poster a previous pass captured. Argument order is the
-        // OPPOSITE of `jobs/flowsheet-linked-reenrichment/job.ts`'s
-        // keep-existing-first `album_metadata.artwork_url` COALESCE.
-        image_url: sql`COALESCE(excluded."image_url", ${concerts.image_url})`,
+        // Incoming-first COALESCE (BS#1742) — a fresh scrape's image wins,
+        // falling back to the stored value only when this pass came back
+        // null. Shared with the triangle-shows writer; see the fragment's
+        // docstring in shared/database/src/concerts-sql.ts.
+        image_url: imageUrlConflictCoalesce(),
         event_url: values.event_url,
         raw_data: values.raw_data,
         scraped_at: values.scraped_at,

--- a/jobs/venue-events-scraper/writer.ts
+++ b/jobs/venue-events-scraper/writer.ts
@@ -254,7 +254,13 @@ export const upsertConcert = async (
         headlining_artist_id: headliningArtistIdConflictClear(),
         supporting_artists_raw: values.supporting_artists_raw,
         ticket_url: values.ticket_url,
-        image_url: values.image_url,
+        // Incoming-first COALESCE (BS#1742): a fresh scrape's image wins
+        // when present, falling back to the stored value only when the
+        // scrape came back null — a later image-less pass must never
+        // clobber a poster a previous pass captured. Argument order is the
+        // OPPOSITE of `jobs/flowsheet-linked-reenrichment/job.ts`'s
+        // keep-existing-first `album_metadata.artwork_url` COALESCE.
+        image_url: sql`COALESCE(excluded."image_url", ${concerts.image_url})`,
         event_url: values.event_url,
         raw_data: values.raw_data,
         scraped_at: values.scraped_at,

--- a/shared/database/src/concerts-sql.ts
+++ b/shared/database/src/concerts-sql.ts
@@ -31,3 +31,16 @@ import { concerts } from './schema.js';
  */
 export const headliningArtistIdConflictClear = (): SQL =>
   sql`CASE WHEN ${concerts.headlining_artist_raw} IS DISTINCT FROM excluded."headlining_artist_raw" THEN NULL ELSE ${concerts.headlining_artist_id} END`;
+
+/**
+ * ON CONFLICT `set` entry for `image_url`: keep the incoming scrape's image
+ * when it has one, but fall back to the stored value when the scrape came
+ * back null — a later image-less pass must never clobber a poster a previous
+ * pass captured (BS#1742). Incoming-first (`excluded` before the stored
+ * column) so a fresh non-null poster still wins; this is the OPPOSITE of
+ * `jobs/flowsheet-linked-reenrichment/job.ts`'s keep-existing-first
+ * `album_metadata.artwork_url` COALESCE, which treats the table as the
+ * authority once populated. As with the fragment above, table-qualified refs
+ * read the EXISTING row and `excluded` reads the proposed insert.
+ */
+export const imageUrlConflictCoalesce = (): SQL => sql`COALESCE(excluded."image_url", ${concerts.image_url})`;

--- a/tests/integration/concerts-image-url-retention.spec.js
+++ b/tests/integration/concerts-image-url-retention.spec.js
@@ -70,7 +70,10 @@ async function upsertConcert(sql, { venueId, sourceId, startsOn, headliningArtis
       starts_on = excluded."starts_on",
       headlining_artist_raw = excluded."headlining_artist_raw",
       ticket_url = excluded."ticket_url",
-      image_url = COALESCE(excluded."image_url", ${sql(SCHEMA)}."concerts"."image_url"),
+      -- Mirrors the writers' \`COALESCE(excluded."image_url", concerts."image_url")\`.
+      -- The stored row is referenced by the bare relation name (its DO UPDATE
+      -- alias), exactly as Drizzle emits it — not schema-qualified.
+      image_url = COALESCE(excluded."image_url", "concerts"."image_url"),
       last_modified = now()
   `;
 }
@@ -129,7 +132,7 @@ describe('concerts.image_url retention on re-upsert (BS#1742)', () => {
     expect(row.image_url).toBe('https://cdn.example/posters/juana-molina.jpg');
   });
 
-  test('a real image populates a previously image-less row (a fresher poster still wins)', async () => {
+  test('a real image populates a previously image-less row', async () => {
     const sourceId = SOURCE_ID_PREFIX + 'populated';
 
     await upsertConcert(sql, {
@@ -153,5 +156,40 @@ describe('concerts.image_url retention on re-upsert (BS#1742)', () => {
 
     const [row] = await sql.unsafe(`SELECT image_url FROM "${SCHEMA}".concerts WHERE source_id = $1`, [sourceId]);
     expect(row.image_url).toBe('https://cdn.example/posters/chuquimamani-condori.jpg');
+  });
+
+  // The load-bearing case for the argument order. The two tests above pass
+  // under BOTH `COALESCE(excluded, stored)` and the flipped
+  // `COALESCE(stored, excluded)` — one has a null incoming, the other a null
+  // stored, so COALESCE returns the same value regardless of order. Only when
+  // BOTH are non-null and DIFFERENT does the order decide the winner, and
+  // incoming-first (the guard under test) must let the fresher poster win.
+  // Flip the writers to keep-existing-first and ONLY this test goes red.
+  test('a fresher poster overwrites a different stored poster (incoming-first, not keep-existing)', async () => {
+    const sourceId = SOURCE_ID_PREFIX + 'refreshed';
+    const oldPoster = 'https://cdn.example/posters/jessica-pratt-old.jpg';
+    const newPoster = 'https://cdn.example/posters/jessica-pratt-new.jpg';
+
+    await upsertConcert(sql, {
+      venueId,
+      sourceId,
+      startsOn: STARTS_ON,
+      headliningArtistRaw: 'Jessica Pratt',
+      ticketUrl: 'https://tickets.example/jessica-pratt',
+      imageUrl: oldPoster,
+    });
+
+    // Re-scrape: the venue swapped in a new poster for the same event.
+    await upsertConcert(sql, {
+      venueId,
+      sourceId,
+      startsOn: STARTS_ON,
+      headliningArtistRaw: 'Jessica Pratt',
+      ticketUrl: 'https://tickets.example/jessica-pratt',
+      imageUrl: newPoster,
+    });
+
+    const [row] = await sql.unsafe(`SELECT image_url FROM "${SCHEMA}".concerts WHERE source_id = $1`, [sourceId]);
+    expect(row.image_url).toBe(newPoster);
   });
 });

--- a/tests/integration/concerts-image-url-retention.spec.js
+++ b/tests/integration/concerts-image-url-retention.spec.js
@@ -1,0 +1,157 @@
+/**
+ * Integration test for the `concerts.image_url` retention guard (BS#1742).
+ *
+ * Both concert writers (`jobs/triangle-shows-etl/writer.ts` and
+ * `jobs/venue-events-scraper/writer.ts`) UPSERT `concerts` keyed on
+ * `(source, source_id)`. Every field in their `onConflictDoUpdate` set is a
+ * plain source-authoritative overwrite EXCEPT `image_url`, which is guarded
+ * with `COALESCE(excluded."image_url", concerts.image_url)` — incoming value
+ * wins when present, falling back to the stored value only when the scrape
+ * came back with a null image. Without the guard, a later image-less scrape
+ * nulls out a poster a previous scrape had captured.
+ *
+ * Argument order matters and is the OPPOSITE of the nearest repo precedent
+ * (`jobs/flowsheet-linked-reenrichment/job.ts`'s `album_metadata.artwork_url`
+ * COALESCE, which is keep-existing-first because that writer treats the
+ * table as the authority once populated). Here the source re-scrape should
+ * win when it has a fresher image, so `excluded` goes first.
+ *
+ * Pure SQL — does NOT import either writer (the integration runner is
+ * babel-jest with no TS support); this mirrors the writers' `onConflictDoUpdate`
+ * set clause and must be kept in sync with them. Modeled on
+ * `concerts-genre-enrichment.spec.js` in shape (real `postgres()` client via
+ * `makeSql()`, source_id-prefix scoping for isolated cleanup).
+ *
+ * Needs CI to run: requires the Docker integration DB (the `pg` marker tier).
+ */
+
+const postgres = require('postgres');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const SOURCE_ID_PREFIX = 'bs1742:';
+const VENUE_SLUG = 'bs1742-probe-room';
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+/** YYYY-MM-DD for today + offsetDays, in America/New_York. */
+function isoDate(offsetDays) {
+  const d = new Date(Date.now() + offsetDays * 24 * 60 * 60 * 1000);
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(d);
+}
+
+const STARTS_ON = isoDate(10);
+
+/**
+ * UPSERT mirror of the `onConflictDoUpdate` set clause both writers share
+ * for `image_url`: source-authoritative for every other column, but
+ * `image_url` is COALESCE(excluded, stored) so a null incoming value never
+ * clobbers a previously-captured poster. Only the columns relevant to that
+ * guard are reimplemented (venue_id/starts_on/headlining_artist_raw/
+ * ticket_url as plain-overwrite contrast columns, image_url guarded).
+ */
+async function upsertConcert(sql, { venueId, sourceId, startsOn, headliningArtistRaw, ticketUrl, imageUrl }) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}."concerts"
+      (source, source_id, venue_id, starts_on, headlining_artist_raw, ticket_url, image_url, raw_data, scraped_at)
+    VALUES
+      ('triangle_shows', ${sourceId}, ${venueId}, ${startsOn}, ${headliningArtistRaw}, ${ticketUrl}, ${imageUrl}, '{}'::jsonb, now())
+    ON CONFLICT (source, source_id) DO UPDATE SET
+      venue_id = excluded."venue_id",
+      starts_on = excluded."starts_on",
+      headlining_artist_raw = excluded."headlining_artist_raw",
+      ticket_url = excluded."ticket_url",
+      image_url = COALESCE(excluded."image_url", ${sql(SCHEMA)}."concerts"."image_url"),
+      last_modified = now()
+  `;
+}
+
+describe('concerts.image_url retention on re-upsert (BS#1742)', () => {
+  let sql;
+  let venueId;
+
+  beforeAll(async () => {
+    sql = makeSql();
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".concerts WHERE source_id LIKE $1`, [`${SOURCE_ID_PREFIX}%`]);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".venues WHERE slug = $1`, [VENUE_SLUG]);
+
+    const [venue] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".venues (slug, name, city, state, address)
+       VALUES ($1, 'BS1742 Probe Room', 'Carrboro', 'NC', '300 E Main St') RETURNING id`,
+      [VENUE_SLUG]
+    );
+    venueId = venue.id;
+  });
+
+  afterAll(async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".concerts WHERE source_id LIKE $1`, [`${SOURCE_ID_PREFIX}%`]);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".venues WHERE slug = $1`, [VENUE_SLUG]);
+    await sql.end();
+  });
+
+  test('a captured poster survives a later re-scrape that comes back with a null image', async () => {
+    const sourceId = SOURCE_ID_PREFIX + 'retained';
+
+    await upsertConcert(sql, {
+      venueId,
+      sourceId,
+      startsOn: STARTS_ON,
+      headliningArtistRaw: 'Juana Molina',
+      ticketUrl: 'https://tickets.example/juana-molina',
+      imageUrl: 'https://cdn.example/posters/juana-molina.jpg',
+    });
+
+    // Re-scrape: same concert, but this pass came back with no image.
+    await upsertConcert(sql, {
+      venueId,
+      sourceId,
+      startsOn: STARTS_ON,
+      headliningArtistRaw: 'Juana Molina',
+      ticketUrl: 'https://tickets.example/juana-molina-v2',
+      imageUrl: null,
+    });
+
+    const [row] = await sql.unsafe(`SELECT ticket_url, image_url FROM "${SCHEMA}".concerts WHERE source_id = $1`, [
+      sourceId,
+    ]);
+    // The other field is plain-overwrite (proves the COALESCE isn't blanket).
+    expect(row.ticket_url).toBe('https://tickets.example/juana-molina-v2');
+    // image_url is retained despite the null incoming value.
+    expect(row.image_url).toBe('https://cdn.example/posters/juana-molina.jpg');
+  });
+
+  test('a real image populates a previously image-less row (a fresher poster still wins)', async () => {
+    const sourceId = SOURCE_ID_PREFIX + 'populated';
+
+    await upsertConcert(sql, {
+      venueId,
+      sourceId,
+      startsOn: STARTS_ON,
+      headliningArtistRaw: 'Chuquimamani-Condori',
+      ticketUrl: 'https://tickets.example/chuquimamani-condori',
+      imageUrl: null,
+    });
+
+    // Re-scrape: this pass captured a poster for the first time.
+    await upsertConcert(sql, {
+      venueId,
+      sourceId,
+      startsOn: STARTS_ON,
+      headliningArtistRaw: 'Chuquimamani-Condori',
+      ticketUrl: 'https://tickets.example/chuquimamani-condori',
+      imageUrl: 'https://cdn.example/posters/chuquimamani-condori.jpg',
+    });
+
+    const [row] = await sql.unsafe(`SELECT image_url FROM "${SCHEMA}".concerts WHERE source_id = $1`, [sourceId]);
+    expect(row.image_url).toBe('https://cdn.example/posters/chuquimamani-condori.jpg');
+  });
+});

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -426,6 +426,11 @@ export const headliningArtistIdConflictClear = (): { sql: readonly string[]; val
   values: ['<concerts.headlining_artist_raw>', '<concerts.headlining_artist_id>'],
 });
 
+export const imageUrlConflictCoalesce = (): { sql: readonly string[]; values: unknown[] } => ({
+  sql: ['COALESCE(excluded."image_url", ', ')'],
+  values: ['<concerts.image_url>'],
+});
+
 // Mock types
 export type AnonymousDevice = {
   id: number;

--- a/tests/unit/database/concerts-sql.test.ts
+++ b/tests/unit/database/concerts-sql.test.ts
@@ -7,7 +7,7 @@
  * whose sql tag returns { sql: templateStrings, values: interpolations }
  * — which makes both halves directly inspectable.
  */
-import { headliningArtistIdConflictClear } from '../../../shared/database/src/concerts-sql';
+import { headliningArtistIdConflictClear, imageUrlConflictCoalesce } from '../../../shared/database/src/concerts-sql';
 import { concerts } from '../../../shared/database/src/schema';
 
 describe('headliningArtistIdConflictClear', () => {
@@ -34,5 +34,39 @@ describe('headliningArtistIdConflictClear', () => {
 
   it('returns a fresh fragment per call (no shared mutable descriptor across upserts)', () => {
     expect(headliningArtistIdConflictClear()).not.toBe(headliningArtistIdConflictClear());
+  });
+});
+
+describe('imageUrlConflictCoalesce', () => {
+  it('builds COALESCE(excluded, stored): the incoming scrape image, then the stored fallback', () => {
+    const frag = imageUrlConflictCoalesce() as unknown as {
+      sql: readonly string[];
+      values: unknown[];
+    };
+    const text = frag.sql.join('<col>');
+
+    expect(text).toBe('COALESCE(excluded."image_url", <col>)');
+  });
+
+  it('is incoming-first, NOT keep-existing-first: excluded precedes the stored-row column', () => {
+    // The load-bearing invariant (BS#1742). Flipping to the
+    // flowsheet-linked-reenrichment keep-existing-first order
+    // (COALESCE(stored, excluded)) would let a stale poster win and turn
+    // this assertion red. `excluded."image_url"` must come BEFORE the
+    // interpolated stored column.
+    const frag = imageUrlConflictCoalesce() as unknown as {
+      sql: readonly string[];
+      values: unknown[];
+    };
+    const text = frag.sql.join('<col>');
+
+    expect(text.indexOf('excluded."image_url"')).toBeLessThan(text.indexOf('<col>'));
+    // The single interpolation is the stored-row column (the fallback arg).
+    expect(frag.values).toHaveLength(1);
+    expect(frag.values[0]).toBe(concerts.image_url);
+  });
+
+  it('returns a fresh fragment per call (no shared mutable descriptor across upserts)', () => {
+    expect(imageUrlConflictCoalesce()).not.toBe(imageUrlConflictCoalesce());
   });
 });


### PR DESCRIPTION
## Summary

- Both concert writers (`jobs/triangle-shows-etl/writer.ts`, `jobs/venue-events-scraper/writer.ts`) overwrote `concerts.image_url` on every re-upsert with whatever the source scrape currently handed over. Since the upstream scrapers are best-effort, a later image-less scrape nulled out a poster a previous scrape had captured.
- Guards `image_url` ONLY with `image_url: sql\`COALESCE(excluded."image_url", ${concerts.image_url})\`` in both writers' `onConflictDoUpdate` set — incoming value wins when present, falling back to the stored value only when the scrape came back null. Every other field in the `set` stays a plain source-authoritative overwrite (deliberately not blanket-COALESCE'd).
- Argument order is the OPPOSITE of the nearest repo precedent (`jobs/flowsheet-linked-reenrichment/job.ts`'s keep-existing-first `album_metadata.artwork_url` COALESCE) — here a re-scrape with a fresher poster should win, so `excluded` goes first.
- No migration; pure query-semantics change.

## Test plan

- [x] New real-Postgres integration spec `tests/integration/concerts-image-url-retention.spec.js` (modeled on `tests/integration/concerts-genre-enrichment.spec.js` — real `postgres()` client, `pg` marker tier, source_id-prefix scoping). Re-implements the writers' shared `image_url` COALESCE clause (the unit tier mocks `@wxyc/database` and can't evaluate SQL).
  - Case 1: upsert with an image, re-upsert same concert with `image_url = null` → image retained.
  - Case 2: upsert with `image_url = null`, re-upsert with a real image → image populated.
  - Verified TDD red/green: reverted the spec's COALESCE to a plain `excluded` overwrite locally and confirmed case 1 fails for the expected reason (`Received: null`), then restored it and confirmed both cases pass.
- [x] `npm run test:unit` — 329 suites / 4971 tests passed (includes both writers' existing unit suites, unaffected by this change).
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` — all clean (pre-push hook also ran `check:docs` / `check:auth-tables-doc`; only pre-existing, unrelated findings).
- [x] `npx tsc --noEmit` against both jobs' own `tsconfig.json` (the root `typecheck` script doesn't cover `jobs/*`) — clean.
- [x] Integration tier: stood up an isolated Postgres container (default CI port 5433 was already bound to an unrelated local process, so used a scratch container on 15433) + the mock-api/auth/backend services per `.github/workflows/test.yml`'s integration-tests job recipe, ran migrations via `dev_env/init-db.mjs`, and executed the new spec plus the closest siblings for regression coverage: `concerts-image-url-retention.spec.js`, `concerts-genre-enrichment.spec.js`, `concerts.spec.js`, `concerts-by-id.spec.js`, `flowsheet-upcoming-show.spec.js` — 62 tests, all green. Scratch container + processes torn down after the run; nothing left running.

Closes #1742

Epic: #1588
Blocks: #1743 (poster-art enrichment/backfill — writes into `concerts.image_url`, depends on this guard)