### PR TITLE
Make library-search artwork enrichment fire-and-forget

### DIFF
--- a/apps/backend/controllers/library.controller.ts
+++ b/apps/backend/controllers/library.controller.ts
@@ -211,37 +211,19 @@ export const searchForAlbum: RequestHandler = async (req: Request<object, object
   const onStreaming = query.on_streaming === 'true' ? true : query.on_streaming === 'false' ? false : undefined;
 
   const response = await libraryService.fuzzySearchLibrary(query.artist_name, query.album_title, query.n, onStreaming);
-  const enriched = await raceEnrichmentBudget(response, libraryService.enrichWithArtwork(response));
-  res.status(200).json(enriched.map((row) => libraryService.serializeLibraryArtistViewEntry(row)));
-};
-
-/**
- * Cap how long an interactive search will wait on artwork enrichment. LML's
- * own per-call timeout is 5s — appropriate for non-interactive callers
- * (request line, single-album lookup) but unacceptable on the search hot path
- * where one cache-miss gates the entire response. If the budget elapses we
- * return the raw search rows; the in-flight LML lookups keep running and still
- * write artwork_url to the DB, so subsequent searches benefit.
- */
-const SEARCH_ENRICHMENT_BUDGET_MS = Number(process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS ?? 500);
-
-async function raceEnrichmentBudget<T>(unenriched: T[], enrichment: Promise<T[]>): Promise<T[]> {
-  let budgetTimer: ReturnType<typeof setTimeout> | undefined;
-  const budget = new Promise<T[]>((resolve) => {
-    budgetTimer = setTimeout(() => resolve(unenriched), SEARCH_ENRICHMENT_BUDGET_MS);
-  });
-  // Swallow rejections from the enrichment promise so the budget path can win
-  // without an unhandledRejection. enrichWithArtwork already collects per-row
-  // failures internally; this guard covers the rare case it throws as a whole.
-  enrichment.catch((err) => {
+  // BS#1828: artwork enrichment is fire-and-forget, off the response path
+  // entirely — search returns local catalog rows immediately. A slow/rate-
+  // limited LML can no longer show up as catalog-search latency. The detached
+  // promise still runs `enrichWithArtwork`'s `updateArtworkUrl` cache-through
+  // write, so an un-warmed album's artwork appears on the *next* search, not
+  // this one. `enrichWithArtwork` already collects per-row failures
+  // internally; the `.catch` here only guards the rare case it rejects as a
+  // whole, so a detached failure can't surface as an unhandledRejection.
+  libraryService.enrichWithArtwork(response).catch((err) => {
     console.warn('[Library] Search-time artwork enrichment failed:', err);
   });
-  try {
-    return await Promise.race([enrichment, budget]);
-  } finally {
-    if (budgetTimer) clearTimeout(budgetTimer);
-  }
-}
+  res.status(200).json(response.map((row) => libraryService.serializeLibraryArtistViewEntry(row)));
+};
 
 type NewArtistRequest = {
   artist_name: string;

--- a/apps/backend/services/library.service.ts
+++ b/apps/backend/services/library.service.ts
@@ -609,11 +609,22 @@ const ROTATION_TRACKLIST_LOOKUP_NEGATIVE_WINDOW_MS = 7 * MS_PER_DAY;
 const ROTATION_LML_LOOKUP_TIMEOUT_MS = 10000;
 
 /**
- * Budget for `enrichWithArtwork` and `searchLibraryByTrack` — both user-visible
- * read paths that would rather degrade than hold the response on an obscure-
- * artist cascade. See `LookupOptions.budgetMs` for mechanics.
+ * Budget for `searchLibraryByTrack` — a user-visible read path that would
+ * rather degrade than hold the response on an obscure-artist cascade. See
+ * `LookupOptions.budgetMs` for mechanics.
  */
 const LIBRARY_INTERACTIVE_LML_BUDGET_MS = envInt('LIBRARY_INTERACTIVE_LML_BUDGET_MS', 5000);
+
+/**
+ * Per-call LML budget for `enrichWithArtwork`'s lookup. BS#1828 took this call
+ * off the `searchForAlbum` response path entirely (fire-and-forget from the
+ * controller), so this budget no longer bounds request latency — it bounds
+ * how long a detached enrichment can hold an LML/Discogs slot before giving
+ * up, stricter than the interactive (5s) and batch (29s) classes since
+ * artwork enrichment is the most droppable of the three. Should fold into
+ * #1826's per-class policy layer when that lands.
+ */
+const LIBRARY_SEARCH_LML_BUDGET_MS = envInt('LIBRARY_SEARCH_LML_BUDGET_MS', 2000);
 
 /**
  * Wire shape returned by `GET /library/rotation/:rotation_id/tracks`. The
@@ -1066,6 +1077,11 @@ export const updateCanonicalEntity = async (id: number, entityId: string, confid
  * fetches artwork from LML in parallel via Promise.allSettled and writes back
  * to the library table (cache-through). Gracefully degrades if LML is
  * unavailable or times out.
+ *
+ * BS#1828: the `searchForAlbum` controller calls this fire-and-forget — it is
+ * never awaited on the response path — so the mutation of `row.artwork_url`
+ * below only benefits *future* searches via the `updateArtworkUrl` write, not
+ * the in-flight request.
  */
 type ArtworkEnrichable = {
   id: number;
@@ -1083,7 +1099,7 @@ export async function enrichWithArtwork<T extends ArtworkEnrichable>(results: T[
   const settlements = await Promise.allSettled(
     uncached.map(async (row) => {
       const lookupResult = await lmlLookupCoordinator.lookup(row.artist_name, row.album_title, undefined, {
-        budgetMs: LIBRARY_INTERACTIVE_LML_BUDGET_MS,
+        budgetMs: LIBRARY_SEARCH_LML_BUDGET_MS,
         caller: 'library-enrich-artwork',
         requireSearchType: 'direct',
       });

--- a/tests/unit/controllers/library.controller.test.ts
+++ b/tests/unit/controllers/library.controller.test.ts
@@ -241,7 +241,27 @@ describe('library.controller', () => {
   });
 
   describe('searchForAlbum', () => {
-    it('returns enriched results when enrichment finishes within the budget', async () => {
+    it('returns local search results without waiting for enrichment to resolve', async () => {
+      const searchResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
+      mockFuzzySearchLibrary.mockResolvedValue(searchResults);
+      // Enrichment that never resolves — proves the response can't be waiting on it.
+      mockEnrichWithArtwork.mockReturnValue(new Promise<unknown[]>(() => undefined));
+
+      const req = { query: { artist_name: 'Autechre' } } as unknown as Request;
+      const res = mockResponse();
+
+      const start = Date.now();
+      await searchForAlbum(req, res, next);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(50);
+      expect(mockFuzzySearchLibrary).toHaveBeenCalledWith('Autechre', undefined, undefined, undefined);
+      expect(mockEnrichWithArtwork).toHaveBeenCalledWith(searchResults);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(searchResults);
+    });
+
+    it('excludes enrichment output from the response even when enrichment resolves immediately', async () => {
       const searchResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
       const enrichedResults = [
         { id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: 'https://i.discogs.com/confield.jpg' },
@@ -254,39 +274,13 @@ describe('library.controller', () => {
 
       await searchForAlbum(req, res, next);
 
-      expect(mockFuzzySearchLibrary).toHaveBeenCalledWith('Autechre', undefined, undefined, undefined);
+      // Fire-and-forget: enrichment is still triggered (and still writes
+      // artwork_url back to the DB for future searches to benefit from), but
+      // the response is built synchronously from the raw search rows before
+      // the detached promise can settle, so it never reflects enrichedResults.
       expect(mockEnrichWithArtwork).toHaveBeenCalledWith(searchResults);
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith(enrichedResults);
-    });
-
-    it('returns raw results without waiting when enrichment exceeds the budget', async () => {
-      const searchResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
-      mockFuzzySearchLibrary.mockResolvedValue(searchResults);
-      // Enrichment that never resolves within any reasonable budget.
-      mockEnrichWithArtwork.mockReturnValue(new Promise<unknown[]>(() => undefined));
-
-      const previous = process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
-      process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = '20';
-      jest.resetModules();
-      const { searchForAlbum: searchWithTightBudget } =
-        await import('../../../apps/backend/controllers/library.controller');
-
-      const req = { query: { artist_name: 'Autechre' } } as unknown as Request;
-      const res = mockResponse();
-
-      const start = Date.now();
-      await searchWithTightBudget(req, res, next);
-      const elapsed = Date.now() - start;
-
-      try {
-        expect(elapsed).toBeLessThan(500);
-        expect(res.status).toHaveBeenCalledWith(200);
-        expect(res.json).toHaveBeenCalledWith(searchResults);
-      } finally {
-        if (previous === undefined) delete process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
-        else process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = previous;
-      }
+      expect(res.json).toHaveBeenCalledWith(searchResults);
     });
 
     it('returns 400 when no query parameters are supplied', async () => {
@@ -331,35 +325,20 @@ describe('library.controller', () => {
       const searchResults = [{ id: 1, artist_name: 'Autechre', album_title: 'Confield', artwork_url: null }];
       mockFuzzySearchLibrary.mockResolvedValue(searchResults);
       const enrichError = new Error('enrichment failed');
-      // Reject *after* the budget would naturally fire — the budget should win
-      // and the rejection should be swallowed.
-      mockEnrichWithArtwork.mockReturnValue(
-        new Promise<unknown[]>((_, reject) => setTimeout(() => reject(enrichError), 500))
-      );
-
-      const previous = process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
-      // Budget << reject delay; 50/500/750ms gives ~10x headroom over the
-      // previous 5/50/75ms shape so CI runners under load don't race-invert
-      // and resolve the rejection before the budget fires.
-      process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = '50';
-      jest.resetModules();
-      const { searchForAlbum: searchWithTightBudget } =
-        await import('../../../apps/backend/controllers/library.controller');
+      // Rejects on the next microtask — well after the handler has already
+      // sent the response, since enrichment is detached and never awaited.
+      mockEnrichWithArtwork.mockReturnValue(Promise.reject(enrichError));
 
       const req = { query: { artist_name: 'Autechre' } } as unknown as Request;
       const res = mockResponse();
 
-      try {
-        await expect(searchWithTightBudget(req, res, next)).resolves.toBeUndefined();
-        expect(res.status).toHaveBeenCalledWith(200);
-        expect(res.json).toHaveBeenCalledWith(searchResults);
-        // Give the late rejection time to settle into the catch handler so the
-        // assertion below isn't subject to a process-level unhandledRejection.
-        await new Promise((resolve) => setTimeout(resolve, 750));
-      } finally {
-        if (previous === undefined) delete process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS;
-        else process.env.LIBRARY_SEARCH_ENRICHMENT_BUDGET_MS = previous;
-      }
+      await expect(searchForAlbum(req, res, next)).resolves.toBeUndefined();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(searchResults);
+      // Give the detached rejection time to settle into the controller's
+      // `.catch` so the assertion above isn't subject to a process-level
+      // unhandledRejection surfacing after this test completes.
+      await new Promise((resolve) => setTimeout(resolve, 10));
     });
   });
 

--- a/tests/unit/services/library.service.test.ts
+++ b/tests/unit/services/library.service.test.ts
@@ -1918,7 +1918,7 @@ describe('library.service', () => {
 
       expect(enriched[0].artwork_url).toBe('https://i.discogs.com/confield.jpg');
       expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'Confield', undefined, {
-        budgetMs: 5000,
+        budgetMs: 2000,
         caller: 'library-enrich-artwork',
         requireSearchType: 'direct',
       });
@@ -2010,7 +2010,7 @@ describe('library.service', () => {
       // Only one LML call (for LP5, not Confield)
       expect(mockLookupMetadata).toHaveBeenCalledTimes(1);
       expect(mockLookupMetadata).toHaveBeenCalledWith('Autechre', 'LP5', undefined, {
-        budgetMs: 5000,
+        budgetMs: 2000,
         caller: 'library-enrich-artwork',
         requireSearchType: 'direct',
       });


### PR DESCRIPTION
## Summary

- Decouples `searchForAlbum` from LML artwork enrichment: the controller now fires `enrichWithArtwork` off the response path entirely instead of racing it against a 500ms budget, so search returns local catalog rows immediately and a slow/rate-limited LML can never show up as catalog-search latency.
- The detached enrichment call still runs `enrichWithArtwork`'s `updateArtworkUrl` cache-through write, so an un-warmed album's artwork appears on the next search rather than this one — the accepted behavior change called out in the ticket.
- Introduces `LIBRARY_SEARCH_LML_BUDGET_MS` (2000ms default), a search-class-specific per-call LML budget stricter than the interactive (5s) and batch (29s) classes, replacing the shared interactive budget for this call site until #1826's per-class policy layer lands.

Closes #1828

## Test plan

- [x] `npm run test:unit` — 5380 tests pass, including rewritten `searchForAlbum` controller tests proving the response returns without waiting on enrichment and updated `enrichWithArtwork` budget assertions
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors, pre-existing warnings only)
- [x] `npm run format:check`