### PR TITLE
fix(lml-client): route checkStreamingAvailability through the shared limiter (B5)

### DIFF
--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -821,13 +821,23 @@ export async function validateTrackOnRelease(releaseId: number, track: string, a
  * @returns Streaming availability result with per-source URLs
  */
 export async function checkStreamingAvailability(artist: string, title: string): Promise<StreamingCheckResponse> {
-  const response = await lmlFetch('/api/v1/streaming-check', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ artist, title }),
-  });
+  // BS#1750 / B5: fires on every album add. Route it through the process-wide
+  // `defaultLimiter` — the same shared concurrency/rate gate as `/lookup` —
+  // so this call participates in the admission budget instead of being an
+  // ungoverned direct call that could overrun LML's real concurrency ceiling
+  // alongside the enrichment/backfill limiters. The fetch runs after the
+  // limiter's `semaphore.acquire()` + `tokenBucket.consume(1)`; the permit is
+  // released in the limiter's `finally`. Behavior is otherwise unchanged —
+  // same path, headers, body, and returned `StreamingCheckResponse`.
+  return defaultLimiter.run(async () => {
+    const response = await lmlFetch('/api/v1/streaming-check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ artist, title }),
+    });
 
-  return (await response.json()) as StreamingCheckResponse;
+    return (await response.json()) as StreamingCheckResponse;
+  });
 }
 
 /**

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -1758,3 +1758,133 @@ describe('lml.client rate-aware /lookup wrapper (BS#906)', () => {
     expect(getLmlQueueDepth()).toBe(0);
   });
 });
+
+// B5 / BS#1750: checkStreamingAvailability fires on every album add. It used
+// to bypass the shared LML-client limiter, so each album-add was an
+// ungoverned LML call outside the admission budget — an uncounted call class
+// that could overrun LML's real concurrency ceiling alongside the enrichment
+// and backfill limiters. These tests pin that the streaming-check now
+// acquires the same process-wide limiter as /lookup, so it participates in
+// the shared concurrency/rate budget.
+describe('checkStreamingAvailability limiter governance (B5 / BS#1750)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      LIBRARY_METADATA_URL: 'http://lml.test:8000',
+      LML_CLIENT_MAX_CONCURRENT: '1',
+      LML_CLIENT_RATE_PER_MIN: '60000', // 1000/sec — effectively no rate cap in tests
+    };
+    _resetLmlClientLimitersForTest();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+    _resetLmlClientLimitersForTest();
+  });
+
+  it('acquires the shared LML limiter before its streaming-check call (governed, not a direct call)', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let releaseBatch: (() => void) | undefined;
+    const batchReady = new Promise<void>((resolve) => {
+      releaseBatch = resolve;
+    });
+
+    mockFetch.mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await batchReady;
+      inFlight -= 1;
+      return {
+        ok: true,
+        json: () => Promise.resolve({ on_streaming: false, sources: {} }),
+      } as unknown as globalThis.Response;
+    });
+
+    // Two concurrent album-add streaming-checks against a MAX_CONCURRENT=1
+    // limiter. If the call were still a direct fetch, both would be in flight
+    // at once (maxInFlight === 2, queueDepth === 0); routed through the shared
+    // limiter, the second queues behind the first's permit.
+    const calls = [
+      checkStreamingAvailability('Stereolab', 'Aluminum Tunes'),
+      checkStreamingAvailability('Juana Molina', 'DOGA'),
+    ];
+
+    // Poll until the first call reaches fetch (mirrors the BS#906 wrapper test:
+    // the acquire → consume → fetch chain depth can shift without warning).
+    // Cap at 200 ms so a regression that never governs the call fails loudly.
+    const deadline = Date.now() + 200;
+    while (inFlight < 1 && Date.now() < deadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    // At most one streaming-check in flight; the other waits on the shared
+    // limiter's queue.
+    expect(maxInFlight).toBe(1);
+    expect(getLmlQueueDepth()).toBeGreaterThan(0);
+
+    // Release the batch and let both finish; the permit + queue drain.
+    if (releaseBatch) releaseBatch();
+    await Promise.all(calls);
+
+    expect(getLmlQueueDepth()).toBe(0);
+  });
+
+  it('shares the same limiter instance as /lookup (a lookup permit blocks a streaming-check)', async () => {
+    // Cross-surface pin: with a single shared permit, an in-flight /lookup must
+    // hold off a concurrent streaming-check. This proves the streaming-check
+    // draws from the same process-wide limiter as /lookup rather than a private
+    // one — the whole point of B5's "shared budget".
+    let lookupInFlight = false;
+    let streamingReached = false;
+    let releaseLookup: (() => void) | undefined;
+    const lookupHold = new Promise<void>((resolve) => {
+      releaseLookup = resolve;
+    });
+
+    mockFetch.mockImplementation(async (input) => {
+      // Every call in this test passes a string URL as the first fetch arg.
+      const url = input as string;
+      if (url.endsWith('/api/v1/lookup')) {
+        lookupInFlight = true;
+        await lookupHold;
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+        } as unknown as globalThis.Response;
+      }
+      // streaming-check
+      streamingReached = true;
+      return {
+        ok: true,
+        json: () => Promise.resolve({ on_streaming: false, sources: {} }),
+      } as unknown as globalThis.Response;
+    });
+
+    const lookupCall = lookupMetadata('Duke Ellington & John Coltrane', 'In a Sentimental Mood');
+    const streamingCall = checkStreamingAvailability('Jessica Pratt', 'On Your Own Love Again');
+
+    // Let the event loop advance; the lookup grabs the only permit and parks.
+    const deadline = Date.now() + 200;
+    while (!lookupInFlight && Date.now() < deadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    // The streaming-check must be queued behind the lookup's permit, so it has
+    // NOT reached fetch yet.
+    expect(lookupInFlight).toBe(true);
+    expect(streamingReached).toBe(false);
+    expect(getLmlQueueDepth()).toBeGreaterThan(0);
+
+    if (releaseLookup) releaseLookup();
+    await Promise.all([lookupCall, streamingCall]);
+
+    // Once the lookup released its permit, the streaming-check ran.
+    expect(streamingReached).toBe(true);
+    expect(getLmlQueueDepth()).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`checkStreamingAvailability` (exported from `shared/lml-client`, invoked by `apps/backend/controllers/library.controller.ts` on **every album add**) bypassed the process-wide LML-client limiter, so each add issued an **ungoverned** streaming-check outside the admission budget — an uncounted call class that could overrun LML's real concurrency ceiling alongside the enrichment and backfill limiters.

This routes the call through the same `defaultLimiter.run()` gate as `/lookup`, so the fetch runs behind `semaphore.acquire()` + `tokenBucket.consume(1)` and participates in the shared concurrency/rate budget. It composes with the bounded-queue/deadline work in #1748 for free once that lands.

Album-add behavior is otherwise unchanged: same path, headers, body, and returned `StreamingCheckResponse`.

## Acceptance criteria

- [x] `checkStreamingAvailability` acquires the shared limiter before its LML call — asserted governed, not a direct call.
- [x] It respects the same bounded-queue/deadline behavior as other LML calls (composes with #1748 once that lands).
- [x] Album-add behavior is otherwise unchanged.
- [x] TDD: failing unit test written first (confirmed RED before the one-line-region wrap).

## Tests

Two new unit tests in `tests/unit/services/lml.client.test.ts` (the home of every other limiter-governance test):

1. With `LML_CLIENT_MAX_CONCURRENT=1`, two concurrent streaming-checks — the second queues behind the shared permit (`maxInFlight === 1`, `getLmlQueueDepth() > 0`). Direct-call behavior would have both in flight at once.
2. Cross-surface pin: an in-flight `/lookup` holding the sole permit holds off a concurrent streaming-check, proving both draw from the **same** process-wide limiter instance.

Full `lml.client` suite (98) + consumer controller suites (120) green; repo `typecheck` and `lint` pass locally.

Part of Epic B (#876).

Closes #1750