### PR TITLE
fix: bind ANY() candidate lists as array literals, not a JS-array splat

### DIFF
--- a/jobs/flowsheet-etl/job.ts
+++ b/jobs/flowsheet-etl/job.ts
@@ -90,6 +90,19 @@ const resolveAlbumIds = async () => {
  */
 const resolveDjNames = async (legacyEntryIds: number[]) => {
   if (legacyEntryIds.length === 0) return;
+  // Bind as a single PG-array-literal string param (`'{2001,2002}'::int[]`)
+  // rather than the bare `${legacyEntryIds}`. Drizzle/postgres-js splats a
+  // JS array into N positional placeholders here — both
+  // `ANY(${array}::int[])` and the bare `ANY(${array})` send
+  // `ANY(($1, $2, …))` over the wire, which PG rejects at arity >= 2 with
+  // "op ANY/ALL (array) requires array on right side" (BS#1071) or "cannot
+  // cast type record to integer[]" (BS#1068). See
+  // jobs/album-level-backfill/job.ts's `resolveAlbums` for the same fix
+  // (BS#1072).
+  //
+  // Safe by construction: TypeScript types `legacyEntryIds: number[]`, so
+  // the join contains only numeric literals — no injection surface.
+  const idArrayLiteral = `{${legacyEntryIds.join(',')}}`;
   // Use rowCount (not the input array length) so the log reflects the actual
   // effect: rows whose dj_name was populated. The two diverge whenever the
   // live insert path beat the ETL to a row, leaving its dj_name already set
@@ -102,7 +115,7 @@ const resolveDjNames = async (legacyEntryIds: number[]) => {
     LEFT JOIN "auth_user" AS u ON u."id" = s."primary_dj_id"
     WHERE f."show_id" = s."id"
       AND f."dj_name" IS NULL
-      AND f."legacy_entry_id" = ANY(${legacyEntryIds})
+      AND f."legacy_entry_id" = ANY(${idArrayLiteral}::int[])
   `);
   const updated = Number(result.count ?? 0);
   log('info', 'resolve-dj-names', `Resolved dj_name for ${updated}/${legacyEntryIds.length} new entries.`, {

--- a/shared/database/src/library-tiebreak.ts
+++ b/shared/database/src/library-tiebreak.ts
@@ -39,12 +39,25 @@ export const pickPrimaryLibraryRow = async (libraryIds: number[]): Promise<numbe
   if (libraryIds.length === 0) return null;
   if (libraryIds.length === 1) return libraryIds[0];
 
+  // Bind as a single PG-array-literal string param (`'{10,11,12}'::int[]`)
+  // rather than the bare `${libraryIds}`. Drizzle/postgres-js splats a JS
+  // array into N positional placeholders here — both `ANY(${array}::int[])`
+  // and the bare `ANY(${array})` send `ANY(($1, $2, …))` over the wire,
+  // which PG rejects at arity >= 2 with "op ANY/ALL (array) requires array
+  // on right side" (BS#1071) or "cannot cast type record to integer[]"
+  // (BS#1068). See jobs/album-level-backfill/job.ts's `resolveAlbums` for
+  // the same fix (BS#1072).
+  //
+  // Safe by construction: TypeScript types `libraryIds: number[]`, so the
+  // join contains only numeric literals — no injection surface.
+  const idArrayLiteral = `{${libraryIds.join(',')}}`;
+
   const rows = (await db.execute(sql`
     SELECT l."id"
     FROM "wxyc_schema"."library" l
     LEFT JOIN "wxyc_schema"."format" f ON f."id" = l."format_id"
     LEFT JOIN "wxyc_schema"."album_plays" ap ON ap."album_id" = l."id"
-    WHERE l."id" = ANY(${libraryIds})
+    WHERE l."id" = ANY(${idArrayLiteral}::int[])
     ORDER BY
       CASE WHEN EXISTS (
         SELECT 1

--- a/tests/unit/database/library-tiebreak.test.ts
+++ b/tests/unit/database/library-tiebreak.test.ts
@@ -155,4 +155,28 @@ describe('pickPrimaryLibraryRow (B-2.3)', () => {
     const picked = await pickPrimaryLibraryRow([5, 6, 7]);
     expect(picked).toBeNull();
   });
+
+  it('binds the multi-element (arity >= 2) candidate list as a single array-literal param, not a splat (BS#1072)', async () => {
+    // postgres-js/drizzle splats `${jsArray}` into N positional
+    // placeholders — `ANY(($1,$2,$3))` — which PG rejects at arity >= 2
+    // with "op ANY/ALL (array) requires array on right side" (BS#1071,
+    // and the cast form `ANY(${array}::int[])` fails the same way per
+    // BS#1068). The only shape that survives is `ANY('{10,11,12}'::int[])`
+    // — a single bound text param cast to int[] inside PG. Matches the
+    // pattern already proven in jobs/album-level-backfill/job.ts.
+    (db.execute as jest.Mock).mockResolvedValueOnce([{ id: 11 }]);
+    await pickPrimaryLibraryRow([10, 11, 12]);
+
+    const call = (db.execute as jest.Mock).mock.calls[0][0] as { values?: unknown[] } | undefined;
+    const sqlText = renderSql(call);
+    expect(sqlText).toMatch(/=\s*ANY\(\s*::int\[\]\)/i);
+
+    const values = call?.values ?? [];
+    expect(values).toContain('{10,11,12}');
+    // Anti-assert the broken shapes: no individual numeric param values
+    // from a splat (the BS#1068/BS#1071 symptom).
+    expect(values).not.toContain(10);
+    expect(values).not.toContain(11);
+    expect(values).not.toContain(12);
+  });
 });

--- a/tests/unit/jobs/flowsheet-etl/job.djName.test.ts
+++ b/tests/unit/jobs/flowsheet-etl/job.djName.test.ts
@@ -131,6 +131,30 @@ describe('runIncremental: dj_name on insert (step 5b.2)', () => {
     expect(djNameUpdate).toBeUndefined();
   });
 
+  it('binds legacy_entry_ids as a single array-literal param at arity >= 2, not a splat (BS#1072)', async () => {
+    // postgres-js/drizzle splats a bare `${jsArray}` in `ANY(${array})`
+    // into N positional placeholders — `ANY(($1,$2,...))` — which PG
+    // rejects at arity >= 2 with "op ANY/ALL (array) requires array on
+    // right side" (BS#1071). The fix binds a single PG array-literal
+    // string (`'{2001,2002}'`) cast with `::int[]`, matching
+    // jobs/album-level-backfill/job.ts's `resolveAlbums`.
+    mockFetchLegacyShows.mockResolvedValue([makeShow()]);
+    mockFetchLegacyEntries.mockResolvedValue([makeEntry({ id: 2001 }), makeEntry({ id: 2002, playOrder: 2 })]);
+
+    await runIncremental();
+
+    const djNameUpdate = findExecuteCallMatching(/UPDATE[\s\S]*flowsheet[\s\S]*dj_name[\s\S]*COALESCE/i);
+    expect(djNameUpdate).toBeDefined();
+    const call = djNameUpdate?.[0] as { values?: unknown[] } | undefined;
+    const sqlText = renderSql(call);
+    expect(sqlText).toMatch(/legacy_entry_id"?\s*=\s*ANY\(\s*::int\[\]\)/i);
+
+    const values = call?.values ?? [];
+    expect(values).toContain('{2001,2002}');
+    expect(values).not.toContain(2001);
+    expect(values).not.toContain(2002);
+  });
+
   it('does not run an unbounded UPDATE (dj_name IS NULL) without a row-id scope', async () => {
     // Regression guard for the wedge: the original resolveDjNames had no
     // row-id scope and rewrote every NULL-dj_name row in flowsheet on each


### PR DESCRIPTION
## Summary

Two callsites used the bare `WHERE col = ANY(${jsArray})` pattern, which postgres-js splats a JS array into N positional placeholders (`ANY(($1,$2,...))`), a shape PG rejects at arity >= 2 with `op ANY/ALL (array) requires array on right side`:

- `shared/database/src/library-tiebreak.ts:47` (`pickPrimaryLibraryRow`) — only runs at arity >= 2 (the function short-circuits length 0/1 earlier).
- `jobs/flowsheet-etl/job.ts:102` (`resolveDjNames`) — guarded against length 0 but not against a multi-row batch.

Both are fixed to match the array-literal pattern already proven in `jobs/album-level-backfill/job.ts`'s `resolveAlbums` (BS#1068 / BS#1071): build a `{id1,id2,...}` PG array-literal string and bind it as a single param cast with `ANY(${literal}::int[])`. Safe by construction — both callers type their input as `number[]`, so the literal is built only from numeric values.

## Test plan

- [x] Added a regression test to `tests/unit/database/library-tiebreak.test.ts` asserting the multi-element candidate list is bound as a single `{10,11,12}` array-literal param (not a splat), following the same wire-shape assertion style already used in `jobs/album-level-backfill/job.test.ts`.
- [x] Added a regression test to `tests/unit/jobs/flowsheet-etl/job.djName.test.ts` asserting the same for `resolveDjNames`'s `legacy_entry_id` binding.
- [x] Both new tests fail against the pre-fix code (verified: `ANY()` renders with no `::int[]` cast) and pass after the fix.
- [x] `npm run typecheck`, `npm run lint`, `npm run test:unit` all green.

Closes #1072