### PR TITLE
1b: extend @wxyc/lml-client with a discogsUnavailable runtime-lookup gate

### DIFF
--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -846,10 +846,23 @@ export async function bulkLookupMetadata(
         if (item.lookup != null) sanitizeLookupStreamingUrls(item.lookup);
       }
 
-      // BS#1293: splice the synthetic skipped verdicts back in at their
-      // original positions and reindex the real verdicts (which LML returned
-      // aligned to `sendItems`, not the caller's original `items`) so the
-      // final array is index-aligned with the caller's input in input order.
+      // BS#1293: with no gated items the wire batch is identical to the
+      // caller's `items` in the same order, so return LML's verdicts
+      // verbatim — preserving each result's own `index`. Reconstructing
+      // positionally in this case would overwrite `.index` with a cursor and
+      // defeat downstream misalignment guards that intentionally trust LML's
+      // reported index (e.g. album-level-backfill's `result.index !== i`
+      // BS#1088 regression pin) and would fabricate `{ index }`-only entries
+      // from a short/gapped response instead of surfacing the mismatch.
+      if (skippedIndices.size === 0) {
+        return { results: parsed.results };
+      }
+
+      // Skips present: the caller's index space diverges from `sendItems`, so
+      // splice the synthetic skipped verdicts back in at their original
+      // positions and reindex the real verdicts (LML returned them aligned to
+      // `sendItems`, not the caller's original `items`) so the final array is
+      // index-aligned with the caller's input in input order.
       let sentCursor = 0;
       const results = items.map((_, index) => {
         if (skippedIndices.has(index)) {

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -86,9 +86,18 @@ const TIMEOUT_MS = 30000;
  * not LML's. Defaults match LML's config; env-overridable so prod can
  * leave headroom for other LML callers (rom + tubafrenzy).
  *
- * Only the `/lookup` chokepoint is wrapped — the other LML endpoints
- * (release, artist, entity, track-releases, streaming-check, library/search)
- * are PG-cached and don't share the Discogs ceiling.
+ * This is the runtime-lookup chokepoint: `lookupMetadata` + `bulkLookupMetadata`
+ * (both funnel through `postLookup`) — the string-resolve surface that can
+ * produce false Discogs matches, and therefore the surface the BS#1293
+ * `discogsUnavailable` gate covers (`LookupOptions.discogsUnavailable` /
+ * `BulkLookupItem.discogsUnavailable` below). A handful of other exports
+ * (`resolveArtistNamesBulk`, `fetchArtistGenresBulk`, `checkStreamingAvailability`)
+ * also share this Semaphore/TokenBucket pair for Discogs back-pressure but are
+ * NOT part of the discogsUnavailable gate — they don't resolve a free-text
+ * artist/album pair against a possibly-flagged catalog row. The remaining
+ * LML-touching exports (`getRelease`, `getArtistDetails`, `resolveEntity`,
+ * `searchTrackReleases`, `validateTrackOnRelease`, `searchLibrary`) call
+ * PG-cached endpoints and share neither the limiter nor the gate.
  *
  * When B4 (#887) extracts `@wxyc/lml-client`, this whole apparatus moves
  * with the client and stays the chokepoint for every consumer.
@@ -425,6 +434,61 @@ export interface LookupOptions {
    * flag-of-shame so untracked call sites surface in queries.
    */
   caller?: string;
+  /**
+   * BS#1293 runtime-lookup gate. When `true` and `forceLookup` is not also
+   * `true`, `lookupMetadata` short-circuits before acquiring a limiter permit
+   * or a token: no LML call is made, no `Semaphore`/`TokenBucket` accounting
+   * happens, and the caller gets back a `GatedLookupResponse` with
+   * `outcome: 'skipped_discogs_unavailable'` — a `LookupResponse`-shaped empty
+   * result plus the discriminator. Callers set this from a pre-read of
+   * `library.discogs_unavailable` (BS#1281); the gate itself does not query
+   * the database. See the "runtime-lookup chokepoint" doc above for scope.
+   */
+  discogsUnavailable?: boolean;
+  /**
+   * Overrides `discogsUnavailable`, forcing the lookup through as normal.
+   * Used by the discogsUnavailable recheck cron (sub-issue 3, BS#1294) so it
+   * can re-ask LML for a target previously flagged unavailable without a
+   * caller-side handshake that flips `discogsUnavailable` itself (self-review
+   * flagged that as refactor-fragile). No effect when `discogsUnavailable`
+   * is not `true`.
+   */
+  forceLookup?: boolean;
+}
+
+/** Discriminator for a runtime-lookup call the BS#1293 gate short-circuited. */
+export type LookupSkippedOutcome = 'skipped_discogs_unavailable';
+
+/**
+ * `LookupResponse` extended with an optional `outcome` discriminator
+ * (BS#1293). Present only when the runtime-lookup gate skipped the call
+ * (`discogsUnavailable: true` + no `forceLookup`); absent on every real LML
+ * response, so existing consumers that only read the base `LookupResponse`
+ * fields (`results`, `search_type`, etc.) are unaffected.
+ */
+export interface GatedLookupResponse extends LookupResponse {
+  outcome?: LookupSkippedOutcome;
+}
+
+/** Sentry `lml.lookup.skipped_reason` value stamped by the BS#1293 gate. */
+const DISCOGS_UNAVAILABLE_SKIPPED_REASON = 'discogs_unavailable';
+
+/**
+ * Builds the `LookupResponse`-shaped skipped outcome the BS#1293 gate
+ * returns in place of a real LML call — the same required fields a genuine
+ * empty result would carry (`results: []`, `search_type: 'none'`, …) plus
+ * the `outcome` discriminator so a caller can tell "asked LML, got nothing"
+ * apart from "never asked."
+ */
+function buildSkippedLookupResponse(): GatedLookupResponse {
+  return {
+    results: [],
+    search_type: 'none',
+    song_not_found: false,
+    found_on_compilation: false,
+    timeout: false,
+    outcome: 'skipped_discogs_unavailable',
+  };
 }
 
 type LookupBody = {
@@ -453,7 +517,7 @@ export async function lookupMetadata(
   album?: string,
   song?: string,
   options?: LookupOptions
-): Promise<LookupResponse> {
+): Promise<GatedLookupResponse> {
   // LML's /lookup contract requires `raw_message` even when artist/album/song
   // are already structured. Synthesize a free-form description that the LML
   // parser would have produced — matches the e2e fixtures in LML's repo.
@@ -473,6 +537,8 @@ export async function lookupMetadata(
     limiter: options?.limiter,
     budgetMs: options?.budgetMs,
     caller: options?.caller,
+    discogsUnavailable: options?.discogsUnavailable,
+    forceLookup: options?.forceLookup,
   });
 }
 
@@ -502,11 +568,36 @@ export async function lookupBySong(
  * `lml.cache.api_calls > 0`) so per-callsite instrumentation isn't needed for
  * the metadata-backfill pilot or the runtime hot path. Sibling LML-side
  * projection at WXYC/library-metadata-lookup#213.
+ *
+ * BS#1293: the `discogsUnavailable` gate short-circuits here, before the
+ * limiter is touched — a gated call consumes no `Semaphore` permit and no
+ * `TokenBucket` token, because the lookup never happens.
  */
 async function postLookup(
   body: LookupBody,
-  options?: { timeoutMs?: number; limiter?: LmlLimiter; budgetMs?: number; caller?: string }
-): Promise<LookupResponse> {
+  options?: {
+    timeoutMs?: number;
+    limiter?: LmlLimiter;
+    budgetMs?: number;
+    caller?: string;
+    discogsUnavailable?: boolean;
+    forceLookup?: boolean;
+  }
+): Promise<GatedLookupResponse> {
+  if (options?.discogsUnavailable && !options?.forceLookup) {
+    return Sentry.startSpan({ name: 'lml.lookup', op: 'lml.lookup.skipped' }, async (span) => {
+      try {
+        span.setAttributes({
+          'lml.lookup.skipped_reason': DISCOGS_UNAVAILABLE_SKIPPED_REASON,
+          'lml.caller': options?.caller ?? 'unknown',
+        });
+      } catch (err) {
+        console.warn('lml.client: failed to project skipped_reason + caller onto span', err);
+      }
+      return buildSkippedLookupResponse();
+    });
+  }
+
   // BS#906 / G4: Mirror LML's Discogs ceilings on the client so back-pressure
   // surfaces at the BS chokepoint, not as queueing inside LML. The limiter
   // (`fn` runs after `semaphore.acquire()` + `tokenBucket.consume(1)`) keeps
@@ -593,18 +684,32 @@ export interface BulkLookupItem {
    * columns survive the batch, matching the per-row `lookupMetadata` path.
    */
   extended?: boolean;
+  /**
+   * BS#1293 runtime-lookup gate, bulk-item form. When `true`, this item is
+   * pulled out of the wire request entirely — it is never sent to LML, never
+   * charges the shared limiter — and its slot in `BulkLookupResponse.results`
+   * comes back as `{ status: 'skipped_discogs_unavailable', lookup: {
+   * outcome: 'skipped_discogs_unavailable', ... } }`. Sibling items without
+   * the flag are unaffected and still batch together in one LML call. There
+   * is no per-item `forceLookup` override (unlike `lookupMetadata`) — the
+   * caller decides which items to flag at construction time.
+   */
+  discogsUnavailable?: boolean;
 }
 
 /**
  * Per-item verdict from the bulk-lookup endpoint (LML#368). Status is the
  * fast signal: `match` (`lookup.results` non-empty), `no_match` (search ran,
- * no rows), or `error` (per-item exception isolated from siblings).
- * `lookup` is null on error; `message` carries the error class on error.
+ * no rows), `error` (per-item exception isolated from siblings), or
+ * `skipped_discogs_unavailable` (BS#1293 — the item never reached LML because
+ * its `discogsUnavailable` flag was set). `lookup` is null on error; on a skip
+ * it is the same `GatedLookupResponse` shape `lookupMetadata`'s single-item
+ * gate returns. `message` carries the error class on error.
  */
 export interface BulkLookupResultItem {
   index: number;
-  status: 'match' | 'no_match' | 'error';
-  lookup: LookupResponse | null;
+  status: 'match' | 'no_match' | 'error' | LookupSkippedOutcome;
+  lookup: GatedLookupResponse | null;
   message?: string;
 }
 
@@ -640,6 +745,13 @@ const BULK_LOOKUP_INPUT_CAP = 100;
  * Client-side validation rejects empty + oversize batches before the wire
  * call — a 422/400 round-trip costs an LML deploy slot and a TCP RTT for
  * no information gain.
+ *
+ * BS#1293: items with `discogsUnavailable: true` are filtered out of the wire
+ * request before it's built — LML never sees them, and if every item in the
+ * batch is flagged, no HTTP call is made at all (no limiter/token spend
+ * either). Skipped items are spliced back into `results` at their original
+ * index so the response stays index-aligned with the caller's input, matching
+ * the non-gated contract.
  */
 export async function bulkLookupMetadata(
   items: BulkLookupItem[],
@@ -653,6 +765,33 @@ export async function bulkLookupMetadata(
       `bulkLookupMetadata exceeded the cap of ${BULK_LOOKUP_INPUT_CAP} items (received ${items.length}).`,
       400
     );
+  }
+
+  const skippedIndices = new Set<number>();
+  items.forEach((item, index) => {
+    if (item.discogsUnavailable) skippedIndices.add(index);
+  });
+  // Wire body must not carry the BS-local `discogsUnavailable` flag — strip it
+  // even from sent items so a stray `false` doesn't reach LML's schema.
+  const sendItems = items
+    .filter((item) => !item.discogsUnavailable)
+    .map(({ discogsUnavailable: _discogsUnavailable, ...wireItem }) => wireItem);
+
+  // Every item flagged: skip the wire call entirely, same gate as the
+  // single-item path — no limiter/token spend, no fetch.
+  if (sendItems.length === 0) {
+    return Sentry.startSpan({ name: 'lml.lookup.bulk', op: 'lml.lookup.skipped' }, async (span) => {
+      try {
+        span.setAttributes({
+          'lml.bulk.size': items.length,
+          'lml.lookup.skipped_reason': DISCOGS_UNAVAILABLE_SKIPPED_REASON,
+          'lml.caller': options?.caller ?? 'unknown',
+        });
+      } catch (err) {
+        console.warn('lml.client: failed to project bulk.size + skipped_reason + caller onto span', err);
+      }
+      return { results: items.map((_, index) => buildSkippedBulkResultItem(index)) };
+    });
   }
 
   const activeLimiter = options?.limiter ?? defaultLimiter;
@@ -673,7 +812,7 @@ export async function bulkLookupMetadata(
         {
           method: 'POST',
           headers: buildLookupHeaders(options?.budgetMs),
-          body: JSON.stringify({ items }),
+          body: JSON.stringify({ items: sendItems }),
         },
         options?.timeoutMs
       );
@@ -707,9 +846,36 @@ export async function bulkLookupMetadata(
         if (item.lookup != null) sanitizeLookupStreamingUrls(item.lookup);
       }
 
-      return { results: parsed.results };
+      // BS#1293: splice the synthetic skipped verdicts back in at their
+      // original positions and reindex the real verdicts (which LML returned
+      // aligned to `sendItems`, not the caller's original `items`) so the
+      // final array is index-aligned with the caller's input in input order.
+      let sentCursor = 0;
+      const results = items.map((_, index) => {
+        if (skippedIndices.has(index)) {
+          return buildSkippedBulkResultItem(index);
+        }
+        const sentResult = parsed.results[sentCursor];
+        sentCursor += 1;
+        return { ...sentResult, index };
+      });
+
+      return { results };
     });
   });
+}
+
+/**
+ * Synthetic `BulkLookupResultItem` for a BS#1293-gated bulk item — same
+ * shape a real skip produces on the single-item path, indexed to the item's
+ * original position in the caller's input array.
+ */
+function buildSkippedBulkResultItem(index: number): BulkLookupResultItem {
+  return {
+    index,
+    status: 'skipped_discogs_unavailable',
+    lookup: buildSkippedLookupResponse(),
+  };
 }
 
 /**

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -483,6 +483,77 @@ describe('lml.client', () => {
     });
   });
 
+  describe('lookupMetadata discogsUnavailable gate (BS#1293)', () => {
+    it('skips the LML call and returns a skipped outcome when discogsUnavailable is true', async () => {
+      const result = await lookupMetadata('Foo', 'Bar', undefined, { discogsUnavailable: true });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        results: [],
+        search_type: 'none',
+        song_not_found: false,
+        found_on_compilation: false,
+        timeout: false,
+        outcome: 'skipped_discogs_unavailable',
+      });
+    });
+
+    it('does not consume a Semaphore permit or a TokenBucket token when skipped', async () => {
+      const limiter = createLmlLimiter({ maxConcurrent: 2, ratePerMinute: 10 });
+      const before = limiter.state();
+
+      await lookupMetadata('Foo', 'Bar', undefined, { discogsUnavailable: true, limiter });
+
+      expect(limiter.state()).toEqual(before);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('calls LML normally when forceLookup overrides discogsUnavailable', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+      const limiter = createLmlLimiter({ maxConcurrent: 2, ratePerMinute: 10 });
+
+      const result = await lookupMetadata('Foo', 'Bar', undefined, {
+        discogsUnavailable: true,
+        forceLookup: true,
+        limiter,
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result.outcome).toBeUndefined();
+      // A real call still holds + releases the permit and consumes exactly
+      // one token — the limiter is back at full capacity once it resolves.
+      expect(limiter.state().availablePermits).toBe(2);
+      expect(limiter.state().availableTokens).toBeCloseTo(9, 0);
+    });
+
+    it('behaves normally (no gate) when discogsUnavailable is omitted', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ results: [], search_type: 'none', song_not_found: false, found_on_compilation: false }),
+      } as unknown as globalThis.Response);
+
+      const result = await lookupMetadata('Foo', 'Bar');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result.outcome).toBeUndefined();
+    });
+
+    it("records lml.lookup.skipped_reason='discogs_unavailable' on the Sentry span", async () => {
+      await lookupMetadata('Foo', 'Bar', undefined, { discogsUnavailable: true });
+
+      const skippedCalls = mockSpanSetAttributes.mock.calls.filter(
+        (args) => (args[0] as Record<string, unknown>)?.['lml.lookup.skipped_reason'] === 'discogs_unavailable'
+      );
+      expect(skippedCalls).toHaveLength(1);
+      expect(mockStartSpan).toHaveBeenCalledWith(expect.objectContaining({ name: 'lml.lookup' }), expect.any(Function));
+    });
+  });
+
   describe('lookupBySong', () => {
     it('sends POST to /api/v1/lookup with only song + raw_message (artist omitted)', async () => {
       // LML's SONG_AS_TRACK strategy is keyed off a song-only request; sending
@@ -776,6 +847,94 @@ describe('lml.client', () => {
       } as unknown as globalThis.Response);
 
       await expect(bulkLookupMetadata([itemFor('A', 'X')])).rejects.toThrow(LmlClientError);
+    });
+  });
+
+  describe('bulkLookupMetadata discogsUnavailable gate (BS#1293)', () => {
+    const itemFor = (artist: string, album?: string, discogsUnavailable?: boolean) => ({
+      artist,
+      album,
+      raw_message: [artist, album].filter(Boolean).join(' - '),
+      ...(discogsUnavailable !== undefined ? { discogsUnavailable } : {}),
+    });
+
+    it('skips the first item and sends only the second item to LML', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [{ index: 0, status: 'match', lookup: { results: [{ library_item: { id: 1 } }] } }],
+          }),
+      } as unknown as globalThis.Response);
+
+      const result = await bulkLookupMetadata([itemFor('A', 'B', true), itemFor('C', 'D')]);
+
+      // Only the unflagged item reaches the wire.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as { items: unknown[] };
+      expect(body.items).toEqual([{ artist: 'C', album: 'D', raw_message: 'C - D' }]);
+
+      // Results stay index-aligned with the caller's original input.
+      expect(result.results).toHaveLength(2);
+      expect(result.results[0]).toEqual({
+        index: 0,
+        status: 'skipped_discogs_unavailable',
+        lookup: {
+          results: [],
+          search_type: 'none',
+          song_not_found: false,
+          found_on_compilation: false,
+          timeout: false,
+          outcome: 'skipped_discogs_unavailable',
+        },
+      });
+      expect(result.results[1]).toMatchObject({ index: 1, status: 'match' });
+    });
+
+    it('makes no LML call when every item is flagged discogsUnavailable', async () => {
+      const result = await bulkLookupMetadata([itemFor('A', 'B', true), itemFor('C', 'D', true)]);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result.results.map((r) => r.status)).toEqual([
+        'skipped_discogs_unavailable',
+        'skipped_discogs_unavailable',
+      ]);
+      expect(result.results.map((r) => r.index)).toEqual([0, 1]);
+    });
+
+    it('does not consume a limiter permit/token when every item is skipped', async () => {
+      const limiter = createLmlLimiter({ maxConcurrent: 2, ratePerMinute: 10 });
+      const before = limiter.state();
+
+      await bulkLookupMetadata([itemFor('A', 'B', true)], { limiter });
+
+      expect(limiter.state()).toEqual(before);
+    });
+
+    it("records lml.lookup.skipped_reason='discogs_unavailable' on the Sentry span for an all-skipped batch", async () => {
+      await bulkLookupMetadata([itemFor('A', 'B', true)]);
+
+      const skippedCalls = mockSpanSetAttributes.mock.calls.filter(
+        (args) => (args[0] as Record<string, unknown>)?.['lml.lookup.skipped_reason'] === 'discogs_unavailable'
+      );
+      expect(skippedCalls).toHaveLength(1);
+    });
+
+    it('processes a batch with no flagged items exactly as before (no regression)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await bulkLookupMetadata([itemFor('A', 'B'), itemFor('C', 'D')]);
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as { items: unknown[] };
+      expect(body.items).toEqual([
+        { artist: 'A', album: 'B', raw_message: 'A - B' },
+        { artist: 'C', album: 'D', raw_message: 'C - D' },
+      ]);
     });
   });
 

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -936,6 +936,34 @@ describe('lml.client', () => {
         { artist: 'C', album: 'D', raw_message: 'C - D' },
       ]);
     });
+
+    // BS#1293 regression: with no flagged items the client must return LML's
+    // verdicts verbatim, preserving each result's own `index`. Reindexing them
+    // positionally would silently defeat downstream misalignment guards that
+    // trust LML's reported index (e.g. album-level-backfill's
+    // `result.index !== i`, BS#1088) — a reordered/gapped response would then
+    // pass the guard and be written against the wrong album.
+    it('preserves LML-reported index for a skip-free batch (no positional reindex)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            // LML returns verdicts out of input order: index 1 before index 0.
+            results: [
+              { index: 1, status: 'match', lookup: { results: [{ library_item: { id: 11 } }] } },
+              { index: 0, status: 'no_match', lookup: { results: [] } },
+            ],
+          }),
+      } as unknown as globalThis.Response);
+
+      const result = await bulkLookupMetadata([itemFor('A', 'B'), itemFor('C', 'D')]);
+
+      // Verbatim passthrough — the reported indices survive in the order LML
+      // sent them, so a positional guard downstream can still catch the skew.
+      expect(result.results.map((r) => r.index)).toEqual([1, 0]);
+      expect(result.results[0]).toMatchObject({ index: 1, status: 'match' });
+      expect(result.results[1]).toMatchObject({ index: 0, status: 'no_match' });
+    });
   });
 
   describe('refreshForIdentities (BS#1381 / LML#525)', () => {


### PR DESCRIPTION
## Summary

Extends the `@wxyc/lml-client` runtime-lookup chokepoint (`lookupMetadata` + `bulkLookupMetadata` in `shared/lml-client/src/index.ts`) with a `discogsUnavailable` gate, per the design at [WXYC/wiki/plans/rotation-discogs-unavailable.md](https://github.com/WXYC/wiki/blob/main/plans/rotation-discogs-unavailable.md).

- `lookupMetadata`'s `LookupOptions` gains `discogsUnavailable?: boolean` + `forceLookup?: boolean`. When `discogsUnavailable === true` and `forceLookup !== true`, the call short-circuits before touching the `Semaphore(5)`/`TokenBucket(50/min)` — no LML call, no limiter/token spend — and returns a `LookupResponse`-shaped skipped outcome (`GatedLookupResponse` with `outcome: 'skipped_discogs_unavailable'`). `forceLookup: true` overrides the gate (for the sub-issue 3 recheck cron).
- `BulkLookupItem` gains a matching per-item `discogsUnavailable?: boolean`. Flagged items are pulled out of the wire batch before the request is built (or the whole call is skipped when every item is flagged); skipped verdicts are spliced back into `BulkLookupResponse.results` at their original index so the response stays index-aligned with the caller's input.
- Both skip paths record `lml.lookup.skipped_reason = 'discogs_unavailable'` on the existing `Sentry.startSpan`.
- Reframes the package's rate-limiter doc comment to describe it as the *runtime-lookup chokepoint* (`lookupMetadata` + `bulkLookupMetadata` only) rather than overselling coverage across all LML-touching exports — the self-review scope correction from [WXYC/wiki#79](https://github.com/WXYC/wiki/pull/79).

Backward compatible: `opts`/the per-item flag are optional, so every existing caller is unaffected.

## Test plan

- [x] `lookupMetadata(..., { discogsUnavailable: true })` skips the LML call and returns the skipped outcome; limiter state unchanged
- [x] `lookupMetadata(..., { discogsUnavailable: true, forceLookup: true })` calls LML normally
- [x] `bulkLookupMetadata` with a mixed batch skips the flagged item, sends only the rest, and returns index-aligned results
- [x] Sentry span records `lml.lookup.skipped_reason = 'discogs_unavailable'` on both the single-item and all-skipped bulk paths
- [x] Existing `lookupMetadata` / `bulkLookupMetadata` tests pass unchanged
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- [x] `npm run test:unit` green (pre-existing, unrelated `ci-env-surface-parity` failure reproduces identically on `main`)

Closes #1293