### PR TITLE
feat(concerts): rank concerts within the station_recommended set by all-time plays

### DIFF
--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gte, isNotNull, isNull, lte, or, sql } from 'drizzle-orm';
+import { and, asc, eq, gte, isNotNull, isNull, lte, or, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
 import {
   artist_metadata,
   artist_similar_artists,
@@ -9,6 +9,7 @@ import {
   discogs_artist_similar_artists,
   library,
   normalizeFreetextArtist,
+  nyCalendarDate,
   rotation,
   type SimilarArtistNeighbor,
   venues,
@@ -102,6 +103,18 @@ export type ConcertDTO = {
   // id OR the nightly enrichment hasn't run. Same optional-and-nullable discipline
   // as `genres`/`similar_artists` (not in the api.yaml `required` set).
   station_plays?: number | null;
+  // 1-based rank of this concert within the station-recommended set (BS#1756,
+  // On Tour "For You" tier — ranks the `station_recommended` gate by all-time
+  // WXYC plays), sourced from a correlated subquery over the ENTIRE gated
+  // upcoming window (`removed_at IS NULL AND starts_on >= from AND
+  // station_recommended` — deliberately NOT the request's `to` bound or
+  // `curated` flag), ordered `COALESCE(plays, 0) DESC, starts_on ASC, id ASC`.
+  // Computed over the whole window regardless of the page's LIMIT/OFFSET, so a
+  // given concert's rank is identical on every page of the same query and
+  // agrees between the list and the by-id read (see `concertPageFields`).
+  // Null for a concert outside the gated set. Same null-safe discipline as
+  // `station_plays` (NOT `station_recommended`'s non-null EXISTS).
+  station_recommended_rank?: number | null;
   // True when the resolved headliner (`headlining_artist_id`) has at least one
   // WXYC library release that has been in rotation, any rotation row past or
   // present (BS#1731, On Tour "For You" tier redesign — supersedes the
@@ -168,6 +181,11 @@ export type ConcertJoinRow = {
   // omits it (the #1616 embed boundary), so its rows leave it undefined and
   // `toConcertDTO` coalesces to null.
   station_plays?: number | null;
+  // Optional: only the `getConcertsPage` / `getConcertById` projection selects the
+  // `station_recommended_rank` correlated-subquery expression (BS#1756). The
+  // `getUpcomingShowsMaps` embed omits it, so its rows leave it undefined and
+  // `toConcertDTO` coalesces to null (same discipline as `station_plays`).
+  station_recommended_rank?: number | null;
   // Optional: only the `getConcertsPage` / `getConcertById` projection selects the
   // `station_recommended` EXISTS subquery. The `getUpcomingShowsMaps` embed omits
   // it, so its rows leave it undefined and `toConcertDTO` passes that through
@@ -249,6 +267,9 @@ export const toConcertDTO = (row: ConcertJoinRow): ConcertDTO => ({
   // Same null-safe discipline (BS#1702): undefined on the embed projection, null
   // for a headliner with no in-library id or no station-plays enrichment row.
   station_plays: row.station_plays ?? null,
+  // Same null-safe discipline as `station_plays` (BS#1756): undefined on the
+  // embed projection, null for a concert outside the gated set.
+  station_recommended_rank: row.station_recommended_rank ?? null,
   // NOT coalesced (BS#1731): the page/by-id projection's EXISTS always supplies a
   // concrete boolean, so `?? false` would never fire there anyway; on the embed
   // projection `row.station_recommended` is `undefined` and must stay that way so
@@ -295,20 +316,66 @@ const buildWhere = ({ from, to, curated }: ConcertsQueryFilters) => {
  */
 const effectiveHeadlinerDiscogsId = sql`COALESCE(${concerts.headlining_discogs_artist_id}, ${artists.discogs_artist_id})`;
 
-// Page projection: the shared concerts⋈venues fields plus the LEFT-joined
-// artist-level genres (BS#1624), affinity neighbors (BS#1626 + BS#1701),
-// station plays (BS#1702), and the station-recommended EXISTS (BS#1731). Kept
-// separate from `concertJoinFields` so the `getUpcomingShowsMaps` / count paths
-// (which don't join the enrichment tables) can't accidentally reference those
-// tables' columns.
-//
-// `similar_artists` COALESCEs the two enrichment lanes (BS#1701): the library
-// lane (`artist_similar_artists`, keyed on `headlining_artist_id`) wins over the
-// discogs lane (`discogs_artist_similar_artists`, keyed on
-// `effectiveHeadlinerDiscogsId`) when both are present — the rare overlap where
-// the same Discogs id was independently enriched via the discogs lane resolves
-// to the same neighbors anyway. Null when the headliner is in NEITHER lane.
-const concertPageFields = {
+/**
+ * True when `headlinerId` has at least one WXYC library release that has been
+ * in rotation — the BS#1731 `station_recommended` gate, factored out (as
+ * `logicalAlbumKeySql` in `logical-album-key.service.ts` factors the
+ * catalog-popularity key derivation) so ONE definition backs both `.station_recommended`'s
+ * outer-row EXISTS and BS#1756's rank subquery, which re-tests the same gate
+ * for an aliased correlated row. Callers pass either a real Drizzle column ref
+ * (`concerts.headlining_artist_id`) or raw aliased SQL for a self-referencing
+ * subquery (`sql.raw('x."headlining_artist_id"')`) — same two-shape contract
+ * as `logicalAlbumKeySql`.
+ */
+const gatedHeadlinerExists = (headlinerId: SQLWrapper): SQL => sql`EXISTS (
+    SELECT 1 FROM ${rotation}
+    JOIN ${library} ON ${library.id} = ${rotation.album_id}
+    WHERE ${library.artist_id} = ${headlinerId}
+  )`;
+
+/**
+ * Page projection, parameterized on `from` (the lower `starts_on` bound of the
+ * BS#1756 rank domain — see `station_recommended_rank` below). Builds a fresh
+ * fields object per call since the rank expression embeds `from` as a bind
+ * value; every other field is `from`-independent.
+ *
+ * The shared concerts⋈venues fields plus the LEFT-joined artist-level genres
+ * (BS#1624), affinity neighbors (BS#1626 + BS#1701), station plays (BS#1702),
+ * the station-recommended EXISTS (BS#1731), and the station-recommended rank
+ * (BS#1756). Kept separate from `concertJoinFields` so the
+ * `getUpcomingShowsMaps` / count paths (which don't join the enrichment
+ * tables) can't accidentally reference those tables' columns.
+ *
+ * `similar_artists` COALESCEs the two enrichment lanes (BS#1701): the library
+ * lane (`artist_similar_artists`, keyed on `headlining_artist_id`) wins over the
+ * discogs lane (`discogs_artist_similar_artists`, keyed on
+ * `effectiveHeadlinerDiscogsId`) when both are present — the rare overlap where
+ * the same Discogs id was independently enriched via the discogs lane resolves
+ * to the same neighbors anyway. Null when the headliner is in NEITHER lane.
+ *
+ * Station-recommended-rank projection (BS#1756): a correlated scalar subquery,
+ * NOT a `.leftJoin`, so — exactly like `station_recommended`'s EXISTS — it
+ * lands in both `getConcertsPage` and `getConcertById` automatically and can
+ * never trip the BS#1694 "table … is not part of the query" hazard (there is
+ * no extra table for the query builder's join graph to be missing). The outer
+ * `CASE` guard re-tests `removed_at IS NULL AND starts_on >= from AND
+ * <gated>` for THIS row before running the inner count, so a row that isn't
+ * itself in the ranked domain — including a past/tombstoned concert reaching
+ * this projection through the WINDOWLESS `getConcertById` query — resolves
+ * null rather than inheriting a rank from a window it isn't in. The inner
+ * correlated subquery re-derives the SAME domain (`removed_at IS NULL AND
+ * starts_on >= from AND <gated>`, aliased `x`/`xsp` to stay distinct from the
+ * outer row) and counts how many domain rows sort strictly before this one
+ * under `COALESCE(plays, 0) DESC, starts_on ASC, id ASC` — that count plus one
+ * is the 1-based rank. Deliberately bounded by `from` ONLY: no `to` bound, no
+ * `curated` flag (the gate is already a strict subset of curated), and NEVER
+ * the outer query's LIMIT/OFFSET — the domain is the entire gated upcoming
+ * window every time, so a concert's rank is identical on every page of the
+ * same query and agrees between the list and the by-id read. A gated
+ * headliner with no `artist_station_plays` row sorts last via
+ * `COALESCE(plays, 0)`.
+ */
+const concertPageFields = (from: string) => ({
   ...concertJoinFields,
   genres: artist_metadata.genres,
   artist_bio: artist_metadata.artist_bio,
@@ -322,12 +389,40 @@ const concertPageFields = {
   // the query" hazard). Always a real boolean — never null — since EXISTS
   // itself never returns NULL; a NULL `headlining_artist_id` (Discogs-only
   // headliner) simply never correlates a match, so it reads false.
-  station_recommended: sql<boolean>`EXISTS (
-    SELECT 1 FROM ${rotation}
-    JOIN ${library} ON ${library.id} = ${rotation.album_id}
-    WHERE ${library.artist_id} = ${concerts.headlining_artist_id}
+  station_recommended: sql<boolean>`${gatedHeadlinerExists(concerts.headlining_artist_id)}`,
+  // Station-recommended-rank (BS#1756): see the `concertPageFields` doc above.
+  // The inner subquery aliases `concerts` as `x` and `artist_station_plays` as
+  // `xsp` — a self-join, since it re-scans the same tables the outer query
+  // already reads — so every raw reference inside it is written
+  // schema-alias-qualified (`x."column"`) rather than through a Drizzle column
+  // ref, which would render fully-qualified to the OUTER (unaliased) table and
+  // collide with the outer row's own reference to that same column.
+  station_recommended_rank: sql<number | null>`(
+    CASE WHEN ${concerts.removed_at} IS NULL
+      AND ${concerts.starts_on} >= ${from}
+      AND ${gatedHeadlinerExists(concerts.headlining_artist_id)}
+    THEN (
+      SELECT (count(*) + 1)::int
+      FROM ${concerts} x
+      LEFT JOIN ${artist_station_plays} xsp ON xsp."artist_id" = x."headlining_artist_id"
+      WHERE x."removed_at" IS NULL
+        AND x."starts_on" >= ${from}
+        AND ${gatedHeadlinerExists(sql.raw('x."headlining_artist_id"'))}
+        AND (
+          COALESCE(xsp."plays", 0) > COALESCE(${artist_station_plays.plays}, 0)
+          OR (
+            COALESCE(xsp."plays", 0) = COALESCE(${artist_station_plays.plays}, 0)
+            AND x."starts_on" < ${concerts.starts_on}
+          )
+          OR (
+            COALESCE(xsp."plays", 0) = COALESCE(${artist_station_plays.plays}, 0)
+            AND x."starts_on" = ${concerts.starts_on}
+            AND x."id" < ${concerts.id}
+          )
+        )
+    ) ELSE NULL END
   )`,
-};
+});
 
 /**
  * One page of upcoming concerts with their venues embedded, ordered by
@@ -350,6 +445,10 @@ const concertPageFields = {
  * library-key only (no COALESCE — station plays are an in-library signal) —
  * surfaces `station_plays: null` for a headliner with no in-library id or no
  * enrichment row.
+ *
+ * Station-recommended-rank projection (BS#1756): `concertPageFields(filters.from)`
+ * — the SAME lower bound this call's own `buildWhere(filters)` already applies —
+ * so the rank domain and the page's own window agree on "upcoming".
  */
 export const getConcertsPage = async (
   filters: ConcertsQueryFilters,
@@ -357,7 +456,7 @@ export const getConcertsPage = async (
   offset: number
 ): Promise<ConcertDTO[]> => {
   const rows = await db
-    .select(concertPageFields)
+    .select(concertPageFields(filters.from))
     .from(concerts)
     .innerJoin(venues, eq(venues.id, concerts.venue_id))
     .leftJoin(artists, eq(artists.id, concerts.headlining_artist_id))
@@ -410,6 +509,16 @@ const MAX_SERIAL_ID = 2_147_483_647;
  * embedded Venue can't satisfy the contract), or when the id is impossible
  * for the int4 serial (non-integral, < 1, or > 2^31-1) — short-circuited
  * below, before any query. The controller maps null → 404.
+ *
+ * Station-recommended-rank projection (BS#1756): windowless like the rest of
+ * this read, so `concertPageFields` is called with venue-local TODAY
+ * (`nyCalendarDate(new Date())`, the same helper the controller's `from`
+ * default uses) rather than any request-supplied `from` — there isn't one
+ * here. A past or tombstoned concert then correctly resolves a null rank (its
+ * `starts_on` fails the `>= today` half of the rank field's own CASE guard)
+ * even though this query's WHERE has no window at all; an UPCOMING gated
+ * concert ranks identically to how it ranks on the list, because both
+ * ultimately bound the same "today forward" domain.
  */
 export const getConcertById = async (id: number): Promise<ConcertDTO | null> => {
   // `concerts.id` is a serial (int4): an id outside (0, MAX_SERIAL_ID] — or a
@@ -423,16 +532,19 @@ export const getConcertById = async (id: number): Promise<ConcertDTO | null> => 
   }
 
   // Join set MUST stay identical to `getConcertsPage`: both select
-  // `concertPageFields`, and Drizzle throws at runtime ("table … is not part
-  // of the query") if the projection references a table the query never
+  // `concertPageFields(...)`, and Drizzle throws at runtime ("table … is not
+  // part of the query") if the projection references a table the query never
   // joined. BS#1626 adding `similar_artists` to the shared projection while
   // this query was in flight is exactly how the by-id read 500'd on every
   // row-returning request (BS#1694 hotfix). BS#1702's `station_plays`
   // (`artist_station_plays` join) and BS#1701's `discogs_artist_similar_artists`
   // COALESCE lane are the same class of hazard, so BOTH LEFT JOINs are mirrored
   // here too — the by-id spec's serialization-parity test is the regression guard.
+  // BS#1756's rank field is exempt from this hazard (see `concertPageFields`'s
+  // doc): it's a correlated scalar subquery, not a `.leftJoin`, so there is no
+  // join to mirror — only the `from` argument (venue-local today) to supply.
   const rows = await db
-    .select(concertPageFields)
+    .select(concertPageFields(nyCalendarDate(new Date())))
     .from(concerts)
     .innerJoin(venues, eq(venues.id, concerts.venue_id))
     .leftJoin(artists, eq(artists.id, concerts.headlining_artist_id))

--- a/tests/integration/concerts.spec.js
+++ b/tests/integration/concerts.spec.js
@@ -664,3 +664,353 @@ describe('GET /concerts station_recommended (BS#1731)', () => {
     expect(discogsOnlyById.body.station_recommended).toBe(false);
   });
 });
+
+/**
+ * BS#1756 — `Concert.station_recommended_rank`: the 1-based rank of a
+ * concert within the BS#1731 `station_recommended` gated set, ordered by
+ * all-time WXYC plays (`artist_station_plays.plays`) descending, ties broken
+ * `starts_on ASC, id ASC`, null plays sorting last. Computed over the ENTIRE
+ * gated upcoming window (`removed_at IS NULL AND starts_on >= from AND
+ * station_recommended`) — bounded by `from` only, never the request's `to`,
+ * `curated`, or (the load-bearing property) the page's `limit`/`offset`.
+ *
+ * Isolated from the BS#1603/BS#1731 describes above (own venue/source_id
+ * prefix, own artist-name prefix) so these seeds can't perturb their
+ * assertions.
+ */
+describe('GET /concerts station_recommended_rank (BS#1756)', () => {
+  const VENUE_SLUG = 'bs1756-probe-room';
+  const SOURCE_ID_PREFIX = 'bs1756:';
+  const ARTIST_NAME_PREFIX = 'BS#1756 Probe ';
+  const RANK1_ARTIST_NAME = `${ARTIST_NAME_PREFIX}Rank1 Artist`; // plays 500
+  const RANK2_ARTIST_NAME = `${ARTIST_NAME_PREFIX}Rank2 Artist`; // plays 300
+  const RANK3_ARTIST_NAME = `${ARTIST_NAME_PREFIX}Rank3 Artist`; // plays 150
+  const TIE_EARLIER_ARTIST_NAME = `${ARTIST_NAME_PREFIX}TieEarlier Artist`; // plays 100, earlier date
+  const TIE_LATER_ARTIST_NAME = `${ARTIST_NAME_PREFIX}TieLater Artist`; // plays 100, later date
+  const NO_PLAYS_ARTIST_NAME = `${ARTIST_NAME_PREFIX}NoPlays Artist`; // gated, no artist_station_plays row
+  const UNROTATED_ARTIST_NAME = `${ARTIST_NAME_PREFIX}Unrotated Artist`; // resolved, not gated
+  const DISCOGS_ONLY_ARTIST_RAW = `${ARTIST_NAME_PREFIX}Discogs-Only Artist`; // never gated
+  const DISCOGS_ONLY_ARTIST_DISCOGS_ID = 91756001;
+
+  // Dates deliberately NOT in plays-descending order (RANK1 sits at day 7, the
+  // tie pair straddles day 1 and day 8) so a regression that ranked by
+  // `starts_on` instead of `plays` fails the plays-desc assertions below
+  // rather than accidentally matching by coincidence.
+  const DAY = {
+    tieEarlier: isoDate(1),
+    rank2: isoDate(2),
+    unrotated: isoDate(3),
+    noPlays: isoDate(4),
+    discogsOnly: isoDate(5),
+    rank3: isoDate(6),
+    rank1: isoDate(7),
+    tieLater: isoDate(8),
+  };
+  const WINDOW_FROM = isoDate(0);
+  const WINDOW_TO = isoDate(30); // comfortably past every DAY.* offset above
+
+  let auth;
+  let sql;
+
+  const insertConcert = async (venueId, key, overrides) => {
+    const defaults = {
+      source: 'triangle_shows',
+      starts_at: null,
+      doors_at: null,
+      headlining_artist_id: null,
+      headlining_discogs_artist_id: null,
+      title: null,
+      supporting_artists: [],
+      ticket_url: null,
+      image_url: null,
+      event_url: null,
+      price_min: null,
+      price_max: null,
+      age_restriction: null,
+      status: 'on_sale',
+      removed_at: null,
+    };
+    const row = { ...defaults, ...overrides };
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".concerts
+         (source, source_id, venue_id, starts_on, starts_at, doors_at,
+          headlining_artist_raw, headlining_artist_id, headlining_discogs_artist_id,
+          title, supporting_artists_raw, ticket_url, image_url, price_min, price_max,
+          age_restriction, status, removed_at, event_url, raw_data, scraped_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, '{}'::jsonb, now())`,
+      [
+        row.source,
+        SOURCE_ID_PREFIX + key,
+        venueId,
+        row.starts_on,
+        row.starts_at,
+        row.doors_at,
+        row.headlining_artist_raw,
+        row.headlining_artist_id,
+        row.headlining_discogs_artist_id,
+        row.title,
+        row.supporting_artists,
+        row.ticket_url,
+        row.image_url,
+        row.price_min,
+        row.price_max,
+        row.age_restriction,
+        row.status,
+        row.removed_at,
+        row.event_url,
+      ]
+    );
+  };
+
+  /** Artist + rotation-linked library release — a BS#1731-gated headliner. */
+  const seedGatedArtist = async (name) => {
+    const [artist] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters)
+       VALUES ($1, $1, 'ZZ') RETURNING id`,
+      [name]
+    );
+    const [libraryRow] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library (artist_id, genre_id, format_id, album_title, code_number)
+       VALUES ($1, (SELECT id FROM "${SCHEMA}".genres LIMIT 1), (SELECT id FROM "${SCHEMA}".format LIMIT 1), $2, 1)
+       RETURNING id`,
+      [artist.id, `${name} LP`]
+    );
+    await sql.unsafe(`INSERT INTO "${SCHEMA}".rotation (album_id, rotation_bin) VALUES ($1, 'H')`, [libraryRow.id]);
+    return artist.id;
+  };
+
+  const seedPlays = async (artistId, plays) => {
+    await sql.unsafe(`INSERT INTO "${SCHEMA}".artist_station_plays (artist_id, plays) VALUES ($1, $2)`, [
+      artistId,
+      plays,
+    ]);
+  };
+
+  const cleanup = async () => {
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".concerts WHERE source_id LIKE $1`, [`${SOURCE_ID_PREFIX}%`]);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".venues WHERE slug = $1`, [VENUE_SLUG]);
+    await sql.unsafe(
+      `DELETE FROM "${SCHEMA}".artist_station_plays WHERE artist_id IN (SELECT id FROM "${SCHEMA}".artists WHERE artist_name LIKE $1)`,
+      [`${ARTIST_NAME_PREFIX}%`]
+    );
+    await sql.unsafe(
+      `DELETE FROM "${SCHEMA}".rotation WHERE album_id IN (SELECT id FROM "${SCHEMA}".library WHERE artist_id IN (SELECT id FROM "${SCHEMA}".artists WHERE artist_name LIKE $1))`,
+      [`${ARTIST_NAME_PREFIX}%`]
+    );
+    await sql.unsafe(
+      `DELETE FROM "${SCHEMA}".library WHERE artist_id IN (SELECT id FROM "${SCHEMA}".artists WHERE artist_name LIKE $1)`,
+      [`${ARTIST_NAME_PREFIX}%`]
+    );
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".artists WHERE artist_name LIKE $1`, [`${ARTIST_NAME_PREFIX}%`]);
+  };
+
+  beforeAll(async () => {
+    auth = createAuthRequest(request, global.access_token);
+    sql = makeSql();
+    await cleanup(); // idempotent across re-runs (shared schema, --runInBand)
+
+    const [venue] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".venues (slug, name, city, state, address)
+       VALUES ($1, 'BS1756 Probe Room', 'Carrboro', 'NC', '300 E Main St')
+       RETURNING id`,
+      [VENUE_SLUG]
+    );
+    const venueId = venue.id;
+
+    const rank1ArtistId = await seedGatedArtist(RANK1_ARTIST_NAME);
+    const rank2ArtistId = await seedGatedArtist(RANK2_ARTIST_NAME);
+    const rank3ArtistId = await seedGatedArtist(RANK3_ARTIST_NAME);
+    const tieEarlierArtistId = await seedGatedArtist(TIE_EARLIER_ARTIST_NAME);
+    const tieLaterArtistId = await seedGatedArtist(TIE_LATER_ARTIST_NAME);
+    // Gated (rotation-linked), but deliberately given NO artist_station_plays
+    // row — the NULL-plays case, which must rank LAST among the gated set.
+    const noPlaysArtistId = await seedGatedArtist(NO_PLAYS_ARTIST_NAME);
+    // Resolved headliner with no rotation-linked release: NOT gated.
+    const [unrotatedArtist] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (artist_name, alphabetical_name, code_letters)
+       VALUES ($1, $1, 'ZZ') RETURNING id`,
+      [UNROTATED_ARTIST_NAME]
+    );
+
+    await seedPlays(rank1ArtistId, 500);
+    await seedPlays(rank2ArtistId, 300);
+    await seedPlays(rank3ArtistId, 150);
+    await seedPlays(tieEarlierArtistId, 100);
+    await seedPlays(tieLaterArtistId, 100);
+    // noPlaysArtistId intentionally gets no artist_station_plays row.
+
+    await insertConcert(venueId, 'rank1', {
+      starts_on: DAY.rank1,
+      headlining_artist_raw: RANK1_ARTIST_NAME,
+      headlining_artist_id: rank1ArtistId,
+    });
+    await insertConcert(venueId, 'rank2', {
+      starts_on: DAY.rank2,
+      headlining_artist_raw: RANK2_ARTIST_NAME,
+      headlining_artist_id: rank2ArtistId,
+    });
+    await insertConcert(venueId, 'rank3', {
+      starts_on: DAY.rank3,
+      headlining_artist_raw: RANK3_ARTIST_NAME,
+      headlining_artist_id: rank3ArtistId,
+    });
+    await insertConcert(venueId, 'tie-earlier', {
+      starts_on: DAY.tieEarlier,
+      headlining_artist_raw: TIE_EARLIER_ARTIST_NAME,
+      headlining_artist_id: tieEarlierArtistId,
+    });
+    await insertConcert(venueId, 'tie-later', {
+      starts_on: DAY.tieLater,
+      headlining_artist_raw: TIE_LATER_ARTIST_NAME,
+      headlining_artist_id: tieLaterArtistId,
+    });
+    await insertConcert(venueId, 'no-plays', {
+      starts_on: DAY.noPlays,
+      headlining_artist_raw: NO_PLAYS_ARTIST_NAME,
+      headlining_artist_id: noPlaysArtistId,
+    });
+    await insertConcert(venueId, 'unrotated', {
+      starts_on: DAY.unrotated,
+      headlining_artist_raw: UNROTATED_ARTIST_NAME,
+      headlining_artist_id: unrotatedArtist.id,
+    });
+    await insertConcert(venueId, 'discogs-only', {
+      starts_on: DAY.discogsOnly,
+      headlining_artist_raw: DISCOGS_ONLY_ARTIST_RAW,
+      headlining_discogs_artist_id: DISCOGS_ONLY_ARTIST_DISCOGS_ID,
+    });
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await sql.end();
+  });
+
+  /** Concerts from a response body that belong to this spec's seed. */
+  const seeded = (body) => body.concerts.filter((c) => c.venue.slug === VENUE_SLUG);
+  const findByRaw = (body, raw) => seeded(body).find((c) => c.headlining_artist_raw === raw);
+
+  it('ranks the gated set 1-based by plays descending', async () => {
+    const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
+    expect(res.status).toBe(200);
+    expect(findByRaw(res.body, RANK1_ARTIST_NAME).station_recommended_rank).toBe(1);
+    expect(findByRaw(res.body, RANK2_ARTIST_NAME).station_recommended_rank).toBe(2);
+    expect(findByRaw(res.body, RANK3_ARTIST_NAME).station_recommended_rank).toBe(3);
+  });
+
+  it('sorts a gated headliner with no artist_station_plays row LAST among the gated set', async () => {
+    const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
+    expect(res.status).toBe(200);
+    const noPlays = findByRaw(res.body, NO_PLAYS_ARTIST_NAME);
+    expect(noPlays).toBeDefined();
+    expect(noPlays.station_recommended).toBe(true); // gated...
+    expect(noPlays.station_recommended_rank).toBe(6); // ...but ranks below every positive-plays gated headliner
+  });
+
+  it('breaks an equal-plays tie by earlier starts_on ranking lower', async () => {
+    const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
+    expect(res.status).toBe(200);
+    const earlier = findByRaw(res.body, TIE_EARLIER_ARTIST_NAME);
+    const later = findByRaw(res.body, TIE_LATER_ARTIST_NAME);
+    expect(earlier.station_recommended_rank).toBe(4);
+    expect(later.station_recommended_rank).toBe(5);
+    expect(earlier.station_recommended_rank).toBeLessThan(later.station_recommended_rank);
+  });
+
+  it('emits null station_recommended_rank for a non-gated headliner (resolved, unrotated)', async () => {
+    const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
+    expect(res.status).toBe(200);
+    const unrotated = findByRaw(res.body, UNROTATED_ARTIST_NAME);
+    expect(unrotated).toBeDefined();
+    expect(unrotated.station_recommended).toBe(false);
+    expect(unrotated.station_recommended_rank).toBeNull();
+  });
+
+  it('emits null station_recommended_rank for a Discogs-only headliner', async () => {
+    const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
+    expect(res.status).toBe(200);
+    const discogsOnly = findByRaw(res.body, DISCOGS_ONLY_ARTIST_RAW);
+    expect(discogsOnly).toBeDefined();
+    expect(discogsOnly.headlining_artist_id).toBeNull();
+    expect(discogsOnly.station_recommended_rank).toBeNull();
+  });
+
+  it('leaves the rank domain unbounded by the request `to` (rank reflects the FULL gated window, not the response subset)', async () => {
+    // Narrow `to` so the response excludes RANK1 (day 7) and TIE_LATER (day 8),
+    // leaving RANK2/RANK3/TIE_EARLIER/NO_PLAYS in the response. If the rank
+    // domain incorrectly picked up the request's `to` bound, RANK2 (the
+    // highest-plays headliner remaining once RANK1 drops out) would shift to
+    // rank 1 instead of staying rank 2 — this is what the ticket's "do NOT
+    // apply the request's `to` bound … to the rank domain" rule guards against.
+    const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: DAY.rank3, limit: 100 });
+    expect(res.status).toBe(200);
+    expect(seeded(res.body).find((c) => c.headlining_artist_raw === RANK1_ARTIST_NAME)).toBeUndefined();
+    expect(seeded(res.body).find((c) => c.headlining_artist_raw === TIE_LATER_ARTIST_NAME)).toBeUndefined();
+    expect(findByRaw(res.body, RANK2_ARTIST_NAME).station_recommended_rank).toBe(2);
+    expect(findByRaw(res.body, RANK3_ARTIST_NAME).station_recommended_rank).toBe(3);
+    expect(findByRaw(res.body, TIE_EARLIER_ARTIST_NAME).station_recommended_rank).toBe(4);
+    expect(findByRaw(res.body, NO_PLAYS_ARTIST_NAME).station_recommended_rank).toBe(6);
+  });
+
+  it('leaves the rank domain unaffected by `curated`', async () => {
+    const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, curated: true, limit: 100 });
+    expect(res.status).toBe(200);
+    expect(findByRaw(res.body, RANK1_ARTIST_NAME).station_recommended_rank).toBe(1);
+    expect(findByRaw(res.body, RANK2_ARTIST_NAME).station_recommended_rank).toBe(2);
+    expect(findByRaw(res.body, NO_PLAYS_ARTIST_NAME).station_recommended_rank).toBe(6);
+  });
+
+  it('holds a stable rank across pagination — identical whether fetched on one page or split across many (the BS#1756 load-bearing property)', async () => {
+    // The naive bug this guards against: a `rank() OVER (...)` scoped to the
+    // CURRENT PAGE (i.e. placed on the paginated query itself, after
+    // LIMIT/OFFSET) would silently re-number 1..N on every page and still pass
+    // a single-page test. Forcing `limit: 2` against 8 seeded concerts spans
+    // at least 4 pages, so the gated set is guaranteed to straddle several.
+    const reference = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
+    expect(reference.status).toBe(200);
+    const referenceRanks = new Map(
+      seeded(reference.body).map((c) => [c.headlining_artist_raw, c.station_recommended_rank])
+    );
+    // Sanity: this test only proves something if our own gated set is actually
+    // present with the expected ranks.
+    expect(referenceRanks.get(RANK1_ARTIST_NAME)).toBe(1);
+    expect(referenceRanks.get(TIE_LATER_ARTIST_NAME)).toBe(5);
+
+    const paginatedRanks = new Map();
+    let page = 1;
+    let hasMore = true;
+    let pagesFetched = 0;
+    const MAX_PAGES = 50; // generous safety cap — real total is small (§ WINDOW_TO)
+    while (hasMore) {
+      if (pagesFetched >= MAX_PAGES) {
+        throw new Error(`station_recommended_rank pagination probe exceeded ${MAX_PAGES} pages — aborting`);
+      }
+      // eslint-disable-next-line no-await-in-loop -- sequential pagination walk
+      const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 2, page });
+      expect(res.status).toBe(200);
+      for (const c of seeded(res.body)) {
+        paginatedRanks.set(c.headlining_artist_raw, c.station_recommended_rank);
+      }
+      hasMore = res.body.pagination.hasMore;
+      page += 1;
+      pagesFetched += 1;
+    }
+    // Genuinely spans multiple pages for OUR OWN concerts: 8 seeded rows at
+    // limit 2 cannot fit on one page.
+    expect(pagesFetched).toBeGreaterThan(1);
+
+    for (const [raw, rank] of referenceRanks) {
+      expect(paginatedRanks.get(raw)).toBe(rank);
+    }
+  });
+
+  it('agrees between GET /concerts and GET /concerts/:id for an upcoming gated concert', async () => {
+    const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
+    const rank1 = findByRaw(res.body, RANK1_ARTIST_NAME);
+    expect(rank1.station_recommended_rank).toBe(1);
+
+    const byId = await auth.get(`/concerts/${rank1.id}`);
+    expect(byId.status).toBe(200);
+    expect(byId.body.station_recommended_rank).toBe(1);
+  });
+});

--- a/tests/integration/concerts.spec.js
+++ b/tests/integration/concerts.spec.js
@@ -677,6 +677,15 @@ describe('GET /concerts station_recommended (BS#1731)', () => {
  * Isolated from the BS#1603/BS#1731 describes above (own venue/source_id
  * prefix, own artist-name prefix) so these seeds can't perturb their
  * assertions.
+ *
+ * The rank domain is GLOBAL — every upcoming gated concert in the DB, not
+ * just this spec's seeded venue — so assertions below prove RELATIVE order
+ * within the seeded set (never an absolute `toBe(N)`), which the SQL
+ * guarantees regardless of what else is gated elsewhere in the DB. Also
+ * covers: a PAST gated concert's by-id rank (null, via the windowless
+ * `getConcertById` read re-testing `starts_on >= today`) and the rank
+ * subquery's final `id ASC` tie-break clause (equal plays AND equal
+ * starts_on).
  */
 describe('GET /concerts station_recommended_rank (BS#1756)', () => {
   const VENUE_SLUG = 'bs1756-probe-room';
@@ -691,6 +700,15 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
   const UNROTATED_ARTIST_NAME = `${ARTIST_NAME_PREFIX}Unrotated Artist`; // resolved, not gated
   const DISCOGS_ONLY_ARTIST_RAW = `${ARTIST_NAME_PREFIX}Discogs-Only Artist`; // never gated
   const DISCOGS_ONLY_ARTIST_DISCOGS_ID = 91756001;
+  // Gated, plays row, but on a PAST date — the by-id windowless+today-guard
+  // case (only reachable via GET /concerts/:id; excluded from the default
+  // GET /concerts window entirely).
+  const PAST_GATED_ARTIST_NAME = `${ARTIST_NAME_PREFIX}PastGated Artist`;
+  // Two gated artists with EQUAL plays whose concerts share a starts_on date,
+  // isolating the rank subquery's final `id ASC` tie-break clause (plays tie
+  // AND date tie, so only concert id can order them).
+  const ID_TIE_ARTIST_A_NAME = `${ARTIST_NAME_PREFIX}IdTieA Artist`;
+  const ID_TIE_ARTIST_B_NAME = `${ARTIST_NAME_PREFIX}IdTieB Artist`;
 
   // Dates deliberately NOT in plays-descending order (RANK1 sits at day 7, the
   // tie pair straddles day 1 and day 8) so a regression that ranked by
@@ -705,12 +723,17 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
     rank3: isoDate(6),
     rank1: isoDate(7),
     tieLater: isoDate(8),
+    idTie: isoDate(9),
   };
   const WINDOW_FROM = isoDate(0);
   const WINDOW_TO = isoDate(30); // comfortably past every DAY.* offset above
+  const PAST_GATED_STARTS_ON = isoDate(-10); // outside the default GET /concerts window
 
   let auth;
   let sql;
+  let pastGatedConcertId;
+  let idTieFirstConcertId;
+  let idTieSecondConcertId;
 
   const insertConcert = async (venueId, key, overrides) => {
     const defaults = {
@@ -731,13 +754,14 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
       removed_at: null,
     };
     const row = { ...defaults, ...overrides };
-    await sql.unsafe(
+    const [inserted] = await sql.unsafe(
       `INSERT INTO "${SCHEMA}".concerts
          (source, source_id, venue_id, starts_on, starts_at, doors_at,
           headlining_artist_raw, headlining_artist_id, headlining_discogs_artist_id,
           title, supporting_artists_raw, ticket_url, image_url, price_min, price_max,
           age_restriction, status, removed_at, event_url, raw_data, scraped_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, '{}'::jsonb, now())`,
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, '{}'::jsonb, now())
+       RETURNING id`,
       [
         row.source,
         SOURCE_ID_PREFIX + key,
@@ -760,6 +784,7 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
         row.event_url,
       ]
     );
+    return inserted.id;
   };
 
   /** Artist + rotation-linked library release — a BS#1731-gated headliner. */
@@ -831,6 +856,12 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
        VALUES ($1, $1, 'ZZ') RETURNING id`,
       [UNROTATED_ARTIST_NAME]
     );
+    // Gated + plays, but its concert is in the PAST — the by-id
+    // windowless+today-guard case (Fix #2).
+    const pastGatedArtistId = await seedGatedArtist(PAST_GATED_ARTIST_NAME);
+    // Two gated artists with EQUAL plays for the id-only tie-break case (Fix #3).
+    const idTieArtistAId = await seedGatedArtist(ID_TIE_ARTIST_A_NAME);
+    const idTieArtistBId = await seedGatedArtist(ID_TIE_ARTIST_B_NAME);
 
     await seedPlays(rank1ArtistId, 500);
     await seedPlays(rank2ArtistId, 300);
@@ -838,6 +869,9 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
     await seedPlays(tieEarlierArtistId, 100);
     await seedPlays(tieLaterArtistId, 100);
     // noPlaysArtistId intentionally gets no artist_station_plays row.
+    await seedPlays(pastGatedArtistId, 200);
+    await seedPlays(idTieArtistAId, 250);
+    await seedPlays(idTieArtistBId, 250);
 
     await insertConcert(venueId, 'rank1', {
       starts_on: DAY.rank1,
@@ -879,6 +913,23 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
       headlining_artist_raw: DISCOGS_ONLY_ARTIST_RAW,
       headlining_discogs_artist_id: DISCOGS_ONLY_ARTIST_DISCOGS_ID,
     });
+    pastGatedConcertId = await insertConcert(venueId, 'past-gated', {
+      starts_on: PAST_GATED_STARTS_ON,
+      headlining_artist_raw: PAST_GATED_ARTIST_NAME,
+      headlining_artist_id: pastGatedArtistId,
+    });
+    // Same starts_on for both — plays are also equal (250/250), so only the
+    // final `id ASC` tie-break clause can order these two.
+    idTieFirstConcertId = await insertConcert(venueId, 'id-tie-a', {
+      starts_on: DAY.idTie,
+      headlining_artist_raw: ID_TIE_ARTIST_A_NAME,
+      headlining_artist_id: idTieArtistAId,
+    });
+    idTieSecondConcertId = await insertConcert(venueId, 'id-tie-b', {
+      starts_on: DAY.idTie,
+      headlining_artist_raw: ID_TIE_ARTIST_B_NAME,
+      headlining_artist_id: idTieArtistBId,
+    });
   });
 
   afterAll(async () => {
@@ -890,12 +941,22 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
   const seeded = (body) => body.concerts.filter((c) => c.venue.slug === VENUE_SLUG);
   const findByRaw = (body, raw) => seeded(body).find((c) => c.headlining_artist_raw === raw);
 
-  it('ranks the gated set 1-based by plays descending', async () => {
+  it('ranks the gated set by plays descending', async () => {
+    // Absolute rank values are NOT asserted here: the rank domain is GLOBAL
+    // (every upcoming gated concert in the DB, not just this spec's venue —
+    // see the describe-level doc), so an unrelated gated concert elsewhere in
+    // the CI clone could insert gaps above these. Only the RELATIVE order
+    // among the seeded set is guaranteed by the SQL.
     const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
     expect(res.status).toBe(200);
-    expect(findByRaw(res.body, RANK1_ARTIST_NAME).station_recommended_rank).toBe(1);
-    expect(findByRaw(res.body, RANK2_ARTIST_NAME).station_recommended_rank).toBe(2);
-    expect(findByRaw(res.body, RANK3_ARTIST_NAME).station_recommended_rank).toBe(3);
+    const rank1 = findByRaw(res.body, RANK1_ARTIST_NAME).station_recommended_rank;
+    const rank2 = findByRaw(res.body, RANK2_ARTIST_NAME).station_recommended_rank;
+    const rank3 = findByRaw(res.body, RANK3_ARTIST_NAME).station_recommended_rank;
+    expect(rank1).not.toBeNull();
+    expect(rank2).not.toBeNull();
+    expect(rank3).not.toBeNull();
+    expect(rank1).toBeLessThan(rank2);
+    expect(rank2).toBeLessThan(rank3);
   });
 
   it('sorts a gated headliner with no artist_station_plays row LAST among the gated set', async () => {
@@ -904,7 +965,24 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
     const noPlays = findByRaw(res.body, NO_PLAYS_ARTIST_NAME);
     expect(noPlays).toBeDefined();
     expect(noPlays.station_recommended).toBe(true); // gated...
-    expect(noPlays.station_recommended_rank).toBe(6); // ...but ranks below every positive-plays gated headliner
+    expect(noPlays.station_recommended_rank).not.toBeNull();
+    // ...but ranks below (a strictly larger rank number than) every
+    // positive-plays gated headliner seeded by this spec, including the
+    // equal-plays id-tie pair (Fix #3) — a higher rank NUMBER here means a
+    // WORSE position, since rank 1 is best.
+    const positivePlaysRanks = [
+      RANK1_ARTIST_NAME,
+      RANK2_ARTIST_NAME,
+      RANK3_ARTIST_NAME,
+      TIE_EARLIER_ARTIST_NAME,
+      TIE_LATER_ARTIST_NAME,
+      ID_TIE_ARTIST_A_NAME,
+      ID_TIE_ARTIST_B_NAME,
+    ].map((name) => findByRaw(res.body, name).station_recommended_rank);
+    for (const rank of positivePlaysRanks) {
+      expect(rank).not.toBeNull();
+      expect(noPlays.station_recommended_rank).toBeGreaterThan(rank);
+    }
   });
 
   it('breaks an equal-plays tie by earlier starts_on ranking lower', async () => {
@@ -912,8 +990,8 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
     expect(res.status).toBe(200);
     const earlier = findByRaw(res.body, TIE_EARLIER_ARTIST_NAME);
     const later = findByRaw(res.body, TIE_LATER_ARTIST_NAME);
-    expect(earlier.station_recommended_rank).toBe(4);
-    expect(later.station_recommended_rank).toBe(5);
+    expect(earlier.station_recommended_rank).not.toBeNull();
+    expect(later.station_recommended_rank).not.toBeNull();
     expect(earlier.station_recommended_rank).toBeLessThan(later.station_recommended_rank);
   });
 
@@ -936,45 +1014,62 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
   });
 
   it('leaves the rank domain unbounded by the request `to` (rank reflects the FULL gated window, not the response subset)', async () => {
-    // Narrow `to` so the response excludes RANK1 (day 7) and TIE_LATER (day 8),
-    // leaving RANK2/RANK3/TIE_EARLIER/NO_PLAYS in the response. If the rank
-    // domain incorrectly picked up the request's `to` bound, RANK2 (the
-    // highest-plays headliner remaining once RANK1 drops out) would shift to
-    // rank 1 instead of staying rank 2 — this is what the ticket's "do NOT
-    // apply the request's `to` bound … to the rank domain" rule guards against.
-    const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: DAY.rank3, limit: 100 });
-    expect(res.status).toBe(200);
-    expect(seeded(res.body).find((c) => c.headlining_artist_raw === RANK1_ARTIST_NAME)).toBeUndefined();
-    expect(seeded(res.body).find((c) => c.headlining_artist_raw === TIE_LATER_ARTIST_NAME)).toBeUndefined();
-    expect(findByRaw(res.body, RANK2_ARTIST_NAME).station_recommended_rank).toBe(2);
-    expect(findByRaw(res.body, RANK3_ARTIST_NAME).station_recommended_rank).toBe(3);
-    expect(findByRaw(res.body, TIE_EARLIER_ARTIST_NAME).station_recommended_rank).toBe(4);
-    expect(findByRaw(res.body, NO_PLAYS_ARTIST_NAME).station_recommended_rank).toBe(6);
+    // The property under test: narrowing `to` to exclude RANK1 must NOT
+    // promote RANK2. Prove it by comparing RANK2's rank across two requests —
+    // the full window and a window narrowed to drop RANK1 (day 7) and
+    // TIE_LATER (day 8) from the response outright — and asserting RANK2's
+    // rank is IDENTICAL in both. If the rank domain wrongly picked up the
+    // request's `to` bound, RANK2 (the highest-plays headliner remaining once
+    // RANK1 drops out of a wrongly-narrowed domain) would shift to the
+    // minimum rank instead of staying put.
+    const full = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
+    expect(full.status).toBe(200);
+    const narrowed = await auth.get('/concerts').query({ from: WINDOW_FROM, to: DAY.rank3, limit: 100 });
+    expect(narrowed.status).toBe(200);
+
+    expect(seeded(narrowed.body).find((c) => c.headlining_artist_raw === RANK1_ARTIST_NAME)).toBeUndefined();
+    expect(seeded(narrowed.body).find((c) => c.headlining_artist_raw === TIE_LATER_ARTIST_NAME)).toBeUndefined();
+
+    const rank2Full = findByRaw(full.body, RANK2_ARTIST_NAME).station_recommended_rank;
+    const rank2Narrowed = findByRaw(narrowed.body, RANK2_ARTIST_NAME).station_recommended_rank;
+    expect(rank2Full).not.toBeNull();
+    expect(rank2Narrowed).toBe(rank2Full);
   });
 
   it('leaves the rank domain unaffected by `curated`', async () => {
     const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, curated: true, limit: 100 });
     expect(res.status).toBe(200);
-    expect(findByRaw(res.body, RANK1_ARTIST_NAME).station_recommended_rank).toBe(1);
-    expect(findByRaw(res.body, RANK2_ARTIST_NAME).station_recommended_rank).toBe(2);
-    expect(findByRaw(res.body, NO_PLAYS_ARTIST_NAME).station_recommended_rank).toBe(6);
+    const rank1 = findByRaw(res.body, RANK1_ARTIST_NAME).station_recommended_rank;
+    const rank2 = findByRaw(res.body, RANK2_ARTIST_NAME).station_recommended_rank;
+    const noPlays = findByRaw(res.body, NO_PLAYS_ARTIST_NAME).station_recommended_rank;
+    expect(rank1).not.toBeNull();
+    expect(rank2).not.toBeNull();
+    expect(noPlays).not.toBeNull();
+    expect(rank1).toBeLessThan(rank2);
+    expect(rank2).toBeLessThan(noPlays);
   });
 
   it('holds a stable rank across pagination — identical whether fetched on one page or split across many (the BS#1756 load-bearing property)', async () => {
     // The naive bug this guards against: a `rank() OVER (...)` scoped to the
     // CURRENT PAGE (i.e. placed on the paginated query itself, after
     // LIMIT/OFFSET) would silently re-number 1..N on every page and still pass
-    // a single-page test. Forcing `limit: 2` against 8 seeded concerts spans
-    // at least 4 pages, so the gated set is guaranteed to straddle several.
+    // a single-page test. Forcing `limit: 2` against the 10 in-window seeded
+    // concerts spans at least 5 pages, so the gated set is guaranteed to
+    // straddle several. (The spec seeds 12 concerts total, but the
+    // past-gated one — Fix #2 — sits outside [WINDOW_FROM, WINDOW_TO] and is
+    // correctly excluded from every page here.)
     const reference = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
     expect(reference.status).toBe(200);
     const referenceRanks = new Map(
       seeded(reference.body).map((c) => [c.headlining_artist_raw, c.station_recommended_rank])
     );
     // Sanity: this test only proves something if our own gated set is actually
-    // present with the expected ranks.
-    expect(referenceRanks.get(RANK1_ARTIST_NAME)).toBe(1);
-    expect(referenceRanks.get(TIE_LATER_ARTIST_NAME)).toBe(5);
+    // present with real (non-null) ranks, and RANK1 (highest plays) actually
+    // outranks TIE_LATER (a lower-plays tie member) — relative, not absolute,
+    // since the rank domain is global (see the describe-level doc).
+    expect(referenceRanks.get(RANK1_ARTIST_NAME)).not.toBeNull();
+    expect(referenceRanks.get(TIE_LATER_ARTIST_NAME)).not.toBeNull();
+    expect(referenceRanks.get(RANK1_ARTIST_NAME)).toBeLessThan(referenceRanks.get(TIE_LATER_ARTIST_NAME));
 
     const paginatedRanks = new Map();
     let page = 1;
@@ -995,8 +1090,8 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
       page += 1;
       pagesFetched += 1;
     }
-    // Genuinely spans multiple pages for OUR OWN concerts: 8 seeded rows at
-    // limit 2 cannot fit on one page.
+    // Genuinely spans multiple pages for OUR OWN concerts: 10 in-window
+    // seeded rows at limit 2 cannot fit on one page.
     expect(pagesFetched).toBeGreaterThan(1);
 
     for (const [raw, rank] of referenceRanks) {
@@ -1007,10 +1102,48 @@ describe('GET /concerts station_recommended_rank (BS#1756)', () => {
   it('agrees between GET /concerts and GET /concerts/:id for an upcoming gated concert', async () => {
     const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
     const rank1 = findByRaw(res.body, RANK1_ARTIST_NAME);
-    expect(rank1.station_recommended_rank).toBe(1);
+    expect(rank1.station_recommended_rank).not.toBeNull();
 
     const byId = await auth.get(`/concerts/${rank1.id}`);
     expect(byId.status).toBe(200);
-    expect(byId.body.station_recommended_rank).toBe(1);
+    // The by-id read recomputes the same rank subquery against venue-local
+    // TODAY rather than the list's `from` — for an UPCOMING concert both
+    // bound the same "today forward" domain, so the two must agree exactly.
+    expect(byId.body.station_recommended_rank).toBe(rank1.station_recommended_rank);
+  });
+
+  it('returns a null station_recommended_rank by id for a PAST gated concert, even though station_recommended stays true', async () => {
+    // GET /concerts/:id is deliberately WINDOWLESS (no `starts_on` bound), so
+    // a past, tombstone-free, gated concert still comes back — but the rank
+    // field's own CASE guard re-tests `starts_on >= today` for THIS row, and
+    // a past `starts_on` fails that regardless of the query's lack of a
+    // window. `station_recommended` is a separate EXISTS with no date
+    // component, so it stays true. A past concert is excluded from the
+    // default GET /concerts window entirely, so it can only be reached here
+    // by id (see the describe-level doc's "windowless+today-guard" note).
+    const byId = await auth.get(`/concerts/${pastGatedConcertId}`);
+    expect(byId.status).toBe(200);
+    expect(byId.body.station_recommended).toBe(true);
+    expect(byId.body.station_recommended_rank).toBeNull();
+  });
+
+  it('breaks an equal-plays, equal-starts_on tie by lower concert id ranking first', async () => {
+    // ID_TIE_ARTIST_A and ID_TIE_ARTIST_B share identical plays (250/250) AND
+    // an identical starts_on (DAY.idTie), so neither the plays-descending nor
+    // the starts_on-ascending clause can order them — only the rank
+    // subquery's final `x."id" < concerts.id` clause can. `idTieFirstConcertId`
+    // and `idTieSecondConcertId` are captured from the seed inserts in
+    // creation order, so the first is guaranteed the lower serial id.
+    expect(idTieFirstConcertId).toBeLessThan(idTieSecondConcertId);
+
+    const res = await auth.get('/concerts').query({ from: WINDOW_FROM, to: WINDOW_TO, limit: 100 });
+    expect(res.status).toBe(200);
+    const first = seeded(res.body).find((c) => c.id === idTieFirstConcertId);
+    const second = seeded(res.body).find((c) => c.id === idTieSecondConcertId);
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(first.station_recommended_rank).not.toBeNull();
+    expect(second.station_recommended_rank).not.toBeNull();
+    expect(first.station_recommended_rank).toBeLessThan(second.station_recommended_rank);
   });
 });

--- a/tests/unit/services/concerts.service.test.ts
+++ b/tests/unit/services/concerts.service.test.ts
@@ -31,8 +31,8 @@ import {
 
 /**
  * Compile-time pin: `ConcertDTO` must match the SSOT `Concert` schema in
- * `wxyc-shared/api.yaml` v1.20.0 (artist_bio added in 1.20.0 / BS#1734,
- * wxyc-shared#247). The published `@wxyc/shared` at this worktree's pin
+ * `wxyc-shared/api.yaml` v1.21.0 (station_recommended_rank added in 1.21.0 /
+ * BS#1756, wxyc-shared#248). The published `@wxyc/shared` at this worktree's pin
  * (`^2.3.0`) does not yet export a `Concert` DTO, so we
  * assert against a hand-mirrored shape derived from the api.yaml operation.
  * When `@wxyc/shared` publishes `Concert`, replace `ApiYamlConcert` below
@@ -83,6 +83,11 @@ type ApiYamlConcert = {
   // station-affinity tier. Optional, NOT nullable — the page/by-id projection's
   // EXISTS always yields a concrete boolean; only the embed omits the key.
   station_recommended?: boolean;
+  // BS#1756 (wxyc-shared#248): 1-based rank within the station_recommended set,
+  // ordered by all-time WXYC plays. Optional + nullable, same discipline as
+  // `station_plays` (its structural twin) — NOT `station_recommended`'s
+  // non-null boolean.
+  station_recommended_rank?: number | null;
 };
 
 type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
@@ -137,6 +142,9 @@ const timedRow: ConcertJoinRow = {
   station_plays: 312,
   // Resolved headliner with a rotation-linked library release (BS#1731).
   station_recommended: true,
+  // Gated (station_recommended: true): the correlated subquery placed it 1st
+  // in the station-recommended set (BS#1756).
+  station_recommended_rank: 1,
 };
 
 const dateOnlyRow: ConcertJoinRow = {
@@ -164,6 +172,8 @@ const dateOnlyRow: ConcertJoinRow = {
   station_plays: null,
   // Unresolved headliner: the EXISTS correlation never matches → false (BS#1731).
   station_recommended: false,
+  // Not gated (station_recommended: false): outside the ranked set → null (BS#1756).
+  station_recommended_rank: null,
 };
 
 describe('ConcertDTO structural pin', () => {
@@ -311,6 +321,27 @@ describe('toConcertDTO', () => {
     expect(dto.station_plays).toBeNull();
   });
 
+  // BS#1756 — station_recommended_rank comes from the correlated-subquery
+  // expression in the page/by-id projection: present for a gated headliner,
+  // null for one outside the gated set, and null (not undefined) when the
+  // embed projection omits the expression — same null-safe discipline as
+  // `station_plays`, its structural twin.
+  it('passes the joined station_recommended_rank through for a gated headliner', () => {
+    const dto = toConcertDTO(timedRow);
+    expect(dto.station_recommended_rank).toBe(1);
+  });
+
+  it('emits null station_recommended_rank for a non-gated headliner', () => {
+    expect(toConcertDTO(dateOnlyRow).station_recommended_rank).toBeNull();
+  });
+
+  it('coalesces an undefined row.station_recommended_rank (embed projection without the expression) to null', () => {
+    const { station_recommended_rank: _drop, ...without } = timedRow;
+    void _drop;
+    const dto = toConcertDTO(without);
+    expect(dto.station_recommended_rank).toBeNull();
+  });
+
   // BS#1731 — station_recommended comes from the EXISTS(rotation ⋈ library)
   // subquery in the page/by-id projection: true for a rotation-linked resolved
   // headliner, false for an unrotated or unresolved one, and OMITTED (not
@@ -358,6 +389,7 @@ describe('toConcertDTO', () => {
         'similar_artists',
         'station_plays',
         'station_recommended',
+        'station_recommended_rank',
       ].sort()
     );
     for (const internal of INTERNAL_COLUMNS) {
@@ -388,6 +420,9 @@ describe('getConcertsPage', () => {
     // BS#1731 — the station_recommended EXISTS is part of the shared page
     // projection, so it must always be selected here.
     expect(Object.keys(projection)).toContain('station_recommended');
+    // BS#1756 — the station_recommended_rank correlated subquery is part of
+    // the shared page projection too, so it must always be selected here.
+    expect(Object.keys(projection)).toContain('station_recommended_rank');
   });
 });
 
@@ -467,13 +502,14 @@ describe('getConcertById', () => {
       expect(selectedColumns).not.toContain(internal);
     }
     // Parity pin: the by-id projection carries the BS#1624 genres, BS#1734
-    // artist_bio, BS#1702 station_plays, and BS#1731 station_recommended
-    // fields, so a by-id read can never lag the list's enrichment fields (the
-    // BS#1694 lockstep-join invariant).
+    // artist_bio, BS#1702 station_plays, BS#1731 station_recommended, and
+    // BS#1756 station_recommended_rank fields, so a by-id read can never lag
+    // the list's enrichment fields (the BS#1694 lockstep-join invariant).
     expect(Object.keys(projection)).toContain('genres');
     expect(Object.keys(projection)).toContain('artist_bio');
     expect(Object.keys(projection)).toContain('station_plays');
     expect(Object.keys(projection)).toContain('station_recommended');
+    expect(Object.keys(projection)).toContain('station_recommended_rank');
   });
 });
 


### PR DESCRIPTION
## Summary

`GET /concerts` and `GET /concerts/:id` now project `station_recommended_rank`: the 1-based rank of a concert within the BS#1731 `station_recommended` gated set, ordered by all-time WXYC plays (`artist_station_plays.plays`) descending, ties broken `starts_on ASC` then `id ASC`, with a gated headliner that has no `artist_station_plays` row sorting last via `COALESCE(plays, 0)`. Null for any concert outside the gated set. Contract already merged in `wxyc-shared` (api.yaml v1.21.0, `station_recommended_rank: integer, nullable`) — WXYC/wxyc-shared#248.

- `station_recommended_rank?: number | null` added to `ConcertDTO`/`ConcertJoinRow`, mirroring `station_plays`'s optional-and-nullable discipline (its structural twin), not `station_recommended`'s non-null boolean.
- `concertPageFields` is now a function of `from`: the list passes `filters.from`, the by-id read passes venue-local today (`nyCalendarDate(new Date())`) since it has no request-supplied window.

## Design note: rank over the whole window, stable across pages

The rank is a correlated scalar subquery embedded directly in `concertPageFields`, not a `rank() OVER (...)` window function on the paginated query. A window function scoped to the paginated `SELECT` would re-number 1..N per page and still pass a naive single-page test — that's the trap this design avoids. The subquery independently re-derives the full gated-window domain (`removed_at IS NULL AND starts_on >= from AND station_recommended` — deliberately **not** the request's `to` bound or `curated` flag; the gate is already a strict subset of curated) and counts how many domain rows sort strictly before the current row under `COALESCE(plays, 0) DESC, starts_on ASC, id ASC`. That domain is computed independently of the outer query's `LIMIT`/`OFFSET`, so a given concert's rank is identical no matter which page it lands on and agrees between the list and the by-id read.

Because it's a scalar subquery — not a `.leftJoin` — it lands in both `getConcertsPage` and `getConcertById` automatically and can never trip the BS#1694 "table … is not part of the query" hazard the way an added join would; only the `from` argument needs to be supplied at each call site. This mirrors the shape `station_recommended`'s own EXISTS already uses, factored into a shared `gatedHeadlinerExists` helper (same two-shape contract as `logicalAlbumKeySql` in `logical-album-key.service.ts`: a real Drizzle column ref for the outer row, raw aliased SQL for the subquery's self-referencing candidate rows).

Integration coverage in `tests/integration/concerts.spec.js` (`GET /concerts station_recommended_rank (BS#1756)`) pins this directly: it seeds 8 concerts (6 gated with distinct/tied play counts including one with no `artist_station_plays` row, one resolved-but-unrotated, one Discogs-only), then fetches the full window at `limit=100` and again by walking every page at `limit=2` (guaranteed to span ≥4 pages), asserting every concert's rank is identical across both — the test that would catch a per-page window-function regression. It also pins that `to` and `curated` don't narrow the rank domain, and that `GET /concerts/:id` agrees with the list for an upcoming gated concert.

## Explicitly out of scope

The deprecated `station_plays` wire projection is left untouched — its removal is tracked separately in #1732. No migration (`artist_station_plays` already exists); no change to `station_recommended` gate semantics.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (pre-existing warning baseline unchanged)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 334 suites / 5013 tests pass
- [x] `CI_DB_PORT=5453 npm run ci:testmock` — `tests/integration/concerts.spec.js` (including the new BS#1756 block) and `tests/integration/concerts-by-id.spec.js` pass in full

Closes #1756

Related: WXYC/wxyc-ios-64#576 (On Tour "For You" tier), WXYC/wxyc-shared#248 (contract)