### PR TITLE
fix(tests): make shape fixture setval calls monotonic against the dev clone

### DIFF
--- a/docs/dev-db-fixture.md
+++ b/docs/dev-db-fixture.md
@@ -9,6 +9,10 @@ The clone gives realistic data for UI/feature work; CI keeps running against the
 
 To refresh the clone, follow the recipe in the comment at the top of `dev_env/seed-clone.sql`.
 
+## Shape fixture sequence pins are monotonic (BS#1728)
+
+`tests/setup/globalSetup.js` loads `tests/fixtures/shape.sql` (the #701 constraint-shape fixture) after every integration run's migrations/seed, whether or not the clone loaded. That fixture advances its sequences (`labels_id_seq`, `artists_id_seq`, `library_id_seq`, `rotation_id_seq`, `shows_id_seq`, `flowsheet_id_seq`, `compilation_track_artist_id_seq`) past its own 7000-range fixture rows so later serial inserts don't collide. Each `setval(...)` uses `GREATEST(<fixture-floor>, (SELECT last_value FROM <seq>))` rather than a bare fixed value — against a clean CI database (no clone) this still establishes the fixture's floor, but against the dev-profile clone (whose sequences are already walked up near their real prod ids, e.g. `library_id_seq` past 70,000) it never rewinds the sequence below `MAX(id)`. A bare fixed `setval` would rewind it, and every subsequent serial insert in `test:integration` would collide with an existing clone row (`duplicate key value violates unique constraint`). If you add a new sequence-bearing table to the fixture, pin it the same way.
+
 ## `npm run dev` predev hook
 
 `npm run dev` automatically rebuilds `@wxyc/database` + `@wxyc/authentication` first via the `predev` lifecycle hook (BS#968). Without this, a fresh clone or a pull that touches `shared/database/src/schema.ts` would serve a stale schema export to the running backend — typically surfacing as a `TypeError: Cannot convert undefined or null to object` deep inside `drizzle-orm/utils.js` with no column name to chase. `apps/backend`'s own `tsup --watch` already rebuilds its own sources, but it doesn't follow workspace dep dists; `predev` covers that gap.

--- a/tests/fixtures/shape.sql
+++ b/tests/fixtures/shape.sql
@@ -31,6 +31,16 @@
 --
 -- Sequence values are advanced past the fixture range with setval() so
 -- subsequent serial inserts (from tests or app code) don't collide.
+--
+-- Every setval() is monotonic (BS#1728): it uses
+-- GREATEST(<fixture-floor>, (SELECT last_value FROM <seq>)) rather than a
+-- bare fixed value. Against a clean CI database this establishes the
+-- fixture's floor same as before. Against the dev-profile clone
+-- (dev_env/seed-clone.sql, loaded BEFORE this fixture and its own sequence
+-- watermarks already past the fixture's range, e.g. library_id_seq at
+-- 70351) a bare setval(seq, 7099, true) would REWIND the sequence below
+-- MAX(id), so the next serial insert collides with an existing clone row.
+-- GREATEST never rewinds an already-ahead sequence.
 -- ==============================================================================
 
 -- ------------------------------------------------------------------------------
@@ -42,7 +52,7 @@ VALUES
   (7001, 'Shape Fixture Label B')
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval('wxyc_schema.labels_id_seq', 7099, true);
+SELECT setval('wxyc_schema.labels_id_seq', GREATEST(7099, (SELECT last_value FROM wxyc_schema.labels_id_seq)), true);
 
 -- ------------------------------------------------------------------------------
 -- Artists (code_letters intentionally outside the canonical seeded set)
@@ -54,7 +64,7 @@ VALUES
   (7002, 'Shape Fixture Artist Gamma', 'Shape Fixture Artist Gamma', 'XC')
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval('wxyc_schema.artists_id_seq', 7099, true);
+SELECT setval('wxyc_schema.artists_id_seq', GREATEST(7099, (SELECT last_value FROM wxyc_schema.artists_id_seq)), true);
 
 -- Crossreference rows so library_artist_view INNER JOINs resolve. The
 -- (artist_id, genre_id) unique key is namespaced by our 7000-range
@@ -94,7 +104,7 @@ VALUES
   (7009, 7000, 11, 2, 'Shape Fixture Album Alpha 3',  4, 'Shape Fixture Artist Alpha', NULL,                    NULL)
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval('wxyc_schema.library_id_seq', 7099, true);
+SELECT setval('wxyc_schema.library_id_seq', GREATEST(7099, (SELECT last_value FROM wxyc_schema.library_id_seq)), true);
 
 -- ------------------------------------------------------------------------------
 -- Rotation (~15 rows)
@@ -149,7 +159,7 @@ VALUES
   (7014, 7007, 'L', '2024-12-01', NULL, 'Shape Fixture Artist Beta',  'Shape Fixture Album Beta 3', NULL,                    70014)
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval('wxyc_schema.rotation_id_seq', 7099, true);
+SELECT setval('wxyc_schema.rotation_id_seq', GREATEST(7099, (SELECT last_value FROM wxyc_schema.rotation_id_seq)), true);
 
 -- ------------------------------------------------------------------------------
 -- Shows
@@ -177,7 +187,7 @@ VALUES
   (7003, NULL, 'Shape Fixture Mixed-Play-Order Show', '2024-11-20 18:00:00+00', '2024-11-20 21:00:00+00', NULL, 'Shape Fixture DJ Mixed')
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval('wxyc_schema.shows_id_seq', 7099, true);
+SELECT setval('wxyc_schema.shows_id_seq', GREATEST(7099, (SELECT last_value FROM wxyc_schema.shows_id_seq)), true);
 
 -- ------------------------------------------------------------------------------
 -- Flowsheet (~10 rows across 2 shows)
@@ -229,7 +239,7 @@ VALUES
    1, false, false, NULL, '2024-12-02 20:05:00+00', 'Shape Fixture DJ Two', '2024-12-02 20:05:01+00')
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval('wxyc_schema.flowsheet_id_seq', 7099, true);
+SELECT setval('wxyc_schema.flowsheet_id_seq', GREATEST(7099, (SELECT last_value FROM wxyc_schema.flowsheet_id_seq)), true);
 
 -- ------------------------------------------------------------------------------
 -- compilation_track_artist (BS#819 — integration tests for CTA-based track search)
@@ -253,7 +263,7 @@ VALUES
   (7002, 7000, 'Shape Fixture Comp Guest Gamma', 'Bioluminescence',   'B1')
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval('wxyc_schema.compilation_track_artist_id_seq', 7099, true);
+SELECT setval('wxyc_schema.compilation_track_artist_id_seq', GREATEST(7099, (SELECT last_value FROM wxyc_schema.compilation_track_artist_id_seq)), true);
 
 -- ------------------------------------------------------------------------------
 -- Track 2 (Discogs cross-ref via LML /lookup) fixture — BS#825
@@ -291,7 +301,7 @@ VALUES
   (7102, 'Plebs Of The Dawnchorus',  'Plebs Of The Dawnchorus',  'PD')
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval('wxyc_schema.artists_id_seq', 7199, true);
+SELECT setval('wxyc_schema.artists_id_seq', GREATEST(7199, (SELECT last_value FROM wxyc_schema.artists_id_seq)), true);
 
 INSERT INTO wxyc_schema.genre_artist_crossreference (artist_id, genre_id, artist_genre_code)
 VALUES
@@ -312,7 +322,7 @@ VALUES
    65882, 'discogs:master:7777',     0.90, NOW())
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval('wxyc_schema.library_id_seq', 7199, true);
+SELECT setval('wxyc_schema.library_id_seq', GREATEST(7199, (SELECT last_value FROM wxyc_schema.library_id_seq)), true);
 
 -- CTA row for the CTA-collision release. track_title carries the nonce
 -- query token so Track 1's ILIKE matches; library 7102's album_title and
@@ -324,4 +334,4 @@ VALUES
   (7100, 7102, 'CTA Collision Comp Guest', 'Wbtr2x Cmprs 9azn5', 'B2')
 ON CONFLICT (id) DO NOTHING;
 
-SELECT setval('wxyc_schema.compilation_track_artist_id_seq', 7199, true);
+SELECT setval('wxyc_schema.compilation_track_artist_id_seq', GREATEST(7199, (SELECT last_value FROM wxyc_schema.compilation_track_artist_id_seq)), true);

--- a/tests/unit/scripts/shape-fixture-monotonic-setval.test.ts
+++ b/tests/unit/scripts/shape-fixture-monotonic-setval.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression test for BS#1728.
+ *
+ * `tests/fixtures/shape.sql` advances its sequences past the fixture's
+ * 7000-range IDs with `setval(...)` so subsequent serial inserts from tests
+ * or app code don't collide with fixture rows. Against a clean CI database
+ * that's harmless — but `npm run db:start` in dev also loads
+ * `dev_env/seed-clone.sql` (a prod snapshot) *before* the shape fixture,
+ * which advances the same sequences to their real prod watermarks (e.g.
+ * `library_id_seq` to 70351). A bare `setval('...', 7099, true)` REWINDS
+ * the sequence below `MAX(id)`, so the next serial insert collides with an
+ * existing clone row and every integration suite that inserts against that
+ * table fails with a duplicate-key pkey violation.
+ *
+ * The fix: every setval in the fixture must be monotonic — it should only
+ * ever advance the sequence, via `GREATEST(<fixed-floor>, (SELECT
+ * last_value FROM <seq>))` — so it establishes the fixture's ID-range floor
+ * against a clean DB without ever rewinding a sequence that's already ahead.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const fixturePath = path.join(repoRoot, 'tests/fixtures/shape.sql');
+const fixtureSql = fs.readFileSync(fixturePath, 'utf-8');
+
+// Matches `SELECT setval('wxyc_schema.foo_id_seq', ...);` bodies, capturing
+// the sequence name and everything between the sequence name and the
+// trailing `, true)` so we can assert the "value" argument is the
+// monotonic GREATEST(...) form rather than a bare integer literal.
+const SETVAL_RE = /SELECT\s+setval\(\s*'([^']+)'\s*,\s*([\s\S]*?)\s*,\s*true\s*\)\s*;/g;
+
+interface SetvalCall {
+  sequence: string;
+  valueExpr: string;
+}
+
+function findSetvalCalls(sql: string): SetvalCall[] {
+  const calls: SetvalCall[] = [];
+  let m: RegExpExecArray | null;
+  const re = new RegExp(SETVAL_RE);
+  while ((m = re.exec(sql)) !== null) {
+    calls.push({ sequence: m[1], valueExpr: m[2] });
+  }
+  return calls;
+}
+
+describe('tests/fixtures/shape.sql sequence advances (BS#1728)', () => {
+  const calls = findSetvalCalls(fixtureSql);
+
+  it('contains at least one setval call (sanity check the regex still matches the file)', () => {
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it('every setval call uses the monotonic GREATEST(floor, last_value) form', () => {
+    for (const { sequence, valueExpr } of calls) {
+      // The value expression must reference GREATEST(...) and read the
+      // sequence's own last_value, not just hardcode a fixed integer.
+      expect(valueExpr).toMatch(/GREATEST\s*\(/i);
+      expect(valueExpr).toMatch(/last_value/i);
+      expect(valueExpr).toContain(sequence);
+    }
+  });
+
+  it('no setval call regresses to a bare fixed-integer value (the BS#1728 bug shape)', () => {
+    // Matches the pre-fix pattern: setval('<seq>', <digits>, true) with no
+    // GREATEST/last_value wrapping around the digits.
+    const bareFixedRe = /SELECT\s+setval\(\s*'[^']+'\s*,\s*\d+\s*,\s*true\s*\)\s*;/g;
+    expect(fixtureSql).not.toMatch(bareFixedRe);
+  });
+
+  it('covers every sequence the fixture touches (labels, artists, library, rotation, shows, flowsheet, compilation_track_artist)', () => {
+    const sequences = new Set(calls.map((c) => c.sequence));
+    for (const expected of [
+      'wxyc_schema.labels_id_seq',
+      'wxyc_schema.artists_id_seq',
+      'wxyc_schema.library_id_seq',
+      'wxyc_schema.rotation_id_seq',
+      'wxyc_schema.shows_id_seq',
+      'wxyc_schema.flowsheet_id_seq',
+      'wxyc_schema.compilation_track_artist_id_seq',
+    ]) {
+      expect(sequences.has(expected)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`tests/fixtures/shape.sql` pins each of its sequences with a fixed `SELECT setval('<seq>', 7099, true)` (and, for three of them, a second fixed pin at 7199 later in the file). Against a clean CI database that's harmless. But `npm run db:start`'s dev profile also loads `dev_env/seed-clone.sql` (a prod snapshot) before Jest's `globalSetup` loads the shape fixture, and the clone walks the same sequences up near their real prod watermarks (`library_id_seq` past 70,000, `artists_id_seq`/`rotation_id_seq` well past 20,000). The fixture's fixed `setval` then rewound each sequence below `MAX(id)`, so every serial insert in `test:integration` collided with an existing clone row until the sequence walked back past it — roughly 40 of 62 integration suites failed with `duplicate key value violates unique constraint`.

CI itself was unaffected: the bare `node dev_env/init-db.mjs` invocation skips the clone (the `LOAD_CLONE_FIXTURE` gate), so 7,099/7,199 stayed safely above the small seed's ids.

## Fix

Every `setval(...)` in the fixture now uses `GREATEST(<fixture-floor>, (SELECT last_value FROM <seq>))` instead of a bare fixed value. Against a clean database this still establishes the fixture's floor exactly as before; against the dev-profile clone it never rewinds a sequence that's already ahead.

## Verification

- Added `tests/unit/scripts/shape-fixture-monotonic-setval.test.ts`, a regression test asserting every `setval` call in the fixture uses the monotonic `GREATEST(...)`/`last_value` form and that none regress to a bare fixed-integer value.
- Manually verified end-to-end against a freshly clone-loaded dev database (`npm run db:start`): before the fix, `library_id_seq`/`artists_id_seq`/`rotation_id_seq` sat at their clone watermarks (70351/27050/21590); loading the fixture with the new monotonic setvals left them unchanged (no rewind), while `labels_id_seq`/`shows_id_seq`/`flowsheet_id_seq` (which the clone doesn't touch) still advanced to the fixture's 7099 floor as intended. A serial insert into `library` afterward landed at id 70352 with no collision, and re-running the fixture stayed idempotent.
- `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm run test:unit` all pass (two pre-existing/unrelated failures — a CI env-var-surface-parity drift and a flaky SIGSEGV in `freetext-norm.test.ts`, both reproduced identically against `main` via `git stash`).
- Updated `docs/dev-db-fixture.md` with a short section documenting the monotonic-setval convention for future fixture additions.

Closes #1728