### PR TITLE
fix(library-identity-consumer): gate canonicalized rows on freshness

### DIFF
--- a/jobs/library-identity-consumer/select.ts
+++ b/jobs/library-identity-consumer/select.ts
@@ -5,10 +5,23 @@
  * (Backend is thin-writer; LML is sole composer):
  *
  *   library.canonical_entity_id IS NOT NULL
- *   OR library.id IN (
- *     SELECT library_id FROM library_identity
- *     WHERE last_verified_at < NOW() - interval '7 days'
+ *   AND (
+ *     NOT EXISTS (SELECT 1 FROM library_identity WHERE library_id = library.id)
+ *     OR EXISTS (
+ *       SELECT 1 FROM library_identity
+ *       WHERE library_id = library.id
+ *         AND last_verified_at < NOW() - interval '7 days'
+ *     )
  *   )
+ *
+ * BS#1144: the predicate used to be `canonical_entity_id IS NOT NULL OR ...`
+ * — an unconditional disjunct that re-fetched every canonicalized row on
+ * every run regardless of freshness, burning LML quota. The freshness guard
+ * above narrows eligibility to rows with no `library_identity` row yet, or
+ * whose existing row is stale. This intentionally does NOT bring
+ * NULL-canonical_entity_id rows into scope — that's #974's separate,
+ * hand-shipped work, and doing so here would create an unresolved-row
+ * hot-loop.
  *
  * Note on the column name: BS#802's ticket body wrote `last_refreshed_at`,
  * but the column on `library_identity` is `last_verified_at`. We use
@@ -105,7 +118,7 @@ export const resolveStaleThreshold = (
 /**
  * Load the next batch of libraries needing identity refresh.
  *
- * The predicate is the disjunction described above. Rows are skipped when
+ * The predicate is the canonicalized-and-fresh gate described above. Rows are skipped when
  * `artist_name` or `album_title` is NULL — LML's bulk endpoint requires
  * both. (`album_title` is NOT NULL in the schema, but `artist_name` is
  * nullable until the Epic A.2 backfill completes for any future-added
@@ -128,11 +141,16 @@ export const loadBatch = async (
     FROM ${LIBRARY_TABLE}
     WHERE "id" > ${afterId}
       AND "artist_name" IS NOT NULL
+      AND "canonical_entity_id" IS NOT NULL
       AND (
-        "canonical_entity_id" IS NOT NULL
-        OR "id" IN (
-          SELECT "library_id" FROM ${LIBRARY_IDENTITY_TABLE}
-          WHERE "last_verified_at" < NOW() - (interval '1 day' * ${staleDays})
+        NOT EXISTS (
+          SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li
+          WHERE li."library_id" = ${LIBRARY_TABLE}."id"
+        )
+        OR EXISTS (
+          SELECT 1 FROM ${LIBRARY_IDENTITY_TABLE} li
+          WHERE li."library_id" = ${LIBRARY_TABLE}."id"
+            AND li."last_verified_at" < NOW() - (interval '1 day' * ${staleDays})
         )
       )
       ${partitionClause}

--- a/tests/unit/jobs/library-identity-consumer/select.test.ts
+++ b/tests/unit/jobs/library-identity-consumer/select.test.ts
@@ -112,7 +112,7 @@ describe('loadBatch', () => {
     jest.clearAllMocks();
   });
 
-  it('issues a SELECT that honors the post-#800 predicate (canonical_entity_id OR stale library_identity)', async () => {
+  it('issues a SELECT that honors the post-#800 predicate (canonical_entity_id AND (no identity row OR stale))', async () => {
     (db.execute as jest.Mock).mockResolvedValue([]);
     await loadBatch(0, 500, null, 7);
     expect((db.execute as jest.Mock).mock.calls.length).toBe(1);
@@ -124,6 +124,17 @@ describe('loadBatch', () => {
     expect(serialized).toMatch(/library_identity/);
     expect(serialized).toMatch(/last_verified_at/);
     expect(serialized).toMatch(/artist_name/);
+  });
+
+  it('gates on a freshness guard so canonicalized rows are not unconditionally re-fetched (BS#1144)', async () => {
+    (db.execute as jest.Mock).mockResolvedValue([]);
+    await loadBatch(0, 500, null, 7);
+    const call = (db.execute as jest.Mock).mock.calls[0][0];
+    const serialized = JSON.stringify(call);
+    // The predicate must gate canonicalized rows behind a freshness check
+    // (NOT EXISTS a library_identity row, or the existing one is stale) —
+    // not just an unconditional `canonical_entity_id IS NOT NULL OR ...`.
+    expect(serialized).toMatch(/NOT EXISTS/);
   });
 
   it('returns the rows surfaced by db.execute', async () => {


### PR DESCRIPTION
Closes #1144

## Problem

`loadBatch` in `jobs/library-identity-consumer/select.ts` selects rows to re-fetch identity for. The predicate was:

```
canonical_entity_id IS NOT NULL
OR id IN (SELECT library_id FROM library_identity WHERE last_verified_at < NOW() - interval '7 days')
```

The first disjunct is unconditional, so every canonicalized library row is re-selected on every run regardless of whether a `library_identity` row already exists and is fresh — burning LML quota re-fetching rows that don't need it.

## Fix

Narrow scope only (does NOT touch NULL-`canonical_entity_id` rows — that's #974's separate, hand-shipped work; bringing those into scope here would create an unresolved-row hot-loop). The predicate is now:

```
canonical_entity_id IS NOT NULL
AND (
  NOT EXISTS (SELECT 1 FROM library_identity WHERE library_id = library.id)
  OR EXISTS (
    SELECT 1 FROM library_identity
    WHERE library_id = library.id
      AND last_verified_at < NOW() - interval '<staleDays> days'
  )
)
```

A canonicalized row is now eligible only when it has no `library_identity` row yet, or its existing row is stale.

## Testing

Added unit coverage in `tests/unit/jobs/library-identity-consumer/select.test.ts` asserting the generated SQL carries the `NOT EXISTS` freshness guard (in addition to the existing fragment checks for `canonical_entity_id` / `library_identity` / `last_verified_at` / `artist_name`). Full `jobs/library-identity-consumer` unit suite (56 tests) passes; scoped `tsc --noEmit`, `eslint`, and `prettier --check` are clean on the touched files.