### PR TITLE
fix(enrichment-worker): restore non-library album resolution on the live bulk-lookup path

### DIFF
--- a/apps/enrichment-worker/lookup-batcher.ts
+++ b/apps/enrichment-worker/lookup-batcher.ts
@@ -31,6 +31,17 @@
  * the bulk path (cache-only there, so zero incremental Discogs cost), so the
  * 8 extended-only `DiscogsMatchResult` fields survive the batch.
  *
+ * `allowReleaseResolutionFallback: true` also rides every dispatch (BS#1815):
+ * `/lookup/bulk` hardcodes `allow_release_resolution_fallback=false`
+ * server-side (LML#671's offline-drain kill switch), which silently dropped
+ * non-library album resolution for this worker after the B3 migration off
+ * single-item `/lookup` (whose per-item default is `true`) — the actual gap
+ * in the "parity with the per-call path" claim above. LML#920 turns the flag
+ * into a per-caller query param so this worker can opt back in without
+ * re-enabling it for the offline drains that share `bulkLookupMetadata`
+ * (`album-level-backfill`, `catalog-popularity-freetext-resolve`,
+ * `flowsheet-linked-reenrichment`), which must keep omitting it.
+ *
  * Ownership note: this module holds process-global mutable state (the buffer
  * and the flush timer). That is intentional — the coalescing point must be a
  * singleton per worker process so concurrent CDC ticks share one buffer.
@@ -137,7 +148,19 @@ async function dispatchChunk(chunk: PendingLookup[]): Promise<void> {
   try {
     const response = await bulkLookupMetadata(
       chunk.map((pending) => pending.item),
-      { budgetMs: ENRICHMENT_LML_BUDGET_MS, caller: ENRICHMENT_CALLER }
+      {
+        budgetMs: ENRICHMENT_LML_BUDGET_MS,
+        caller: ENRICHMENT_CALLER,
+        // BS#1815: restore non-library album resolution on the live
+        // enrichment path. `/lookup/bulk` hardcodes the LML#671 offline-drain
+        // kill switch (allow_release_resolution_fallback=false) unless the
+        // caller opts in via LML#920's per-caller query flag. The single-item
+        // `/lookup` this worker used pre-B3 (BS#1749) defaulted the flag
+        // true; only THIS live caller should opt back in — the offline
+        // drains (album-level-backfill, catalog-popularity-freetext-resolve,
+        // flowsheet-linked-reenrichment) must keep the kill switch on.
+        allowReleaseResolutionFallback: true,
+      }
     );
 
     // LML returns one verdict per input in input order, tagged with the

--- a/shared/lml-client/src/index.ts
+++ b/shared/lml-client/src/index.ts
@@ -755,7 +755,33 @@ const BULK_LOOKUP_INPUT_CAP = 100;
  */
 export async function bulkLookupMetadata(
   items: BulkLookupItem[],
-  options?: { timeoutMs?: number; limiter?: LmlLimiter; budgetMs?: number; caller?: string }
+  options?: {
+    timeoutMs?: number;
+    limiter?: LmlLimiter;
+    budgetMs?: number;
+    caller?: string;
+    /**
+     * BS#1815 / LML#920: `/lookup/bulk` hardcodes
+     * `allow_release_resolution_fallback=False` server-side (the LML#671
+     * offline-drain kill switch, built so the 35k-album bulk backfill never
+     * triggers a per-row live Discogs probe). Single-item `/lookup` defaults
+     * that same flag `True`, so the divergence silently disabled non-library
+     * album resolution for any bulk caller — including the live enrichment
+     * worker after it migrated from `/lookup` to `/lookup/bulk` (B3,
+     * BS#1749), which is the regression BS#1815 fixes.
+     *
+     * LML#920 makes the flag a per-caller query param on `/lookup/bulk`
+     * (`?allow_release_resolution_fallback=true`), defaulting to the
+     * pre-existing `false` when omitted. Set this `true` ONLY on the live
+     * enrichment path (`apps/enrichment-worker/lookup-batcher.ts`), which
+     * wants parity with the single-item default. The offline drains
+     * (`jobs/album-level-backfill`, `jobs/catalog-popularity-freetext-resolve`,
+     * `jobs/flowsheet-linked-reenrichment`) must keep omitting it so the
+     * kill switch's actual purpose — no per-row live Discogs on a 35k-item
+     * drain — stays intact.
+     */
+    allowReleaseResolutionFallback?: boolean;
+  }
 ): Promise<BulkLookupResponse> {
   if (items.length === 0) {
     throw new LmlClientError('bulkLookupMetadata requires at least 1 item.', 400);
@@ -807,8 +833,16 @@ export async function bulkLookupMetadata(
         console.warn('lml.client: failed to project queue_depth + bulk.size + caller onto span', err);
       }
 
+      // BS#1815 / LML#920: query-flag opt-in, mirroring the doc comment on
+      // `allowReleaseResolutionFallback` above. Omitted (not `?...=false`)
+      // when unset so the wire request is byte-identical to the pre-#1815
+      // shape for every caller that doesn't pass the option.
+      const bulkPath = options?.allowReleaseResolutionFallback
+        ? '/api/v1/lookup/bulk?allow_release_resolution_fallback=true'
+        : '/api/v1/lookup/bulk';
+
       const response = await lmlFetch(
-        '/api/v1/lookup/bulk',
+        bulkPath,
         {
           method: 'POST',
           headers: buildLookupHeaders(options?.budgetMs),

--- a/tests/unit/apps/enrichment-worker/lookup-batcher.test.ts
+++ b/tests/unit/apps/enrichment-worker/lookup-batcher.test.ts
@@ -133,6 +133,23 @@ describe('enrichmentBulkLookup burst coalescing (B3 / BS#1749)', () => {
     expect(options).toMatchObject({ caller: 'enrichment-worker', budgetMs: 29000 });
   });
 
+  it('sets allowReleaseResolutionFallback:true on the bulk dispatch (BS#1815 non-library resolution restore)', async () => {
+    // BS#1815: B3 (f3fbff5e) migrated this worker from single /lookup (which
+    // defaults allow_release_resolution_fallback=true) to /lookup/bulk (which
+    // hardcodes it false server-side, the LML#671 offline-drain kill switch),
+    // silently disabling non-library album resolution for live enrichment.
+    // LML#920 makes the flag a per-caller query param; the live enrichment
+    // worker must be the one bulk caller that opts back in.
+    mockBulkLookupMetadata.mockImplementation((items) => Promise.resolve(echoAllMatched(items)));
+
+    const p = enrichmentBulkLookup(makeInput('Boards of Canada', 'Inferno'));
+    await flushWindow();
+    await p;
+
+    const [, options] = mockBulkLookupMetadata.mock.calls[0];
+    expect(options).toMatchObject({ allowReleaseResolutionFallback: true });
+  });
+
   it('sets extended:true and synthesizes raw_message + fields on each item', async () => {
     mockBulkLookupMetadata.mockImplementation((items) => Promise.resolve(echoAllMatched(items)));
 

--- a/tests/unit/services/lml.client.test.ts
+++ b/tests/unit/services/lml.client.test.ts
@@ -848,6 +848,48 @@ describe('lml.client', () => {
 
       await expect(bulkLookupMetadata([itemFor('A', 'X')])).rejects.toThrow(LmlClientError);
     });
+
+    // BS#1815 / LML#920: `/lookup/bulk` hardcodes allow_release_resolution_fallback
+    // =false server-side (the LML#671 offline-drain kill switch) unless the caller
+    // opts in via this per-caller query flag. The live enrichment worker is the
+    // only caller that should opt in (lookup-batcher.ts); the offline drains
+    // (album-level-backfill, catalog-popularity-freetext-resolve,
+    // flowsheet-linked-reenrichment) must keep the kill switch on by omitting it.
+    it('appends allow_release_resolution_fallback=true to the URL when allowReleaseResolutionFallback is set (BS#1815)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await bulkLookupMetadata([itemFor('A', 'X')], { allowReleaseResolutionFallback: true });
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://lml.test:8000/api/v1/lookup/bulk?allow_release_resolution_fallback=true');
+    });
+
+    it('omits allow_release_resolution_fallback from the URL when the option is not set (BS#1815)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await bulkLookupMetadata([itemFor('A', 'X')]);
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://lml.test:8000/api/v1/lookup/bulk');
+    });
+
+    it('omits allow_release_resolution_fallback from the URL when the option is explicitly false (BS#1815)', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      } as unknown as globalThis.Response);
+
+      await bulkLookupMetadata([itemFor('A', 'X')], { allowReleaseResolutionFallback: false });
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://lml.test:8000/api/v1/lookup/bulk');
+    });
   });
 
   describe('bulkLookupMetadata discogsUnavailable gate (BS#1293)', () => {


### PR DESCRIPTION
## Summary

- B3 (`f3fbff5e`, BS#1749) moved the live flowsheet enrichment worker off per-row `/lookup` (defaults `allow_release_resolution_fallback=true`) onto `/lookup/bulk` (hardcodes it `false` server-side — the LML#671 kill switch built for the 35k-item offline drains), silently disabling non-library album resolution for every live enrichment call since 2026-07-22. Org-wide album_id-NULL enrichment no-match rate stepped from ~18% to 78-88%, blanking artwork/Discogs/release-year/streaming metadata for new rotation and freetext albums in the iOS playlist.
- `@wxyc/lml-client`'s `bulkLookupMetadata` gains an `allowReleaseResolutionFallback` option that appends `?allow_release_resolution_fallback=true` to the `/lookup/bulk` request when set; omitted (byte-identical prior wire shape) otherwise.
- `apps/enrichment-worker/lookup-batcher.ts` — the only caller that should regain non-library resolution — sets it `true` on every live dispatch.
- The offline drains that share `bulkLookupMetadata` (`jobs/album-level-backfill`, `jobs/catalog-popularity-freetext-resolve`, `jobs/flowsheet-linked-reenrichment`) are untouched and keep the kill switch on by omitting the option; their existing strict-equality (`toEqual`) assertions on the options passed to `bulkLookupMetadata` already guard against a future regression there.

## Deploy order (important)

**This PR is a no-op until `WXYC/library-metadata-lookup#920` ships to production.** LML's `/lookup/bulk` doesn't yet recognize the `allow_release_resolution_fallback` query param — until it does, sending it has no effect, so LML#920 must deploy first. Do not merge/deploy this ahead of it.

## Related

- Closes #1815
- LML-side contract: WXYC/library-metadata-lookup#920 (adds the per-caller query flag this PR opts into)
- Epic: #1810

## Test plan

- [x] TDD: added failing tests first, confirmed red, then implemented (see below)
- [x] `packages` unit test (`tests/unit/services/lml.client.test.ts`): `bulkLookupMetadata({ allowReleaseResolutionFallback: true })` issues a request whose URL carries `allow_release_resolution_fallback=true`; omitted/false → param absent
- [x] `apps/enrichment-worker` unit test (`tests/unit/apps/enrichment-worker/lookup-batcher.test.ts`): the live bulk dispatch passes `allowReleaseResolutionFallback: true` through to the client call
- [x] Verified the three offline-drain job test suites (`album-level-backfill`, `catalog-popularity-freetext-resolve`, `flowsheet-linked-reenrichment`) still pass unmodified — no behavior change for the drains
- [x] `npm run test:unit` (full suite: 349 suites / 5213 tests) green
- [x] `npm run typecheck` (all workspaces) green
- [x] `npm run lint` green (0 errors; only pre-existing warnings, none in touched files)
- [x] `npm run format:check` green
- [x] `npm run build` green