### PR TITLE
fix(flowsheet): single freshness validator on watermarked routes

### DIFF
--- a/apps/backend/middleware/conditionalGet.ts
+++ b/apps/backend/middleware/conditionalGet.ts
@@ -34,6 +34,54 @@ export type WatermarkProvider = () => Promise<Date>;
  * purely because the HTTP `Date` header carries whole-second precision, and
  * applies to both providers.
  */
+/**
+ * Sentinel written to the `ETag` header before the route handler runs, so
+ * that Express's own per-body ETag generation never fires (see below), then
+ * stripped again right before the response is flushed.
+ */
+const ETAG_SUPPRESSED = 'wxyc-no-etag';
+
+/**
+ * Forces `conditionalGet`'s watermark `Last-Modified` to be the SINGLE
+ * freshness validator on a route, by suppressing Express's default per-body
+ * weak `ETag` and marking the response `Cache-Control: no-cache` (BS#1689).
+ *
+ * Without this, a watermarked route emits two independent validators: the
+ * `Last-Modified` this middleware's sibling `conditionalGet` sets, and
+ * Express's own body-hash `ETag`. Express computes that `ETag` and evaluates
+ * `req.fresh` (comparing it and `Last-Modified` against the request's
+ * `If-None-Match`/`If-Modified-Since`) *inside* `res.send`, independently of
+ * — and racing — `conditionalGet`'s own explicit watermark check upstream.
+ * A client whose cached `ETag` happens to match can trip Express's internal
+ * freshness conversion to a raw 304 that never went through
+ * `conditionalGet`'s decision at all, which is how an unspliced empty-body
+ * 304 reached the dj-site frontend (dj-site#983 / dj-site#982).
+ *
+ * Mechanism: `res.send`'s own check is `!this.get('ETag') && typeof etagFn
+ * === 'function'` — pre-setting a sentinel `ETag` here makes that check false,
+ * so Express never computes (or compares against) a real per-body hash. The
+ * sentinel must then be removed from the actual response: overriding
+ * `res.end` (rather than `res.send`/`res.json`) is necessary because Express
+ * sets the `ETag` header synchronously *inside* `send`, before it calls
+ * `this.end(...)` at the very end of that same function — stripping the
+ * header from within our wrapped `end` runs after Express is done with it but
+ * before Node flushes headers to the socket.
+ *
+ * Must run before the route handler.
+ */
+export const singleValidatorCache: RequestHandler = (_req, res, next) => {
+  res.set('ETag', ETAG_SUPPRESSED);
+  res.set('Cache-Control', 'no-cache');
+
+  const originalEnd = res.end.bind(res);
+  res.end = ((...args: Parameters<typeof originalEnd>) => {
+    res.removeHeader('ETag');
+    return originalEnd(...args);
+  }) as typeof res.end;
+
+  next();
+};
+
 export const conditionalGet =
   (getWatermark: WatermarkProvider): RequestHandler =>
   async (req: Request, res: Response, next: NextFunction): Promise<void> => {

--- a/apps/backend/routes/flowsheet.route.ts
+++ b/apps/backend/routes/flowsheet.route.ts
@@ -5,14 +5,22 @@ import * as searchController from '../controllers/search.controller';
 import * as suggestController from '../controllers/suggest.controller';
 import * as flowsheet_service from '../services/flowsheet.service';
 import { flowsheetMirror } from '../middleware/legacy/flowsheet.mirror';
-import { conditionalGet } from '../middleware/conditionalGet';
+import { conditionalGet, singleValidatorCache } from '../middleware/conditionalGet';
 import { showMemberMiddleware } from '../middleware/checkShowMember';
 
 export const flowsheet_route = Router();
 
 // Conditional-GET over the flowsheet watermark (BS#902); the catalog passes a
 // different provider (BS#1467) but reuses the same middleware factory.
-const flowsheetConditionalGet = conditionalGet(flowsheet_service.getLastModifiedAt);
+// `singleValidatorCache` (BS#1689) makes the watermark `Last-Modified` this
+// sets the SINGLE freshness validator on these routes — it suppresses
+// Express's own default per-body `ETag` and marks `Cache-Control: no-cache`,
+// so a client can't trip an independent, un-watermarked 304 off a stale
+// cached ETag. Order matters: it must run before the route handler emits a
+// body, so it's chained ahead of the mirror/controller handlers below rather
+// than folded into the conditionalGet factory (which the catalog route also
+// uses, out of this fix's scope).
+const flowsheetConditionalGet = [conditionalGet(flowsheet_service.getLastModifiedAt), singleValidatorCache];
 
 // Public playlist archive search
 flowsheet_route.get('/search', searchController.searchFlowsheetEndpoint);

--- a/tests/unit/middleware/conditionalGet.singleValidator.test.ts
+++ b/tests/unit/middleware/conditionalGet.singleValidator.test.ts
@@ -1,0 +1,59 @@
+/**
+ * BS#1689: watermarked flowsheet routes must carry exactly one freshness
+ * validator (`conditionalGet`'s `Last-Modified`). Express's own default
+ * weak per-body `ETag` is a second, independent validator — a client that
+ * has cached both can revalidate against the ETag alone and get a 304 that
+ * never passed through `conditionalGet`'s watermark check, which is how an
+ * unspliced empty-body 304 reached the dj-site frontend (dj-site#983/#982).
+ *
+ * These tests exercise `singleValidatorCache` against a real Express app (not
+ * a mocked `res`) because the bug and the fix both live inside Express's own
+ * `res.send`/`res.json` internals (ETag generation happens synchronously
+ * before `res.end` flushes headers) — a mocked response object can't
+ * reproduce that ordering.
+ */
+import express from 'express';
+import request from 'supertest';
+
+import { singleValidatorCache } from '../../../apps/backend/middleware/conditionalGet.js';
+
+describe('singleValidatorCache middleware', () => {
+  const buildApp = () => {
+    const app = express();
+    app.get('/watermarked', singleValidatorCache, (_req, res) => {
+      res.status(200).json({ hello: 'world' });
+    });
+    app.get('/unwrapped', (_req, res) => {
+      res.status(200).json({ hello: 'world' });
+    });
+    return app;
+  };
+
+  it('sends no ETag header on a watermarked route', async () => {
+    const res = await request(buildApp()).get('/watermarked');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.etag).toBeUndefined();
+  });
+
+  it('sends Cache-Control: no-cache on a watermarked route', async () => {
+    const res = await request(buildApp()).get('/watermarked');
+
+    expect(res.headers['cache-control']).toBe('no-cache');
+  });
+
+  it('still delivers the response body untouched', async () => {
+    const res = await request(buildApp()).get('/watermarked');
+
+    expect(res.body).toEqual({ hello: 'world' });
+  });
+
+  // Control case: without the middleware, Express's default weak ETag is
+  // present — confirms the test would fail without the fix, i.e. the
+  // suppression is doing real work rather than Express never emitting one.
+  it('control: the unwrapped route still gets Express default ETag', async () => {
+    const res = await request(buildApp()).get('/unwrapped');
+
+    expect(res.headers.etag).toBeDefined();
+  });
+});

--- a/tests/unit/routes/flowsheet.singleValidator.route.test.ts
+++ b/tests/unit/routes/flowsheet.singleValidator.route.test.ts
@@ -1,0 +1,69 @@
+/**
+ * BS#1689: `GET /flowsheet/` and `GET /flowsheet/latest` are watermarked via
+ * `conditionalGet`. Route-wiring check (mirrors tests/unit/routes/concerts.route.test.ts)
+ * that both carry the fix end to end through the real route module: no
+ * Express `ETag` header, and `Cache-Control: no-cache`.
+ */
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+const mockGetLastModifiedAt = jest.fn<() => Promise<Date>>().mockResolvedValue(new Date('2026-01-01T00:00:00Z'));
+const mockGetEntriesByPage = jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]);
+const mockGetEntryCount = jest.fn<() => Promise<number>>().mockResolvedValue(0);
+const mockGetOnAirDJName = jest.fn<() => Promise<string | null>>().mockResolvedValue(null);
+const mockAttachUpcomingShows = jest.fn((entries: unknown[]) => Promise.resolve(entries));
+const mockTransformToV2 = jest.fn((entry: unknown) => entry);
+
+jest.mock('../../../apps/backend/services/flowsheet.service', () => ({
+  getLastModifiedAt: mockGetLastModifiedAt,
+  getEntriesByPage: mockGetEntriesByPage,
+  getEntryCount: mockGetEntryCount,
+  getOnAirDJName: mockGetOnAirDJName,
+  attachUpcomingShows: mockAttachUpcomingShows,
+  transformToV2: mockTransformToV2,
+}));
+
+const passThrough = (_req: unknown, _res: unknown, next: () => void) => next();
+
+jest.mock('../../../apps/backend/middleware/legacy/flowsheet.mirror', () => ({
+  flowsheetMirror: {
+    getEntries: passThrough,
+    addEntry: passThrough,
+    updateEntry: passThrough,
+    deleteEntry: passThrough,
+    startShow: passThrough,
+    endShow: passThrough,
+  },
+}));
+
+import { flowsheet_route } from '../../../apps/backend/routes/flowsheet.route';
+
+const app = express();
+app.use(express.json());
+app.use('/flowsheet', flowsheet_route);
+
+describe('flowsheet route single-validator headers (BS#1689)', () => {
+  beforeEach(() => {
+    mockGetLastModifiedAt.mockClear().mockResolvedValue(new Date('2026-01-01T00:00:00Z'));
+    mockGetEntriesByPage.mockClear().mockResolvedValue([]);
+    mockGetEntryCount.mockClear().mockResolvedValue(0);
+    mockGetOnAirDJName.mockClear().mockResolvedValue(null);
+  });
+
+  it('GET /flowsheet/latest carries no ETag and Cache-Control: no-cache', async () => {
+    const res = await request(app).get('/flowsheet/latest');
+
+    expect(res.status).toBe(204);
+    expect(res.headers.etag).toBeUndefined();
+    expect(res.headers['cache-control']).toBe('no-cache');
+  });
+
+  it('GET /flowsheet/ carries no ETag and Cache-Control: no-cache', async () => {
+    const res = await request(app).get('/flowsheet/');
+
+    expect(res.status).toBe(200);
+    expect(res.headers.etag).toBeUndefined();
+    expect(res.headers['cache-control']).toBe('no-cache');
+  });
+});


### PR DESCRIPTION
## Summary

Watermarked flowsheet routes (`GET /flowsheet/latest`, `GET /flowsheet/`) emitted two independent freshness validators on every response: `conditionalGet`'s watermark `Last-Modified`, and Express's default per-body weak `ETag`. With no `Cache-Control` sent, the two validators could disagree — Express computes/evaluates the `ETag` and `req.fresh` inside `res.send`, independent of and after `conditionalGet`'s own upstream watermark decision, so a client with a stale cached `ETag` could trip an un-watermarked, empty-body `304` that never passed through `conditionalGet`'s logic. That's the root cause behind the unspliced empty-body `304`s reaching the dj-site frontend (dj-site#983, dj-site#982).

## Change

Adds `singleValidatorCache`, a small middleware in `apps/backend/middleware/conditionalGet.ts`, and chains it onto `conditionalGet(flowsheet_service.getLastModifiedAt)` for the flowsheet routes that use it:

- Pre-seeds a sentinel `ETag` header before the route handler runs so Express's own generation check (`!this.get('ETag') && typeof etagFn === 'function'`) short-circuits and never computes a real per-body hash.
- Overrides `res.end` to strip that sentinel immediately before the response flushes, so the final response carries no `ETag` header at all.
- Sets `Cache-Control: no-cache`.

Scoped to the flowsheet routes per the triage decision — the catalog route (`library.route.ts`) reuses the same `conditionalGet` factory but is out of this fix's scope.

## Tests

- `tests/unit/middleware/conditionalGet.singleValidator.test.ts` — exercises the middleware against a real Express app (not a mocked `res`), since the bug and fix both live inside Express's own `send`/`end` internals. Verifies no `ETag` header, `Cache-Control: no-cache`, an untouched body, and a control case showing the unwrapped route still gets Express's default `ETag`.
- `tests/unit/routes/flowsheet.singleValidator.route.test.ts` — route-wiring check that `GET /flowsheet/latest` and `GET /flowsheet/` carry the fix end-to-end through the real route module.

Closes #1689