### PR TITLE
fix(jobs): default cron logger tracesSampleRate to 1.0 instead of 0

### DIFF
--- a/jobs/album-level-backfill/logger.ts
+++ b/jobs/album-level-backfill/logger.ts
@@ -31,9 +31,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/album-reviews-etl/logger.ts
+++ b/jobs/album-reviews-etl/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/apple-music-url-backfill/logger.ts
+++ b/jobs/apple-music-url-backfill/logger.ts
@@ -22,9 +22,9 @@ type BaseTags = { repo: string; tool: string; run_id: string };
 let baseTags: BaseTags | null = null;
 
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/artist-search-alias-consumer/logger.ts
+++ b/jobs/artist-search-alias-consumer/logger.ts
@@ -28,9 +28,9 @@ type BaseTags = { repo: string; tool: string; run_id: string };
 let baseTags: BaseTags | null = null;
 
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/catalog-popularity-freetext-resolve/logger.ts
+++ b/jobs/catalog-popularity-freetext-resolve/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/concerts-artist-lml-resolver/logger.ts
+++ b/jobs/concerts-artist-lml-resolver/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/concerts-artist-resolver/logger.ts
+++ b/jobs/concerts-artist-resolver/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/concerts-genre-enrichment/logger.ts
+++ b/jobs/concerts-genre-enrichment/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/concerts-poster-enrichment/logger.ts
+++ b/jobs/concerts-poster-enrichment/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/concerts-similar-artists-enrichment/logger.ts
+++ b/jobs/concerts-similar-artists-enrichment/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/flowsheet-artwork-repair/logger.ts
+++ b/jobs/flowsheet-artwork-repair/logger.ts
@@ -25,9 +25,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/flowsheet-etl/logger.ts
+++ b/jobs/flowsheet-etl/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/flowsheet-linked-reenrichment/logger.ts
+++ b/jobs/flowsheet-linked-reenrichment/logger.ts
@@ -31,9 +31,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/flowsheet-reenrichment/logger.ts
+++ b/jobs/flowsheet-reenrichment/logger.ts
@@ -22,9 +22,9 @@ type BaseTags = { repo: string; tool: string; run_id: string };
 let baseTags: BaseTags | null = null;
 
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/legacy-mirror-reconcile/logger.ts
+++ b/jobs/legacy-mirror-reconcile/logger.ts
@@ -32,9 +32,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/library-identity-consumer/logger.ts
+++ b/jobs/library-identity-consumer/logger.ts
@@ -29,9 +29,9 @@ type BaseTags = { repo: string; tool: string; run_id: string };
 let baseTags: BaseTags | null = null;
 
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/rotation-lml-identity-backfill/logger.ts
+++ b/jobs/rotation-lml-identity-backfill/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/rotation-release-id-backfill/logger.ts
+++ b/jobs/rotation-release-id-backfill/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/streaming-url-remediation/logger.ts
+++ b/jobs/streaming-url-remediation/logger.ts
@@ -22,9 +22,9 @@ type BaseTags = { repo: string; tool: string; run_id: string };
 let baseTags: BaseTags | null = null;
 
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/streaming-url-upgrade/logger.ts
+++ b/jobs/streaming-url-upgrade/logger.ts
@@ -22,9 +22,9 @@ type BaseTags = { repo: string; tool: string; run_id: string };
 let baseTags: BaseTags | null = null;
 
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/triangle-shows-etl/logger.ts
+++ b/jobs/triangle-shows-etl/logger.ts
@@ -30,9 +30,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/jobs/venue-events-scraper/logger.ts
+++ b/jobs/venue-events-scraper/logger.ts
@@ -24,9 +24,9 @@ let baseTags: BaseTags | null = null;
 
 // `@sentry/node` v10 silently produces zero spans when tracesSampleRate is unset.
 export const resolveTracesSampleRate = (raw: string | undefined = process.env.SENTRY_TRACES_SAMPLE_RATE): number => {
-  if (raw === undefined) return 0;
+  if (raw === undefined) return 1;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 1;
   return parsed;
 };
 

--- a/tests/unit/jobs/album-level-backfill/logger.test.ts
+++ b/tests/unit/jobs/album-level-backfill/logger.test.ts
@@ -9,8 +9,8 @@
 import { resolveTracesSampleRate } from '../../../../jobs/album-level-backfill/logger';
 
 describe('resolveTracesSampleRate', () => {
-  it('defaults to 0 when env var is unset', () => {
-    expect(resolveTracesSampleRate(undefined)).toBe(0);
+  it('defaults to 1 when env var is unset', () => {
+    expect(resolveTracesSampleRate(undefined)).toBe(1);
   });
 
   it('parses valid values in [0, 1]', () => {
@@ -20,11 +20,11 @@ describe('resolveTracesSampleRate', () => {
     expect(resolveTracesSampleRate('1.0')).toBe(1);
   });
 
-  it('falls back to 0 on malformed or out-of-range values', () => {
-    expect(resolveTracesSampleRate('abc')).toBe(0);
-    expect(resolveTracesSampleRate('-0.5')).toBe(0);
-    expect(resolveTracesSampleRate('1.5')).toBe(0);
-    expect(resolveTracesSampleRate('NaN')).toBe(0);
-    expect(resolveTracesSampleRate('Infinity')).toBe(0);
+  it('falls back to 1 on malformed or out-of-range values', () => {
+    expect(resolveTracesSampleRate('abc')).toBe(1);
+    expect(resolveTracesSampleRate('-0.5')).toBe(1);
+    expect(resolveTracesSampleRate('1.5')).toBe(1);
+    expect(resolveTracesSampleRate('NaN')).toBe(1);
+    expect(resolveTracesSampleRate('Infinity')).toBe(1);
   });
 });

--- a/tests/unit/jobs/flowsheet-etl/logger.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/logger.test.ts
@@ -9,8 +9,8 @@
 import { resolveTracesSampleRate } from '../../../../jobs/flowsheet-etl/logger';
 
 describe('resolveTracesSampleRate', () => {
-  it('defaults to 0 when env var is unset', () => {
-    expect(resolveTracesSampleRate(undefined)).toBe(0);
+  it('defaults to 1 when env var is unset', () => {
+    expect(resolveTracesSampleRate(undefined)).toBe(1);
   });
 
   it('parses valid values in [0, 1]', () => {
@@ -20,12 +20,12 @@ describe('resolveTracesSampleRate', () => {
     expect(resolveTracesSampleRate('1.0')).toBe(1);
   });
 
-  it('falls back to 0 on malformed or out-of-range values', () => {
-    expect(resolveTracesSampleRate('abc')).toBe(0);
-    expect(resolveTracesSampleRate('-0.5')).toBe(0);
-    expect(resolveTracesSampleRate('1.5')).toBe(0);
-    expect(resolveTracesSampleRate('NaN')).toBe(0);
-    expect(resolveTracesSampleRate('Infinity')).toBe(0);
+  it('falls back to 1 on malformed or out-of-range values', () => {
+    expect(resolveTracesSampleRate('abc')).toBe(1);
+    expect(resolveTracesSampleRate('-0.5')).toBe(1);
+    expect(resolveTracesSampleRate('1.5')).toBe(1);
+    expect(resolveTracesSampleRate('NaN')).toBe(1);
+    expect(resolveTracesSampleRate('Infinity')).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

`@sentry/node` v10 treats an unset `tracesSampleRate` as `0`, silently dropping every `Sentry.startSpan` call. Every cron job logger under `jobs/*/logger.ts` whose `resolveTracesSampleRate` left `SENTRY_TRACES_SAMPLE_RATE` unresolved (undefined, or malformed/out-of-range) defaulted to `0`, matching the bug rather than guarding against it. The runtime apps (`apps/backend`, `apps/auth`) already default to `1.0` — this brings the cron loggers in line.

Flips the default (both the `raw === undefined` branch and the malformed/out-of-range fallback) from `0` to `1` in all 22 job loggers that still had the old default:

- album-level-backfill, album-reviews-etl, apple-music-url-backfill, artist-search-alias-consumer, catalog-popularity-freetext-resolve, concerts-artist-lml-resolver, concerts-artist-resolver, concerts-genre-enrichment, concerts-poster-enrichment, concerts-similar-artists-enrichment, flowsheet-artwork-repair, flowsheet-etl, flowsheet-linked-reenrichment, flowsheet-reenrichment, legacy-mirror-reconcile, library-identity-consumer, rotation-lml-identity-backfill, rotation-release-id-backfill, streaming-url-remediation, streaming-url-upgrade, triangle-shows-etl, venue-events-scraper

`jobs/flowsheet-metadata-backfill` and `jobs/rotation-artist-backfill` already defaulted to `1` and are untouched.

Updates the two logger unit tests that pinned the old default (`tests/unit/jobs/flowsheet-etl/logger.test.ts`, `tests/unit/jobs/album-level-backfill/logger.test.ts`).

This is the code-only half of the fix. The EC2 `.env` / deploy-container env change (setting `SENTRY_TRACES_SAMPLE_RATE` explicitly where desired) is a separate infra task, intentionally not included here.

Closes #1299

## Test plan

- [x] `npm run test:unit` — same 300 passing / 37 pre-existing-failing suites as baseline (unrelated `lru-cache` typing issue), all logger tests green
- [x] Direct `tsc --noEmit` on the touched job packages (flowsheet-etl, album-level-backfill) — clean
- [x] `eslint` + `prettier --check` on all touched files — clean