### PR TITLE
Extract resolveLinkedAlbumId into @wxyc/database

### DIFF
--- a/apps/backend/services/album-metadata-lookup.service.ts
+++ b/apps/backend/services/album-metadata-lookup.service.ts
@@ -36,26 +36,23 @@
  * interest to a detail-view fetch).
  */
 import { sql, eq, desc } from 'drizzle-orm';
-import { db, flowsheet, album_metadata, album_critic_reviews } from '@wxyc/database';
+import { db, album_metadata, album_critic_reviews } from '@wxyc/database';
 import type { CriticReviewItem } from '@wxyc/shared/dtos';
 import type { DiscogsResolvedToken, DiscogsTrackItem } from '@wxyc/lml-client';
 
-const flowsheetLookupKey = sql<string>`lower(trim(${flowsheet.artist_name})) || '-' || lower(trim(coalesce(${flowsheet.album_title}, '')))`;
-
 /**
- * JS-side normalized lookup key. The order of trim() and toLowerCase()
- * is irrelevant for the column shapes in flowsheet (artist names and
- * album titles are ASCII or Latin-1 in steady state), but match the SQL
- * literally for forward-compatibility with Unicode-bearing rows. PG's
- * `trim()` strips only ASCII space by default while JS `.trim()` strips
- * all Unicode whitespace — divergence can produce silent cache misses
- * on NBSP-padded inputs. Documented here so future maintainers see the
- * gap; aligning would require a generated column or a normalize_key()
- * SQL function (migration), so deferred.
+ * Thin re-export shim — `resolveLinkedAlbumId` moved to `@wxyc/database`
+ * (BS#1829, `shared/database/src/album-resolve.ts`) so the upcoming
+ * `jobs/album-critic-reviews-etl/` (#1830) can call the SAME resolver a
+ * `jobs/` workspace can't reach into `apps/backend` for. This path is
+ * preserved deliberately (mirrors the `@wxyc/legacy-mirror` BS#1707
+ * extraction and `concerts-recompute.ts`'s BS#1763 shim in
+ * `jobs/concerts-artist-resolver/recompute.ts`): `apps/backend/controllers/
+ * proxy.controller.ts` still imports from here, so its import site doesn't
+ * need touching. New code should import from `@wxyc/database` directly, as
+ * `scripts/seed-critic-reviews.ts` now does.
  */
-function lookupKey(artist: string, album?: string): string {
-  return `${artist.toLowerCase().trim()}-${(album ?? '').toLowerCase().trim()}`;
-}
+export { resolveLinkedAlbumId } from '@wxyc/database';
 
 /**
  * Persisted album metadata projection. Matches the 18 columns on
@@ -89,52 +86,6 @@ export interface PersistedAlbumMetadata {
   tracklist: DiscogsTrackItem[] | null;
   artist_image_url: string | null;
   bio_tokens: DiscogsResolvedToken[] | null;
-}
-
-/**
- * Resolve `(artistName, releaseTitle)` to the `library.id` of a matching
- * linked flowsheet row, or `null` when no `album_id`-bearing flowsheet row
- * exists for the key. Shared Step-1 for both the album-metadata read
- * (`lookupAlbumMetadataById`) and the critic-reviews read
- * (`lookupCriticReviewsByAlbumId`). Callers that need both — the
- * `/proxy/metadata/album` handler — resolve the key *once* here and pass the
- * id to both reads, so a concurrent flowsheet insert can't make the two
- * reads disagree on which album they describe. The seed writer
- * (`scripts/seed-critic-reviews.ts`) imports this to key its UPSERTs against
- * the exact same normalized flowsheet key the serve path reads.
- *
- * Uses the partial functional index `flowsheet_album_link_lookup_idx`. The
- * explicit `flowsheet.album_id IS NOT NULL` predicate matches the index's
- * WHERE clause verbatim so the planner uses the partial index. `ORDER BY
- * flowsheet.id DESC LIMIT 1` makes the row-pick deterministic on
- * multi-album_id keys (V/A multi-format, dual-pressing, librarian
- * duplicates — verified to exist in the live `album_id` corpus). Two
- * requests for the same lookup key resolve to the same row, eliminating a
- * flapping-response edge that would otherwise let iOS see two different
- * albums for the same query across polls. Sort cost is bounded: the
- * most-popular key has hundreds of matches, not thousands; the post-filter
- * `id DESC` sort on the small match set is sub-ms in practice.
- *
- * An empty/whitespace-only `artistName` or `releaseTitle` short-circuits to
- * `null`: the key `'<artist>-'` (blank release) would otherwise match any
- * linked flowsheet row whose DJ left `album_title` blank and return an
- * arbitrary `album_id`.
- */
-export async function resolveLinkedAlbumId(artistName: string, releaseTitle?: string): Promise<number | null> {
-  const trimmedArtist = artistName.trim();
-  const trimmedRelease = (releaseTitle ?? '').trim();
-  if (trimmedArtist.length === 0 || trimmedRelease.length === 0) return null;
-
-  const key = lookupKey(trimmedArtist, trimmedRelease);
-
-  const candidate = await db
-    .select({ album_id: flowsheet.album_id })
-    .from(flowsheet)
-    .where(sql`${flowsheetLookupKey} = ${key} AND ${flowsheet.album_id} IS NOT NULL`)
-    .orderBy(desc(flowsheet.id))
-    .limit(1);
-
-  return candidate[0]?.album_id ?? null;
 }
 
 /**

--- a/scripts/seed-critic-reviews.ts
+++ b/scripts/seed-critic-reviews.ts
@@ -60,8 +60,7 @@ config();
 
 import { readFileSync } from 'node:fs';
 import { sql } from 'drizzle-orm';
-import { db, closeDatabaseConnection, album_critic_reviews } from '@wxyc/database';
-import { resolveLinkedAlbumId } from '../apps/backend/services/album-metadata-lookup.service.js';
+import { db, closeDatabaseConnection, album_critic_reviews, resolveLinkedAlbumId } from '@wxyc/database';
 
 /** One candidate review, normalized from either source (b1) or (b2). */
 export interface CorpusItem {

--- a/shared/database/src/album-resolve.ts
+++ b/shared/database/src/album-resolve.ts
@@ -1,0 +1,90 @@
+/**
+ * Normalized `(artist, album)` → linked `library.id` resolver (BS#1829,
+ * extracted from `apps/backend/services/album-metadata-lookup.service.ts` —
+ * album-critic-reviews slice, ADR 0012 — parent epic #1718).
+ *
+ * Lives here (not in `apps/backend`) so a `jobs/` workspace can import it:
+ * each job's Dockerfile copies only the job dir + `@wxyc/database`, and an
+ * `apps/backend` import fails that build stage (see the header comment of
+ * `jobs/artist-search-alias-consumer/compilation.ts` and
+ * `jobs/flowsheet-artwork-repair/repair.ts`). The upcoming
+ * `jobs/album-critic-reviews-etl/` (#1830) needs the SAME exact-match
+ * semantics the serve path uses, or seeded rows drift from what
+ * `GET /proxy/metadata/album` can actually find.
+ *
+ * Behavior-preserving move: the exact-match semantics —
+ * `lower(trim(artist)) || '-' || lower(trim(coalesce(album,'')))` against
+ * `flowsheet` rows where `album_id IS NOT NULL`, most-recent wins — are
+ * unchanged. `apps/backend/services/album-metadata-lookup.service.ts` now
+ * carries a thin re-export shim (`export { resolveLinkedAlbumId } from
+ * '@wxyc/database';`) so its existing import site stays untouched, mirroring
+ * the `@wxyc/legacy-mirror` (BS#1707) and `concerts-recompute.ts` (BS#1763)
+ * extractions. `scripts/seed-critic-reviews.ts` imports this directly.
+ */
+import { sql, desc } from 'drizzle-orm';
+import { db } from './client.js';
+import { flowsheet } from './schema.js';
+
+const flowsheetLookupKey = sql<string>`lower(trim(${flowsheet.artist_name})) || '-' || lower(trim(coalesce(${flowsheet.album_title}, '')))`;
+
+/**
+ * JS-side normalized lookup key. The order of trim() and toLowerCase()
+ * is irrelevant for the column shapes in flowsheet (artist names and
+ * album titles are ASCII or Latin-1 in steady state), but match the SQL
+ * literally for forward-compatibility with Unicode-bearing rows. PG's
+ * `trim()` strips only ASCII space by default while JS `.trim()` strips
+ * all Unicode whitespace — divergence can produce silent cache misses
+ * on NBSP-padded inputs. Documented here so future maintainers see the
+ * gap; aligning would require a generated column or a normalize_key()
+ * SQL function (migration), so deferred.
+ */
+function lookupKey(artist: string, album?: string): string {
+  return `${artist.toLowerCase().trim()}-${(album ?? '').toLowerCase().trim()}`;
+}
+
+/**
+ * Resolve `(artistName, releaseTitle)` to the `library.id` of a matching
+ * linked flowsheet row, or `null` when no `album_id`-bearing flowsheet row
+ * exists for the key. Shared Step-1 for both the album-metadata read
+ * (`lookupAlbumMetadataById`) and the critic-reviews read
+ * (`lookupCriticReviewsByAlbumId`) in
+ * `apps/backend/services/album-metadata-lookup.service.ts`. Callers that
+ * need both — the `/proxy/metadata/album` handler — resolve the key *once*
+ * here and pass the id to both reads, so a concurrent flowsheet insert can't
+ * make the two reads disagree on which album they describe. The seed writer
+ * (`scripts/seed-critic-reviews.ts`) imports this to key its UPSERTs against
+ * the exact same normalized flowsheet key the serve path reads.
+ *
+ * Uses the partial functional index `flowsheet_album_link_lookup_idx`. The
+ * explicit `flowsheet.album_id IS NOT NULL` predicate matches the index's
+ * WHERE clause verbatim so the planner uses the partial index. `ORDER BY
+ * flowsheet.id DESC LIMIT 1` makes the row-pick deterministic on
+ * multi-album_id keys (V/A multi-format, dual-pressing, librarian
+ * duplicates — verified to exist in the live `album_id` corpus). Two
+ * requests for the same lookup key resolve to the same row, eliminating a
+ * flapping-response edge that would otherwise let iOS see two different
+ * albums for the same query across polls. Sort cost is bounded: the
+ * most-popular key has hundreds of matches, not thousands; the post-filter
+ * `id DESC` sort on the small match set is sub-ms in practice.
+ *
+ * An empty/whitespace-only `artistName` or `releaseTitle` short-circuits to
+ * `null`: the key `'<artist>-'` (blank release) would otherwise match any
+ * linked flowsheet row whose DJ left `album_title` blank and return an
+ * arbitrary `album_id`.
+ */
+export async function resolveLinkedAlbumId(artistName: string, releaseTitle?: string): Promise<number | null> {
+  const trimmedArtist = artistName.trim();
+  const trimmedRelease = (releaseTitle ?? '').trim();
+  if (trimmedArtist.length === 0 || trimmedRelease.length === 0) return null;
+
+  const key = lookupKey(trimmedArtist, trimmedRelease);
+
+  const candidate = await db
+    .select({ album_id: flowsheet.album_id })
+    .from(flowsheet)
+    .where(sql`${flowsheetLookupKey} = ${key} AND ${flowsheet.album_id} IS NOT NULL`)
+    .orderBy(desc(flowsheet.id))
+    .limit(1);
+
+  return candidate[0]?.album_id ?? null;
+}

--- a/shared/database/src/index.ts
+++ b/shared/database/src/index.ts
@@ -13,3 +13,4 @@ export * from './freetext-norm.js';
 export * from './ny-time.js';
 export * from './concerts-sql.js';
 export * from './concerts-recompute.js';
+export * from './album-resolve.js';

--- a/tests/mocks/database.mock.ts
+++ b/tests/mocks/database.mock.ts
@@ -434,6 +434,17 @@ export const recomputeHasResolvedSupport = jest
   .fn<() => Promise<RecomputeOutcome>>()
   .mockResolvedValue({ updated: 0, updated_true: 0, updated_false: 0 });
 
+// Stub of shared/database/src/album-resolve.ts's `resolveLinkedAlbumId`
+// (BS#1829, extracted from apps/backend/services/album-metadata-lookup.
+// service.ts). Consumers (the service's thin re-export, scripts/
+// seed-critic-reviews.ts, and eventually jobs/album-critic-reviews-etl)
+// only need a controllable resolved value here — the real lookup-key +
+// ORDER BY contract is pinned against the actual module by
+// tests/unit/database/album-resolve.test.ts.
+export const resolveLinkedAlbumId = jest
+  .fn<(artistName: string, releaseTitle?: string) => Promise<number | null>>()
+  .mockResolvedValue(null);
+
 export { requirePositiveInt, requireNonNegativeInt } from '../../shared/database/src/env-parsers.js';
 export type { IntParserOptions } from '../../shared/database/src/env-parsers.js';
 

--- a/tests/unit/database/album-resolve.test.ts
+++ b/tests/unit/database/album-resolve.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for shared/database/src/album-resolve.ts (BS#1829, extracted
+ * from apps/backend/services/album-metadata-lookup.service.ts so a `jobs/`
+ * workspace — the upcoming `jobs/album-critic-reviews-etl/`, #1830 — can
+ * import the resolver without reaching into `apps/backend`).
+ *
+ * These cases moved verbatim from
+ * tests/unit/services/album-metadata-lookup.service.test.ts's
+ * `resolveLinkedAlbumId` describe block. That file mocks the whole
+ * `@wxyc/database` package (`jest.mock('@wxyc/database', factory)`) to drive
+ * `lookupAlbumMetadataById` / `lookupCriticReviewsByAlbumId`, which still live
+ * in the service — but `resolveLinkedAlbumId`'s IMPLEMENTATION now lives
+ * inside that same mocked package, so a whole-package mock can no longer
+ * exercise its real behavior (the mock factory never includes it, so the
+ * service's re-export would resolve to `undefined`). Tests the REAL module
+ * directly instead, mocking only its `./client.js` dependency — mirroring
+ * `tests/unit/database/concerts-recompute.test.ts` (BS#1763, the same
+ * @wxyc/database extraction shape) — so `flowsheet` here is the real Drizzle
+ * schema.ts column set, not the string stand-ins the service-level mock used.
+ * The SQL text itself isn't asserted (that's schema.flowsheet-album-link-
+ * lookup-idx.test.ts's job); these pin the JS-side guard/pick behavior.
+ */
+import { jest } from '@jest/globals';
+
+// --- Drizzle DB chain mock ---
+//
+// Each `db.select(...)` call returns a fresh chain whose terminal awaitable
+// is the next array of rows pushed via `mockRowsQueue`. The mock's
+// .from/.where/.orderBy/.limit are also captured on `chainSpy` so tests can
+// pin the SQL contract (`ORDER BY` presence per query). Same shape as the
+// service-level mock this replaces.
+
+const mockRowsQueue: Array<Array<Record<string, unknown>>> = [];
+
+const mockSelect = jest.fn();
+const chainSpy = {
+  from: jest.fn(),
+  where: jest.fn(),
+  orderBy: jest.fn(),
+  limit: jest.fn(),
+};
+
+function makeChain() {
+  let resolveValue: Array<Record<string, unknown>> = [];
+  const chain = {
+    from: (...args: unknown[]) => {
+      chainSpy.from(...args);
+      return chain;
+    },
+    where: (...args: unknown[]) => {
+      chainSpy.where(...args);
+      return chain;
+    },
+    orderBy: (...args: unknown[]) => {
+      chainSpy.orderBy(...args);
+      return chain;
+    },
+    limit: (...args: unknown[]) => {
+      chainSpy.limit(...args);
+      return Promise.resolve(resolveValue);
+    },
+  };
+  resolveValue = mockRowsQueue.shift() ?? [];
+  return chain;
+}
+
+mockSelect.mockImplementation(() => makeChain());
+
+// Mocks only the `db` client this module depends on; `flowsheet` resolves to
+// the real shared/database/src/schema.ts export (real Drizzle columns), same
+// as concerts-recompute.test.ts's treatment of client.js. `virtual: true`
+// matters here: without it, jest.unit.config.ts's own moduleNameMapper rule
+// (`^.*/shared/database/src/client(\.js)?$`) would redirect THIS registration
+// to tests/mocks/database.mock.ts, while album-resolve.ts's own `./client.js`
+// (a plain relative specifier that doesn't match that pattern) resolves to
+// the real file — a mismatch that leaves the real client.ts loaded and
+// throwing on missing DB env vars. `virtual: true` makes jest register this
+// mock at the plain-resolved path instead, matching album-resolve.ts's import.
+jest.mock(
+  '../../../shared/database/src/client.js',
+  () => ({
+    db: {
+      select: (...args: unknown[]) => mockSelect(...args),
+    },
+  }),
+  { virtual: true }
+);
+
+import { resolveLinkedAlbumId } from '../../../shared/database/src/album-resolve';
+
+describe('album-resolve (shared/database)', () => {
+  beforeEach(() => {
+    mockRowsQueue.length = 0;
+    mockSelect.mockClear();
+    chainSpy.from.mockClear();
+    chainSpy.where.mockClear();
+    chainSpy.orderBy.mockClear();
+    chainSpy.limit.mockClear();
+  });
+
+  describe('resolveLinkedAlbumId', () => {
+    describe('empty-key guard', () => {
+      // Pin the contract that the guard prevents *any* DB call: a regression
+      // that removes the guard would shift these from `select=0` to `select=1`,
+      // letting `'-'`-keyed requests reach the partial index and resolve an
+      // arbitrary album_id.
+      it('returns null without touching the DB when artistName is empty', async () => {
+        expect(await resolveLinkedAlbumId('', 'Some Album')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when artistName is whitespace-only', async () => {
+        expect(await resolveLinkedAlbumId('   ', 'Some Album')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when releaseTitle is undefined (artist-card surfaces fall through to LML)', async () => {
+        expect(await resolveLinkedAlbumId('Some Artist', undefined)).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when releaseTitle is empty', async () => {
+        expect(await resolveLinkedAlbumId('Some Artist', '')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+
+      it('returns null when releaseTitle is whitespace-only', async () => {
+        expect(await resolveLinkedAlbumId('Some Artist', '\t  ')).toBeNull();
+        expect(mockSelect).not.toHaveBeenCalled();
+      });
+    });
+
+    it('returns null on the cold case (no matching album_id-bearing flowsheet row)', async () => {
+      mockRowsQueue.push([]);
+      expect(await resolveLinkedAlbumId('Unknown Artist', 'Unknown Album')).toBeNull();
+      expect(mockSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the album_id and issues ORDER BY for a deterministic row-pick on multi-album_id keys', async () => {
+      // Pin BS#1331 round-2 review fix: dropping the ORDER BY here would
+      // re-introduce iOS-visible flapping between distinct album_metadata
+      // payloads when a lookup key resolves to multiple album_ids
+      // (V/A multi-format, dual-pressings, librarian duplicates — empirically
+      // present in the live `album_id` corpus).
+      mockRowsQueue.push([{ album_id: 42 }]);
+      const albumId = await resolveLinkedAlbumId('Multi Artist', 'Same Title Different Pressings');
+      expect(albumId).toBe(42);
+      expect(chainSpy.orderBy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/services/album-metadata-lookup.service.test.ts
+++ b/tests/unit/services/album-metadata-lookup.service.test.ts
@@ -5,14 +5,21 @@
  * feeds it to `lookupAlbumMetadataById` and `lookupCriticReviewsByAlbumId`;
  * all three are mocked away in the controller's suite, so these tests cover
  * the JS-side shape that wouldn't otherwise surface in CI until prod:
- *   - `resolveLinkedAlbumId`: empty/whitespace-key guard (artist or release
- *     blank → null, no DB), cold-case (no match → null), deterministic
- *     `ORDER BY id DESC LIMIT 1` on multi-album_id keys
  *   - `lookupAlbumMetadataById`: PK-lookup projection; absent row → null
  *     fallthrough; no ORDER BY (it's a PK read, not a pick)
  *   - `lookupCriticReviewsByAlbumId`: newest-first ORDER BY, wire-shape
  *     projection (url ← source_url, publishedDate ← published_at, null
  *     optionals omitted)
+ *
+ * `resolveLinkedAlbumId`'s own tests moved to
+ * `tests/unit/database/album-resolve.test.ts` (BS#1829): its implementation
+ * now lives in `@wxyc/database` (`shared/database/src/album-resolve.ts`),
+ * and this file's whole-package `jest.mock('@wxyc/database', ...)` below
+ * can't exercise it — the mock factory doesn't (and can't cheaply) include
+ * a working real implementation, so the service's thin re-export of it would
+ * resolve to `undefined` under this mock. This file still imports it (via
+ * the re-export shim) only insofar as `lookupAlbumMetadataById` /
+ * `lookupCriticReviewsByAlbumId` don't call it directly — they don't.
  *
  * The drizzle DB chain is mocked at the module level so test cases can stub
  * each query's resolved rows independently. Each by-id helper issues exactly
@@ -109,7 +116,6 @@ jest.mock('@wxyc/database', () => ({
 }));
 
 import {
-  resolveLinkedAlbumId,
   lookupAlbumMetadataById,
   lookupCriticReviewsByAlbumId,
 } from '../../../apps/backend/services/album-metadata-lookup.service';
@@ -122,57 +128,6 @@ describe('album-metadata-lookup.service', () => {
     chainSpy.where.mockClear();
     chainSpy.orderBy.mockClear();
     chainSpy.limit.mockClear();
-  });
-
-  describe('resolveLinkedAlbumId', () => {
-    describe('empty-key guard', () => {
-      // Pin the contract that the guard prevents *any* DB call: a regression
-      // that removes the guard would shift these from `select=0` to `select=1`,
-      // letting `'-'`-keyed requests reach the partial index and resolve an
-      // arbitrary album_id.
-      it('returns null without touching the DB when artistName is empty', async () => {
-        expect(await resolveLinkedAlbumId('', 'Some Album')).toBeNull();
-        expect(mockSelect).not.toHaveBeenCalled();
-      });
-
-      it('returns null when artistName is whitespace-only', async () => {
-        expect(await resolveLinkedAlbumId('   ', 'Some Album')).toBeNull();
-        expect(mockSelect).not.toHaveBeenCalled();
-      });
-
-      it('returns null when releaseTitle is undefined (artist-card surfaces fall through to LML)', async () => {
-        expect(await resolveLinkedAlbumId('Some Artist', undefined)).toBeNull();
-        expect(mockSelect).not.toHaveBeenCalled();
-      });
-
-      it('returns null when releaseTitle is empty', async () => {
-        expect(await resolveLinkedAlbumId('Some Artist', '')).toBeNull();
-        expect(mockSelect).not.toHaveBeenCalled();
-      });
-
-      it('returns null when releaseTitle is whitespace-only', async () => {
-        expect(await resolveLinkedAlbumId('Some Artist', '\t  ')).toBeNull();
-        expect(mockSelect).not.toHaveBeenCalled();
-      });
-    });
-
-    it('returns null on the cold case (no matching album_id-bearing flowsheet row)', async () => {
-      mockRowsQueue.push([]);
-      expect(await resolveLinkedAlbumId('Unknown Artist', 'Unknown Album')).toBeNull();
-      expect(mockSelect).toHaveBeenCalledTimes(1);
-    });
-
-    it('returns the album_id and issues ORDER BY for a deterministic row-pick on multi-album_id keys', async () => {
-      // Pin BS#1331 round-2 review fix: dropping the ORDER BY here would
-      // re-introduce iOS-visible flapping between distinct album_metadata
-      // payloads when a lookup key resolves to multiple album_ids
-      // (V/A multi-format, dual-pressings, librarian duplicates — empirically
-      // present in the live `album_id` corpus).
-      mockRowsQueue.push([{ album_id: 42 }]);
-      const albumId = await resolveLinkedAlbumId('Multi Artist', 'Same Title Different Pressings');
-      expect(albumId).toBe(42);
-      expect(chainSpy.orderBy).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('lookupAlbumMetadataById', () => {


### PR DESCRIPTION
## Summary

Moves `resolveLinkedAlbumId` (plus its `lookupKey`/`flowsheetLookupKey` helpers) from `apps/backend/services/album-metadata-lookup.service.ts` into a new `shared/database/src/album-resolve.ts`, exported from `@wxyc/database`'s package entry point. This unblocks the upcoming `jobs/album-critic-reviews-etl/` (#1830), which needs the exact same normalized-flowsheet-key resolver the serve path uses but, as a `jobs/` workspace, cannot import from `apps/backend` (its Dockerfile build stage only copies the job dir + `@wxyc/database`).

Behavior-preserving move: the `lower(trim(artist)) || '-' || lower(trim(coalesce(album,'')))` exact-match key against `flowsheet` rows where `album_id IS NOT NULL`, with most-recent-row-wins tiebreak, is unchanged — only the import path moves.

`apps/backend/services/album-metadata-lookup.service.ts` keeps a thin `export { resolveLinkedAlbumId } from '@wxyc/database';` re-export shim so `apps/backend/controllers/proxy.controller.ts` (and its test's mock target) keep importing from the same path, mirroring the `concerts-recompute.ts` (BS#1763) and `@wxyc/legacy-mirror` (BS#1707) extraction precedents. `scripts/seed-critic-reviews.ts` now imports the resolver from `@wxyc/database` directly.

## Test changes

`resolveLinkedAlbumId`'s own test cases moved from `tests/unit/services/album-metadata-lookup.service.test.ts` to a new `tests/unit/database/album-resolve.test.ts`, testing the real module directly (mocking only its `client.js` dependency, the same shape `concerts-recompute.test.ts` uses) instead of through the service test's whole-package `jest.mock('@wxyc/database', ...)`. That whole-package mock can no longer exercise `resolveLinkedAlbumId`'s real behavior now that its implementation lives inside the mocked package — the mock factory doesn't include it, so the re-export would resolve to `undefined` under that mock. `tests/mocks/database.mock.ts` gains a `resolveLinkedAlbumId` stub for any other consumer resolving `@wxyc/database` through the default mock, matching the existing `recomputeHasResolvedSupport` precedent.

All 7 moved test cases are preserved verbatim (empty-key guard x5, cold-case, multi-`album_id` ORDER BY pick).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (787 pre-existing warnings, 0 errors)
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 352 suites / 5260 tests passing
- [x] `npm run check:auth-tables-doc` — passing

Closes #1829