### PR TITLE
fix(auth): dedupe default-user bootstrap on username (BS#1670)

### DIFF
--- a/apps/auth/app.ts
+++ b/apps/auth/app.ts
@@ -21,6 +21,7 @@ import { fallbackErrorHandler } from './fallback-error-handler';
 import { lookupEmailByIdentifier } from './lookup-email';
 import { provisionUser, ProvisionError } from './provision-user';
 import { createAutoDjUser } from './create-auto-dj-user';
+import { createDefaultUser } from './create-default-user';
 import { resolveOrganization } from './resolve-organization';
 import { shouldCaptureAuthExpressError } from './sentry-error-filter';
 import { E2E_INCOMPLETE_USER_ID, E2E_INCOMPLETE_USER_PASSWORD } from './e2e-test-constants';
@@ -460,70 +461,6 @@ Sentry.setupExpressErrorHandler(app, { shouldHandleError: shouldCaptureAuthExpre
 app.use(fallbackErrorHandler);
 
 // Create default user if needed
-const createDefaultUser = async () => {
-  if (process.env.CREATE_DEFAULT_USER !== 'TRUE') return;
-
-  try {
-    const email = process.env.DEFAULT_USER_EMAIL;
-    const username = process.env.DEFAULT_USER_USERNAME;
-    const password = process.env.DEFAULT_USER_PASSWORD;
-    const djName = process.env.DEFAULT_USER_DJ_NAME;
-    const realName = process.env.DEFAULT_USER_REAL_NAME;
-
-    const organizationSlug = process.env.DEFAULT_ORG_SLUG;
-    const organizationName = process.env.DEFAULT_ORG_NAME;
-
-    if (!username || !email || !password || !djName || !realName || !organizationSlug || !organizationName) {
-      throw new Error('Default user credentials are not fully set in environment variables.');
-    }
-
-    const context = await auth.$context;
-    const internalAdapter = context.internalAdapter;
-
-    const existingUser = await internalAdapter.findUserByEmail(email);
-
-    if (existingUser) {
-      console.log('Default user already exists, skipping creation.');
-      return;
-    }
-
-    // Ensure the organization exists (bootstrap: create if missing)
-    const existingOrganization = await context.adapter.findOne<{ id: string }>({
-      model: 'organization',
-      where: [{ field: 'slug', value: organizationSlug }],
-    });
-
-    if (!existingOrganization) {
-      await context.adapter.create({
-        model: 'organization',
-        data: {
-          name: organizationName,
-          slug: organizationSlug,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-      });
-    }
-
-    // Provision user + credential + membership atomically
-    await provisionUser({
-      email,
-      username,
-      password,
-      name: username,
-      realName,
-      djName,
-      organizationSlug,
-      role: 'stationManager',
-    });
-
-    console.log('Default user created successfully with admin role.');
-  } catch (error) {
-    console.error('[DEFAULT USER] Error creating default user:', error);
-    Sentry.captureException(error, { level: 'warning', tags: { subsystem: 'default-user' } });
-  }
-};
-
 // Fix admin roles for existing stationManagers (one-time migration)
 const syncAdminRoles = async () => {
   try {

--- a/apps/auth/create-default-user.ts
+++ b/apps/auth/create-default-user.ts
@@ -1,0 +1,107 @@
+/**
+ * Idempotent startup bootstrap for the environment's default admin user
+ * (+ its organization). Gated by `CREATE_DEFAULT_USER`, defaulting off; mints a
+ * `stationManager` account from the `DEFAULT_USER_*` env vars via
+ * `provisionUser()`, bootstrapping the default organization first if missing.
+ *
+ * Extracted from `app.ts` (mirroring `create-auto-dj-user.ts`) so the bootstrap
+ * is unit-testable without importing `app.ts`, which self-executes `listen()`.
+ *
+ * Idempotency (BS#1670): skips if a user with the configured email **or**
+ * username already exists. The username check matters because `auth_user`
+ * carries its own unique index on `username`, independent of `id`/`email`. A
+ * seeded fixture row (e.g. the e2e `test_dj1`) or any prior row can already own
+ * the username while its email differs from `DEFAULT_USER_EMAIL`; without the
+ * username guard the email lookup misses, `provisionUser` INSERTs a fresh id,
+ * and the insert trips `auth_user_username_key` mid-run — the e2e flake in
+ * WXYC/dj-site#579 / BS#1670. Converging on a username match makes the
+ * bootstrap idempotent regardless of which env/config enabled it or whether the
+ * configured email matches the existing row.
+ *
+ * This bootstrap-only convergence is deliberately NOT pushed into
+ * `provisionUser()`: the interactive admin path (`POST /auth/admin/provision-user`)
+ * should still surface a username collision as an error, not silently skip.
+ */
+
+import * as Sentry from '@sentry/node';
+import { auth } from '@wxyc/authentication';
+import { provisionUser } from './provision-user';
+
+export const createDefaultUser = async (): Promise<void> => {
+  if (process.env.CREATE_DEFAULT_USER !== 'TRUE') return;
+
+  try {
+    const email = process.env.DEFAULT_USER_EMAIL;
+    const username = process.env.DEFAULT_USER_USERNAME;
+    const password = process.env.DEFAULT_USER_PASSWORD;
+    const djName = process.env.DEFAULT_USER_DJ_NAME;
+    const realName = process.env.DEFAULT_USER_REAL_NAME;
+
+    const organizationSlug = process.env.DEFAULT_ORG_SLUG;
+    const organizationName = process.env.DEFAULT_ORG_NAME;
+
+    if (!username || !email || !password || !djName || !realName || !organizationSlug || !organizationName) {
+      throw new Error('Default user credentials are not fully set in environment variables.');
+    }
+
+    const context = await auth.$context;
+    const internalAdapter = context.internalAdapter;
+
+    const existingUser = await internalAdapter.findUserByEmail(email);
+
+    if (existingUser) {
+      console.log('Default user already exists, skipping creation.');
+      return;
+    }
+
+    // BS#1670: `auth_user.username` has its own unique index, independent of
+    // id/email. If a row (e.g. a seeded e2e `test_dj1`) already owns this
+    // username under a different email, the email lookup above misses but a
+    // fresh provision would trip `auth_user_username_key` mid-run. Converge by
+    // skipping when the username is already taken.
+    const existingByUsername = await context.adapter.findOne<{ id: string }>({
+      model: 'user',
+      where: [{ field: 'username', value: username }],
+    });
+
+    if (existingByUsername) {
+      console.log('Default user username already exists, skipping creation.');
+      return;
+    }
+
+    // Ensure the organization exists (bootstrap: create if missing)
+    const existingOrganization = await context.adapter.findOne<{ id: string }>({
+      model: 'organization',
+      where: [{ field: 'slug', value: organizationSlug }],
+    });
+
+    if (!existingOrganization) {
+      await context.adapter.create({
+        model: 'organization',
+        data: {
+          name: organizationName,
+          slug: organizationSlug,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+    }
+
+    // Provision user + credential + membership atomically
+    await provisionUser({
+      email,
+      username,
+      password,
+      name: username,
+      realName,
+      djName,
+      organizationSlug,
+      role: 'stationManager',
+    });
+
+    console.log('Default user created successfully with admin role.');
+  } catch (error) {
+    console.error('[DEFAULT USER] Error creating default user:', error);
+    Sentry.captureException(error, { level: 'warning', tags: { subsystem: 'default-user' } });
+  }
+};

--- a/tests/unit/auth/create-default-user.test.ts
+++ b/tests/unit/auth/create-default-user.test.ts
@@ -1,0 +1,144 @@
+import { jest } from '@jest/globals';
+
+// --- Mocks ---
+
+const mockSentryCaptureException = jest.fn();
+jest.mock('@sentry/node', () => ({
+  captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
+}));
+
+const mockFindUserByEmail = jest.fn<(email: string) => Promise<unknown>>();
+const mockAdapterFindOne =
+  jest.fn<(args: { model: string; where: { field: string; value: unknown }[] }) => Promise<unknown>>();
+const mockAdapterCreate = jest.fn();
+
+const mockAuthContext = {
+  internalAdapter: { findUserByEmail: mockFindUserByEmail },
+  adapter: { findOne: mockAdapterFindOne, create: mockAdapterCreate },
+};
+
+jest.mock('@wxyc/authentication', () => ({
+  auth: { $context: Promise.resolve(mockAuthContext) },
+}));
+
+const mockProvisionUser = jest.fn();
+jest.mock('../../../apps/auth/provision-user', () => ({
+  provisionUser: (...args: unknown[]) => mockProvisionUser(...args),
+}));
+
+// --- Import after mocks ---
+import { createDefaultUser } from '../../../apps/auth/create-default-user';
+
+// --- Helpers ---
+const fakeOrg = { id: 'default-org-id-000000000000001', slug: 'wxyc', name: 'WXYC' };
+
+const ENV_KEYS = [
+  'CREATE_DEFAULT_USER',
+  'DEFAULT_USER_EMAIL',
+  'DEFAULT_USER_USERNAME',
+  'DEFAULT_USER_PASSWORD',
+  'DEFAULT_USER_DJ_NAME',
+  'DEFAULT_USER_REAL_NAME',
+  'DEFAULT_ORG_SLUG',
+  'DEFAULT_ORG_NAME',
+] as const;
+
+function setHappyEnv() {
+  process.env.CREATE_DEFAULT_USER = 'TRUE';
+  process.env.DEFAULT_USER_EMAIL = 'default@wxyc.org';
+  process.env.DEFAULT_USER_USERNAME = 'test_dj1';
+  process.env.DEFAULT_USER_PASSWORD = 'super-secret';
+  process.env.DEFAULT_USER_DJ_NAME = 'DJ Default';
+  process.env.DEFAULT_USER_REAL_NAME = 'Default User';
+  process.env.DEFAULT_ORG_SLUG = 'wxyc';
+  process.env.DEFAULT_ORG_NAME = 'WXYC';
+}
+
+// Route adapter.findOne by model: 'user' → username lookup, 'organization' → org.
+function wireAdapter({ userByUsername }: { userByUsername: unknown }) {
+  mockAdapterFindOne.mockImplementation(({ model }) =>
+    Promise.resolve(model === 'user' ? userByUsername : model === 'organization' ? fakeOrg : null)
+  );
+}
+
+describe('createDefaultUser()', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+    for (const key of ENV_KEYS) delete process.env[key];
+
+    jest.clearAllMocks();
+    // Default happy adapter behavior: no existing user by email or username, org present.
+    mockFindUserByEmail.mockResolvedValue(null);
+    wireAdapter({ userByUsername: null });
+    mockProvisionUser.mockResolvedValue({ user: { id: 'u1' }, member: { id: 'm1' }, emailSent: true });
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  it('no-ops when CREATE_DEFAULT_USER is not TRUE', async () => {
+    await createDefaultUser();
+    expect(mockFindUserByEmail).not.toHaveBeenCalled();
+    expect(mockProvisionUser).not.toHaveBeenCalled();
+  });
+
+  it('provisions the default user when neither the email nor the username is taken', async () => {
+    setHappyEnv();
+
+    await createDefaultUser();
+
+    expect(mockFindUserByEmail).toHaveBeenCalledWith('default@wxyc.org');
+    // Username was checked before provisioning.
+    expect(mockAdapterFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'user', where: [{ field: 'username', value: 'test_dj1' }] })
+    );
+    expect(mockProvisionUser).toHaveBeenCalledTimes(1);
+    expect(mockProvisionUser).toHaveBeenCalledWith(
+      expect.objectContaining({ username: 'test_dj1', role: 'stationManager' })
+    );
+  });
+
+  it('skips creation when the email already exists (existing behavior)', async () => {
+    setHappyEnv();
+    mockFindUserByEmail.mockResolvedValue({ id: 'existing-by-email' });
+
+    await createDefaultUser();
+
+    expect(mockProvisionUser).not.toHaveBeenCalled();
+  });
+
+  // BS#1670: the seeded e2e `test_dj1` owns the username under a different
+  // email; the email lookup misses, so without the username guard a fresh
+  // provision would trip `auth_user_username_key` mid-run.
+  it('skips creation when the username is already taken under a different email (BS#1670)', async () => {
+    setHappyEnv();
+    // Email miss (configured email differs from the seeded row's email)...
+    mockFindUserByEmail.mockResolvedValue(null);
+    // ...but the username is already owned by a seeded row.
+    wireAdapter({ userByUsername: { id: 'seeded-test-dj1-id' } });
+
+    await createDefaultUser();
+
+    expect(mockAdapterFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'user', where: [{ field: 'username', value: 'test_dj1' }] })
+    );
+    // No colliding INSERT.
+    expect(mockProvisionUser).not.toHaveBeenCalled();
+    expect(mockAdapterCreate).not.toHaveBeenCalled();
+  });
+
+  it('captures to Sentry (does not throw) when required env vars are missing', async () => {
+    process.env.CREATE_DEFAULT_USER = 'TRUE'; // gate on, but no DEFAULT_USER_* set
+
+    await expect(createDefaultUser()).resolves.toBeUndefined();
+
+    expect(mockProvisionUser).not.toHaveBeenCalled();
+    expect(mockSentryCaptureException).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

`createDefaultUser()` deduped only on **email** (`findUserByEmail` → skip). But `auth_user.username` carries its own unique index independent of id/email. A row that already owns the configured username under a *different* email — e.g. the seeded e2e `test_dj1` — slips past the email lookup, and the subsequent `provisionUser()` INSERT mints a fresh id and trips `auth_user_username_key` **mid-run**. That's the `auth_user_username_key` violation observed in the dj-site#579 e2e window (BS#1670).

## Fix (trigger-agnostic)

Add a **username pre-check** before provisioning: if `adapter.findOne({ model: 'user', where: username })` returns a row, skip (converge), same as the existing email skip. This makes the bootstrap idempotent regardless of *which* env/config enabled it or whether `DEFAULT_USER_EMAIL` matches the existing row's email — so it doesn't depend on pinning down the exact CI trigger (which lives in CI secrets, not the repo).

Extracted the function from `app.ts` into `apps/auth/create-default-user.ts` (mirroring the sibling `create-auto-dj-user.ts`) so it's unit-testable without importing `app.ts`, which self-executes `listen()`.

**Scope:** the convergence is bootstrap-only. The interactive `POST /auth/admin/provision-user` path intentionally still surfaces a username collision as an error rather than silently skipping.

## Tests

New `tests/unit/auth/create-default-user.test.ts` (5 cases): gate-off no-op; happy provision (asserts the username check runs before provisioning); skip-on-email-exists (existing behavior); **skip-on-username-taken-under-different-email (BS#1670)**; missing-env → Sentry capture, no throw. Verified failing-first against the pre-fix code path.

Local: full `typecheck`, `lint` (0 errors), `format:check`, and the `tests/unit/auth` + `tests/unit/authentication` suites (28 suites / 353 tests) all green.

Closes #1670