### PR TITLE
fix(flowsheet): 404 on unknown show_id instead of 500

### DIFF
--- a/apps/backend/controllers/flowsheet.controller.ts
+++ b/apps/backend/controllers/flowsheet.controller.ts
@@ -579,6 +579,14 @@ export const getShowInfo: RequestHandler<object, unknown, object, { show_id: str
     flowsheet_service.getEntriesByShow(showId),
   ]);
 
+  // `getShowMetadata` returns undefined when show_id doesn't exist in `shows`
+  // (deleted show, typo, scraping the URL space) — without this guard the
+  // spread below throws a bare TypeError that the centralized errorHandler
+  // maps to 500 instead of the correct 404 (BS#1113).
+  if (!showMetadata) {
+    throw new WxycError(`Show ${showId} not found`, 404);
+  }
+
   await flowsheet_service.attachUpcomingShows(entries);
 
   res.status(200).json({

--- a/apps/backend/services/flowsheet.service.ts
+++ b/apps/backend/services/flowsheet.service.ts
@@ -1125,9 +1125,16 @@ export const changeOrder = async (entry_id: number, position_new: number): Promi
   return response[0];
 };
 
-/** Gets show metadata (DJs, specialty show name) without fetching entries */
-export const getShowMetadata = async (show_id: number): Promise<ShowMetadata> => {
+/**
+ * Gets show metadata (DJs, specialty show name) without fetching entries.
+ * Returns `undefined` when `show_id` doesn't exist (BS#1113) — mirrors the
+ * `library.service.ts:getAlbumFromDB` convention; the controller translates
+ * this to a 404.
+ */
+export const getShowMetadata = async (show_id: number): Promise<ShowMetadata | undefined> => {
   const show = await db.select().from(shows).where(eq(shows.id, show_id));
+
+  if (!show[0]) return undefined;
 
   const showDJs = (await getDJsInShow(show_id, false)).map((dj) => ({
     id: dj.id,

--- a/tests/integration/flowsheet.spec.js
+++ b/tests/integration/flowsheet.spec.js
@@ -1509,6 +1509,16 @@ describe('Retrieve Playlist Object', () => {
   });
 });
 
+describe('Retrieve Playlist Object — unknown show_id', () => {
+  // BS#1113: an unknown show_id previously crashed getShowMetadata's bare
+  // `show[0].specialty_id` dereference into a bare TypeError, surfaced by the
+  // centralized errorHandler as a 500. It should 404 instead. No show/track
+  // fixture needed — the request never gets past the show lookup.
+  test('Unknown show_id returns 404, not 500', async () => {
+    await request.get('/flowsheet/playlist').query({ show_id: 999999999 }).send().expect(404);
+  });
+});
+
 describe('Paginated ordering with ETL-imported entries', () => {
   const postgres = require('postgres');
   let sql;

--- a/tests/unit/controllers/flowsheet.controller.test.ts
+++ b/tests/unit/controllers/flowsheet.controller.test.ts
@@ -450,6 +450,20 @@ describe('flowsheet.controller', () => {
       expect(mockGetEntriesByShow).not.toHaveBeenCalled();
     });
 
+    it('throws 404 WxycError when getShowMetadata resolves undefined (unknown show_id)', async () => {
+      mockGetShowMetadata.mockResolvedValue(undefined);
+      mockGetEntriesByShow.mockResolvedValue([]);
+
+      const req = createMockReq({ show_id: '999999999' });
+      const res = createMockRes();
+
+      await expect(getShowInfo(req as Request, res as Response, mockNext)).rejects.toThrow(WxycError);
+      await expect(getShowInfo(req as Request, res as Response, mockNext)).rejects.toMatchObject({
+        statusCode: 404,
+      });
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
     it('rejects with error on service failure', async () => {
       const error = new Error('Show not found');
       mockGetShowMetadata.mockRejectedValue(error);

--- a/tests/unit/services/flowsheet.getShowMetadata.test.ts
+++ b/tests/unit/services/flowsheet.getShowMetadata.test.ts
@@ -1,0 +1,62 @@
+import { db, createMockQueryChain } from '../../mocks/database.mock';
+import { getShowMetadata } from '../../../apps/backend/services/flowsheet.service';
+
+describe('getShowMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined when show_id does not exist — controller maps this to 404 (BS#1113)', async () => {
+    const showSelect = createMockQueryChain();
+    showSelect.where.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(showSelect);
+
+    const result = await getShowMetadata(999999999);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('does not query DJs or the specialty show once the show lookup comes back empty', async () => {
+    const showSelect = createMockQueryChain();
+    showSelect.where.mockResolvedValue([]);
+    db.select.mockReturnValueOnce(showSelect);
+
+    await getShowMetadata(999999999);
+
+    // The only db.select call should be the show lookup itself — no
+    // show_djs/user (getDJsInShow) or specialty_shows follow-up queries.
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns show metadata with DJs and specialty name when the show exists', async () => {
+    const showSelect = createMockQueryChain();
+    showSelect.where.mockResolvedValue([{ id: 42, specialty_id: 7, show_name: 'Test Show' }]);
+    db.select.mockReturnValueOnce(showSelect);
+
+    // getDJsInShow(show_id, false): show_djs select, then user select
+    const showDjsSelect = createMockQueryChain();
+    showDjsSelect.where.mockResolvedValue([{ dj_id: 'user-1' }]);
+    db.select.mockReturnValueOnce(showDjsSelect);
+
+    const userSelect = createMockQueryChain();
+    userSelect.where.mockResolvedValue([{ id: 'user-1', djName: 'DJ Test' }]);
+    db.select.mockReturnValueOnce(userSelect);
+
+    // specialty_shows select
+    const specialtySelect = createMockQueryChain();
+    specialtySelect.where.mockResolvedValue([{ id: 7, specialty_name: 'Jazz Hour' }]);
+    db.select.mockReturnValueOnce(specialtySelect);
+
+    const result = await getShowMetadata(42);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 42,
+        specialty_id: 7,
+        show_name: 'Test Show',
+        specialty_show_name: 'Jazz Hour',
+        show_djs: [{ id: 'user-1', dj_name: 'DJ Test' }],
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`getShowMetadata` (`apps/backend/services/flowsheet.service.ts`) dereferenced `db.select().from(shows).where(eq(shows.id, show_id))[0]` without a null guard. An unknown `show_id` (deleted show, typo, scraping the URL space) made `show[0]` `undefined`, and the very next line (`show[0].specialty_id`) threw a bare `TypeError` that the centralized error handler mapped to a 500 instead of the correct 404.

`library.service.ts:getAlbumFromDB` already handles this shape correctly (`if (!album[0]) return undefined`); this PR brings `getShowMetadata` in line with that convention.

## Fix

- `getShowMetadata` now returns `undefined` when the show doesn't exist, before touching `getDJsInShow` or the specialty-show lookup (avoids the extra queries too).
- `getShowInfo` (the controller backing `GET /flowsheet/playlist` and `GET /flowsheet/show-info`) throws `WxycError('Show <id> not found', 404)` when `getShowMetadata` resolves `undefined`.

## Scope note

The original report also named a `getPlaylist` function in `apps/backend/services/djs.service.ts` with the same bug shape, on a `GET /djs/playlist` route. That function and route no longer exist — both were removed as dead code in an earlier, unrelated refactor (`043e8230`, "drop dead djs getPlaylist"). `djs.service.ts`'s current multi-show query (`getPlaylistsForDJ`) already degrades gracefully (returns `[]`) and isn't affected by this bug. This PR is scoped to the remaining `flowsheet.service.ts` / `flowsheet.controller.ts` fix, keeping the diff minimal for the parallel BS#1110 work touching the same files.

## Tests

- Unit: `tests/unit/services/flowsheet.getShowMetadata.test.ts` (new) — asserts `undefined` on an unknown show, and that no DJ/specialty follow-up queries fire once the show lookup comes back empty.
- Unit: `tests/unit/controllers/flowsheet.controller.test.ts` — asserts `getShowInfo` throws a 404 `WxycError` when the service resolves `undefined`.
- Integration: `tests/integration/flowsheet.spec.js` — `GET /flowsheet/playlist?show_id=999999999` now expects `404` (previously would have 500'd).

Closes #1113