### PR TITLE
fix(flowsheet): show WXYC for an anonymous human on air instead of AUTO DJ

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -156,9 +156,11 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
   // `on_air` lets clients render the on-air banner without scanning the fetched
   // entry window for a show_start marker (which can fall outside a 30-entry
   // page). Three states, matching wxyc-shared api.yaml FlowsheetV2PaginatedResponse:
-  // an OnAirInfo object = a named DJ is live; `null` = confirmed automation; the
-  // field ABSENT = the banner query failed (unknown). Only the default paginated
-  // branch carries it — the iOS app polls this branch.
+  // an OnAirInfo object = a human is live (a resolved DJ handle, or the "WXYC"
+  // station brand when the open show has no resolvable name — see
+  // getOnAirDJName); `null` = confirmed automation; the field ABSENT = the banner
+  // query failed (unknown). Only the default paginated branch carries it — the
+  // iOS app polls this branch.
   //
   // Freshness note: this route is wrapped in conditionalGet(getLastModifiedAt),
   // which 304s on the flowsheet watermark. A rare `on_air` change that writes no

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -892,7 +892,16 @@ export const getLatestShow = async (): Promise<Show | undefined> => {
 };
 
 /**
- * Resolve the display name of the DJ currently on air, or `null` when the
+ * Display name shown on air for a live show whose DJ we cannot name — an
+ * anonymous human at the controls. The most common cause is a tubafrenzy
+ * sign-on with a blank `djHandle`, which leaves `shows.legacy_dj_name` null:
+ * a human is genuinely live, we just don't have their handle. We surface the
+ * station brand rather than lie about automation. See `getOnAirDJName`.
+ */
+export const ANONYMOUS_ON_AIR_NAME = 'WXYC';
+
+/**
+ * Resolve the display name of whoever is currently on air, or `null` when the
  * station is on automation.
  *
  * Backs the `on_air` field on the default paginated GET /flowsheet response.
@@ -901,29 +910,41 @@ export const getLatestShow = async (): Promise<Show | undefined> => {
  * (`dj_name_override` → primary DJ's `user.djName` → `legacy_dj_name`) used to
  * denormalize DJ names onto flowsheet rows.
  *
+ * The invariant callers rely on: **an open show is a human on air, so it always
+ * returns a non-null name; `null` is reserved exclusively for automation (no
+ * open show).** When the open show has no resolvable name — an anonymous human,
+ * e.g. a tubafrenzy sign-on with a blank `djHandle` — this returns
+ * `ANONYMOUS_ON_AIR_NAME` ("WXYC") rather than `null`. Downstream, a name
+ * renders the banner and `null` renders "AUTO DJ"; collapsing the anonymous
+ * case to `null` was the "AUTO DJ while a human DJ is live" bug for handleless
+ * sign-ons.
+ *
  * Deliberately does NOT consult the `show_djs` join table the way
  * `getDJsInCurrentShow`/`getOnAirStatusForDJ` do: tubafrenzy-mirrored shows have
  * no `show_djs` rows (the DJ has no Backend-Service account), so a join-table
- * read reports automation for essentially every legacy live show — the "AUTO DJ
- * while a human DJ is live" bug. `legacy_dj_name` is the authoritative identity
- * for those shows, and `resolveDjNameForShow` already reads it.
+ * read reports automation for essentially every legacy live show — the same
+ * class of bug. `legacy_dj_name` is the authoritative identity for those shows,
+ * and `resolveDjNameForShow` already reads it.
  *
  * Known limitation (inherited from the `getLatestShow`-based on-air endpoints):
  * legacy/tubafrenzy shows are created open (`end_time: null`) and closed later by
  * the ETL. Between a legacy show actually ending and the ETL stamping `end_time`,
- * this reports that DJ as live — i.e. `on_air` can name a just-departed DJ during
- * real automation. That is the lesser evil versus the false-"Auto DJ" bug this
- * fixes, and it is the practical limit of the "`null` means automation" guarantee.
+ * this reports that show as live — i.e. `on_air` can name a just-departed DJ (or
+ * "WXYC") during real automation. That is the lesser evil versus the
+ * false-"Auto DJ" bug, and it is the practical limit of the "`null` means
+ * automation" guarantee.
  *
- * @returns the on-air DJ's display name, or `null` when no show is open or the
- *   open show has no resolvable name.
+ * @returns the on-air display name — a resolved DJ handle, or
+ *   `ANONYMOUS_ON_AIR_NAME` when the open show has no resolvable name — or
+ *   `null` only when no show is open (automation).
  */
 export const getOnAirDJName = async (): Promise<string | null> => {
   const latest_show = await getLatestShow();
   if (!latest_show || latest_show.end_time !== null) {
     return null;
   }
-  return await resolveDjNameForShow(latest_show);
+  const resolved = (await resolveDjNameForShow(latest_show))?.trim();
+  return resolved && resolved.length > 0 ? resolved : ANONYMOUS_ON_AIR_NAME;
 };
 
 /**

--- a/tests/unit/services/flowsheet.getOnAirDJName.test.ts
+++ b/tests/unit/services/flowsheet.getOnAirDJName.test.ts
@@ -17,7 +17,7 @@
 import { jest } from '@jest/globals';
 
 import { db } from '@wxyc/database';
-import { getOnAirDJName } from '../../../apps/backend/services/flowsheet.service';
+import { ANONYMOUS_ON_AIR_NAME, getOnAirDJName } from '../../../apps/backend/services/flowsheet.service';
 
 const mockDb = db as unknown as { _chain: Record<string, jest.Mock> };
 const chain = mockDb._chain;
@@ -46,10 +46,21 @@ describe('getOnAirDJName', () => {
     expect(await getOnAirDJName()).toBe('DJ HOUNDSTOOTH');
   });
 
-  it('returns null for an open show with no resolvable DJ name', async () => {
+  it('returns the WXYC station brand for an open show with no resolvable DJ name — an anonymous human at the controls', async () => {
+    // A tubafrenzy sign-on with a blank djHandle leaves legacy_dj_name null. A
+    // human is still live, so the banner must read "WXYC", not falsely claim
+    // automation (which is what a null return renders as "AUTO DJ" downstream).
     queueLimit([{ id: 3, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: null }]);
 
-    expect(await getOnAirDJName()).toBeNull();
+    expect(await getOnAirDJName()).toBe(ANONYMOUS_ON_AIR_NAME);
+  });
+
+  it('returns the WXYC station brand for an open show whose legacy_dj_name is blank/whitespace', async () => {
+    // resolveDjNameForShow can return an empty or whitespace legacy_dj_name
+    // verbatim; that is still an anonymous human, not automation.
+    queueLimit([{ id: 6, end_time: null, primary_dj_id: null, dj_name_override: null, legacy_dj_name: '   ' }]);
+
+    expect(await getOnAirDJName()).toBe(ANONYMOUS_ON_AIR_NAME);
   });
 
   it('returns null when the latest show has already ended (end_time set) — automation', async () => {


### PR DESCRIPTION
## Problem

The on-air banner shows **AUTO DJ** while a human DJ is live, whenever that DJ signed on without a handle. Observed live 2026-07-22: a DJ signed on at 9:04 AM ET and ~2h later the iOS banner still read "AUTO DJ".

`getOnAirDJName` returned `null` both when no show is open (real automation) **and** when an open show has no resolvable DJ name (a human is live, we just lack their handle). `on_air` collapses both to `null`, which every client renders as "AUTO DJ". A tubafrenzy sign-on with a blank `djHandle` leaves `legacy_dj_name` null, so a handleless human gets an "AUTO DJ" banner. This is the residue of #1723 that the webhook heal can't cover — it carries a handle faster but can't invent one that doesn't exist.

## Change

Split the two cases. An **open show is always a human on air** and now returns a non-null name — the resolved handle, or the `"WXYC"` station brand (`ANONYMOUS_ON_AIR_NAME`) when the handle is blank/whitespace. `null` becomes the sole automation signal.

Backend-only: the controller already maps a truthy name to `on_air.dj_name`, so iOS / archive / Android / dj-site render "WXYC" with **no `api.yaml` change and no client change**.

## Testing

TDD. New unit cases for the anonymous-human and blank/whitespace paths (`tests/unit/services/flowsheet.getOnAirDJName.test.ts`); the ended-show / no-show cases keep returning `null`. Full flowsheet controller+service unit suite (84 tests), `npm run typecheck`, and `eslint` all green locally.

Closes #1751
