### PR TITLE
fix(playlist-proxy): deterministic artwork tie-break for split-format albums

### DIFF
--- a/apps/backend/services/playlist-proxy.service.ts
+++ b/apps/backend/services/playlist-proxy.service.ts
@@ -21,7 +21,7 @@
  */
 import { EventSource } from 'eventsource';
 import { db, flowsheet, album_metadata } from '@wxyc/database';
-import { sql, inArray, and, isNotNull, eq } from 'drizzle-orm';
+import { sql, inArray, and, isNotNull, eq, asc } from 'drizzle-orm';
 
 const TUBAFRENZY_URL = process.env.TUBAFRENZY_URL ?? 'https://www.wxyc.info';
 const MAX_ENTRIES = 200;
@@ -356,7 +356,15 @@ async function enrichPlaycuts(): Promise<void> {
     const rows = await db
       .select({
         key: flowsheetLookupKey,
-        artwork_url: album_metadata.artwork_url,
+        // The legacy library is per-physical-format (BS#1105): multiple
+        // `library` rows — and therefore multiple `album_metadata` rows —
+        // can share one flowsheetLookupKey (same artist_name + album_title,
+        // distinct album_id/artwork_url). Grouping by key alone would be
+        // ambiguous about which artwork_url to keep, so the tie-break is
+        // pinned in SQL: aggregate all matching artwork_urls into an array
+        // ordered by album_id ascending and take the first — deterministically
+        // the lowest album_id's artwork, independent of scan/plan order.
+        artwork_url: sql<string>`(array_agg(${album_metadata.artwork_url} order by ${album_metadata.album_id} asc))[1]`,
       })
       .from(flowsheet)
       // INNER JOIN to album_metadata drops `flowsheet.album_id IS NULL` rows
@@ -367,7 +375,7 @@ async function enrichPlaycuts(): Promise<void> {
       // #511 for what happens when the planner falls off the index.
       .innerJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
       .where(and(inArray(flowsheetLookupKey, keys), isNotNull(album_metadata.artwork_url)))
-      .groupBy(flowsheetLookupKey, album_metadata.artwork_url);
+      .groupBy(flowsheetLookupKey);
 
     // Build new map and only swap on success — preserves existing artwork on DB failure
     const newMap = new Map<number, string>();
@@ -404,6 +412,9 @@ async function enrichSinglePlaycut(entry: TubafrenzyEntry): Promise<void> {
       // Same JOIN + partial-index alignment as enrichPlaycuts — see comment there.
       .innerJoin(album_metadata, eq(album_metadata.album_id, flowsheet.album_id))
       .where(and(inArray(flowsheetLookupKey, [key]), isNotNull(album_metadata.artwork_url)))
+      // Deterministic tie-break for split-format albums (BS#1105): lowest
+      // album_id wins, matching enrichPlaycuts' array_agg ordering above.
+      .orderBy(asc(album_metadata.album_id))
       .limit(1);
 
     if (rows.length > 0 && rows[0].artwork_url) {

--- a/tests/integration/playlist-proxy-artwork-tiebreak.spec.js
+++ b/tests/integration/playlist-proxy-artwork-tiebreak.spec.js
@@ -1,0 +1,181 @@
+/**
+ * Integration test for the playlist-proxy artwork tie-break contract
+ * (BS#1105), against a REAL Postgres.
+ *
+ * `enrichPlaycuts` / `enrichSinglePlaycut` in
+ * `apps/backend/services/playlist-proxy.service.ts` join `flowsheet` to
+ * `album_metadata` via `flowsheet.album_id`. Per the `library` schema
+ * comment (`shared/database/src/schema.ts`, "Multiple library rows pointing
+ * at the same (artists.id, album_title)"), the legacy library is
+ * per-physical-format: a CD and an LP issue of the same album are distinct
+ * `library` rows, each with its own `album_metadata.artwork_url`. Before the
+ * fix, the batch query grouped by `(flowsheetLookupKey, artwork_url)` and
+ * the single-entry query had no `ORDER BY` before `LIMIT 1` — both let
+ * Postgres row order (unspecified without an explicit ORDER BY) decide
+ * which format's artwork won, non-deterministically across runs.
+ *
+ * DECISION: tie-break = lowest `album_id` wins. This spec mirrors the fixed
+ * SQL directly (pure SQL, no TS import — the integration runner is
+ * babel-jest with no TS support; see `album-metadata-upsert.spec.js` and
+ * `album-popularity-refresh.spec.js` for the same division of
+ * responsibility). When the service's query shape changes, this SQL must
+ * follow.
+ *
+ * Unit coverage (`tests/unit/services/playlist-proxy.service.test.ts`)
+ * covers the Drizzle builder shape (array_agg/orderBy wiring); this spec
+ * covers the actual PostgreSQL non-determinism this fixes.
+ *
+ * Probe rows live in the reserved 7150-range, reusing fixture artist 7000
+ * ('XA'), genre 11 ('Rock'), format 1 ('cd') — see
+ * `album-popularity-refresh.spec.js` for the same shared fixture.
+ */
+
+const { getTestDb } = require('../utils/db');
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const ART = 7000; // fixture artist (code_letters 'XA')
+const GEN = 11; // 'Rock'
+const FMT = 1; // 'cd'
+
+const PRESS_CD = 7150; // lower album_id -> must win the tie-break
+const PRESS_LP = 7151; // higher album_id, same artist+album, distinct artwork
+
+const ARTIST_NAME = 'BS1105 Split Format Artist';
+const ALBUM_TITLE = 'BS1105 Split Format Album';
+const LOOKUP_KEY = `${ARTIST_NAME.toLowerCase().trim()}-${ALBUM_TITLE.toLowerCase().trim()}`;
+
+const CD_ARTWORK = 'https://i.discogs.com/bs1105-cd.jpg';
+const LP_ARTWORK = 'https://i.discogs.com/bs1105-lp.jpg';
+
+async function seedLibrary(sql, id, codeNumber) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.library
+      (id, artist_id, genre_id, format_id, album_title, code_number, artist_name)
+    VALUES (${id}, ${ART}, ${GEN}, ${FMT}, ${ALBUM_TITLE}, ${codeNumber}, ${ARTIST_NAME})
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+async function seedAlbumMetadata(sql, albumId, artworkUrl) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.album_metadata (album_id, artwork_url)
+    VALUES (${albumId}, ${artworkUrl})
+    ON CONFLICT (album_id) DO UPDATE SET artwork_url = EXCLUDED.artwork_url
+  `;
+}
+
+async function seedPlay(sql, albumId, playOrder) {
+  await sql`
+    INSERT INTO ${sql(SCHEMA)}.flowsheet
+      (album_id, entry_type, play_order, artist_name, album_title, track_title)
+    VALUES (${albumId}, 'track', ${playOrder}, ${ARTIST_NAME}, ${ALBUM_TITLE}, 'probe track')
+  `;
+}
+
+/**
+ * Mirror of the FIXED `enrichPlaycuts` batch query: group by lookup key
+ * alone, fold candidate artwork_urls through array_agg ordered by album_id
+ * ascending, take the first element.
+ */
+async function batchQuery(sql, keys) {
+  return sql`
+    SELECT
+      (lower(trim(f.artist_name)) || '-' || lower(trim(coalesce(f.album_title, '')))) AS "key",
+      (array_agg(am.artwork_url ORDER BY am.album_id ASC))[1] AS "artwork_url"
+    FROM ${sql(SCHEMA)}.flowsheet f
+    INNER JOIN ${sql(SCHEMA)}.album_metadata am ON am.album_id = f.album_id
+    WHERE (lower(trim(f.artist_name)) || '-' || lower(trim(coalesce(f.album_title, '')))) = ANY(${keys})
+      AND am.artwork_url IS NOT NULL
+    GROUP BY (lower(trim(f.artist_name)) || '-' || lower(trim(coalesce(f.album_title, ''))))
+  `;
+}
+
+/**
+ * Mirror of the FIXED `enrichSinglePlaycut` query: same JOIN + filter,
+ * explicit ORDER BY album_id ASC before LIMIT 1.
+ */
+async function singleQuery(sql, key) {
+  return sql`
+    SELECT am.artwork_url AS "artwork_url"
+    FROM ${sql(SCHEMA)}.flowsheet f
+    INNER JOIN ${sql(SCHEMA)}.album_metadata am ON am.album_id = f.album_id
+    WHERE (lower(trim(f.artist_name)) || '-' || lower(trim(coalesce(f.album_title, '')))) = ${key}
+      AND am.artwork_url IS NOT NULL
+    ORDER BY am.album_id ASC
+    LIMIT 1
+  `;
+}
+
+/** Mirror of the PRE-FIX batch query (grouped by key + artwork_url, no tie-break). */
+async function preFixBatchQuery(sql, keys) {
+  return sql`
+    SELECT
+      (lower(trim(f.artist_name)) || '-' || lower(trim(coalesce(f.album_title, '')))) AS "key",
+      am.artwork_url AS "artwork_url"
+    FROM ${sql(SCHEMA)}.flowsheet f
+    INNER JOIN ${sql(SCHEMA)}.album_metadata am ON am.album_id = f.album_id
+    WHERE (lower(trim(f.artist_name)) || '-' || lower(trim(coalesce(f.album_title, '')))) = ANY(${keys})
+      AND am.artwork_url IS NOT NULL
+    GROUP BY (lower(trim(f.artist_name)) || '-' || lower(trim(coalesce(f.album_title, '')))), am.artwork_url
+  `;
+}
+
+describe('playlist-proxy artwork tie-break for split-format albums (real PG, BS#1105)', () => {
+  let sql;
+  const libraryIds = [PRESS_CD, PRESS_LP];
+
+  beforeAll(async () => {
+    sql = getTestDb();
+
+    await seedLibrary(sql, PRESS_CD, 150);
+    await seedLibrary(sql, PRESS_LP, 151);
+    await seedAlbumMetadata(sql, PRESS_CD, CD_ARTWORK);
+    await seedAlbumMetadata(sql, PRESS_LP, LP_ARTWORK);
+    await seedPlay(sql, PRESS_CD, 9150);
+    await seedPlay(sql, PRESS_LP, 9151);
+  });
+
+  afterAll(async () => {
+    if (!sql) return;
+    for (const id of libraryIds) {
+      await sql`DELETE FROM ${sql(SCHEMA)}.flowsheet WHERE album_id = ${id}`;
+    }
+    await sql`DELETE FROM ${sql(SCHEMA)}.album_metadata WHERE album_id = ANY(${libraryIds})`;
+    await sql`DELETE FROM ${sql(SCHEMA)}.library WHERE id = ANY(${libraryIds})`;
+  });
+
+  it('pre-fix query shape demonstrates the bug: two rows for one lookup key', async () => {
+    // Documents the failure this ticket fixes: grouping by (key, artwork_url)
+    // returns one row per distinct artwork_url sharing the key, so a
+    // last-write-wins Map.set over the result set is order-dependent.
+    const rows = await preFixBatchQuery(sql, [LOOKUP_KEY]);
+    expect(rows).toHaveLength(2);
+    const artworkUrls = rows.map((r) => r.artwork_url).sort();
+    expect(artworkUrls).toEqual([CD_ARTWORK, LP_ARTWORK].sort());
+  });
+
+  it('fixed batch query returns exactly one deterministic row per lookup key', async () => {
+    const rows = await batchQuery(sql, [LOOKUP_KEY]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].artwork_url).toBe(CD_ARTWORK); // lowest album_id (PRESS_CD) wins
+  });
+
+  it('fixed batch query returns the identical artwork_url across repeated runs', async () => {
+    const first = await batchQuery(sql, [LOOKUP_KEY]);
+    const second = await batchQuery(sql, [LOOKUP_KEY]);
+    const third = await batchQuery(sql, [LOOKUP_KEY]);
+
+    expect(first[0].artwork_url).toBe(CD_ARTWORK);
+    expect(second[0].artwork_url).toBe(CD_ARTWORK);
+    expect(third[0].artwork_url).toBe(CD_ARTWORK);
+  });
+
+  it('fixed single-entry query (ORDER BY + LIMIT 1) returns the lowest album_id row deterministically', async () => {
+    const first = await singleQuery(sql, LOOKUP_KEY);
+    const second = await singleQuery(sql, LOOKUP_KEY);
+
+    expect(first).toHaveLength(1);
+    expect(first[0].artwork_url).toBe(CD_ARTWORK);
+    expect(second[0].artwork_url).toBe(CD_ARTWORK);
+  });
+});

--- a/tests/unit/services/playlist-proxy.service.test.ts
+++ b/tests/unit/services/playlist-proxy.service.test.ts
@@ -15,6 +15,7 @@ const mockFrom = jest.fn();
 const mockInnerJoin = jest.fn();
 const mockWhere = jest.fn();
 const mockGroupBy = jest.fn();
+const mockOrderBy = jest.fn();
 const mockLimit = jest.fn();
 
 const mockDbChain = {
@@ -23,6 +24,7 @@ const mockDbChain = {
   innerJoin: mockInnerJoin,
   where: mockWhere,
   groupBy: mockGroupBy,
+  orderBy: mockOrderBy,
   limit: mockLimit,
 };
 mockSelect.mockReturnValue(mockDbChain);
@@ -30,6 +32,7 @@ mockFrom.mockReturnValue(mockDbChain);
 mockInnerJoin.mockReturnValue(mockDbChain);
 mockWhere.mockReturnValue(mockDbChain);
 mockGroupBy.mockResolvedValue([]);
+mockOrderBy.mockReturnValue(mockDbChain);
 mockLimit.mockResolvedValue([]);
 
 jest.mock('@wxyc/database', () => ({
@@ -39,6 +42,7 @@ jest.mock('@wxyc/database', () => ({
     innerJoin: (...args: unknown[]) => mockInnerJoin(...args),
     where: (...args: unknown[]) => mockWhere(...args),
     groupBy: (...args: unknown[]) => mockGroupBy(...args),
+    orderBy: (...args: unknown[]) => mockOrderBy(...args),
     limit: (...args: unknown[]) => mockLimit(...args),
   },
   flowsheet: {
@@ -59,6 +63,7 @@ jest.mock('drizzle-orm', () => ({
   isNotNull: jest.fn(),
   and: jest.fn(),
   eq: jest.fn(),
+  asc: jest.fn(),
 }));
 
 // Mock EventSource — we do not want to open real SSE connections in tests.
@@ -160,6 +165,7 @@ describe('playlist-proxy.service', () => {
     mockInnerJoin.mockReturnValue(mockDbChain);
     mockWhere.mockReturnValue(mockDbChain);
     mockGroupBy.mockResolvedValue([]); // batch enrichment default
+    mockOrderBy.mockReturnValue(mockDbChain);
     mockLimit.mockResolvedValue([]); // single enrichment default
   });
 
@@ -467,6 +473,66 @@ describe('playlist-proxy.service', () => {
       // catches the regression at PR time before the next D4 attempt wedges
       // on a missing column.
       expect(proxySource).not.toMatch(/flowsheet\.artwork_url/);
+    });
+
+    it('enrichPlaycuts groups by lookup key alone and aggregates artwork_url deterministically by lowest album_id (BS#1105)', () => {
+      // Split-format albums (BS#1105): multiple library rows — and therefore
+      // multiple album_metadata rows — can share one flowsheetLookupKey.
+      // Grouping by (key, artwork_url) as before lets the GROUP BY emit one
+      // row per distinct artwork_url for the same key, and Map.set's
+      // last-write-wins made the pick depend on unspecified row order.
+      // The fix groups by the key alone and folds candidates through
+      // array_agg ordered by album_id ascending, taking the first element —
+      // deterministically the lowest album_id's artwork.
+      const chains = proxySource.match(/db\s*\.\s*select[\s\S]*?\.\s*groupBy\([\s\S]*?\)\s*;/g) ?? [];
+      const batchChain = chains.find((c) => /flowsheetLookupKey/.test(c));
+      expect(batchChain).toBeDefined();
+      expect(batchChain).toMatch(/\.groupBy\(\s*flowsheetLookupKey\s*\)/);
+      expect(batchChain).not.toMatch(/\.groupBy\(\s*flowsheetLookupKey\s*,\s*album_metadata\.artwork_url\s*\)/);
+      expect(batchChain).toMatch(
+        /array_agg\(\s*\$\{album_metadata\.artwork_url\}\s*order by\s*\$\{album_metadata\.album_id\}\s*asc\s*\)\)\[1\]/
+      );
+    });
+
+    it('enrichSinglePlaycut orders by album_id ascending before limit(1) (BS#1105)', () => {
+      // Without an ORDER BY, `.limit(1)` on a multi-row match (split-format
+      // album) picks whichever row the planner happens to scan first — the
+      // same non-determinism as enrichPlaycuts, just via LIMIT instead of
+      // GROUP BY. Pin it to the same lowest-album_id tie-break.
+      const chains = proxySource.match(/db\s*\.\s*select[\s\S]*?\.\s*limit\([\s\S]*?\)\s*;/g) ?? [];
+      const singleChain = chains.find((c) => /flowsheetLookupKey/.test(c));
+      expect(singleChain).toBeDefined();
+      expect(singleChain).toMatch(/\.orderBy\(\s*asc\(\s*album_metadata\.album_id\s*\)\s*\)/);
+      // orderBy must precede limit in the chain, not just appear somewhere in it.
+      const orderByIdx = singleChain.indexOf('.orderBy(');
+      const limitIdx = singleChain.indexOf('.limit(');
+      expect(orderByIdx).toBeGreaterThan(-1);
+      expect(orderByIdx).toBeLessThan(limitIdx);
+    });
+
+    it('imports `asc` from drizzle-orm for the single-playcut tie-break', () => {
+      expect(proxySource).toMatch(/\basc\b/);
+    });
+  });
+
+  describe('artwork tie-break: split-format albums (BS#1105)', () => {
+    // Behavioral coverage of the tie-break contract at the drizzle-builder
+    // boundary: enrichSinglePlaycut's query chain must route through
+    // orderBy before limit(1) resolves. The real determinism guarantee (that
+    // Postgres actually returns the lowest album_id's row first) is a SQL
+    // property covered by the real-Postgres integration spec
+    // (tests/integration/playlist-proxy-artwork-tiebreak.spec.js); this mock
+    // can only assert the builder wires orderBy into the chain at all.
+    it('enrichSinglePlaycut calls orderBy before resolving limit(1)', async () => {
+      mockLimit.mockResolvedValue([{ artwork_url: 'https://i.discogs.com/lowest-album-id.jpg' }]);
+
+      await processInitEvent(JSON.stringify([talksetEntry]));
+      await processCreatedEvent(JSON.stringify(juanaMolinaEntry));
+
+      expect(mockOrderBy).toHaveBeenCalled();
+      const result = getRecentEntries(50);
+      const juana = result.playcuts.find((p) => p.artistName === 'Juana Molina');
+      expect(juana?.artworkURL).toBe('https://i.discogs.com/lowest-album-id.jpg');
     });
   });
 });


### PR DESCRIPTION
## Problem

`enrichPlaycuts` in the playlist proxy could map a single playcut entry to different `album_metadata.artwork_url` values across runs. The legacy library is per-physical-format (multiple `library` rows can share one `(artists.id, album_title)`, each with its own `album_metadata` row), and the batch query grouped by `(flowsheetLookupKey, artwork_url)` with no tiebreak — the final pick depended on unspecified Postgres row order. `enrichSinglePlaycut` had the same shape via an unordered `LIMIT 1`.

## Fix

Deterministic tie-break: **lowest `album_id` wins**.

- `enrichPlaycuts` now groups by the lookup key alone and folds candidate `artwork_url`s through `array_agg(... ORDER BY album_id ASC)`, taking the first element.
- `enrichSinglePlaycut` adds an explicit `.orderBy(asc(album_metadata.album_id))` before `.limit(1)`.

## Testing

- Unit: extended `tests/unit/services/playlist-proxy.service.test.ts` with source-shape assertions for both query sites plus a behavioral check that `enrichSinglePlaycut` routes through `orderBy` before `limit(1)` resolves.
- Integration: added `tests/integration/playlist-proxy-artwork-tiebreak.spec.js` (pure SQL, matching the repo's existing division of responsibility for this integration runner) that fixtures two `(library, album_metadata)` rows sharing artist+album with distinct `artwork_url`, reproduces the pre-fix non-determinism, and asserts the fixed query returns the identical (lowest-`album_id`) `artwork_url` across repeated runs.
- Manually verified the exact SQL against a live Postgres instance: the pre-fix query returns 2 rows for one lookup key (the bug); the fixed query returns exactly 1 row, identical across 3 repeated runs, matching the lower `album_id`'s artwork.

Closes #1105