### PR TITLE
fix(freetext-resolve): bound the nightly run to the overnight window (BS#1814)

### DIFF
--- a/jobs/catalog-popularity-freetext-resolve/README.md
+++ b/jobs/catalog-popularity-freetext-resolve/README.md
@@ -33,6 +33,15 @@ There is **no "retire after N"**. A pair with a release id is permanent (never r
 
 Default `45 4 * * *` UTC (00:45 ET) from `package.json` `cron-schedule`, registered via deploy-base. Chosen to sit in the overnight low-traffic window in a free minute that does not collide with the other LML-bounded crons (`artist-search-alias-consumer` 04:15, `rotation-artist-backfill` 04:30, `flowsheet-metadata-backfill` 06:00), so they don't all fan out to LML at once.
 
+### The run is bounded to the overnight window (BS#1814)
+
+Each batch is 5 free-text pairs drawn from _unlinked_ plays — the least-cached lookups in the system — so nearly every item triggers a full Discogs cascade and holds LML's `Semaphore(5)` for ~25–30 s. At the default rate (1 batch/min) an unbounded run of a large backlog takes 16+ hours of wall clock, so a run that started at 04:45 UTC would overrun deep into the daytime peak and starve LML into a congestion collapse (the 2026-07-25 incident). Two bounds keep the run inside the overnight window:
+
+- **Absolute stop-by wall-clock — `FREETEXT_RESOLVE_STOP_BY_UTC` (default `11:00` UTC, ≈4 AM PT).** Checked before each batch: once the wall clock reaches today's stop-by, the run finishes the in-flight batch and exits (`stop_reason=stop_by_reached`); it never _starts_ a batch past the deadline. The default gives the 04:45 UTC cron a ~6h15m window and stops well before the daytime peak. Because the bound is an **absolute** time-of-day computed against today's date (never rolled forward to tomorrow), it also no-ops a manually-launched or misfired **daytime** run for free — such a run is already past today's stop hour and exits with zero batches. The remaining pairs drain on the next run: UPSERTs are idempotent and the attempt-marker / no-match-TTL retry policy (below) resumes partial progress, so a mid-run stop — even a `SIGKILL` — loses nothing. The stop-by also bounds the cooperative pause: if a DJ is active near the stop hour, the pause loop yields at the deadline instead of spinning `sleep→re-probe` past it. Set the var empty to disable the bound (for a supervised manual full-drain only).
+- **Strengthened cooperative pause — `LIVE_ACTIVITY_LOOKBACK_SECONDS` (default `420`, was `60`).** WXYC broadcasts 24/7, so a live DJ can be adding tracks _during_ the overnight window. The old 60 s lookback slipped through the 3–5 min gap between songs and the job proceeded right into the streaming-check-on-add window. 420 s (7 min) is well above the song-gap range, so an active show reliably parks the job between tracks; it only resumes after ~7 min of true silence. The stop-by bounds the total, so this parking can never carry the run into the daytime.
+
+Together: the **stop-by** bounds the daytime blast radius (the incident), and the **strengthened pause** bounds the overnight residual (yielding to a live overnight show).
+
 ## Run procedure (manual, e.g. catch-up)
 
 ```bash
@@ -46,26 +55,31 @@ ssh wxyc-ec2
 docker run --rm --env-file .env <image> --dry-run
 
 # 4. Run for real. At defaults (batch=5, rate=1/min ≈ 5 pairs/min, cap 5000/run)
-#    one nightly run drains up to 5000 eligible pairs. For a catch-up backfill
-#    of the full long tail, bump FREETEXT_RESOLVE_BULK_RATE_PER_MIN and
-#    FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN=0 (disable the cap).
+#    a nightly run drains what fits in the overnight window before the
+#    FREETEXT_RESOLVE_STOP_BY_UTC=11:00 stop-by (~1875 pairs at the default
+#    rate), then exits; the rest drains on later runs. For a SUPERVISED catch-up
+#    backfill of the full long tail, bump FREETEXT_RESOLVE_BULK_RATE_PER_MIN,
+#    set FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN=0 (disable the pair cap), AND set
+#    FREETEXT_RESOLVE_STOP_BY_UTC= (empty, disable the window bound) — only while
+#    you are watching LML load, since that removes the overrun guard.
 docker run --rm --env-file .env <image> 2>&1 | tee /tmp/freetext-resolve.log
 ```
 
 ## Env knobs
 
-| Variable                             | Default            | Meaning                                                                                             |
-| ------------------------------------ | ------------------ | --------------------------------------------------------------------------------------------------- |
-| `FREETEXT_RESOLVE_BULK_BATCH_SIZE`   | `5`                | Items per LML bulk request. LML caps at 100. Raising this scales the per-batch fetch timeout.       |
-| `FREETEXT_RESOLVE_BULK_RATE_PER_MIN` | `1`                | Batches per minute. At the default batch size, 1/min ≈ 5 pairs/min sustained.                       |
-| `FREETEXT_RESOLVE_BULK_BUDGET_MS`    | `25000`            | Per-item budget forwarded to LML as `X-Caller-Budget-Ms`. NOT the batch fetch timeout.              |
-| `FREETEXT_RESOLVE_NO_MATCH_TTL_DAYS` | `30`               | A no-match pair is re-attempted once its `attempt_at` is older than this.                           |
-| `FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN` | `5000`             | Cap on distinct eligible pairs processed per run. `0` disables the cap (drain everything eligible). |
-| `FREETEXT_RESOLVE_READ_TIMEOUT_MS`   | `300000` (5min)    | `SET LOCAL statement_timeout` for the DISTINCT enumerate scan.                                      |
-| `LIVE_ACTIVITY_LOOKBACK_SECONDS`     | `60`               | Cooperative-pause lookback window; `0` disables.                                                    |
-| `LIBRARY_METADATA_URL`               | (required)         | LML base URL.                                                                                       |
-| `LML_API_KEY`                        | (required in prod) | LML bearer token.                                                                                   |
-| `DATABASE_URL`                       | (required)         | Postgres connection string.                                                                         |
+| Variable                             | Default            | Meaning                                                                                                                                                                                                     |
+| ------------------------------------ | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FREETEXT_RESOLVE_BULK_BATCH_SIZE`   | `5`                | Items per LML bulk request. LML caps at 100. Raising this scales the per-batch fetch timeout.                                                                                                               |
+| `FREETEXT_RESOLVE_BULK_RATE_PER_MIN` | `1`                | Batches per minute. At the default batch size, 1/min ≈ 5 pairs/min sustained.                                                                                                                               |
+| `FREETEXT_RESOLVE_BULK_BUDGET_MS`    | `25000`            | Per-item budget forwarded to LML as `X-Caller-Budget-Ms`. NOT the batch fetch timeout.                                                                                                                      |
+| `FREETEXT_RESOLVE_NO_MATCH_TTL_DAYS` | `30`               | A no-match pair is re-attempted once its `attempt_at` is older than this.                                                                                                                                   |
+| `FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN` | `5000`             | Cap on distinct eligible pairs processed per run. `0` disables the cap (drain everything eligible).                                                                                                         |
+| `FREETEXT_RESOLVE_STOP_BY_UTC`       | `11:00`            | Absolute stop-by wall-clock (UTC `HH` or `HH:MM`). Finishes the in-flight batch then exits once reached; never starts a batch past it. Empty disables the bound (supervised full-drain only). See Schedule. |
+| `FREETEXT_RESOLVE_READ_TIMEOUT_MS`   | `300000` (5min)    | `SET LOCAL statement_timeout` for the DISTINCT enumerate scan.                                                                                                                                              |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`     | `420`              | Cooperative-pause lookback window (7 min, well above the 3–5 min song gap so an overnight live show parks the job). `0` disables. See Schedule.                                                             |
+| `LIBRARY_METADATA_URL`               | (required)         | LML base URL.                                                                                                                                                                                               |
+| `LML_API_KEY`                        | (required in prod) | LML bearer token.                                                                                                                                                                                           |
+| `DATABASE_URL`                       | (required)         | Postgres connection string.                                                                                                                                                                                 |
 
 ## Acceptance verification
 

--- a/jobs/catalog-popularity-freetext-resolve/job.ts
+++ b/jobs/catalog-popularity-freetext-resolve/job.ts
@@ -103,12 +103,32 @@ export const READ_TIMEOUT_ENV = 'FREETEXT_RESOLVE_READ_TIMEOUT_MS';
 export const READ_TIMEOUT_DEFAULT = 5 * 60 * 1000;
 
 /** Cooperative-pause lookback window (seconds). If the most recent flowsheet
- * track was added within this many seconds, defer. `0` disables the probe. */
+ * track was added within this many seconds, defer. `0` disables the probe.
+ *
+ * Sized WELL ABOVE the 3–5 min gap between songs (BS#1814): at the old 60s a
+ * live overnight show slipped through the between-songs gap and the job
+ * proceeded right into the streaming-check-on-add window, contending with the
+ * DJ's live lookups. 420s (7 min) exceeds the upper end of the song-gap range
+ * with margin, so an active show reliably keeps the job parked between tracks;
+ * it only resumes after ~7 min of true silence (the show ended). The stop-by
+ * wall-clock (below) bounds the total so this parking can never carry the run
+ * into the daytime peak. */
 export const LIVE_ACTIVITY_LOOKBACK_ENV = 'LIVE_ACTIVITY_LOOKBACK_SECONDS';
-export const LIVE_ACTIVITY_LOOKBACK_DEFAULT = 60;
+export const LIVE_ACTIVITY_LOOKBACK_DEFAULT = 420;
 
 /** Sleep between re-probes when DJ activity is detected. */
 export const LIVE_ACTIVITY_PAUSE_MS_DEFAULT = 30_000;
+
+/** Absolute stop-by wall-clock (UTC time-of-day) past which a run must not start
+ * a new batch — the hard overnight-window bound (BS#1814). Parsed as `HH` or
+ * `HH:MM` UTC; an explicitly empty value disables the bound (for a supervised
+ * manual full-drain). Default 11:00 UTC (≈4 AM PT): the 04:45 UTC cron gets a
+ * ~6h15m window and stops well before the daytime peak that the 2026-07-25
+ * incident spanned. An ABSOLUTE wall-clock (not a relative runtime cap) also
+ * no-ops a manually-launched or misfired daytime run for free — it is already
+ * past today's stop hour. */
+export const STOP_BY_ENV = 'FREETEXT_RESOLVE_STOP_BY_UTC';
+export const STOP_BY_DEFAULT = '11:00';
 
 // -- Source query ------------------------------------------------------------
 
@@ -359,6 +379,57 @@ export const verdictFromLookup = (
   };
 };
 
+// -- Stop-by wall-clock bound (BS#1814) --------------------------------------
+
+/** A parsed stop-by wall-clock, as a UTC time-of-day. */
+export interface StopBy {
+  hours: number;
+  minutes: number;
+}
+
+/** Parse `FREETEXT_RESOLVE_STOP_BY_UTC` (`HH` or `HH:MM`, UTC) into a `StopBy`,
+ * or `null` when the bound is disabled.
+ *
+ * `undefined` (env unset) falls back to `fallback`; an explicitly empty /
+ * whitespace value disables the bound (returns `null`) — the escape hatch for a
+ * supervised manual full-drain. A malformed or out-of-range value throws, so a
+ * typo fails the run loudly instead of silently running unbounded. */
+export const parseStopByUtc = (raw: string | undefined, fallback: string): StopBy | null => {
+  const value = raw === undefined ? fallback : raw;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  const m = /^(\d{1,2})(?::(\d{2}))?$/.exec(trimmed);
+  const hours = m ? Number(m[1]) : NaN;
+  const minutes = m && m[2] !== undefined ? Number(m[2]) : 0;
+  if (!m || hours > 23 || minutes > 59) {
+    throw new Error(
+      `[${JOB_NAME}] Invalid ${STOP_BY_ENV}=${JSON.stringify(raw)}: ` +
+        `expected a UTC 'HH' or 'HH:MM' in 00:00–23:59, or empty to disable.`
+    );
+  }
+  return { hours, minutes };
+};
+
+/** Whether `now` is at or past TODAY's UTC occurrence of the stop-by wall-clock.
+ *
+ * The deadline is computed against `now`'s own UTC date and is NEVER rolled
+ * forward to tomorrow: a stop hour that has already passed today reads as past
+ * (returns `true`), which is exactly what no-ops a manually-launched or misfired
+ * daytime run. A disabled bound (`null`) is never past. */
+export const isPastStopBy = (stopBy: StopBy | null, now: Date): boolean => {
+  if (!stopBy) return false;
+  const deadline = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+    stopBy.hours,
+    stopBy.minutes,
+    0,
+    0
+  );
+  return now.getTime() >= deadline;
+};
+
 // -- Cooperative pause -------------------------------------------------------
 
 /** Probe `flowsheet` for a track row added in the last `lookbackSeconds`.
@@ -378,9 +449,21 @@ export const checkLiveActivity = async (lookbackSeconds: number): Promise<boolea
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-/** Loop: probe → if active, sleep pauseMs → re-probe. Returns when quiet. */
-export const awaitQuietWindow = async (lookbackSeconds: number, pauseMs: number): Promise<void> => {
+/** Loop: probe → if active, sleep pauseMs → re-probe. Returns when quiet.
+ *
+ * `shouldStop` bounds the pause with the stop-by wall-clock (BS#1814): a DJ
+ * active near the stop hour must not carry the run past the deadline via the
+ * sleep→re-probe spin. We treat "already past stop-by" as an immediate exit
+ * before even probing, and re-check after each detected-active probe so the loop
+ * yields the moment the deadline passes rather than sleeping through it. */
+export const awaitQuietWindow = async (
+  lookbackSeconds: number,
+  pauseMs: number,
+  shouldStop: () => boolean = () => false
+): Promise<void> => {
+  if (shouldStop()) return;
   while (await checkLiveActivity(lookbackSeconds)) {
+    if (shouldStop()) return;
     log('info', 'live_activity_pause', `live DJ activity within ${lookbackSeconds}s; deferring ${pauseMs}ms`, {
       lookback_seconds: lookbackSeconds,
       pause_ms: pauseMs,
@@ -524,16 +607,26 @@ export const runBatch = async (
 
 // -- Top-level orchestration -------------------------------------------------
 
+/** Why the resolve loop stopped. `backlog_drained` = ran out of eligible pairs
+ * (or the max-pairs slice) within the window; `stop_by_reached` = hit the
+ * absolute stop-by wall-clock and exited after the in-flight batch (BS#1814).
+ * Logged so future overruns are visible. */
+export type StopReason = 'backlog_drained' | 'stop_by_reached';
+
 export interface ResolveSummary {
   scanned: number;
   eligible: number;
+  /** Pairs actually processed this run (batches that ran). On a stop-by-
+   * truncated run this is less than `eligible` — the remainder drains next run. */
   processed: number;
+  /** Batches that actually ran (not the planned chunk count). */
   batches: number;
   match: number;
   no_match: number;
   error: number;
   upserts: number;
   unexpected_index: number;
+  stop_reason: StopReason;
 }
 
 export interface ResolveOptions {
@@ -546,6 +639,11 @@ export interface ResolveOptions {
   liveActivityLookbackSeconds: number;
   liveActivityPauseMs: number;
   dryRun: boolean;
+  /** Absolute stop-by wall-clock (UTC), or `null` when the bound is disabled.
+   * Optional so existing callers/tests default to an unbounded run. */
+  stopByUtc?: StopBy | null;
+  /** Injectable clock (test seam); defaults to the real wall clock. */
+  now?: () => Date;
 }
 
 export const resolveOptions = (env: NodeJS.ProcessEnv = process.env, args: string[] = process.argv): ResolveOptions => {
@@ -574,6 +672,8 @@ export const resolveOptions = (env: NodeJS.ProcessEnv = process.env, args: strin
       ctx
     ),
     liveActivityPauseMs: LIVE_ACTIVITY_PAUSE_MS_DEFAULT,
+    stopByUtc: parseStopByUtc(env[STOP_BY_ENV], STOP_BY_DEFAULT),
+    now: () => new Date(),
     dryRun: args.includes('--dry-run'),
   };
 };
@@ -585,12 +685,19 @@ const chunk = <T>(arr: T[], size: number): T[][] => {
 };
 
 export const runResolve = async (options: ResolveOptions): Promise<ResolveSummary> => {
+  const now = options.now ?? (() => new Date());
+  const stopBy = options.stopByUtc ?? null;
+  /** True once the wall clock is at/past today's stop-by (BS#1814). */
+  const shouldStop = (): boolean => isPastStopBy(stopBy, now());
+
   log('info', 'started', `${JOB_NAME} starting`, {
     batch_size: options.batchSize,
     rate_per_min: options.ratePerMin,
     budget_ms: options.budgetMs,
     no_match_ttl_days: options.noMatchTtlDays,
     max_pairs_per_run: options.maxPairsPerRun,
+    stop_by_utc: stopBy ? `${String(stopBy.hours).padStart(2, '0')}:${String(stopBy.minutes).padStart(2, '0')}` : null,
+    live_activity_lookback_seconds: options.liveActivityLookbackSeconds,
     dry_run: options.dryRun,
   });
 
@@ -633,6 +740,7 @@ export const runResolve = async (options: ResolveOptions): Promise<ResolveSummar
       error: 0,
       upserts: 0,
       unexpected_index: 0,
+      stop_reason: 'backlog_drained',
     };
   }
 
@@ -644,14 +752,34 @@ export const runResolve = async (options: ResolveOptions): Promise<ResolveSummar
   let totalError = 0;
   let totalUpserts = 0;
   let totalUnexpectedIndex = 0;
+  let batchesRun = 0;
+  let processedPairs = 0;
+  let stopReason: StopReason = 'backlog_drained';
 
   for (let i = 0; i < batches.length; i += 1) {
-    await awaitQuietWindow(options.liveActivityLookbackSeconds, options.liveActivityPauseMs);
+    // Stop-by check BEFORE the batch (and before the pause): never START a new
+    // batch past the deadline (BS#1814). A misfired daytime run trips here on
+    // the first iteration and no-ops with zero batches.
+    if (shouldStop()) {
+      stopReason = 'stop_by_reached';
+      break;
+    }
+
+    await awaitQuietWindow(options.liveActivityLookbackSeconds, options.liveActivityPauseMs, shouldStop);
+
+    // The cooperative pause may have carried us to/past the stop-by; re-check so
+    // a DJ active near the stop hour doesn't push a new batch past the deadline.
+    if (shouldStop()) {
+      stopReason = 'stop_by_reached';
+      break;
+    }
 
     const t0 = Date.now();
     const result = await runBatch(batches[i], { budgetMs: options.budgetMs, dryRun: false });
     const wallClockMs = Date.now() - t0;
 
+    batchesRun += 1;
+    processedPairs += batches[i].length;
     totalMatch += result.match;
     totalNoMatch += result.no_match;
     totalError += result.error;
@@ -675,16 +803,27 @@ export const runResolve = async (options: ResolveOptions): Promise<ResolveSummar
     }
   }
 
+  // Log the stop reason distinctly so a future overrun (or a run that keeps
+  // hitting the stop-by with a large backlog) is visible in the logs.
+  log('info', 'loop_complete', `resolve loop stopped: ${stopReason}`, {
+    stop_reason: stopReason,
+    batches_run: batchesRun,
+    batches_planned: batches.length,
+    processed: processedPairs,
+    eligible: eligibleTotal,
+  });
+
   return {
     scanned: raw.length,
     eligible: eligibleTotal,
-    processed: eligible.length,
-    batches: batches.length,
+    processed: processedPairs,
+    batches: batchesRun,
     match: totalMatch,
     no_match: totalNoMatch,
     error: totalError,
     upserts: totalUpserts,
     unexpected_index: totalUnexpectedIndex,
+    stop_reason: stopReason,
   };
 };
 

--- a/tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts
+++ b/tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts
@@ -64,8 +64,13 @@ import {
   READ_TIMEOUT_DEFAULT,
   LIVE_ACTIVITY_LOOKBACK_DEFAULT,
   LIVE_ACTIVITY_LOOKBACK_ENV,
+  STOP_BY_ENV,
+  STOP_BY_DEFAULT,
+  parseStopByUtc,
+  isPastStopBy,
   type NormalizedPair,
   type ResolveOptions,
+  type StopBy,
 } from '../../../../jobs/catalog-popularity-freetext-resolve/job';
 
 type SqlLike = {
@@ -111,6 +116,7 @@ const RESET_ENV_KEYS = [
   NO_MATCH_TTL_DAYS_ENV,
   MAX_PAIRS_PER_RUN_ENV,
   LIVE_ACTIVITY_LOOKBACK_ENV,
+  STOP_BY_ENV,
 ];
 const stripEnv = (env: NodeJS.ProcessEnv): NodeJS.ProcessEnv => {
   const out = { ...env };
@@ -526,6 +532,33 @@ describe('checkLiveActivity / awaitQuietWindow', () => {
     await awaitQuietWindow(60, 1);
     expect(probe).toHaveBeenCalledTimes(2);
   });
+
+  // BS#1814: the stop-by must bound the pause so an active DJ near the stop hour
+  // cannot carry the run past the deadline via the sleep→re-probe spin.
+  it('awaitQuietWindow returns immediately without probing when shouldStop() is already true', async () => {
+    await awaitQuietWindow(420, 1_000_000, () => true);
+    expect(db.execute as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('awaitQuietWindow stops re-probing once shouldStop() flips true, even while a DJ stays active', async () => {
+    const probe = db.execute as jest.Mock;
+    let stop = false;
+    // The probe reports a DJ active forever AND flips the stop predicate; without
+    // the stop-by bound this would spin indefinitely.
+    probe.mockImplementation(() => {
+      stop = true;
+      return Promise.resolve([{}]);
+    });
+    await awaitQuietWindow(420, 1, () => stop);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  // BS#1814: the pause lookback is strengthened from 60s (which slipped through
+  // the 3–5 min song gap) to 420s (7 min) — well above the gap, so an overnight
+  // live show reliably parks the job between songs.
+  it('the strengthened live-activity lookback default is well above the 3–5 min song gap', () => {
+    expect(LIVE_ACTIVITY_LOOKBACK_DEFAULT).toBe(420);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -651,17 +684,30 @@ describe('resolveOptions', () => {
     expect(opts.dryRun).toBe(false);
   });
 
+  it('defaults the stop-by to the overnight bound (11:00 UTC)', () => {
+    const opts = resolveOptions(stripEnv(process.env), []);
+    expect(STOP_BY_DEFAULT).toBe('11:00');
+    expect(opts.stopByUtc).toEqual({ hours: 11, minutes: 0 });
+  });
+
   it('honors env overrides', () => {
     const env = {
       ...stripEnv(process.env),
       [BULK_BATCH_SIZE_ENV]: '10',
       [NO_MATCH_TTL_DAYS_ENV]: '7',
       [MAX_PAIRS_PER_RUN_ENV]: '0',
+      [STOP_BY_ENV]: '10:30',
     };
     const opts = resolveOptions(env, []);
     expect(opts.batchSize).toBe(10);
     expect(opts.noMatchTtlDays).toBe(7);
     expect(opts.maxPairsPerRun).toBe(0); // 0 allowed (non-negative) → disables cap
+    expect(opts.stopByUtc).toEqual({ hours: 10, minutes: 30 });
+  });
+
+  it('disables the stop-by when FREETEXT_RESOLVE_STOP_BY_UTC is set empty', () => {
+    const opts = resolveOptions({ ...stripEnv(process.env), [STOP_BY_ENV]: '' }, []);
+    expect(opts.stopByUtc).toBeNull();
   });
 
   it('throws on invalid batch size', () => {
@@ -786,5 +832,197 @@ describe('runResolve', () => {
     expect(summary.processed).toBe(2);
     expect(summary.batches).toBe(2);
     expect(mockBulkLookupMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Stop-by wall-clock bound (BS#1814). The nightly cron must not run past an
+  // absolute overnight stop hour and starve LML during the daytime peak.
+  // -------------------------------------------------------------------------
+
+  /** A fixed UTC instant on the incident date, for a deterministic clock. */
+  const utc = (h: number, m = 0): Date => new Date(Date.UTC(2026, 6, 25, h, m, 0, 0));
+
+  it('drains the full eligible set and reports backlog_drained when the stop-by is not reached', async () => {
+    const mock = db.execute as jest.Mock;
+    for (const v of enumerateResult([
+      { artist_name: 'Stereolab', album_title: 'Dots and Loops' },
+      { artist_name: 'Juana Molina', album_title: 'Halo' },
+    ])) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mock.mockResolvedValueOnce([]); // loadSkipKeys empty
+
+    mockBulkLookupMetadata.mockResolvedValue({
+      results: [{ index: 0, status: 'no_match', lookup: { results: [] } }],
+    });
+
+    // 06:00 UTC is well inside the overnight window (before the 11:00 stop-by).
+    const summary = await runResolve(
+      baseOptions({ batchSize: 1, stopByUtc: { hours: 11, minutes: 0 }, now: () => utc(6) })
+    );
+
+    expect(mockBulkLookupMetadata).toHaveBeenCalledTimes(2);
+    expect(summary.stop_reason).toBe('backlog_drained');
+    expect(summary.processed).toBe(2);
+  });
+
+  it('no-ops a misfired daytime run: already past the stop-by → zero batches, stop_by_reached', async () => {
+    const mock = db.execute as jest.Mock;
+    for (const v of enumerateResult([{ artist_name: 'Stereolab', album_title: 'Dots and Loops' }])) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mock.mockResolvedValueOnce([]); // loadSkipKeys empty
+
+    // 14:00 UTC — a manual/misfired daytime run. Today's 11:00 stop-by has
+    // already passed, so the loop must no-op immediately (the absolute wall-clock
+    // must NOT roll forward to tomorrow's 11:00).
+    const summary = await runResolve(
+      baseOptions({ batchSize: 1, stopByUtc: { hours: 11, minutes: 0 }, now: () => utc(14) })
+    );
+
+    expect(mockBulkLookupMetadata).not.toHaveBeenCalled();
+    expect(db.insert as jest.Mock).not.toHaveBeenCalled();
+    expect(summary.stop_reason).toBe('stop_by_reached');
+    expect(summary.processed).toBe(0);
+  });
+
+  it('finishes the in-flight batch then stops when the stop-by passes mid-run (no new batch after deadline)', async () => {
+    const mock = db.execute as jest.Mock;
+    for (const v of enumerateResult([
+      { artist_name: 'Stereolab', album_title: 'Dots and Loops' },
+      { artist_name: 'Jessica Pratt', album_title: 'On Your Own Love Again' },
+    ])) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mock.mockResolvedValueOnce([]); // loadSkipKeys empty
+
+    // Start 30s before the stop-by; running the first batch advances the wall
+    // clock past 11:00, so the second iteration's pre-batch check must break.
+    let clockMs = utc(10, 59).getTime();
+    const now = (): Date => new Date(clockMs);
+    mockBulkLookupMetadata.mockImplementation(() => {
+      clockMs = utc(11, 1).getTime(); // now past the stop-by
+      return Promise.resolve({ results: [{ index: 0, status: 'no_match', lookup: { results: [] } }] });
+    });
+
+    const summary = await runResolve(baseOptions({ batchSize: 1, stopByUtc: { hours: 11, minutes: 0 }, now }));
+
+    // Batch 1 ran to completion; batch 2 was never started (deadline hit at the
+    // top of iteration 2). The unprocessed pair stays unwritten → attempt_at IS
+    // NULL → resumable next run with no lost or duplicated work.
+    expect(mockBulkLookupMetadata).toHaveBeenCalledTimes(1);
+    expect((db.insert as jest.Mock).mock.calls.length).toBe(1); // only batch 1's no-match UPSERT
+    expect(summary.stop_reason).toBe('stop_by_reached');
+    expect(summary.processed).toBe(1);
+  });
+
+  it('bounds the cooperative pause: a DJ active at the stop hour still exits (does not spin past it)', async () => {
+    const mock = db.execute as jest.Mock;
+    // enumerate (SET LOCAL + SELECT) + loadSkipKeys, then the live-activity probe.
+    mock
+      .mockResolvedValueOnce({}) // SET LOCAL
+      .mockResolvedValueOnce([{ artist_name: 'Stereolab', album_title: 'Dots and Loops' }])
+      .mockResolvedValueOnce([]); // loadSkipKeys empty
+
+    // Start 30s before the stop-by. The live-activity probe reports a DJ AND
+    // advances the wall clock past 11:00, so the pause loop must exit on the
+    // deadline instead of spinning sleep→re-probe into the daytime peak.
+    let clockMs = new Date(Date.UTC(2026, 6, 25, 10, 59, 30)).getTime();
+    const now = (): Date => new Date(clockMs);
+    mock.mockImplementation(() => {
+      clockMs = new Date(Date.UTC(2026, 6, 25, 11, 0, 30)).getTime(); // now past 11:00
+      return Promise.resolve([{}]); // DJ active
+    });
+
+    const summary = await runResolve(
+      baseOptions({
+        batchSize: 1,
+        liveActivityLookbackSeconds: 420,
+        liveActivityPauseMs: 1,
+        stopByUtc: { hours: 11, minutes: 0 },
+        now,
+      })
+    );
+
+    expect(mockBulkLookupMetadata).not.toHaveBeenCalled();
+    expect(summary.stop_reason).toBe('stop_by_reached');
+    expect(summary.processed).toBe(0);
+  });
+
+  it('disabled stop-by (null) drains the backlog regardless of wall-clock', async () => {
+    const mock = db.execute as jest.Mock;
+    for (const v of enumerateResult([{ artist_name: 'Stereolab', album_title: 'Dots and Loops' }])) {
+      mock.mockResolvedValueOnce(v);
+    }
+    mock.mockResolvedValueOnce([]); // loadSkipKeys empty
+
+    mockBulkLookupMetadata.mockResolvedValue({
+      results: [{ index: 0, status: 'no_match', lookup: { results: [] } }],
+    });
+
+    // Middle of the day, but the stop-by is explicitly disabled (supervised
+    // manual full-drain per the README) — the run proceeds.
+    const summary = await runResolve(baseOptions({ batchSize: 1, stopByUtc: null, now: () => utc(14) }));
+
+    expect(mockBulkLookupMetadata).toHaveBeenCalledTimes(1);
+    expect(summary.stop_reason).toBe('backlog_drained');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stop-by parsing + predicate (BS#1814).
+// ---------------------------------------------------------------------------
+
+describe('parseStopByUtc', () => {
+  it('parses a bare UTC hour', () => {
+    expect(parseStopByUtc('11', '00:00')).toEqual({ hours: 11, minutes: 0 });
+  });
+
+  it('parses HH:MM', () => {
+    expect(parseStopByUtc('11:30', '00:00')).toEqual({ hours: 11, minutes: 30 });
+  });
+
+  it('falls back to the default when the raw value is undefined (env unset)', () => {
+    expect(parseStopByUtc(undefined, '11:00')).toEqual({ hours: 11, minutes: 0 });
+  });
+
+  it('disables the bound (null) on an explicit empty / whitespace value', () => {
+    expect(parseStopByUtc('', '11:00')).toBeNull();
+    expect(parseStopByUtc('   ', '11:00')).toBeNull();
+  });
+
+  it('throws on a malformed value', () => {
+    expect(() => parseStopByUtc('garbage', '11:00')).toThrow(/FREETEXT_RESOLVE_STOP_BY_UTC/);
+  });
+
+  it('throws on an out-of-range hour or minute', () => {
+    expect(() => parseStopByUtc('25:00', '11:00')).toThrow();
+    expect(() => parseStopByUtc('11:60', '11:00')).toThrow();
+  });
+});
+
+describe('isPastStopBy', () => {
+  const on = (h: number, m = 0): Date => new Date(Date.UTC(2026, 6, 25, h, m, 0, 0));
+  const eleven: StopBy = { hours: 11, minutes: 0 };
+
+  it('is never past when the bound is disabled (null)', () => {
+    expect(isPastStopBy(null, on(23))).toBe(false);
+  });
+
+  it('is false before the stop-by', () => {
+    expect(isPastStopBy(eleven, on(10, 59))).toBe(false);
+    expect(isPastStopBy(eleven, on(4, 45))).toBe(false); // the nightly cron start
+  });
+
+  it('is true at and after the stop-by', () => {
+    expect(isPastStopBy(eleven, on(11, 0))).toBe(true);
+    expect(isPastStopBy(eleven, on(11, 1))).toBe(true);
+  });
+
+  it('does NOT roll forward to tomorrow: a stop hour already passed today reads as past', () => {
+    // The critical semantic: a 14:00 run with an 11:00 stop-by must be "past",
+    // not "not-yet (tomorrow 11:00)". Rollover would defeat the daytime no-op.
+    expect(isPastStopBy(eleven, on(14))).toBe(true);
+    expect(isPastStopBy(eleven, on(23, 59))).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

The `jobs/catalog-popularity-freetext-resolve` nightly cron cannot finish inside the overnight low-traffic window, so it overruns into daytime live traffic and starves LML into a congestion collapse.

The arithmetic guarantees the overrun. At the defaults (`FREETEXT_RESOLVE_MAX_PAIRS_PER_RUN=5000`, `FREETEXT_RESOLVE_BULK_BATCH_SIZE=5`, `FREETEXT_RESOLVE_BULK_RATE_PER_MIN=1`), an unbounded run of a large backlog is 5000 ÷ 5 = 1000 batches at ~1/min — 16+ hours of wall clock — so a run that starts at 04:45 UTC cannot finish before mid-afternoon PT. Each batch draws 5 free-text `(artist, album)` pairs from *unlinked* plays (`flowsheet.album_id IS NULL`), the least-cached lookups in the system, and holds LML's Discogs `Semaphore(5)` for ~25-30 s against a single uvicorn worker. Under daytime load this tips into a self-sustaining collapse.

On 2026-07-25 this caused a live incident: LML went to 503, request-o-matic posted "Search unavailable" to Slack, and it was resolved only by manually stopping the cron container.

## Fix (caller-side only; does not depend on any LML change)

**1. Absolute stop-by wall-clock — `FREETEXT_RESOLVE_STOP_BY_UTC` (default `11:00` UTC, ~4 AM PT).** Checked before each batch. Once today's stop-by is reached, the run finishes the in-flight batch and exits; it never *starts* a batch past the deadline. The default gives the 04:45 UTC cron a ~6h15m window and stops well before the daytime peak.

- An **absolute** time-of-day (computed against today's date, *never* rolled forward to tomorrow) also no-ops a manually-launched or misfired **daytime** run for free — it is already past today's stop hour — which a relative runtime cap would not.
- The stop-by also **bounds the cooperative pause**, so a DJ active near the stop hour cannot carry the run past the deadline via the `sleep → re-probe` spin.
- Remaining pairs drain on the next run: the idempotent UPSERTs plus the attempt-marker / no-match-TTL retry policy resume partial progress, so a mid-run stop (even `SIGKILL`) loses nothing.
- Set the var empty to disable the bound (supervised manual full-drain only).

**2. Strengthened cooperative pause — `LIVE_ACTIVITY_LOOKBACK_SECONDS` default 60 → 420 s.** WXYC broadcasts 24/7, so a live overnight show can be adding tracks *during* the window. The old 60 s lookback slipped through the 3-5 min gap between songs and the job proceeded right into the streaming-check-on-add window. 420 s (7 min) sits well above the song-gap range, so an active show reliably parks the job between tracks.

The **deadline** bounds the daytime blast radius (the incident); the **stronger pause** bounds the overnight residual (yielding to a live overnight show). `BULK_RATE_PER_MIN` is unchanged and the existing pause safety is preserved (strengthened, not weakened).

**3. Stop-reason logging.** A distinct `loop_complete` log records `stop_by_reached` vs `backlog_drained` so future overruns are visible.

## New env var

| Variable | Default | Meaning |
|---|---|---|
| `FREETEXT_RESOLVE_STOP_BY_UTC` | `11:00` | Absolute stop-by wall-clock (UTC `HH` or `HH:MM`). Finishes the in-flight batch then exits once reached; never starts a batch past it. Empty disables the bound. |
| `LIVE_ACTIVITY_LOOKBACK_SECONDS` | `420` (was `60`) | Cooperative-pause lookback; strengthened well above the 3-5 min song gap. |

Default reasoning: 11:00 UTC ≈ 4 AM PT — still pre-dawn, before the morning live ramp and well before the daytime peak the incident spanned. At the current rate that drains ~1875 pairs/night while staying bounded; the rest drains across later nightly runs. Not defaulted to unbounded.

## Tests (TDD, red → green)

New unit tests in `tests/unit/jobs/catalog-popularity-freetext-resolve/job.test.ts` (47 → 67):

- `parseStopByUtc` — `HH` / `HH:MM` parsing, default fallback, empty→disabled, throw on malformed/out-of-range.
- `isPastStopBy` — before/at/after; disabled (null) never past; **no roll-forward** (a stop hour already passed today reads as past).
- `awaitQuietWindow` stop-bounding — exits immediately when already past; stops re-probing once the deadline flips true even with a DJ active.
- `runResolve` — drains fully within the window (`backlog_drained`); no-ops a misfired daytime run (zero batches, `stop_by_reached`); finishes the in-flight batch then stops mid-run without starting a new one (resumable, no lost/duplicated work); bounds the pause with a DJ active at the stop hour; disabled bound drains regardless of clock.
- `resolveOptions` stop-by default (`11:00`) / override / disable; strengthened lookback default (`420`) pinned.

Local checks green: `npm run typecheck`, `npm run lint` (0 errors), `npm run format:check`, `npm run build`, and the full unit suite (5229 passing).

Fast-follow (separate ticket, out of scope here): a play-floor on the eligible set per the ticket's Suggested-approach #4.

Closes #1814