### PR TITLE
fix(ses-events): fold measurements into span creation-time attributes

### DIFF
--- a/apps/backend/services/ses-events/emit-span.ts
+++ b/apps/backend/services/ses-events/emit-span.ts
@@ -36,18 +36,9 @@ export function emitSesEventSpan(event: SesEvent): void {
     {
       name: 'ses.event',
       op: 'email.ses',
-      attributes: buildAttributes(event),
+      attributes: { ...buildAttributes(event), ...buildMeasurements(event) },
     },
     (span) => {
-      const measurements = buildMeasurements(event);
-      for (const [name, value] of Object.entries(measurements)) {
-        // Sentry's setAttribute is the supported v10 path; measurements
-        // surface in the trace explorer the same way once attributes start
-        // with a known numeric metric key. We accept the slight loss of
-        // dedicated "measurements" semantics in exchange for an API that
-        // does not require us to chase SDK-internal types.
-        span.setAttribute(name, value);
-      }
       span.setStatus(buildStatus(event));
     }
   );

--- a/tests/unit/services/ses-events/emit-span.test.ts
+++ b/tests/unit/services/ses-events/emit-span.test.ts
@@ -72,8 +72,10 @@ describe('emitSesEventSpan', () => {
       processingTimeMillis: 1234,
     };
     emitSesEventSpan(event);
-    expect(setAttribute).toHaveBeenCalledWith('ses.delivery_latency_ms', 2500);
-    expect(setAttribute).toHaveBeenCalledWith('ses.processing_time_ms', 1234);
+    const callArgs = startSpan.mock.calls[0] as unknown as [Record<string, unknown>, unknown];
+    const attrs = callArgs[0].attributes as Record<string, unknown>;
+    expect(attrs['ses.delivery_latency_ms']).toBe(2500);
+    expect(attrs['ses.processing_time_ms']).toBe(1234);
   });
 
   it('clamps negative latency to 0 (clock skew defense)', () => {
@@ -87,7 +89,9 @@ describe('emitSesEventSpan', () => {
       processingTimeMillis: 100,
     };
     emitSesEventSpan(event);
-    expect(setAttribute).toHaveBeenCalledWith('ses.delivery_latency_ms', 0);
+    const callArgs = startSpan.mock.calls[0] as unknown as [Record<string, unknown>, unknown];
+    const attrs = callArgs[0].attributes as Record<string, unknown>;
+    expect(attrs['ses.delivery_latency_ms']).toBe(0);
   });
 
   it('sets failed_precondition status on Bounce', () => {


### PR DESCRIPTION
Closes #1081

## Problem

`emitSesEventSpan` in `apps/backend/services/ses-events/emit-span.ts` sets `ses.delivery_latency_ms` and `ses.processing_time_ms` via `span.setAttribute` *after* the span is created. Sentry indexes attributes added this way as string-typed, which breaks `avg`/`p50`/`p90`/`p99` aggregation over these measurements in the trace explorer.

## Fix

Fold `buildMeasurements(event)` into the same attributes bag passed to `Sentry.startSpan` at creation time (`attributes: { ...buildAttributes(event), ...buildMeasurements(event) }`), and drop the post-creation `for...setAttribute` loop and its justifying comment. The PII-domain-only guard (never the recipient local-part) is untouched.

## Tests

Updated `tests/unit/services/ses-events/emit-span.test.ts` to assert the numeric measurements land in the `attributes` bag passed to `Sentry.startSpan`, rather than via a separate `setAttribute` call. The PII-guard test is unchanged.

Post-deploy verification that Sentry's `avg`/percentile aggregations now return numeric results is out of scope for this PR — the gate here is the unit test asserting attributes-bag shape.