### PR TITLE
fix(flowsheet): 400 on non-numeric or inverted start_id/end_id range query

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -115,10 +115,23 @@ export const getEntries: RequestHandler<object, unknown, object, QueryParams> = 
   }
 
   if (query.start_id !== undefined && query.end_id !== undefined) {
-    if (parseInt(query.end_id) - parseInt(query.start_id) - DELETION_OFFSET > MAX_ITEMS) {
+    const startId = parseInt(query.start_id);
+    const endId = parseInt(query.end_id);
+    if (!Number.isInteger(startId)) {
+      throw new WxycError('start_id must be a valid integer', 400);
+    }
+    if (!Number.isInteger(endId)) {
+      throw new WxycError('end_id must be a valid integer', 400);
+    }
+    // end_id < start_id would compute a negative-length range; reject rather
+    // than silently returning an empty/inverted result from getEntriesByRange.
+    if (endId < startId) {
+      throw new WxycError('end_id must not be less than start_id', 400);
+    }
+    if (endId - startId - DELETION_OFFSET > MAX_ITEMS) {
       throw new WxycError('Requested too many entries', 400);
     }
-    const entries = await flowsheet_service.getEntriesByRange(parseInt(query.start_id), parseInt(query.end_id));
+    const entries = await flowsheet_service.getEntriesByRange(startId, endId);
     if (entries.length) {
       await flowsheet_service.attachUpcomingShows(entries);
       res.status(200).json(entries.map(flowsheet_service.transformToV2));

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -9,6 +9,7 @@ jest.mock('@sentry/node', () => ({ captureException: mockCaptureException }));
 const mockGetEntriesByPage = jest.fn<() => Promise<unknown[]>>();
 const mockGetEntryCount = jest.fn<() => Promise<number>>();
 const mockGetEntriesByShow = jest.fn<() => Promise<unknown[]>>();
+const mockGetEntriesByRange = jest.fn<() => Promise<unknown[]>>();
 const mockGetNShows = jest.fn<() => Promise<unknown[]>>();
 const mockGetShowMetadata = jest.fn<() => Promise<Record<string, unknown>>>();
 const mockTransformToV2 = jest.fn((entry: unknown) => ({ ...(entry as Record<string, unknown>), v2: true }));
@@ -35,6 +36,7 @@ jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
   getEntriesByPage: mockGetEntriesByPage,
   getEntryCount: mockGetEntryCount,
   getEntriesByShow: mockGetEntriesByShow,
+  getEntriesByRange: mockGetEntriesByRange,
   getNShows: mockGetNShows,
   getShowMetadata: mockGetShowMetadata,
   transformToV2: mockTransformToV2,
@@ -198,6 +200,62 @@ describe('flowsheet.controller', () => {
       expect(mockGetOnAirDJName).not.toHaveBeenCalled();
       const body = (res.json as jest.Mock).mock.calls[0][0];
       expect(Array.isArray(body)).toBe(true);
+    });
+
+    // BS#1110: non-numeric start_id/end_id used to flow straight into
+    // parseInt arithmetic (yielding NaN), pass the MAX_ITEMS check, and blow up
+    // downstream as a Postgres "invalid input syntax for type integer: NaN"
+    // 500. These must 400 with a message naming the bad parameter instead.
+    describe('range mode validation (BS#1110)', () => {
+      it('rejects a non-numeric start_id with 400 naming start_id', async () => {
+        const req = createMockReq({ start_id: 'abc', end_id: '150' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(
+          'start_id must be a valid integer'
+        );
+        expect(mockGetEntriesByRange).not.toHaveBeenCalled();
+      });
+
+      it('rejects a non-numeric end_id with 400 naming end_id', async () => {
+        const req = createMockReq({ start_id: '100', end_id: 'def' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(
+          'end_id must be a valid integer'
+        );
+        expect(mockGetEntriesByRange).not.toHaveBeenCalled();
+      });
+
+      it('rejects when both start_id and end_id are non-numeric', async () => {
+        const req = createMockReq({ start_id: 'abc', end_id: 'def' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toBeInstanceOf(WxycError);
+        expect(mockGetEntriesByRange).not.toHaveBeenCalled();
+      });
+
+      it('rejects end_id < start_id with 400', async () => {
+        const req = createMockReq({ start_id: '100', end_id: '50' });
+        const res = createMockRes();
+
+        await expect(getEntries(req as Request, res as Response, mockNext)).rejects.toThrow(
+          'end_id must not be less than start_id'
+        );
+        expect(mockGetEntriesByRange).not.toHaveBeenCalled();
+      });
+
+      it('accepts a valid numeric range', async () => {
+        mockGetEntriesByRange.mockResolvedValue([createMockEntry(100)]);
+
+        const req = createMockReq({ start_id: '100', end_id: '105' });
+        const res = createMockRes();
+
+        await getEntries(req as Request, res as Response, mockNext);
+
+        expect(mockGetEntriesByRange).toHaveBeenCalledWith(100, 105);
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
     });
 
     it('calculates offset from page and limit', async () => {


### PR DESCRIPTION
## Summary

GET /v2/flowsheet's range mode (`?start_id=...&end_id=...`) fed unvalidated `parseInt(start_id)`/`parseInt(end_id)` straight into arithmetic and `getEntriesByRange`. A non-numeric value produced `NaN`, which passed the `MAX_ITEMS` guard unchecked and blew up downstream as a Postgres `invalid input syntax for type integer: NaN` 500.

- Validate both `start_id` and `end_id` with `Number.isInteger` before any arithmetic, mirroring the existing `isNaN` guards already used for `limit`/`page`/`shows_limit` in this same handler.
- Return 400 naming the specific offending parameter (`start_id must be a valid integer` / `end_id must be a valid integer`).
- Reject `end_id < start_id` with 400 (`end_id must not be less than start_id`) instead of silently computing a negative-length range.

## Test plan

- [x] Unit tests added in `tests/unit/controllers/flowsheet.controller.test.ts` covering: non-numeric `start_id`, non-numeric `end_id`, both non-numeric, `end_id < start_id`, and the valid-range happy path.
- [x] `npm run test:unit` — all green except one pre-existing, unrelated failure (`tests/unit/scripts/ci-env-surface-parity.test.ts`, confirmed failing identically with this change reverted — local `.env` drift, not caused by this PR).
- [x] `npm run typecheck` clean across all workspaces.
- [x] `npm run lint` — 0 errors (771 pre-existing warnings, unrelated).
- [x] `npm run format:check` clean.

No integration test was added: this is pure input validation that returns before any DB query, matching how the existing `limit`/`page`/`shows_limit` validations in the same handler are exercised at the unit level only.

Closes #1110