### PR TITLE
fix(backend): capture Sentry exceptions on fire-and-forget CDC startup calls

### DIFF
--- a/apps/backend/app.ts
+++ b/apps/backend/app.ts
@@ -173,14 +173,20 @@ const server = app.listen(port, () => {
   // (`setupMetadataBroadcast`, future consumers) fire whether or not
   // CDC_SECRET is set (BS#1187). The websocket call below self-no-ops
   // when the secret is unset.
-  void startCdcDispatcher();
+  void startCdcDispatcher().catch((err) => {
+    console.error('startCdcDispatcher failed to start:', err);
+    Sentry.captureException(err, { tags: { subsystem: 'cdc' } });
+  });
   // Second CDC handler: rebroadcasts terminal metadata UPDATEs as SSE
   // `liveFs:update` so dj-site stays in sync after the enrichment-worker
   // (BS#892) finalizes a row. Closes BS#893 + BS#628. Registers a handler
   // on the same per-process LISTEN connection — independent of the
   // websocket handler, both fire on every event.
   setupMetadataBroadcast();
-  void setupCdcWebSocket(server);
+  void setupCdcWebSocket(server).catch((err) => {
+    console.error('setupCdcWebSocket failed to start:', err);
+    Sentry.captureException(err, { tags: { subsystem: 'cdc' } });
+  });
   // One-shot warm of the rotation-tracks picker LRUs in
   // `library.service.ts`. Fire-and-forget — the walk shares the LML
   // semaphore with concurrent traffic, and the LRUs are process-local so

--- a/tests/unit/config/cdc-startup-error-handling.test.ts
+++ b/tests/unit/config/cdc-startup-error-handling.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Source-grep regression test for BS#1222: the two fire-and-forget CDC
+ * startup calls in `apps/backend/app.ts` (`startCdcDispatcher` and
+ * `setupCdcWebSocket`) must attach a `.catch` handler that logs to stderr
+ * and reports to Sentry, so a DB-unreachable startup failure isn't silently
+ * swallowed by the bare `void` call.
+ *
+ * Mirrors the `server-timeout.test.ts` / `healthcheck-shape.test.ts` style:
+ * app.ts calls `app.listen(...)` unconditionally at module load, so
+ * importing it directly would spin up a real server + DB connection. We
+ * assert the source shape instead.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const appSource = readFileSync(resolve(__dirname, '../../../apps/backend/app.ts'), 'utf-8');
+
+describe('CDC startup error handling (BS#1222)', () => {
+  it('attaches a .catch to the startCdcDispatcher() call', () => {
+    const match = appSource.match(/void startCdcDispatcher\(\)\.catch\(\s*\([^)]*\)\s*=>\s*\{([\s\S]*?)\}\s*\);/);
+    expect(match).not.toBeNull();
+    if (!match) return;
+
+    const catchBody = match[1];
+    expect(catchBody).toMatch(/console\.error\(/);
+    expect(catchBody).toMatch(/Sentry\.captureException\(/);
+    expect(catchBody).toMatch(/subsystem:\s*['"]cdc['"]/);
+  });
+
+  it('attaches a .catch to the setupCdcWebSocket(server) call', () => {
+    const match = appSource.match(/void setupCdcWebSocket\(server\)\.catch\(\s*\([^)]*\)\s*=>\s*\{([\s\S]*?)\}\s*\);/);
+    expect(match).not.toBeNull();
+    if (!match) return;
+
+    const catchBody = match[1];
+    expect(catchBody).toMatch(/console\.error\(/);
+    expect(catchBody).toMatch(/Sentry\.captureException\(/);
+    expect(catchBody).toMatch(/subsystem:\s*['"]cdc['"]/);
+  });
+
+  it('does not leave either call as a bare unhandled void call', () => {
+    expect(appSource).not.toMatch(/void startCdcDispatcher\(\);/);
+    expect(appSource).not.toMatch(/void setupCdcWebSocket\(server\);/);
+  });
+});


### PR DESCRIPTION
## Summary

- `startCdcDispatcher()` and `setupCdcWebSocket()` are invoked with a bare `void` at server listen time. If either throws (e.g. the DB is unreachable at boot), the rejection was silently swallowed — no log, no Sentry report.
- Attach a `.catch` to both calls: `console.error` to stderr plus `Sentry.captureException` tagged `subsystem: 'cdc'`, matching the existing `legacy-mirror` middleware pattern (`tags: { subsystem: 'legacy-mirror', ... }`) elsewhere in this app.
- Happy-path behavior is unchanged.

Closes #1222

## Test plan

- [x] `tests/unit/config/cdc-startup-error-handling.test.ts` (source-grep style, matching the existing `server-timeout.test.ts` / `healthcheck-shape.test.ts` convention for `app.ts` since it calls `app.listen(...)` unconditionally at import time): asserts both calls have a `.catch` whose body calls `console.error` and `Sentry.captureException` tagged `subsystem: 'cdc'`, and that neither remains a bare unhandled `void` call.
- [x] `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run test:unit` all green.