### PR TITLE
fix(library-identity-consumer): validate result.library_id against the batch input set

### DIFF
--- a/jobs/library-identity-consumer/orchestrate.ts
+++ b/jobs/library-identity-consumer/orchestrate.ts
@@ -75,6 +75,7 @@ export type Totals = {
     lml_error: number;
     writer_error: number;
     lml_cardinality_mismatch: number;
+    lml_untrusted_library_id: number;
   };
   source_rows_skipped_null_confidence: number;
   lml_total_calls: number;
@@ -91,6 +92,7 @@ export type DryRunReport = {
     compilation: number;
     lml_error: number;
     lml_cardinality_mismatch: number;
+    lml_untrusted_library_id: number;
   };
   source_rows_skipped_null_confidence: number;
 };
@@ -111,6 +113,7 @@ const emptyTotals = (): Totals => ({
     lml_error: 0,
     writer_error: 0,
     lml_cardinality_mismatch: 0,
+    lml_untrusted_library_id: 0,
   },
   source_rows_skipped_null_confidence: 0,
   lml_total_calls: 0,
@@ -122,6 +125,7 @@ const formatTotals = (t: Totals): string =>
   `skipped.compilation=${t.rows_skipped.compilation} skipped.lml_error=${t.rows_skipped.lml_error} ` +
   `skipped.writer_error=${t.rows_skipped.writer_error} ` +
   `skipped.lml_cardinality_mismatch=${t.rows_skipped.lml_cardinality_mismatch} ` +
+  `skipped.lml_untrusted_library_id=${t.rows_skipped.lml_untrusted_library_id} ` +
   `source_rows_skipped_null_confidence=${t.source_rows_skipped_null_confidence} ` +
   `lml_calls=${t.lml_total_calls} lml_latency_ms=${t.lml_total_latency_ms}`;
 
@@ -212,7 +216,40 @@ export const runConsumer = async (opts: {
       }
     }
 
+    // Per-row membership validation. The cardinality check above only
+    // catches a short response; it says nothing about whether the
+    // `library_id` on each individual result actually belongs to this
+    // batch's inputs (a duplicated id compensating for a dropped one keeps
+    // response.results.length === rows.length and would sail through the
+    // length-only check). Build the batch's input-id set once and validate
+    // every result's `library_id` against it, tracking already-seen ids so
+    // a duplicate within the same batch is also flagged rather than
+    // silently double-written.
+    const inputIds = new Set(rows.map((r) => r.id));
+    const consumedIds = new Set<number>();
+
     for (const result of response.results) {
+      if (!inputIds.has(result.library_id) || consumedIds.has(result.library_id)) {
+        totals.scanned += 1;
+        totals.rows_skipped.lml_untrusted_library_id += 1;
+        log(
+          'warn',
+          'lml_untrusted_library_id',
+          `LML returned library_id=${result.library_id} not present (or already consumed) in batch ${batchIndex}'s input set`,
+          {
+            batch_index: batchIndex,
+            library_id: result.library_id,
+          }
+        );
+        captureError(
+          new Error(`LML untrusted library_id: ${result.library_id} not in batch ${batchIndex}'s input set`),
+          'lml_untrusted_library_id',
+          { batch_index: batchIndex, library_id: result.library_id }
+        );
+        continue;
+      }
+      consumedIds.add(result.library_id);
+
       totals.scanned += 1;
       switch (result.kind) {
         case 'single_artist':
@@ -266,6 +303,7 @@ export const runConsumer = async (opts: {
           compilation: totals.rows_skipped.compilation,
           lml_error: totals.rows_skipped.lml_error,
           lml_cardinality_mismatch: totals.rows_skipped.lml_cardinality_mismatch,
+          lml_untrusted_library_id: totals.rows_skipped.lml_untrusted_library_id,
         },
         // Source-row unit, not library_id — kept outside `would_skip` so the
         // library_id-level accounting stays clean.

--- a/tests/unit/jobs/library-identity-consumer/orchestrate.test.ts
+++ b/tests/unit/jobs/library-identity-consumer/orchestrate.test.ts
@@ -301,7 +301,8 @@ describe('runConsumer — counter unit cleanliness', () => {
       result.totals.rows_skipped.compilation +
       result.totals.rows_skipped.lml_error +
       result.totals.rows_skipped.writer_error +
-      result.totals.rows_skipped.lml_cardinality_mismatch;
+      result.totals.rows_skipped.lml_cardinality_mismatch +
+      result.totals.rows_skipped.lml_untrusted_library_id;
     expect(
       result.totals.scanned === result.totals.rows_resolved + result.totals.rows_unresolved + libraryIdLevelSkipSum
     ).toBe(true);
@@ -341,6 +342,116 @@ describe('runConsumer — counter unit cleanliness', () => {
     expect(result.totals.scanned).toBe(3);
     expect(result.totals.rows_unresolved).toBe(2);
     expect(result.totals.rows_skipped.lml_cardinality_mismatch).toBe(1);
+  });
+
+  it('skips a result whose library_id is not present in the batch input set', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'A', album_title: 'a' },
+        { id: 2, artist_name: 'B', album_title: 'b' },
+      ])
+      .mockResolvedValue([]);
+
+    // LML returns a result for library_id=999, which was never part of
+    // this batch's inputs. Length still matches rows.length, so the
+    // cardinality check alone would miss this.
+    const bulkResolve = jest.fn<BulkResolveFn>().mockResolvedValue({
+      results: [
+        { kind: 'unresolved', library_id: 1, provenance: [] },
+        { kind: 'unresolved', library_id: 999, provenance: [] },
+      ],
+    });
+    const writeSingleArtist = jest.fn<WriteSingleArtistFn>().mockResolvedValue({
+      source_rows_written: 0,
+      source_rows_skipped_null_confidence: 0,
+    });
+
+    const result = await runConsumer({
+      bulkResolve,
+      writeSingleArtist,
+      batchSize: 500,
+      throttleMs: 0,
+      staleDays: 7,
+      partition: { sqlFragment: null, description: 'partition=none' },
+      dryRun: false,
+    });
+
+    expect(result.totals.scanned).toBe(2);
+    expect(result.totals.rows_unresolved).toBe(1);
+    expect(result.totals.rows_skipped.lml_untrusted_library_id).toBe(1);
+  });
+
+  it('skips a result whose library_id is missing from the batch input set (short response)', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'A', album_title: 'a' },
+        { id: 2, artist_name: 'B', album_title: 'b' },
+      ])
+      .mockResolvedValue([]);
+
+    // LML drops library_id=2 entirely (short response) — caught by the
+    // pre-existing cardinality-mismatch check, not the membership check.
+    const bulkResolve = jest.fn<BulkResolveFn>().mockResolvedValue({
+      results: [{ kind: 'unresolved', library_id: 1, provenance: [] }],
+    });
+    const writeSingleArtist = jest.fn<WriteSingleArtistFn>().mockResolvedValue({
+      source_rows_written: 0,
+      source_rows_skipped_null_confidence: 0,
+    });
+
+    const result = await runConsumer({
+      bulkResolve,
+      writeSingleArtist,
+      batchSize: 500,
+      throttleMs: 0,
+      staleDays: 7,
+      partition: { sqlFragment: null, description: 'partition=none' },
+      dryRun: false,
+    });
+
+    expect(result.totals.scanned).toBe(2);
+    expect(result.totals.rows_unresolved).toBe(1);
+    expect(result.totals.rows_skipped.lml_cardinality_mismatch).toBe(1);
+    expect(result.totals.rows_skipped.lml_untrusted_library_id).toBe(0);
+  });
+
+  it('flags a duplicated library_id that compensates for a dropped one (length matches, membership does not)', async () => {
+    (db.execute as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, artist_name: 'A', album_title: 'a' },
+        { id: 2, artist_name: 'B', album_title: 'b' },
+      ])
+      .mockResolvedValue([]);
+
+    // LML returns library_id=1 twice and drops library_id=2, keeping
+    // response.results.length === rows.length. The length-only cardinality
+    // check would see nothing wrong; the membership check must flag the
+    // duplicate.
+    const bulkResolve = jest.fn<BulkResolveFn>().mockResolvedValue({
+      results: [
+        { kind: 'unresolved', library_id: 1, provenance: [] },
+        { kind: 'unresolved', library_id: 1, provenance: [] },
+      ],
+    });
+    const writeSingleArtist = jest.fn<WriteSingleArtistFn>().mockResolvedValue({
+      source_rows_written: 0,
+      source_rows_skipped_null_confidence: 0,
+    });
+
+    const result = await runConsumer({
+      bulkResolve,
+      writeSingleArtist,
+      batchSize: 500,
+      throttleMs: 0,
+      staleDays: 7,
+      partition: { sqlFragment: null, description: 'partition=none' },
+      dryRun: false,
+    });
+
+    expect(result.totals.scanned).toBe(2);
+    expect(result.totals.rows_unresolved).toBe(1);
+    expect(result.totals.rows_skipped.lml_cardinality_mismatch).toBe(0);
+    expect(result.totals.rows_skipped.lml_untrusted_library_id).toBe(1);
   });
 });
 
@@ -415,7 +526,7 @@ describe('runConsumer — DRY_RUN', () => {
       ].sort()
     );
     expect(Object.keys(captured.would_skip).sort()).toEqual(
-      ['compilation', 'lml_cardinality_mismatch', 'lml_error'].sort()
+      ['compilation', 'lml_cardinality_mismatch', 'lml_error', 'lml_untrusted_library_id'].sort()
     );
     expect(captured.scanned).toBe(3);
     expect(captured.would_resolve).toBe(1);
@@ -423,6 +534,7 @@ describe('runConsumer — DRY_RUN', () => {
     expect(captured.would_skip.compilation).toBe(1);
     expect(captured.would_skip.lml_error).toBe(0);
     expect(captured.would_skip.lml_cardinality_mismatch).toBe(0);
+    expect(captured.would_skip.lml_untrusted_library_id).toBe(0);
     expect(captured.source_rows_skipped_null_confidence).toBe(0);
     expect(captured.lml_total_calls).toBe(1);
   });


### PR DESCRIPTION
## Summary

The `library-identity-consumer` orchestrator's cardinality check only compares `response.results.length` to `rows.length`, so it can't detect that an individual result's `library_id` doesn't actually belong to the batch that was sent. A duplicated `library_id` compensating for a dropped one keeps the lengths equal and sails straight through undetected — the writer would then double-write for the duplicated id and the dropped id's row never gets a verdict, with no signal in the run summary.

This builds a `Set` of the batch's input ids in `orchestrate.ts` and validates every result's `library_id` against it before dispatching to the writer, also tracking already-consumed ids within the batch so an in-batch duplicate is caught. Any mismatch (unknown id or duplicate) is skipped, logged with a Sentry breadcrumb, and counted under a new `rows_skipped.lml_untrusted_library_id` bucket (mirrored into the `DryRunReport.would_skip` shape) instead of being trusted verbatim.

Closes #1086

## Test plan

- [x] New unit tests in `tests/unit/jobs/library-identity-consumer/orchestrate.test.ts`:
  - a result whose `library_id` is not present in the batch's input set is skipped and counted
  - a result missing from a short response is still caught by the pre-existing cardinality-mismatch check (unaffected by this change)
  - a duplicated `library_id` that compensates for a dropped one (equal lengths, but membership violated) is flagged under the new bucket
- [x] `npm run test:unit` — same pre-existing failures as `main` (lru-cache version mismatch, unrelated), no new failures
- [x] `npm run lint` / `npm run format:check` clean for touched files
- [x] `tsc --noEmit` on the job package clean