### PR TITLE
fix(#1814): bound catalog-popularity-freetext-resolve to an absolute UTC stop-by wall clock

### DIFF
--- a/jobs/catalog-popularity-freetext-resolve/README.md
+++ b/jobs/catalog-popularity-freetext-resolve/README.md
@@ -39,6 +39,8 @@ The naive arithmetic at the pre-BS#1814 defaults (`MAX_PAIRS_PER_RUN=5000`, `BUL
 
 This is a **same-day-only** deadline — it deliberately does NOT roll forward to tomorrow. The nightly `04:45 UTC` run sees a deadline hours in its own future and proceeds normally; a run launched AFTER the stop hour (a manual catch-up, or a misfired daytime launch) sees a deadline already in the past and no-ops immediately rather than computing "the next `11:00`" and running all day. See `computeStopByDeadlineMs`/`isPastStopBy` in `job.ts`.
 
+**Disabling the bound (supervised full-drain only).** Setting `FREETEXT_RESOLVE_STOP_BY_UTC=` to an explicitly-empty value disables the deadline entirely, so the run drains the whole eligible backlog (capped only by `MAX_PAIRS_PER_RUN` and the cooperative pause) with no window cutoff. This is the escape hatch for a supervised manual catch-up — never for the scheduled cron. Note the deliberate unset-vs-empty distinction: an **unset** var falls back to the default `11:00` bound (the cron stays protected even if the var is dropped from the deploy config); only an **explicitly-empty** var opts into unbounded, and a whitespace-only value counts as empty so a stray space can't silently re-arm the default.
+
 The run's summary and terminal log line record why it stopped: `stopReason: 'backlog_drained'` (every eligible pair for this run was processed before the deadline) vs `'stop_by_reached'` (the deadline cut the run short) — so a future overrun is visible in the logs instead of silently bleeding into daytime.
 
 ### Strengthened cooperative pause (BS#1814)
@@ -63,26 +65,28 @@ docker run --rm --env-file .env <image> --dry-run
 
 # 4. Run for real. At defaults (batch=5, rate=1/min ≈ 5 pairs/min, cap 5000/run)
 #    one nightly run drains up to 5000 eligible pairs. For a catch-up backfill
-#    of the full long tail, bump FREETEXT_RESOLVE_BULK_RATE_PER_MIN and
-#    FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN=0 (disable the cap).
+#    of the full long tail, bump FREETEXT_RESOLVE_BULK_RATE_PER_MIN,
+#    FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN=0 (disable the cap), and — for a
+#    supervised drain that must run past the overnight window —
+#    FREETEXT_RESOLVE_STOP_BY_UTC= (empty, disables the wall-clock stop-by).
 docker run --rm --env-file .env <image> 2>&1 | tee /tmp/freetext-resolve.log
 ```
 
 ## Env knobs
 
-| Variable                             | Default                   | Meaning                                                                                                                                                                    |
-| ------------------------------------ | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FREETEXT_RESOLVE_BULK_BATCH_SIZE`   | `5`                       | Items per LML bulk request. LML caps at 100. Raising this scales the per-batch fetch timeout.                                                                              |
-| `FREETEXT_RESOLVE_BULK_RATE_PER_MIN` | `1`                       | Batches per minute. At the default batch size, 1/min ≈ 5 pairs/min sustained.                                                                                              |
-| `FREETEXT_RESOLVE_BULK_BUDGET_MS`    | `25000`                   | Per-item budget forwarded to LML as `X-Caller-Budget-Ms`. NOT the batch fetch timeout.                                                                                     |
-| `FREETEXT_RESOLVE_NO_MATCH_TTL_DAYS` | `30`                      | A no-match pair is re-attempted once its `attempt_at` is older than this.                                                                                                  |
-| `FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN` | `5000`                    | Cap on distinct eligible pairs processed per run. `0` disables the cap (drain everything eligible).                                                                        |
-| `FREETEXT_RESOLVE_READ_TIMEOUT_MS`   | `300000` (5min)           | `SET LOCAL statement_timeout` for the DISTINCT enumerate scan.                                                                                                             |
-| `FREETEXT_RESOLVE_STOP_BY_UTC`       | `11:00`                   | BS#1814 absolute UTC wall-clock stop-by ("HH:MM", 24h, zero-padded). Same-day only — never rolls to tomorrow. Checked before every batch and around the cooperative pause. |
-| `LIVE_ACTIVITY_LOOKBACK_SECONDS`     | `300` (BS#1814, was `60`) | Cooperative-pause lookback window; `0` disables. Deadline-aware (BS#1814): won't spin past `FREETEXT_RESOLVE_STOP_BY_UTC`.                                                 |
-| `LIBRARY_METADATA_URL`               | (required)                | LML base URL.                                                                                                                                                              |
-| `LML_API_KEY`                        | (required in prod)        | LML bearer token.                                                                                                                                                          |
-| `DATABASE_URL`                       | (required)                | Postgres connection string.                                                                                                                                                |
+| Variable                             | Default                   | Meaning                                                                                                                                                                                                                                                                                  |
+| ------------------------------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FREETEXT_RESOLVE_BULK_BATCH_SIZE`   | `5`                       | Items per LML bulk request. LML caps at 100. Raising this scales the per-batch fetch timeout.                                                                                                                                                                                            |
+| `FREETEXT_RESOLVE_BULK_RATE_PER_MIN` | `1`                       | Batches per minute. At the default batch size, 1/min ≈ 5 pairs/min sustained.                                                                                                                                                                                                            |
+| `FREETEXT_RESOLVE_BULK_BUDGET_MS`    | `25000`                   | Per-item budget forwarded to LML as `X-Caller-Budget-Ms`. NOT the batch fetch timeout.                                                                                                                                                                                                   |
+| `FREETEXT_RESOLVE_NO_MATCH_TTL_DAYS` | `30`                      | A no-match pair is re-attempted once its `attempt_at` is older than this.                                                                                                                                                                                                                |
+| `FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN` | `5000`                    | Cap on distinct eligible pairs processed per run. `0` disables the cap (drain everything eligible).                                                                                                                                                                                      |
+| `FREETEXT_RESOLVE_READ_TIMEOUT_MS`   | `300000` (5min)           | `SET LOCAL statement_timeout` for the DISTINCT enumerate scan.                                                                                                                                                                                                                           |
+| `FREETEXT_RESOLVE_STOP_BY_UTC`       | `11:00`                   | BS#1814 absolute UTC wall-clock stop-by ("HH:MM", 24h, zero-padded). Same-day only — never rolls to tomorrow. Checked before every batch and around the cooperative pause. Explicitly empty (`=`) disables the bound (unbounded supervised full-drain); unset falls back to the default. |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`     | `300` (BS#1814, was `60`) | Cooperative-pause lookback window; `0` disables. Deadline-aware (BS#1814): won't spin past `FREETEXT_RESOLVE_STOP_BY_UTC`.                                                                                                                                                               |
+| `LIBRARY_METADATA_URL`               | (required)                | LML base URL.                                                                                                                                                                                                                                                                            |
+| `LML_API_KEY`                        | (required in prod)        | LML bearer token.                                                                                                                                                                                                                                                                        |
+| `DATABASE_URL`                       | (required)                | Postgres connection string.                                                                                                                                                                                                                                                              |
 
 ## Acceptance verification
 

--- a/jobs/catalog-popularity-freetext-resolve/README.md
+++ b/jobs/catalog-popularity-freetext-resolve/README.md
@@ -16,7 +16,7 @@ Free text keeps growing: every show adds more unlinked plays. The cron drains th
    - **match** with `release_id > 0` → `discogs_release_id` set, `match_confidence` set, `resolved_at = now()`.
    - **no_match** (or the BS#1185 `release_id == 0` streaming-only sentinel) → `discogs_release_id = NULL`, `resolved_at = NULL`. Still UPSERTed (a responded outcome) so `attempt_at` is stamped and the TTL retry window arms.
    - **error** (per-item LML exception) or an HTTP-level throw → NOT written, so the pair stays `attempt_at IS NULL` and retries on the next sweep.
-6. Cooperative pause (`awaitQuietWindow`) before each batch yields to live DJ activity.
+6. Before each batch: check the BS#1814 absolute stop-by deadline (below) and, if not yet reached, the cooperative pause (`awaitQuietWindow`) yields to live DJ activity. Both checks are re-applied around the pause, so a DJ active exactly at the stop hour still exits at the stop hour rather than spinning.
 
 `discogs_master_id` stays NULL: Track 1's release leg is independent of LML Track 0 (which surfaces `master_id` in the lookup result). The UPSERT omits `discogs_master_id` from both the INSERT and the UPDATE `set` clause, so a later Track-0-aware run PRESERVES any master id it wrote — never clobbers it back to NULL.
 
@@ -32,6 +32,22 @@ There is **no "retire after N"**. A pair with a release id is permanent (never r
 ## Schedule
 
 Default `45 4 * * *` UTC (00:45 ET) from `package.json` `cron-schedule`, registered via deploy-base. Chosen to sit in the overnight low-traffic window in a free minute that does not collide with the other LML-bounded crons (`artist-search-alias-consumer` 04:15, `rotation-artist-backfill` 04:30, `flowsheet-metadata-backfill` 06:00), so they don't all fan out to LML at once.
+
+### Window bound (BS#1814)
+
+The naive arithmetic at the pre-BS#1814 defaults (`MAX_PAIRS_PER_RUN=5000`, `BULK_BATCH_SIZE=5`, `BULK_RATE_PER_MIN=1`) guaranteed a run could take ~17-24h — well past the overnight window and straight into daytime peak, starving LML's single-worker Discogs concurrency for live callers (the 2026-07-25 incident: a run still alive 15h in, LML `/health` `503`, tubafrenzy/ROM timing out). `FREETEXT_RESOLVE_STOP_BY_UTC` (default `11:00`, ~4 AM PT) is an **absolute UTC wall-clock stop-by**, checked before every batch (and re-checked around the cooperative pause below): once `now` reaches or passes today's stop-by time, the run exits after its in-flight batch — remaining pairs simply drain on the next scheduled run (UPSERTs are idempotent; unwritten pairs stay `attempt_at IS NULL` and are picked up again, so a mid-run stop, even a hard `SIGKILL`, loses no data).
+
+This is a **same-day-only** deadline — it deliberately does NOT roll forward to tomorrow. The nightly `04:45 UTC` run sees a deadline hours in its own future and proceeds normally; a run launched AFTER the stop hour (a manual catch-up, or a misfired daytime launch) sees a deadline already in the past and no-ops immediately rather than computing "the next `11:00`" and running all day. See `computeStopByDeadlineMs`/`isPastStopBy` in `job.ts`.
+
+The run's summary and terminal log line record why it stopped: `stopReason: 'backlog_drained'` (every eligible pair for this run was processed before the deadline) vs `'stop_by_reached'` (the deadline cut the run short) — so a future overrun is visible in the logs instead of silently bleeding into daytime.
+
+### Strengthened cooperative pause (BS#1814)
+
+`LIVE_ACTIVITY_LOOKBACK_SECONDS` default raised `60s → 300s` (5 min). The flowsheet gap between songs is 3-5 min, so the old 60s lookback read "quiet" between almost every track and the job proceeded right into the streaming-check-on-add window a fresh add triggers — the pause never reliably parked the job for an overnight live show. 300s comfortably covers the song gap. The pause loop (`awaitQuietWindow`) is also now deadline-aware: without that, a DJ active continuously right at the stop hour would otherwise carry the run past the deadline indefinitely (the loop previously only exited on quiet). **Note:** `LIVE_ACTIVITY_LOOKBACK_SECONDS` is a generic env-var name shared across jobs — this raised compiled default only changes behavior for _this job's_ container, and only when the var is unset there; if prod sets it explicitly for this job already, update that value too.
+
+### Out of scope (follow-up)
+
+A play-floor on the eligible set (gate free-text pairs on a minimum play count, mirroring BS#1591's `flowsheet-metadata-backfill` fix) would shrink the backlog structurally so the deadline rarely even binds — tracked as a separate fast-follow, not part of BS#1814.
 
 ## Run procedure (manual, e.g. catch-up)
 
@@ -54,18 +70,19 @@ docker run --rm --env-file .env <image> 2>&1 | tee /tmp/freetext-resolve.log
 
 ## Env knobs
 
-| Variable                             | Default            | Meaning                                                                                             |
-| ------------------------------------ | ------------------ | --------------------------------------------------------------------------------------------------- |
-| `FREETEXT_RESOLVE_BULK_BATCH_SIZE`   | `5`                | Items per LML bulk request. LML caps at 100. Raising this scales the per-batch fetch timeout.       |
-| `FREETEXT_RESOLVE_BULK_RATE_PER_MIN` | `1`                | Batches per minute. At the default batch size, 1/min ≈ 5 pairs/min sustained.                       |
-| `FREETEXT_RESOLVE_BULK_BUDGET_MS`    | `25000`            | Per-item budget forwarded to LML as `X-Caller-Budget-Ms`. NOT the batch fetch timeout.              |
-| `FREETEXT_RESOLVE_NO_MATCH_TTL_DAYS` | `30`               | A no-match pair is re-attempted once its `attempt_at` is older than this.                           |
-| `FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN` | `5000`             | Cap on distinct eligible pairs processed per run. `0` disables the cap (drain everything eligible). |
-| `FREETEXT_RESOLVE_READ_TIMEOUT_MS`   | `300000` (5min)    | `SET LOCAL statement_timeout` for the DISTINCT enumerate scan.                                      |
-| `LIVE_ACTIVITY_LOOKBACK_SECONDS`     | `60`               | Cooperative-pause lookback window; `0` disables.                                                    |
-| `LIBRARY_METADATA_URL`               | (required)         | LML base URL.                                                                                       |
-| `LML_API_KEY`                        | (required in prod) | LML bearer token.                                                                                   |
-| `DATABASE_URL`                       | (required)         | Postgres connection string.                                                                         |
+| Variable                             | Default                   | Meaning                                                                                                                                                                    |
+| ------------------------------------ | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FREETEXT_RESOLVE_BULK_BATCH_SIZE`   | `5`                       | Items per LML bulk request. LML caps at 100. Raising this scales the per-batch fetch timeout.                                                                              |
+| `FREETEXT_RESOLVE_BULK_RATE_PER_MIN` | `1`                       | Batches per minute. At the default batch size, 1/min ≈ 5 pairs/min sustained.                                                                                              |
+| `FREETEXT_RESOLVE_BULK_BUDGET_MS`    | `25000`                   | Per-item budget forwarded to LML as `X-Caller-Budget-Ms`. NOT the batch fetch timeout.                                                                                     |
+| `FREETEXT_RESOLVE_NO_MATCH_TTL_DAYS` | `30`                      | A no-match pair is re-attempted once its `attempt_at` is older than this.                                                                                                  |
+| `FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN` | `5000`                    | Cap on distinct eligible pairs processed per run. `0` disables the cap (drain everything eligible).                                                                        |
+| `FREETEXT_RESOLVE_READ_TIMEOUT_MS`   | `300000` (5min)           | `SET LOCAL statement_timeout` for the DISTINCT enumerate scan.                                                                                                             |
+| `FREETEXT_RESOLVE_STOP_BY_UTC`       | `11:00`                   | BS#1814 absolute UTC wall-clock stop-by ("HH:MM", 24h, zero-padded). Same-day only — never rolls to tomorrow. Checked before every batch and around the cooperative pause. |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`     | `300` (BS#1814, was `60`) | Cooperative-pause lookback window; `0` disables. Deadline-aware (BS#1814): won't spin past `FREETEXT_RESOLVE_STOP_BY_UTC`.                                                 |
+| `LIBRARY_METADATA_URL`               | (required)                | LML base URL.                                                                                                                                                              |
+| `LML_API_KEY`                        | (required in prod)        | LML bearer token.                                                                                                                                                          |
+| `DATABASE_URL`                       | (required)                | Postgres connection string.                                                                                                                                                |
 
 ## Acceptance verification
 
@@ -104,6 +121,7 @@ After the re-arm, the next scheduled run (or a manual catch-up per "Run procedur
 
 ## Related
 
+- [BS#1814](https://github.com/WXYC/Backend-Service/issues/1814) — the absolute stop-by wall-clock bound + strengthened cooperative pause (this README's "Window bound" and "Strengthened cooperative pause" sections above), fixing the overnight-window overrun that starved LML into a congestion collapse on 2026-07-25.
 - [BS#1767](https://github.com/WXYC/Backend-Service/issues/1767) — carries a representative track title into the bulk lookup (this README's "Post-deploy re-drain" section); +16pts / ~3.7x match-rate lift, 0 regressions in the A/B probe.
 - [BS#1491](https://github.com/WXYC/Backend-Service/issues/1491) — this job's parent issue (blocks Track 2, BS#1492).
 - [BS#1486](https://github.com/WXYC/Backend-Service/issues/1486) — Phase-2 catalog-popularity epic.

--- a/jobs/catalog-popularity-freetext-resolve/job.ts
+++ b/jobs/catalog-popularity-freetext-resolve/job.ts
@@ -103,12 +103,33 @@ export const READ_TIMEOUT_ENV = 'FREETEXT_RESOLVE_READ_TIMEOUT_MS';
 export const READ_TIMEOUT_DEFAULT = 5 * 60 * 1000;
 
 /** Cooperative-pause lookback window (seconds). If the most recent flowsheet
- * track was added within this many seconds, defer. `0` disables the probe. */
+ * track was added within this many seconds, defer. `0` disables the probe.
+ *
+ * BS#1814: raised from the original 60s default. The flowsheet gap between
+ * songs is 3-5 minutes, so a 60s lookback almost always reads quiet between
+ * tracks and the job proceeds right into the streaming-check-on-add window a
+ * fresh add triggers — the pause never actually parks the job for an
+ * overnight live show. 300s (5 min) comfortably covers the song gap so a
+ * live DJ reliably keeps the job paused. NOTE: `LIVE_ACTIVITY_LOOKBACK_SECONDS`
+ * is a generic env-var name reused across jobs; raising this compiled default
+ * only changes behavior for THIS job's container, and only when the var is
+ * unset in its environment — if prod sets it explicitly, update that value too. */
 export const LIVE_ACTIVITY_LOOKBACK_ENV = 'LIVE_ACTIVITY_LOOKBACK_SECONDS';
-export const LIVE_ACTIVITY_LOOKBACK_DEFAULT = 60;
+export const LIVE_ACTIVITY_LOOKBACK_DEFAULT = 300;
 
 /** Sleep between re-probes when DJ activity is detected. */
 export const LIVE_ACTIVITY_PAUSE_MS_DEFAULT = 30_000;
+
+/** Absolute UTC wall-clock stop-by time ("HH:MM", 24-hour), the BS#1814
+ * primary fix for the overnight-window overrun. Checked before every batch
+ * (and bounds the cooperative pause below) so a run can never bleed past this
+ * time of day, no matter how large the eligible backlog is or how long DJ
+ * activity holds the pause open. `04:45 UTC start + 11:00 UTC stop` leaves a
+ * ~6h15m nightly window, closing well before the daytime peak while sitting
+ * clear of the `rotation-lml-identity-backfill` 09:00 UTC heavy drain's own
+ * start (see docs/ops-cron-scheduling.md) for most of a healthy run. */
+export const STOP_BY_UTC_ENV = 'FREETEXT_RESOLVE_STOP_BY_UTC';
+export const STOP_BY_UTC_DEFAULT = '11:00';
 
 // -- Source query ------------------------------------------------------------
 
@@ -359,6 +380,46 @@ export const verdictFromLookup = (
   };
 };
 
+// -- Absolute stop-by wall-clock bound (BS#1814) -----------------------------
+
+/** 24-hour "HH:MM" UTC time-of-day shape. Zero-padded, strict (no "9:00") —
+ * this is an ops-set env var, not a scraped feed field, so the stricter shape
+ * (vs. e.g. `shared/database/src/ny-time.ts`'s lenient unpadded-hour parser)
+ * fails fast on a fat-fingered value instead of silently misreading it. */
+const STOP_BY_SHAPE = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+/** Parse a "HH:MM" (24-hour, UTC) time-of-day string into its hour/minute
+ * parts. Throws with an attributed message on anything else, same fail-fast
+ * posture as `requirePositiveInt`. */
+export const parseStopByUtc = (raw: string, envName: string = STOP_BY_UTC_ENV): { hour: number; minute: number } => {
+  const m = STOP_BY_SHAPE.exec(raw);
+  if (!m) {
+    throw new Error(`Invalid ${envName}=${JSON.stringify(raw)}: must be a 24-hour "HH:MM" UTC time (e.g. "11:00").`);
+  }
+  return { hour: Number(m[1]), minute: Number(m[2]) };
+};
+
+/**
+ * The absolute stop-by deadline (epoch ms): TODAY's UTC calendar date — the
+ * date `nowMs` falls on — at `stopByUtc` ("HH:MM").
+ *
+ * Deliberately same-day-only: this NEVER rolls forward to tomorrow when `now`
+ * is already past today's stop-by time. That is the crux of BS#1814 — the
+ * nightly 04:45 UTC run sees a deadline several hours in its own future and
+ * proceeds normally, but a run launched AFTER the stop hour (a manual
+ * catch-up or a misfired daytime launch, e.g. started 20:00 UTC against an
+ * 11:00 UTC stop-by) must see a deadline already in the past and stop
+ * immediately — not compute "the next 11:00" and run all day until then.
+ */
+export const computeStopByDeadlineMs = (nowMs: number, stopByUtc: string): number => {
+  const { hour, minute } = parseStopByUtc(stopByUtc);
+  const now = new Date(nowMs);
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), hour, minute, 0, 0);
+};
+
+/** True once `nowMs` has reached or passed `deadlineMs`. */
+export const isPastStopBy = (nowMs: number, deadlineMs: number): boolean => nowMs >= deadlineMs;
+
 // -- Cooperative pause -------------------------------------------------------
 
 /** Probe `flowsheet` for a track row added in the last `lookbackSeconds`.
@@ -378,9 +439,24 @@ export const checkLiveActivity = async (lookbackSeconds: number): Promise<boolea
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-/** Loop: probe → if active, sleep pauseMs → re-probe. Returns when quiet. */
-export const awaitQuietWindow = async (lookbackSeconds: number, pauseMs: number): Promise<void> => {
-  while (await checkLiveActivity(lookbackSeconds)) {
+/** Loop: probe → if active, sleep pauseMs → re-probe. Returns when quiet OR
+ * when `deadlineMs` (BS#1814 stop-by bound) is reached — whichever first.
+ *
+ * Without this, a DJ active near the stop hour would otherwise carry the pause
+ * loop PAST the deadline indefinitely (the loop only exits on quiet). The
+ * caller (`runResolve`) must still re-check `isPastStopBy` after this
+ * returns: a deadline-triggered return means activity may still be ongoing,
+ * so the caller must stop rather than proceed into the next batch.
+ *
+ * `deadlineMs`/`now` default to values that reproduce the pre-BS#1814
+ * behavior (never trips) so callers that don't pass them are unaffected. */
+export const awaitQuietWindow = async (
+  lookbackSeconds: number,
+  pauseMs: number,
+  deadlineMs: number = Infinity,
+  now: () => number = Date.now
+): Promise<void> => {
+  while ((await checkLiveActivity(lookbackSeconds)) && !isPastStopBy(now(), deadlineMs)) {
     log('info', 'live_activity_pause', `live DJ activity within ${lookbackSeconds}s; deferring ${pauseMs}ms`, {
       lookback_seconds: lookbackSeconds,
       pause_ms: pauseMs,
@@ -524,16 +600,27 @@ export const runBatch = async (
 
 // -- Top-level orchestration -------------------------------------------------
 
+/** Why the run stopped. `stop_by_reached` means the BS#1814 deadline cut the
+ * run short with backlog remaining (safe — it drains next run); `backlog_drained`
+ * means every eligible pair for this run was processed before the deadline. */
+export type StopReason = 'backlog_drained' | 'stop_by_reached';
+
 export interface ResolveSummary {
   scanned: number;
   eligible: number;
   processed: number;
+  /** Planned batch count (`ceil(processed / batchSize)`) — unchanged by a
+   * deadline stop, so it always reflects the full plan for this run. */
   batches: number;
+  /** Batches actually executed before returning. Equal to `batches` unless
+   * `stopReason === 'stop_by_reached'` cut the loop short. */
+  batchesRun: number;
   match: number;
   no_match: number;
   error: number;
   upserts: number;
   unexpected_index: number;
+  stopReason: StopReason;
 }
 
 export interface ResolveOptions {
@@ -545,11 +632,21 @@ export interface ResolveOptions {
   readTimeoutMs: number;
   liveActivityLookbackSeconds: number;
   liveActivityPauseMs: number;
+  /** "HH:MM" 24-hour UTC wall-clock stop-by bound (BS#1814). */
+  stopByUtc: string;
+  /** Injectable clock so tests can drive the deadline deterministically
+   * without fake timers. Defaults to the real `Date.now`. */
+  now: () => number;
   dryRun: boolean;
 }
 
 export const resolveOptions = (env: NodeJS.ProcessEnv = process.env, args: string[] = process.argv): ResolveOptions => {
   const ctx = { context: JOB_NAME };
+  const rawStopByUtc = env[STOP_BY_UTC_ENV];
+  const stopByUtc = rawStopByUtc === undefined || rawStopByUtc.trim() === '' ? STOP_BY_UTC_DEFAULT : rawStopByUtc;
+  // Validate eagerly (fail fast at option-resolution time), same posture as
+  // the `require*Int` helpers throwing on a malformed value.
+  parseStopByUtc(stopByUtc, STOP_BY_UTC_ENV);
   return {
     batchSize: requirePositiveInt(env[BULK_BATCH_SIZE_ENV], BULK_BATCH_SIZE_ENV, BULK_BATCH_SIZE_DEFAULT, ctx),
     ratePerMin: requirePositiveInt(env[BULK_RATE_PER_MIN_ENV], BULK_RATE_PER_MIN_ENV, BULK_RATE_PER_MIN_DEFAULT, ctx),
@@ -574,6 +671,8 @@ export const resolveOptions = (env: NodeJS.ProcessEnv = process.env, args: strin
       ctx
     ),
     liveActivityPauseMs: LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+    stopByUtc,
+    now: Date.now,
     dryRun: args.includes('--dry-run'),
   };
 };
@@ -584,15 +683,49 @@ const chunk = <T>(arr: T[], size: number): T[][] => {
   return out;
 };
 
+/** The no-op summary returned when the BS#1814 stop-by deadline has already
+ * passed before any work starts (the daytime-manual-launch case). */
+const stopByReachedAtStartupSummary = (): ResolveSummary => ({
+  scanned: 0,
+  eligible: 0,
+  processed: 0,
+  batches: 0,
+  batchesRun: 0,
+  match: 0,
+  no_match: 0,
+  error: 0,
+  upserts: 0,
+  unexpected_index: 0,
+  stopReason: 'stop_by_reached',
+});
+
 export const runResolve = async (options: ResolveOptions): Promise<ResolveSummary> => {
+  const nowFn = options.now ?? Date.now;
+  const deadlineMs = computeStopByDeadlineMs(nowFn(), options.stopByUtc);
+
   log('info', 'started', `${JOB_NAME} starting`, {
     batch_size: options.batchSize,
     rate_per_min: options.ratePerMin,
     budget_ms: options.budgetMs,
     no_match_ttl_days: options.noMatchTtlDays,
     max_pairs_per_run: options.maxPairsPerRun,
+    stop_by_utc: options.stopByUtc,
+    stop_by_deadline: new Date(deadlineMs).toISOString(),
     dry_run: options.dryRun,
   });
+
+  // BS#1814: a run launched after today's stop-by time (a manual catch-up or
+  // a misfired daytime launch) must no-op immediately — no enumerate scan, no
+  // LML calls, no writes — rather than doing any work at all.
+  if (isPastStopBy(nowFn(), deadlineMs)) {
+    log(
+      'warn',
+      'stop_by_reached',
+      `${JOB_NAME}: stop-by deadline (${options.stopByUtc} UTC) already passed at startup; no-op`,
+      { stop_by_utc: options.stopByUtc, stop_by_deadline: new Date(deadlineMs).toISOString() }
+    );
+    return stopByReachedAtStartupSummary();
+  }
 
   const raw = await enumerateFreetextPairs(options.readTimeoutMs);
   const normalized = normalizePairs(raw);
@@ -628,11 +761,13 @@ export const runResolve = async (options: ResolveOptions): Promise<ResolveSummar
       eligible: eligibleTotal,
       processed: eligible.length,
       batches: batches.length,
+      batchesRun: 0,
       match: 0,
       no_match: 0,
       error: 0,
       upserts: 0,
       unexpected_index: 0,
+      stopReason: 'backlog_drained',
     };
   }
 
@@ -644,10 +779,44 @@ export const runResolve = async (options: ResolveOptions): Promise<ResolveSummar
   let totalError = 0;
   let totalUpserts = 0;
   let totalUnexpectedIndex = 0;
+  let batchesRun = 0;
+  let stopReason: StopReason = 'backlog_drained';
 
   for (let i = 0; i < batches.length; i += 1) {
-    await awaitQuietWindow(options.liveActivityLookbackSeconds, options.liveActivityPauseMs);
+    // BS#1814: check before entering the batch (covers the "in flight when
+    // the stop hour passes" case for the PRIOR batch's post-work) as well as
+    // before pausing, so a run that's already past the deadline never even
+    // probes for live activity.
+    if (isPastStopBy(nowFn(), deadlineMs)) {
+      stopReason = 'stop_by_reached';
+      log(
+        'warn',
+        'stop_by_reached',
+        `${JOB_NAME}: stop-by deadline (${options.stopByUtc} UTC) reached before batch ${i + 1}/${batches.length}; stopping`,
+        { batch_index: i + 1, batches: batches.length, stop_by_utc: options.stopByUtc }
+      );
+      break;
+    }
 
+    // The pause loop itself is deadline-aware (BS#1814): a DJ active AT the
+    // stop hour would otherwise carry the run past it indefinitely. But a
+    // deadline-triggered return from the pause doesn't mean activity actually
+    // cleared, so re-check immediately below rather than assuming it's safe
+    // to proceed into the batch.
+    await awaitQuietWindow(options.liveActivityLookbackSeconds, options.liveActivityPauseMs, deadlineMs, nowFn);
+
+    if (isPastStopBy(nowFn(), deadlineMs)) {
+      stopReason = 'stop_by_reached';
+      log(
+        'warn',
+        'stop_by_reached',
+        `${JOB_NAME}: stop-by deadline (${options.stopByUtc} UTC) reached while paused for live activity before batch ${i + 1}/${batches.length}; stopping`,
+        { batch_index: i + 1, batches: batches.length, stop_by_utc: options.stopByUtc }
+      );
+      break;
+    }
+
+    batchesRun += 1;
     const t0 = Date.now();
     const result = await runBatch(batches[i], { budgetMs: options.budgetMs, dryRun: false });
     const wallClockMs = Date.now() - t0;
@@ -675,16 +844,25 @@ export const runResolve = async (options: ResolveOptions): Promise<ResolveSummar
     }
   }
 
+  if (stopReason === 'backlog_drained') {
+    log('info', 'backlog_drained', `${JOB_NAME}: drained the eligible backlog for this run (no deadline hit)`, {
+      batches_run: batchesRun,
+      batches: batches.length,
+    });
+  }
+
   return {
     scanned: raw.length,
     eligible: eligibleTotal,
     processed: eligible.length,
     batches: batches.length,
+    batchesRun,
     match: totalMatch,
     no_match: totalNoMatch,
     error: totalError,
     upserts: totalUpserts,
     unexpected_index: totalUnexpectedIndex,
+    stopReason,
   };
 };
 

--- a/jobs/catalog-popularity-freetext-resolve/job.ts
+++ b/jobs/catalog-popularity-freetext-resolve/job.ts
@@ -632,8 +632,11 @@ export interface ResolveOptions {
   readTimeoutMs: number;
   liveActivityLookbackSeconds: number;
   liveActivityPauseMs: number;
-  /** "HH:MM" 24-hour UTC wall-clock stop-by bound (BS#1814). */
-  stopByUtc: string;
+  /** "HH:MM" 24-hour UTC wall-clock stop-by bound (BS#1814), or `null` when the
+   * bound is disabled — an explicitly-empty env var requests an unbounded,
+   * supervised full-drain (capped only by `maxPairsPerRun` + the cooperative
+   * pause). An UNSET env var resolves to the default bound, not `null`. */
+  stopByUtc: string | null;
   /** Injectable clock so tests can drive the deadline deterministically
    * without fake timers. Defaults to the real `Date.now`. */
   now: () => number;
@@ -643,10 +646,23 @@ export interface ResolveOptions {
 export const resolveOptions = (env: NodeJS.ProcessEnv = process.env, args: string[] = process.argv): ResolveOptions => {
   const ctx = { context: JOB_NAME };
   const rawStopByUtc = env[STOP_BY_UTC_ENV];
-  const stopByUtc = rawStopByUtc === undefined || rawStopByUtc.trim() === '' ? STOP_BY_UTC_DEFAULT : rawStopByUtc;
-  // Validate eagerly (fail fast at option-resolution time), same posture as
-  // the `require*Int` helpers throwing on a malformed value.
-  parseStopByUtc(stopByUtc, STOP_BY_UTC_ENV);
+  // UNSET (undefined) → default bound; an EXPLICITLY-empty / whitespace-only
+  // value → disabled (`null`, an unbounded supervised full-drain); any other
+  // value is taken as the bound and validated eagerly below. The unset-vs-empty
+  // distinction is deliberate: an operator must opt into unbounded by clearing
+  // the var, and a stray whitespace value can't silently re-arm the default.
+  let stopByUtc: string | null;
+  if (rawStopByUtc === undefined) {
+    stopByUtc = STOP_BY_UTC_DEFAULT;
+  } else if (rawStopByUtc.trim() === '') {
+    stopByUtc = null;
+  } else {
+    stopByUtc = rawStopByUtc;
+  }
+  // Validate eagerly (fail fast at option-resolution time), same posture as the
+  // `require*Int` helpers throwing on a malformed value. A disabled (`null`)
+  // bound has nothing to validate.
+  if (stopByUtc !== null) parseStopByUtc(stopByUtc, STOP_BY_UTC_ENV);
   return {
     batchSize: requirePositiveInt(env[BULK_BATCH_SIZE_ENV], BULK_BATCH_SIZE_ENV, BULK_BATCH_SIZE_DEFAULT, ctx),
     ratePerMin: requirePositiveInt(env[BULK_RATE_PER_MIN_ENV], BULK_RATE_PER_MIN_ENV, BULK_RATE_PER_MIN_DEFAULT, ctx),
@@ -701,7 +717,10 @@ const stopByReachedAtStartupSummary = (): ResolveSummary => ({
 
 export const runResolve = async (options: ResolveOptions): Promise<ResolveSummary> => {
   const nowFn = options.now ?? Date.now;
-  const deadlineMs = computeStopByDeadlineMs(nowFn(), options.stopByUtc);
+  // A disabled bound (`stopByUtc === null`) resolves to an Infinite deadline
+  // that no `isPastStopBy` check can ever reach, so every deadline guard below
+  // is a no-op and the run is unbounded (the supervised full-drain path).
+  const deadlineMs = options.stopByUtc === null ? Infinity : computeStopByDeadlineMs(nowFn(), options.stopByUtc);
 
   log('info', 'started', `${JOB_NAME} starting`, {
     batch_size: options.batchSize,
@@ -709,8 +728,8 @@ export const runResolve = async (options: ResolveOptions): Promise<ResolveSummar
     budget_ms: options.budgetMs,
     no_match_ttl_days: options.noMatchTtlDays,
     max_pairs_per_run: options.maxPairsPerRun,
-    stop_by_utc: options.stopByUtc,
-    stop_by_deadline: new Date(deadlineMs).toISOString(),
+    stop_by_utc: options.stopByUtc ?? 'disabled',
+    stop_by_deadline: Number.isFinite(deadlineMs) ? new Date(deadlineMs).toISOString() : null,
     dry_run: options.dryRun,
   });
 

--- a/tests/unit/jobs/catalog-popularity-freetext-resolve/job.stop-by-log.test.ts
+++ b/tests/unit/jobs/catalog-popularity-freetext-resolve/job.stop-by-log.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Pins the BS#1814 stop-reason log line (`stop_by_reached` vs
+ * `backlog_drained`) — a separate file that mocks the job's local logger
+ * module so `log()` calls are observable, mirroring the established
+ * isolation pattern in
+ * tests/unit/jobs/concerts-poster-enrichment/orchestrate.capture.test.ts (a
+ * separate file so the logger mock can't leak into job.test.ts, which relies
+ * on the real no-op logger — `log()` silently no-ops there because
+ * `initLogger()` is never called in the unit suite).
+ */
+import { jest } from '@jest/globals';
+
+const mockBulkLookupMetadata = jest.fn<(items: unknown, opts?: unknown) => Promise<unknown>>();
+jest.mock('@wxyc/lml-client', () => ({
+  __esModule: true,
+  bulkLookupMetadata: mockBulkLookupMetadata,
+}));
+
+jest.mock('@sentry/node', () => ({
+  __esModule: true,
+  addBreadcrumb: jest.fn(),
+  captureMessage: jest.fn(),
+  init: jest.fn(),
+  setTag: jest.fn(),
+  captureException: jest.fn(),
+  close: jest.fn(() => Promise.resolve(true)),
+}));
+
+const mockLog = jest.fn();
+jest.mock('../../../../jobs/catalog-popularity-freetext-resolve/logger', () => ({
+  __esModule: true,
+  log: mockLog,
+  captureError: jest.fn(),
+  initLogger: jest.fn(() => 'run-id'),
+  closeLogger: jest.fn(() => Promise.resolve()),
+}));
+
+import { db } from '@wxyc/database';
+import { runResolve, type ResolveOptions } from '../../../../jobs/catalog-popularity-freetext-resolve/job';
+
+const baseOptions = (over: Partial<ResolveOptions> = {}): ResolveOptions => ({
+  batchSize: 5,
+  ratePerMin: 600,
+  budgetMs: 25000,
+  noMatchTtlDays: 30,
+  maxPairsPerRun: 0,
+  readTimeoutMs: 300_000,
+  liveActivityLookbackSeconds: 0,
+  liveActivityPauseMs: 1,
+  stopByUtc: '23:59',
+  now: () => Date.UTC(2026, 0, 1, 0, 0, 0),
+  dryRun: false,
+  ...over,
+});
+
+const stepsLogged = (): string[] => mockLog.mock.calls.map((call) => call[1] as string);
+
+describe('runResolve — stop-reason log line (BS#1814)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs stop_by_reached (and does NOT log backlog_drained) when the deadline has already passed at startup', async () => {
+    const now = jest.fn<() => number>().mockReturnValue(Date.UTC(2026, 6, 25, 20, 0, 0));
+
+    await runResolve(baseOptions({ stopByUtc: '11:00', now }));
+
+    expect(stepsLogged()).toContain('stop_by_reached');
+    expect(stepsLogged()).not.toContain('backlog_drained');
+  });
+
+  it('logs stop_by_reached (and does NOT log backlog_drained) when the deadline is reached mid-run', async () => {
+    const mock = db.execute as jest.Mock;
+    mock
+      .mockResolvedValueOnce({}) // SET LOCAL
+      .mockResolvedValueOnce([
+        { artist_name: 'A', album_title: 'X' },
+        { artist_name: 'B', album_title: 'Y' },
+      ])
+      .mockResolvedValueOnce([]); // loadSkipKeys
+
+    mockBulkLookupMetadata.mockResolvedValueOnce({
+      results: [{ index: 0, status: 'no_match', lookup: { results: [] } }],
+    });
+
+    const T_START = Date.UTC(2026, 6, 25, 4, 45, 0);
+    const T_PAST = Date.UTC(2026, 6, 25, 12, 0, 1);
+    const now = jest
+      .fn<() => number>()
+      .mockReturnValueOnce(T_START) // initial deadline computation
+      .mockReturnValueOnce(T_START) // startup no-op check
+      .mockReturnValueOnce(T_START) // batch 0's pre-pause check
+      .mockReturnValueOnce(T_START) // batch 0's post-pause check
+      .mockReturnValue(T_PAST); // batch 1's pre-pause check onward: past the deadline
+
+    await runResolve(baseOptions({ batchSize: 1, stopByUtc: '12:00', now }));
+
+    expect(stepsLogged()).toContain('stop_by_reached');
+    expect(stepsLogged()).not.toContain('backlog_drained');
+  });
+
+  it('logs backlog_drained (and does NOT log stop_by_reached) when the run completes before the deadline', async () => {
+    const mock = db.execute as jest.Mock;
+    mock
+      .mockResolvedValueOnce({}) // SET LOCAL
+      .mockResolvedValueOnce([{ artist_name: 'J Dilla', album_title: 'Donuts' }])
+      .mockResolvedValueOnce([]); // loadSkipKeys
+
+    mockBulkLookupMetadata.mockResolvedValue({
+      results: [{ index: 0, status: 'no_match', lookup: { results: [] } }],
+    });
+
+    await runResolve(baseOptions());
+
+    expect(stepsLogged()).toContain('backlog_drained');
+    expect(stepsLogged()).not.toContain('stop_by_reached');
+  });
+});

--- a/tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts
+++ b/tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts
@@ -64,6 +64,11 @@ import {
   READ_TIMEOUT_DEFAULT,
   LIVE_ACTIVITY_LOOKBACK_DEFAULT,
   LIVE_ACTIVITY_LOOKBACK_ENV,
+  STOP_BY_UTC_DEFAULT,
+  STOP_BY_UTC_ENV,
+  parseStopByUtc,
+  computeStopByDeadlineMs,
+  isPastStopBy,
   type NormalizedPair,
   type ResolveOptions,
 } from '../../../../jobs/catalog-popularity-freetext-resolve/job';
@@ -111,6 +116,7 @@ const RESET_ENV_KEYS = [
   NO_MATCH_TTL_DAYS_ENV,
   MAX_PAIRS_PER_RUN_ENV,
   LIVE_ACTIVITY_LOOKBACK_ENV,
+  STOP_BY_UTC_ENV,
 ];
 const stripEnv = (env: NodeJS.ProcessEnv): NodeJS.ProcessEnv => {
   const out = { ...env };
@@ -526,6 +532,43 @@ describe('checkLiveActivity / awaitQuietWindow', () => {
     await awaitQuietWindow(60, 1);
     expect(probe).toHaveBeenCalledTimes(2);
   });
+
+  it('awaitQuietWindow with no deadline argument behaves exactly as before (never trips)', async () => {
+    // Backward-compatibility pin: callers that don't pass deadlineMs/now (the
+    // pre-BS#1814 call shape) must see identical behavior — the loop is
+    // bounded ONLY by live activity clearing.
+    const probe = db.execute as jest.Mock;
+    probe.mockResolvedValueOnce([{}]).mockResolvedValueOnce([{}]).mockResolvedValueOnce([]);
+    await awaitQuietWindow(60, 1);
+    expect(probe).toHaveBeenCalledTimes(3);
+  });
+
+  it('awaitQuietWindow exits at the stop-by deadline even while live activity never clears (BS#1814)', async () => {
+    // A DJ active continuously AT the stop hour must not carry the run past
+    // it indefinitely. deadlineMs is already reached relative to `now`, so
+    // the loop must exit after (at most) its first probe — NOT keep sleeping
+    // and re-probing. A very large pauseMs makes a regression (the loop not
+    // exiting) manifest as a jest timeout rather than a silent pass.
+    const probe = db.execute as jest.Mock;
+    probe.mockResolvedValue([{}]); // "always active" — never quiets down on its own
+    const deadlineMs = Date.UTC(2026, 6, 25, 11, 0, 0);
+    const now = jest.fn<() => number>().mockReturnValue(deadlineMs);
+
+    await awaitQuietWindow(60, 999_000, deadlineMs, now);
+
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('awaitQuietWindow keeps pausing past a future deadline while activity persists, then exits once quiet', async () => {
+    const probe = db.execute as jest.Mock;
+    probe.mockResolvedValueOnce([{}]).mockResolvedValueOnce([]);
+    const deadlineMs = Date.UTC(2026, 6, 25, 11, 0, 0);
+    const now = jest.fn<() => number>().mockReturnValue(deadlineMs - 60_000); // a minute before the deadline, both probes
+
+    await awaitQuietWindow(60, 1, deadlineMs, now);
+
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -648,6 +691,7 @@ describe('resolveOptions', () => {
     expect(opts.maxPairsPerRun).toBe(MAX_PAIRS_PER_RUN_DEFAULT);
     expect(opts.readTimeoutMs).toBe(READ_TIMEOUT_DEFAULT);
     expect(opts.liveActivityLookbackSeconds).toBe(LIVE_ACTIVITY_LOOKBACK_DEFAULT);
+    expect(opts.stopByUtc).toBe(STOP_BY_UTC_DEFAULT);
     expect(opts.dryRun).toBe(false);
   });
 
@@ -657,15 +701,23 @@ describe('resolveOptions', () => {
       [BULK_BATCH_SIZE_ENV]: '10',
       [NO_MATCH_TTL_DAYS_ENV]: '7',
       [MAX_PAIRS_PER_RUN_ENV]: '0',
+      [STOP_BY_UTC_ENV]: '13:30',
     };
     const opts = resolveOptions(env, []);
     expect(opts.batchSize).toBe(10);
     expect(opts.noMatchTtlDays).toBe(7);
     expect(opts.maxPairsPerRun).toBe(0); // 0 allowed (non-negative) → disables cap
+    expect(opts.stopByUtc).toBe('13:30');
   });
 
   it('throws on invalid batch size', () => {
     expect(() => resolveOptions({ ...stripEnv(process.env), [BULK_BATCH_SIZE_ENV]: '0' }, [])).toThrow();
+  });
+
+  it('throws on a malformed FREETEXT_RESOLVE_STOP_BY_UTC', () => {
+    expect(() => resolveOptions({ ...stripEnv(process.env), [STOP_BY_UTC_ENV]: 'garbage' }, [])).toThrow();
+    expect(() => resolveOptions({ ...stripEnv(process.env), [STOP_BY_UTC_ENV]: '24:00' }, [])).toThrow();
+    expect(() => resolveOptions({ ...stripEnv(process.env), [STOP_BY_UTC_ENV]: '9:00' }, [])).toThrow();
   });
 
   it('detects --dry-run', () => {
@@ -674,8 +726,61 @@ describe('resolveOptions', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Absolute stop-by wall-clock bound (BS#1814).
+// ---------------------------------------------------------------------------
+
+describe('parseStopByUtc / computeStopByDeadlineMs / isPastStopBy', () => {
+  it('parses a valid zero-padded 24-hour HH:MM', () => {
+    expect(parseStopByUtc('11:00')).toEqual({ hour: 11, minute: 0 });
+    expect(parseStopByUtc('00:00')).toEqual({ hour: 0, minute: 0 });
+    expect(parseStopByUtc('23:59')).toEqual({ hour: 23, minute: 59 });
+  });
+
+  it('rejects malformed stop-by strings', () => {
+    for (const bad of ['garbage', '24:00', '9:00', '11:60', '11', '11:0', '']) {
+      expect(() => parseStopByUtc(bad)).toThrow();
+    }
+  });
+
+  it('computes the deadline as TODAY (same UTC calendar date as now) at the given HH:MM', () => {
+    const nowMs = Date.UTC(2026, 6, 25, 4, 45, 0); // 2026-07-25T04:45:00Z (the nightly run start)
+    const deadlineMs = computeStopByDeadlineMs(nowMs, '11:00');
+    expect(deadlineMs).toBe(Date.UTC(2026, 6, 25, 11, 0, 0, 0));
+  });
+
+  it('is not past stop-by while now is before the same-day deadline', () => {
+    const nowMs = Date.UTC(2026, 6, 25, 4, 45, 0);
+    const deadlineMs = computeStopByDeadlineMs(nowMs, '11:00');
+    expect(isPastStopBy(nowMs, deadlineMs)).toBe(false);
+  });
+
+  it('is past stop-by once now reaches or passes the deadline', () => {
+    const deadlineMs = computeStopByDeadlineMs(Date.UTC(2026, 6, 25, 4, 45, 0), '11:00');
+    expect(isPastStopBy(deadlineMs, deadlineMs)).toBe(true); // exactly at the deadline
+    expect(isPastStopBy(deadlineMs + 1, deadlineMs)).toBe(true); // past it
+  });
+
+  it("does NOT roll the deadline forward to tomorrow when now is already past today's stop-by (daytime manual launch)", () => {
+    // A run launched at 20:00 UTC against an 11:00 UTC stop-by: the naive
+    // "next occurrence of 11:00" would be TOMORROW at 11:00, which would let
+    // the run proceed for another 15h. The correct behavior is a same-day
+    // deadline that's already in the past, so the run stops immediately.
+    const nowMs = Date.UTC(2026, 6, 25, 20, 0, 0); // 2026-07-25T20:00:00Z
+    const deadlineMs = computeStopByDeadlineMs(nowMs, '11:00');
+    expect(deadlineMs).toBe(Date.UTC(2026, 6, 25, 11, 0, 0, 0)); // SAME calendar day, not the 26th
+    expect(new Date(deadlineMs).getUTCDate()).toBe(25);
+    expect(isPastStopBy(nowMs, deadlineMs)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Top-level orchestration.
 // ---------------------------------------------------------------------------
+
+// Arbitrary fixed instant comfortably before the '23:59' stopByUtc default
+// below, so pre-existing (non-deadline) tests never trip the BS#1814 bound
+// regardless of the real wall-clock time the suite happens to run at.
+const FIXED_NOW_MS = Date.UTC(2026, 0, 1, 0, 0, 0); // 2026-01-01T00:00:00Z
 
 const baseOptions = (over: Partial<ResolveOptions> = {}): ResolveOptions => ({
   batchSize: 2,
@@ -686,6 +791,8 @@ const baseOptions = (over: Partial<ResolveOptions> = {}): ResolveOptions => ({
   readTimeoutMs: 300_000,
   liveActivityLookbackSeconds: 0,
   liveActivityPauseMs: 1,
+  stopByUtc: '23:59',
+  now: () => FIXED_NOW_MS,
   dryRun: false,
   ...over,
 });
@@ -786,5 +893,131 @@ describe('runResolve', () => {
     expect(summary.processed).toBe(2);
     expect(summary.batches).toBe(2);
     expect(mockBulkLookupMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it('a normal drained run reports stopReason backlog_drained and batchesRun === batches', async () => {
+    const mock = db.execute as jest.Mock;
+    for (const v of enumerateResult([{ artist_name: 'J Dilla', album_title: 'Donuts' }])) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mock.mockResolvedValueOnce([]); // loadSkipKeys empty
+    mockBulkLookupMetadata.mockResolvedValue({
+      results: [{ index: 0, status: 'no_match', lookup: { results: [] } }],
+    });
+
+    const summary = await runResolve(baseOptions({ batchSize: 5 }));
+
+    expect(summary.stopReason).toBe('backlog_drained');
+    expect(summary.batchesRun).toBe(summary.batches);
+    expect(summary.batchesRun).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Absolute stop-by wall-clock bound — runResolve integration (BS#1814).
+// ---------------------------------------------------------------------------
+
+describe('runResolve — absolute stop-by deadline (BS#1814)', () => {
+  const enumerateResult = (rows: unknown[]): [unknown, unknown] => [{}, rows];
+
+  it('no-ops immediately (no enumerate, no LML calls, no writes) when the deadline has already passed at startup (daytime manual launch)', async () => {
+    // now is fixed at 20:00 UTC on 2026-07-25; stopByUtc '11:00' resolves to a
+    // same-day 11:00 deadline already 9h in the past — must stop before doing
+    // ANY work, not merely before the first batch.
+    const now = jest.fn<() => number>().mockReturnValue(Date.UTC(2026, 6, 25, 20, 0, 0));
+
+    const summary = await runResolve(baseOptions({ stopByUtc: '11:00', now }));
+
+    expect(summary).toMatchObject({
+      scanned: 0,
+      eligible: 0,
+      processed: 0,
+      batches: 0,
+      batchesRun: 0,
+      stopReason: 'stop_by_reached',
+    });
+    expect(db.execute as jest.Mock).not.toHaveBeenCalled();
+    expect(mockBulkLookupMetadata).not.toHaveBeenCalled();
+    expect(db.insert as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('stops the batch loop once the deadline passes mid-run, leaving later pairs unattempted and resumable', async () => {
+    const mock = db.execute as jest.Mock;
+    for (const v of enumerateResult([
+      { artist_name: 'A', album_title: 'X' },
+      { artist_name: 'B', album_title: 'Y' },
+      { artist_name: 'C', album_title: 'Z' },
+    ])) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mock.mockResolvedValueOnce([]); // loadSkipKeys empty
+
+    mockBulkLookupMetadata.mockResolvedValueOnce({
+      results: [{ index: 0, status: 'match', lookup: lookupWithRelease(1) }],
+    });
+
+    const T_START = Date.UTC(2026, 6, 25, 4, 45, 0);
+    const T_PAST = Date.UTC(2026, 6, 25, 12, 0, 1);
+    const now = jest
+      .fn<() => number>()
+      .mockReturnValueOnce(T_START) // initial deadline computation
+      .mockReturnValueOnce(T_START) // startup no-op check
+      .mockReturnValueOnce(T_START) // batch 0's pre-pause check
+      .mockReturnValueOnce(T_START) // batch 0's post-pause check
+      .mockReturnValue(T_PAST); // batch 1's pre-pause check onward: past the deadline
+
+    const summary = await runResolve(baseOptions({ batchSize: 1, stopByUtc: '12:00', now }));
+
+    // Only the first of 3 planned batches actually ran.
+    expect(mockBulkLookupMetadata).toHaveBeenCalledTimes(1);
+    expect((db.insert as jest.Mock).mock.calls.length).toBe(1); // only pair A got UPSERTed
+    expect(summary).toMatchObject({
+      batches: 3, // full plan, unchanged
+      batchesRun: 1, // only one actually executed
+      match: 1,
+      stopReason: 'stop_by_reached',
+    });
+    // Pairs B and C were never sent to runBatch, so upsertVerdict was never
+    // called for them — their flowsheet_freetext_resolution rows (if any)
+    // keep attempt_at IS NULL and are picked up again by loadSkipKeys/
+    // filterEligible on the NEXT run. Nothing was lost or double-written.
+  });
+
+  it('a run with live activity AT the stop hour exits at the deadline instead of spinning in awaitQuietWindow', async () => {
+    const mock = db.execute as jest.Mock;
+    for (const v of enumerateResult([{ artist_name: 'J Dilla', album_title: 'Donuts' }])) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mock.mockResolvedValueOnce([]); // loadSkipKeys empty
+    // Every subsequent db.execute call is the live-activity probe — always
+    // "active" (never quiets down).
+    mock.mockResolvedValue([{}]);
+
+    // The startup/pre-loop checks read as "not yet past" (T_BEFORE) so the
+    // run actually reaches `awaitQuietWindow` — the thing under test — rather
+    // than short-circuiting on the startup no-op guard. Once inside the pause
+    // loop's first probe, `now` reads as AT the deadline, so the loop must
+    // exit on its first iteration instead of sleeping and re-probing.
+    const deadlineInstant = Date.UTC(2026, 6, 25, 11, 0, 0);
+    const now = jest
+      .fn<() => number>()
+      .mockReturnValueOnce(deadlineInstant - 1) // initial deadline computation
+      .mockReturnValueOnce(deadlineInstant - 1) // startup no-op check
+      .mockReturnValueOnce(deadlineInstant - 1) // loop pre-pause check
+      .mockReturnValue(deadlineInstant); // inside awaitQuietWindow onward: AT the deadline
+
+    const summary = await runResolve(
+      baseOptions({
+        batchSize: 5,
+        stopByUtc: '11:00',
+        now,
+        liveActivityLookbackSeconds: 60,
+        liveActivityPauseMs: 999_000, // a regression that fails to break out would time out the test
+      })
+    );
+
+    expect(mockBulkLookupMetadata).not.toHaveBeenCalled();
+    expect(summary.stopReason).toBe('stop_by_reached');
+    expect(summary.batchesRun).toBe(0);
   });
 });

--- a/tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts
+++ b/tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts
@@ -720,6 +720,17 @@ describe('resolveOptions', () => {
     expect(() => resolveOptions({ ...stripEnv(process.env), [STOP_BY_UTC_ENV]: '9:00' }, [])).toThrow();
   });
 
+  it('treats an explicitly-empty FREETEXT_RESOLVE_STOP_BY_UTC as disabled (null), distinct from unset', () => {
+    // Escape hatch ported from PR #1818: UNSET resolves to the default bound
+    // (covered by "uses defaults when env is unset" above), but an operator who
+    // EXPLICITLY empties the var is asking for an unbounded, supervised
+    // full-drain, so it resolves to `null` (no deadline) — not the default.
+    // Whitespace-only counts as empty (trimmed) so a stray space can't silently
+    // re-arm the bound.
+    expect(resolveOptions({ ...stripEnv(process.env), [STOP_BY_UTC_ENV]: '' }, []).stopByUtc).toBeNull();
+    expect(resolveOptions({ ...stripEnv(process.env), [STOP_BY_UTC_ENV]: '   ' }, []).stopByUtc).toBeNull();
+  });
+
   it('detects --dry-run', () => {
     expect(resolveOptions(stripEnv(process.env), ['node', 'job.js', '--dry-run']).dryRun).toBe(true);
   });
@@ -1019,5 +1030,29 @@ describe('runResolve — absolute stop-by deadline (BS#1814)', () => {
     expect(mockBulkLookupMetadata).not.toHaveBeenCalled();
     expect(summary.stopReason).toBe('stop_by_reached');
     expect(summary.batchesRun).toBe(0);
+  });
+
+  it('runs unbounded when stopByUtc is null (disabled) — a run past the would-be stop hour still drains, not no-ops', async () => {
+    // The empty-var escape hatch: with the bound disabled, even a run at
+    // 20:00 UTC — hours past any HH:MM stop hour — enumerates and processes
+    // normally (deadline is Infinity, so no isPastStopBy check ever trips) and
+    // reports backlog_drained. Guards against a null leaking into
+    // computeStopByDeadlineMs (which would throw) or a stray no-op.
+    const mock = db.execute as jest.Mock;
+    for (const v of enumerateResult([{ artist_name: 'J Dilla', album_title: 'Donuts' }])) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mock.mockResolvedValueOnce([]); // loadSkipKeys empty
+    mockBulkLookupMetadata.mockResolvedValue({
+      results: [{ index: 0, status: 'no_match', lookup: { results: [] } }],
+    });
+
+    const now = jest.fn<() => number>().mockReturnValue(Date.UTC(2026, 6, 25, 20, 0, 0));
+    const summary = await runResolve(baseOptions({ batchSize: 5, stopByUtc: null, now }));
+
+    expect(mockBulkLookupMetadata).toHaveBeenCalledTimes(1);
+    expect(summary.stopReason).toBe('backlog_drained');
+    expect(summary.batches).toBe(1);
+    expect(summary.batchesRun).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1814

The `catalog-popularity-freetext-resolve` nightly cron's own arithmetic guaranteed an overnight-window overrun: at the pre-fix defaults (`FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN=5000`, `FREETEXT_RESOLVE_BULK_BATCH_SIZE=5`, `FREETEXT_RESOLVE_BULK_RATE_PER_MIN=1`) a run needed roughly 17-24h to finish, so the 04:45 UTC nightly cron was still alive 15h later on 2026-07-25, hammering LML's single-worker Discogs concurrency straight through daytime peak until LML's health checks went 503 and tubafrenzy/request-o-matic started timing out. The only recovery was manually killing the container.

- Adds `FREETEXT_RESOLVE_STOP_BY_UTC` (default `11:00` UTC, ~4 AM PT), an absolute **same-day** UTC wall-clock deadline checked before every batch. Deliberately does **not** roll forward to tomorrow: a run launched after the stop hour (manual catch-up, or a misfired daytime launch) sees a deadline already in the past and no-ops immediately, without any enumerate scan, LML calls, or writes. Implemented as pure, injectable-clock helpers (`computeStopByDeadlineMs`, `isPastStopBy`, `parseStopByUtc`) so the semantics are unit-testable without fake timers.
- The cooperative pause (`awaitQuietWindow`) is now deadline-aware too: a DJ active continuously at the stop hour no longer carries the run past the deadline indefinitely — the pause loop exits at the deadline, and the caller re-checks before proceeding into the next batch (a deadline-triggered pause exit doesn't guarantee activity actually cleared).
- Raises `LIVE_ACTIVITY_LOOKBACK_SECONDS`' compiled default `60s -> 300s` for this job so the pause reliably reads "active" across the flowsheet's 3-5 minute song gap instead of reading quiet between almost every track. Note: `LIVE_ACTIVITY_LOOKBACK_SECONDS` is a generic env-var name shared across jobs — this only changes the compiled default for *this job's* container, and only when the var is unset there; if prod already sets it explicitly for this job, that value needs updating too.
- Records why a run stopped (`stopReason: 'stop_by_reached' | 'backlog_drained'`) in both the run summary and a terminal log line, so a future overrun is visible without digging through container uptime.
- Idempotent by construction: a deadline-truncated run leaves later pairs' `attempt_at` untouched (`IS NULL`), so they're picked up on the next scheduled run with no lost or duplicated work; already-UPSERTed pairs are unaffected.

## Out of scope (follow-ups, intentionally not in this PR)

- The play-floor on the eligible set (issue's Suggested approach #4, mirroring BS#1591's structural fix for the sibling `flowsheet-metadata-backfill` job) is a separate fast-follow, not part of this stop-the-bleed fix.
- `BULK_RATE_PER_MIN` is intentionally left unraised (would increase per-minute LML load, the wrong direction).
- `BULK_BATCH_SIZE` is intentionally left unchanged to keep this PR focused; lowering it from 5 (which exactly fills LML's `Semaphore(5)`) is a cheap complementary lever worth a follow-up if per-batch starvation needs softening further during the window.

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass (0 errors; pre-existing warning classes only)
- [x] `npm run format:check` — pass
- [x] `npm run test:unit` — pass (350 suites / 5226 tests)
- New unit tests in `tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts`: the deadline computation helpers (same-day future deadline vs. already-past/no roll-to-tomorrow, including the daytime-manual-launch no-op case), `awaitQuietWindow`'s deadline-awareness (including a live-activity-never-clears case bounded by the deadline rather than a real sleep), `runResolve`'s startup no-op / mid-run stop / pause-bound stop paths, and the `stopReason` field.
- New isolated `tests/unit/jobs/catalog-popularity-freetext-resolve/job.stop-by-log.test.ts` (mocks the job's logger module, mirroring the existing isolation pattern in `concerts-poster-enrichment/orchestrate.capture.test.ts`) pins the `stop_by_reached` vs `backlog_drained` log line content.