### PR TITLE
fix(library-search): rotation-bin dedup surfaces the heaviest active bin

### DIFF
--- a/apps/backend/services/library-search.service.ts
+++ b/apps/backend/services/library-search.service.ts
@@ -86,6 +86,16 @@ const FIELD_COLUMNS: Record<CatalogField, SQL> = {
 const albumPlaysJoin = sql`LEFT JOIN ${album_plays} ON ${album_plays.album_id} = ${library_artist_view.id}`;
 const playsColumn = sql`COALESCE(${album_plays.plays}, 0)`;
 
+// BS#1554: when an album has more than one active rotation row (e.g. H and
+// M simultaneously), the DISTINCT ON (id) dedup below must keep the
+// heaviest active bin, not the lightest. `rotation_bin`'s underlying
+// `freq_enum` sorts S < L < M < H < N, so a bare `rotation_bin ASC`/`DESC`
+// picks the wrong end (ASC kept the lightest bin; a bare DESC would let N —
+// which WXYC never treats as a rotation weight — win). This explicit CASE
+// assigns H the lowest ordinal (favored by the `ASC` used at every
+// DISTINCT-ON site) and pins N last so it can never be the surfaced bin.
+const ROTATION_BIN_DEDUP_ORDINAL = sql`CASE rotation_bin WHEN 'H' THEN 1 WHEN 'M' THEN 2 WHEN 'L' THEN 3 WHEN 'S' THEN 4 ELSE 5 END`;
+
 const SORT_COLUMNS: Record<CatalogSort, SQL> = {
   artist: sql`${library_artist_view.artist_name}`,
   album: sql`${library_artist_view.album_title}`,
@@ -268,7 +278,7 @@ export async function searchLibrary(
       ${cte}
       SELECT * FROM (
         SELECT DISTINCT ON (id) * FROM (${unionBody}) AS raw
-        ORDER BY id ASC, rotation_bin ASC
+        ORDER BY id ASC, ${ROTATION_BIN_DEDUP_ORDINAL} ASC
       ) AS deduped
       ORDER BY ${orderBy}
       LIMIT ${params.limit} OFFSET ${offset}
@@ -277,7 +287,7 @@ export async function searchLibrary(
       ${cte}
       SELECT COUNT(*)::int AS total FROM (
         SELECT DISTINCT ON (id) id FROM (${unionBody}) AS raw
-        ORDER BY id ASC, rotation_bin ASC
+        ORDER BY id ASC, ${ROTATION_BIN_DEDUP_ORDINAL} ASC
       ) AS deduped
     `;
   } else {
@@ -311,7 +321,7 @@ export async function searchLibrary(
     dataQuery = sql`
       SELECT * FROM (
         SELECT DISTINCT ON (id) * FROM (${innerSelect}) AS raw
-        ORDER BY id ASC, rotation_bin ASC
+        ORDER BY id ASC, ${ROTATION_BIN_DEDUP_ORDINAL} ASC
       ) AS deduped
       ORDER BY ${orderBy}
       LIMIT ${params.limit} OFFSET ${offset}
@@ -319,7 +329,7 @@ export async function searchLibrary(
     countQuery = sql`
       SELECT COUNT(*)::int AS total FROM (
         SELECT DISTINCT ON (id) id FROM (${innerSelect}) AS raw
-        ORDER BY id ASC, rotation_bin ASC
+        ORDER BY id ASC, ${ROTATION_BIN_DEDUP_ORDINAL} ASC
       ) AS deduped
     `;
   }

--- a/tests/integration/library-query.spec.js
+++ b/tests/integration/library-query.spec.js
@@ -470,7 +470,9 @@ describe('GET /library/query — review-feedback regressions (PR #1154)', () => 
     expect(res.body.total).toBe(0);
   });
 
-  test('an album with multiple active rotation rows appears once', async () => {
+  test('an album with multiple active rotation rows appears once, surfacing the heaviest bin', async () => {
+    // BS#1554: an album active in both H and M must dedup to the single
+    // heaviest active bin (H), not the alphabetically/lightest-first pick.
     await auth.post('/library/rotation').send({ album_id: album.id, rotation_bin: 'H' }).expect(201);
     await auth.post('/library/rotation').send({ album_id: album.id, rotation_bin: 'M' }).expect(201);
 
@@ -480,9 +482,11 @@ describe('GET /library/query — review-feedback regressions (PR #1154)', () => 
       .expect(200);
     const rows = res.body.results.filter((r) => r.id === album.id);
     expect(rows.length).toBe(1);
+    expect(rows[0].rotation_bin).toBe('H');
 
     const binFiltered = await auth.get('/library/query').query({ rotation_bins: 'H,M', limit: 100 }).expect(200);
     const binRows = binFiltered.body.results.filter((r) => r.id === album.id);
     expect(binRows.length).toBe(1);
+    expect(binRows[0].rotation_bin).toBe('H');
   });
 });


### PR DESCRIPTION
## Summary

The four `DISTINCT ON (id)` dedup sites in `library-search.service.ts` (added in #1154) collapsed an album's fanned-out rotation rows with `ORDER BY id ASC, rotation_bin ASC`, which kept the lowest `freq_enum` value (`S < L < M < H < N`) — an album active in both Heavy and Medium surfaced Medium instead of Heavy.

This replaces the bare `rotation_bin` column order with an explicit `CASE`-based ordinal (`ROTATION_BIN_DEDUP_ORDINAL`) that ranks H first, then M, L, S, with N pinned last — N/New must never surface as the winning bin since WXYC doesn't use it as a rotation weight, and a bare `DESC` on the enum would have let N win.

## Changes

- `apps/backend/services/library-search.service.ts`: added the shared `ROTATION_BIN_DEDUP_ORDINAL` CASE expression and applied it at all four `DISTINCT ON (id)` sites (data + count queries, alias-on and alias-off paths).
- `tests/integration/library-query.spec.js`: the existing "multiple active rotation rows" test now pins `rotation_bin === 'H'` on the surviving row (in both the unfiltered and `rotation_bins=H,M`-filtered cases), not just row count.

## Verification

- `npm run typecheck` / `npm run lint` / `npm run format:check` — clean.
- `npm run test:unit` — full suite green (5060/5062; the 2 pre-existing failures are an unrelated CI env-var doc-parity check, untouched by this diff).
- Verified the exact `CASE` ordinal expression directly against the dev Postgres instance with a synthetic multi-bin fixture: H+M → H wins, S+N → S wins, N-only → N surfaces only as last resort.
- The updated `library-query.spec.js` assertion (H+M → surfaced bin is H) could not be exercised live in this sandbox due to a pre-existing auth-service sign-in rate limiter shared across concurrently-running local dev stacks on the same box; it will run under CI's isolated docker-compose stack.

Closes #1554