### PR TITLE
fix(library): move GET /library/genres to the unauthenticated tier

### DIFF
--- a/apps/backend/routes/library.route.ts
+++ b/apps/backend/routes/library.route.ts
@@ -66,7 +66,10 @@ library_route.get('/formats', requirePermissions({ catalog: ['read'] }), library
 
 library_route.post('/formats', requirePermissions({ catalog: ['write'] }), libraryController.addFormat);
 
-library_route.get('/genres', requirePermissions({ catalog: ['read'] }), libraryController.getGenres);
+// BS#1682: genre names are non-sensitive station-wide reference data (same
+// tier as /playlists and /concerts), and dj-site#1004's argument-pure SSR
+// seed cannot attach a JWT. Public GET; POST stays catalog:write-gated below.
+library_route.get('/genres', libraryController.getGenres);
 
 library_route.post('/genres', requirePermissions({ catalog: ['write'] }), libraryController.addGenre);
 

--- a/tests/unit/routes/library-genres-permissions.route.test.ts
+++ b/tests/unit/routes/library-genres-permissions.route.test.ts
@@ -1,0 +1,124 @@
+// Set required env vars before module load (ts-jest transforms imports to
+// requires, so these execute before the auth middleware module's top-level
+// code runs). Mirrors tests/unit/routes/library-missing-found-permissions.route.test.ts.
+process.env.BETTER_AUTH_JWKS_URL = 'https://test.example.com/.well-known/jwks.json';
+process.env.BETTER_AUTH_ISSUER = 'https://test.example.com';
+process.env.BETTER_AUTH_AUDIENCE = 'https://test.example.com';
+delete process.env.AUTH_BYPASS;
+
+// Mock jose so we can hand back an arbitrary role in the verified JWT payload
+// without a real JWKS endpoint. requirePermissions's non-bypass branch is
+// what actually enforces role/permission checks. Note: integration tests run
+// with AUTH_BYPASS=true, whose branch short-circuits to next() before any
+// permission check runs, so they cannot exercise this route's auth tier --
+// hence this real-middleware unit test.
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn(() => jest.fn()),
+  jwtVerify: jest.fn(),
+  decodeJwt: jest.fn(),
+}));
+
+// jest.unit.config.ts's moduleNameMapper sends `@wxyc/authentication` to
+// tests/mocks/authentication.mock.ts (a stub whose requirePermissions only
+// checks for an Authorization header, ignoring the role/permission argument
+// entirely). library.route.ts imports requirePermissions from that package
+// specifier, so this route-wiring test needs the REAL implementation wired
+// back in to actually exercise the catalog:read vs public gate.
+jest.mock('@wxyc/authentication', () => jest.requireActual('../../../shared/authentication/src/auth.middleware'));
+
+import express from 'express';
+import request from 'supertest';
+
+// Collaborator mocks below mirror tests/unit/routes/library-missing-found-permissions.route.test.ts
+// -- only enough is stubbed here to let library.route's import chain resolve
+// without touching a real DB, LML, or lru-cache.
+const mockGetGenresFromDB = jest.fn<() => Promise<Array<{ id: number; genre: string }>>>();
+
+jest.mock('../../../apps/backend/services/library.service', () => ({
+  markAlbumMissing: jest.fn(),
+  markAlbumFound: jest.fn(),
+  getAlbumFromDB: jest.fn(),
+  getCatalogLastModifiedAt: jest.fn(),
+  serializeLibraryArtistViewEntry: (row: unknown) => row,
+  serializeArtist: (row: unknown) => row,
+  fuzzySearchLibrary: jest.fn(),
+  enrichWithArtwork: jest.fn(),
+  getFormatsFromDB: jest.fn(),
+  getRotationFromDB: jest.fn(),
+  addToRotation: jest.fn(),
+  killRotationInDB: jest.fn(),
+  insertAlbum: jest.fn(),
+  updateArtworkUrl: jest.fn(),
+  updateOnStreaming: jest.fn(),
+  updateCanonicalEntity: jest.fn(),
+  mapLookupToCanonicalEntity: jest.fn(),
+  artistIdFromName: jest.fn(),
+  getArtistNameById: jest.fn(),
+  insertArtist: jest.fn(),
+  insertArtistGenreCrossreference: jest.fn(),
+  getArtistByCode: jest.fn(),
+  generateAlbumCodeNumber: jest.fn(),
+  generateArtistNumber: jest.fn(),
+  getGenresFromDB: mockGetGenresFromDB,
+  insertGenre: jest.fn(),
+  insertFormat: jest.fn(),
+  getFormatById: jest.fn(),
+  isISODate: jest.fn(),
+  resolveRotationPickerSource: jest.fn(),
+  getRotationTracksFromRelease: jest.fn(),
+  getLibraryRowById: jest.fn(),
+  updateAlbumInDB: jest.fn(),
+  artistExistsInGenre: jest.fn(),
+  albumCodeNumberTaken: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/labels.service', () => ({
+  createLabel: jest.fn(),
+  getLabelById: jest.fn(),
+}));
+
+jest.mock('../../../apps/backend/services/library-search.service', () => ({
+  parseEnumQueryList: () => undefined,
+  parseRotationBinsQueryList: () => undefined,
+  searchLibrary: jest.fn(),
+}));
+
+jest.mock('@wxyc/lml-client', () => ({
+  checkStreamingAvailability: jest.fn(),
+  lookupMetadata: jest.fn(),
+  isLmlConfigured: () => false,
+  envInt: (_name: string, fallback: number) => fallback,
+}));
+
+jest.mock('../../../apps/backend/services/lml/lookup-coordinator', () => ({
+  lmlLookupCoordinator: { lookup: jest.fn() },
+}));
+
+jest.mock('../../../apps/backend/controllers/requestLine.controller', () => ({
+  searchLibraryEndpoint: (_req: unknown, res: { status: (n: number) => { json: (b: unknown) => void } }) =>
+    res.status(200).json([]),
+}));
+
+import { library_route } from '../../../apps/backend/routes/library.route';
+
+const app = express();
+app.use(express.json());
+app.use('/library', library_route);
+
+/**
+ * BS#1682: GET /library/genres is non-sensitive station-wide reference data
+ * (same tier as /playlists and /concerts), and dj-site#1004's argument-pure
+ * SSR seed cannot attach a JWT. Relaxed the GET (only) to the unauthenticated
+ * tier; POST /genres stays catalog:write-gated.
+ */
+describe('GET /library/genres — public tier (BS#1682)', () => {
+  beforeEach(() => {
+    mockGetGenresFromDB.mockReset().mockResolvedValue([{ id: 1, genre: 'Rock' }]);
+  });
+
+  test('a request with no Authorization header succeeds', async () => {
+    const res = await request(app).get('/library/genres');
+    expect(res.status).toBe(200);
+    expect(mockGetGenresFromDB).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
GET /library/genres moves to the unauthenticated tier, mounted like the public /playlists route — genre names are non-sensitive station-wide reference data. POST /library/genres stays catalog:write-gated. Unblocks dj-site#1004's argument-pure SSR seed, which cannot attach a JWT.

Closes #1682

## Test plan
- Added tests/unit/routes/library-genres-permissions.route.test.ts asserting GET /library/genres succeeds with no Authorization header (real auth middleware wired in, matching the library-missing-found-permissions pattern)
- npm run lint / format:check / typecheck all clean
- npm run test:unit green (one pre-existing unrelated failure in ci-env-surface-parity.test.ts, confirmed present on main before this change)