### PR TITLE
fix(ci): tolerate comments inside env blocks in ci-env-surface-parity extractors

### DIFF
--- a/tests/unit/scripts/ci-env-surface-parity.test.ts
+++ b/tests/unit/scripts/ci-env-surface-parity.test.ts
@@ -202,7 +202,11 @@ function extractTopLevelEnv(workflow: string): string[] {
     throw new Error('workflow has no top-level `jobs:` key');
   }
   const preJobs = workflow.slice(0, jobsIdx);
-  const topMatch = preJobs.match(/^env:\n((?:\s+[A-Z][A-Z0-9_]*:.*\n)+)/m);
+  // Capture every indented-or-blank line after `env:` — NOT only `KEY:`
+  // lines — so a `#` comment inside the block (e.g. the BS#1729 CI_DB_PORT
+  // annotation) can't truncate the capture and silently drop the keys below
+  // it. The key extraction below already skips comment and blank lines.
+  const topMatch = preJobs.match(/^env:\n((?:(?:[ \t]+\S.*|[ \t]*)\n)+)/m);
   if (!topMatch) {
     throw new Error('workflow top-level `env:` block not found');
   }
@@ -239,7 +243,10 @@ function extractIntegrationTestsJobEnv(workflow: string): string[] {
   // it the LAST entry in the env block (today: BETTER_AUTH_SECRET) is
   // silently dropped.
   const boundedSlice = jobSlice.slice(0, stepsIdx + 1);
-  const envMatch = boundedSlice.match(/\n {4}env:\n((?: {6}[A-Z][A-Z0-9_]*:.*\n)+)/);
+  // Same comment-tolerance as extractTopLevelEnv: capture 6-space-indented
+  // or blank lines (not only `KEY:` lines) so a comment in the job-level env
+  // block can't truncate the capture and drop keys below it.
+  const envMatch = boundedSlice.match(/\n {4}env:\n((?:(?: {6}\S.*| *)\n)+)/);
   if (!envMatch) {
     throw new Error('Integration-Tests job-level `env:` block not found');
   }


### PR DESCRIPTION
## Problem

The BS#958 CI env-var parity guard (`tests/unit/scripts/ci-env-surface-parity.test.ts`) fails against `main`'s own files. `extractTopLevelEnv` and `extractIntegrationTestsJobEnv` capture the workflow `env:` block with a `(?:\s+[A-Z][A-Z0-9_]*:.*\n)+` sequence that matches only *consecutive* `KEY:` lines and halts at the first line that isn't one. BS#1729 (`a3d2b3dc`) added a six-line `#` comment block inside the top-level `env:` of `.github/workflows/test.yml` documenting the intentional `CI_DB_PORT` divergence — so the capture now truncates at the comment and drops every key below it (`CI_DB_PORT`, `CI_PORT`, …), flipping both parity assertions.

It stayed invisible in CI because `detect-changes` did not run the unit-tests job on the infra/docs-only commits that added the comment, so the guard never executed there. It surfaces on any PR whose diff triggers the unit job.

## Fix

Harden both block-capture regexes to include indented-or-blank lines (comments included) rather than only `KEY:` lines. The downstream key-extraction `matchAll(/^\s+([A-Z][A-Z0-9_]*):/gm)` already skips comment and blank lines, so the extracted key set — and the `EXPECTED_ONLY_IN_WORKFLOW` / `EXPECTED_ONLY_IN_COMPOSE` allowlists — are unchanged. This restores the parser; it does not relax the guard. Because `test.yml` now carries a comment inside its top-level `env:`, a green parity test is the live regression fixture going forward.

## Verification

- `ci-env-surface-parity.test.ts`: 2/2 pass against current `main` files (was 2/2 fail).
- Allowlists untouched (diff is 9 insertions / 2 deletions, extractor regexes only).
- Local: `format:check`, `lint`, `typecheck`, full `test:unit` (5062/5062) green.

Closes #1786