### PR TITLE
fix(ci): move CI_DB_PORT default off the org-contested 5433 band

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,7 +67,7 @@ DB_NAME=wxyc_db
 DB_USERNAME=your_db_username
 DB_PASSWORD=your_db_password
 DB_PORT=5432
-CI_DB_PORT=5433
+CI_DB_PORT=15433
 
 ### Cognito Auth Info for Starting Backend Service Auth
 COGNITO_USERPOOL_ID=your_userpool_id

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,12 @@ on:
 
 env:
   TEST_HOST: http://localhost
+  # Intentionally kept at 5433 (unlike the local-dev default in
+  # dev_env/docker-compose.yml / scripts/ci-test.sh, bumped to 15433 by
+  # BS#1729). GHA runners are ephemeral and never have a local
+  # discogs-cache PG bound to 5433, so there's no collision class here —
+  # changing this value is out of scope for BS#1729's acceptance criteria
+  # ("CI (GitHub Actions) behavior unchanged").
   CI_DB_PORT: 5433
   CI_PORT: 8081
   PORT: 8081

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ DB_NAME=wxyc_db
 DB_USERNAME={{placeholder}}
 DB_PASSWORD={{placeholder}}
 DB_PORT=5432
-CI_DB_PORT=5433
+CI_DB_PORT=15433
 
 ### Better-Auth Configuration
 # Base URL for the auth service (must end with /auth)

--- a/dev_env/db_setup.sh
+++ b/dev_env/db_setup.sh
@@ -5,7 +5,7 @@ DB_HOST="localhost"
 DB_PORT=${DB_PORT:-5432}
 
 if [ "$USE_CI" = true ] ; then
-    DB_PORT=${CI_DB_PORT:-5433}
+    DB_PORT=${CI_DB_PORT:-15433}
 fi
 
 PGPASSWORD=$DB_PASSWORD psql -q -h $DB_HOST -p $DB_PORT -U $DB_USERNAME -d 'wxyc_db' < $BASEDIR/install_extensions.sql

--- a/dev_env/docker-compose.yml
+++ b/dev_env/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       PGUSER: ${DB_USERNAME}
       POSTGRES_DB: ${DB_NAME}
     ports:
-      - '${CI_DB_PORT:-5433}:5432'
+      - '${CI_DB_PORT:-15433}:5432'
     volumes:
       - ci-pg-data:/var/lib/postgresql/data
     healthcheck:

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -15,7 +15,7 @@ Full reference. CLAUDE.md links here. Variables marked _required_ have no defaul
 
 - `DB_HOST`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` _required_
 - `DB_PORT` (default `5432`)
-- `CI_DB_PORT` (default `5433`)
+- `CI_DB_PORT` (default `15433`) — Host port the `ci-db` container publishes on; kept outside the org's contested local-Postgres port band (5433/5434/5435/5442 — see `docs/testing.md`) so `ci:testmock` doesn't silently shadow onto a native listener on a developer's machine.
 - `WXYC_SCHEMA_NAME` (default `wxyc_schema`)
 - `DB_STATEMENT_TIMEOUT_MS` (default `5000` / 5s) — Server-enforced per-statement timeout on every postgres-js connection. Backend and auth inherit the default — any HTTP-handler query that runs longer than 5s is by definition an orphan (Express's request timeout has already fired). ETLs override to `300000` (5 min) in their Dockerfiles because their bulk passes can legitimately take tens of seconds. Backfills override similarly. Set `0` to disable (use only for unit-test fixtures).
 - `DB_APPLICATION_NAME` (default `wxyc-backend`) — Sets `application_name` on the postgres connection so `pg_stat_activity` makes the source obvious during incident triage. Each Dockerfile overrides this with its own service name (`wxyc-backend`, `wxyc-auth`, `wxyc-flowsheet-etl`, etc.).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,6 +42,8 @@ npm run ci:clean         # Tear down containers, volumes, networks
 
 The CI environment uses `dev_env/docker-compose.yml` with Docker profiles (`ci`, `e2e`).
 
+`CI_DB_PORT` (default `15433`) is the host port the ci-db container publishes on, read by `dev_env/docker-compose.yml`, `scripts/ci-test.sh`, `dev_env/db_setup.sh`, and the `ci:test:parallel` npm script. It defaults outside the org's contested local-Postgres band (5433 discogs-cache, 5434 musicbrainz-cache/staging, 5435 wikidata-cache, 5442 BS dev DB — see the org CLAUDE.md) so `ci:testmock` doesn't silently connect to a native listener on one of those ports instead of the Docker-mapped ci-db. If `15433` is also taken on your machine, override it: `CI_DB_PORT=<port> npm run ci:testmock`.
+
 ## CI/CD workflow
 
 GitHub Actions workflow (`.github/workflows/test.yml`) runs on PRs to `main`:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ci:env:full": "./scripts/ci-env.sh --full",
     "ci:test": "./scripts/ci-test.sh",
     "ci:test:full": "./scripts/ci-test.sh --full",
-    "ci:test:parallel": "DB_PORT=${CI_DB_PORT:-5433} PORT=${CI_PORT:-8081} BETTER_AUTH_URL=${CI_BETTER_AUTH_URL:-http://localhost:8083/auth} dotenvx run -f .env -- jest --config jest.parallel.config.json --coverage",
+    "ci:test:parallel": "DB_PORT=${CI_DB_PORT:-15433} PORT=${CI_PORT:-8081} BETTER_AUTH_URL=${CI_BETTER_AUTH_URL:-http://localhost:8083/auth} dotenvx run -f .env -- jest --config jest.parallel.config.json --coverage",
     "ci:clean": "docker compose -f dev_env/docker-compose.yml --env-file .env --profile ci down -v",
     "ci:testmock": "npm run ci:env && npm run ci:test && npm run ci:clean",
     "ci:testmock:full": "npm run ci:env:full && npm run ci:test:full && npm run ci:clean",

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -23,7 +23,7 @@ done
 
 # Base environment variables
 export DB_HOST=localhost
-export DB_PORT=${CI_DB_PORT:-5433}
+export DB_PORT=${CI_DB_PORT:-15433}
 export PORT=${CI_PORT:-8081}
 export BETTER_AUTH_URL=${CI_BETTER_AUTH_URL:-http://localhost:8083/auth}
 export MOCK_API_URL=http://localhost:${MOCK_API_PORT:-9090}


### PR DESCRIPTION
## Problem

`npm run ci:testmock` fails in jest's globalSetup with a misleading auth error when a native PostgreSQL is listening on port 5433 — which, per the org port conventions, is exactly where the local discogs-cache PG lives. A native postgres bound to `127.0.0.1:5433`/`[::1]:5433` coexists with Docker's proxy on `*:5433` (both binds succeed), so host-side jest resolves `localhost` to the more-specific native listener and silently connects to the wrong Postgres server.

## Fix

Move the `CI_DB_PORT` default from `5433` to `15433`, outside the org's contested local-Postgres band (5433 discogs-cache, 5434 musicbrainz-cache/staging, 5435 wikidata-cache, 5442 BS dev DB), across:

- `dev_env/docker-compose.yml` (ci profile host mapping)
- `scripts/ci-test.sh`
- `dev_env/db_setup.sh`
- the `ci:test:parallel` npm script
- `.env.example` and `README.md`

Documents the `CI_DB_PORT` override in `docs/testing.md` and `docs/env-vars.md`.

GitHub Actions' `CI_DB_PORT` stays at `5433` intentionally (annotated with a comment) — ephemeral runners never have a local discogs-cache PG to collide with, and the issue's acceptance criteria call for GHA behavior to stay unchanged.

## Verification

Reproduced the exact bug locally (native postgres bound to `5433` via `lsof`), then confirmed `npm run ci:testmock`'s globalSetup connects cleanly to the ci-db container and loads the shape fixture with no `ECONNREFUSED`/wrong-role error — the failure mode described in the issue. `npm run typecheck`, `npm run lint`, and `npm run format:check` all pass; `npm run test:unit` is green (5049/5049).

Closes #1729