### PR TITLE
feat(#1823): add BACKFILL_WINDOW_START_TS for scoped regression-window re-enrichment

### DIFF
--- a/jobs/flowsheet-reenrichment/README.md
+++ b/jobs/flowsheet-reenrichment/README.md
@@ -2,6 +2,8 @@
 
 One-shot re-enrichment drain for BS#1433. Rescues ~11,965 `flowsheet` rows written as `enriched_no_match` before LML#583 (merged 2026-06-16T17:53:53Z) closed the library-miss recall gap.
 
+BS#1823 adapted the same drain for a second run shape: re-enriching a recent, bounded slice of a _later_ regression backlog (see "Regression-window run" below), by adding an optional lower bound alongside the original cutoff.
+
 ## Problem
 
 Before LML#583, `(artist, album)` pairs not in the WXYC library returned `results: []` from LML, causing `metadata_status='enriched_no_match'` to be written. Those rows are terminal in the new enum — the CDC consumer never revisits them. With LML#583 live, the same pairs now return Discogs metadata; this job performs a single sweep to recover them.
@@ -78,6 +80,31 @@ docker run --rm --name flowsheet-reenrichment --env-file .env \
 
 > **Note on env-var read timing**: `lml-fetch.ts` reads `BACKFILL_LML_PER_CALL_TIMEOUT_MS` and `lml-limiter.ts` reads `BACKFILL_LML_MAX_CONCURRENT` / `BACKFILL_LML_RATE_PER_MIN` at module-load time. The `--env-file .env` pattern above passes env vars to the container's PID 1 (Node) so they're visible before any module loads. Do NOT export env vars from inside the container after start — they'll be silently ignored.
 
+### Regression-window run (BS#1823)
+
+The same drain also re-enriches a recent, bounded slice of a _later_ regression backlog — e.g. `enriched_no_match` / `album_id`-NULL flowsheet rows written while non-library resolution was briefly broken (the B3 regression, #1815 + LML#920). Set `BACKFILL_WINDOW_START_TS` (optionally alongside `BACKFILL_CUTOFF_TS`) instead of relying on the original pre-LML#583 cutoff alone:
+
+```bash
+docker run --rm --name flowsheet-reenrichment --env-file .env \
+  -e BACKFILL_WINDOW_START_TS='2026-07-22T00:00:00Z' \
+  <ECR-URI>/flowsheet-reenrichment:<tag> 2>&1 \
+  | tee /tmp/flowsheet-reenrichment-window-$(date +%Y%m%d-%H%M%S).log
+```
+
+At least one of `BACKFILL_CUTOFF_TS` / `BACKFILL_WINDOW_START_TS` is required; the job fails fast (before scanning any rows) if neither is set. Window-start-only applies no upper bound (through "now", in effect) — the cohort is `add_time >= BACKFILL_WINDOW_START_TS`. Setting both narrows to their intersection. Each bound is validated independently as strict ISO 8601 (same rules as the original cutoff — see "Environment variables" below); a malformed value fails the same way a malformed cutoff always has.
+
+No new LML flag is needed for either run shape: this job already calls LML via single `lookupMetadata` (`/lookup`), which defaults `allow_release_resolution_fallback=True` and therefore resolves non-library albums on its own — unlike `/lookup/bulk`, which the B3 regression traced to (WXYC/Backend-Service#1815).
+
+**No dry-run mode.** Unlike some sibling jobs (e.g. `rotation-release-id-backfill`, `library-identity-consumer`), this job does not implement `DRY_RUN` — setting it has no effect, and a run performs live UPDATEs immediately. To gauge scope before committing to a run, preview the candidate count for your window first:
+
+```sql
+SELECT COUNT(*) FROM wxyc_schema.flowsheet
+WHERE metadata_status = 'enriched_no_match'
+  AND album_id IS NULL
+  AND artist_name IS NOT NULL
+  AND add_time >= '2026-07-22T00:00:00Z'::timestamptz;
+```
+
 ## Pacing & wall-clock estimate
 
 - Sem(1) + TB(20/min): ~12k rows ÷ 20/min ≈ ~10 hours raw rate
@@ -152,14 +179,15 @@ Monitor real-time LML p95 via Sentry trace explorer; stay within +20% of baselin
 
 ## Environment variables
 
-| Variable                           | Default    | Notes                                                                                              |
-| ---------------------------------- | ---------- | -------------------------------------------------------------------------------------------------- |
-| `BACKFILL_CUTOFF_TS`               | (required) | LML#583 merge timestamp: `2026-06-16T17:53:53Z`. Validated as ISO 8601 + not-in-future at startup. |
-| `LIBRARY_METADATA_URL`             | (required) | LML endpoint                                                                                       |
-| `BACKFILL_BATCH_SIZE`              | 100        | Rows per SELECT                                                                                    |
-| `BACKFILL_LML_MAX_CONCURRENT`      | 1          | Semaphore permit count (positive integer)                                                          |
-| `BACKFILL_LML_RATE_PER_MIN`        | 20         | Token bucket rate (positive integer)                                                               |
-| `BACKFILL_LML_PER_CALL_TIMEOUT_MS` | 35000      | Per-LML-call timeout (ms)                                                                          |
-| `LIVE_ACTIVITY_LOOKBACK_SECONDS`   | 60         | Set 0 to disable cooperative pause                                                                 |
-| `LIVE_ACTIVITY_PAUSE_MS`           | 30000      | Pause duration when DJ activity detected (ms)                                                      |
-| `SENTRY_DSN`                       | (optional) | Sentry error reporting                                                                             |
+| Variable                           | Default                                             | Notes                                                                                                                                                                                                                                                                                                             |
+| ---------------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BACKFILL_CUTOFF_TS`               | (required unless `BACKFILL_WINDOW_START_TS` is set) | LML#583 merge timestamp: `2026-06-16T17:53:53Z`. Validated as ISO 8601 + not-in-future at startup. Upper bound (`add_time < cutoff`).                                                                                                                                                                             |
+| `BACKFILL_WINDOW_START_TS`         | (optional)                                          | Lower bound (`add_time >= start`) for a scoped regression-window run (BS#1823), e.g. `2026-07-22T00:00:00Z`. Validated as strict ISO 8601 at startup — same rules as `BACKFILL_CUTOFF_TS` except a future value is allowed (it simply selects nothing until reached). At least one of the two bounds is required. |
+| `LIBRARY_METADATA_URL`             | (required)                                          | LML endpoint                                                                                                                                                                                                                                                                                                      |
+| `BACKFILL_BATCH_SIZE`              | 100                                                 | Rows per SELECT                                                                                                                                                                                                                                                                                                   |
+| `BACKFILL_LML_MAX_CONCURRENT`      | 1                                                   | Semaphore permit count (positive integer)                                                                                                                                                                                                                                                                         |
+| `BACKFILL_LML_RATE_PER_MIN`        | 20                                                  | Token bucket rate (positive integer)                                                                                                                                                                                                                                                                              |
+| `BACKFILL_LML_PER_CALL_TIMEOUT_MS` | 35000                                               | Per-LML-call timeout (ms)                                                                                                                                                                                                                                                                                         |
+| `LIVE_ACTIVITY_LOOKBACK_SECONDS`   | 60                                                  | Set 0 to disable cooperative pause                                                                                                                                                                                                                                                                                |
+| `LIVE_ACTIVITY_PAUSE_MS`           | 30000                                               | Pause duration when DJ activity detected (ms)                                                                                                                                                                                                                                                                     |
+| `SENTRY_DSN`                       | (optional)                                          | Sentry error reporting                                                                                                                                                                                                                                                                                            |

--- a/jobs/flowsheet-reenrichment/job.ts
+++ b/jobs/flowsheet-reenrichment/job.ts
@@ -5,6 +5,13 @@
  * LML#583 (merged 2026-06-16T17:53:53Z) closed the library-miss recall
  * gap. Set BACKFILL_CUTOFF_TS to the LML#583 merge timestamp.
  *
+ * BS#1823 additionally supports BACKFILL_WINDOW_START_TS — an optional
+ * lower bound so the same drain can re-enrich a recent, bounded slice of a
+ * later regression backlog instead of only the original pre-LML#583
+ * cohort. At least one of BACKFILL_CUTOFF_TS / BACKFILL_WINDOW_START_TS is
+ * required; see jobs/flowsheet-reenrichment/README.md for the
+ * regression-window run example.
+ *
  * Run via deploy-manual.yml (target=flowsheet-reenrichment, version=latest),
  * then SSH to EC2 and:
  *
@@ -47,9 +54,16 @@ const requireLmlConfigured = (): void => {
   }
 };
 
-const requireCutoffConfigured = (): void => {
-  if (!process.env.BACKFILL_CUTOFF_TS) {
-    throw new Error('BACKFILL_CUTOFF_TS is not configured; set to the LML#583 merge timestamp (2026-06-16T17:53:53Z).');
+// BS#1823: the drain now accepts either boundary env var (or both). This is
+// an existence-only pre-flight guard — format/calendar/future-timestamp
+// validation for whichever is set stays solely in orchestrate.ts's
+// resolveTimeWindow (via resolveCutoffTs / resolveWindowStartTs), so the
+// strictness can't drift between the two layers.
+const requireTimeWindowConfigured = (): void => {
+  if (!process.env.BACKFILL_CUTOFF_TS && !process.env.BACKFILL_WINDOW_START_TS) {
+    throw new Error(
+      'At least one of BACKFILL_CUTOFF_TS or BACKFILL_WINDOW_START_TS is required; neither is configured.'
+    );
   }
 };
 
@@ -71,8 +85,11 @@ const main = async () => {
   registerSignalHandlers();
   try {
     requireLmlConfigured();
-    requireCutoffConfigured();
-    log('info', 'init', `${JOB_NAME} initialized`, { cutoff_ts: process.env.BACKFILL_CUTOFF_TS });
+    requireTimeWindowConfigured();
+    log('info', 'init', `${JOB_NAME} initialized`, {
+      cutoff_ts: process.env.BACKFILL_CUTOFF_TS ?? null,
+      window_start_ts: process.env.BACKFILL_WINDOW_START_TS ?? null,
+    });
     const result = await runReenrichment({
       lookup: lookupMetadata,
       enrich: reenrichRow,

--- a/jobs/flowsheet-reenrichment/orchestrate.ts
+++ b/jobs/flowsheet-reenrichment/orchestrate.ts
@@ -5,7 +5,15 @@
  *   metadata_status = 'enriched_no_match'
  *   AND album_id IS NULL
  *   AND artist_name IS NOT NULL
- *   AND add_time < $BACKFILL_CUTOFF_TS
+ *   AND add_time < $BACKFILL_CUTOFF_TS       (optional upper bound)
+ *   AND add_time >= $BACKFILL_WINDOW_START_TS (optional lower bound, BS#1823)
+ *
+ * BS#1823 added the optional BACKFILL_WINDOW_START_TS lower bound so the
+ * same drain can re-enrich a recent, bounded slice of the backlog (e.g. the
+ * B3 regression window, LML#920) instead of only the original pre-LML#583
+ * cohort. At least one of the two bounds is required — see
+ * `resolveTimeWindow`. Cutoff-only preserves the original behavior exactly;
+ * window-start-only applies no upper bound (through "now", in effect).
  *
  * Per-row (not bulk): the cohort is cascade-bound on cold Discogs lookups
  * (the library-miss-by-definition path LML#583 introduces). Per-row gating
@@ -78,6 +86,48 @@ export const resolveBatchSize = (raw: string | undefined = process.env.BACKFILL_
   requirePositiveInt(raw, 'BACKFILL_BATCH_SIZE', BATCH_SIZE);
 
 /**
+ * Shared strict ISO 8601 + calendar validator for the drain's two boundary
+ * env vars (BACKFILL_CUTOFF_TS, BACKFILL_WINDOW_START_TS — BS#1823).
+ * Extracted from resolveCutoffTs's original inline checks so
+ * BACKFILL_WINDOW_START_TS can't drift from BACKFILL_CUTOFF_TS's exact
+ * strictness. Throws using `envName` in the message so each caller's
+ * errors stay field-specific despite sharing one validation path.
+ *
+ * Catches Date.parse-passes-but-PG-rejects inputs like '2026-6-16',
+ * '2026/06/16', '2026', '6/16/2026'. Also enforces calendar-field bounds
+ * (irrespective of TZ) so normalized out-of-range days (e.g. '2026-02-30'
+ * → '2026-03-02') are rejected even though Date.parse accepts them.
+ *
+ * Returns the Date.parse'd epoch ms so a caller needing a future-timestamp
+ * check (only resolveCutoffTs does — see BS#1823's decision that a future
+ * window-start is valid, not an error) doesn't need to re-parse.
+ */
+const validateStrictIso8601 = (raw: string, envName: string): number => {
+  if (!ISO_8601_RE.test(raw)) {
+    throw new Error(
+      `${envName}=${JSON.stringify(raw)} is not strict ISO 8601 (e.g. 2026-06-16T17:53:53Z or 2026-06-16T10:53:53-07:00).`
+    );
+  }
+  const year = Number(raw.slice(0, 4));
+  const month = Number(raw.slice(5, 7));
+  const day = Number(raw.slice(8, 10));
+  const hour = Number(raw.slice(11, 13));
+  const minute = Number(raw.slice(14, 16));
+  const second = Number(raw.slice(17, 19));
+  // Calendar bounds — month, hour, minute, second. Days-in-month uses Date
+  // (day 0 of next month is the last day of this month).
+  const lastDayOfMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  if (month < 1 || month > 12 || day < 1 || day > lastDayOfMonth || hour > 23 || minute > 59 || second > 59) {
+    throw new Error(`${envName}=${JSON.stringify(raw)} has an out-of-range field (calendar / 24h validation failed).`);
+  }
+  const parsed = Date.parse(raw);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`${envName}=${JSON.stringify(raw)} is not a parseable timestamp.`);
+  }
+  return parsed;
+};
+
+/**
  * Throws when BACKFILL_CUTOFF_TS is missing, syntactically invalid (not
  * strict ISO 8601), has an out-of-range calendar day/hour/etc, or is in
  * the future. Fail-fast so the operator sees a clear message rather than
@@ -91,35 +141,64 @@ export const resolveCutoffTs = (raw: string | undefined = process.env.BACKFILL_C
   if (!raw) {
     throw new Error('BACKFILL_CUTOFF_TS is required; set to the LML#583 merge timestamp (2026-06-16T17:53:53Z).');
   }
-  if (!ISO_8601_RE.test(raw)) {
-    throw new Error(
-      `BACKFILL_CUTOFF_TS=${JSON.stringify(raw)} is not strict ISO 8601 (e.g. 2026-06-16T17:53:53Z or 2026-06-16T10:53:53-07:00).`
-    );
-  }
-  const year = Number(raw.slice(0, 4));
-  const month = Number(raw.slice(5, 7));
-  const day = Number(raw.slice(8, 10));
-  const hour = Number(raw.slice(11, 13));
-  const minute = Number(raw.slice(14, 16));
-  const second = Number(raw.slice(17, 19));
-  // Calendar bounds — month, hour, minute, second. Days-in-month uses Date
-  // (day 0 of next month is the last day of this month).
-  const lastDayOfMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
-  if (month < 1 || month > 12 || day < 1 || day > lastDayOfMonth || hour > 23 || minute > 59 || second > 59) {
-    throw new Error(
-      `BACKFILL_CUTOFF_TS=${JSON.stringify(raw)} has an out-of-range field (calendar / 24h validation failed).`
-    );
-  }
-  const parsed = Date.parse(raw);
-  if (Number.isNaN(parsed)) {
-    throw new Error(`BACKFILL_CUTOFF_TS=${JSON.stringify(raw)} is not a parseable timestamp.`);
-  }
+  const parsed = validateStrictIso8601(raw, 'BACKFILL_CUTOFF_TS');
   if (parsed > Date.now()) {
     throw new Error(
       `BACKFILL_CUTOFF_TS=${JSON.stringify(raw)} is in the future; cohort would include legitimately-terminal post-fix rows. Use the LML#583 merge timestamp.`
     );
   }
   return raw;
+};
+
+/**
+ * Optional lower-bound companion to resolveCutoffTs (BS#1823 — scoped
+ * re-enrichment of a recent regression-backlog window). Mirrors its strict
+ * ISO 8601 + calendar validation exactly (shared via validateStrictIso8601),
+ * but differs in two ways:
+ *
+ *   - Unset is valid: returns undefined (the caller applies no lower
+ *     bound), since this bound is optional wherever BACKFILL_CUTOFF_TS is
+ *     supplied instead — see resolveTimeWindow for the "at least one of
+ *     the two" rule.
+ *   - A future timestamp is NOT rejected. A window start staged ahead of
+ *     time simply selects nothing until that instant arrives — a valid
+ *     (if inert) configuration, unlike a future cutoff (which would widen
+ *     the cohort to include legitimately-terminal post-fix rows).
+ */
+export const resolveWindowStartTs = (
+  raw: string | undefined = process.env.BACKFILL_WINDOW_START_TS
+): string | undefined => {
+  if (!raw) return undefined;
+  validateStrictIso8601(raw, 'BACKFILL_WINDOW_START_TS');
+  return raw;
+};
+
+export type TimeWindow = { cutoffTs?: string; windowStartTs?: string };
+
+/**
+ * Resolves the drain's cohort time-window from BACKFILL_CUTOFF_TS /
+ * BACKFILL_WINDOW_START_TS (or explicit overrides — see runReenrichment's
+ * opts). At least one bound is required: a drain with neither has no
+ * defined cohort (an unbounded sweep of the entire enriched_no_match
+ * backlog was never an intended run shape).
+ *
+ *   - Cutoff-only reproduces resolveCutoffTs's exact original behavior
+ *     (required-if-called-alone semantics live in resolveCutoffTs itself;
+ *     here it's simply invoked when cutoffRaw is present).
+ *   - Window-start-only is a valid open-ended "everything from X to now"
+ *     run — no upper bound is applied.
+ *   - Both set narrows to the intersection (a bounded window).
+ */
+export const resolveTimeWindow = (
+  cutoffRaw: string | undefined = process.env.BACKFILL_CUTOFF_TS,
+  windowStartRaw: string | undefined = process.env.BACKFILL_WINDOW_START_TS
+): TimeWindow => {
+  if (!cutoffRaw && !windowStartRaw) {
+    throw new Error('At least one of BACKFILL_CUTOFF_TS or BACKFILL_WINDOW_START_TS is required; neither is set.');
+  }
+  const cutoffTs = cutoffRaw ? resolveCutoffTs(cutoffRaw) : undefined;
+  const windowStartTs = resolveWindowStartTs(windowStartRaw);
+  return { cutoffTs, windowStartTs };
 };
 
 export const resolveLiveActivityLookback = (
@@ -193,7 +272,25 @@ const stopAwareSleep = async (ms: number): Promise<void> => {
   }
 };
 
-const loadBatchOnce = async (afterId: number, batchSize: number, cutoffTs: string): Promise<ReenrichRow[]> => {
+/**
+ * Optional-bound composition (BS#1823): each clause is included only when
+ * its bound is set, mirroring the `cond ? sql\`AND ...\` : sql\`\`` pattern
+ * used elsewhere in this codebase for dynamic WHERE clauses (e.g.
+ * apps/backend/services/library.service.ts's streamingClause,
+ * jobs/flowsheet-metadata-backfill/worklist.ts's partitionFilter). At least
+ * one of cutoffTs/windowStartTs is always set by the time this is called
+ * (resolveTimeWindow enforces it), but both branches degrade to `sql\`\``
+ * (a no-op fragment) when their bound is absent, so this function itself
+ * doesn't need to re-assert that invariant.
+ */
+const loadBatchOnce = async (
+  afterId: number,
+  batchSize: number,
+  cutoffTs: string | undefined,
+  windowStartTs: string | undefined
+): Promise<ReenrichRow[]> => {
+  const cutoffClause = cutoffTs ? sql`AND "add_time" < ${cutoffTs}::timestamptz` : sql``;
+  const windowStartClause = windowStartTs ? sql`AND "add_time" >= ${windowStartTs}::timestamptz` : sql``;
   const rows = (await db.execute(sql`
     SELECT
       "id",
@@ -204,7 +301,8 @@ const loadBatchOnce = async (afterId: number, batchSize: number, cutoffTs: strin
     WHERE "metadata_status" = 'enriched_no_match'
       AND "album_id" IS NULL
       AND "artist_name" IS NOT NULL
-      AND "add_time" < ${cutoffTs}::timestamptz
+      ${cutoffClause}
+      ${windowStartClause}
       AND "id" > ${afterId}
     ORDER BY "id" ASC
     LIMIT ${batchSize}
@@ -222,11 +320,16 @@ const loadBatchOnce = async (afterId: number, batchSize: number, cutoffTs: strin
  * — no custom sentinel needed, since the flag was true at throw time and
  * stays true until __resetStopForTesting (production never resets it).
  */
-const loadBatch = async (afterId: number, batchSize: number, cutoffTs: string): Promise<ReenrichRow[]> => {
+const loadBatch = async (
+  afterId: number,
+  batchSize: number,
+  cutoffTs: string | undefined,
+  windowStartTs: string | undefined
+): Promise<ReenrichRow[]> => {
   let lastError: unknown;
   for (let attempt = 0; attempt < LOAD_BATCH_MAX_ATTEMPTS; attempt += 1) {
     try {
-      return await loadBatchOnce(afterId, batchSize, cutoffTs);
+      return await loadBatchOnce(afterId, batchSize, cutoffTs, windowStartTs);
     } catch (error) {
       lastError = error;
       if (stopRequested || attempt + 1 >= LOAD_BATCH_MAX_ATTEMPTS) throw error;
@@ -297,12 +400,19 @@ export const runReenrichment = async (opts: {
   lookup: LookupFn;
   enrich: EnrichFn;
   cutoffTs?: string;
+  windowStartTs?: string;
   batchSize?: number;
   liveActivityLookbackSeconds?: number;
   liveActivityPauseMs?: number;
   checkLiveActivity?: CheckLiveActivityFn;
 }): Promise<RunResult> => {
-  const cutoffTs = opts.cutoffTs ?? resolveCutoffTs();
+  // BS#1823: resolveTimeWindow enforces "at least one of cutoffTs /
+  // windowStartTs" and applies each bound's own validation (cutoff:
+  // required-if-alone + future-rejection; window-start: optional +
+  // future-allowed). Explicit opts pass through the same validation as
+  // env-sourced values — a caller-supplied override is no longer a
+  // silent bypass.
+  const { cutoffTs, windowStartTs } = resolveTimeWindow(opts.cutoffTs, opts.windowStartTs);
   const batchSize = opts.batchSize ?? resolveBatchSize();
   const liveActivityLookbackSeconds = opts.liveActivityLookbackSeconds ?? resolveLiveActivityLookback();
   const liveActivityPauseMs = opts.liveActivityPauseMs ?? resolveLiveActivityPauseMs();
@@ -343,7 +453,8 @@ export const runReenrichment = async (opts: {
   };
 
   log('info', 'started', `${JOB_NAME} starting`, {
-    cutoff_ts: cutoffTs,
+    cutoff_ts: cutoffTs ?? null,
+    window_start_ts: windowStartTs ?? null,
     batch_size: batchSize,
     live_activity_lookback_seconds: liveActivityLookbackSeconds,
     live_activity_pause_ms: liveActivityPauseMs,
@@ -374,7 +485,7 @@ export const runReenrichment = async (opts: {
 
       let rows: ReenrichRow[];
       try {
-        rows = await loadBatch(lastId, batchSize, cutoffTs);
+        rows = await loadBatch(lastId, batchSize, cutoffTs, windowStartTs);
       } catch (error) {
         // Distinguish stop-triggered exit from real failure via the same
         // module flag the inner retry observed. No custom sentinel class

--- a/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
+++ b/tests/unit/jobs/flowsheet-reenrichment/orchestrate.test.ts
@@ -27,27 +27,56 @@ import {
   BATCH_SIZE,
   resolveBatchSize,
   resolveCutoffTs,
+  resolveWindowStartTs,
+  resolveTimeWindow,
   resolveLiveActivityLookback,
   resolveLiveActivityPauseMs,
   requestStop,
   __resetStopForTesting,
 } from '../../../../jobs/flowsheet-reenrichment/orchestrate';
 
-type SqlLike = { sql?: string | string[]; queryChunks?: Array<string | { value?: unknown }> };
+/**
+ * Render a drizzle `sql` template object to a string for substring
+ * assertions. Under this repo's test mock (tests/__mocks__/drizzle-orm.ts),
+ * `db.execute(sql\`...\`)`'s argument serializes to `{ sql: string[], values:
+ * unknown[] }`, where `sql` is the literal template fragments and `values`
+ * is the interpolated parameters in positional order — reconstruct the
+ * rendered SQL by interleaving them (a bare `.join('')` of `sql` alone
+ * silently drops every interpolated value, which is invisible only as long
+ * as no assertion needs text that falls after an interpolation point).
+ *
+ * Each value can itself be a nested `sql.raw(...)` chunk (`{ raw: string }`
+ * — e.g. the FLOWSHEET_TABLE identifier) or another nested `sql\`...\`\``
+ * fragment (`{ sql, values }` again) — the BACKFILL_WINDOW_START_TS /
+ * BACKFILL_CUTOFF_TS optional-clause pattern (`cond ? sql\`AND ...\` :
+ * sql\`\``, BS#1823) produces exactly this nesting. Recurse where applicable.
+ */
+type SqlChunk = { sql?: string | string[]; values?: unknown[]; raw?: string };
 const renderSql = (value: unknown): string => {
-  const obj = value as SqlLike | null | undefined;
+  const obj = value as SqlChunk | null | undefined;
   if (!obj) return '';
-  if (Array.isArray(obj.sql)) return obj.sql.join('');
+  if (Array.isArray(obj.sql)) {
+    const fragments = obj.sql;
+    const values = obj.values ?? [];
+    let out = '';
+    for (let i = 0; i < fragments.length; i++) {
+      out += fragments[i];
+      if (i < values.length) out += renderValue(values[i]);
+    }
+    return out;
+  }
   if (typeof obj.sql === 'string') return obj.sql;
-  if (obj.queryChunks) {
-    return obj.queryChunks
-      .map((chunk) => {
-        if (typeof chunk === 'string') return chunk;
-        if (Array.isArray(chunk.value)) return chunk.value.join('');
-        if (typeof chunk.value === 'number' || typeof chunk.value === 'string') return String(chunk.value);
-        return '';
-      })
-      .join('');
+  return '';
+};
+
+/** Render a single interpolated value: scalars verbatim, nested SQL/raw fragments recursively. */
+const renderValue = (v: unknown): string => {
+  if (v == null) return '';
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return String(v);
+  if (typeof v === 'object') {
+    const o = v as SqlChunk;
+    if (typeof o.raw === 'string') return o.raw;
+    if (Array.isArray(o.sql)) return renderSql(o);
   }
   return '';
 };
@@ -66,6 +95,8 @@ const matchedResult = () => ({ response: matchedResponse, cacheHit: false as con
 const noMatchResult = () => ({ response: noMatchResponse, cacheHit: false as const });
 
 const CUTOFF = '2026-06-16T17:53:53Z';
+// BS#1823 regression-window lower bound — matches the README's run example.
+const WINDOW_START = '2026-07-22T00:00:00Z';
 
 const makeRow = (id: number) => ({
   id,
@@ -130,6 +161,81 @@ describe('resolveCutoffTs', () => {
   });
 });
 
+describe('resolveWindowStartTs', () => {
+  // BS#1823: optional lower bound for the regression-window re-enrichment
+  // run. Mirrors resolveCutoffTs's strict ISO 8601 + calendar validation
+  // exactly (shared validator), but differs in two ways pinned below:
+  // unset is valid (not required), and a future timestamp is not rejected.
+  it('returns undefined when BACKFILL_WINDOW_START_TS is not set (optional, unlike cutoff)', () => {
+    expect(resolveWindowStartTs(undefined)).toBeUndefined();
+  });
+
+  it('returns the value when set to a valid past ISO timestamp', () => {
+    expect(resolveWindowStartTs(WINDOW_START)).toBe(WINDOW_START);
+  });
+
+  it('returns the value when set to a valid FUTURE ISO timestamp (not rejected, unlike cutoff)', () => {
+    expect(resolveWindowStartTs('2099-01-01T00:00:00Z')).toBe('2099-01-01T00:00:00Z');
+  });
+
+  it('throws on garbage', () => {
+    expect(() => resolveWindowStartTs('not-a-date')).toThrow(/strict ISO 8601/);
+    expect(() => resolveWindowStartTs('yesterday')).toThrow(/strict ISO 8601/);
+  });
+
+  it('throws on non-strict-ISO formats Date.parse accepts but PG would reject (or interpret differently)', () => {
+    expect(() => resolveWindowStartTs('2026-6-16T17:53:53Z')).toThrow(/strict ISO 8601/);
+    expect(() => resolveWindowStartTs('2026/06/16 17:53:53')).toThrow(/strict ISO 8601/);
+    expect(() => resolveWindowStartTs('2026')).toThrow(/strict ISO 8601/);
+    expect(() => resolveWindowStartTs('2026-06-16')).toThrow(/strict ISO 8601/); // date-only
+  });
+
+  it('throws on out-of-range day that Date.parse silently normalizes', () => {
+    expect(() => resolveWindowStartTs('2026-02-30T00:00:00Z')).toThrow(/out-of-range field/);
+    expect(() => resolveWindowStartTs('2026-06-31T00:00:00Z')).toThrow(/out-of-range field/);
+    expect(() => resolveWindowStartTs('2026-13-01T00:00:00Z')).toThrow(/out-of-range field/);
+    expect(() => resolveWindowStartTs('2026-06-16T25:00:00Z')).toThrow(/out-of-range field/);
+  });
+
+  it('accepts timezone-offset form (e.g. -07:00)', () => {
+    expect(resolveWindowStartTs('2026-06-16T10:53:53-07:00')).toBe('2026-06-16T10:53:53-07:00');
+  });
+
+  it('error message names BACKFILL_WINDOW_START_TS, not BACKFILL_CUTOFF_TS (same validator, distinct field)', () => {
+    expect(() => resolveWindowStartTs('garbage')).toThrow(/BACKFILL_WINDOW_START_TS/);
+  });
+});
+
+describe('resolveTimeWindow', () => {
+  // BS#1823: composes the two optional bounds and enforces "at least one is
+  // required" — the drain has no defined cohort with neither set.
+  it('throws when neither BACKFILL_CUTOFF_TS nor BACKFILL_WINDOW_START_TS is set', () => {
+    expect(() => resolveTimeWindow(undefined, undefined)).toThrow(/BACKFILL_CUTOFF_TS/);
+    expect(() => resolveTimeWindow(undefined, undefined)).toThrow(/BACKFILL_WINDOW_START_TS/);
+  });
+
+  it("cutoff-only: resolves cutoffTs, leaves windowStartTs undefined (today's exact behavior preserved)", () => {
+    expect(resolveTimeWindow(CUTOFF, undefined)).toEqual({ cutoffTs: CUTOFF, windowStartTs: undefined });
+  });
+
+  it('window-start-only: resolves windowStartTs, leaves cutoffTs undefined (no upper bound)', () => {
+    expect(resolveTimeWindow(undefined, WINDOW_START)).toEqual({ cutoffTs: undefined, windowStartTs: WINDOW_START });
+  });
+
+  it('both set: resolves both bounds (intersection)', () => {
+    expect(resolveTimeWindow(CUTOFF, WINDOW_START)).toEqual({ cutoffTs: CUTOFF, windowStartTs: WINDOW_START });
+  });
+
+  it('propagates resolveCutoffTs future-rejection when cutoff is set', () => {
+    expect(() => resolveTimeWindow('2099-01-01T00:00:00Z', undefined)).toThrow(/in the future/);
+  });
+
+  it('a malformed BACKFILL_WINDOW_START_TS is rejected the same way a malformed cutoff is', () => {
+    expect(() => resolveTimeWindow(CUTOFF, 'not-a-date')).toThrow(/strict ISO 8601/);
+    expect(() => resolveTimeWindow(undefined, 'not-a-date')).toThrow(/strict ISO 8601/);
+  });
+});
+
 describe('resolveLiveActivityLookback', () => {
   it('falls back to 60 when env var is unset', () => {
     expect(resolveLiveActivityLookback(undefined)).toBe(60);
@@ -189,6 +295,89 @@ describe('runReenrichment — WHERE filter', () => {
     // All 3 rows were scanned
     expect(result.totals.scanned).toBe(3);
     expect(result.totals.still_no_match).toBe(3);
+  });
+
+  // BS#1823: regression-window re-enrichment adds an optional lower bound.
+  it('window-start-only: SELECT carries add_time >= start and omits the upper bound', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('match');
+
+    await runReenrichment({
+      lookup,
+      enrich,
+      windowStartTs: WINDOW_START,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    const firstSelectSql = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]);
+    expect(firstSelectSql).toMatch(/enriched_no_match/);
+    expect(firstSelectSql).toMatch(/album_id.*IS NULL|IS NULL.*album_id/i);
+    expect(firstSelectSql.toLowerCase()).toMatch(/artist_name.*is not null/);
+    expect(firstSelectSql).toMatch(/add_time"\s*>=\s*/);
+    expect(firstSelectSql).toContain(WINDOW_START);
+    // No upper bound at all — the cutoff's `<` comparison must be absent.
+    // (The id-cursor predicate uses a bare `>`, never `<`, so this is safe.)
+    expect(firstSelectSql).not.toContain('<');
+  });
+
+  it('both bounds set: SELECT carries the intersection (add_time >= start AND add_time < cutoff)', async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('match');
+
+    await runReenrichment({
+      lookup,
+      enrich,
+      cutoffTs: CUTOFF,
+      windowStartTs: WINDOW_START,
+      batchSize: 100,
+      liveActivityLookbackSeconds: 0,
+    });
+
+    const firstSelectSql = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]);
+    expect(firstSelectSql).toMatch(/add_time"\s*>=\s*/);
+    expect(firstSelectSql).toMatch(/add_time"\s*<\s*/);
+    expect(firstSelectSql).toContain(WINDOW_START);
+    expect(firstSelectSql).toContain(CUTOFF);
+  });
+
+  it("cutoff-only (today's existing config): SELECT has no add_time >= lower bound", async () => {
+    (db.execute as jest.Mock).mockResolvedValueOnce([makeRow(1)]).mockResolvedValueOnce([]);
+
+    const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult());
+    const enrich = jest.fn<EnrichFn>().mockResolvedValue('match');
+
+    await runReenrichment({ lookup, enrich, cutoffTs: CUTOFF, batchSize: 100, liveActivityLookbackSeconds: 0 });
+
+    const firstSelectSql = renderSql((db.execute as jest.Mock).mock.calls[0]?.[0]);
+    expect(firstSelectSql).not.toMatch(/add_time"\s*>=\s*/);
+    expect(firstSelectSql).toMatch(/add_time"\s*<\s*/);
+  });
+
+  it('neither bound set: rejects before any DB call', async () => {
+    const originalCutoff = process.env.BACKFILL_CUTOFF_TS;
+    const originalWindowStart = process.env.BACKFILL_WINDOW_START_TS;
+    delete process.env.BACKFILL_CUTOFF_TS;
+    delete process.env.BACKFILL_WINDOW_START_TS;
+
+    try {
+      const lookup = jest.fn<LookupFn>().mockResolvedValue(matchedResult());
+      const enrich = jest.fn<EnrichFn>().mockResolvedValue('match');
+
+      await expect(runReenrichment({ lookup, enrich, batchSize: 100, liveActivityLookbackSeconds: 0 })).rejects.toThrow(
+        /At least one of BACKFILL_CUTOFF_TS or BACKFILL_WINDOW_START_TS is required/
+      );
+      expect(db.execute).not.toHaveBeenCalled();
+    } finally {
+      if (originalCutoff === undefined) delete process.env.BACKFILL_CUTOFF_TS;
+      else process.env.BACKFILL_CUTOFF_TS = originalCutoff;
+      if (originalWindowStart === undefined) delete process.env.BACKFILL_WINDOW_START_TS;
+      else process.env.BACKFILL_WINDOW_START_TS = originalWindowStart;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Adapts the existing one-shot `jobs/flowsheet-reenrichment` drain so it can also re-enrich a recent, bounded slice of the B3 non-library-resolution regression backlog (#1815 + WXYC/library-metadata-lookup#920, both merged & deployed), rather than only the original pre-LML#583 cohort it was built for.

- Adds an optional `BACKFILL_WINDOW_START_TS` env var (lower bound, `add_time >= start`), validated with the exact same strict-ISO-8601 + calendar rules as `BACKFILL_CUTOFF_TS` (shared via an extracted `validateStrictIso8601` helper) — except a future window-start is allowed (it simply selects nothing yet), unlike a future cutoff.
- Composes it into the candidate SELECT alongside the existing optional cutoff (`add_time < cutoff`), following this codebase's established `cond ? sql\`AND ...\` : sql\`\`` pattern for optional WHERE clauses.
- Requires at least one of `BACKFILL_CUTOFF_TS` / `BACKFILL_WINDOW_START_TS`. Cutoff-only preserves today's exact behavior; window-start-only applies no upper bound; both together narrow to their intersection; neither throws a clear error (both in the job's pre-flight check and in the orchestrator's own resolution).
- No change to the cohort predicate otherwise, the idempotency UPDATE guard, the rate limiter, the batching/`afterId` paging, or the LML call — this job already resolves non-library albums via single `lookupMetadata` (`/lookup`, which defaults `allow_release_resolution_fallback=True`), so no bulk flag is needed.
- README updated with the regression-window run example and an explicit note that this job has no `DRY_RUN` mode (verified: unlike a few sibling jobs, `DRY_RUN` was never implemented here) — a COUNT-first preview query is documented as the safety check instead of a nonfunctional flag.

## Test plan

- [x] TDD: added failing tests first for `resolveWindowStartTs`, `resolveTimeWindow`, and the WHERE-composition cases, confirmed red, then implemented.
- [x] `resolveWindowStartTs`: unset → undefined, valid past/future ISO timestamps accepted (future explicitly allowed, unlike cutoff), garbage/non-strict-ISO/out-of-range/malformed inputs rejected with the same style as `resolveCutoffTs`.
- [x] `resolveTimeWindow`: neither bound → throws; cutoff-only → today's exact behavior; window-start-only → no upper bound; both → intersection; malformed window-start rejected same as malformed cutoff.
- [x] `runReenrichment` WHERE-filter cases: window-start-only SELECT carries `add_time >=` and omits the upper bound; both-bounds SELECT carries the intersection; cutoff-only (existing test) stays green; neither-bound rejects before any DB call.
- [x] Full local CI green: `npm run typecheck` (root workspaces) + a direct `tsc --noEmit -p jobs/flowsheet-reenrichment/tsconfig.json` (the root script doesn't cover `jobs/**`) + `npm run lint` + `npm run format:check` + `npm run test:unit` (350 suites / 5250 tests) + `npm run build --workspace=@wxyc/flowsheet-reenrichment`.

Closes #1823

## Related

Follow-up to #1815; relates to the BS#895 safety-net epic; under epic #1810.