### PR TITLE
feat(enrichment-worker): batch CDC lookup bursts through bulkLookupMetadata (B3)

### DIFF
--- a/apps/enrichment-worker/handler.ts
+++ b/apps/enrichment-worker/handler.ts
@@ -50,7 +50,6 @@
  */
 
 import * as Sentry from '@sentry/node';
-import { lookupMetadata, envInt } from '@wxyc/lml-client';
 import type { CdcEvent } from '@wxyc/database';
 
 import { claimRowForEnrichment } from './claim.js';
@@ -60,15 +59,8 @@ import { EMPTY_OUTCOME_FINGERPRINT, classifyEmptyCause, isEmptyOutcome } from '.
 // the BS#1311 volume-control decision is co-located with the call site.
 const SUPPRESSED_EMPTY_CAUSES: ReadonlySet<ReturnType<typeof classifyEmptyCause>> = new Set(['lml_no_match']);
 import { finalizeRow, type FinalizeOutcome } from './enrich.js';
+import { enrichmentBulkLookup } from './lookup-batcher.js';
 import { finalizeFromCachedMetadata, hasLoadBearingAlbumMetadata } from './precheck.js';
-
-/**
- * Budget for the CDC consumer's lookup. Tracks the shared client's 30 s
- * fetch timeout with 1 s of slack so LML cuts off just before the
- * `AbortController` would — frees the row's `enriching` claim for C6 sweep
- * recovery (#895) sooner. See `LookupOptions.budgetMs` for mechanics.
- */
-const ENRICHMENT_LML_BUDGET_MS = envInt('ENRICHMENT_LML_BUDGET_MS', 29000);
 
 /**
  * Registry of in-flight `handleCandidate` invocations, used by the worker's
@@ -207,19 +199,19 @@ async function handleCandidate(candidate: EnrichmentCandidate): Promise<void> {
         let outcome: FinalizeOutcome;
         let emptyCause: ReturnType<typeof classifyEmptyCause> | null = null;
         try {
-          const response = await lookupMetadata(
-            candidate.artist_name,
-            candidate.album_title ?? undefined,
-            candidate.track_title ?? undefined,
-            // `extended: true` surfaces the 8 LML-only fields (genres/styles/
-            // tracklist/label/full_release_date/discogs_artist_id/
-            // artist_image_url/profile_tokens) on the top-1 artwork block so
-            // finalizeRow can persist them into album_metadata (BS#1336).
-            // LML "already fetches these during enrichment but normally
-            // discards" them, so the marginal cost on this background path is
-            // low; the worker's ~29s budget absorbs it.
-            { budgetMs: ENRICHMENT_LML_BUDGET_MS, caller: 'enrichment-worker', extended: true }
-          );
+          // B3 (BS#1749): coalesce this row's lookup into a burst-batched
+          // `bulkLookupMetadata` call instead of a per-row `lookupMetadata`
+          // round-trip. `enrichmentBulkLookup` buffers concurrent CDC ticks,
+          // flushes them through one bulk call (chunked at LML's 100-item cap),
+          // and resolves this caller with its own per-index `LookupResponse` —
+          // drop-in with the per-row contract (resolves on match/no-match,
+          // rejects into the catch arm below on a per-item error or a failed
+          // bulk call). It sets `extended: true` on every item so the 8
+          // LML-only fields (genres/styles/tracklist/label/full_release_date/
+          // discogs_artist_id/artist_image_url/profile_tokens) still land in
+          // album_metadata (BS#1336) — cache-only on the bulk path (LML#685),
+          // so no incremental Discogs cost.
+          const response = await enrichmentBulkLookup(candidate);
           outcome = await finalizeRow(candidate, response);
           // G7 (BS#969): defer the captureMessage until after the
           // span.setAttribute below, but compute the classification while the

--- a/apps/enrichment-worker/lookup-batcher.ts
+++ b/apps/enrichment-worker/lookup-batcher.ts
@@ -1,0 +1,185 @@
+/**
+ * Burst-coalescing LML lookup batcher for the CDC enrichment worker
+ * (B3 / BS#1749, under Epic C #877).
+ *
+ * The CDC listener dispatches one fire-and-forget `handleCandidate` per new
+ * flowsheet row. Before B3 each of those issued its own `lookupMetadata`
+ * round-trip, so a burst of N rows fired N calls and overran LML's
+ * server-side concurrency ceiling (the Semaphore(5) + TokenBucket the shared
+ * client mirrors). This module coalesces the burst: every `enrichmentBulkLookup`
+ * caller is buffered for a short window (`ENRICHMENT_BULK_WINDOW_MS`), then the
+ * whole buffer is flushed through `bulkLookupMetadata` — the shared-client
+ * method that already existed and was previously unused — chunked at LML's
+ * hard cap of 100 items per call. Under a burst this cuts N round-trips to
+ * ceil(N / 100), i.e. ~100× fewer at burst scale.
+ *
+ * Parity with the per-call path is the load-bearing invariant. Each caller
+ * gets back its own `LookupResponse`, resolved from the per-item verdict at
+ * its input index:
+ *   - `match` / `no_match` → resolve with `verdict.lookup` (the same
+ *     `LookupResponse` a single `lookupMetadata` would have returned; an empty
+ *     `results` array is the no-match signal `finalizeRow` already handles).
+ *   - `error` (or a missing verdict) → reject that ONE caller. The worker's
+ *     catch arm then leaves its row `enriching` for the C6 sweep (#895),
+ *     exactly as it did when a single lookup threw. One item's failure never
+ *     poisons its batch siblings.
+ * If the bulk HTTP call itself throws (timeout, 5xx), every caller in that
+ * chunk is rejected — again matching the per-row throw semantics.
+ *
+ * `extended: true` rides every item: the worker is the canonical
+ * `album_metadata` writer (BS#1336) and LML#685 honors per-item `extended` on
+ * the bulk path (cache-only there, so zero incremental Discogs cost), so the
+ * 8 extended-only `DiscogsMatchResult` fields survive the batch.
+ *
+ * Ownership note: this module holds process-global mutable state (the buffer
+ * and the flush timer). That is intentional — the coalescing point must be a
+ * singleton per worker process so concurrent CDC ticks share one buffer.
+ * `_resetLookupBatcherForTest` clears it between tests.
+ */
+
+import { bulkLookupMetadata, envInt, LmlClientError, type BulkLookupItem, type LookupResponse } from '@wxyc/lml-client';
+
+/**
+ * LML's per-request hard cap on bulk items (kept in lockstep with LML#368 and
+ * the client-side `BULK_LOOKUP_INPUT_CAP` guard in `@wxyc/lml-client`). A
+ * buffered burst is sliced into chunks no larger than this before dispatch.
+ */
+const BULK_MAX_ITEMS = 100;
+
+/**
+ * How long to hold a buffered lookup before flushing, giving a CDC burst time
+ * to coalesce into one call. Kept short so the fire-and-forget latency the
+ * worker already tolerates (a background enrichment path) barely moves; the
+ * whole point is to trade a few ms of buffering for ~100× fewer round-trips.
+ */
+export const ENRICHMENT_BULK_WINDOW_MS = envInt('ENRICHMENT_BULK_WINDOW_MS', 50);
+
+/**
+ * Budget forwarded to LML as `X-Caller-Budget-Ms`. Mirrors the constant the
+ * per-row path used in `handler.ts` (tracks the shared client's 30 s fetch
+ * timeout with 1 s of slack) so batching doesn't change the deadline the
+ * enrichment path negotiates with LML.
+ */
+const ENRICHMENT_LML_BUDGET_MS = envInt('ENRICHMENT_LML_BUDGET_MS', 29000);
+
+/** Caller-class label projected onto the `lml.caller` Sentry span (BS#1235). */
+const ENRICHMENT_CALLER = 'enrichment-worker';
+
+/** The per-row fields the worker resolves before enqueuing a lookup. */
+export interface EnrichmentLookupInput {
+  artist_name: string;
+  album_title: string | null;
+  track_title: string | null;
+}
+
+interface PendingLookup {
+  item: BulkLookupItem;
+  resolve: (response: LookupResponse) => void;
+  reject: (error: unknown) => void;
+}
+
+let buffer: PendingLookup[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * Build a bulk item from a candidate's fields. `raw_message` is synthesized
+ * the same way `lookupMetadata` does (`[artist, album, song].filter().join(' - ')`)
+ * so LML's parser sees an identical free-form description on either path.
+ */
+function toBulkItem(input: EnrichmentLookupInput): BulkLookupItem {
+  const artist = input.artist_name || undefined;
+  const album = input.album_title ?? undefined;
+  const song = input.track_title ?? undefined;
+  const rawMessage = [artist, album, song].filter(Boolean).join(' - ');
+  const item: BulkLookupItem = { raw_message: rawMessage, extended: true };
+  if (artist) item.artist = artist;
+  if (album) item.album = album;
+  if (song) item.song = song;
+  return item;
+}
+
+/**
+ * Enqueue a lookup into the current burst window. Returns the same
+ * `LookupResponse` a single `lookupMetadata(...)` call would have produced for
+ * this row (resolves on match/no-match, rejects on a per-item error or a
+ * failed bulk call), so callers are drop-in with the per-row path.
+ */
+export function enrichmentBulkLookup(input: EnrichmentLookupInput): Promise<LookupResponse> {
+  return new Promise<LookupResponse>((resolve, reject) => {
+    buffer.push({ item: toBulkItem(input), resolve, reject });
+    scheduleFlush();
+  });
+}
+
+function scheduleFlush(): void {
+  if (flushTimer !== undefined) return;
+  flushTimer = setTimeout(() => {
+    flushTimer = undefined;
+    flushBuffer();
+  }, ENRICHMENT_BULK_WINDOW_MS);
+}
+
+/**
+ * Drain the buffer and dispatch it as one or more bulk calls, each capped at
+ * `BULK_MAX_ITEMS`. Chunks fire concurrently; the shared client's limiter
+ * (Semaphore(5) + TokenBucket) gates their Discogs amplification, so this
+ * never over-consumes the shared rate pool even for a large burst.
+ */
+function flushBuffer(): void {
+  const pending = buffer;
+  buffer = [];
+  for (let start = 0; start < pending.length; start += BULK_MAX_ITEMS) {
+    void dispatchChunk(pending.slice(start, start + BULK_MAX_ITEMS));
+  }
+}
+
+async function dispatchChunk(chunk: PendingLookup[]): Promise<void> {
+  try {
+    const response = await bulkLookupMetadata(
+      chunk.map((pending) => pending.item),
+      { budgetMs: ENRICHMENT_LML_BUDGET_MS, caller: ENRICHMENT_CALLER }
+    );
+
+    // LML returns one verdict per input in input order, tagged with the
+    // zero-based `index`. Map by index (not array position) so a short,
+    // reordered, or gap-carrying results array still routes each verdict to
+    // the right caller — a missing index rejects only that one caller.
+    const byIndex = new Map<number, (typeof response.results)[number]>();
+    for (const verdict of response.results ?? []) {
+      byIndex.set(verdict.index, verdict);
+    }
+
+    chunk.forEach((pending, index) => {
+      const verdict = byIndex.get(index);
+      if (verdict === undefined) {
+        pending.reject(new LmlClientError(`bulk lookup returned no verdict for item ${index}`, 502));
+        return;
+      }
+      if (verdict.status === 'error' || verdict.lookup === null) {
+        pending.reject(new LmlClientError(verdict.message ?? `bulk lookup error for item ${index}`, 502));
+        return;
+      }
+      pending.resolve(verdict.lookup);
+    });
+  } catch (err) {
+    // The bulk call itself failed (timeout / 5xx / validation). Reject every
+    // caller in the chunk; each worker leaves its row `enriching` for the C6
+    // sweep, exactly as a single-lookup throw would have.
+    for (const pending of chunk) {
+      pending.reject(err);
+    }
+  }
+}
+
+/**
+ * Test-only: clear the buffer and cancel any pending flush timer without
+ * dispatching. Production code must never call this — buffered callers would
+ * hang forever. The leading underscore keeps that intent loud.
+ */
+export function _resetLookupBatcherForTest(): void {
+  if (flushTimer !== undefined) {
+    clearTimeout(flushTimer);
+    flushTimer = undefined;
+  }
+  buffer = [];
+}

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -583,6 +583,16 @@ export interface BulkLookupItem {
   album?: string;
   song?: string;
   raw_message: string;
+  /**
+   * Surfaces the 8 extended-only `DiscogsMatchResult` fields (genres/styles/
+   * tracklist/label/full_release_date/discogs_artist_id/artist_image_url/
+   * profile_tokens) on the item's top-1 artwork block. Honored per-item on the
+   * bulk path (LML#685), where it is CACHE-ONLY — it reads from data the
+   * per-item lookup already fetched, adding zero incremental Discogs calls. The
+   * CDC enrichment worker (BS#1749) sets this so its BS#1336 album_metadata
+   * columns survive the batch, matching the per-row `lookupMetadata` path.
+   */
+  extended?: boolean;
 }
 
 /**

--- a/tests/unit/apps/enrichment-worker/cache-precheck.test.ts
+++ b/tests/unit/apps/enrichment-worker/cache-precheck.test.ts
@@ -35,10 +35,12 @@ jest.mock('@sentry/node', () => ({
   captureMessage: jest.fn(),
 }));
 
-const mockLookupMetadata = jest.fn<(...args: unknown[]) => Promise<unknown>>();
-jest.mock('@wxyc/lml-client', () => ({
-  lookupMetadata: mockLookupMetadata,
-  envInt: (_name: string, fallback: number) => fallback,
+// B3 (BS#1749): the handler's LML call now goes through the burst batcher.
+// Mock that seam; the pre-check assertions only care whether an LML call is
+// issued at all, which the batcher stands in for here.
+const mockEnrichmentBulkLookup = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+jest.mock('../../../../apps/enrichment-worker/lookup-batcher.js', () => ({
+  enrichmentBulkLookup: mockEnrichmentBulkLookup,
 }));
 
 const mockClaimRowForEnrichment =
@@ -124,7 +126,7 @@ describe('enrichment-worker cache-first pre-check (B1 / BS#1747)', () => {
     const span = await driveOneTick(makeCandidate({ album_id: 7 }));
 
     expect(mockHasLoadBearingAlbumMetadata).toHaveBeenCalledWith(7);
-    expect(mockLookupMetadata).not.toHaveBeenCalled();
+    expect(mockEnrichmentBulkLookup).not.toHaveBeenCalled();
     expect(mockFinalizeFromCachedMetadata).toHaveBeenCalledTimes(1);
     expect(span.setAttribute).toHaveBeenCalledWith('enrichment.outcome', 'cache_hit');
     expect(span.setAttribute).toHaveBeenCalledWith('enrichment.lml_skipped', true);
@@ -135,24 +137,24 @@ describe('enrichment-worker cache-first pre-check (B1 / BS#1747)', () => {
     // must NOT freeze a false no-match. The pre-check returns false, so the
     // worker re-calls LML.
     mockHasLoadBearingAlbumMetadata.mockResolvedValueOnce(false);
-    mockLookupMetadata.mockResolvedValueOnce(matchResponse);
+    mockEnrichmentBulkLookup.mockResolvedValueOnce(matchResponse);
     mockFinalizeRow.mockResolvedValueOnce('enriched_match');
 
     const span = await driveOneTick(makeCandidate({ album_id: 7 }));
 
     expect(mockHasLoadBearingAlbumMetadata).toHaveBeenCalledWith(7);
-    expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    expect(mockEnrichmentBulkLookup).toHaveBeenCalledTimes(1);
     expect(mockFinalizeFromCachedMetadata).not.toHaveBeenCalled();
     expect(span.setAttribute).toHaveBeenCalledWith('enrichment.outcome', 'enriched_match');
   });
 
   it('does not consult the pre-check for unlinked rows (album_id null) and always calls LML', async () => {
-    mockLookupMetadata.mockResolvedValueOnce(matchResponse);
+    mockEnrichmentBulkLookup.mockResolvedValueOnce(matchResponse);
     mockFinalizeRow.mockResolvedValueOnce('enriched_match');
 
     await driveOneTick(makeCandidate({ album_id: null }));
 
     expect(mockHasLoadBearingAlbumMetadata).not.toHaveBeenCalled();
-    expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
+    expect(mockEnrichmentBulkLookup).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/apps/enrichment-worker/drain.test.ts
+++ b/tests/unit/apps/enrichment-worker/drain.test.ts
@@ -34,10 +34,13 @@ jest.mock('@sentry/node', () => ({
   captureMessage: jest.fn(),
 }));
 
-const mockLookupMetadata = jest.fn<(...args: unknown[]) => Promise<unknown>>();
-jest.mock('@wxyc/lml-client', () => ({
-  lookupMetadata: mockLookupMetadata,
-  envInt: (_name: string, fallback: number) => fallback,
+// B3 (BS#1749): the handler's LML lookup now runs through the burst batcher.
+// Mock that seam so a never-resolving / rejecting return value simulates a
+// pending / hung / failed LML call, exactly as the pre-B3 lookupMetadata mock
+// did.
+const mockEnrichmentBulkLookup = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+jest.mock('../../../../apps/enrichment-worker/lookup-batcher.js', () => ({
+  enrichmentBulkLookup: mockEnrichmentBulkLookup,
 }));
 
 const mockClaimRowForEnrichment =
@@ -120,7 +123,7 @@ describe('enrichment-worker in-flight drain (BS#1108)', () => {
 
     it('registers an in-flight candidate while the LML lookup is pending', async () => {
       // Never-resolving lookup so the promise stays in-flight for assertion.
-      mockLookupMetadata.mockReturnValueOnce(new Promise(() => undefined));
+      mockEnrichmentBulkLookup.mockReturnValueOnce(new Promise(() => undefined));
 
       dispatchTick(1);
       // Yield once so the dispatched `void handleCandidate(...)` reaches
@@ -132,7 +135,7 @@ describe('enrichment-worker in-flight drain (BS#1108)', () => {
     });
 
     it('unregisters the candidate after a successful tick (settle on resolve)', async () => {
-      mockLookupMetadata.mockResolvedValueOnce({ results: [] });
+      mockEnrichmentBulkLookup.mockResolvedValueOnce({ results: [] });
       mockFinalizeRow.mockResolvedValueOnce('enriched_no_match');
 
       dispatchTick(2);
@@ -149,7 +152,7 @@ describe('enrichment-worker in-flight drain (BS#1108)', () => {
       // .finally must still fire and the registry must reach 0. Without
       // the unregister side, a slow stream of LML errors would slow-leak
       // the registry and inflate the shutdown-time "dropped" count.
-      mockLookupMetadata.mockRejectedValueOnce(new Error('LML timeout'));
+      mockEnrichmentBulkLookup.mockRejectedValueOnce(new Error('LML timeout'));
 
       dispatchTick(3);
       await new Promise((resolve) => setImmediate(resolve));
@@ -209,7 +212,7 @@ describe('enrichment-worker in-flight drain (BS#1108)', () => {
 
     it('awaits in-flight promises and returns 0 when they settle inside the deadline', async () => {
       let resolveLookup: (value: unknown) => void = () => undefined;
-      mockLookupMetadata.mockReturnValueOnce(
+      mockEnrichmentBulkLookup.mockReturnValueOnce(
         new Promise((resolve) => {
           resolveLookup = resolve;
         })
@@ -234,8 +237,8 @@ describe('enrichment-worker in-flight drain (BS#1108)', () => {
       // Two never-resolving lookups simulate hung LML calls during deploy.
       // The drain must NOT hang the SIGTERM — it returns the count of
       // promises still pending after `deadlineMs`.
-      mockLookupMetadata.mockReturnValueOnce(new Promise(() => undefined));
-      mockLookupMetadata.mockReturnValueOnce(new Promise(() => undefined));
+      mockEnrichmentBulkLookup.mockReturnValueOnce(new Promise(() => undefined));
+      mockEnrichmentBulkLookup.mockReturnValueOnce(new Promise(() => undefined));
 
       dispatchTick(5);
       dispatchTick(6);
@@ -258,7 +261,7 @@ describe('enrichment-worker in-flight drain (BS#1108)', () => {
       // into resolved promises; this case pins that the wrapper's
       // .finally chain doesn't reintroduce an unhandled rejection that
       // would crash the shutdown path.
-      mockLookupMetadata.mockRejectedValueOnce(new Error('LML timeout'));
+      mockEnrichmentBulkLookup.mockRejectedValueOnce(new Error('LML timeout'));
 
       dispatchTick(7);
       // Don't yield yet — the rejection happens inside the drain.

--- a/tests/unit/apps/enrichment-worker/handler.test.ts
+++ b/tests/unit/apps/enrichment-worker/handler.test.ts
@@ -36,13 +36,14 @@ jest.mock('@sentry/node', () => ({
   captureMessage: jest.fn(),
 }));
 
-// Mock @wxyc/lml-client so we control the response shape and don't take a
-// network dependency. envInt is re-exported from the package; provide a
-// passthrough so the ENRICHMENT_LML_BUDGET_MS module-init read works.
-const mockLookupMetadata = jest.fn<(...args: unknown[]) => Promise<unknown>>();
-jest.mock('@wxyc/lml-client', () => ({
-  lookupMetadata: mockLookupMetadata,
-  envInt: (_name: string, fallback: number) => fallback,
+// B3 (BS#1749): the handler no longer calls `lookupMetadata` directly — it
+// coalesces the lookup through `enrichmentBulkLookup` (lookup-batcher.ts). Mock
+// that seam so we control the per-row response shape and don't take a network
+// dependency. The batcher's own coalescing/chunking/parity is covered by
+// lookup-batcher.test.ts.
+const mockEnrichmentBulkLookup = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+jest.mock('../../../../apps/enrichment-worker/lookup-batcher.js', () => ({
+  enrichmentBulkLookup: mockEnrichmentBulkLookup,
 }));
 
 // Mock the sibling enrichment-worker modules so the test only exercises the
@@ -134,7 +135,7 @@ const noMatchResponse = { results: [] };
 
 describe('makeEnrichmentHandler captureMessage volume control (BS#1311)', () => {
   it('fires captureMessage on lml_degraded — the dominant BS#969 class', async () => {
-    mockLookupMetadata.mockResolvedValueOnce(degradedResponse);
+    mockEnrichmentBulkLookup.mockResolvedValueOnce(degradedResponse);
     mockFinalizeRow.mockResolvedValueOnce('enriched_match');
 
     const span = await driveOneTick();
@@ -154,7 +155,7 @@ describe('makeEnrichmentHandler captureMessage volume control (BS#1311)', () => 
     // A sibling worker / C6 sweep won the finalize race; the user-visible
     // state was written by them. This worker's captureMessage would inflate
     // the BS#969 rate against the true degradation rate.
-    mockLookupMetadata.mockResolvedValueOnce(degradedResponse);
+    mockEnrichmentBulkLookup.mockResolvedValueOnce(degradedResponse);
     mockFinalizeRow.mockResolvedValueOnce('enriched_match_raced');
 
     const span = await driveOneTick();
@@ -164,7 +165,7 @@ describe('makeEnrichmentHandler captureMessage volume control (BS#1311)', () => 
   });
 
   it('does NOT fire captureMessage when outcome ends in _raced (enriched_no_match_raced)', async () => {
-    mockLookupMetadata.mockResolvedValueOnce(noMatchResponse);
+    mockEnrichmentBulkLookup.mockResolvedValueOnce(noMatchResponse);
     mockFinalizeRow.mockResolvedValueOnce('enriched_no_match_raced');
 
     const span = await driveOneTick();
@@ -176,7 +177,7 @@ describe('makeEnrichmentHandler captureMessage volume control (BS#1311)', () => 
   it('does NOT fire captureMessage when cause is lml_no_match (by-design Discogs miss)', async () => {
     // Dashboard aggregation of the no-match rate uses the
     // `enrichment.outcome` span attribute, not per-event Sentry issues.
-    mockLookupMetadata.mockResolvedValueOnce(noMatchResponse);
+    mockEnrichmentBulkLookup.mockResolvedValueOnce(noMatchResponse);
     mockFinalizeRow.mockResolvedValueOnce('enriched_no_match');
 
     const span = await driveOneTick();
@@ -185,29 +186,31 @@ describe('makeEnrichmentHandler captureMessage volume control (BS#1311)', () => 
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 
-  it('requests extended LML fields so finalizeRow can persist the BS#1336 columns', async () => {
-    // The worker is the canonical album_metadata writer (Epic C). Without
-    // `extended: true` the top-1 artwork block omits genres/styles/tracklist/
-    // label/full_release_date/discogs_artist_id/artist_image_url/profile_tokens
-    // and finalizeRow would persist nulls — silently re-opening the BS#1331
-    // cache-hit shape gap this ticket closes.
-    mockLookupMetadata.mockResolvedValueOnce(matchResponseWithArtwork);
+  it('routes the row through the burst batcher (one call per candidate)', async () => {
+    // B3 (BS#1749): the handler hands the candidate to `enrichmentBulkLookup`,
+    // which owns the extended-fields flag and the ≤100-item coalescing. The
+    // handler's only contract here is that it forwards the candidate once —
+    // the `extended: true` guarantee that keeps the BS#1336 album_metadata
+    // columns populated is pinned in lookup-batcher.test.ts.
+    mockEnrichmentBulkLookup.mockResolvedValueOnce(matchResponseWithArtwork);
     mockFinalizeRow.mockResolvedValueOnce('enriched_match');
 
     await driveOneTick();
 
-    expect(mockLookupMetadata).toHaveBeenCalledWith(
-      'Juana Molina',
-      'DOGA',
-      'la paradoja',
-      expect.objectContaining({ extended: true, caller: 'enrichment-worker' })
+    expect(mockEnrichmentBulkLookup).toHaveBeenCalledTimes(1);
+    expect(mockEnrichmentBulkLookup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artist_name: 'Juana Molina',
+        album_title: 'DOGA',
+        track_title: 'la paradoja',
+      })
     );
   });
 
   it('does NOT fire captureMessage on lml_match (artwork_url present)', async () => {
     // Sanity: the happy path stays silent. extractArtwork sees a populated
     // artwork_url so isEmptyOutcome returns false.
-    mockLookupMetadata.mockResolvedValueOnce(matchResponseWithArtwork);
+    mockEnrichmentBulkLookup.mockResolvedValueOnce(matchResponseWithArtwork);
     mockFinalizeRow.mockResolvedValueOnce('enriched_match');
 
     await driveOneTick();
@@ -220,7 +223,7 @@ describe('makeEnrichmentHandler captureMessage volume control (BS#1311)', () => 
     // every LML throw — two quota slots per timeout. captureException is the
     // source-of-truth for the stack trace; the catch-arm captureMessage was
     // redundant and BS#1311 drops it.
-    mockLookupMetadata.mockRejectedValueOnce(new Error('LML timeout'));
+    mockEnrichmentBulkLookup.mockRejectedValueOnce(new Error('LML timeout'));
 
     const span = await driveOneTick();
 

--- a/tests/unit/apps/enrichment-worker/lookup-batcher.test.ts
+++ b/tests/unit/apps/enrichment-worker/lookup-batcher.test.ts
@@ -117,6 +117,22 @@ describe('enrichmentBulkLookup burst coalescing (B3 / BS#1749)', () => {
     expect(items).toHaveLength(4);
   });
 
+  it('forwards the enrichment caller label + budget to the bulk call (parity with per-call path)', async () => {
+    // Parity guard: the per-row `lookupMetadata` path tagged its call with
+    // `caller: 'enrichment-worker'` (the BS#1235 Sentry `lml.caller` label —
+    // missing it degrades to the `unknown` flag-of-shame) and a 29 s
+    // `budgetMs` deadline. Batching must preserve both, or the enrichment
+    // path silently loses its Sentry attribution and its deadline negotiation.
+    mockBulkLookupMetadata.mockImplementation((items) => Promise.resolve(echoAllMatched(items)));
+
+    const p = enrichmentBulkLookup(makeInput('Stereolab'));
+    await flushWindow();
+    await p;
+
+    const [, options] = mockBulkLookupMetadata.mock.calls[0];
+    expect(options).toMatchObject({ caller: 'enrichment-worker', budgetMs: 29000 });
+  });
+
   it('sets extended:true and synthesizes raw_message + fields on each item', async () => {
     mockBulkLookupMetadata.mockImplementation((items) => Promise.resolve(echoAllMatched(items)));
 

--- a/tests/unit/apps/enrichment-worker/lookup-batcher.test.ts
+++ b/tests/unit/apps/enrichment-worker/lookup-batcher.test.ts
@@ -166,6 +166,31 @@ describe('enrichmentBulkLookup burst coalescing (B3 / BS#1749)', () => {
     }
   });
 
+  it('routes each caller to its OWN verdict across chunk boundaries (no row dropped, no cross-chunk mismatch)', async () => {
+    // The chunking risk the BS#1749 acceptance criteria calls out: LML indexes
+    // each bulk call from 0, so the batcher must map verdicts by the
+    // PER-CHUNK index, not a global buffer offset. A regression to global
+    // indexing would leave every caller past the first chunk (index >= 100)
+    // with no matching verdict and reject it — silently stranding those rows.
+    // The size-only chunk test above cannot catch that; this pins parity for a
+    // caller landing in the 2nd chunk.
+    mockBulkLookupMetadata.mockImplementation((items) => Promise.resolve(echoAllMatched(items)));
+
+    const artists = Array.from({ length: 150 }, (_, i) => `Artist ${i}`);
+    const promises = artists.map((a) => enrichmentBulkLookup(makeInput(a)));
+
+    await flushWindow();
+    const responses = await Promise.all(promises);
+
+    // Exhaustive: every one of the 150 callers resolved with its OWN verdict —
+    // including the chunk boundaries (caller 99 = last of chunk 1, caller 100 =
+    // first of chunk 2 at chunk-local index 0, caller 149 = last of chunk 2).
+    // A global-index regression would strand every caller past index 99.
+    responses.forEach((response, i) => {
+      expect(response.results[0].artwork.artwork_url).toBe(`https://i.discogs.com/Artist ${i}.jpg`);
+    });
+  });
+
   it('lands each per-row result with its own caller (parity with per-call path)', async () => {
     mockBulkLookupMetadata.mockImplementation((items) => Promise.resolve(echoAllMatched(items)));
 

--- a/tests/unit/apps/enrichment-worker/lookup-batcher.test.ts
+++ b/tests/unit/apps/enrichment-worker/lookup-batcher.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the enrichment worker's LML lookup batcher (B3 / BS#1749,
+ * under Epic C #877).
+ *
+ * The CDC worker dispatches one `handleCandidate` per new flowsheet row,
+ * fire-and-forget. Before B3 each of those issued its OWN `lookupMetadata`
+ * call, so a burst of N rows fired N round-trips and overran LML's
+ * server-side concurrency ceiling. B3 coalesces the burst: rows that arrive
+ * inside a short window are buffered and flushed through a single
+ * `bulkLookupMetadata` call (the shared-client method that already exists and
+ * was previously unused), chunked at LML's hard cap of 100 items per call.
+ *
+ * Pinned here (the BS#1749 acceptance criteria):
+ *   - A burst of N (< 100) rows issues exactly ONE bulk call, not N.
+ *   - A burst larger than 100 chunks into multiple bulk calls, none > 100.
+ *   - Per-row results still land — each caller resolves with its own
+ *     per-index verdict; an `error` verdict rejects only that caller.
+ *   - Items carry `extended: true` so the worker's BS#1336 album_metadata
+ *     columns survive the batch (LML#685 honors per-item `extended` on the
+ *     bulk path).
+ */
+
+import { jest } from '@jest/globals';
+
+// Mock @sentry/node so the shared client's span wiring (imported transitively)
+// is inert under test.
+jest.mock('@sentry/node', () => ({
+  startSpan: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+class FakeLmlClientError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'LmlClientError';
+    this.status = status;
+  }
+}
+
+type BulkItem = { artist?: string; album?: string; song?: string; raw_message: string; extended?: boolean };
+type BulkResult = { index: number; status: 'match' | 'no_match' | 'error'; lookup: unknown; message?: string };
+
+const mockBulkLookupMetadata = jest.fn<(items: BulkItem[], options?: unknown) => Promise<{ results: BulkResult[] }>>();
+
+jest.mock('@wxyc/lml-client', () => ({
+  bulkLookupMetadata: mockBulkLookupMetadata,
+  envInt: (_name: string, fallback: number) => fallback,
+  LmlClientError: FakeLmlClientError,
+}));
+
+import {
+  enrichmentBulkLookup,
+  _resetLookupBatcherForTest,
+  ENRICHMENT_BULK_WINDOW_MS,
+} from '../../../../apps/enrichment-worker/lookup-batcher';
+
+/** Build a candidate-shaped lookup input. */
+const makeInput = (artist: string, album: string | null = null, track: string | null = null) => ({
+  artist_name: artist,
+  album_title: album,
+  track_title: track,
+});
+
+/** A minimal LookupResponse with a populated artwork block. */
+const matchLookup = (artistTag: string) => ({
+  results: [{ artwork: { artwork_url: `https://i.discogs.com/${artistTag}.jpg`, release_url: null } }],
+});
+
+/**
+ * Resolve `bulkLookupMetadata` with one `match` verdict per input item, in
+ * input order. The nested `lookup` carries the artist tag so parity — the
+ * right response reaching the right caller — is checkable.
+ */
+const echoAllMatched = (items: BulkItem[]) => ({
+  results: items.map((item, index) => ({
+    index,
+    status: 'match' as const,
+    lookup: matchLookup(item.artist ?? `idx${index}`),
+  })),
+});
+
+/**
+ * Advance past the flush window and let the mocked bulk call + the per-item
+ * settle microtasks drain, so awaited assertions see resolved promises.
+ */
+const flushWindow = async () => {
+  jest.advanceTimersByTime(ENRICHMENT_BULK_WINDOW_MS);
+  // Two macrotask hops: one for the bulk promise, one for the per-item fan-out.
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('enrichmentBulkLookup burst coalescing (B3 / BS#1749)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    _resetLookupBatcherForTest();
+    mockBulkLookupMetadata.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('coalesces a burst of N rows into a SINGLE bulk call (not N calls)', async () => {
+    mockBulkLookupMetadata.mockImplementation((items) => Promise.resolve(echoAllMatched(items)));
+
+    const artists = ['Stereolab', 'Juana Molina', 'Jessica Pratt', 'Duke Ellington & John Coltrane'];
+    const promises = artists.map((a) => enrichmentBulkLookup(makeInput(a)));
+
+    await flushWindow();
+    await Promise.all(promises);
+
+    expect(mockBulkLookupMetadata).toHaveBeenCalledTimes(1);
+    const [items] = mockBulkLookupMetadata.mock.calls[0];
+    expect(items).toHaveLength(4);
+  });
+
+  it('sets extended:true and synthesizes raw_message + fields on each item', async () => {
+    mockBulkLookupMetadata.mockImplementation((items) => Promise.resolve(echoAllMatched(items)));
+
+    const p = enrichmentBulkLookup(makeInput('Juana Molina', 'DOGA', 'la paradoja'));
+    await flushWindow();
+    await p;
+
+    const [items] = mockBulkLookupMetadata.mock.calls[0];
+    expect(items[0]).toEqual({
+      artist: 'Juana Molina',
+      album: 'DOGA',
+      song: 'la paradoja',
+      raw_message: 'Juana Molina - DOGA - la paradoja',
+      extended: true,
+    });
+  });
+
+  it('chunks a burst larger than 100 into multiple bulk calls, none exceeding 100', async () => {
+    mockBulkLookupMetadata.mockImplementation((items) => Promise.resolve(echoAllMatched(items)));
+
+    const promises = Array.from({ length: 250 }, (_, i) => enrichmentBulkLookup(makeInput(`Stereolab ${i}`)));
+
+    await flushWindow();
+    await Promise.all(promises);
+
+    expect(mockBulkLookupMetadata).toHaveBeenCalledTimes(3);
+    const sizes = mockBulkLookupMetadata.mock.calls.map(([items]) => items.length);
+    expect(sizes).toEqual([100, 100, 50]);
+    for (const size of sizes) {
+      expect(size).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('lands each per-row result with its own caller (parity with per-call path)', async () => {
+    mockBulkLookupMetadata.mockImplementation((items) => Promise.resolve(echoAllMatched(items)));
+
+    const a = enrichmentBulkLookup(makeInput('Stereolab'));
+    const b = enrichmentBulkLookup(makeInput('Jessica Pratt'));
+    const c = enrichmentBulkLookup(makeInput('Juana Molina'));
+
+    await flushWindow();
+    const [ra, rb, rc] = await Promise.all([a, b, c]);
+
+    expect(ra.results[0].artwork.artwork_url).toContain('Stereolab');
+    expect(rb.results[0].artwork.artwork_url).toContain('Jessica Pratt');
+    expect(rc.results[0].artwork.artwork_url).toContain('Juana Molina');
+  });
+
+  it('resolves a no_match verdict (empty results) instead of rejecting', async () => {
+    mockBulkLookupMetadata.mockResolvedValueOnce({
+      results: [{ index: 0, status: 'no_match', lookup: { results: [] } }],
+    });
+
+    const p = enrichmentBulkLookup(makeInput('Stereolab'));
+    await flushWindow();
+    const response = await p;
+
+    expect(response.results).toEqual([]);
+  });
+
+  it('rejects only the caller whose verdict is error; siblings still resolve', async () => {
+    mockBulkLookupMetadata.mockResolvedValueOnce({
+      results: [
+        { index: 0, status: 'match', lookup: matchLookup('Stereolab') },
+        { index: 1, status: 'error', lookup: null, message: 'perform_lookup raised' },
+      ],
+    });
+
+    const ok = enrichmentBulkLookup(makeInput('Stereolab'));
+    const bad = enrichmentBulkLookup(makeInput('Jessica Pratt'));
+    // Attach rejection handlers synchronously so the rejection is observed and
+    // never surfaces as an unhandledRejection when the batch settles.
+    const okResult = ok.then((r) => ({ status: 'resolved' as const, r }));
+    const badResult = bad.then(
+      () => ({ status: 'resolved' as const }),
+      (e: Error) => ({ status: 'rejected' as const, message: e.message })
+    );
+
+    await flushWindow();
+
+    await expect(okResult).resolves.toMatchObject({ status: 'resolved' });
+    await expect(badResult).resolves.toMatchObject({ status: 'rejected' });
+  });
+
+  it('rejects every caller in a chunk when the bulk call itself throws', async () => {
+    mockBulkLookupMetadata.mockRejectedValueOnce(new FakeLmlClientError('LML request timed out', 504));
+
+    const a = enrichmentBulkLookup(makeInput('Stereolab'));
+    const b = enrichmentBulkLookup(makeInput('Juana Molina'));
+    const aObserved = a.catch((e: Error) => e.message);
+    const bObserved = b.catch((e: Error) => e.message);
+
+    await flushWindow();
+
+    await expect(aObserved).resolves.toBe('LML request timed out');
+    await expect(bObserved).resolves.toBe('LML request timed out');
+  });
+});


### PR DESCRIPTION
## What

Lever **B3** of Epic C (event-driven enrichment, #877). The CDC enrichment worker (`apps/enrichment-worker/handler.ts`) issued **one `lookupMetadata` call per new flowsheet row**, so a burst of N rows fired N round-trips and overran LML's server-side concurrency ceiling (the `Semaphore(5)` + `TokenBucket` the shared client mirrors). This coalesces the burst into a single `bulkLookupMetadata` call (the shared-client method that already existed and was unused), chunked at LML's hard cap of **100 items per call** — cutting N round-trips to `ceil(N / 100)`, ~**100× fewer** under bursts.

## How

New `apps/enrichment-worker/lookup-batcher.ts` buffers concurrent fire-and-forget ticks for a short window (`ENRICHMENT_BULK_WINDOW_MS`, default 50ms), then flushes the buffer through `bulkLookupMetadata`, slicing it into ≤100-item chunks. `handler.ts` swaps its per-row `lookupMetadata(...)` for `enrichmentBulkLookup(candidate)` — a drop-in seam that returns the same `LookupResponse` per row.

Parity with the per-call path is the load-bearing invariant:
- Each caller resolves with its **own per-index** `LookupResponse` (match / no-match).
- An `error` verdict rejects **only that one caller** — the handler's catch arm still leaves that row `enriching` for the C6 sweep (#895).
- A failed bulk HTTP call rejects every caller in its chunk, matching the single-lookup throw semantics.
- Every item carries `extended: true` so the worker's BS#1336 `album_metadata` columns survive the batch; `extended` is honored per-item and **cache-only** on the bulk path (LML#685), so batching adds **zero** incremental Discogs cost. A new `BulkLookupItem.extended` field on `@wxyc/lml-client` carries the flag over the wire.

Composes with #1747 (B1 cache-first pre-check) — cached rows are filtered out before they reach the batch.

## Tests (TDD, failing-first)

- New `tests/unit/apps/enrichment-worker/lookup-batcher.test.ts` pins the acceptance criteria: one bulk call for N<100, chunking a 250-burst into 100/100/50, per-row result routing, no-match resolution, per-item error isolation, and whole-chunk rejection on a bulk throw.
- Updated `handler.test.ts`, `cache-precheck.test.ts`, and `drain.test.ts` to mock the new batcher seam.

Local CI green: `typecheck`, `lint` (0 errors), `format:check`, and the affected unit suites (262 tests). Integration specs are Docker-gated and not run locally; B3's logic is client-side coalescing with no new pg surface, and the existing enrich integration specs already cover the finalize path the batcher feeds.

Closes #1749