### PR TITLE
feat(enrichment-worker): cache-first LML skip on confirmed load-bearing album_metadata (B1)

### DIFF
--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -60,6 +60,7 @@ import { EMPTY_OUTCOME_FINGERPRINT, classifyEmptyCause, isEmptyOutcome } from '.
 // the BS#1311 volume-control decision is co-located with the call site.
 const SUPPRESSED_EMPTY_CAUSES: ReadonlySet<ReturnType<typeof classifyEmptyCause>> = new Set(['lml_no_match']);
 import { finalizeRow, type FinalizeOutcome } from './enrich.js';
+import { finalizeFromCachedMetadata, hasLoadBearingAlbumMetadata } from './precheck.js';
 
 /**
  * Budget for the CDC consumer's lookup. Tracks the shared client's 30 s
@@ -184,6 +185,22 @@ async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
         const claim = await claimRowForEnrichment(candidate.id);
         if (!claim.claimed) {
           span.setAttribute('enrichment.outcome', 'claim_lost');
+          return;
+        }
+
+        // B1 (BS#1747): cache-first. Only linked rows (album_id non-null)
+        // have an album_metadata row to consult. Skip the LML call only when
+        // a load-bearing field (artwork_url / discogs_url) is already
+        // non-null — a real, persisted Discogs match. Null and
+        // search-URL-only shells fall through and still call LML, so a false
+        // no-match written during a cold-cache degradation window self-heals
+        // (BS#1089 negative-cache-poisoning guard — see precheck.ts). This is
+        // the largest LML call-count cut in the latency plan: it kills the
+        // 50×/album amplifier where a release played 50× paid 50 cold lookups.
+        if (candidate.album_id !== null && (await hasLoadBearingAlbumMetadata(candidate.album_id))) {
+          const cacheOutcome = await finalizeFromCachedMetadata(candidate);
+          span.setAttribute('enrichment.outcome', cacheOutcome);
+          span.setAttribute('enrichment.lml_skipped', true);
           return;
         }
 

--- a/apps/enrichment-worker/precheck.ts
+++ b/apps/enrichment-worker/precheck.ts
@@ -1,0 +1,93 @@
+/**
+ * Cache-first pre-check for the enrichment consumer (B1 / BS#1747, under
+ * Epic C #877).
+ *
+ * The CDC worker issued one LML lookup per new flowsheet row with no
+ * `album_metadata` pre-check, so a release played 50× paid 50 cold lookups.
+ * Epic D (#899) collapsed the per-play *writes* — the worker now UPSERTs
+ * `album_metadata` once per album — but not the per-play *LML call*. B1
+ * closes that gap at the call level: read `album_metadata` for the row's
+ * album before calling LML and skip the call when the album already carries
+ * a load-bearing field. This is the single largest LML call-count cut in the
+ * latency plan (it kills the 50×/album amplifier).
+ *
+ * Regression safety — BS#1089 negative-cache poisoning (MUST HOLD):
+ *   A naive "skip if any `album_metadata` row exists" would freeze a false
+ *   no-match forever. The no-match arm of `enrich.ts` writes an
+ *   `album_metadata` row carrying ONLY the four synthesized search URLs
+ *   (`spotify_url` / `youtube_music_url` / `bandcamp_url` / `soundcloud_url`)
+ *   and leaves `artwork_url` / `discogs_url` NULL. Such a shell — or a null
+ *   `artwork_url` written during a cold-cache degradation window — is exactly
+ *   the state that must keep re-calling LML so it self-heals. So the skip
+ *   keys on a confirmed non-null *load-bearing* field only.
+ *
+ * Load-bearing fields: `artwork_url` and `discogs_url`. These are the
+ * `album_metadata` columns that carry a real, resolved Discogs match (a
+ * cover image or a canonical release URL). The BS#1747 body names the LML
+ * triad `discogs_url` / `release_id` / `artwork_url`; `album_metadata` has no
+ * `release_id` column — the release identity is carried by `discogs_url`
+ * (the `.../release/<id>` URL) — so the two persisted columns are the
+ * complete load-bearing set here. The four search-URL columns are
+ * deliberately excluded: they are synthesized locally on every no-match and
+ * so never distinguish a real match from a poisoned shell.
+ */
+
+import { and, eq, isNotNull, or } from 'drizzle-orm';
+import { album_metadata, db, flowsheet } from '@wxyc/database';
+
+import { resolveComposer, type EnrichRow } from './enrich.js';
+
+/**
+ * True when the album already has a persisted, load-bearing Discogs match in
+ * `album_metadata` — i.e. `artwork_url` OR `discogs_url` is non-null. False
+ * when the row is missing, all-null, or a search-URL-only shell, so the
+ * caller re-calls LML and the false no-match self-heals (BS#1089 guard).
+ *
+ * Only linked rows (flowsheet `album_id` non-null) have an `album_metadata`
+ * row to consult; the caller gates on that before invoking this.
+ */
+export async function hasLoadBearingAlbumMetadata(albumId: number): Promise<boolean> {
+  const rows = await db
+    .select({ album_id: album_metadata.album_id })
+    .from(album_metadata)
+    .where(
+      and(
+        eq(album_metadata.album_id, albumId),
+        or(isNotNull(album_metadata.artwork_url), isNotNull(album_metadata.discogs_url))
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+export type CacheHitOutcome = 'cache_hit' | 'cache_hit_raced';
+
+/**
+ * Finalize an enriching row from already-cached `album_metadata` — the skip
+ * path. No `album_metadata` write happens: the album-level columns are
+ * already populated (that's why we skipped LML). We only flip the flowsheet
+ * row's `metadata_status` off `'enriching'` to a terminal `'enriched_match'`
+ * so the C6 stranded-claim sweep (#895) doesn't revert it and re-drive a
+ * lookup, and we stamp the per-playcut composer.
+ *
+ * Composer resolves via the artist-as-proxy fallback (BS#1499's dominant
+ * ~79% case): the skip trades the small chance of surfacing per-playcut
+ * Discogs writer credits on a repeat play for eliminating the 50×/album LML
+ * amplifier. `resolveComposer(row, null)` is the identical value the
+ * no-credit LML arms already write, so the skip stays consistent with the
+ * full path.
+ *
+ * The WHERE narrows by `metadata_status = 'enriching'` (the same idempotency
+ * guard `finalizeRow` uses): if a sibling worker or the C6 sweep already
+ * moved the row off `'enriching'`, the UPDATE matches 0 rows and we report
+ * `'cache_hit_raced'`.
+ */
+export async function finalizeFromCachedMetadata(row: EnrichRow): Promise<CacheHitOutcome> {
+  const { composer, composer_source } = resolveComposer(row, null);
+  const updated = await db
+    .update(flowsheet)
+    .set({ metadata_status: 'enriched_match', composer, composer_source })
+    .where(and(eq(flowsheet.id, row.id), eq(flowsheet.metadata_status, 'enriching')))
+    .returning({ id: flowsheet.id });
+  return updated.length === 0 ? 'cache_hit_raced' : 'cache_hit';
+}

--- a/tests/integration/enrichment-worker-cache-precheck.spec.js
+++ b/tests/integration/enrichment-worker-cache-precheck.spec.js
@@ -1,0 +1,162 @@
+/**
+ * Integration test for the enrichment worker's cache-first pre-check
+ * (B1 / BS#1747, under Epic C #877).
+ *
+ * B1 reads `album_metadata` for a linked flowsheet row's album BEFORE calling
+ * LML and skips the call only when a load-bearing field (`artwork_url` /
+ * `discogs_url`) is already non-null. This spec validates the exact SQL
+ * predicate that decision keys on, against the live `album_metadata` table
+ * (FK to `library`, PK on `album_id`, the real column NULLability).
+ *
+ * The regression this locks down is BS#1089 negative-cache poisoning: the
+ * no-match arm of `enrich.ts` writes an `album_metadata` row carrying ONLY
+ * the four synthesized search URLs and leaves `artwork_url` / `discogs_url`
+ * NULL. A naive "skip if any row exists" would freeze that false no-match
+ * forever. The predicate under test MUST return false for such a shell (and
+ * for an all-null row, and for a missing row) so the worker re-calls LML and
+ * the row self-heals — and true ONLY when a real, persisted match is present.
+ *
+ * Pure SQL — does NOT import `apps/enrichment-worker/precheck.ts`. The
+ * integration runner is babel-jest with no TS support (drizzle-orm + ts-jest
+ * incompatibility; see `enrichment-worker-claim.spec.js` and
+ * `album-metadata-upsert.spec.js` headers). The `hasLoadBearingMetadata`
+ * helper is the shared canonical mirror of the TS SELECT in
+ * `tests/utils/enrichment-precheck.js`; when `precheck.ts` is hand-edited
+ * that helper must follow. Division of responsibility:
+ *   - Unit (tests/unit/apps/enrichment-worker/cache-precheck.test.ts):
+ *     the handler honors the pre-check verdict — skip vs. re-call LML.
+ *   - Integration (this file): the SQL predicate's verdict for each real
+ *     album_metadata shape.
+ *
+ * @see WXYC/Backend-Service#1747
+ * @see WXYC/Backend-Service#1089
+ */
+
+const { getTestDb } = require('../utils/db');
+const { hasLoadBearingMetadata } = require('../utils/enrichment-precheck');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * Insert a fresh library album to act as the album_metadata FK target.
+ * Mirrors `album-metadata-upsert.spec.js#insertLibraryAlbum`: the seeded
+ * fixture guarantees artist_id 1, genre_id 11, format_id 1 exist. Returns the
+ * new id.
+ */
+async function insertLibraryAlbum(sql, suffix) {
+  const rows = await sql`
+    INSERT INTO ${sql(SCHEMA)}.library
+      (artist_id, genre_id, format_id, album_title, code_number, artist_name)
+    VALUES
+      (1, 11, 1, ${'b1-precheck-test-album-' + suffix}, 9999, 'Stereolab')
+    RETURNING id
+  `;
+  return rows[0].id;
+}
+
+describe('enrichment-worker cache-first pre-check predicate (real PG)', () => {
+  let sql;
+  /** album_ids inserted; deleted in afterAll regardless of pass/fail. */
+  const insertedAlbumIds = [];
+
+  beforeAll(() => {
+    sql = getTestDb();
+  });
+
+  afterAll(async () => {
+    if (insertedAlbumIds.length > 0) {
+      // album_metadata FK cascades on delete from library; delete it first
+      // explicitly in case the FK is ever loosened.
+      await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${insertedAlbumIds})`;
+      await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${insertedAlbumIds})`;
+    }
+    // Pool is shared with the rest of the integration suite; do NOT close it.
+  });
+
+  test('SKIP: non-null artwork_url is load-bearing → true', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'artwork');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url, updated_at)
+      VALUES (${albumId}, 'https://i.discogs.com/b1/cover.jpg', NOW())
+    `;
+
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+
+  test('SKIP: non-null discogs_url is load-bearing → true', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'discogs');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, discogs_url, updated_at)
+      VALUES (${albumId}, 'https://www.discogs.com/release/12345', NOW())
+    `;
+
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+
+  test('SELF-HEAL: missing album_metadata row → false (worker calls LML)', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'missing');
+    insertedAlbumIds.push(albumId);
+    // No album_metadata row inserted.
+
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
+  });
+
+  test('SELF-HEAL: all-null-load-bearing row → false (worker calls LML)', async () => {
+    const albumId = await insertLibraryAlbum(sql, 'all-null');
+    insertedAlbumIds.push(albumId);
+    // Row exists but both load-bearing columns are NULL (e.g. a row that only
+    // ever recorded release_year, or a torn write).
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, release_year, updated_at)
+      VALUES (${albumId}, 2022, NOW())
+    `;
+
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
+  });
+
+  test('SELF-HEAL (BS#1089 guard): search-URL-only shell → false (worker calls LML)', async () => {
+    // The exact shape enrich.ts's linked no-match arm writes: the four
+    // synthesized search URLs, both load-bearing columns NULL. This is the
+    // poisoned no-match that must NOT be frozen — the predicate returns false
+    // so the worker re-calls LML and the row self-heals.
+    const albumId = await insertLibraryAlbum(sql, 'search-shell');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, spotify_url, youtube_music_url, bandcamp_url, soundcloud_url, updated_at)
+      VALUES
+        (${albumId},
+         'https://open.spotify.com/search/Stereolab%20Aluminum%20Tunes',
+         'https://music.youtube.com/search?q=Stereolab%20Aluminum%20Tunes',
+         'https://bandcamp.com/search?q=Stereolab%20Aluminum%20Tunes',
+         'https://soundcloud.com/search?q=Stereolab%20Aluminum%20Tunes',
+         NOW())
+    `;
+
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
+  });
+
+  test('SKIP: a shell later healed to carry artwork_url flips false → true', async () => {
+    // End-to-end of the self-heal contract at the predicate layer: a poisoned
+    // search-URL-only shell reads false (re-call), then once LML resolves a
+    // real match and the load-bearing column is populated, the predicate
+    // reads true (subsequent plays skip). No frozen false no-match.
+    const albumId = await insertLibraryAlbum(sql, 'heal-flip');
+    insertedAlbumIds.push(albumId);
+    await sql`
+      INSERT INTO ${sql(SCHEMA)}.album_metadata
+        (album_id, spotify_url, updated_at)
+      VALUES (${albumId}, 'https://open.spotify.com/search/Stereolab', NOW())
+    `;
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(false);
+
+    await sql`
+      UPDATE ${sql(SCHEMA)}.album_metadata
+         SET artwork_url = 'https://i.discogs.com/b1/healed.jpg', updated_at = NOW()
+       WHERE album_id = ${albumId}
+    `;
+    expect(await hasLoadBearingMetadata(sql, albumId)).toBe(true);
+  });
+});

--- a/tests/unit/apps/enrichment-worker/cache-precheck.test.ts
+++ b/tests/unit/apps/enrichment-worker/cache-precheck.test.ts
@@ -91,15 +91,11 @@ const makeCandidate = (overrides: Record<string, unknown> = {}) => ({
 
 const driveOneTick = async (candidate: ReturnType<typeof makeCandidate>): Promise<SpanLike> => {
   const span: SpanLike = { setAttribute: jest.fn() };
-  (Sentry.startSpan as jest.Mock).mockImplementation(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (_opts: unknown, fn: any) => fn(span)
-  );
+  (Sentry.startSpan as jest.Mock).mockImplementation((_opts: unknown, fn: any) => fn(span));
   mockFilterForEnrichment.mockReturnValueOnce(candidate);
   mockClaimRowForEnrichment.mockResolvedValueOnce({ claimed: true, id: candidate.id });
 
   const handler = makeEnrichmentHandler();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   handler({} as any);
   await new Promise((resolve) => setImmediate(resolve));
   return span;

--- a/tests/unit/apps/enrichment-worker/cache-precheck.test.ts
+++ b/tests/unit/apps/enrichment-worker/cache-precheck.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for the enrichment worker's cache-first pre-check (B1 /
+ * BS#1747, under Epic C #877).
+ *
+ * The CDC worker used to issue one LML lookup per new flowsheet row with no
+ * `album_metadata` pre-check, so a release played 50× paid 50 cold lookups
+ * (Epic D collapsed the per-play *writes* but not the per-play *LML calls*).
+ * B1 reads `album_metadata` for the row's album before calling LML and skips
+ * the call when the album already carries a load-bearing field.
+ *
+ * The regression this test locks down (BS#1089 negative-cache poisoning): a
+ * naive "skip if any album_metadata row exists" would freeze a false
+ * no-match forever — a null `artwork_url` written during a cold-cache
+ * degradation window would never be retried. The skip therefore keys on a
+ * confirmed non-null load-bearing field (`artwork_url` / `discogs_url`); null
+ * and search-URL-only shells still call LML so they self-heal. That decision
+ * lives in `precheck.ts#hasLoadBearingAlbumMetadata`; here we pin that the
+ * handler honors its verdict:
+ *   - verdict true  → LML is NOT called, the row is finalized from cache.
+ *   - verdict false → LML IS called (self-heal path).
+ *   - album_id null → the pre-check is not even consulted (unlinked rows have
+ *     no album_metadata row); LML is always called.
+ *
+ * The SQL contract of `hasLoadBearingAlbumMetadata` itself (which column
+ * shapes count as load-bearing vs. a self-heal-eligible shell) is validated
+ * against real PostgreSQL in
+ * `tests/integration/enrichment-worker-cache-precheck.spec.js`.
+ */
+
+import { jest } from '@jest/globals';
+
+jest.mock('@sentry/node', () => ({
+  startSpan: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+const mockLookupMetadata = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+jest.mock('@wxyc/lml-client', () => ({
+  lookupMetadata: mockLookupMetadata,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+const mockClaimRowForEnrichment =
+  jest.fn<(id: number) => Promise<{ claimed: true; id: number } | { claimed: false }>>();
+jest.mock('../../../../apps/enrichment-worker/claim.js', () => ({
+  claimRowForEnrichment: mockClaimRowForEnrichment,
+}));
+
+const mockFilterForEnrichment = jest.fn<(event: unknown) => unknown>();
+jest.mock('../../../../apps/enrichment-worker/cdc-subscriber.js', () => ({
+  filterForEnrichment: mockFilterForEnrichment,
+}));
+
+// Stub finalizeRow (the LML-path finalize) but keep the real extractArtwork
+// that empty-outcome.ts re-imports.
+const mockFinalizeRow = jest.fn<(...args: unknown[]) => Promise<string>>();
+jest.mock('../../../../apps/enrichment-worker/enrich.js', () => {
+  const actual = jest.requireActual<typeof import('../../../../apps/enrichment-worker/enrich')>(
+    '../../../../apps/enrichment-worker/enrich'
+  );
+  return { ...actual, finalizeRow: mockFinalizeRow };
+});
+
+// The pre-check module under test at the seam. Both functions are mocked so
+// this file exercises only the handler's branching; their DB behavior is
+// covered by the integration spec + precheck.test.ts.
+const mockHasLoadBearingAlbumMetadata = jest.fn<(albumId: number) => Promise<boolean>>();
+const mockFinalizeFromCachedMetadata = jest.fn<(...args: unknown[]) => Promise<string>>();
+jest.mock('../../../../apps/enrichment-worker/precheck.js', () => ({
+  hasLoadBearingAlbumMetadata: mockHasLoadBearingAlbumMetadata,
+  finalizeFromCachedMetadata: mockFinalizeFromCachedMetadata,
+}));
+
+import * as Sentry from '@sentry/node';
+
+import { makeEnrichmentHandler } from '../../../../apps/enrichment-worker/handler';
+
+type SpanLike = { setAttribute: jest.Mock };
+
+const makeCandidate = (overrides: Record<string, unknown> = {}) => ({
+  id: 42,
+  entry_type: 'track' as const,
+  metadata_status: 'pending' as const,
+  artist_name: 'Juana Molina',
+  album_title: 'DOGA',
+  track_title: 'la paradoja',
+  album_id: 7 as number | null,
+  ...overrides,
+});
+
+const driveOneTick = async (candidate: ReturnType<typeof makeCandidate>): Promise<SpanLike> => {
+  const span: SpanLike = { setAttribute: jest.fn() };
+  (Sentry.startSpan as jest.Mock).mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (_opts: unknown, fn: any) => fn(span)
+  );
+  mockFilterForEnrichment.mockReturnValueOnce(candidate);
+  mockClaimRowForEnrichment.mockResolvedValueOnce({ claimed: true, id: candidate.id });
+
+  const handler = makeEnrichmentHandler();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler({} as any);
+  await new Promise((resolve) => setImmediate(resolve));
+  return span;
+};
+
+const matchResponse = {
+  results: [
+    {
+      artwork: {
+        artwork_url: 'https://i.discogs.com/abc/cover.jpg',
+        release_url: 'https://discogs.com/release/123',
+      },
+    },
+  ],
+};
+
+describe('enrichment-worker cache-first pre-check (B1 / BS#1747)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips the LML call when album_metadata already carries a load-bearing field', async () => {
+    mockHasLoadBearingAlbumMetadata.mockResolvedValueOnce(true);
+    mockFinalizeFromCachedMetadata.mockResolvedValueOnce('cache_hit');
+
+    const span = await driveOneTick(makeCandidate({ album_id: 7 }));
+
+    expect(mockHasLoadBearingAlbumMetadata).toHaveBeenCalledWith(7);
+    expect(mockLookupMetadata).not.toHaveBeenCalled();
+    expect(mockFinalizeFromCachedMetadata).toHaveBeenCalledTimes(1);
+    expect(span.setAttribute).toHaveBeenCalledWith('enrichment.outcome', 'cache_hit');
+    expect(span.setAttribute).toHaveBeenCalledWith('enrichment.lml_skipped', true);
+  });
+
+  it('still calls LML when the album row is a self-heal-eligible shell (verdict false)', async () => {
+    // BS#1089 regression guard: a null / search-URL-only album_metadata row
+    // must NOT freeze a false no-match. The pre-check returns false, so the
+    // worker re-calls LML.
+    mockHasLoadBearingAlbumMetadata.mockResolvedValueOnce(false);
+    mockLookupMetadata.mockResolvedValueOnce(matchResponse);
+    mockFinalizeRow.mockResolvedValueOnce('enriched_match');
+
+    const span = await driveOneTick(makeCandidate({ album_id: 7 }));
+
+    expect(mockHasLoadBearingAlbumMetadata).toHaveBeenCalledWith(7);
+    expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    expect(mockFinalizeFromCachedMetadata).not.toHaveBeenCalled();
+    expect(span.setAttribute).toHaveBeenCalledWith('enrichment.outcome', 'enriched_match');
+  });
+
+  it('does not consult the pre-check for unlinked rows (album_id null) and always calls LML', async () => {
+    mockLookupMetadata.mockResolvedValueOnce(matchResponse);
+    mockFinalizeRow.mockResolvedValueOnce('enriched_match');
+
+    await driveOneTick(makeCandidate({ album_id: null }));
+
+    expect(mockHasLoadBearingAlbumMetadata).not.toHaveBeenCalled();
+    expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/utils/enrichment-precheck.js
+++ b/tests/utils/enrichment-precheck.js
@@ -1,0 +1,42 @@
+/**
+ * Shared test helper for the enrichment worker's cache-first pre-check
+ * (B1 / BS#1747).
+ *
+ * `hasLoadBearingMetadata` is the ONE canonical mirror of the SELECT in
+ * `apps/enrichment-worker/precheck.ts#hasLoadBearingAlbumMetadata`. The
+ * integration runner is babel-jest with no TS support (drizzle-orm + ts-jest
+ * incompatibility; see `enrichment-worker-claim.spec.js` header and the
+ * sibling `enrichment-claim.js`), so the SQL is duplicated from the TS source
+ * rather than imported — and kept in exactly one place so a hand-edit to the
+ * predicate is chased through one file.
+ *
+ * The predicate is the load-bearing test the worker uses to decide whether to
+ * skip the LML call: skip only when `artwork_url` OR `discogs_url` is
+ * non-null. The four synthesized search-URL columns are deliberately NOT part
+ * of the predicate — a search-URL-only shell is the BS#1089 poisoned-null
+ * shape that must keep re-calling LML to self-heal.
+ */
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+
+/**
+ * Return true iff the album already has a persisted load-bearing Discogs
+ * match in `album_metadata` (`artwork_url` OR `discogs_url` non-null).
+ *
+ * @param {import('postgres').Sql} sql - the shared test pool from `getTestDb()`.
+ * @param {number} albumId - the `album_metadata.album_id` (== `library.id`).
+ * @returns {Promise<boolean>} true → the worker skips LML; false → it calls
+ *   LML (self-heal path).
+ */
+async function hasLoadBearingMetadata(sql, albumId) {
+  const rows = await sql`
+    SELECT 1
+      FROM ${sql(SCHEMA)}.album_metadata
+     WHERE album_id = ${albumId}
+       AND (artwork_url IS NOT NULL OR discogs_url IS NOT NULL)
+     LIMIT 1
+  `;
+  return rows.length > 0;
+}
+
+module.exports = { hasLoadBearingMetadata };


### PR DESCRIPTION
## What

Lever B1 of the enrichment latency plan (Epic C, #877). The CDC enrichment worker now reads `album_metadata` for a linked flowsheet row's album **before** calling LML, and skips the LML call **only when a load-bearing field (`artwork_url` / `discogs_url`) is already non-null** — a real, persisted Discogs match. On a hit the row is finalized straight from cache (flowsheet `metadata_status` → `enriched_match`, artist-as-proxy composer); no `album_metadata` write.

Today the worker issues one LML call per new flowsheet row with no `album_metadata` pre-check, so a release played 50× pays 50 cold lookups. Epic D (#899) collapsed the per-play *writes* (UPSERT once per album) but not the per-play *LML call*. This kills that 50×/album amplifier — the single largest LML call-count cut in the latency plan.

## Regression safety (BS#1089 negative-cache poisoning)

The skip keys on a **confirmed non-null load-bearing column**, not mere row existence. The no-match arm of `enrich.ts` writes an `album_metadata` shell carrying only the four synthesized search URLs with `artwork_url` / `discogs_url` NULL; a naive "skip if any row exists" would freeze that false no-match forever. Null rows and search-URL-only shells therefore **fall through and still call LML**, so a false no-match written during a cold-cache degradation window self-heals. Unlinked rows (`album_id` null) have no `album_metadata` row and always call LML.

Note: `album_metadata` has no `release_id` column (the issue names the LML triad `discogs_url` / `release_id` / `artwork_url`); release identity is carried by `discogs_url`, so `artwork_url` + `discogs_url` are the complete load-bearing set here.

## Tests (TDD — failing test first)

- **Unit** (`tests/unit/apps/enrichment-worker/cache-precheck.test.ts`): the handler honors the pre-check verdict — skip + finalize-from-cache on a hit, re-call LML on a shell (self-heal), never consult the pre-check for unlinked rows. Confirmed RED before wiring the handler, then GREEN.
- **Integration** (`tests/integration/enrichment-worker-cache-precheck.spec.js`, `pg`): pure-SQL contract for the load-bearing predicate against the live `album_metadata` table — match / missing / all-null / search-URL-only shell / shell-then-healed. Mirrors the claim/upsert spec pattern (babel-jest has no TS support); the canonical SQL mirror lives in `tests/utils/enrichment-precheck.js`. The predicate was exercised against a real seeded Postgres locally (all cases pass); the full jest integration harness requires the NPM_TOKEN-gated app stack, so it runs in CI.

Local CI green: `typecheck`, `lint` (0 errors), `format:check`, and the full `apps/enrichment-worker` unit suite (102 passing).

Closes #1747