### PR TITLE
feat(concerts): two-pass getUpcomingShowsMaps support matching

### DIFF
--- a/apps/backend/services/concerts.service.ts
+++ b/apps/backend/services/concerts.service.ts
@@ -4,6 +4,7 @@ import {
   artist_similar_artists,
   artist_station_plays,
   artists,
+  concertPerformers,
   concerts,
   db,
   discogs_artist_similar_artists,
@@ -648,6 +649,52 @@ type UpcomingShowJoinRow = ConcertJoinRow & { artist_name: string | null };
  *
  * The venue-embedding join and DTO mapping reuse `getConcertsPage`'s projection
  * so the wire shape can't drift.
+ *
+ * Two-pass construction (BS#1761, parent #1618): the above is PASS 1
+ * (headliners) — unchanged since BS#1613. PASS 2 (support acts) runs after
+ * Pass 1 has fully populated both maps, and reads `concert_performers`
+ * (`role = 'support'`, `removed_at IS NULL`, i.e. "active") INNER JOINed to
+ * the SAME `buildWhere({ from: today, curated: false })`-windowed `concerts`
+ * — an upcoming, non-tombstoned concert with no active support rows
+ * contributes nothing to Pass 2. Reads `concerts_active_starts_on_id_idx` to
+ * drive the outer `concerts` scan, nested-loop into `concert_performers` via
+ * the leading `concert_id` column of `concert_performers_concert_role_
+ * raw_name_idx` — no new index needed (EXPLAIN-verified; see the BS#1761
+ * ticket). Ordered `starts_on ASC, concerts.id ASC, concert_performers.id ASC`
+ * (the last only as a tiebreak among several support acts on ONE concert,
+ * where ordering is otherwise immaterial: every support row on a given
+ * concert maps to the identical `toConcertDTO` output for that concert).
+ *
+ * For each active support row:
+ *   - id-arm — keyed on `concert_performers.artist_id` (the library FK;
+ *     RESOLVED supports only — a Discogs-only-resolved support, a future
+ *     Phase-D concept, has no `artists.id`, so no play's
+ *     `flowsheet.album_id -> library.artist_id` can ever equal it; the name
+ *     arm is that case's only route);
+ *   - name-arm — keyed on `normalizeFreetextArtist(concert_performers.raw_name)`
+ *     for EVERY active support row, resolved or not. Deliberately NOT Pass 1's
+ *     canonical-or-raw preference: a junction `raw_name` is already a clean
+ *     single name post-`parseBilling` (`jobs/triangle-shows-etl/headliner.ts`),
+ *     so an unresolved support name is its own inert-but-matchable key exactly
+ *     like an unresolved clean headliner (BS#1613) — no `artists` join is
+ *     needed to compute it, and a resolved support's raw billing text is used
+ *     even though its canonical catalog name may differ.
+ *
+ * Both arms add a key ONLY when Pass 1 — or an earlier (soonest) Pass-2 row —
+ * hasn't already claimed it (`!byArtistId.has(...)` / `!byNormName.has(...)`).
+ * Because Pass 1 runs to completion first, EVERY headliner key of ANY
+ * upcoming date is already in the map before Pass 2 evaluates a single support
+ * row, so a headliner CTA beats a support CTA for the same key REGARDLESS of
+ * date — no date comparison against the headliner is performed or needed.
+ * Within Pass 2 itself the identical first-write-wins trick (rows ordered
+ * soonest-first) collapses several support dates for the same key to the
+ * soonest, i.e. "soonest wins within a role". No tribute-name guard here
+ * (unlike the BS#1760 SQL resolve arm's `raw_name !~* '\mtribute'` candidate
+ * filter): that guard only protects RESOLUTION from minting a wrong
+ * `artist_id` off a tribute-act's billing text — it doesn't apply to matching
+ * an already-decided key, so an unresolved tribute-act name lighting the name
+ * arm off a coincidentally identical free-text play is the same low-harm
+ * homonym-collision class as the RESIDUAL noted above, not a new risk.
  */
 export const getUpcomingShowsMaps = async (
   today: string
@@ -655,6 +702,7 @@ export const getUpcomingShowsMaps = async (
   const byArtistId = new Map<number, ConcertDTO>();
   const byNormName = new Map<string, ConcertDTO>();
 
+  // Pass 1 — headliners (BS#1607, widened BS#1613). Unchanged.
   const rows = await db
     .select(upcomingShowJoinFields)
     .from(concerts)
@@ -683,6 +731,50 @@ export const getUpcomingShowsMaps = async (
     const dto = toConcertDTO(row);
     if (needsId && artistId !== null) {
       byArtistId.set(artistId, dto);
+    }
+    if (needsName) {
+      byNormName.set(nameKey, dto);
+    }
+  }
+
+  // Pass 2 (BS#1761) — support acts. See the doc comment above for the full
+  // precedence proof: a `.has()` miss below can only mean no headliner (of any
+  // date) claimed this key, since Pass 1 has already fully run.
+  type SupportRow = ConcertJoinRow & { raw_name: string; support_artist_id: number | null };
+
+  const supportRows = await db
+    .select({
+      ...concertJoinFields,
+      raw_name: concertPerformers.raw_name,
+      support_artist_id: concertPerformers.artist_id,
+    })
+    .from(concerts)
+    .innerJoin(concertPerformers, eq(concertPerformers.concert_id, concerts.id))
+    .innerJoin(venues, eq(venues.id, concerts.venue_id))
+    .where(
+      and(
+        eq(concertPerformers.role, 'support'),
+        isNull(concertPerformers.removed_at),
+        buildWhere({ from: today, curated: false })
+      )
+    )
+    .orderBy(asc(concerts.starts_on), asc(concerts.id), asc(concertPerformers.id));
+
+  for (const row of supportRows as SupportRow[]) {
+    // name arm — ALWAYS the raw junction name, resolved or not (see the doc
+    // comment above for why this deliberately skips Pass 1's canonical-or-raw
+    // preference).
+    const nameKey = normalizeFreetextArtist(row.raw_name);
+
+    const needsId = row.support_artist_id !== null && !byArtistId.has(row.support_artist_id);
+    const needsName = nameKey !== '' && !byNormName.has(nameKey);
+    if (!needsId && !needsName) {
+      continue; // a headliner (or an earlier, soonest support) already claimed both arms
+    }
+
+    const dto = toConcertDTO(row);
+    if (needsId && row.support_artist_id !== null) {
+      byArtistId.set(row.support_artist_id, dto);
     }
     if (needsName) {
       byNormName.set(nameKey, dto);

--- a/tests/integration/flowsheet-upcoming-show-support.spec.js
+++ b/tests/integration/flowsheet-upcoming-show-support.spec.js
@@ -1,0 +1,443 @@
+/**
+ * BS#1761 — PASS 2 of the V2 flowsheet `upcoming_show` embed: support acts.
+ *
+ * `getUpcomingShowsMaps` (apps/backend/services/concerts.service.ts) widens
+ * from a single headliner-only pass (BS#1607, BS#1613) to two passes: the
+ * existing headliner pass, then a new pass over active (non-tombstoned)
+ * `concert_performers` rows with `role = 'support'`. This spec is the
+ * end-to-end, Postgres-backed proof — sibling to
+ * tests/integration/flowsheet-upcoming-show.spec.js, which pins Pass 1 and is
+ * left untouched by this change.
+ *
+ * Pins:
+ *   - a play of a library artist who only SUPPORTS an upcoming show (never
+ *     headlines) carries `upcoming_show` via the id arm
+ *     (`concert_performers.artist_id`);
+ *   - a free-text play matches an UNRESOLVED support act by its raw junction
+ *     name (the name arm) — no library id required;
+ *   - a headliner CTA beats a support CTA for the SAME artist regardless of
+ *     date: a LATER headliner concert wins over an EARLIER support concert;
+ *   - soonest wins WITHIN the support arm across several support dates;
+ *   - a TOMBSTONED (`removed_at` set) support row is excluded from both arms;
+ *   - EXPLAIN proves the support query can drive off
+ *     `concerts_active_starts_on_id_idx` and reach `concert_performers` via
+ *     the leading `concert_id` column of its
+ *     `concert_performers_concert_role_raw_name_idx` — no seq scan required
+ *     at production scale (BS#1761 ticket constraint).
+ *
+ * Artist/library fixtures: this spec creates its OWN `artists` + `library`
+ * rows (cleaned up in `afterAll`) rather than assuming specific ids from
+ * `dev_env/seed_db.sql`. Local dev database volumes persist across sessions
+ * (`npm run db:stop` drops it; nothing else does) and accumulate drift from
+ * whatever has run against them, so a fixed-id assumption like "library id 4
+ * is Sufjan Stevens" — true on a freshly-provisioned DB — is not safe to rely
+ * on here. Creating fresh rows sidesteps that drift entirely and matches the
+ * precedent in concerts-genre-enrichment.spec.js / concerts-by-id.spec.js /
+ * flowsheet-artwork-repair.spec.js, among others.
+ */
+
+const postgres = require('postgres');
+const request = require('supertest')(`${process.env.TEST_HOST}:${process.env.PORT}`);
+
+const SCHEMA = process.env.WXYC_SCHEMA_NAME || 'wxyc_schema';
+const SOURCE_ID_PREFIX = 'bs1761:';
+const VENUE_SLUG = 'bs1761-probe-room';
+const SHOW_NAME = 'BS#1761 support-embed probe';
+const ARTIST_NAME_PREFIX = 'BS1761 Probe Artist ';
+
+function makeSql() {
+  return postgres({
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || process.env.CI_DB_PORT || '5433', 10),
+    database: process.env.DB_NAME || 'wxyc_db',
+    user: process.env.DB_USERNAME || 'test-user',
+    password: process.env.DB_PASSWORD || 'test-pw',
+    onnotice: () => {},
+    max: 2,
+  });
+}
+
+/** YYYY-MM-DD for today + offsetDays, America/New_York (matches the feed's "today"). */
+function isoDate(offsetDays) {
+  const d = new Date(Date.now() + offsetDays * 24 * 60 * 60 * 1000);
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(d);
+}
+
+// Precedence dates: the SUPPORT date is sooner, the HEADLINER date is later —
+// the headliner must still win.
+const PRECEDENCE_SUPPORT_SOON = isoDate(3);
+const PRECEDENCE_HEADLINER_LATER = isoDate(30);
+
+// Soonest-within-support dates for the same normalized name.
+const SUPPORT_SOON = isoDate(5);
+const SUPPORT_LATER = isoDate(28);
+
+const SUPPORT_ONLY_DATE = isoDate(9);
+const NAME_ARM_DATE = isoDate(11);
+const TOMBSTONED_DATE = isoDate(13);
+
+describe('V2 flowsheet upcoming_show enrichment — support arm (BS#1761)', () => {
+  let sql;
+  let venueId;
+  let showId;
+  let insertedTrackIds = [];
+  let genreId;
+  let formatId;
+  // Resolved id-arm fixtures, created fresh in beforeAll (see file header).
+  let artistSupportOnly; // { artistId, libraryId } — support-only base case
+  let artistPrecedence; // { artistId, libraryId } — headliner-beats-support case
+
+  const seedConcert = async (overrides) => {
+    const defaults = {
+      source: 'triangle_shows',
+      starts_at: null,
+      doors_at: null,
+      headlining_artist_id: null,
+      title: null,
+      supporting_artists: [],
+      ticket_url: null,
+      image_url: null,
+      price_min: null,
+      price_max: null,
+      age_restriction: null,
+      status: 'on_sale',
+      removed_at: null,
+    };
+    const row = { ...defaults, ...overrides };
+    const [inserted] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".concerts
+         (source, source_id, venue_id, starts_on, starts_at, doors_at,
+          headlining_artist_raw, headlining_artist_id, title, supporting_artists_raw,
+          ticket_url, image_url, price_min, price_max, age_restriction, status,
+          removed_at, raw_data, scraped_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, '{}'::jsonb, now())
+       RETURNING id`,
+      [
+        row.source,
+        SOURCE_ID_PREFIX + row.key,
+        row.venue_id,
+        row.starts_on,
+        row.starts_at,
+        row.doors_at,
+        row.headlining_artist_raw,
+        row.headlining_artist_id,
+        row.title,
+        row.supporting_artists,
+        row.ticket_url,
+        row.image_url,
+        row.price_min,
+        row.price_max,
+        row.age_restriction,
+        row.status,
+        row.removed_at,
+      ]
+    );
+    return inserted.id;
+  };
+
+  /** Insert one active (or, if removedAt given, tombstoned) `support` performer row. */
+  const seedSupportPerformer = async (concertId, rawName, { artistId = null, removedAt = null } = {}) => {
+    await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".concert_performers
+         (concert_id, raw_name, role, artist_id, removed_at)
+       VALUES ($1, $2, 'support', $3, $4)`,
+      [concertId, rawName, artistId, removedAt]
+    );
+  };
+
+  /** Insert one flowsheet track row, returning its id. */
+  const seedTrack = async ({ albumId, artistName, playOrder }) => {
+    const [inserted] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".flowsheet
+         (show_id, album_id, entry_type, artist_name, album_title, track_title, play_order, add_time, metadata_status)
+       VALUES ($1, $2, 'track', $3, 'Probe Album', 'Probe Track', $4, now(), 'enriched_match')
+       RETURNING id`,
+      [showId, albumId, artistName, playOrder]
+    );
+    return inserted.id;
+  };
+
+  /**
+   * Create a fresh `artists` row plus one linked `library` row, so this spec
+   * has a real, unambiguous `(artist_id, library_id)` pair for the id-arm
+   * tests without assuming anything about pre-existing seed data (see file
+   * header). Name is distinct from every OTHER free-text fixture name used in
+   * this file so a stray cross-match would be obvious.
+   *
+   * Explicit id (`COALESCE(MAX(id), 0) + 1`, computed in the same statement as
+   * the INSERT) rather than the column's SERIAL default: this dev DB's clone
+   * fixture (`dev_env/seed-clone.sql`, see docs/dev-db-fixture.md) loads
+   * `artists`/`library` rows with explicit ids without advancing
+   * `artists_id_seq`/`library_id_seq` to match, so a plain `nextval()`-backed
+   * insert collides with an existing row (`artists_pkey`/`library_pkey`
+   * violation) on this environment. Computing the id directly sidesteps the
+   * desynced sequence entirely rather than depending on it being resynced.
+   */
+  const createResolvedArtist = async (name) => {
+    const [artist] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".artists (id, artist_name, alphabetical_name, code_letters)
+       SELECT COALESCE(MAX(id), 0) + 1, $1, $1, 'ZZ' FROM "${SCHEMA}".artists
+       RETURNING id`,
+      [ARTIST_NAME_PREFIX + name]
+    );
+    const [library] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".library (id, artist_id, genre_id, format_id, album_title, code_number)
+       SELECT COALESCE(MAX(id), 0) + 1, $1, $2, $3, $4, 0 FROM "${SCHEMA}".library
+       RETURNING id`,
+      [artist.id, genreId, formatId, `BS1761 Probe Album ${name}`]
+    );
+    return { artistId: artist.id, libraryId: library.id };
+  };
+
+  const cleanup = async () => {
+    // ON DELETE CASCADE on concert_performers.concert_id removes this spec's
+    // performer rows automatically when their parent concert is deleted.
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".concerts WHERE source_id LIKE $1`, [`${SOURCE_ID_PREFIX}%`]);
+    if (insertedTrackIds.length > 0) {
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".flowsheet WHERE id = ANY($1::int[])`, [insertedTrackIds]);
+    }
+    if (showId) {
+      await sql.unsafe(`DELETE FROM "${SCHEMA}".shows WHERE id = $1`, [showId]);
+    }
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".venues WHERE slug = $1`, [VENUE_SLUG]);
+    // library rows first (FK -> artists), then the artists themselves. Scoped
+    // by the distinctive name prefix as a belt-and-suspenders match alongside
+    // the id lists, in case a prior run's ids were lost (e.g. a crash before
+    // this cleanup ran).
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".library WHERE album_title LIKE 'BS1761 Probe Album%'`);
+    await sql.unsafe(`DELETE FROM "${SCHEMA}".artists WHERE artist_name LIKE $1`, [`${ARTIST_NAME_PREFIX}%`]);
+  };
+
+  /** Mirrors flowsheet-upcoming-show.spec.js's cache-reset helper (BS#1616). */
+  const resetUpcomingShowsCache = async () => {
+    const res = await request.post('/internal/test/reset-upcoming-shows-cache');
+    expect(res.status).toBe(204);
+  };
+
+  beforeAll(async () => {
+    sql = makeSql();
+    await cleanup();
+
+    const [genre] = await sql.unsafe(`SELECT id FROM "${SCHEMA}".genres ORDER BY id LIMIT 1`);
+    genreId = genre.id;
+    const [format] = await sql.unsafe(`SELECT id FROM "${SCHEMA}".format ORDER BY id LIMIT 1`);
+    formatId = format.id;
+
+    const [venue] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".venues (slug, name, city, state, address)
+       VALUES ($1, 'BS1761 Probe Room', 'Carrboro', 'NC', '300 E Main St')
+       RETURNING id`,
+      [VENUE_SLUG]
+    );
+    venueId = venue.id;
+
+    const [show] = await sql.unsafe(
+      `INSERT INTO "${SCHEMA}".shows (show_name, start_time) VALUES ($1, now()) RETURNING id`,
+      [SHOW_NAME]
+    );
+    showId = show.id;
+
+    artistSupportOnly = await createResolvedArtist('Support Only');
+    artistPrecedence = await createResolvedArtist('Precedence');
+
+    // --- Case 1: resolved support, id arm, no competing headliner ---
+    const supportOnlyConcertId = await seedConcert({
+      key: 'support-only',
+      venue_id: venueId,
+      starts_on: SUPPORT_ONLY_DATE,
+      headlining_artist_raw: 'Some Unrelated Headliner',
+    });
+    await seedSupportPerformer(supportOnlyConcertId, ARTIST_NAME_PREFIX + 'Support Only', {
+      artistId: artistSupportOnly.artistId,
+    });
+
+    // --- Case 2: unresolved support, name arm ---
+    const nameArmConcertId = await seedConcert({
+      key: 'name-arm',
+      venue_id: venueId,
+      starts_on: NAME_ARM_DATE,
+      headlining_artist_raw: 'A Different Headliner',
+    });
+    await seedSupportPerformer(nameArmConcertId, 'Carmen Villain');
+
+    // --- Case 3: headliner beats support regardless of date (id arm) ---
+    const precedenceHeadlinerConcertId = await seedConcert({
+      key: 'precedence-headliner',
+      venue_id: venueId,
+      starts_on: PRECEDENCE_HEADLINER_LATER, // LATER
+      headlining_artist_raw: ARTIST_NAME_PREFIX + 'Precedence',
+      headlining_artist_id: artistPrecedence.artistId,
+    });
+    const precedenceSupportConcertId = await seedConcert({
+      key: 'precedence-support',
+      venue_id: venueId,
+      starts_on: PRECEDENCE_SUPPORT_SOON, // EARLIER — must still lose
+      headlining_artist_raw: 'Some Other Headliner',
+    });
+    await seedSupportPerformer(precedenceSupportConcertId, ARTIST_NAME_PREFIX + 'Precedence', {
+      artistId: artistPrecedence.artistId,
+    });
+
+    // --- Case 4: soonest wins within the support arm (name arm) ---
+    const supportLaterConcertId = await seedConcert({
+      key: 'support-soonest-later',
+      venue_id: venueId,
+      starts_on: SUPPORT_LATER,
+      headlining_artist_raw: 'Headliner For Later Support Show',
+    });
+    await seedSupportPerformer(supportLaterConcertId, 'Angel Olsen');
+    const supportSoonConcertId = await seedConcert({
+      key: 'support-soonest-soon',
+      venue_id: venueId,
+      starts_on: SUPPORT_SOON,
+      headlining_artist_raw: 'Headliner For Soon Support Show',
+    });
+    await seedSupportPerformer(supportSoonConcertId, 'Angel Olsen');
+
+    // --- Case 5: a tombstoned support row is excluded from both arms ---
+    const tombstonedConcertId = await seedConcert({
+      key: 'tombstoned-support',
+      venue_id: venueId,
+      starts_on: TOMBSTONED_DATE,
+      headlining_artist_raw: 'Headliner For Tombstoned Support Show',
+    });
+    await seedSupportPerformer(tombstonedConcertId, 'Big Thief', { removedAt: new Date().toISOString() });
+
+    // Track rows.
+    const t1 = await seedTrack({
+      albumId: artistSupportOnly.libraryId,
+      artistName: ARTIST_NAME_PREFIX + 'Support Only',
+      playOrder: 1,
+    });
+    const t2 = await seedTrack({ albumId: null, artistName: 'Carmen Villain', playOrder: 2 });
+    const t3 = await seedTrack({
+      albumId: artistPrecedence.libraryId,
+      artistName: ARTIST_NAME_PREFIX + 'Precedence',
+      playOrder: 3,
+    });
+    const t4 = await seedTrack({ albumId: null, artistName: 'Angel Olsen', playOrder: 4 });
+    const t5 = await seedTrack({ albumId: null, artistName: 'Big Thief', playOrder: 5 });
+    insertedTrackIds = [t1, t2, t3, t4, t5];
+
+    // Force a genuine cold read so the server rebuilds the maps against these
+    // freshly seeded fixtures (BS#1616 per-process cache).
+    await resetUpcomingShowsCache();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await sql.end();
+  });
+
+  /** Fetch this spec's seeded track rows via the V2 range read. */
+  const fetchSeededTracks = async () => {
+    const startId = Math.min(...insertedTrackIds);
+    const endId = Math.max(...insertedTrackIds);
+    const res = await request.get('/flowsheet').query({ start_id: startId, end_id: endId });
+    expect(res.status).toBe(200);
+    const bySeed = new Set(insertedTrackIds);
+    return res.body.filter((e) => bySeed.has(e.id));
+  };
+
+  it('attaches a support-only concert to a linked track via the id arm', async () => {
+    const tracks = await fetchSeededTracks();
+    const t = tracks.find((e) => e.album_id === artistSupportOnly.libraryId);
+    expect(t).toBeDefined();
+    expect(t.upcoming_show).toBeDefined();
+    expect(t.upcoming_show).toMatchObject({
+      starts_on: SUPPORT_ONLY_DATE,
+      headlining_artist_raw: 'Some Unrelated Headliner',
+      headlining_artist_id: null,
+      venue: { slug: VENUE_SLUG },
+    });
+    // Leak barrier: the support-matched show carries no internal ingestion columns.
+    for (const internal of ['source', 'source_id', 'raw_data', 'scraped_at', 'first_scraped_at', 'removed_at']) {
+      expect(t.upcoming_show).not.toHaveProperty(internal);
+    }
+  });
+
+  it('attaches an unresolved support to a free-text play via the name arm', async () => {
+    const tracks = await fetchSeededTracks();
+    const t = tracks.find((e) => e.album_id === null && e.artist_name === 'Carmen Villain');
+    expect(t).toBeDefined();
+    expect(t.upcoming_show).toBeDefined();
+    expect(t.upcoming_show).toMatchObject({
+      starts_on: NAME_ARM_DATE,
+      headlining_artist_raw: 'A Different Headliner',
+      headlining_artist_id: null, // the CONCERT's headliner is unresolved — matched via the support name arm
+      venue: { slug: VENUE_SLUG },
+    });
+  });
+
+  it('a headliner beats a support for the same artist regardless of date (later headliner, earlier support)', async () => {
+    const tracks = await fetchSeededTracks();
+    const t = tracks.find((e) => e.album_id === artistPrecedence.libraryId);
+    expect(t).toBeDefined();
+    expect(t.upcoming_show).toBeDefined();
+    // The LATER headliner concert wins, even though the support concert is sooner.
+    expect(t.upcoming_show.starts_on).toBe(PRECEDENCE_HEADLINER_LATER);
+    expect(t.upcoming_show.starts_on).not.toBe(PRECEDENCE_SUPPORT_SOON);
+    expect(t.upcoming_show.headlining_artist_id).toBe(artistPrecedence.artistId);
+  });
+
+  it('collapses several support dates for the same name to the SOONEST', async () => {
+    const tracks = await fetchSeededTracks();
+    const t = tracks.find((e) => e.album_id === null && e.artist_name === 'Angel Olsen');
+    expect(t).toBeDefined();
+    expect(t.upcoming_show).toBeDefined();
+    expect(t.upcoming_show.starts_on).toBe(SUPPORT_SOON);
+    expect(t.upcoming_show.starts_on).not.toBe(SUPPORT_LATER);
+  });
+
+  it('a tombstoned (removed_at set) support row does not attach', async () => {
+    const tracks = await fetchSeededTracks();
+    const t = tracks.find((e) => e.album_id === null && e.artist_name === 'Big Thief');
+    expect(t).toBeDefined();
+    expect(t).not.toHaveProperty('upcoming_show');
+  });
+
+  /**
+   * EXPLAIN proof (BS#1761 ticket constraint): the support query can drive
+   * off `concerts_active_starts_on_id_idx` for the outer `concerts` scan and
+   * reach `concert_performers` via the leading `concert_id` column of
+   * `concert_performers_concert_role_raw_name_idx` — no new index required.
+   *
+   * Mirrors the `concerts-artist-lml-resolver-writer.spec.js` EXPLAIN
+   * pattern: `enable_seqscan = off` inside a ROLLED-BACK transaction
+   * neutralizes the tiny-test-dataset confounder (a handful of rows makes a
+   * seq scan cheaper regardless of index availability), so the plan reflects
+   * what the query is structurally capable of at production scale. The
+   * sentinel throw guarantees the setting never leaks past this test.
+   *
+   * The SQL below is a hand mirror of the Drizzle query in
+   * `getUpcomingShowsMaps`'s Pass 2 (apps/backend/services/concerts.service.ts)
+   * — when that query's join/where shape changes, this mirror must follow.
+   */
+  it('EXPLAIN: the support query can drive off concerts_active_starts_on_id_idx into concert_performers', async () => {
+    let planJson;
+    const sentinel = new Error('rollback-explain-probe');
+    try {
+      await sql.begin(async (tx) => {
+        await tx.unsafe(`SET LOCAL enable_seqscan = off`);
+        const rows = await tx.unsafe(
+          `EXPLAIN (FORMAT JSON)
+           SELECT c."id", v."id", cp."raw_name", cp."artist_id"
+           FROM "${SCHEMA}".concerts c
+           JOIN "${SCHEMA}".concert_performers cp ON cp."concert_id" = c."id"
+           JOIN "${SCHEMA}".venues v ON v."id" = c."venue_id"
+           WHERE cp."role" = 'support'
+             AND cp."removed_at" IS NULL
+             AND c."removed_at" IS NULL
+             AND c."starts_on" >= CURRENT_DATE
+           ORDER BY c."starts_on" ASC, c."id" ASC, cp."id" ASC`
+        );
+        planJson = JSON.stringify(rows[0]['QUERY PLAN']);
+        throw sentinel;
+      });
+    } catch (err) {
+      if (err !== sentinel) throw err;
+    }
+    expect(planJson).toContain('concerts_active_starts_on_id_idx');
+    expect(planJson).toContain('concert_performers');
+  });
+});

--- a/tests/unit/services/concerts.service.test.ts
+++ b/tests/unit/services/concerts.service.test.ts
@@ -526,6 +526,14 @@ describe('getConcertById', () => {
  *
  * These fixtures carry the extra `artist_name` (the canonical name the LEFT
  * JOIN sources) that `ConcertJoinRow` doesn't; the row shape is a superset.
+ *
+ * BS#1761 adds a SECOND pass (support acts) after this one, reading
+ * `concert_performers` — see the sibling `describe('getUpcomingShowsMaps
+ * support arm (BS#1761)', ...)` block below for those tests. This suite pins
+ * PASS 1 (headliners) only and is otherwise unchanged, so every test here
+ * queues an additional empty `orderBy` result for Pass 2's query (its rows
+ * never affect a headliner-only scenario, per the "only add where absent"
+ * precedence rule).
  */
 describe('getUpcomingShowsMaps (BS#1613)', () => {
   type UpcomingRow = ConcertJoinRow & { artist_name: string | null };
@@ -566,14 +574,16 @@ describe('getUpcomingShowsMaps (BS#1613)', () => {
   };
 
   it('builds byArtistId from resolved rows only, keyed by headlining_artist_id', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([resolvedRow, unresolvedCleanRow]));
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([resolvedRow, unresolvedCleanRow])) // pass 1: headliners
+      .mockReturnValueOnce(Promise.resolve([])); // pass 2: no support rows
     const { byArtistId } = await getUpcomingShowsMaps('2026-08-01');
     expect(byArtistId.size).toBe(1); // the unresolved row is not in the id map
     expect(byArtistId.get(4211)).toEqual(toConcertDTO(resolvedRow));
   });
 
   it('keys a resolved row in byNormName off the CANONICAL name, not the raw', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([resolvedRow]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([resolvedRow])).mockReturnValueOnce(Promise.resolve([]));
     const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
     // canonical 'Nilüfer Yanya' → 'nilüfer yanya'; the diacritic-free raw
     // 'Nilufer Yanya' → 'nilufer yanya' is NOT the key.
@@ -582,14 +592,16 @@ describe('getUpcomingShowsMaps (BS#1613)', () => {
   });
 
   it('keys an unresolved clean row in byNormName off the raw name', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([unresolvedCleanRow]));
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([unresolvedCleanRow]))
+      .mockReturnValueOnce(Promise.resolve([]));
     const { byArtistId, byNormName } = await getUpcomingShowsMaps('2026-08-01');
     expect(byArtistId.size).toBe(0); // unresolved → absent from the id map
     expect(byNormName.get('wishy')).toEqual(toConcertDTO(unresolvedCleanRow));
   });
 
   it('keys a billing-string raw off its ENTIRE normalized string (inert key)', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([billingRow]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([billingRow])).mockReturnValueOnce(Promise.resolve([]));
     const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
     expect(byNormName.get('circle jerks & municipal waste')).toEqual(toConcertDTO(billingRow));
     // The individual acts are NOT keys, so a single-artist play can't match.
@@ -610,7 +622,7 @@ describe('getUpcomingShowsMaps (BS#1613)', () => {
       headlining_artist_raw: ' J  Dilla ',
       starts_on: '2026-08-11',
     };
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([messy]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([messy])).mockReturnValueOnce(Promise.resolve([]));
     const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
     // Collapsed + trimmed → a play typed 'J Dilla' (single space) matches.
     expect(byNormName.get('j dilla')).toEqual(toConcertDTO(messy));
@@ -623,7 +635,7 @@ describe('getUpcomingShowsMaps (BS#1613)', () => {
     // occurrence of a key is the soonest.
     const soon: UpcomingRow = { ...unresolvedCleanRow, id: 400, starts_on: '2026-08-10' };
     const later: UpcomingRow = { ...unresolvedCleanRow, id: 401, starts_on: '2026-09-10' };
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([soon, later]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([soon, later])).mockReturnValueOnce(Promise.resolve([]));
     const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
     expect(byNormName.get('wishy')).toEqual(toConcertDTO(soon));
   });
@@ -631,13 +643,13 @@ describe('getUpcomingShowsMaps (BS#1613)', () => {
   it('collapses multiple dates for one artist id to the SOONEST (first row wins)', async () => {
     const soon: UpcomingRow = { ...resolvedRow, id: 500, starts_on: '2026-08-10' };
     const later: UpcomingRow = { ...resolvedRow, id: 501, starts_on: '2026-09-10' };
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([soon, later]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([soon, later])).mockReturnValueOnce(Promise.resolve([]));
     const { byArtistId } = await getUpcomingShowsMaps('2026-08-01');
     expect(byArtistId.get(4211)).toEqual(toConcertDTO(soon));
   });
 
   it('LEFT JOINs artists so a resolved row can source its canonical name', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
     await getUpcomingShowsMaps('2026-08-01');
     // The join to artists must be a LEFT join — an INNER join would silently
     // drop every unresolved concert (headlining_artist_id IS NULL), which is
@@ -646,8 +658,9 @@ describe('getUpcomingShowsMaps (BS#1613)', () => {
   });
 
   it('never selects internal ingestion columns', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
     await getUpcomingShowsMaps('2026-08-01');
+    // Pass 1's (headliner) projection is the first db.select call.
     const projection = mockDb._chain.select.mock.calls[0][0] as Record<string, string>;
     const selectedColumns = Object.values(projection);
     for (const internal of INTERNAL_COLUMNS) {
@@ -656,10 +669,206 @@ describe('getUpcomingShowsMaps (BS#1613)', () => {
   });
 
   it('returns two empty maps for an empty upcoming set', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
     const { byArtistId, byNormName } = await getUpcomingShowsMaps('2026-08-01');
     expect(byArtistId.size).toBe(0);
     expect(byNormName.size).toBe(0);
+  });
+});
+
+/**
+ * BS#1761 — PASS 2 of `getUpcomingShowsMaps`: support acts. Reads active
+ * (non-tombstoned) `concert_performers` rows with `role = 'support'`, joined
+ * to the SAME upcoming/non-tombstoned `concerts` window as Pass 1, ordered
+ * `starts_on ASC, concerts.id ASC` (a `concert_performers.id` tiebreak for
+ * several support rows on ONE concert — see the production doc comment for
+ * why that tie is harmless: every support row on a given concert maps to the
+ * SAME `toConcertDTO` output regardless of which one is processed first).
+ *
+ * Precedence proof: Pass 1 runs to completion (fully populates both maps)
+ * BEFORE Pass 2 evaluates a single row, so `!byArtistId.has(...)` /
+ * `!byNormName.has(...)` can only be true when NO headliner — of ANY upcoming
+ * date — claimed that key. That is the entire "headliner beats support
+ * regardless of date" rule; no date comparison against the headliner's date
+ * is needed or performed.
+ *
+ * Each test here queues an EMPTY Pass 1 result (unless a test explicitly
+ * needs a competing headliner) followed by the Pass 2 fixture rows.
+ */
+describe('getUpcomingShowsMaps support arm (BS#1761)', () => {
+  // Row shape Pass 2 selects: the shared concert⋈venue fields plus the
+  // junction's raw_name and (resolved-or-null) artist_id — see
+  // `concertJoinFields` reuse in the production `getUpcomingShowsMaps`.
+  type SupportRow = ConcertJoinRow & { raw_name: string; support_artist_id: number | null };
+  // Pass-1 fixture shape (mirrors the sibling BS#1613 describe block's
+  // `UpcomingRow`), needed here only for the precedence tests that seed a
+  // competing headliner row.
+  type HeadlinerRow = ConcertJoinRow & { artist_name: string | null };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // A RESOLVED support act (concert_performers.artist_id set), no competing headliner.
+  const resolvedSupport: SupportRow = {
+    ...timedRow,
+    id: 701,
+    headlining_artist_id: null,
+    headlining_artist_raw: 'Some Unrelated Headliner',
+    starts_on: '2026-08-16',
+    raw_name: 'Kelela',
+    support_artist_id: 850,
+  };
+
+  // An UNRESOLVED support act: a clean single name (post-parseBilling), no artist_id.
+  const unresolvedSupport: SupportRow = {
+    ...timedRow,
+    id: 702,
+    headlining_artist_id: null,
+    headlining_artist_raw: 'A Different Headliner',
+    starts_on: '2026-08-18',
+    raw_name: 'Carmen Villain',
+    support_artist_id: null,
+  };
+
+  it('adds a resolved support to byArtistId when no headliner has claimed the key', async () => {
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([])) // pass 1: no headliners
+      .mockReturnValueOnce(Promise.resolve([resolvedSupport])); // pass 2
+    const { byArtistId } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byArtistId.get(850)).toEqual(toConcertDTO(resolvedSupport));
+  });
+
+  it('adds an unresolved support to byNormName keyed off its raw name', async () => {
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([]))
+      .mockReturnValueOnce(Promise.resolve([unresolvedSupport]));
+    const { byArtistId, byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byArtistId.size).toBe(0); // unresolved — absent from the id map
+    expect(byNormName.get('carmen villain')).toEqual(toConcertDTO(unresolvedSupport));
+  });
+
+  it('adds a RESOLVED support to byNormName too, keyed off the RAW name (not a canonical/artists-joined name)', async () => {
+    // Deliberate divergence from Pass 1's headliner arm: the support name arm
+    // always keys off concert_performers.raw_name — resolved or not — never a
+    // canonical `artists.artist_name` substitution. `raw_name` is already a
+    // clean single name post-parseBilling, so no `artists` join is needed.
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([]))
+      .mockReturnValueOnce(Promise.resolve([resolvedSupport]));
+    const { byArtistId, byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byArtistId.get(850)).toEqual(toConcertDTO(resolvedSupport));
+    expect(byNormName.get('kelela')).toEqual(toConcertDTO(resolvedSupport));
+  });
+
+  it('a headliner beats a support for the SAME id key regardless of date (later headliner, earlier support)', async () => {
+    const laterHeadliner: HeadlinerRow = {
+      ...timedRow,
+      id: 703,
+      headlining_artist_id: 850,
+      headlining_artist_raw: 'Headliner Billing',
+      artist_name: 'Headliner Canonical',
+      starts_on: '2026-09-20', // LATER than the support's date
+    };
+    const earlierSupport: SupportRow = { ...resolvedSupport, starts_on: '2026-08-05' }; // EARLIER
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([laterHeadliner])) // pass 1
+      .mockReturnValueOnce(Promise.resolve([earlierSupport])); // pass 2
+    const { byArtistId } = await getUpcomingShowsMaps('2026-08-01');
+    // The LATER headliner wins the key even though the support's date is sooner.
+    expect(byArtistId.get(850)).toEqual(toConcertDTO(laterHeadliner));
+  });
+
+  it('a headliner beats a support for the SAME name key regardless of date (later headliner, earlier support)', async () => {
+    const laterHeadliner: HeadlinerRow = {
+      ...timedRow,
+      id: 704,
+      headlining_artist_id: null, // unresolved: name arm keys off the raw
+      headlining_artist_raw: 'Colleen',
+      artist_name: null,
+      starts_on: '2026-09-22', // LATER
+    };
+    const earlierSupport: SupportRow = {
+      ...unresolvedSupport,
+      raw_name: 'Colleen', // same normalized key as the headliner's raw
+      starts_on: '2026-08-06', // EARLIER
+    };
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([laterHeadliner]))
+      .mockReturnValueOnce(Promise.resolve([earlierSupport]));
+    const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byNormName.get('colleen')).toEqual(toConcertDTO(laterHeadliner));
+  });
+
+  it('collapses multiple support dates for the SAME id key to the SOONEST (first write wins within support)', async () => {
+    const soon: SupportRow = { ...resolvedSupport, id: 705, starts_on: '2026-08-05' };
+    const later: SupportRow = { ...resolvedSupport, id: 706, starts_on: '2026-09-05' };
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([])) // pass 1: no headliners
+      .mockReturnValueOnce(Promise.resolve([soon, later])); // pass 2, ordered starts_on ASC
+    const { byArtistId } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byArtistId.get(850)).toEqual(toConcertDTO(soon));
+  });
+
+  it('collapses multiple support dates for the SAME name key to the SOONEST (first write wins within support)', async () => {
+    const soon: SupportRow = { ...unresolvedSupport, id: 707, starts_on: '2026-08-07' };
+    const later: SupportRow = { ...unresolvedSupport, id: 708, starts_on: '2026-09-07' };
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([soon, later]));
+    const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byNormName.get('carmen villain')).toEqual(toConcertDTO(soon));
+  });
+
+  it('skips a support row entirely once a headliner already claims BOTH its id key and its name key', async () => {
+    const headliner: HeadlinerRow = {
+      ...timedRow,
+      id: 709,
+      headlining_artist_id: 860,
+      headlining_artist_raw: 'Anjimile',
+      artist_name: 'Anjimile',
+      starts_on: '2026-08-09',
+    };
+    const support: SupportRow = {
+      ...resolvedSupport,
+      id: 710,
+      support_artist_id: 860,
+      raw_name: 'Anjimile',
+      starts_on: '2026-08-02', // even sooner — must still lose on BOTH arms
+    };
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([headliner]))
+      .mockReturnValueOnce(Promise.resolve([support]));
+    const { byArtistId, byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byArtistId.get(860)).toEqual(toConcertDTO(headliner));
+    expect(byNormName.get('anjimile')).toEqual(toConcertDTO(headliner));
+  });
+
+  it('is a no-op when there are no active support rows (byte-identical to pre-1761 output)', async () => {
+    const headliner: HeadlinerRow = { ...timedRow, id: 711, artist_name: 'Nilüfer Yanya' };
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([headliner])).mockReturnValueOnce(Promise.resolve([])); // pass 2: nothing active
+    const { byArtistId, byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byArtistId.get(4211)).toEqual(toConcertDTO(headliner));
+    expect(byNormName.get('nilüfer yanya')).toEqual(toConcertDTO(headliner));
+    expect(byArtistId.size).toBe(1);
+    expect(byNormName.size).toBe(1);
+  });
+
+  it('collapses stray + doubled whitespace in the support name key (free-text SSOT — same normalizer as Pass 1)', async () => {
+    const messy: SupportRow = { ...unresolvedSupport, id: 712, raw_name: ' Carmen  Villain ' };
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([messy]));
+    const { byNormName } = await getUpcomingShowsMaps('2026-08-01');
+    expect(byNormName.get('carmen villain')).toEqual(toConcertDTO(messy));
+    expect(byNormName.has(' carmen  villain ')).toBe(false);
+  });
+
+  it('never selects internal ingestion columns in the support-pass projection', async () => {
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
+    await getUpcomingShowsMaps('2026-08-01');
+    // Pass 2's (support) projection is the second db.select call.
+    const projection = mockDb._chain.select.mock.calls[1][0] as Record<string, string>;
+    const selectedColumns = Object.values(projection);
+    for (const internal of INTERNAL_COLUMNS) {
+      expect(selectedColumns).not.toContain(internal);
+    }
   });
 });
 
@@ -674,10 +883,12 @@ describe('getUpcomingShowsMaps (BS#1613)', () => {
  * builder itself stays pure and is pinned by the suite above; these pin only the
  * cache behavior.
  *
- * Build count == `db.select` call count: the builder issues exactly one
- * `db.select(...)` per invocation, and the DB mock aliases `db.select` to
- * `mockDb._chain.select`, so a warm hit (no build) leaves the counter fixed. The
- * cache is module-scoped, so `__resetUpcomingShowsMapsCacheForTests()` runs in
+ * Build count × 2 == `db.select` call count: BS#1761 widened the builder to
+ * TWO passes (headliners, then support acts), so ONE invocation now issues
+ * TWO `db.select(...)` calls — and the DB mock aliases `db.select` to
+ * `mockDb._chain.select`, so a warm hit (no build) still leaves the counter
+ * fixed, but a cold build now advances it by 2, not 1. The cache is
+ * module-scoped, so `__resetUpcomingShowsMapsCacheForTests()` runs in
  * `beforeEach` to keep a prior case's maps from leaking into the next.
  */
 describe('getUpcomingShowsMapsCached (BS#1616 per-process map cache)', () => {
@@ -687,58 +898,69 @@ describe('getUpcomingShowsMapsCached (BS#1616 per-process map cache)', () => {
   });
 
   it('builds once on a cold miss', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
     await getUpcomingShowsMapsCached('2026-08-01');
-    expect(mockDb._chain.select).toHaveBeenCalledTimes(1);
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(2); // pass 1 + pass 2
   });
 
   it('serves a warm hit within the TTL without re-querying (identical maps reference)', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
     const first = await getUpcomingShowsMapsCached('2026-08-01');
     const second = await getUpcomingShowsMapsCached('2026-08-01');
     // Same object reference proves the second call resolved the cached promise,
     // not a fresh build.
     expect(second).toBe(first);
-    expect(mockDb._chain.select).toHaveBeenCalledTimes(1);
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(2);
   });
 
   it('rebuilds after __resetUpcomingShowsMapsCacheForTests clears the cache', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([]))
+      .mockReturnValueOnce(Promise.resolve([]))
+      .mockReturnValueOnce(Promise.resolve([]))
+      .mockReturnValueOnce(Promise.resolve([]));
     await getUpcomingShowsMapsCached('2026-08-01');
     __resetUpcomingShowsMapsCacheForTests();
     await getUpcomingShowsMapsCached('2026-08-01');
-    expect(mockDb._chain.select).toHaveBeenCalledTimes(2);
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(4); // 2 builds × 2 passes
   });
 
   it('rebuilds for a distinct today key (date roll → miss)', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
+    mockDb._chain.orderBy
+      .mockReturnValueOnce(Promise.resolve([]))
+      .mockReturnValueOnce(Promise.resolve([]))
+      .mockReturnValueOnce(Promise.resolve([]))
+      .mockReturnValueOnce(Promise.resolve([]));
     await getUpcomingShowsMapsCached('2026-08-01');
     await getUpcomingShowsMapsCached('2026-08-02'); // a different ET calendar day
-    expect(mockDb._chain.select).toHaveBeenCalledTimes(2);
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(4); // 2 builds × 2 passes
   });
 
   it('coalesces two concurrent cold calls into a single build', async () => {
-    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([]));
+    mockDb._chain.orderBy.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
     const [a, b] = await Promise.all([
       getUpcomingShowsMapsCached('2026-08-01'),
       getUpcomingShowsMapsCached('2026-08-01'),
     ]);
     // Both callers awaited the same in-flight promise → same resolved object.
     expect(a).toBe(b);
-    expect(mockDb._chain.select).toHaveBeenCalledTimes(1);
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(2); // one build's pass 1 + pass 2
   });
 
   it('does not cache a rejected build — the next call retries', async () => {
+    // Pass 1 rejects, so the build never reaches pass 2's query (sequential
+    // awaits) — only ONE queued value is consumed by the failed attempt.
     mockDb._chain.orderBy
       .mockReturnValueOnce(Promise.reject(new Error('boom')))
+      .mockReturnValueOnce(Promise.resolve([]))
       .mockReturnValueOnce(Promise.resolve([]));
     await expect(getUpcomingShowsMapsCached('2026-08-01')).rejects.toThrow('boom');
     // The failed promise was evicted, so this is a fresh cold miss (not a cached
-    // error): the builder runs again and resolves.
+    // error): the builder runs again — pass 1 then pass 2 — and resolves.
     await expect(getUpcomingShowsMapsCached('2026-08-01')).resolves.toEqual({
       byArtistId: new Map(),
       byNormName: new Map(),
     });
-    expect(mockDb._chain.select).toHaveBeenCalledTimes(2);
+    expect(mockDb._chain.select).toHaveBeenCalledTimes(3); // failed pass 1 + successful pass 1 + pass 2
   });
 });


### PR DESCRIPTION
## Summary

Extends the flowsheet `upcoming_show` embed so a play of a WXYC library artist who is opening (supporting) an upcoming Triangle show gets the On Tour CTA, not just headliners.

`getUpcomingShowsMaps` (`apps/backend/services/concerts.service.ts`) widens from a single headliner-only pass to two passes over the same `byArtistId`/`byNormName` maps:

1. **Pass 1 (unchanged)** — the existing headliner query, soonest-wins.
2. **Pass 2 (new)** — a second query over active (`removed_at IS NULL`) `concert_performers` rows with `role = 'support'`, INNER JOINed to the same upcoming/non-tombstoned `concerts` window. For each row, the id-arm (`concert_performers.artist_id`, resolved supports only) and name-arm (`normalizeFreetextArtist(raw_name)`, every active support) each add a key only where Pass 1 hasn't already claimed it.

Because Pass 1 runs to completion before Pass 2 evaluates a single row, a headliner CTA beats a support CTA for the same artist key regardless of date — no date comparison against the headliner is needed. The same first-write-wins ordering (`starts_on ASC`) gives soonest-wins within the support arm for free.

The support name arm keys on the junction's `raw_name` directly rather than a canonical-artist-name substitution: post-`parseBilling`, `raw_name` is already a clean single name, so an unresolved support lights the name arm off capture alone (the same inert-but-matchable-key pattern #1613 established for unresolved headliners), and no `artists` join is needed to compute it.

`attachUpcomingShows` (`apps/backend/services/flowsheet.service.ts`) is untouched — it already consumes the two maps id-arm-then-name-arm, so the precedence lives entirely in map construction.

Closes #1761
Part of #1618

## Test plan

- Unit tests (`tests/unit/services/concerts.service.test.ts`): a new `describe('getUpcomingShowsMaps support arm (BS#1761)', ...)` block covers the id arm, the name arm, the deliberate raw-vs-canonical divergence from the headliner arm, cross-role precedence on both arms (later headliner beats earlier support), soonest-wins within support on both arms, the both-arms-already-claimed skip branch, the no-active-support no-op case, the free-text whitespace drift guard, and the leak barrier. Every pre-existing Pass-1 test was updated to account for the function now issuing two queries instead of one; `getUpcomingShowsMapsCached`'s tests and doc comment were updated for the same reason (one cache build now advances `db.select` by 2, not 1). `npm run test:unit` — 349 suites, 5185 tests, all green.
- New `pg` integration spec (`tests/integration/flowsheet-upcoming-show-support.spec.js`), sibling to `flowsheet-upcoming-show.spec.js` (BS#1607/#1613, left untouched): proves the end-to-end embed through the real `/flowsheet` endpoint — a support-only resolved match via the id arm, an unresolved support match via the name arm, the headliner-beats-support precedence (later headliner, earlier support, same artist), soonest-wins across two support dates, and a tombstoned support row staying excluded from both arms. A final EXPLAIN test (mirroring the `enable_seqscan = off` + rolled-back-transaction pattern in `concerts-artist-lml-resolver-writer.spec.js`) confirms the support query can drive off `concerts_active_starts_on_id_idx` into `concert_performers` via the leading `concert_id` column of `concert_performers_concert_role_raw_name_idx` — no new index needed.
- `npm run typecheck`, `npm run lint` (0 errors, pre-existing warnings only), `npm run format:check` — all clean.
- `npm run ci:testmock` (Docker-isolated CI mirror): a full clean run passed 66/67 suites (636/644 tests, 1 pre-existing skipped suite, 8 pre-existing skipped tests) with zero failures, including full regression coverage of `flowsheet-upcoming-show.spec.js` and `concerts.spec.js`.